### PR TITLE
feat(desktop): add v1 import intro page + fix preset import

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
@@ -29,8 +29,12 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 		[collections],
 	);
 
-	const importedV1Ids = useMemo(
-		() => new Set(v2Presets.map((p) => p.id)),
+	const importedAgentIds = useMemo(
+		() => new Set(v2Presets.flatMap((p) => (p.agentId ? [p.agentId] : []))),
+		[v2Presets],
+	);
+	const importedNames = useMemo(
+		() => new Set(v2Presets.map((p) => p.name)),
 		[v2Presets],
 	);
 
@@ -56,15 +60,28 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 			onRefresh={refresh}
 			isRefreshing={isRefreshing}
 		>
-			{presets.map((preset, index) => (
-				<PresetRow
-					key={preset.id}
-					preset={preset}
-					tabOrder={index}
-					alreadyImported={importedV1Ids.has(preset.id)}
-					organizationId={organizationId}
-				/>
-			))}
+			{presets.map((preset, index) => {
+				const linkedAgentId = BUILTIN_AGENT_IDS.has(preset.name)
+					? (preset.name as AgentType)
+					: undefined;
+				const v2Name = linkedAgentId
+					? AGENT_LABELS[linkedAgentId]
+					: preset.name;
+				const alreadyImported = linkedAgentId
+					? importedAgentIds.has(linkedAgentId)
+					: importedNames.has(v2Name);
+				return (
+					<PresetRow
+						key={preset.id}
+						preset={preset}
+						tabOrder={index}
+						linkedAgentId={linkedAgentId}
+						v2Name={v2Name}
+						alreadyImported={alreadyImported}
+						organizationId={organizationId}
+					/>
+				);
+			})}
 		</ImportPageShell>
 	);
 }
@@ -72,6 +89,8 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 interface PresetRowProps {
 	preset: TerminalPreset;
 	tabOrder: number;
+	linkedAgentId: AgentType | undefined;
+	v2Name: string;
 	alreadyImported: boolean;
 	organizationId: string;
 }
@@ -79,6 +98,8 @@ interface PresetRowProps {
 function PresetRow({
 	preset,
 	tabOrder,
+	linkedAgentId,
+	v2Name,
 	alreadyImported,
 	organizationId,
 }: PresetRowProps) {
@@ -90,15 +111,9 @@ function PresetRow({
 		setRunning(true);
 		setErrorMessage(null);
 		try {
-			const linkedAgentId: AgentType | undefined = BUILTIN_AGENT_IDS.has(
-				preset.name,
-			)
-				? (preset.name as AgentType)
-				: undefined;
-
 			const row: V2TerminalPresetRow = {
-				id: preset.id,
-				name: linkedAgentId ? AGENT_LABELS[linkedAgentId] : preset.name,
+				id: crypto.randomUUID(),
+				name: v2Name,
 				description: preset.description,
 				cwd: preset.cwd,
 				commands: preset.commands,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
@@ -34,7 +34,7 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 		[v2Presets],
 	);
 	const importedNames = useMemo(
-		() => new Set(v2Presets.map((p) => p.name)),
+		() => new Set(v2Presets.flatMap((p) => (p.agentId ? [] : [p.name]))),
 		[v2Presets],
 	);
 
@@ -152,7 +152,7 @@ function PresetRow({
 	return (
 		<ImportRow
 			icon={<LuTerminal className="size-3.5" strokeWidth={2} />}
-			primary={preset.name}
+			primary={v2Name}
 			secondary={preset.description ?? preset.commands[0]}
 			action={action}
 		/>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
@@ -14,6 +14,7 @@ import {
 	V1_IMPORT_PAGE_ORDER,
 } from "renderer/stores/v1-import-modal";
 import { MOCK_ORG_ID } from "shared/constants";
+import { IntroPage } from "./components/IntroPage";
 import { WelcomePage } from "./components/WelcomePage";
 import { ImportPresetsPage } from "./ImportPresetsPage";
 import { ImportProjectsPage } from "./ImportProjectsPage";
@@ -51,15 +52,20 @@ export function V1ImportModal() {
 				onInteractOutside={(event) => event.preventDefault()}
 			>
 				<DialogTitle className="sr-only">
-					{page === "welcome" ? "Welcome to Superset v2" : "Import from v1"}
+					{page === "welcome"
+						? "Welcome to Superset v2"
+						: page === "intro"
+							? "Let's get you started"
+							: "Import from v1"}
 				</DialogTitle>
 				<DialogDescription className="sr-only">
-					Bring projects, workspaces, and terminal presets from Superset v1 into
-					v2.
+					Let's get your workspaces and projects ported over. Terminal sessions
+					won't be carried over, but you can still access v1 at any time.
 				</DialogDescription>
 
 				<div key={page} className="animate-in fade-in duration-200">
 					{page === "welcome" && <WelcomePage />}
+					{page === "intro" && <IntroPage />}
 					{(page === "projects" || page === "workspaces") && !activeHostUrl && (
 						<div className="flex h-[454px] items-center justify-center bg-background px-6 text-center text-sm text-muted-foreground">
 							Host service is not ready yet. This window will populate as soon

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/IntroPage/IntroPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/IntroPage/IntroPage.tsx
@@ -1,0 +1,13 @@
+export function IntroPage() {
+	return (
+		<div className="flex h-[454px] flex-col items-center justify-center bg-background px-14 text-center">
+			<div className="text-2xl font-semibold text-foreground">
+				Let's get you started
+			</div>
+			<p className="mt-3 max-w-md text-sm text-muted-foreground">
+				Let's get your workspaces and projects ported over. Terminal sessions
+				won't be carried over, but you can still access v1 at any time.
+			</p>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/IntroPage/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/IntroPage/index.ts
@@ -1,0 +1,1 @@
+export { IntroPage } from "./IntroPage";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/WelcomePage/WelcomePage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/WelcomePage/WelcomePage.tsx
@@ -26,10 +26,6 @@ export function WelcomePage() {
 				<div className="text-3xl font-semibold text-white">
 					Welcome to Superset v2
 				</div>
-				<p className="mt-3 max-w-md text-sm text-white/80">
-					Bring your v1 projects, workspaces, and terminal presets over. Import
-					each one with a single click — nothing happens automatically.
-				</p>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/stores/v1-import-modal.ts
+++ b/apps/desktop/src/renderer/stores/v1-import-modal.ts
@@ -1,10 +1,16 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
-export type V1ImportPage = "welcome" | "projects" | "workspaces" | "presets";
+export type V1ImportPage =
+	| "welcome"
+	| "intro"
+	| "projects"
+	| "workspaces"
+	| "presets";
 
 export const V1_IMPORT_PAGE_ORDER: V1ImportPage[] = [
 	"welcome",
+	"intro",
 	"projects",
 	"workspaces",
 	"presets",


### PR DESCRIPTION
## Summary

- Split the v1 import welcome screen into two pages: the existing "Welcome to Superset v2" hero (copy removed) and a new `IntroPage` that sets expectations — "let's get your workspaces and projects ported over. Terminal sessions won't be carried over, but you can still access v1 at any time."
- Fix the preset import path that threw `Invalid input - path: id` for builtin agent presets (`claude`, `codex`). v1 keys those presets by agent name; v2 requires `id` to be a UUID. The import now generates a fresh UUID, sets `agentId` for the link, and dedups on `agentId` (builtins) or `name` (custom) instead of v1's id.

## Test plan

- [ ] Open v1→v2 import modal, click through Welcome → Intro → Projects (Back/Next both directions).
- [ ] On the Presets page, import a builtin agent preset (Claude / Codex) and verify it lands in v2 with the right label and a UUID id.
- [ ] Verify the imported row is marked "Imported" (dedup by agentId) on subsequent renders.
- [ ] Import a custom-named v1 preset and verify it lands without an `agentId` and dedups by name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the v1→v2 import flow into a welcome hero and a short intro to set expectations. Also fixed builtin preset import errors, label mismatch, and tightened deduping.

- **New Features**
  - Added an Intro page after Welcome. Clarifies that workspaces and projects migrate, terminal sessions do not. Updated page order and a11y titles/descriptions.

- **Bug Fixes**
  - Fixed preset import for builtin agents (`claude`, `codex`): generate a UUID for `id`, set `agentId` for linking, dedup by `agentId` (builtins) or name (custom), show the v2 display label in the picker, and exclude builtin-linked rows from name-based dedup to avoid false “Imported”.

<sup>Written for commit e20b4e2c95c1c7d7045296d5e534c08573b824c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Added an introductory step to the V1 import wizard that explains what will and won't be transferred during the migration process
- Enhanced preset importing to automatically match presets with corresponding built-in agents and display appropriate labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->