### PR TITLE
release(cli): cut v0.2.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -677,7 +677,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.5";
+const VERSION = "0.2.6";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bumps `@superset/cli` to **v0.2.6**.
- Fix shipped since v0.2.5: spawn-helper bundled without exec bit on darwin → every terminal open crashed with `posix_spawnp failed.` (#4058).

## Release plan
After this PR merges, push the `cli-v0.2.6` tag to fire `.github/workflows/release-cli.yml`. The new live PTY spawn smoke test will run on all three matrix targets and would catch a regression in this class (spawn-helper exec bit, pty.node ABI mismatch, etc.) before the release tarball publishes.

## Test plan
- [ ] CI green
- [ ] After tag push, all three matrix targets pass the live `pty.spawn` smoke test
- [ ] On a fresh machine: `superset auth login` → `superset start` → open a terminal → succeeds (no `posix_spawnp failed`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@superset/cli` to v0.2.6 and fixes a macOS crash caused by a non-executable spawn-helper (posix_spawnp failed). The release pipeline runs a live PTY spawn smoke test across all targets to prevent this regression class.

<sup>Written for commit 0ae6bde33e0f9ca7f937f559e5b4171c754e7808. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI package version to 0.2.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->