### PR TITLE
fix(desktop): place new v2 workspace at top of sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -8,25 +8,12 @@ import {
 } from "renderer/routes/_authenticated/components/utils/paneLifecycleRows";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
-import { isSidebarWorkspaceVisible } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import {
+	getNextTabOrder,
+	getPrependTabOrder,
+	isSidebarWorkspaceVisible,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { PROJECT_CUSTOM_COLORS } from "shared/constants/project-colors";
-
-function getNextTabOrder(items: Array<{ tabOrder: number }>): number {
-	const maxTabOrder = items.reduce(
-		(maxValue, item) => Math.max(maxValue, item.tabOrder),
-		0,
-	);
-	return maxTabOrder + 1;
-}
-
-function getPrependTabOrder(items: Array<{ tabOrder: number }>): number {
-	if (items.length === 0) return 1;
-	const minTabOrder = items.reduce(
-		(minValue, item) => Math.min(minValue, item.tabOrder),
-		Number.POSITIVE_INFINITY,
-	);
-	return minTabOrder - 1;
-}
 
 type ProjectTopLevelItem = {
 	type: "workspace" | "section";

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/index.ts
@@ -1,2 +1,3 @@
 export * from "./schema";
 export * from "./sidebarVisibility";
+export * from "./tabOrder";

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/tabOrder.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/tabOrder.ts
@@ -1,0 +1,22 @@
+/**
+ * Lower tabOrder = appears earlier in the sidebar (queries sort ASC).
+ * Prepending therefore picks one less than the smallest existing tabOrder
+ * so the new item lands at the top regardless of whether existing items
+ * are positive (newly defaulted) or negative (after prior prepends).
+ */
+export function getPrependTabOrder(items: Array<{ tabOrder: number }>): number {
+	if (items.length === 0) return 1;
+	const minTabOrder = items.reduce(
+		(minValue, item) => Math.min(minValue, item.tabOrder),
+		Number.POSITIVE_INFINITY,
+	);
+	return minTabOrder - 1;
+}
+
+export function getNextTabOrder(items: Array<{ tabOrder: number }>): number {
+	const maxTabOrder = items.reduce(
+		(maxValue, item) => Math.max(maxValue, item.tabOrder),
+		0,
+	);
+	return maxTabOrder + 1;
+}

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -5,6 +5,10 @@ import { authClient } from "renderer/lib/auth-client";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import {
+	getPrependTabOrder,
+	isSidebarWorkspaceVisible,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { appendLaunchesToPaneLayout } from "./appendLaunchesToPaneLayout";
 import {
@@ -82,12 +86,26 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 						},
 					);
 				} else {
+					const projectId = result.workspace.projectId;
+					const topLevelItems = [
+						...Array.from(collections.v2WorkspaceLocalState.state.values())
+							.filter(
+								(item) =>
+									item.sidebarState.projectId === projectId &&
+									item.sidebarState.sectionId === null &&
+									isSidebarWorkspaceVisible(item),
+							)
+							.map((item) => ({ tabOrder: item.sidebarState.tabOrder })),
+						...Array.from(collections.v2SidebarSections.state.values())
+							.filter((item) => item.projectId === projectId)
+							.map((item) => ({ tabOrder: item.tabOrder })),
+					];
 					collections.v2WorkspaceLocalState.insert({
 						workspaceId: result.workspace.id,
 						createdAt: new Date(),
 						sidebarState: {
-							projectId: result.workspace.projectId,
-							tabOrder: 0,
+							projectId,
+							tabOrder: getPrependTabOrder(topLevelItems),
 							sectionId: null,
 							changesFilter: { kind: "all" },
 							activeTab: "changes",


### PR DESCRIPTION
## Summary

- Reverting #4120 in #4135 restored `tabOrder: 0` in the v2 `workspace.create` path. Existing rows also default to `0`, so new workspaces tied with them and didn't deterministically land at the top.
- Restores `getPrependTabOrder` from #4120 as a shared util in `dashboardSidebarLocal/`, and calls it from `useWorkspaceCreates` so new rows pick `min(existing tabOrder) - 1` and always sit strictly above every other top-level item — which is what the pending-row injection in `useDashboardSidebarData` already assumes (see comment at `useDashboardSidebarData.ts:24-26`).
- `useDashboardSidebarState` now imports the helpers from the shared module instead of keeping local copies.

## Test plan

- [ ] Open desktop on an account with multiple existing v2 workspaces in the same project; create a new workspace from the new-workspace modal — confirm it appears at the top of that project in the sidebar.
- [ ] Create a few back-to-back; confirm each new one lands above the previous, not interleaved.
- [ ] Drag-reorder existing workspaces, then create another; confirm the new one still lands above the dragged ones (no collision with reordered `tabOrder >= 1` rows).
- [ ] Adopt an existing worktree (server returns `alreadyExists`) — confirm we don't move the existing row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure new v2 workspaces always appear at the top of the project sidebar by computing a prepend tab order instead of defaulting to 0. Fixes nondeterministic ordering when existing items also had `tabOrder: 0`.

- **Bug Fixes**
  - Added shared `getPrependTabOrder`/`getNextTabOrder` utilities in `dashboardSidebarLocal/tabOrder.ts` and re-exported.
  - `useWorkspaceCreates` now sets `tabOrder` to `min(top-level items) - 1`, checking visible workspaces and sections in the project.
  - `useDashboardSidebarState` now imports these helpers and removes local duplicates.

<sup>Written for commit f1ae9fcc909436641029e14315f45f53a975f437. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar item ordering for newly created workspaces to properly respect existing item positions instead of always appearing at the top.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->