### PR TITLE
style(desktop): refine v2 workspace creating state

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -105,6 +105,7 @@ function V2WorkspacePage() {
 				<WorkspaceCreatingState
 					name={inFlight.snapshot.name}
 					branch={inFlight.snapshot.branch}
+					startedAt={inFlight.startedAt}
 				/>
 			);
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.css
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.css
@@ -3,22 +3,15 @@
 	height: 1px;
 	width: 100%;
 	overflow: hidden;
-	background: hsl(var(--border) / 0.5);
+	background: hsl(var(--border) / 0.6);
 }
 
 .wcs-bar-fill {
 	position: absolute;
 	inset-block: 0;
 	left: 0;
-	background: linear-gradient(
-		to right,
-		hsl(24 95% 60% / 0),
-		hsl(24 95% 60% / 0.9) 40%,
-		hsl(24 95% 60% / 1) 80%,
-		hsl(24 95% 60% / 0.85)
-	);
+	background: hsl(var(--foreground) / 0.75);
 	transition: width 0.7s cubic-bezier(0.22, 1, 0.36, 1);
-	box-shadow: 0 0 12px 0 hsl(24 95% 60% / 0.45);
 }
 
 .wcs-bar-sweep {
@@ -27,7 +20,7 @@
 	background: linear-gradient(
 		90deg,
 		transparent,
-		hsl(0 0% 100% / 0.18) 50%,
+		hsl(var(--foreground) / 0.25) 50%,
 		transparent
 	);
 	transform: translateX(-100%);
@@ -43,31 +36,6 @@
 	}
 }
 
-.wcs-step-active-shimmer {
-	background: linear-gradient(
-		90deg,
-		hsl(var(--foreground) / 0.55) 0%,
-		hsl(var(--foreground)) 40%,
-		hsl(var(--foreground)) 60%,
-		hsl(var(--foreground) / 0.55) 100%
-	);
-	background-size: 200% 100%;
-	background-clip: text;
-	-webkit-background-clip: text;
-	color: transparent;
-	-webkit-text-fill-color: transparent;
-	animation: wcs-shimmer 2s linear infinite;
-}
-
-@keyframes wcs-shimmer {
-	0% {
-		background-position: 100% 0;
-	}
-	100% {
-		background-position: -100% 0;
-	}
-}
-
 .wcs-active-ring {
 	animation: wcs-pulse 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
@@ -79,14 +47,13 @@
 		transform: scale(1);
 	}
 	50% {
-		opacity: 0.9;
-		transform: scale(1.35);
+		opacity: 0.85;
+		transform: scale(1.4);
 	}
 }
 
 @media (prefers-reduced-motion: reduce) {
 	.wcs-bar-sweep,
-	.wcs-step-active-shimmer,
 	.wcs-active-ring {
 		animation: none;
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.css
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.css
@@ -1,0 +1,93 @@
+.wcs-bar-track {
+	position: relative;
+	height: 1px;
+	width: 100%;
+	overflow: hidden;
+	background: hsl(var(--border) / 0.5);
+}
+
+.wcs-bar-fill {
+	position: absolute;
+	inset-block: 0;
+	left: 0;
+	background: linear-gradient(
+		to right,
+		hsl(24 95% 60% / 0),
+		hsl(24 95% 60% / 0.9) 40%,
+		hsl(24 95% 60% / 1) 80%,
+		hsl(24 95% 60% / 0.85)
+	);
+	transition: width 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+	box-shadow: 0 0 12px 0 hsl(24 95% 60% / 0.45);
+}
+
+.wcs-bar-sweep {
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(
+		90deg,
+		transparent,
+		hsl(0 0% 100% / 0.18) 50%,
+		transparent
+	);
+	transform: translateX(-100%);
+	animation: wcs-sweep 2.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+@keyframes wcs-sweep {
+	0% {
+		transform: translateX(-100%);
+	}
+	100% {
+		transform: translateX(100%);
+	}
+}
+
+.wcs-step-active-shimmer {
+	background: linear-gradient(
+		90deg,
+		hsl(var(--foreground) / 0.55) 0%,
+		hsl(var(--foreground)) 40%,
+		hsl(var(--foreground)) 60%,
+		hsl(var(--foreground) / 0.55) 100%
+	);
+	background-size: 200% 100%;
+	background-clip: text;
+	-webkit-background-clip: text;
+	color: transparent;
+	-webkit-text-fill-color: transparent;
+	animation: wcs-shimmer 2s linear infinite;
+}
+
+@keyframes wcs-shimmer {
+	0% {
+		background-position: 100% 0;
+	}
+	100% {
+		background-position: -100% 0;
+	}
+}
+
+.wcs-active-ring {
+	animation: wcs-pulse 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+@keyframes wcs-pulse {
+	0%,
+	100% {
+		opacity: 0.35;
+		transform: scale(1);
+	}
+	50% {
+		opacity: 0.9;
+		transform: scale(1.35);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.wcs-bar-sweep,
+	.wcs-step-active-shimmer,
+	.wcs-active-ring {
+		animation: none;
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -1,30 +1,172 @@
-import { Loader2 } from "lucide-react";
+import { cn } from "@superset/ui/utils";
+import { Check, GitBranch } from "lucide-react";
+import { useEffect, useState } from "react";
+import "./WorkspaceCreatingState.css";
+
+interface Step {
+	id: string;
+	label: string;
+	/** Cumulative seconds at which this step is considered complete. */
+	doneAt: number;
+}
+
+const STEPS: readonly Step[] = [
+	{ id: "allocate", label: "Allocating sandbox", doneAt: 3 },
+	{ id: "clone", label: "Cloning repository", doneAt: 12 },
+	{ id: "branch", label: "Configuring branch", doneAt: 16 },
+	{ id: "tools", label: "Installing tools", doneAt: 22 },
+	{ id: "finalize", label: "Finalizing", doneAt: 28 },
+] as const;
+
+const TOTAL_SECONDS = STEPS[STEPS.length - 1].doneAt;
+// Cap synthetic progress so the bar never reaches 100% before real completion.
+const PROGRESS_CAP = 0.94;
 
 interface WorkspaceCreatingStateProps {
 	name?: string;
 	branch?: string;
+	startedAt?: number;
 }
 
 export function WorkspaceCreatingState({
 	name,
 	branch,
+	startedAt,
 }: WorkspaceCreatingStateProps) {
+	const elapsed = useElapsedSeconds(startedAt);
+	const activeIndex = getActiveIndex(elapsed);
+	const progress = Math.min(elapsed / TOTAL_SECONDS, PROGRESS_CAP);
+
 	return (
-		<div className="flex h-full w-full items-center justify-center p-6">
-			<div className="flex w-full max-w-md flex-col items-center rounded-xl border border-border bg-card px-6 py-8 text-center">
-				<div className="mb-4 rounded-full border border-border bg-muted/40 p-3 text-muted-foreground">
-					<Loader2 className="size-5 animate-spin" />
+		<div className="relative flex h-full w-full items-center justify-center overflow-hidden p-6">
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-0"
+				style={{
+					background:
+						"radial-gradient(ellipse 55% 45% at 50% 35%, hsl(var(--muted) / 0.55), transparent 70%)",
+				}}
+			/>
+			<div className="relative w-full max-w-[420px]">
+				<div className="overflow-hidden rounded-xl border border-border/70 bg-card shadow-[0_1px_0_0_hsl(0_0%_100%/0.04)_inset,0_10px_40px_-12px_hsl(0_0%_0%/0.45)]">
+					<div className="wcs-bar-track">
+						<div
+							className="wcs-bar-fill"
+							style={{ width: `${progress * 100}%` }}
+						/>
+						<div className="wcs-bar-sweep" />
+					</div>
+
+					<div className="px-6 pt-6 pb-5">
+						<div className="space-y-2">
+							<p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/70">
+								Creating workspace
+							</p>
+							<h1 className="truncate text-[17px] font-semibold leading-tight tracking-tight text-foreground">
+								{name || "Untitled workspace"}
+							</h1>
+							{branch && (
+								<div className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/70 bg-muted/40 px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+									<GitBranch className="size-3 shrink-0" />
+									<span className="truncate">{branch}</span>
+								</div>
+							)}
+						</div>
+
+						<ul className="mt-5 space-y-2">
+							{STEPS.map((step, i) => {
+								const state: StepState =
+									i < activeIndex
+										? "done"
+										: i === activeIndex
+											? "active"
+											: "pending";
+								return (
+									<StepRow key={step.id} label={step.label} state={state} />
+								);
+							})}
+						</ul>
+
+						<div className="mt-5 flex items-center justify-between border-t border-border/60 pt-3 text-[11px] text-muted-foreground">
+							<span>This usually takes ~{TOTAL_SECONDS}s</span>
+							<span className="font-mono tabular-nums text-muted-foreground/85">
+								{formatElapsed(elapsed)}
+							</span>
+						</div>
+					</div>
 				</div>
-				<h1 className="text-lg font-semibold tracking-tight">
-					Creating workspace
-				</h1>
-				{name && <p className="mt-2 text-sm text-muted-foreground">{name}</p>}
-				{branch && (
-					<p className="mt-1 text-xs text-muted-foreground/80">
-						Branch: {branch}
-					</p>
-				)}
 			</div>
 		</div>
 	);
+}
+
+type StepState = "done" | "active" | "pending";
+
+function StepRow({ label, state }: { label: string; state: StepState }) {
+	return (
+		<li
+			className={cn(
+				"flex items-center gap-2.5 text-[13px] leading-tight transition-colors duration-300",
+				state === "done" && "text-foreground/80",
+				state === "active" && "text-foreground",
+				state === "pending" && "text-muted-foreground/55",
+			)}
+		>
+			<StepIcon state={state} />
+			{state === "active" ? (
+				<span className="wcs-step-active-shimmer font-medium">{label}</span>
+			) : (
+				<span className={cn(state === "done" && "font-medium")}>{label}</span>
+			)}
+		</li>
+	);
+}
+
+function StepIcon({ state }: { state: StepState }) {
+	if (state === "done") {
+		return (
+			<span className="grid size-4 shrink-0 place-items-center rounded-full bg-foreground/85 text-background">
+				<Check className="size-2.5" strokeWidth={3} />
+			</span>
+		);
+	}
+	if (state === "active") {
+		return (
+			<span className="relative grid size-4 shrink-0 place-items-center">
+				<span className="absolute inset-0 rounded-full border border-orange-400/40" />
+				<span className="wcs-active-ring absolute inset-0 rounded-full border border-orange-400/70" />
+				<span className="size-1.5 rounded-full bg-orange-400 shadow-[0_0_6px_0_hsl(24_95%_60%/0.7)]" />
+			</span>
+		);
+	}
+	return (
+		<span className="grid size-4 shrink-0 place-items-center">
+			<span className="size-1.5 rounded-full bg-muted-foreground/40" />
+		</span>
+	);
+}
+
+function getActiveIndex(elapsed: number): number {
+	for (let i = 0; i < STEPS.length; i++) {
+		if (elapsed < STEPS[i].doneAt) return i;
+	}
+	// Past the synthetic budget — keep the last step active until real completion.
+	return STEPS.length - 1;
+}
+
+function formatElapsed(seconds: number): string {
+	const total = Math.max(0, Math.floor(seconds));
+	const m = Math.floor(total / 60);
+	const s = total % 60;
+	return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function useElapsedSeconds(startedAt: number | undefined): number {
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		const id = window.setInterval(() => setNow(Date.now()), 250);
+		return () => window.clearInterval(id);
+	}, []);
+	if (!startedAt) return 0;
+	return Math.max(0, (now - startedAt) / 1000);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@superset/ui/utils";
-import { Check, GitBranch } from "lucide-react";
+import { Check, GitBranch, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import "./WorkspaceCreatingState.css";
 
@@ -19,7 +19,8 @@ const STEPS: readonly Step[] = [
 ] as const;
 
 const TOTAL_SECONDS = STEPS[STEPS.length - 1].doneAt;
-// Cap synthetic progress so the bar never reaches 100% before real completion.
+// Cap synthetic progress so the bar never claims completion before the real
+// workspaces.create mutation resolves.
 const PROGRESS_CAP = 0.94;
 
 interface WorkspaceCreatingStateProps {
@@ -38,17 +39,49 @@ export function WorkspaceCreatingState({
 	const progress = Math.min(elapsed / TOTAL_SECONDS, PROGRESS_CAP);
 
 	return (
-		<div className="relative flex h-full w-full items-center justify-center overflow-hidden p-6">
-			<div
-				aria-hidden
-				className="pointer-events-none absolute inset-0"
-				style={{
-					background:
-						"radial-gradient(ellipse 55% 45% at 50% 35%, hsl(var(--muted) / 0.55), transparent 70%)",
-				}}
-			/>
-			<div className="relative w-full max-w-[420px]">
-				<div className="overflow-hidden rounded-xl border border-border/70 bg-card shadow-[0_1px_0_0_hsl(0_0%_100%/0.04)_inset,0_10px_40px_-12px_hsl(0_0%_0%/0.45)]">
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div className="flex w-full max-w-sm flex-col items-start gap-5">
+				<Loader2
+					className="size-5 animate-spin text-muted-foreground"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Creating workspace
+					</h1>
+					<p className="truncate text-[13px] leading-relaxed text-muted-foreground">
+						{name || "Untitled workspace"}
+					</p>
+				</div>
+
+				{branch && (
+					<div className="flex w-full items-center gap-2">
+						<GitBranch
+							className="size-3 shrink-0 text-muted-foreground/80"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+						<code className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+							{branch}
+						</code>
+					</div>
+				)}
+
+				<ul className="flex w-full flex-col gap-2">
+					{STEPS.map((step, i) => {
+						const state: StepState =
+							i < activeIndex
+								? "done"
+								: i === activeIndex
+									? "active"
+									: "pending";
+						return <StepRow key={step.id} label={step.label} state={state} />;
+					})}
+				</ul>
+
+				<div className="flex w-full flex-col gap-2">
 					<div className="wcs-bar-track">
 						<div
 							className="wcs-bar-fill"
@@ -56,43 +89,11 @@ export function WorkspaceCreatingState({
 						/>
 						<div className="wcs-bar-sweep" />
 					</div>
-
-					<div className="px-6 pt-6 pb-5">
-						<div className="space-y-2">
-							<p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/70">
-								Creating workspace
-							</p>
-							<h1 className="truncate text-[17px] font-semibold leading-tight tracking-tight text-foreground">
-								{name || "Untitled workspace"}
-							</h1>
-							{branch && (
-								<div className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/70 bg-muted/40 px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
-									<GitBranch className="size-3 shrink-0" />
-									<span className="truncate">{branch}</span>
-								</div>
-							)}
-						</div>
-
-						<ul className="mt-5 space-y-2">
-							{STEPS.map((step, i) => {
-								const state: StepState =
-									i < activeIndex
-										? "done"
-										: i === activeIndex
-											? "active"
-											: "pending";
-								return (
-									<StepRow key={step.id} label={step.label} state={state} />
-								);
-							})}
-						</ul>
-
-						<div className="mt-5 flex items-center justify-between border-t border-border/60 pt-3 text-[11px] text-muted-foreground">
-							<span>This usually takes ~{TOTAL_SECONDS}s</span>
-							<span className="font-mono tabular-nums text-muted-foreground/85">
-								{formatElapsed(elapsed)}
-							</span>
-						</div>
+					<div className="flex items-center justify-between text-[11px] text-muted-foreground/80">
+						<span className="font-mono tabular-nums">
+							{formatElapsed(elapsed)}
+						</span>
+						<span>~{TOTAL_SECONDS}s typical</span>
 					</div>
 				</div>
 			</div>
@@ -113,11 +114,7 @@ function StepRow({ label, state }: { label: string; state: StepState }) {
 			)}
 		>
 			<StepIcon state={state} />
-			{state === "active" ? (
-				<span className="wcs-step-active-shimmer font-medium">{label}</span>
-			) : (
-				<span className={cn(state === "done" && "font-medium")}>{label}</span>
-			)}
+			<span>{label}</span>
 		</li>
 	);
 }
@@ -125,23 +122,22 @@ function StepRow({ label, state }: { label: string; state: StepState }) {
 function StepIcon({ state }: { state: StepState }) {
 	if (state === "done") {
 		return (
-			<span className="grid size-4 shrink-0 place-items-center rounded-full bg-foreground/85 text-background">
-				<Check className="size-2.5" strokeWidth={3} />
+			<span className="grid size-3.5 shrink-0 place-items-center rounded-full bg-foreground/85 text-background">
+				<Check className="size-2" strokeWidth={3.5} />
 			</span>
 		);
 	}
 	if (state === "active") {
 		return (
-			<span className="relative grid size-4 shrink-0 place-items-center">
-				<span className="absolute inset-0 rounded-full border border-orange-400/40" />
-				<span className="wcs-active-ring absolute inset-0 rounded-full border border-orange-400/70" />
-				<span className="size-1.5 rounded-full bg-orange-400 shadow-[0_0_6px_0_hsl(24_95%_60%/0.7)]" />
+			<span className="relative grid size-3.5 shrink-0 place-items-center">
+				<span className="wcs-active-ring absolute inset-0 rounded-full border border-foreground/40" />
+				<span className="size-1.5 rounded-full bg-foreground/85" />
 			</span>
 		);
 	}
 	return (
-		<span className="grid size-4 shrink-0 place-items-center">
-			<span className="size-1.5 rounded-full bg-muted-foreground/40" />
+		<span className="grid size-3.5 shrink-0 place-items-center">
+			<span className="size-1.5 rounded-full bg-muted-foreground/35" />
 		</span>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -10,12 +10,17 @@ interface Step {
 	doneAt: number;
 }
 
+// Mirrors the v1 init step order in shared/types/workspace-init.ts so the
+// labels feel real — v2 workspaces.create runs the same git work server-side
+// without streaming progress events, so timings here are estimates.
 const STEPS: readonly Step[] = [
-	{ id: "allocate", label: "Allocating sandbox", doneAt: 3 },
-	{ id: "clone", label: "Cloning repository", doneAt: 12 },
-	{ id: "branch", label: "Configuring branch", doneAt: 16 },
-	{ id: "tools", label: "Installing tools", doneAt: 22 },
-	{ id: "finalize", label: "Finalizing", doneAt: 28 },
+	{ id: "preparing", label: "Preparing", doneAt: 1 },
+	{ id: "syncing", label: "Syncing with remote", doneAt: 4 },
+	{ id: "verifying", label: "Verifying base branch", doneAt: 5 },
+	{ id: "fetching", label: "Fetching latest changes", doneAt: 15 },
+	{ id: "creating_worktree", label: "Creating git worktree", doneAt: 18 },
+	{ id: "copying_config", label: "Copying configuration", doneAt: 20 },
+	{ id: "finalizing", label: "Finalizing setup", doneAt: 23 },
 ] as const;
 
 const TOTAL_SECONDS = STEPS[STEPS.length - 1].doneAt;


### PR DESCRIPTION
## Summary
- Replace the v2 \"Creating workspace\" spinner card with a Linear-style progress card: thin gradient bar with a continuous shimmer sweep, time-based step list with status dots (done check / pulsing orange ring / dim pending dot), shimmering active label, monospaced elapsed counter, and a bordered branch chip.
- Anchor elapsed time + step pacing to the in-flight entry's \`startedAt\` so retries and slow renders stay accurate.
- \`workspaces.create\` is a single mutation with no streamed progress, so steps are time-paced for perception (allocate \xe2\x86\x92 clone \xe2\x86\x92 branch \xe2\x86\x92 tools \xe2\x86\x92 finalize, ~28s budget). The bar caps at 94% until the workspace actually appears in the live collection, and the last step keeps spinning if the call exceeds the synthetic budget.
- Honors \`prefers-reduced-motion\` (no sweep / shimmer / pulse).

## Test plan
- [ ] Create a new v2 workspace and confirm the card animates: gradient bar fills, sweep + step pulse run, label shimmers, steps tick over, elapsed counter increments.
- [ ] Verify the bar never reads 100% before the workspace mounts \xe2\x80\x94 it should snap from <94% to gone when the real workspace appears.
- [ ] Trigger a slow create (>28s) and confirm \"Finalizing\" stays active rather than disappearing.
- [ ] Toggle \`prefers-reduced-motion\` and confirm the sweep / pulse / shimmer disable.
- [ ] Long workspace name and long branch name don't break layout (truncate cleanly).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the v2 “Creating workspace” spinner with a Linear‑style, left‑aligned progress view. Uses time‑paced steps that mirror v1 init phases, a 1px sweep bar, and an elapsed timer anchored to `startedAt`; progress stays below 100% until the workspace mounts.

- **New Features**
  - Matched not‑found brand: left‑aligned max‑w‑sm layout, monochrome dots, transparent branch line; removed bordered card, backdrop, chip fill, and orange accents.
  - Respects prefers‑reduced‑motion; last step stays active since `workspaces.create` is non‑streaming.

<sup>Written for commit f78e17992dfa5af8d12d0dd9b79db39ffae13ed8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace-creation screen with a time-driven progress indicator and per-step statuses (done/active/pending).
  * Progress bar now reflects elapsed time and clamps typical completion estimates.
  * Step icons update to show completed checks, an animated active state, or muted pending dots.

* **Accessibility**
  * Respects prefers-reduced-motion by disabling sweep and pulse animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->