### PR TITLE
fix(terminal): respawn lost sessions on attach; route WS errors to log

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -40,9 +40,9 @@ class MockWebSocket {
 		this.sent.push(data);
 	}
 
-	close() {
+	close(code = 1000, reason = "") {
 		this.readyState = MockWebSocket.CLOSED;
-		this.dispatch("close", { code: 1000, reason: "" });
+		this.dispatch("close", { code, reason });
 	}
 
 	open() {
@@ -93,6 +93,40 @@ afterEach(() => {
 });
 
 describe("terminal-ws-transport", () => {
+	test("server-sent error routes to logs, not xterm, and stops reconnect", () => {
+		const transport = createTransport();
+		const writelnCalls: string[] = [];
+		const terminal = createMockTerminal();
+		(terminal as unknown as { writeln: (s: string) => void }).writeln = (
+			s: string,
+		) => {
+			writelnCalls.push(s);
+		};
+
+		connect(transport, terminal, "ws://host/terminal/t1");
+		const socket = MockWebSocket.instances[0];
+		if (!socket) throw new Error("expected websocket instance");
+		socket.open();
+
+		socket.message(
+			JSON.stringify({
+				type: "error",
+				message:
+					'Terminal session "t1" is not active; create it before connecting.',
+			}),
+		);
+
+		expect(writelnCalls).toEqual([]);
+		expect(transport.logs).toHaveLength(1);
+		expect(transport.logs[0]?.level).toBe("error");
+		expect(transport.logs[0]?.message).toContain("is not active");
+
+		// 1011 is what host-service sends after an attach error; the close
+		// handler would otherwise schedule a reconnect.
+		socket.close(1011, "session not active");
+		expect(transport._reconnectTimer).toBeNull();
+	});
+
 	test("waits for server attach before sending resize or input", () => {
 		const transport = createTransport();
 		const terminal = createMockTerminal();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -312,7 +312,11 @@ function attachSocketListeners(
 		}
 
 		if (message.type === "error") {
-			terminal.writeln(`\r\n[terminal] ${message.message}`);
+			pushLog(transport, "error", message.message);
+			// Server closes after this; reconnecting would just hit the same
+			// error, so flag the transport done to suppress the retry loop.
+			transport._exited = true;
+			cancelReconnect(transport);
 			return;
 		}
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -48,6 +48,12 @@ export interface TerminalTransport {
 	/** Set when the server sends an exit message — no reconnect after this. */
 	_exited: boolean;
 	/**
+	 * Set when the server rejects attach with an `error` frame. Distinct from
+	 * `_exited` (which means the PTY itself died) so future consumers can tell
+	 * "shell finished" apart from "server refused us"; both suppress reconnect.
+	 */
+	_fatalError: boolean;
+	/**
 	 * Flips true after the first PTY-output frame lands in xterm. Subsequent
 	 * connects send `?replay=0` so the server doesn't re-deliver scrollback.
 	 * Tracked on first bytes (not first open) so a WS that opens-and-closes
@@ -133,12 +139,13 @@ export function createTransport(): TerminalTransport {
 		_terminal: null,
 		_hasReceivedBytes: false,
 		_exited: false,
+		_fatalError: false,
 	};
 }
 
 function scheduleReconnect(transport: TerminalTransport) {
 	if (transport._reconnectTimer) return;
-	if (transport._exited) return;
+	if (transport._exited || transport._fatalError) return;
 	if (!transport.currentUrl || !transport._terminal) return;
 	if (transport._reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) return;
 
@@ -215,6 +222,7 @@ export function connect(
 	transport.currentUrl = wsUrl;
 	transport._terminal = terminal;
 	transport._exited = false;
+	transport._fatalError = false;
 	setConnectionState(transport, "connecting");
 	const actualUrl = transport._hasReceivedBytes
 		? appendQueryParam(wsUrl, "replay", "0")
@@ -314,8 +322,9 @@ function attachSocketListeners(
 		if (message.type === "error") {
 			pushLog(transport, "error", message.message);
 			// Server closes after this; reconnecting would just hit the same
-			// error, so flag the transport done to suppress the retry loop.
-			transport._exited = true;
+			// error. _fatalError suppresses the retry loop without overloading
+			// _exited's "PTY exited normally" semantic.
+			transport._fatalError = true;
 			cancelReconnect(transport);
 			return;
 		}
@@ -333,7 +342,7 @@ function attachSocketListeners(
 		if (transport.socket !== socket) return;
 		setConnectionState(transport, "closed");
 		transport.socket = null;
-		if (!transport._exited && event.code !== 1000) {
+		if (!transport._exited && !transport._fatalError && event.code !== 1000) {
 			const willReconnect =
 				!transport._reconnectTimer &&
 				Boolean(transport.currentUrl && transport._terminal) &&

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -47,11 +47,9 @@ export interface TerminalTransport {
 	_terminal: XTerm | null;
 	/** Set when the server sends an exit message — no reconnect after this. */
 	_exited: boolean;
-	/**
-	 * Set when the server rejects attach with an `error` frame. Distinct from
-	 * `_exited` (which means the PTY itself died) so future consumers can tell
-	 * "shell finished" apart from "server refused us"; both suppress reconnect.
-	 */
+	/** Set when the server rejects attach with an `error` frame — kept separate
+	 * from `_exited` (PTY died) since both suppress reconnect but mean
+	 * different things to consumers. */
 	_fatalError: boolean;
 	/**
 	 * Flips true after the first PTY-output frame lands in xterm. Subsequent
@@ -321,9 +319,7 @@ function attachSocketListeners(
 
 		if (message.type === "error") {
 			pushLog(transport, "error", message.message);
-			// Server closes after this; reconnecting would just hit the same
-			// error. _fatalError suppresses the retry loop without overloading
-			// _exited's "PTY exited normally" semantic.
+			// Server closes after this; reconnecting would just hit the same error.
 			transport._fatalError = true;
 			cancelReconnect(transport);
 			return;

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -45,12 +45,9 @@ export interface TerminalTransport {
 	_reconnectAttempt: number;
 	/** The xterm instance used for reconnection. */
 	_terminal: XTerm | null;
-	/** Set when the server sends an exit message — no reconnect after this. */
-	_exited: boolean;
-	/** Set when the server rejects attach with an `error` frame — kept separate
-	 * from `_exited` (PTY died) since both suppress reconnect but mean
-	 * different things to consumers. */
-	_fatalError: boolean;
+	/** Set when the server signals the session is done (PTY exit or fatal
+	 * attach error). Suppresses the auto-reconnect loop. */
+	_terminated: boolean;
 	/**
 	 * Flips true after the first PTY-output frame lands in xterm. Subsequent
 	 * connects send `?replay=0` so the server doesn't re-deliver scrollback.
@@ -136,14 +133,13 @@ export function createTransport(): TerminalTransport {
 		_reconnectAttempt: 0,
 		_terminal: null,
 		_hasReceivedBytes: false,
-		_exited: false,
-		_fatalError: false,
+		_terminated: false,
 	};
 }
 
 function scheduleReconnect(transport: TerminalTransport) {
 	if (transport._reconnectTimer) return;
-	if (transport._exited || transport._fatalError) return;
+	if (transport._terminated) return;
 	if (!transport.currentUrl || !transport._terminal) return;
 	if (transport._reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) return;
 
@@ -219,8 +215,7 @@ export function connect(
 	cancelReconnect(transport);
 	transport.currentUrl = wsUrl;
 	transport._terminal = terminal;
-	transport._exited = false;
-	transport._fatalError = false;
+	transport._terminated = false;
 	setConnectionState(transport, "connecting");
 	const actualUrl = transport._hasReceivedBytes
 		? appendQueryParam(wsUrl, "replay", "0")
@@ -320,13 +315,13 @@ function attachSocketListeners(
 		if (message.type === "error") {
 			pushLog(transport, "error", message.message);
 			// Server closes after this; reconnecting would just hit the same error.
-			transport._fatalError = true;
+			transport._terminated = true;
 			cancelReconnect(transport);
 			return;
 		}
 
 		if (message.type === "exit") {
-			transport._exited = true;
+			transport._terminated = true;
 			cancelReconnect(transport);
 			terminal.writeln(
 				`\r\n[terminal] exited with code ${message.exitCode} (signal ${message.signal})`,
@@ -338,7 +333,7 @@ function attachSocketListeners(
 		if (transport.socket !== socket) return;
 		setConnectionState(transport, "closed");
 		transport.socket = null;
-		if (!transport._exited && !transport._fatalError && event.code !== 1000) {
+		if (!transport._terminated && event.code !== 1000) {
 			const willReconnect =
 				!transport._reconnectTimer &&
 				Boolean(transport.currentUrl && transport._terminal) &&

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -75,15 +75,15 @@ export function TerminalPane({
 
 	// themeType is forwarded so a respawn (host-side fallback when an
 	// "active" DB row's daemon PTY is gone) spawns the new shell with the
-	// correct COLORFGBG env var. The PTY env is set at spawn time only —
-	// changing the renderer theme afterwards won't reach the shell.
+	// correct COLORFGBG env var. PTY env is set at spawn time only — the
+	// reconnect effect uses `baseWebsocketUrl` as its trigger so a theme
+	// toggle doesn't tear down the live shell for a purely visual change.
 	const activeTheme = useTheme();
 	const themeType = resolveTerminalThemeType({
 		activeThemeType: activeTheme?.type,
 	});
-	const websocketUrl = useWorkspaceWsUrl(
-		`/terminal/${terminalId}?themeType=${themeType}`,
-	);
+	const baseWebsocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`);
+	const websocketUrl = `${baseWebsocketUrl}?themeType=${encodeURIComponent(themeType)}`;
 	const websocketUrlRef = useRef(websocketUrl);
 	websocketUrlRef.current = websocketUrl;
 	const workspaceIdRef = useRef(workspaceId);
@@ -189,13 +189,17 @@ export function TerminalPane({
 	// URL re-resolution on provider remount). Reconnect only if the transport
 	// is already live — on initial mount the transport is "disconnected" and
 	// we let the mount path above open it.
+	// baseWebsocketUrl is the intentional reconnect trigger; the full URL
+	// (including themeType) is read from a ref so a theme toggle doesn't
+	// tear down the live shell for a purely visual change.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
 	useEffect(() => {
 		terminalRuntimeRegistry.reconnect(
 			terminalId,
-			websocketUrl,
+			websocketUrlRef.current,
 			terminalInstanceId,
 		);
-	}, [terminalId, terminalInstanceId, websocketUrl]);
+	}, [terminalId, terminalInstanceId, baseWebsocketUrl]);
 
 	useEffect(() => {
 		terminalRuntimeRegistry.updateAppearance(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -73,11 +73,8 @@ export function TerminalPane({
 	const appearanceRef = useRef(appearance);
 	appearanceRef.current = appearance;
 
-	// themeType is forwarded so a respawn (host-side fallback when an
-	// "active" DB row's daemon PTY is gone) spawns the new shell with the
-	// correct COLORFGBG env var. PTY env is set at spawn time only — the
-	// reconnect effect uses `baseWebsocketUrl` as its trigger so a theme
-	// toggle doesn't tear down the live shell for a purely visual change.
+	// themeType reaches the host-side respawn fallback so a restored shell
+	// gets the right COLORFGBG; PTY env is set at spawn time only.
 	const activeTheme = useTheme();
 	const themeType = resolveTerminalThemeType({
 		activeThemeType: activeTheme?.type,
@@ -189,9 +186,8 @@ export function TerminalPane({
 	// URL re-resolution on provider remount). Reconnect only if the transport
 	// is already live — on initial mount the transport is "disconnected" and
 	// we let the mount path above open it.
-	// baseWebsocketUrl is the intentional reconnect trigger; the full URL
-	// (including themeType) is read from a ref so a theme toggle doesn't
-	// tear down the live shell for a purely visual change.
+	// Reconnect on base-URL change only; themeType lives on the ref so a
+	// theme toggle doesn't tear down a live shell for a visual-only change.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
 	useEffect(() => {
 		terminalRuntimeRegistry.reconnect(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -33,6 +33,8 @@ import { openUrlInV2Workspace } from "renderer/routes/_authenticated/_dashboard/
 import { useWorkspaceWsUrl } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
 import { ScrollToBottomButton } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton";
 import { TerminalSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalSearch";
+import { useTheme } from "renderer/stores/theme";
+import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
 import { useLinkClickHint } from "./hooks/useLinkClickHint";
 import { type HoveredLink, useLinkHoverState } from "./hooks/useLinkHoverState";
 import { useTerminalAppearance } from "./hooks/useTerminalAppearance";
@@ -71,7 +73,17 @@ export function TerminalPane({
 	const appearanceRef = useRef(appearance);
 	appearanceRef.current = appearance;
 
-	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`);
+	// themeType is forwarded so a respawn (host-side fallback when an
+	// "active" DB row's daemon PTY is gone) spawns the new shell with the
+	// correct COLORFGBG env var. The PTY env is set at spawn time only —
+	// changing the renderer theme afterwards won't reach the shell.
+	const activeTheme = useTheme();
+	const themeType = resolveTerminalThemeType({
+		activeThemeType: activeTheme?.type,
+	});
+	const websocketUrl = useWorkspaceWsUrl(
+		`/terminal/${terminalId}?themeType=${themeType}`,
+	);
 	const websocketUrlRef = useRef(websocketUrl);
 	websocketUrlRef.current = websocketUrl;
 	const workspaceIdRef = useRef(workspaceId);

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -976,11 +976,9 @@ export function registerWorkspaceTerminalRoute({
 					};
 				}
 
-				// Attach is by terminal id only. If host-service lost in-memory
-				// state during a restart, recover from the server-owned session row
-				// and let createTerminalSessionInternal adopt the daemon PTY when it
-				// still exists.
-				return createTerminalSessionInternal({
+				// Prefer adoption: if the daemon still owns the PTY across a
+				// host-service restart, we keep the live shell + ring buffer.
+				const adopted = await createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
 					db,
@@ -988,6 +986,18 @@ export function registerWorkspaceTerminalRoute({
 					adoptOnly: true,
 					// Renderer passes `?replay=0` on reconnect; see replayOnAdoption.
 					replayOnAdoption: c.req.query("replay") !== "0",
+				});
+				if (!("error" in adopted)) return adopted;
+
+				// Active row but daemon no longer owns the PTY (laptop sleep,
+				// daemon restart, machine reboot). Respawn rather than dead-end
+				// the pane — the renderer's xterm scrollback stays painted above.
+				console.log(`[terminal] respawning lost session ${terminalId}`);
+				return createTerminalSessionInternal({
+					terminalId,
+					workspaceId: record.originWorkspaceId,
+					db,
+					eventBus,
 				});
 			};
 

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -976,8 +976,6 @@ export function registerWorkspaceTerminalRoute({
 					};
 				}
 
-				// parseThemeType narrows string | undefined to "dark" | "light" |
-				// undefined without throwing — safe to use unwrapped.
 				const themeType = parseThemeType(c.req.query("themeType"));
 
 				// Prefer adoption: if the daemon still owns the PTY across a

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -976,9 +976,8 @@ export function registerWorkspaceTerminalRoute({
 					};
 				}
 
-				// `c.req.query()` returns `string | undefined`; parseThemeType is
-				// pure and rejects anything other than "dark" | "light", so no
-				// try/catch is needed for malformed input.
+				// parseThemeType narrows string | undefined to "dark" | "light" |
+				// undefined without throwing — safe to use unwrapped.
 				const themeType = parseThemeType(c.req.query("themeType"));
 
 				// Prefer adoption: if the daemon still owns the PTY across a
@@ -998,8 +997,6 @@ export function registerWorkspaceTerminalRoute({
 				// Active row but daemon no longer owns the PTY (laptop sleep,
 				// daemon restart, machine reboot). Respawn rather than dead-end
 				// the pane — the renderer's xterm scrollback stays painted above.
-				// themeType is forwarded so the new PTY's COLORFGBG matches the
-				// renderer's current theme (env vars are only set at spawn).
 				console.log(`[terminal] respawning lost session ${terminalId}`);
 				return createTerminalSessionInternal({
 					terminalId,

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -976,11 +976,17 @@ export function registerWorkspaceTerminalRoute({
 					};
 				}
 
+				// `c.req.query()` returns `string | undefined`; parseThemeType is
+				// pure and rejects anything other than "dark" | "light", so no
+				// try/catch is needed for malformed input.
+				const themeType = parseThemeType(c.req.query("themeType"));
+
 				// Prefer adoption: if the daemon still owns the PTY across a
 				// host-service restart, we keep the live shell + ring buffer.
 				const adopted = await createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
+					themeType,
 					db,
 					eventBus,
 					adoptOnly: true,
@@ -992,10 +998,13 @@ export function registerWorkspaceTerminalRoute({
 				// Active row but daemon no longer owns the PTY (laptop sleep,
 				// daemon restart, machine reboot). Respawn rather than dead-end
 				// the pane — the renderer's xterm scrollback stays painted above.
+				// themeType is forwarded so the new PTY's COLORFGBG matches the
+				// renderer's current theme (env vars are only set at spawn).
 				console.log(`[terminal] respawning lost session ${terminalId}`);
 				return createTerminalSessionInternal({
 					terminalId,
 					workspaceId: record.originWorkspaceId,
+					themeType,
 					db,
 					eventBus,
 				});


### PR DESCRIPTION
## Summary

- **Host-service:** when WS attach hits an `"active"` DB row whose daemon PTY no longer exists (laptop sleep, daemon restart, machine reboot), respawn a fresh PTY at the same terminalId instead of returning `"Terminal session is not active; create it before connecting."`. Restores the pre-#4056 recovery path; the renderer's xterm scrollback stays painted above and the user gets a working shell again.
- **Renderer:** route server-sent `{ type: "error" }` messages through the pane log (`pushLog`) rather than dumping them into the xterm buffer. Also flag the transport done so the close-handler doesn't schedule the same error up to 10 reconnect attempts.

The host-side respawn should make most users never see the renderer error path; the renderer fix covers the remaining genuinely-fatal cases (no DB row, disposed, exited, missing workspace).

## Test plan

- [x] Added `terminal-ws-transport.test.ts` test covering: server `error` message lands in `transport.logs`, not `xterm.writeln`; subsequent 1011 close does not schedule reconnect. Verified each assertion catches a regression by reverting that half of the fix independently.
- [x] `bun test apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts` — 2 pass.
- [x] `tsc --noEmit` clean for `apps/desktop` and `packages/host-service`.
- [x] `bun run lint` clean on touched files.
- [ ] Manual: open a workspace terminal, kill the pty-daemon process, reconnect — pane respawns instead of erroring.
- [ ] Manual: dispose a session, then try to reattach — error appears in pane log, not in xterm scrollback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respawns lost terminal sessions on attach and routes server WS errors to the pane log to prevent dead panes and noisy scrollback. Respawns honor the current terminal theme, terminated sessions stop reconnect loops, and theme toggles no longer drop a live shell.

- **Bug Fixes**
  - Host-service WS attach: if the DB row is active but the daemon PTY is gone, try adoption; if it fails, spawn a new PTY at the same `terminalId`. Read `themeType` from the WS URL so respawns set COLORFGBG correctly.
  - Renderer: on `{ type: "error" }`, send to `pushLog`, set `_terminated`, and cancel reconnect so a 1011 close doesn’t schedule retries.
  - TerminalPane: include `themeType` in the WS URL but split the base URL from the param and read it via a ref, so theme changes don’t trigger reconnects.

<sup>Written for commit 11b0096d35b74c787cd4fb6959db7dd55752db60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed duplicate terminal output and prevented unnecessary reconnects after server-reported terminal errors or closes; close/logging now avoid misleading warnings.
  * Session attach now attempts adoption and falls back to respawn if adoption fails; attach failures are logged and stop reconnection attempts.

* **UI**
  * Terminal connections include the current UI theme so sessions respect theme changes without forcing full reconnects.

* **Tests**
  * Added tests for server-sent error handling and websocket close behavior; mock socket supports close parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->