### PR TITLE
docs(agents): document agents CLI/SDK/MCP and drop stale references

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -489,6 +489,63 @@ superset workspaces delete ws_a ws_b ws_c
 
 ---
 
+### agents
+
+Agents are terminal-agent rows configured on a host (the same rows shown in
+Settings → Agents on that machine). Each row stores a `command`, `args`,
+prompt-transport mode, and environment used to launch the agent in a fresh
+terminal session inside a workspace.
+
+<Command
+	name="superset agents list"
+	options={[
+		{ flag: "--host <id>", description: "Target host machineId." },
+		{ flag: "--local", description: "Target this machine. Mutually exclusive with --host; exactly one is required." },
+	]}
+	output={`Array<{
+  id: string;
+  presetId: string;
+  label: string;
+  command: string;
+  args: string[];
+  promptTransport: "argv" | "stdin";
+  promptArgs: string[];
+  env: Record<string, string>;
+  order: number;
+}>`}
+	humanColumns={["LABEL", "PRESET", "COMMAND", "ID"]}
+	quiet="agent instance IDs"
+>
+List agents configured on a host. First call on a fresh host seeds the
+bundled defaults.
+
+```bash
+superset agents list --local
+superset agents list --host host_…
+```
+</Command>
+
+<Command
+	name="superset agents run"
+	options={[
+		{ flag: "--workspace <id>", required: true, description: "Workspace UUID to run the agent in." },
+		{ flag: "--agent <preset|uuid>", required: true, description: "Agent preset id (e.g. `claude`, `codex`) or HostAgentConfig instance UUID." },
+		{ flag: "--prompt <text>", required: true, description: "Prompt sent to the agent." },
+		{ flag: "--attachment-id <uuid>", description: "Host-scoped attachment UUID; pass repeatedly for multiple attachments." },
+	]}
+	output={`{ sessionId: string; label: string }`}
+>
+Launch an agent inside an existing workspace. Resolves the host that owns the
+workspace and starts the named preset (or HostAgentConfig instance) in a
+fresh terminal session on that host.
+
+```bash
+superset agents run --workspace ws_… --agent claude --prompt "Audit the login flow"
+```
+</Command>
+
+---
+
 ### tasks (alias: `t`)
 
 Tasks are units of work in your organization's task tracker.

--- a/apps/docs/content/docs/mcp.mdx
+++ b/apps/docs/content/docs/mcp.mdx
@@ -244,6 +244,13 @@ API keys grant full access to your organization. Keep them secret and never comm
 | `workspaces_create` | Create a workspace on a host (branch-scoped git worktree) |
 | `workspaces_delete` | Delete a workspace by UUID; idempotent |
 
+### Agents
+
+| Tool | Description |
+|------|-------------|
+| `agents_list` | List agents configured on a host |
+| `agents_run` | Launch an agent inside an existing workspace |
+
 ### Automations
 
 | Tool | Description |
@@ -265,7 +272,6 @@ API keys grant full access to your organization. Keep them secret and never comm
 | Tool | Description |
 |------|-------------|
 | `projects_list` | List projects (checked-out repos) in the active organization |
-| `projects_create` | Register a project on a host: clone a Git URL or import an existing local repo |
 
 ### Hosts
 

--- a/apps/docs/content/docs/sdk/advanced.mdx
+++ b/apps/docs/content/docs/sdk/advanced.mdx
@@ -11,10 +11,6 @@ The SDK's individual methods are simple. The interesting part is what you compos
 
 ## Sentry webhook → agent on the bug
 
-<Callout type="info">
-**TODO** — the `agents: [{ prompt }]` shorthand below is the API we're aiming for. Today the SDK sends a minimal `agentConfig: { id: 'claude', kind: 'terminal' }`; the host service still needs full launch info (`command`, `promptCommand`, …) to actually start the agent. We'll bake in defaults for built-in presets in a follow-up. Until then you can pass a full `agentConfig` per agent — crib one from `(await client.automations.list())[0].agentConfig`.
-</Callout>
-
 When Sentry fires an alert, file a task and spawn an agent to investigate — all in two SDK calls. (In production, verify the Sentry signature header before trusting any payload — that part is omitted here for clarity.)
 
 ```ts title="sentry-webhook.ts"

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -119,9 +119,7 @@ Returns `Array<Workspace>`.
 
 Create a worktree on a specific host. Optionally spawn one or more agents inside it as soon as the worktree is ready. Goes through the relay tunnel — the host must be online.
 
-<Callout type="info">
-**TODO** — the `agents` shorthand is the surface we're aiming for. The SDK currently sends a minimal `agentConfig: { id: 'claude', kind: 'terminal' }`; the host service still needs full launch info (`command`, `promptCommand`, …) to actually start the agent. We'll bake in defaults for built-in presets in a follow-up. Until then, pass a full `agentConfig` (crib one from `(await client.automations.list())[0].agentConfig`).
-</Callout>
+Each entry in `agents` takes a preset id (e.g. `"claude"`) or a `HostAgentConfig` instance UUID — the host service resolves it against its configured rows and copies their stored `command`, `args`, and `env`. Use [`agents.list({ hostId })`](#agentslist-hostid-) to enumerate what's installed.
 
 ```ts
 const ws = await client.workspaces.create({
@@ -173,6 +171,42 @@ List developer machines registered in the org. Returns `Array<Host>` with `id` (
 ```ts
 const hosts = await client.hosts.list();
 const online = hosts.filter((h) => h.online);
+```
+
+---
+
+## agents
+
+Terminal-agent rows configured on a specific host (the same rows shown in
+Settings → Agents on that machine). Reads route through the relay tunnel —
+the target host must be online.
+
+### `agents.list({ hostId })`
+
+List configured agents on a host in persisted display order. First call on a
+fresh host seeds the bundled defaults. Returns `Array<HostAgentConfig>` —
+each row carries `id`, `presetId`, `label`, `command`, `args`, `env`, and
+prompt-transport fields used to launch the agent.
+
+```ts
+const agents = await client.agents.list({ hostId: '<machineId>' });
+```
+
+### `agents.run({ workspaceId, agent, prompt, attachmentIds? }, { hostId? })`
+
+Launch an agent inside an existing workspace. By default looks up the host
+that owns the workspace via the cloud index; pass an explicit `hostId` to
+skip the lookup.
+
+`agent` accepts either a preset id (e.g. `"claude"`) or a `HostAgentConfig`
+instance UUID. Returns `{ sessionId, label }`.
+
+```ts
+const { sessionId } = await client.agents.run({
+  workspaceId: '<uuid>',
+  agent: 'claude',
+  prompt: 'Audit the login flow for race conditions.',
+});
 ```
 
 ---

--- a/skills/superset/SKILL.md
+++ b/skills/superset/SKILL.md
@@ -42,7 +42,6 @@ Provide exactly one of `--branch` or `--pr`. With `--pr`, the host runs `gh pr c
 ```bash
 superset agents list --host <id>                 # Configured agents on a host (LABEL, PRESET, COMMAND, ID)
 superset agents list --local                     # Same, for this machine
-superset agents list --local --presets           # Available presets you could add
 superset agents run --workspace <id> --agent claude --prompt "..."
 ```
 


### PR DESCRIPTION
## Summary

Catches the docs and the Superset CLI skill up to #4097, which added `superset agents list`, the SDK `Agents` resource (`list` + `run`), and the `agents_list` MCP tool — while removing `listPresets` and reshaping `add` to take the full launch row.

## Changes

**Skill** (`skills/superset/SKILL.md`, hardlinked to `plugins/superset/skills/superset/SKILL.md`):
- Drop the `superset agents list --local --presets` example — that flag was removed when the preset catalog stopped being a runtime API resource. An agent following the skill verbatim would hit "Unknown option: --presets".

**CLI reference** (`apps/docs/content/docs/cli/cli-reference.mdx`):
- New `### agents` section between `### workspaces` and `### tasks` with Command blocks for `superset agents list` (was added in #4097) and `superset agents run` (existed before but was never documented).
- `output` uses an inline structural literal matching `hosts list` / `workspaces list` style.

**MCP doc** (`apps/docs/content/docs/mcp.mdx`):
- New `### Agents` table row covering `agents_list` (added in #4097) and `agents_run` (existed but undocumented).
- Removed the `projects_create` row — there's no such MCP tool registered in `packages/mcp-v2/src/tools/register.ts`. Pre-existing wrong claim, caught while auditing.

**SDK reference** (`apps/docs/content/docs/sdk/reference.mdx`):
- Removed the stale `**TODO**` Callout in `workspaces.create` claiming the SDK sends a minimal `agentConfig: { id: 'claude', kind: 'terminal' }`. The SDK now uses the v2 host-service launch shape directly (`{ agent: string, prompt, attachmentIds }`).
- New `## agents` section documenting `client.agents.list({ hostId })` and `client.agents.run({ workspaceId, agent, prompt, attachmentIds? }, { hostId? })`.

**SDK advanced** (`apps/docs/content/docs/sdk/advanced.mdx`):
- Removed the matching stale `**TODO**` Callout above the Sentry → agent recipe.

## Out of scope

- Updating `apps/docs/content/docs/agent-integration.mdx` to reflect the V2 Settings → Agents UI fields (`command`, `args`, `promptTransport`, `promptArgs`, `env`) instead of the V1 fields it currently lists. Tangled with the V1/V2 split and probably wants UI screenshots refreshed; deserves its own pass.

## Test plan

- [x] `bun run lint` clean
- [ ] Eyeball the rendered docs site (`bun run dev` in `apps/docs`) to confirm the new Command blocks render correctly and the new `## agents` section anchors work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Agents surface across CLI, SDK, and MCP, and removes stale flags and TODOs. Brings docs in line with `superset agents list/run` and the SDK `Agents` resource.

- **Docs**
  - CLI: Add `agents` section with `superset agents list` and `superset agents run` (output shape, examples).
  - SDK: Add `agents.list({ hostId })` and `agents.run({ workspaceId, agent, prompt, attachmentIds? }, { hostId? })`. Update `workspaces.create` to describe the v2 launch shape; remove outdated TODOs.
  - MCP: Add `agents_list` and `agents_run`; remove `projects_create` (no such tool).
  - Skill: Remove `--presets` example from `superset agents list` (flag no longer exists).

<sup>Written for commit 2b995d4bfee90d9bc904f7a068d91a11b504c077. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added CLI command documentation for `superset agents list` and `superset agents run`
* Documented new agents tools and updated SDK reference to reflect agents functionality across CLI, SDK, and MCP interfaces
* Updated skill documentation for agents management commands
* Removed outdated placeholder documentation from SDK reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->