### PR TITLE
feat(cli): add desktop + web deep links to workspaces create and agents run results

### DIFF
--- a/packages/cli/src/commands/agents/run/command.ts
+++ b/packages/cli/src/commands/agents/run/command.ts
@@ -1,5 +1,7 @@
 import { CLIError, string } from "@superset/cli-framework";
+import { chatSessionLink, terminalLink } from "@superset/shared/deep-links";
 import { command } from "../../../lib/command";
+import { env } from "../../../lib/env";
 import { resolveHostTarget } from "../../../lib/host-target";
 import { uploadAttachments } from "../../../lib/upload-attachments";
 
@@ -54,13 +56,19 @@ export default command({
 			attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
 		});
 
+		const linkOpts = { webBaseUrl: env.SUPERSET_WEB_URL };
+		const link =
+			result.kind === "chat"
+				? chatSessionLink(options.workspace, result.sessionId, linkOpts)
+				: terminalLink(options.workspace, result.sessionId, linkOpts);
+
 		const sessionDescriptor =
 			result.kind === "chat"
 				? `chat session ${result.sessionId}`
 				: `terminal ${result.sessionId}`;
 		return {
-			data: result,
-			message: `Launched ${result.label} (${sessionDescriptor}) in workspace ${options.workspace}`,
+			data: { ...result, link },
+			message: `Launched ${result.label} (${sessionDescriptor}) in workspace ${options.workspace}\n  Open: ${link.desktop}`,
 		};
 	},
 });

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -1,5 +1,11 @@
 import { boolean, CLIError, number, string } from "@superset/cli-framework";
+import {
+	chatSessionLink,
+	terminalLink,
+	workspaceLink,
+} from "@superset/shared/deep-links";
 import { command } from "../../../lib/command";
+import { env } from "../../../lib/env";
 import { requireHostTarget, resolveHostTarget } from "../../../lib/host-target";
 import { uploadAttachments } from "../../../lib/upload-attachments";
 
@@ -94,11 +100,34 @@ export default command({
 			agents,
 		});
 
+		const linkOpts = { webBaseUrl: env.SUPERSET_WEB_URL };
+		const wsId = result.workspace.id;
+
+		const links = {
+			workspace: workspaceLink(wsId, linkOpts),
+			terminals: result.terminals.map((t) => ({
+				terminalId: t.terminalId,
+				label: t.label,
+				link: terminalLink(wsId, t.terminalId, linkOpts),
+			})),
+			chat: result.agents
+				.filter(
+					(a): a is Extract<typeof a, { ok: true; kind: "chat" }> =>
+						a.ok === true && a.kind === "chat",
+				)
+				.map((a) => ({
+					sessionId: a.sessionId,
+					label: a.label,
+					link: chatSessionLink(wsId, a.sessionId, linkOpts),
+				}))[0],
+		};
+
+		const verb = result.alreadyExists ? "Reused existing" : "Created";
+		const summary = `${verb} workspace "${result.workspace.name}" on host ${target.hostId}`;
+
 		return {
-			data: result,
-			message: result.alreadyExists
-				? `Reused existing workspace "${result.workspace.name}" on host ${target.hostId}`
-				: `Created workspace "${result.workspace.name}" on host ${target.hostId}`,
+			data: { ...result, links },
+			message: `${summary}\n  Open: ${links.workspace.desktop}`,
 		};
 	},
 });

--- a/packages/mcp-v2/src/tools/agents/run.ts
+++ b/packages/mcp-v2/src/tools/agents/run.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { chatSessionLink, terminalLink } from "@superset/shared/deep-links";
 import { z } from "zod";
 import { createMcpCaller } from "../../caller";
 import { defineTool } from "../../define-tool";
@@ -38,7 +39,7 @@ export function register(server: McpServer): void {
 				throw new Error(`Workspace not found: ${input.workspaceId}`);
 			}
 
-			return hostServiceCall<
+			const result = await hostServiceCall<
 				| { kind: "terminal"; sessionId: string; label: string }
 				| { kind: "chat"; sessionId: string; label: string }
 			>(
@@ -57,6 +58,13 @@ export function register(server: McpServer): void {
 					attachmentIds: input.attachmentIds,
 				},
 			);
+
+			const link =
+				result.kind === "chat"
+					? chatSessionLink(input.workspaceId, result.sessionId)
+					: terminalLink(input.workspaceId, result.sessionId);
+
+			return { ...result, link };
 		},
 	});
 }

--- a/packages/mcp-v2/src/tools/workspaces/create.ts
+++ b/packages/mcp-v2/src/tools/workspaces/create.ts
@@ -1,4 +1,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+	chatSessionLink,
+	terminalLink,
+	workspaceLink,
+} from "@superset/shared/deep-links";
 import { z } from "zod";
 import { defineTool } from "../../define-tool";
 import { hostServiceCall } from "../../host-service-client";
@@ -65,7 +70,12 @@ export function register(server: McpServer): void {
 				),
 		},
 		handler: async (input, ctx) => {
-			return hostServiceCall<{
+			type AgentResult =
+				| { ok: true; kind: "terminal"; sessionId: string; label: string }
+				| { ok: true; kind: "chat"; sessionId: string; label: string }
+				| { ok: false; error: string };
+
+			const result = await hostServiceCall<{
 				workspace: {
 					id: string;
 					projectId: string;
@@ -73,11 +83,7 @@ export function register(server: McpServer): void {
 					branch: string;
 				};
 				terminals: Array<{ terminalId: string; label?: string }>;
-				agents: Array<
-					| { ok: true; kind: "terminal"; sessionId: string; label: string }
-					| { ok: true; kind: "chat"; sessionId: string; label: string }
-					| { ok: false; error: string }
-				>;
+				agents: AgentResult[];
 				alreadyExists: boolean;
 			}>(
 				{
@@ -98,6 +104,28 @@ export function register(server: McpServer): void {
 					agents: input.agents,
 				},
 			);
+
+			const wsId = result.workspace.id;
+			const links = {
+				workspace: workspaceLink(wsId),
+				terminals: result.terminals.map((t) => ({
+					terminalId: t.terminalId,
+					label: t.label,
+					link: terminalLink(wsId, t.terminalId),
+				})),
+				chat: result.agents
+					.filter(
+						(a): a is Extract<AgentResult, { ok: true; kind: "chat" }> =>
+							a.ok === true && a.kind === "chat",
+					)
+					.map((a) => ({
+						sessionId: a.sessionId,
+						label: a.label,
+						link: chatSessionLink(wsId, a.sessionId),
+					}))[0],
+			};
+
+			return { ...result, links };
 		},
 	});
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -55,6 +55,7 @@ export {
 	type TaskListResponse,
 	Tasks,
 	type TaskUpdateParams,
+	type DeepLink,
 	type Workspace,
 	type WorkspaceAgentLaunch,
 	type WorkspaceCreateAgentResult,

--- a/packages/sdk/src/resources/agents.ts
+++ b/packages/sdk/src/resources/agents.ts
@@ -111,12 +111,19 @@ interface HostLookup {
 	hostId: string;
 }
 
+/** A pair of desktop (`superset://…`) and web (`https://app.superset.sh/…`) URLs. */
+export interface DeepLink {
+	desktop: string;
+	web: string;
+}
+
 export type AgentRunResult =
-	| { kind: "terminal"; sessionId: string; label: string }
-	| { kind: "chat"; sessionId: string; label: string };
+	| { kind: "terminal"; sessionId: string; label: string; link?: DeepLink }
+	| { kind: "chat"; sessionId: string; label: string; link?: DeepLink };
 
 export declare namespace Agents {
 	export type {
+		DeepLink,
 		HostAgentConfig,
 		AgentListResponse,
 		AgentListParams,

--- a/packages/sdk/src/resources/index.ts
+++ b/packages/sdk/src/resources/index.ts
@@ -7,6 +7,7 @@ export {
 	type HostAgentConfig,
 	type PromptTransport,
 } from "./agents";
+export { type DeepLink } from "./workspaces";
 export {
 	type AgentConfig,
 	type Automation,

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -95,6 +95,12 @@ export class Workspaces extends APIResource {
 	}
 }
 
+/** A pair of desktop (`superset://…`) and web (`https://app.superset.sh/…`) URLs. */
+export interface DeepLink {
+	desktop: string;
+	web: string;
+}
+
 /** Cloud-index workspace row (from the API). */
 export interface Workspace {
 	id: string;
@@ -177,6 +183,12 @@ export interface WorkspaceCreateResult {
 	terminals: Array<{ terminalId: string; label?: string }>;
 	agents: WorkspaceCreateAgentResult[];
 	alreadyExists: boolean;
+	/** Deep links added by the CLI/SDK layer (not returned by the host service). */
+	links?: {
+		workspace: DeepLink;
+		terminals: Array<{ terminalId: string; label?: string; link: DeepLink }>;
+		chat?: { sessionId: string; label: string; link: DeepLink };
+	};
 }
 
 export interface WorkspaceDeleteResult {
@@ -185,6 +197,7 @@ export interface WorkspaceDeleteResult {
 
 export declare namespace Workspaces {
 	export type {
+		DeepLink,
 		Workspace,
 		HostWorkspace,
 		WorkspaceListResponse,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,10 @@
 			"types": "./src/constants.ts",
 			"default": "./src/constants.ts"
 		},
+		"./deep-links": {
+			"types": "./src/deep-links.ts",
+			"default": "./src/deep-links.ts"
+		},
 		"./names": {
 			"types": "./src/names/index.ts",
 			"default": "./src/names/index.ts"

--- a/packages/shared/src/deep-links.ts
+++ b/packages/shared/src/deep-links.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared deep-link URL builders for desktop (`superset://`) and web
+ * (`https://app.superset.sh/`) entry points. Used by CLI, SDK, and MCP so
+ * every surface returns identical URLs.
+ *
+ * Desktop deep links are handled by `processDeepLink` in
+ * `apps/desktop/src/main/index.ts` which strips the scheme and navigates to
+ * the path in the renderer.
+ */
+
+import { PROTOCOL_SCHEMES } from "./constants";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DeepLink {
+	desktop: string;
+	web: string;
+}
+
+export interface DeepLinkOptions {
+	/** Base web URL, e.g. `"https://app.superset.sh"`. */
+	webBaseUrl?: string;
+	/**
+	 * Protocol scheme for the desktop link. Defaults to `"superset"`.
+	 * Use `"superset-dev"` for local development builds.
+	 */
+	desktopScheme?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WEB_BASE = "https://app.superset.sh";
+const DEFAULT_SCHEME = PROTOCOL_SCHEMES.PROD;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function buildPair(path: string, opts: DeepLinkOptions | undefined): DeepLink {
+	const scheme = opts?.desktopScheme ?? DEFAULT_SCHEME;
+	const webBase = (opts?.webBaseUrl ?? DEFAULT_WEB_BASE).replace(/\/+$/, "");
+	return {
+		desktop: `${scheme}://${path}`,
+		web: `${webBase}/${path}`,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Public builders
+// ---------------------------------------------------------------------------
+
+/** Link to the workspace overview. */
+export function workspaceLink(
+	workspaceId: string,
+	opts?: DeepLinkOptions,
+): DeepLink {
+	return buildPair(`v2-workspace/${workspaceId}`, opts);
+}
+
+/** Link to a specific terminal inside a workspace. */
+export function terminalLink(
+	workspaceId: string,
+	terminalId: string,
+	opts?: DeepLinkOptions,
+): DeepLink {
+	return buildPair(
+		`v2-workspace/${workspaceId}?terminalId=${encodeURIComponent(terminalId)}`,
+		opts,
+	);
+}
+
+/** Link to a chat session inside a workspace. */
+export function chatSessionLink(
+	workspaceId: string,
+	sessionId: string,
+	opts?: DeepLinkOptions,
+): DeepLink {
+	return buildPair(
+		`v2-workspace/${workspaceId}?chatSessionId=${encodeURIComponent(sessionId)}`,
+		opts,
+	);
+}


### PR DESCRIPTION
## Summary

Adds deep links (desktop `superset://` + web `https://app.superset.sh/`) to `workspaces create` and `agents run` results across CLI, SDK, and MCP.

### What changed

**Shared URL builder** (`packages/shared/src/deep-links.ts`)
- `workspaceLink(id)` → `{ desktop: "superset://v2-workspace/<id>", web: "https://app.superset.sh/v2-workspace/<id>" }`
- `terminalLink(workspaceId, terminalId)` → same paths with `?terminalId=<id>`
- `chatSessionLink(workspaceId, sessionId)` → same paths with `?chatSessionId=<id>`
- Accepts optional `DeepLinkOptions` for custom web base URL / dev scheme

**CLI**
- `workspaces create` — adds `links` to `data` (workspace link, per-terminal links, chat link) and prints the desktop link in the message
- `agents run` — adds `link` to `data` and prints the desktop link in the message

**SDK**
- `WorkspaceCreateResult` now includes `links: { workspace, terminals, chat? }` with `DeepLink` type
- `AgentRunResult` now includes `link: DeepLink`
- New `DeepLink` type exported from `@superset_sh/sdk`

**MCP-v2**
- `workspaces_create` and `agents_run` tool outputs include the same link fields

### URL conventions

| Target | Desktop | Web |
|--------|---------|-----|
| Workspace | `superset://v2-workspace/<id>` | `https://app.superset.sh/v2-workspace/<id>` |
| Terminal | `superset://v2-workspace/<id>?terminalId=<tid>` | same |
| Chat | `superset://v2-workspace/<id>?chatSessionId=<sid>` | same |

Desktop links match the renderer route `/v2-workspace/$workspaceId` with its existing search params. Host routing is resolved at the tRPC layer, not in the URL.

### Test plan

- [ ] `superset workspaces create --project <p> --name test --branch main --local` → message shows `superset://` link, `--json` output includes `links`
- [ ] `superset agents run --workspace <w> --agent claude --prompt "hi"` → message shows `superset://` link, `--json` output includes `link`
- [ ] Click desktop link in terminal → Superset desktop opens to workspace
- [ ] Lint + typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds desktop (superset://) and web (https://app.superset.sh/) deep links to `workspaces create` and `agents run` so users can open workspaces, terminals, and chat sessions directly. Links are returned in CLI/SDK/MCP results and the CLI prints a clickable desktop link.

- **New Features**
  - Shared builders in `@superset/shared` (`workspaceLink`, `terminalLink`, `chatSessionLink`) with optional custom web base URL and desktop scheme.
  - CLI: `workspaces create` now returns `links` and prints “Open: <superset://…>”; `agents run` returns `link` and prints the same.
  - SDK (`@superset_sh/sdk`): exports `DeepLink`; `WorkspaceCreateResult.links` and `AgentRunResult.link` include desktop/web URLs.
  - MCP-v2 tools: `workspaces_create` and `agents_run` include the same link fields.
  - URL formats: `superset://v2-workspace/<id>` and `https://app.superset.sh/v2-workspace/<id>` with `?terminalId=<id>` or `?chatSessionId=<id>` for scoped links.

<sup>Written for commit dca1a8c48b7454275b13622130b1b1ac56aee5a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Deep-links are now generated for agent runs and workspace creation, enabling quick access to sessions via both desktop (`superset://`) and web-based URLs.
* Terminal and chat session links are automatically included in responses when sessions are created or launched.
* Workspace creation now provides direct links to the workspace and its associated terminals and chat sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->