### PR TITLE
fix(desktop): reserve space for delete-dialog warning banner

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx
@@ -31,7 +31,6 @@ export function DashboardSidebarDeleteDialog({
 		hasUnpushedCommits,
 		canConfirm,
 		blockingReason,
-		isCheckingStatus,
 		error,
 		handleOpenChange,
 		run,
@@ -68,7 +67,6 @@ export function DashboardSidebarDeleteDialog({
 			hasUnpushedCommits={hasUnpushedCommits}
 			canConfirm={canConfirm}
 			blockingReason={blockingReason}
-			isCheckingStatus={isCheckingStatus}
 			onConfirm={() => run(hasWarnings)}
 			confirmLabel={confirmLabel}
 		/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
@@ -21,7 +21,6 @@ interface DestroyConfirmPaneProps {
 	hasUnpushedCommits: boolean;
 	canConfirm: boolean;
 	blockingReason: string | null;
-	isCheckingStatus: boolean;
 	onConfirm: () => void;
 	confirmLabel: string;
 }
@@ -36,7 +35,6 @@ export function DestroyConfirmPane({
 	hasUnpushedCommits,
 	canConfirm,
 	blockingReason,
-	isCheckingStatus,
 	onConfirm,
 	confirmLabel,
 }: DestroyConfirmPaneProps) {
@@ -54,22 +52,24 @@ export function DestroyConfirmPane({
 						also be removed.
 					</AlertDialogDescription>
 				</AlertDialogHeader>
-				{isCheckingStatus && !hasWarnings && (
-					<div className="px-4 pb-2 text-xs text-muted-foreground">
-						Checking delete status…
-					</div>
-				)}
-				{hasWarnings && (
-					<div className="px-4 pb-2">
-						<div className="text-xs text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-500/10 border border-yellow-200 dark:border-yellow-500/20 rounded-md px-2.5 py-1.5">
-							{hasChanges && hasUnpushedCommits
+				<div className="px-4 pb-2">
+					<div
+						className={
+							hasWarnings
+								? "text-xs rounded-md border px-2.5 py-1.5 text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-500/10 border-yellow-200 dark:border-yellow-500/20"
+								: "text-xs rounded-md border border-transparent px-2.5 py-1.5"
+						}
+						aria-hidden={hasWarnings ? undefined : true}
+					>
+						{hasWarnings
+							? hasChanges && hasUnpushedCommits
 								? "Has uncommitted changes and unpushed commits"
 								: hasChanges
 									? "Has uncommitted changes"
-									: "Has unpushed commits"}
-						</div>
+									: "Has unpushed commits"
+							: " "}
 					</div>
-				)}
+				</div>
 				{blockingReason && (
 					<div className="px-4 pb-2">
 						<div className="text-xs text-destructive bg-destructive/10 border border-destructive/20 rounded-md px-2.5 py-1.5">


### PR DESCRIPTION
## Summary
- Collapsed the delete-workspace dialog's loading text + uncommitted-changes banner into a single fixed-height slot so the dialog no longer shifts when the git status check resolves.
- Dropped the now-unused \`isCheckingStatus\` prop — the loading message was visually noisy ("looks cheap") and the reserved slot already absorbs the latency.

## Test plan
- [ ] Open the dashboard sidebar delete dialog on a clean workspace — slot stays empty, no shift on resolve.
- [ ] Open it on a workspace with uncommitted changes / unpushed commits — banner appears in pre-reserved space, no shift.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents layout shift in the desktop delete-workspace dialog by reserving a fixed-height slot for the warning banner and removing the loading message. The dialog now stays stable whether or not there are uncommitted changes or unpushed commits.

- **Bug Fixes**
  - Collapsed loading text and uncommitted-changes banner into a single fixed-height slot.
  - When there are no warnings, the slot remains transparent, avoiding any UI shift when the git status resolves.

- **Refactors**
  - Removed the unused `isCheckingStatus` prop from the dialog and confirm pane.

<sup>Written for commit 9016528e461034b312ab371c9fb6279ed6b40e76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the delete confirmation dialog to better inform users about repository state with clear warnings for uncommitted changes and unpushed commits
  * Removed the "checking delete status" indicator to provide a cleaner, more responsive user experience
  * Improved the warning banner display to make critical repository status information more prominent during the deletion confirmation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->