### PR TITLE
fix(desktop): dedup in-flight v2 create row vs real workspace in sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -467,6 +467,7 @@ export function useDashboardSidebarData() {
 		// Inject in-flight workspaces (creating / failed) from the renderer-side
 		// in-flight store.
 		for (const pw of inFlightSidebarRows) {
+			if (localStateWorkspaceIds.has(pw.id)) continue;
 			const project = projectsById.get(pw.projectId);
 			if (!project) continue;
 
@@ -542,6 +543,7 @@ export function useDashboardSidebarData() {
 		machineId,
 		pullRequestsByWorkspaceId,
 		inFlightSidebarRows,
+		localStateWorkspaceIds,
 		sidebarProjects,
 		sidebarSections,
 		visibleSidebarWorkspaces,


### PR DESCRIPTION
## Summary

- The v2 workspace sidebar pulled from two sources without dedup: the renderer-side in-flight Zustand store (added at submit) and the `v2WorkspaceLocalState` ⋈ `v2Workspaces` inner-join (the real row).
- `WorkspaceCreatesManager` only removed the in-flight entry after Electric sync delivered `v2Workspaces`, so users reliably saw two sidebar rows for the same workspace during the sync gap.
- Skip the in-flight entry in `useDashboardSidebarData` when its id is already present in `localStateWorkspaceIds` — the in-flight row stays visible through the local-insert/Electric-sync window and disappears the moment the real row joins. No flicker, no duplicate.

## Test plan

- [ ] Create a new v2 workspace from the sidebar `+` and confirm only one row is visible at all times (in-flight → real, no overlap).
- [ ] Trigger a slow/failing Electric sync and confirm the in-flight row remains visible until the real row arrives.
- [ ] Create a workspace that hits the `alreadyExists` path (canonical id ≠ snapshot id) and confirm no orphaned in-flight row.
- [ ] Failing create still shows the failed in-flight row with a dismiss action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate rows in the v2 workspace sidebar during create. Only one row is shown at all times, with no flicker during sync.

- **Bug Fixes**
  - In `useDashboardSidebarData`, skip the in-flight row when its id exists in `localStateWorkspaceIds` (the joined `v2WorkspaceLocalState` ⋈ `v2Workspaces` set).
  - Added `localStateWorkspaceIds` to memo deps so the sidebar updates as soon as the real row appears.

<sup>Written for commit 35fd9d92e25e46c769aa9d0f5922421816404bb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dashboard sidebar workspace display by preventing duplicate entries when workspaces are in creating or failed states
  * Enhanced sidebar consistency when workspace presence changes locally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->