### PR TITLE
fix(api): wrap Slack JSON.parse calls in try-catch

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/route.ts
+++ b/apps/api/src/app/api/integrations/slack/events/route.ts
@@ -25,7 +25,12 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
 	}
 
-	const payload = JSON.parse(body);
+	let payload: Record<string, unknown>;
+	try {
+		payload = JSON.parse(body);
+	} catch {
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+	}
 
 	// Slack sends this once when configuring the Events URL
 	if (payload.type === "url_verification") {

--- a/apps/api/src/app/api/integrations/slack/events/route.ts
+++ b/apps/api/src/app/api/integrations/slack/events/route.ts
@@ -25,7 +25,8 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
 	}
 
-	let payload: Record<string, unknown>;
+	// biome-ignore lint/suspicious/noExplicitAny: Slack payload shape varies by event type
+	let payload: any;
 	try {
 		payload = JSON.parse(body);
 	} catch {

--- a/apps/api/src/app/api/integrations/slack/interactions/route.ts
+++ b/apps/api/src/app/api/integrations/slack/interactions/route.ts
@@ -29,7 +29,12 @@ export async function POST(request: Request) {
 		return new Response("ok", { status: 200 });
 	}
 
-	const payload = JSON.parse(payloadRaw);
+	let payload: Record<string, unknown>;
+	try {
+		payload = JSON.parse(payloadRaw);
+	} catch {
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+	}
 
 	if (payload.type === "block_actions") {
 		const teamId: string = payload.team?.id;

--- a/apps/api/src/app/api/integrations/slack/interactions/route.ts
+++ b/apps/api/src/app/api/integrations/slack/interactions/route.ts
@@ -29,7 +29,8 @@ export async function POST(request: Request) {
 		return new Response("ok", { status: 200 });
 	}
 
-	let payload: Record<string, unknown>;
+	// biome-ignore lint/suspicious/noExplicitAny: Slack payload shape varies by event type
+	let payload: any;
 	try {
 		payload = JSON.parse(payloadRaw);
 	} catch {


### PR DESCRIPTION
## Summary

Solves Bug  #4142 

- Wraps `JSON.parse()` in try-catch in the Slack **events** and **interactions** route handlers
- Returns `400 Bad Request` on malformed JSON instead of an unhandled 500
- Matches the existing pattern in `link/route.ts`

## Problem

`JSON.parse()` is called without error handling in two Slack API routes. If the body contains invalid JSON (e.g., corrupted in transit), the unhandled exception returns a 500, causing Slack to retry up to 3 times — each also failing.

## Changes

| File | Change |
|---|---|
| `apps/api/src/app/api/integrations/slack/events/route.ts` | Wrap `JSON.parse(body)` in try-catch, return 400 |
| `apps/api/src/app/api/integrations/slack/interactions/route.ts` | Wrap `JSON.parse(payloadRaw)` in try-catch, return 400 |

## Test plan

- [x] Verify Slack events (mentions, DMs) still work end-to-end
- [x] Verify Slack interactions (model select, disconnect) still work
- [x] Confirm malformed JSON payloads return 400 instead of 500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid JSON payloads received by Slack event and interaction endpoints. Malformed payloads now return a 400 response with a clear error message instead of causing unhandled failures, improving reliability and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->