### PR TITLE
release(cli): cut v0.2.11

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -50,7 +50,6 @@ jobs:
             release-artifacts/*.tar.gz \
             --title "Superset CLI ${{ github.ref_name }}" \
             --generate-notes \
-            --draft \
             --prerelease
 
       - name: Publish version manifest

--- a/bun.lock
+++ b/bun.lock
@@ -679,7 +679,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.10";
+const VERSION = "0.2.11";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Bump `@superset/cli` to **v0.2.11**. Changes since v0.2.10:

- **host-service:** gh CLI is first-class for PR/issue search; failures surface in the UI instead of silently degrading. (#4140)
- **host-service:** respawn lost terminal sessions on attach instead of dead-ending the pane after laptop sleep / daemon restart. (#4149)
- **host-service:** don't crash startup when the shell env probe fails. (#4150)

These ship to anyone running `superset` as a remote host that desktop v1.8.5 talks to.

Also drops `--draft` from `.github/workflows/release-cli.yml` so future CLI releases auto-publish alongside the `cli-latest` rolling pointer. `--prerelease` stays (still required to keep desktop's auto-updater from picking up CLI releases on `/releases/latest/`).

Push the `cli-v0.2.11` tag after this merges to fire the release pipeline.

## Test plan

- [ ] `bun run typecheck` clean
- [ ] After merge, `git tag cli-v0.2.11 <merge-sha> && git push origin cli-v0.2.11`
- [ ] Confirm the Release CLI workflow auto-publishes (no draft) and refreshes `cli-latest`
- [ ] Run `superset update` on a workstation, expect 0.2.11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.11 and switch the CLI release workflow to auto-publish by removing `--draft` (keeps `--prerelease`). This ships host-service reliability improvements for remote hosts used by desktop v1.8.5.

- **Bug Fixes**
  - Make `gh` CLI first-class for PR/issue search and show errors in the UI.
  - Respawn lost terminal sessions on attach after sleep or daemon restart.
  - Prevent startup crash when the shell env probe fails.

<sup>Written for commit bfa4f18f75da138711274cc1a5df2ae0d6f6ee83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI version bumped to 0.2.11
  * Release workflow configuration updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->