### PR TITLE
fix(desktop): redesign v2 workspace create error state

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -4,19 +4,7 @@ Please use alias as defined in `tsconfig.json` when possible
 
 ## Error text must be selectable
 
-The renderer globally disables text selection (`globals.css` sets `user-select: none` on `body`), so any text the user might want to copy needs an explicit `select-text` (and usually `cursor-text`) class. **Always make user-facing error messages selectable** — error strings, stack traces, failure reasons, exception bodies — so users can paste them into bug reports or search them.
-
-```tsx
-// CORRECT: error text the user can copy
-<p className="select-text cursor-text font-mono text-xs text-destructive">
-  {error.message}
-</p>
-
-// WRONG: silently un-selectable due to body { user-select: none }
-<p className="font-mono text-xs text-destructive">{error.message}</p>
-```
-
-This applies to error overlays, error pages, error banners, failure states, and any rendered exception detail. Toast bodies are an exception — Sonner manages its own selection rules.
+The renderer sets `user-select: none` on `body`, so rendered errors need explicit `select-text cursor-text` classes — otherwise users can't copy them into bug reports. (Sonner toasts are exempt; they manage selection themselves.)
 
 ## tRPC Subscriptions (trpc-electron)
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -2,6 +2,22 @@
 For Electron interprocess communication, ALWAYS use trpc as defined in `src/lib/trpc`
 Please use alias as defined in `tsconfig.json` when possible
 
+## Error text must be selectable
+
+The renderer globally disables text selection (`globals.css` sets `user-select: none` on `body`), so any text the user might want to copy needs an explicit `select-text` (and usually `cursor-text`) class. **Always make user-facing error messages selectable** — error strings, stack traces, failure reasons, exception bodies — so users can paste them into bug reports or search them.
+
+```tsx
+// CORRECT: error text the user can copy
+<p className="select-text cursor-text font-mono text-xs text-destructive">
+  {error.message}
+</p>
+
+// WRONG: silently un-selectable due to body { user-select: none }
+<p className="font-mono text-xs text-destructive">{error.message}</p>
+```
+
+This applies to error overlays, error pages, error banners, failure states, and any rendered exception detail. Toast bodies are an exception — Sonner manages its own selection rules.
+
 ## tRPC Subscriptions (trpc-electron)
 
 **Important:** While standard tRPC recommends async generators for subscriptions, `trpc-electron` (used for Electron IPC) **only supports observables**. The library explicitly checks `isObservable(result)` and throws an error otherwise. Use the `observable` pattern:

--- a/apps/desktop/src/renderer/components/BootErrorBoundary/BootErrorBoundary.tsx
+++ b/apps/desktop/src/renderer/components/BootErrorBoundary/BootErrorBoundary.tsx
@@ -45,13 +45,34 @@ export class BootErrorBoundary extends Component<
 					textAlign: "center",
 				}}
 			>
-				<div style={{ maxWidth: "520px" }}>
+				<div style={{ maxWidth: "520px", userSelect: "text" }}>
 					<h1 style={{ fontSize: "18px", marginBottom: "8px" }}>
 						Superset failed to start
 					</h1>
 					<p style={{ fontSize: "14px", opacity: 0.8 }}>
 						The renderer crashed during startup. Please check logs for details.
 					</p>
+					{this.state.error?.message && (
+						<pre
+							style={{
+								marginTop: "12px",
+								padding: "10px 12px",
+								fontSize: "12px",
+								fontFamily:
+									"ui-monospace, SFMono-Regular, Menlo, Monaco, monospace",
+								background: "#1a1a1a",
+								border: "1px solid #2a2a2a",
+								borderRadius: "6px",
+								color: "#f87171",
+								textAlign: "left",
+								whiteSpace: "pre-wrap",
+								wordBreak: "break-word",
+								cursor: "text",
+							}}
+						>
+							{this.state.error.message}
+						</pre>
+					)}
 
 					<button
 						type="button"

--- a/apps/desktop/src/renderer/components/BootErrorBoundary/BootErrorBoundary.tsx
+++ b/apps/desktop/src/renderer/components/BootErrorBoundary/BootErrorBoundary.tsx
@@ -45,7 +45,7 @@ export class BootErrorBoundary extends Component<
 					textAlign: "center",
 				}}
 			>
-				<div style={{ maxWidth: "520px", userSelect: "text" }}>
+				<div className="select-text" style={{ maxWidth: "520px" }}>
 					<h1 style={{ fontSize: "18px", marginBottom: "8px" }}>
 						Superset failed to start
 					</h1>
@@ -54,6 +54,7 @@ export class BootErrorBoundary extends Component<
 					</p>
 					{this.state.error?.message && (
 						<pre
+							className="select-text cursor-text"
 							style={{
 								marginTop: "12px",
 								padding: "10px 12px",
@@ -67,7 +68,6 @@ export class BootErrorBoundary extends Component<
 								textAlign: "left",
 								whiteSpace: "pre-wrap",
 								wordBreak: "break-word",
-								cursor: "text",
 							}}
 						>
 							{this.state.error.message}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserErrorOverlay/BrowserErrorOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserErrorOverlay/BrowserErrorOverlay.tsx
@@ -88,7 +88,7 @@ export function BrowserErrorOverlay({
 				</div>
 				{showDetails && (
 					<div className="flex items-center gap-2 w-full rounded-md border border-muted-foreground/20 px-3 py-2">
-						<span className="flex-1 text-sm text-muted-foreground/50 truncate">
+						<span className="flex-1 text-sm text-muted-foreground/50 truncate select-text cursor-text">
 							{detailsText}
 						</span>
 						<button

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/ErrorState/ErrorState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/ErrorState/ErrorState.tsx
@@ -30,7 +30,9 @@ export function ErrorState({
 }: ErrorStateProps) {
 	return (
 		<div className="flex h-full w-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
-			<span>{message ?? MESSAGES[reason]}</span>
+			<span className="select-text cursor-text">
+				{message ?? MESSAGES[reason]}
+			</span>
 			{reason === "too-large" && onOpenAnyway && (
 				<Button variant="outline" size="sm" onClick={onOpenAnyway}>
 					Open anyway

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/SaveErrorBanner/SaveErrorBanner.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/SaveErrorBanner/SaveErrorBanner.tsx
@@ -11,7 +11,9 @@ export function SaveErrorBanner({
 }: SaveErrorBannerProps) {
 	return (
 		<div className="flex items-center gap-2 border-b border-border bg-destructive/10 px-3 py-1.5 text-xs text-destructive-foreground">
-			<span className="flex-1 truncate">Save failed: {message}</span>
+			<span className="flex-1 truncate select-text cursor-text">
+				Save failed: {message}
+			</span>
 			{onRetry && (
 				<button
 					type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreateErrorState/WorkspaceCreateErrorState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreateErrorState/WorkspaceCreateErrorState.tsx
@@ -26,7 +26,11 @@ export function WorkspaceCreateErrorState({
 
 	return (
 		<div className="flex h-full w-full items-center justify-center p-6">
-			<div className="flex w-full max-w-sm flex-col items-start gap-5">
+			<div
+				role="alert"
+				aria-live="assertive"
+				className="flex w-full max-w-sm flex-col items-start gap-5"
+			>
 				<AlertCircle
 					className="size-5 text-destructive"
 					strokeWidth={1.5}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreateErrorState/WorkspaceCreateErrorState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreateErrorState/WorkspaceCreateErrorState.tsx
@@ -56,7 +56,7 @@ export function WorkspaceCreateErrorState({
 				)}
 
 				<div className="w-full rounded-md border border-destructive/20 bg-destructive/[0.04] px-3 py-2.5">
-					<p className="font-mono text-[11px] leading-relaxed text-destructive/90 break-words whitespace-pre-wrap">
+					<p className="select-text font-mono text-[11px] leading-relaxed text-destructive/90 break-words whitespace-pre-wrap cursor-text">
 						{error}
 					</p>
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreateErrorState/WorkspaceCreateErrorState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreateErrorState/WorkspaceCreateErrorState.tsx
@@ -1,17 +1,19 @@
 import { Button } from "@superset/ui/button";
 import { useNavigate } from "@tanstack/react-router";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, GitBranch } from "lucide-react";
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 
 interface WorkspaceCreateErrorStateProps {
 	workspaceId: string;
 	name?: string;
+	branch?: string;
 	error: string;
 }
 
 export function WorkspaceCreateErrorState({
 	workspaceId,
 	name,
+	branch,
 	error,
 }: WorkspaceCreateErrorStateProps) {
 	const navigate = useNavigate();
@@ -24,20 +26,46 @@ export function WorkspaceCreateErrorState({
 
 	return (
 		<div className="flex h-full w-full items-center justify-center p-6">
-			<div className="flex w-full max-w-md flex-col items-center rounded-xl border border-border bg-card px-6 py-8 text-center">
-				<div className="mb-4 rounded-full border border-destructive/30 bg-destructive/10 p-3 text-destructive">
-					<AlertCircle className="size-5" />
+			<div className="flex w-full max-w-sm flex-col items-start gap-5">
+				<AlertCircle
+					className="size-5 text-destructive"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Couldn't create workspace
+					</h1>
+					<p className="truncate text-[13px] leading-relaxed text-muted-foreground">
+						{name || "Untitled workspace"}
+					</p>
 				</div>
-				<h1 className="text-lg font-semibold tracking-tight">
-					Failed to create workspace
-				</h1>
-				{name && <p className="mt-2 text-sm text-muted-foreground">{name}</p>}
-				<p className="mt-3 text-xs text-destructive/90 break-words">{error}</p>
-				<div className="mt-6 flex items-center gap-2">
+
+				{branch && (
+					<div className="flex w-full items-center gap-2">
+						<GitBranch
+							className="size-3 shrink-0 text-muted-foreground/80"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+						<code className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+							{branch}
+						</code>
+					</div>
+				)}
+
+				<div className="w-full rounded-md border border-destructive/20 bg-destructive/[0.04] px-3 py-2.5">
+					<p className="font-mono text-[11px] leading-relaxed text-destructive/90 break-words whitespace-pre-wrap">
+						{error}
+					</p>
+				</div>
+
+				<div className="flex items-center gap-2">
 					<Button size="sm" onClick={() => void retry(workspaceId)}>
-						Retry
+						Try again
 					</Button>
-					<Button size="sm" variant="outline" onClick={handleDismiss}>
+					<Button size="sm" variant="ghost" onClick={handleDismiss}>
 						Dismiss
 					</Button>
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -67,6 +67,7 @@ function V2WorkspaceLayout() {
 				<WorkspaceCreateErrorState
 					workspaceId={workspaceId}
 					name={inFlight.snapshot.name}
+					branch={inFlight.snapshot.branch}
 					error={inFlight.error ?? "Unknown error"}
 				/>
 			);

--- a/apps/desktop/src/renderer/screens/main/components/StartView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/StartView/index.tsx
@@ -198,7 +198,9 @@ export function StartView() {
 
 					{error && !isDragOver && (
 						<div className="mt-5 w-full flex items-start gap-2 rounded-md px-4 py-3 bg-destructive/10 border border-destructive/20">
-							<span className="flex-1 text-sm text-destructive">{error}</span>
+							<span className="flex-1 text-sm text-destructive select-text cursor-text">
+								{error}
+							</span>
 							<button
 								type="button"
 								onClick={() => setError(null)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserErrorOverlay/BrowserErrorOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserErrorOverlay/BrowserErrorOverlay.tsx
@@ -88,7 +88,7 @@ export function BrowserErrorOverlay({
 				</div>
 				{showDetails && (
 					<div className="flex items-center gap-2 w-full rounded-md border border-muted-foreground/20 px-3 py-2">
-						<span className="flex-1 text-sm text-muted-foreground/50 truncate">
+						<span className="flex-1 text-sm text-muted-foreground/50 truncate select-text cursor-text">
 							{detailsText}
 						</span>
 						<button


### PR DESCRIPTION
## Summary
- Redesign `WorkspaceCreateErrorState` to mirror the Linear-style `WorkspaceCreatingState`: flat layout (no card), `max-w-sm`, left-aligned, matching icon size/stroke and typography hierarchy.
- Show the git branch row when available, identical to the creating screen.
- Render the error message in a subtle bordered/tinted block with monospace and preserved line breaks.
- Primary "Try again" + ghost "Dismiss" actions.
- Pass `branch` through from `layout.tsx`.

## Test plan
- [ ] Trigger a v2 workspace create failure and confirm the new layout matches the creating screen visually
- [ ] Confirm branch displays when present and is hidden otherwise
- [ ] Retry button reattempts the create; Dismiss returns to /v2-workspaces

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the v2 workspace create error screen to match the creating screen. Made user-facing error text selectable across the app and announced the failed-create state to assistive tech; documented the selection rule in `apps/desktop/AGENTS.md`.

- **Refactors**
  - Flat, left-aligned layout at `max-w-sm` with matching icon size/stroke and typography.
  - Shows branch row when present; passes `branch` through from `layout.tsx`.
  - Error rendered in a selectable, subtle bordered/tinted monospace block with preserved line breaks.
  - Primary “Try again” and ghost “Dismiss” actions.
  - Announces the error screen via `role="alert"` + `aria-live="assertive"`.
  - Defaults name to “Untitled workspace” when missing.

<sup>Written for commit cfbd44ee1ea2a39ff052c6e771779517df679b76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git branch info now shown in workspace creation error states when available
  * Workspace name defaults to "Untitled workspace" when missing

* **Style**
  * Redesigned workspace error layout with left-aligned stacked typography
  * Primary button label changed to "Try again"; dismiss button uses a ghost style

* **Bug Fixes**
  * Error and details text across multiple error screens are now selectable and preserve formatting

* **Documentation**
  * Guidance added about ensuring error text is selectable in the renderer UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->