### PR TITLE
fix(relay): carry binary tunnel WS frames as base64

### DIFF
--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -2,7 +2,7 @@ import { createApiClient } from "./api-client";
 import type { TunnelHttpResponse, TunnelRequest } from "./types";
 
 type WsSocket = {
-	send: (data: string) => void;
+	send: (data: string | ArrayBuffer | Uint8Array<ArrayBuffer>) => void;
 	readyState: number;
 	close: (code?: number, reason?: string) => void;
 };
@@ -174,7 +174,13 @@ export class TunnelManager {
 			}
 		} else if (msg.type === "ws:frame") {
 			const clientWs = tunnel.activeChannels.get(msg.id as string);
-			if (clientWs?.readyState === 1) clientWs.send(msg.data as string);
+			if (clientWs?.readyState === 1) {
+				if (msg.encoding === "base64") {
+					clientWs.send(Buffer.from(msg.data as string, "base64"));
+				} else {
+					clientWs.send(msg.data as string);
+				}
+			}
 		} else if (msg.type === "ws:close") {
 			const clientWs = tunnel.activeChannels.get(msg.id as string);
 			if (clientWs) {

--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -173,12 +173,13 @@ export class TunnelManager {
 				pending.resolve(msg as unknown as TunnelHttpResponse);
 			}
 		} else if (msg.type === "ws:frame") {
+			if (typeof msg.data !== "string") return;
 			const clientWs = tunnel.activeChannels.get(msg.id as string);
 			if (clientWs?.readyState === 1) {
 				if (msg.encoding === "base64") {
-					clientWs.send(Buffer.from(msg.data as string, "base64"));
+					clientWs.send(Buffer.from(msg.data, "base64"));
 				} else {
-					clientWs.send(msg.data as string);
+					clientWs.send(msg.data);
 				}
 			}
 		} else if (msg.type === "ws:close") {

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -191,9 +191,22 @@ export class TunnelClient {
 		}
 
 		const localWs = new WebSocket(wsUrl.toString());
+		localWs.binaryType = "arraybuffer";
 
 		localWs.onmessage = (event) => {
-			this.send({ type: "ws:frame", id: request.id, data: String(event.data) });
+			const data = event.data;
+			if (typeof data === "string") {
+				this.send({ type: "ws:frame", id: request.id, data });
+				return;
+			}
+			if (data instanceof ArrayBuffer) {
+				this.send({
+					type: "ws:frame",
+					id: request.id,
+					data: Buffer.from(data).toString("base64"),
+					encoding: "base64",
+				});
+			}
 		};
 
 		localWs.onclose = (event) => {

--- a/packages/shared/src/tunnel-protocol.ts
+++ b/packages/shared/src/tunnel-protocol.ts
@@ -20,6 +20,7 @@ export interface TunnelWsFrame {
 	type: "ws:frame";
 	id: string;
 	data: string;
+	encoding?: "base64";
 }
 
 export interface TunnelWsClose {


### PR DESCRIPTION
## Summary

- Cross-host terminals through the relay log `[terminal] invalid server payload` and never render PTY output. Root cause is a version skew with `901622573` (PTY output bytes end-to-end): the host-service tunnel client at `packages/host-service/src/tunnel/tunnel-client.ts:196` UTF-8-decoded binary WS frames from its local loopback socket via `String(buffer)`, the relay forwarded the mangled string as a text frame, and the renderer's JSON.parse fell through to the error label.
- Add an optional `encoding: "base64"` discriminator to `TunnelWsFrame`. tunnel-client now sets `binaryType = "arraybuffer"` and base64-encodes binary frames; relay decodes and `clientWs.send(buffer)` emits a real binary WS frame. The renderer's existing `event.data instanceof ArrayBuffer` fast path picks it up unchanged.
- Browser→host direction (keystrokes) stays text-only — no relay-side change there.

## Trace of the loss (one PTY byte)

1. `packages/host-service/src/terminal/terminal.ts:410,822` — host-service sends `Uint8Array`. ✓
2. `packages/host-service/src/tunnel/tunnel-client.ts:193-196` — loopback WS receives a Buffer; `String(event.data)` mangles it. ← origin
3. `packages/host-service/src/tunnel/tunnel-client.ts:110` — mangled string JSON-stringified to relay.
4. `apps/relay/src/tunnel.ts:175-177` — relay `clientWs.send(string)` — text frame, no binary path.
5. `apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts:239-249` — JSON.parse fails → `[terminal] invalid server payload`.

## Rollout

Relay and desktop ship together — no backwards compat needed.

1. Merge.
2. `cd apps/relay && fly deploy -a superset-relay` (no CI auto-deploy for the relay).
3. Next canary desktop build picks up the host-service tunnel-client change.
4. Hosts auto-update on canary; cross-host terminals start working.

## Test plan

- [ ] Run relay locally (`cd apps/relay && bun run dev`) with two desktops pointed at it via `RELAY_URL=http://localhost:8080`.
- [ ] Open a remote-host terminal, confirm `[terminal] invalid server payload` is gone and PTY output renders.
- [ ] Stress binary path: `vim`, `htop`, `ls --color=always`, `printf '\xff\xfe\x00\x01'`.
- [ ] Type input — confirm keystrokes still flow (browser→host text path unchanged).
- [ ] Open a local-machine terminal — no regression.
- [ ] Reconnect/disconnect tunnel WS — binary path survives reconnect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes corrupted PTY output by sending binary tunnel WebSocket frames as base64 through the relay, restoring cross-host terminal rendering. Also guards against malformed frames to avoid relay crashes; keystrokes remain unchanged.

- **Bug Fixes**
  - Added optional `encoding: "base64"` to `TunnelWsFrame` in `packages/shared`.
  - `packages/host-service` tunnel client: set `binaryType = "arraybuffer"`, base64-encode binary frames, and include `encoding: "base64"`.
  - `apps/relay`: decode base64 frames and `send` as real binary; text frames unchanged.
  - `apps/relay`: drop `ws:frame` messages with non-string `data` before decode to prevent tunnel teardown on malformed frames.

- **Migration**
  - Deploy `apps/relay` first; desktop canary picks up the tunnel client change. No back-compat required.

<sup>Written for commit ad1445ab87a37f197da0090cb55d10078cb6f2e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket relay now supports binary frames in addition to text, preserving binary fidelity.
  * Messages can be marked with base64 encoding so binary payloads are transmitted reliably.
* **Bug Fixes**
  * Fixed incorrect handling of non-text frames so binary messages are no longer corrupted or dropped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->