### PR TITLE
fix(cli): chmod +x bundled spawn-helper + add live PTY spawn smoke test

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -109,15 +109,19 @@ jobs:
               cwd: process.env.HOME || "/", env: process.env,
             });
             let got = "";
-            term.onData((d) => { got += d.toString(); });
-            term.onExit(({ exitCode }) => {
-              if (got.includes("SPAWN_OK") && exitCode === 0) {
-                console.log("pty spawn OK");
-                process.exit(0);
+            let exited = null;
+            const check = () => {
+              if (got.includes("SPAWN_OK") && exited && exited.exitCode === 0) {
+                console.log("pty spawn OK"); process.exit(0);
               }
-              console.error("pty spawn FAIL exit=" + exitCode + " got=" + JSON.stringify(got));
+              console.error("pty spawn FAIL exit=" + (exited && exited.exitCode) + " got=" + JSON.stringify(got));
               process.exit(1);
-            });
+            };
+            term.onData((d) => { got += d.toString(); });
+            // onExit can fire before the final onData chunk is delivered
+            // (SIGCHLD and EOF on the pty master are independent events).
+            // Defer the assertion one tick so any in-flight onData runs first.
+            term.onExit((e) => { exited = e; setTimeout(check, 100); });
             setTimeout(() => { console.error("pty spawn timeout"); process.exit(1); }, 5000);
           '
 

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -68,17 +68,57 @@ jobs:
 
       - name: Smoke test binary
         run: |
-          DIST="./packages/cli/dist/superset-${{ matrix.target }}"
+          # Resolve dist as an absolute path before changing cwd. The smoke
+          # tests below run from /tmp instead of the workspace because
+          # Node's module resolution walks up from cwd before consulting
+          # NODE_PATH — staying in $GITHUB_WORKSPACE leaks into the host
+          # repo's node_modules and silently masks bundle issues.
+          DIST="$(pwd)/packages/cli/dist/superset-${{ matrix.target }}"
           "$DIST/bin/superset" --version
           "$DIST/bin/superset" --help
           "$DIST/lib/node" --version
           test -f "$DIST/lib/host-service.js" || (echo "missing host-service.js" >&2; exit 1)
           test -f "$DIST/lib/pty-daemon.js" || (echo "missing pty-daemon.js" >&2; exit 1)
+          if [[ "${{ matrix.target }}" == darwin-* ]]; then
+            ARCH="${{ matrix.target }}"
+            ARCH="${ARCH#darwin-}"
+            HELPER="$DIST/lib/node_modules/node-pty/prebuilds/darwin-$ARCH/spawn-helper"
+            test -x "$HELPER" || (echo "spawn-helper not executable: $HELPER" >&2; exit 1)
+          fi
+          cd /tmp
           NODE_PATH="$DIST/lib/node_modules" "$DIST/lib/node" -e '
             for (const m of ["better-sqlite3", "node-pty", "@parcel/watcher", "libsql"]) {
               require(m);
               console.log(m, "OK");
             }
+          '
+          # Actually spawn a PTY against the bundled Node + bundled prebuild.
+          # Catches the runtime failures `require()` can't see — spawn-helper
+          # exec bit, pty.node ABI mismatch, arch mismatch, etc. Asserts
+          # node-pty resolves to the bundled copy so a host-tree leak
+          # (described above) doesn't silently make this pass.
+          NODE_PATH="$DIST/lib/node_modules" DIST="$DIST" "$DIST/lib/node" -e '
+            const resolved = require.resolve("node-pty/lib/unixTerminal");
+            if (!resolved.startsWith(process.env.DIST)) {
+              console.error("node-pty leaked from non-bundled tree:", resolved);
+              process.exit(1);
+            }
+            const pty = require("node-pty");
+            const term = pty.spawn("/bin/sh", ["-c", "echo SPAWN_OK"], {
+              name: "xterm", cols: 80, rows: 24,
+              cwd: process.env.HOME || "/", env: process.env,
+            });
+            let got = "";
+            term.onData((d) => { got += d.toString(); });
+            term.onExit(({ exitCode }) => {
+              if (got.includes("SPAWN_OK") && exitCode === 0) {
+                console.log("pty spawn OK");
+                process.exit(0);
+              }
+              console.error("pty spawn FAIL exit=" + exitCode + " got=" + JSON.stringify(got));
+              process.exit(1);
+            });
+            setTimeout(() => { console.error("pty spawn timeout"); process.exit(1); }, 5000);
           '
 
       - name: Upload tarball

--- a/packages/cli/scripts/build-dist-linux-docker.sh
+++ b/packages/cli/scripts/build-dist-linux-docker.sh
@@ -89,15 +89,20 @@ docker run --rm --platform "$PLATFORM" \
         cwd: process.env.HOME || \"/\", env: process.env,
       });
       let got = \"\";
-      term.onData((d) => { got += d.toString(); });
-      term.onExit((e) => {
-        if (got.includes(\"SPAWN_OK\") && e.exitCode === 0) {
+      let exited = null;
+      const check = () => {
+        if (got.includes(\"SPAWN_OK\") && exited && exited.exitCode === 0) {
           console.log(\"pty spawn OK\"); process.exit(0);
         }
-        console.error(\"pty spawn FAIL exit=\" + e.exitCode + \" got=\" + JSON.stringify(got));
+        console.error(\"pty spawn FAIL exit=\" + (exited && exited.exitCode) + \" got=\" + JSON.stringify(got));
         process.exit(1);
-      });
+      };
+      term.onData((d) => { got += d.toString(); });
+      // onExit can fire before the final onData chunk is delivered (SIGCHLD
+      // and EOF on the pty master are independent events). Defer the
+      // assertion one tick so any in-flight onData callback runs first.
+      term.onExit((e) => { exited = e; setTimeout(check, 100); });
       setTimeout(() => { console.error(\"pty spawn timeout\"); process.exit(1); }, 5000);
     "
-    echo "[docker-build] tarball: $(ls -la dist/superset-${TARGET}.tar.gz)"
+    echo "[docker-build] tarball: $(ls -la "$DIST.tar.gz")"
   '

--- a/packages/cli/scripts/build-dist-linux-docker.sh
+++ b/packages/cli/scripts/build-dist-linux-docker.sh
@@ -62,17 +62,42 @@ docker run --rm --platform "$PLATFORM" \
     cd packages/cli
     bun run build:dist --target="$TARGET"
 
-    DIST="./dist/superset-${TARGET}"
+    DIST="$(pwd)/dist/superset-${TARGET}"
     "$DIST/bin/superset" --version
     "$DIST/bin/superset" --help | head -5
     "$DIST/lib/node" --version
     test -f "$DIST/lib/host-service.js" || (echo "missing host-service.js" >&2; exit 1)
     test -f "$DIST/lib/pty-daemon.js" || (echo "missing pty-daemon.js" >&2; exit 1)
+    # Run from /tmp so Node module resolution does not walk up into the
+    # repo and leak into a non-bundled node-pty (host-tree shadowing).
+    cd /tmp
     NODE_PATH="$DIST/lib/node_modules" "$DIST/lib/node" -e "
       for (const m of [\"better-sqlite3\", \"node-pty\", \"@parcel/watcher\", \"libsql\"]) {
         require(m);
         console.log(m, \"OK\");
       }
+    "
+    NODE_PATH="$DIST/lib/node_modules" DIST="$DIST" "$DIST/lib/node" -e "
+      const resolved = require.resolve(\"node-pty/lib/unixTerminal\");
+      if (!resolved.startsWith(process.env.DIST)) {
+        console.error(\"node-pty leaked from non-bundled tree:\", resolved);
+        process.exit(1);
+      }
+      const pty = require(\"node-pty\");
+      const term = pty.spawn(\"/bin/sh\", [\"-c\", \"echo SPAWN_OK\"], {
+        name: \"xterm\", cols: 80, rows: 24,
+        cwd: process.env.HOME || \"/\", env: process.env,
+      });
+      let got = \"\";
+      term.onData((d) => { got += d.toString(); });
+      term.onExit((e) => {
+        if (got.includes(\"SPAWN_OK\") && e.exitCode === 0) {
+          console.log(\"pty spawn OK\"); process.exit(0);
+        }
+        console.error(\"pty spawn FAIL exit=\" + e.exitCode + \" got=\" + JSON.stringify(got));
+        process.exit(1);
+      });
+      setTimeout(() => { console.error(\"pty spawn timeout\"); process.exit(1); }, 5000);
     "
     echo "[docker-build] tarball: $(ls -la dist/superset-${TARGET}.tar.gz)"
   '

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -343,6 +343,27 @@ async function fixNativeBinariesForNode(
 		);
 		rmSync(nodePtyBuild, { recursive: true, force: true });
 	}
+
+	// node-pty's `prebuilds/darwin-{arch}/spawn-helper` ships from npm with
+	// mode 0644. node-pty posix_spawnp's it as the actual fork helper at
+	// terminal-open time — without +x the kernel returns EACCES and the
+	// failure surfaces only as the cryptic "posix_spawnp failed" with no
+	// errno. The normal install path runs `npm rebuild` which fixes the
+	// mode; we ship raw prebuilds so we have to fix it ourselves.
+	if (platform === "darwin") {
+		const { arch } = targetParts(target);
+		const spawnHelper = join(
+			destModules,
+			"node-pty",
+			"prebuilds",
+			`darwin-${arch}`,
+			"spawn-helper",
+		);
+		if (existsSync(spawnHelper)) {
+			console.log(`[build-dist] chmod +x ${spawnHelper}`);
+			chmodSync(spawnHelper, 0o755);
+		}
+	}
 }
 
 async function buildCli(target: Target, outputPath: string): Promise<void> {


### PR DESCRIPTION
## Why
User reported on cli-v0.2.5:

```
[terminal] open cfcc863f-...: spawn failed (shell=/bin/zsh cwd=/Users/codetown/code/superset): posix_spawnp failed.
```

The dist tarball ships `lib/node_modules/node-pty/prebuilds/darwin-<arch>/spawn-helper` directly from node-pty's npm package, which lands with mode `0644` (npm strips exec bits on tarball pack). On darwin, node-pty `posix_spawnp`s `spawn-helper` as the actual fork helper for every terminal. Without `+x` the kernel returns EACCES and the failure surfaces as the cryptic `posix_spawnp failed` with no errno. The normal install path runs `npm rebuild node-pty` which restores the bit; we ship the raw prebuild so we have to fix it ourselves.

## Why earlier smoke tests didn't catch it
1. The smoke test only asserted `require()` worked, not that PTY spawn worked.
2. When I added a `pty.spawn` smoke test in an earlier iteration, I ran it from the workspace cwd. Node's module resolution walks up from cwd before consulting `NODE_PATH`, so `node-pty` resolved to **the host repo's** `node_modules/node-pty` (electron-rebuilt by the desktop app, with proper `+x`). The smoke test passed against a broken bundle.

## What changes

### `packages/cli/scripts/build-dist.ts`
After the existing darwin `node-pty/build/` removal step (which forces the loader onto the prebuild path), `chmodSync(spawn-helper, 0o755)`.

### Smoke test (`build-cli.yml` + `build-dist-linux-docker.sh`)
- `cd /tmp` before running the smoke test scripts so Node module resolution doesn't walk up into the host repo.
- Assert `require.resolve("node-pty/lib/unixTerminal")` starts with the expected dist path — host-tree leaks now hard-fail the build instead of silently passing.
- Static `test -x` on `spawn-helper` for darwin targets.
- Live `pty.spawn("/bin/sh", ["-c", "echo SPAWN_OK"])` against the bundled Node + bundled prebuild. Asserts the spawn actually emits the expected bytes and exits 0.

## Verification
Reproduced and fixed against the published `cli-v0.2.5` tarball locally:

```
=== fixed mode (0755) ===
--- pty-spawn smoke (expect OK):
pty spawn OK
exit:0

=== broken mode (0644) ===
--- pty-spawn smoke (expect FAIL):
caught: posix_spawnp failed.
exit:1
```

The "broken mode" output matches the user's production error verbatim — meaning the new smoke test would have caught this exact bug, and would catch any future regression in the same class (spawn-helper, pty.node ABI mismatch, arch mismatch).

## Test plan
- [ ] CI green on this PR — the new smoke test runs on all three matrix targets
- [ ] After merge, cut `cli-v0.2.6`, push tag, confirm release artifacts pass smoke test in CI
- [ ] On a fresh machine, `superset start` → open a terminal → succeeds (no `posix_spawnp failed`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS terminal spawn failures by making the bundled `node-pty` `spawn-helper` executable. Adds and hardens a live PTY spawn smoke test to catch exec-bit, ABI/arch, and host-tree leak issues.

- **Bug Fixes**
  - Build: set 0755 on `lib/node_modules/node-pty/prebuilds/darwin-*/spawn-helper` during dist packaging.
  - CI smoke: resolve `DIST` as an absolute path before `cd /tmp`; assert `node-pty` resolves from the dist; verify `spawn-helper` is `+x` on darwin; run `pty.spawn("/bin/sh","-c","echo SPAWN_OK")` and expect output and exit 0; defer the check a tick to avoid `onExit`/`onData` race; fix Docker script to print `"$DIST.tar.gz"` instead of a relative path.

<sup>Written for commit ff9fe0aafe1052facd6968c7c789327c229cc4f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS CLI runtime permission preventing bundled terminal helper from executing.

* **Chores**
  * Strengthened CLI build/post-build validation with stricter runtime checks to ensure bundled modules load correctly.
  * Added a runtime integration test that verifies terminal spawn behavior and command execution.
  * Improved Linux Docker build validation with explicit module presence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->