### PR TITLE
refactor(desktop): drop v1_migration_state from importer UX

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/migration/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/migration/index.ts
@@ -1,22 +1,7 @@
-import {
-	projects,
-	v1MigrationState,
-	workspaces,
-	worktrees,
-} from "@superset/local-db";
-import { eq, isNotNull, isNull } from "drizzle-orm";
+import { projects, workspaces, worktrees } from "@superset/local-db";
+import { isNotNull, isNull } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
-import { z } from "zod";
 import { publicProcedure, router } from "../..";
-
-const migrationStateRowSchema = z.object({
-	v1Id: z.string().min(1),
-	kind: z.enum(["project", "workspace", "preset"]),
-	v2Id: z.string().nullable(),
-	organizationId: z.string().min(1),
-	status: z.enum(["success", "linked", "error", "skipped"]),
-	reason: z.string().nullable().optional(),
-});
 
 export const createMigrationRouter = () => {
 	return router({
@@ -42,45 +27,5 @@ export const createMigrationRouter = () => {
 		readV1Worktrees: publicProcedure.query(() => {
 			return localDb.select().from(worktrees).all();
 		}),
-
-		listState: publicProcedure
-			.input(z.object({ organizationId: z.string().min(1) }))
-			.query(({ input }) => {
-				return localDb
-					.select()
-					.from(v1MigrationState)
-					.where(eq(v1MigrationState.organizationId, input.organizationId))
-					.all();
-			}),
-
-		upsertState: publicProcedure
-			.input(migrationStateRowSchema)
-			.mutation(({ input }) => {
-				localDb
-					.insert(v1MigrationState)
-					.values({
-						v1Id: input.v1Id,
-						kind: input.kind,
-						v2Id: input.v2Id,
-						organizationId: input.organizationId,
-						status: input.status,
-						reason: input.reason ?? null,
-						migratedAt: Date.now(),
-					})
-					.onConflictDoUpdate({
-						target: [
-							v1MigrationState.organizationId,
-							v1MigrationState.v1Id,
-							v1MigrationState.kind,
-						],
-						set: {
-							v2Id: input.v2Id,
-							status: input.status,
-							reason: input.reason ?? null,
-							migratedAt: Date.now(),
-						},
-					})
-					.run();
-			}),
 	});
 };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/V1ImportBanner/V1ImportBanner.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/V1ImportBanner/V1ImportBanner.tsx
@@ -1,10 +1,13 @@
 import { Button } from "@superset/ui/button";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { LuArrowRight, LuX } from "react-icons/lu";
 import { env } from "renderer/env.renderer";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useOpenV1ImportModal } from "renderer/stores/v1-import-modal";
 import { MOCK_ORG_ID } from "shared/constants";
 
@@ -26,39 +29,41 @@ export function V1ImportBanner() {
 		? MOCK_ORG_ID
 		: (session?.session?.activeOrganizationId ?? null);
 	const openModal = useOpenV1ImportModal();
+	const { activeHostUrl } = useLocalHostService();
 	const [dismissed, setDismissed] = useState(() =>
 		readDismissed(organizationId),
 	);
 
-	// Re-sync local state when the active org changes — dismissal is per
-	// org, so flipping orgs should reveal the banner again if it hasn't
-	// been dismissed there yet.
 	useEffect(() => {
 		setDismissed(readDismissed(organizationId));
 	}, [organizationId]);
 
+	const enabled = isV2CloudEnabled && !!organizationId && !dismissed;
+
 	const projectsQuery = electronTrpc.migration.readV1Projects.useQuery(
 		undefined,
-		{ enabled: isV2CloudEnabled && !!organizationId && !dismissed },
+		{ enabled },
 	);
-	const auditQuery = electronTrpc.migration.listState.useQuery(
-		{ organizationId: organizationId ?? "" },
-		{ enabled: isV2CloudEnabled && !!organizationId && !dismissed },
-	);
+	const hostProjectListQuery = useQuery({
+		queryKey: ["v1-import-banner", "hostProjectList", activeHostUrl],
+		queryFn: async () => {
+			if (!activeHostUrl) return [];
+			const client = getHostServiceClientByUrl(activeHostUrl);
+			return client.project.list.query();
+		},
+		enabled: enabled && !!activeHostUrl,
+		retry: false,
+	});
 
 	if (!isV2CloudEnabled || !organizationId || dismissed) return null;
 
 	const projects = projectsQuery.data ?? [];
-	const importedV1Ids = new Set(
-		(auditQuery.data ?? [])
-			.filter(
-				(row) =>
-					row.kind === "project" &&
-					(row.status === "success" || row.status === "linked"),
-			)
-			.map((row) => row.v1Id),
+	const importedRepoPaths = new Set(
+		(hostProjectListQuery.data ?? []).map((p) => p.repoPath),
 	);
-	const remaining = projects.filter((p) => !importedV1Ids.has(p.id)).length;
+	const remaining = projects.filter(
+		(p) => !importedRepoPaths.has(p.mainRepoPath),
+	).length;
 
 	if (remaining === 0) return null;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
@@ -4,7 +4,8 @@ import {
 	AGENT_TYPES,
 	type AgentType,
 } from "@superset/shared/agent-command";
-import { useState } from "react";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useMemo, useState } from "react";
 import { LuTerminal } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -16,38 +17,30 @@ interface ImportPresetsPageProps {
 	organizationId: string;
 }
 
-interface AuditLogEntry {
-	v2Id: string | null;
-	status: string;
-	reason: string | null;
-}
-
 const BUILTIN_AGENT_IDS = new Set<string>(AGENT_TYPES);
 
 export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
+	const collections = useCollections();
 	const presetsQuery = electronTrpc.settings.getTerminalPresets.useQuery();
-	const auditQuery = electronTrpc.migration.listState.useQuery({
-		organizationId,
-	});
 	const [isRefreshing, setIsRefreshing] = useState(false);
 
-	const isLoading = presetsQuery.isPending || auditQuery.isPending;
-	const presets = presetsQuery.data ?? [];
+	const { data: v2Presets = [] } = useLiveQuery(
+		(query) => query.from({ v2TerminalPresets: collections.v2TerminalPresets }),
+		[collections],
+	);
 
-	const auditByV1Id = new Map<string, AuditLogEntry>();
-	for (const row of auditQuery.data ?? []) {
-		if (row.kind !== "preset") continue;
-		auditByV1Id.set(row.v1Id, {
-			v2Id: row.v2Id,
-			status: row.status,
-			reason: row.reason,
-		});
-	}
+	const importedV1Ids = useMemo(
+		() => new Set(v2Presets.map((p) => p.id)),
+		[v2Presets],
+	);
+
+	const isLoading = presetsQuery.isPending;
+	const presets = presetsQuery.data ?? [];
 
 	const refresh = async () => {
 		setIsRefreshing(true);
 		try {
-			await Promise.all([presetsQuery.refetch(), auditQuery.refetch()]);
+			await presetsQuery.refetch();
 		} finally {
 			setIsRefreshing(false);
 		}
@@ -68,7 +61,7 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 					key={preset.id}
 					preset={preset}
 					tabOrder={index}
-					audit={auditByV1Id.get(preset.id)}
+					alreadyImported={importedV1Ids.has(preset.id)}
 					organizationId={organizationId}
 				/>
 			))}
@@ -79,25 +72,19 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 interface PresetRowProps {
 	preset: TerminalPreset;
 	tabOrder: number;
-	audit: AuditLogEntry | undefined;
+	alreadyImported: boolean;
 	organizationId: string;
 }
 
 function PresetRow({
 	preset,
 	tabOrder,
-	audit,
+	alreadyImported,
 	organizationId,
 }: PresetRowProps) {
 	const collections = useCollections();
-	const upsertState = electronTrpc.migration.upsertState.useMutation();
-	const trpcUtils = electronTrpc.useUtils();
 	const [running, setRunning] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-	const auditImported = audit !== undefined && audit.status === "success";
-	const auditError =
-		audit !== undefined && audit.status === "error" ? audit.reason : null;
 
 	const runImport = async () => {
 		setRunning(true);
@@ -109,13 +96,8 @@ function PresetRow({
 				? (preset.name as AgentType)
 				: undefined;
 
-			// Reuse the audit row's v2Id when present so a retry after a
-			// partial failure (insert succeeded, audit upsert failed) doesn't
-			// create a duplicate v2 preset row. Insert is upsert-by-id, so
-			// re-running with the same id is a no-op.
-			const v2Id = audit?.v2Id ?? crypto.randomUUID();
 			const row: V2TerminalPresetRow = {
-				id: v2Id,
+				id: preset.id,
 				name: linkedAgentId ? AGENT_LABELS[linkedAgentId] : preset.name,
 				description: preset.description,
 				cwd: preset.cwd,
@@ -130,36 +112,14 @@ function PresetRow({
 				agentId: linkedAgentId,
 			};
 			collections.v2TerminalPresets.insert(row);
-
-			await upsertState.mutateAsync({
-				v1Id: preset.id,
-				kind: "preset",
-				v2Id,
-				organizationId,
-				status: "success",
-				reason: null,
-			});
-
-			await trpcUtils.migration.listState.invalidate({ organizationId });
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			setErrorMessage(message);
-			await upsertState
-				.mutateAsync({
-					v1Id: preset.id,
-					kind: "preset",
-					v2Id: null,
-					organizationId,
-					status: "error",
-					reason: message,
-				})
-				.catch((auditErr) => {
-					console.warn(
-						"[v1-import] failed to record preset import error in audit",
-						{ presetId: preset.id, auditErr },
-					);
-				});
-			await trpcUtils.migration.listState.invalidate({ organizationId });
+			console.error("[v1-import] preset import failed", {
+				v1PresetId: preset.id,
+				organizationId,
+				err,
+			});
 		} finally {
 			setRunning(false);
 		}
@@ -167,12 +127,9 @@ function PresetRow({
 
 	const action: RowAction = (() => {
 		if (running) return { kind: "running" };
-		if (auditImported) return { kind: "imported" };
+		if (alreadyImported) return { kind: "imported" };
 		if (errorMessage) {
 			return { kind: "error", message: errorMessage, onRetry: runImport };
-		}
-		if (auditError) {
-			return { kind: "error", message: auditError, onRetry: runImport };
 		}
 		return { kind: "ready", label: "Import", onClick: runImport };
 	})();

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { LuFolder } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -13,14 +13,7 @@ interface ImportProjectsPageProps {
 	activeHostUrl: string;
 }
 
-interface AuditLogEntry {
-	v2Id: string | null;
-	status: string;
-	reason: string | null;
-}
-
 const FIND_BY_PATH_KEY_PREFIX = ["v1-import", "findByPath"] as const;
-const PROJECT_CLOUD_LIST_KEY = ["v1-import", "projectCloudList"] as const;
 
 export function ImportProjectsPage({
 	organizationId,
@@ -28,41 +21,9 @@ export function ImportProjectsPage({
 }: ImportProjectsPageProps) {
 	const queryClient = useQueryClient();
 	const projectsQuery = electronTrpc.migration.readV1Projects.useQuery();
-	const auditQuery = electronTrpc.migration.listState.useQuery({
-		organizationId,
-	});
-	const cloudProjectsQuery = useQuery({
-		queryKey: [...PROJECT_CLOUD_LIST_KEY, organizationId, activeHostUrl],
-		queryFn: async () => {
-			const client = getHostServiceClientByUrl(activeHostUrl);
-			return client.project.cloudList.query();
-		},
-		retry: false,
-	});
 	const [isRefreshing, setIsRefreshing] = useState(false);
 
-	const liveProjectIds = useMemo(() => {
-		// Returns null until the cloud query resolves so per-row code can
-		// distinguish "we don't know yet" from "it's gone".
-		if (!cloudProjectsQuery.data) return null;
-		return new Set(cloudProjectsQuery.data.map((p) => p.id));
-	}, [cloudProjectsQuery.data]);
-
-	// Note: don't gate on `!projectsQuery.data`. If readV1Projects errors,
-	// `isPending` flips to false but `data` stays undefined, which would
-	// trap us in a permanent loading spinner. Falling through to itemCount=0
-	// shows the empty-state message instead of a dead-end loader.
-	const isLoading = projectsQuery.isPending || auditQuery.isPending;
-
-	const auditByV1Id = new Map<string, AuditLogEntry>();
-	for (const row of auditQuery.data ?? []) {
-		if (row.kind !== "project") continue;
-		auditByV1Id.set(row.v1Id, {
-			v2Id: row.v2Id,
-			status: row.status,
-			reason: row.reason,
-		});
-	}
+	const isLoading = projectsQuery.isPending;
 
 	const projects = projectsQuery.data ?? [];
 
@@ -71,8 +32,6 @@ export function ImportProjectsPage({
 		try {
 			await Promise.all([
 				projectsQuery.refetch(),
-				auditQuery.refetch(),
-				cloudProjectsQuery.refetch(),
 				queryClient.invalidateQueries({ queryKey: FIND_BY_PATH_KEY_PREFIX }),
 			]);
 		} finally {
@@ -94,8 +53,6 @@ export function ImportProjectsPage({
 				<ProjectRow
 					key={project.id}
 					project={project}
-					audit={auditByV1Id.get(project.id)}
-					liveProjectIds={liveProjectIds}
 					organizationId={organizationId}
 					activeHostUrl={activeHostUrl}
 				/>
@@ -111,25 +68,15 @@ interface ProjectRowProps {
 		mainRepoPath: string;
 		githubOwner: string | null;
 	};
-	audit: AuditLogEntry | undefined;
-	/** Live cloud project ids in the org. `null` while still loading. */
-	liveProjectIds: Set<string> | null;
 	organizationId: string;
 	activeHostUrl: string;
 }
 
-/**
- * Detects host-service `project.setup` CONFLICT thrown when the v2 project
- * is already registered at a different folder on this device. The server
- * supports `allowRelocate: true` to repoint, but only with explicit caller
- * consent — so we surface a confirm instead of silently relocating.
- */
 function isAlreadySetUpElsewhereError(err: unknown): boolean {
 	if (!(err instanceof Error)) return false;
 	return err.message.includes("Project is already set up on this device at");
 }
 
-/** Pulls the existing repo path out of the server's CONFLICT message. */
 function extractExistingPath(message: string): string | null {
 	const match = message.match(
 		/already set up on this device at (.+?)\.\s+Remove/,
@@ -143,10 +90,6 @@ function expectedRemoteUrlFor(project: {
 	githubOwner: string | null;
 }): string | undefined {
 	if (!project.githubOwner) return undefined;
-	// v1 doesn't store the repo name explicitly. Use the basename of the
-	// repo path — more reliable than the project's display name (which
-	// users can rename) and `getBaseName` already handles POSIX, Windows,
-	// and UNC/mixed separators.
 	const repoName = getBaseName(project.mainRepoPath);
 	if (!repoName) return undefined;
 	return `https://github.com/${project.githubOwner}/${repoName}`;
@@ -154,35 +97,18 @@ function expectedRemoteUrlFor(project: {
 
 function ProjectRow({
 	project,
-	audit,
-	liveProjectIds,
 	organizationId,
 	activeHostUrl,
 }: ProjectRowProps) {
 	const queryClient = useQueryClient();
 	const finalizeSetup = useFinalizeProjectSetup();
-	const upsertState = electronTrpc.migration.upsertState.useMutation();
-	const trpcUtils = electronTrpc.useUtils();
 	const [running, setRunning] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [pendingRelocate, setPendingRelocate] = useState<{
 		v2ProjectId: string;
 		message: string;
 	} | null>(null);
-
-	// Audit says we already imported, but the v2 project may have been
-	// deleted from cloud (by another device or user) since. Demote to
-	// "available to import" when we can confirm cloud no longer has it.
-	const auditClaimsImported =
-		audit !== undefined &&
-		(audit.status === "success" || audit.status === "linked");
-	const auditGhost =
-		auditClaimsImported &&
-		liveProjectIds !== null &&
-		(!audit?.v2Id || !liveProjectIds.has(audit.v2Id));
-	const auditImported = auditClaimsImported && !auditGhost;
-	const auditError =
-		audit !== undefined && audit.status === "error" ? audit.reason : null;
+	const [linkedV2Id, setLinkedV2Id] = useState<string | null>(null);
 
 	const expectedRemoteUrl = expectedRemoteUrlFor(project);
 
@@ -201,9 +127,13 @@ function ProjectRow({
 				expectedRemoteUrl,
 			});
 		},
-		enabled: !auditImported,
 		retry: false,
 	});
+
+	const importedCandidate = findByPathQuery.data?.candidates.find(
+		(c) => c.source === "local-path",
+	);
+	const isImported = !!importedCandidate || !!linkedV2Id;
 
 	const runImport = async (
 		linkToProjectId?: string,
@@ -219,16 +149,11 @@ function ProjectRow({
 			let v2ProjectId: string;
 			let mainWorkspaceId: string | null = null;
 			let repoPath = project.mainRepoPath;
-			let status: "success" | "linked";
 
 			const targetCandidate = linkToProjectId
 				? candidates.find((c) => c.id === linkToProjectId)
 				: candidates[0];
 
-			// Don't silently fall through to project.create when the user
-			// explicitly asked to link to a specific id — that would
-			// duplicate the v2 project. The candidate may have gone stale
-			// between picker render and click; tell the user to refresh.
 			if (linkToProjectId && !targetCandidate) {
 				throw new Error(
 					"Selected v2 project is no longer in the candidate list. Refresh and pick again.",
@@ -248,12 +173,7 @@ function ProjectRow({
 					v2ProjectId = targetCandidate.id;
 					mainWorkspaceId = result.mainWorkspaceId;
 					repoPath = result.repoPath;
-					status = "linked";
 				} catch (err) {
-					// Setup throws CONFLICT when the v2 project is already set
-					// up at a different folder on this device. Surface a
-					// confirm so the user can opt in to repointing instead of
-					// silently failing.
 					if (isAlreadySetUpElsewhereError(err) && !options.allowRelocate) {
 						setPendingRelocate({
 							v2ProjectId: targetCandidate.id,
@@ -272,17 +192,7 @@ function ProjectRow({
 				v2ProjectId = result.projectId;
 				mainWorkspaceId = result.mainWorkspaceId;
 				repoPath = result.repoPath;
-				status = "success";
 			}
-
-			await upsertState.mutateAsync({
-				v1Id: project.id,
-				kind: "project",
-				v2Id: v2ProjectId,
-				organizationId,
-				status,
-				reason: null,
-			});
 
 			finalizeSetup(activeHostUrl, {
 				projectId: v2ProjectId,
@@ -290,37 +200,19 @@ function ProjectRow({
 				mainWorkspaceId,
 			});
 
-			await trpcUtils.migration.listState.invalidate({ organizationId });
+			setLinkedV2Id(v2ProjectId);
 			await queryClient.invalidateQueries({
 				queryKey: [...FIND_BY_PATH_KEY_PREFIX, project.mainRepoPath],
-			});
-			// Crucial: cloudList is what the audit-ghost detector cross-
-			// checks against. Without invalidating, the freshly-created v2
-			// project isn't in the cached set and the row gets demoted from
-			// "Imported" back to "available" — looks like the import didn't
-			// finish even though it did.
-			await queryClient.invalidateQueries({
-				queryKey: PROJECT_CLOUD_LIST_KEY,
 			});
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			setErrorMessage(message);
-			await upsertState
-				.mutateAsync({
-					v1Id: project.id,
-					kind: "project",
-					v2Id: null,
-					organizationId,
-					status: "error",
-					reason: message,
-				})
-				.catch((auditErr) => {
-					console.warn(
-						"[v1-import] failed to record project import error in audit",
-						{ projectId: project.id, auditErr },
-					);
-				});
-			await trpcUtils.migration.listState.invalidate({ organizationId });
+			console.error("[v1-import] project import failed", {
+				v1ProjectId: project.id,
+				mainRepoPath: project.mainRepoPath,
+				organizationId,
+				err,
+			});
 		} finally {
 			setRunning(false);
 		}
@@ -346,23 +238,13 @@ function ProjectRow({
 				onCancel: () => setPendingRelocate(null),
 			};
 		}
-		if (auditImported) {
-			return {
-				kind: "imported",
-				label: audit?.status === "linked" ? "Linked" : "Imported",
-			};
+		if (isImported) {
+			return { kind: "imported", label: "Linked" };
 		}
 		if (errorMessage) {
 			return {
 				kind: "error",
 				message: errorMessage,
-				onRetry: () => runImport(),
-			};
-		}
-		if (auditError) {
-			return {
-				kind: "error",
-				message: auditError,
 				onRetry: () => runImport(),
 			};
 		}
@@ -382,9 +264,6 @@ function ProjectRow({
 		}
 		const candidates = findByPathQuery.data?.candidates ?? [];
 		const cloudErrors = findByPathQuery.data?.cloudErrors ?? [];
-		// If we got nothing from cloud AND any cloud query failed, surface
-		// the failure rather than offering Import (which would silently
-		// create a duplicate v2 project on next sync).
 		if (candidates.length === 0 && cloudErrors.length > 0) {
 			const first = cloudErrors[0];
 			return {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
@@ -14,6 +14,7 @@ interface ImportProjectsPageProps {
 }
 
 const FIND_BY_PATH_KEY_PREFIX = ["v1-import", "findByPath"] as const;
+const HOST_PROJECT_LIST_KEY_PREFIX = ["v1-import", "hostProjectList"] as const;
 
 export function ImportProjectsPage({
 	organizationId,
@@ -201,9 +202,14 @@ function ProjectRow({
 			});
 
 			setLinkedV2Id(v2ProjectId);
-			await queryClient.invalidateQueries({
-				queryKey: [...FIND_BY_PATH_KEY_PREFIX, project.mainRepoPath],
-			});
+			await Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: [...FIND_BY_PATH_KEY_PREFIX, project.mainRepoPath],
+				}),
+				queryClient.invalidateQueries({
+					queryKey: HOST_PROJECT_LIST_KEY_PREFIX,
+				}),
+			]);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			setErrorMessage(message);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -12,14 +12,9 @@ interface ImportWorkspacesPageProps {
 	activeHostUrl: string;
 }
 
-interface AuditLogEntry {
-	v2Id: string | null;
-	status: string;
-	reason: string | null;
-}
-
 const WORKTREE_LIST_KEY_PREFIX = ["v1-import", "projectWorktrees"] as const;
 const WORKSPACE_CLOUD_LIST_KEY = ["v1-import", "workspaceCloudList"] as const;
+const HOST_PROJECT_LIST_KEY = ["v1-import", "hostProjectList"] as const;
 
 function trpcCode(err: unknown): string | null {
 	if (typeof err !== "object" || err === null) return null;
@@ -37,9 +32,16 @@ export function ImportWorkspacesPage({
 	const projectsQuery = electronTrpc.migration.readV1Projects.useQuery();
 	const workspacesQuery = electronTrpc.migration.readV1Workspaces.useQuery();
 	const worktreesQuery = electronTrpc.migration.readV1Worktrees.useQuery();
-	const auditQuery = electronTrpc.migration.listState.useQuery({
-		organizationId,
+
+	const hostProjectListQuery = useQuery({
+		queryKey: [...HOST_PROJECT_LIST_KEY, activeHostUrl],
+		queryFn: async () => {
+			const client = getHostServiceClientByUrl(activeHostUrl);
+			return client.project.list.query();
+		},
+		retry: false,
 	});
+
 	const cloudWorkspacesQuery = useQuery({
 		queryKey: [...WORKSPACE_CLOUD_LIST_KEY, organizationId, activeHostUrl],
 		queryFn: async () => {
@@ -49,34 +51,28 @@ export function ImportWorkspacesPage({
 		retry: false,
 	});
 
-	const liveWorkspaceIds = useMemo(() => {
-		if (!cloudWorkspacesQuery.data) return null;
-		return new Set(cloudWorkspacesQuery.data.map((w) => w.id));
+	const v2ProjectIdByV1Id = useMemo(() => {
+		const v2ByPath = new Map<string, string>();
+		for (const v2 of hostProjectListQuery.data ?? []) {
+			v2ByPath.set(v2.repoPath, v2.id);
+		}
+		const map = new Map<string, string>();
+		for (const v1 of projectsQuery.data ?? []) {
+			const v2Id = v2ByPath.get(v1.mainRepoPath);
+			if (v2Id) map.set(v1.id, v2Id);
+		}
+		return map;
+	}, [hostProjectListQuery.data, projectsQuery.data]);
+
+	const cloudWorkspaceKeys = useMemo(() => {
+		const set = new Set<string>();
+		for (const w of cloudWorkspacesQuery.data ?? []) {
+			set.add(`${w.projectId}\0${w.branch}`);
+		}
+		return set;
 	}, [cloudWorkspacesQuery.data]);
 
-	const projectAuditByV1Id = new Map<string, AuditLogEntry>();
-	const workspaceAuditByV1Id = new Map<string, AuditLogEntry>();
-	for (const row of auditQuery.data ?? []) {
-		const entry: AuditLogEntry = {
-			v2Id: row.v2Id,
-			status: row.status,
-			reason: row.reason,
-		};
-		if (row.kind === "project") projectAuditByV1Id.set(row.v1Id, entry);
-		else if (row.kind === "workspace")
-			workspaceAuditByV1Id.set(row.v1Id, entry);
-	}
-
-	// Live `git worktree list` per imported v2 project — used to filter out
-	// v1 workspaces whose branch no longer has a worktree (folder deleted,
-	// branch pruned, etc.) so we don't surface guaranteed-to-fail rows.
-	const importedV2ProjectIds = Array.from(projectAuditByV1Id.values())
-		.filter(
-			(entry) =>
-				!!entry.v2Id &&
-				(entry.status === "success" || entry.status === "linked"),
-		)
-		.map((entry) => entry.v2Id as string);
+	const importedV2ProjectIds = Array.from(new Set(v2ProjectIdByV1Id.values()));
 
 	const worktreeListQueries = useQueries({
 		queries: importedV2ProjectIds.map((v2ProjectId) => ({
@@ -111,7 +107,7 @@ export function ImportWorkspacesPage({
 		projectsQuery.isPending ||
 		workspacesQuery.isPending ||
 		worktreesQuery.isPending ||
-		auditQuery.isPending ||
+		hostProjectListQuery.isPending ||
 		worktreeListQueries.some((q) => q.isPending);
 
 	const [isRefreshing, setIsRefreshing] = useState(false);
@@ -122,7 +118,7 @@ export function ImportWorkspacesPage({
 				projectsQuery.refetch(),
 				workspacesQuery.refetch(),
 				worktreesQuery.refetch(),
-				auditQuery.refetch(),
+				hostProjectListQuery.refetch(),
 				cloudWorkspacesQuery.refetch(),
 				queryClient.invalidateQueries({
 					queryKey: WORKTREE_LIST_KEY_PREFIX,
@@ -143,26 +139,14 @@ export function ImportWorkspacesPage({
 
 	const visibleWorkspaces: typeof allWorkspaces = [];
 	for (const workspace of allWorkspaces) {
-		const projAudit = projectAuditByV1Id.get(workspace.projectId);
-		const parentImported =
-			!!projAudit?.v2Id &&
-			(projAudit.status === "success" || projAudit.status === "linked");
-		// Only surface workspaces whose v1 project has already been brought
-		// over to v2 — workspaces under un-imported projects are useless
-		// rows.
-		if (!parentImported) continue;
+		const v2ProjectId = v2ProjectIdByV1Id.get(workspace.projectId);
+		if (!v2ProjectId) continue;
 
-		const wsAudit = workspaceAuditByV1Id.get(workspace.id);
-		// Audit rows can be ghosts: status=success but cloud no longer has
-		// the v2 workspace. Only treat as "already imported" when the cloud
-		// list confirms it (or when the cloud list hasn't loaded yet, in
-		// which case we trust audit until proven otherwise).
-		const alreadyImported =
-			wsAudit?.status === "success" &&
-			(liveWorkspaceIds === null ||
-				(!!wsAudit.v2Id && liveWorkspaceIds.has(wsAudit.v2Id)));
-		if (!alreadyImported && projAudit?.v2Id) {
-			const validBranches = validBranchesByV2ProjectId.get(projAudit.v2Id);
+		const alreadyImported = cloudWorkspaceKeys.has(
+			`${v2ProjectId}\0${workspace.branch}`,
+		);
+		if (!alreadyImported) {
+			const validBranches = validBranchesByV2ProjectId.get(v2ProjectId);
 			if (validBranches !== undefined && !validBranches.has(workspace.branch)) {
 				continue;
 			}
@@ -222,9 +206,14 @@ export function ImportWorkspacesPage({
 										null)
 									: null
 							}
-							projectAudit={projectAuditByV1Id.get(workspace.projectId)}
-							workspaceAudit={workspaceAuditByV1Id.get(workspace.id)}
-							liveWorkspaceIds={liveWorkspaceIds}
+							v2ProjectId={v2ProjectIdByV1Id.get(workspace.projectId) ?? null}
+							alreadyImported={(() => {
+								const v2ProjectId = v2ProjectIdByV1Id.get(workspace.projectId);
+								if (!v2ProjectId) return false;
+								return cloudWorkspaceKeys.has(
+									`${v2ProjectId}\0${workspace.branch}`,
+								);
+							})()}
 							organizationId={organizationId}
 							activeHostUrl={activeHostUrl}
 						/>
@@ -244,10 +233,8 @@ interface WorkspaceRowProps {
 	};
 	worktreePath: string | undefined;
 	baseBranch: string | null;
-	projectAudit: AuditLogEntry | undefined;
-	workspaceAudit: AuditLogEntry | undefined;
-	/** Live cloud workspace ids in the org. `null` while still loading. */
-	liveWorkspaceIds: Set<string> | null;
+	v2ProjectId: string | null;
+	alreadyImported: boolean;
 	organizationId: string;
 	activeHostUrl: string;
 }
@@ -256,37 +243,18 @@ function WorkspaceRow({
 	workspace,
 	worktreePath,
 	baseBranch,
-	projectAudit,
-	workspaceAudit,
-	liveWorkspaceIds,
+	v2ProjectId,
+	alreadyImported,
 	organizationId,
 	activeHostUrl,
 }: WorkspaceRowProps) {
 	const queryClient = useQueryClient();
-	const upsertState = electronTrpc.migration.upsertState.useMutation();
-	const trpcUtils = electronTrpc.useUtils();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const [running, setRunning] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const [adoptedV2Id, setAdoptedV2Id] = useState<string | null>(null);
 
-	const parentImported =
-		projectAudit !== undefined &&
-		projectAudit.v2Id !== null &&
-		(projectAudit.status === "success" || projectAudit.status === "linked");
-	const v2ProjectId = parentImported ? (projectAudit?.v2Id ?? null) : null;
-
-	// Same ghost-detection as page-level filter: audit success is a lie if
-	// cloud confirms the v2 workspace is gone.
-	const auditClaimsImported =
-		workspaceAudit !== undefined && workspaceAudit.status === "success";
-	const auditImported =
-		auditClaimsImported &&
-		(liveWorkspaceIds === null ||
-			(!!workspaceAudit?.v2Id && liveWorkspaceIds.has(workspaceAudit.v2Id)));
-	const auditError =
-		workspaceAudit !== undefined && workspaceAudit.status === "error"
-			? workspaceAudit.reason
-			: null;
+	const isImported = alreadyImported || !!adoptedV2Id;
 
 	const runImport = async () => {
 		if (!v2ProjectId) return;
@@ -299,7 +267,6 @@ function WorkspaceRow({
 				workspaceName: workspace.name,
 				branch: workspace.branch,
 				baseBranch: baseBranch ?? undefined,
-				existingWorkspaceId: workspaceAudit?.v2Id ?? undefined,
 			};
 			let result: Awaited<
 				ReturnType<typeof client.workspaceCreation.adopt.mutate>
@@ -310,9 +277,6 @@ function WorkspaceRow({
 					worktreePath,
 				});
 			} catch (err) {
-				// v1's worktree row can be stale (folder moved/deleted) while git still
-				// has the branch registered at the canonical worktree path. Retry by
-				// branch before giving up.
 				if (worktreePath && trpcCode(err) === "NOT_FOUND") {
 					result = await client.workspaceCreation.adopt.mutate(adoptArgs);
 				} else {
@@ -320,42 +284,21 @@ function WorkspaceRow({
 				}
 			}
 
-			await upsertState.mutateAsync({
-				v1Id: workspace.id,
-				kind: "workspace",
-				v2Id: result.workspace.id,
-				organizationId,
-				status: "success",
-				reason: null,
-			});
-
 			ensureWorkspaceInSidebar(result.workspace.id, v2ProjectId);
-			await trpcUtils.migration.listState.invalidate({ organizationId });
-			// Without this, the freshly-adopted workspace isn't in the
-			// cached cloud-list snapshot, so the audit-ghost detector flips
-			// the row from "Imported" back to a fresh Adopt button.
+			setAdoptedV2Id(result.workspace.id);
 			await queryClient.invalidateQueries({
 				queryKey: WORKSPACE_CLOUD_LIST_KEY,
 			});
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			setErrorMessage(message);
-			await upsertState
-				.mutateAsync({
-					v1Id: workspace.id,
-					kind: "workspace",
-					v2Id: null,
-					organizationId,
-					status: "error",
-					reason: message,
-				})
-				.catch((auditErr) => {
-					console.warn(
-						"[v1-import] failed to record workspace adopt error in audit",
-						{ workspaceId: workspace.id, auditErr },
-					);
-				});
-			await trpcUtils.migration.listState.invalidate({ organizationId });
+			console.error("[v1-import] workspace adopt failed", {
+				v1WorkspaceId: workspace.id,
+				v2ProjectId,
+				branch: workspace.branch,
+				organizationId,
+				err,
+			});
 		} finally {
 			setRunning(false);
 		}
@@ -363,8 +306,8 @@ function WorkspaceRow({
 
 	const action: RowAction = (() => {
 		if (running) return { kind: "running" };
-		if (auditImported) return { kind: "imported" };
-		if (!parentImported) {
+		if (isImported) return { kind: "imported" };
+		if (!v2ProjectId) {
 			return {
 				kind: "blocked",
 				reason: "Import the project on the Projects tab first.",
@@ -372,9 +315,6 @@ function WorkspaceRow({
 		}
 		if (errorMessage) {
 			return { kind: "error", message: errorMessage, onRetry: runImport };
-		}
-		if (auditError) {
-			return { kind: "error", message: auditError, onRetry: runImport };
 		}
 		return { kind: "ready", label: "Adopt", onClick: runImport };
 	})();

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -14,7 +14,7 @@ interface ImportWorkspacesPageProps {
 
 const WORKTREE_LIST_KEY_PREFIX = ["v1-import", "projectWorktrees"] as const;
 const WORKSPACE_CLOUD_LIST_KEY = ["v1-import", "workspaceCloudList"] as const;
-const HOST_PROJECT_LIST_KEY = ["v1-import", "hostProjectList"] as const;
+const HOST_PROJECT_LIST_KEY_PREFIX = ["v1-import", "hostProjectList"] as const;
 
 function trpcCode(err: unknown): string | null {
 	if (typeof err !== "object" || err === null) return null;
@@ -34,7 +34,7 @@ export function ImportWorkspacesPage({
 	const worktreesQuery = electronTrpc.migration.readV1Worktrees.useQuery();
 
 	const hostProjectListQuery = useQuery({
-		queryKey: [...HOST_PROJECT_LIST_KEY, activeHostUrl],
+		queryKey: [...HOST_PROJECT_LIST_KEY_PREFIX, activeHostUrl],
 		queryFn: async () => {
 			const client = getHostServiceClientByUrl(activeHostUrl);
 			return client.project.list.query();
@@ -137,7 +137,12 @@ export function ImportWorkspacesPage({
 	);
 	const allWorkspaces = workspacesQuery.data ?? [];
 
-	const visibleWorkspaces: typeof allWorkspaces = [];
+	type VisibleWorkspace = {
+		workspace: (typeof allWorkspaces)[number];
+		v2ProjectId: string;
+		alreadyImported: boolean;
+	};
+	const visibleWorkspaces: VisibleWorkspace[] = [];
 	for (const workspace of allWorkspaces) {
 		const v2ProjectId = v2ProjectIdByV1Id.get(workspace.projectId);
 		if (!v2ProjectId) continue;
@@ -151,25 +156,25 @@ export function ImportWorkspacesPage({
 				continue;
 			}
 		}
-		visibleWorkspaces.push(workspace);
+		visibleWorkspaces.push({ workspace, v2ProjectId, alreadyImported });
 	}
 
 	const grouped = new Map<
 		string,
 		{
 			projectName: string;
-			items: typeof visibleWorkspaces;
+			items: VisibleWorkspace[];
 		}
 	>();
-	for (const workspace of visibleWorkspaces) {
-		const project = projectsById.get(workspace.projectId);
+	for (const entry of visibleWorkspaces) {
+		const project = projectsById.get(entry.workspace.projectId);
 		if (!project) continue;
-		const bucket = grouped.get(workspace.projectId) ?? {
+		const bucket = grouped.get(entry.workspace.projectId) ?? {
 			projectName: project.name,
 			items: [],
 		};
-		bucket.items.push(workspace);
-		grouped.set(workspace.projectId, bucket);
+		bucket.items.push(entry);
+		grouped.set(entry.workspace.projectId, bucket);
 	}
 
 	return (
@@ -191,7 +196,7 @@ export function ImportWorkspacesPage({
 					<div className="px-3 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
 						{group.projectName}
 					</div>
-					{group.items.map((workspace) => (
+					{group.items.map(({ workspace, v2ProjectId, alreadyImported }) => (
 						<WorkspaceRow
 							key={workspace.id}
 							workspace={workspace}
@@ -206,14 +211,8 @@ export function ImportWorkspacesPage({
 										null)
 									: null
 							}
-							v2ProjectId={v2ProjectIdByV1Id.get(workspace.projectId) ?? null}
-							alreadyImported={(() => {
-								const v2ProjectId = v2ProjectIdByV1Id.get(workspace.projectId);
-								if (!v2ProjectId) return false;
-								return cloudWorkspaceKeys.has(
-									`${v2ProjectId}\0${workspace.branch}`,
-								);
-							})()}
+							v2ProjectId={v2ProjectId}
+							alreadyImported={alreadyImported}
 							organizationId={organizationId}
 							activeHostUrl={activeHostUrl}
 						/>
@@ -233,7 +232,7 @@ interface WorkspaceRowProps {
 	};
 	worktreePath: string | undefined;
 	baseBranch: string | null;
-	v2ProjectId: string | null;
+	v2ProjectId: string;
 	alreadyImported: boolean;
 	organizationId: string;
 	activeHostUrl: string;
@@ -257,7 +256,6 @@ function WorkspaceRow({
 	const isImported = alreadyImported || !!adoptedV2Id;
 
 	const runImport = async () => {
-		if (!v2ProjectId) return;
 		setRunning(true);
 		setErrorMessage(null);
 		try {
@@ -267,6 +265,7 @@ function WorkspaceRow({
 				workspaceName: workspace.name,
 				branch: workspace.branch,
 				baseBranch: baseBranch ?? undefined,
+				existingWorkspaceId: adoptedV2Id ?? undefined,
 			};
 			let result: Awaited<
 				ReturnType<typeof client.workspaceCreation.adopt.mutate>
@@ -307,12 +306,6 @@ function WorkspaceRow({
 	const action: RowAction = (() => {
 		if (running) return { kind: "running" };
 		if (isImported) return { kind: "imported" };
-		if (!v2ProjectId) {
-			return {
-				kind: "blocked",
-				reason: "Import the project on the Projects tab first.",
-			};
-		}
 		if (errorMessage) {
 			return { kind: "error", message: errorMessage, onRetry: runImport };
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
@@ -5,8 +5,6 @@ import {
 	DialogDescription,
 	DialogTitle,
 } from "@superset/ui/dialog";
-import { cn } from "@superset/ui/utils";
-import { useState } from "react";
 import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -14,15 +12,12 @@ import {
 	useCloseV1ImportModal,
 	useV1ImportModalStore,
 	V1_IMPORT_PAGE_ORDER,
-	type V1ImportPage,
 } from "renderer/stores/v1-import-modal";
 import { MOCK_ORG_ID } from "shared/constants";
 import { WelcomePage } from "./components/WelcomePage";
 import { ImportPresetsPage } from "./ImportPresetsPage";
 import { ImportProjectsPage } from "./ImportProjectsPage";
 import { ImportWorkspacesPage } from "./ImportWorkspacesPage";
-
-const TRANSITION_MS = 160;
 
 export function V1ImportModal() {
 	const isOpen = useV1ImportModalStore((s) => s.isOpen);
@@ -35,18 +30,7 @@ export function V1ImportModal() {
 		? MOCK_ORG_ID
 		: (session?.session?.activeOrganizationId ?? null);
 
-	const [isTransitioning, setIsTransitioning] = useState(false);
-
 	if (!organizationId) return null;
-
-	const transitionToPage = (next: V1ImportPage) => {
-		if (next === page || isTransitioning) return;
-		setIsTransitioning(true);
-		window.setTimeout(() => {
-			setPage(next);
-			setIsTransitioning(false);
-		}, TRANSITION_MS);
-	};
 
 	const currentIndex = V1_IMPORT_PAGE_ORDER.indexOf(page);
 	const previousPage = V1_IMPORT_PAGE_ORDER[currentIndex - 1];
@@ -74,12 +58,7 @@ export function V1ImportModal() {
 					v2.
 				</DialogDescription>
 
-				<div
-					className={cn(
-						"transition-opacity duration-200 ease-out",
-						isTransitioning ? "opacity-0" : "opacity-100",
-					)}
-				>
+				<div key={page} className="animate-in fade-in duration-200">
 					{page === "welcome" && <WelcomePage />}
 					{(page === "projects" || page === "workspaces") && !activeHostUrl && (
 						<div className="flex h-[454px] items-center justify-center bg-background px-6 text-center text-sm text-muted-foreground">
@@ -106,27 +85,18 @@ export function V1ImportModal() {
 
 				<div className="box-border flex items-center justify-between border-t bg-background px-5 py-4">
 					{previousPage ? (
-						<Button
-							variant="outline"
-							disabled={isTransitioning}
-							onClick={() => transitionToPage(previousPage)}
-						>
+						<Button variant="outline" onClick={() => setPage(previousPage)}>
 							Back
 						</Button>
 					) : (
 						<div />
 					)}
 					{nextPage ? (
-						<Button
-							disabled={isTransitioning}
-							onClick={() => transitionToPage(nextPage)}
-						>
+						<Button onClick={() => setPage(nextPage)}>
 							{page === "welcome" ? "Get started" : "Next"}
 						</Button>
 					) : (
-						<Button disabled={isTransitioning} onClick={close}>
-							Done
-						</Button>
+						<Button onClick={close}>Done</Button>
 					)}
 				</div>
 			</DialogContent>

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",

--- a/packages/host-service/src/trpc/router/project/project.ts
+++ b/packages/host-service/src/trpc/router/project/project.ts
@@ -39,18 +39,6 @@ export const projectRouter = router({
 			.all();
 	}),
 
-	/**
-	 * Asks cloud (not the local DB cache) for the live set of v2 projects in
-	 * this org. Used by the v1→v2 importer to detect stale audit-log rows
-	 * that point at projects another device or user has since deleted.
-	 */
-	cloudList: protectedProcedure.query(async ({ ctx }) => {
-		const rows = await ctx.api.v2Project.list.query({
-			organizationId: ctx.organizationId,
-		});
-		return rows.map((row) => ({ id: row.id, name: row.name }));
-	}),
-
 	get: protectedProcedure
 		.input(z.object({ projectId: z.string().uuid() }))
 		.query(({ ctx, input }) => {

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -23,18 +23,16 @@ export const workspaceRouter = router({
 			return localWorkspace;
 		}),
 
-	/**
-	 * Asks cloud (not this device's local DB) for the live set of v2
-	 * workspace ids in the org. Used by the v1→v2 importer to detect audit
-	 * rows that map to workspaces another device or user has since deleted.
-	 * Returns just `{ id }[]` to keep the payload small — list calls
-	 * already paginate workspace metadata where it's needed.
-	 */
 	cloudList: protectedProcedure.query(async ({ ctx }) => {
 		const rows = await ctx.api.v2Workspace.list.query({
 			organizationId: ctx.organizationId,
 		});
-		return rows.map((row) => ({ id: row.id }));
+		return rows.map((row) => ({
+			id: row.id,
+			projectId: row.projectId,
+			branch: row.branch,
+			hostId: row.hostId,
+		}));
 	}),
 
 	gitStatus: protectedProcedure

--- a/packages/host-service/test/integration/project.integration.test.ts
+++ b/packages/host-service/test/integration/project.integration.test.ts
@@ -89,7 +89,7 @@ describe("project router integration", () => {
 			repoPath: repo.repoPath,
 		});
 		expect(result.candidates).toHaveLength(1);
-		expect(result.candidates[0]).toEqual({ id, name: "local-name" });
+		expect(result.candidates[0]).toMatchObject({ id, name: "local-name" });
 		expect(
 			host.apiCalls.some(
 				(c) => c.path === "v2Project.findByGitHubRemote.query",
@@ -130,9 +130,11 @@ describe("project router integration", () => {
 		const result = await host.trpc.project.findByPath.query({
 			repoPath: repo.repoPath,
 		});
-		expect(result.candidates).toEqual([
-			{ id: "cloud-project-id", name: "octocat/hello" },
-		]);
+		expect(result.candidates).toHaveLength(1);
+		expect(result.candidates[0]).toMatchObject({
+			id: "cloud-project-id",
+			name: "octocat/hello",
+		});
 		expect(
 			host.apiCalls.some(
 				(c) => c.path === "v2Project.findByGitHubRemote.query",

--- a/scripts/v1v2-import-test-cleanup.sh
+++ b/scripts/v1v2-import-test-cleanup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Undoes everything v1v2-import-test-setup.sh did. Idempotent.
+
+set -euo pipefail
+
+SATYA_TEST_ORG=b2c3d4e5-f6a7-4890-9bcd-ef1234567891
+SUPERSET_ORG=a1b2c3d4-e5f6-7890-abcd-ef1234567890
+DEV_DATA_LOCAL_DB="$(pwd)/superset-dev-data/local.db"
+SATYA_TEST_HOST_DB="$(pwd)/superset-dev-data/host/$SATYA_TEST_ORG/host.db"
+SUPERSET_HOST_DB="$(pwd)/superset-dev-data/host/$SUPERSET_ORG/host.db"
+
+NEW_NO_REMOTE_ID=22222222-bbbb-4bbb-8bbb-000000000001
+NEW_GHOST_ID=22222222-bbbb-4bbb-8bbb-000000000002
+
+echo "→ removing on-disk fixture repos"
+if [ -d "$HOME/code/onbook-relocate-clone/.git" ]; then
+  for branch in v1v2-test-clean v1v2-test-stale-fallback v1v2-test-ghost; do
+    git -C "$HOME/code/onbook-relocate-clone" worktree remove -f \
+      ".worktrees/$branch" 2>/dev/null || true
+    git -C "$HOME/code/onbook-relocate-clone" branch -D "$branch" 2>/dev/null || true
+  done
+fi
+rm -rf "$HOME/code/onbook-relocate-clone" \
+       "$HOME/code/v1v2-no-remote" \
+       "$HOME/code/v1v2-ghost"
+
+echo "→ removing fakeupstream remote from onlook"
+git -C "$HOME/code/onlook" remote remove fakeupstream 2>/dev/null || true
+
+echo "→ restoring v1 onbook mainRepoPath + clearing fixtures we added"
+sqlite3 "$DEV_DATA_LOCAL_DB" <<SQL
+UPDATE projects SET tab_order = NULL WHERE name IN ('cal.com','onlook','mastra','chatbot');
+UPDATE projects SET tab_order = NULL, main_repo_path = '$HOME/code/onbook' WHERE name = 'onbook';
+DELETE FROM projects WHERE id IN ('$NEW_NO_REMOTE_ID','$NEW_GHOST_ID');
+DELETE FROM workspaces WHERE id LIKE '55555555-dddd-4ddd-8ddd-%';
+DELETE FROM worktrees WHERE id LIKE '44444444-cccc-4ccc-8ccc-%';
+SQL
+
+echo "→ removing fixture host.db rows from both orgs"
+sqlite3 "$SATYA_TEST_HOST_DB" \
+  "DELETE FROM projects WHERE id LIKE '11111111-aaaa-4aaa-8aaa-%'"
+sqlite3 "$SUPERSET_HOST_DB" \
+  "DELETE FROM projects WHERE id LIKE '33333333-aaaa-4aaa-8aaa-%'"
+
+echo "→ deleting fixture v2 projects from dev cloud"
+PGURL=$(grep '^DATABASE_URL=' .env | sed 's/^DATABASE_URL=//;s/^"//;s/"$//')
+psql "$PGURL" -c "DELETE FROM public.v2_projects WHERE id::text LIKE '11111111-aaaa-4aaa-8aaa-%' OR id::text LIKE '33333333-aaaa-4aaa-8aaa-%'" >/dev/null
+
+echo "✓ cleanup done"

--- a/scripts/v1v2-import-test-setup.sh
+++ b/scripts/v1v2-import-test-setup.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Set up the manual test fixtures for the v1→v2 importer.
+#
+# Idempotent — safe to re-run. Pair with v1v2-import-test-cleanup.sh.
+#
+# Targets:
+#   - Dev neon branch via .env DATABASE_URL (must be a non-prod branch)
+#   - superset-dev-data/local.db          (v1 fixtures)
+#   - superset-dev-data/host/<orgId>/host.db  (host.db fixtures)
+#   - ~/code/<repo>                       (on-disk fixture repos)
+#
+# v1 local DB project rows that already exist (superset, cal.com, onbook,
+# onlook, mastra, chatbot) are NOT recreated — we just bump their tab_order
+# so they show up in the importer. New synthetic rows (v1v2-no-remote,
+# v1v2-ghost) are inserted with id prefix 22222222-bbbb-...
+
+set -euo pipefail
+
+SATYA_TEST_ORG=b2c3d4e5-f6a7-4890-9bcd-ef1234567891
+SUPERSET_ORG=a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+DEV_DATA="$(pwd)/superset-dev-data"
+DEV_DATA_LOCAL_DB="$DEV_DATA/local.db"
+SATYA_TEST_HOST_DB="$DEV_DATA/host/$SATYA_TEST_ORG/host.db"
+SUPERSET_HOST_DB="$DEV_DATA/host/$SUPERSET_ORG/host.db"
+
+NEW_NO_REMOTE_ID=22222222-bbbb-4bbb-8bbb-000000000001
+NEW_GHOST_ID=22222222-bbbb-4bbb-8bbb-000000000002
+
+ONBOOK_V1_ID=098e54ad-7160-497f-aae3-57c68c8b6a8e
+ONBOOK_FIXTURE_V2_ID=33333333-aaaa-4aaa-8aaa-000000000004
+
+# ---- 0. sanity checks --------------------------------------------------------
+
+if [ ! -f "$DEV_DATA_LOCAL_DB" ]; then
+  echo "✗ $DEV_DATA_LOCAL_DB missing — run the dev build at least once first."
+  exit 1
+fi
+
+PGURL=$(grep '^DATABASE_URL=' .env | sed 's/^DATABASE_URL=//;s/^"//;s/"$//')
+BRANCH_NAME=$(grep '^NEON_BRANCH_ID=' .env | sed 's/^NEON_BRANCH_ID=//;s/^"//;s/"$//')
+if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "br-billowing-dream-af839yib" ]; then
+  echo "✗ refusing to seed — .env DATABASE_URL points at the prod neon branch."
+  echo "  Spin up a dev branch and update .env first."
+  exit 1
+fi
+
+echo "→ targeting neon branch $BRANCH_NAME"
+
+# ---- 1. on-disk fixture repos -----------------------------------------------
+
+echo "→ adding fakeupstream remote to ~/code/onlook"
+git -C "$HOME/code/onlook" remote remove fakeupstream 2>/dev/null || true
+git -C "$HOME/code/onlook" remote add fakeupstream \
+  https://github.com/satya-fake-org/onlook.git
+
+echo "→ cloning onbook → ~/code/onbook-relocate-clone"
+rm -rf "$HOME/code/onbook-relocate-clone"
+git clone --quiet --depth 1 "$HOME/code/onbook" "$HOME/code/onbook-relocate-clone"
+git -C "$HOME/code/onbook-relocate-clone" remote set-url origin \
+  https://github.com/onlook-dev/onbook.git
+
+echo "→ creating ~/code/v1v2-no-remote (local-only fixture)"
+rm -rf "$HOME/code/v1v2-no-remote"
+mkdir -p "$HOME/code/v1v2-no-remote"
+(
+  cd "$HOME/code/v1v2-no-remote"
+  git init -q -b main
+  echo "# v1v2-no-remote — local-only fixture" > README.md
+  git -c user.email=test@superset.sh -c user.name=Test add README.md
+  git -c user.email=test@superset.sh -c user.name=Test commit -q -m init
+)
+
+echo "→ creating ~/code/v1v2-ghost (single-remote fixture)"
+rm -rf "$HOME/code/v1v2-ghost"
+mkdir -p "$HOME/code/v1v2-ghost"
+(
+  cd "$HOME/code/v1v2-ghost"
+  git init -q -b main
+  git remote add origin https://github.com/satya-fake-org/v1v2-ghost.git
+  echo "# v1v2-ghost fixture" > README.md
+  git -c user.email=test@superset.sh -c user.name=Test add README.md
+  git -c user.email=test@superset.sh -c user.name=Test commit -q -m init
+)
+
+echo "→ adding worktrees to ~/code/onbook-relocate-clone"
+for branch in v1v2-test-clean v1v2-test-stale-fallback v1v2-test-ghost; do
+  git -C "$HOME/code/onbook-relocate-clone" worktree remove -f \
+    ".worktrees/$branch" 2>/dev/null || true
+  git -C "$HOME/code/onbook-relocate-clone" branch -D "$branch" 2>/dev/null || true
+  git -C "$HOME/code/onbook-relocate-clone" worktree add -q \
+    ".worktrees/$branch" -b "$branch"
+done
+
+# ---- 2. cloud v2 fixtures (Satya Test Org) ----------------------------------
+
+echo "→ seeding v2 projects in Satya Test Org"
+psql "$PGURL" >/dev/null <<SQL
+INSERT INTO public.v2_projects (id, organization_id, name, slug, repo_clone_url) VALUES
+  ('11111111-aaaa-4aaa-8aaa-000000000001', '$SATYA_TEST_ORG', 'cal.com (calcom)',      'cal-com-calcom',     'https://github.com/calcom/cal.com'),
+  ('11111111-aaaa-4aaa-8aaa-000000000002', '$SATYA_TEST_ORG', 'cal.com (onlook fork)', 'cal-com-onlook-dev', 'https://github.com/onlook-dev/cal.com'),
+  ('11111111-aaaa-4aaa-8aaa-000000000003', '$SATYA_TEST_ORG', 'onlook',                'onlook-v1v2-test',   'https://github.com/onlook-dev/onlook'),
+  ('11111111-aaaa-4aaa-8aaa-000000000004', '$SATYA_TEST_ORG', 'onbook',                'onbook-v1v2-test',   'https://github.com/onlook-dev/onbook')
+ON CONFLICT (id) DO NOTHING;
+SQL
+
+# ---- 3. cloud v2 fixtures (Superset Org — where active session usually is) --
+
+echo "→ seeding v2 projects in Superset Org"
+psql "$PGURL" >/dev/null <<SQL
+INSERT INTO public.v2_projects (id, organization_id, name, slug, repo_clone_url) VALUES
+  ('33333333-aaaa-4aaa-8aaa-000000000001', '$SUPERSET_ORG', 'cal.com (calcom)',      'v1v2-test-cal-com-calcom',     'https://github.com/calcom/cal.com'),
+  ('33333333-aaaa-4aaa-8aaa-000000000002', '$SUPERSET_ORG', 'cal.com (onlook fork)', 'v1v2-test-cal-com-onlook-dev', 'https://github.com/onlook-dev/cal.com'),
+  ('33333333-aaaa-4aaa-8aaa-000000000003', '$SUPERSET_ORG', 'onlook (test fixture)', 'v1v2-test-onlook',             'https://github.com/onlook-dev/onlook'),
+  ('$ONBOOK_FIXTURE_V2_ID',                '$SUPERSET_ORG', 'onbook (test fixture)', 'v1v2-test-onbook',             'https://github.com/onlook-dev/onbook')
+ON CONFLICT (id) DO NOTHING;
+SQL
+
+# ---- 4. v1 local.db fixtures ------------------------------------------------
+
+echo "→ updating v1 local.db"
+sqlite3 "$DEV_DATA_LOCAL_DB" <<SQL
+-- Surface existing v1 projects in the importer (tab_order IS NOT NULL gate)
+UPDATE projects SET tab_order = 1 WHERE name = 'cal.com';
+UPDATE projects SET tab_order = 2 WHERE name = 'onlook';
+UPDATE projects SET tab_order = 3, main_repo_path = '$HOME/code/onbook-relocate-clone' WHERE name = 'onbook';
+UPDATE projects SET tab_order = 4 WHERE name = 'mastra';
+UPDATE projects SET tab_order = 5 WHERE name = 'chatbot';
+
+-- Synthetic v1 projects: one local-only, one with a parseable but unreachable remote
+INSERT INTO projects (id, main_repo_path, name, color, tab_order, last_opened_at, created_at, default_branch, github_owner)
+VALUES
+  ('$NEW_NO_REMOTE_ID', '$HOME/code/v1v2-no-remote', 'v1v2-no-remote', 'default', 6, strftime('%s','now')*1000, strftime('%s','now')*1000, 'main', NULL),
+  ('$NEW_GHOST_ID',     '$HOME/code/v1v2-ghost',     'v1v2-ghost',     'default', 7, strftime('%s','now')*1000, strftime('%s','now')*1000, 'main', NULL)
+ON CONFLICT (id) DO UPDATE SET
+  main_repo_path = excluded.main_repo_path,
+  tab_order = excluded.tab_order;
+
+-- Worktrees under onbook for the workspace-tab tests
+INSERT INTO worktrees (id, project_id, path, branch, base_branch, created_at, created_by_superset)
+VALUES
+  ('44444444-cccc-4ccc-8ccc-000000000001', '$ONBOOK_V1_ID', '$HOME/code/onbook-relocate-clone/.worktrees/v1v2-test-clean',           'v1v2-test-clean',           'main', strftime('%s','now')*1000, 1),
+  ('44444444-cccc-4ccc-8ccc-000000000002', '$ONBOOK_V1_ID', '/tmp/v1v2-stale-path-nowhere',                                          'v1v2-test-stale-fallback', 'main', strftime('%s','now')*1000, 1),
+  ('44444444-cccc-4ccc-8ccc-000000000003', '$ONBOOK_V1_ID', '$HOME/code/onbook-relocate-clone/.worktrees/v1v2-test-orphan-branch',   'v1v2-test-orphan-branch',  'main', strftime('%s','now')*1000, 1),
+  ('44444444-cccc-4ccc-8ccc-000000000004', '$ONBOOK_V1_ID', '$HOME/code/onbook-relocate-clone/.worktrees/v1v2-test-ghost',           'v1v2-test-ghost',          'main', strftime('%s','now')*1000, 1)
+ON CONFLICT (id) DO UPDATE SET path = excluded.path, branch = excluded.branch;
+
+-- Workspaces using those worktrees
+INSERT INTO workspaces (id, project_id, worktree_id, type, branch, name, tab_order, created_at, updated_at, last_opened_at)
+VALUES
+  ('55555555-dddd-4ddd-8ddd-000000000001', '$ONBOOK_V1_ID', '44444444-cccc-4ccc-8ccc-000000000001', 'worktree', 'v1v2-test-clean',           'clean adopt fixture',           100, strftime('%s','now')*1000, strftime('%s','now')*1000, strftime('%s','now')*1000),
+  ('55555555-dddd-4ddd-8ddd-000000000002', '$ONBOOK_V1_ID', '44444444-cccc-4ccc-8ccc-000000000002', 'worktree', 'v1v2-test-stale-fallback', 'stale path -> branch fallback', 101, strftime('%s','now')*1000, strftime('%s','now')*1000, strftime('%s','now')*1000),
+  ('55555555-dddd-4ddd-8ddd-000000000003', '$ONBOOK_V1_ID', '44444444-cccc-4ccc-8ccc-000000000003', 'worktree', 'v1v2-test-orphan-branch',  'orphan (should be hidden)',     102, strftime('%s','now')*1000, strftime('%s','now')*1000, strftime('%s','now')*1000),
+  ('55555555-dddd-4ddd-8ddd-000000000004', '$ONBOOK_V1_ID', '44444444-cccc-4ccc-8ccc-000000000004', 'worktree', 'v1v2-test-ghost',          'v1v2-test-ghost',               103, strftime('%s','now')*1000, strftime('%s','now')*1000, strftime('%s','now')*1000)
+ON CONFLICT (id) DO UPDATE SET
+  worktree_id = excluded.worktree_id,
+  branch = excluded.branch,
+  name = excluded.name;
+SQL
+
+# ---- 5. host.db row for relocate scenario -----------------------------------
+
+echo "→ inserting host.db relocate row (Superset org)"
+sqlite3 "$SUPERSET_HOST_DB" <<SQL
+INSERT INTO projects (id, repo_path, created_at, repo_provider, repo_owner, repo_name, repo_url, remote_name)
+VALUES (
+  '$ONBOOK_FIXTURE_V2_ID',
+  '$HOME/code/onbook',
+  strftime('%s','now') * 1000,
+  'github', 'onlook-dev', 'onbook',
+  'https://github.com/onlook-dev/onbook',
+  'origin'
+)
+ON CONFLICT (id) DO UPDATE SET repo_path = excluded.repo_path;
+SQL
+
+echo "✓ setup done"
+echo ""
+echo "v1 projects you'll see in the importer:"
+sqlite3 -separator $'\t' "$DEV_DATA_LOCAL_DB" \
+  "SELECT tab_order, name, main_repo_path FROM projects WHERE tab_order IS NOT NULL ORDER BY tab_order"


### PR DESCRIPTION
## Summary

The pull-based v1→v2 importer ([#4122](https://github.com/superset-sh/superset/pull/4122)) used `v1_migration_state` as the single source of truth for both "already imported" and "last attempt failed". That created a class of false-failure bugs where a stale audit row from a prior run kept a row showing "Retry — Project not found" forever, even when the live state had changed and the new pull-based logic would handle it cleanly. Original report: a teammate seeing "Retry — Project not found" for a project that exists on disk and in v1 (the path was correct, the v2 cloud row had been deleted under an older auto-batch migration).

Removes the audit log as a UX driver. Every surface now derives from real app state:

| Surface | Imported state derived from |
|---|---|
| Projects | host-service `findByPath` → `local-path` candidate (cloud-staleness-filtered server-side) |
| Workspaces | host-service `project.list` (repoPath match) + cloud workspace list keyed on (projectId, branch) |
| Presets | reuses v1 preset id as v2 collection row id; "imported" = `v2TerminalPresets.has(preset.id)` |
| Banner | v1 projects whose `mainRepoPath` isn't in host-service `project.list` |

Errors live in component state for the modal session + `console.error` for the log file (no longer persisted to a table that drives UI).

### Wire shape change

`workspace.cloudList` now returns `{id, projectId, branch, hostId}` instead of `{id}`. Verified the only caller is the importer.

### Removed

- `migration.listState`, `migration.upsertState` trpc procedures
- `project.cloudList` host-service procedure (no remaining callers)

### Kept inert

`v1_migration_state` table + migration `0041_v1_migration_state.sql` stay in place. Nothing reads or writes them. Drop in a follow-up after the rollout settles to keep the rollout reversible.

### Folded in

- `V1ImportModal.tsx` page-transition simplification (`key={page}` + Tailwind `animate-in` over manual `isTransitioning` fade)
- `findByPath` integration test assertions loosened to `toMatchObject` — wire shape grew in #4122 but assertions weren't updated; ports the fix from the migration-rewrite-manual branch

### Manual test fixtures

Second commit lands two scripts in `scripts/`:
- `v1v2-import-test-setup.sh` — seeds dev neon branch, v1 local.db, host.db, and on-disk repos to exercise every importer scenario (clean / fork ambiguity / relocate-confirm / stale-path fallback / orphan-branch hidden / local-only / unreachable remote)
- `v1v2-import-test-cleanup.sh` — reverses everything; idempotent

setup.sh refuses to run if `.env` points at the prod neon branch.

### Out of scope (follow-ups)

- Case-insensitive path comparison for `host.db projects.repo_path` lookups (macOS APFS): same path in different case is treated as two projects today.
- Unique constraint on `host.db projects.repo_path`: nothing prevents two rows pointing at the same path.

Both pre-existing.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `packages/host-service/test/integration/project.integration.test.ts` — 7/7 pass (was 5/7 on main)
- [x] Manual walk on dev branch with `scripts/v1v2-import-test-setup.sh`:
  - [x] cal.com — linked to existing v2 fixture by remote URL
  - [x] onlook — linked to fixture, picked correct origin past the fakeupstream decoy
  - [x] onbook — relocate-confirm fired, "Use this folder" repointed host.db at the relocate-clone path
  - [x] v1v2-no-remote — created fresh local-only v2 project
  - [x] v1v2-ghost — created fresh v2 project with parsed remote
  - [x] Workspaces tab: 3 of 4 onbook workspaces visible (orphan-branch correctly hidden), all 3 adopted, stale-path-fallback successfully retried by branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the `v1_migration_state` audit log from the v1→v2 importer UI and derives import status from live app state. Fixes sticky “Retry — Project not found” errors and makes the flow resilient to cross‑device/cloud changes.

- **Bug Fixes**
  - Removes false failures from stale audit rows; importer now reads live state for projects, workspaces, and presets.
  - Workspaces: adopt retry is idempotent by passing `existingWorkspaceId`; removed unreachable “blocked” branch.
  - Projects: invalidates the Workspaces tab’s host `project.list` cache after import for immediate refresh.

- **Refactors**
  - State sources: projects via host-service `project.findByPath`; workspaces via `project.list` + cloud list keyed by `(projectId, branch)`; presets by reusing v1 `preset.id` in `v2TerminalPresets`.
  - API cleanup: removed `migration.listState`, `migration.upsertState`, and host-service `project.cloudList`; `workspace.cloudList` now returns `{id, projectId, branch, hostId}`; kept `v1_migration_state` table inert.
  - UI/tests/tooling: simplified modal transitions; relaxed `findByPath` test assertions to `toMatchObject`; added `scripts/v1v2-import-test-setup.sh` and `scripts/v1v2-import-test-cleanup.sh`.

<sup>Written for commit c1727da68d9138af056a5e7bebd856e56904bbc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features & Improvements**
  * Enhanced v1→v2 import flow with host-backed project lookup, improved import status, and organization-level dismissal persistence
  * Better detection/handling of already-imported projects, workspaces, and terminal presets; clearer import states and streamlined navigation
* **API Changes**
  * Removed an older migration state endpoint; adjusted cloud listing behavior between project and workspace services
* **Tests & Tools**
  * Added idempotent test setup/cleanup scripts and loosened integration assertions for more robust tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->