### PR TITLE
fix(cli): auto-refresh OAuth access token

### DIFF
--- a/packages/cli/src/commands/auth/login/command.ts
+++ b/packages/cli/src/commands/auth/login/command.ts
@@ -55,6 +55,7 @@ export default command({
 
 		config.auth = {
 			accessToken: result.accessToken,
+			refreshToken: result.refreshToken,
 			expiresAt: result.expiresAt,
 		};
 		writeConfig(config);

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -5,12 +5,13 @@ import { env } from "./env";
 
 const CLIENT_ID = "superset-cli";
 const PASTE_REDIRECT_PATH = "/cli/auth/code";
-const SCOPE = "openid profile email";
+const SCOPE = "openid profile email offline_access";
 const LOOPBACK_PORTS = [51789, 51790, 51791, 51792, 51793];
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
 
 export interface LoginResult {
 	accessToken: string;
+	refreshToken?: string;
 	expiresAt: number;
 }
 
@@ -238,11 +239,51 @@ async function exchangeCodeForToken({
 		access_token: string;
 		token_type: string;
 		expires_in?: number;
+		refresh_token?: string;
 	};
 
-	const expiresIn = data.expires_in ?? 60 * 60 * 24 * 30;
+	const expiresIn = data.expires_in ?? 60 * 60;
 	return {
 		accessToken: data.access_token,
+		refreshToken: data.refresh_token,
+		expiresAt: Date.now() + expiresIn * 1000,
+	};
+}
+
+export async function refreshAccessToken(
+	refreshToken: string,
+): Promise<LoginResult> {
+	const apiUrl = env.SUPERSET_API_URL;
+	const response = await fetch(`${apiUrl}/api/auth/oauth2/token`, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "refresh_token",
+			refresh_token: refreshToken,
+			client_id: CLIENT_ID,
+			resource: apiUrl,
+		}),
+	});
+
+	if (!response.ok) {
+		const body = await response.text();
+		throw new CLIError(
+			`Token refresh failed: ${response.status}`,
+			body || "Run `superset auth login` again.",
+		);
+	}
+
+	const data = (await response.json()) as {
+		access_token: string;
+		token_type: string;
+		expires_in?: number;
+		refresh_token?: string;
+	};
+
+	const expiresIn = data.expires_in ?? 60 * 60;
+	return {
+		accessToken: data.access_token,
+		refreshToken: data.refresh_token ?? refreshToken,
 		expiresAt: Date.now() + expiresIn * 1000,
 	};
 }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -13,6 +13,7 @@ import { env } from "./env";
 export type SupersetConfig = {
 	auth?: {
 		accessToken: string;
+		refreshToken?: string;
 		expiresAt: number;
 	};
 	organizationId?: string;

--- a/packages/cli/src/lib/resolve-auth.ts
+++ b/packages/cli/src/lib/resolve-auth.ts
@@ -1,6 +1,7 @@
 import { CLIError } from "@superset/cli-framework";
 import { type ApiClient, createApiClient } from "./api-client";
-import { readConfig, type SupersetConfig } from "./config";
+import { refreshAccessToken } from "./auth";
+import { readConfig, type SupersetConfig, writeConfig } from "./config";
 
 export type AuthSource = "flag" | "env" | "oauth";
 
@@ -11,10 +12,12 @@ export type ResolvedAuth = {
 	authSource: AuthSource;
 };
 
+const REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+
 export async function resolveAuth(
 	apiKeyOption: string | undefined,
 ): Promise<ResolvedAuth> {
-	const config = readConfig();
+	let config = readConfig();
 
 	let bearer = apiKeyOption?.trim();
 	let authSource: AuthSource = bearer ? "flag" : "oauth";
@@ -30,11 +33,30 @@ export async function resolveAuth(
 				"Run: superset auth login (or set SUPERSET_API_KEY)",
 			);
 		}
-		const CLOCK_SKEW_MS = 5 * 60 * 1000;
-		if (config.auth.expiresAt + CLOCK_SKEW_MS < Date.now()) {
-			throw new CLIError("Session expired", "Run: superset auth login");
+
+		const auth = config.auth;
+		if (auth.expiresAt - REFRESH_LEEWAY_MS < Date.now()) {
+			if (!auth.refreshToken) {
+				throw new CLIError("Session expired", "Run: superset auth login");
+			}
+			try {
+				const refreshed = await refreshAccessToken(auth.refreshToken);
+				config = {
+					...config,
+					auth: {
+						accessToken: refreshed.accessToken,
+						refreshToken: refreshed.refreshToken,
+						expiresAt: refreshed.expiresAt,
+					},
+				};
+				writeConfig(config);
+				bearer = refreshed.accessToken;
+			} catch {
+				throw new CLIError("Session expired", "Run: superset auth login");
+			}
+		} else {
+			bearer = auth.accessToken;
 		}
-		bearer = config.auth.accessToken;
 	}
 
 	const api = createApiClient({


### PR DESCRIPTION
## Summary

- CLI now requests `offline_access`, persists the returned refresh token, and silently exchanges it for a new access token in `resolveAuth` when the current token is within 5 minutes of expiry.
- Only falls through to "Session expired → run login" if the refresh call itself fails (e.g. refresh token revoked or > 30d old).
- Sign in once, stay signed in indefinitely so long as `superset` is invoked within the refresh token's rotating 30d window.

Previously the 1h access-token TTL with no refresh path forced users to re-login multiple times per day.

No server-side changes — the prod `superset-cli` OAuth client row already has `refresh_token` in `grant_types` and `offline_access` in `scopes`.

## Test plan

- [ ] `superset auth login`, confirm `~/.superset/config.json` now has `auth.refreshToken`.
- [ ] Manually expire the access token (set `auth.expiresAt` in config to a past timestamp), run any `superset` command, confirm it succeeds and `expiresAt` is updated.
- [ ] Wipe `auth.refreshToken` from config and expire `expiresAt`, confirm command fails with `Session expired`.
- [ ] `superset auth logout` still clears credentials cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-refresh OAuth access tokens in the CLI using a stored refresh token to keep users signed in. We request `offline_access`, save the refresh token, and refresh within 5 minutes of expiry; only prompt login if refresh is missing or fails.

- **New Features**
  - Request `offline_access` and persist `auth.refreshToken` in `~/.superset/config.json`.
  - In `resolveAuth`, silently refresh when near expiry and update `accessToken`, `expiresAt`, and `refreshToken` if rotated.
  - Fall back to “Session expired → run login” only on refresh errors; no server changes needed.

<sup>Written for commit e574725db1ceff2993a2630931426f4f918586dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now automatically refresh using stored tokens when approaching expiration, reducing the need for manual re-authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->