### PR TITLE
fix(host-service): read remote URLs from git config, not git remote -v

### DIFF
--- a/packages/host-service/src/trpc/router/project/utils/git-remote.ts
+++ b/packages/host-service/src/trpc/router/project/utils/git-remote.ts
@@ -9,10 +9,9 @@ export type { ParsedGitHubRemote };
 /**
  * Map of remote name → URL, read from git config.
  *
- * Reads config directly instead of parsing `git remote -v` because `-v` output
- * appends partial-clone markers like `[blob:none]` after `(fetch)` when
- * `remote.<name>.promisor` is set, and is otherwise human-readable rather than
- * machine-stable.
+ * Avoids `git remote -v`: that output appends partial-clone markers like
+ * `[blob:none]` after `(fetch)` when `remote.<name>.promisor` is set, and is
+ * otherwise human-readable rather than machine-stable.
  */
 export async function getAllRemoteUrls(
 	git: SimpleGit,
@@ -21,7 +20,6 @@ export async function getAllRemoteUrls(
 	const output = await git
 		.raw(["config", "--get-regexp", "^remote\\..*\\.url$"])
 		.catch(() => "");
-	if (!output) return remotes;
 
 	for (const line of output.split(/\r?\n/)) {
 		const spaceIdx = line.indexOf(" ");
@@ -30,9 +28,9 @@ export async function getAllRemoteUrls(
 		const url = line.slice(spaceIdx + 1);
 		// Greedy `.+` so a remote literally named `foo.url` resolves to
 		// `foo.url`, not `foo`.
-		const match = key.match(/^remote\.(.+)\.url$/);
-		if (match?.[1] && url) {
-			remotes.set(match[1], url);
+		const remoteName = key.match(/^remote\.(.+)\.url$/)?.[1];
+		if (remoteName && url) {
+			remotes.set(remoteName, url);
 		}
 	}
 

--- a/packages/host-service/src/trpc/router/project/utils/git-remote.ts
+++ b/packages/host-service/src/trpc/router/project/utils/git-remote.ts
@@ -7,20 +7,32 @@ import type { SimpleGit } from "simple-git";
 export type { ParsedGitHubRemote };
 
 /**
- * Get all fetch remote URLs from a git repository.
- * Returns a map of remote name → fetch URL.
+ * Map of remote name → URL, read from git config.
+ *
+ * Reads config directly instead of parsing `git remote -v` because `-v` output
+ * appends partial-clone markers like `[blob:none]` after `(fetch)` when
+ * `remote.<name>.promisor` is set, and is otherwise human-readable rather than
+ * machine-stable.
  */
 export async function getAllRemoteUrls(
 	git: SimpleGit,
 ): Promise<Map<string, string>> {
 	const remotes = new Map<string, string>();
-	const output = await git.remote(["-v"]);
+	const output = await git
+		.raw(["config", "--get-regexp", "^remote\\..*\\.url$"])
+		.catch(() => "");
 	if (!output) return remotes;
 
-	for (const line of output.trim().split(/\r?\n/)) {
-		const match = line.trim().match(/^(\S+)\s+(\S+)\s+\(fetch\)$/);
-		if (match?.[1] && match[2]) {
-			remotes.set(match[1], match[2]);
+	for (const line of output.split(/\r?\n/)) {
+		const spaceIdx = line.indexOf(" ");
+		if (spaceIdx <= 0) continue;
+		const key = line.slice(0, spaceIdx);
+		const url = line.slice(spaceIdx + 1);
+		// Greedy `.+` so a remote literally named `foo.url` resolves to
+		// `foo.url`, not `foo`.
+		const match = key.match(/^remote\.(.+)\.url$/);
+		if (match?.[1] && url) {
+			remotes.set(match[1], url);
 		}
 	}
 

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
@@ -107,6 +107,26 @@ describe("resolveLocalRepo", () => {
 		expect(resolved.parsed?.name).toBe("App");
 	});
 
+	test("returns origin when it is configured as a partial clone (`[blob:none]` suffix)", async () => {
+		// Partial clones (e.g. `git clone --filter=blob:none`) make
+		// `git remote -v` append a `[blob:none]` marker after the URL.
+		// Earlier the parser anchored on `(fetch)$`, so the origin line was
+		// silently skipped and we fell back to the alphabetically-first
+		// remote. Regression: `aaa` must NOT win over a partial-clone origin.
+		const repo = join(workRoot, "partial-clone-origin");
+		const git = await initRepoAt(repo);
+		await git.addRemote("aaa", "https://github.com/Other/Repo.git");
+		await git.addRemote("origin", "git@github.com:Acme/App.git");
+		await git.raw(["config", "remote.origin.promisor", "true"]);
+		await git.raw(["config", "remote.origin.partialclonefilter", "blob:none"]);
+
+		const resolved = await resolveLocalRepo(repo);
+
+		expect(resolved.remoteName).toBe("origin");
+		expect(resolved.parsed?.owner).toBe("Acme");
+		expect(resolved.parsed?.name).toBe("App");
+	});
+
 	test("falls back to first GitHub remote when origin is missing", async () => {
 		const repo = join(workRoot, "no-origin");
 		const git = await initRepoAt(repo);


### PR DESCRIPTION
## Summary
- `git remote -v` appends partial-clone markers (`[blob:none]`, `[treeless]`, …) after `(fetch)` whenever `remote.<name>.promisor` is set. The parser anchored on `(fetch)$` silently dropped those lines, and `resolveLocalRepo` fell back to the alphabetically-first remote — e.g. `origin: superset-sh/superset` was dropped, leaving `andreasasprou/superset` to win for users who cloned with `--filter=blob:none`.
- Fix: read remotes from `git config --get-regexp '^remote\..*\.url$'` instead. The format is rigid and machine-stable (`<key> <value>` per line, no human-readable suffix), which kills the entire class of `git remote -v` format-drift bugs at the source rather than patching the regex.
- Alternative considered: tightening the existing regex to tolerate `[blob:none]` (#4064). That works for the reported bug but leaves the parser dependent on `git remote -v`'s human-readable format — any future cosmetic addition resurfaces the same class. This PR supersedes that approach.

## Test plan
- [x] `bun test packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts` — 24 pass (includes new regression test for `--filter=blob:none` + alphabetically-earlier sibling remote)
- [x] `bun test` host-service full suite — 489 pass / 0 fail
- [x] `bun run typecheck` host-service — clean
- [x] `bun run lint` — clean
- [x] End-to-end against a real partial-clone repo with `aaa` (alphabetical first) + `origin` — `resolveLocalRepo` correctly returns `origin → superset-sh/superset`
- [ ] Manually re-add a `--filter=blob:none` clone in the v2 desktop UI and confirm `origin` is detected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read Git remote URLs from `git config` instead of `git remote -v` to make detection stable and fix wrong remote selection in partial clones. Ensures `resolveLocalRepo` picks `origin` when present.

- Bug Fixes
  - Use `git config --get-regexp '^remote\..*\.url$'` instead of parsing `git remote -v`.
  - Handle partial-clone markers like `[blob:none]` so `origin` is not skipped; adds a regression test and minor cleanup in `getAllRemoteUrls`.

<sup>Written for commit f012f704818260cbc6cdce25c0e334935aa3dab5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed remote URL parsing so the correct repository remote (e.g., origin) is chosen even when partial-clone filters are configured.

* **Tests**
  * Added an integration test to verify remote selection and parsing when remotes use partial-clone settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->