### PR TITLE
feat(slack): add slack-mcp-v2 flag + align mcp-v2/cli/sdk surface

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/mcp-clients.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/mcp-clients.ts
@@ -1,7 +1,9 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { McpContext } from "@superset/mcp/auth";
-import { createInMemoryMcpClient } from "@superset/mcp/in-memory";
+import { createInMemoryMcpClient as createV1Client } from "@superset/mcp/in-memory";
+import { createInMemoryMcpClient as createV2Client } from "@superset/mcp-v2/in-memory";
+import { env } from "@/env";
 import { posthog } from "@/lib/analytics";
 
 interface McpTool {
@@ -9,6 +11,8 @@ interface McpTool {
 	description?: string;
 	inputSchema: unknown;
 }
+
+const SLACK_CLIENT_LABEL = "slack-agent";
 
 // Uses InMemoryTransport — no HTTP, no forgeable headers.
 export async function createSupersetMcpClient({
@@ -18,7 +22,7 @@ export async function createSupersetMcpClient({
 	organizationId: string;
 	userId: string;
 }): Promise<{ client: Client; cleanup: () => Promise<void> }> {
-	return createInMemoryMcpClient({
+	return createV1Client({
 		organizationId,
 		userId,
 		source: "slack",
@@ -31,6 +35,38 @@ export async function createSupersetMcpClient({
 					source: ctx.source,
 					org_id: ctx.organizationId,
 				},
+			});
+		},
+	});
+}
+
+export async function createSupersetMcpV2Client({
+	organizationId,
+	userId,
+}: {
+	organizationId: string;
+	userId: string;
+}): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+	return createV2Client({
+		organizationId,
+		userId,
+		clientLabel: SLACK_CLIENT_LABEL,
+		relayUrl: env.RELAY_URL,
+		onToolCall: (event) => {
+			posthog.capture({
+				distinctId: event.userId,
+				event: "mcp_tool_called",
+				properties: {
+					tool: event.toolName,
+					organization_id: event.organizationId,
+					auth_source: event.source,
+					client_label: event.clientLabel,
+					duration_ms: event.durationMs,
+					success: event.success,
+					error_message: event.errorMessage,
+					mcp_server: "superset-v2",
+				},
+				groups: { organization: event.organizationId },
 			});
 		},
 	});

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -1,12 +1,15 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { WebClient } from "@slack/web-api";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { env } from "@/env";
+import { posthog } from "@/lib/analytics";
 import { DEFAULT_SLACK_MODEL } from "../../../constants";
 import type { AgentAction } from "../slack-blocks";
 import type { SlackImageAsset } from "../slack-image-assets";
 import {
 	createSupersetMcpClient,
+	createSupersetMcpV2Client,
 	mcpToolToAnthropicTool,
 	parseToolName,
 } from "./mcp-clients";
@@ -159,6 +162,7 @@ function getActionFromToolResult(
 	const data = result.structuredContent ?? parseTextContent(result.content);
 	if (!data) return null;
 
+	// v1 tool names — kept while the feature flag rollout is incomplete.
 	if (toolName === "create_task" && data.created) {
 		return {
 			type: "task_created",
@@ -225,6 +229,38 @@ function getActionFromToolResult(
 		};
 	}
 
+	// v2 tool names. Wire format differs: tasks_create/update return
+	// `{ task, txid }`, tasks_delete returns `{ txid }` only (no task info
+	// — we skip surfacing that as an action), workspaces_create returns
+	// `{ workspace: { id, name, branch }, ... }`.
+	if (toolName === "tasks_create" && data.task) {
+		const t = data.task as { id: string; slug: string; title: string };
+		return {
+			type: "task_created",
+			tasks: [{ id: t.id, slug: t.slug, title: t.title, status: "Backlog" }],
+		};
+	}
+
+	if (toolName === "tasks_update" && data.task) {
+		const t = data.task as { id: string; slug: string; title: string };
+		return {
+			type: "task_updated",
+			tasks: [{ id: t.id, slug: t.slug, title: t.title }],
+		};
+	}
+
+	if (toolName === "workspaces_create" && data.workspace) {
+		const w = data.workspace as {
+			id: string;
+			name: string;
+			branch: string;
+		};
+		return {
+			type: "workspace_created",
+			workspaces: [{ id: w.id, name: w.name, branch: w.branch }],
+		};
+	}
+
 	return null;
 }
 
@@ -262,6 +298,7 @@ function stripServerToolBlocks(
 }
 
 const TOOL_PROGRESS_STATUS: Record<string, string> = {
+	// v1
 	create_task: "Creating task...",
 	update_task: "Updating task...",
 	delete_task: "Deleting task...",
@@ -270,16 +307,41 @@ const TOOL_PROGRESS_STATUS: Record<string, string> = {
 	create_workspace: "Creating workspace...",
 	list_workspaces: "Fetching workspaces...",
 	list_projects: "Fetching projects...",
+	// v2
+	tasks_create: "Creating task...",
+	tasks_update: "Updating task...",
+	tasks_delete: "Deleting task...",
+	tasks_list: "Searching tasks...",
+	tasks_get: "Fetching task details...",
+	workspaces_create: "Creating workspace...",
+	workspaces_list: "Fetching workspaces...",
+	workspaces_delete: "Deleting workspace...",
+	projects_list: "Fetching projects...",
+	hosts_list: "Fetching hosts...",
+	organization_members_list: "Fetching members...",
+	tasks_statuses_list: "Fetching task statuses...",
+	automations_list: "Fetching automations...",
+	automations_run: "Running automation...",
+	agents_list: "Fetching agents...",
+	agents_run: "Launching agent...",
+	// Server-side
 	slack_get_channel_history: "Reading channel history...",
 };
 
-// Tools excluded from Slack agent context
-const DENIED_SUPERSET_TOOLS = new Set([
+// v1 tools excluded from the Slack agent's tool list (preloaded as context).
+const DENIED_SUPERSET_TOOLS_V1 = new Set([
 	"switch_workspace",
 	"get_app_context",
 	"list_members",
 	"list_task_statuses",
 	"list_devices",
+]);
+
+// v2 tools excluded for the same reason.
+const DENIED_SUPERSET_TOOLS_V2 = new Set([
+	"organization_members_list",
+	"tasks_statuses_list",
+	"hosts_list",
 ]);
 
 const SLACK_GET_CHANNEL_HISTORY_TOOL: Anthropic.Tool = {
@@ -361,17 +423,28 @@ Context gathering:
 async function fetchAgentContext({
 	mcpClient,
 	userId,
+	useV2,
 }: {
 	mcpClient: Client;
 	userId: string;
+	useV2: boolean;
 }): Promise<string> {
-	const [membersResult, statusesResult, devicesResult] = await Promise.all([
-		mcpClient.callTool({ name: "list_members", arguments: {} }),
-		mcpClient.callTool({ name: "list_task_statuses", arguments: {} }),
-		mcpClient.callTool({
-			name: "list_devices",
-			arguments: {},
-		}),
+	const toolNames = useV2
+		? {
+				members: "organization_members_list",
+				statuses: "tasks_statuses_list",
+				hosts: "hosts_list",
+			}
+		: {
+				members: "list_members",
+				statuses: "list_task_statuses",
+				hosts: "list_devices",
+			};
+
+	const [membersResult, statusesResult, hostsResult] = await Promise.all([
+		mcpClient.callTool({ name: toolNames.members, arguments: {} }),
+		mcpClient.callTool({ name: toolNames.statuses, arguments: {} }),
+		mcpClient.callTool({ name: toolNames.hosts, arguments: {} }),
 	]);
 
 	const sections: string[] = [];
@@ -403,20 +476,33 @@ async function fetchAgentContext({
 		sections.push(`Task statuses:\n${lines.join("\n")}`);
 	}
 
-	const devicesData = devicesResult.structuredContent as {
-		devices: {
-			deviceId: string;
-			deviceName: string | null;
-			ownerName: string | null;
-			ownerEmail: string;
-		}[];
-	} | null;
-	if (devicesData?.devices?.length) {
-		const lines = devicesData.devices.map(
-			(d) =>
-				`- ${d.deviceName ?? "Unknown"} (id: ${d.deviceId}, owner: ${d.ownerName ?? d.ownerEmail})`,
-		);
-		sections.push(`Devices:\n${lines.join("\n")}`);
+	if (useV2) {
+		// v2 hosts_list returns a bare array, which the SDK wraps as `{ result }`.
+		const hostsData = hostsResult.structuredContent as {
+			result: { id: string; name: string; online: boolean }[];
+		} | null;
+		if (hostsData?.result?.length) {
+			const lines = hostsData.result.map(
+				(h) => `- ${h.name} (id: ${h.id}, online: ${h.online ? "yes" : "no"})`,
+			);
+			sections.push(`Hosts:\n${lines.join("\n")}`);
+		}
+	} else {
+		const devicesData = hostsResult.structuredContent as {
+			devices: {
+				deviceId: string;
+				deviceName: string | null;
+				ownerName: string | null;
+				ownerEmail: string;
+			}[];
+		} | null;
+		if (devicesData?.devices?.length) {
+			const lines = devicesData.devices.map(
+				(d) =>
+					`- ${d.deviceName ?? "Unknown"} (id: ${d.deviceId}, owner: ${d.ownerName ?? d.ownerEmail})`,
+			);
+			sections.push(`Devices:\n${lines.join("\n")}`);
+		}
 	}
 
 	return sections.join("\n\n");
@@ -464,6 +550,19 @@ export async function runSlackAgent(
 	const anthropic = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
 	const actions: AgentAction[] = [];
 
+	let useV2 = false;
+	try {
+		useV2 = Boolean(
+			await posthog.getFeatureFlag(
+				FEATURE_FLAGS.SLACK_MCP_V2,
+				params.organizationId,
+				{ groups: { organization: params.organizationId } },
+			),
+		);
+	} catch (error) {
+		console.warn("[slack-agent] Failed to load mcp-v2 flag:", error);
+	}
+
 	let supersetMcp: Client | null = null;
 	let cleanupSuperset: (() => Promise<void>) | null = null;
 
@@ -474,10 +573,15 @@ export async function runSlackAgent(
 				channelId: params.channelId,
 				threadTs: params.threadTs,
 			}),
-			createSupersetMcpClient({
-				organizationId: params.organizationId,
-				userId: params.userId,
-			}),
+			useV2
+				? createSupersetMcpV2Client({
+						organizationId: params.organizationId,
+						userId: params.userId,
+					})
+				: createSupersetMcpClient({
+						organizationId: params.organizationId,
+						userId: params.userId,
+					}),
 		]);
 
 		supersetMcp = supersetMcpResult.client;
@@ -488,11 +592,15 @@ export async function runSlackAgent(
 			fetchAgentContext({
 				mcpClient: supersetMcp,
 				userId: params.userId,
+				useV2,
 			}),
 		]);
 
+		const deniedTools = useV2
+			? DENIED_SUPERSET_TOOLS_V2
+			: DENIED_SUPERSET_TOOLS_V1;
 		const supersetTools = supersetToolsResult.tools
-			.filter((t) => !DENIED_SUPERSET_TOOLS.has(t.name))
+			.filter((t) => !deniedTools.has(t.name))
 			.map((t) => mcpToolToAnthropicTool(t, "superset"));
 
 		const tools: Anthropic.Messages.ToolUnion[] = [

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -553,11 +553,7 @@ export async function runSlackAgent(
 	let useV2 = false;
 	try {
 		useV2 = Boolean(
-			await posthog.getFeatureFlag(
-				FEATURE_FLAGS.SLACK_MCP_V2,
-				params.organizationId,
-				{ groups: { organization: params.organizationId } },
-			),
+			await posthog.getFeatureFlag(FEATURE_FLAGS.SLACK_MCP_V2, params.userId),
 		);
 	} catch (error) {
 		console.warn("[slack-agent] Failed to load mcp-v2 flag:", error);

--- a/packages/cli/src/commands/organization/members/list/command.ts
+++ b/packages/cli/src/commands/organization/members/list/command.ts
@@ -1,0 +1,22 @@
+import { number, string, table } from "@superset/cli-framework";
+import { command } from "../../../../lib/command";
+
+export default command({
+	description: "List members of the active organization",
+	options: {
+		search: string().alias("s").desc("Search by name or email"),
+		limit: number().default(50).desc("Max results"),
+	},
+	display: (data) =>
+		table(
+			data as Record<string, unknown>[],
+			["name", "email", "role", "id"],
+			["NAME", "EMAIL", "ROLE", "ID"],
+		),
+	run: async ({ ctx, options }) => {
+		return ctx.api.organization.members.list.query({
+			search: options.search ?? undefined,
+			limit: options.limit,
+		});
+	},
+});

--- a/packages/cli/src/commands/organization/members/meta.ts
+++ b/packages/cli/src/commands/organization/members/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	description: "Manage organization members",
+};

--- a/packages/cli/src/commands/tasks/statuses/list/command.ts
+++ b/packages/cli/src/commands/tasks/statuses/list/command.ts
@@ -1,0 +1,15 @@
+import { table } from "@superset/cli-framework";
+import { command } from "../../../../lib/command";
+
+export default command({
+	description: "List task statuses in the active organization",
+	display: (data) =>
+		table(
+			data as Record<string, unknown>[],
+			["name", "type", "position", "id"],
+			["NAME", "TYPE", "POS", "ID"],
+		),
+	run: async ({ ctx }) => {
+		return ctx.api.task.statuses.list.query();
+	},
+});

--- a/packages/cli/src/commands/tasks/statuses/meta.ts
+++ b/packages/cli/src/commands/tasks/statuses/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	description: "Manage task statuses",
+};

--- a/packages/mcp-v2/src/in-memory.ts
+++ b/packages/mcp-v2/src/in-memory.ts
@@ -5,6 +5,7 @@ import { db } from "@superset/db/client";
 import { members, users } from "@superset/db/schema";
 import { eq } from "drizzle-orm";
 import type { McpContext } from "./auth";
+import type { McpToolCallEmitter } from "./define-tool";
 import { createMcpServer } from "./server";
 
 export interface InMemoryClientOptions {
@@ -12,6 +13,7 @@ export interface InMemoryClientOptions {
 	organizationId: string;
 	clientLabel: string;
 	relayUrl: string;
+	onToolCall?: McpToolCallEmitter;
 }
 
 /**
@@ -28,6 +30,7 @@ export async function createInMemoryMcpClient({
 	organizationId,
 	clientLabel,
 	relayUrl,
+	onToolCall,
 }: InMemoryClientOptions): Promise<{
 	client: Client;
 	cleanup: () => Promise<void>;
@@ -72,7 +75,7 @@ export async function createInMemoryMcpClient({
 		relayUrl,
 	};
 
-	const server = createMcpServer();
+	const server = createMcpServer({ onToolCall });
 	const [serverTransport, clientTransport] =
 		InMemoryTransport.createLinkedPair();
 

--- a/packages/mcp-v2/src/tools/organization/members/list.ts
+++ b/packages/mcp-v2/src/tools/organization/members/list.ts
@@ -1,0 +1,31 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createMcpCaller } from "../../../caller";
+import { defineTool } from "../../../define-tool";
+
+export function register(server: McpServer): void {
+	defineTool(server, {
+		name: "organization_members_list",
+		description:
+			"List members of the active organization. Use this to look up a user's id by name or email before assigning a task or filtering by assignee.",
+		inputSchema: {
+			search: z
+				.string()
+				.min(1)
+				.nullish()
+				.describe("Free-text search on name or email."),
+			limit: z
+				.number()
+				.int()
+				.positive()
+				.max(100)
+				.default(50)
+				.describe("Max members to return. Default 50, max 100."),
+		},
+		handler: async (input, ctx) => {
+			const caller = createMcpCaller(ctx);
+			const rows = await caller.organization.members.list(input ?? {});
+			return { members: rows };
+		},
+	});
+}

--- a/packages/mcp-v2/src/tools/register.ts
+++ b/packages/mcp-v2/src/tools/register.ts
@@ -18,11 +18,13 @@ import * as automationsRun from "./automations/run";
 import * as automationsSetPrompt from "./automations/set_prompt";
 import * as automationsUpdate from "./automations/update";
 import * as hostsList from "./hosts/list";
+import * as organizationMembersList from "./organization/members/list";
 import * as projectsList from "./projects/list";
 import * as tasksCreate from "./tasks/create";
 import * as tasksDelete from "./tasks/delete";
 import * as tasksGet from "./tasks/get";
 import * as tasksList from "./tasks/list";
+import * as tasksStatusesList from "./tasks/statuses/list";
 import * as tasksUpdate from "./tasks/update";
 import * as workspacesCreate from "./workspaces/create";
 import * as workspacesDelete from "./workspaces/delete";
@@ -34,6 +36,8 @@ const REGISTRARS = [
 	tasksCreate,
 	tasksUpdate,
 	tasksDelete,
+	tasksStatusesList,
+	organizationMembersList,
 	automationsList,
 	automationsGet,
 	automationsGetPrompt,

--- a/packages/mcp-v2/src/tools/tasks/statuses/list.ts
+++ b/packages/mcp-v2/src/tools/tasks/statuses/list.ts
@@ -1,0 +1,16 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createMcpCaller } from "../../../caller";
+import { defineTool } from "../../../define-tool";
+
+export function register(server: McpServer): void {
+	defineTool(server, {
+		name: "tasks_statuses_list",
+		description:
+			"List the available task statuses in the active organization. Use this to look up a status id by name (e.g. 'In Progress', 'Done') before creating or updating a task.",
+		handler: async (_input, ctx) => {
+			const caller = createMcpCaller(ctx);
+			const rows = await caller.task.statuses.list();
+			return { statuses: rows };
+		},
+	});
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -73,6 +73,17 @@ import {
 } from "./resources/automations";
 import { Host, HostListResponse, Hosts } from "./resources/hosts";
 import * as API from "./resources/index";
+import {
+	Member,
+	MemberAddParams,
+	MemberListParams,
+	MemberListResponse,
+	MemberRemoveParams,
+	MemberRemoveResult,
+	Members,
+	Organization,
+	OrganizationRole,
+} from "./resources/organization";
 import { Project, ProjectListResponse, Projects } from "./resources/projects";
 import {
 	Task,
@@ -81,6 +92,9 @@ import {
 	TaskListParams,
 	TaskListResponse,
 	Tasks,
+	TaskStatus,
+	TaskStatuses,
+	TaskStatusListResponse,
 	TaskUpdateParams,
 } from "./resources/tasks";
 import {
@@ -1099,7 +1113,7 @@ export class Superset {
 
 	static toFile = Uploads.toFile;
 
-	/** Tasks: create, list (with filters), retrieve, update, delete. */
+	/** Tasks: create, list (with filters), retrieve, update, delete; nested `tasks.statuses.list`. */
 	tasks: API.Tasks = new API.Tasks(this);
 	/** Workspaces (cloud records): list, delete. */
 	workspaces: API.Workspaces = new API.Workspaces(this);
@@ -1111,6 +1125,8 @@ export class Superset {
 	automations: API.Automations = new API.Automations(this);
 	/** Agents (per-host terminal-agent rows): list, run. */
 	agents: API.Agents = new API.Agents(this);
+	/** Active-organization config: nested `organization.members.list/add/remove`. */
+	organization: API.Organization = new API.Organization(this);
 }
 
 Superset.Tasks = Tasks;
@@ -1119,6 +1135,7 @@ Superset.Projects = Projects;
 Superset.Hosts = Hosts;
 Superset.Automations = Automations;
 Superset.Agents = Agents;
+Superset.Organization = Organization;
 
 export declare namespace Superset {
 	export type RequestOptions = Opts.RequestOptions;
@@ -1131,6 +1148,21 @@ export declare namespace Superset {
 		TaskCreateParams,
 		TaskUpdateParams,
 		TaskListParams,
+		TaskStatuses,
+		TaskStatus,
+		TaskStatusListResponse,
+	};
+
+	export {
+		Organization,
+		Members,
+		Member,
+		MemberListResponse,
+		MemberListParams,
+		MemberAddParams,
+		MemberRemoveParams,
+		MemberRemoveResult,
+		OrganizationRole,
 	};
 
 	export {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -75,11 +75,8 @@ import { Host, HostListResponse, Hosts } from "./resources/hosts";
 import * as API from "./resources/index";
 import {
 	Member,
-	MemberAddParams,
 	MemberListParams,
 	MemberListResponse,
-	MemberRemoveParams,
-	MemberRemoveResult,
 	Members,
 	Organization,
 	OrganizationRole,
@@ -1125,7 +1122,7 @@ export class Superset {
 	automations: API.Automations = new API.Automations(this);
 	/** Agents (per-host terminal-agent rows): list, run. */
 	agents: API.Agents = new API.Agents(this);
-	/** Active-organization config: nested `organization.members.list/add/remove`. */
+	/** Active-organization config: nested `organization.members.list`. */
 	organization: API.Organization = new API.Organization(this);
 }
 
@@ -1159,9 +1156,6 @@ export declare namespace Superset {
 		Member,
 		MemberListResponse,
 		MemberListParams,
-		MemberAddParams,
-		MemberRemoveParams,
-		MemberRemoveResult,
 		OrganizationRole,
 	};
 

--- a/packages/sdk/src/resources/index.ts
+++ b/packages/sdk/src/resources/index.ts
@@ -21,6 +21,17 @@ export {
 	type AutomationUpdateParams,
 } from "./automations";
 export { type Host, type HostListResponse, Hosts } from "./hosts";
+export {
+	type Member,
+	type MemberAddParams,
+	type MemberListParams,
+	type MemberListResponse,
+	type MemberRemoveParams,
+	type MemberRemoveResult,
+	Members,
+	Organization,
+	type OrganizationRole,
+} from "./organization";
 export { type Project, type ProjectListResponse, Projects } from "./projects";
 export {
 	type Task,
@@ -29,6 +40,9 @@ export {
 	type TaskListParams,
 	type TaskListResponse,
 	Tasks,
+	type TaskStatus,
+	type TaskStatusListResponse,
+	TaskStatuses,
 	type TaskUpdateParams,
 } from "./tasks";
 export {

--- a/packages/sdk/src/resources/index.ts
+++ b/packages/sdk/src/resources/index.ts
@@ -23,11 +23,8 @@ export {
 export { type Host, type HostListResponse, Hosts } from "./hosts";
 export {
 	type Member,
-	type MemberAddParams,
 	type MemberListParams,
 	type MemberListResponse,
-	type MemberRemoveParams,
-	type MemberRemoveResult,
 	Members,
 	Organization,
 	type OrganizationRole,

--- a/packages/sdk/src/resources/organization.ts
+++ b/packages/sdk/src/resources/organization.ts
@@ -1,0 +1,98 @@
+import type { APIPromise } from "../core/api-promise";
+import { APIResource } from "../core/resource";
+import type { RequestOptions } from "../internal/request-options";
+
+export class Members extends APIResource {
+	/**
+	 * List members of the active organization.
+	 *
+	 * Mirrors `superset organization members list`.
+	 */
+	list(
+		query?: MemberListParams | null,
+		options?: RequestOptions,
+	): APIPromise<MemberListResponse> {
+		return this._client.query<MemberListResponse>(
+			"organization.members.list",
+			query ?? undefined,
+			options,
+		);
+	}
+
+	/**
+	 * Add an existing user to the active organization. The user must already
+	 * have a Superset account — pass their userId.
+	 */
+	add(body: MemberAddParams, options?: RequestOptions): APIPromise<Member> {
+		return this._client.mutation<Member>(
+			"organization.members.add",
+			body,
+			options,
+		);
+	}
+
+	/**
+	 * Remove a member from the organization by userId.
+	 */
+	remove(
+		body: MemberRemoveParams,
+		options?: RequestOptions,
+	): APIPromise<MemberRemoveResult> {
+		return this._client.mutation<MemberRemoveResult>(
+			"organization.members.remove",
+			body,
+			options,
+		);
+	}
+}
+
+export class Organization extends APIResource {
+	/**
+	 * Member management for the active organization.
+	 */
+	members: Members = new Members(this._client);
+}
+
+export type OrganizationRole = "member" | "admin" | "owner";
+
+export interface Member {
+	id: string;
+	name: string | null;
+	email: string;
+	image: string | null;
+	role: OrganizationRole;
+}
+
+export type MemberListResponse = Array<Member>;
+
+export interface MemberListParams {
+	search?: string | null;
+	limit?: number;
+}
+
+export interface MemberAddParams {
+	organizationId: string;
+	userId: string;
+	role?: OrganizationRole;
+}
+
+export interface MemberRemoveParams {
+	organizationId: string;
+	userId: string;
+}
+
+export interface MemberRemoveResult {
+	success: boolean;
+}
+
+export declare namespace Organization {
+	export type {
+		Member,
+		MemberAddParams,
+		MemberListParams,
+		MemberListResponse,
+		MemberRemoveParams,
+		MemberRemoveResult,
+		OrganizationRole,
+	};
+}

--- a/packages/sdk/src/resources/organization.ts
+++ b/packages/sdk/src/resources/organization.ts
@@ -18,37 +18,12 @@ export class Members extends APIResource {
 			options,
 		);
 	}
-
-	/**
-	 * Add an existing user to the active organization. The user must already
-	 * have a Superset account — pass their userId.
-	 */
-	add(body: MemberAddParams, options?: RequestOptions): APIPromise<Member> {
-		return this._client.mutation<Member>(
-			"organization.members.add",
-			body,
-			options,
-		);
-	}
-
-	/**
-	 * Remove a member from the organization by userId.
-	 */
-	remove(
-		body: MemberRemoveParams,
-		options?: RequestOptions,
-	): APIPromise<MemberRemoveResult> {
-		return this._client.mutation<MemberRemoveResult>(
-			"organization.members.remove",
-			body,
-			options,
-		);
-	}
 }
 
 export class Organization extends APIResource {
 	/**
-	 * Member management for the active organization.
+	 * Member listing for the active organization. Member add/remove
+	 * intentionally lives in the app — the programmatic API is read-only.
 	 */
 	members: Members = new Members(this._client);
 }
@@ -70,29 +45,11 @@ export interface MemberListParams {
 	limit?: number;
 }
 
-export interface MemberAddParams {
-	organizationId: string;
-	userId: string;
-	role?: OrganizationRole;
-}
-
-export interface MemberRemoveParams {
-	organizationId: string;
-	userId: string;
-}
-
-export interface MemberRemoveResult {
-	success: boolean;
-}
-
 export declare namespace Organization {
 	export type {
 		Member,
-		MemberAddParams,
 		MemberListParams,
 		MemberListResponse,
-		MemberRemoveParams,
-		MemberRemoveResult,
 		OrganizationRole,
 	};
 }

--- a/packages/sdk/src/resources/tasks.ts
+++ b/packages/sdk/src/resources/tasks.ts
@@ -16,7 +16,27 @@ type ListRowWire = {
 	statusName: string | null;
 };
 
+export class TaskStatuses extends APIResource {
+	/**
+	 * List the task statuses configured for the active organization.
+	 *
+	 * Mirrors `superset tasks statuses list`.
+	 */
+	list(options?: RequestOptions): APIPromise<TaskStatusListResponse> {
+		return this._client.query<TaskStatusListResponse>(
+			"task.statuses.list",
+			undefined,
+			options,
+		);
+	}
+}
+
 export class Tasks extends APIResource {
+	/**
+	 * Status configuration (workflow states) for the active organization's tasks.
+	 */
+	statuses: TaskStatuses = new TaskStatuses(this._client);
+
 	/**
 	 * Create a task.
 	 *
@@ -179,6 +199,16 @@ export interface TaskListParams {
 	offset?: number;
 }
 
+export interface TaskStatus {
+	id: string;
+	name: string;
+	color: string;
+	type: string;
+	position: number;
+}
+
+export type TaskStatusListResponse = Array<TaskStatus>;
+
 export declare namespace Tasks {
 	export type {
 		Task,
@@ -187,5 +217,7 @@ export declare namespace Tasks {
 		TaskCreateParams,
 		TaskUpdateParams,
 		TaskListParams,
+		TaskStatus,
+		TaskStatusListResponse,
 	};
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -78,4 +78,10 @@ export const FEATURE_FLAGS = {
 	 * UI visibility and staged rollout.
 	 */
 	AUTOMATIONS_ACCESS: "automations-access",
+	/**
+	 * Routes the Slack agent to the v2 MCP server (`@superset/mcp-v2`)
+	 * instead of v1 (`@superset/mcp`). Evaluated per-organization so a
+	 * Slack workspace flips wholesale rather than per-user. Off → v1.
+	 */
+	SLACK_MCP_V2: "slack-mcp-v2",
 } as const;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -80,8 +80,9 @@ export const FEATURE_FLAGS = {
 	AUTOMATIONS_ACCESS: "automations-access",
 	/**
 	 * Routes the Slack agent to the v2 MCP server (`@superset/mcp-v2`)
-	 * instead of v1 (`@superset/mcp`). Evaluated per-organization so a
-	 * Slack workspace flips wholesale rather than per-user. Off → v1.
+	 * instead of v1 (`@superset/mcp`). Evaluated against the linking
+	 * user's id (the Superset user behind the Slack mention) so it
+	 * piggybacks on the existing All Access cohort. Off → v1.
 	 */
 	SLACK_MCP_V2: "slack-mcp-v2",
 } as const;

--- a/packages/trpc/src/router/organization/members.ts
+++ b/packages/trpc/src/router/organization/members.ts
@@ -1,0 +1,136 @@
+import { db } from "@superset/db/client";
+import { members, users } from "@superset/db/schema";
+import { canRemoveMember, type OrganizationRole } from "@superset/shared/auth";
+import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
+import { and, eq, ilike, or } from "drizzle-orm";
+import { z } from "zod";
+import { protectedProcedure } from "../../trpc";
+import { verifyOrgAdmin } from "../integration/utils";
+import { requireActiveOrgMembership } from "../utils/active-org";
+
+export const organizationMembersRouter = {
+	list: protectedProcedure
+		.input(
+			z
+				.object({
+					search: z.string().min(1).nullish(),
+					limit: z.number().int().positive().max(100).default(50),
+				})
+				.nullish(),
+		)
+		.query(async ({ ctx, input }) => {
+			const organizationId = await requireActiveOrgMembership(ctx);
+			const conditions = [eq(members.organizationId, organizationId)];
+			if (input?.search) {
+				const pattern = `%${input.search}%`;
+				const match = or(
+					ilike(users.name, pattern),
+					ilike(users.email, pattern),
+				);
+				if (match) conditions.push(match);
+			}
+
+			return db
+				.select({
+					id: users.id,
+					name: users.name,
+					email: users.email,
+					image: users.image,
+					role: members.role,
+				})
+				.from(members)
+				.innerJoin(users, eq(members.userId, users.id))
+				.where(and(...conditions))
+				.limit(input?.limit ?? 50);
+		}),
+
+	add: protectedProcedure
+		.input(
+			z.object({
+				organizationId: z.string().uuid(),
+				userId: z.string().uuid(),
+				role: z.enum(["member", "admin", "owner"]).default("member"),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
+			return ctx.auth.api.addMember({
+				body: {
+					organizationId: input.organizationId,
+					userId: input.userId,
+					role: input.role,
+				},
+				headers: ctx.headers,
+			});
+		}),
+
+	remove: protectedProcedure
+		.input(
+			z.object({
+				organizationId: z.uuid(),
+				userId: z.uuid(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const allMembers = await db.query.members.findMany({
+				where: eq(members.organizationId, input.organizationId),
+			});
+
+			const targetMember = allMembers.find((m) => m.userId === input.userId);
+			if (!targetMember) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Member not found",
+				});
+			}
+
+			const actorMembership = allMembers.find(
+				(m) => m.userId === ctx.session.user.id,
+			);
+			if (!actorMembership) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You are not a member of this organization",
+				});
+			}
+
+			const ownerCount = allMembers.filter((m) => m.role === "owner").length;
+			const isTargetSelf = targetMember.userId === ctx.session.user.id;
+
+			const canRemove = canRemoveMember(
+				actorMembership.role as OrganizationRole,
+				targetMember.role as OrganizationRole,
+				isTargetSelf,
+				ownerCount,
+			);
+
+			if (!canRemove) {
+				if (isTargetSelf) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message: "Cannot remove yourself",
+					});
+				}
+				if (targetMember.role === "owner" && ownerCount === 1) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message: "Cannot remove the last owner. Transfer ownership first.",
+					});
+				}
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You don't have permission to remove this member",
+				});
+			}
+
+			await ctx.auth.api.removeMember({
+				body: {
+					organizationId: input.organizationId,
+					memberIdOrEmail: targetMember.id,
+				},
+				headers: ctx.headers,
+			});
+
+			return { success: true };
+		}),
+} satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/organization/members.ts
+++ b/packages/trpc/src/router/organization/members.ts
@@ -1,11 +1,9 @@
 import { db } from "@superset/db/client";
 import { members, users } from "@superset/db/schema";
-import { canRemoveMember, type OrganizationRole } from "@superset/shared/auth";
-import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
+import type { TRPCRouterRecord } from "@trpc/server";
 import { and, eq, ilike, or } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../trpc";
-import { verifyOrgAdmin } from "../integration/utils";
 import { requireActiveOrgMembership } from "../utils/active-org";
 
 export const organizationMembersRouter = {
@@ -42,95 +40,5 @@ export const organizationMembersRouter = {
 				.innerJoin(users, eq(members.userId, users.id))
 				.where(and(...conditions))
 				.limit(input?.limit ?? 50);
-		}),
-
-	add: protectedProcedure
-		.input(
-			z.object({
-				organizationId: z.string().uuid(),
-				userId: z.string().uuid(),
-				role: z.enum(["member", "admin", "owner"]).default("member"),
-			}),
-		)
-		.mutation(async ({ ctx, input }) => {
-			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
-			return ctx.auth.api.addMember({
-				body: {
-					organizationId: input.organizationId,
-					userId: input.userId,
-					role: input.role,
-				},
-				headers: ctx.headers,
-			});
-		}),
-
-	remove: protectedProcedure
-		.input(
-			z.object({
-				organizationId: z.uuid(),
-				userId: z.uuid(),
-			}),
-		)
-		.mutation(async ({ ctx, input }) => {
-			const allMembers = await db.query.members.findMany({
-				where: eq(members.organizationId, input.organizationId),
-			});
-
-			const targetMember = allMembers.find((m) => m.userId === input.userId);
-			if (!targetMember) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Member not found",
-				});
-			}
-
-			const actorMembership = allMembers.find(
-				(m) => m.userId === ctx.session.user.id,
-			);
-			if (!actorMembership) {
-				throw new TRPCError({
-					code: "FORBIDDEN",
-					message: "You are not a member of this organization",
-				});
-			}
-
-			const ownerCount = allMembers.filter((m) => m.role === "owner").length;
-			const isTargetSelf = targetMember.userId === ctx.session.user.id;
-
-			const canRemove = canRemoveMember(
-				actorMembership.role as OrganizationRole,
-				targetMember.role as OrganizationRole,
-				isTargetSelf,
-				ownerCount,
-			);
-
-			if (!canRemove) {
-				if (isTargetSelf) {
-					throw new TRPCError({
-						code: "FORBIDDEN",
-						message: "Cannot remove yourself",
-					});
-				}
-				if (targetMember.role === "owner" && ownerCount === 1) {
-					throw new TRPCError({
-						code: "FORBIDDEN",
-						message: "Cannot remove the last owner. Transfer ownership first.",
-					});
-				}
-				throw new TRPCError({
-					code: "FORBIDDEN",
-					message: "You don't have permission to remove this member",
-				});
-			}
-
-			await ctx.auth.api.removeMember({
-				body: {
-					organizationId: input.organizationId,
-					memberIdOrEmail: targetMember.id,
-				},
-				headers: ctx.headers,
-			});
-
-			return { success: true };
 		}),
 } satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 import { generateImagePathname, uploadImage } from "../../lib/upload";
 import { jwtProcedure, protectedProcedure, publicProcedure } from "../../trpc";
 import { verifyOrgAdmin } from "../integration/utils";
+import { organizationMembersRouter } from "./members";
 
 async function getInvitationById(invitationId: string) {
 	const invitation = await db.query.invitations.findFirst({
@@ -55,6 +56,8 @@ function verificationMatchesInvitation({
 }
 
 export const organizationRouter = {
+	members: organizationMembersRouter,
+
 	getActive: protectedProcedure.query(async ({ ctx }) => {
 		const orgId = ctx.activeOrganizationId;
 		if (!orgId) return null;

--- a/packages/trpc/src/router/task/statuses.ts
+++ b/packages/trpc/src/router/task/statuses.ts
@@ -1,0 +1,23 @@
+import { db } from "@superset/db/client";
+import { taskStatuses } from "@superset/db/schema";
+import type { TRPCRouterRecord } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import { protectedProcedure } from "../../trpc";
+import { requireActiveOrgMembership } from "../utils/active-org";
+
+export const taskStatusesRouter = {
+	list: protectedProcedure.query(async ({ ctx }) => {
+		const organizationId = await requireActiveOrgMembership(ctx);
+		return db
+			.select({
+				id: taskStatuses.id,
+				name: taskStatuses.name,
+				color: taskStatuses.color,
+				type: taskStatuses.type,
+				position: taskStatuses.position,
+			})
+			.from(taskStatuses)
+			.where(eq(taskStatuses.organizationId, organizationId))
+			.orderBy(taskStatuses.position);
+	}),
+} satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/task/task.ts
+++ b/packages/trpc/src/router/task/task.ts
@@ -23,6 +23,7 @@ import {
 	taskListInputSchema,
 	updateTaskSchema,
 } from "./schema";
+import { taskStatusesRouter } from "./statuses";
 
 const TASK_SLUG_CONSTRAINT = "tasks_org_slug_unique";
 const TASK_SLUG_RETRY_LIMIT = 5;
@@ -265,6 +266,8 @@ async function createTask(
 }
 
 export const taskRouter = {
+	statuses: taskStatusesRouter,
+
 	/**
 	 * @deprecated Use `task.list` instead. Kept for one release cycle so the
 	 * shipped CLI on `main` keeps compiling against the new backend during


### PR DESCRIPTION
## Summary

- **Slack agent feature flag** — new `slack-mcp-v2` PostHog flag (evaluated per-organization) routes the Slack agent to `@superset/mcp-v2` instead of `@superset/mcp`. Off → v1, on → v2. Two MCP clients constructed in `mcp-clients.ts`; the agent picks one in `runSlackAgent`.
- **mcp-v2 is now tRPC-only** — refactored both new tools (`organization_members_list`, `tasks_statuses_list`) to call `createMcpCaller(ctx)`. No more direct DB imports. Matches how every other v2 tool works (`tasks_*`, `workspaces_*`, etc).
- **Nested API alignment** across tRPC + mcp-v2 + CLI + SDK so the four surfaces share one shape:
  - `organization.members.list/add/remove` — `add`/`remove` are thin wrappers over the existing `organization.addMember`/`removeMember` logic (kept in place for the existing dashboard callers).
  - `task.statuses.list` — new sub-router on `taskRouter`.

### New surface
| Layer | Path |
|---|---|
| tRPC | `organization.members.{list,add,remove}`, `task.statuses.list` |
| mcp-v2 tools | `organization_members_list`, `tasks_statuses_list` |
| CLI | `superset organization members list`, `superset tasks statuses list` |
| SDK | `client.organization.members.{list,add,remove}`, `client.tasks.statuses.list` |

### Slack agent specifics
- v2 path preloads context via `organization_members_list` + `tasks_statuses_list` + `hosts_list` (matches v1's `list_members`/`list_task_statuses`/`list_devices`).
- `getActionFromToolResult` handles both wire shapes (v1 `{ created/updated/deleted }`, v2 `{ task, txid }` / `{ workspace, ... }`).
- `TOOL_PROGRESS_STATUS` and a per-version deny list cover both naming conventions.
- mcp-v2 in-memory client now accepts an `onToolCall` so PostHog `mcp_tool_called` events fire on the v2 Slack path too.

## Test plan

- [ ] Lint + typecheck pass (verified: `bun run lint` clean, `bun run typecheck` 29/29, trpc `bun test` 44 pass).
- [ ] With flag off: Slack `@mentions` still work end-to-end (v1 path, no behavior change expected).
- [ ] Flip `slack-mcp-v2` on for one test org in PostHog → `@mention` should still work, with `mcp_server: superset-v2` properties on `mcp_tool_called` events.
- [ ] CLI smoke: `superset organization members list`, `superset tasks statuses list`.
- [ ] SDK smoke: `client.organization.members.list()` and `client.tasks.statuses.list()` against staging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-user `slack-mcp-v2` flag to route the Slack agent to `@superset/mcp-v2`, and aligns nested APIs across tRPC/mcp‑v2/CLI/SDK for organization members (list-only) and task statuses. Default stays on v1 for a safe rollout with consistent tooling and telemetry.

- **New Features**
  - Route Slack via PostHog `slack-mcp-v2` (person-level; off → v1, on → v2).
  - `@superset/mcp-v2` is tRPC‑only; adds tools `organization_members_list` and `tasks_statuses_list`; in‑memory client emits `mcp_tool_called`.
  - Slack agent supports v1+v2 result shapes, preloads members/statuses/hosts, and uses versioned deny lists and progress labels.
  - Unified nested API: tRPC `organization.members.list` and `task.statuses.list`; CLI `superset organization members list` and `superset tasks statuses list`; SDK `client.organization.members.list()` (read‑only) and `client.tasks.statuses.list()`.

- **Migration**
  - No breaking changes. To try v2 in Slack, enable `slack-mcp-v2` for a test user in PostHog. Organization member add/remove remain app-only.

<sup>Written for commit 4e397f4d71036947be96cd4df3a13137f25677b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-flagged Slack MCP V2 support for agents
  * CLI commands to list organization members and task statuses
  * SDK now exposes organization membership and task-status APIs
  * New API endpoints to list organization members and to list task statuses

* **Enhancements**
  * MCP v2 tools for listing members and task statuses
  * Added feature flag to toggle Slack MCP V2 behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->