### PR TITLE
fix(desktop): align v2 sidebar shortcuts with rendered project order

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -98,7 +98,6 @@ export function DashboardSidebar({
 }: DashboardSidebarProps) {
 	const { groups, refreshWorkspacePullRequest, toggleProjectCollapsed } =
 		useDashboardSidebarData();
-	const workspaceShortcutLabels = useDashboardSidebarShortcuts(groups);
 	const { reorderProjects } = useDashboardSidebarState();
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -135,6 +134,8 @@ export function DashboardSidebar({
 			.map((id) => byId.get(id))
 			.filter((g): g is DashboardSidebarProject => g != null);
 	}, [groups, projectOrder]);
+
+	const workspaceShortcutLabels = useDashboardSidebarShortcuts(orderedGroups);
 
 	const activeV2Project = useMemo(() => {
 		if (!activeV2WorkspaceId) return null;


### PR DESCRIPTION
## Summary
- Project shortcuts (⌘1–⌘9) were indexed off the live-query `groups`, so after a drag reorder they kept the original order until the persisted `tabOrder` write round-tripped — pressing ⌘1/⌘2/⌘3 jumped 1 → 3 → 2.
- Drive `useDashboardSidebarShortcuts` off `orderedGroups` (the same locally-applied order the sidebar renders) so shortcuts track the visible layout immediately.

## Test plan
- [ ] Open desktop app with ≥3 projects, drag a project to a new position
- [ ] Verify ⌘1 / ⌘2 / ⌘3 jump to the workspaces in the visible top-to-bottom order, not the pre-drag order
- [ ] Verify shortcut labels next to each workspace match the new order

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 sidebar shortcuts (⌘1–⌘9) to follow the visible project order immediately after drag reordering. Shortcuts and labels now match the rendered layout by using `orderedGroups` instead of live `groups`.

- **Bug Fixes**
  - Drive `useDashboardSidebarShortcuts` from `orderedGroups` so shortcuts reflect the locally rendered order.
  - Prevents jumps like 1 → 3 → 2 after reordering; labels and navigation now match top-to-bottom order.

<sup>Written for commit ed128529d038f003a60847c76d4084d7ddf12261. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar shortcut labels to remain synchronized with the reordered project list when users reorganize items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->