### PR TITLE
fix(desktop): keep v2 workspace provider mounted across host-service restarts

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -47,11 +47,32 @@ function V2WorkspaceLayout() {
 	const workspace = workspaces[0] ?? null;
 
 	const isLocal = workspace?.hostId === machineId;
-	const hostUrl = !workspace
+	const liveHostUrl = !workspace
 		? null
 		: isLocal
 			? activeHostUrl
 			: `${env.RELAY_URL}/hosts/${buildHostRoutingKey(workspace.organizationId, workspace.hostId)}`;
+
+	// Sticky hostUrl: hold the last good value while a local host-service
+	// momentarily reports no active connection (5s poll race during restart,
+	// brief "starting" window). Without this the provider tears down and any
+	// child reading useWorkspaceClient synchronously throws. Scoped to the
+	// current workspace.id so switching workspaces never reuses a stale URL.
+	const lastGoodHostUrlRef = useRef<{
+		workspaceId: string;
+		url: string;
+	} | null>(null);
+	if (workspace && liveHostUrl) {
+		lastGoodHostUrlRef.current = {
+			workspaceId: workspace.id,
+			url: liveHostUrl,
+		};
+	}
+	const hostUrl =
+		liveHostUrl ??
+		(workspace && lastGoodHostUrlRef.current?.workspaceId === workspace.id
+			? lastGoodHostUrlRef.current.url
+			: null);
 
 	const lastEnsuredWorkspaceIdRef = useRef<string | null>(null);
 
@@ -66,8 +87,10 @@ function V2WorkspaceLayout() {
 		return null;
 	}
 
+	// Don't render <Outlet /> without the provider — child routes call
+	// useWorkspaceClient hooks synchronously during render and would throw.
 	if (!workspace || !hostUrl) {
-		return <Outlet />;
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
## Summary

- Replace bare `<Outlet />` with `null` when v2-workspace layout has no workspace or `hostUrl`. Child routes call `useWorkspaceClient` synchronously during render, so the previous fallback guaranteed a `useWorkspaceClient must be used within WorkspaceClientProvider` crash any time `hostUrl` flickered to null.
- Add a sticky `hostUrl`: cache the last good value scoped to the current `workspace.id` and reuse it during transient nulls (HostServiceCoordinator status flipping `running` → `starting` → `running` during restart, where the renderer's 5s `getConnection` poll catches the gap). Switching workspaces drops the cache, so stale URLs never cross workspaces.

## Why

`useLocalHostService.activeHostUrl` is null whenever `HostServiceCoordinator.getConnection` returns null — i.e., the local host-service for the active org isn't in `running` status (post-launch warm-up, mid-restart, manual stop). On a 5s poll that overlaps such a window, the layout took its `!hostUrl` branch and rendered `<Outlet />` with no provider in scope. `TerminalPane`'s `useWorkspaceWsUrl` (and ~50 other `workspaceTrpc.*` consumers under `$workspaceId`) throws on the next render.

The sticky URL closes the timing window for the *same* workspace; the `null` return closes the broader class for any future child whose render path doesn't tolerate a missing provider.

## Test plan

- [ ] Open a v2 workspace, restart the local host-service (or stop/start its instance), and confirm the workspace stays mounted with no error boundary
- [ ] Switch from a local workspace to another workspace whose host-service hasn't started — confirm the layout renders empty (no crash) until the new connection comes up
- [ ] Switch back-and-forth between local and remote workspaces, confirm `hostUrl` doesn't get reused across workspace IDs
- [ ] Smoke test the terminal: open a terminal pane, confirm WS connects on first mount and after a host-service restart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the v2 workspace provider mounted across local host-service restarts to prevent crashes in routes that use `useWorkspaceClient`. This closes the timing gap where `hostUrl` briefly becomes null and avoids the `WorkspaceClientProvider` missing error.

- **Bug Fixes**
  - Return `null` instead of `<Outlet />` when `workspace` or `hostUrl` is missing, so child routes never render without `WorkspaceClientProvider`.
  - Add a sticky `hostUrl`: cache the last good URL per `workspace.id` and reuse it during brief host-service nulls; switching workspaces clears the cache.

<sup>Written for commit dca19f8995cadb5823639a44b68a0dbeaf4ee117. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace stability during host service transitions and restarts by enhancing URL state management.
  * Enhanced error handling when workspace context becomes temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->