### PR TITLE
fix(desktop): prefer cloud-confirmed v2 project in v1→v2 workspace adopt

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -122,6 +122,7 @@ export function ImportWorkspacesPage({
 		workspacesQuery.isPending ||
 		worktreesQuery.isPending ||
 		hostProjectListQuery.isPending ||
+		cloudWorkspacesQuery.isPending ||
 		worktreeListQueries.some((q) => q.isPending);
 
 	const [isRefreshing, setIsRefreshing] = useState(false);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -52,9 +52,19 @@ export function ImportWorkspacesPage({
 	});
 
 	const v2ProjectIdByV1Id = useMemo(() => {
+		const projectIdsInCloud = new Set(
+			(cloudWorkspacesQuery.data ?? []).map((w) => w.projectId),
+		);
 		const v2ByPath = new Map<string, string>();
 		for (const v2 of hostProjectListQuery.data ?? []) {
-			v2ByPath.set(v2.repoPath, v2.id);
+			const existing = v2ByPath.get(v2.repoPath);
+			if (!existing) {
+				v2ByPath.set(v2.repoPath, v2.id);
+				continue;
+			}
+			if (projectIdsInCloud.has(v2.id) && !projectIdsInCloud.has(existing)) {
+				v2ByPath.set(v2.repoPath, v2.id);
+			}
 		}
 		const map = new Map<string, string>();
 		for (const v1 of projectsQuery.data ?? []) {
@@ -62,7 +72,11 @@ export function ImportWorkspacesPage({
 			if (v2Id) map.set(v1.id, v2Id);
 		}
 		return map;
-	}, [hostProjectListQuery.data, projectsQuery.data]);
+	}, [
+		hostProjectListQuery.data,
+		projectsQuery.data,
+		cloudWorkspacesQuery.data,
+	]);
 
 	const cloudWorkspaceKeys = useMemo(() => {
 		const set = new Set<string>();


### PR DESCRIPTION
## Summary
- v1→v2 workspace adopt fails with "Failed to create workspace: Project not found in this organization" when `host.db` has two `projects` rows sharing the same `repo_path`. `ImportWorkspacesPage` builds its `repoPath → v2 id` map with last-write-wins `Map.set`, so an orphan local row (e.g. left over from a manual repair where the cloud counterpart got hard-deleted) can shadow the canonical id. Adopt then forwards the orphan to `v2Workspace.create`, which can't find it under the user's org.
- Prefer ids that already appear as a `projectId` on `workspace.cloudList` — that's a cheap proxy for "actually exists in cloud" since `v2_workspaces` FK to `v2_projects`. Falls back to first-seen when no candidate has cloud workspaces, so the common single-row case is unchanged.
- Repro on my machine: host.db had `1c99c8eb…` (canonical, 26 cloud workspaces) and `07682010…` (orphan, no cloud row) both pointing at `/Users/satyapatel/code/superset`. Pre-fix: every Adopt button errored with the org-scope message. Post-fix: importer resolves to `1c99c8eb…` and Adopt succeeds.

## Test plan
- [ ] On a host with a duplicate `projects` row (one cloud-backed, one orphan) sharing a `repo_path`, open the V1 import modal → "Bring over your workspaces" → Adopt completes for every row.
- [ ] Single-row case still works (regression check on a clean host with one v2 project per repo path).
- [ ] No-candidate case (every host project orphan / no cloud workspaces yet) still falls back to the existing first-seen behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v1→v2 workspace adopt failures by preferring the cloud-backed v2 project when multiple host `projects` rows share the same repo path. Prevents "Project not found in this organization" errors during Adopt.

- **Bug Fixes**
  - When multiple v2 project ids exist for a `repoPath`, choose the id that appears as a `projectId` in the cloud workspace list; otherwise keep the first seen.
  - Gate the modal’s Adopt actions on `cloudWorkspacesQuery` loading and include `cloudWorkspacesQuery.data` in the memo deps so the mapping updates once cloud data arrives.
  - Single-row and no-cloud cases keep the previous behavior.

<sup>Written for commit 24adbb50bee98214881f91d6e82a54d6c67153cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace import functionality to better handle duplicate repository paths by prioritizing identifiers that already exist in cloud workspaces.
  * Enhanced the import loading state mechanism to more accurately reflect cloud workspace data availability, providing more reliable progress indication during the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->