### PR TITLE
feat(desktop): toggle to disable adaptive keyboard-layout mapping

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/hooks/useBinding/useBinding.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useBinding/useBinding.ts
@@ -1,6 +1,7 @@
 import { HOTKEYS, type HotkeyId } from "../../registry";
 import { useHotkeyOverridesStore } from "../../stores/hotkeyOverridesStore";
 import { useKeyboardLayoutStore } from "../../stores/keyboardLayoutStore";
+import { useKeyboardPreferencesStore } from "../../stores/keyboardPreferencesStore";
 import type { ShortcutBinding } from "../../types";
 import { bindingToDispatchChord } from "../../utils/binding";
 
@@ -33,8 +34,7 @@ export function getBinding(id: HotkeyId): ShortcutBinding | null {
  * the bound handler on non-US layouts.
  */
 export function getDispatchChord(id: HotkeyId): string | null {
-	return bindingToDispatchChord(
-		getBinding(id),
-		useKeyboardLayoutStore.getState().map,
-	);
+	const adaptive = useKeyboardPreferencesStore.getState().adaptiveLayoutEnabled;
+	const layoutMap = adaptive ? useKeyboardLayoutStore.getState().map : null;
+	return bindingToDispatchChord(getBinding(id), layoutMap);
 }

--- a/apps/desktop/src/renderer/hotkeys/hooks/useHotkeyDisplay/useHotkeyDisplay.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useHotkeyDisplay/useHotkeyDisplay.ts
@@ -2,13 +2,22 @@ import { useMemo } from "react";
 import { formatHotkeyDisplay } from "../../display";
 import { PLATFORM } from "../../registry";
 import { useKeyboardLayoutStore } from "../../stores/keyboardLayoutStore";
+import { useKeyboardPreferencesStore } from "../../stores/keyboardPreferencesStore";
 import type { HotkeyDisplay, ShortcutBinding } from "../../types";
 import { bindingToDispatchChord } from "../../utils/binding";
 import { useBinding } from "../useBinding";
 
+/** Effective layout map for display: null when the user has disabled
+ *  adaptive layout mapping, so glyphs match the authored chord. */
+function useActiveLayoutMap(): ReadonlyMap<string, string> | null {
+	const layoutMap = useKeyboardLayoutStore((s) => s.map);
+	const adaptive = useKeyboardPreferencesStore((s) => s.adaptiveLayoutEnabled);
+	return adaptive ? layoutMap : null;
+}
+
 export function useHotkeyDisplay(id: string): HotkeyDisplay {
 	const binding = useBinding(id as Parameters<typeof useBinding>[0]);
-	const layoutMap = useKeyboardLayoutStore((s) => s.map);
+	const layoutMap = useActiveLayoutMap();
 	const chord = bindingToDispatchChord(binding, layoutMap);
 	return useMemo(
 		() => formatHotkeyDisplay(chord, PLATFORM, layoutMap),
@@ -25,7 +34,7 @@ export function useHotkeyDisplay(id: string): HotkeyDisplay {
 export function useFormatBinding(
 	binding: ShortcutBinding | null,
 ): HotkeyDisplay {
-	const layoutMap = useKeyboardLayoutStore((s) => s.map);
+	const layoutMap = useActiveLayoutMap();
 	const chord = bindingToDispatchChord(binding, layoutMap);
 	return useMemo(
 		() => formatHotkeyDisplay(chord, PLATFORM, layoutMap),

--- a/apps/desktop/src/renderer/hotkeys/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/index.ts
@@ -10,7 +10,10 @@ export {
 	useRecordHotkeys,
 } from "./hooks";
 export { HOTKEYS, type HotkeyId, PLATFORM } from "./registry";
-export { useHotkeyOverridesStore } from "./stores";
+export {
+	useHotkeyOverridesStore,
+	useKeyboardPreferencesStore,
+} from "./stores";
 export type {
 	BindingMode,
 	HotkeyCategory,

--- a/apps/desktop/src/renderer/hotkeys/stores/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/stores/index.ts
@@ -1,1 +1,2 @@
 export { useHotkeyOverridesStore } from "./hotkeyOverridesStore";
+export { useKeyboardPreferencesStore } from "./keyboardPreferencesStore";

--- a/apps/desktop/src/renderer/hotkeys/stores/keyboardPreferencesStore.ts
+++ b/apps/desktop/src/renderer/hotkeys/stores/keyboardPreferencesStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+interface KeyboardPreferencesState {
+	/** Opt-in: when true, logical bindings are translated through the OS
+	 *  keyboard layout — e.g. `⌘Z` dispatches to physical KeyY on QWERTZ.
+	 *  Defaults to false so bindings dispatch and display as if on US-ANSI
+	 *  regardless of the current input source. */
+	adaptiveLayoutEnabled: boolean;
+	setAdaptiveLayoutEnabled: (enabled: boolean) => void;
+}
+
+export const useKeyboardPreferencesStore = create<KeyboardPreferencesState>()(
+	persist(
+		(set) => ({
+			adaptiveLayoutEnabled: false,
+			setAdaptiveLayoutEnabled: (enabled) =>
+				set({ adaptiveLayoutEnabled: enabled }),
+		}),
+		{
+			name: "keyboard-preferences",
+			storage: createJSONStorage(() => localStorage),
+			partialize: (state) => ({
+				adaptiveLayoutEnabled: state.adaptiveLayoutEnabled,
+			}),
+		},
+	),
+);

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -1,8 +1,18 @@
 import { HOTKEYS, type HotkeyId } from "../registry";
 import { useHotkeyOverridesStore } from "../stores/hotkeyOverridesStore";
 import { useKeyboardLayoutStore } from "../stores/keyboardLayoutStore";
+import { useKeyboardPreferencesStore } from "../stores/keyboardPreferencesStore";
 import type { ShortcutBinding } from "../types";
 import { bindingToDispatchChord } from "./binding";
+
+/** Layout map for the resolver — null when the user has disabled adaptive
+ *  layout mapping, so logical bindings keep their authored chord. */
+function activeLayoutMap(): ReadonlyMap<string, string> | null {
+	if (!useKeyboardPreferencesStore.getState().adaptiveLayoutEnabled) {
+		return null;
+	}
+	return useKeyboardLayoutStore.getState().map;
+}
 
 /**
  * KeyboardEvent → registered {@link HotkeyId}, or `null` if unbound. Uses the
@@ -134,21 +144,28 @@ function buildRegisteredAppChords(
 	return map;
 }
 
-// Reassigned on each override OR layout change; `let` is required so the
-// subscribe callbacks can replace the reference the resolver reads.
+// Reassigned on each override, layout, OR adaptive-layout-toggle change;
+// `let` is required so the subscribe callbacks can replace the reference
+// the resolver reads.
 let registeredAppChords = buildRegisteredAppChords(
 	useHotkeyOverridesStore.getState().overrides,
-	useKeyboardLayoutStore.getState().map,
+	activeLayoutMap(),
 );
 useHotkeyOverridesStore.subscribe((state) => {
 	registeredAppChords = buildRegisteredAppChords(
 		state.overrides,
-		useKeyboardLayoutStore.getState().map,
+		activeLayoutMap(),
 	);
 });
-useKeyboardLayoutStore.subscribe((state) => {
+useKeyboardLayoutStore.subscribe(() => {
 	registeredAppChords = buildRegisteredAppChords(
 		useHotkeyOverridesStore.getState().overrides,
-		state.map,
+		activeLayoutMap(),
+	);
+});
+useKeyboardPreferencesStore.subscribe(() => {
+	registeredAppChords = buildRegisteredAppChords(
+		useHotkeyOverridesStore.getState().overrides,
+		activeLayoutMap(),
 	);
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/keyboard/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/keyboard/page.tsx
@@ -24,9 +24,9 @@ import {
 	useFormatBinding,
 	useHotkeyDisplay,
 	useHotkeyOverridesStore,
+	useKeyboardPreferencesStore,
 	useRecordHotkeys,
 } from "renderer/hotkeys";
-import { useKeyboardPreferencesStore } from "renderer/hotkeys/stores/keyboardPreferencesStore";
 
 const CATEGORY_ORDER: HotkeyCategory[] = [
 	"Navigation",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/keyboard/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/keyboard/page.tsx
@@ -9,7 +9,9 @@ import {
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
 import { Kbd, KbdGroup } from "@superset/ui/kbd";
+import { Label } from "@superset/ui/label";
 import { toast } from "@superset/ui/sonner";
+import { Switch } from "@superset/ui/switch";
 import { cn } from "@superset/ui/utils";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
@@ -24,6 +26,7 @@ import {
 	useHotkeyOverridesStore,
 	useRecordHotkeys,
 } from "renderer/hotkeys";
+import { useKeyboardPreferencesStore } from "renderer/hotkeys/stores/keyboardPreferencesStore";
 
 const CATEGORY_ORDER: HotkeyCategory[] = [
 	"Navigation",
@@ -137,6 +140,13 @@ function KeyboardShortcutsPage() {
 	const resetAll = useHotkeyOverridesStore((s) => s.resetAll);
 	const setOverride = useHotkeyOverridesStore((s) => s.setOverride);
 
+	const adaptiveLayoutEnabled = useKeyboardPreferencesStore(
+		(s) => s.adaptiveLayoutEnabled,
+	);
+	const setAdaptiveLayoutEnabled = useKeyboardPreferencesStore(
+		(s) => s.setAdaptiveLayoutEnabled,
+	);
+
 	useRecordHotkeys(recordingId, {
 		// New printable bindings follow the printed character (matches what the
 		// user sees on their keyboard). F-keys / named keys are forced to
@@ -213,6 +223,25 @@ function KeyboardShortcutsPage() {
 				>
 					Reset all
 				</Button>
+			</div>
+
+			{/* Preferences */}
+			<div className="mb-8 flex items-center justify-between gap-4">
+				<div className="space-y-0.5">
+					<Label htmlFor="adaptive-layout" className="text-sm font-medium">
+						Adaptive layout mapping
+					</Label>
+					<p className="text-xs text-muted-foreground">
+						Remap shortcuts to your current keyboard layout (e.g. ⌘Z dispatches
+						to physical KeyY on QWERTZ). When off, shortcuts always match the
+						keys you bound.
+					</p>
+				</div>
+				<Switch
+					id="adaptive-layout"
+					checked={adaptiveLayoutEnabled}
+					onCheckedChange={setAdaptiveLayoutEnabled}
+				/>
 			</div>
 
 			{/* Search */}


### PR DESCRIPTION
## Summary
- Adds an opt-in "Adaptive layout mapping" preference on the keyboard settings page (defaults off).
- When off, shortcuts dispatch and render exactly as bound — `⌘Z` stays `⌘Z` on QWERTZ instead of being remapped to physical `KeyY`.
- Resolver index, display hooks (`useHotkeyDisplay` / `useFormatBinding`), and imperative `getDispatchChord` all read the preference and pass `null` for the layout map when adaptive is off; resolver subscribes so toggling rebuilds the chord index live.

## Test plan
- [ ] Open Settings → Keyboard, see new "Adaptive layout mapping" toggle styled like the General page rows
- [ ] With toggle off (default) on QWERTZ: `⌘Z` fires the bound handler and renders as `⌘Z` (not `⌘Y`)
- [ ] Flip toggle on: existing layout-aware behavior returns (display + dispatch follow the OS layout)
- [ ] Reload the app — preference persists via localStorage
- [ ] `bun run lint` and existing hotkey tests still green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in “Adaptive layout mapping” toggle in Keyboard settings to control layout-aware shortcuts. When off (default), shortcuts dispatch and display exactly as bound (e.g., ⌘Z stays ⌘Z on QWERTZ).

- **New Features**
  - Toggle appears in Settings → Keyboard and persists via `localStorage` (`zustand` `persist`).
  - Resolver and display respect the preference: `useHotkeyDisplay`, `useFormatBinding`, and `getDispatchChord` pass a null layout map when disabled.
  - Resolver reindexes on overrides, layout changes, and toggle changes; turning it on restores layout-aware behavior.

- **Refactors**
  - Export `useKeyboardPreferencesStore` from the hotkeys barrel to simplify imports.

<sup>Written for commit eb30829292e10b4b6d1ebfa0ca9513ba65925175. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Adaptive layout mapping" toggle to keyboard shortcuts settings to enable/disable adaptive remapping.
  * Hotkey display, resolution, and behavior now respect the new toggle — when disabled, authored chord mappings are preserved; when enabled, layouts are adaptively applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->