### PR TITLE
feat(panes): elevate live pane titles to tab name

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -43,6 +43,8 @@ export interface TerminalTransport {
 	_reconnectTimer: ReturnType<typeof setTimeout> | null;
 	/** Internal: reconnect attempt count for backoff. */
 	_reconnectAttempt: number;
+	/** Internal: title-change debounce timer; see TITLE_COALESCE_MS. */
+	_titleNotifyTimer: ReturnType<typeof setTimeout> | null;
 	/** The xterm instance used for reconnection. */
 	_terminal: XTerm | null;
 	/** Set when the server signals the session is done (PTY exit or fatal
@@ -70,15 +72,31 @@ function setConnectionState(
 	}
 }
 
+// Debounce window for title-change notifications. transport.title updates
+// immediately so getTitle() reads the latest; only listener notifications wait,
+// preventing flicker when shells retitle rapidly. Matches ghostty's 75ms.
+const TITLE_COALESCE_MS = 75;
+
+function notifyTitleListeners(transport: TerminalTransport) {
+	transport._titleNotifyTimer = null;
+	for (const listener of transport.titleListeners) {
+		listener();
+	}
+}
+
 function setTerminalTitle(
 	transport: TerminalTransport,
 	title: string | null | undefined,
 ) {
 	if (transport.title === title) return;
 	transport.title = title;
-	for (const listener of transport.titleListeners) {
-		listener();
+	if (transport._titleNotifyTimer !== null) {
+		clearTimeout(transport._titleNotifyTimer);
 	}
+	transport._titleNotifyTimer = setTimeout(
+		() => notifyTitleListeners(transport),
+		TITLE_COALESCE_MS,
+	);
 }
 
 function pushLog(
@@ -130,6 +148,7 @@ export function createTransport(): TerminalTransport {
 		logs: [],
 		logListeners: new Set(),
 		_reconnectTimer: null,
+		_titleNotifyTimer: null,
 		_reconnectAttempt: 0,
 		_terminal: null,
 		_hasReceivedBytes: false,
@@ -417,6 +436,10 @@ export function disposeTransport(transport: TerminalTransport) {
 	transport.onDataDisposable?.dispose();
 	transport.onDataDisposable = null;
 	transport.stateListeners.clear();
+	if (transport._titleNotifyTimer !== null) {
+		clearTimeout(transport._titleNotifyTimer);
+		transport._titleNotifyTimer = null;
+	}
 	transport.titleListeners.clear();
 	transport.logs = [];
 	transport.logListeners.clear();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -243,6 +243,22 @@ export function usePaneRegistry({
 			terminal: {
 				getIcon: () => <TerminalSquare className="size-3.5" />,
 				getTitle: () => "Terminal",
+				titleSource: (pane) => {
+					const { terminalId } = pane.data as TerminalPaneData;
+					const instanceId = pane.id;
+					return {
+						subscribe: (callback) =>
+							terminalRuntimeRegistry.onTitleChange(
+								terminalId,
+								callback,
+								instanceId,
+							),
+						getSnapshot: () =>
+							terminalRuntimeRegistry
+								.getTitle(terminalId, instanceId)
+								?.trim() || undefined,
+					};
+				},
 				onAfterClose: (pane) => {
 					const { terminalId } = pane.data as TerminalPaneData;
 					if (consumeTerminalBackgroundIntent(terminalId)) {

--- a/packages/panes/src/index.ts
+++ b/packages/panes/src/index.ts
@@ -17,12 +17,13 @@ export type {
 	PaneContext,
 	PaneDefinition,
 	PaneRegistry,
+	PaneTitleSource,
 	RendererContext,
 	TabContext,
 	WorkspaceInteractionState,
 	WorkspaceProps,
 } from "./react";
-export { resolveTabTitle, Workspace } from "./react";
+export { resolveTabTitle, useTabTitle, Workspace } from "./react";
 export type {
 	LayoutNode,
 	Pane,

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -6,7 +6,6 @@ import type { WorkspaceProps } from "../../types";
 import { Tab } from "./components/Tab";
 import { TabBar } from "./components/TabBar";
 import { useWorkspaceInteractionState } from "./hooks/useWorkspaceInteractionState";
-import { resolveTabTitle } from "./utils/resolveTabTitle";
 
 export function Workspace<TData>({
 	store,
@@ -72,6 +71,7 @@ export function Workspace<TData>({
 		>
 			<TabBar
 				tabs={tabs}
+				registry={registry}
 				activeTabId={activeTabId}
 				onSelectTab={(tabId) => store.getState().setActiveTab(tabId)}
 				onCloseTab={closeTab}
@@ -94,7 +94,6 @@ export function Workspace<TData>({
 				onMovePaneToNewTab={(paneId, toIndex) =>
 					store.getState().movePaneToNewTab({ paneId, toIndex })
 				}
-				getTabTitle={(tab) => resolveTabTitle(tab, tabs, registry)}
 				renderTabIcon={renderTabIcon}
 				renderAddTabMenu={renderAddTabMenu}
 				renderTabAccessory={renderTabAccessory}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -15,12 +15,14 @@ import {
 } from "react";
 import { useDrop } from "react-dnd";
 import type { Tab } from "../../../../../types";
+import type { PaneRegistry } from "../../../../types";
 import { PANE_DRAG_TYPE } from "../Tab/components/Pane/components/PaneHeader";
 import { TAB_DRAG_TYPE, TabItem } from "./components/TabItem";
 import { computeInsertIndex, TAB_WIDTH } from "./utils";
 
 interface TabBarProps<TData> {
 	tabs: Tab<TData>[];
+	registry: PaneRegistry<TData>;
 	activeTabId: string | null;
 	onSelectTab: (tabId: string) => void;
 	onCloseTab: (tabId: string) => void;
@@ -29,7 +31,6 @@ interface TabBarProps<TData> {
 	onRenameTab: (tabId: string, title: string | undefined) => void;
 	onReorderTab: (tabId: string, toIndex: number) => void;
 	onMovePaneToNewTab: (paneId: string, toIndex: number) => void;
-	getTabTitle: (tab: Tab<TData>) => string;
 	renderTabIcon?: (tab: Tab<TData>) => ReactNode;
 	renderAddTabMenu?: () => ReactNode;
 	renderTabAccessory?: (tab: Tab<TData>) => ReactNode;
@@ -70,6 +71,7 @@ function AddTabButton<_TData>({
 
 export function TabBar<TData>({
 	tabs,
+	registry,
 	activeTabId,
 	onSelectTab,
 	onCloseTab,
@@ -78,7 +80,6 @@ export function TabBar<TData>({
 	onRenameTab,
 	onReorderTab,
 	onMovePaneToNewTab,
-	getTabTitle,
 	renderTabIcon,
 	renderAddTabMenu,
 	renderTabAccessory,
@@ -195,6 +196,8 @@ export function TabBar<TData>({
 						>
 							<TabItem
 								tab={tab}
+								tabs={tabs}
+								registry={registry}
 								index={i}
 								isActive={tab.id === activeTabId}
 								onSelect={() => onSelectTab(tab.id)}
@@ -202,7 +205,6 @@ export function TabBar<TData>({
 								onCloseOthers={() => onCloseOtherTabs(tab.id)}
 								onCloseAll={onCloseAllTabs}
 								onRename={(title) => onRenameTab(tab.id, title)}
-								getTitle={getTabTitle}
 								icon={renderTabIcon?.(tab)}
 								accessory={renderTabAccessory?.(tab)}
 							/>

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -13,6 +13,8 @@ import { PencilIcon, XIcon } from "lucide-react";
 import { type ReactNode, useCallback, useRef, useState } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import type { Tab } from "../../../../../../../types";
+import type { PaneRegistry } from "../../../../../../types";
+import { useTabTitle } from "../../../../utils/useTabTitle";
 import { PANE_DRAG_TYPE } from "../../../Tab/components/Pane/components/PaneHeader";
 import { TabRenameInput } from "./components/TabRenameInput";
 
@@ -20,6 +22,8 @@ export const TAB_DRAG_TYPE = "tab";
 
 interface TabItemProps<TData> {
 	tab: Tab<TData>;
+	tabs: Tab<TData>[];
+	registry: PaneRegistry<TData>;
 	index: number;
 	isActive: boolean;
 	onSelect: () => void;
@@ -27,13 +31,14 @@ interface TabItemProps<TData> {
 	onCloseOthers: () => void;
 	onCloseAll: () => void;
 	onRename: (title: string | undefined) => void;
-	getTitle: (tab: Tab<TData>) => string;
 	icon?: ReactNode;
 	accessory?: ReactNode;
 }
 
 export function TabItem<TData>({
 	tab,
+	tabs,
+	registry,
 	index,
 	isActive,
 	onSelect,
@@ -41,13 +46,12 @@ export function TabItem<TData>({
 	onCloseOthers,
 	onCloseAll,
 	onRename,
-	getTitle,
 	icon,
 	accessory,
 }: TabItemProps<TData>) {
 	const [isEditing, setIsEditing] = useState(false);
 	const [editValue, setEditValue] = useState("");
-	const title = getTitle(tab);
+	const title = useTabTitle(tab, tabs, registry);
 
 	const startEditing = () => {
 		setEditValue(title);

--- a/packages/panes/src/react/components/Workspace/index.ts
+++ b/packages/panes/src/react/components/Workspace/index.ts
@@ -1,2 +1,3 @@
 export { resolveTabTitle } from "./utils/resolveTabTitle";
+export { useTabTitle } from "./utils/useTabTitle";
 export { Workspace } from "./Workspace";

--- a/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.test.ts
+++ b/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "bun:test";
+import type { Pane, Tab } from "../../../../types";
+import type { PaneRegistry } from "../../../types";
+import { resolveTabTitle } from "./resolveTabTitle";
+
+interface TestData {
+	label?: string;
+}
+
+const registry: PaneRegistry<TestData> = {
+	titled: {
+		renderPane: () => null,
+		getTitle: (pane) => pane.data.label ?? "",
+	},
+	untitled: {
+		renderPane: () => null,
+		// no getTitle — exercises the fallback path
+	},
+};
+
+function pane(id: string, kind: string, label?: string): Pane<TestData> {
+	return { id, kind, data: { label } };
+}
+
+function tab(args: {
+	id: string;
+	titleOverride?: string;
+	activePaneId: string | null;
+	panes: Pane<TestData>[];
+}): Tab<TestData> {
+	const panesMap: Record<string, Pane<TestData>> = {};
+	for (const p of args.panes) panesMap[p.id] = p;
+	return {
+		id: args.id,
+		titleOverride: args.titleOverride,
+		createdAt: 0,
+		activePaneId: args.activePaneId,
+		layout: { type: "pane", paneId: args.panes[0]?.id ?? "" },
+		panes: panesMap,
+	};
+}
+
+describe("resolveTabTitle", () => {
+	it("uses tab.titleOverride when set", () => {
+		const t = tab({
+			id: "t1",
+			titleOverride: "Custom",
+			activePaneId: "p1",
+			panes: [pane("p1", "titled", "from-pane")],
+		});
+		expect(resolveTabTitle(t, [t], registry)).toBe("Custom");
+	});
+
+	it("single-pane: elevates pane.titleOverride", () => {
+		const p = {
+			...pane("p1", "titled", "registry"),
+			titleOverride: "Override",
+		};
+		const t = tab({ id: "t1", activePaneId: "p1", panes: [p] });
+		expect(resolveTabTitle(t, [t], registry)).toBe("Override");
+	});
+
+	it("single-pane: elevates registry.getTitle", () => {
+		const t = tab({
+			id: "t1",
+			activePaneId: "p1",
+			panes: [pane("p1", "titled", "from-registry")],
+		});
+		expect(resolveTabTitle(t, [t], registry)).toBe("from-registry");
+	});
+
+	it("single-pane: falls back to Tab N when registry returns empty", () => {
+		const t = tab({
+			id: "t1",
+			activePaneId: "p1",
+			panes: [pane("p1", "untitled")],
+		});
+		expect(resolveTabTitle(t, [t], registry)).toBe("Tab 1");
+	});
+
+	it("multi-pane: elevates active pane's title", () => {
+		const t = tab({
+			id: "t1",
+			activePaneId: "p2",
+			panes: [pane("p1", "titled", "first"), pane("p2", "titled", "second")],
+		});
+		expect(resolveTabTitle(t, [t], registry)).toBe("second");
+	});
+
+	it("multi-pane: falls back to Tab N when active pane has no title", () => {
+		const t = tab({
+			id: "t1",
+			activePaneId: "p2",
+			panes: [pane("p1", "titled", "first"), pane("p2", "untitled")],
+		});
+		expect(resolveTabTitle(t, [t], registry)).toBe("Tab 1");
+	});
+
+	it("multi-pane: falls back to Tab N when activePaneId references missing pane", () => {
+		const t = tab({
+			id: "t1",
+			activePaneId: "stale",
+			panes: [pane("p1", "titled", "first"), pane("p2", "titled", "second")],
+		});
+		expect(resolveTabTitle(t, [t], registry)).toBe("Tab 1");
+	});
+
+	it("multi-pane: falls back to Tab N when activePaneId is null", () => {
+		const t = tab({
+			id: "t1",
+			activePaneId: null,
+			panes: [pane("p1", "titled", "first"), pane("p2", "titled", "second")],
+		});
+		expect(resolveTabTitle(t, [t], registry)).toBe("Tab 1");
+	});
+
+	it("uses tab index from the tabs array for the Tab N fallback", () => {
+		const t1 = tab({
+			id: "t1",
+			activePaneId: "p1",
+			panes: [pane("p1", "untitled")],
+		});
+		const t2 = tab({
+			id: "t2",
+			activePaneId: "p2",
+			panes: [pane("p2", "untitled")],
+		});
+		expect(resolveTabTitle(t2, [t1, t2], registry)).toBe("Tab 2");
+	});
+});

--- a/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
+++ b/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
@@ -1,5 +1,27 @@
-import type { Tab } from "../../../../types";
+import type { Pane, Tab } from "../../../../types";
 import type { PaneRegistry } from "../../../types";
+
+/**
+ * The pane that drives the tab title: the only pane (single-pane tab) or
+ * the active pane (multi-pane tab). Undefined for empty tabs or stale
+ * activePaneId references.
+ */
+export function pickTabTitlePane<TData>(
+	tab: Tab<TData>,
+): Pane<TData> | undefined {
+	const panes = Object.values(tab.panes);
+	if (panes.length === 1) return panes[0];
+	if (panes.length > 1 && tab.activePaneId) return tab.panes[tab.activePaneId];
+	return undefined;
+}
+
+function paneTitle<TData>(
+	pane: Pane<TData> | undefined,
+	registry: PaneRegistry<TData>,
+): string | undefined {
+	if (!pane) return undefined;
+	return pane.titleOverride ?? registry[pane.kind]?.getTitle?.(pane);
+}
 
 export function resolveTabTitle<TData>(
 	tab: Tab<TData>,
@@ -7,12 +29,7 @@ export function resolveTabTitle<TData>(
 	registry: PaneRegistry<TData>,
 ): string {
 	if (tab.titleOverride) return tab.titleOverride;
-	const panes = Object.values(tab.panes);
-	const onlyPane = panes.length === 1 ? panes[0] : undefined;
-	if (onlyPane) {
-		const fromPane =
-			onlyPane.titleOverride ?? registry[onlyPane.kind]?.getTitle?.(onlyPane);
-		if (fromPane) return fromPane;
-	}
+	const fromPane = paneTitle(pickTabTitlePane(tab), registry);
+	if (fromPane) return fromPane;
 	return `Tab ${tabs.indexOf(tab) + 1}`;
 }

--- a/packages/panes/src/react/components/Workspace/utils/useTabTitle.ts
+++ b/packages/panes/src/react/components/Workspace/utils/useTabTitle.ts
@@ -1,0 +1,59 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import type { Pane, Tab } from "../../../../types";
+import type { PaneRegistry, PaneTitleSource } from "../../../types";
+import { pickTabTitlePane } from "./resolveTabTitle";
+
+const noopUnsubscribe = () => {};
+const noopSubscribe = () => noopUnsubscribe;
+const undefinedSnapshot = () => undefined;
+
+/**
+ * Live title from a pane's registry-defined titleSource. Always calls a
+ * single useSyncExternalStore so kind changes (active-pane swap, replacePane)
+ * don't violate rules of hooks.
+ */
+function useReactivePaneTitle<TData>(
+	pane: Pane<TData> | undefined,
+	registry: PaneRegistry<TData>,
+): string | undefined {
+	const source: PaneTitleSource | undefined = useMemo(
+		() => (pane ? registry[pane.kind]?.titleSource?.(pane) : undefined),
+		[pane, registry],
+	);
+	const subscribe = useCallback(
+		(callback: () => void) => source?.subscribe(callback) ?? noopUnsubscribe,
+		[source],
+	);
+	const getSnapshot = useCallback(() => source?.getSnapshot(), [source]);
+	return useSyncExternalStore(
+		source ? subscribe : noopSubscribe,
+		source ? getSnapshot : undefinedSnapshot,
+	);
+}
+
+/**
+ * Reactive tab title. Precedence:
+ *
+ *   tab.titleOverride
+ *   pane.titleOverride           (only/active pane)
+ *   pane.titleSource (live)      (only/active pane)
+ *   registry.getTitle(pane)      (only/active pane)
+ *   "Tab N"
+ */
+export function useTabTitle<TData>(
+	tab: Tab<TData>,
+	tabs: Tab<TData>[],
+	registry: PaneRegistry<TData>,
+): string {
+	const titlePane = pickTabTitlePane(tab);
+	const reactiveTitle = useReactivePaneTitle(titlePane, registry)?.trim();
+
+	if (tab.titleOverride) return tab.titleOverride;
+	if (titlePane?.titleOverride) return titlePane.titleOverride;
+	if (reactiveTitle) return reactiveTitle;
+	const staticTitle = titlePane
+		? registry[titlePane.kind]?.getTitle?.(titlePane)
+		: undefined;
+	if (staticTitle) return staticTitle;
+	return `Tab ${tabs.indexOf(tab) + 1}`;
+}

--- a/packages/panes/src/react/index.ts
+++ b/packages/panes/src/react/index.ts
@@ -1,10 +1,15 @@
-export { resolveTabTitle, Workspace } from "./components/Workspace";
+export {
+	resolveTabTitle,
+	useTabTitle,
+	Workspace,
+} from "./components/Workspace";
 export type {
 	ContextMenuActionConfig,
 	PaneActionConfig,
 	PaneContext,
 	PaneDefinition,
 	PaneRegistry,
+	PaneTitleSource,
 	RendererContext,
 	TabContext,
 	WorkspaceInteractionState,

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -56,9 +56,20 @@ export interface RendererContext<TData> {
 	};
 }
 
+export interface PaneTitleSource {
+	subscribe: (callback: () => void) => () => void;
+	getSnapshot: () => string | undefined;
+}
+
 export interface PaneDefinition<TData> {
 	renderPane(context: RendererContext<TData>): ReactNode;
 	getTitle?(pane: Pane<TData>): string | undefined;
+	/**
+	 * Optional reactive title source. When defined, the tab title (and other
+	 * title-aware UI) subscribes to it and re-renders when the runtime title
+	 * changes — without mirroring runtime state into the pane store.
+	 */
+	titleSource?(pane: Pane<TData>): PaneTitleSource | undefined;
 	getIcon?(context: RendererContext<TData>): ReactNode;
 	renderTitle?(context: RendererContext<TData>): ReactNode;
 	renderHeaderExtras?(context: RendererContext<TData>): ReactNode;

--- a/packages/shared/src/terminal-title-scanner.test.ts
+++ b/packages/shared/src/terminal-title-scanner.test.ts
@@ -125,6 +125,28 @@ describe("terminal title scanner", () => {
 		expect(state.buffer.length).toBe(0);
 	});
 
+	it("skips OSC 0/2 titles that normalize to nothing so the previous title persists", () => {
+		const state = createTerminalTitleScanState();
+
+		// Real title arrives, then a Braille-only spinner frame, then another real title.
+		expect(
+			scanForTerminalTitle(
+				state,
+				enc.encode("\x1b]2;Editor\x07\x1b]2;⠂\x07\x1b]2;Editor 2\x07"),
+			).updates,
+		).toEqual(["Editor", "Editor 2"]);
+	});
+
+	it("preserves the explicit OSC 9;3; reset distinct from a normalized-empty title", () => {
+		const state = createTerminalTitleScanState();
+
+		// Explicit reset emits null; normalized-empty (all Braille) emits nothing.
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]9;3;\x07\x1b]9;3;⠂⠐\x07"))
+				.updates,
+		).toEqual([null]);
+	});
+
 	it("preserves multi-byte UTF-8 in titles when split across chunks", () => {
 		// Regression: pre-byte-rewrite, the upstream did Buffer.toString('utf8')
 		// per chunk and would mangle the smiley if its 4 bytes split across the
@@ -155,5 +177,22 @@ describe("normalizeTerminalTitle", () => {
 		const title = `${"a".repeat(199)}🙂extra`;
 
 		expect(Array.from(normalizeTerminalTitle(title) ?? "")).toHaveLength(200);
+	});
+
+	it("strips Braille spinner glyphs so spinner frames don't freeze the tab", () => {
+		// Claude Code and most CLI spinner libraries animate via the Braille
+		// block. Each frame collapses to the same stable text after stripping.
+		expect(normalizeTerminalTitle("⠂ Claude Code")).toBe("Claude Code");
+		expect(normalizeTerminalTitle("⠐ Claude Code")).toBe("Claude Code");
+		expect(normalizeTerminalTitle("⠇⠋⠙⠸ Loading")).toBe("Loading");
+	});
+
+	it("returns null when only Braille glyphs remain", () => {
+		expect(normalizeTerminalTitle("⠂⠐⠇")).toBeNull();
+	});
+
+	it("strips the UTF-8 replacement character from upstream decode failures", () => {
+		expect(normalizeTerminalTitle("Claude� Code")).toBe("Claude Code");
+		expect(normalizeTerminalTitle("�")).toBeNull();
 	});
 });

--- a/packages/shared/src/terminal-title-scanner.ts
+++ b/packages/shared/src/terminal-title-scanner.ts
@@ -38,11 +38,23 @@ export function normalizeTerminalTitle(title: string): string | null {
 	const normalized = Array.from(title)
 		.filter((char) => {
 			const codePoint = char.codePointAt(0) ?? 0;
-			return !(
+			// Strip C0 controls, DEL, C1 controls.
+			if (
 				codePoint <= 0x1f ||
 				codePoint === 0x7f ||
 				(codePoint >= 0x80 && codePoint <= 0x9f)
-			);
+			) {
+				return false;
+			}
+			// Strip the UTF-8 replacement character — only ever appears when
+			// some upstream layer mis-decoded a byte sequence.
+			if (codePoint === 0xfffd) return false;
+			// Strip Braille block. CLIs (Claude Code, ora, oclif, etc.) animate
+			// progress spinners with these glyphs via OSC title updates; left
+			// in place they freeze on the last frame in the tab title once the
+			// spinner stops.
+			if (codePoint >= 0x2800 && codePoint <= 0x28ff) return false;
+			return true;
 		})
 		.join("")
 		.trim();
@@ -118,14 +130,18 @@ function parseTitlePayload(payload: string): string | null | undefined {
 	const command = payload.slice(0, firstSeparator);
 	const value = payload.slice(firstSeparator + 1);
 
+	// A title that normalizes to null (all-Braille, all-U+FFFD, or whitespace
+	// after stripping) is treated as "no meaningful update" — return undefined
+	// so the scanner skips it and the previous title stays in place. The
+	// explicit OSC 9;3; reset path below still returns null to clear.
 	if (command === "0" || command === "2") {
-		return normalizeTerminalTitle(value);
+		return normalizeTerminalTitle(value) ?? undefined;
 	}
 
 	if (command !== "9") return undefined;
 	if (value === "3;") return null;
 	if (!value.startsWith("3;")) return undefined;
-	return normalizeTerminalTitle(value.slice(2));
+	return normalizeTerminalTitle(value.slice(2)) ?? undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Tab title elevates from the only pane (single-pane tab) or the active pane (multi-pane tab); falls back to "Tab N". Mirrors v1's autoname pattern.
- New `PaneDefinition.titleSource` (subscribe + getSnapshot) lets pane kinds advertise a runtime-driven title without mirroring it into the pane store. The terminal pane wires this to `terminalRuntimeRegistry`.
- New `useTabTitle` hook resolves the tab title reactively, calling a single `useSyncExternalStore` so kind switches (active-pane swap, replacePane) don't violate rules of hooks. `resolveTabTitle` stays exported for non-reactive callers.
- OSC title scanner: strips Braille block (U+2800–U+28FF) so CLI spinner glyphs (Claude Code, ora, oclif, etc.) don't freeze in the tab title once the spinner stops; strips U+FFFD; treats normalize-to-empty as "skip update" so the previous title persists. Explicit OSC 9;3; reset still clears.
- WS transport coalesces title-change notifications by 75ms (matches ghostty). Stored title updates immediately; only listener notifications wait.

## Test plan
- [ ] Single terminal pane: run `vim foo.txt` → tab title follows xterm title.
- [ ] Run `claude` → tab settles on "Claude Code" (Braille spinner stripped); doesn't flicker during animation.
- [ ] Split into multiple panes; switching active pane updates the tab title.
- [ ] User-renamed tab still wins over auto-elevation.
- [ ] Reload app → tab title initializes to "Terminal" then updates as runtime reconnects (no stale persisted title).
- [ ] Non-terminal panes (file, diff, chat) keep existing titles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal pane titles now update dynamically to reflect active applications within the terminal.

* **Bug Fixes**
  * Reduced visual flicker when terminal titles change rapidly.
  * Improved handling of special characters in terminal titles.

* **Tests**
  * Added coverage for terminal title behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->