### PR TITLE
feat(desktop): allow skipping every onboarding step and the whole flow

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/setup/components/OnboardingProgress/OnboardingProgress.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/components/OnboardingProgress/OnboardingProgress.tsx
@@ -23,8 +23,14 @@ export function OnboardingProgress() {
 	const currentStep = useOnboardingStore((s) => s.currentStep);
 	const completed = useOnboardingStore((s) => s.completed);
 	const skipped = useOnboardingStore((s) => s.skipped);
+	const skipAll = useOnboardingStore((s) => s.skipAll);
 	const backTo = useSetupChromeStore((s) => s.backTo);
 	const currentIdx = ONBOARDING_STEP_ORDER.indexOf(currentStep);
+
+	const handleSkipAll = () => {
+		skipAll();
+		navigate({ to: "/welcome", replace: true });
+	};
 
 	const pillBase =
 		"inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-[12px] font-medium transition-colors";
@@ -100,7 +106,18 @@ export function OnboardingProgress() {
 				})}
 			</div>
 
-			<div />
+			<div className="flex items-center justify-end">
+				<button
+					type="button"
+					onClick={handleSkipAll}
+					className={cn(
+						pillBase,
+						"border-transparent text-[#a8a5a3] hover:bg-white/5 hover:text-[#eae8e6]",
+					)}
+				>
+					Skip onboarding
+				</button>
+			</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/permissions/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/permissions/page.tsx
@@ -25,6 +25,7 @@ function OnboardingPermissionsPage() {
 	const navigate = useNavigate();
 	const goTo = useOnboardingStore((s) => s.goTo);
 	const markComplete = useOnboardingStore((s) => s.markComplete);
+	const markSkipped = useOnboardingStore((s) => s.markSkipped);
 
 	const { data: status, isPending } =
 		electronTrpc.permissions.getStatus.useQuery(undefined, {
@@ -49,6 +50,11 @@ function OnboardingPermissionsPage() {
 	const handleContinue = () => {
 		if (!requiredSatisfied) return;
 		markComplete("permissions");
+		navigate({ to: STEP_ROUTES.project });
+	};
+
+	const handleSkip = () => {
+		markSkipped("permissions");
 		navigate({ to: STEP_ROUTES.project });
 	};
 
@@ -99,6 +105,9 @@ function OnboardingPermissionsPage() {
 			<div className="flex w-[273px] flex-col gap-2 self-center">
 				<SetupButton onClick={handleContinue} disabled={!requiredSatisfied}>
 					Continue
+				</SetupButton>
+				<SetupButton variant="link" onClick={handleSkip}>
+					Skip for now
 				</SetupButton>
 			</div>
 		</StepShell>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -30,6 +30,7 @@ function OnboardingProjectPage() {
 	const navigate = useNavigate();
 	const goTo = useOnboardingStore((s) => s.goTo);
 	const markComplete = useOnboardingStore((s) => s.markComplete);
+	const markSkipped = useOnboardingStore((s) => s.markSkipped);
 	const completed = useOnboardingStore((s) => s.completed.project);
 	const manualWalkthrough = useOnboardingStore((s) => s.manualWalkthrough);
 	const setManualWalkthrough = useOnboardingStore(
@@ -120,6 +121,11 @@ function OnboardingProjectPage() {
 
 	const handleContinueWithCurrent = () => {
 		markComplete("project");
+		navigate({ to: STEP_ROUTES["adopt-worktrees"] });
+	};
+
+	const handleSkipStep = () => {
+		markSkipped("project");
 		navigate({ to: STEP_ROUTES["adopt-worktrees"] });
 	};
 
@@ -221,6 +227,9 @@ function OnboardingProjectPage() {
 					>
 						Clone from GitHub
 					</SetupButton>
+					<SetupButton variant="link" onClick={handleSkipStep}>
+						Skip for now
+					</SetupButton>
 				</div>
 			</StepShell>
 		);
@@ -243,6 +252,9 @@ function OnboardingProjectPage() {
 					onClick={() => navigate({ to: "/new-project" })}
 				>
 					Clone from GitHub
+				</SetupButton>
+				<SetupButton variant="link" onClick={handleSkipStep}>
+					Skip for now
 				</SetupButton>
 			</div>
 		</StepShell>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
@@ -22,6 +22,7 @@ function OnboardingProvidersPage() {
 	const navigate = useNavigate();
 	const goTo = useOnboardingStore((s) => s.goTo);
 	const markComplete = useOnboardingStore((s) => s.markComplete);
+	const markSkipped = useOnboardingStore((s) => s.markSkipped);
 	const completed = useOnboardingStore((s) => s.completed.providers);
 	const manualWalkthrough = useOnboardingStore((s) => s.manualWalkthrough);
 
@@ -74,6 +75,11 @@ function OnboardingProvidersPage() {
 
 	const handleContinueToNextStep = () => {
 		markComplete("providers");
+		navigate({ to: STEP_ROUTES["gh-cli"] });
+	};
+
+	const handleSkipStep = () => {
+		markSkipped("providers");
 		navigate({ to: STEP_ROUTES["gh-cli"] });
 	};
 
@@ -252,24 +258,26 @@ function OnboardingProvidersPage() {
 									? `Reconfigure ${providerLabel}`
 									: `Connect ${providerLabel}`}
 							</SetupButton>
-							{(atLeastOneConnected || isReconfiguring) && (
-								<SetupButton
-									variant="link"
-									onClick={() => {
-										if (isReconfiguring) {
-											if (provider === "claude-code")
-												setReconfiguringClaude(false);
-											else setReconfiguringCodex(false);
-										} else {
-											handleContinueToNextStep();
-										}
-									}}
-								>
-									{isReconfiguring
-										? "Cancel — keep current"
-										: "Skip — continue to next step"}
-								</SetupButton>
-							)}
+							<SetupButton
+								variant="link"
+								onClick={() => {
+									if (isReconfiguring) {
+										if (provider === "claude-code")
+											setReconfiguringClaude(false);
+										else setReconfiguringCodex(false);
+									} else if (atLeastOneConnected) {
+										handleContinueToNextStep();
+									} else {
+										handleSkipStep();
+									}
+								}}
+							>
+								{isReconfiguring
+									? "Cancel — keep current"
+									: atLeastOneConnected
+										? "Skip — continue to next step"
+										: "Skip for now"}
+							</SetupButton>
 						</>
 					);
 				})()}

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
@@ -275,7 +275,7 @@ function OnboardingProvidersPage() {
 								{isReconfiguring
 									? "Cancel — keep current"
 									: atLeastOneConnected
-										? "Skip — continue to next step"
+										? "Continue to next step"
 										: "Skip for now"}
 							</SetupButton>
 						</>

--- a/apps/desktop/src/renderer/stores/onboarding/onboardingStore.ts
+++ b/apps/desktop/src/renderer/stores/onboarding/onboardingStore.ts
@@ -55,6 +55,7 @@ interface OnboardingState {
 interface OnboardingActions {
 	markComplete: (step: OnboardingStep) => void;
 	markSkipped: (step: OnboardingStep) => void;
+	skipAll: () => void;
 	goTo: (step: OnboardingStep) => void;
 	next: () => OnboardingStep | null;
 	back: () => OnboardingStep | null;
@@ -118,6 +119,29 @@ export const useOnboardingStore = create<OnboardingStore>()(
 						completedAt: allDone ? Date.now() : prev.completedAt,
 					});
 				},
+				skipAll: () => {
+					const prev = get();
+					const startedAt = prev.startedAt ?? Date.now();
+					track("onboarding_finished", {
+						outcome: "skipped_all",
+						duration_ms: prev.startedAt ? Date.now() - prev.startedAt : null,
+					});
+					const skipped = { ...prev.skipped };
+					for (const step of ONBOARDING_STEP_ORDER) {
+						if (!prev.completed[step]) {
+							if (!skipped[step]) {
+								track("onboarding_step_skipped", { step });
+							}
+							skipped[step] = true;
+						}
+					}
+					set({
+						skipped,
+						startedAt,
+						completedAt: Date.now(),
+						manualWalkthrough: false,
+					});
+				},
 				goTo: (step) => {
 					const prev = get();
 					if (prev.currentStep === step && prev.startedAt !== null) return;
@@ -162,10 +186,7 @@ export const useOnboardingStore = create<OnboardingStore>()(
 );
 
 export function selectRequiredStepsComplete(state: OnboardingState): boolean {
-	// Required steps must be explicitly completed — skipping is not enough.
-	// This prevents a stray markSkipped("providers") or markSkipped("project")
-	// from bypassing the dashboard gate.
-	return REQUIRED_STEPS.every((s) => state.completed[s]);
+	return REQUIRED_STEPS.every((s) => state.completed[s] || state.skipped[s]);
 }
 
 export function selectFirstIncompleteStep(


### PR DESCRIPTION
## Summary
- Add a per-step \"Skip for now\" link on the providers, permissions, and project steps (the gh-cli and adopt-worktrees steps already had one).
- Add a \"Skip onboarding\" button to the setup chrome that marks every remaining step as skipped and routes the user to `/welcome`.
- Update the dashboard gate so skipped required steps (`providers`, `project`) count as satisfied — previously skipping wasn't enough to leave the flow.

## Test plan
- [ ] Walk through onboarding and confirm a Skip option appears on every step
- [ ] On each step, click Skip for now and confirm it advances to the next step
- [ ] From any step, click Skip onboarding (top-right of chrome) and confirm it lands on `/welcome` and doesn't bounce back into setup
- [ ] Re-open the app after skipping and confirm the dashboard renders without redirecting to setup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds skip controls to onboarding so users can bypass any step or the entire flow. Skipped required steps now unlock the dashboard and no longer bounce users back into setup.

- **New Features**
  - Added “Skip for now” to `providers`, `permissions`, and `project` steps; marks the step as skipped and moves to the next.
  - Added “Skip onboarding” in the setup chrome; calls `skipAll()`, records analytics, and navigates to `/welcome`.
  - Dashboard gate treats skipped required steps (`providers`, `project`) as satisfied.

- **Bug Fixes**
  - On the `providers` step, the secondary action now reads “Continue to next step” when a provider is connected (removes the misleading “Skip” prefix).

<sup>Written for commit 02b0d6712f4f71ef212910c721afa29d7677011d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global "Skip onboarding" action to bypass all steps at once.
  * Added "Skip for now" options on individual setup steps (permissions, projects, providers).
  * Secondary action adapts label and behavior based on connection/status (Cancel / Continue / Skip).
  * Skipped steps now count toward required-step completion and onboarding records skip-all outcome/timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->