### PR TITLE
fix(host-service): refresh stale auth token on remote workspace ops

### DIFF
--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -19,6 +19,7 @@ import {
 	resolveTerminalBaseEnv,
 } from "@superset/host-service/terminal-env";
 import { connectRelay } from "@superset/host-service/tunnel";
+import { loadToken } from "lib/trpc/routers/auth/utils/auth-functions";
 import { writeManifest } from "main/lib/host-service-manifest";
 import { env } from "./env";
 
@@ -26,10 +27,17 @@ async function main(): Promise<void> {
 	const terminalBaseEnv = await resolveTerminalBaseEnv();
 	initTerminalBaseEnv(terminalBaseEnv);
 
-	const authProvider = new JwtApiAuthProvider(
-		env.AUTH_TOKEN,
-		env.SUPERSET_API_URL,
-	);
+	const authProvider = new JwtApiAuthProvider({
+		// Read fresh from disk every time we need to mint a new JWT, so that
+		// re-logins in the desktop renderer (which rewrites auth-token.enc)
+		// are picked up without restarting the host-service child. Falls back
+		// to the boot-time token if the file is missing for any reason.
+		getSessionToken: async () => {
+			const { token } = await loadToken();
+			return token ?? env.AUTH_TOKEN;
+		},
+		apiUrl: env.SUPERSET_API_URL,
+	});
 
 	const { app, injectWebSocket, api } = createApp({
 		config: {

--- a/packages/host-service/src/api/createApiClient/createApiClient.ts
+++ b/packages/host-service/src/api/createApiClient/createApiClient.ts
@@ -1,8 +1,54 @@
 import type { AppRouter } from "@superset/trpc";
-import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import { createTRPCClient, httpBatchLink, type TRPCLink } from "@trpc/client";
+import { observable } from "@trpc/server/observable";
 import SuperJSON from "superjson";
 import type { ApiAuthProvider } from "../../providers/auth";
 import type { ApiClient } from "../../types";
+
+function isUnauthorizedError(err: unknown): boolean {
+	if (!err || typeof err !== "object") return false;
+	const e = err as { data?: { code?: string; httpStatus?: number } };
+	return e.data?.code === "UNAUTHORIZED" || e.data?.httpStatus === 401;
+}
+
+/**
+ * One-shot retry on UNAUTHORIZED. The provider's cached JWT can outlive its
+ * actual validity (clock skew, JWKS rotation, session revoked mid-flight) —
+ * dropping the cache and retrying once recovers without bubbling 401 back
+ * up to user-facing flows like "register host".
+ */
+function retryOnUnauthorizedLink(
+	authProvider: ApiAuthProvider,
+): TRPCLink<AppRouter> {
+	return () =>
+		({ op, next }) =>
+			observable((observer) => {
+				let attempted = false;
+				let subscription: { unsubscribe: () => void } | undefined;
+
+				const start = () => {
+					subscription = next(op).subscribe({
+						next: (value) => observer.next(value),
+						error: (err) => {
+							if (!attempted && isUnauthorizedError(err)) {
+								attempted = true;
+								authProvider.invalidateCache();
+								start();
+								return;
+							}
+							observer.error(err);
+						},
+						complete: () => observer.complete(),
+					});
+				};
+
+				start();
+
+				return () => {
+					subscription?.unsubscribe();
+				};
+			});
+}
 
 export function createApiClient(
 	baseUrl: string,
@@ -10,6 +56,7 @@ export function createApiClient(
 ): ApiClient {
 	return createTRPCClient<AppRouter>({
 		links: [
+			retryOnUnauthorizedLink(authProvider),
 			httpBatchLink({
 				url: `${baseUrl}/api/trpc`,
 				transformer: SuperJSON,

--- a/packages/host-service/src/providers/auth/DeviceKeyAuthProvider/DeviceKeyAuthProvider.ts
+++ b/packages/host-service/src/providers/auth/DeviceKeyAuthProvider/DeviceKeyAuthProvider.ts
@@ -10,4 +10,8 @@ export class DeviceKeyApiAuthProvider implements ApiAuthProvider {
 	async getHeaders(): Promise<Record<string, string>> {
 		return { "X-Device-Key": this.apiKey };
 	}
+
+	invalidateCache(): void {
+		// Device keys don't expire and aren't cached; nothing to drop.
+	}
 }

--- a/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts
+++ b/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts
@@ -8,15 +8,25 @@ function looksLikeJwt(token: string): boolean {
 	return parts.length === 3 && parts.every(Boolean);
 }
 
+export interface JwtApiAuthProviderOptions {
+	/**
+	 * Returns the current session/api-key/JWT token to authenticate with.
+	 * Called whenever a fresh JWT needs to be minted, so token rotations
+	 * (re-login, refresh) are picked up without restarting the host-service.
+	 */
+	getSessionToken: () => Promise<string>;
+	apiUrl: string;
+}
+
 export class JwtApiAuthProvider implements ApiAuthProvider {
-	private readonly sessionToken: string;
+	private readonly getSessionToken: () => Promise<string>;
 	private readonly apiUrl: string;
 	private cachedJwt: string | null = null;
 	private cachedJwtExpiresAt = 0;
 
-	constructor(sessionToken: string, apiUrl: string) {
-		this.sessionToken = sessionToken;
-		this.apiUrl = apiUrl;
+	constructor(options: JwtApiAuthProviderOptions) {
+		this.getSessionToken = options.getSessionToken;
+		this.apiUrl = options.apiUrl;
 	}
 
 	async getHeaders(): Promise<Record<string, string>> {
@@ -24,17 +34,12 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 		return { Authorization: `Bearer ${jwt}` };
 	}
 
-	async getJwt(): Promise<string> {
-		// CLI OAuth code+PKCE login stores the OAuth access token directly,
-		// which is already a JWT signed by the same JWKS the relay verifies
-		// against and carries `organizationIds` via customAccessTokenClaims.
-		// Pass it through — no /api/auth/token exchange needed (and the
-		// better-auth jwt plugin endpoint doesn't accept OAuth tokens
-		// anyway, only sessions and api keys).
-		if (looksLikeJwt(this.sessionToken)) {
-			return this.sessionToken;
-		}
+	invalidateCache(): void {
+		this.cachedJwt = null;
+		this.cachedJwtExpiresAt = 0;
+	}
 
+	async getJwt(): Promise<string> {
 		if (
 			this.cachedJwt &&
 			Date.now() < this.cachedJwtExpiresAt - JWT_REFRESH_BUFFER_MS
@@ -42,13 +47,25 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 			return this.cachedJwt;
 		}
 
+		const sessionToken = await this.getSessionToken();
+
+		// CLI OAuth code+PKCE login stores the OAuth access token directly,
+		// which is already a JWT signed by the same JWKS the relay verifies
+		// against and carries `organizationIds` via customAccessTokenClaims.
+		// Pass it through — no /api/auth/token exchange needed (and the
+		// better-auth jwt plugin endpoint doesn't accept OAuth tokens
+		// anyway, only sessions and api keys).
+		if (looksLikeJwt(sessionToken)) {
+			return sessionToken;
+		}
+
 		// better-auth's apiKey plugin reads `sk_live_…` from x-api-key, not
 		// Authorization: Bearer; mirror what the CLI's tRPC client does in
 		// packages/cli/src/lib/api-client.ts.
 		const response = await fetch(`${this.apiUrl}/api/auth/token`, {
-			headers: this.sessionToken.startsWith("sk_live_")
-				? { "x-api-key": this.sessionToken }
-				: { Authorization: `Bearer ${this.sessionToken}` },
+			headers: sessionToken.startsWith("sk_live_")
+				? { "x-api-key": sessionToken }
+				: { Authorization: `Bearer ${sessionToken}` },
 		});
 		if (!response.ok) {
 			throw new Error(`Failed to mint JWT: ${response.status}`);

--- a/packages/host-service/src/providers/auth/types.ts
+++ b/packages/host-service/src/providers/auth/types.ts
@@ -1,3 +1,10 @@
 export interface ApiAuthProvider {
 	getHeaders(): Promise<Record<string, string>>;
+	/**
+	 * Drop any cached credentials so the next `getHeaders()` call re-derives
+	 * them from the underlying source. The cloud trpc client calls this on
+	 * 401 to recover from stale-credential cases (JWT expired, session
+	 * rotated, JWKS rolled).
+	 */
+	invalidateCache(): void;
 }

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -26,10 +26,10 @@ async function main(): Promise<void> {
 	// daemon takes time to come up or fails entirely.
 	startDaemonBootstrap(env.ORGANIZATION_ID);
 
-	const authProvider = new JwtApiAuthProvider(
-		env.AUTH_TOKEN,
-		env.SUPERSET_API_URL,
-	);
+	const authProvider = new JwtApiAuthProvider({
+		getSessionToken: async () => env.AUTH_TOKEN,
+		apiUrl: env.SUPERSET_API_URL,
+	});
 
 	const { app, injectWebSocket, api } = createApp({
 		config: {


### PR DESCRIPTION
## Summary

- Workspace create/delete against remote hosts was failing with **"Failed to register host: Not authenticated. Provide a bearer JWT, x-api-key, or session."** once the host-service's session token aged out.
- The host-service's `JwtApiAuthProvider` captured the token at child-process spawn time and never observed re-logins in the desktop renderer (which rewrite `auth-token.enc`). The cached JWT also had no 401-driven invalidation, so once the cloud started rejecting it (clock skew, JWKS rotation, mid-flight session revoke) every retry served the same stale value.
- Provider now takes a `getSessionToken: () => Promise<string>` loader consulted on each cache miss, exposes `invalidateCache()`, and `createApiClient` wraps `httpBatchLink` with a one-shot retry-on-UNAUTHORIZED link that drops the cache and retries.
- Desktop entry's loader reads `auth-token.enc` from disk; standalone `serve.ts` keeps the env-var path.

## Test plan

Verified end-to-end against `https://api.superset.sh` with the user's real auth token:

- [x] Cache hit/miss: loader fires once on cold start, cached on hit, re-invoked after `invalidateCache()`.
- [x] Loader rotation pickup: rotating the loader's return value + `invalidateCache` causes the next mint to use the new value.
- [x] Retry link on `UNAUTHORIZED`: retries exactly once, calls `invalidateCache`.
- [x] Retry link ignores non-401: a 500 surfaces immediately with no retry.
- [x] **End-to-end recovery from poisoned cache:** corrupted the cached JWT, made a real `host.list` call, received a real 401 from the cloud, link invalidated and re-minted, request returned the user's actual hosts.
- [x] Lint, typecheck, and full host-service test suite (499 pass, 0 fail) green.

## Out of scope (follow-ups)

- Cross-user re-login on the same machine leaves the cached JWT (with the old user's identity) valid until expiry — the cloud accepts it because it's cryptographically valid. Real fix is coordinator-driven host-service restart on auth changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote workspace create/delete failures caused by stale auth tokens by loading fresh session tokens and retrying once on 401. This makes `@superset/host-service` recover automatically from expired or rotated credentials.

- **Bug Fixes**
  - `JwtApiAuthProvider` now accepts `getSessionToken` to fetch a fresh token on cache miss and exposes `invalidateCache()`.
  - Added one-shot retry-on-UNAUTHORIZED in `createApiClient` that drops the JWT cache and retries, wrapping `httpBatchLink`.
  - Desktop entry reads `auth-token.enc` for token minting; `serve.ts` continues using the env var path.

<sup>Written for commit b8ad7c1a68007f570d9ea5c780a2a18fcf75f137. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic retry mechanism for failed authentication requests, improving resilience to temporary authorization issues.
  * Added dynamic session token retrieval with automatic fallback to environment configuration.

* **Bug Fixes**
  * Enhanced authentication flow to handle and recover from unauthorized errors more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->