### PR TITLE
fix(desktop): return direct-lookup PR/issue regardless of state

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-github-issues.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-github-issues.ts
@@ -112,9 +112,6 @@ export const searchGitHubIssues = protectedProcedure
 				if (issue.url.includes("/pull/")) {
 					return { issues: [] };
 				}
-				if (!input.includeClosed && issue.state !== "open") {
-					return { issues: [] };
-				}
 				return { issues: [issue] };
 			}
 			const issues = await ghSearch(
@@ -143,9 +140,6 @@ export const searchGitHubIssues = protectedProcedure
 					issue_number: issueNumber,
 				});
 				if (issue.pull_request) {
-					return { issues: [] };
-				}
-				if (!input.includeClosed && issue.state !== "open") {
 					return { issues: [] };
 				}
 				return {

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
@@ -119,9 +119,6 @@ export const searchPullRequests = protectedProcedure
 			if (normalized.isDirectLookup) {
 				const prNumber = Number.parseInt(effectiveQuery, 10);
 				const pr = await ghDirectLookup(ctx.execGh, repo, prNumber);
-				if (!input.includeClosed && pr.state !== "open") {
-					return { pullRequests: [] };
-				}
 				return { pullRequests: [pr] };
 			}
 			const pullRequests = await ghSearch(
@@ -150,9 +147,6 @@ export const searchPullRequests = protectedProcedure
 					pull_number: prNumber,
 				});
 				const state = normalizePullRequestState(pr.state, pr.merged_at);
-				if (!input.includeClosed && state !== "open") {
-					return { pullRequests: [] };
-				}
 				return {
 					pullRequests: [
 						{


### PR DESCRIPTION
## Summary

- Pasting a same-repo PR URL (or `#N`) into the v2 new-workspace modal returned an empty list when the PR was closed or merged. The direct-lookup branch was applying the same `!includeClosed && state !== open` filter as the text-search branch, so the dropdown rendered "No open pull requests found." with no hint that the PR actually existed.
- Direct lookups are unambiguous: the user named a specific PR/issue and wants that one back. State filtering only makes sense for the browse/text-search branch where it bounds an open-ended result set.
- Drop the state guard from both gh and Octokit direct-lookup branches in `searchPullRequests` and `searchGitHubIssues`. Kept the entity-type guards (`/pull/` URL check, `issue.pull_request`) that prevent issues from leaking into PR results and vice versa.

## Test plan

- [ ] Open v2 new-workspace modal, click PR icon, paste a URL of an **open** PR for the project's repo → resolves to that PR
- [ ] Same dropdown, paste URL of a **merged** PR with "Show closed" unchecked → resolves to that PR (was returning empty)
- [ ] Same dropdown, paste URL of a **closed** PR with "Show closed" unchecked → resolves to that PR
- [ ] Paste `#N` shorthand for a closed PR → resolves
- [ ] Paste cross-repo URL → still shows "PR URL must match owner/name"
- [ ] Type free text → text-search branch still respects "Show closed"
- [ ] Repeat the above for the GitHub issue dropdown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the exact PR/issue when a same-repo URL or `#N` is pasted in the v2 new-workspace modal, even if it’s closed or merged. Text search still respects “Show closed”.

- **Bug Fixes**
  - Removed state filtering from direct-lookup paths in `searchPullRequests` and `searchGitHubIssues` (GH and Octokit).
  - Kept entity-type guards to prevent PRs from appearing in issues (and vice versa).

<sup>Written for commit c4a8a8f5a1f850457668a06c30605c9e8f9bd051. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Direct pull request lookups now consistently return results regardless of the open/closed state filter.
* Improved pull request detection in GitHub issue searches to prevent incorrect filtering.
* Enhanced consistency between direct lookups and general search queries for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->