### PR TITLE
feat(desktop): show pick-workspace prompt on cross-version routes

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/CrossVersionMismatchState/CrossVersionMismatchState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/CrossVersionMismatchState/CrossVersionMismatchState.tsx
@@ -1,0 +1,23 @@
+import { ArrowLeftFromLine } from "lucide-react";
+
+export function CrossVersionMismatchState() {
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div className="flex w-full max-w-sm flex-col items-start gap-5">
+				<ArrowLeftFromLine
+					className="size-5 text-muted-foreground"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground select-text cursor-text">
+						Pick a workspace
+					</h1>
+					<p className="text-[13px] leading-relaxed text-muted-foreground select-text cursor-text">
+						Select a workspace from the sidebar to get started.
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/CrossVersionMismatchState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/CrossVersionMismatchState/index.ts
@@ -1,0 +1,1 @@
+export { CrossVersionMismatchState } from "./CrossVersionMismatchState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -22,6 +22,7 @@ import {
 	useWorkspaceSidebarStore,
 } from "renderer/stores/workspace-sidebar-state";
 import { AddRepositoryModals } from "./components/AddRepositoryModals";
+import { CrossVersionMismatchState } from "./components/CrossVersionMismatchState";
 import { TopBar } from "./components/TopBar";
 
 export const Route = createFileRoute("/_authenticated/_dashboard")({
@@ -41,6 +42,15 @@ function DashboardLayout() {
 	});
 	const currentWorkspaceId =
 		currentWorkspaceMatch !== false ? currentWorkspaceMatch.workspaceId : null;
+	const v2WorkspaceMatch = matchRoute({
+		to: "/v2-workspace/$workspaceId",
+		fuzzy: true,
+	});
+	const onV1WorkspaceRoute = currentWorkspaceMatch !== false;
+	const onV2WorkspaceRoute = v2WorkspaceMatch !== false;
+	const versionMismatch =
+		(isV2CloudEnabled && onV1WorkspaceRoute) ||
+		(!isV2CloudEnabled && onV2WorkspaceRoute);
 
 	const { data: currentWorkspace } = electronTrpc.workspaces.get.useQuery(
 		{ id: currentWorkspaceId ?? "" },
@@ -134,7 +144,7 @@ function DashboardLayout() {
 				<div className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
 					{!sidebarOutsideColumn && sidebarPanel}
 					<div className="flex flex-1 min-h-0 min-w-0">
-						<Outlet />
+						{versionMismatch ? <CrossVersionMismatchState /> : <Outlet />}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- When the active version (v1 vs v2) doesn't match the current workspace route, swap the content `<Outlet />` for a "Pick a workspace" placeholder so users see the version-correct sidebar list instead of a v1 page rendering inside a v2 shell (or vice versa).

## Why / Context
The dashboard sidebar shows v1 or v2 entries based on `useIsV2CloudEnabled`, but the router still resolves the previously-visited `/workspace/$id` or `/v2-workspace/$id` route after a version flip. The user lands on a workspace they can't navigate to from the current sidebar, with no obvious next step.

## How It Works
- `DashboardLayout` already calls `useMatchRoute` for `/workspace/$workspaceId`. Added a parallel match for `/v2-workspace/$workspaceId` and a `versionMismatch` boolean — true when the active version disagrees with the matched route.
- When mismatched, the content slot renders `CrossVersionMismatchState` (a small empty-state with the existing `select-text cursor-text` treatment) instead of `<Outlet />`. The sidebar is untouched, so picking any workspace from it routes the user back to a matching shell.
- The placeholder copy is generic ("Pick a workspace") — no v1/v2 mention, since to the user this just looks like they haven't chosen one yet.

## Manual QA Checklist

### v2 active, v1 workspace route
- [ ] In v2 mode, navigate to a `/workspace/$id` URL (e.g. via back button after toggling)
- [ ] Content shows "Pick a workspace" placeholder, sidebar still shows v2 entries
- [ ] Clicking a v2 workspace from the sidebar renders normally

### v1 active, v2 workspace route
- [ ] In v1 mode, navigate to a `/v2-workspace/$id` URL
- [ ] Content shows the placeholder, sidebar shows v1 entries
- [ ] Clicking a v1 workspace from the sidebar renders normally

### No regression on matching routes
- [ ] v2 active + `/v2-workspace/$id` → workspace renders as before
- [ ] v1 active + `/workspace/$id` → workspace renders as before
- [ ] Non-workspace routes (settings, automations, tasks, etc.) unaffected in both modes

## Testing
- `bun run lint:fix` (clean)
- Typecheck: no new errors introduced (pre-existing route-tree errors unrelated)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a "Pick a workspace" placeholder when the active version (v1/v2) doesn't match the current workspace route. In this case, `DashboardLayout` renders `CrossVersionMismatchState` instead of the `<Outlet />`, keeping the sidebar intact so users can pick a workspace from the correct version.

<sup>Written for commit a73988fb8f9246c74d8f0c1c05b8aa3094a6048a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new cross-version mismatch state that displays when a workspace version is incompatible with your current application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->