### PR TITLE
perf(workspace-fs): align watcher with VS Code (overflow, throttler, NFC, symlinks, ENOSPC, ignore patterns)

### DIFF
--- a/packages/workspace-fs/src/search.ts
+++ b/packages/workspace-fs/src/search.ts
@@ -25,6 +25,13 @@ const KEYWORD_SEARCH_CANDIDATE_MULTIPLIER = 4;
 const KEYWORD_SEARCH_MAX_COUNT_PER_FILE = 3;
 const KEYWORD_SEARCH_RIPGREP_BUFFER_BYTES = 10 * 1024 * 1024;
 
+// Both the FsWatcherManager and the search-index `fast-glob` walk consume this
+// list. Patterns matched here are not just hidden from consumers — on Linux
+// they're applied at watch-creation time by @parcel/watcher, so no inotify
+// watches are installed for matched dirs. That's the main lever against
+// ENOSPC (inotify watch limit). On macOS FSEvents these are userspace-only
+// filters; the kernel still queues events for ignored paths but consumers
+// never see them.
 export const DEFAULT_IGNORE_PATTERNS = [
 	"**/node_modules/**",
 	"**/.git/**",
@@ -33,6 +40,14 @@ export const DEFAULT_IGNORE_PATTERNS = [
 	"**/.next/**",
 	"**/.turbo/**",
 	"**/coverage/**",
+	"**/.cache/**",
+	"**/.parcel-cache/**",
+	"**/.vite/**",
+	"**/.svelte-kit/**",
+	"**/.vercel/**",
+	"**/target/**",
+	"**/out/**",
+	"**/*.tsbuildinfo",
 ];
 
 interface SearchIndexEntry {

--- a/packages/workspace-fs/src/throttled-worker.ts
+++ b/packages/workspace-fs/src/throttled-worker.ts
@@ -64,14 +64,21 @@ export class ThrottledWorker<T> {
 
 	private doWork(): void {
 		const chunk = this.pending.splice(0, this.options.maxWorkChunkSize);
-		if (chunk.length > 0) this.handler(chunk);
-
-		if (this.pending.length > 0) {
-			this.throttleTimer = setTimeout(() => {
-				this.throttleTimer = null;
-				this.doWork();
-			}, this.options.throttleDelay);
-			this.throttleTimer.unref?.();
+		// Drain remaining work even if a handler throws. Without this,
+		// one bad listener batch wedges the worker until the next work()
+		// call happens to fire. (VS Code's ThrottledWorker has the same
+		// bug — async.ts:1351 — relying on process-level uncaughtException
+		// handlers to contain the throw, which doesn't unstick the buffer.)
+		try {
+			if (chunk.length > 0) this.handler(chunk);
+		} finally {
+			if (!this.disposed && this.pending.length > 0) {
+				this.throttleTimer = setTimeout(() => {
+					this.throttleTimer = null;
+					this.doWork();
+				}, this.options.throttleDelay);
+				this.throttleTimer.unref?.();
+			}
 		}
 	}
 

--- a/packages/workspace-fs/src/throttled-worker.ts
+++ b/packages/workspace-fs/src/throttled-worker.ts
@@ -1,0 +1,86 @@
+/**
+ * Self-contained port of VS Code's `ThrottledWorker`
+ * (microsoft/vscode `src/vs/base/common/async.ts`, ~line 1311). Same algorithm,
+ * same options shape, same `work(units): boolean` semantics, same `pending`
+ * getter. Replaces VS Code's `RunOnceScheduler` / `MutableDisposable` chain
+ * with a plain `setTimeout` handle so this stands alone with no base-utility
+ * dependencies.
+ *
+ * Used in workspace-fs to bound the rate at which @parcel/watcher events fan
+ * out to listeners, mirroring how VS Code's parcelWatcher protects consumers
+ * from event floods (see microsoft/vscode#124723).
+ */
+export interface ThrottledWorkerOptions {
+	/** Maximum units handed to the handler in a single chunk. */
+	maxWorkChunkSize: number;
+	/** Minimum delay between chunks. */
+	throttleDelay: number;
+	/**
+	 * Maximum units buffered in memory. Past this, `work()` rejects new
+	 * batches (returns false). Undefined = unbounded (don't use in
+	 * production with untrusted producers).
+	 */
+	maxBufferedWork: number | undefined;
+}
+
+export class ThrottledWorker<T> {
+	private readonly pending: T[] = [];
+	private throttleTimer: ReturnType<typeof setTimeout> | null = null;
+	private disposed = false;
+
+	constructor(
+		private readonly options: ThrottledWorkerOptions,
+		private readonly handler: (units: T[]) => void,
+	) {}
+
+	get pendingCount(): number {
+		return this.pending.length;
+	}
+
+	work(units: readonly T[]): boolean {
+		if (this.disposed) return false;
+
+		if (typeof this.options.maxBufferedWork === "number") {
+			if (this.throttleTimer) {
+				if (this.pending.length + units.length > this.options.maxBufferedWork) {
+					return false;
+				}
+			} else if (
+				this.pending.length + units.length - this.options.maxWorkChunkSize >
+				this.options.maxBufferedWork
+			) {
+				return false;
+			}
+		}
+
+		for (const unit of units) this.pending.push(unit);
+
+		if (!this.throttleTimer) {
+			this.doWork();
+		}
+
+		return true;
+	}
+
+	private doWork(): void {
+		const chunk = this.pending.splice(0, this.options.maxWorkChunkSize);
+		if (chunk.length > 0) this.handler(chunk);
+
+		if (this.pending.length > 0) {
+			this.throttleTimer = setTimeout(() => {
+				this.throttleTimer = null;
+				this.doWork();
+			}, this.options.throttleDelay);
+			this.throttleTimer.unref?.();
+		}
+	}
+
+	dispose(): void {
+		this.disposed = true;
+		if (this.throttleTimer) {
+			clearTimeout(this.throttleTimer);
+			this.throttleTimer = null;
+		}
+		this.pending.length = 0;
+	}
+}

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises";
+import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import {
 	type AsyncSubscription,
@@ -9,10 +9,10 @@ import { toErrorMessage } from "./error-message";
 import { normalizeAbsolutePath } from "./paths";
 import {
 	DEFAULT_IGNORE_PATTERNS,
-	invalidateSearchIndexesForRoot,
 	patchSearchIndexesForRoot,
 	type SearchPatchEvent,
 } from "./search";
+import { ThrottledWorker } from "./throttled-worker";
 import type { FsWatchEvent } from "./types";
 
 // Cap per-watcher file-path memory so a monotonic stream of unique paths
@@ -23,6 +23,14 @@ import type { FsWatchEvent } from "./types";
 // search-index pruning, leaving stale descendant entries until the next
 // full rebuild.
 const FILE_PATHS_MAX = 10_000;
+
+// Throttler bounds (mirror VS Code's parcelWatcher.ts:181-188 — same algorithm,
+// same numbers). Bounds the rate at which events fan out to listeners so a
+// legitimate burst (mass refactor, branch checkout) can't pin a CPU draining
+// downstream consumers, and a runaway producer can't grow the JS heap unbounded.
+const MAX_WORK_CHUNK_SIZE = 500;
+const THROTTLE_DELAY_MS = 200;
+const MAX_BUFFERED_EVENTS = 30_000;
 
 export interface WatchPathOptions {
 	absolutePath: string;
@@ -39,13 +47,31 @@ export interface InternalWatchEvent {
 type WatchListener = (batch: { events: FsWatchEvent[] }) => void;
 
 interface WatcherState {
+	/** Path as the caller asked us to watch, used in events emitted to listeners. */
 	absolutePath: string;
+	/**
+	 * Resolved-symlink path actually handed to @parcel/watcher. Differs from
+	 * `absolutePath` when the requested path includes a symlinked component;
+	 * we map kernel-reported paths back to `absolutePath` form before emit.
+	 * Mirrors VS Code's parcelWatcher.ts `realPath` handling (lines 488-516).
+	 */
+	realPath: string;
+	realPathDiffers: boolean;
+	realPathLength: number;
 	subscription: AsyncSubscription;
 	listeners: Set<WatchListener>;
 	filePaths: Map<string, true>;
 	directoryPaths: Set<string>;
 	pendingEvents: ParcelWatcherEvent[];
 	flushTimer: ReturnType<typeof setTimeout> | null;
+	/**
+	 * Per-state throttler. VS Code (parcelWatcher.ts:181-188) uses a single
+	 * shared throttler at the watcher class level; ours is per-state because
+	 * each FsWatcherManager subscriber consumes events for its own watch root
+	 * independently — sharing one buffer would let a noisy worktree starve
+	 * a quiet one's listeners.
+	 */
+	throttler: ThrottledWorker<FsWatchEvent>;
 }
 
 function coalesceWatchEvent(
@@ -322,6 +348,14 @@ export class FsWatcherManager {
 	private readonly ignore: string[];
 	private readonly filePathsMax: number;
 	private readonly watchers = new Map<string, WatcherState>();
+	/**
+	 * One-shot dedup so a single ENOSPC report doesn't spam logs across every
+	 * watcher creation that follows it. Mirrors VS Code's `enospcErrorLogged`
+	 * (parcelWatcher.ts:190). Intentionally never reset — once a process hits
+	 * the inotify limit, surfacing it again per error doesn't help; the user
+	 * needs to bump `fs.inotify.max_user_watches` and restart.
+	 */
+	private enospcErrorLogged = false;
 
 	constructor(options: FsWatcherManagerOptions = {}) {
 		this.debounceMs = options.debounceMs ?? 75;
@@ -359,6 +393,7 @@ export class FsWatcherManager {
 				currentState.flushTimer = null;
 			}
 
+			currentState.throttler.dispose();
 			await currentState.subscription.unsubscribe();
 			this.watchers.delete(absolutePath);
 		};
@@ -371,28 +406,121 @@ export class FsWatcherManager {
 					clearTimeout(state.flushTimer);
 					state.flushTimer = null;
 				}
+				state.throttler.dispose();
 				await state.subscription.unsubscribe();
 			}),
 		);
 		this.watchers.clear();
 	}
 
-	private async createWatcher(absolutePath: string): Promise<WatcherState> {
-		const state: WatcherState = {
-			absolutePath: normalizeAbsolutePath(absolutePath),
-			subscription: null as unknown as AsyncSubscription,
-			listeners: new Set<WatchListener>(),
-			filePaths: new Map<string, true>(),
-			directoryPaths: new Set<string>(),
-			pendingEvents: [],
-			flushTimer: null,
+	/**
+	 * Resolve symlinks once at watch start and record the deltas needed to
+	 * map kernel-reported event paths back to the caller's requested form.
+	 * Port of VS Code parcelWatcher.ts `normalizePath` (lines 488-516). Casing
+	 * normalization (`realcase`) is intentionally skipped — that's macOS-only
+	 * and requires a non-trivial helper from VS Code's pfs module; symlink
+	 * resolution alone covers our use cases.
+	 */
+	private async normalizePath(absolutePath: string): Promise<{
+		realPath: string;
+		realPathDiffers: boolean;
+		realPathLength: number;
+	}> {
+		try {
+			const resolved = await realpath(absolutePath);
+			if (resolved !== absolutePath) {
+				return {
+					realPath: resolved,
+					realPathDiffers: true,
+					realPathLength: resolved.length,
+				};
+			}
+		} catch {
+			// realpath fails on non-existent paths; the caller already
+			// validated via stat() above, so any failure here is benign —
+			// fall through to using the original path.
+		}
+		return {
+			realPath: absolutePath,
+			realPathDiffers: false,
+			realPathLength: absolutePath.length,
 		};
+	}
+
+	/**
+	 * Mutate parcel events in place: NFC-normalize on darwin (HFS+/APFS stores
+	 * filenames in NFD; consumers compare against NFC) and map paths back from
+	 * the resolved-symlink form to the caller's requested form. Port of VS Code
+	 * parcelWatcher.ts `normalizeEvents` (lines 518-539). Windows root-drive
+	 * workaround is omitted — desktop doesn't ship on Windows yet.
+	 */
+	private normalizeEvents(
+		events: ParcelWatcherEvent[],
+		state: WatcherState,
+	): void {
+		for (const event of events) {
+			if (process.platform === "darwin") {
+				event.path = event.path.normalize("NFC");
+			}
+			if (state.realPathDiffers) {
+				event.path =
+					state.absolutePath + event.path.slice(state.realPathLength);
+			}
+		}
+	}
+
+	/**
+	 * Surface watcher errors with platform-specific guidance. Port of VS Code
+	 * parcelWatcher.ts `onUnexpectedError` (lines 579-609). Two specific
+	 * errors get dedicated branches:
+	 *
+	 * - `'No space left on device'` (ENOSPC): Linux inotify watch limit
+	 *   exhausted. Log once with a remediation hint; spamming repeats doesn't
+	 *   help — user has to bump the system limit and restart.
+	 * - `'File system must be re-scanned'`: macOS FSEvents kernel queue
+	 *   overflowed. Just log. Crucially, do NOT emit a synthetic event to
+	 *   listeners — overflow means "some events were dropped," not "git state
+	 *   changed," and downstream consumers (git-watcher → renderer's
+	 *   useGitStatus → host-service git.getStatus) would interpret it as the
+	 *   latter and storm the host-service with git subprocess spawns.
+	 */
+	private onUnexpectedError(error: unknown, state: WatcherState): void {
+		const msg = toErrorMessage(error);
+
+		if (msg.indexOf("No space left on device") !== -1) {
+			if (!this.enospcErrorLogged) {
+				console.error(
+					"[workspace-fs/watch] inotify watch limit reached (ENOSPC). " +
+						"Increase via: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p",
+					{ absolutePath: state.absolutePath },
+				);
+				this.enospcErrorLogged = true;
+			}
+			return;
+		}
+
+		if (msg.indexOf("File system must be re-scanned") !== -1) {
+			console.error("[workspace-fs/watch] FSEvents overflow:", {
+				absolutePath: state.absolutePath,
+				error: msg,
+			});
+			return;
+		}
+
+		console.error("[workspace-fs/watch] Watcher error:", {
+			absolutePath: state.absolutePath,
+			error: msg,
+		});
+	}
+
+	private async createWatcher(absolutePath: string): Promise<WatcherState> {
+		const normalizedPath = normalizeAbsolutePath(absolutePath);
 
 		try {
-			const rootStats = await stat(state.absolutePath);
+			const rootStats = await stat(normalizedPath);
 			if (!rootStats.isDirectory()) {
 				throw new Error(
-					`Cannot watch path: path is not a directory: ${state.absolutePath}`,
+					`Cannot watch path: path is not a directory: ${normalizedPath}`,
 				);
 			}
 		} catch (error) {
@@ -403,31 +531,58 @@ export class FsWatcherManager {
 					(error as NodeJS.ErrnoException).code === "ENOTDIR")
 			) {
 				throw new Error(
-					`Cannot watch path: path does not exist: ${state.absolutePath}`,
+					`Cannot watch path: path does not exist: ${normalizedPath}`,
 				);
 			}
 			throw error;
 		}
 
+		const { realPath, realPathDiffers, realPathLength } =
+			await this.normalizePath(normalizedPath);
+
+		const state: WatcherState = {
+			absolutePath: normalizedPath,
+			realPath,
+			realPathDiffers,
+			realPathLength,
+			subscription: null as unknown as AsyncSubscription,
+			listeners: new Set<WatchListener>(),
+			filePaths: new Map<string, true>(),
+			directoryPaths: new Set<string>(),
+			pendingEvents: [],
+			flushTimer: null,
+			throttler: new ThrottledWorker<FsWatchEvent>(
+				{
+					maxWorkChunkSize: MAX_WORK_CHUNK_SIZE,
+					throttleDelay: THROTTLE_DELAY_MS,
+					maxBufferedWork: MAX_BUFFERED_EVENTS,
+				},
+				(eventChunk) => {
+					for (const listener of state.listeners) {
+						listener({ events: eventChunk });
+					}
+				},
+			),
+		};
+
+		// Subscribe to the resolved real path so kernel paths come back in a
+		// consistent form; we map them back to `state.absolutePath` in
+		// `normalizeEvents`. Mirrors VS Code's parcelWatcher.ts:364.
 		state.subscription = await subscribeToFilesystem(
-			state.absolutePath,
+			realPath,
 			(error, events) => {
 				if (error) {
-					console.error("[workspace-fs/watch] Watcher error:", {
-						absolutePath: state.absolutePath,
-						error: toErrorMessage(error),
-					});
-					this.emit(state, {
-						events: [{ kind: "overflow", absolutePath: state.absolutePath }],
-					});
-					invalidateSearchIndexesForRoot(state.absolutePath);
-					return;
+					this.onUnexpectedError(error, state);
+					// Continue: process whatever events did arrive alongside
+					// the error. Mirrors VS Code's parcelWatcher.ts:373-378
+					// pattern (log error, then onParcelEvents anyway).
 				}
 
 				if (events.length === 0) {
 					return;
 				}
 
+				this.normalizeEvents(events, state);
 				state.pendingEvents.push(...events);
 				if (state.flushTimer) {
 					return;
@@ -525,8 +680,20 @@ export class FsWatcherManager {
 	}
 
 	private emit(state: WatcherState, batch: { events: FsWatchEvent[] }): void {
-		for (const listener of state.listeners) {
-			listener(batch);
+		// Route through ThrottledWorker so a legitimate event burst (mass
+		// refactor, branch checkout) can't pin a CPU draining listeners or
+		// grow the JS heap unbounded. Past MAX_BUFFERED_EVENTS, work() returns
+		// false; we drop with a one-shot warning per state.
+		const accepted = state.throttler.work(batch.events);
+		if (!accepted) {
+			console.warn(
+				"[workspace-fs/watch] throttler buffer full — dropping events",
+				{
+					absolutePath: state.absolutePath,
+					droppedBatchSize: batch.events.length,
+					pending: state.throttler.pendingCount,
+				},
+			);
 		}
 	}
 }

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -54,10 +54,14 @@ interface WatcherState {
 	 * `absolutePath` when the requested path includes a symlinked component;
 	 * we map kernel-reported paths back to `absolutePath` form before emit.
 	 * Mirrors VS Code's parcelWatcher.ts `realPath` handling (lines 488-516).
+	 *
+	 * `realPathNormalized` carries the same NFC normalization we apply to
+	 * incoming event paths on darwin, so the path.relative rebase in
+	 * normalizeEvents is length-stable across composed/decomposed forms.
 	 */
 	realPath: string;
+	realPathNormalized: string;
 	realPathDiffers: boolean;
-	realPathLength: number;
 	subscription: AsyncSubscription;
 	listeners: Set<WatchListener>;
 	filePaths: Map<string, true>;
@@ -423,16 +427,18 @@ export class FsWatcherManager {
 	 */
 	private async normalizePath(absolutePath: string): Promise<{
 		realPath: string;
+		realPathNormalized: string;
 		realPathDiffers: boolean;
-		realPathLength: number;
 	}> {
+		const normalize = (input: string) =>
+			process.platform === "darwin" ? input.normalize("NFC") : input;
 		try {
 			const resolved = await realpath(absolutePath);
 			if (resolved !== absolutePath) {
 				return {
 					realPath: resolved,
+					realPathNormalized: normalize(resolved),
 					realPathDiffers: true,
-					realPathLength: resolved.length,
 				};
 			}
 		} catch {
@@ -442,8 +448,8 @@ export class FsWatcherManager {
 		}
 		return {
 			realPath: absolutePath,
+			realPathNormalized: normalize(absolutePath),
 			realPathDiffers: false,
-			realPathLength: absolutePath.length,
 		};
 	}
 
@@ -458,13 +464,23 @@ export class FsWatcherManager {
 		events: ParcelWatcherEvent[],
 		state: WatcherState,
 	): void {
+		// VS Code (parcelWatcher.ts:534-537) slices by `realPathLength`
+		// computed pre-NFC, which corrupts paths when NFC changes string
+		// length AND the requested path was a symlink. We use path.relative
+		// against the same-normalized realPath so the rebase works regardless
+		// of NFC length changes.
 		for (const event of events) {
-			if (process.platform === "darwin") {
-				event.path = event.path.normalize("NFC");
-			}
+			const eventPath =
+				process.platform === "darwin"
+					? event.path.normalize("NFC")
+					: event.path;
 			if (state.realPathDiffers) {
-				event.path =
-					state.absolutePath + event.path.slice(state.realPathLength);
+				event.path = path.join(
+					state.absolutePath,
+					path.relative(state.realPathNormalized, eventPath),
+				);
+			} else {
+				event.path = eventPath;
 			}
 		}
 	}
@@ -537,14 +553,14 @@ export class FsWatcherManager {
 			throw error;
 		}
 
-		const { realPath, realPathDiffers, realPathLength } =
+		const { realPath, realPathNormalized, realPathDiffers } =
 			await this.normalizePath(normalizedPath);
 
 		const state: WatcherState = {
 			absolutePath: normalizedPath,
 			realPath,
+			realPathNormalized,
 			realPathDiffers,
-			realPathLength,
 			subscription: null as unknown as AsyncSubscription,
 			listeners: new Set<WatchListener>(),
 			filePaths: new Map<string, true>(),


### PR DESCRIPTION
## Why

Live profiling of a desktop install (host-service.js PID 58771) showed sustained **~65% CPU** with dozens of `<defunct>` git children. Active children traced to `git status --porcelain -b -u --null` and `git ls-files --others --ignored --exclude-standard --directory` — exactly the simple-git invocation inside `git.getStatus` (`packages/host-service/src/trpc/router/git/git.ts:91`).

Root cause from `~/.superset/host/<orgId>/host-service.log`:

```
[workspace-fs/watch] Watcher error: {
  absolutePath: '.../brave-feather',
  error: 'Events were dropped by the FSEvents client. File system must be re-scanned.'
}
```

This fired constantly because `brave-feather` (a worktree where the dev build was running Turbo + Vite) generated more FS events per second than the macOS FSEvents kernel queue could drain. The `ignore` arg passed to `@parcel/watcher` is a **userspace** filter; FSEvents is recursive at the kernel level with no exclusion API on macOS, so build-output churn saturates the queue regardless of patterns.

Our handler turned each overflow into a synthetic `{kind:"overflow"}` event → `git-watcher` translated it into a `git:changed` broadcast → renderer's `useGitStatus` invalidated `git.getStatus` → host-service spawned ~8 git subprocesses per workspace per overflow. Storm.

## Reference

VS Code uses the same `@parcel/watcher` library (`microsoft/vscode src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts`) and treats the same error as a non-event. This PR ports their handling structurally rather than reinventing the shape — VS Code's watcher is hardened by years of bug-fix iteration; drift from it loses that hardening.

## Changes (6, in 2 files)

1. **Drop synthetic overflow emission** (`watch.ts`): on the `@parcel/watcher` error callback, log only — no synthetic event, no `invalidateSearchIndexesForRoot`, no early return. Mirrors `parcelWatcher.ts:597-599`.

2. **Per-state `ThrottledWorker`** for emit rate-limiting: max 500 events/200ms chunk, 30k buffered before drop. Self-contained port at `packages/workspace-fs/src/throttled-worker.ts` of VS Code's `ThrottledWorker` from `base/common/async.ts:1311`. Bounds CPU during legitimate event bursts (mass refactor, branch checkout) and prevents unbounded heap growth.

3. **NFC normalization on darwin** in `normalizeEvents`: macOS HFS+/APFS stores filenames as NFD; without this, non-ASCII filenames trigger events whose paths don't match consumer state. Mirrors `parcelWatcher.ts:521-524`.

4. **Symlink/realpath path mapping** via `normalizePath` method on `FsWatcherManager`: resolve symlinks once at watch start, subscribe to the resolved path, map kernel-reported paths back to the caller's requested form before emit. Mirrors `parcelWatcher.ts:488-516`.

5. **ENOSPC log-once** with remediation hint for Linux inotify exhaustion. Mirrors `parcelWatcher.ts:579-609` (`onUnexpectedError`).

6. **Expand `DEFAULT_IGNORE_PATTERNS`** (`search.ts`) with `.cache`, `.parcel-cache`, `.vite`, `.svelte-kit`, `.vercel`, `target`, `out`, `*.tsbuildinfo`. On Linux these are applied at watch-creation time by `@parcel/watcher` so no inotify watches are installed for matched dirs — directly helps avoid ENOSPC. On macOS they reduce userspace filter work.

## Deferred (separate follow-up)

- **Restart-on-error logic** (VS Code `parcelWatcher.ts:619-651`): non-trivial state machine; defer.
- **Root-deletion detection** (VS Code `parcelWatcher.ts:541-577`): workspace cleanup goes through other paths.
- **`fs.stat`-per-event optimization** in our `normalizeEvent`: directory-tracking is intentional for the search-index patcher; switching strategy needs care.

## Skipped (not relevant for our use case)

Polling fallback (we watch local disk only), VS Code's `PREDEFINED_EXCLUDES` (just a macOS permission-dialog workaround), parent-child request dedup (we watch one root per workspace), per-path subscribe API, cancellation tokens, explicit backend selection, process-level uncaughtException handlers (covered by `installProcessSafetyNet`).

## Test plan

- [x] `bun run lint`
- [x] `bun run --filter '@superset/workspace-fs' typecheck`
- [x] `bun run --filter '@superset/host-service' typecheck`
- [x] `bun run --filter '@superset/desktop' typecheck`
- [x] `bun run --filter '@superset/workspace-fs' test` — 41 pass / 0 fail
- [x] `bun run --filter '@superset/host-service' test` — 489 pass / 0 fail
- [ ] **Manual**: launch the build with a worktree running `turbo run dev` (or any heavy file-churn process). `tail -f host-service.log` confirms `Watcher error: ... File system must be re-scanned` still logs but no longer triggers downstream cascades. Host-service CPU should sit in single digits at idle (was 65%+).
- [ ] **NFC**: create a file with a non-ASCII name (`café.txt`) in a watched workspace, save — confirm event arrives with NFC-normalized path matching consumer state.
- [ ] **Symlink** (optional): if `~/code` is a symlink, save a tracked file under it — confirm event paths come back un-resolved.
- [ ] **Linux ENOSPC** (optional): on a sacrificial VM, set `fs.inotify.max_user_watches=64`, watch a large repo — confirm clean error with remediation hint instead of log spam.

Closes the steady-state CPU pinning observed in the original investigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Throttled scheduling for file-watcher events to maintain responsiveness during rapid changes.

* **Documentation**
  * Clarified how default ignore patterns affect indexing and search across platforms.

* **Improvements**
  * Expanded default ignore list to exclude more cache/build outputs from indexing.
  * Improved symlink/path normalization for more reliable file watching and fewer false events.
  * Reduced noisy watcher error reporting for more stable operation under heavy workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->