### PR TITLE
feat(desktop): add catchall error page for runtime route errors

### DIFF
--- a/apps/desktop/src/renderer/routes/__root.tsx
+++ b/apps/desktop/src/renderer/routes/__root.tsx
@@ -1,6 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
 import { RootLayout } from "./-layout";
+import { ErrorPage } from "./error";
 import { NotFound } from "./not-found";
 
 interface RouterContext {
@@ -10,6 +11,13 @@ interface RouterContext {
 export const Route = createRootRouteWithContext<RouterContext>()({
 	component: RootComponent,
 	notFoundComponent: NotFound,
+	errorComponent: ErrorPage,
+	onCatch: (error) => {
+		console.error("[renderer] Route error caught:", error);
+		void import("@sentry/electron/renderer")
+			.then((Sentry) => Sentry.captureException(error))
+			.catch(() => {});
+	},
 });
 
 function RootComponent() {

--- a/apps/desktop/src/renderer/routes/__root.tsx
+++ b/apps/desktop/src/renderer/routes/__root.tsx
@@ -12,12 +12,6 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 	component: RootComponent,
 	notFoundComponent: NotFound,
 	errorComponent: ErrorPage,
-	onCatch: (error) => {
-		console.error("[renderer] Route error caught:", error);
-		void import("@sentry/electron/renderer")
-			.then((Sentry) => Sentry.captureException(error))
-			.catch(() => {});
-	},
 });
 
 function RootComponent() {

--- a/apps/desktop/src/renderer/routes/error.tsx
+++ b/apps/desktop/src/renderer/routes/error.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@superset/ui/button";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
 	HiCheck,
 	HiExclamationTriangle,
@@ -10,15 +10,28 @@ import {
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 
 const IS_DEV = process.env.NODE_ENV === "development";
+const ERROR_DETAILS_ID = "error-details";
 
-export function ErrorPage({ error }: ErrorComponentProps) {
+export function ErrorPage({ error, info }: ErrorComponentProps) {
 	const message =
 		error instanceof Error ? error.message : String(error ?? "Unknown error");
 	const stack = error instanceof Error ? error.stack : undefined;
 	const details = stack ?? message;
+	const componentStack = info?.componentStack;
 
 	const [showDetails, setShowDetails] = useState(IS_DEV);
 	const { copyToClipboard, copied } = useCopyToClipboard();
+
+	useEffect(() => {
+		console.error("[renderer] Route error caught:", error, componentStack);
+		void import("@sentry/electron/renderer")
+			.then((Sentry) =>
+				Sentry.captureException(error, {
+					extra: componentStack ? { componentStack } : undefined,
+				}),
+			)
+			.catch(() => {});
+	}, [error, componentStack]);
 
 	return (
 		<div className="flex flex-col h-full w-full bg-background">
@@ -47,16 +60,20 @@ export function ErrorPage({ error }: ErrorComponentProps) {
 					<button
 						type="button"
 						onClick={() => setShowDetails((value) => !value)}
+						aria-expanded={showDetails}
+						aria-controls={ERROR_DETAILS_ID}
 						className="text-xs text-muted-foreground hover:text-foreground transition-colors"
 					>
 						{showDetails ? "Hide details" : "Show details"}
 					</button>
 
 					{showDetails && (
-						<div className="relative w-full">
+						<div id={ERROR_DETAILS_ID} className="relative w-full">
 							<button
 								type="button"
-								onClick={() => copyToClipboard(details)}
+								onClick={() => {
+									void copyToClipboard(details).catch(() => {});
+								}}
 								className="absolute top-2 right-2 flex items-center justify-center h-6 w-6 bg-background/80 backdrop-blur border border-border rounded hover:bg-accent transition-colors"
 								aria-label="Copy error details"
 							>

--- a/apps/desktop/src/renderer/routes/error.tsx
+++ b/apps/desktop/src/renderer/routes/error.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@superset/ui/button";
+import type { ErrorComponentProps } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
+import { useState } from "react";
+import {
+	HiCheck,
+	HiExclamationTriangle,
+	HiOutlineClipboard,
+} from "react-icons/hi2";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+
+const IS_DEV = process.env.NODE_ENV === "development";
+
+export function ErrorPage({ error }: ErrorComponentProps) {
+	const message =
+		error instanceof Error ? error.message : String(error ?? "Unknown error");
+	const stack = error instanceof Error ? error.stack : undefined;
+	const details = stack ?? message;
+
+	const [showDetails, setShowDetails] = useState(IS_DEV);
+	const { copyToClipboard, copied } = useCopyToClipboard();
+
+	return (
+		<div className="flex flex-col h-full w-full bg-background">
+			<div className="h-12 w-full drag shrink-0" />
+
+			<div className="flex flex-1 items-start justify-center overflow-y-auto pt-[18vh] pb-12">
+				<div className="flex flex-col items-center w-full max-w-2xl px-8 gap-6">
+					<div className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+						<HiExclamationTriangle className="h-8 w-8 text-destructive" />
+					</div>
+
+					<div className="flex flex-col items-center gap-2 text-center">
+						<h1 className="text-xl font-semibold">Something went wrong</h1>
+						<p className="text-sm text-muted-foreground">
+							Superset hit an unexpected error. Reload to try again.
+						</p>
+					</div>
+
+					<div className="flex items-center gap-3">
+						<Button onClick={() => window.location.reload()}>Reload</Button>
+						<Button variant="outline" asChild>
+							<Link to="/">Go home</Link>
+						</Button>
+					</div>
+
+					<button
+						type="button"
+						onClick={() => setShowDetails((value) => !value)}
+						className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+					>
+						{showDetails ? "Hide details" : "Show details"}
+					</button>
+
+					{showDetails && (
+						<div className="relative w-full">
+							<button
+								type="button"
+								onClick={() => copyToClipboard(details)}
+								className="absolute top-2 right-2 flex items-center justify-center h-6 w-6 bg-background/80 backdrop-blur border border-border rounded hover:bg-accent transition-colors"
+								aria-label="Copy error details"
+							>
+								{copied ? (
+									<HiCheck className="w-3.5 h-3.5 text-green-500" />
+								) : (
+									<HiOutlineClipboard className="w-3.5 h-3.5" />
+								)}
+							</button>
+							<pre className="w-full max-h-80 overflow-auto rounded-md border border-border bg-muted/40 p-3 pr-10 text-left text-xs text-muted-foreground select-text">
+								{details}
+							</pre>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Mounts a TanStack Router `errorComponent` on the root route so any post-mount render/loader failure lands on a recoverable page instead of a blank window — closes the gap that previously left users with cmd+R as their only escape hatch.
- The page offers **Reload** (full window reload) and **Go home** (router navigate to `/`) as recovery CTAs, with a collapsible details panel — open by default in dev, closed in prod — and a copy-to-clipboard button on the stack trace for bug reports.
- Layout is top-anchored (`items-start pt-[18vh]`) so toggling details grows the page downward without shifting the header/CTAs; `onCatch` logs the error and reports it to Sentry.

## Test plan
- [ ] Temporarily throw inside `AuthenticatedLayout` (or any route component) and confirm the error page renders instead of a blank screen.
- [ ] Click **Reload** → window reloads.
- [ ] Click **Go home** → routes to `/`.
- [ ] Toggle **Show details** / **Hide details** → header and CTAs do not shift; only the panel below grows/collapses.
- [ ] Click the copy icon → check icon flashes; pasting yields the full stack trace.
- [ ] In a production build, confirm details start collapsed.
- [ ] Resize the window small → verify the page itself becomes scrollable rather than clipping the trace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a catch‑all error page for runtime route errors in the desktop app. Users now see a recoverable screen instead of a blank window, with quick actions to reload or go home.

- **New Features**
  - Mounts a root `errorComponent` in `@tanstack/react-router` to render an error page on post-mount render/loader failures.
  - Provides Reload (full window reload) and Go home (navigate to `/`) actions, plus collapsible error details (open in dev, closed in prod) with copy-to-clipboard.
  - Logs errors from the `ErrorPage` and reports to Sentry with component stack context via `@sentry/electron/renderer`.

- **Bug Fixes**
  - Catch clipboard copy failures to avoid unhandled promise rejections.
  - Add `aria-expanded` and `aria-controls` to the details toggle for better accessibility.

<sup>Written for commit 8653bb97e96f6cd8e457c86861c72429abf266c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error page that displays a friendly "Something went wrong" message with recovery options (Reload, Go home).
  * Toggleable error details section with copy-to-clipboard for easy sharing.
  * Integrated error reporting to capture and send diagnostics for unhandled route errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->