### PR TITLE
fix(host-service): exhaustive worktree search in v2 branch picker

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/adopt.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/adopt.ts
@@ -149,11 +149,7 @@ export const adopt = protectedProcedure
 			branch = actualBranch;
 			worktreePath = input.worktreePath;
 		} else {
-			const { worktreeMap } = await listWorktreeBranches(
-				ctx,
-				git,
-				input.projectId,
-			);
+			const { worktreeMap } = await listWorktreeBranches(git);
 			const found = worktreeMap.get(branch);
 			if (!found) {
 				throw new TRPCError({

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-branches.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-branches.ts
@@ -50,11 +50,7 @@ export const searchBranches = protectedProcedure
 		}
 
 		const defaultBranch = await resolveDefaultBranchName(git);
-		const { worktreeMap, checkedOutBranches } = await listWorktreeBranches(
-			ctx,
-			git,
-			input.projectId,
-		);
+		const { worktreeMap, checkedOutBranches } = await listWorktreeBranches(git);
 		const recencyMap = await getRecentBranchOrder(git, 30);
 
 		// Branches that already have a workspace row on this host. The

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.test.ts
@@ -136,9 +136,13 @@ describe("collectWorktreesFromGit vs raw git worktree list", () => {
 			["foreign-feat", "main", "managed-feat"].sort(),
 		);
 
-		// And the worktreeMap should include every branch that has a
-		// worktree on this machine, not just the ones under managedRoot.
-		// This is the user-reported bug: foreign worktrees go missing.
-		expect([...worktreeMap.keys()].sort()).toEqual([...fromGit.keys()].sort());
+		// And the worktreeMap should mirror git's view exactly — same
+		// branches AND same paths. Comparing full entries (not just
+		// keys) catches the case where a branch is present but the
+		// path got mangled, which would still let stale or wrong paths
+		// surface in the picker.
+		const sortEntries = (m: Map<string, string>) =>
+			[...m.entries()].sort(([a], [b]) => a.localeCompare(b));
+		expect(sortEntries(worktreeMap)).toEqual(sortEntries(fromGit));
 	});
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.test.ts
@@ -4,7 +4,11 @@ import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import simpleGit, { type SimpleGit } from "simple-git";
-import { findWorktreeAtPath, getWorktreeBranchAtPath } from "./branch-search";
+import {
+	collectWorktreesFromGit,
+	findWorktreeAtPath,
+	getWorktreeBranchAtPath,
+} from "./branch-search";
 
 async function initRepo(path: string): Promise<SimpleGit> {
 	const git = simpleGit(path);
@@ -51,5 +55,90 @@ describe("worktree branch lookup", () => {
 		await expect(
 			findWorktreeAtPath(git, worktreePath, "renamed"),
 		).resolves.toBe(true);
+	});
+});
+
+// Parses `git worktree list --porcelain` into (branch -> path) pairs so the
+// tests can assert against git's own view of reality. Skips entries with no
+// `branch refs/heads/...` line (detached HEAD).
+function parsePorcelain(raw: string): Map<string, string> {
+	const out = new Map<string, string>();
+	let currentPath: string | null = null;
+	for (const line of raw.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			currentPath = line.slice("worktree ".length).trim();
+		} else if (line.startsWith("branch refs/heads/") && currentPath) {
+			const branch = line.slice("branch refs/heads/".length).trim();
+			if (branch) out.set(branch, currentPath);
+		} else if (line === "") {
+			currentPath = null;
+		}
+	}
+	return out;
+}
+
+describe("collectWorktreesFromGit vs raw git worktree list", () => {
+	let root: string;
+	let repo: string;
+	let managedRoot: string;
+	let foreignRoot: string;
+	let git: SimpleGit;
+
+	beforeEach(async () => {
+		root = mkdtempSync(join(tmpdir(), "superset-collect-worktrees-"));
+		repo = join(root, "repo");
+		managedRoot = join(root, "managed", "project-id");
+		foreignRoot = join(root, "elsewhere");
+		mkdirSync(repo);
+		mkdirSync(managedRoot, { recursive: true });
+		mkdirSync(foreignRoot, { recursive: true });
+		git = await initRepo(repo);
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	test("includes every branch git worktree list reports", async () => {
+		// One worktree under the managed root, one outside it.
+		await git.raw([
+			"worktree",
+			"add",
+			"-b",
+			"managed-feat",
+			join(managedRoot, "managed-feat"),
+			"main",
+		]);
+		await git.raw([
+			"worktree",
+			"add",
+			"-b",
+			"foreign-feat",
+			join(foreignRoot, "foreign-feat"),
+			"main",
+		]);
+
+		const raw = await git.raw(["worktree", "list", "--porcelain"]);
+		const fromGit = parsePorcelain(raw);
+
+		const { worktreeMap, checkedOutBranches } =
+			await collectWorktreesFromGit(git);
+
+		// Sanity: git itself sees all three branches (main + both worktrees).
+		expect([...fromGit.keys()].sort()).toEqual(
+			["foreign-feat", "main", "managed-feat"].sort(),
+		);
+
+		// `checkedOutBranches` is supposed to mirror git's view — used to
+		// gate the Checkout action — so it must include every branch that
+		// has a worktree, regardless of where the worktree lives.
+		expect([...checkedOutBranches].sort()).toEqual(
+			["foreign-feat", "main", "managed-feat"].sort(),
+		);
+
+		// And the worktreeMap should include every branch that has a
+		// worktree on this machine, not just the ones under managedRoot.
+		// This is the user-reported bug: foreign worktrees go missing.
+		expect([...worktreeMap.keys()].sort()).toEqual([...fromGit.keys()].sort());
 	});
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.test.ts
@@ -5,9 +5,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import simpleGit, { type SimpleGit } from "simple-git";
 import {
-	collectWorktreesFromGit,
 	findWorktreeAtPath,
 	getWorktreeBranchAtPath,
+	listWorktreeBranches,
 } from "./branch-search";
 
 async function initRepo(path: string): Promise<SimpleGit> {
@@ -77,7 +77,7 @@ function parsePorcelain(raw: string): Map<string, string> {
 	return out;
 }
 
-describe("collectWorktreesFromGit vs raw git worktree list", () => {
+describe("listWorktreeBranches vs raw git worktree list", () => {
 	let root: string;
 	let repo: string;
 	let managedRoot: string;
@@ -100,7 +100,6 @@ describe("collectWorktreesFromGit vs raw git worktree list", () => {
 	});
 
 	test("includes every branch git worktree list reports", async () => {
-		// One worktree under the managed root, one outside it.
 		await git.raw([
 			"worktree",
 			"add",
@@ -120,27 +119,19 @@ describe("collectWorktreesFromGit vs raw git worktree list", () => {
 
 		const raw = await git.raw(["worktree", "list", "--porcelain"]);
 		const fromGit = parsePorcelain(raw);
-
-		const { worktreeMap, checkedOutBranches } =
-			await collectWorktreesFromGit(git);
+		const { worktreeMap, checkedOutBranches } = await listWorktreeBranches(git);
 
 		// Sanity: git itself sees all three branches (main + both worktrees).
 		expect([...fromGit.keys()].sort()).toEqual(
 			["foreign-feat", "main", "managed-feat"].sort(),
 		);
 
-		// `checkedOutBranches` is supposed to mirror git's view — used to
-		// gate the Checkout action — so it must include every branch that
-		// has a worktree, regardless of where the worktree lives.
 		expect([...checkedOutBranches].sort()).toEqual(
 			["foreign-feat", "main", "managed-feat"].sort(),
 		);
 
-		// And the worktreeMap should mirror git's view exactly — same
-		// branches AND same paths. Comparing full entries (not just
-		// keys) catches the case where a branch is present but the
-		// path got mangled, which would still let stale or wrong paths
-		// surface in the picker.
+		// Compare full entries, not just keys — a regression that mangled
+		// the path while preserving the branch name would otherwise pass.
 		const sortEntries = (m: Map<string, string>) =>
 			[...m.entries()].sort(([a], [b]) => a.localeCompare(b));
 		expect(sortEntries(worktreeMap)).toEqual(sortEntries(fromGit));

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.ts
@@ -1,4 +1,3 @@
-import type { HostServiceContext } from "../../../../types";
 import type { GitClient } from "./types";
 import { listGitWorktrees, normalizeWorktreePath } from "./worktree-list";
 
@@ -40,28 +39,11 @@ export function markRefetchRemote(projectId: string): void {
 	lastRemoteRefetch.set(projectId, Date.now());
 }
 
-export async function listWorktreeBranches(
-	_ctx: HostServiceContext,
-	git: GitClient,
-	_projectId: string,
-): Promise<{
-	// Every branch with a worktree git knows about — no gating on managed
-	// root or workspace rows. Foreign worktrees (user ran `git worktree
-	// add` themselves) surface here too so the v2 branch search shows
-	// everything git would.
-	worktreeMap: Map<string, string>;
-	// Every branch checked out in any git worktree, including the primary
-	// working tree. Used to disable the Checkout action when a branch is
-	// already in use elsewhere — `git worktree add <path> <branch>` would fail.
-	checkedOutBranches: Set<string>;
-}> {
-	return collectWorktreesFromGit(git);
-}
-
-// Exported for tests. Returns every branch-bearing worktree git knows
-// about. Built on the shared `parseWorktreeList` parser — do not add a
-// second porcelain parser here; extend `worktree-list.ts` instead.
-export async function collectWorktreesFromGit(git: GitClient): Promise<{
+// No gating on managed root or workspaces table — foreign worktrees
+// (user ran `git worktree add` themselves) surface too, so the v2
+// picker shows everything git would. `checkedOutBranches` is used to
+// disable Checkout when a branch is already in use elsewhere.
+export async function listWorktreeBranches(git: GitClient): Promise<{
 	worktreeMap: Map<string, string>;
 	checkedOutBranches: Set<string>;
 }> {

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.ts
@@ -1,10 +1,7 @@
 import { realpathSync } from "node:fs";
-import { resolve as resolvePath, sep } from "node:path";
-import { eq } from "drizzle-orm";
-import { workspaces } from "../../../../db/schema";
+import { resolve as resolvePath } from "node:path";
 import type { HostServiceContext } from "../../../../types";
 import type { GitClient } from "./types";
-import { projectWorktreesRoot } from "./worktree-paths";
 
 function encodeCursor(offset: number): string {
 	return Buffer.from(JSON.stringify({ offset })).toString("base64url");
@@ -53,29 +50,29 @@ function normalizeWorktreePath(path: string): string {
 }
 
 export async function listWorktreeBranches(
-	ctx: HostServiceContext,
+	_ctx: HostServiceContext,
 	git: GitClient,
-	projectId: string,
+	_projectId: string,
 ): Promise<{
-	// A worktree counts as "ours" if its path either matches a row in
-	// the local `workspaces` table or lives under our managed root. The
-	// second case catches orphans (worktree on disk, no workspaces row,
-	// e.g. partial create rollback) so they surface for adoption.
+	// Every branch with a worktree git knows about — no gating on managed
+	// root or workspace rows. Foreign worktrees (user ran `git worktree
+	// add` themselves) surface here too so the v2 branch search shows
+	// everything git would.
 	worktreeMap: Map<string, string>;
 	// Every branch checked out in any git worktree, including the primary
 	// working tree. Used to disable the Checkout action when a branch is
 	// already in use elsewhere — `git worktree add <path> <branch>` would fail.
 	checkedOutBranches: Set<string>;
 }> {
-	const managedRoot = projectWorktreesRoot(projectId);
-	const knownPaths = new Set<string>(
-		ctx.db
-			.select({ path: workspaces.worktreePath })
-			.from(workspaces)
-			.where(eq(workspaces.projectId, projectId))
-			.all()
-			.map((w) => w.path),
-	);
+	return collectWorktreesFromGit(git);
+}
+
+// Exported for tests. Parses `git worktree list --porcelain` and returns
+// every branch-bearing worktree git knows about.
+export async function collectWorktreesFromGit(git: GitClient): Promise<{
+	worktreeMap: Map<string, string>;
+	checkedOutBranches: Set<string>;
+}> {
 	const worktreeMap = new Map<string, string>();
 	const checkedOutBranches = new Set<string>();
 	try {
@@ -88,12 +85,7 @@ export async function listWorktreeBranches(
 				const branch = line.slice("branch refs/heads/".length).trim();
 				if (!branch) continue;
 				checkedOutBranches.add(branch);
-				if (
-					knownPaths.has(currentPath) ||
-					currentPath.startsWith(managedRoot + sep)
-				) {
-					worktreeMap.set(branch, currentPath);
-				}
+				worktreeMap.set(branch, currentPath);
 			} else if (line === "") {
 				currentPath = null;
 			}

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.ts
@@ -1,7 +1,6 @@
-import { realpathSync } from "node:fs";
-import { resolve as resolvePath } from "node:path";
 import type { HostServiceContext } from "../../../../types";
 import type { GitClient } from "./types";
+import { listGitWorktrees, normalizeWorktreePath } from "./worktree-list";
 
 function encodeCursor(offset: number): string {
 	return Buffer.from(JSON.stringify({ offset })).toString("base64url");
@@ -41,14 +40,6 @@ export function markRefetchRemote(projectId: string): void {
 	lastRemoteRefetch.set(projectId, Date.now());
 }
 
-function normalizeWorktreePath(path: string): string {
-	try {
-		return realpathSync.native(path);
-	} catch {
-		return resolvePath(path);
-	}
-}
-
 export async function listWorktreeBranches(
 	_ctx: HostServiceContext,
 	git: GitClient,
@@ -67,34 +58,19 @@ export async function listWorktreeBranches(
 	return collectWorktreesFromGit(git);
 }
 
-// Exported for tests. Parses `git worktree list --porcelain` and returns
-// every branch-bearing worktree git knows about.
+// Exported for tests. Returns every branch-bearing worktree git knows
+// about. Built on the shared `parseWorktreeList` parser — do not add a
+// second porcelain parser here; extend `worktree-list.ts` instead.
 export async function collectWorktreesFromGit(git: GitClient): Promise<{
 	worktreeMap: Map<string, string>;
 	checkedOutBranches: Set<string>;
 }> {
 	const worktreeMap = new Map<string, string>();
 	const checkedOutBranches = new Set<string>();
-	try {
-		const raw = await git.raw(["worktree", "list", "--porcelain"]);
-		let currentPath: string | null = null;
-		for (const line of raw.split("\n")) {
-			if (line.startsWith("worktree ")) {
-				currentPath = line.slice("worktree ".length).trim();
-			} else if (line.startsWith("branch refs/heads/") && currentPath) {
-				const branch = line.slice("branch refs/heads/".length).trim();
-				if (!branch) continue;
-				checkedOutBranches.add(branch);
-				worktreeMap.set(branch, currentPath);
-			} else if (line === "") {
-				currentPath = null;
-			}
-		}
-	} catch (err) {
-		console.warn(
-			"[workspace-creation] git worktree list failed; treating no branches as checked out:",
-			err,
-		);
+	for (const wt of await listGitWorktrees(git)) {
+		if (!wt.branch) continue;
+		checkedOutBranches.add(wt.branch);
+		worktreeMap.set(wt.branch, wt.path);
 	}
 	return { worktreeMap, checkedOutBranches };
 }
@@ -124,27 +100,10 @@ export async function getWorktreeBranchAtPath(
 	worktreePath: string,
 ): Promise<string | null> {
 	const targetPath = normalizeWorktreePath(worktreePath);
-	try {
-		const raw = await git.raw(["worktree", "list", "--porcelain"]);
-		let currentPath: string | null = null;
-		for (const line of raw.split("\n")) {
-			if (line.startsWith("worktree ")) {
-				currentPath = normalizeWorktreePath(
-					line.slice("worktree ".length).trim(),
-				);
-			} else if (line.startsWith("branch refs/heads/") && currentPath) {
-				if (currentPath !== targetPath) continue;
-				const branch = line.slice("branch refs/heads/".length).trim();
-				return branch || null;
-			} else if (line === "") {
-				currentPath = null;
-			}
+	for (const wt of await listGitWorktrees(git)) {
+		if (normalizeWorktreePath(wt.path) === targetPath) {
+			return wt.branch;
 		}
-	} catch (err) {
-		console.warn(
-			"[workspace-creation] git worktree list failed in findWorktreeAtPath:",
-			err,
-		);
 	}
 	return null;
 }

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-list.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-list.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit, { type SimpleGit } from "simple-git";
+import { listGitWorktrees, parseWorktreeList } from "./worktree-list";
+
+describe("parseWorktreeList", () => {
+	test("parses a branch worktree", () => {
+		const raw = [
+			"worktree /repo",
+			"HEAD abc123",
+			"branch refs/heads/main",
+			"",
+		].join("\n");
+		expect(parseWorktreeList(raw)).toEqual([
+			{
+				path: "/repo",
+				head: "abc123",
+				branch: "main",
+				detached: false,
+				bare: false,
+				locked: null,
+				prunable: null,
+			},
+		]);
+	});
+
+	test("parses a detached worktree", () => {
+		const raw = ["worktree /repo/wt", "HEAD abc123", "detached", ""].join("\n");
+		const [record] = parseWorktreeList(raw);
+		expect(record).toMatchObject({
+			path: "/repo/wt",
+			branch: null,
+			detached: true,
+		});
+	});
+
+	test("parses a bare worktree", () => {
+		const raw = ["worktree /repo/bare", "bare", ""].join("\n");
+		const [record] = parseWorktreeList(raw);
+		expect(record).toMatchObject({
+			path: "/repo/bare",
+			head: null,
+			branch: null,
+			bare: true,
+		});
+	});
+
+	test("parses locked and prunable with reasons", () => {
+		const raw = [
+			"worktree /a",
+			"HEAD aaa",
+			"branch refs/heads/a",
+			"locked manual lock",
+			"",
+			"worktree /b",
+			"HEAD bbb",
+			"branch refs/heads/b",
+			"prunable gitdir invalid",
+			"",
+		].join("\n");
+		const records = parseWorktreeList(raw);
+		expect(records[0]?.locked).toEqual({ reason: "manual lock" });
+		expect(records[0]?.prunable).toBeNull();
+		expect(records[1]?.prunable).toEqual({ reason: "gitdir invalid" });
+		expect(records[1]?.locked).toBeNull();
+	});
+
+	test("parses locked/prunable with no reason as empty string", () => {
+		const raw = [
+			"worktree /a",
+			"HEAD aaa",
+			"branch refs/heads/a",
+			"locked",
+			"prunable",
+			"",
+		].join("\n");
+		const [record] = parseWorktreeList(raw);
+		expect(record?.locked).toEqual({ reason: "" });
+		expect(record?.prunable).toEqual({ reason: "" });
+	});
+
+	test("parses multiple records and tolerates missing trailing newline", () => {
+		const raw = [
+			"worktree /one",
+			"HEAD 111",
+			"branch refs/heads/one",
+			"",
+			"worktree /two",
+			"HEAD 222",
+			"branch refs/heads/feat/two",
+		].join("\n");
+		const records = parseWorktreeList(raw);
+		expect(records).toHaveLength(2);
+		expect(records[1]).toMatchObject({ path: "/two", branch: "feat/two" });
+	});
+});
+
+async function initRepo(path: string): Promise<SimpleGit> {
+	const git = simpleGit(path);
+	await git.init();
+	await git.raw(["config", "user.email", "test@example.com"]);
+	await git.raw(["config", "user.name", "test"]);
+	await git.raw(["config", "commit.gpgsign", "false"]);
+	await git.raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+	await writeFile(join(path, "README.md"), "test\n");
+	await git.raw(["add", "README.md"]);
+	await git.raw(["commit", "-m", "initial"]);
+	return git;
+}
+
+describe("listGitWorktrees", () => {
+	let root: string;
+	let repo: string;
+	let git: SimpleGit;
+
+	beforeEach(async () => {
+		root = mkdtempSync(join(tmpdir(), "superset-list-worktrees-"));
+		repo = join(root, "repo");
+		mkdirSync(repo);
+		git = await initRepo(repo);
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	test("matches the raw porcelain output's worktree set", async () => {
+		await git.raw([
+			"worktree",
+			"add",
+			"-b",
+			"feat",
+			join(root, "wt-feat"),
+			"main",
+		]);
+		await git.raw([
+			"worktree",
+			"add",
+			"--detach",
+			join(root, "wt-detached"),
+			"main",
+		]);
+
+		const records = await listGitWorktrees(git);
+		const raw = await git.raw(["worktree", "list", "--porcelain"]);
+		const fromRaw = parseWorktreeList(raw);
+
+		expect(records).toEqual(fromRaw);
+		expect(records.map((r) => r.branch).sort()).toEqual(
+			[null, "feat", "main"].sort(),
+		);
+		expect(records.find((r) => r.detached)).toBeDefined();
+	});
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-list.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-list.ts
@@ -1,0 +1,94 @@
+import { realpathSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import type { GitClient } from "./types";
+
+// Single source of truth for parsing `git worktree list --porcelain`.
+// Every consumer in this package MUST go through `parseWorktreeList` /
+// `listGitWorktrees` instead of re-parsing the porcelain output inline.
+// Inline parsers drift apart silently — that is exactly how the
+// "missing worktrees" bug crept in: one parser gated by managed-root
+// prefix, another by realpath, and they disagreed.
+
+export type WorktreeRecord = {
+	// Path as git reports it (already realpath-canonicalized by git).
+	path: string;
+	// HEAD sha, or null for a bare worktree.
+	head: string | null;
+	// Branch short name (without `refs/heads/`), or null when detached or bare.
+	branch: string | null;
+	detached: boolean;
+	bare: boolean;
+	// `locked` and `prunable` carry a reason string when present (possibly
+	// empty), or null when the flag isn't set on this worktree.
+	locked: { reason: string } | null;
+	prunable: { reason: string } | null;
+};
+
+export function parseWorktreeList(raw: string): WorktreeRecord[] {
+	const records: WorktreeRecord[] = [];
+	let current: WorktreeRecord | null = null;
+	const flush = () => {
+		if (current) {
+			records.push(current);
+			current = null;
+		}
+	};
+	for (const line of raw.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			flush();
+			current = {
+				path: line.slice("worktree ".length).trim(),
+				head: null,
+				branch: null,
+				detached: false,
+				bare: false,
+				locked: null,
+				prunable: null,
+			};
+		} else if (!current) {
+			// Stray line before the first `worktree` block — ignore.
+		} else if (line.startsWith("HEAD ")) {
+			current.head = line.slice("HEAD ".length).trim() || null;
+		} else if (line.startsWith("branch ")) {
+			const ref = line.slice("branch ".length).trim();
+			current.branch = ref.startsWith("refs/heads/")
+				? ref.slice("refs/heads/".length)
+				: ref;
+		} else if (line === "detached") {
+			current.detached = true;
+		} else if (line === "bare") {
+			current.bare = true;
+		} else if (line === "locked" || line.startsWith("locked ")) {
+			current.locked = { reason: line.slice("locked".length).trim() };
+		} else if (line === "prunable" || line.startsWith("prunable ")) {
+			current.prunable = { reason: line.slice("prunable".length).trim() };
+		} else if (line === "") {
+			flush();
+		}
+	}
+	flush();
+	return records;
+}
+
+export async function listGitWorktrees(
+	git: GitClient,
+): Promise<WorktreeRecord[]> {
+	try {
+		const raw = await git.raw(["worktree", "list", "--porcelain"]);
+		return parseWorktreeList(raw);
+	} catch (err) {
+		console.warn("[workspace-creation] git worktree list failed:", err);
+		return [];
+	}
+}
+
+// Resolves a filesystem path through realpath when possible. Used to
+// compare paths from git (which it canonicalizes) against caller-supplied
+// paths (which may still contain symlinks like macOS `/var` → `/private/var`).
+export function normalizeWorktreePath(path: string): string {
+	try {
+		return realpathSync.native(path);
+	} catch {
+		return resolvePath(path);
+	}
+}


### PR DESCRIPTION
## Summary

- `listWorktreeBranches` was filtering its `worktreeMap` to paths under `~/.superset/worktrees/<projectId>/` or rows in the `workspaces` table, dropping two legitimate cases that users were noticing as "missing worktrees" in the v2 branch picker:
  - **Symlink mismatch** — git canonicalizes paths (e.g. `/private/var/folders/...` on macOS) while our managed-root string was built without realpath, so `startsWith(managedRoot + sep)` failed and even our own managed worktrees went missing.
  - **Foreign worktrees** — anything created via `git worktree add` outside the managed root was filtered out, even though git knows about it.
- Drop the gating: `worktreeMap` now mirrors `git worktree list --porcelain` directly, matching what `checkedOutBranches` already did. Adoption is unaffected (it takes an explicit path).

## Test plan

- [x] New unit test creates one managed + one foreign worktree, then asserts `collectWorktreesFromGit` returns the same set as raw `git worktree list --porcelain` (the regression guard).
- [x] `bun test packages/host-service/src/trpc/router/workspace-creation/shared/branch-search.test.ts` — passes.
- [x] `bun run typecheck --filter=@superset/host-service` — passes.
- [x] `bun run lint` — clean.
- [ ] Manual: open the v2 branch picker on a project with a worktree created outside `~/.superset/worktrees/<projectId>/` and confirm it shows up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows every git worktree in the v2 branch picker by mirroring `git worktree list --porcelain`. Fixes missing worktrees caused by path canonicalization and excluding user-created worktrees outside the managed root.

- **Bug Fixes**
  - `listWorktreeBranches` drops managed-root/`workspaces` gating and builds `worktreeMap` + `checkedOutBranches` from `listGitWorktrees`. API simplified to `listWorktreeBranches(git)`; updated `adopt` and `searchBranches` call sites.
  - Added a shared parser in worktree-list.ts (`parseWorktreeList`/`listGitWorktrees`/`normalizeWorktreePath`) used by `listWorktreeBranches` and `getWorktreeBranchAtPath`, plus unit and integration tests in `@superset/host-service`.
  - Strengthened tests to compare full branch→path entries (not just keys) to catch path-mangling regressions.

<sup>Written for commit 451a7094ad0fd8a794cd4b33e1c34626d315817e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Now detects all checked-out branches across all worktree locations, including external/foreign worktrees, and maps each branch to its exact path.

* **Improvements**
  * More reliable parsing and path normalization for Git worktree listings; handles detached, locked, prunable, bare, and other edge cases.

* **Tests**
  * Expanded test coverage verifying parsing, listing, and branch-to-path mapping end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->