### PR TITLE
fix(desktop): drop onboarding auto-skip, align SetupButton with design system

### DIFF
--- a/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
+++ b/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
@@ -1,25 +1,27 @@
 import { SidebarCard } from "@superset/ui/sidebar-card";
+import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { useV2AvailableBannerStore } from "renderer/stores/v2-available-banner";
-import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 export function V2AvailableBanner() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const dismissed = useV2AvailableBannerStore((s) => s.dismissed);
 	const dismiss = useV2AvailableBannerStore((s) => s.dismiss);
-	const setOptInV2 = useV2LocalOverrideStore((s) => s.setOptInV2);
+	const navigate = useNavigate();
 
-	function handleSwitch() {
-		track("surface_toggled", { from: "v1", to: "v2", source: "v1_banner" });
-		setOptInV2(true);
+	function handleManage() {
+		track("v2_banner_manage_clicked");
+		navigate({ to: "/settings/experimental" });
 	}
 
 	function handleDismiss() {
 		track("v2_banner_dismissed");
 		dismiss();
 	}
+
+	if (isV2CloudEnabled) return null;
 
 	return (
 		<AnimatePresence>
@@ -34,9 +36,9 @@ export function V2AvailableBanner() {
 					<SidebarCard
 						badge="New"
 						title="Superset v2 is here"
-						description="The new cloud workspace experience is now available."
-						actionLabel={isV2CloudEnabled ? undefined : "Switch to v2"}
-						onAction={isV2CloudEnabled ? undefined : handleSwitch}
+						description="Try the new cloud workspace experience."
+						actionLabel="Try new version of Superset"
+						onAction={handleManage}
 						onDismiss={handleDismiss}
 					/>
 				</motion.div>

--- a/apps/desktop/src/renderer/hooks/useEnsureV2Project/index.ts
+++ b/apps/desktop/src/renderer/hooks/useEnsureV2Project/index.ts
@@ -1,0 +1,4 @@
+export {
+	type EnsureV2ProjectResult,
+	useEnsureV2Project,
+} from "./useEnsureV2Project";

--- a/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
+++ b/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
@@ -1,0 +1,66 @@
+import { useCallback } from "react";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+
+export interface EnsureV2ProjectResult {
+	hostUrl: string;
+	projectId: string;
+	repoPath: string;
+	mainWorkspaceId: string | null;
+}
+
+export function useEnsureV2Project(): (args: {
+	repoPath: string;
+	name: string;
+}) => Promise<EnsureV2ProjectResult> {
+	const { activeHostUrl } = useLocalHostService();
+
+	return useCallback(
+		async ({ repoPath, name }) => {
+			if (!activeHostUrl) {
+				throw new Error("No active host service");
+			}
+			const hostService = getHostServiceClientByUrl(activeHostUrl);
+
+			const found = await hostService.project.findByPath.query({ repoPath });
+			const candidate = found.candidates[0];
+			if (candidate) {
+				try {
+					const setupResult = await hostService.project.setup.mutate({
+						projectId: candidate.id,
+						mode: { kind: "import", repoPath },
+					});
+					return {
+						hostUrl: activeHostUrl,
+						projectId: candidate.id,
+						repoPath: setupResult.repoPath,
+						mainWorkspaceId: setupResult.mainWorkspaceId,
+					};
+				} catch (err) {
+					// findByPath returns local sqlite rows even when no cloud v2 project
+					// exists for that id; setup → v2Project.get → NOT_FOUND. Only that
+					// case is safe to fall through to create — every other error
+					// (network, auth, 5xx) must propagate so retries don't silently mint
+					// duplicate cloud projects.
+					const code = (err as { data?: { code?: string } } | null | undefined)
+						?.data?.code;
+					if (code !== "NOT_FOUND") {
+						throw err;
+					}
+				}
+			}
+
+			const created = await hostService.project.create.mutate({
+				name,
+				mode: { kind: "importLocal", repoPath },
+			});
+			return {
+				hostUrl: activeHostUrl,
+				projectId: created.projectId,
+				repoPath: created.repoPath,
+				mainWorkspaceId: created.mainWorkspaceId,
+			};
+		},
+		[activeHostUrl],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -4,11 +4,14 @@ import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GoGitBranch } from "react-icons/go";
-import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { useEnsureV2Project } from "renderer/hooks/useEnsureV2Project";
 import { track } from "renderer/lib/analytics";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { useImportExternalWorktrees } from "renderer/react-query/workspaces/useImportExternalWorktrees";
+import { useFinalizeProjectSetup } from "renderer/react-query/projects/useFinalizeProjectSetup";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
+import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import { SetupButton } from "../components/SetupButton";
 import { StepHeader, StepShell } from "../components/StepShell";
 import {
@@ -34,8 +37,6 @@ function OnboardingAdoptWorktreesPage() {
 	const markComplete = useOnboardingStore((s) => s.markComplete);
 	const markSkipped = useOnboardingStore((s) => s.markSkipped);
 
-	const utils = electronTrpc.useUtils();
-	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { data: projects, isPending } =
 		electronTrpc.projects.getRecents.useQuery();
 
@@ -43,48 +44,11 @@ function OnboardingAdoptWorktreesPage() {
 		goTo("adopt-worktrees");
 	}, [goTo]);
 
-	const navigateAfterFlow = useCallback(
-		async (replace: boolean) => {
-			try {
-				const grouped = await utils.workspaces.getAllGrouped.fetch();
-				const allWorkspaces = grouped.flatMap((g) => g.workspaces);
-				const lastViewedId = localStorage.getItem("lastViewedWorkspaceId");
-				const candidates = isV2CloudEnabled
-					? allWorkspaces.filter((w) => w.type === "worktree")
-					: allWorkspaces;
-				const target =
-					candidates.find((w) => w.id === lastViewedId) ?? candidates[0];
-				if (target) {
-					if (isV2CloudEnabled) {
-						navigate({
-							to: "/v2-workspace/$workspaceId",
-							params: { workspaceId: target.id },
-							replace,
-						});
-					} else {
-						navigate({
-							to: "/workspace/$workspaceId",
-							params: { workspaceId: target.id },
-							replace,
-						});
-					}
-					return;
-				}
-			} catch {
-				// fall through to project / welcome routing
-			}
-			const project = projects?.[0];
-			if (project) {
-				navigate({
-					to: "/project/$projectId",
-					params: { projectId: project.id },
-					replace,
-				});
-				return;
-			}
-			navigate({ to: "/welcome", replace });
+	const goToDashboard = useCallback(
+		(replace: boolean) => {
+			navigate({ to: "/v2-workspaces", replace });
 		},
-		[utils, isV2CloudEnabled, navigate, projects],
+		[navigate],
 	);
 
 	const finishFlow = useCallback(() => {
@@ -94,8 +58,8 @@ function OnboardingAdoptWorktreesPage() {
 			duration_ms: startedAt ? Date.now() - startedAt : null,
 		});
 		markComplete("adopt-worktrees");
-		void navigateAfterFlow(true);
-	}, [markComplete, navigateAfterFlow]);
+		goToDashboard(true);
+	}, [markComplete, goToDashboard]);
 
 	const skipFlow = useCallback(() => {
 		const startedAt = useOnboardingStore.getState().startedAt;
@@ -104,8 +68,8 @@ function OnboardingAdoptWorktreesPage() {
 			duration_ms: startedAt ? Date.now() - startedAt : null,
 		});
 		markSkipped("adopt-worktrees");
-		void navigateAfterFlow(true);
-	}, [markSkipped, navigateAfterFlow]);
+		goToDashboard(true);
+	}, [markSkipped, goToDashboard]);
 
 	if (isPending) {
 		return (
@@ -117,7 +81,11 @@ function OnboardingAdoptWorktreesPage() {
 
 	return (
 		<AdoptWorktreesContent
-			projects={(projects ?? []).map((p) => ({ id: p.id, name: p.name }))}
+			projects={(projects ?? []).map((p) => ({
+				id: p.id,
+				name: p.name,
+				mainRepoPath: p.mainRepoPath,
+			}))}
 			onSkip={skipFlow}
 			onFinish={finishFlow}
 		/>
@@ -130,7 +98,7 @@ interface ProjectResult {
 }
 
 interface AdoptWorktreesContentProps {
-	projects: { id: string; name: string }[];
+	projects: { id: string; name: string; mainRepoPath: string }[];
 	onSkip: () => void;
 	onFinish: () => void;
 }
@@ -140,9 +108,19 @@ function AdoptWorktreesContent({
 	onSkip,
 	onFinish,
 }: AdoptWorktreesContentProps) {
-	const importExternalWorktrees = useImportExternalWorktrees();
+	const { submit } = useWorkspaceCreates();
+	const { machineId, activeHostUrl } = useLocalHostService();
+	const ensureV2Project = useEnsureV2Project();
+	const finalizeProjectSetup = useFinalizeProjectSetup();
+	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const [results, setResults] = useState<Record<string, ProjectResult>>({});
 	const [selected, setSelected] = useState<SelectionState>({});
+	const [isImporting, setIsImporting] = useState(false);
+	const [progress, setProgress] = useState<{
+		current: number;
+		total: number;
+	} | null>(null);
+	const hostNotReady = !activeHostUrl;
 
 	const allLoaded = projects.every((p) => results[p.id]?.loaded);
 	const total = useMemo(
@@ -192,23 +170,73 @@ function AdoptWorktreesContent({
 	);
 
 	const handleImportSelected = async () => {
+		if (!machineId) {
+			toast.error("No active host");
+			return;
+		}
+		const totalToImport = totalSelected;
+		setIsImporting(true);
+		setProgress({ current: 0, total: totalToImport });
 		let totalImported = 0;
-		for (const project of projects) {
-			const paths = Array.from(selected[project.id] ?? []);
-			if (paths.length === 0) continue;
-			try {
-				const result = await importExternalWorktrees.mutateAsync({
-					projectId: project.id,
-					paths,
-				});
-				totalImported += result.imported;
-			} catch (err) {
-				toast.error(
-					err instanceof Error
-						? err.message
-						: `Failed to import worktrees for ${project.name}`,
-				);
+		try {
+			for (const project of projects) {
+				const paths = Array.from(selected[project.id] ?? []);
+				if (paths.length === 0) continue;
+				const projectResult = results[project.id];
+				if (!projectResult) continue;
+
+				let v2ProjectId: string;
+				try {
+					const ensureResult = await ensureV2Project({
+						repoPath: project.mainRepoPath,
+						name: project.name,
+					});
+					v2ProjectId = ensureResult.projectId;
+					finalizeProjectSetup(ensureResult.hostUrl, {
+						projectId: ensureResult.projectId,
+						repoPath: ensureResult.repoPath,
+						mainWorkspaceId: ensureResult.mainWorkspaceId,
+					});
+				} catch (err) {
+					toast.error(
+						err instanceof Error
+							? `Could not link "${project.name}" to v2: ${err.message}`
+							: `Could not link "${project.name}" to v2`,
+					);
+					continue;
+				}
+
+				for (const path of paths) {
+					const wt = projectResult.worktrees.find((w) => w.path === path);
+					if (!wt) continue;
+					const result = await submit({
+						hostId: machineId,
+						snapshot: {
+							id: crypto.randomUUID(),
+							projectId: v2ProjectId,
+							name: wt.branch,
+							branch: wt.branch,
+						},
+					});
+					if (result.ok) {
+						totalImported++;
+						ensureWorkspaceInSidebar(result.workspaceId, v2ProjectId);
+					} else {
+						toast.error(`Failed to import ${wt.branch}: ${result.error}`);
+					}
+					setProgress({ current: totalImported, total: totalToImport });
+				}
 			}
+		} finally {
+			setIsImporting(false);
+			setProgress(null);
+		}
+
+		const hadSelections = projects.some((p) => (selected[p.id]?.size ?? 0) > 0);
+		if (hadSelections && totalImported === 0) {
+			// All selected imports failed. Errors were already toasted; keep the
+			// user here to retry rather than yanking them into the dashboard.
+			return;
 		}
 		if (totalImported > 0) {
 			toast.success(
@@ -225,11 +253,13 @@ function AdoptWorktreesContent({
 			<StepHeader
 				title="Adopt existing worktrees"
 				subtitle={
-					!allLoaded
-						? "Scanning your projects for unadopted worktrees…"
-						: nothingToAdopt
-							? "All worktrees on disk are already tracked."
-							: `Found ${total} worktree${total === 1 ? "" : "s"} on disk that aren't yet tracked.`
+					isImporting && progress
+						? `Importing ${progress.current} of ${progress.total} workspace${progress.total === 1 ? "" : "s"}…`
+						: !allLoaded
+							? "Scanning your projects for unadopted worktrees…"
+							: nothingToAdopt
+								? "All worktrees on disk are already tracked."
+								: `Found ${total} worktree${total === 1 ? "" : "s"} on disk that aren't yet tracked.`
 				}
 			/>
 
@@ -264,22 +294,18 @@ function AdoptWorktreesContent({
 						<SetupButton
 							onClick={handleImportSelected}
 							disabled={
-								!allLoaded ||
-								totalSelected === 0 ||
-								importExternalWorktrees.isPending
+								!allLoaded || totalSelected === 0 || isImporting || hostNotReady
 							}
 						>
-							{importExternalWorktrees.isPending
-								? "Importing…"
-								: totalSelected === 0
-									? "Select worktrees"
-									: `Import ${totalSelected} selected`}
+							{isImporting && progress
+								? `Importing ${progress.current} of ${progress.total}…`
+								: hostNotReady
+									? "Connecting…"
+									: totalSelected === 0
+										? "Select worktrees"
+										: `Import ${totalSelected} selected`}
 						</SetupButton>
-						<SetupButton
-							variant="link"
-							onClick={onSkip}
-							disabled={importExternalWorktrees.isPending}
-						>
+						<SetupButton variant="link" onClick={onSkip} disabled={isImporting}>
 							Skip for now
 						</SetupButton>
 					</>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -33,10 +33,6 @@ function OnboardingAdoptWorktreesPage() {
 	const goTo = useOnboardingStore((s) => s.goTo);
 	const markComplete = useOnboardingStore((s) => s.markComplete);
 	const markSkipped = useOnboardingStore((s) => s.markSkipped);
-	const manualWalkthrough = useOnboardingStore((s) => s.manualWalkthrough);
-	const setManualWalkthrough = useOnboardingStore(
-		(s) => s.setManualWalkthrough,
-	);
 
 	const utils = electronTrpc.useUtils();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
@@ -98,9 +94,8 @@ function OnboardingAdoptWorktreesPage() {
 			duration_ms: startedAt ? Date.now() - startedAt : null,
 		});
 		markComplete("adopt-worktrees");
-		setManualWalkthrough(false);
 		void navigateAfterFlow(true);
-	}, [markComplete, setManualWalkthrough, navigateAfterFlow]);
+	}, [markComplete, navigateAfterFlow]);
 
 	const skipFlow = useCallback(() => {
 		const startedAt = useOnboardingStore.getState().startedAt;
@@ -109,9 +104,8 @@ function OnboardingAdoptWorktreesPage() {
 			duration_ms: startedAt ? Date.now() - startedAt : null,
 		});
 		markSkipped("adopt-worktrees");
-		setManualWalkthrough(false);
 		void navigateAfterFlow(true);
-	}, [markSkipped, setManualWalkthrough, navigateAfterFlow]);
+	}, [markSkipped, navigateAfterFlow]);
 
 	if (isPending) {
 		return (
@@ -121,28 +115,12 @@ function OnboardingAdoptWorktreesPage() {
 		);
 	}
 
-	if (!projects || projects.length === 0) {
-		return <AutoAdvance onAdvance={finishFlow} />;
-	}
-
 	return (
 		<AdoptWorktreesContent
-			projects={projects.map((p) => ({ id: p.id, name: p.name }))}
+			projects={(projects ?? []).map((p) => ({ id: p.id, name: p.name }))}
 			onSkip={skipFlow}
 			onFinish={finishFlow}
-			manualWalkthrough={manualWalkthrough}
 		/>
-	);
-}
-
-function AutoAdvance({ onAdvance }: { onAdvance: () => void }) {
-	useEffect(() => {
-		onAdvance();
-	}, [onAdvance]);
-	return (
-		<div className="flex h-full w-full items-center justify-center bg-[#151110]">
-			<Spinner className="size-6 text-[#a8a5a3]" />
-		</div>
 	);
 }
 
@@ -155,14 +133,12 @@ interface AdoptWorktreesContentProps {
 	projects: { id: string; name: string }[];
 	onSkip: () => void;
 	onFinish: () => void;
-	manualWalkthrough: boolean;
 }
 
 function AdoptWorktreesContent({
 	projects,
 	onSkip,
 	onFinish,
-	manualWalkthrough,
 }: AdoptWorktreesContentProps) {
 	const importExternalWorktrees = useImportExternalWorktrees();
 	const [results, setResults] = useState<Record<string, ProjectResult>>({});
@@ -178,10 +154,6 @@ function AdoptWorktreesContent({
 		[results],
 	);
 	const totalSelected = useMemo(() => countSelected(selected), [selected]);
-
-	useEffect(() => {
-		if (allLoaded && total === 0 && !manualWalkthrough) onFinish();
-	}, [allLoaded, total, manualWalkthrough, onFinish]);
 
 	const handleResult = useCallback(
 		(projectId: string, worktrees: ExternalWorktree[]) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/components/SetupButton/SetupButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/components/SetupButton/SetupButton.tsx
@@ -1,35 +1,36 @@
+import { Button } from "@superset/ui/button";
 import { cn } from "@superset/ui/utils";
-import type { ButtonHTMLAttributes, ReactNode } from "react";
+import type { ComponentProps } from "react";
 
 type Variant = "primary" | "secondary" | "link";
 
-interface SetupButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface SetupButtonProps
+	extends Omit<ComponentProps<typeof Button>, "variant" | "size"> {
 	variant?: Variant;
-	children: ReactNode;
 }
 
-const VARIANT_STYLES: Record<Variant, string> = {
-	primary:
-		"relative h-[28px] w-full rounded-[4px] border border-[rgba(255,136,70,0.8)] bg-[rgba(255,91,0,0.8)] px-2 text-[12px] font-medium text-[#eae8e6] shadow-[inset_0_1px_6.9px_0_rgba(255,255,255,0.14)] transition-colors hover:bg-[rgba(255,91,0,0.95)] disabled:opacity-60",
-	secondary:
-		"relative h-[28px] w-full rounded-[4px] border border-[#2a2827] bg-[#201e1c] px-2 text-[12px] font-medium text-[#eae8e6] shadow-[inset_0_1px_6.9px_0_rgba(255,255,255,0.1)] transition-colors hover:bg-[#2a2827] disabled:opacity-60",
-	link: "text-[12px] font-medium text-[#a8a5a3] underline-offset-4 transition-colors hover:text-[#eae8e6] hover:underline",
-};
+const VARIANT_MAP = {
+	primary: "default",
+	secondary: "secondary",
+	link: "link",
+} as const satisfies Record<Variant, ComponentProps<typeof Button>["variant"]>;
 
 export function SetupButton({
 	variant = "primary",
 	className,
-	children,
 	type = "button",
+	children,
 	...rest
 }: SetupButtonProps) {
 	return (
-		<button
+		<Button
 			type={type}
-			className={cn(VARIANT_STYLES[variant], className)}
+			variant={VARIANT_MAP[variant]}
+			size="xs"
+			className={cn(variant !== "link" && "w-full", className)}
 			{...rest}
 		>
 			{children}
-		</button>
+		</Button>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/gh-cli/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/gh-cli/page.tsx
@@ -17,9 +17,6 @@ function OnboardingGhCliPage() {
 	const goTo = useOnboardingStore((s) => s.goTo);
 	const markComplete = useOnboardingStore((s) => s.markComplete);
 	const markSkipped = useOnboardingStore((s) => s.markSkipped);
-	const completed = useOnboardingStore((s) => s.completed["gh-cli"]);
-	const skipped = useOnboardingStore((s) => s.skipped["gh-cli"]);
-	const manualWalkthrough = useOnboardingStore((s) => s.manualWalkthrough);
 
 	const {
 		data: ghStatus,
@@ -32,19 +29,6 @@ function OnboardingGhCliPage() {
 		goTo("gh-cli");
 	}, [goTo]);
 
-	const shouldAutoAdvance =
-		!completed &&
-		!skipped &&
-		!manualWalkthrough &&
-		ghStatus?.installed === true;
-
-	useEffect(() => {
-		if (shouldAutoAdvance) {
-			markComplete("gh-cli");
-			navigate({ to: STEP_ROUTES.permissions, replace: true });
-		}
-	}, [shouldAutoAdvance, markComplete, navigate]);
-
 	const handleSkip = () => {
 		markSkipped("gh-cli");
 		navigate({ to: STEP_ROUTES.permissions });
@@ -54,7 +38,7 @@ function OnboardingGhCliPage() {
 		navigate({ to: STEP_ROUTES.permissions });
 	};
 
-	if (isPending || shouldAutoAdvance) {
+	if (isPending) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
 				<Spinner className="size-6 text-[#a8a5a3]" />

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -61,10 +61,6 @@ function OnboardingProjectPage() {
 		const result = await folderImport.start();
 		if (result) {
 			markComplete("project");
-			navigate({
-				to: "/project/$projectId",
-				params: { projectId: result.projectId },
-			});
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -1,24 +1,16 @@
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-	AlertDialogTrigger,
-} from "@superset/ui/alert-dialog";
 import { toast } from "@superset/ui/sonner";
 import { Spinner } from "@superset/ui/spinner";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
-import { LuFolder, LuX } from "react-icons/lu";
-import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
-import { electronTrpc } from "renderer/lib/electron-trpc";
-import { useOpenProject } from "renderer/react-query/projects/useOpenProject";
+import { LuFolder } from "react-icons/lu";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
+import { MOCK_ORG_ID } from "shared/constants";
 import { SetupButton } from "../components/SetupButton";
 import { StepHeader, StepShell, SupersetPill } from "../components/StepShell";
 import { SupersetIcon } from "../providers/components/SupersetIcon";
@@ -33,78 +25,46 @@ function OnboardingProjectPage() {
 	const markComplete = useOnboardingStore((s) => s.markComplete);
 	const markSkipped = useOnboardingStore((s) => s.markSkipped);
 
-	const { data: projects, isPending } =
-		electronTrpc.projects.getRecents.useQuery();
-	const { openNew, isPending: isOpenPending } = useOpenProject();
-	const utils = electronTrpc.useUtils();
-	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const collections = useCollections();
+	const { data: session } = authClient.useSession();
+	const activeOrganizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
+
+	const { data: projects = [], isLoading } = useLiveQuery(
+		(q) =>
+			q
+				.from({ projects: collections.v2Projects })
+				.where(({ projects }) =>
+					eq(projects.organizationId, activeOrganizationId ?? ""),
+				)
+				.select(({ projects }) => ({
+					id: projects.id,
+					name: projects.name,
+					repoCloneUrl: projects.repoCloneUrl,
+				})),
+		[collections, activeOrganizationId],
+	);
+
 	const folderImport = useFolderFirstImport({
 		onError: (message) => toast.error(message),
 	});
-	const closeProject = electronTrpc.projects.close.useMutation({
-		onSuccess: async () => {
-			await utils.projects.getRecents.invalidate();
-		},
-	});
-
-	const handleRemoveProject = async (id: string, name: string) => {
-		try {
-			await closeProject.mutateAsync({ id });
-			toast.success(`Removed ${name}`);
-		} catch (err) {
-			toast.error(
-				err instanceof Error ? err.message : "Failed to remove project",
-			);
-		}
-	};
 
 	useEffect(() => {
 		goTo("project");
 	}, [goTo]);
 
-	const projectCount = projects?.length ?? 0;
+	const projectCount = projects.length;
 	const hasProjects = projectCount > 0;
 
-	const openV1ProjectInWorkspace = async (projectId: string) => {
-		try {
-			const grouped = await utils.workspaces.getAllGrouped.fetch();
-			const wsForProject = grouped
-				.flatMap((g) => g.workspaces)
-				.find((w) => w.projectId === projectId);
-			if (wsForProject) {
-				navigate({
-					to: "/workspace/$workspaceId",
-					params: { workspaceId: wsForProject.id },
-				});
-				return;
-			}
-		} catch {
-			// fall through
-		}
-		navigate({
-			to: "/project/$projectId",
-			params: { projectId },
-		});
-	};
-
 	const handleSelectNewRepo = async () => {
-		if (isV2CloudEnabled) {
-			const result = await folderImport.start();
-			if (result) {
-				markComplete("project");
-				navigate({
-					to: "/project/$projectId",
-					params: { projectId: result.projectId },
-				});
-			}
-			return;
-		}
-
-		const created = await openNew();
-		const project = created[0];
-		if (project) {
+		const result = await folderImport.start();
+		if (result) {
 			markComplete("project");
-			await openV1ProjectInWorkspace(project.id);
+			navigate({
+				to: "/project/$projectId",
+				params: { projectId: result.projectId },
+			});
 		}
 	};
 
@@ -118,7 +78,7 @@ function OnboardingProjectPage() {
 		navigate({ to: STEP_ROUTES["adopt-worktrees"] });
 	};
 
-	if (isPending) {
+	if (isLoading) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
 				<Spinner className="size-6 text-[#a8a5a3]" />
@@ -134,7 +94,7 @@ function OnboardingProjectPage() {
 		</SupersetPill>
 	);
 
-	if (hasProjects && projects) {
+	if (hasProjects) {
 		return (
 			<StepShell backTo={STEP_ROUTES.permissions}>
 				<StepHeader
@@ -148,7 +108,7 @@ function OnboardingProjectPage() {
 						{projects.map((project) => (
 							<div
 								key={project.id}
-								className="group flex items-center gap-3 px-4 py-3"
+								className="flex items-center gap-3 px-4 py-3"
 							>
 								<div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-[#151110] text-[#a8a5a3]">
 									<LuFolder className="size-4" />
@@ -157,43 +117,12 @@ function OnboardingProjectPage() {
 									<p className="truncate text-[12px] font-medium text-[#eae8e6]">
 										{project.name}
 									</p>
-									<p className="truncate font-mono text-[10px] text-[#a8a5a3]">
-										{project.mainRepoPath}
-									</p>
+									{project.repoCloneUrl && (
+										<p className="truncate font-mono text-[10px] text-[#a8a5a3]">
+											{project.repoCloneUrl}
+										</p>
+									)}
 								</div>
-								<AlertDialog>
-									<AlertDialogTrigger asChild>
-										<button
-											type="button"
-											aria-label={`Remove ${project.name}`}
-											className="flex size-7 shrink-0 items-center justify-center rounded text-[#a8a5a3] opacity-0 transition-opacity hover:bg-white/5 hover:text-[#eae8e6] group-hover:opacity-100 focus-visible:opacity-100"
-										>
-											<LuX className="size-4" />
-										</button>
-									</AlertDialogTrigger>
-									<AlertDialogContent>
-										<AlertDialogHeader>
-											<AlertDialogTitle>
-												Remove {project.name}?
-											</AlertDialogTitle>
-											<AlertDialogDescription>
-												This removes the project and its tracked workspaces from
-												Superset. The folder on disk and your git history are
-												untouched — you can re-add it any time.
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel>Cancel</AlertDialogCancel>
-											<AlertDialogAction
-												onClick={() =>
-													handleRemoveProject(project.id, project.name)
-												}
-											>
-												Remove
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
 							</div>
 						))}
 					</div>
@@ -203,18 +132,8 @@ function OnboardingProjectPage() {
 					<SetupButton onClick={handleContinueWithCurrent}>
 						Continue with current
 					</SetupButton>
-					<SetupButton
-						variant="secondary"
-						onClick={handleSelectNewRepo}
-						disabled={isOpenPending}
-					>
-						{isOpenPending ? "Opening…" : "Select new repo"}
-					</SetupButton>
-					<SetupButton
-						variant="secondary"
-						onClick={() => navigate({ to: "/new-project" })}
-					>
-						Clone from GitHub
+					<SetupButton variant="secondary" onClick={handleSelectNewRepo}>
+						Select new repo
 					</SetupButton>
 					<SetupButton variant="link" onClick={handleSkipStep}>
 						Skip for now
@@ -233,15 +152,7 @@ function OnboardingProjectPage() {
 			/>
 
 			<div className="flex w-[273px] flex-col gap-2 self-center">
-				<SetupButton onClick={handleSelectNewRepo} disabled={isOpenPending}>
-					{isOpenPending ? "Opening…" : "Select new repo"}
-				</SetupButton>
-				<SetupButton
-					variant="secondary"
-					onClick={() => navigate({ to: "/new-project" })}
-				>
-					Clone from GitHub
-				</SetupButton>
+				<SetupButton onClick={handleSelectNewRepo}>Select new repo</SetupButton>
 				<SetupButton variant="link" onClick={handleSkipStep}>
 					Skip for now
 				</SetupButton>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -17,6 +17,7 @@ import { LuFolder, LuX } from "react-icons/lu";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenProject } from "renderer/react-query/projects/useOpenProject";
+import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
 import { SetupButton } from "../components/SetupButton";
 import { StepHeader, StepShell, SupersetPill } from "../components/StepShell";
@@ -37,6 +38,9 @@ function OnboardingProjectPage() {
 	const { openNew, isPending: isOpenPending } = useOpenProject();
 	const utils = electronTrpc.useUtils();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const folderImport = useFolderFirstImport({
+		onError: (message) => toast.error(message),
+	});
 	const closeProject = electronTrpc.projects.close.useMutation({
 		onSuccess: async () => {
 			await utils.projects.getRecents.invalidate();
@@ -61,20 +65,7 @@ function OnboardingProjectPage() {
 	const projectCount = projects?.length ?? 0;
 	const hasProjects = projectCount > 0;
 
-	// After creating a new project, route to the project page in v2 — that's
-	// where the user creates their first proper worktree workspace (which sets
-	// up the v2 pane layout). The default "branch" workspace auto-created by
-	// openNew → ensureMainWorkspace has no pane layout, so navigating there
-	// renders an empty workspace surface. In v1, navigate to the existing
-	// branch workspace as before.
-	const openProjectInWorkspace = async (projectId: string) => {
-		if (isV2CloudEnabled) {
-			navigate({
-				to: "/project/$projectId",
-				params: { projectId },
-			});
-			return;
-		}
+	const openV1ProjectInWorkspace = async (projectId: string) => {
 		try {
 			const grouped = await utils.workspaces.getAllGrouped.fetch();
 			const wsForProject = grouped
@@ -97,11 +88,23 @@ function OnboardingProjectPage() {
 	};
 
 	const handleSelectNewRepo = async () => {
+		if (isV2CloudEnabled) {
+			const result = await folderImport.start();
+			if (result) {
+				markComplete("project");
+				navigate({
+					to: "/project/$projectId",
+					params: { projectId: result.projectId },
+				});
+			}
+			return;
+		}
+
 		const created = await openNew();
 		const project = created[0];
 		if (project) {
 			markComplete("project");
-			await openProjectInWorkspace(project.id);
+			await openV1ProjectInWorkspace(project.id);
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -31,11 +31,6 @@ function OnboardingProjectPage() {
 	const goTo = useOnboardingStore((s) => s.goTo);
 	const markComplete = useOnboardingStore((s) => s.markComplete);
 	const markSkipped = useOnboardingStore((s) => s.markSkipped);
-	const completed = useOnboardingStore((s) => s.completed.project);
-	const manualWalkthrough = useOnboardingStore((s) => s.manualWalkthrough);
-	const setManualWalkthrough = useOnboardingStore(
-		(s) => s.setManualWalkthrough,
-	);
 
 	const { data: projects, isPending } =
 		electronTrpc.projects.getRecents.useQuery();
@@ -65,14 +60,6 @@ function OnboardingProjectPage() {
 
 	const projectCount = projects?.length ?? 0;
 	const hasProjects = projectCount > 0;
-	const shouldAutoAdvance = !completed && !manualWalkthrough && hasProjects;
-
-	useEffect(() => {
-		if (shouldAutoAdvance) {
-			markComplete("project");
-			navigate({ to: STEP_ROUTES["adopt-worktrees"], replace: true });
-		}
-	}, [shouldAutoAdvance, markComplete, navigate]);
 
 	// After creating a new project, route to the project page in v2 — that's
 	// where the user creates their first proper worktree workspace (which sets
@@ -114,7 +101,6 @@ function OnboardingProjectPage() {
 		const project = created[0];
 		if (project) {
 			markComplete("project");
-			setManualWalkthrough(false);
 			await openProjectInWorkspace(project.id);
 		}
 	};
@@ -129,7 +115,7 @@ function OnboardingProjectPage() {
 		navigate({ to: STEP_ROUTES["adopt-worktrees"] });
 	};
 
-	if (isPending || shouldAutoAdvance) {
+	if (isPending) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
 				<Spinner className="size-6 text-[#a8a5a3]" />

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -9,6 +9,7 @@ import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
 import { MOCK_ORG_ID } from "shared/constants";
 import { SetupButton } from "../components/SetupButton";
@@ -49,6 +50,8 @@ function OnboardingProjectPage() {
 	const folderImport = useFolderFirstImport({
 		onError: (message) => toast.error(message),
 	});
+	const { activeHostUrl } = useLocalHostService();
+	const hostReady = activeHostUrl !== null;
 
 	useEffect(() => {
 		goTo("project");
@@ -128,8 +131,12 @@ function OnboardingProjectPage() {
 					<SetupButton onClick={handleContinueWithCurrent}>
 						Continue with current
 					</SetupButton>
-					<SetupButton variant="secondary" onClick={handleSelectNewRepo}>
-						Select new repo
+					<SetupButton
+						variant="secondary"
+						onClick={handleSelectNewRepo}
+						disabled={!hostReady}
+					>
+						{hostReady ? "Select new repo" : "Connecting…"}
 					</SetupButton>
 					<SetupButton variant="link" onClick={handleSkipStep}>
 						Skip for now
@@ -148,7 +155,9 @@ function OnboardingProjectPage() {
 			/>
 
 			<div className="flex w-[273px] flex-col gap-2 self-center">
-				<SetupButton onClick={handleSelectNewRepo}>Select new repo</SetupButton>
+				<SetupButton onClick={handleSelectNewRepo} disabled={!hostReady}>
+					{hostReady ? "Select new repo" : "Connecting…"}
+				</SetupButton>
 				<SetupButton variant="link" onClick={handleSkipStep}>
 					Skip for now
 				</SetupButton>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
@@ -1,7 +1,7 @@
 import { chatServiceTrpc } from "@superset/chat/client";
 import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { LuKeyRound, LuSettings } from "react-icons/lu";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
 import { SetupButton } from "../components/SetupButton";
@@ -21,8 +21,6 @@ function OnboardingProvidersPage() {
 	const goTo = useOnboardingStore((s) => s.goTo);
 	const markComplete = useOnboardingStore((s) => s.markComplete);
 	const markSkipped = useOnboardingStore((s) => s.markSkipped);
-	const completed = useOnboardingStore((s) => s.completed.providers);
-	const manualWalkthrough = useOnboardingStore((s) => s.manualWalkthrough);
 
 	const { data: anthropicAuthStatus, isPending: isAnthropicPending } =
 		chatServiceTrpc.auth.getAnthropicStatus.useQuery();
@@ -36,13 +34,6 @@ function OnboardingProvidersPage() {
 	const isStatusPending = isAnthropicPending || isOpenAIPending;
 	const atLeastOneConnected = claudeConnected || codexConnected;
 
-	const wasConfiguredOnMount = useRef<boolean | null>(null);
-	useEffect(() => {
-		if (!isStatusPending && wasConfiguredOnMount.current === null) {
-			wasConfiguredOnMount.current = atLeastOneConnected;
-		}
-	}, [isStatusPending, atLeastOneConnected]);
-
 	const [claudeMethod, setClaudeMethod] = useState<ConnectionMethod>("oauth");
 	const [codexMethod, setCodexMethod] = useState<ConnectionMethod>("oauth");
 	const [reconfiguringClaude, setReconfiguringClaude] = useState(false);
@@ -52,17 +43,7 @@ function OnboardingProvidersPage() {
 		goTo("providers");
 	}, [goTo]);
 
-	const shouldAutoAdvance =
-		!completed && !manualWalkthrough && wasConfiguredOnMount.current === true;
-
-	useEffect(() => {
-		if (shouldAutoAdvance) {
-			markComplete("providers");
-			navigate({ to: STEP_ROUTES["gh-cli"], replace: true });
-		}
-	}, [shouldAutoAdvance, markComplete, navigate]);
-
-	if (isStatusPending || shouldAutoAdvance) {
+	if (isStatusPending) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
 				<Spinner className="size-6 text-[#a8a5a3]" />

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
@@ -38,6 +38,14 @@ function OnboardingProvidersPage() {
 	const [codexMethod, setCodexMethod] = useState<ConnectionMethod>("oauth");
 	const [reconfiguringClaude, setReconfiguringClaude] = useState(false);
 	const [reconfiguringCodex, setReconfiguringCodex] = useState(false);
+	const [activeProvider, setActiveProvider] = useState<"claude" | "codex">(
+		"claude",
+	);
+
+	useEffect(() => {
+		if (claudeConnected && !codexConnected) setActiveProvider("codex");
+		else if (!claudeConnected && codexConnected) setActiveProvider("claude");
+	}, [claudeConnected, codexConnected]);
 
 	useEffect(() => {
 		goTo("providers");
@@ -74,114 +82,157 @@ function OnboardingProvidersPage() {
 		? "Add another provider or continue to the next step."
 		: "Connect Claude Code, Codex, or both to get started.";
 
+	const inAnyStep =
+		!claudeConnected ||
+		!codexConnected ||
+		reconfiguringClaude ||
+		reconfiguringCodex;
+	const effectiveProvider: "claude" | "codex" = reconfiguringClaude
+		? "claude"
+		: reconfiguringCodex
+			? "codex"
+			: activeProvider;
+	const showBothCompact = !inAnyStep;
+	const showClaude = showBothCompact || effectiveProvider === "claude";
+	const showCodex = showBothCompact || effectiveProvider === "codex";
+	// Only offer the switcher when neither provider is connected. Once one is
+	// connected, the auto-switch effect points activeProvider at the unconnected
+	// one, so "Set up <connected> instead" would just drop the user into a
+	// Reconfigure panel for an already-working provider.
+	const showSwitcher =
+		!claudeConnected &&
+		!codexConnected &&
+		!reconfiguringClaude &&
+		!reconfiguringCodex;
+	const otherLabel = effectiveProvider === "claude" ? "Codex" : "Claude Code";
+
 	return (
 		<StepShell maxWidth="lg">
 			<StepHeader title="Connect AI Provider" subtitle={subtitle} />
 
-			<ProviderSection
-				label="Claude Code"
-				connected={claudeConnected}
-				reconfiguring={reconfiguringClaude}
-				onConnect={() =>
-					handleConnect("/setup/providers/claude-code", claudeMethod)
-				}
-				onReconfigure={() => setReconfiguringClaude(true)}
-				onCancelReconfigure={() => setReconfiguringClaude(false)}
-				connectedPanel={
-					<ConnectedPanel
-						icon={
-							<ClaudeBrandIcon
-								className="size-11 rounded-lg"
-								iconClassName="size-6"
-							/>
-						}
-						title="Claude Code is connected"
-					/>
-				}
-				options={
-					<>
-						<ProviderOptionCard
+			{showClaude && (
+				<ProviderSection
+					label="Claude Code"
+					connected={claudeConnected}
+					reconfiguring={reconfiguringClaude}
+					onConnect={() =>
+						handleConnect("/setup/providers/claude-code", claudeMethod)
+					}
+					onReconfigure={() => setReconfiguringClaude(true)}
+					onCancelReconfigure={() => setReconfiguringClaude(false)}
+					connectedPanel={
+						<ConnectedPanel
 							icon={
-								<ClaudeBrandIcon className="size-full" iconClassName="size-6" />
+								<ClaudeBrandIcon
+									className="size-11 rounded-lg"
+									iconClassName="size-6"
+								/>
 							}
-							title="Claude Pro/Max"
-							description="Use your Claude subscription for unlimited access."
-							recommended
-							selected={claudeMethod === "oauth"}
-							onSelect={() => setClaudeMethod("oauth")}
+							title="Claude Code is connected"
 						/>
-						<ProviderOptionCard
-							icon={<MutedIcon icon={<LuKeyRound className="size-5" />} />}
-							title="Anthropic API Key"
-							description="Pay-as-you-go with your own API key."
-							selected={claudeMethod === "api-key"}
-							onSelect={() => setClaudeMethod("api-key")}
-						/>
-						<ProviderOptionCard
-							icon={<MutedIcon icon={<LuSettings className="size-5" />} />}
-							title="Custom Model"
-							description="Use a custom base URL and model."
-							selected={claudeMethod === "custom"}
-							onSelect={() => setClaudeMethod("custom")}
-						/>
-					</>
-				}
-			/>
-
-			<ProviderSection
-				label="Codex"
-				connected={codexConnected}
-				reconfiguring={reconfiguringCodex}
-				onConnect={() => handleConnect("/setup/providers/codex", codexMethod)}
-				onReconfigure={() => setReconfiguringCodex(true)}
-				onCancelReconfigure={() => setReconfiguringCodex(false)}
-				connectedPanel={
-					<ConnectedPanel
-						icon={
-							<CodexBrandIcon
-								className="size-11 rounded-lg bg-[#eae8e6]"
-								iconClassName="size-6 text-[#151110]"
+					}
+					options={
+						<>
+							<ProviderOptionCard
+								icon={
+									<ClaudeBrandIcon
+										className="size-full"
+										iconClassName="size-6"
+									/>
+								}
+								title="Claude Pro/Max"
+								description="Use your Claude subscription for unlimited access."
+								recommended
+								selected={claudeMethod === "oauth"}
+								onSelect={() => setClaudeMethod("oauth")}
 							/>
-						}
-						title="Codex is connected"
-					/>
-				}
-				options={
-					<>
-						<ProviderOptionCard
+							<ProviderOptionCard
+								icon={<MutedIcon icon={<LuKeyRound className="size-5" />} />}
+								title="Anthropic API Key"
+								description="Pay-as-you-go with your own API key."
+								selected={claudeMethod === "api-key"}
+								onSelect={() => setClaudeMethod("api-key")}
+							/>
+							<ProviderOptionCard
+								icon={<MutedIcon icon={<LuSettings className="size-5" />} />}
+								title="Custom Model"
+								description="Use a custom base URL and model."
+								selected={claudeMethod === "custom"}
+								onSelect={() => setClaudeMethod("custom")}
+							/>
+						</>
+					}
+				/>
+			)}
+
+			{showCodex && (
+				<ProviderSection
+					label="Codex"
+					connected={codexConnected}
+					reconfiguring={reconfiguringCodex}
+					onConnect={() => handleConnect("/setup/providers/codex", codexMethod)}
+					onReconfigure={() => setReconfiguringCodex(true)}
+					onCancelReconfigure={() => setReconfiguringCodex(false)}
+					connectedPanel={
+						<ConnectedPanel
 							icon={
 								<CodexBrandIcon
-									className="size-full bg-[#eae8e6]"
+									className="size-11 rounded-lg bg-[#eae8e6]"
 									iconClassName="size-6 text-[#151110]"
 								/>
 							}
-							title="ChatGPT Plus/Pro"
-							description="Use your ChatGPT subscription via Codex."
-							recommended
-							selected={codexMethod === "oauth"}
-							onSelect={() => setCodexMethod("oauth")}
+							title="Codex is connected"
 						/>
-						<ProviderOptionCard
-							icon={<MutedIcon icon={<LuKeyRound className="size-5" />} />}
-							title="OpenAI API Key"
-							description="Pay-as-you-go with your own API key."
-							selected={codexMethod === "api-key"}
-							onSelect={() => setCodexMethod("api-key")}
-						/>
-						<ProviderOptionCard
-							icon={<MutedIcon icon={<LuSettings className="size-5" />} />}
-							title="Custom Model"
-							description="Use a custom base URL and model."
-							selected={codexMethod === "custom"}
-							onSelect={() => setCodexMethod("custom")}
-						/>
-					</>
-				}
-			/>
+					}
+					options={
+						<>
+							<ProviderOptionCard
+								icon={
+									<CodexBrandIcon
+										className="size-full bg-[#eae8e6]"
+										iconClassName="size-6 text-[#151110]"
+									/>
+								}
+								title="ChatGPT Plus/Pro"
+								description="Use your ChatGPT subscription via Codex."
+								recommended
+								selected={codexMethod === "oauth"}
+								onSelect={() => setCodexMethod("oauth")}
+							/>
+							<ProviderOptionCard
+								icon={<MutedIcon icon={<LuKeyRound className="size-5" />} />}
+								title="OpenAI API Key"
+								description="Pay-as-you-go with your own API key."
+								selected={codexMethod === "api-key"}
+								onSelect={() => setCodexMethod("api-key")}
+							/>
+							<ProviderOptionCard
+								icon={<MutedIcon icon={<LuSettings className="size-5" />} />}
+								title="Custom Model"
+								description="Use a custom base URL and model."
+								selected={codexMethod === "custom"}
+								onSelect={() => setCodexMethod("custom")}
+							/>
+						</>
+					}
+				/>
+			)}
 
 			<div className="flex w-[273px] flex-col gap-2 self-center">
-				{atLeastOneConnected && (
+				{atLeastOneConnected && !inAnyStep && (
 					<SetupButton onClick={handleContinueToNextStep}>Continue</SetupButton>
+				)}
+				{showSwitcher && (
+					<SetupButton
+						variant="link"
+						onClick={() =>
+							setActiveProvider(
+								effectiveProvider === "claude" ? "codex" : "claude",
+							)
+						}
+					>
+						Set up {otherLabel} instead
+					</SetupButton>
 				)}
 				<SetupButton variant="link" onClick={handleSkipStep}>
 					Skip for now

--- a/apps/desktop/src/renderer/stores/onboarding/onboardingStore.ts
+++ b/apps/desktop/src/renderer/stores/onboarding/onboardingStore.ts
@@ -44,12 +44,6 @@ interface OnboardingState {
 	skipped: Record<OnboardingStep, boolean>;
 	startedAt: number | null;
 	completedAt: number | null;
-	/**
-	 * When true, the user explicitly restarted onboarding from Settings.
-	 * Steps must NOT auto-advance based on already-satisfied prerequisites —
-	 * the user wants to walk through. Cleared when the flow finishes.
-	 */
-	manualWalkthrough: boolean;
 }
 
 interface OnboardingActions {
@@ -59,7 +53,6 @@ interface OnboardingActions {
 	next: () => OnboardingStep | null;
 	back: () => OnboardingStep | null;
 	reset: () => void;
-	setManualWalkthrough: (value: boolean) => void;
 }
 
 type OnboardingStore = OnboardingState & OnboardingActions;
@@ -70,7 +63,6 @@ const initialState: OnboardingState = {
 	skipped: { ...STEP_FLAGS_INITIAL },
 	startedAt: null,
 	completedAt: null,
-	manualWalkthrough: false,
 };
 
 function getNextStep(step: OnboardingStep): OnboardingStep | null {
@@ -150,10 +142,8 @@ export const useOnboardingStore = create<OnboardingStore>()(
 						skipped: { ...STEP_FLAGS_INITIAL },
 						startedAt: null,
 						completedAt: null,
-						manualWalkthrough: false,
 					});
 				},
-				setManualWalkthrough: (value) => set({ manualWalkthrough: value }),
 			}),
 			{ name: "superset-onboarding-v1" },
 		),

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Onboarding step pages auto-advance away when system state already satisfies a step (provider connected, gh installed, project added). The gate that was supposed to suppress this — `manualWalkthrough` — is never set to `true` anywhere, so the auto-skip always fires. Symptom: clicking **Configure Codex** while Claude is already connected reroutes you to `/setup/gh-cli` before you can do anything.
- Rips out `shouldAutoAdvance` from `providers`, `gh-cli`, and `project` step pages, plus the no-projects / no-worktrees auto-finish in `adopt-worktrees`. Drops the dead `manualWalkthrough` field and `setManualWalkthrough` action from the store. Per-step **Skip for now** buttons are unchanged.
- Rewrites `SetupButton` as a thin wrapper around `@superset/ui/button` (`primary` → `default`, `secondary` → `secondary`, `link` → `link`, `size="xs"`, `w-full` for non-link). Onboarding CTAs now share theming, focus ring, and hover with the rest of the app instead of using the hardcoded orange + inset shadow.

## Test plan
- [ ] Restart onboarding from Settings → Experimental and walk through every step manually; nothing auto-advances.
- [ ] On `/setup/providers` with one provider connected, click **Reconfigure** on the other — page stays put.
- [ ] On `/setup/gh-cli` with `gh` installed, the "GitHub CLI is installed" view renders instead of auto-advancing.
- [ ] On `/setup/project` with existing projects, the project list renders with **Continue with current** instead of auto-advancing.
- [ ] On `/setup/adopt-worktrees` with no projects, the empty "nothing to adopt" state renders with a working **Continue** button.
- [ ] Buttons across all setup pages render in the themed design-system style (no orange custom CTA), focus rings work, hover states feel consistent with `StartView` etc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops onboarding from auto-skipping, switches setup buttons to the design system, and makes the flow v2-first end to end. Project and worktree steps now create real cloud projects/workspaces and keep users in the flow.

- **Bug Fixes**
  - Removed auto-advance in providers, gh-cli, project, and adopt-worktrees. Steps render and can be completed or skipped manually.
  - Project step reads org projects from `collections.v2Projects` via `useLiveQuery`; list shows name and `repoCloneUrl`. “Select new repo” uses `useFolderFirstImport` and stays on `/setup/project` until the new project appears. Dropped v1 paths and removed “Clone from GitHub” and per-row delete.
  - Gated v2 actions on host readiness. “Select new repo” and worktree import show “Connecting…” until the host is available.

- **New Features**
  - Adopt worktrees in v2: per project, ensure a v2 project and finalize setup, then create v2 workspaces for selected worktrees (with “Importing X of Y…” progress). Stay on page if all imports fail and route to `/v2-workspaces` on finish. Uses `useEnsureV2Project` to avoid duplicate cloud projects.
  - Provider setup UX: focus one provider at a time, default to the unconnected provider when the other is connected, offer “Set up X instead” when neither is connected, and hide Continue while configuring.
  - V2 banner shows only for v1 users and opens Settings → Experimental (“Try new version of Superset”).

<sup>Written for commit 85125db5f501cf580e7ab1ab6bf5efac001f641e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed manual walkthrough and auto-advance behavior across onboarding; simplified onboarding screens, navigation, and loading/spinner logic.
  * Streamlined provider, project, worktree, and CLI setup flows for clearer state and controls.

* **New Features**
  * Added a v2 cloud project import path with per-project import handling, import progress UI, improved host-connection messaging, and safer project mapping.

* **Style**
  * Updated setup button to use a unified button component with adjusted sizing and full-width behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->