### PR TITLE
feat(desktop): default new users to v2 and surface a v2 banner in v1

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx
+++ b/apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx
@@ -1,19 +1,13 @@
 import { useEffect } from "react";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { posthog } from "renderer/lib/posthog";
-import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 export function PostHogSurfaceTagger() {
-	const { isV2CloudEnabled, isRemoteV2Enabled } = useIsV2CloudEnabled();
-	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	useEffect(() => {
 		const surface = isV2CloudEnabled ? "v2" : "v1";
-		const surface_source = !isRemoteV2Enabled
-			? "v2-flag-off"
-			: optInV2
-				? "opted-in"
-				: "opted-out";
+		const surface_source = isV2CloudEnabled ? "opted-in" : "opted-out";
 
 		posthog.register({ surface, surface_source });
 
@@ -24,7 +18,7 @@ export function PostHogSurfaceTagger() {
 				surface_ever_v2: true,
 			});
 		}
-	}, [isV2CloudEnabled, isRemoteV2Enabled, optInV2]);
+	}, [isV2CloudEnabled]);
 
 	return null;
 }

--- a/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
+++ b/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
@@ -1,0 +1,46 @@
+import { SidebarCard } from "@superset/ui/sidebar-card";
+import { AnimatePresence, motion } from "framer-motion";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { track } from "renderer/lib/analytics";
+import { useV2AvailableBannerStore } from "renderer/stores/v2-available-banner";
+import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+
+export function V2AvailableBanner() {
+	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const dismissed = useV2AvailableBannerStore((s) => s.dismissed);
+	const dismiss = useV2AvailableBannerStore((s) => s.dismiss);
+	const setOptInV2 = useV2LocalOverrideStore((s) => s.setOptInV2);
+
+	function handleSwitch() {
+		track("surface_toggled", { from: "v1", to: "v2", source: "v1_banner" });
+		setOptInV2(true);
+	}
+
+	function handleDismiss() {
+		track("v2_banner_dismissed");
+		dismiss();
+	}
+
+	return (
+		<AnimatePresence>
+			{!dismissed && (
+				<motion.div
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					exit={{ opacity: 0, y: 8 }}
+					transition={{ duration: 0.2 }}
+					className="px-3 pb-2"
+				>
+					<SidebarCard
+						badge="New"
+						title="Superset v2 is here"
+						description="The new cloud workspace experience is now available."
+						actionLabel={isV2CloudEnabled ? undefined : "Switch to v2"}
+						onAction={isV2CloudEnabled ? undefined : handleSwitch}
+						onDismiss={handleDismiss}
+					/>
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+}

--- a/apps/desktop/src/renderer/components/V2AvailableBanner/index.ts
+++ b/apps/desktop/src/renderer/components/V2AvailableBanner/index.ts
@@ -1,0 +1,1 @@
+export { V2AvailableBanner } from "./V2AvailableBanner";

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -1,29 +1,6 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
-const IS_DEV = process.env.NODE_ENV === "development";
-
-/**
- * Returns effective v2 state: remote PostHog flag AND local opt-in.
- * Also returns the raw remote flag so the toggle can be shown conditionally.
- */
-export function useIsV2CloudEnabled() {
-	const remoteV2Enabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
-	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
-
-	if (IS_DEV) {
-		return {
-			isV2CloudEnabled: optInV2,
-			isRemoteV2Enabled: true,
-		};
-	}
-
-	return {
-		/** The effective value — use this wherever you previously checked the flag directly. */
-		isV2CloudEnabled: remoteV2Enabled && optInV2,
-		/** Whether the remote PostHog flag is on (for showing the toggle). */
-		isRemoteV2Enabled: remoteV2Enabled,
-	};
+/** Returns whether v2 is currently active for this user. */
+export function useIsV2CloudEnabled(): boolean {
+	return useV2LocalOverrideStore((s) => s.optInV2);
 }

--- a/apps/desktop/src/renderer/lib/hasPriorSupersetUsage.ts
+++ b/apps/desktop/src/renderer/lib/hasPriorSupersetUsage.ts
@@ -1,0 +1,9 @@
+/**
+ * True when this install has been used before. Backed by `tabs-storage`,
+ * which is written the first time any workspace tab opens. Use this to
+ * distinguish a fresh install from a returning user.
+ */
+export function hasPriorSupersetUsage(): boolean {
+	if (typeof localStorage === "undefined") return false;
+	return localStorage.getItem("tabs-storage") !== null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -24,6 +24,7 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { HiOutlineCog6Tooth } from "react-icons/hi2";
+import { V2AvailableBanner } from "renderer/components/V2AvailableBanner";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -236,6 +237,7 @@ export function DashboardSidebar({
 								projectName={activeV2Project.name}
 							/>
 						)}
+						{!isCollapsed && <V2AvailableBanner />}
 						<div
 							className={cn(
 								"border-t border-border",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -30,7 +30,7 @@ export function TopBar() {
 		{ enabled: !!workspaceId && !isV2WorkspaceRoute },
 	);
 	const isOnline = useOnlineStatus();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const isSidebarOpen = useWorkspaceSidebarStore((s) => s.isOpen);
 	const isSidebarCollapsed = useWorkspaceSidebarStore((s) => s.isCollapsed());
 	// Default to Mac layout while loading to avoid overlap with traffic lights

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -32,7 +32,7 @@ export const Route = createFileRoute("/_authenticated/_dashboard")({
 function DashboardLayout() {
 	const navigate = useNavigate();
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	useDevSeedV2Sidebar();
 	useMigrateV1DataToV2();
 	// Get current workspace from route to pre-select project in new workspace modal

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/PropertiesSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/PropertiesSidebar.tsx
@@ -14,7 +14,7 @@ interface PropertiesSidebarProps {
 
 export function PropertiesSidebar({ task }: PropertiesSidebarProps) {
 	const labels = task.labels ?? [];
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	return (
 		<div className="w-64 border-l border-border shrink-0">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
@@ -70,7 +70,7 @@ export function TasksTopBar({
 	const selectedCount = selectedTasks.length;
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const [isCreateTaskOpen, setIsCreateTaskOpen] = useState(false);
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	useHotkey(
 		"FOCUS_TASK_SEARCH",

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/useMigrateV1DataToV2.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/useMigrateV1DataToV2.ts
@@ -102,7 +102,7 @@ export function useMigrateV1DataToV2({
 } = {}) {
 	const { data: session } = authClient.useSession();
 	const { activeHostUrl } = useLocalHostService();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const collections = useCollections();
 	const isRunning = useSyncExternalStore(
 		subscribeMigrationRunning,

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -64,7 +64,7 @@ function AuthenticatedLayout() {
 	const setOriginRoute = useSettingsStore((s) => s.setOriginRoute);
 	const utils = electronTrpc.useUtils();
 	const shownWorkspaceInitWarningsRef = useRef(new Set<string>());
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const requiredComplete = useOnboardingStore(selectRequiredStepsComplete);
 	const firstIncompleteStep = useOnboardingStore(selectFirstIncompleteStep);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettings/AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettings/AgentsSettings.tsx
@@ -18,7 +18,7 @@ export function AgentsSettings({
 	visibleItems,
 	initialAgentPresetId,
 }: AgentsSettingsProps) {
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	if (isV2CloudEnabled) {
 		return <V2AgentsSettings initialAgentPresetId={initialAgentPresetId} />;
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/page.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/_authenticated/settings/behavior/")({
 
 function BehaviorSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	const visibleItems = useMemo(
 		() =>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
@@ -205,7 +205,7 @@ export function GeneralSettings({ matchCounts }: GeneralSettingsProps) {
 	const matchRoute = useMatchRoute();
 	const { data: platform } = electronTrpc.window.getPlatform.useQuery();
 	const isMac = platform === "darwin";
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const allowedSections = useMemo(
 		() => getAllowedSectionsForVariant(isV2CloudEnabled),
 		[isV2CloudEnabled],

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
@@ -19,7 +19,7 @@ export function SettingsSidebar() {
 	const searchQuery = useSettingsSearchQuery();
 	const setSearchQuery = useSetSettingsSearchQuery();
 	const originRoute = useSettingsOriginRoute();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const normalizedSearchQuery = searchQuery.trim();
 	const matchCounts = normalizedSearchQuery
 		? getVisibleMatchCountBySection(normalizedSearchQuery, isV2CloudEnabled)

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -55,7 +55,7 @@ export function ExperimentalSettings({
 		SETTING_ITEM_ID.EXPERIMENTAL_RESTART_ONBOARDING,
 		visibleItems,
 	);
-	const { isV2CloudEnabled, isRemoteV2Enabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { rerun, isRunning } = useMigrateV1DataToV2({ autoRun: false });
 	const setOptInV2 = useV2LocalOverrideStore((state) => state.setOptInV2);
 	const resetOnboarding = useOnboardingStore((state) => state.reset);
@@ -98,13 +98,8 @@ export function ExperimentalSettings({
 								Try Superset v2
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Use the new workspace experience when early access is available.
+								Use the new workspace experience.
 							</p>
-							{!isRemoteV2Enabled && (
-								<p className="text-xs text-muted-foreground">
-									Early access is not enabled for this account.
-								</p>
-							)}
 						</div>
 						<Switch
 							id="superset-v2"
@@ -112,11 +107,10 @@ export function ExperimentalSettings({
 							onCheckedChange={(enabled) => {
 								track("surface_toggled", {
 									from: isV2CloudEnabled ? "v2" : "v1",
-									to: enabled && isRemoteV2Enabled ? "v2" : "v1",
+									to: enabled ? "v2" : "v1",
 								});
 								setOptInV2(enabled);
 							}}
-							disabled={!isRemoteV2Enabled}
 						/>
 					</div>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/page.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/_authenticated/settings/experimental/")({
 
 function ExperimentalSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	const visibleItems = useMemo(
 		() =>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/git/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/git/page.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/_authenticated/settings/git/")({
 
 function GitSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	const visibleItems = useMemo(
 		() =>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/links/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/links/page.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/_authenticated/settings/links/")({
 
 function LinksSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	const visibleItems = useMemo(
 		() =>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
@@ -47,7 +47,7 @@ export function TerminalSettings({
 	pendingCreateProjectId,
 	onPendingCreateProjectIdChange,
 }: TerminalSettingsProps) {
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const showPresets = isItemVisible(
 		SETTING_ITEM_ID.TERMINAL_PRESETS,
 		visibleItems,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/page.tsx
@@ -28,7 +28,7 @@ function TerminalSettingsPage() {
 	const navigate = Route.useNavigate();
 	const { editPresetId, createProjectId } = Route.useSearch();
 	const searchQuery = useSettingsSearchQuery();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	const visibleItems = useMemo(
 		() =>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -31,7 +31,7 @@ function OnboardingAdoptWorktreesPage() {
 	);
 
 	const utils = electronTrpc.useUtils();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { data: projects, isPending } =
 		electronTrpc.projects.getRecents.useQuery();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -41,7 +41,7 @@ function OnboardingProjectPage() {
 		electronTrpc.projects.getRecents.useQuery();
 	const { openNew, isPending: isOpenPending } = useOpenProject();
 	const utils = electronTrpc.useUtils();
-	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const closeProject = electronTrpc.projects.close.useMutation({
 		onSuccess: async () => {
 			await utils.projects.getRecents.invalidate();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo } from "react";
+import { V2AvailableBanner } from "renderer/components/V2AvailableBanner";
 import { useWorkspaceShortcuts } from "renderer/hooks/useWorkspaceShortcuts";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
 import { MultiDragPreview } from "./MultiDragPreview";
@@ -114,6 +115,8 @@ export function WorkspaceSidebar({
 				projectId={activeProjectId}
 				projectName={activeProjectName}
 			/>
+
+			{!isCollapsed && <V2AvailableBanner />}
 
 			<WorkspaceSidebarFooter isCollapsed={isCollapsed} />
 			<MultiDragPreview />

--- a/apps/desktop/src/renderer/stores/v2-available-banner/index.ts
+++ b/apps/desktop/src/renderer/stores/v2-available-banner/index.ts
@@ -1,0 +1,1 @@
+export { useV2AvailableBannerStore } from "./store";

--- a/apps/desktop/src/renderer/stores/v2-available-banner/store.ts
+++ b/apps/desktop/src/renderer/stores/v2-available-banner/store.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+interface V2AvailableBannerState {
+	dismissed: boolean;
+	dismiss: () => void;
+}
+
+export const useV2AvailableBannerStore = create<V2AvailableBannerState>()(
+	devtools(
+		persist(
+			(set) => ({
+				dismissed: false,
+				dismiss: () => set({ dismissed: true }),
+			}),
+			{ name: "v2-available-banner-v1" },
+		),
+		{ name: "V2AvailableBannerStore" },
+	),
+);

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -1,7 +1,6 @@
+import { hasPriorSupersetUsage } from "renderer/lib/hasPriorSupersetUsage";
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
-
-const IS_DEV = process.env.NODE_ENV === "development";
 
 interface V2LocalOverrideState {
 	/** When true, the user has opted into v2. v2 is gated behind both the remote flag and this opt-in. */
@@ -9,11 +8,16 @@ interface V2LocalOverrideState {
 	setOptInV2: (optInV2: boolean) => void;
 }
 
+// Fresh installs default to v2; returning v1 users default to v1 and discover
+// v2 via the in-sidebar banner. Persist hydration overrides this for anyone
+// with a saved override.
+const initialOptInV2 = !hasPriorSupersetUsage();
+
 export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
 	devtools(
 		persist(
 			(set) => ({
-				optInV2: IS_DEV,
+				optInV2: initialOptInV2,
 				setOptInV2: (optInV2) => set({ optInV2 }),
 			}),
 			{ name: "v2-local-override-v2" },

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -71,8 +71,6 @@ export const FEATURE_FLAGS = {
 	CLOUD_ACCESS: "cloud-access",
 	/** When enabled, blocks remote agent execution on the desktop (e.g., for enterprise orgs). */
 	DISABLE_REMOTE_AGENT: "disable-remote-agent",
-	/** Gates access to V2 Cloud features (host-service, cloud sprites). */
-	V2_CLOUD: "v2-cloud",
 	/**
 	 * Gates the Automations feature in the UI (sidebar entry, routes, create
 	 * flow). Complementary to the subscriptions.plan paid-tier check —


### PR DESCRIPTION
## Summary

- Drops the `v2-cloud` PostHog feature flag (rolled out broadly via `desktop_version semver_gte 1.6.3`; current desktop is 1.8.4). `useIsV2CloudEnabled` is now a boolean read of the local override; every callsite is updated. *Follow-up: a separate task is open to bump the desktop minimum supported version, after which the PostHog flag itself can be deleted.*
- Adds a dismissible "Superset v2 is here" banner anchored at the bottom of both the v1 and v2 dashboard sidebars. Action only renders for v1 users (`Switch to v2` flips `optInV2`; the auth layout redirects into setup and `useMigrateV1DataToV2` auto-runs). v2 users see the announcement + dismiss only.
- Defaults `optInV2` to `true` for fresh installs while keeping returning v1 users on v1, gated by a synchronous `tabs-storage` localStorage probe (`hasPriorSupersetUsage`). Persist hydration still wins for anyone with a saved override.

## Test plan

- [ ] Fresh-install simulation: clear `localStorage`, launch desktop → lands on v2 dashboard (no v1 detour).
- [ ] Returning v1 user: with `tabs-storage` populated and no `v2-local-override-v2` key, launch → stays on v1 sidebar.
- [ ] V1 banner: visible at the bottom of `WorkspaceSidebar` above the footer; "Switch to v2" flips into v2 setup; dismiss persists across reloads.
- [ ] V2 banner: visible at the bottom of `DashboardSidebar`; no action button; dismiss persists.
- [ ] Toggle Experimental → "Try Superset v2" — switch is no longer disabled and tracks `surface_toggled` cleanly.
- [ ] PostHog `surface` / `surface_source` properties update to `opted-in` / `opted-out` (no more `v2-flag-off`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default new desktop installs to v2 and add a dismissible “Superset v2 is here” banner in the sidebar to help v1 users switch. Removes the `v2-cloud` flag and simplifies v2 activation to a local override.

- **New Features**
  - Banner at the bottom of v1 and v2 sidebars; v1 shows “Switch to v2”, v2 is announcement + dismiss.
  - Dismissal persists via `v2-available-banner-v1`.
  - Fresh installs default to v2 using `hasPriorSupersetUsage` (`tabs-storage` probe); returning v1 users stay on v1.

- **Refactors**
  - `useIsV2CloudEnabled` now returns a boolean from `v2-local-override`; remote flag logic removed across call sites.
  - Deleted `FEATURE_FLAGS.V2_CLOUD` from `packages/shared/src/constants.ts`.
  - PostHog tagging simplified: `surface` and `surface_source` now `v1`/`v2` and `opted-in`/`opted-out`.
  - Experimental settings toggle is always enabled and tracks `surface_toggled`.

<sup>Written for commit 8bb6ecb6687f189862bd304ea38845cadad40966. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an animated banner prompting users to switch to Superset v2, with dismissal capability and analytics tracking for user interactions.

* **Refactor**
  * Simplified v2 cloud enablement logic to improve the migration experience for returning users.

* **Chores**
  * Removed unused feature flag configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->