### PR TITLE
feat(cli/sdk/mcp): add workspaces update for renaming

### DIFF
--- a/packages/cli/src/commands/workspaces/update/command.ts
+++ b/packages/cli/src/commands/workspaces/update/command.ts
@@ -1,0 +1,31 @@
+import { CLIError, positional, string } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+
+export default command({
+	description: "Update a workspace",
+	args: [positional("id").required().desc("Workspace UUID")],
+	options: {
+		name: string().desc("Workspace name"),
+	},
+	run: async ({ ctx, args, options }) => {
+		const id = args.id as string;
+		const organizationId = ctx.config.organizationId;
+		if (!organizationId) {
+			throw new CLIError("No active organization", "Run: superset auth login");
+		}
+
+		if (options.name === undefined) {
+			throw new CLIError("No fields to update", "Pass --name <new-name>");
+		}
+
+		const updated = await ctx.api.v2Workspace.update.mutate({
+			id,
+			name: options.name,
+		});
+
+		return {
+			data: updated,
+			message: `Updated workspace ${id}`,
+		};
+	},
+});

--- a/packages/mcp-v2/src/tools/register.ts
+++ b/packages/mcp-v2/src/tools/register.ts
@@ -27,6 +27,7 @@ import * as tasksUpdate from "./tasks/update";
 import * as workspacesCreate from "./workspaces/create";
 import * as workspacesDelete from "./workspaces/delete";
 import * as workspacesList from "./workspaces/list";
+import * as workspacesUpdate from "./workspaces/update";
 
 const REGISTRARS = [
 	tasksList,
@@ -47,6 +48,7 @@ const REGISTRARS = [
 	automationsLogs,
 	workspacesList,
 	workspacesCreate,
+	workspacesUpdate,
 	workspacesDelete,
 	agentsRun,
 	agentsList,

--- a/packages/mcp-v2/src/tools/workspaces/update.ts
+++ b/packages/mcp-v2/src/tools/workspaces/update.ts
@@ -13,12 +13,6 @@ export function register(server: McpServer): void {
 			name: z.string().min(1).optional().describe("New workspace name."),
 		},
 		handler: async (input, ctx) => {
-			const { id: _id, ...fields } = input;
-			if (Object.keys(fields).length === 0) {
-				throw new Error(
-					"No fields to update. Pass at least one field such as --name.",
-				);
-			}
 			const caller = createMcpCaller(ctx);
 			return caller.v2Workspace.update(input);
 		},

--- a/packages/mcp-v2/src/tools/workspaces/update.ts
+++ b/packages/mcp-v2/src/tools/workspaces/update.ts
@@ -7,12 +7,18 @@ export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_update",
 		description:
-			"Update fields on an existing workspace (cloud-index metadata). Only the fields you pass are changed; omitted fields preserve their current value.",
+			"Update fields on an existing workspace. At least one field is required.",
 		inputSchema: {
 			id: z.string().uuid().describe("Workspace UUID."),
 			name: z.string().min(1).optional().describe("New workspace name."),
 		},
 		handler: async (input, ctx) => {
+			const { id: _id, ...fields } = input;
+			if (Object.keys(fields).length === 0) {
+				throw new Error(
+					"No fields to update. Pass at least one field such as --name.",
+				);
+			}
 			const caller = createMcpCaller(ctx);
 			return caller.v2Workspace.update(input);
 		},

--- a/packages/mcp-v2/src/tools/workspaces/update.ts
+++ b/packages/mcp-v2/src/tools/workspaces/update.ts
@@ -1,0 +1,20 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createMcpCaller } from "../../caller";
+import { defineTool } from "../../define-tool";
+
+export function register(server: McpServer): void {
+	defineTool(server, {
+		name: "workspaces_update",
+		description:
+			"Update fields on an existing workspace (cloud-index metadata). Only the fields you pass are changed; omitted fields preserve their current value.",
+		inputSchema: {
+			id: z.string().uuid().describe("Workspace UUID."),
+			name: z.string().min(1).optional().describe("New workspace name."),
+		},
+		handler: async (input, ctx) => {
+			const caller = createMcpCaller(ctx);
+			return caller.v2Workspace.update(input);
+		},
+	});
+}

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -59,9 +59,9 @@ export class Workspaces extends APIResource {
 	}
 
 	/**
-	 * Update fields on a workspace (cloud-index metadata). Currently only the
-	 * `name` is exposed — git branch and host moves require host-side
-	 * orchestration and aren't safe to set through the cloud directly.
+	 * Update fields on a workspace. At least one field is required. Currently
+	 * only `name` is exposed — branch and host moves require host-side
+	 * orchestration and aren't safe to set directly.
 	 *
 	 * Mirrors `superset workspaces update`.
 	 */

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -59,6 +59,25 @@ export class Workspaces extends APIResource {
 	}
 
 	/**
+	 * Update fields on a workspace (cloud-index metadata). Currently only the
+	 * `name` is exposed — git branch and host moves require host-side
+	 * orchestration and aren't safe to set through the cloud directly.
+	 *
+	 * Mirrors `superset workspaces update`.
+	 */
+	update(
+		id: string,
+		params: WorkspaceUpdateParams,
+		options?: RequestOptions,
+	): APIPromise<WorkspaceUpdateResult> {
+		return this._client.mutation<WorkspaceUpdateResult>(
+			"v2Workspace.update",
+			{ id, ...params },
+			options,
+		);
+	}
+
+	/**
 	 * Delete a workspace by id. Looks up the host the workspace lives on (via
 	 * the cloud index) and routes the delete to that host's service through
 	 * the relay. Pass an explicit `hostId` to skip the lookup.
@@ -179,6 +198,26 @@ export interface WorkspaceCreateResult {
 	alreadyExists: boolean;
 }
 
+export interface WorkspaceUpdateParams {
+	/** New workspace name. */
+	name?: string;
+}
+
+export interface WorkspaceUpdateResult {
+	id: string;
+	name: string;
+	branch: string;
+	organizationId: string;
+	projectId: string;
+	hostId: string;
+	type: "main" | "worktree";
+	createdByUserId: string | null;
+	taskId: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+	txid: number;
+}
+
 export interface WorkspaceDeleteResult {
 	[key: string]: unknown;
 }
@@ -193,6 +232,8 @@ export declare namespace Workspaces {
 		WorkspaceAgentLaunch,
 		WorkspaceCreateAgentResult,
 		WorkspaceCreateResult,
+		WorkspaceUpdateParams,
+		WorkspaceUpdateResult,
 		WorkspaceDeleteResult,
 	};
 }

--- a/skills/superset/SKILL.md
+++ b/skills/superset/SKILL.md
@@ -32,6 +32,7 @@ If `$SUPERSET_WORKSPACE_ID` is unset, you're not inside a Superset workspace —
 superset workspaces create --project <id> --host <id> --name "..." --branch <branch>
 superset workspaces create --project <id> --local --name "..." --pr <number>
 superset workspaces list [--host <id> | --local]
+superset workspaces update <id> --name "..."
 superset workspaces delete <id> [<id>...]
 ```
 


### PR DESCRIPTION
## Summary

Expose `workspaces update` across all three client surfaces so workspaces can be renamed without going through the desktop UI:

- **CLI**: `superset workspaces update <id> --name "..."`
- **SDK**: `client.workspaces.update(id, { name })`
- **MCP-v2**: `workspaces_update` tool

The cloud `v2Workspace.update` procedure already accepts `name`, `branch`, and `hostId` patches. Only `name` is wired through here — branch and host moves require host-side git orchestration that isn't safe to drive directly from the cloud.

The schema leaves room for additional fields when a clear use case shows up.

## Why this PR

The CLI/SDK/MCP previously only had `create / list / delete` for workspaces — no way to rename one once it existed. The desktop app's host service has an `aiRename` flow but no plain "set the name" entry point exposed externally.

## Test plan

- [ ] `superset workspaces update <id> --name "New name"` updates the cloud row and the change appears in `superset workspaces list`
- [ ] SDK: `await client.workspaces.update(id, { name: "..." })` returns the updated row
- [ ] MCP: invoke `workspaces_update` from a connected MCP client and confirm the rename
- [ ] Omitting `--name` returns "No fields to update" (CLI) / cloud-side BAD_REQUEST (SDK/MCP)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add workspace rename support across CLI, SDK, and MCP so you can rename a workspace without the desktop app. Routes through cloud `v2Workspace.update`; only `name` is supported (branch/host moves are out of scope).

- **New Features**
  - CLI: `superset workspaces update <id> --name "New name"`; errors with "No fields to update" if `--name` is missing.
  - SDK: `client.workspaces.update(id, { name })` returns the updated workspace.
  - MCP-v2: `workspaces_update` tool accepts `id` and optional `name`; validation is handled server-side.
  - Docs: added `superset workspaces update` to the CLI reference.

<sup>Written for commit d3f10b84c87e80ec254ebb28edf79c3dde169248. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add workspace update: rename a workspace via a new CLI command and via the API/SDK.
  * Backend tool added to expose workspace update capability to integrations.

* **Documentation**
  * Updated guides to document the new "workspace update" command and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->