### PR TITLE
fix(workspace-client): drop noisy server-error console log

### DIFF
--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -103,7 +103,9 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 	}
 
 	if (message.type === "error") {
-		console.error("[event-bus-client]", message.message);
+		// Server-side bus errors aren't actionable from the client; the
+		// reconnect loop already handles transient failures, and logging
+		// here just floods the console when a host bounces offline.
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- The event bus logged every `{type:"error"}` message from the relay to the console, which floods devtools when a host bounces offline.
- The reconnect loop already handles transient failures, so the log was pure noise — dropped it and left a comment on why.

## Test plan
- [ ] Open desktop app with at least one offline remote host present
- [ ] Confirm the previous `[event-bus-client] ...` lines are gone from devtools
- [ ] Trigger a real server error (e.g. invalid token) and verify the bus still recovers via reconnect

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed console logging for relay `{type:"error"}` events in `workspace-client` to stop devtools spam when a host goes offline. Reconnect logic still handles transient failures; this only quiets noisy logs.

<sup>Written for commit 21e7afe94c87d8698366a11a0ca2a52deea68880. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal debug logging from event handling to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->