### PR TITLE
feat(desktop): re-add Settings to org dropdown for v1

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -6,6 +6,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
+	DropdownMenuShortcut,
 	DropdownMenuSub,
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
@@ -18,8 +19,10 @@ import {
 	HiCheck,
 	HiChevronUpDown,
 	HiOutlineArrowRightOnRectangle,
+	HiOutlineCog6Tooth,
 } from "react-icons/hi2";
 import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
+import { useHotkeyDisplay } from "renderer/hotkeys";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -33,6 +36,7 @@ export function OrganizationDropdown({
 	const collections = useCollections();
 	const signOutMutation = electronTrpc.auth.signOut.useMutation();
 	const navigate = useNavigate();
+	const settingsHotkey = useHotkeyDisplay("OPEN_SETTINGS").text;
 
 	const activeOrganizationId = session?.session?.activeOrganizationId;
 
@@ -131,6 +135,16 @@ export function OrganizationDropdown({
 				}
 			>
 				{/* Organization */}
+				{/* TODO(v1): Settings lives in the sidebar footer in v2; kept here for v1. Remove once v1 is gone. */}
+				<DropdownMenuItem
+					onSelect={() => navigate({ to: "/settings/account" })}
+				>
+					<HiOutlineCog6Tooth className="h-4 w-4" />
+					<span>Settings</span>
+					{settingsHotkey !== "Unassigned" && (
+						<DropdownMenuShortcut>{settingsHotkey}</DropdownMenuShortcut>
+					)}
+				</DropdownMenuItem>
 				<DropdownMenuItem
 					onSelect={() => navigate({ to: "/settings/organization" })}
 				>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -6,7 +6,6 @@ import {
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
-	DropdownMenuShortcut,
 	DropdownMenuSub,
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
@@ -21,8 +20,8 @@ import {
 	HiOutlineArrowRightOnRectangle,
 	HiOutlineCog6Tooth,
 } from "react-icons/hi2";
+import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
 import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
-import { useHotkeyDisplay } from "renderer/hotkeys";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -36,7 +35,6 @@ export function OrganizationDropdown({
 	const collections = useCollections();
 	const signOutMutation = electronTrpc.auth.signOut.useMutation();
 	const navigate = useNavigate();
-	const settingsHotkey = useHotkeyDisplay("OPEN_SETTINGS").text;
 
 	const activeOrganizationId = session?.session?.activeOrganizationId;
 
@@ -141,9 +139,7 @@ export function OrganizationDropdown({
 				>
 					<HiOutlineCog6Tooth className="h-4 w-4" />
 					<span>Settings</span>
-					{settingsHotkey !== "Unassigned" && (
-						<DropdownMenuShortcut>{settingsHotkey}</DropdownMenuShortcut>
-					)}
+					<HotkeyMenuShortcut hotkeyId="OPEN_SETTINGS" />
 				</DropdownMenuItem>
 				<DropdownMenuItem
 					onSelect={() => navigate({ to: "/settings/organization" })}


### PR DESCRIPTION
## Summary
- Re-adds the Settings entry to `OrganizationDropdown` so v1 users can reach `/settings/account` from the org menu (it was removed when Settings moved to the v2 sidebar footer).
- Marked with a `TODO(v1)` comment so it can be removed once v1 is gone.
- Because the dropdown is shared, the item now shows in both places it's mounted: the topbar (`TopBar`) and the sidebar header (`DashboardSidebarHeader`, collapsed + expanded).

## Test plan
- [ ] In v1 mode, open the topbar org dropdown — Settings appears with the `OPEN_SETTINGS` hotkey shortcut and navigates to `/settings/account`.
- [ ] In v1 mode, open the sidebar header org dropdown (both collapsed and expanded) — Settings appears in the same spot.
- [ ] Verify hotkey shortcut renders only when assigned.
- [ ] `bun run typecheck` and `bun run lint` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-added a Settings item to the organization dropdown so v1 users can open `/settings/account` from the menu again. It appears in both the topbar and sidebar header dropdowns, shows the `OPEN_SETTINGS` shortcut via `HotkeyMenuShortcut`, and is tagged `TODO(v1)` for removal after v1.

<sup>Written for commit c30e64611cede1f289426bfcac2f0275994b48f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings entry to the organization dropdown menu, including a gear icon and an optional keyboard shortcut indicator for quicker access to account settings and improved navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->