### PR TITLE
release(cli): cut v0.2.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",
@@ -677,7 +677,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.8";
+const VERSION = "0.2.9";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Bump `@superset/cli` to **v0.2.9**. Changes since v0.2.8:

- `superset agents list` and demote "presets" to a UI-only configuration. CLI reads canonical agents from host-service. (#4097)
- Host-service: refresh stale OAuth access tokens on remote workspace ops instead of failing the request. (#4106)
- Host-service: `workspace.create` adopts an existing worktree at any path, not just the canonical one. (#4096)
- Host-service: AI workspace naming times out after 5s and falls back to a deterministic name. (#4102)

Push the `cli-v0.2.9` tag after this merges to fire the release pipeline (`.github/workflows/release-cli.yml`).

## Test plan

- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] After merge, `git tag cli-v0.2.9 <merge-sha> && git push origin cli-v0.2.9` and confirm the Release CLI workflow publishes a draft release + updates `cli-latest`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.9. Adds `superset agents list` and improves host-service reliability (token refresh, worktree adoption, naming timeout fallback).

- New Features
  - CLI: Added `superset agents list`; "presets" are now UI-only; CLI reads canonical agents from host-service.
  - Host-service: Refresh stale OAuth tokens during remote workspace ops.
  - Host-service: `workspace.create` can adopt an existing worktree at any path.
  - Host-service: AI workspace naming times out after 5s and falls back to a deterministic name.

- Migration
  - After merge, push tag `cli-v0.2.9` to trigger `.github/workflows/release-cli.yml`.

<sup>Written for commit 6665a019decedbb5b18b12f636e2484f9f42481e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI package version to 0.2.9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->