### PR TITLE
release(cli): cut v0.2.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -679,7 +679,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.9";
+const VERSION = "0.2.10";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Bump `@superset/cli` to **v0.2.10**. Changes since v0.2.9:

- New built-in `superset` chat agent now surfaces in `agents list`. (#4116)
- `workspaces create` accepts `--agent`, `--prompt`, and `--attachment` to spawn a session at create-time. (#4116)
- `agents run` accepts `--attachment` to upload local files alongside a prompt. (#4116)
- `agents run --agent superset` returns immediately once streaming begins instead of waiting on the full assistant reply (~18s → ~2s). (#4116)

Push the `cli-v0.2.10` tag after this merges to fire the release pipeline (`.github/workflows/release-cli.yml`).

## Test plan

- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] After merge, `git tag cli-v0.2.10 <merge-sha> && git push origin cli-v0.2.10` and confirm the Release CLI workflow publishes a draft release + updates `cli-latest`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.10. Adds a built-in `superset` chat agent, create-time session flags, file attachments, and faster streaming.

- **New Features**
  - `superset` agent now appears in `agents list`.
  - `workspaces create` supports `--agent`, `--prompt`, `--attachment`.
  - `agents run` supports `--attachment`.
  - `agents run --agent superset` returns as soon as streaming starts (~18s → ~2s).

- **Migration**
  - After merge, push `cli-v0.2.10` to trigger the release workflow.

<sup>Written for commit d9bad9dca1e855b4c9963dbebe64204fffef5a58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CLI package version updated to 0.2.10 (from 0.2.9). No user-facing behavior or feature changes included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->