### PR TITLE
feat(desktop): wire v2 workspace create into task view

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/PropertiesSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/PropertiesSidebar.tsx
@@ -1,8 +1,10 @@
 import { Badge } from "@superset/ui/badge";
 import { ScrollArea } from "@superset/ui/scroll-area";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import type { TaskWithStatus } from "../../../components/TasksView/hooks/useTasksTable";
 import { AssigneeProperty } from "./components/AssigneeProperty";
 import { OpenInWorkspace } from "./components/OpenInWorkspace";
+import { OpenInWorkspaceV2 } from "./components/OpenInWorkspaceV2";
 import { PriorityProperty } from "./components/PriorityProperty";
 import { StatusProperty } from "./components/StatusProperty";
 
@@ -12,6 +14,7 @@ interface PropertiesSidebarProps {
 
 export function PropertiesSidebar({ task }: PropertiesSidebarProps) {
 	const labels = task.labels ?? [];
+	const { isV2CloudEnabled } = useIsV2CloudEnabled();
 
 	return (
 		<div className="w-64 border-l border-border shrink-0">
@@ -43,7 +46,11 @@ export function PropertiesSidebar({ task }: PropertiesSidebarProps) {
 						)}
 					</div>
 
-					<OpenInWorkspace task={task} />
+					{isV2CloudEnabled ? (
+						<OpenInWorkspaceV2 task={task} />
+					) : (
+						<OpenInWorkspace task={task} />
+					)}
 				</div>
 			</ScrollArea>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
@@ -1,0 +1,350 @@
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useMemo, useState } from "react";
+import { HiArrowRight, HiChevronDown } from "react-icons/hi2";
+import { AgentSelect } from "renderer/components/AgentSelect";
+import { env } from "renderer/env.renderer";
+import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
+import { authClient } from "renderer/lib/auth-client";
+import { DevicePicker } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker";
+import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
+import { useSelectedHostProjectIds } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceModalContent/hooks/useSelectedHostProjectIds";
+import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
+import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
+import { MOCK_ORG_ID } from "shared/constants";
+import type { TaskWithStatus } from "../../../../../components/TasksView/hooks/useTasksTable";
+import { deriveBranchName } from "../../../../utils/deriveBranchName";
+
+const AGENT_STORAGE_KEY = "lastSelectedV2TaskAgent";
+const NONE = "none" as const;
+type SelectedAgent = string | typeof NONE;
+
+interface OpenInWorkspaceV2Props {
+	task: TaskWithStatus;
+}
+
+function synthesizeTaskPrompt(task: TaskWithStatus): string {
+	const header = `${task.slug}: ${task.title}`;
+	const body = task.description?.trim();
+	return body ? `${header}\n\n${body}` : header;
+}
+
+function readStoredAgent(): SelectedAgent {
+	if (typeof window === "undefined") return NONE;
+	const stored = window.localStorage.getItem(AGENT_STORAGE_KEY);
+	return stored ? (stored as SelectedAgent) : NONE;
+}
+
+export function OpenInWorkspaceV2({ task }: OpenInWorkspaceV2Props) {
+	const navigate = useNavigate();
+	const collections = useCollections();
+	const { machineId, activeHostUrl } = useLocalHostService();
+	const { otherHosts } = useWorkspaceHostOptions();
+	const { data: session } = authClient.useSession();
+	const activeOrganizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
+
+	const { submit } = useWorkspaceCreates();
+	const lastProjectId = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.lastProjectId,
+	);
+	const setLastProjectId = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.setLastProjectId,
+	);
+	const lastHostId = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.lastHostId,
+	);
+	const setLastHostId = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.setLastHostId,
+	);
+
+	const [hostId, setHostId] = useState<string | null>(
+		lastHostId ?? machineId ?? null,
+	);
+
+	const { data: v2Projects } = useLiveQuery(
+		(q) =>
+			q
+				.from({ projects: collections.v2Projects })
+				.where(({ projects }) =>
+					eq(projects.organizationId, activeOrganizationId ?? ""),
+				)
+				.select(({ projects }) => ({ ...projects })),
+		[collections, activeOrganizationId],
+	);
+
+	const { data: githubRepositories } = useLiveQuery(
+		(q) =>
+			q.from({ repos: collections.githubRepositories }).select(({ repos }) => ({
+				id: repos.id,
+				owner: repos.owner,
+				name: repos.name,
+			})),
+		[collections],
+	);
+
+	const setUpProjectIds = useSelectedHostProjectIds(hostId);
+	const recentProjects = useMemo(() => {
+		const repoById = new Map(
+			(githubRepositories ?? []).map((repo) => [repo.id, repo]),
+		);
+		return (v2Projects ?? []).map((project) => {
+			const repo = project.githubRepositoryId
+				? (repoById.get(project.githubRepositoryId) ?? null)
+				: null;
+			return {
+				id: project.id,
+				name: project.name,
+				githubOwner: repo?.owner ?? null,
+				iconUrl: project.iconUrl ?? null,
+				needsSetup:
+					setUpProjectIds === null ? null : !setUpProjectIds.has(project.id),
+			};
+		});
+	}, [v2Projects, githubRepositories, setUpProjectIds]);
+
+	const launchHostUrl = useHostUrl(hostId);
+	const v2AgentConfigsQuery = useV2AgentConfigs(launchHostUrl);
+	const v2Agents = useMemo(
+		() =>
+			(v2AgentConfigsQuery.data ?? []).map((config) => ({
+				id: config.id,
+				label: config.label,
+				iconId: config.presetId,
+			})),
+		[v2AgentConfigsQuery.data],
+	);
+	const validAgentIds = useMemo(
+		() => new Set(v2Agents.map((agent) => agent.id)),
+		[v2Agents],
+	);
+
+	const seededProjectId =
+		lastProjectId &&
+		recentProjects.some((project) => project.id === lastProjectId)
+			? lastProjectId
+			: (recentProjects[0]?.id ?? null);
+	const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
+		seededProjectId,
+	);
+	useEffect(() => {
+		if (
+			selectedProjectId &&
+			recentProjects.some((project) => project.id === selectedProjectId)
+		) {
+			return;
+		}
+		setSelectedProjectId(seededProjectId);
+	}, [seededProjectId, selectedProjectId, recentProjects]);
+
+	const [selectedAgent, setSelectedAgentState] =
+		useState<SelectedAgent>(readStoredAgent);
+	useEffect(() => {
+		if (!v2AgentConfigsQuery.isFetched) return;
+		if (selectedAgent !== NONE && validAgentIds.has(selectedAgent)) return;
+		const stored = readStoredAgent();
+		if (stored !== NONE && validAgentIds.has(stored)) {
+			setSelectedAgentState(stored);
+		} else if (selectedAgent !== NONE) {
+			setSelectedAgentState(NONE);
+		}
+	}, [v2AgentConfigsQuery.isFetched, validAgentIds, selectedAgent]);
+	const setSelectedAgent = (next: SelectedAgent) => {
+		setSelectedAgentState(next);
+		if (typeof window !== "undefined") {
+			window.localStorage.setItem(AGENT_STORAGE_KEY, next);
+		}
+	};
+
+	const selectedProject = recentProjects.find(
+		(project) => project.id === selectedProjectId,
+	);
+
+	const handleSelectProject = (projectId: string) => {
+		setSelectedProjectId(projectId);
+		setLastProjectId(projectId);
+	};
+
+	const submitBlocker = useMemo<string | null>(() => {
+		if (!selectedProjectId) return "Select a project";
+		if (!hostId) return "No active host";
+		if (hostId !== machineId) {
+			const remote = otherHosts.find((host) => host.id === hostId);
+			if (!remote?.isOnline) return "Host is offline";
+		} else if (!activeHostUrl) {
+			return "Host service is not running";
+		}
+		if (selectedProject?.needsSetup === true) {
+			return "Project not set up on this host";
+		}
+		return null;
+	}, [
+		selectedProjectId,
+		selectedProject?.needsSetup,
+		hostId,
+		machineId,
+		otherHosts,
+		activeHostUrl,
+	]);
+
+	const handleOpen = () => {
+		if (submitBlocker) {
+			toast.error(submitBlocker);
+			return;
+		}
+		if (!selectedProjectId || !hostId) return;
+
+		const snapshotId = crypto.randomUUID();
+		const branch = deriveBranchName({ slug: task.slug, title: task.title });
+		const agents =
+			selectedAgent === NONE
+				? undefined
+				: [
+						{
+							agent: selectedAgent,
+							prompt: synthesizeTaskPrompt(task),
+						},
+					];
+
+		// Navigate optimistically — the host service uses our supplied id for new
+		// workspaces, so the route is correct in the common case. If the server
+		// found an existing workspace under a different id, the success handler
+		// replaces the URL.
+		void navigate({
+			to: "/v2-workspace/$workspaceId",
+			params: { workspaceId: snapshotId },
+		});
+
+		const promise = submit({
+			hostId,
+			snapshot: {
+				id: snapshotId,
+				projectId: selectedProjectId,
+				name: task.title,
+				branch,
+				taskId: task.id,
+				agents,
+			},
+		}).then((result) => {
+			if (!result.ok) throw new Error(result.error);
+			if (result.workspaceId !== snapshotId) {
+				void navigate({
+					to: "/v2-workspace/$workspaceId",
+					params: { workspaceId: result.workspaceId },
+					replace: true,
+				});
+			}
+			return result;
+		});
+
+		toast.promise(promise, {
+			loading: "Creating workspace...",
+			success: (result) =>
+				result.alreadyExists
+					? "Opened existing workspace"
+					: "Workspace created",
+			error: (err) => (err instanceof Error ? err.message : String(err)),
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<span className="text-xs text-muted-foreground">Open in workspace</span>
+			<DevicePicker
+				hostId={hostId}
+				onSelectHostId={(next) => {
+					setHostId(next);
+					setLastHostId(next);
+				}}
+				className="w-full max-w-none h-8"
+			/>
+			<div className="flex gap-1.5">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							variant="outline"
+							size="sm"
+							className="flex-1 justify-between font-normal h-8 min-w-0"
+						>
+							<span className="flex items-center gap-2 truncate">
+								{selectedProject ? (
+									<>
+										<ProjectThumbnail
+											projectName={selectedProject.name}
+											iconUrl={selectedProject.iconUrl}
+											className="size-4"
+										/>
+										<span className="truncate">{selectedProject.name}</span>
+									</>
+								) : (
+									<span className="text-muted-foreground">Select project</span>
+								)}
+							</span>
+							<HiChevronDown className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent
+						align="start"
+						className="w-[--radix-dropdown-menu-trigger-width]"
+					>
+						{recentProjects.length === 0 ? (
+							<DropdownMenuItem disabled>No projects found</DropdownMenuItem>
+						) : (
+							recentProjects.map((project) => (
+								<DropdownMenuItem
+									key={project.id}
+									onClick={() => handleSelectProject(project.id)}
+									className="flex items-center gap-2"
+								>
+									<ProjectThumbnail
+										projectName={project.name}
+										iconUrl={project.iconUrl}
+										className="size-4"
+									/>
+									<span className="flex-1 truncate">{project.name}</span>
+									{project.needsSetup === true && (
+										<span className="text-[10px] text-amber-500 shrink-0">
+											not set up
+										</span>
+									)}
+								</DropdownMenuItem>
+							))
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
+				<Button
+					size="icon"
+					className="h-8 w-8 shrink-0"
+					disabled={!!submitBlocker}
+					onClick={handleOpen}
+				>
+					<HiArrowRight className="w-3.5 h-3.5" />
+				</Button>
+			</div>
+			<AgentSelect<SelectedAgent>
+				agents={v2Agents}
+				value={selectedAgent}
+				placeholder="Select agent"
+				onValueChange={setSelectedAgent}
+				triggerClassName="h-8 text-xs"
+				allowNone
+				noneLabel="No agent"
+				noneValue={NONE}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
@@ -188,6 +188,10 @@ export function OpenInWorkspaceV2({ task }: OpenInWorkspaceV2Props) {
 		} else if (!activeHostUrl) {
 			return "Host service is not running";
 		}
+		// While the host's project list is still loading, needsSetup is null —
+		// block until we know whether the project is actually set up on the
+		// chosen host, otherwise the server-side guard becomes the only check.
+		if (setUpProjectIds === null) return "Checking host…";
 		if (selectedProject?.needsSetup === true) {
 			return "Project not set up on this host";
 		}
@@ -195,6 +199,7 @@ export function OpenInWorkspaceV2({ task }: OpenInWorkspaceV2Props) {
 	}, [
 		selectedProjectId,
 		selectedProject?.needsSetup,
+		setUpProjectIds,
 		hostId,
 		machineId,
 		otherHosts,
@@ -240,7 +245,16 @@ export function OpenInWorkspaceV2({ task }: OpenInWorkspaceV2Props) {
 				agents,
 			},
 		}).then((result) => {
-			if (!result.ok) throw new Error(result.error);
+			if (!result.ok) {
+				// We optimistically navigated to the snapshot URL — bounce back to
+				// the task on failure so the user isn't stranded on a dead route.
+				void navigate({
+					to: "/tasks/$taskId",
+					params: { taskId: task.id },
+					replace: true,
+				});
+				throw new Error(result.error);
+			}
 			if (result.workspaceId !== snapshotId) {
 				void navigate({
 					to: "/v2-workspace/$workspaceId",
@@ -328,6 +342,7 @@ export function OpenInWorkspaceV2({ task }: OpenInWorkspaceV2Props) {
 				</DropdownMenu>
 				<Button
 					size="icon"
+					aria-label="Open in workspace"
 					className="h-8 w-8 shrink-0"
 					disabled={!!submitBlocker}
 					onClick={handleOpen}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
@@ -195,11 +195,24 @@ export function OpenInWorkspaceV2({ task }: OpenInWorkspaceV2Props) {
 		if (selectedProject?.needsSetup === true) {
 			return "Project not set up on this host";
 		}
+		// Agent UUIDs are host-scoped. Right after a host switch the stored id
+		// from the previous host is still in selectedAgent until the agent
+		// query resolves and the corrective effect runs — block submission so
+		// we don't send an id this host doesn't recognize.
+		if (selectedAgent !== NONE) {
+			if (!v2AgentConfigsQuery.isFetched) return "Checking agents…";
+			if (!validAgentIds.has(selectedAgent)) {
+				return "Selected agent is not available on this host";
+			}
+		}
 		return null;
 	}, [
 		selectedProjectId,
 		selectedProject?.needsSetup,
 		setUpProjectIds,
+		selectedAgent,
+		v2AgentConfigsQuery.isFetched,
+		validAgentIds,
 		hostId,
 		machineId,
 		otherHosts,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/index.ts
@@ -1,0 +1,1 @@
+export { OpenInWorkspaceV2 } from "./OpenInWorkspaceV2";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
@@ -10,6 +10,7 @@ import {
 	HiOutlineViewColumns,
 	HiXMark,
 } from "react-icons/hi2";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useHotkey } from "renderer/hotkeys";
 import type { ViewMode } from "../../../../stores/tasks-filter-state";
 import type { TaskWithStatus } from "../../hooks/useTasksData";
@@ -19,6 +20,7 @@ import { BacklogIcon } from "../shared/icons/BacklogIcon";
 import { AssigneeFilter } from "./components/AssigneeFilter";
 import { CreateTaskDialog } from "./components/CreateTaskDialog";
 import { RunInWorkspacePopover } from "./components/RunInWorkspacePopover";
+import { RunInWorkspacePopoverV2 } from "./components/RunInWorkspacePopoverV2";
 
 export type TabValue = "all" | "active" | "backlog";
 
@@ -68,6 +70,7 @@ export function TasksTopBar({
 	const selectedCount = selectedTasks.length;
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const [isCreateTaskOpen, setIsCreateTaskOpen] = useState(false);
+	const { isV2CloudEnabled } = useIsV2CloudEnabled();
 
 	useHotkey(
 		"FOCUS_TASK_SEARCH",
@@ -99,10 +102,17 @@ export function TasksTopBar({
 								{selectedCount} selected
 							</span>
 							<div className="h-4 w-px bg-border" />
-							<RunInWorkspacePopover
-								tasks={selectedTasks}
-								onComplete={onClearSelection ?? (() => {})}
-							/>
+							{isV2CloudEnabled ? (
+								<RunInWorkspacePopoverV2
+									tasks={selectedTasks}
+									onComplete={onClearSelection ?? (() => {})}
+								/>
+							) : (
+								<RunInWorkspacePopover
+									tasks={selectedTasks}
+									onComplete={onClearSelection ?? (() => {})}
+								/>
+							)}
 						</>
 					) : (
 						<>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
@@ -198,11 +198,22 @@ export function RunInWorkspacePopoverV2({
 		if (selectedProject?.needsSetup === true) {
 			return "Project not set up on this host";
 		}
+		// Agent UUIDs are host-scoped; block until the host-specific config
+		// query resolves and the selection is verified to exist there.
+		if (selectedAgent !== NONE) {
+			if (!v2AgentConfigsQuery.isFetched) return "Checking agents…";
+			if (!validAgentIds.has(selectedAgent)) {
+				return "Selected agent is not available on this host";
+			}
+		}
 		return null;
 	}, [
 		selectedProjectId,
 		selectedProject?.needsSetup,
 		setUpProjectIds,
+		selectedAgent,
+		v2AgentConfigsQuery.isFetched,
+		validAgentIds,
 		hostId,
 		machineId,
 		otherHosts,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
@@ -1,0 +1,370 @@
+import { Button } from "@superset/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@superset/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { toast } from "@superset/ui/sonner";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { ChevronDownIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { HiCheck, HiMiniPlay } from "react-icons/hi2";
+import { AgentSelect } from "renderer/components/AgentSelect";
+import { env } from "renderer/env.renderer";
+import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
+import { authClient } from "renderer/lib/auth-client";
+import { DevicePicker } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker";
+import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
+import { useSelectedHostProjectIds } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceModalContent/hooks/useSelectedHostProjectIds";
+import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
+import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
+import { MOCK_ORG_ID } from "shared/constants";
+import { deriveBranchName } from "../../../../../../$taskId/utils/deriveBranchName";
+import type { TaskWithStatus } from "../../../../hooks/useTasksTable";
+
+const AGENT_STORAGE_KEY = "lastSelectedV2TaskBatchAgent";
+const NONE = "none" as const;
+type SelectedAgent = string | typeof NONE;
+
+interface RunInWorkspacePopoverV2Props {
+	tasks: TaskWithStatus[];
+	onComplete: () => void;
+}
+
+function synthesizeTaskPrompt(task: TaskWithStatus): string {
+	const header = `${task.slug}: ${task.title}`;
+	const body = task.description?.trim();
+	return body ? `${header}\n\n${body}` : header;
+}
+
+function readStoredAgent(): SelectedAgent {
+	if (typeof window === "undefined") return NONE;
+	const stored = window.localStorage.getItem(AGENT_STORAGE_KEY);
+	return stored ? (stored as SelectedAgent) : NONE;
+}
+
+export function RunInWorkspacePopoverV2({
+	tasks,
+	onComplete,
+}: RunInWorkspacePopoverV2Props) {
+	const collections = useCollections();
+	const { machineId, activeHostUrl } = useLocalHostService();
+	const { data: session } = authClient.useSession();
+	const activeOrganizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
+	const { otherHosts } = useWorkspaceHostOptions();
+	const { submit } = useWorkspaceCreates();
+
+	const lastHostId = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.lastHostId,
+	);
+	const setLastHostId = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.setLastHostId,
+	);
+	const lastProjectId = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.lastProjectId,
+	);
+	const setLastProjectId = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.setLastProjectId,
+	);
+
+	const [hostId, setHostId] = useState<string | null>(
+		lastHostId ?? machineId ?? null,
+	);
+
+	const launchHostUrl = useHostUrl(hostId);
+	const setUpProjectIds = useSelectedHostProjectIds(hostId);
+
+	const { data: v2Projects } = useLiveQuery(
+		(q) =>
+			q
+				.from({ projects: collections.v2Projects })
+				.where(({ projects }) =>
+					eq(projects.organizationId, activeOrganizationId ?? ""),
+				)
+				.select(({ projects }) => ({ ...projects })),
+		[collections, activeOrganizationId],
+	);
+
+	const { data: githubRepositories } = useLiveQuery(
+		(q) =>
+			q.from({ repos: collections.githubRepositories }).select(({ repos }) => ({
+				id: repos.id,
+				owner: repos.owner,
+				name: repos.name,
+			})),
+		[collections],
+	);
+
+	const recentProjects = useMemo(() => {
+		const repoById = new Map(
+			(githubRepositories ?? []).map((repo) => [repo.id, repo]),
+		);
+		return (v2Projects ?? []).map((project) => {
+			const repo = project.githubRepositoryId
+				? (repoById.get(project.githubRepositoryId) ?? null)
+				: null;
+			return {
+				id: project.id,
+				name: project.name,
+				githubOwner: repo?.owner ?? null,
+				iconUrl: project.iconUrl ?? null,
+				needsSetup:
+					setUpProjectIds === null ? null : !setUpProjectIds.has(project.id),
+			};
+		});
+	}, [v2Projects, githubRepositories, setUpProjectIds]);
+
+	const seededProjectId =
+		lastProjectId &&
+		recentProjects.some((project) => project.id === lastProjectId)
+			? lastProjectId
+			: (recentProjects[0]?.id ?? null);
+	const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
+		seededProjectId,
+	);
+	useEffect(() => {
+		if (
+			selectedProjectId &&
+			recentProjects.some((project) => project.id === selectedProjectId)
+		) {
+			return;
+		}
+		setSelectedProjectId(seededProjectId);
+	}, [seededProjectId, selectedProjectId, recentProjects]);
+	const selectedProject = recentProjects.find(
+		(project) => project.id === selectedProjectId,
+	);
+
+	const v2AgentConfigsQuery = useV2AgentConfigs(launchHostUrl);
+	const v2Agents = useMemo(
+		() =>
+			(v2AgentConfigsQuery.data ?? []).map((config) => ({
+				id: config.id,
+				label: config.label,
+				iconId: config.presetId,
+			})),
+		[v2AgentConfigsQuery.data],
+	);
+	const validAgentIds = useMemo(
+		() => new Set(v2Agents.map((agent) => agent.id)),
+		[v2Agents],
+	);
+
+	const [selectedAgent, setSelectedAgentState] =
+		useState<SelectedAgent>(readStoredAgent);
+	useEffect(() => {
+		if (!v2AgentConfigsQuery.isFetched) return;
+		if (selectedAgent !== NONE && validAgentIds.has(selectedAgent)) return;
+		const stored = readStoredAgent();
+		if (stored !== NONE && validAgentIds.has(stored)) {
+			setSelectedAgentState(stored);
+		} else if (selectedAgent !== NONE) {
+			setSelectedAgentState(NONE);
+		}
+	}, [v2AgentConfigsQuery.isFetched, validAgentIds, selectedAgent]);
+	const setSelectedAgent = (next: SelectedAgent) => {
+		setSelectedAgentState(next);
+		if (typeof window !== "undefined") {
+			window.localStorage.setItem(AGENT_STORAGE_KEY, next);
+		}
+	};
+
+	const [open, setOpen] = useState(false);
+	const [projectPickerOpen, setProjectPickerOpen] = useState(false);
+
+	const submitBlocker = useMemo<string | null>(() => {
+		if (!selectedProjectId) return "Select a project";
+		if (!hostId) return "No active host";
+		if (hostId !== machineId) {
+			const remote = otherHosts.find((host) => host.id === hostId);
+			if (!remote?.isOnline) return "Host is offline";
+		} else if (!activeHostUrl) {
+			return "Host service is not running";
+		}
+		if (selectedProject?.needsSetup === true) {
+			return "Project not set up on this host";
+		}
+		return null;
+	}, [
+		selectedProjectId,
+		selectedProject?.needsSetup,
+		hostId,
+		machineId,
+		otherHosts,
+		activeHostUrl,
+	]);
+
+	const handleRun = () => {
+		if (!selectedProjectId || !hostId) return;
+		if (submitBlocker) {
+			toast.error(submitBlocker);
+			return;
+		}
+
+		const submissions = tasks.map((task) =>
+			submit({
+				hostId,
+				snapshot: {
+					id: crypto.randomUUID(),
+					projectId: selectedProjectId,
+					name: task.title,
+					branch: deriveBranchName({ slug: task.slug, title: task.title }),
+					taskId: task.id,
+					agents:
+						selectedAgent === NONE
+							? undefined
+							: [
+									{
+										agent: selectedAgent,
+										prompt: synthesizeTaskPrompt(task),
+									},
+								],
+				},
+			}),
+		);
+
+		const promise = Promise.all(submissions).then((results) => {
+			const failed = results.filter((r) => !r.ok).length;
+			if (failed > 0) {
+				throw new Error(
+					`${results.length - failed} of ${results.length} succeeded`,
+				);
+			}
+			return results.length;
+		});
+
+		toast.promise(promise, {
+			loading: `Creating ${tasks.length} workspace${tasks.length === 1 ? "" : "s"}...`,
+			success: (count) => `Created ${count} workspace${count === 1 ? "" : "s"}`,
+			error: (err) => (err instanceof Error ? err.message : String(err)),
+		});
+
+		setOpen(false);
+		onComplete();
+	};
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-7 text-xs gap-1.5 bg-muted/50"
+				>
+					<HiMiniPlay className="size-3" />
+					Run in Workspace
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-72 p-0">
+				<div className="flex flex-col gap-2 p-2">
+					<DevicePicker
+						hostId={hostId}
+						onSelectHostId={(next) => {
+							setHostId(next);
+							setLastHostId(next);
+						}}
+						className="w-full max-w-none"
+					/>
+
+					<Popover open={projectPickerOpen} onOpenChange={setProjectPickerOpen}>
+						<PopoverTrigger asChild>
+							<Button
+								variant="ghost"
+								size="sm"
+								className="w-full justify-between font-normal h-8 min-w-0 bg-muted/50 rounded-md"
+							>
+								<span className="flex items-center gap-2 truncate">
+									{selectedProject ? (
+										<>
+											<ProjectThumbnail
+												projectName={selectedProject.name}
+												iconUrl={selectedProject.iconUrl}
+												className="size-4"
+											/>
+											<span className="truncate">{selectedProject.name}</span>
+										</>
+									) : (
+										<span className="text-muted-foreground">
+											Select project
+										</span>
+									)}
+								</span>
+								<ChevronDownIcon className="size-4 opacity-50 shrink-0" />
+							</Button>
+						</PopoverTrigger>
+						<PopoverContent align="start" className="w-60 p-0">
+							<Command>
+								<CommandInput placeholder="Search projects..." />
+								<CommandList>
+									<CommandEmpty>No projects found.</CommandEmpty>
+									<CommandGroup>
+										{recentProjects.map((project) => (
+											<CommandItem
+												key={project.id}
+												value={project.name}
+												onSelect={() => {
+													setSelectedProjectId(project.id);
+													setLastProjectId(project.id);
+													setProjectPickerOpen(false);
+												}}
+											>
+												<ProjectThumbnail
+													projectName={project.name}
+													iconUrl={project.iconUrl}
+													className="size-4"
+												/>
+												<span className="flex-1 truncate">{project.name}</span>
+												{project.needsSetup === true && (
+													<span className="text-[10px] text-amber-500">
+														not set up
+													</span>
+												)}
+												{project.id === selectedProjectId && (
+													<HiCheck className="size-3.5 shrink-0" />
+												)}
+											</CommandItem>
+										))}
+									</CommandGroup>
+								</CommandList>
+							</Command>
+						</PopoverContent>
+					</Popover>
+
+					<AgentSelect<SelectedAgent>
+						agents={v2Agents}
+						value={selectedAgent}
+						placeholder="Select agent"
+						onValueChange={setSelectedAgent}
+						onBeforeConfigureAgents={() => setOpen(false)}
+						triggerClassName="h-8 text-xs w-full border-0 shadow-none bg-muted/50 rounded-md"
+						allowNone
+						noneLabel="No agent"
+						noneValue={NONE}
+					/>
+				</div>
+
+				<div className="border-t border-border p-2">
+					<Button
+						size="sm"
+						className="w-full h-8"
+						disabled={!!submitBlocker}
+						onClick={handleRun}
+					>
+						Run {tasks.length} Workspace{tasks.length === 1 ? "" : "s"}
+					</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
@@ -192,6 +192,9 @@ export function RunInWorkspacePopoverV2({
 		} else if (!activeHostUrl) {
 			return "Host service is not running";
 		}
+		// Block while the host's project list is still loading — otherwise users
+		// can submit before we know whether the project is set up there.
+		if (setUpProjectIds === null) return "Checking host…";
 		if (selectedProject?.needsSetup === true) {
 			return "Project not set up on this host";
 		}
@@ -199,6 +202,7 @@ export function RunInWorkspacePopoverV2({
 	}, [
 		selectedProjectId,
 		selectedProject?.needsSetup,
+		setUpProjectIds,
 		hostId,
 		machineId,
 		otherHosts,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/index.ts
@@ -1,0 +1,1 @@
+export { RunInWorkspacePopoverV2 } from "./RunInWorkspacePopoverV2";

--- a/apps/desktop/src/renderer/stores/workspace-creates/index.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./store";
 export {
 	type SubmitArgs,
+	type SubmitResult,
 	type UseWorkspaceCreatesApi,
 	useWorkspaceCreates,
 } from "./useWorkspaceCreates";

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -98,6 +98,14 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 						recentlyViewedFiles: [],
 					});
 				}
+				// On alreadyExists the server returns the canonical workspace id,
+				// which can differ from our optimistic snapshot id. The in-flight
+				// entry is still keyed by snapshot id and won't ever resolve, so
+				// drop it — the canonical workspace now lives in collections and
+				// callers redirect there.
+				if (result.alreadyExists && result.workspace.id !== workspaceId) {
+					useWorkspaceCreatesStore.getState().remove(workspaceId);
+				}
 				return {
 					ok: true,
 					workspaceId: result.workspace.id,

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -18,9 +18,13 @@ export interface SubmitArgs {
 	snapshot: WorkspacesCreateInput;
 }
 
+export type SubmitResult =
+	| { ok: true; workspaceId: string; alreadyExists: boolean }
+	| { ok: false; error: string };
+
 export interface UseWorkspaceCreatesApi {
 	entries: InFlightEntry[];
-	submit: (args: SubmitArgs) => Promise<void>;
+	submit: (args: SubmitArgs) => Promise<SubmitResult>;
 	retry: (workspaceId: string) => Promise<void>;
 	dismiss: (workspaceId: string) => void;
 }
@@ -33,7 +37,7 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 	const collections = useCollections();
 
 	const dispatch = useCallback(
-		async (args: SubmitArgs) => {
+		async (args: SubmitArgs): Promise<SubmitResult> => {
 			const workspaceId = args.snapshot.id;
 			if (!workspaceId) {
 				throw new Error(
@@ -41,10 +45,9 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 				);
 			}
 			if (!organizationId) {
-				useWorkspaceCreatesStore
-					.getState()
-					.markError(workspaceId, "No active organization");
-				return;
+				const error = "No active organization";
+				useWorkspaceCreatesStore.getState().markError(workspaceId, error);
+				return { ok: false, error };
 			}
 			const hostUrl = resolveHostUrl({
 				hostId: args.hostId,
@@ -53,10 +56,9 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 				organizationId,
 			});
 			if (!hostUrl) {
-				useWorkspaceCreatesStore
-					.getState()
-					.markError(workspaceId, "Host service not available");
-				return;
+				const error = "Host service not available";
+				useWorkspaceCreatesStore.getState().markError(workspaceId, error);
+				return { ok: false, error };
 			}
 			try {
 				const client = getHostServiceClientByUrl(hostUrl);
@@ -96,20 +98,22 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 						recentlyViewedFiles: [],
 					});
 				}
+				return {
+					ok: true,
+					workspaceId: result.workspace.id,
+					alreadyExists: result.alreadyExists,
+				};
 			} catch (err) {
-				useWorkspaceCreatesStore
-					.getState()
-					.markError(
-						workspaceId,
-						err instanceof Error ? err.message : String(err),
-					);
+				const error = err instanceof Error ? err.message : String(err);
+				useWorkspaceCreatesStore.getState().markError(workspaceId, error);
+				return { ok: false, error };
 			}
 		},
 		[machineId, activeHostUrl, organizationId, collections],
 	);
 
 	const submit = useCallback(
-		async (args: SubmitArgs) => {
+		async (args: SubmitArgs): Promise<SubmitResult> => {
 			const workspaceId = args.snapshot.id;
 			if (!workspaceId) {
 				throw new Error(
@@ -121,7 +125,7 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 				snapshot: args.snapshot,
 				state: "creating",
 			});
-			await dispatch(args);
+			return await dispatch(args);
 		},
 		[dispatch],
 	);


### PR DESCRIPTION
## Summary
- v2 users in the task view now create v2 workspaces (was hitting the v1 trpc path).
- **Per-task** (`OpenInWorkspaceV2` in `PropertiesSidebar`): inline picker — DevicePicker + project dropdown + agent select. Submits via `useWorkspaceCreates.submit`, optimistically navigates to the snapshot id, replaces the URL on `alreadyExists`. `toast.promise` tracks the create.
- **Bulk** (`RunInWorkspacePopoverV2` in `TasksTopBar`): same picker stack with "not set up" markers for projects missing on the picked host. Click → close popover → fire all submits in parallel, wrap in `toast.promise`. The in-flight workspace-creates store + sidebar already surface per-workspace progress.
- Both gated on `useIsV2CloudEnabled()` at the parent. v1 components untouched.
- `useWorkspaceCreates.submit` now returns `{ ok: true; workspaceId; alreadyExists } | { ok: false; error }` so callers land on the real workspace id; existing `void submit(...)` callers stay compatible.

## Test plan
- [ ] As a v2 user, open a task → pick host/project/agent → click → land in the new v2 workspace
- [ ] Re-click the same task → toast shows "Opened existing workspace", URL is the existing workspace id
- [ ] Pick a project that's not set up on the chosen host → submit blocked with "Project not set up on this host"
- [ ] Multi-select tasks → "Run in Workspace" → popover closes immediately, toast shows progress, all v2 workspaces created with `taskId` linked
- [ ] As a v1 user, both flows unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes v2 users in the Task view to create v2 workspaces via the host service. Adds per‑task and bulk “Run in Workspace” with host/project/agent pickers, optimistic navigation, and clear feedback.

- **New Features**
  - Per-task: `OpenInWorkspaceV2` with `DevicePicker`, v2 project dropdown, and agent select (`useV2AgentConfigs`). Optimistic navigate; replace URL if `alreadyExists`. `toast.promise` tracks status.
  - Bulk: `RunInWorkspacePopoverV2` with the same pickers and “not set up” markers. Closes popover, fires parallel creates, and tracks with `toast.promise`.
  - Gated with `useIsV2CloudEnabled`; v1 components remain for non‑v2 users.
  - `useWorkspaceCreates.submit` returns `{ ok: true; workspaceId; alreadyExists } | { ok: false; error }` so callers land on the real workspace id.

- **Bug Fixes**
  - Block submit while the host’s project setup or agent configs are still loading, and prevent submitting with stale/unavailable agent IDs on the selected host.
  - On per-task failures, bounce back to `/tasks/$taskId` so users aren’t left on an optimistic URL.
  - Remove orphan in‑flight entries when the server returns a different canonical id on `alreadyExists`.
  - Add `aria-label="Open in workspace"` to the icon-only launch button.

<sup>Written for commit 3477d2f2b68d2a9b03d18f58280f814c187fbbfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * V2 workspace flow: open tasks in a v2 workspace with host/device, recent-project selection, and optional agent selection (last agent choice persisted).
  * Batch "Run in workspace" for multiple tasks with per-task snapshots and synthesized prompts when an agent is selected.
  * Conditional UI switches to V2 controls when enabled; submissions are blocked with clear errors until prerequisites are met and navigate to the created workspace on success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->