### PR TITLE
fix(desktop): resolve v2 default from local db, not stale localStorage

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -330,6 +330,15 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				return resolveDefaultEditor(input.projectId);
 			}),
 
+		hasAny: publicProcedure.query(() => {
+			const row = localDb
+				.select({ id: projects.id })
+				.from(projects)
+				.limit(1)
+				.all();
+			return row.length > 0;
+		}),
+
 		getRecents: publicProcedure.query((): Project[] => {
 			return localDb
 				.select()

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
@@ -95,6 +95,15 @@ export const createQueryProcedures = () => {
 				.sort((a, b) => a.tabOrder - b.tabOrder);
 		}),
 
+		hasAny: publicProcedure.query(() => {
+			const row = localDb
+				.select({ id: workspaces.id })
+				.from(workspaces)
+				.limit(1)
+				.all();
+			return row.length > 0;
+		}),
+
 		getAllGrouped: publicProcedure.query(() => {
 			type WorkspaceItem = {
 				id: string;

--- a/apps/desktop/src/renderer/components/V2DefaultResolver/V2DefaultResolver.tsx
+++ b/apps/desktop/src/renderer/components/V2DefaultResolver/V2DefaultResolver.tsx
@@ -4,24 +4,28 @@ import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 export function V2DefaultResolver() {
 	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
+	const isFreshInstall = useV2LocalOverrideStore((s) => s.isFreshInstall);
 	const setOptInV2 = useV2LocalOverrideStore((s) => s.setOptInV2);
+	const setIsFreshInstall = useV2LocalOverrideStore((s) => s.setIsFreshInstall);
 	const utils = electronTrpc.useUtils();
 
 	useEffect(() => {
-		if (optInV2 !== null) return;
+		if (optInV2 !== null && isFreshInstall !== null) return;
 		let cancelled = false;
 		void Promise.all([
 			utils.workspaces.hasAny.fetch(),
 			utils.projects.hasAny.fetch(),
 		]).then(([hasWorkspace, hasProject]) => {
 			if (cancelled) return;
-			if (useV2LocalOverrideStore.getState().optInV2 !== null) return;
-			setOptInV2(!hasWorkspace && !hasProject);
+			const isFresh = !hasWorkspace && !hasProject;
+			const current = useV2LocalOverrideStore.getState();
+			if (current.optInV2 === null) setOptInV2(isFresh);
+			if (current.isFreshInstall === null) setIsFreshInstall(isFresh);
 		});
 		return () => {
 			cancelled = true;
 		};
-	}, [optInV2, setOptInV2, utils]);
+	}, [optInV2, isFreshInstall, setOptInV2, setIsFreshInstall, utils]);
 
 	return null;
 }

--- a/apps/desktop/src/renderer/components/V2DefaultResolver/V2DefaultResolver.tsx
+++ b/apps/desktop/src/renderer/components/V2DefaultResolver/V2DefaultResolver.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+
+export function V2DefaultResolver() {
+	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
+	const setOptInV2 = useV2LocalOverrideStore((s) => s.setOptInV2);
+	const utils = electronTrpc.useUtils();
+
+	useEffect(() => {
+		if (optInV2 !== null) return;
+		let cancelled = false;
+		void Promise.all([
+			utils.workspaces.hasAny.fetch(),
+			utils.projects.hasAny.fetch(),
+		]).then(([hasWorkspace, hasProject]) => {
+			if (cancelled) return;
+			if (useV2LocalOverrideStore.getState().optInV2 !== null) return;
+			setOptInV2(!hasWorkspace && !hasProject);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [optInV2, setOptInV2, utils]);
+
+	return null;
+}

--- a/apps/desktop/src/renderer/components/V2DefaultResolver/index.ts
+++ b/apps/desktop/src/renderer/components/V2DefaultResolver/index.ts
@@ -1,0 +1,1 @@
+export { V2DefaultResolver } from "./V2DefaultResolver";

--- a/apps/desktop/src/renderer/hooks/useIsFreshInstall.ts
+++ b/apps/desktop/src/renderer/hooks/useIsFreshInstall.ts
@@ -1,0 +1,6 @@
+import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+
+/** Returns whether this install was empty when first detected, or null if still resolving. */
+export function useIsFreshInstall(): boolean | null {
+	return useV2LocalOverrideStore((s) => s.isFreshInstall);
+}

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -2,5 +2,5 @@ import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 /** Returns whether v2 is currently active for this user. */
 export function useIsV2CloudEnabled(): boolean {
-	return useV2LocalOverrideStore((s) => s.optInV2);
+	return useV2LocalOverrideStore((s) => s.optInV2 === true);
 }

--- a/apps/desktop/src/renderer/lib/hasPriorSupersetUsage.ts
+++ b/apps/desktop/src/renderer/lib/hasPriorSupersetUsage.ts
@@ -1,9 +1,0 @@
-/**
- * True when this install has been used before. Backed by `tabs-storage`,
- * which is written the first time any workspace tab opens. Use this to
- * distinguish a fresh install from a returning user.
- */
-export function hasPriorSupersetUsage(): boolean {
-	if (typeof localStorage === "undefined") return false;
-	return localStorage.getItem("tabs-storage") !== null;
-}

--- a/apps/desktop/src/renderer/routes/-layout.tsx
+++ b/apps/desktop/src/renderer/routes/-layout.tsx
@@ -4,6 +4,7 @@ import { PostHogSurfaceTagger } from "renderer/components/PostHogSurfaceTagger";
 import { PostHogUserIdentifier } from "renderer/components/PostHogUserIdentifier";
 import { TelemetrySync } from "renderer/components/TelemetrySync";
 import { ThemedToaster } from "renderer/components/ThemedToaster";
+import { V2DefaultResolver } from "renderer/components/V2DefaultResolver";
 import { AuthProvider } from "renderer/providers/AuthProvider";
 import { ElectronTRPCProvider } from "renderer/providers/ElectronTRPCProvider";
 import { PostHogProvider } from "renderer/providers/PostHogProvider";
@@ -12,6 +13,7 @@ export function RootLayout({ children }: { children: ReactNode }) {
 	return (
 		<PostHogProvider>
 			<ElectronTRPCProvider>
+				<V2DefaultResolver />
 				<PostHogUserIdentifier />
 				<PostHogSurfaceTagger />
 				<TelemetrySync />

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -15,6 +15,7 @@ import { NewWorkspaceModal } from "renderer/components/NewWorkspaceModal";
 import { Paywall } from "renderer/components/Paywall";
 import { useUpdateListener } from "renderer/components/UpdateToast";
 import { env } from "renderer/env.renderer";
+import { useIsFreshInstall } from "renderer/hooks/useIsFreshInstall";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";
@@ -65,6 +66,7 @@ function AuthenticatedLayout() {
 	const utils = electronTrpc.useUtils();
 	const shownWorkspaceInitWarningsRef = useRef(new Set<string>());
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const isFreshInstall = useIsFreshInstall();
 	const requiredComplete = useOnboardingStore(selectRequiredStepsComplete);
 	const firstIncompleteStep = useOnboardingStore(selectFirstIncompleteStep);
 
@@ -205,7 +207,12 @@ function AuthenticatedLayout() {
 	}
 
 	const isOnSetupRoute = location.pathname.startsWith("/setup");
-	if (isV2CloudEnabled && !requiredComplete && !isOnSetupRoute) {
+	if (
+		isV2CloudEnabled &&
+		isFreshInstall === true &&
+		!requiredComplete &&
+		!isOnSetupRoute
+	) {
 		return <Navigate to={STEP_ROUTES[firstIncompleteStep]} replace />;
 	}
 

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -2,14 +2,10 @@ import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
 interface V2LocalOverrideState {
-	/**
-	 * The user's v2 opt-in state.
-	 * - `null` means unresolved on this install — `V2DefaultResolver` will set it
-	 *   once based on whether any v1 workspace exists.
-	 * - `true` / `false` is a concrete choice (resolver default or user toggle).
-	 */
 	optInV2: boolean | null;
+	isFreshInstall: boolean | null;
 	setOptInV2: (optInV2: boolean) => void;
+	setIsFreshInstall: (isFreshInstall: boolean) => void;
 }
 
 export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
@@ -17,7 +13,9 @@ export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
 		persist(
 			(set) => ({
 				optInV2: null,
+				isFreshInstall: null,
 				setOptInV2: (optInV2) => set({ optInV2 }),
+				setIsFreshInstall: (isFreshInstall) => set({ isFreshInstall }),
 			}),
 			{ name: "v2-local-override-v2" },
 		),

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -1,23 +1,22 @@
-import { hasPriorSupersetUsage } from "renderer/lib/hasPriorSupersetUsage";
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
 interface V2LocalOverrideState {
-	/** When true, the user has opted into v2. v2 is gated behind both the remote flag and this opt-in. */
-	optInV2: boolean;
+	/**
+	 * The user's v2 opt-in state.
+	 * - `null` means unresolved on this install — `V2DefaultResolver` will set it
+	 *   once based on whether any v1 workspace exists.
+	 * - `true` / `false` is a concrete choice (resolver default or user toggle).
+	 */
+	optInV2: boolean | null;
 	setOptInV2: (optInV2: boolean) => void;
 }
-
-// Fresh installs default to v2; returning v1 users default to v1 and discover
-// v2 via the in-sidebar banner. Persist hydration overrides this for anyone
-// with a saved override.
-const initialOptInV2 = !hasPriorSupersetUsage();
 
 export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
 	devtools(
 		persist(
 			(set) => ({
-				optInV2: initialOptInV2,
+				optInV2: null,
 				setOptInV2: (optInV2) => set({ optInV2 }),
 			}),
 			{ name: "v2-local-override-v2" },


### PR DESCRIPTION
## Summary
Two related bugs:

**1. v2 default signal was always wrong.** #4115 used `localStorage.getItem("tabs-storage")` to detect returning users, but tabs state moved off localStorage to `app-state.json` (lowdb) back in #303 (2025-12-10). The key has been `null` for every install since, so `!hasPriorSupersetUsage()` was `true` for everyone and force-flipped anyone without an explicit toggle into v2.

**2. Existing v1 users who opted into v2 got force-walked through onboarding.** The gate in `_authenticated/layout.tsx` only required `isV2CloudEnabled && !requiredComplete`, with no "is this a fresh user?" check — so any existing user who toggled v2 ON in Experimental Settings was redirected to `/setup/providers`.

## Fix
- New `workspaces.hasAny` and `projects.hasAny` procedures (cheap `LIMIT 1` reads on `localDb`/`host.db`).
- `v2-local-override` store now has two flags, both `boolean | null`:
  - `optInV2` — user-controllable (resolver default or Experimental toggle).
  - `isFreshInstall` — sticky one-shot detection set by the resolver; never changes from a user toggle.
- `V2DefaultResolver` (mounted in `RootLayout`) runs whenever either flag is null, queries the two `hasAny` procedures once, and fills in whichever flags are still null with `!hasWorkspace && !hasProject`. Users who got force-pulled by the broken release but never toggled have no persisted `optInV2`, so they self-heal back to v1.
- Onboarding gate now requires `isV2CloudEnabled && isFreshInstall === true && !requiredComplete && !isOnSetupRoute` — so existing users opting into v2 land on the dashboard, not setup.
- `useIsV2CloudEnabled` returns `optInV2 === true` (null → v1, no flicker before resolution).
- Deletes the dead `hasPriorSupersetUsage.ts`.

## Test plan
- [ ] Fresh install → defaults to v2 AND walks through onboarding.
- [ ] Returning v1 user (has projects/workspaces) → stays on v1, no onboarding redirect.
- [ ] CLI-only user (projects, no workspaces) → stays on v1, no onboarding.
- [ ] Existing v1 user toggles v2 ON in Experimental Settings → flips to v2, lands on dashboard (NOT /setup/providers).
- [ ] Affected user upgrading from broken release (force-pulled, never toggled) → resolver fills in null `optInV2` → back to v1.
- [ ] User who explicitly toggled v2 ON before this fix → keeps v2; resolver backfills `isFreshInstall=false`; if they hadn't completed onboarding they stop being force-walked through it.
- [ ] Fresh user quits mid-onboarding and relaunches → still routed back to setup (`isFreshInstall` is sticky).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Detect whether any workspace or project exists to drive onboarding defaults.
  * Added a startup resolver that initializes v2 opt-in and fresh-install state.

* **Improvements**
  * v2 opt-in state is now tri-state (true/false/null) and resolves explicitly at startup.
  * Hook now returns strict booleans where appropriate and a dedicated fresh-install hook added.

* **Removed**
  * Legacy prior-usage detection helper removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->