### PR TITLE
fix(mcp-v2): don't claim relay-tunnel disconnects mean toggle is off

### DIFF
--- a/packages/mcp-v2/src/host-service-client.ts
+++ b/packages/mcp-v2/src/host-service-client.ts
@@ -95,7 +95,7 @@ function describeRelayFailure(
 ): string {
 	const trimmed = rawBody.slice(0, 200);
 	if (status === 503 && /host not connected/i.test(trimmed)) {
-		return `Host ${hostId} has not enabled remote access. Toggle "Allow remote workspaces to access this device" in Settings → Security on that machine.`;
+		return `Host ${hostId} relay tunnel is not connected.`;
 	}
 	if (status === 401) return "You are not authenticated";
 	if (status === 403) return `You don't have access to host ${hostId}`;


### PR DESCRIPTION
## Summary
- The relay returns `503 {"error":"Host not connected"}` whenever `tunnelManager.hasTunnel(hostId)` is false (apps/relay/src/index.ts:55-56). That fires for several distinct conditions: toggle off, desktop app closed, WebSocket dropped mid-session, tunnel auth failed during WS upgrade, or tunnel not yet established.
- `describeRelayFailure` in packages/mcp-v2/src/host-service-client.ts named only the toggle case and pushed a remediation step that's wrong in the other scenarios.
- Replaces the message with a terse statement of fact (`Host <id> relay tunnel is not connected.`) matching the surrounding `'You are not authenticated'` / `Host ${hostId} not found` style.

Skipped the optional relay-side enrichment (`{ error: 'host_not_connected', reason: ... }`) — it's a non-trivial cross-package change, would need new types, and wasn't required for the fix. Leaving for a follow-up if we want to surface the actual disconnect reason.

## Test plan
- [x] `bun run lint:fix` clean
- [x] `bun run typecheck` clean
- [x] Verified no other consumers in the repo key on the old string (the toggle UI label in apps/desktop SecuritySettings is a separate independent string)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix inaccurate error text for relay 503 "Host not connected" responses. Now shows "Host <id> relay tunnel is not connected." instead of telling users to enable remote access, which was wrong for cases like app closed, dropped WS, auth failure, or a not-yet-established tunnel.

<sup>Written for commit b6a7b6fa4c4e5f6d262a789af34ab46f82b01687. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for host connection failures to provide clearer feedback when a host becomes unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->