### PR TITLE
release(cli): cut v0.2.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -679,7 +679,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.11";
+const VERSION = "0.2.12";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Cuts CLI v0.2.12.

Changes since v0.2.11:

- **workspaces** — add `superset workspaces update <id> --name "..."` for renaming. Branch/host moves stay desktop-only; they require host-side git orchestration that isn't safe to drive from the cloud directly. (#4189)
- **organization** — new `superset organization members list` command (also surfaced via SDK + mcp-v2). Read-only — add/remove keep their existing UI flows. (#4197)
- **tasks** — new `superset tasks statuses list` command surfacing the organization's configured task statuses. (#4197)
- **host-service** — paste a closed/merged PR URL or `#N` into the v2 new-workspace modal and the dropdown actually returns the PR instead of "No open pull requests found." Direct lookups now ignore the open-only state filter that bounds text-search results. (#4190)

## Test plan

- [ ] `bun run typecheck --filter=@superset/cli` passes
- [ ] `superset workspaces update <id> --name "..."` smokes locally
- [ ] `superset organization members list` and `superset tasks statuses list` smoke locally
- [ ] After merge: push `cli-v0.2.12` tag to fire the release pipeline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.12. Adds workspace rename and read-only org/task listing commands, plus improved PR lookup in the v2 new-workspace modal.

- **New Features**
  - `superset workspaces update <id> --name "..."` to rename workspaces. Branch/host moves remain desktop-only.
  - `superset organization members list` to list members (read-only; add/remove stays in UI).
  - `superset tasks statuses list` to list configured task statuses.

- **Bug Fixes**
  - v2 new-workspace modal: pasting a closed/merged PR URL or `#N` now returns the PR; direct lookups ignore the open-only filter.

<sup>Written for commit bcbec8639873d28904a35643a38b90a26a603584. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI package version to 0.2.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->