### PR TITLE
fix(desktop): use searchParams not string concat for terminal WS URL

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -80,7 +80,9 @@ export function TerminalPane({
 		activeThemeType: activeTheme?.type,
 	});
 	const baseWebsocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`);
-	const websocketUrl = `${baseWebsocketUrl}?themeType=${encodeURIComponent(themeType)}`;
+	const themedUrl = new URL(baseWebsocketUrl);
+	themedUrl.searchParams.set("themeType", themeType);
+	const websocketUrl = themedUrl.toString();
 	const websocketUrlRef = useRef(websocketUrl);
 	websocketUrlRef.current = websocketUrl;
 	const workspaceIdRef = useRef(workspaceId);


### PR DESCRIPTION
## Summary

#4149 appended `?themeType=...` to a URL that already had `?token=<jwt>`, producing `?token=jwt?themeType=light`. Two failures:

1. **Auth breaks for every terminal.** Server's `c.req.query(\"token\")` (`packages/host-service/src/app.ts:143`) reads everything after the first `?token=` up to the next `&` — so the parsed token is `eyJ...?themeType=light`, which fails `validateToken()`. Every WS upgrade gets 401. This is the \"every terminal unreachable\" symptom that surfaced on the desktop-v1.8.5 draft.
2. **The themeType forwarding doesn't work.** Server's `c.req.query(\"themeType\")` returns `null` because there's no real `&themeType=...` in the URL — it's part of the token value. So the host-side respawn fallback that #4149 was trying to make theme-aware silently uses defaults.

## Fix

Build the URL via `URL.searchParams` so the existing `token` param is preserved and `themeType` lands as a real query parameter:

```ts
const baseWebsocketUrl = useWorkspaceWsUrl(\`/terminal/\${terminalId}\`);
const themedUrl = new URL(baseWebsocketUrl);
themedUrl.searchParams.set(\"themeType\", themeType);
const websocketUrl = themedUrl.toString();
```

Preserves the PR's design intent (\`baseWebsocketUrl\` stays stable so theme toggles don't trigger reconnects via the effect deps; \`websocketUrl\` is read off the ref inside the effect).

## Test plan

- [x] Verified locally: terminals connect again
- [x] Confirmed via Node URL parser that the malformed string is parsed as `token=\"eyJ...?themeType=light\", themeType=null`
- [ ] Re-tag `desktop-v1.8.5` after merge, confirm the new draft build shows working terminals

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal WebSocket URL building in Desktop by using URL.searchParams instead of string concatenation. Preserves the existing `token` and correctly forwards `themeType`, restoring auth and theme-aware respawn.

- **Bug Fixes**
  - Build terminal WS URL via `URL.searchParams` to append `themeType` without corrupting `token`.
  - Terminals connect again (no 401). Server now receives a real `themeType` query param.

<sup>Written for commit 8b3502bff4ce94128d5d4ae4138bdad5e9bce898. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal WebSocket URL construction for terminal components to use standard URL handling methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->