### PR TITLE
fix(desktop): unblock v2 workspace render when Electric is slow

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -33,12 +33,16 @@ function V2WorkspaceLayout() {
 				.where(({ v2Workspaces }) => eq(v2Workspaces.id, workspaceId ?? "")),
 		[collections, workspaceId],
 	);
-	const workspace = workspaces?.[0] ?? null;
+	const syncedWorkspace = workspaces?.[0] ?? null;
 	const inFlight = useWorkspaceCreatesStore((store) =>
 		workspaceId
 			? store.entries.find((entry) => entry.snapshot.id === workspaceId)
 			: undefined,
 	);
+	// Fall back to the cloud row cached on the in-flight entry while
+	// Electric hasn't yet delivered the synced row. The cloud has already
+	// confirmed the workspace at this point — no need to block on sync.
+	const workspace = syncedWorkspace ?? inFlight?.cloudRow ?? null;
 
 	const lastEnsuredWorkspaceIdRef = useRef<string | null>(null);
 	useEffect(() => {

--- a/apps/desktop/src/renderer/stores/workspace-creates/store.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/store.ts
@@ -1,3 +1,4 @@
+import type { SelectV2Workspace } from "@superset/db/schema";
 import type { AppRouter } from "@superset/host-service";
 import type { inferRouterInputs } from "@trpc/server";
 import { create } from "zustand";
@@ -11,6 +12,13 @@ export interface InFlightEntry {
 	state: "creating" | "error";
 	error?: string;
 	startedAt: number;
+	/**
+	 * Cloud row returned by the host-service mutation. Set once
+	 * `workspaces.create` resolves successfully — the workspace detail
+	 * layout falls back to this row while Electric hasn't yet delivered
+	 * the synced row into `collections.v2Workspaces`.
+	 */
+	cloudRow?: SelectV2Workspace;
 }
 
 interface WorkspaceCreatesState {
@@ -18,6 +26,7 @@ interface WorkspaceCreatesState {
 	add: (entry: Omit<InFlightEntry, "startedAt">) => void;
 	markError: (workspaceId: string, error: string) => void;
 	markCreating: (workspaceId: string) => void;
+	markCloudRow: (workspaceId: string, cloudRow: SelectV2Workspace) => void;
 	remove: (workspaceId: string) => void;
 }
 
@@ -42,6 +51,12 @@ export const useWorkspaceCreatesStore = create<WorkspaceCreatesState>(
 					entry.snapshot.id === workspaceId
 						? { ...entry, state: "creating", error: undefined }
 						: entry,
+				),
+			})),
+		markCloudRow: (workspaceId, cloudRow) =>
+			set((state) => ({
+				entries: state.entries.map((entry) =>
+					entry.snapshot.id === workspaceId ? { ...entry, cloudRow } : entry,
 				),
 			})),
 		remove: (workspaceId) =>

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -64,6 +64,14 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 				const client = getHostServiceClientByUrl(hostUrl);
 				const result = await client.workspaces.create.mutate(args.snapshot);
 
+				// Cache the cloud row on the in-flight entry so the workspace
+				// detail layout can render the workspace immediately, without
+				// waiting for Electric to deliver the synced row. Manager.tsx
+				// removes the entry once the row appears in collections.
+				useWorkspaceCreatesStore
+					.getState()
+					.markCloudRow(result.workspace.id, result.workspace);
+
 				const existing = collections.v2WorkspaceLocalState.get(
 					result.workspace.id,
 				);

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -74,18 +74,17 @@ type AgentLaunchResult =
 	| ({ ok: true } & AgentRunResult)
 	| { ok: false; error: string };
 
-interface ResolvedWorkspace {
-	id: string;
-	projectId: string;
-	name: string;
-	branch: string;
-}
+type CloudWorkspace = NonNullable<
+	Awaited<
+		ReturnType<HostServiceContext["api"]["v2Workspace"]["getFromHost"]["query"]>
+	>
+>;
 
 async function findExistingWorkspaceByBranch(
 	ctx: HostServiceContext,
 	projectId: string,
 	branch: string,
-): Promise<ResolvedWorkspace | null> {
+): Promise<CloudWorkspace | null> {
 	const local = ctx.db.query.workspaces
 		.findFirst({
 			where: and(
@@ -100,13 +99,7 @@ async function findExistingWorkspaceByBranch(
 		organizationId: ctx.organizationId,
 		id: local.id,
 	});
-	if (!cloud) return null;
-	return {
-		id: cloud.id,
-		projectId: cloud.projectId,
-		name: cloud.name,
-		branch: cloud.branch,
-	};
+	return cloud ?? null;
 }
 
 interface PrMetadata {
@@ -381,7 +374,7 @@ async function registerCloudAndLocal(args: {
 	taskId: string | undefined;
 	rollbackWorktree: () => Promise<void>;
 	hostPromise: Promise<{ machineId: string }>;
-}): Promise<{ id: string; projectId: string; name: string; branch: string }> {
+}): Promise<CloudWorkspace> {
 	const { ctx } = args;
 	let host: { machineId: string };
 	try {
@@ -443,12 +436,7 @@ async function registerCloudAndLocal(args: {
 		});
 	}
 
-	return {
-		id: cloudRow.id,
-		projectId: cloudRow.projectId,
-		name: cloudRow.name,
-		branch: cloudRow.branch,
-	};
+	return cloudRow;
 }
 
 async function dispatchSugarAgents(
@@ -526,12 +514,7 @@ export const workspacesRouter = router({
 			let resolvedBranch: string;
 			let worktreePath: string;
 			let alreadyExists = false;
-			let workspaceRow: {
-				id: string;
-				projectId: string;
-				name: string;
-				branch: string;
-			};
+			let workspaceRow: CloudWorkspace;
 			let prMetadata: PrMetadata | null = null;
 
 			if (input.pr !== undefined) {
@@ -872,12 +855,7 @@ export const workspacesRouter = router({
 			);
 
 			return {
-				workspace: {
-					id: workspaceRow.id,
-					projectId: workspaceRow.projectId,
-					name: workspaceRow.name,
-					branch: workspaceRow.branch,
-				},
+				workspace: workspaceRow,
 				terminals: terminalsResult,
 				agents: agentsResult,
 				alreadyExists,

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -163,9 +163,16 @@ export type WorkspaceCreateAgentResult =
 export interface WorkspaceCreateResult {
 	workspace: {
 		id: string;
+		organizationId: string;
 		projectId: string;
+		hostId: string;
 		name: string;
 		branch: string;
+		type: "main" | "worktree";
+		createdByUserId: string | null;
+		taskId: string | null;
+		createdAt: Date;
+		updatedAt: Date;
 	};
 	terminals: Array<{ terminalId: string; label?: string }>;
 	agents: WorkspaceCreateAgentResult[];


### PR DESCRIPTION
## Summary

- After `workspaces.create` resolved end-to-end on the host service, the detail page (`v2-workspace/layout.tsx`) sat on `WorkspaceCreatingState` until Electric pushed the synced row into `collections.v2Workspaces`. If Electric was slow or the persisted shape was stale, the page perma-loaded even though the workspace was fully usable on the cloud and host.
- Cache the cloud row returned by the mutation on the in-flight entry; have the layout fall back to it while the live query is empty. `Manager.tsx` still cleans up the entry the moment Electric delivers, and the live query takes over seamlessly.
- Cloud is the source of truth — no optimistic rollback machinery, no ghost-row failure mode (unlike the reverted #4120).

## Scope

- Host-service `workspaces.create` now returns the full `SelectV2Workspace` row instead of a four-field projection. Threaded through `registerCloudAndLocal`, `findExistingWorkspaceByBranch`, and the final return.
- `adopt-existing-worktree.ts` already returned the full row — no changes there.
- SDK `WorkspaceCreateResult.workspace` widened to mirror the new shape; additive for all existing callers (CLI / MCP / automation dispatch only read `id`/`name`/`branch`).
- Renderer `InFlightEntry` gains optional `cloudRow`; populated immediately after the mutation resolves; layout reads `workspace ?? inFlight?.cloudRow`.

## Why this is safe

- Existing UX gating in `DashboardSidebarWorkspaceItem` already disables the entire context menu (rename, host-change, move-to-section, etc.) for in-flight workspaces via `isPending = !!creationStatus` — so the only surface that mutates `collections.v2Workspaces` directly can't fire against a missing row.
- All other consumers of `collections.v2Workspaces` (notifications controller, host pickers, `useWorkspaceHostTarget`) degrade gracefully — features briefly inert until Electric catches up.
- `WorkspaceProvider` resolves `hostUrl` straight from `workspace.hostId` (not via `useWorkspaceHostTarget`), so the workspace tRPC connection wires up correctly from the cached row.

## Test plan

- [ ] Happy path: create a workspace from the modal — detail page flips from `WorkspaceCreatingState` to the real workspace immediately when the mutation resolves.
- [ ] Slow Electric: block `NEXT_PUBLIC_ELECTRIC_URL` in DevTools after the mutation resolves — workspace renders normally via the cached cloud row; sidebar entry stays "creating" until Electric is unblocked, then merges seamlessly.
- [ ] `alreadyExists` divergent id: confirm the early-remove branch in `useWorkspaceCreates.ts` still fires and redirect to canonical id works without flashing not-found.
- [ ] Error path: kill host service mid-create — `WorkspaceCreateErrorState` renders as before; retry/dismiss work.
- [ ] `bun run lint && bun run typecheck` pass clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 workspace detail page hanging on “Creating” when Electric sync is slow by caching the cloud workspace row from `workspaces.create` and rendering from it until the synced row arrives. The page now shows the workspace immediately after the mutation resolves, then hands off to live data when available.

- **Bug Fixes**
  - Renderer: cache the cloud row on the in‑flight entry and fall back to `inFlight.cloudRow` when `collections.v2Workspaces` hasn’t synced yet; clean up the entry once Electric delivers.
  - Host service: `workspaces.create` returns the full `SelectV2Workspace` row; SDK widens `WorkspaceCreateResult.workspace` (additive, no breaking changes).
  - Cloud remains the source of truth; no optimistic rollback paths.

<sup>Written for commit c47b6e27b43a6b7c79f00e1f62a8c112ffba431a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace creation API now returns expanded workspace metadata, including type, timestamps, organization and host information.

* **Refactor**
  * Improved workspace resolution logic with fallback support for enhanced reliability during workspace initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->