### PR TITLE
release(cli): cut v0.2.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.1",
+      "version": "1.8.3",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",
@@ -677,7 +677,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.7";
+const VERSION = "0.2.8";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Two CLI changes since v0.2.7, both fixing remote-auth UX:

- **`superset auth login` works reliably on remote terminals (#4072)**: races the loopback callback and the paste prompt in parallel with a new Ink UI. Fixes login on remote machines where `SSH_CONNECTION` isn't set (tmux reattach, VS Code Remote, Codespaces, mosh). `c` copies the auth URL via OSC 52 (cross-device through SSH) with native `pbcopy` / `clip` / `wl-copy` / `xclip` / `xsel` fallback. Esc / Ctrl-C exit cleanly with `Login interrupted`.
- **Polish on the paste-code page + readline keybindings (#4075)**: rebuilt `/cli/auth/code` to match Claude Code's UI (single-line code box, ghost copy button that flips to "✓ Copied!", click-anywhere-on-the-box copy with selection-on-release fallback). Wired standard readline shortcuts in the CLI paste prompt: `option+backspace` / `ctrl+w` delete previous word; `cmd+backspace` / `ctrl+u` / `ctrl+k` clear the buffer. Plain backspace still deletes one char.

Push `cli-v0.2.8` after this lands to fire the release pipeline.

## Test plan

- [ ] Local TTY golden path: browser auto-opens, callback fires, paste prompt auto-cancels, `Authorized!` prints
- [ ] Remote ssh / tmux reattach without `SSH_CONNECTION`: paste path completes successfully
- [ ] `c` keybinding copies via OSC 52 over SSH; toast appears for 1.5s
- [ ] Esc cancellation: `Login interrupted` exit 0, no stack trace
- [ ] Paste prompt: `option+backspace` deletes a word, `ctrl+u` clears the buffer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.8. Improves remote auth reliability and polishes the paste-code flow for a smoother login on local and remote terminals.

- **Bug Fixes**
  - Remote login: race loopback callback and paste prompt with a new Ink UI; works without `SSH_CONNECTION` (tmux, VS Code Remote, Codespaces, mosh). `c` copies the auth URL via OSC 52 with native `pbcopy`/`clip`/`wl-copy`/`xclip`/`xsel` fallbacks. Esc/Ctrl-C exit cleanly with “Login interrupted”.
  - Paste-code UX: rebuilt `/cli/auth/code` (single-line code box, ghost copy that flips to “✓ Copied!”, click-to-copy with selection fallback). Added readline shortcuts in the CLI prompt: option+backspace/ctrl+w delete word; cmd+backspace/ctrl+u/ctrl+k clear; backspace deletes a char.

<sup>Written for commit 77a56e063c0857dc4e9e8e23f81138860b2aa5c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI package version from 0.2.7 to 0.2.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->