### PR TITLE
feat(desktop): restore preset-bar hide toggle in v2

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -20,6 +20,7 @@ export interface V2UserPreferencesApi {
 	setRightSidebarTab: (next: RightSidebarTab) => void;
 	setRightSidebarWidth: (next: number) => void;
 	setDeleteLocalBranch: (next: boolean) => void;
+	setShowPresetsBar: (next: boolean) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -149,6 +150,25 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		[collections],
 	);
 
+	const setShowPresetsBar = useCallback(
+		(next: boolean) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					showPresetsBar: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.showPresetsBar = next;
+			});
+		},
+		[collections],
+	);
+
 	return {
 		preferences,
 		setFileLinks,
@@ -158,5 +178,6 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setRightSidebarTab,
 		setRightSidebarWidth,
 		setDeleteLocalBranch,
+		setShowPresetsBar,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/AddTabMenu/AddTabMenu.tsx
@@ -1,4 +1,8 @@
-import { DropdownMenuItem } from "@superset/ui/dropdown-menu";
+import {
+	DropdownMenuCheckboxItem,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+} from "@superset/ui/dropdown-menu";
 import { BsTerminalPlus } from "react-icons/bs";
 import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
@@ -7,12 +11,16 @@ interface AddTabMenuProps {
 	onAddTerminal: () => void;
 	onAddChat: () => void;
 	onAddBrowser: () => void;
+	showPresetsBar: boolean;
+	onToggleShowPresetsBar: (enabled: boolean) => void;
 }
 
 export function AddTabMenu({
 	onAddTerminal,
 	onAddChat,
 	onAddBrowser,
+	showPresetsBar,
+	onToggleShowPresetsBar,
 }: AddTabMenuProps) {
 	return (
 		<>
@@ -31,6 +39,14 @@ export function AddTabMenu({
 				<span>Browser</span>
 				<HotkeyMenuShortcut hotkeyId="NEW_BROWSER" />
 			</DropdownMenuItem>
+			<DropdownMenuSeparator />
+			<DropdownMenuCheckboxItem
+				checked={showPresetsBar}
+				onCheckedChange={(checked) => onToggleShowPresetsBar(checked === true)}
+				onSelect={(event) => event.preventDefault()}
+			>
+				Show Preset Bar
+			</DropdownMenuCheckboxItem>
 		</>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
+	DropdownMenuCheckboxItem,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuSeparator,
@@ -24,6 +25,8 @@ import { V2PresetBarItem } from "./components/V2PresetBarItem";
 interface V2PresetsBarProps {
 	matchedPresets: V2TerminalPresetRow[];
 	executePreset: (preset: V2TerminalPresetRow) => void | Promise<void>;
+	showPresetsBar: boolean;
+	onToggleShowPresetsBar: (enabled: boolean) => void;
 }
 
 // Co-located to keep v2 self-contained. Mirrors the v1 array in
@@ -63,6 +66,8 @@ function getVisiblePresetOrder(
 export function V2PresetsBar({
 	matchedPresets,
 	executePreset,
+	showPresetsBar,
+	onToggleShowPresetsBar,
 }: V2PresetsBarProps) {
 	const navigate = useNavigate();
 	const isDark = useIsDarkTheme();
@@ -242,6 +247,16 @@ export function V2PresetsBar({
 							</DropdownMenuItem>
 						);
 					})}
+					<DropdownMenuSeparator />
+					<DropdownMenuCheckboxItem
+						checked={showPresetsBar}
+						onCheckedChange={(checked) =>
+							onToggleShowPresetsBar(checked === true)
+						}
+						onSelect={(event) => event.preventDefault()}
+					>
+						Show Preset Bar
+					</DropdownMenuCheckboxItem>
 					<DropdownMenuSeparator />
 					<DropdownMenuItem
 						className="gap-2"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -83,7 +83,9 @@ function V2WorkspacePage() {
 		setRightSidebarOpen,
 		setRightSidebarTab,
 		setRightSidebarWidth,
+		setShowPresetsBar,
 	} = useV2UserPreferences();
+	const showPresetsBar = v2UserPreferences.showPresetsBar;
 	const { store } = useV2WorkspacePaneLayout();
 	useClearActivePaneAttention({ store });
 	const launcher = useV2TerminalLauncher();
@@ -195,17 +197,25 @@ function V2WorkspacePage() {
 								sources={getV2NotificationSourcesForTab(tab)}
 							/>
 						)}
-						renderBelowTabBar={() => (
-							<V2PresetsBar
-								matchedPresets={matchedPresets}
-								executePreset={executePreset}
-							/>
-						)}
+						renderBelowTabBar={
+							showPresetsBar
+								? () => (
+										<V2PresetsBar
+											matchedPresets={matchedPresets}
+											executePreset={executePreset}
+											showPresetsBar={showPresetsBar}
+											onToggleShowPresetsBar={setShowPresetsBar}
+										/>
+									)
+								: undefined
+						}
 						renderAddTabMenu={() => (
 							<AddTabMenu
 								onAddTerminal={addTerminalTab}
 								onAddChat={addChatTab}
 								onAddBrowser={addBrowserTab}
+								showPresetsBar={showPresetsBar}
+								onToggleShowPresetsBar={setShowPresetsBar}
 							/>
 						)}
 						renderEmptyState={() => (

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -175,6 +175,7 @@ export const v2UserPreferencesSchema = z.object({
 	rightSidebarTab: z.enum(["changes", "files"]).default("changes"),
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
+	showPresetsBar: z.boolean().default(true),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
@@ -190,6 +191,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	rightSidebarTab: "changes",
 	rightSidebarWidth: 340,
 	deleteLocalBranch: false,
+	showPresetsBar: true,
 };
 
 /**


### PR DESCRIPTION
## Summary
- v2 was missing v1's "Show Preset Bar" toggle, so users couldn't hide the preset bar above the tab content.
- Adds `showPresetsBar` to the v2 `useV2UserPreferences` collection (separate from v1's `electronTrpc.settings.showPresetsBar` so v1 and v2 are decoupled). Existing rows heal to `true` via `healV2UserPreferences`.
- Toggle surfaces in two places (mirroring v1): the gear-icon dropdown inside `V2PresetsBar` (to hide), and the tab-bar add-menu in `AddTabMenu` (to re-show when hidden).

## Test plan
- [ ] Open a v2 workspace and uncheck "Show Preset Bar" from the gear-icon dropdown — the preset bar disappears.
- [ ] With the bar hidden, open the tab bar's `+` add-menu — "Show Preset Bar" is unchecked; toggling it re-shows the bar.
- [ ] Reload the workspace — preference persists.
- [ ] Toggling in v2 does not affect v1's `Show Preset Bar` setting (different storage).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the "Show Preset Bar" toggle in v2 so users can hide the presets bar and bring it back easily. The setting is stored in v2 user preferences and does not affect v1.

- **New Features**
  - Added `showPresetsBar` to `v2UserPreferences` (defaults to true; persists across reloads; decoupled from v1).
  - Toggle is available in the `V2PresetsBar` gear menu and in the tab bar `AddTabMenu` when the bar is hidden.

<sup>Written for commit 2fea16aff8e646c96cbf8a7f4076b15aa484a223. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Show Preset Bar" toggle that allows users to control the visibility of the Preset Bar. The preference is automatically saved and persists across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->