### PR TITLE
ci: run full CLI dist matrix on PRs

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -10,6 +10,11 @@ on:
         description: 'JSON array of {os, target} build matrix entries'
         required: true
         type: string
+      upload:
+        description: 'Upload built tarballs as artifacts (release pipeline needs them; PR CI does not)'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -126,6 +131,7 @@ jobs:
           '
 
       - name: Upload tarball
+        if: inputs.upload
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: superset-${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,4 +155,5 @@ jobs:
     uses: ./.github/workflows/build-cli.yml
     with:
       targets: '[{"os":"ubuntu-latest","target":"linux-x64"},{"os":"macos-14","target":"darwin-arm64"},{"os":"ubuntu-24.04-arm","target":"linux-arm64"}]'
+      upload: false
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,29 +152,7 @@ jobs:
 
   build-cli:
     name: Build CLI
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Setup Bun
-        id: setup-bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version-file: .bun-version
-
-      - name: Cache dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-revision }}-${{ hashFiles('bun.lock') }}
-
-      - name: Install dependencies
-        run: bun install --frozen --ignore-scripts
-
-      - name: Build CLI
-        env:
-          RELAY_URL: ${{ secrets.RELAY_URL }}
-          SUPERSET_API_URL: ${{ vars.SUPERSET_API_URL }}
-          SUPERSET_WEB_URL: ${{ vars.SUPERSET_WEB_URL }}
-        run: bun turbo run build --filter=@superset/cli
+    uses: ./.github/workflows/build-cli.yml
+    with:
+      targets: '[{"os":"ubuntu-latest","target":"linux-x64"},{"os":"macos-14","target":"darwin-arm64"},{"os":"ubuntu-24.04-arm","target":"linux-arm64"}]'
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replaces the lightweight `bun turbo run build --filter=@superset/cli` step in `ci.yml` with a `workflow_call` to `build-cli.yml`, using the same 3-target matrix as `release-cli.yml` (linux-x64, linux-arm64, darwin-arm64).
- Runs the full dist build, native-binary smoke tests, and live PTY spawn check on every PR — catches regressions like spawn-helper exec bit, ABI mismatch, prebuild download flakes, and node-pty bundling at PR time instead of at release time.
- Recent release timings: ~2 minutes wall-clock for all three targets in parallel. Runners are free on this public repo.

## Test plan
- [ ] CI runs on this PR show three new checks: `build-cli / Build linux-x64`, `build-cli / Build linux-arm64`, `build-cli / Build darwin-arm64` — all green.
- [ ] After merge, update required-status-checks in branch protection: drop the old singular `build-cli` and add the three new matrix names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the full CLI dist build matrix on every PR using the reusable workflow for linux-x64, linux-arm64, and darwin-arm64. Build and smoke-test binaries without uploading artifacts to catch native-binary regressions early with a small CI time increase.

- **Refactors**
  - Replace the local `@superset/cli` build in `.github/workflows/ci.yml` with `workflow_call` to `build-cli.yml` using a 3-target matrix; add an `upload` input and set `upload: false` on PRs to skip tarball artifacts.
  - Run full dist build, native-binary smoke tests, and a live PTY spawn check on each PR.

- **Migration**
  - Update required checks: remove `build-cli`; add `build-cli / Build linux-x64`, `build-cli / Build linux-arm64`, `build-cli / Build darwin-arm64`.

<sup>Written for commit 49453a507a216c9bc82acfa618d6009e890bb6a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked CLI build to use a reusable workflow, added multi-platform build targets, made artifact upload configurable (can be disabled), and simplified secret handling.
  * Internal infrastructure changes only — no user-facing behavior or UI changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->