### PR TITLE
fix(desktop): keep onboarding skip visible during loading

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/adopt-worktrees/page.tsx
@@ -73,9 +73,20 @@ function OnboardingAdoptWorktreesPage() {
 
 	if (isPending) {
 		return (
-			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
-				<Spinner className="size-6 text-[#a8a5a3]" />
-			</div>
+			<StepShell backTo={STEP_ROUTES.project}>
+				<StepHeader
+					title="Looking for existing worktrees…"
+					subtitle="Scanning your recent projects."
+				/>
+				<div className="flex justify-center py-2">
+					<Spinner className="size-6 text-[#a8a5a3]" />
+				</div>
+				<div className="flex w-[273px] flex-col gap-2 self-center">
+					<SetupButton variant="link" onClick={skipFlow}>
+						Skip for now
+					</SetupButton>
+				</div>
+			</StepShell>
 		);
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/gh-cli/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/gh-cli/page.tsx
@@ -40,9 +40,20 @@ function OnboardingGhCliPage() {
 
 	if (isPending) {
 		return (
-			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
-				<Spinner className="size-6 text-[#a8a5a3]" />
-			</div>
+			<StepShell backTo={STEP_ROUTES.providers}>
+				<StepHeader
+					title="Checking GitHub CLI…"
+					subtitle="Looking for gh on your system."
+				/>
+				<div className="flex justify-center py-2">
+					<Spinner className="size-6 text-[#a8a5a3]" />
+				</div>
+				<div className="flex w-[273px] flex-col gap-2 self-center">
+					<SetupButton variant="link" onClick={handleSkip}>
+						Skip for now
+					</SetupButton>
+				</div>
+			</StepShell>
 		);
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/permissions/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/permissions/page.tsx
@@ -60,9 +60,20 @@ function OnboardingPermissionsPage() {
 
 	if (isPending) {
 		return (
-			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
-				<Spinner className="size-6 text-[#a8a5a3]" />
-			</div>
+			<StepShell backTo={STEP_ROUTES["gh-cli"]} maxWidth="lg">
+				<StepHeader
+					title="Grant macOS permissions"
+					subtitle="Checking current permission status…"
+				/>
+				<div className="flex justify-center py-2">
+					<Spinner className="size-6 text-[#a8a5a3]" />
+				</div>
+				<div className="flex w-[273px] flex-col gap-2 self-center">
+					<SetupButton variant="link" onClick={handleSkip}>
+						Skip for now
+					</SetupButton>
+				</div>
+			</StepShell>
 		);
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/project/page.tsx
@@ -1,14 +1,13 @@
 import { toast } from "@superset/ui/sonner";
 import { Spinner } from "@superset/ui/spinner";
-import { eq } from "@tanstack/db";
-import { useLiveQuery } from "@tanstack/react-db";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { LuFolder } from "react-icons/lu";
 import { env } from "renderer/env.renderer";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
 import { MOCK_ORG_ID } from "shared/constants";
@@ -26,26 +25,19 @@ function OnboardingProjectPage() {
 	const markComplete = useOnboardingStore((s) => s.markComplete);
 	const markSkipped = useOnboardingStore((s) => s.markSkipped);
 
-	const collections = useCollections();
 	const { data: session } = authClient.useSession();
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION
 		? MOCK_ORG_ID
 		: (session?.session?.activeOrganizationId ?? null);
 
-	const { data: projects = [], isLoading } = useLiveQuery(
-		(q) =>
-			q
-				.from({ projects: collections.v2Projects })
-				.where(({ projects }) =>
-					eq(projects.organizationId, activeOrganizationId ?? ""),
-				)
-				.select(({ projects }) => ({
-					id: projects.id,
-					name: projects.name,
-					repoCloneUrl: projects.repoCloneUrl,
-				})),
-		[collections, activeOrganizationId],
-	);
+	const { data: projects = [], isLoading } = useQuery({
+		queryKey: ["onboarding", "v2Projects", activeOrganizationId],
+		enabled: !!activeOrganizationId,
+		queryFn: () =>
+			apiTrpcClient.v2Project.list.query({
+				organizationId: activeOrganizationId as string,
+			}),
+	});
 
 	const folderImport = useFolderFirstImport({
 		onError: (message) => toast.error(message),
@@ -77,14 +69,6 @@ function OnboardingProjectPage() {
 		navigate({ to: STEP_ROUTES["adopt-worktrees"] });
 	};
 
-	if (isLoading) {
-		return (
-			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
-				<Spinner className="size-6 text-[#a8a5a3]" />
-			</div>
-		);
-	}
-
 	const supersetIcon = (
 		<SupersetPill>
 			<div className="flex size-[48px] items-center justify-center rounded-[12px] bg-[#151110]">
@@ -92,6 +76,26 @@ function OnboardingProjectPage() {
 			</div>
 		</SupersetPill>
 	);
+
+	if (isLoading) {
+		return (
+			<StepShell backTo={STEP_ROUTES.permissions}>
+				<StepHeader
+					icon={supersetIcon}
+					title="Loading projects…"
+					subtitle="Checking for existing projects in your organization"
+				/>
+				<div className="flex justify-center py-2">
+					<Spinner className="size-6 text-[#a8a5a3]" />
+				</div>
+				<div className="flex w-[273px] flex-col gap-2 self-center">
+					<SetupButton variant="link" onClick={handleSkipStep}>
+						Skip for now
+					</SetupButton>
+				</div>
+			</StepShell>
+		);
+	}
 
 	if (hasProjects) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/setup/providers/page.tsx
@@ -51,14 +51,6 @@ function OnboardingProvidersPage() {
 		goTo("providers");
 	}, [goTo]);
 
-	if (isStatusPending) {
-		return (
-			<div className="flex h-full w-full items-center justify-center bg-[#151110]">
-				<Spinner className="size-6 text-[#a8a5a3]" />
-			</div>
-		);
-	}
-
 	const handleContinueToNextStep = () => {
 		markComplete("providers");
 		navigate({ to: STEP_ROUTES["gh-cli"] });
@@ -68,6 +60,25 @@ function OnboardingProvidersPage() {
 		markSkipped("providers");
 		navigate({ to: STEP_ROUTES["gh-cli"] });
 	};
+
+	if (isStatusPending) {
+		return (
+			<StepShell maxWidth="lg">
+				<StepHeader
+					title="Connect AI Provider"
+					subtitle="Checking your provider connections…"
+				/>
+				<div className="flex justify-center py-2">
+					<Spinner className="size-6 text-[#a8a5a3]" />
+				</div>
+				<div className="flex w-[273px] flex-col gap-2 self-center">
+					<SetupButton variant="link" onClick={handleSkipStep}>
+						Skip for now
+					</SetupButton>
+				</div>
+			</StepShell>
+		);
+	}
 
 	const handleConnect = (
 		base: "/setup/providers/claude-code" | "/setup/providers/codex",


### PR DESCRIPTION
## Summary
- Every setup step (`providers`, `gh-cli`, `permissions`, `project`, `adopt-worktrees`) short-circuited to a full-screen spinner while its initial query was pending, hiding the "Skip for now" CTA. The project step was hit hardest because its underlying Electric `v2_projects` shape has to wait behind ~25 org collections warming up at signin — users with no escape from the spinner reported feeling stuck.
- Each loading branch now renders inside the existing `StepShell` with the skip link still surfaced, so users always have a way out.
- Swapped the project step from a `useLiveQuery` over `collections.v2Projects` to an imperative `apiTrpcClient.v2Project.list` query — the page only needs "do you have any projects?" and shouldn't pay the Electric warm-up cost for an answer used once.

## Test plan
- [ ] Sign in fresh and walk through onboarding; confirm "Skip for now" is visible on each step's loading state.
- [ ] On the project step, verify the project list shows up via the new trpc call (with and without existing projects in the org).
- [ ] Click "Skip for now" from the project loading state — should jump to `/setup/adopt-worktrees`.
- [ ] Verify the rest of the project step flow still works: select new repo, continue with current, back to permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep “Skip for now” visible on all onboarding steps during loading so users aren’t stuck behind full-screen spinners. Also reduces load time on the project step by avoiding Electric shape warm‑up.

- **Bug Fixes**
  - Render loading states inside `StepShell` with the skip CTA for providers, gh-cli, permissions, project, and adopt-worktrees.

- **Refactors**
  - Replace `useLiveQuery` over `collections.v2Projects` with `apiTrpcClient.v2Project.list` via `@tanstack/react-query`, fetching only the needed project presence to avoid ~25 org collections warm-up.

<sup>Written for commit 471c44f896302cd1db0401542a9c113980588069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Setup steps now display descriptive loading states with step headers and status information instead of blank spinners.
  * Added visible "Skip for now" options throughout the setup process for easier navigation.
  * Enhanced visual consistency and clarity across the onboarding wizard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->