### PR TITLE
feat(desktop): polish v2 banner and onboarding setup flow

### DIFF
--- a/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
+++ b/apps/desktop/src/renderer/components/V2AvailableBanner/V2AvailableBanner.tsx
@@ -1,19 +1,24 @@
 import { SidebarCard } from "@superset/ui/sidebar-card";
+import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
+import { useOnboardingStore } from "renderer/stores/onboarding";
 import { useV2AvailableBannerStore } from "renderer/stores/v2-available-banner";
-import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 export function V2AvailableBanner() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const dismissed = useV2AvailableBannerStore((s) => s.dismissed);
 	const dismiss = useV2AvailableBannerStore((s) => s.dismiss);
-	const setOptInV2 = useV2LocalOverrideStore((s) => s.setOptInV2);
+	const onboardingCompletedAt = useOnboardingStore((s) => s.completedAt);
+	const navigate = useNavigate();
+	const hideForV2User = isV2CloudEnabled && onboardingCompletedAt !== null;
 
-	function handleSwitch() {
-		track("surface_toggled", { from: "v1", to: "v2", source: "v1_banner" });
-		setOptInV2(true);
+	function handleManage() {
+		track("v2_banner_manage_clicked", {
+			isV2CloudEnabled,
+		});
+		navigate({ to: "/settings/experimental" });
 	}
 
 	function handleDismiss() {
@@ -23,7 +28,7 @@ export function V2AvailableBanner() {
 
 	return (
 		<AnimatePresence>
-			{!dismissed && (
+			{!dismissed && !hideForV2User && (
 				<motion.div
 					initial={{ opacity: 0, y: 8 }}
 					animate={{ opacity: 1, y: 0 }}
@@ -34,9 +39,13 @@ export function V2AvailableBanner() {
 					<SidebarCard
 						badge="New"
 						title="Superset v2 is here"
-						description="The new cloud workspace experience is now available."
-						actionLabel={isV2CloudEnabled ? undefined : "Switch to v2"}
-						onAction={isV2CloudEnabled ? undefined : handleSwitch}
+						description="Try the new cloud workspace experience."
+						actionLabel={
+							isV2CloudEnabled
+								? "Manage in settings"
+								: "Try new version of Superset"
+						}
+						onAction={handleManage}
 						onDismiss={handleDismiss}
 					/>
 				</motion.div>

--- a/apps/desktop/src/renderer/hooks/useEnsureV2Project/index.ts
+++ b/apps/desktop/src/renderer/hooks/useEnsureV2Project/index.ts
@@ -1,0 +1,1 @@
+export { useEnsureV2Project } from "./useEnsureV2Project";

--- a/apps/desktop/src/renderer/hooks/useEnsureV2Project/index.ts
+++ b/apps/desktop/src/renderer/hooks/useEnsureV2Project/index.ts
@@ -1,1 +1,4 @@
-export { useEnsureV2Project } from "./useEnsureV2Project";
+export {
+	type EnsureV2ProjectResult,
+	useEnsureV2Project,
+} from "./useEnsureV2Project";

--- a/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
+++ b/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
@@ -1,0 +1,47 @@
+import { useCallback } from "react";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+
+/**
+ * Ensures a v2 cloud project exists for `repoPath`, returning the v2 project
+ * id. Used during onboarding to mint the v2_projects row that v2 workspace
+ * creation FK-depends on. Idempotent: if a v2 project already exists for the
+ * repo (via cloud `findByPath`), reuses it and registers the local sqlite
+ * mirror via `project.setup`. Otherwise creates a fresh v2 project (which
+ * also writes a local sqlite row sharing the same id).
+ */
+export function useEnsureV2Project(): (args: {
+	repoPath: string;
+	name: string;
+}) => Promise<string> {
+	const { activeHostUrl } = useLocalHostService();
+
+	return useCallback(
+		async ({ repoPath, name }) => {
+			if (!activeHostUrl) {
+				throw new Error("No active host service");
+			}
+			const hostService = getHostServiceClientByUrl(activeHostUrl);
+
+			const found = await hostService.project.findByPath.query({ repoPath });
+			if (found.candidates.length > 0) {
+				const candidate = found.candidates[0];
+				if (!candidate) {
+					throw new Error("findByPath returned empty candidate");
+				}
+				await hostService.project.setup.mutate({
+					projectId: candidate.id,
+					mode: { kind: "import", repoPath },
+				});
+				return candidate.id;
+			}
+
+			const created = await hostService.project.create.mutate({
+				name,
+				mode: { kind: "importLocal", repoPath },
+			});
+			return created.projectId;
+		},
+		[activeHostUrl],
+	);
+}

--- a/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
+++ b/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
@@ -58,10 +58,17 @@ export function useEnsureV2Project(): (args: {
 					};
 				} catch (err) {
 					// `findByPath` returns local sqlite rows even when no cloud v2
-					// project exists for that id; setup → v2Project.get → NOT_FOUND in
-					// that case. Fall through to create a fresh v2 project.
+					// project exists for that id; setup → v2Project.get → NOT_FOUND.
+					// Only that case is safe to fall through to create — every other
+					// error (network, auth, 5xx) must propagate or repeated retries
+					// would silently mint duplicate cloud projects for the same repo.
+					const code = (err as { data?: { code?: string } } | null | undefined)
+						?.data?.code;
+					if (code !== "NOT_FOUND") {
+						throw err;
+					}
 					console.warn(
-						"[ensureV2Project] setup failed, falling through to create",
+						"[ensureV2Project] no v2 project for candidate id, falling through to create",
 						err,
 					);
 				}

--- a/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
+++ b/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
@@ -2,10 +2,18 @@ import { useCallback } from "react";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 
+export interface EnsureV2ProjectResult {
+	hostUrl: string;
+	projectId: string;
+	repoPath: string;
+	mainWorkspaceId: string | null;
+}
+
 /**
- * Ensures a v2 cloud project exists for `repoPath`, returning the v2 project
- * id. Used during onboarding to mint the v2_projects row that v2 workspace
- * creation FK-depends on.
+ * Ensures a v2 cloud project exists for `repoPath`, returning the resolved
+ * project id (and main workspace id when the host can produce one). Used
+ * during onboarding to mint the v2_projects row that v2 workspace creation
+ * FK-depends on.
  *
  * Strategy:
  *  1. `findByPath` — returns either an existing local sqlite row OR a cloud
@@ -18,12 +26,13 @@ import { useLocalHostService } from "renderer/routes/_authenticated/providers/Lo
  *     and a local sqlite row sharing the same id.
  *
  * Net effect: always returns a v2 cloud project id whose v2_workspaces FK is
- * satisfiable.
+ * satisfiable. Callers can pass the result straight to `useFinalizeProjectSetup`
+ * to pin the project (and main workspace, if any) to the sidebar.
  */
 export function useEnsureV2Project(): (args: {
 	repoPath: string;
 	name: string;
-}) => Promise<string> {
+}) => Promise<EnsureV2ProjectResult> {
 	const { activeHostUrl } = useLocalHostService();
 
 	return useCallback(
@@ -37,11 +46,16 @@ export function useEnsureV2Project(): (args: {
 			const candidate = found.candidates[0];
 			if (candidate) {
 				try {
-					await hostService.project.setup.mutate({
+					const setupResult = await hostService.project.setup.mutate({
 						projectId: candidate.id,
 						mode: { kind: "import", repoPath },
 					});
-					return candidate.id;
+					return {
+						hostUrl: activeHostUrl,
+						projectId: candidate.id,
+						repoPath: setupResult.repoPath,
+						mainWorkspaceId: setupResult.mainWorkspaceId,
+					};
 				} catch (err) {
 					// `findByPath` returns local sqlite rows even when no cloud v2
 					// project exists for that id; setup → v2Project.get → NOT_FOUND in
@@ -57,7 +71,12 @@ export function useEnsureV2Project(): (args: {
 				name,
 				mode: { kind: "importLocal", repoPath },
 			});
-			return created.projectId;
+			return {
+				hostUrl: activeHostUrl,
+				projectId: created.projectId,
+				repoPath: created.repoPath,
+				mainWorkspaceId: created.mainWorkspaceId,
+			};
 		},
 		[activeHostUrl],
 	);

--- a/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
+++ b/apps/desktop/src/renderer/hooks/useEnsureV2Project/useEnsureV2Project.ts
@@ -5,10 +5,20 @@ import { useLocalHostService } from "renderer/routes/_authenticated/providers/Lo
 /**
  * Ensures a v2 cloud project exists for `repoPath`, returning the v2 project
  * id. Used during onboarding to mint the v2_projects row that v2 workspace
- * creation FK-depends on. Idempotent: if a v2 project already exists for the
- * repo (via cloud `findByPath`), reuses it and registers the local sqlite
- * mirror via `project.setup`. Otherwise creates a fresh v2 project (which
- * also writes a local sqlite row sharing the same id).
+ * creation FK-depends on.
+ *
+ * Strategy:
+ *  1. `findByPath` — returns either an existing local sqlite row OR a cloud
+ *     match by GitHub remote.
+ *  2. If a candidate exists, try `setup({ kind: "import" })` to register the
+ *     local mirror against the cloud project.
+ *  3. If `setup` throws (typically because the candidate is a *local-only*
+ *     sqlite row from a prior `projects.openNew`, with no cloud counterpart),
+ *     fall through to `project.create` which creates both the cloud project
+ *     and a local sqlite row sharing the same id.
+ *
+ * Net effect: always returns a v2 cloud project id whose v2_workspaces FK is
+ * satisfiable.
  */
 export function useEnsureV2Project(): (args: {
 	repoPath: string;
@@ -24,16 +34,23 @@ export function useEnsureV2Project(): (args: {
 			const hostService = getHostServiceClientByUrl(activeHostUrl);
 
 			const found = await hostService.project.findByPath.query({ repoPath });
-			if (found.candidates.length > 0) {
-				const candidate = found.candidates[0];
-				if (!candidate) {
-					throw new Error("findByPath returned empty candidate");
+			const candidate = found.candidates[0];
+			if (candidate) {
+				try {
+					await hostService.project.setup.mutate({
+						projectId: candidate.id,
+						mode: { kind: "import", repoPath },
+					});
+					return candidate.id;
+				} catch (err) {
+					// `findByPath` returns local sqlite rows even when no cloud v2
+					// project exists for that id; setup → v2Project.get → NOT_FOUND in
+					// that case. Fall through to create a fresh v2 project.
+					console.warn(
+						"[ensureV2Project] setup failed, falling through to create",
+						err,
+					);
 				}
-				await hostService.project.setup.mutate({
-					projectId: candidate.id,
-					mode: { kind: "import", repoPath },
-				});
-				return candidate.id;
 			}
 
 			const created = await hostService.project.create.mutate({

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -59,11 +59,15 @@ export function ExperimentalSettings({
 	const { rerun, isRunning } = useMigrateV1DataToV2({ autoRun: false });
 	const setOptInV2 = useV2LocalOverrideStore((state) => state.setOptInV2);
 	const resetOnboarding = useOnboardingStore((state) => state.reset);
+	const setManualWalkthrough = useOnboardingStore(
+		(state) => state.setManualWalkthrough,
+	);
 	const lastRunAt = useLastMigrationRunAt();
 	const navigate = useNavigate();
 
 	function handleRestartOnboarding() {
 		resetOnboarding();
+		setManualWalkthrough(true);
 		void navigate({ to: STEP_ROUTES.providers });
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -334,6 +334,13 @@ function AdoptWorktreesContent({
 			}
 		}
 
+		const hadSelections = projects.some((p) => (selected[p.id]?.size ?? 0) > 0);
+		if (hadSelections && totalImported === 0) {
+			// Every selected import failed. Errors were already toasted; keep the
+			// user on the page so they can retry or explicitly Skip rather than
+			// being yanked into a post-onboarding route on a sea of red toasts.
+			return;
+		}
 		if (totalImported > 0) {
 			toast.success(
 				`Imported ${totalImported} workspace${totalImported === 1 ? "" : "s"}`,

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -4,11 +4,14 @@ import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GoGitBranch } from "react-icons/go";
+import { useEnsureV2Project } from "renderer/hooks/useEnsureV2Project";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useImportExternalWorktrees } from "renderer/react-query/workspaces/useImportExternalWorktrees";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
+import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import { SetupButton } from "../components/SetupButton";
 import { StepHeader, StepShell } from "../components/StepShell";
 import {
@@ -48,30 +51,40 @@ function OnboardingAdoptWorktreesPage() {
 	}, [goTo]);
 
 	const navigateAfterFlow = useCallback(
-		async (replace: boolean) => {
+		async (replace: boolean, importedV2WorkspaceId?: string) => {
+			if (isV2CloudEnabled) {
+				if (importedV2WorkspaceId) {
+					navigate({
+						to: "/v2-workspace/$workspaceId",
+						params: { workspaceId: importedV2WorkspaceId },
+						replace,
+					});
+					return;
+				}
+				const project = projects?.[0];
+				if (project) {
+					navigate({
+						to: "/project/$projectId",
+						params: { projectId: project.id },
+						replace,
+					});
+					return;
+				}
+				navigate({ to: "/welcome", replace });
+				return;
+			}
 			try {
 				const grouped = await utils.workspaces.getAllGrouped.fetch();
 				const allWorkspaces = grouped.flatMap((g) => g.workspaces);
 				const lastViewedId = localStorage.getItem("lastViewedWorkspaceId");
-				const candidates = isV2CloudEnabled
-					? allWorkspaces.filter((w) => w.type === "worktree")
-					: allWorkspaces;
 				const target =
-					candidates.find((w) => w.id === lastViewedId) ?? candidates[0];
+					allWorkspaces.find((w) => w.id === lastViewedId) ?? allWorkspaces[0];
 				if (target) {
-					if (isV2CloudEnabled) {
-						navigate({
-							to: "/v2-workspace/$workspaceId",
-							params: { workspaceId: target.id },
-							replace,
-						});
-					} else {
-						navigate({
-							to: "/workspace/$workspaceId",
-							params: { workspaceId: target.id },
-							replace,
-						});
-					}
+					navigate({
+						to: "/workspace/$workspaceId",
+						params: { workspaceId: target.id },
+						replace,
+					});
 					return;
 				}
 			} catch {
@@ -91,16 +104,19 @@ function OnboardingAdoptWorktreesPage() {
 		[utils, isV2CloudEnabled, navigate, projects],
 	);
 
-	const finishFlow = useCallback(() => {
-		const startedAt = useOnboardingStore.getState().startedAt;
-		track("onboarding_finished", {
-			outcome: "completed",
-			duration_ms: startedAt ? Date.now() - startedAt : null,
-		});
-		markComplete("adopt-worktrees");
-		setManualWalkthrough(false);
-		void navigateAfterFlow(true);
-	}, [markComplete, setManualWalkthrough, navigateAfterFlow]);
+	const finishFlow = useCallback(
+		(importedV2WorkspaceId?: string) => {
+			const startedAt = useOnboardingStore.getState().startedAt;
+			track("onboarding_finished", {
+				outcome: "completed",
+				duration_ms: startedAt ? Date.now() - startedAt : null,
+			});
+			markComplete("adopt-worktrees");
+			setManualWalkthrough(false);
+			void navigateAfterFlow(true, importedV2WorkspaceId);
+		},
+		[markComplete, setManualWalkthrough, navigateAfterFlow],
+	);
 
 	const skipFlow = useCallback(() => {
 		const startedAt = useOnboardingStore.getState().startedAt;
@@ -127,7 +143,11 @@ function OnboardingAdoptWorktreesPage() {
 
 	return (
 		<AdoptWorktreesContent
-			projects={projects.map((p) => ({ id: p.id, name: p.name }))}
+			projects={projects.map((p) => ({
+				id: p.id,
+				name: p.name,
+				mainRepoPath: p.mainRepoPath,
+			}))}
 			onSkip={skipFlow}
 			onFinish={finishFlow}
 			manualWalkthrough={manualWalkthrough}
@@ -152,9 +172,9 @@ interface ProjectResult {
 }
 
 interface AdoptWorktreesContentProps {
-	projects: { id: string; name: string }[];
+	projects: { id: string; name: string; mainRepoPath: string }[];
 	onSkip: () => void;
-	onFinish: () => void;
+	onFinish: (importedV2WorkspaceId?: string) => void;
 	manualWalkthrough: boolean;
 }
 
@@ -165,8 +185,13 @@ function AdoptWorktreesContent({
 	manualWalkthrough,
 }: AdoptWorktreesContentProps) {
 	const importExternalWorktrees = useImportExternalWorktrees();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const { submit } = useWorkspaceCreates();
+	const { machineId } = useLocalHostService();
+	const ensureV2Project = useEnsureV2Project();
 	const [results, setResults] = useState<Record<string, ProjectResult>>({});
 	const [selected, setSelected] = useState<SelectionState>({});
+	const [isV2Importing, setIsV2Importing] = useState(false);
 
 	const allLoaded = projects.every((p) => results[p.id]?.loaded);
 	const total = useMemo(
@@ -221,29 +246,85 @@ function AdoptWorktreesContent({
 
 	const handleImportSelected = async () => {
 		let totalImported = 0;
-		for (const project of projects) {
-			const paths = Array.from(selected[project.id] ?? []);
-			if (paths.length === 0) continue;
+		let firstImportedV2Id: string | undefined;
+
+		if (isV2CloudEnabled) {
+			if (!machineId) {
+				toast.error("No active host");
+				return;
+			}
+			setIsV2Importing(true);
 			try {
-				const result = await importExternalWorktrees.mutateAsync({
-					projectId: project.id,
-					paths,
-				});
-				totalImported += result.imported;
-			} catch (err) {
-				toast.error(
-					err instanceof Error
-						? err.message
-						: `Failed to import worktrees for ${project.name}`,
-				);
+				for (const project of projects) {
+					const paths = Array.from(selected[project.id] ?? []);
+					if (paths.length === 0) continue;
+					const projectResult = results[project.id];
+					if (!projectResult) continue;
+
+					let v2ProjectId: string;
+					try {
+						v2ProjectId = await ensureV2Project({
+							repoPath: project.mainRepoPath,
+							name: project.name,
+						});
+					} catch (err) {
+						toast.error(
+							err instanceof Error
+								? `Could not link "${project.name}" to v2: ${err.message}`
+								: `Could not link "${project.name}" to v2`,
+						);
+						continue;
+					}
+
+					for (const path of paths) {
+						const wt = projectResult.worktrees.find((w) => w.path === path);
+						if (!wt) continue;
+						const result = await submit({
+							hostId: machineId,
+							snapshot: {
+								id: crypto.randomUUID(),
+								projectId: v2ProjectId,
+								name: wt.branch,
+								branch: wt.branch,
+							},
+						});
+						if (result.ok) {
+							totalImported++;
+							firstImportedV2Id = firstImportedV2Id ?? result.workspaceId;
+						} else {
+							toast.error(`Failed to import ${wt.branch}: ${result.error}`);
+						}
+					}
+				}
+			} finally {
+				setIsV2Importing(false);
+			}
+		} else {
+			for (const project of projects) {
+				const paths = Array.from(selected[project.id] ?? []);
+				if (paths.length === 0) continue;
+				try {
+					const result = await importExternalWorktrees.mutateAsync({
+						projectId: project.id,
+						paths,
+					});
+					totalImported += result.imported;
+				} catch (err) {
+					toast.error(
+						err instanceof Error
+							? err.message
+							: `Failed to import worktrees for ${project.name}`,
+					);
+				}
 			}
 		}
+
 		if (totalImported > 0) {
 			toast.success(
 				`Imported ${totalImported} workspace${totalImported === 1 ? "" : "s"}`,
 			);
 		}
-		onFinish();
+		onFinish(firstImportedV2Id);
 	};
 
 	const nothingToAdopt = allLoaded && total === 0;
@@ -282,7 +363,7 @@ function AdoptWorktreesContent({
 			<div className="flex w-[273px] flex-col gap-2 self-center">
 				{nothingToAdopt ? (
 					<>
-						<SetupButton onClick={onFinish}>Continue</SetupButton>
+						<SetupButton onClick={() => onFinish()}>Continue</SetupButton>
 						<SetupButton variant="link" onClick={onSkip}>
 							Skip for now
 						</SetupButton>
@@ -294,10 +375,11 @@ function AdoptWorktreesContent({
 							disabled={
 								!allLoaded ||
 								totalSelected === 0 ||
-								importExternalWorktrees.isPending
+								importExternalWorktrees.isPending ||
+								isV2Importing
 							}
 						>
-							{importExternalWorktrees.isPending
+							{importExternalWorktrees.isPending || isV2Importing
 								? "Importing…"
 								: totalSelected === 0
 									? "Select worktrees"
@@ -306,7 +388,7 @@ function AdoptWorktreesContent({
 						<SetupButton
 							variant="link"
 							onClick={onSkip}
-							disabled={importExternalWorktrees.isPending}
+							disabled={importExternalWorktrees.isPending || isV2Importing}
 						>
 							Skip for now
 						</SetupButton>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -63,16 +63,11 @@ function OnboardingAdoptWorktreesPage() {
 					});
 					return;
 				}
-				const project = projects?.[0];
-				if (project) {
-					navigate({
-						to: "/project/$projectId",
-						params: { projectId: project.id },
-						replace,
-					});
-					return;
-				}
-				navigate({ to: "/welcome", replace });
+				// `/project/$projectId` is the v1 dashboard page (with the v1
+				// create-workspace flow). v2 users should never land there from
+				// onboarding — send them to the v2 workspaces list instead so they
+				// can pick or create a workspace via the v2 surface.
+				navigate({ to: "/v2-workspaces", replace });
 				return;
 			}
 			try {

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -187,11 +187,12 @@ function AdoptWorktreesContent({
 	const importExternalWorktrees = useImportExternalWorktrees();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { submit } = useWorkspaceCreates();
-	const { machineId } = useLocalHostService();
+	const { machineId, activeHostUrl } = useLocalHostService();
 	const ensureV2Project = useEnsureV2Project();
 	const [results, setResults] = useState<Record<string, ProjectResult>>({});
 	const [selected, setSelected] = useState<SelectionState>({});
 	const [isV2Importing, setIsV2Importing] = useState(false);
+	const v2NeedsHost = isV2CloudEnabled && !activeHostUrl;
 
 	const allLoaded = projects.every((p) => results[p.id]?.loaded);
 	const total = useMemo(
@@ -376,14 +377,17 @@ function AdoptWorktreesContent({
 								!allLoaded ||
 								totalSelected === 0 ||
 								importExternalWorktrees.isPending ||
-								isV2Importing
+								isV2Importing ||
+								v2NeedsHost
 							}
 						>
 							{importExternalWorktrees.isPending || isV2Importing
 								? "Importing…"
-								: totalSelected === 0
-									? "Select worktrees"
-									: `Import ${totalSelected} selected`}
+								: v2NeedsHost
+									? "Connecting…"
+									: totalSelected === 0
+										? "Select worktrees"
+										: `Import ${totalSelected} selected`}
 						</SetupButton>
 						<SetupButton
 							variant="link"

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -8,7 +8,9 @@ import { useEnsureV2Project } from "renderer/hooks/useEnsureV2Project";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useFinalizeProjectSetup } from "renderer/react-query/projects/useFinalizeProjectSetup";
 import { useImportExternalWorktrees } from "renderer/react-query/workspaces/useImportExternalWorktrees";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
@@ -189,9 +191,15 @@ function AdoptWorktreesContent({
 	const { submit } = useWorkspaceCreates();
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const ensureV2Project = useEnsureV2Project();
+	const finalizeProjectSetup = useFinalizeProjectSetup();
+	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const [results, setResults] = useState<Record<string, ProjectResult>>({});
 	const [selected, setSelected] = useState<SelectionState>({});
 	const [isV2Importing, setIsV2Importing] = useState(false);
+	const [v2Progress, setV2Progress] = useState<{
+		current: number;
+		total: number;
+	} | null>(null);
 	const v2NeedsHost = isV2CloudEnabled && !activeHostUrl;
 
 	const allLoaded = projects.every((p) => results[p.id]?.loaded);
@@ -254,7 +262,9 @@ function AdoptWorktreesContent({
 				toast.error("No active host");
 				return;
 			}
+			const totalToImport = totalSelected;
 			setIsV2Importing(true);
+			setV2Progress({ current: 0, total: totalToImport });
 			try {
 				for (const project of projects) {
 					const paths = Array.from(selected[project.id] ?? []);
@@ -264,9 +274,15 @@ function AdoptWorktreesContent({
 
 					let v2ProjectId: string;
 					try {
-						v2ProjectId = await ensureV2Project({
+						const ensureResult = await ensureV2Project({
 							repoPath: project.mainRepoPath,
 							name: project.name,
+						});
+						v2ProjectId = ensureResult.projectId;
+						finalizeProjectSetup(ensureResult.hostUrl, {
+							projectId: ensureResult.projectId,
+							repoPath: ensureResult.repoPath,
+							mainWorkspaceId: ensureResult.mainWorkspaceId,
 						});
 					} catch (err) {
 						toast.error(
@@ -292,13 +308,16 @@ function AdoptWorktreesContent({
 						if (result.ok) {
 							totalImported++;
 							firstImportedV2Id = firstImportedV2Id ?? result.workspaceId;
+							ensureWorkspaceInSidebar(result.workspaceId, v2ProjectId);
 						} else {
 							toast.error(`Failed to import ${wt.branch}: ${result.error}`);
 						}
+						setV2Progress({ current: totalImported, total: totalToImport });
 					}
 				}
 			} finally {
 				setIsV2Importing(false);
+				setV2Progress(null);
 			}
 		} else {
 			for (const project of projects) {
@@ -335,11 +354,13 @@ function AdoptWorktreesContent({
 			<StepHeader
 				title="Adopt existing worktrees"
 				subtitle={
-					!allLoaded
-						? "Scanning your projects for unadopted worktrees…"
-						: nothingToAdopt
-							? "All worktrees on disk are already tracked."
-							: `Found ${total} worktree${total === 1 ? "" : "s"} on disk that aren't yet tracked.`
+					isV2Importing && v2Progress
+						? `Creating ${v2Progress.current} of ${v2Progress.total} workspace${v2Progress.total === 1 ? "" : "s"} in v2…`
+						: !allLoaded
+							? "Scanning your projects for unadopted worktrees…"
+							: nothingToAdopt
+								? "All worktrees on disk are already tracked."
+								: `Found ${total} worktree${total === 1 ? "" : "s"} on disk that aren't yet tracked.`
 				}
 			/>
 
@@ -381,13 +402,15 @@ function AdoptWorktreesContent({
 								v2NeedsHost
 							}
 						>
-							{importExternalWorktrees.isPending || isV2Importing
-								? "Importing…"
-								: v2NeedsHost
-									? "Connecting…"
-									: totalSelected === 0
-										? "Select worktrees"
-										: `Import ${totalSelected} selected`}
+							{isV2Importing && v2Progress
+								? `Importing ${v2Progress.current} of ${v2Progress.total}…`
+								: importExternalWorktrees.isPending || isV2Importing
+									? "Importing…"
+									: v2NeedsHost
+										? "Connecting…"
+										: totalSelected === 0
+											? "Select worktrees"
+											: `Import ${totalSelected} selected`}
 						</SetupButton>
 						<SetupButton
 							variant="link"

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -12,8 +12,9 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { LuFolder, LuX } from "react-icons/lu";
+import { useEnsureV2Project } from "renderer/hooks/useEnsureV2Project";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenProject } from "renderer/react-query/projects/useOpenProject";
@@ -40,6 +41,8 @@ function OnboardingProjectPage() {
 	const { openNew, isPending: isOpenPending } = useOpenProject();
 	const utils = electronTrpc.useUtils();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const ensureV2Project = useEnsureV2Project();
+	const [isContinuing, setIsContinuing] = useState(false);
 	const closeProject = electronTrpc.projects.close.useMutation({
 		onSuccess: async () => {
 			await utils.projects.getRecents.invalidate();
@@ -102,14 +105,53 @@ function OnboardingProjectPage() {
 	const handleSelectNewRepo = async () => {
 		const created = await openNew();
 		const project = created[0];
-		if (project) {
-			markComplete("project");
-			setManualWalkthrough(false);
-			await openProjectInWorkspace(project.id);
+		if (!project) return;
+
+		let navigateProjectId = project.id;
+		if (isV2CloudEnabled) {
+			try {
+				navigateProjectId = await ensureV2Project({
+					repoPath: project.mainRepoPath,
+					name: project.name,
+				});
+				await utils.projects.getRecents.invalidate();
+			} catch (err) {
+				toast.error(
+					err instanceof Error
+						? `Could not link to v2: ${err.message}`
+						: "Could not link project to v2",
+				);
+				return;
+			}
 		}
+
+		markComplete("project");
+		setManualWalkthrough(false);
+		await openProjectInWorkspace(navigateProjectId);
 	};
 
-	const handleContinueWithCurrent = () => {
+	const handleContinueWithCurrent = async () => {
+		if (isV2CloudEnabled && projects) {
+			setIsContinuing(true);
+			try {
+				for (const project of projects) {
+					await ensureV2Project({
+						repoPath: project.mainRepoPath,
+						name: project.name,
+					});
+				}
+				await utils.projects.getRecents.invalidate();
+			} catch (err) {
+				toast.error(
+					err instanceof Error
+						? `Could not link projects to v2: ${err.message}`
+						: "Could not link projects to v2",
+				);
+				setIsContinuing(false);
+				return;
+			}
+			setIsContinuing(false);
+		}
 		markComplete("project");
 		navigate({ to: STEP_ROUTES["adopt-worktrees"] });
 	};
@@ -201,23 +243,31 @@ function OnboardingProjectPage() {
 				</div>
 
 				<div className="flex w-[273px] flex-col gap-2 self-center">
-					<SetupButton onClick={handleContinueWithCurrent}>
-						Continue with current
+					<SetupButton
+						onClick={handleContinueWithCurrent}
+						disabled={isContinuing || isOpenPending}
+					>
+						{isContinuing ? "Linking…" : "Continue with current"}
 					</SetupButton>
 					<SetupButton
 						variant="secondary"
 						onClick={handleSelectNewRepo}
-						disabled={isOpenPending}
+						disabled={isOpenPending || isContinuing}
 					>
 						{isOpenPending ? "Opening…" : "Select new repo"}
 					</SetupButton>
 					<SetupButton
 						variant="secondary"
 						onClick={() => navigate({ to: "/new-project" })}
+						disabled={isContinuing}
 					>
 						Clone from GitHub
 					</SetupButton>
-					<SetupButton variant="link" onClick={handleSkipStep}>
+					<SetupButton
+						variant="link"
+						onClick={handleSkipStep}
+						disabled={isContinuing}
+					>
 						Skip for now
 					</SetupButton>
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -31,8 +31,6 @@ function OnboardingProjectPage() {
 	const goTo = useOnboardingStore((s) => s.goTo);
 	const markComplete = useOnboardingStore((s) => s.markComplete);
 	const markSkipped = useOnboardingStore((s) => s.markSkipped);
-	const completed = useOnboardingStore((s) => s.completed.project);
-	const manualWalkthrough = useOnboardingStore((s) => s.manualWalkthrough);
 	const setManualWalkthrough = useOnboardingStore(
 		(s) => s.setManualWalkthrough,
 	);
@@ -65,14 +63,6 @@ function OnboardingProjectPage() {
 
 	const projectCount = projects?.length ?? 0;
 	const hasProjects = projectCount > 0;
-	const shouldAutoAdvance = !completed && !manualWalkthrough && hasProjects;
-
-	useEffect(() => {
-		if (shouldAutoAdvance) {
-			markComplete("project");
-			navigate({ to: STEP_ROUTES["adopt-worktrees"], replace: true });
-		}
-	}, [shouldAutoAdvance, markComplete, navigate]);
 
 	// After creating a new project, route to the project page in v2 — that's
 	// where the user creates their first proper worktree workspace (which sets
@@ -129,7 +119,7 @@ function OnboardingProjectPage() {
 		navigate({ to: STEP_ROUTES["adopt-worktrees"] });
 	};
 
-	if (isPending || shouldAutoAdvance) {
+	if (isPending) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
 				<Spinner className="size-6 text-[#a8a5a3]" />

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -18,6 +18,7 @@ import { useEnsureV2Project } from "renderer/hooks/useEnsureV2Project";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenProject } from "renderer/react-query/projects/useOpenProject";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
 import { SetupButton } from "../components/SetupButton";
 import { StepHeader, StepShell, SupersetPill } from "../components/StepShell";
@@ -41,8 +42,10 @@ function OnboardingProjectPage() {
 	const { openNew, isPending: isOpenPending } = useOpenProject();
 	const utils = electronTrpc.useUtils();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const { activeHostUrl } = useLocalHostService();
 	const ensureV2Project = useEnsureV2Project();
 	const [isContinuing, setIsContinuing] = useState(false);
+	const v2NeedsHost = isV2CloudEnabled && !activeHostUrl;
 	const closeProject = electronTrpc.projects.close.useMutation({
 		onSuccess: async () => {
 			await utils.projects.getRecents.invalidate();
@@ -245,21 +248,29 @@ function OnboardingProjectPage() {
 				<div className="flex w-[273px] flex-col gap-2 self-center">
 					<SetupButton
 						onClick={handleContinueWithCurrent}
-						disabled={isContinuing || isOpenPending}
+						disabled={isContinuing || isOpenPending || v2NeedsHost}
 					>
-						{isContinuing ? "Linking…" : "Continue with current"}
+						{isContinuing
+							? "Linking…"
+							: v2NeedsHost
+								? "Connecting…"
+								: "Continue with current"}
 					</SetupButton>
 					<SetupButton
 						variant="secondary"
 						onClick={handleSelectNewRepo}
-						disabled={isOpenPending || isContinuing}
+						disabled={isOpenPending || isContinuing || v2NeedsHost}
 					>
-						{isOpenPending ? "Opening…" : "Select new repo"}
+						{isOpenPending
+							? "Opening…"
+							: v2NeedsHost
+								? "Connecting…"
+								: "Select new repo"}
 					</SetupButton>
 					<SetupButton
 						variant="secondary"
 						onClick={() => navigate({ to: "/new-project" })}
-						disabled={isContinuing}
+						disabled={isContinuing || v2NeedsHost}
 					>
 						Clone from GitHub
 					</SetupButton>
@@ -284,12 +295,20 @@ function OnboardingProjectPage() {
 			/>
 
 			<div className="flex w-[273px] flex-col gap-2 self-center">
-				<SetupButton onClick={handleSelectNewRepo} disabled={isOpenPending}>
-					{isOpenPending ? "Opening…" : "Select new repo"}
+				<SetupButton
+					onClick={handleSelectNewRepo}
+					disabled={isOpenPending || v2NeedsHost}
+				>
+					{isOpenPending
+						? "Opening…"
+						: v2NeedsHost
+							? "Connecting…"
+							: "Select new repo"}
 				</SetupButton>
 				<SetupButton
 					variant="secondary"
 					onClick={() => navigate({ to: "/new-project" })}
+					disabled={v2NeedsHost}
 				>
 					Clone from GitHub
 				</SetupButton>

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -72,18 +72,25 @@ function OnboardingProjectPage() {
 	const projectCount = projects?.length ?? 0;
 	const hasProjects = projectCount > 0;
 
-	// After creating a new project, route to the project page in v2 — that's
-	// where the user creates their first proper worktree workspace (which sets
-	// up the v2 pane layout). The default "branch" workspace auto-created by
-	// openNew → ensureMainWorkspace has no pane layout, so navigating there
-	// renders an empty workspace surface. In v1, navigate to the existing
-	// branch workspace as before.
-	const openProjectInWorkspace = async (projectId: string) => {
+	// In v1, navigate to the project's existing branch workspace (which has a
+	// real layout). v2 users go straight to the just-created main workspace —
+	// `/project/$projectId` is the v1-only page, so v2 must not route through
+	// it from onboarding. Falls back to the v2 workspaces list when no main
+	// workspace id is available (e.g. ensure-v2 returned a linked project that
+	// the host couldn't construct a main workspace for).
+	const openProjectInWorkspace = async (
+		projectId: string,
+		v2MainWorkspaceId: string | null,
+	) => {
 		if (isV2CloudEnabled) {
-			navigate({
-				to: "/project/$projectId",
-				params: { projectId },
-			});
+			if (v2MainWorkspaceId) {
+				navigate({
+					to: "/v2-workspace/$workspaceId",
+					params: { workspaceId: v2MainWorkspaceId },
+				});
+				return;
+			}
+			navigate({ to: "/v2-workspaces" });
 			return;
 		}
 		try {
@@ -113,6 +120,7 @@ function OnboardingProjectPage() {
 		if (!project) return;
 
 		let navigateProjectId = project.id;
+		let v2MainWorkspaceId: string | null = null;
 		if (isV2CloudEnabled) {
 			try {
 				const result = await ensureV2Project({
@@ -125,6 +133,7 @@ function OnboardingProjectPage() {
 					mainWorkspaceId: result.mainWorkspaceId,
 				});
 				navigateProjectId = result.projectId;
+				v2MainWorkspaceId = result.mainWorkspaceId;
 				await utils.projects.getRecents.invalidate();
 			} catch (err) {
 				toast.error(
@@ -138,7 +147,7 @@ function OnboardingProjectPage() {
 
 		markComplete("project");
 		setManualWalkthrough(false);
-		await openProjectInWorkspace(navigateProjectId);
+		await openProjectInWorkspace(navigateProjectId, v2MainWorkspaceId);
 	};
 
 	const handleContinueWithCurrent = async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -17,6 +17,7 @@ import { LuFolder, LuX } from "react-icons/lu";
 import { useEnsureV2Project } from "renderer/hooks/useEnsureV2Project";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useFinalizeProjectSetup } from "renderer/react-query/projects/useFinalizeProjectSetup";
 import { useOpenProject } from "renderer/react-query/projects/useOpenProject";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
@@ -44,6 +45,7 @@ function OnboardingProjectPage() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { activeHostUrl } = useLocalHostService();
 	const ensureV2Project = useEnsureV2Project();
+	const finalizeProjectSetup = useFinalizeProjectSetup();
 	const [isContinuing, setIsContinuing] = useState(false);
 	const v2NeedsHost = isV2CloudEnabled && !activeHostUrl;
 	const closeProject = electronTrpc.projects.close.useMutation({
@@ -113,10 +115,16 @@ function OnboardingProjectPage() {
 		let navigateProjectId = project.id;
 		if (isV2CloudEnabled) {
 			try {
-				navigateProjectId = await ensureV2Project({
+				const result = await ensureV2Project({
 					repoPath: project.mainRepoPath,
 					name: project.name,
 				});
+				finalizeProjectSetup(result.hostUrl, {
+					projectId: result.projectId,
+					repoPath: result.repoPath,
+					mainWorkspaceId: result.mainWorkspaceId,
+				});
+				navigateProjectId = result.projectId;
 				await utils.projects.getRecents.invalidate();
 			} catch (err) {
 				toast.error(
@@ -138,9 +146,14 @@ function OnboardingProjectPage() {
 			setIsContinuing(true);
 			try {
 				for (const project of projects) {
-					await ensureV2Project({
+					const result = await ensureV2Project({
 						repoPath: project.mainRepoPath,
 						name: project.name,
+					});
+					finalizeProjectSetup(result.hostUrl, {
+						projectId: result.projectId,
+						repoPath: result.repoPath,
+						mainWorkspaceId: result.mainWorkspaceId,
 					});
 				}
 				await utils.projects.getRecents.invalidate();

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
@@ -47,6 +47,14 @@ function OnboardingProvidersPage() {
 	const [codexMethod, setCodexMethod] = useState<ConnectionMethod>("oauth");
 	const [reconfiguringClaude, setReconfiguringClaude] = useState(false);
 	const [reconfiguringCodex, setReconfiguringCodex] = useState(false);
+	const [activeProvider, setActiveProvider] = useState<"claude" | "codex">(
+		"claude",
+	);
+
+	useEffect(() => {
+		if (claudeConnected && !codexConnected) setActiveProvider("codex");
+		else if (!claudeConnected && codexConnected) setActiveProvider("claude");
+	}, [claudeConnected, codexConnected]);
 
 	useEffect(() => {
 		goTo("providers");
@@ -93,114 +101,150 @@ function OnboardingProvidersPage() {
 		? "Add another provider or continue to the next step."
 		: "Connect Claude Code, Codex, or both to get started.";
 
+	const inAnyStep =
+		!claudeConnected ||
+		!codexConnected ||
+		reconfiguringClaude ||
+		reconfiguringCodex;
+	const effectiveProvider: "claude" | "codex" = reconfiguringClaude
+		? "claude"
+		: reconfiguringCodex
+			? "codex"
+			: activeProvider;
+	const showBothCompact = !inAnyStep;
+	const showClaude = showBothCompact || effectiveProvider === "claude";
+	const showCodex = showBothCompact || effectiveProvider === "codex";
+	const showSwitcher =
+		!showBothCompact && !reconfiguringClaude && !reconfiguringCodex;
+	const otherLabel = effectiveProvider === "claude" ? "Codex" : "Claude Code";
+
 	return (
 		<StepShell maxWidth="lg">
 			<StepHeader title="Connect AI Provider" subtitle={subtitle} />
 
-			<ProviderSection
-				label="Claude Code"
-				connected={claudeConnected}
-				reconfiguring={reconfiguringClaude}
-				onConnect={() =>
-					handleConnect("/setup/providers/claude-code", claudeMethod)
-				}
-				onReconfigure={() => setReconfiguringClaude(true)}
-				onCancelReconfigure={() => setReconfiguringClaude(false)}
-				connectedPanel={
-					<ConnectedPanel
-						icon={
-							<ClaudeBrandIcon
-								className="size-11 rounded-lg"
-								iconClassName="size-6"
-							/>
-						}
-						title="Claude Code is connected"
-					/>
-				}
-				options={
-					<>
-						<ProviderOptionCard
+			{showClaude && (
+				<ProviderSection
+					label="Claude Code"
+					connected={claudeConnected}
+					reconfiguring={reconfiguringClaude}
+					onConnect={() =>
+						handleConnect("/setup/providers/claude-code", claudeMethod)
+					}
+					onReconfigure={() => setReconfiguringClaude(true)}
+					onCancelReconfigure={() => setReconfiguringClaude(false)}
+					connectedPanel={
+						<ConnectedPanel
 							icon={
-								<ClaudeBrandIcon className="size-full" iconClassName="size-6" />
+								<ClaudeBrandIcon
+									className="size-11 rounded-lg"
+									iconClassName="size-6"
+								/>
 							}
-							title="Claude Pro/Max"
-							description="Use your Claude subscription for unlimited access."
-							recommended
-							selected={claudeMethod === "oauth"}
-							onSelect={() => setClaudeMethod("oauth")}
+							title="Claude Code is connected"
 						/>
-						<ProviderOptionCard
-							icon={<MutedIcon icon={<LuKeyRound className="size-5" />} />}
-							title="Anthropic API Key"
-							description="Pay-as-you-go with your own API key."
-							selected={claudeMethod === "api-key"}
-							onSelect={() => setClaudeMethod("api-key")}
-						/>
-						<ProviderOptionCard
-							icon={<MutedIcon icon={<LuSettings className="size-5" />} />}
-							title="Custom Model"
-							description="Use a custom base URL and model."
-							selected={claudeMethod === "custom"}
-							onSelect={() => setClaudeMethod("custom")}
-						/>
-					</>
-				}
-			/>
-
-			<ProviderSection
-				label="Codex"
-				connected={codexConnected}
-				reconfiguring={reconfiguringCodex}
-				onConnect={() => handleConnect("/setup/providers/codex", codexMethod)}
-				onReconfigure={() => setReconfiguringCodex(true)}
-				onCancelReconfigure={() => setReconfiguringCodex(false)}
-				connectedPanel={
-					<ConnectedPanel
-						icon={
-							<CodexBrandIcon
-								className="size-11 rounded-lg bg-[#eae8e6]"
-								iconClassName="size-6 text-[#151110]"
+					}
+					options={
+						<>
+							<ProviderOptionCard
+								icon={
+									<ClaudeBrandIcon
+										className="size-full"
+										iconClassName="size-6"
+									/>
+								}
+								title="Claude Pro/Max"
+								description="Use your Claude subscription for unlimited access."
+								recommended
+								selected={claudeMethod === "oauth"}
+								onSelect={() => setClaudeMethod("oauth")}
 							/>
-						}
-						title="Codex is connected"
-					/>
-				}
-				options={
-					<>
-						<ProviderOptionCard
+							<ProviderOptionCard
+								icon={<MutedIcon icon={<LuKeyRound className="size-5" />} />}
+								title="Anthropic API Key"
+								description="Pay-as-you-go with your own API key."
+								selected={claudeMethod === "api-key"}
+								onSelect={() => setClaudeMethod("api-key")}
+							/>
+							<ProviderOptionCard
+								icon={<MutedIcon icon={<LuSettings className="size-5" />} />}
+								title="Custom Model"
+								description="Use a custom base URL and model."
+								selected={claudeMethod === "custom"}
+								onSelect={() => setClaudeMethod("custom")}
+							/>
+						</>
+					}
+				/>
+			)}
+
+			{showCodex && (
+				<ProviderSection
+					label="Codex"
+					connected={codexConnected}
+					reconfiguring={reconfiguringCodex}
+					onConnect={() => handleConnect("/setup/providers/codex", codexMethod)}
+					onReconfigure={() => setReconfiguringCodex(true)}
+					onCancelReconfigure={() => setReconfiguringCodex(false)}
+					connectedPanel={
+						<ConnectedPanel
 							icon={
 								<CodexBrandIcon
-									className="size-full bg-[#eae8e6]"
+									className="size-11 rounded-lg bg-[#eae8e6]"
 									iconClassName="size-6 text-[#151110]"
 								/>
 							}
-							title="ChatGPT Plus/Pro"
-							description="Use your ChatGPT subscription via Codex."
-							recommended
-							selected={codexMethod === "oauth"}
-							onSelect={() => setCodexMethod("oauth")}
+							title="Codex is connected"
 						/>
-						<ProviderOptionCard
-							icon={<MutedIcon icon={<LuKeyRound className="size-5" />} />}
-							title="OpenAI API Key"
-							description="Pay-as-you-go with your own API key."
-							selected={codexMethod === "api-key"}
-							onSelect={() => setCodexMethod("api-key")}
-						/>
-						<ProviderOptionCard
-							icon={<MutedIcon icon={<LuSettings className="size-5" />} />}
-							title="Custom Model"
-							description="Use a custom base URL and model."
-							selected={codexMethod === "custom"}
-							onSelect={() => setCodexMethod("custom")}
-						/>
-					</>
-				}
-			/>
+					}
+					options={
+						<>
+							<ProviderOptionCard
+								icon={
+									<CodexBrandIcon
+										className="size-full bg-[#eae8e6]"
+										iconClassName="size-6 text-[#151110]"
+									/>
+								}
+								title="ChatGPT Plus/Pro"
+								description="Use your ChatGPT subscription via Codex."
+								recommended
+								selected={codexMethod === "oauth"}
+								onSelect={() => setCodexMethod("oauth")}
+							/>
+							<ProviderOptionCard
+								icon={<MutedIcon icon={<LuKeyRound className="size-5" />} />}
+								title="OpenAI API Key"
+								description="Pay-as-you-go with your own API key."
+								selected={codexMethod === "api-key"}
+								onSelect={() => setCodexMethod("api-key")}
+							/>
+							<ProviderOptionCard
+								icon={<MutedIcon icon={<LuSettings className="size-5" />} />}
+								title="Custom Model"
+								description="Use a custom base URL and model."
+								selected={codexMethod === "custom"}
+								onSelect={() => setCodexMethod("custom")}
+							/>
+						</>
+					}
+				/>
+			)}
 
 			<div className="flex w-[273px] flex-col gap-2 self-center">
-				{atLeastOneConnected && (
+				{atLeastOneConnected && !inAnyStep && (
 					<SetupButton onClick={handleContinueToNextStep}>Continue</SetupButton>
+				)}
+				{showSwitcher && (
+					<SetupButton
+						variant="link"
+						onClick={() =>
+							setActiveProvider(
+								effectiveProvider === "claude" ? "codex" : "claude",
+							)
+						}
+					>
+						Set up {otherLabel} instead
+					</SetupButton>
 				)}
 				<SetupButton variant="link" onClick={handleSkipStep}>
 					Skip for now

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
@@ -114,8 +114,15 @@ function OnboardingProvidersPage() {
 	const showBothCompact = !inAnyStep;
 	const showClaude = showBothCompact || effectiveProvider === "claude";
 	const showCodex = showBothCompact || effectiveProvider === "codex";
+	// Only show the switcher when neither provider is connected. After auto-
+	// switch flips activeProvider to the unconnected one, offering "Set up X
+	// instead" for the already-connected one is misleading — clicking it just
+	// drops the user into the connected-with-Reconfigure panel.
 	const showSwitcher =
-		!showBothCompact && !reconfiguringClaude && !reconfiguringCodex;
+		!claudeConnected &&
+		!codexConnected &&
+		!reconfiguringClaude &&
+		!reconfiguringCodex;
 	const otherLabel = effectiveProvider === "claude" ? "Codex" : "Claude Code";
 
 	return (


### PR DESCRIPTION
## Summary

- **V2 sidebar banner**: hide entirely for v2 users who have already completed onboarding; replace the inline Switch + secondary "Manage in settings" link with a single action button that routes to Settings → Experimental. Label adapts to user state — "Try new version of Superset" for v1, "Manage in settings" for v2 mid-onboarding.
- **Providers setup step**: only one provider section is shown while the user is configuring or reconfiguring. Smart-defaults to the unconnected provider when one is already connected; offers a "Set up *other* instead" switcher when neither is connected. Continue is hidden while any step is active.
- **Project setup step**: removed auto-advance when prior projects exist. Returning users now see their projects list and must explicitly pick **Continue with current**, **Select new repo**, **Clone from GitHub**, or **Skip for now**.

## Test plan

- [ ] v1 user (default) sees the v2 banner with "Try new version of Superset"; click routes to `/settings/experimental`.
- [ ] v2 user mid-onboarding sees the banner with "Manage in settings".
- [ ] v2 user post-onboarding (`completedAt !== null`) does **not** see the banner.
- [ ] Dismiss (X) on the banner persists across reloads.
- [ ] Onboarding › Providers: with neither connected, only Claude shows by default; "Set up Codex instead" toggles to Codex; first auth flips active provider to the unconnected one.
- [ ] Onboarding › Providers: clicking Reconfigure on a connected provider hides the other section; Cancel restores both.
- [ ] Onboarding › Providers: Continue only appears when both providers are connected and neither is being reconfigured.
- [ ] Onboarding › Project: with existing projects, the page renders the list (no auto-skip); Continue/Select-new/Skip all work.
- [ ] `bun run lint` and `bun run typecheck` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the v2 banner and onboarding so v2 users land in a working v2 workspace (or the v2 workspaces list), with v2-only actions gated on host readiness and clear import progress. Tightens v2 project linking to avoid duplicate cloud projects.

- **New Features**
  - V2 banner: hidden for v2 users post-onboarding; single action to Settings → Experimental; label adapts (“Try new version of Superset” for v1, “Manage in settings” for v2 mid-onboarding).
  - Providers step: focus one provider at a time with a smart default to the unconnected one; switcher appears only when neither is connected; Continue is hidden while a step is active.
  - Project step: removed auto-advance; choose Continue/Select new/Clone/Skip; for v2, link via `useEnsureV2Project`, finalize via `useFinalizeProjectSetup`, pin to the sidebar; buttons show “Connecting…” until the host is ready.
  - Adopt worktrees: link each project to v2 before creating workspaces, pin each to the sidebar, and show “Importing X of Y…” in the subtitle and button.

- **Bug Fixes**
  - Restart from Settings enables the manual walkthrough to prevent auto-skip.
  - Reliable v2 linking with `useEnsureV2Project`: falls back from `setup` to `project.create` only on TRPC NOT_FOUND, avoiding duplicate cloud projects on transient errors.
  - Navigation: v2 onboarding never routes through the v1 project page; after project/create or import, open the created v2 workspace, otherwise fall back to `/v2-workspaces`.
  - Adopt worktrees: if selections were made but every import failed, stay on the page (don’t auto-finish) so users can retry.

<sup>Written for commit 911c2f10f1068ff5a41a88441aeaac781067fd15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * V2 linking/import flows expanded: repo imports and continue flows show V2 linking progress, can link multiple projects, and handle V2 workspace creation.
  * Added a helper to ensure V2 projects during import to streamline cloud project creation.

* **Refactor**
  * V2 availability banner now respects onboarding state and provides a management action that navigates to settings.
  * Onboarding no longer auto-advances; provider setup is conditional with a provider switcher and refined UI/flow.

* **Style**
  * Restarting onboarding now enables the manual walkthrough by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->