### PR TITLE
feat(plugin): add superset Claude Code plugin + marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+	"name": "superset",
+	"owner": {
+		"name": "Superset",
+		"url": "https://superset.sh"
+	},
+	"plugins": [
+		{
+			"name": "superset",
+			"source": "./plugins/superset",
+			"description": "Drive Superset from Claude Code — named slash commands for spawning agents in workspaces, managing tasks, and editing automation prompts. Bundles the superset SKILL.md and wires the official Superset MCP server."
+		}
+	]
+}

--- a/plugins/superset/.claude-plugin/plugin.json
+++ b/plugins/superset/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+	"name": "superset",
+	"version": "0.1.0",
+	"description": "Drive Superset from Claude Code — named slash commands for spawning agents in workspaces, managing tasks, and editing automation prompts. Bundles the superset SKILL.md and wires the official Superset MCP server.",
+	"author": {
+		"name": "Superset",
+		"url": "https://superset.sh"
+	},
+	"homepage": "https://docs.superset.sh",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/superset-sh/superset"
+	},
+	"license": "MIT",
+	"keywords": [
+		"superset",
+		"agents",
+		"workspaces",
+		"automations",
+		"orchestration"
+	]
+}

--- a/plugins/superset/commands/superset-automation-edit.md
+++ b/plugins/superset/commands/superset-automation-edit.md
@@ -1,0 +1,35 @@
+---
+description: Round-trip edit a Superset automation's prompt body via $EDITOR.
+argument-hint: <automation-id-or-slug>
+allowed-tools: Bash(superset:*), Bash(mktemp:*), Bash(${EDITOR}:*), Bash(${VISUAL}:*), Bash(vi:*), Bash(vim:*), Bash(nano:*)
+---
+
+Edit a Superset automation prompt in place using the CLI's byte-exact `prompt get | prompt set` round-trip.
+
+This command requires the CLI — there's no terminal-editor flow over MCP. If `superset` isn't on PATH, tell the user to install it: `curl -fsSL https://superset.sh/cli/install.sh | sh`.
+
+## Steps
+
+1. Resolve the automation id from `$ARGUMENTS`. If empty, ask the user.
+2. Pull the current prompt to a tempfile, open the user's editor, then push it back:
+
+```bash
+ID="$ARGUMENTS"
+TMP=$(mktemp -t superset-prompt.XXXXXX.md)
+superset automations prompt get "$ID" > "$TMP"
+${EDITOR:-${VISUAL:-vi}} "$TMP"
+
+# Skip the upload if the user quit without saving
+if [ ! -s "$TMP" ]; then
+  echo "Empty prompt — refusing to write."
+  rm -f "$TMP"
+  exit 1
+fi
+
+superset automations prompt set "$ID" --from-file "$TMP"
+rm -f "$TMP"
+```
+
+3. Confirm the new length. The user can open the automation in Superset to verify.
+
+The CLI refuses to write an empty prompt server-side as well, so the safety check above is belt-and-suspenders.

--- a/plugins/superset/commands/superset-spawn.md
+++ b/plugins/superset/commands/superset-spawn.md
@@ -1,0 +1,48 @@
+---
+description: Create a Superset workspace and spawn an agent inside it in one go.
+argument-hint: [optional one-line agent prompt]
+allowed-tools: Bash(superset:*), Bash(command:*), Bash(jq:*), mcp__superset__projects_list, mcp__superset__hosts_list, mcp__superset__workspaces_create, AskUserQuestion
+---
+
+You are creating a Superset workspace and spawning an agent in it.
+
+## Pick the transport
+
+1. Run `command -v superset >/dev/null 2>&1 && echo cli || echo mcp`. If `cli`, use the CLI path. Otherwise use the MCP path.
+
+## Gather inputs
+
+Collect these four values. Use `$ARGUMENTS` as the agent prompt if non-empty; otherwise ask the user for a prompt at the end.
+
+- **project** — call `superset projects list --json` (or `mcp__superset__projects_list`). If exactly one matches the user's current repo by `repoCloneUrl`, pick it silently. Otherwise show the list and ask which one.
+- **host** — call `superset hosts list --json` (or `mcp__superset__hosts_list`). Filter to `online: yes/true`. If only one online host, pick it. Otherwise ask.
+- **branch** — ask the user. Default suggestion: a kebab-case slug of the prompt (e.g. "fix login bug" → `fix-login-bug`). If the user wants a PR, accept `--pr <number>` instead.
+- **agent preset** — default `claude`. Only ask if the user gives a hint they want something else (e.g. mentions "codex").
+
+Use `AskUserQuestion` for any of these that need confirmation. Batch into one prompt if multiple are needed.
+
+## Create + spawn
+
+**CLI path:**
+```bash
+WS=$(superset workspaces create \
+  --project <projectId> --host <hostId> \
+  --name "<short name from prompt>" --branch <branch> --json | jq -r .id)
+superset agents run --workspace "$WS" --agent <preset> --prompt "<full prompt>"
+```
+
+**MCP path** (single call — `workspaces_create` accepts an `agents` array that spawns the agent immediately after the worktree is materialized):
+```
+mcp__superset__workspaces_create with {
+  projectId, hostId, name, branch,
+  agents: [{ agent: "<preset>", prompt: "<full prompt>" }]
+}
+```
+
+Prefer the MCP path when both are available — it's a single round trip and avoids the `--json | jq` dance.
+
+## Report
+
+Print the workspace ID and the agent session id. The user can open the workspace in Superset to monitor it.
+
+If creation failed because the host hasn't enabled remote workspace access, tell the user to toggle "Allow remote workspaces to access this device" in Settings → Security on that machine and retry.

--- a/plugins/superset/commands/superset-tasks.md
+++ b/plugins/superset/commands/superset-tasks.md
@@ -1,0 +1,37 @@
+---
+description: List or create Superset tasks without leaving Claude Code.
+argument-hint: [list | new <title>]
+allowed-tools: Bash(superset:*), Bash(command:*), Bash(jq:*), Bash(column:*), mcp__superset__tasks_list, mcp__superset__tasks_create, AskUserQuestion
+---
+
+Manage Superset tasks. Inspect `$ARGUMENTS`:
+
+- `list` (or empty) — show recent tasks.
+- `new <title>` — create a new task with that title.
+
+## Pick the transport
+
+Run `command -v superset >/dev/null 2>&1 && echo cli || echo mcp`. Use the CLI when present, fall back to MCP.
+
+## List
+
+**CLI:**
+```bash
+superset tasks list --json | jq -r '.[] | "\(.slug)\t\(.priority // "—")\t\(.title)"' | column -t -s$'\t'
+```
+Render the result as a table. If the user passed filter words after `list` (e.g. `list urgent`), map them to `--priority`/`--assignee-me`/`--search` as appropriate.
+
+**MCP:** call `mcp__superset__tasks_list` and render the same columns.
+
+## Create
+
+Take the title from `$ARGUMENTS` (everything after `new`). If empty, use `AskUserQuestion` to ask. Optionally ask for priority (urgent/high/medium/low/none) — default `none`.
+
+**CLI:**
+```bash
+superset tasks create --title "<title>" [--priority <level>] --json
+```
+
+**MCP:** call `mcp__superset__tasks_create` with `{ title, priority }`.
+
+Print the slug. The user can open the task in Superset to view details.

--- a/plugins/superset/skills/superset
+++ b/plugins/superset/skills/superset
@@ -1,0 +1,1 @@
+../../../skills/superset

--- a/skills/superset/SKILL.md
+++ b/skills/superset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superset
-description: Enables orchestration of coding agents across devices, including the creation of isolated workspaces, planning work in tasks, and more.
+description: Drives the Superset CLI to orchestrate coding agents across devices. Use when the user wants to spawn an agent, create or manage workspaces, schedule automations, or interact with Superset projects, hosts, or tasks from the terminal.
 allowed-tools: Bash(superset:*)
 ---
 


### PR DESCRIPTION
## Summary

- Turns this repo into a [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) by adding `.claude-plugin/marketplace.json` at the root
- Adds a `superset` plugin at `plugins/superset/` with three named slash commands (`/superset-spawn`, `/superset-tasks`, `/superset-automation-edit`), an auto-wired MCP server, and the existing `skills/superset/SKILL.md` symlinked in as the bundled skill
- Sharpens the SKILL.md description into a stronger routing rule so agents match it on "spawn an agent" / "create a workspace" intents

## Why

The skill at `skills/superset/SKILL.md` (shipped in #4098) is passive context — it teaches *any* agent about the Superset CLI but doesn't add invocable commands. This plugin gives Claude Code users named entry points (`/superset-spawn ...`) for the high-frequency flows, plus the MCP wired in by default so the commands work even when the CLI isn't installed.

The skill remains the cross-agent procedural surface (Cursor, Codex, Cline, etc., via `npx skills add superset-sh/superset`). The plugin is the Claude-Code-only richer version. Both reference the same SKILL.md file via a symlink — single source of truth, no drift.

## How users install

```bash
# In Claude Code:
/plugin marketplace add superset-sh/superset
/plugin install superset@superset
```

After install:
- `/superset-spawn fix the auth bug` → creates a workspace and runs an agent in one shot
- `/superset-tasks list` → renders tasks; `/superset-tasks new "<title>"` creates one
- `/superset-automation-edit <id>` → opens the automation prompt in `\$EDITOR`, saves on close

## Layout

```
.claude-plugin/marketplace.json          # marketplace catalog
plugins/superset/
├── .claude-plugin/plugin.json           # plugin manifest
├── .mcp.json                            # superset MCP at api.superset.sh/api/v2/agent/mcp
├── commands/
│   ├── superset-spawn.md
│   ├── superset-tasks.md
│   └── superset-automation-edit.md
└── skills/superset → ../../../skills/superset    # symlink to the marketplace SKILL.md
```

## Test plan

- [x] `bun run lint` exits 0
- [x] `bun run typecheck` exits 0
- [x] `plugin-validator` agent reports 0 critical / 0 warnings
- [x] Plugin tree validates: manifest valid, commands have correct frontmatter (`description`, `argument-hint`, `allowed-tools`), `.mcp.json` shape correct, skill symlink resolves
- [ ] After merge: `claude` → `/plugin marketplace add superset-sh/superset` → `/plugin install superset@superset` → run each of the three commands end-to-end against a real Superset workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Superset Claude Code plugin and a local marketplace so users can spawn agents, manage tasks, and edit automations from Claude Code, even without the CLI. Provides named slash commands and auto-wires the Superset MCP server for zero-setup usage.

- **New Features**
  - Adds `.claude-plugin/marketplace.json` to expose a marketplace with one plugin, `superset`.
  - Introduces three slash commands: `/superset-spawn`, `/superset-tasks`, `/superset-automation-edit`.
  - Auto-configures the official Superset MCP server (`api.superset.sh/api/v2/agent/mcp`) so commands work without the CLI; falls back to CLI when present.
  - Bundles the existing skill via symlink to `skills/superset/SKILL.md` and sharpens its description to better route “spawn agent”, workspace, task, and automation intents.

<sup>Written for commit 97c139cb8664c026d66fe0ca2cc99101be699d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Superset plugin now available, enabling orchestration of workspaces and agents
  * Added commands to edit automation prompts in place, spawn agents within workspaces, and manage tasks
  * Updated Superset skill documentation to reflect enhanced capabilities for project and task interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->