### PR TITLE
fix(host-service): time out AI workspace naming after 5s

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-branch-name.ts
@@ -6,6 +6,7 @@ const BRANCH_NAME_INSTRUCTIONS =
 	"Generate a concise git branch name (2-4 words, kebab-case, descriptive, 20 characters or less). Return ONLY the branch name, nothing else.";
 
 const MAX_BRANCH_LENGTH = 100;
+const GENERATE_TIMEOUT_MS = 5_000;
 
 /**
  * Light sanitizer for AI-generated branch names — lowercase, kebab-case,
@@ -35,14 +36,22 @@ export async function generateBranchNameFromPrompt(
 
 	let generated: string | null;
 	try {
-		generated = await generateTitleFromMessage({
-			message: prompt,
-			agentModel: model,
-			agentId: "branch-namer",
-			agentName: "Branch Namer",
-			instructions: BRANCH_NAME_INSTRUCTIONS,
-			tracingContext: { surface: "host-service-branch-name" },
-		});
+		generated = await Promise.race([
+			generateTitleFromMessage({
+				message: prompt,
+				agentModel: model,
+				agentId: "branch-namer",
+				agentName: "Branch Namer",
+				instructions: BRANCH_NAME_INSTRUCTIONS,
+				tracingContext: { surface: "host-service-branch-name" },
+			}),
+			new Promise<never>((_, reject) =>
+				setTimeout(
+					() => reject(new Error(`timed out after ${GENERATE_TIMEOUT_MS}ms`)),
+					GENERATE_TIMEOUT_MS,
+				),
+			),
+		]);
 	} catch (error) {
 		console.warn("[generateBranchNameFromPrompt] generation failed:", error);
 		return null;

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
@@ -9,6 +9,7 @@ import { deduplicateBranchName } from "./sanitize-branch";
 
 const WORKSPACE_TITLE_MAX = 150;
 const BRANCH_NAME_MAX = 25;
+const GENERATE_TIMEOUT_MS = 5_000;
 
 function sanitizeBranchCandidate(raw: string): string {
 	return raw
@@ -81,12 +82,20 @@ export async function generateWorkspaceNamesFromPrompt(
 	});
 
 	try {
-		const { object } = await agent.generate(cleaned, {
-			structuredOutput: {
-				schema: workspaceNamesSchema,
-				jsonPromptInjection: true,
-			},
-		});
+		const { object } = await Promise.race([
+			agent.generate(cleaned, {
+				structuredOutput: {
+					schema: workspaceNamesSchema,
+					jsonPromptInjection: true,
+				},
+			}),
+			new Promise<never>((_, reject) =>
+				setTimeout(
+					() => reject(new Error(`timed out after ${GENERATE_TIMEOUT_MS}ms`)),
+					GENERATE_TIMEOUT_MS,
+				),
+			),
+		]);
 		return object;
 	} catch (error) {
 		console.warn(


### PR DESCRIPTION
## Summary
- mastra `agent.generate` had no timeout — a hang in the small model call (e.g. provider stall) would block `workspaces.create` indefinitely with no fallback.
- Wrap `generateWorkspaceNamesFromPrompt` and `generateBranchNameFromPrompt` with a 5s `Promise.race`. On timeout the existing `catch` returns `null`, which the create flow already handles by falling back to `generateFriendlyBranchName()` (and the branch as title).
- PR-create path is unaffected — it never calls AI naming (uses GitHub PR title + derived branch).

## Test plan
- [ ] Force a hang in the small model (e.g. invalid creds / network blackhole) and confirm `workspaces.create` completes within ~5s using a friendly random branch name.
- [ ] Normal happy path still produces an AI title + branch.
- [ ] PR create still uses the PR title.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `workspaces.create` from hanging by timing out workspace and branch name generation after 5s in `host-service`.

- **Bug Fixes**
  - Wrap `generateWorkspaceNamesFromPrompt` and `generateBranchNameFromPrompt` in a 5s `Promise.race` (`GENERATE_TIMEOUT_MS`).
  - On timeout or error, return `null` to trigger the existing fallback (`generateFriendlyBranchName()` and use the branch as the title).
  - PR creation path is unchanged; it uses the GitHub PR title.

<sup>Written for commit 337fd2d42a2bc87fddc27de1b6a4f5659c0adc57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AI-powered name generation for branches and workspaces by adding timeout protection to prevent operations from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->