### PR TITLE
release(sdk): cut alpha.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -929,7 +929,7 @@
     },
     "packages/sdk": {
       "name": "@superset/sdk",
-      "version": "0.0.1-alpha.8",
+      "version": "0.0.1-alpha.9",
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "bun-types": "^1.3.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/sdk",
-	"version": "0.0.1-alpha.8",
+	"version": "0.0.1-alpha.9",
 	"description": "TypeScript SDK for the Superset API",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## Summary

Cuts SDK `0.0.1-alpha.9` (publishes as `@superset_sh/sdk@0.0.1-alpha.9`).

Changes since alpha.8:

- **workspaces.update** accepts `{ name }` for renaming. Branch/host moves stay desktop-only; they require host-side git orchestration that isn't safe to drive from the cloud. (#4189)
- **organization.members.list** — read-only listing of org members. `add`/`remove` are deliberately not exposed; they have UI-side concerns (invites, ownership transfer, audit) that aren't ready for a programmatic API. (#4197)
- **task.statuses.list** — list configured task statuses for the org. (#4197)

## Test plan

- [ ] `bun run typecheck --filter=@superset/sdk` passes
- [ ] After merge: `cd packages/sdk && bun run build && cd dist && npm publish --access public`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/sdk@0.0.1-alpha.9` with workspace rename support and two new read-only org endpoints.

- **New Features**
  - `workspaces.update` now accepts `{ name }` to rename a workspace. Branch/host moves remain desktop-only.
  - `organization.members.list` returns a read-only list of org members.
  - `task.statuses.list` returns configured task statuses for the org.

<sup>Written for commit e29ac23d9b00adbf78113ae169ad42329133bcb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to `0.0.1-alpha.9`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->