### PR TITLE
fix(host-service): tolerate `[blob:none]` suffix in `git remote -v`

### DIFF
--- a/packages/host-service/src/trpc/router/project/utils/git-remote.ts
+++ b/packages/host-service/src/trpc/router/project/utils/git-remote.ts
@@ -18,7 +18,11 @@ export async function getAllRemoteUrls(
 	if (!output) return remotes;
 
 	for (const line of output.trim().split(/\r?\n/)) {
-		const match = line.trim().match(/^(\S+)\s+(\S+)\s+\(fetch\)$/);
+		// Don't anchor on `(fetch)` at end-of-line: git appends partial-clone
+		// markers like ` [blob:none]` when `remote.<name>.promisor=true`, and
+		// dropping those lines silently loses the remote (we then fall back to
+		// the alphabetically-first remote, which is almost always wrong).
+		const match = line.trim().match(/^(\S+)\s+(\S+)\s+\(fetch\)(?:\s|$)/);
 		if (match?.[1] && match[2]) {
 			remotes.set(match[1], match[2]);
 		}

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
@@ -107,6 +107,26 @@ describe("resolveLocalRepo", () => {
 		expect(resolved.parsed?.name).toBe("App");
 	});
 
+	test("returns origin when it is configured as a partial clone (`[blob:none]` suffix)", async () => {
+		// Partial clones (e.g. `git clone --filter=blob:none`) make
+		// `git remote -v` append a `[blob:none]` marker after the URL.
+		// Earlier the parser anchored on `(fetch)$`, so the origin line was
+		// silently skipped and we fell back to the alphabetically-first
+		// remote. Regression: `aaa` must NOT win over a partial-clone origin.
+		const repo = join(workRoot, "partial-clone-origin");
+		const git = await initRepoAt(repo);
+		await git.addRemote("aaa", "https://github.com/Other/Repo.git");
+		await git.addRemote("origin", "git@github.com:Acme/App.git");
+		await git.raw(["config", "remote.origin.promisor", "true"]);
+		await git.raw(["config", "remote.origin.partialclonefilter", "blob:none"]);
+
+		const resolved = await resolveLocalRepo(repo);
+
+		expect(resolved.remoteName).toBe("origin");
+		expect(resolved.parsed?.owner).toBe("Acme");
+		expect(resolved.parsed?.name).toBe("App");
+	});
+
 	test("falls back to first GitHub remote when origin is missing", async () => {
 		const repo = join(workRoot, "no-origin");
 		const git = await initRepoAt(repo);


### PR DESCRIPTION
## Summary
- `git remote -v` appends a partial-clone marker (`[blob:none]`, `[treeless]`, …) after `(fetch)` whenever `remote.<name>.promisor` is set. The parser anchored on `(fetch)$`, so the line was silently dropped from `getAllRemoteUrls` and `resolveLocalRepo` fell back to the alphabetically-first remote.
- For users who cloned with `--filter=blob:none` (very common for monorepos), the v2 add-folder flow detected the wrong remote URL and either rejected the folder or matched against an unrelated cloud project — e.g. `origin: superset-sh/superset` was dropped, leaving `andreasasprou/superset` to win as alphabetically first.
- Fix: drop the `$` end-of-line anchor and require `(fetch)` to be followed by whitespace or end-of-line. Strict superset of the prior matches; no input correctly parsed before is now mishandled.

## Test plan
- [x] `bun test packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts` — 24 pass
- [x] New regression test fails on the pre-fix regex (returns `"aaa"` instead of `"origin"`) and passes after
- [x] `bun run lint` clean
- [ ] Manually re-add a `--filter=blob:none` clone in the v2 desktop UI and confirm `origin` is detected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote URL parsing to handle partial-clone markers like `[blob:none]` in `git remote -v`, so we correctly detect `origin` in the v2 add-folder flow. Prevents falling back to the alphabetically-first remote and picking the wrong project.

- Bug Fixes
  - Relaxed regex to match `(fetch)` followed by whitespace or end-of-line, tolerating markers like `[blob:none]` and `[treeless]`.
  - Added a regression test to ensure `origin` is kept when partial-clone markers are present.

<sup>Written for commit defc69a0f5be24f25799e24ebf103254513301ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed parsing of git remotes that include partial-clone markers (e.g., when using sparse checkout). Previously, such remotes were skipped, preventing accurate GitHub repository detection. This fix ensures the correct remote is always identified, improving reliability when working with repositories using advanced git configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->