### PR TITLE
fix(desktop): release v2 terminal WebGL contexts when parked

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -13,18 +13,17 @@ export interface LoadAddonsResult {
 	dispose: () => void;
 }
 
-// Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
+// Once WebGL fails (construction throw or runtime context loss), skip it for
+// the rest of the session. Both signals indicate the GPU path is unhealthy
+// in this renderer process — VS Code does the same.
 let suggestedRendererType: "webgl" | "dom" | undefined;
 
 /**
- * Load optional addons onto an already-opened terminal. Returns a cleanup
- * function and addon instances. WebGL is deferred to rAF to avoid
- * racing with xterm's post-open viewport sync.
+ * Load non-renderer addons onto an already-opened terminal. The WebGL renderer
+ * is intentionally not attached here — it's tied to container lifecycle by
+ * `attachWebglRenderer` so parked terminals don't hold GPU contexts.
  */
 export function loadAddons(terminal: XTerm): LoadAddonsResult {
-	let disposed = false;
-	let webglAddon: WebglAddon | null = null;
-
 	terminal.loadAddon(new ClipboardAddon());
 
 	const unicode11 = new Unicode11Addon();
@@ -43,33 +42,53 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 		terminal.loadAddon(new LigaturesAddon());
 	} catch {}
 
-	const rafId = requestAnimationFrame(() => {
-		if (disposed || suggestedRendererType === "dom") return;
-
-		try {
-			webglAddon = new WebglAddon();
-			webglAddon.onContextLoss(() => {
-				webglAddon?.dispose();
-				webglAddon = null;
-				terminal.refresh(0, terminal.rows - 1);
-			});
-			terminal.loadAddon(webglAddon);
-		} catch {
-			suggestedRendererType = "dom";
-			webglAddon = null;
-		}
-	});
-
 	return {
 		searchAddon,
 		progressAddon,
-		dispose: () => {
-			disposed = true;
-			cancelAnimationFrame(rafId);
-			try {
-				webglAddon?.dispose();
-			} catch {}
-			webglAddon = null;
-		},
+		dispose: () => {},
 	};
+}
+
+/**
+ * Attach the WebGL renderer to a terminal whose wrapper is in the live DOM.
+ * Returns null when WebGL is unavailable (construction failed or a prior
+ * context loss flipped the session to DOM-only). On context loss, the addon
+ * disposes itself and the session falls back to DOM rendering.
+ */
+export function attachWebglRenderer(terminal: XTerm): WebglAddon | null {
+	if (suggestedRendererType === "dom") return null;
+
+	let addon: WebglAddon;
+	try {
+		addon = new WebglAddon();
+	} catch {
+		suggestedRendererType = "dom";
+		return null;
+	}
+
+	addon.onContextLoss(() => {
+		suggestedRendererType = "dom";
+		try {
+			addon.dispose();
+		} catch {}
+		terminal.refresh(0, terminal.rows - 1);
+	});
+
+	try {
+		terminal.loadAddon(addon);
+	} catch {
+		suggestedRendererType = "dom";
+		try {
+			addon.dispose();
+		} catch {}
+		return null;
+	}
+
+	return addon;
+}
+
+export function detachWebglRenderer(addon: WebglAddon): void {
+	try {
+		addon.dispose();
+	} catch {}
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -53,9 +53,15 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
  * Attach the WebGL renderer to a terminal whose wrapper is in the live DOM.
  * Returns null when WebGL is unavailable (construction failed or a prior
  * context loss flipped the session to DOM-only). On context loss, the addon
- * disposes itself and the session falls back to DOM rendering.
+ * disposes itself and the session falls back to DOM rendering. The caller
+ * supplies `onLost` so it can clear its own reference to the now-disposed
+ * addon (the runtime keeps a `webglAddon` field that would otherwise hold a
+ * stale handle until the next attach/detach cycle).
  */
-export function attachWebglRenderer(terminal: XTerm): WebglAddon | null {
+export function attachWebglRenderer(
+	terminal: XTerm,
+	onLost?: () => void,
+): WebglAddon | null {
 	if (suggestedRendererType === "dom") return null;
 
 	let addon: WebglAddon;
@@ -71,6 +77,7 @@ export function attachWebglRenderer(terminal: XTerm): WebglAddon | null {
 		try {
 			addon.dispose();
 		} catch {}
+		onLost?.();
 		terminal.refresh(0, terminal.rows - 1);
 	});
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -2,10 +2,15 @@ import { FitAddon } from "@xterm/addon-fit";
 import type { ProgressAddon } from "@xterm/addon-progress";
 import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import type { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
-import { loadAddons } from "./terminal-addons";
+import {
+	attachWebglRenderer,
+	detachWebglRenderer,
+	loadAddons,
+} from "./terminal-addons";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
 
@@ -23,6 +28,7 @@ export interface TerminalRuntime {
 	serializeAddon: SerializeAddon;
 	searchAddon: SearchAddon | null;
 	progressAddon: ProgressAddon | null;
+	webglAddon: WebglAddon | null;
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
@@ -223,6 +229,7 @@ export function createRuntime(
 		serializeAddon,
 		searchAddon: addonsResult.searchAddon,
 		progressAddon: addonsResult.progressAddon,
+		webglAddon: null,
 		wrapper,
 		container: null,
 		resizeObserver: null,
@@ -250,6 +257,15 @@ export function attachToContainer(
 
 	runtime.container = container;
 	container.appendChild(runtime.wrapper);
+
+	// WebGL is gated to the active tab: only terminals in the live tree hold a
+	// GPU context. Parked terminals release theirs to keep the per-renderer
+	// context count low and avoid the "all panes lose context at once"
+	// cascade under heavy redraw bursts.
+	if (runtime.webglAddon === null) {
+		runtime.webglAddon = attachWebglRenderer(runtime.terminal);
+	}
+
 	if (measureAndResize(runtime)) onResize?.();
 
 	runtime._disposeResizeObserver?.();
@@ -271,6 +287,10 @@ export function detachFromContainer(runtime: TerminalRuntime) {
 	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
+	if (runtime.webglAddon !== null) {
+		detachWebglRenderer(runtime.webglAddon);
+		runtime.webglAddon = null;
+	}
 	// Park instead of .remove() so xterm survives the React unmount —
 	// see getTerminalParkingContainer.
 	getTerminalParkingContainer().appendChild(runtime.wrapper);
@@ -312,6 +332,10 @@ export function disposeRuntime(
 	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
+	if (runtime.webglAddon !== null) {
+		detachWebglRenderer(runtime.webglAddon);
+		runtime.webglAddon = null;
+	}
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
 	if (clearPersistedState) {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -263,7 +263,9 @@ export function attachToContainer(
 	// context count low and avoid the "all panes lose context at once"
 	// cascade under heavy redraw bursts.
 	if (runtime.webglAddon === null) {
-		runtime.webglAddon = attachWebglRenderer(runtime.terminal);
+		runtime.webglAddon = attachWebglRenderer(runtime.terminal, () => {
+			runtime.webglAddon = null;
+		});
 	}
 
 	if (measureAndResize(runtime)) onResize?.();


### PR DESCRIPTION
## Summary

Pressing Enter in Claude Code inside a v2 workspace caused all visible terminal panes' WebGL contexts to be lost simultaneously, leaving them frozen until the renderer was reloaded:

- Three `CONTEXT_LOST_WEBGL` events firing at once, then ~70 `INVALID_OPERATION: delete: object does not belong to this context` errors as `@xterm/addon-webgl` cleaned up GL handles against the now-restored (different) context.
- Root cause: every terminal — active, parked across tabs/workspaces — held a live WebGL canvas at `-9999px` via the parking pattern. With three or more contexts up, Claude Code's heavy alt-screen redraw on prompt submit pushed Chromium past its per-renderer GPU memory threshold and the GPU process dropped every WebGL context in the renderer.
- v1 isn't affected because it's tab-based and rarely has more than one terminal in the live tree at once.

## Fix

Tie the xterm WebGL addon lifecycle to the existing parking lifecycle:

- `attachToContainer` allocates the addon when a terminal enters the live tree.
- `detachFromContainer` disposes it before parking the wrapper.
- `disposeRuntime` mirrors the cleanup.

Net effect: only terminals in the active tab hold GPU contexts. Switching tabs/workspaces frees the GPU memory of everything you've left behind, so the per-renderer count stays low and Chromium isn't pressured into dropping contexts under load. `onContextLoss` also now flips the session-level `suggestedRendererType = "dom"` so a genuine GPU hiccup doesn't get immediately re-armed on the next attach.

No changes to `TerminalPane`, the registry, or the panes store — the parking signal already maps perfectly to "is this in the active tab."

## Test plan

- [ ] Open v2 workspace with 3+ split terminal panes; run Claude Code in one
- [ ] Press Enter in Claude Code several times — confirm no `webglcontextlost` cascade in devtools
- [ ] Switch to another workspace tab and back — confirm parked terminal re-renders cleanly
- [ ] Force-disable WebGL (devtools → block GPU) and verify DOM fallback still works for the session

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release WebGL contexts for parked v2 terminals by attaching the `@xterm/addon-webgl` renderer only when a pane is in the live DOM, and clear the runtime reference on inline context loss. This prevents GPU context drops and frozen panes during heavy redraws (e.g., pressing Enter in Claude Code).

- **Bug Fixes**
  - Tie WebGL to container lifecycle: allocate on `attachToContainer`; dispose on `detachFromContainer` and runtime dispose, so only active panes hold GPU contexts.
  - Clear `runtime.webglAddon` when a context-loss event occurs while attached (via an `onLost` hook).
  - Fall back to DOM for the session when WebGL construction fails or `onContextLoss` fires (`suggestedRendererType = "dom"`).
  - Move WebGL out of `loadAddons`; add `attachWebglRenderer`/`detachWebglRenderer` helpers used by the runtime.

<sup>Written for commit 8226b60ced11ca27a6badf4cf8beefbb57f848b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved terminal rendering architecture with clearer separation of WebGL lifecycle management.
  * WebGL attach/detach moved to a dedicated mechanism for more robust handling.
* **Bug Fixes**
  * Enhanced fallback: terminal now gracefully switches when WebGL is unavailable or lost.
  * Strengthened error handling and recovery for graphics initialization and context loss.
* **Chores**
  * Non-visual addons (search, progress, clipboard, unicode, image) load reliably; cleanup flow simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->