### PR TITLE
feat(desktop): wire pi terminal agent to notification hooks

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-pi.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-pi.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { writeFileIfChanged } from "./agent-wrappers-common";
+
+export const PI_EXTENSION_FILE = "superset-hooks.ts";
+
+const PI_EXTENSION_SIGNATURE = "// Superset pi extension";
+const PI_EXTENSION_VERSION = "v1";
+export const PI_EXTENSION_MARKER = `${PI_EXTENSION_SIGNATURE} ${PI_EXTENSION_VERSION}`;
+
+const PI_EXTENSION_TEMPLATE_PATH = path.join(
+	__dirname,
+	"templates",
+	"pi-extension.template.ts",
+);
+
+/**
+ * Returns the global pi extensions directory used by pi's auto-discovery.
+ *
+ * Decision (see PRD): we install into the user's global `~/.pi/agent/extensions/`
+ * rather than an env-scoped Superset-private path. Pi reads
+ * `PI_CODING_AGENT_DIR` exclusively when set, so an env-scoped install would
+ * shadow user-installed extensions. Cursor-agent is the precedent for
+ * "global install, no env override."
+ */
+export function getPiExtensionPath(): string {
+	return path.join(
+		os.homedir(),
+		".pi",
+		"agent",
+		"extensions",
+		PI_EXTENSION_FILE,
+	);
+}
+
+/**
+ * Renders the pi extension content with the marker substituted.
+ *
+ * The template is environment-independent: it computes the notify.sh path at
+ * runtime from `SUPERSET_HOME_DIR` (which is set in every Superset terminal
+ * for both dev and prod installs).
+ */
+export function getPiExtensionContent(): string {
+	const template = fs.readFileSync(PI_EXTENSION_TEMPLATE_PATH, "utf-8");
+	return template.replace("{{MARKER}}", PI_EXTENSION_MARKER);
+}
+
+/**
+ * Writes the Superset-managed pi extension into the global pi extensions
+ * directory. Idempotent via `writeFileIfChanged`.
+ *
+ * Pi auto-discovers extensions in this directory at session start, so no
+ * registration step is required. The install is unconditional on whether
+ * pi itself is installed: if the user later installs pi via npm, hooks
+ * start working with no further setup.
+ */
+export function createPiExtension(): void {
+	const extensionPath = getPiExtensionPath();
+	const content = getPiExtensionContent();
+	fs.mkdirSync(path.dirname(extensionPath), { recursive: true });
+	const changed = writeFileIfChanged(extensionPath, content, 0o644);
+	console.log(`[agent-setup] ${changed ? "Updated" : "Verified"} pi extension`);
+}

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -66,6 +66,7 @@ const {
 	createDroidSettingsJson,
 	createDroidWrapper,
 	createMastraWrapper,
+	createPiExtension,
 	getClaudeGlobalSettingsJsonContent,
 	getClaudeManagedHookCommand,
 	getCodexGlobalHooksJsonContent,
@@ -74,6 +75,9 @@ const {
 	getDroidSettingsJsonContent,
 	getGeminiSettingsJsonContent,
 	getMastraHooksJsonContent,
+	getPiExtensionContent,
+	getPiExtensionPath,
+	PI_EXTENSION_MARKER,
 } = await import("./agent-wrappers");
 const { reconcileManagedEntries } = await import("./agent-wrappers-common");
 
@@ -1281,5 +1285,47 @@ describe("agent-wrappers codex hooks.json", () => {
 		expect(
 			getCodexGlobalHooksJsonContent("/tmp/.superset/hooks/notify.sh"),
 		).toBeNull();
+	});
+});
+
+describe("agent-wrappers pi", () => {
+	beforeEach(() => {
+		mockedHomeDir = path.join(TEST_ROOT, "home");
+		mkdirSync(TEST_BIN_DIR, { recursive: true });
+		mkdirSync(TEST_HOOKS_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(TEST_ROOT, { recursive: true, force: true });
+	});
+
+	it("renders pi extension content with the marker substituted", () => {
+		const content = getPiExtensionContent();
+		expect(content).toContain(PI_EXTENSION_MARKER);
+		expect(content).not.toContain("{{MARKER}}");
+	});
+
+	it("renders pi extension content as a valid extension default-export shape", () => {
+		const content = getPiExtensionContent();
+		expect(content).toContain("export default function");
+	});
+
+	it("installs the pi extension into the global ~/.pi/agent/extensions directory", () => {
+		const extensionPath = getPiExtensionPath();
+		expect(extensionPath).toBe(
+			path.join(
+				mockedHomeDir,
+				".pi",
+				"agent",
+				"extensions",
+				"superset-hooks.ts",
+			),
+		);
+
+		createPiExtension();
+
+		const installed = readFileSync(extensionPath, "utf-8");
+		expect(installed).toContain(PI_EXTENSION_MARKER);
+		expect(installed).toContain("export default function");
 	});
 });

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -68,3 +68,10 @@ export {
 	getMastraGlobalHooksJsonPath,
 	getMastraHooksJsonContent,
 } from "./agent-wrappers-mastra";
+export {
+	createPiExtension,
+	getPiExtensionContent,
+	getPiExtensionPath,
+	PI_EXTENSION_FILE,
+	PI_EXTENSION_MARKER,
+} from "./agent-wrappers-pi";

--- a/apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts
+++ b/apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts
@@ -14,6 +14,7 @@ export const DESKTOP_AGENT_SETUP_ACTIONS = [
 	"droid-settings-json",
 	"opencode-plugin",
 	"opencode-wrapper",
+	"pi-extension",
 	"cursor-hook-script",
 	"cursor-agent-wrapper",
 	"cursor-hooks-json",
@@ -65,6 +66,10 @@ export const DESKTOP_AGENT_SETUP_TARGETS = [
 		id: "opencode",
 		setupActions: ["opencode-plugin", "opencode-wrapper"],
 		managedBinary: true,
+	},
+	{
+		id: "pi",
+		setupActions: ["pi-extension"],
 	},
 	{
 		id: "cursor-agent",

--- a/apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts
+++ b/apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts
@@ -19,6 +19,7 @@ import {
 	createMastraWrapper,
 	createOpenCodePlugin,
 	createOpenCodeWrapper,
+	createPiExtension,
 } from "./agent-wrappers";
 import {
 	DESKTOP_AGENT_SETUP_BOOTSTRAP_ACTIONS,
@@ -40,6 +41,7 @@ const DESKTOP_AGENT_SETUP_RUNNERS: Record<DesktopAgentSetupAction, () => void> =
 		"droid-settings-json": createDroidSettingsJson,
 		"opencode-plugin": createOpenCodePlugin,
 		"opencode-wrapper": createOpenCodeWrapper,
+		"pi-extension": createPiExtension,
 		"cursor-hook-script": createCursorHookScript,
 		"cursor-agent-wrapper": createCursorAgentWrapper,
 		"cursor-hooks-json": createCursorHooksJson,

--- a/apps/desktop/src/main/lib/agent-setup/templates/pi-extension.template.ts
+++ b/apps/desktop/src/main/lib/agent-setup/templates/pi-extension.template.ts
@@ -1,0 +1,98 @@
+// {{MARKER}}
+/**
+ * Superset Notification Extension for pi
+ *
+ * Emits Claude-Code-compatible lifecycle hooks to Superset's notify.sh so
+ * the host UI gets a "working" indicator (and completion chime) for pi
+ * sessions, the same way it does for Claude Code, Codex, etc.
+ *
+ * Mapping:
+ *   pi `before_agent_start`  → Claude `UserPromptSubmit`  → Superset `Start`
+ *   pi `tool_execution_end`  → Claude `PostToolUse`       → progress signal
+ *   pi `agent_end`           → Claude `Stop`              → completion / chime
+ *   pi `session_shutdown`    → Claude `Stop`              → cleanup on quit/reload
+ *
+ * Activates only when running inside a Superset terminal (detected via
+ * SUPERSET_TERMINAL_ID / SUPERSET_TAB_ID / SUPERSET_PANE_ID). Outside
+ * Superset it's a complete no-op. If notify.sh is missing it's also a
+ * no-op (Superset uninstalled / never installed).
+ *
+ * Hook dispatch is fire-and-forget: failures to spawn or curl never
+ * affect the agent loop. notify.sh has its own connect/max timeouts.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export default function (pi: ExtensionAPI) {
+	// Only activate inside a Superset terminal. Both v2 (host-service) and
+	// v1 (electron localhost) shells set at least one of these.
+	const insideSuperset = Boolean(
+		process.env.SUPERSET_TERMINAL_ID ||
+			process.env.SUPERSET_TAB_ID ||
+			process.env.SUPERSET_PANE_ID,
+	);
+	if (!insideSuperset) return;
+
+	const supersetHome =
+		process.env.SUPERSET_HOME_DIR || join(homedir(), ".superset");
+	const notifyScript = join(supersetHome, "hooks", "notify.sh");
+	if (!existsSync(notifyScript)) return;
+
+	const fire = (eventName: string) => {
+		try {
+			const child = spawn(notifyScript, [], {
+				stdio: ["pipe", "ignore", "ignore"],
+				detached: true,
+				env: process.env,
+			});
+			child.on("error", () => {
+				/* swallow — never let hook failures affect pi */
+			});
+			child.stdin?.on("error", () => {
+				/* swallow — happens if notify.sh exits before we finish writing */
+			});
+			child.stdin?.end(JSON.stringify({ hook_event_name: eventName }));
+			child.unref();
+		} catch {
+			// spawn() can throw synchronously (EACCES, ENOENT). Stay silent.
+		}
+	};
+
+	// Gate every hook on ctx.hasUI: when this is explicitly false (print
+	// mode `-p`, JSON mode), pi is running as a subagent or non-interactive
+	// helper and should NOT drive Superset's working indicator. Interactive
+	// and RPC sessions (the user-facing ones) have hasUI=true.
+	//
+	// We deliberately check `=== false` rather than `!ctx.hasUI` so that pi
+	// versions older than 0.38.0 (where `hasUI` did not yet exist) still
+	// fire hooks. On those older versions subagent flicker is possible, but
+	// that's a niche regression; on >=0.38.0 the gate works precisely.
+	const skip = (ctx: { hasUI?: boolean }) => ctx.hasUI === false;
+
+	pi.on("before_agent_start", (_event, ctx) => {
+		if (skip(ctx)) return;
+		fire("UserPromptSubmit");
+	});
+
+	pi.on("tool_execution_end", (_event, ctx) => {
+		if (skip(ctx)) return;
+		fire("PostToolUse");
+	});
+
+	pi.on("agent_end", (_event, ctx) => {
+		if (skip(ctx)) return;
+		fire("Stop");
+	});
+
+	// Ensure we mark the agent as "stopped" if pi is killed mid-run, so the
+	// Superset working indicator doesn't get stuck on. Fires on Ctrl+C,
+	// SIGTERM, SIGHUP, /quit, /reload, /new, /resume, /fork.
+	pi.on("session_shutdown", (_event, ctx) => {
+		if (skip(ctx)) return;
+		fire("Stop");
+	});
+}

--- a/apps/desktop/src/main/lib/agent-setup/templates/pi-extension.template.ts
+++ b/apps/desktop/src/main/lib/agent-setup/templates/pi-extension.template.ts
@@ -1,4 +1,4 @@
-// {{MARKER}}
+{{MARKER}}
 /**
  * Superset Notification Extension for pi
  *

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -11,6 +11,7 @@
 			"!**/drizzle",
 			"!**/*.template.js",
 			"!**/*.template.sh",
+			"!**/*.template.ts",
 			"!**/plans",
 			"!apps/mobile/uniwind-types.d.ts",
 			"!packages/sdk/src"


### PR DESCRIPTION
Closes #4082.

Follow-up to #2562, which added pi as a built-in agent (preset, command, icon, settings UI, docs). This PR adds the corresponding notification-hook integration in `apps/desktop/src/main/lib/agent-setup/`, so pi participates in the same Start/Stop/PostToolUse lifecycle that drives Superset's working indicator and completion chime for claude, codex, gemini, cursor, copilot, opencode, mastra, amp, and droid.

## Mechanism

Ship a small TypeScript pi extension to the global pi extensions directory (`~/.pi/agent/extensions/superset-hooks.ts`). The extension subscribes to pi's lifecycle events and spawns `notify.sh` with Claude-Code-format `hook_event_name` JSON payloads, which the existing `notify.sh` dispatcher already speaks natively — no per-agent translator shim needed.

Install lifecycle: at desktop app launch, the new wrapper writes the extension using the standard `writeFileIfChanged` + signature-marker + version pattern. Pi's auto-discovery picks it up at the next session start. Install is unconditional on whether pi is installed — if pi is later installed via npm, hooks just start working.

## Event mapping

| pi lifecycle event       | emitted as            | Superset normalizes to    |
|---|---|---|
| `before_agent_start`     | `UserPromptSubmit`    | `Start`                   |
| `tool_execution_end`     | `PostToolUse`         | `PostToolUse` (progress)  |
| `agent_end`              | `Stop`                | `Stop`                    |
| `session_shutdown`       | `Stop`                | `Stop` (cleanup on Ctrl+C, SIGTERM, SIGHUP, /quit, /reload, /new, /resume, /fork) |

## Subagent filtering

Every event is gated on `ctx.hasUI === false`. Subagents spawned via the bundled `subagent` extension run via `pi --mode json -p` and have `hasUI: false`; user-facing interactive and RPC sessions have `hasUI: true`. The strict-equality check (rather than `!ctx.hasUI`) is intentional: pi versions older than 0.38.0 (where `hasUI` did not yet exist) still fire hooks correctly because `undefined !== false`. Subagent flicker is possible on those older versions only — documented limitation.

## Structural symmetry

Identical to the opencode integration:
- `agent-wrappers-pi.ts` — wrapper module exporting `createPiExtension`, `getPiExtensionPath`, `getPiExtensionContent`, `PI_EXTENSION_MARKER`
- `templates/pi-extension.template.ts` — the extension itself, with `// {{MARKER}}` placeholder substituted at install time
- `agent-wrappers.ts` — barrel re-export
- `desktop-agent-capabilities.ts` — adds `"pi-extension"` action and `{ id: "pi", setupActions: ["pi-extension"] }` target (no `managedBinary` — pi is user-installed via npm; cursor-agent is precedent)
- `desktop-agent-setup.ts` — runners map entry

No changes required to `notify.sh`, the v2 host-service tRPC endpoint, the renderer event bus, or the server-side `mapEventType`.

## Failure modes

All silent: notify.sh missing, spawn errors (EACCES/ENOENT), broken pipe, missing curl. Outside Superset (no `SUPERSET_TERMINAL_ID`/`SUPERSET_TAB_ID`/`SUPERSET_PANE_ID` set) the extension is a complete no-op.

## Pi version compatibility

Soft minimum (not enforced): pi 0.31.0 introduced `before_agent_start` and `session_shutdown`; 0.38.0 introduced `ctx.hasUI`; 0.52.10 introduced `tool_execution_end`; 0.67.3 made `session_shutdown` fire on SIGHUP/SIGTERM. Pi's `pi.on(eventName, handler)` is permissive — unknown event names silently never fire. Extension degrades gracefully on older versions.

## Tests

Three new `it()` blocks under `describe("agent-wrappers pi", ...)` in `agent-wrappers.test.ts`:
1. `getPiExtensionContent()` returns a string containing `PI_EXTENSION_MARKER` (cleanup recognition).
2. `getPiExtensionContent()` returns a string containing `export default function` (valid pi extension shape).
3. `createPiExtension()` writes to `~/.pi/agent/extensions/superset-hooks.ts` with marker present.

Local validation:
- `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` → 29 pass / 0 fail
- `bunx biome check apps/desktop/src/main/lib/agent-setup/ biome.jsonc` → clean
- `bun --filter='./apps/desktop' typecheck` → exit 0
- `bun run lint` (whole repo) → clean

End-to-end was smoke-tested against `notify.sh` during the design conversation: `SUPERSET_DEBUG_HOOKS=1 echo '{"hook_event_name":"UserPromptSubmit"}' | ~/.superset/hooks/notify.sh` returned HTTP 200 for all three managed event types (`UserPromptSubmit`, `PostToolUse`, `Stop`).

## Out of scope (flagged for visibility)

- **#3931** (`SUPERSET_HOST_AGENT_HOOK_URL` not set in v2 hook env) — affects all agents; will mask pi's improvements until fixed independently.
- **#3689** (`Stop` hook transitions pane to `idle` instead of `review`) — affects all agents; same disposition.
- **PermissionRequest** for pi — pi has no public `before_permission_request` lifecycle event; permission UI is in-process via `ctx.ui.confirm`. Reaching parity with Claude requires a new pi feature filed upstream at `badlogic/pi-mono`.
- **Subagent flicker on pi <0.38.0** — niche regression on a 5-week range of old pi releases.
- **Cleanup function** (`cleanupGlobalPiExtension`) — not needed in v1; no prior install location to migrate from.
- **User docs update** — `apps/docs/content/docs/agent-integration.mdx` already promises this works for "agents" generically and lists pi under Supported Agents. This PR makes that promise true; pi-specific copy under Notifications would be off-pattern.

---

Allowing edits from maintainers per `CONTRIBUTING.md`. Requesting review from @Kitenite (shipped #2562, has full pi context).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the `pi` desktop agent to Superset’s notification hooks so the working indicator and completion chime fire during runs. Installs a global `pi` extension that maps lifecycle events to `notify.sh`, addressing #4082.

- New Features
  - Installs `~/.pi/agent/extensions/superset-hooks.ts` at app launch (idempotent, version-marked).
  - Maps `pi` events to Claude-Code hooks sent to `notify.sh`: Start, `PostToolUse`, Stop.
  - Skips subagents via `ctx.hasUI === false`; no-op outside Superset or when `notify.sh` is missing; failures are silent.

- Bug Fixes
  - Removed a duplicate comment prefix in the extension template header so the installed file starts with a single marker line.

<sup>Written for commit 9ce69be586b96d603f1ffde2a7d7cd48c059dce6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Pi agent extension that triggers notifications for agent lifecycle events when running inside Superset terminal; installer runs during agent setup and is idempotent.

* **Tests**
  * Adds tests validating rendered extension content and that the installer writes the extension file with the expected marker and shape.

* **Chores**
  * Updated tooling config to include template file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->