### PR TITLE
feat(mcp-v2): add agent spawn tools

### DIFF
--- a/packages/mcp-v2/src/tools/agents/run.ts
+++ b/packages/mcp-v2/src/tools/agents/run.ts
@@ -1,0 +1,66 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createMcpCaller } from "../../caller";
+import { defineTool } from "../../define-tool";
+import { hostServiceMutation } from "../../host-service-client";
+
+export function register(server: McpServer): void {
+	defineTool(server, {
+		name: "agents_run",
+		description:
+			"Launch an agent inside an existing workspace. Resolves the host that owns the workspace, then runs the named agent preset (or HostAgentConfig instance) with the given prompt in a fresh terminal session. Use this to start a second agent in a workspace that already exists; for create-and-spawn in a single call, pass `agents` to workspaces_create instead.",
+		inputSchema: {
+			workspaceId: z
+				.string()
+				.uuid()
+				.describe("Workspace UUID to run the agent in."),
+			agent: z
+				.string()
+				.min(1)
+				.describe(
+					"Agent preset id (e.g. `claude`, `codex`) or HostAgentConfig instance UUID.",
+				),
+			prompt: z.string().min(1).describe("Prompt sent to the agent."),
+			attachmentIds: z
+				.array(z.string().uuid())
+				.optional()
+				.describe(
+					"Host-scoped attachment UUIDs. The host resolves these to absolute paths and appends them to the prompt.",
+				),
+		},
+		handler: async (input, ctx) => {
+			const caller = createMcpCaller(ctx);
+			const workspace = await caller.v2Workspace.getFromHost({
+				organizationId: ctx.organizationId,
+				id: input.workspaceId,
+			});
+			if (!workspace) {
+				throw new Error(`Workspace not found: ${input.workspaceId}`);
+			}
+
+			return hostServiceMutation<
+				{
+					workspaceId: string;
+					agent: string;
+					prompt: string;
+					attachmentIds?: string[];
+				},
+				{ sessionId: string; label: string }
+			>(
+				{
+					relayUrl: ctx.relayUrl,
+					organizationId: ctx.organizationId,
+					hostId: workspace.hostId,
+					jwt: ctx.bearerToken,
+				},
+				"agents.run",
+				{
+					workspaceId: input.workspaceId,
+					agent: input.agent,
+					prompt: input.prompt,
+					attachmentIds: input.attachmentIds,
+				},
+			);
+		},
+	});
+}

--- a/packages/mcp-v2/src/tools/register.ts
+++ b/packages/mcp-v2/src/tools/register.ts
@@ -4,6 +4,7 @@ import {
 	setServerToolCallEmitter,
 } from "../define-tool";
 
+import * as agentsRun from "./agents/run";
 import * as automationsCreate from "./automations/create";
 import * as automationsDelete from "./automations/delete";
 import * as automationsGet from "./automations/get";
@@ -46,6 +47,7 @@ const REGISTRARS = [
 	workspacesList,
 	workspacesCreate,
 	workspacesDelete,
+	agentsRun,
 	projectsList,
 	hostsList,
 ];

--- a/packages/mcp-v2/src/tools/workspaces/create.ts
+++ b/packages/mcp-v2/src/tools/workspaces/create.ts
@@ -3,11 +3,27 @@ import { z } from "zod";
 import { defineTool } from "../../define-tool";
 import { hostServiceMutation } from "../../host-service-client";
 
+const agentLaunchSchema = z.object({
+	agent: z
+		.string()
+		.min(1)
+		.describe(
+			"Agent preset id (e.g. `claude`, `codex`) or HostAgentConfig instance UUID.",
+		),
+	prompt: z.string().min(1).describe("Initial prompt the agent starts with."),
+	attachmentIds: z
+		.array(z.string().uuid())
+		.optional()
+		.describe(
+			"Host-scoped attachment UUIDs. The host resolves these to absolute paths and appends them to the prompt.",
+		),
+});
+
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_create",
 		description:
-			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. Provide exactly one of `branch` or `pr`. Use projects_list and hosts_list first to get the projectId and hostId.",
+			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. Provide exactly one of `branch` or `pr`. Optionally pass `agents` to spawn one or more agents in the workspace as soon as it is ready (each entry runs the equivalent of `agents_run` against the new workspace). Use projects_list and hosts_list first to get the projectId and hostId.",
 		inputSchema: {
 			projectId: z.string().uuid().describe("Project UUID."),
 			name: z.string().min(1).describe("Workspace name (display)."),
@@ -41,6 +57,12 @@ export function register(server: McpServer): void {
 				.uuid()
 				.optional()
 				.describe("Optional Superset task id to link to the new workspace."),
+			agents: z
+				.array(agentLaunchSchema)
+				.optional()
+				.describe(
+					"Agents to spawn in the workspace immediately after creation.",
+				),
 		},
 		handler: async (input, ctx) => {
 			return hostServiceMutation<
@@ -51,6 +73,11 @@ export function register(server: McpServer): void {
 					pr?: number;
 					baseBranch?: string;
 					taskId?: string;
+					agents?: Array<{
+						agent: string;
+						prompt: string;
+						attachmentIds?: string[];
+					}>;
 				},
 				{
 					workspace: {
@@ -60,7 +87,10 @@ export function register(server: McpServer): void {
 						branch: string;
 					};
 					terminals: Array<{ terminalId: string; label?: string }>;
-					agents: Array<unknown>;
+					agents: Array<
+						| { ok: true; sessionId: string; label: string }
+						| { ok: false; error: string }
+					>;
 					alreadyExists: boolean;
 				}
 			>(
@@ -78,6 +108,7 @@ export function register(server: McpServer): void {
 					pr: input.pr,
 					baseBranch: input.baseBranch,
 					taskId: input.taskId,
+					agents: input.agents,
 				},
 			);
 		},


### PR DESCRIPTION
## Summary

v2 MCP previously had no way to spawn an agent — neither standalone nor as part of `workspaces_create` — even though the CLI (`superset agents run`) and SDK (`workspaces.create({ agents })`) both support it. This wires both shapes through:

- **`agents_run`** (new) — launches an agent inside an existing workspace. Resolves the host that owns the workspace (same `caller.v2Workspace.getFromHost` pattern used by `workspaces_delete`), then calls host `agents.run`. Mirrors `superset agents run`.
- **`workspaces_create`** — now accepts an optional `agents[]` matching the SDK's `WorkspaceAgentLaunch` shape (`agent`, `prompt`, optional `attachmentIds`). Pass-through to the host's existing `agents` param. Also tightens the response type from `Array<unknown>` to the discriminated union (`{ ok: true, sessionId, label } | { ok: false, error }`) the host already returns.

Both tools target host RPCs (`agents.run`, `workspaces.create`) that are already proven via CLI + SDK, so this is purely additive plumbing.

## Test plan

- [ ] Reconnect to v2 MCP and verify `agents_run` and the new `agents` param on `workspaces_create` show up in the tool list.
- [ ] Spawn an agent into an existing workspace via `agents_run` (preset id, e.g. `claude`).
- [ ] Create a workspace with `agents: [{ agent: "claude", prompt: "..." }]` and confirm the terminal session opens.
- [ ] Verify error path: pass a bogus `workspaceId` to `agents_run` → "Workspace not found".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `agents_run` and adds `agents[]` to `workspaces_create` so MCP v2 can spawn agents in existing or new workspaces. Aligns with CLI `superset agents run` and SDK `workspaces.create({ agents })`. No breaking changes.

- **New Features**
  - New `agents_run`: resolves the workspace’s host and calls host `agents.run`. Inputs: `workspaceId`, `agent`, `prompt`, optional `attachmentIds`.
  - `workspaces_create`: accepts optional `agents[]` to spawn agents on create (same shape as SDK: `agent`, `prompt`, optional `attachmentIds`).
  - Tightened response typing for `workspaces_create` `agents` results to a discriminated union: `{ ok: true, sessionId, label } | { ok: false, error }`.

<sup>Written for commit c8cadc98dd070b59c1b4c1eca081ac3f649fd4cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New agent execution tool allows running agents with custom prompts and optional attachments.
  * Workspace creation now supports launching agents automatically during workspace setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->