### PR TITLE
fix(desktop): stop new-project modal from closing on open

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
@@ -132,7 +132,7 @@ export function NewProjectModal({
 	};
 
 	return (
-		<Dialog open={open} onOpenChange={handleOpenChange}>
+		<Dialog open={open} onOpenChange={handleOpenChange} modal>
 			<DialogContent className="max-w-[420px]">
 				<DialogHeader>
 					<DialogTitle>Clone a repository</DialogTitle>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -61,6 +61,7 @@ export function DashboardSidebarHeader({
 			toast.success("Project ready — open it from the sidebar.");
 		}
 	};
+
 	const shortcutText = useHotkeyDisplay("NEW_WORKSPACE").text;
 	const { data: platform } = electronTrpc.window.getPlatform.useQuery();
 	// Default to Mac while loading so we don't briefly cover the traffic lights.
@@ -192,7 +193,10 @@ export function DashboardSidebarHeader({
 						</TooltipTrigger>
 						<TooltipContent side="right">Add repository</TooltipContent>
 					</Tooltip>
-					<DropdownMenuContent align="start">
+					<DropdownMenuContent
+						align="start"
+						onCloseAutoFocus={(event) => event.preventDefault()}
+					>
 						<DropdownMenuItem onSelect={() => openNewProject()}>
 							<HiMiniPlus className="size-4" />
 							Create new project
@@ -300,7 +304,10 @@ export function DashboardSidebarHeader({
 						</TooltipTrigger>
 						<TooltipContent side="right">Add repository</TooltipContent>
 					</Tooltip>
-					<DropdownMenuContent align="end">
+					<DropdownMenuContent
+						align="end"
+						onCloseAutoFocus={(event) => event.preventDefault()}
+					>
 						<DropdownMenuItem onSelect={() => openNewProject()}>
 							<HiMiniPlus className="size-4" />
 							Create new project


### PR DESCRIPTION
## Summary
- The "Create new project" entry in the v2 sidebar's add-repository dropdown sometimes opened the modal and instantly closed it. The dropdown's closing pointerup was racing the dialog and firing `onPointerDownOutside` on it.
- The shared `Dialog` wrapper (`packages/ui/src/components/ui/dialog.tsx`) defaults to `modal={false}`, so any outside pointer event dismisses it. Pass `modal` on `NewProjectModal` so Radix renders an overlay that catches the stray pointerup; outside-click-to-close still works via the dimmed overlay.
- Defense-in-depth: add `onCloseAutoFocus={(e) => e.preventDefault()}` on the dropdown content (matches `DashboardSidebarWorkspaceContextMenu.tsx:83`, `DashboardSidebarSectionContextMenu.tsx:25`, etc.) so focus doesn't snap back to the trigger as the dialog opens.

## Test plan
- [ ] Open the v2 sidebar's add-repository dropdown (folder+ icon) and click "Create new project" — modal stays open every time.
- [ ] Repeat in the collapsed sidebar variant.
- [ ] Click the dimmed overlay outside the modal — modal still closes.
- [ ] Press Escape / click Cancel / click the X — all still close as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Create new project” modal closing immediately when opened from the Add repository dropdown in the v2 sidebar. The modal now stays open; clicking the overlay or pressing Escape still closes it.

- **Bug Fixes**
  - Set `modal` on the `Dialog` in `NewProjectModal` so the overlay absorbs the dropdown’s trailing pointerup.
  - Added `onCloseAutoFocus={(e) => e.preventDefault()}` to `DropdownMenuContent` (both sidebar variants) to avoid focus snapping back to the trigger.

<sup>Written for commit ef30a76644b6987cd545082e05442ca7e148af04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal behavior during project creation workflow
  * Fixed auto-focus behavior in the dashboard sidebar dropdown menu for a smoother user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->