### PR TITLE
release(sdk): cut alpha.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -929,7 +929,7 @@
     },
     "packages/sdk": {
       "name": "@superset/sdk",
-      "version": "0.0.1-alpha.7",
+      "version": "0.0.1-alpha.8",
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "bun-types": "^1.3.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/sdk",
-	"version": "0.0.1-alpha.7",
+	"version": "0.0.1-alpha.8",
 	"description": "TypeScript SDK for the Superset API",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## Summary

Bump `@superset/sdk` to **0.0.1-alpha.8** and ship the current repo state to npm as `@superset_sh/sdk@0.0.1-alpha.8`.

State of npm: `alpha.6` is the most recent published version. `alpha.7` was bumped in 71bf008c6 (#3956) but never `npm publish`-ed, so it's skipped on the registry.

## Changes since alpha.6

- `workspaces.create` adopts the canonical host-service shape. (#3893)
- `automations.list` accepts `--name` filter. (#3952)
- `automations.prompt` split into `automations.prompt.get` / `automations.prompt.set`. (#3959)
- `agents.list` exposed; presets demoted to UI-only configuration. (#4097)
- `agents.run` / `workspaces.create` gain the `superset-chat` agent plus a `kind` discriminator (`"terminal"` vs `"chat"`) on launch results. (#4116)
- Type adjustments for the v2 workspace render path. (#4141)
- (Was alpha.7) Redact `x-api-key` in debug-log header dumps. (#3956)

## Publish

After merge:

```bash
cd packages/sdk
bun run build
cd dist
npm publish --access public
```

## Test plan

- [ ] `bun run --cwd packages/sdk typecheck` clean
- [ ] `bun run --cwd packages/sdk build` produces `dist/` with bundled .js/.cjs + .d.ts
- [ ] `npm publish --access public` from `packages/sdk/dist` succeeds; `npm view @superset_sh/sdk version` returns `0.0.1-alpha.8`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/sdk` 0.0.1-alpha.8 and publish as `@superset_sh/sdk@0.0.1-alpha.8`. Includes changes since alpha.6; alpha.7 was not published and is skipped.

- **New Features**
  - Workspaces: `workspaces.create` uses the canonical host-service shape; v2 render path types updated; launch results include `kind` ("terminal" | "chat").
  - Automations: `automations.list` supports a `--name` filter; `automations.prompt` split into `automations.prompt.get` and `.set`.
  - Agents: `agents.list` is now exposed; add `superset-chat` to `agents.run` and `workspaces.create`; presets are UI-only.
  - Security: redact `x-api-key` in debug header logs.

- **Migration**
  - Replace `automations.prompt` calls with `.get` or `.set`.
  - Update consumers of `workspaces.create` and launch results for the host-service shape and `kind` field.

<sup>Written for commit e29304c431dcdd9e1e1b1dcc1a060a9776bdad19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * SDK package version updated from `0.0.1-alpha.7` to `0.0.1-alpha.8`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->