### PR TITLE
release(cli): cut v0.2.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -677,7 +677,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.6";
+const VERSION = "0.2.7";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Three fixes since v0.2.6:

- **relay tunnel: carry binary WS frames as base64** — the host-service tunnel client UTF-8-decoded binary WS frames via `String(buffer)`, corrupting PTY output bytes (`901622573` made PTY output binary end-to-end). Cross-host workspaces logged `[terminal] invalid server payload` and never rendered output. New base64 envelope discriminator on both legs of the relay tunnel. (#4066)
- **host-service: read remote URLs from git config** — switch from parsing `git remote -v` to `git config`. (#4065)
- **cli: auto-refresh OAuth access token** — use the refresh token instead of re-prompting on expiry. (#4069)

## Release plan

After this PR merges, push the `cli-v0.2.7` tag to fire `.github/workflows/release-cli.yml`.

## Test plan

- [ ] CI green on this PR
- [ ] After tag push, all three matrix targets land artifacts
- [ ] On a host running v0.2.7 talking to the new relay (already deployed): `superset start` boots, `superset auth login` refreshes silently after token expiry, and a remote-host terminal renders PTY output without `[terminal] invalid server payload`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.7 with three fixes that improve terminal reliability and auth UX. PTY output now renders over cross-host workspaces, git remotes are read via config, and OAuth tokens auto-refresh.

- **Bug Fixes**
  - Relay tunnel: send binary WebSocket frames as base64 to prevent UTF-8 corruption; fixes “[terminal] invalid server payload” and restores PTY output.
  - Host-service: read remote URLs using `git config` instead of parsing `git remote -v`.
  - CLI: auto-refresh OAuth access token with the refresh token to avoid re-prompts on expiry.

<sup>Written for commit c15015a45c7127c1c448397d8edab898c9ebd7df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI version to 0.2.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->