### PR TITLE
fix(desktop): consolidate v2 workspace context behind a single provider

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2NotificationStatusIndicator/V2NotificationStatusIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2NotificationStatusIndicator/V2NotificationStatusIndicator.tsx
@@ -1,3 +1,4 @@
+import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import {
 	useV2SourcesNotificationStatus,
@@ -5,17 +6,16 @@ import {
 } from "renderer/stores/v2-notifications";
 
 interface V2NotificationStatusIndicatorProps {
-	workspaceId: string;
 	sources: Iterable<V2NotificationSourceInput>;
 	className?: string;
 }
 
 export function V2NotificationStatusIndicator({
-	workspaceId,
 	sources,
 	className,
 }: V2NotificationStatusIndicatorProps) {
-	const status = useV2SourcesNotificationStatus(workspaceId, sources);
+	const { workspace } = useWorkspace();
+	const status = useV2SourcesNotificationStatus(workspace.id, sources);
 	if (!status) return null;
 	return <StatusIndicator status={status} className={className} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useClearActivePaneAttention/useClearActivePaneAttention.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useClearActivePaneAttention/useClearActivePaneAttention.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceStore } from "@superset/panes";
 import { useEffect } from "react";
+import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import {
 	getV2NotificationSourcesForPane,
 	useV2NotificationStore,
@@ -10,19 +11,21 @@ import type { StoreApi } from "zustand/vanilla";
 import type { PaneViewerData } from "../../types";
 
 export function useClearActivePaneAttention({
-	workspaceId,
 	store,
 }: {
-	workspaceId: string;
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
 }): void {
+	const { workspace } = useWorkspace();
 	const activePane = useStore(store, (state) => {
 		const tab = state.tabs.find(
 			(candidate) => candidate.id === state.activeTabId,
 		);
 		return tab?.activePaneId ? tab.panes[tab.activePaneId] : undefined;
 	});
-	const activePaneStatus = useV2PaneNotificationStatus(workspaceId, activePane);
+	const activePaneStatus = useV2PaneNotificationStatus(
+		workspace.id,
+		activePane,
+	);
 	const clearSourceAttention = useV2NotificationStore(
 		(state) => state.clearSourceAttention,
 	);
@@ -30,7 +33,7 @@ export function useClearActivePaneAttention({
 	useEffect(() => {
 		if (activePaneStatus !== "review") return;
 		for (const source of getV2NotificationSourcesForPane(activePane)) {
-			clearSourceAttention(source, workspaceId);
+			clearSourceAttention(source, workspace.id);
 		}
-	}, [activePane, activePaneStatus, clearSourceAttention, workspaceId]);
+	}, [activePane, activePaneStatus, clearSourceAttention, workspace.id]);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDirtyTabCloseGuard/useDirtyTabCloseGuard.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDirtyTabCloseGuard/useDirtyTabCloseGuard.ts
@@ -2,6 +2,7 @@ import type { WorkspaceProps } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
 import { useCallback } from "react";
 import { getBaseName } from "renderer/lib/pathBasename";
+import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { getDocument } from "../../state/fileDocumentStore";
 import type { FilePaneData, PaneViewerData } from "../../types";
 
@@ -9,11 +10,9 @@ type OnBeforeCloseTab = NonNullable<
 	WorkspaceProps<PaneViewerData>["onBeforeCloseTab"]
 >;
 
-export function useDirtyTabCloseGuard({
-	workspaceId,
-}: {
-	workspaceId: string;
-}): OnBeforeCloseTab {
+export function useDirtyTabCloseGuard(): OnBeforeCloseTab {
+	const { workspace } = useWorkspace();
+	const workspaceId = workspace.id;
 	return useCallback<OnBeforeCloseTab>(
 		(tab) => {
 			const dirtyPanes = Object.values(tab.panes).filter((pane) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/ChatPaneTitle/ChatPaneTitle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/ChatPaneTitle/ChatPaneTitle.tsx
@@ -45,7 +45,6 @@ export function ChatPaneTitle({ context, workspaceId }: ChatPaneTitleProps) {
 				onDeleteSession={handleDeleteSession}
 			/>
 			<V2NotificationStatusIndicator
-				workspaceId={workspaceId}
 				sources={getV2NotificationSourcesForPane(context.pane)}
 			/>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -26,6 +26,7 @@ import { useHotkeyDisplay } from "renderer/hotkeys";
 import { getBaseName } from "renderer/lib/pathBasename";
 import { consumeTerminalBackgroundIntent } from "renderer/lib/terminal/terminal-background-intents";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 import {
 	clearV2TerminalRunStatus,
@@ -107,10 +108,12 @@ interface UsePaneRegistryOptions {
 	onRevealPath: (path: string) => void;
 }
 
-export function usePaneRegistry(
-	workspaceId: string,
-	{ onOpenFile, onRevealPath }: UsePaneRegistryOptions,
-): PaneRegistry<PaneViewerData> {
+export function usePaneRegistry({
+	onOpenFile,
+	onRevealPath,
+}: UsePaneRegistryOptions): PaneRegistry<PaneViewerData> {
+	const { workspace } = useWorkspace();
+	const workspaceId = workspace.id;
 	const clearShortcut = useHotkeyDisplay("CLEAR_TERMINAL").text;
 	const scrollToBottomShortcut = useHotkeyDisplay("SCROLL_TO_BOTTOM").text;
 	const workspaceTrpcUtils = workspaceTrpc.useUtils();
@@ -254,7 +257,6 @@ export function usePaneRegistry(
 					<div className="flex min-w-0 flex-1 items-center gap-1.5">
 						<TerminalSessionDropdown context={ctx} workspaceId={workspaceId} />
 						<V2NotificationStatusIndicator
-							workspaceId={workspaceId}
 							sources={getV2NotificationSourcesForPane(ctx.pane)}
 						/>
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -2,6 +2,7 @@ import type { CreatePaneInput, WorkspaceStore } from "@superset/panes";
 import { toast } from "@superset/ui/sonner";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useCallback, useMemo } from "react";
+import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { getPresetLaunchPlan } from "renderer/stores/tabs/preset-launch";
@@ -27,14 +28,11 @@ function resolveTarget(executionMode: V2TerminalPresetRow["executionMode"]) {
 
 interface UseV2PresetExecutionArgs {
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
-	workspaceId: string;
-	projectId: string;
 }
 
-export function useV2PresetExecution({
-	store,
-	projectId,
-}: UseV2PresetExecutionArgs) {
+export function useV2PresetExecution({ store }: UseV2PresetExecutionArgs) {
+	const { workspace } = useWorkspace();
+	const projectId = workspace.projectId;
 	const collections = useCollections();
 
 	const { data: allPresets = [] } = useLiveQuery(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -2,7 +2,7 @@ import { createWorkspaceStore, type WorkspaceState } from "@superset/panes";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { PaneViewerData } from "../../types";
 
@@ -16,17 +16,10 @@ function getSnapshot(state: WorkspaceState<PaneViewerData>): string {
 	return JSON.stringify(state);
 }
 
-interface UseV2WorkspacePaneLayoutParams {
-	projectId: string;
-	workspaceId: string;
-}
-
-export function useV2WorkspacePaneLayout({
-	projectId,
-	workspaceId,
-}: UseV2WorkspacePaneLayoutParams) {
+export function useV2WorkspacePaneLayout() {
+	const { workspace } = useWorkspace();
+	const workspaceId = workspace.id;
 	const collections = useCollections();
-	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const [store] = useState(() =>
 		createWorkspaceStore<PaneViewerData>({
 			initialState: EMPTY_STATE,
@@ -51,10 +44,6 @@ export function useV2WorkspacePaneLayout({
 				| undefined) ?? EMPTY_STATE,
 		[localWorkspaceState],
 	);
-
-	useEffect(() => {
-		ensureWorkspaceInSidebar(workspaceId, projectId);
-	}, [ensureWorkspaceInSidebar, projectId, workspaceId]);
 
 	useEffect(() => {
 		const nextSnapshot = getSnapshot(persistedPaneLayout);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceFileNavigation/useWorkspaceFileNavigation.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceFileNavigation/useWorkspaceFileNavigation.ts
@@ -2,6 +2,7 @@ import type { WorkspaceStore } from "@superset/panes";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { V2UserPreferencesApi } from "renderer/hooks/useV2UserPreferences";
+import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import {
 	toAbsoluteWorkspacePath,
 	toRelativeWorkspacePath,
@@ -20,12 +21,10 @@ interface PendingReveal {
 }
 
 export function useWorkspaceFileNavigation({
-	workspaceId,
 	store,
 	setRightSidebarOpen,
 	setRightSidebarTab,
 }: {
-	workspaceId: string;
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
 	setRightSidebarOpen: V2UserPreferencesApi["setRightSidebarOpen"];
 	setRightSidebarTab: V2UserPreferencesApi["setRightSidebarTab"];
@@ -42,12 +41,13 @@ export function useWorkspaceFileNavigation({
 	recentFiles: RecentFile[];
 	openFilePaths: Set<string>;
 } {
+	const { workspace } = useWorkspace();
 	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
-		id: workspaceId,
+		id: workspace.id,
 	});
 	const worktreePath = workspaceQuery.data?.worktreePath ?? "";
 
-	const { recentFiles, recordView } = useRecentlyViewedFiles(workspaceId);
+	const { recentFiles, recordView } = useRecentlyViewedFiles(workspace.id);
 
 	const activeFilePanePath = useStore(store, (state) => {
 		const tab = state.tabs.find(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,19 +1,13 @@
 import { Workspace } from "@superset/panes";
-import { eq } from "@tanstack/db";
-import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { CommandPalette } from "renderer/screens/main/components/CommandPalette";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { getV2NotificationSourcesForTab } from "renderer/stores/v2-notifications";
-import { useWorkspaceCreatesStore } from "renderer/stores/workspace-creates";
-import { WorkspaceCreateErrorState } from "../components/WorkspaceCreateErrorState";
-import { WorkspaceCreatingState } from "../components/WorkspaceCreatingState";
-import { WorkspaceNotFoundState } from "../components/WorkspaceNotFoundState";
+import { useWorkspace } from "../providers/WorkspaceProvider";
 import { AddTabMenu } from "./components/AddTabMenu";
 import { V2NotificationStatusIndicator } from "./components/V2NotificationStatusIndicator";
 import { V2PresetsBar } from "./components/V2PresetsBar";
@@ -72,7 +66,6 @@ export const Route = createFileRoute(
 });
 
 function V2WorkspacePage() {
-	const { workspaceId } = Route.useParams();
 	const {
 		terminalId,
 		chatSessionId,
@@ -81,98 +74,18 @@ function V2WorkspacePage() {
 		openUrlTarget,
 		openUrlRequestId,
 	} = Route.useSearch();
-	const collections = useCollections();
+	const { workspace } = useWorkspace();
+	const workspaceId = workspace.id;
 
-	const { data: workspaces } = useLiveQuery(
-		(q) =>
-			q
-				.from({ v2Workspaces: collections.v2Workspaces })
-				.where(({ v2Workspaces }) => eq(v2Workspaces.id, workspaceId)),
-		[collections, workspaceId],
-	);
-	const workspace = workspaces?.[0] ?? null;
-	const inFlight = useWorkspaceCreatesStore((store) =>
-		store.entries.find((entry) => entry.snapshot.id === workspaceId),
-	);
-
-	if (!workspaces) {
-		return <div className="flex h-full w-full" />;
-	}
-
-	if (!workspace) {
-		if (inFlight?.state === "creating") {
-			return (
-				<WorkspaceCreatingState
-					name={inFlight.snapshot.name}
-					branch={inFlight.snapshot.branch}
-					startedAt={inFlight.startedAt}
-				/>
-			);
-		}
-		if (inFlight?.state === "error") {
-			return (
-				<WorkspaceCreateErrorState
-					workspaceId={workspaceId}
-					name={inFlight.snapshot.name}
-					error={inFlight.error ?? "Unknown error"}
-				/>
-			);
-		}
-		return <WorkspaceNotFoundState workspaceId={workspaceId} />;
-	}
-
-	return (
-		// key={workspaceId} so each workspace gets its own pane store rather
-		// than sharing one and replaceState-ing data across switches.
-		<WorkspaceContent
-			key={workspace.id}
-			projectId={workspace.projectId}
-			workspaceId={workspace.id}
-			terminalId={terminalId}
-			chatSessionId={chatSessionId}
-			focusRequestId={focusRequestId}
-			openUrl={openUrl}
-			openUrlTarget={openUrlTarget}
-			openUrlRequestId={openUrlRequestId}
-		/>
-	);
-}
-
-function WorkspaceContent({
-	projectId,
-	workspaceId,
-	terminalId,
-	chatSessionId,
-	focusRequestId,
-	openUrl,
-	openUrlTarget,
-	openUrlRequestId,
-}: {
-	projectId: string;
-	workspaceId: string;
-	terminalId?: string;
-	chatSessionId?: string;
-	focusRequestId?: string;
-	openUrl?: string;
-	openUrlTarget?: V2WorkspaceUrlOpenTarget;
-	openUrlRequestId?: string;
-}) {
 	const {
 		preferences: v2UserPreferences,
 		setRightSidebarOpen,
 		setRightSidebarTab,
 		setRightSidebarWidth,
 	} = useV2UserPreferences();
-	const { store } = useV2WorkspacePaneLayout({
-		projectId,
-		workspaceId,
-	});
-	useClearActivePaneAttention({ workspaceId, store });
-	const { matchedPresets, executePreset } = useV2PresetExecution({
-		store,
-		workspaceId,
-		projectId,
-	});
+	const { store } = useV2WorkspacePaneLayout();
+	useClearActivePaneAttention({ store });
+	const { matchedPresets, executePreset } = useV2PresetExecution({ store });
 	useConsumeAutomationRunLink({
 		store,
 		terminalId,
@@ -194,13 +107,12 @@ function WorkspaceContent({
 		recentFiles,
 		openFilePaths,
 	} = useWorkspaceFileNavigation({
-		workspaceId,
 		store,
 		setRightSidebarOpen,
 		setRightSidebarTab,
 	});
 
-	const paneRegistry = usePaneRegistry(workspaceId, {
+	const paneRegistry = usePaneRegistry({
 		onOpenFile: openFilePane,
 		onRevealPath: revealPath,
 	});
@@ -216,7 +128,7 @@ function WorkspaceContent({
 	const [quickOpenOpen, setQuickOpenOpen] = useState(false);
 	const handleQuickOpen = useCallback(() => setQuickOpenOpen(true), []);
 	const defaultPaneActions = useDefaultPaneActions();
-	const onBeforeCloseTab = useDirtyTabCloseGuard({ workspaceId });
+	const onBeforeCloseTab = useDirtyTabCloseGuard();
 
 	const sidebarOpen = v2UserPreferences.rightSidebarOpen;
 	// Fallback for rows persisted before the rightSidebarWidth field existed —
@@ -258,7 +170,7 @@ function WorkspaceContent({
 	useHotkey("QUICK_OPEN", handleQuickOpen);
 
 	return (
-		<FileDocumentStoreProvider workspaceId={workspaceId}>
+		<FileDocumentStoreProvider>
 			<div className="flex min-h-0 min-w-0 flex-1">
 				<div
 					className="flex min-h-0 min-w-[320px] flex-1 flex-col overflow-hidden"
@@ -271,7 +183,6 @@ function WorkspaceContent({
 						renderTabIcon={renderBrowserTabIcon}
 						renderTabAccessory={(tab) => (
 							<V2NotificationStatusIndicator
-								workspaceId={workspaceId}
 								sources={getV2NotificationSourcesForTab(tab)}
 							/>
 						)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/FileDocumentStoreProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/FileDocumentStoreProvider.tsx
@@ -1,18 +1,16 @@
 import type { ReactNode } from "react";
 import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
+import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { dispatchFsEvent } from "./fileDocumentStore";
 
-interface FileDocumentStoreProviderProps {
-	workspaceId: string;
-	children: ReactNode;
-}
-
 export function FileDocumentStoreProvider({
-	workspaceId,
 	children,
-}: FileDocumentStoreProviderProps) {
-	useWorkspaceEvent("fs:events", workspaceId, (event) => {
-		dispatchFsEvent(workspaceId, event);
+}: {
+	children: ReactNode;
+}) {
+	const { workspace } = useWorkspace();
+	useWorkspaceEvent("fs:events", workspace.id, (event) => {
+		dispatchFsEvent(workspace.id, event);
 	});
 
 	return <>{children}</>;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -1,17 +1,14 @@
-import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
-import { env } from "renderer/env.renderer";
-import {
-	getHostServiceHeaders,
-	getHostServiceWsToken,
-} from "renderer/lib/host-service-auth";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import { WorkspaceTrpcProvider } from "./providers/WorkspaceTrpcProvider";
+import { useWorkspaceCreatesStore } from "renderer/stores/workspace-creates";
+import { WorkspaceCreateErrorState } from "./components/WorkspaceCreateErrorState";
+import { WorkspaceCreatingState } from "./components/WorkspaceCreatingState";
+import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
+import { WorkspaceProvider } from "./providers/WorkspaceProvider";
 
 export const Route = createFileRoute("/_authenticated/_dashboard/v2-workspace")(
 	{
@@ -27,34 +24,23 @@ function V2WorkspaceLayout() {
 	const workspaceId =
 		workspaceMatch !== false ? workspaceMatch.workspaceId : null;
 	const collections = useCollections();
-	const { machineId, activeHostUrl } = useLocalHostService();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 
-	const { data: workspaces = [], isReady } = useLiveQuery(
+	const { data: workspaces, isReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ v2Workspaces: collections.v2Workspaces })
-				.where(({ v2Workspaces }) => eq(v2Workspaces.id, workspaceId ?? ""))
-				.select(({ v2Workspaces }) => ({
-					id: v2Workspaces.id,
-					organizationId: v2Workspaces.organizationId,
-					hostId: v2Workspaces.hostId,
-					projectId: v2Workspaces.projectId,
-					branch: v2Workspaces.branch,
-				})),
+				.where(({ v2Workspaces }) => eq(v2Workspaces.id, workspaceId ?? "")),
 		[collections, workspaceId],
 	);
-	const workspace = workspaces[0] ?? null;
-
-	const isLocal = workspace?.hostId === machineId;
-	const hostUrl = !workspace
-		? null
-		: isLocal
-			? activeHostUrl
-			: `${env.RELAY_URL}/hosts/${buildHostRoutingKey(workspace.organizationId, workspace.hostId)}`;
+	const workspace = workspaces?.[0] ?? null;
+	const inFlight = useWorkspaceCreatesStore((store) =>
+		workspaceId
+			? store.entries.find((entry) => entry.snapshot.id === workspaceId)
+			: undefined,
+	);
 
 	const lastEnsuredWorkspaceIdRef = useRef<string | null>(null);
-
 	useEffect(() => {
 		if (!workspace || lastEnsuredWorkspaceIdRef.current === workspace.id)
 			return;
@@ -62,23 +48,35 @@ function V2WorkspaceLayout() {
 		ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
 	}, [ensureWorkspaceInSidebar, workspace]);
 
-	if (!workspaceId || !isReady) {
-		return null;
+	if (!workspaceId || !isReady || !workspaces) {
+		return <div className="flex h-full w-full" />;
 	}
 
-	if (!workspace || !hostUrl) {
-		return <Outlet />;
+	if (!workspace) {
+		if (inFlight?.state === "creating") {
+			return (
+				<WorkspaceCreatingState
+					name={inFlight.snapshot.name}
+					branch={inFlight.snapshot.branch}
+					startedAt={inFlight.startedAt}
+				/>
+			);
+		}
+		if (inFlight?.state === "error") {
+			return (
+				<WorkspaceCreateErrorState
+					workspaceId={workspaceId}
+					name={inFlight.snapshot.name}
+					error={inFlight.error ?? "Unknown error"}
+				/>
+			);
+		}
+		return <WorkspaceNotFoundState workspaceId={workspaceId} />;
 	}
 
 	return (
-		<WorkspaceTrpcProvider
-			cacheKey={workspace.id}
-			key={`${workspace.id}:${hostUrl}`}
-			hostUrl={hostUrl}
-			headers={() => getHostServiceHeaders(hostUrl)}
-			wsToken={() => getHostServiceWsToken(hostUrl)}
-		>
+		<WorkspaceProvider workspace={workspace}>
 			<Outlet />
-		</WorkspaceTrpcProvider>
+		</WorkspaceProvider>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
@@ -1,0 +1,60 @@
+import type { SelectV2Workspace } from "@superset/db/schema";
+import { buildHostRoutingKey } from "@superset/shared/host-routing";
+import { createContext, type ReactNode, useContext } from "react";
+import { env } from "renderer/env.renderer";
+import {
+	getHostServiceHeaders,
+	getHostServiceWsToken,
+} from "renderer/lib/host-service-auth";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { WorkspaceTrpcProvider } from "../WorkspaceTrpcProvider";
+
+interface WorkspaceContextValue {
+	workspace: SelectV2Workspace;
+	hostUrl: string;
+}
+
+const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+
+export function WorkspaceProvider({
+	workspace,
+	children,
+}: {
+	workspace: SelectV2Workspace;
+	children: ReactNode;
+}) {
+	const { machineId, activeHostUrl } = useLocalHostService();
+	const hostUrl =
+		workspace.hostId === machineId
+			? activeHostUrl
+			: `${env.RELAY_URL}/hosts/${buildHostRoutingKey(
+					workspace.organizationId,
+					workspace.hostId,
+				)}`;
+
+	if (!hostUrl) {
+		return <div className="flex h-full w-full" />;
+	}
+
+	return (
+		<WorkspaceContext.Provider value={{ workspace, hostUrl }}>
+			<WorkspaceTrpcProvider
+				cacheKey={workspace.id}
+				key={`${workspace.id}:${hostUrl}`}
+				hostUrl={hostUrl}
+				headers={() => getHostServiceHeaders(hostUrl)}
+				wsToken={() => getHostServiceWsToken(hostUrl)}
+			>
+				{children}
+			</WorkspaceTrpcProvider>
+		</WorkspaceContext.Provider>
+	);
+}
+
+export function useWorkspace(): WorkspaceContextValue {
+	const ctx = useContext(WorkspaceContext);
+	if (!ctx) {
+		throw new Error("useWorkspace must be used within WorkspaceProvider");
+	}
+	return ctx;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspace, WorkspaceProvider } from "./WorkspaceProvider";


### PR DESCRIPTION
## Summary

- Fix a workspace-switch crash where TerminalPane threw `useWorkspaceClient must be used within WorkspaceClientProvider`. The v2 layout and the workspace page each ran their own `useLiveQuery` for the workspace; during a switch they could disagree for a render — the layout would strip `WorkspaceTrpcProvider` while the page still rendered `WorkspaceContent`.
- Move the provider mount into a new `WorkspaceProvider` that takes the resolved workspace, derives `hostUrl` once from `useLocalHostService`, and mounts `WorkspaceTrpcProvider` internally. The layout owns existence: creating / error / not-found states render in the layout itself, never via `<Outlet />` without a provider.
- Replace `workspaceId` props on inner hooks and v2-only components (`useV2WorkspacePaneLayout`, `useV2PresetExecution`, `usePaneRegistry`, `useWorkspaceFileNavigation`, `useDirtyTabCloseGuard`, `useClearActivePaneAttention`, `V2NotificationStatusIndicator`, `FileDocumentStoreProvider`) with `useWorkspace()`, so future callers can't drift the trpc client from the workspaceId used in queries / storage keys.

## Test plan

- [ ] Open the desktop app, switch rapidly between two v2 workspaces with terminal panes open — no `useWorkspaceClient` crash.
- [ ] Navigate to `/v2-workspace/<id>` for a workspace that doesn't exist — see `WorkspaceNotFoundState`.
- [ ] Trigger a workspace create from the task view — see `WorkspaceCreatingState` and transition into the workspace tree once the row lands.
- [ ] Trigger a workspace create error — see `WorkspaceCreateErrorState`.
- [ ] Confirm the right sidebar (files, changes), preset bar, command palette, and pane menus still work after switching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates v2 workspace context behind a single provider to fix workspace-switch crashes and keep the TRPC client in sync. The layout now mounts the provider and handles existence states to avoid mismatched renders.

- Bug Fixes
  - Prevents “useWorkspaceClient must be used within WorkspaceClientProvider” when switching workspaces.
  - Layout owns creating/error/not-found states; no `<Outlet />` without a provider.
  - Ensures provider and page agree during navigation, avoiding transient unmounts.

- Refactors
  - Added `WorkspaceProvider` that derives `hostUrl` once and mounts `WorkspaceTrpcProvider` with a `${workspace.id}:${hostUrl}` key.
  - Replaced `workspaceId` props with `useWorkspace()` across v2 hooks/components (pane layout, presets, file nav, dirty-close guard, notifications, `FileDocumentStoreProvider`).
  - Layout ensures the workspace appears in the sidebar and passes the resolved workspace to `WorkspaceProvider`.

<sup>Written for commit 5c8d1a56450464680aa6e3ba5d3accc18d4673da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized workspace component hierarchy through improved state management patterns and reduced prop passing.
  * Streamlined hook interfaces by eliminating redundant parameters and leveraging context providers for workspace data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->