### PR TITLE
feat(desktop): default new accounts to v2, preserve existing prefs

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx
+++ b/apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx
@@ -11,9 +11,11 @@ export function PostHogSurfaceTagger() {
 		const surface = isV2CloudEnabled ? "v2" : "v1";
 		const surface_source = !isRemoteV2Enabled
 			? "v2-flag-off"
-			: optInV2
+			: optInV2 === true
 				? "opted-in"
-				: "opted-out";
+				: optInV2 === false
+					? "opted-out"
+					: "default";
 
 		posthog.register({ surface, surface_source });
 

--- a/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
+++ b/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
@@ -19,6 +19,7 @@ export function PostHogUserIdentifier() {
 				email: user.email,
 				name: user.name,
 				desktop_version: window.App.appVersion,
+				user_created_at: user.createdAt,
 			});
 			posthog.reloadFeatureFlags();
 			setUserId({ userId: user.id });

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -1,8 +1,23 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useFeatureFlagEnabled } from "posthog-js/react";
+import { authClient } from "renderer/lib/auth-client";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 const IS_DEV = process.env.NODE_ENV === "development";
+
+/**
+ * Accounts created on/after this date default to v2. Older accounts default to v1
+ * to preserve their existing experience until they explicitly opt in.
+ */
+const V2_DEFAULT_CUTOFF_MS = Date.UTC(2026, 4, 4); // 2026-05-04
+
+function deriveDefaultOptIn(createdAt: string | Date | null | undefined) {
+	if (!createdAt) return false;
+	const ms =
+		createdAt instanceof Date ? createdAt.getTime() : Date.parse(createdAt);
+	if (Number.isNaN(ms)) return false;
+	return ms >= V2_DEFAULT_CUTOFF_MS;
+}
 
 /**
  * Returns effective v2 state: remote PostHog flag AND local opt-in.
@@ -12,17 +27,21 @@ export function useIsV2CloudEnabled() {
 	const remoteV2Enabled =
 		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
 	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
+	const { data: session } = authClient.useSession();
+
+	const effectiveOptIn =
+		optInV2 ?? deriveDefaultOptIn(session?.user?.createdAt);
 
 	if (IS_DEV) {
 		return {
-			isV2CloudEnabled: optInV2,
+			isV2CloudEnabled: effectiveOptIn,
 			isRemoteV2Enabled: true,
 		};
 	}
 
 	return {
 		/** The effective value — use this wherever you previously checked the flag directly. */
-		isV2CloudEnabled: remoteV2Enabled && optInV2,
+		isV2CloudEnabled: remoteV2Enabled && effectiveOptIn,
 		/** Whether the remote PostHog flag is on (for showing the toggle). */
 		isRemoteV2Enabled: remoteV2Enabled,
 	};

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -1,36 +1,25 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useFeatureFlagEnabled } from "posthog-js/react";
-import { authClient } from "renderer/lib/auth-client";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 const IS_DEV = process.env.NODE_ENV === "development";
 
 /**
- * Accounts created on/after this date default to v2. Older accounts default to v1
- * to preserve their existing experience until they explicitly opt in.
- */
-const V2_DEFAULT_CUTOFF_MS = Date.UTC(2026, 4, 4); // 2026-05-04
-
-function deriveDefaultOptIn(createdAt: string | Date | null | undefined) {
-	if (!createdAt) return false;
-	const ms =
-		createdAt instanceof Date ? createdAt.getTime() : Date.parse(createdAt);
-	if (Number.isNaN(ms)) return false;
-	return ms >= V2_DEFAULT_CUTOFF_MS;
-}
-
-/**
- * Returns effective v2 state: remote PostHog flag AND local opt-in.
- * Also returns the raw remote flag so the toggle can be shown conditionally.
+ * Returns effective v2 state: capability AND preference.
+ *
+ * - Capability comes from the `v2-cloud` flag (rollout gate).
+ * - Preference is the user's explicit toggle if they've made one, otherwise
+ *   the `v2-default-on` flag (typically targeted at new accounts via the
+ *   `user_created_at` person property — managed in PostHog, not in code).
  */
 export function useIsV2CloudEnabled() {
 	const remoteV2Enabled =
 		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const v2DefaultOn =
+		useFeatureFlagEnabled(FEATURE_FLAGS.V2_DEFAULT_ON) ?? false;
 	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
-	const { data: session } = authClient.useSession();
 
-	const effectiveOptIn =
-		optInV2 ?? deriveDefaultOptIn(session?.user?.createdAt);
+	const effectiveOptIn = optInV2 ?? v2DefaultOn;
 
 	if (IS_DEV) {
 		return {

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -1,11 +1,13 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
-const IS_DEV = process.env.NODE_ENV === "development";
-
 interface V2LocalOverrideState {
-	/** When true, the user has opted into v2. v2 is gated behind both the remote flag and this opt-in. */
-	optInV2: boolean;
+	/**
+	 * The user's explicit v2 opt-in choice.
+	 * - `null` means no explicit choice — the effective default is derived from account age (see `useIsV2CloudEnabled`).
+	 * - `true` / `false` means the user toggled the setting and that choice should win.
+	 */
+	optInV2: boolean | null;
 	setOptInV2: (optInV2: boolean) => void;
 }
 
@@ -13,7 +15,7 @@ export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
 	devtools(
 		persist(
 			(set) => ({
-				optInV2: IS_DEV,
+				optInV2: null,
 				setOptInV2: (optInV2) => set({ optInV2 }),
 			}),
 			{ name: "v2-local-override-v2" },

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -608,8 +608,17 @@ export const auth = betterAuth({
 				plan = subscription?.plan ?? null;
 			}
 
+			const userCreatedAt = (user as { createdAt?: Date | string | null })
+				.createdAt;
+
 			return {
-				user,
+				user: {
+					...user,
+					createdAt:
+						userCreatedAt instanceof Date
+							? userCreatedAt.toISOString()
+							: (userCreatedAt ?? null),
+				},
 				session: {
 					...session,
 					activeOrganizationId,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -74,6 +74,13 @@ export const FEATURE_FLAGS = {
 	/** Gates access to V2 Cloud features (host-service, cloud sprites). */
 	V2_CLOUD: "v2-cloud",
 	/**
+	 * When enabled for a user, v2 is the default surface for them (used when
+	 * they have not explicitly toggled the setting). Targeted via PostHog
+	 * release conditions on the `user_created_at` person property so the
+	 * cutoff for "new users" can be adjusted without a desktop release.
+	 */
+	V2_DEFAULT_ON: "v2-default-on",
+	/**
 	 * Gates the Automations feature in the UI (sidebar entry, routes, create
 	 * flow). Complementary to the subscriptions.plan paid-tier check —
 	 * server-side procedures still enforce paid plan; this flag controls


### PR DESCRIPTION
## Summary
- New accounts (created on/after **2026-05-04**) default to v2; existing accounts continue to default to v1 until they opt in.
- Users who explicitly toggled the v2 switch — either direction — keep their choice. The PostHog `v2-cloud` flag still gates everything in prod.

## How
- `customSession` (packages/auth/src/server.ts) now exposes `user.createdAt` as an ISO string so the renderer can read it from `authClient.useSession()`.
- `v2-local-override` store: `optInV2` is now `boolean | null`, defaulting to `null`. `null` = no explicit choice; `true`/`false` = explicit toggle. Existing persisted values are preserved verbatim.
- `useIsV2CloudEnabled`: when `optInV2 === null`, the default is derived from `session.user.createdAt` against a single constant (`V2_DEFAULT_CUTOFF_MS`).
- `PostHogSurfaceTagger`: `surface_source` now distinguishes `"default"` from explicit `"opted-in"` / `"opted-out"`.

## Behavior matrix
| User | localStorage | Result |
|---|---|---|
| Existing, never toggled | empty | v1 (createdAt < cutoff) |
| Existing, toggled to v2 | `{optInV2: true}` | v2 |
| Existing, toggled to v1 | `{optInV2: false}` | v1 |
| New (≥ 2026-05-04), no toggle | empty | **v2** |
| New, toggled to v1 | `{optInV2: false}` | v1 |

## Test plan
- [ ] Existing prod user with no prior toggle stays on v1 after upgrading.
- [ ] User who toggled to v2 still lands on v2.
- [ ] User who toggled to v1 still lands on v1.
- [ ] Fresh signup (createdAt today+) lands on v2 if PostHog flag is on.
- [ ] User on desktop < 1.6.3 (PostHog flag off) stays on v1 regardless.
- [ ] Toggling the switch in Settings → Experimental still works in both directions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default new desktop accounts to v2 via the PostHog `v2-default-on` flag while preserving existing users’ preferences; still gated by `v2-cloud`. Adds analytics to distinguish default vs explicit opt-in/out and sets `user_created_at` for targeting.

- **New Features**
  - `packages/auth` + `PostHogUserIdentifier`: expose `user.createdAt` (ISO) and send `user_created_at` on identify for `v2-default-on` rollout targeting.
  - Local override: `optInV2` is `boolean | null`; `null` = no explicit choice (existing stored values kept).
  - `useIsV2CloudEnabled`: when `optInV2 === null`, defer to `v2-default-on`; effective v2 = `v2-cloud` AND preference.
  - `PostHogSurfaceTagger`: `surface_source` reports "default", "opted-in", "opted-out", or "v2-flag-off"; `surface` remains v1/v2.

<sup>Written for commit e6726b8b43143eb99a8e3b4423f7708430274a06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Accurate V2 opt-in handling now differentiates "opted-in", "opted-out", and "default" instead of treating non-explicit choices as opted-out
  * Session handling now normalizes user creation timestamps

* **New Features**
  * Local opt-in override can represent "no explicit choice" so defaults are derived elsewhere
  * Analytics now include user creation time in identify calls
  * Added a feature-flag to enable V2 by default for new users
<!-- end of auto-generated comment: release notes by coderabbit.ai -->