### PR TITLE
feat(cli-auth): polish paste-code page + CLI keybindings

### DIFF
--- a/apps/web/src/app/cli/auth/code/components/CliAuthCodeDisplay/CliAuthCodeDisplay.tsx
+++ b/apps/web/src/app/cli/auth/code/components/CliAuthCodeDisplay/CliAuthCodeDisplay.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Button } from "@superset/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useEffect, useRef, useState } from "react";
-import { LuClipboard, LuClipboardCheck } from "react-icons/lu";
+import { LuCheck, LuClipboard } from "react-icons/lu";
 
 interface CliAuthCodeDisplayProps {
 	code: string;
@@ -36,9 +35,11 @@ async function copyToClipboard(value: string): Promise<boolean> {
 	}
 }
 
-function useCopiedFlag() {
+export function CliAuthCodeDisplay({ code, state }: CliAuthCodeDisplayProps) {
+	const value = `${code}#${state}`;
 	const [copied, setCopied] = useState(false);
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const codeRef = useRef<HTMLElement>(null);
 
 	useEffect(() => {
 		return () => {
@@ -46,70 +47,61 @@ function useCopiedFlag() {
 		};
 	}, []);
 
-	const flash = () => {
+	const selectCode = () => {
+		const node = codeRef.current;
+		if (!node || typeof window === "undefined") return;
+		const selection = window.getSelection();
+		if (!selection) return;
+		const range = document.createRange();
+		range.selectNodeContents(node);
+		selection.removeAllRanges();
+		selection.addRange(range);
+	};
+
+	const handleCopy = async () => {
 		setCopied(true);
 		if (timerRef.current) clearTimeout(timerRef.current);
 		timerRef.current = setTimeout(() => setCopied(false), 2000);
-	};
-	return [copied, flash] as const;
-}
-
-export function CliAuthCodeDisplay({ code, state }: CliAuthCodeDisplayProps) {
-	const value = `${code}#${state}`;
-	const [boxCopied, flashBox] = useCopiedFlag();
-	const [buttonCopied, flashButton] = useCopiedFlag();
-
-	const handleCopy = async (flash: () => void) => {
-		const ok = await copyToClipboard(value);
-		if (ok) flash();
+		await copyToClipboard(value);
+		selectCode();
 	};
 
 	return (
-		<div className="mx-auto flex w-full max-w-2xl flex-col items-center space-y-6 px-6 text-center">
+		<div className="flex w-full flex-col items-center space-y-6 px-6 text-center">
 			<h1 className="text-3xl font-semibold tracking-tight">
 				Authentication Code
 			</h1>
 			<p className="text-muted-foreground">Paste this into Superset CLI:</p>
 
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={() => handleCopy(flashBox)}
-						className="bg-muted/50 hover:bg-muted/70 focus-visible:ring-ring/50 w-full cursor-pointer overflow-x-auto rounded-lg border px-6 py-4 text-left transition-colors focus-visible:ring-[3px] focus-visible:outline-none"
-					>
-						<code className="font-mono text-sm break-all select-all">
-							{value}
-						</code>
-					</button>
-				</TooltipTrigger>
-				<TooltipContent>
-					{boxCopied ? "Copied!" : "Click to copy"}
-				</TooltipContent>
-			</Tooltip>
+			{/* biome-ignore lint/a11y/useSemanticElements: keep as div so the inner <code> stays selectable as a ctrl+c fallback if clipboard write fails — wrapping in a button disrupts selection focus */}
+			<div
+				role="button"
+				tabIndex={0}
+				onClick={handleCopy}
+				onKeyDown={(event) => {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						void handleCopy();
+					}
+				}}
+				className="bg-muted/50 hover:bg-muted/70 focus-visible:ring-ring/50 w-fit max-w-full cursor-pointer overflow-x-auto rounded-lg border px-6 py-4 text-left transition-colors focus-visible:ring-[3px] focus-visible:outline-none"
+			>
+				<code ref={codeRef} className="font-mono text-sm whitespace-nowrap">
+					{value}
+				</code>
+			</div>
 
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<Button onClick={() => handleCopy(flashButton)}>
-						{buttonCopied ? (
-							<>
-								<LuClipboardCheck /> Copied!
-							</>
-						) : (
-							<>
-								<LuClipboard /> Copy code
-							</>
-						)}
-					</Button>
-				</TooltipTrigger>
-				<TooltipContent>
-					{buttonCopied ? "Copied!" : "Copy to clipboard"}
-				</TooltipContent>
-			</Tooltip>
-
-			<p className="text-muted-foreground text-xs">
-				You can close this tab once the code is pasted.
-			</p>
+			<Button variant="ghost" onClick={handleCopy}>
+				{copied ? (
+					<>
+						<LuCheck /> Copied!
+					</>
+				) : (
+					<>
+						<LuClipboard /> Copy Code
+					</>
+				)}
+			</Button>
 		</div>
 	);
 }

--- a/apps/web/src/app/cli/auth/code/components/CliAuthCodeDisplay/CliAuthCodeDisplay.tsx
+++ b/apps/web/src/app/cli/auth/code/components/CliAuthCodeDisplay/CliAuthCodeDisplay.tsx
@@ -59,11 +59,12 @@ export function CliAuthCodeDisplay({ code, state }: CliAuthCodeDisplayProps) {
 	};
 
 	const handleCopy = async () => {
+		const ok = await copyToClipboard(value);
+		selectCode();
+		if (!ok) return;
 		setCopied(true);
 		if (timerRef.current) clearTimeout(timerRef.current);
 		timerRef.current = setTimeout(() => setCopied(false), 2000);
-		await copyToClipboard(value);
-		selectCode();
 	};
 
 	return (

--- a/packages/cli/src/commands/auth/login/LoginUI.tsx
+++ b/packages/cli/src/commands/auth/login/LoginUI.tsx
@@ -47,6 +47,21 @@ export function LoginUI({
 			return;
 		}
 
+		if (key.ctrl && (input === "u" || input === "k")) {
+			setValue("");
+			setValidationError(null);
+			return;
+		}
+
+		if (
+			(key.meta && (key.backspace || key.delete)) ||
+			(key.ctrl && input === "w")
+		) {
+			setValue((v) => v.replace(/\s*\S+\s*$/, ""));
+			setValidationError(null);
+			return;
+		}
+
 		if (key.backspace || key.delete) {
 			setValue((v) => v.slice(0, -1));
 			setValidationError(null);

--- a/packages/cli/src/commands/auth/login/LoginUI.tsx
+++ b/packages/cli/src/commands/auth/login/LoginUI.tsx
@@ -57,7 +57,7 @@ export function LoginUI({
 			(key.meta && (key.backspace || key.delete)) ||
 			(key.ctrl && input === "w")
 		) {
-			setValue((v) => v.replace(/\s*\S+\s*$/, ""));
+			setValue((v) => v.replace(/\S+\s*$/, ""));
 			setValidationError(null);
 			return;
 		}


### PR DESCRIPTION
## Summary
- Rewrote the `/cli/auth/code` page to match Claude Code's auth-code UI: single-line `w-fit` code box, ghost copy button that flips to "✓ Copied!" on press, click-anywhere-on-the-box to copy, and selection happens on release (programmatic `Range`) so it stays as a ctrl+c fallback if `clipboard.writeText` silently fails.
- Wired standard terminal readline shortcuts in the CLI paste-code prompt: `option+backspace` / `ctrl+w` delete the previous word, `cmd+backspace` / `ctrl+u` / `ctrl+k` clear the buffer. Plain `backspace` still deletes one char.

No DB or schema changes. Prod `superset-cli` `oauth_clients` row is unaffected (verified).

## Test plan
- [ ] `superset auth login` against local dev: paste flow renders the new page, click on text or button copies, selection highlights on release.
- [ ] `superset auth login` paste prompt: `option+backspace` deletes a word, `ctrl+u` clears the buffer.
- [ ] `superset auth login` against prod still works (no redirect_uri changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the CLI auth paste-code flow. Rebuilt the web auth-code page to match Claude Code and added readline shortcuts in the CLI prompt; copy feedback is now accurate and word deletion matches readline.

- New Features
  - Web page (/cli/auth/code): single-line code box; click box or ghost button to copy; programmatic selection on copy for reliable Ctrl/Cmd+C fallback.
  - CLI prompt: Option+Backspace/Ctrl+W delete previous word; Cmd+Backspace/Ctrl+U/Ctrl+K clear input; Backspace still deletes one char.

- Bug Fixes
  - Copy button only shows “Copied!” when clipboard write succeeds; selection still happens for manual copy fallback.
  - Word-delete now preserves the preceding space (e.g., "hello world" + Ctrl+W → "hello ").

<sup>Written for commit c3cb97d1365c7ceff0eb4935fe2aaa2b4972ed84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI login shortcuts: Ctrl+U or Ctrl+K to clear input; improved word/suffix deletion via Meta+Backspace/Delete and Ctrl+W.

* **Refactor**
  * Simplified CLI auth code display: unified copy state, more reliable copy + manual-selection fallback, streamlined copy button and keyboard interaction, and removed tooltip for a cleaner UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->