### PR TITLE
perf(host-service): listBranches single git spawn instead of 4×N

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
@@ -17,7 +17,14 @@ export function useDiffStats(workspaceId: string): DiffStats | null {
 	const utils = workspaceTrpc.useUtils();
 	const { data: status } = workspaceTrpc.git.getStatus.useQuery(
 		{ workspaceId },
-		{ enabled: Boolean(workspaceId) },
+		{
+			enabled: Boolean(workspaceId),
+			// Match the pre-RQ behavior: only update on `git:changed`, never
+			// on focus. Multiple sidebar tiles each have their own query key,
+			// so focus refetch would re-fan out the very work this hook is
+			// supposed to consolidate.
+			refetchOnWindowFocus: false,
+		},
 	);
 
 	const invalidate = useCallback(() => {

--- a/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
-import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useCallback, useMemo } from "react";
 import { useWorkspaceEvent } from "../useWorkspaceEvent";
-import { useWorkspaceHostUrl } from "../useWorkspaceHostUrl";
 
 export interface DiffStats {
 	additions: number;
@@ -9,54 +8,39 @@ export interface DiffStats {
 }
 
 /**
- * Fetches diff stats for a single workspace, auto-updates on git changes.
- * Just pass the workspaceId — host resolution is handled internally.
+ * Diff stats for a single workspace, derived from the shared `git.getStatus`
+ * query cache. Subscribes to `git:changed` and invalidates the query — React
+ * Query collapses concurrent invalidations from sibling consumers (e.g.
+ * `useGitStatus`, multiple sidebar tiles) into a single refetch.
  */
 export function useDiffStats(workspaceId: string): DiffStats | null {
-	const [stats, setStats] = useState<DiffStats | null>(null);
-	const hostUrl = useWorkspaceHostUrl(workspaceId);
+	const utils = workspaceTrpc.useUtils();
+	const { data: status } = workspaceTrpc.git.getStatus.useQuery(
+		{ workspaceId },
+		{ enabled: Boolean(workspaceId) },
+	);
 
-	const fetchStats = useCallback(async () => {
-		if (!hostUrl) return;
-		try {
-			const client = getHostServiceClientByUrl(hostUrl);
-			const status = await client.git.getStatus.query({ workspaceId });
+	const invalidate = useCallback(() => {
+		void utils.git.getStatus.invalidate({ workspaceId });
+	}, [utils, workspaceId]);
 
-			// Deduplicate by path — a file can appear in multiple categories
-			const byPath = new Map<
-				string,
-				{ additions: number; deletions: number }
-			>();
-			for (const file of status.againstBase) {
-				byPath.set(file.path, file);
-			}
-			for (const file of status.staged) {
-				byPath.set(file.path, file);
-			}
-			for (const file of status.unstaged) {
-				byPath.set(file.path, file);
-			}
+	useWorkspaceEvent("git:changed", workspaceId, invalidate);
 
-			let additions = 0;
-			let deletions = 0;
-			for (const file of byPath.values()) {
-				additions += file.additions;
-				deletions += file.deletions;
-			}
+	return useMemo<DiffStats | null>(() => {
+		if (!status) return null;
 
-			setStats({ additions, deletions });
-		} catch {
-			// Host unavailable or workspace deleted
+		// Deduplicate by path — a file can appear in multiple categories.
+		const byPath = new Map<string, { additions: number; deletions: number }>();
+		for (const file of status.againstBase) byPath.set(file.path, file);
+		for (const file of status.staged) byPath.set(file.path, file);
+		for (const file of status.unstaged) byPath.set(file.path, file);
+
+		let additions = 0;
+		let deletions = 0;
+		for (const file of byPath.values()) {
+			additions += file.additions;
+			deletions += file.deletions;
 		}
-	}, [hostUrl, workspaceId]);
-
-	useEffect(() => {
-		void fetchStats();
-	}, [fetchStats]);
-
-	useWorkspaceEvent("git:changed", workspaceId, () => {
-		void fetchStats();
-	});
-
-	return stats;
+		return { additions, deletions };
+	}, [status]);
 }

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -65,26 +65,31 @@ export const gitRouter = router({
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const git = await ctx.git(worktreePath);
 
-			const currentBranchName = (
-				await git.revparse(["--abbrev-ref", "HEAD"]).catch(() => "")
-			).trim();
-			const base = await resolveBaseComparison(git);
-
-			let branchNames: string[] = [];
+			// `%(HEAD)` emits "*" for the checked-out branch, " " otherwise.
+			// Single spawn — independent of branch count. Only `name`/`isHead`
+			// are read by the v2 sidebar's BaseBranchSelector; the other
+			// per-branch fields the previous implementation computed (upstream,
+			// ahead/behind, last-commit) cost 4 spawns each and were unused.
+			let branches: { name: string; isHead: boolean }[] = [];
 			try {
 				const raw = await git.raw([
-					"branch",
-					"--list",
-					"--format=%(refname:short)",
+					"for-each-ref",
+					"refs/heads/",
+					"--format=%(HEAD)\t%(refname:short)",
 				]);
-				branchNames = raw.trim().split("\n").filter(Boolean);
+				branches = raw
+					.trim()
+					.split("\n")
+					.filter(Boolean)
+					.map((line) => {
+						const tab = line.indexOf("\t");
+						if (tab < 0) return { name: line, isHead: false };
+						return {
+							isHead: line.slice(0, tab) === "*",
+							name: line.slice(tab + 1),
+						};
+					});
 			} catch {}
-
-			const branches = await Promise.all(
-				branchNames.map((name) =>
-					buildBranch(git, name, name === currentBranchName, base?.baseRef),
-				),
-			);
 
 			return { branches };
 		}),


### PR DESCRIPTION
## Summary

- `listBranches` was running 4 sequential `git` child processes per local branch (`git config remote`, `git config merge`, `git rev-list --left-right`, `git log -1`) for an O(N) fanout, but the only renderer consumer (`BaseBranchSelector` in the v2 sidebar) reads `branch.name` plus a UI check on `isHead`. Replaced with a single `git for-each-ref refs/heads/ --format='%(HEAD)\t%(refname:short)'` call — **O(1) regardless of branch count**.
- `useDiffStats` was bypassing React Query (called `client.git.getStatus.query()` directly), so each sidebar workspace tile issued its own uncached `getStatus` per `git:changed` event with no possibility of cache sharing. Switched to `workspaceTrpc.git.getStatus.useQuery()` + invalidate-on-event so concurrent invalidations from sibling consumers collapse to one refetch. Same update semantics, shared cache.
- Adds an investigation plan documenting the diagnostic methodology (sample(1) on the wrong PID, realising PID 2182 was the host-service running via `ELECTRON_RUN_AS_NODE`, in-process spawn tracer, root-cause).

For a repo with ~1k local branches: previously ~3700 spawns per `listBranches` call, now 1. With the v2 sidebar polling every 30s and invalidating on git events, this was sustained near-100% CPU on the host-service event loop.

## Test plan

- [ ] Open a v2 workspace, expand the Changes tab — `BaseBranchSelector` lists all local branches
- [ ] Pick a different base branch from the picker — works as before, status updates
- [ ] Make a file edit in the worktree — diff-stats badge on the dashboard sidebar tile updates within ~300ms
- [ ] Multiple workspace tiles visible simultaneously — they all update on the same `git:changed` event without N independent refetches (verify with network tab or spawn-trace-style instrumentation)
- [ ] CPU stays low while sitting on a Changes tab with the worktree idle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts host-service CPU by collapsing `git.listBranches` to one spawn and moving diff stats to a shared React Query cache. Prevents multi-tile refetches on window focus and keeps the sidebar responsive.

- **Performance**
  - Host-service: `git.listBranches` now uses `git for-each-ref refs/heads/ --format='%(HEAD)\t%(refname:short)'` to return `{ name, isHead }` in one spawn.
  - Renderer: `useDiffStats` switches to `workspaceTrpc.git.getStatus.useQuery()` with invalidate on `git:changed`, so sibling consumers share one refetch.
  - Renderer: disables `refetchOnWindowFocus` to match previous behavior and avoid per-tile refetch storms.

<sup>Written for commit 7586b453b59d61254ac1d616e9e2ec3d8377dd9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More reliable and timely diff statistics display by centralizing status updates and automatic refresh.
  * Faster and simpler branch listing with streamlined retrieval, improving responsiveness when viewing branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->