### PR TITLE
fix(desktop): make v1 import modal closable + responsive

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -208,7 +208,10 @@ export function ImportWorkspacesPage({
 		>
 			{Array.from(grouped.entries()).map(([projectV1Id, group]) => (
 				<div key={projectV1Id} className="mb-2 flex min-w-0 flex-col">
-					<div className="px-3 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+					<div
+						className="truncate px-3 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+						title={group.projectName}
+					>
 						{group.projectName}
 					</div>
 					{group.items.map(({ workspace, v2ProjectId, alreadyImported }) => (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
@@ -45,8 +45,7 @@ export function V1ImportModal() {
 			}}
 		>
 			<DialogContent
-				className="!w-[744px] !max-w-[744px] p-0 gap-0 overflow-hidden !rounded-none"
-				showCloseButton={false}
+				className="flex flex-col w-[min(744px,calc(100vw-2rem))] !max-w-[744px] h-[min(540px,calc(100vh-2rem))] max-h-[calc(100vh-2rem)] p-0 gap-0 overflow-hidden !rounded-none [&>[data-slot=dialog-close]]:top-5 [&>[data-slot=dialog-close]]:right-5 [&>[data-slot=dialog-close]]:z-10 [&>[data-slot=dialog-close]]:opacity-100 [&>[data-slot=dialog-close]]:text-muted-foreground hover:[&>[data-slot=dialog-close]]:text-foreground"
 				onEscapeKeyDown={(event) => event.preventDefault()}
 				onPointerDownOutside={(event) => event.preventDefault()}
 				onInteractOutside={(event) => event.preventDefault()}
@@ -63,11 +62,14 @@ export function V1ImportModal() {
 					won't be carried over, but you can still access v1 at any time.
 				</DialogDescription>
 
-				<div key={page} className="animate-in fade-in duration-200">
+				<div
+					key={page}
+					className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden animate-in fade-in duration-200"
+				>
 					{page === "welcome" && <WelcomePage />}
 					{page === "intro" && <IntroPage />}
 					{(page === "projects" || page === "workspaces") && !activeHostUrl && (
-						<div className="flex h-[454px] items-center justify-center bg-background px-6 text-center text-sm text-muted-foreground">
+						<div className="flex flex-1 items-center justify-center bg-background px-6 text-center text-sm text-muted-foreground">
 							Host service is not ready yet. This window will populate as soon
 							as the local host service comes online.
 						</div>
@@ -89,20 +91,26 @@ export function V1ImportModal() {
 					)}
 				</div>
 
-				<div className="box-border flex items-center justify-between border-t bg-background px-5 py-4">
+				<div className="box-border flex shrink-0 items-center justify-between gap-3 border-t bg-background px-5 py-4">
 					{previousPage ? (
-						<Button variant="outline" onClick={() => setPage(previousPage)}>
+						<Button
+							variant="outline"
+							onClick={() => setPage(previousPage)}
+							className="shrink-0"
+						>
 							Back
 						</Button>
 					) : (
 						<div />
 					)}
 					{nextPage ? (
-						<Button onClick={() => setPage(nextPage)}>
+						<Button onClick={() => setPage(nextPage)} className="shrink-0">
 							{page === "welcome" ? "Get started" : "Next"}
 						</Button>
 					) : (
-						<Button onClick={close}>Done</Button>
+						<Button onClick={close} className="shrink-0">
+							Done
+						</Button>
 					)}
 				</div>
 			</DialogContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportPageShell/ImportPageShell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportPageShell/ImportPageShell.tsx
@@ -25,12 +25,16 @@ export function ImportPageShell({
 	children,
 }: ImportPageShellProps) {
 	return (
-		<div className="flex h-[454px] flex-col bg-background">
-			<div className="flex items-start gap-3 border-b px-8 py-5">
+		<div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
+			<div className="flex items-start gap-3 border-b px-8 py-5 pr-20">
 				<div className="min-w-0 flex-1">
-					<div className="text-lg font-semibold text-foreground">{title}</div>
+					<div className="truncate text-lg font-semibold text-foreground">
+						{title}
+					</div>
 					{description && (
-						<p className="mt-1 text-xs text-muted-foreground">{description}</p>
+						<p className="mt-1 truncate text-xs text-muted-foreground">
+							{description}
+						</p>
 					)}
 				</div>
 				{onRefresh && (
@@ -50,7 +54,7 @@ export function ImportPageShell({
 					</Button>
 				)}
 			</div>
-			<div className="flex min-h-0 min-w-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 py-3">
+			<div className="flex min-h-0 min-w-0 flex-1 flex-col gap-0.5 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-3">
 				{isLoading ? (
 					<div className="flex flex-1 items-center justify-center">
 						<Spinner className="size-5" />

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
@@ -52,33 +52,45 @@ export function ImportRow({
 	action,
 }: ImportRowProps) {
 	return (
-		<div className="flex min-w-0 items-center gap-3 px-3 py-2">
+		<div className="flex w-full min-w-0 max-w-full items-center gap-3 overflow-hidden px-3 py-2">
 			{icon && (
 				<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
 					{icon}
 				</div>
 			)}
 			<div className="flex min-w-0 flex-1 flex-col">
-				<span className="truncate text-sm font-medium text-foreground">
+				<span
+					className="truncate text-sm font-medium text-foreground"
+					title={primary}
+				>
 					{primary}
 				</span>
 				{secondary && (
-					<span className="truncate font-mono text-[11px] text-muted-foreground">
+					<span
+						className="truncate font-mono text-[11px] text-muted-foreground"
+						title={secondary}
+					>
 						{secondary}
 					</span>
 				)}
 				{action.kind === "error" && (
-					<span className="select-text cursor-text truncate text-[11px] text-destructive">
+					<span
+						className="select-text cursor-text truncate text-[11px] text-destructive"
+						title={action.message}
+					>
 						{action.message}
 					</span>
 				)}
 				{action.kind === "blocked" && (
-					<span className="truncate text-[11px] text-muted-foreground">
+					<span
+						className="truncate text-[11px] text-muted-foreground"
+						title={action.reason}
+					>
 						{action.reason}
 					</span>
 				)}
 				{action.kind === "confirm" && (
-					<span className="select-text cursor-text text-[11px] text-muted-foreground">
+					<span className="select-text cursor-text text-[11px] text-muted-foreground [overflow-wrap:anywhere]">
 						{action.message}
 					</span>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/IntroPage/IntroPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/IntroPage/IntroPage.tsx
@@ -1,6 +1,6 @@
 export function IntroPage() {
 	return (
-		<div className="flex h-[454px] flex-col items-center justify-center bg-background px-14 text-center">
+		<div className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto bg-background px-14 py-8 text-center">
 			<div className="text-2xl font-semibold text-foreground">
 				Let's get you started
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/WelcomePage/WelcomePage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/WelcomePage/WelcomePage.tsx
@@ -16,7 +16,7 @@ const GRADIENT_COLORS = [
 
 export function WelcomePage() {
 	return (
-		<div className="relative h-[454px] overflow-hidden bg-[#080a12]">
+		<div className="relative flex min-h-0 flex-1 overflow-hidden bg-[#080a12]">
 			<DitheredBackground
 				colors={GRADIENT_COLORS}
 				className="absolute inset-0 h-full w-full"


### PR DESCRIPTION
## Summary
- Always-visible close (X) button on the v1→v2 import modal — previously the only exit was clicking through to "Done" with escape and outside-click both blocked.
- Responsive width and height clamps (`w-[min(744px,calc(100vw-2rem))]`, `h-[min(540px,calc(100vh-2rem))]`) so the modal shrinks to fit narrow or short windows; Back/Next/Done and the X stay reachable.
- Long workspace, project, and group names truncate with hover tooltips so they can't push the per-row Adopt/Import/Link button off-screen; row containers use `min-w-0 overflow-hidden`, footer buttons get `shrink-0`.
- Reserved a header gutter (`pr-20`) so the close X doesn't overlap the refresh icon.
- Internal scroll on the page body (`overflow-x-hidden overflow-y-auto overscroll-contain`) and `min-h-0 flex-1` on Welcome/Intro/host-not-ready so they shrink with the modal instead of pushing the footer out of the clipped area.

## Test plan
- [ ] Open the v1 import modal — confirm X is visible on every page (Welcome, Intro, Projects, Workspaces, Presets) and dismisses the modal.
- [ ] Resize the window narrow (~600px) — modal shrinks horizontally; X, Back, Next/Done all stay clickable.
- [ ] Resize the window short (~400px tall) — modal shrinks vertically; footer stays pinned, body scrolls internally.
- [ ] Verify with a v1 workspace whose name is very long (no spaces / a long URL-style string) — the row truncates with an ellipsis, the Adopt button stays visible, and the title attribute reveals the full name on hover.
- [ ] Confirm the refresh button on Projects/Workspaces/Presets pages no longer overlaps the X.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the v1→v2 import modal closable and responsive. Users can dismiss it from any page, and it now fits small windows without cutting off controls.

- **New Features**
  - Always-visible Close (X) button on the import modal.

- **Bug Fixes**
  - Clamp modal size to the viewport so Back/Next/Done and Close stay reachable.
  - Add internal body scrolling; keep the footer pinned.
  - Truncate long project/workspace/group names with hover tooltips to keep action buttons visible.
  - Reserve header gutter so Close no longer overlaps the refresh button.

<sup>Written for commit 83bd5e87ca682174e7c9447080086451b02390b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced text truncation and overflow handling throughout import dialogs, improving display of long project names
  * Improved responsive layouts with refined scrolling and spacing behavior
  * Refined navigation button and footer styling for better visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->