### PR TITLE
fix(desktop): forward Ctrl+V on non-text clipboard paste (#4029)

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import {
+	handleImagePasteFallback,
+	isNonTextPaste,
+} from "./terminal-image-paste-fallback";
+
+interface FakeClipboardData {
+	types: readonly string[];
+	getData: (type: string) => string;
+	files?: { length: number };
+}
+
+function clipboardEvent(data: FakeClipboardData) {
+	const flags = { defaultPrevented: false, immediateStopped: false };
+	const event = {
+		type: "paste",
+		clipboardData: { files: { length: 0 }, ...data },
+		preventDefault() {
+			flags.defaultPrevented = true;
+		},
+		stopImmediatePropagation() {
+			flags.immediateStopped = true;
+		},
+	} as unknown as ClipboardEvent;
+	return { event, flags };
+}
+
+function makeFakeTerminal() {
+	const input = mock(() => {});
+	return { terminal: { input } as unknown as XTerm, input };
+}
+
+describe("isNonTextPaste", () => {
+	it("returns true for clipboard with files only", () => {
+		const { event } = clipboardEvent({
+			types: ["Files"],
+			getData: () => "",
+		});
+		expect(isNonTextPaste(event)).toBe(true);
+	});
+
+	it("returns true for image MIME types only", () => {
+		const { event } = clipboardEvent({
+			types: ["image/png"],
+			getData: () => "",
+		});
+		expect(isNonTextPaste(event)).toBe(true);
+	});
+
+	it("returns false when text/plain has content", () => {
+		const { event } = clipboardEvent({
+			types: ["text/plain"],
+			getData: (t) => (t === "text/plain" ? "hello" : ""),
+		});
+		expect(isNonTextPaste(event)).toBe(false);
+	});
+
+	it("returns false when text/plain has content alongside image", () => {
+		const { event } = clipboardEvent({
+			types: ["text/plain", "image/png"],
+			getData: (t) => (t === "text/plain" ? "url" : ""),
+		});
+		expect(isNonTextPaste(event)).toBe(false);
+	});
+
+	it("returns false when types is empty", () => {
+		const { event } = clipboardEvent({ types: [], getData: () => "" });
+		expect(isNonTextPaste(event)).toBe(false);
+	});
+
+	it("returns true when files is populated but types is empty (browser quirk)", () => {
+		const { event } = clipboardEvent({
+			types: [],
+			getData: () => "",
+			files: { length: 1 },
+		});
+		expect(isNonTextPaste(event)).toBe(true);
+	});
+
+	it.each([
+		["Files"],
+		["image/png"],
+		["image/jpeg"],
+		["image/gif"],
+		["image/webp"],
+		["image/svg+xml"],
+		["application/x-moz-file"],
+		["text/uri-list"],
+		["DownloadURL"],
+		["text/html"],
+	])("returns true for non-text type %j with no text/plain", (type) => {
+		const { event } = clipboardEvent({ types: [type], getData: () => "" });
+		expect(isNonTextPaste(event)).toBe(true);
+	});
+
+	it("returns false when only text/plain is present but empty", () => {
+		// Nothing to attach — let xterm emit its empty bracketed paste rather
+		// than firing a misleading ^V.
+		const { event } = clipboardEvent({
+			types: ["text/plain"],
+			getData: () => "",
+		});
+		expect(isNonTextPaste(event)).toBe(false);
+	});
+});
+
+describe("handleImagePasteFallback", () => {
+	it("forwards Ctrl+V (\\x16) when clipboard has files but no text", () => {
+		const { event, flags } = clipboardEvent({
+			types: ["Files"],
+			getData: () => "",
+		});
+		const { terminal, input } = makeFakeTerminal();
+
+		handleImagePasteFallback(event, terminal);
+
+		expect(input).toHaveBeenCalledTimes(1);
+		expect(input).toHaveBeenCalledWith("\x16", true);
+		expect(flags.defaultPrevented).toBe(true);
+		expect(flags.immediateStopped).toBe(true);
+	});
+
+	it("does not call terminal.input for text paste — xterm's built-in handles it", () => {
+		const { event, flags } = clipboardEvent({
+			types: ["text/plain"],
+			getData: (t) => (t === "text/plain" ? "hello" : ""),
+		});
+		const { terminal, input } = makeFakeTerminal();
+
+		handleImagePasteFallback(event, terminal);
+
+		expect(input).not.toHaveBeenCalled();
+		expect(flags.defaultPrevented).toBe(false);
+		expect(flags.immediateStopped).toBe(false);
+	});
+
+	it("does not call terminal.input for mixed text+image paste", () => {
+		// Mixed payloads (e.g. image with alt text, labeled file URL) prefer
+		// the text path so users can still paste URLs into the shell.
+		const { event } = clipboardEvent({
+			types: ["text/plain", "image/png"],
+			getData: (t) => (t === "text/plain" ? "url-as-text" : ""),
+		});
+		const { terminal, input } = makeFakeTerminal();
+
+		handleImagePasteFallback(event, terminal);
+
+		expect(input).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import {
 	handleImagePasteFallback,
+	installImagePasteFallback,
 	isNonTextPaste,
 } from "./terminal-image-paste-fallback";
 
@@ -145,6 +146,95 @@ describe("handleImagePasteFallback", () => {
 		const { terminal, input } = makeFakeTerminal();
 
 		handleImagePasteFallback(event, terminal);
+
+		expect(input).not.toHaveBeenCalled();
+	});
+});
+
+describe("installImagePasteFallback", () => {
+	function makeFakeWrapper() {
+		const handlers: Array<{
+			type: string;
+			handler: EventListener;
+			options: AddEventListenerOptions | boolean | undefined;
+		}> = [];
+		const wrapper = {
+			addEventListener: mock(
+				(
+					type: string,
+					handler: EventListener,
+					options?: AddEventListenerOptions | boolean,
+				) => {
+					handlers.push({ type, handler, options });
+				},
+			),
+			removeEventListener: mock(
+				(
+					type: string,
+					handler: EventListener,
+					options?: AddEventListenerOptions | boolean,
+				) => {
+					const idx = handlers.findIndex(
+						(h) =>
+							h.type === type &&
+							h.handler === handler &&
+							JSON.stringify(h.options) === JSON.stringify(options),
+					);
+					if (idx >= 0) handlers.splice(idx, 1);
+				},
+			),
+		};
+		return { wrapper: wrapper as unknown as HTMLElement, handlers };
+	}
+
+	it("registers a capture-phase paste listener on the wrapper", () => {
+		const { wrapper, handlers } = makeFakeWrapper();
+		const { terminal } = makeFakeTerminal();
+
+		installImagePasteFallback(terminal, wrapper);
+
+		expect(handlers).toHaveLength(1);
+		expect(handlers[0]?.type).toBe("paste");
+		expect(handlers[0]?.options).toEqual({ capture: true });
+	});
+
+	it("dispose removes the listener with matching capture option", () => {
+		// Regression guard: removeEventListener silently no-ops if `capture`
+		// doesn't match the registration. A leaked listener would survive
+		// terminal disposal and fire on a stale runtime.
+		const { wrapper, handlers } = makeFakeWrapper();
+		const { terminal } = makeFakeTerminal();
+
+		const dispose = installImagePasteFallback(terminal, wrapper);
+		expect(handlers).toHaveLength(1);
+		dispose();
+		expect(handlers).toHaveLength(0);
+	});
+
+	it("registered handler forwards Ctrl+V on non-text paste", () => {
+		const { wrapper, handlers } = makeFakeWrapper();
+		const { terminal, input } = makeFakeTerminal();
+		installImagePasteFallback(terminal, wrapper);
+
+		const { event } = clipboardEvent({
+			types: ["Files"],
+			getData: () => "",
+		});
+		handlers[0]?.handler(event);
+
+		expect(input).toHaveBeenCalledWith("\x16", true);
+	});
+
+	it("registered handler ignores text paste", () => {
+		const { wrapper, handlers } = makeFakeWrapper();
+		const { terminal, input } = makeFakeTerminal();
+		installImagePasteFallback(terminal, wrapper);
+
+		const { event } = clipboardEvent({
+			types: ["text/plain"],
+			getData: (t) => (t === "text/plain" ? "hello" : ""),
+		});
+		handlers[0]?.handler(event);
 
 		expect(input).not.toHaveBeenCalled();
 	});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
@@ -131,7 +131,7 @@ describe("handleImagePasteFallback", () => {
 	});
 
 	it("does not call terminal.input for mixed text+image paste", () => {
-		const { event } = clipboardEvent({
+		const { event, flags } = clipboardEvent({
 			types: ["text/plain", "image/png"],
 			getData: (t) => (t === "text/plain" ? "url-as-text" : ""),
 			files: { length: 1 },
@@ -141,6 +141,8 @@ describe("handleImagePasteFallback", () => {
 		handleImagePasteFallback(event, terminal);
 
 		expect(input).not.toHaveBeenCalled();
+		expect(flags.defaultPrevented).toBe(false);
+		expect(flags.immediateStopped).toBe(false);
 	});
 });
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts
@@ -33,18 +33,14 @@ function makeFakeTerminal() {
 }
 
 describe("isNonTextPaste", () => {
-	it("returns true for clipboard with files only", () => {
+	it("returns true when files are present (screenshot, copied file, web image)", () => {
+		// Chromium synthesizes a File entry for any image/file clipboard payload,
+		// so files.length is the universal signal across all source types
+		// (Cmd+Shift+Ctrl+4, Finder copy, right-click Copy Image, drag-drop).
 		const { event } = clipboardEvent({
 			types: ["Files"],
 			getData: () => "",
-		});
-		expect(isNonTextPaste(event)).toBe(true);
-	});
-
-	it("returns true for image MIME types only", () => {
-		const { event } = clipboardEvent({
-			types: ["image/png"],
-			getData: () => "",
+			files: { length: 1 },
 		});
 		expect(isNonTextPaste(event)).toBe(true);
 	});
@@ -58,50 +54,47 @@ describe("isNonTextPaste", () => {
 	});
 
 	it("returns false when text/plain has content alongside image", () => {
+		// Mixed payloads (e.g. image with alt text, labeled file URL) prefer
+		// the text path so users can still paste URLs into the shell.
 		const { event } = clipboardEvent({
 			types: ["text/plain", "image/png"],
 			getData: (t) => (t === "text/plain" ? "url" : ""),
-		});
-		expect(isNonTextPaste(event)).toBe(false);
-	});
-
-	it("returns false when types is empty", () => {
-		const { event } = clipboardEvent({ types: [], getData: () => "" });
-		expect(isNonTextPaste(event)).toBe(false);
-	});
-
-	it("returns true when files is populated but types is empty (browser quirk)", () => {
-		const { event } = clipboardEvent({
-			types: [],
-			getData: () => "",
 			files: { length: 1 },
 		});
-		expect(isNonTextPaste(event)).toBe(true);
-	});
-
-	it.each([
-		["Files"],
-		["image/png"],
-		["image/jpeg"],
-		["image/gif"],
-		["image/webp"],
-		["image/svg+xml"],
-		["application/x-moz-file"],
-		["text/uri-list"],
-		["DownloadURL"],
-		["text/html"],
-	])("returns true for non-text type %j with no text/plain", (type) => {
-		const { event } = clipboardEvent({ types: [type], getData: () => "" });
-		expect(isNonTextPaste(event)).toBe(true);
+		expect(isNonTextPaste(event)).toBe(false);
 	});
 
 	it("returns false when only text/plain is present but empty", () => {
-		// Nothing to attach — let xterm emit its empty bracketed paste rather
-		// than firing a misleading ^V.
 		const { event } = clipboardEvent({
 			types: ["text/plain"],
 			getData: () => "",
 		});
+		expect(isNonTextPaste(event)).toBe(false);
+	});
+
+	it("returns false for text/html-only rich text (no file payload)", () => {
+		// Rare edge case: some rich-text editors put only text/html on the
+		// clipboard. The TUI's clipboard reader will find no image, so firing
+		// ^V would surface a "Failed to paste image" error in Codex.
+		const { event } = clipboardEvent({
+			types: ["text/html"],
+			getData: () => "",
+		});
+		expect(isNonTextPaste(event)).toBe(false);
+	});
+
+	it("returns false when types lists image but no File entry exists", () => {
+		// Synthetic case (e.g. setData("image/png", "...")) — no real file
+		// to attach, the TUI's OS-clipboard read will fail.
+		const { event } = clipboardEvent({
+			types: ["image/png"],
+			getData: () => "",
+		});
+		expect(isNonTextPaste(event)).toBe(false);
+	});
+
+	it("returns false when clipboard is empty", () => {
+		const { event } = clipboardEvent({ types: [], getData: () => "" });
 		expect(isNonTextPaste(event)).toBe(false);
 	});
 });
@@ -111,6 +104,7 @@ describe("handleImagePasteFallback", () => {
 		const { event, flags } = clipboardEvent({
 			types: ["Files"],
 			getData: () => "",
+			files: { length: 1 },
 		});
 		const { terminal, input } = makeFakeTerminal();
 
@@ -137,11 +131,10 @@ describe("handleImagePasteFallback", () => {
 	});
 
 	it("does not call terminal.input for mixed text+image paste", () => {
-		// Mixed payloads (e.g. image with alt text, labeled file URL) prefer
-		// the text path so users can still paste URLs into the shell.
 		const { event } = clipboardEvent({
 			types: ["text/plain", "image/png"],
 			getData: (t) => (t === "text/plain" ? "url-as-text" : ""),
+			files: { length: 1 },
 		});
 		const { terminal, input } = makeFakeTerminal();
 
@@ -211,7 +204,7 @@ describe("installImagePasteFallback", () => {
 		expect(handlers).toHaveLength(0);
 	});
 
-	it("registered handler forwards Ctrl+V on non-text paste", () => {
+	it("registered handler forwards Ctrl+V on file paste", () => {
 		const { wrapper, handlers } = makeFakeWrapper();
 		const { terminal, input } = makeFakeTerminal();
 		installImagePasteFallback(terminal, wrapper);
@@ -219,6 +212,7 @@ describe("installImagePasteFallback", () => {
 		const { event } = clipboardEvent({
 			types: ["Files"],
 			getData: () => "",
+			files: { length: 1 },
 		});
 		handlers[0]?.handler(event);
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.ts
@@ -1,14 +1,20 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 
-// For non-text clipboard payloads (image / file / screenshot), xterm.js's
-// built-in paste handler reads an empty string from
+// For file/image clipboard payloads (screenshot, copied file, web image),
+// xterm.js's built-in paste handler reads an empty string from
 // `clipboardData.getData("text/plain")` and still emits empty bracketed-paste
 // markers (`\x1b[200~\x1b[201~`). TUIs that key off `^V` to attach the image
-// (Codex, Claude Code) never see the signal.
+// (Codex, Claude Code, opencode) never see the signal.
 //
 // Forward `\x16` (Ctrl+V) instead, mirroring iTerm's "Paste or send ^V".
 // Restores the fallback that was removed alongside the rest of
 // `setupPasteHandler` in #3582.
+//
+// Trigger only on `data.files.length > 0` (W3C `DataTransfer.files`):
+// Chromium synthesizes a File entry for any image/file clipboard payload, so
+// this matches Codex's `arboard.file_list()` primary path. A broader
+// "any non-text/plain MIME" heuristic over-fires on `text/html`-only
+// clipboards and triggers a "Failed to paste image" error toast in Codex.
 //
 // Capture phase on the wrapper runs before xterm's textarea/element paste
 // listeners, so `stopImmediatePropagation` cleanly preempts the bracketed-paste
@@ -17,18 +23,8 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 export function isNonTextPaste(event: ClipboardEvent): boolean {
 	const data = event.clipboardData;
 	if (!data) return false;
-	const text = data.getData("text/plain");
-	if (text) return false;
-	// Some browsers leave `types` empty for direct file payloads — check
-	// `files` independently so we don't miss them.
-	if ((data.files?.length ?? 0) > 0) return true;
-	const types = Array.from(data.types);
-	// Trade-off: any non-text/plain type (including a rare `text/html`-only
-	// clipboard from some rich-text editors) triggers `^V`. Matches the
-	// pre-#3582 behavior. In a plain shell readline interprets `^V` as
-	// "verbatim-next" and stalls one keystroke; we accept that to avoid
-	// false negatives on image/file payloads where `types` is non-standard.
-	return types.length > 0 && types.some((t) => t !== "text/plain");
+	if (data.getData("text/plain")) return false;
+	return (data.files?.length ?? 0) > 0;
 }
 
 export function handleImagePasteFallback(

--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.ts
@@ -23,6 +23,11 @@ export function isNonTextPaste(event: ClipboardEvent): boolean {
 	// `files` independently so we don't miss them.
 	if ((data.files?.length ?? 0) > 0) return true;
 	const types = Array.from(data.types);
+	// Trade-off: any non-text/plain type (including a rare `text/html`-only
+	// clipboard from some rich-text editors) triggers `^V`. Matches the
+	// pre-#3582 behavior. In a plain shell readline interprets `^V` as
+	// "verbatim-next" and stalls one keystroke; we accept that to avoid
+	// false negatives on image/file payloads where `types` is non-standard.
 	return types.length > 0 && types.some((t) => t !== "text/plain");
 }
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-image-paste-fallback.ts
@@ -1,0 +1,51 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+// For non-text clipboard payloads (image / file / screenshot), xterm.js's
+// built-in paste handler reads an empty string from
+// `clipboardData.getData("text/plain")` and still emits empty bracketed-paste
+// markers (`\x1b[200~\x1b[201~`). TUIs that key off `^V` to attach the image
+// (Codex, Claude Code) never see the signal.
+//
+// Forward `\x16` (Ctrl+V) instead, mirroring iTerm's "Paste or send ^V".
+// Restores the fallback that was removed alongside the rest of
+// `setupPasteHandler` in #3582.
+//
+// Capture phase on the wrapper runs before xterm's textarea/element paste
+// listeners, so `stopImmediatePropagation` cleanly preempts the bracketed-paste
+// wrap.
+
+export function isNonTextPaste(event: ClipboardEvent): boolean {
+	const data = event.clipboardData;
+	if (!data) return false;
+	const text = data.getData("text/plain");
+	if (text) return false;
+	// Some browsers leave `types` empty for direct file payloads — check
+	// `files` independently so we don't miss them.
+	if ((data.files?.length ?? 0) > 0) return true;
+	const types = Array.from(data.types);
+	return types.length > 0 && types.some((t) => t !== "text/plain");
+}
+
+export function handleImagePasteFallback(
+	event: ClipboardEvent,
+	terminal: XTerm,
+): void {
+	if (!isNonTextPaste(event)) return;
+	event.preventDefault();
+	event.stopImmediatePropagation();
+	terminal.input("\x16", true);
+}
+
+export function installImagePasteFallback(
+	terminal: XTerm,
+	wrapper: HTMLElement,
+): () => void {
+	const handler = (event: ClipboardEvent) => {
+		handleImagePasteFallback(event, terminal);
+	};
+
+	wrapper.addEventListener("paste", handler, { capture: true });
+	return () => {
+		wrapper.removeEventListener("paste", handler, { capture: true });
+	};
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -6,6 +6,7 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
 import { loadAddons } from "./terminal-addons";
+import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
 
@@ -30,6 +31,7 @@ export interface TerminalRuntime {
 	lastCols: number;
 	lastRows: number;
 	_disposeAddons: (() => void) | null;
+	_disposeImagePasteFallback: (() => void) | null;
 }
 
 function createTerminal(
@@ -216,6 +218,11 @@ export function createRuntime(
 		restoreBuffer(terminalId, terminal);
 	}
 
+	const disposeImagePasteFallback = installImagePasteFallback(
+		terminal,
+		wrapper,
+	);
+
 	return {
 		terminalId,
 		terminal,
@@ -230,6 +237,7 @@ export function createRuntime(
 		lastCols: cols,
 		lastRows: rows,
 		_disposeAddons: addonsResult.dispose,
+		_disposeImagePasteFallback: disposeImagePasteFallback,
 	};
 }
 
@@ -306,6 +314,8 @@ export function disposeRuntime(
 		persistBuffer(runtime.terminalId, runtime.serializeAddon);
 		persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	}
+	runtime._disposeImagePasteFallback?.();
+	runtime._disposeImagePasteFallback = null;
 	runtime._disposeAddons?.();
 	runtime._disposeAddons = null;
 	runtime._disposeResizeObserver?.();


### PR DESCRIPTION
**Links**
- Issue: #4029

## Summary
- Forward `\x16` (Ctrl+V) when the clipboard has an image / file / screenshot but no `text/plain`, so TUIs (Codex, Claude Code) receive their image-attach signal instead of empty bracketed-paste markers.

## Why / Context
xterm.js's built-in paste handler reads `clipboardData.getData("text/plain")`, gets `""` for image-only clipboards, and still wraps the empty string in `\x1b[200~\x1b[201~`. The TUI sees a bracketed paste with no payload and silently no-ops. This was previously handled by `setupPasteHandler` and got dropped along with the rest of that helper in #3582 (which removed it because of unrelated multi-line paste bugs).

Diagnosed by instrumenting the four paste checkpoints (window.keydown, paste-on-textarea/element/wrapper, xterm.onData) under issue-#4029 conditions. The trace showed image-paste in a TUI emitting `len: 12, preview: '\x1b[200~\x1b[201~'` (empty bracketed paste) instead of any useful signal.

## How It Works
- `terminal-image-paste-fallback.ts` adds a capture-phase `paste` listener on the runtime wrapper.
- `isNonTextPaste(event)` returns true when `text/plain` is empty AND either `clipboardData.files` is populated OR `types` contains a non-`text/plain` entry. The `files` probe is defensive against browsers that leave `types` empty for direct file payloads.
- On match, the handler `preventDefault` + `stopImmediatePropagation` to preempt xterm's listeners, then calls `terminal.input("\x16", true)` so the byte flows through the existing onData → WS path. Plain text and mixed text+image paste fall through to xterm's built-in (so URL paste keeps working).
- Wired into `terminal-runtime.ts::createRuntime` so v1 and v2 terminals both get it; cleanup runs from `disposeRuntime`.

Mirrors iTerm's "Paste or send ^V" convention. The same broad type check is what the original `setupPasteHandler` used (commit `580a4d7cd` "Codex image paste fallback"); this restores that proven behavior in the shared runtime.

## Manual QA Checklist

### Image paste (the bug)
- [ ] Screenshot via Cmd+Shift+Ctrl+4, paste into Codex / Claude Code TUI → image attaches
- [ ] Right-click "Copy Image" on a webpage, paste into TUI → image attaches
- [ ] Cmd+C a file in Finder, paste into TUI → file attaches

### Text paste (must not regress)
- [ ] Plain text paste into shell prompt still works
- [ ] Multi-line text paste still works (bracketed paste markers around real content)
- [ ] URL with rich-text source (HTML+plain) pastes as text, not as `^V`
- [ ] Right-click → Paste menu in v2 terminal still works

### TUI states
- [ ] Image paste works in `vim` / `htop` (alternate buffer)
- [ ] Image paste works in `opencode` (kitty keyboard active)

### Cross-terminal
- [ ] v1 terminal (main screen) and v2 terminal (workspace) both pick up the fallback

## Testing
- `bun run typecheck` ✓
- `bun run lint` ✓
- `bun test src/renderer/lib/terminal/terminal-image-paste-fallback.test.ts` ✓ (20 pass)
- Manual: image paste into Codex TUI confirmed via diagnostic trace — `xterm.onData` emits `len: 1, preview: '\x16'` instead of empty bracketed paste

## Design Decisions
- **Wrapper-level capture vs. patching xterm.textarea listener**: capture phase on the wrapper preempts xterm's textarea/element listeners with `stopImmediatePropagation`, avoiding races with xterm's bracketed-paste wrap and keeping the fix isolated to our code.
- **Broad `types !== "text/plain"` check**: matches the original `setupPasteHandler` behavior. Narrower allow-lists (image MIME types only) miss browser quirks and platform-specific types like `DownloadURL`. The `files.length` probe covers cases where `types` is empty.
- **Why not adopt VSCode's pattern (explicit Cmd+V hotkey)?** VSCode binds paste explicitly for product reasons (multi-line confirm dialog, clipboard-hijack stripping, telemetry events) — not because xterm's built-in is broken. Theia, WeTTY, ttyd, and the xterm.js demo all rely on the built-in. Our bug was a narrow regression in the non-text branch; targeted fix is preferable to rewriting the whole paste flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image/file paste in the desktop terminal by forwarding Ctrl+V when the clipboard has files and no `text/plain`, so TUIs can attach images instead of receiving empty bracketed-paste. Fixes #4029.

- **Bug Fixes**
  - Adds a capture-phase paste listener on the terminal wrapper to preempt `@xterm/xterm` and send `\x16` when `text/plain` is empty and `DataTransfer.files.length > 0`; mixed text+image falls through to normal paste, and `text/html`-only clipboards are ignored to avoid false positives.
  - Integrated into v1 and v2 terminal runtimes with proper disposal; adds tests for install/dispose and handler routing.

<sup>Written for commit 8189cd2ed8f027aa83a682d8cca9244087393562. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal paste handling: detects non-text/image file pastes, suppresses default browser paste, forwards a paste keystroke to the terminal when appropriate, and installs a capture-phase paste listener tied to terminal lifecycle (registered on mount, removed on dispose).

* **Tests**
  * Added tests covering non-text, text-only, mixed-content pastes, event suppression, keystroke forwarding, listener registration, and disposal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->