### PR TITLE
fix(host-service): don't crash startup when shell env probe fails

### DIFF
--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -1,8 +1,10 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import * as os from "node:os";
 
 const SHELL_ENV_TIMEOUT_MS = 8_000;
 const CACHE_TTL_MS = 60_000;
 const DELIMITER = "__SUPERSET_SHELL_ENV__";
+const DIAGNOSTIC_OUTPUT_LIMIT = 200;
 
 const SHELL_BOOTSTRAP_KEYS = [
 	"HOME",
@@ -29,7 +31,7 @@ const COMMON_MACOS_PATHS = [
 	"/usr/local/sbin",
 ];
 
-function augmentPathForMacOS(
+export function augmentPathForMacOS(
 	env: Record<string, string>,
 	platform: NodeJS.Platform = process.platform,
 ): void {
@@ -90,11 +92,24 @@ function parseEnvOutput(stdout: string): Record<string, string> {
 	return result;
 }
 
+function truncateForDiagnostics(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.length <= DIAGNOSTIC_OUTPUT_LIMIT) return trimmed;
+	return `${trimmed.slice(0, DIAGNOSTIC_OUTPUT_LIMIT)}…`;
+}
+
 function spawnCleanShellEnv(): Promise<Record<string, string>> {
 	return new Promise((resolve, reject) => {
 		const shell = resolveShellForEnv();
 		const env = buildMinimalEnv();
 		const command = `echo -n "${DELIMITER}"; command env; echo -n "${DELIMITER}"; exit`;
+
+		// Anchor at $HOME so the snapshot shell doesn't inherit a cwd
+		// host-service has no control over. Tools called from interactive
+		// rc files — brew is the recurring offender (#4025) — abort when
+		// pwd isn't readable to the invoking user, and Electron helpers
+		// can land at /private/var/... or similar at launch.
+		const cwd = env.HOME || os.homedir();
 
 		let child: ChildProcess;
 		try {
@@ -102,6 +117,7 @@ function spawnCleanShellEnv(): Promise<Record<string, string>> {
 				detached: true,
 				stdio: ["ignore", "pipe", "pipe"],
 				env,
+				cwd,
 			});
 		} catch (error) {
 			return reject(
@@ -139,6 +155,7 @@ function spawnCleanShellEnv(): Promise<Record<string, string>> {
 		child.on("close", (code, signal) => {
 			clearTimeout(timeout);
 
+			const stdout = Buffer.concat(stdoutBuffers).toString("utf8");
 			const stderr = Buffer.concat(stderrBuffers).toString("utf8").trim();
 			if (stderr) {
 				console.debug("[terminal-clean-shell-env] stderr:", stderr);
@@ -147,15 +164,25 @@ function spawnCleanShellEnv(): Promise<Record<string, string>> {
 			if (code !== 0 && code !== null) {
 				return reject(
 					new Error(
-						`Shell ${shell} exited with code ${code}${signal ? `, signal ${signal}` : ""}`,
+						`Shell ${shell} exited with code ${code}${signal ? `, signal ${signal}` : ""}` +
+							(stderr ? ` stderr=${truncateForDiagnostics(stderr)}` : "") +
+							(stdout ? ` stdout=${truncateForDiagnostics(stdout)}` : ""),
 					),
 				);
 			}
 
 			try {
-				resolve(parseEnvOutput(Buffer.concat(stdoutBuffers).toString("utf8")));
+				resolve(parseEnvOutput(stdout));
 			} catch (error) {
-				reject(error);
+				const detail = error instanceof Error ? error.message : String(error);
+				reject(
+					new Error(
+						`${detail} (shell=${shell}` +
+							` stdout=${truncateForDiagnostics(stdout)}` +
+							(stderr ? ` stderr=${truncateForDiagnostics(stderr)}` : "") +
+							")",
+					),
+				);
 			}
 		});
 

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -20,6 +20,7 @@ export {
 import fs from "node:fs";
 import os from "node:os";
 import {
+	augmentPathForMacOS,
 	clearStrictShellEnvCache,
 	getStrictShellEnvironment,
 } from "./clean-shell-env.ts";
@@ -56,11 +57,25 @@ function snapshotStringEnv(
 /**
  * Resolve the shell-derived terminal base env inside the host-service process.
  * Desktop main should not construct or own this snapshot.
+ *
+ * Falls back to a process.env snapshot if the user's login shell can't be
+ * probed — crashing host-service startup over a degraded PTY env strands
+ * users on v2. v1 desktop main does the same in apps/desktop shell-env.ts.
  */
 export async function resolveTerminalBaseEnv(): Promise<
 	Record<string, string>
 > {
-	return getStrictShellEnvironment();
+	try {
+		return await getStrictShellEnvironment();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(
+			`[host-service] Shell env snapshot failed, falling back to process.env: ${message}`,
+		);
+		const fallback = snapshotStringEnv(process.env);
+		augmentPathForMacOS(fallback);
+		return fallback;
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

User report (john@benomadic.co): can open v1 workspaces but every v2 attempt errors at startup with

```
[host-service] Failed to start: Error: Failed to parse shell env output - delimiter not found
    at parseEnvOutput (.../host-service.js:27624:11)
```

v1 desktop main has had a `process.env` fallback in `apps/desktop/src/lib/.../shell-env.ts:76-95` since launch — when its login-shell probe fails, it logs a warning and keeps going. v2 host-service uses its own probe in `packages/host-service/src/terminal/clean-shell-env.ts` and any failure propagates to `process.exit(1)` in `apps/desktop/src/main/host-service/index.ts`. That asymmetry is the v1-works/v2-doesn't symptom.

## Changes

- `terminal/env.ts:resolveTerminalBaseEnv` — try/catch around `getStrictShellEnvironment`; on failure, log a warning with the underlying error and fall back to a `process.env` snapshot + `augmentPathForMacOS`. Same shape as v1.
- `terminal/clean-shell-env.ts` — pin the snapshot shell's `cwd` to `$HOME` (backport of `4feaa3d0`, issue #4025; the brew "current working directory must be readable" failure mode), and include truncated stdout/stderr in the thrown error so the next user report surfaces *which* shell behaviour broke instead of a blind "delimiter not found".
- Export `augmentPathForMacOS` from `clean-shell-env.ts` so the fallback path can reuse it.

`exec-gh` already wraps `getStrictShellEnvironment().catch(...)`, so making the strict probe throw richer errors doesn't regress that consumer.

## Test plan

- [x] `bun run lint` clean
- [x] `tsc --noEmit` clean (host-service)
- [x] `bun test src/terminal/` — 37 pass, 0 fail
- [ ] TestFlight build to john; confirm host-service starts and capture the new `[host-service] Shell env snapshot failed, falling back to process.env: <details>` line so we can see his actual shell output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop host-service from crashing at startup when the shell env probe fails by falling back to a `process.env` snapshot (same as v1). Also improves diagnostics and stability of the shell probe.

- **Bug Fixes**
  - In `packages/host-service/src/terminal/env.ts`, wrap `getStrictShellEnvironment` with try/catch; on failure log a warning and fall back to `process.env` + `augmentPathForMacOS` (now exported).
  - In `packages/host-service/src/terminal/clean-shell-env.ts`, run the probe shell with `cwd` set to `$HOME` to avoid unreadable-cwd issues (e.g., brew).
  - Include truncated stdout/stderr in thrown errors to make probe failures diagnosable.

<sup>Written for commit 4641abe840fb8b0f0aefa47d542764ab5e7cc2d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal environment resolution now includes fallback mechanism to ensure continued functionality if shell initialization fails.
  * Error messages now provide comprehensive diagnostics (stdout and stderr) while being truncated for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->