### PR TITLE
feat(desktop): host-offline + version-mismatch screens for v2 workspaces

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -5,6 +5,7 @@ import * as fs from "node:fs";
 import path from "node:path";
 import { settings } from "@superset/local-db";
 import { getHostId, getHostName } from "@superset/shared/host-info";
+import { MIN_HOST_SERVICE_VERSION } from "@superset/shared/host-version";
 import { app } from "electron";
 import { env } from "main/env.main";
 import semver from "semver";
@@ -28,40 +29,6 @@ import {
 } from "./host-service-utils";
 import { localDb } from "./local-db";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
-
-/**
- * Minimum host-service version this app can work with. Bumping this forces
- * the coordinator to kill + respawn any adopted service older than this,
- * which is how we prevent the renderer from talking to a stale host-service
- * that's missing newly-added procedures/params.
- *
- * 0.4.0: terminal launch moved from `terminal.ensureSession` to
- * `terminal.launchSession` plus WebSocket attach params.
- * 0.3.0: host-service registers via cloud `host.ensure` (was
- * `device.ensureV2Host`); v2_hosts/v2_users_hosts/v2_workspaces use
- * machineId text instead of uuid surrogates.
- * 0.2.0: `workspaceCreation.adopt` gained optional `worktreePath`.
- *
- * 0.5.0 — pty-daemon supervision migrated into host-service. New
- * `terminal.daemon` tRPC namespace; older 0.4.x host-services don't
- * expose it. Adopting one in place would leave the new desktop
- * talking to old code: Settings → Manage daemon would silently
- * fail, and the v2 PTY survival promise is broken. Bumping the
- * floor forces the coordinator's `tryAdopt` (host-service-coordinator
- * line ~308) to SIGTERM old host-services on first launch and
- * respawn with the new bundle. One-time terminal-session loss for
- * users on upgrade — accepted per release-notes guidance.
- *
- * 0.7.0 — canonical `workspaces.create` flow + `settings.hostAgentConfigs`
- * router (PR1, #3893). Older 0.6.x host-services don't expose either,
- * so adopting one in place would break new-project creation and the
- * agent-config settings UI. Force respawn on first launch.
- *
- * 0.8.0 — v2 terminal creation moved to `terminal.createSession`; the
- * WebSocket route is attach-only by `terminalId`. Older host-services would
- * reject the renderer's creation call and still expect socket-side startup.
- */
-const MIN_HOST_SERVICE_VERSION = "0.8.0";
 
 export type HostServiceStatus = "starting" | "running" | "stopped";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/WorkspaceHostIncompatibleState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/WorkspaceHostIncompatibleState.tsx
@@ -1,0 +1,71 @@
+import { Button } from "@superset/ui/button";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, MonitorCog } from "lucide-react";
+
+interface WorkspaceHostIncompatibleStateProps {
+	hostName: string;
+	hostVersion: string;
+	minVersion: string;
+}
+
+export function WorkspaceHostIncompatibleState({
+	hostName,
+	hostVersion,
+	minVersion,
+}: WorkspaceHostIncompatibleStateProps) {
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div className="flex w-full max-w-sm flex-col items-start gap-5">
+				<MonitorCog
+					className="size-5 text-muted-foreground"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Host needs an update
+					</h1>
+					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
+						<span className="font-medium text-foreground">{hostName}</span> is
+						running Superset {hostVersion}, but this client requires{" "}
+						{minVersion} or newer. Update the Superset app on that device to
+						reconnect this workspace.
+					</p>
+				</div>
+				<div className="flex w-full flex-col gap-1.5 rounded-md border border-border/60 bg-muted/30 px-2.5 py-2">
+					<div className="flex items-center justify-between gap-3">
+						<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+							Host
+						</span>
+						<code className="select-text cursor-text min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+							{hostVersion}
+						</code>
+					</div>
+					<div className="flex items-center justify-between gap-3">
+						<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+							Required
+						</span>
+						<code className="select-text cursor-text min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+							{minVersion}
+						</code>
+					</div>
+				</div>
+				<Button
+					asChild
+					size="sm"
+					variant="ghost"
+					className="-ml-2 h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
+				>
+					<Link to="/v2-workspaces">
+						Browse workspaces
+						<ArrowRight
+							className="size-3.5"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+					</Link>
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/WorkspaceHostIncompatibleState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/WorkspaceHostIncompatibleState.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@superset/ui/button";
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, MonitorCog } from "lucide-react";
+import { ArrowRight, ArrowUpCircle, Monitor } from "lucide-react";
 
 interface WorkspaceHostIncompatibleStateProps {
 	hostName: string;
@@ -15,41 +15,67 @@ export function WorkspaceHostIncompatibleState({
 }: WorkspaceHostIncompatibleStateProps) {
 	return (
 		<div className="flex h-full w-full items-center justify-center p-6">
-			<div className="flex w-full max-w-sm flex-col items-start gap-5">
-				<MonitorCog
-					className="size-5 text-muted-foreground"
-					strokeWidth={1.5}
-					aria-hidden="true"
-				/>
+			<div className="flex w-full max-w-sm flex-col items-start gap-6">
+				<div className="relative">
+					<div className="grid size-10 place-items-center rounded-lg border border-border/60 bg-muted/30">
+						<Monitor
+							className="size-[18px] text-muted-foreground"
+							strokeWidth={1.5}
+							aria-hidden="true"
+						/>
+					</div>
+					<span
+						aria-hidden="true"
+						className="absolute -bottom-0.5 -right-0.5 grid size-3.5 place-items-center rounded-full bg-amber-500/90 text-background ring-2 ring-background"
+					>
+						<ArrowUpCircle className="size-2.5" strokeWidth={3} />
+					</span>
+				</div>
+
 				<div className="flex flex-col gap-1.5">
 					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
 						Host needs an update
 					</h1>
 					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
-						<span className="font-medium text-foreground">{hostName}</span> is
-						running Superset {hostVersion}, but this client requires{" "}
-						{minVersion} or newer. Update the Superset app on that device to
-						reconnect this workspace.
+						This workspace's host is on an older version of Superset than this
+						client supports. Update the Superset app on that device to
+						reconnect.
 					</p>
 				</div>
-				<div className="flex w-full flex-col gap-1.5 rounded-md border border-border/60 bg-muted/30 px-2.5 py-2">
-					<div className="flex items-center justify-between gap-3">
-						<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
-							Host
+
+				<div className="flex w-full flex-col gap-0 overflow-hidden rounded-md border border-border/60 bg-muted/30">
+					<div className="flex items-center gap-2.5 px-3 py-2">
+						<span
+							aria-hidden="true"
+							className="size-1.5 shrink-0 rounded-full bg-emerald-500"
+						/>
+						<span
+							className="select-text cursor-text min-w-0 truncate text-[13px] font-medium text-foreground"
+							title={hostName}
+						>
+							{hostName}
 						</span>
-						<code className="select-text cursor-text min-w-0 truncate font-mono text-[11px] text-muted-foreground">
-							{hostVersion}
-						</code>
 					</div>
-					<div className="flex items-center justify-between gap-3">
-						<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
-							Required
-						</span>
-						<code className="select-text cursor-text min-w-0 truncate font-mono text-[11px] text-muted-foreground">
-							{minVersion}
-						</code>
+					<div className="border-t border-border/60 px-3 py-2">
+						<div className="flex items-center justify-between gap-3">
+							<span className="text-[11px] uppercase tracking-wider text-muted-foreground/70">
+								Running
+							</span>
+							<code className="select-text cursor-text font-mono text-[12px] tabular-nums text-foreground">
+								{hostVersion}
+							</code>
+						</div>
+						<div className="mt-1 flex items-center justify-between gap-3">
+							<span className="text-[11px] uppercase tracking-wider text-muted-foreground/70">
+								Required
+							</span>
+							<code className="select-text cursor-text font-mono text-[12px] tabular-nums text-muted-foreground">
+								≥ {minVersion}
+							</code>
+						</div>
 					</div>
 				</div>
+
 				<Button
 					asChild
 					size="sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceHostIncompatibleState } from "./WorkspaceHostIncompatibleState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/WorkspaceHostOfflineState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/WorkspaceHostOfflineState.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@superset/ui/button";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, MonitorOff } from "lucide-react";
+
+interface WorkspaceHostOfflineStateProps {
+	hostName: string;
+}
+
+export function WorkspaceHostOfflineState({
+	hostName,
+}: WorkspaceHostOfflineStateProps) {
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div className="flex w-full max-w-sm flex-col items-start gap-5">
+				<MonitorOff
+					className="size-5 text-muted-foreground"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Host is offline
+					</h1>
+					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
+						This workspace lives on{" "}
+						<span className="font-medium text-foreground">{hostName}</span>,
+						which isn't reachable right now. Reconnect that device's Superset
+						app and the workspace will come back online.
+					</p>
+				</div>
+				<Button
+					asChild
+					size="sm"
+					variant="ghost"
+					className="-ml-2 h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
+				>
+					<Link to="/v2-workspaces">
+						Browse workspaces
+						<ArrowRight
+							className="size-3.5"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+					</Link>
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/WorkspaceHostOfflineState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/WorkspaceHostOfflineState.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@superset/ui/button";
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, MonitorOff } from "lucide-react";
+import { ArrowRight, Monitor } from "lucide-react";
 
 interface WorkspaceHostOfflineStateProps {
 	hostName: string;
@@ -11,23 +11,47 @@ export function WorkspaceHostOfflineState({
 }: WorkspaceHostOfflineStateProps) {
 	return (
 		<div className="flex h-full w-full items-center justify-center p-6">
-			<div className="flex w-full max-w-sm flex-col items-start gap-5">
-				<MonitorOff
-					className="size-5 text-muted-foreground"
-					strokeWidth={1.5}
-					aria-hidden="true"
-				/>
+			<div className="flex w-full max-w-sm flex-col items-start gap-6">
+				<div className="relative">
+					<div className="grid size-10 place-items-center rounded-lg border border-border/60 bg-muted/30">
+						<Monitor
+							className="size-[18px] text-muted-foreground"
+							strokeWidth={1.5}
+							aria-hidden="true"
+						/>
+					</div>
+					<span
+						aria-hidden="true"
+						className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full bg-muted-foreground/50 ring-2 ring-background"
+					/>
+				</div>
+
 				<div className="flex flex-col gap-1.5">
 					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
 						Host is offline
 					</h1>
 					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
-						This workspace lives on{" "}
-						<span className="font-medium text-foreground">{hostName}</span>,
-						which isn't reachable right now. Reconnect that device's Superset
-						app and the workspace will come back online.
+						This workspace lives on a device that isn't reachable right now.
+						Open Superset on that device to bring the workspace back online.
 					</p>
 				</div>
+
+				<div className="flex w-full items-center gap-2.5 rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+					<span
+						aria-hidden="true"
+						className="size-1.5 shrink-0 rounded-full bg-muted-foreground/50"
+					/>
+					<span
+						className="select-text cursor-text min-w-0 truncate text-[13px] font-medium text-foreground"
+						title={hostName}
+					>
+						{hostName}
+					</span>
+					<span className="ml-auto shrink-0 text-[11px] uppercase tracking-wider text-muted-foreground/70">
+						Offline
+					</span>
+				</div>
+
 				<Button
 					asChild
 					size="sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceHostOfflineState } from "./WorkspaceHostOfflineState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/index.ts
@@ -1,0 +1,4 @@
+export {
+	type RemoteHostStatus,
+	useRemoteHostStatus,
+} from "./useRemoteHostStatus";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -88,14 +88,7 @@ export function useRemoteHostStatus(
 	}
 
 	const hostVersion = infoQuery.data.version;
-	// `includePrerelease` keeps dev/staging builds (e.g. 0.9.0-dev.1) from
-	// being rejected by `>=0.8.0` — by default, semver excludes prereleases
-	// from range comparisons unless the range itself names one.
-	if (
-		!semver.satisfies(hostVersion, `>=${MIN_HOST_SERVICE_VERSION}`, {
-			includePrerelease: true,
-		})
-	) {
+	if (!semver.satisfies(hostVersion, `>=${MIN_HOST_SERVICE_VERSION}`)) {
 		return {
 			status: "incompatible",
 			hostName: hostRow.name,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -69,7 +69,10 @@ export function useRemoteHostStatus(
 	if (!workspace) return { status: "loading" };
 	if (isLocal) return { status: "skip" };
 	if (!isReady) return { status: "loading" };
-	if (!hostRow) return { status: "loading" };
+	// No matching v2Hosts row once the collection is ready — host was
+	// deregistered while the workspace record stuck around. Surface the
+	// offline screen so users have a recovery path instead of a blank div.
+	if (!hostRow) return { status: "offline", hostName: "Unknown host" };
 
 	if (!hostRow.isOnline) {
 		return { status: "offline", hostName: hostRow.name };
@@ -85,7 +88,14 @@ export function useRemoteHostStatus(
 	}
 
 	const hostVersion = infoQuery.data.version;
-	if (!semver.satisfies(hostVersion, `>=${MIN_HOST_SERVICE_VERSION}`)) {
+	// `includePrerelease` keeps dev/staging builds (e.g. 0.9.0-dev.1) from
+	// being rejected by `>=0.8.0` — by default, semver excludes prereleases
+	// from range comparisons unless the range itself names one.
+	if (
+		!semver.satisfies(hostVersion, `>=${MIN_HOST_SERVICE_VERSION}`, {
+			includePrerelease: true,
+		})
+	) {
 		return {
 			status: "incompatible",
 			hostName: hostRow.name,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -1,0 +1,98 @@
+import type { SelectV2Workspace } from "@superset/db/schema";
+import { buildHostRoutingKey } from "@superset/shared/host-routing";
+import { MIN_HOST_SERVICE_VERSION } from "@superset/shared/host-version";
+import { and, eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useQuery } from "@tanstack/react-query";
+import { env } from "renderer/env.renderer";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import semver from "semver";
+
+export type RemoteHostStatus =
+	| { status: "skip" }
+	| { status: "loading" }
+	| { status: "offline"; hostName: string }
+	| {
+			status: "incompatible";
+			hostName: string;
+			hostVersion: string;
+			minVersion: string;
+	  }
+	| { status: "ready" };
+
+const HOST_INFO_STALE_MS = 30_000;
+
+export function useRemoteHostStatus(
+	workspace: SelectV2Workspace | null,
+): RemoteHostStatus {
+	const collections = useCollections();
+	const { machineId } = useLocalHostService();
+	const organizationId = workspace?.organizationId ?? "";
+	const hostId = workspace?.hostId ?? "";
+	const isLocal =
+		workspace != null && machineId != null && workspace.hostId === machineId;
+	const filterMachineId = !workspace || isLocal ? "" : hostId;
+
+	const { data: hostRows = [], isReady } = useLiveQuery(
+		(q) =>
+			q
+				.from({ hosts: collections.v2Hosts })
+				.where(({ hosts }) =>
+					and(
+						eq(hosts.organizationId, organizationId),
+						eq(hosts.machineId, filterMachineId),
+					),
+				)
+				.select(({ hosts }) => ({
+					name: hosts.name,
+					isOnline: hosts.isOnline,
+				})),
+		[collections, organizationId, filterMachineId],
+	);
+	const hostRow = hostRows[0] ?? null;
+
+	const hostUrl = `${env.RELAY_URL}/hosts/${buildHostRoutingKey(
+		organizationId,
+		hostId,
+	)}`;
+
+	const infoQuery = useQuery({
+		queryKey: ["remoteHostInfo", organizationId, hostId],
+		queryFn: () => getHostServiceClientByUrl(hostUrl).host.info.query(),
+		enabled: workspace != null && !isLocal && hostRow?.isOnline === true,
+		staleTime: HOST_INFO_STALE_MS,
+		retry: false,
+	});
+
+	if (!workspace) return { status: "loading" };
+	if (isLocal) return { status: "skip" };
+	if (!isReady) return { status: "loading" };
+	if (!hostRow) return { status: "loading" };
+
+	if (!hostRow.isOnline) {
+		return { status: "offline", hostName: hostRow.name };
+	}
+
+	if (infoQuery.isPending) return { status: "loading" };
+
+	if (infoQuery.isError) {
+		// Cloud reports the host online but the relay round-trip failed —
+		// treat as offline; the most common cause is a stale `isOnline`
+		// flag after the host crashed without a clean disconnect.
+		return { status: "offline", hostName: hostRow.name };
+	}
+
+	const hostVersion = infoQuery.data.version;
+	if (!semver.satisfies(hostVersion, `>=${MIN_HOST_SERVICE_VERSION}`)) {
+		return {
+			status: "incompatible",
+			hostName: hostRow.name,
+			hostVersion,
+			minVersion: MIN_HOST_SERVICE_VERSION,
+		};
+	}
+
+	return { status: "ready" };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -7,7 +7,10 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import { useWorkspaceCreatesStore } from "renderer/stores/workspace-creates";
 import { WorkspaceCreateErrorState } from "./components/WorkspaceCreateErrorState";
 import { WorkspaceCreatingState } from "./components/WorkspaceCreatingState";
+import { WorkspaceHostIncompatibleState } from "./components/WorkspaceHostIncompatibleState";
+import { WorkspaceHostOfflineState } from "./components/WorkspaceHostOfflineState";
 import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
+import { useRemoteHostStatus } from "./hooks/useRemoteHostStatus";
 import { WorkspaceProvider } from "./providers/WorkspaceProvider";
 
 export const Route = createFileRoute("/_authenticated/_dashboard/v2-workspace")(
@@ -48,6 +51,8 @@ function V2WorkspaceLayout() {
 		ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
 	}, [ensureWorkspaceInSidebar, workspace]);
 
+	const hostStatus = useRemoteHostStatus(workspace);
+
 	if (!workspaceId || !isReady || !workspaces) {
 		return <div className="flex h-full w-full" />;
 	}
@@ -73,6 +78,22 @@ function V2WorkspaceLayout() {
 			);
 		}
 		return <WorkspaceNotFoundState workspaceId={workspaceId} />;
+	}
+
+	if (hostStatus.status === "offline") {
+		return <WorkspaceHostOfflineState hostName={hostStatus.hostName} />;
+	}
+	if (hostStatus.status === "incompatible") {
+		return (
+			<WorkspaceHostIncompatibleState
+				hostName={hostStatus.hostName}
+				hostVersion={hostStatus.hostVersion}
+				minVersion={hostStatus.minVersion}
+			/>
+		);
+	}
+	if (hostStatus.status === "loading") {
+		return <div className="flex h-full w-full" />;
 	}
 
 	return (

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -96,6 +96,10 @@
 			"types": "./src/host-routing.ts",
 			"default": "./src/host-routing.ts"
 		},
+		"./host-version": {
+			"types": "./src/host-version.ts",
+			"default": "./src/host-version.ts"
+		},
 		"./github-remote": {
 			"types": "./src/github-remote.ts",
 			"default": "./src/github-remote.ts"

--- a/packages/shared/src/host-version.ts
+++ b/packages/shared/src/host-version.ts
@@ -1,0 +1,29 @@
+/**
+ * Minimum host-service version this app can work with. Bumping this forces
+ * the desktop coordinator to kill + respawn any adopted local service older
+ * than this, and gates v2 workspace UIs from mounting against a remote host
+ * whose CLI is still on an older version.
+ *
+ * 0.4.0: terminal launch moved from `terminal.ensureSession` to
+ * `terminal.launchSession` plus WebSocket attach params.
+ * 0.3.0: host-service registers via cloud `host.ensure` (was
+ * `device.ensureV2Host`); v2_hosts/v2_users_hosts/v2_workspaces use
+ * machineId text instead of uuid surrogates.
+ * 0.2.0: `workspaceCreation.adopt` gained optional `worktreePath`.
+ *
+ * 0.5.0 — pty-daemon supervision migrated into host-service. New
+ * `terminal.daemon` tRPC namespace; older 0.4.x host-services don't
+ * expose it. Adopting one in place would leave the new desktop
+ * talking to old code: Settings → Manage daemon would silently
+ * fail, and the v2 PTY survival promise is broken.
+ *
+ * 0.7.0 — canonical `workspaces.create` flow + `settings.hostAgentConfigs`
+ * router (PR1, #3893). Older 0.6.x host-services don't expose either,
+ * so adopting one in place would break new-project creation and the
+ * agent-config settings UI.
+ *
+ * 0.8.0 — v2 terminal creation moved to `terminal.createSession`; the
+ * WebSocket route is attach-only by `terminalId`. Older host-services would
+ * reject the renderer's creation call and still expect socket-side startup.
+ */
+export const MIN_HOST_SERVICE_VERSION = "0.8.0";


### PR DESCRIPTION
## Summary
- Opening a v2 workspace on an unreachable remote host previously rendered the workspace UI normally — queries would 503 silently and buttons did nothing. Gate `WorkspaceProvider` on a new `useRemoteHostStatus` hook that reads `v2Hosts.isOnline` from the live collection for the offline case and fires `host.info` via the workspace tRPC URL for the version-mismatch case.
- New `WorkspaceHostOfflineState` and `WorkspaceHostIncompatibleState` screens sit alongside the existing `WorkspaceCreatingState` / `WorkspaceCreateErrorState` / `WorkspaceNotFoundState` siblings; the layout switches on the hook's status before mounting the workspace.
- Moved `MIN_HOST_SERVICE_VERSION` out of `host-service-coordinator.ts` into a new `@superset/shared/host-version` module so the renderer enforces the same floor the desktop main process already uses.

## Test plan
- [ ] Open a v2 workspace whose remote host's CLI is stopped → offline screen with the host's name
- [ ] Open a v2 workspace whose remote host is on a CLI older than `MIN_HOST_SERVICE_VERSION` → incompatible screen with current vs required versions
- [ ] Open a v2 workspace on a healthy remote host → normal workspace UI, no flicker on subsequent navigations (host.info is cached)
- [ ] Open a v2 workspace on the local device (`hostId === machineId`) → bypasses the gate (existing `LocalHostServiceProvider` lifecycle still owns it)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show offline and version-mismatch screens when opening a v2 workspace on an unreachable or outdated remote host, and block mounting until the host is ready. Also centralizes the version floor in `@superset/shared/host-version` so main and renderer enforce the same check.

- **New Features**
  - Gate `WorkspaceProvider` with `useRemoteHostStatus` that checks `v2Hosts.isOnline` and `host.info` (skips local hosts; caches `host.info` for 30s).
  - Show `WorkspaceHostOfflineState` or `WorkspaceHostIncompatibleState` before mounting.

- **Bug Fixes**
  - If `v2Hosts` has no row for the workspace host, show the offline state instead of a blank screen.
  - Align version comparison with main: use standard semver (no prerelease allowance) against `MIN_HOST_SERVICE_VERSION`.

<sup>Written for commit f5ffad96c7115b6d073fbda9971f580dd7c1da7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote host status monitoring now shows clear states: loading, offline, incompatible, and ready.
  * New workspace UI states: “Host is offline” and “Host needs an update,” showing host name and version details.
  * Quick navigation to browse workspaces when a host is offline or incompatible.
  * Minimum required host service version bumped to 0.8.0 to ensure compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->