### PR TITLE
feat(desktop): add tray "Quit Superset Completely" for full shutdown

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -163,12 +163,20 @@ app.on("open-url", async (event, url) => {
 
 let isQuitting = false;
 let skipQuitConfirmation = false;
+let forceFullCleanup = false;
 
 export function setSkipQuitConfirmation(): void {
 	skipQuitConfirmation = true;
 }
 
 export function quitApp(): void {
+	setSkipQuitConfirmation();
+	app.quit();
+}
+
+/** Nuclear quit: also kills host-service(s) and pty-daemon/terminal-host. */
+export function quitAppCompletely(): void {
+	forceFullCleanup = true;
 	setSkipQuitConfirmation();
 	app.quit();
 }
@@ -214,7 +222,7 @@ app.on("before-quit", async (event) => {
 
 	isQuitting = true;
 	try {
-		if (isDev) {
+		if (isDev || forceFullCleanup) {
 			await runDevQuitCleanup();
 		} else {
 			// Prod: leave services running so the next launch re-adopts via manifest.
@@ -229,8 +237,9 @@ app.on("before-quit", async (event) => {
 });
 
 /**
- * Dev only — kill host-service + terminal-host children. They're spawned
- * attached + ref'd in dev, so they'd reparent to init without an explicit stop.
+ * Full cleanup — kill host-service + terminal-host children. Used in dev (where
+ * they'd reparent to init without an explicit stop) and on the tray's
+ * "Quit Superset Completely" path in prod.
  */
 async function runDevQuitCleanup(): Promise<void> {
 	getHostServiceCoordinator().stopAll();

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -9,7 +9,7 @@ import {
 } from "electron";
 import { loadToken } from "lib/trpc/routers/auth/utils/auth-functions";
 import { env } from "main/env.main";
-import { focusMainWindow, quitApp } from "main/index";
+import { focusMainWindow, quitApp, quitAppCompletely } from "main/index";
 import {
 	getHostServiceCoordinator,
 	type HostServiceStatusEvent,
@@ -231,6 +231,11 @@ async function updateTrayMenu(): Promise<void> {
 		{
 			label: "Quit Superset",
 			click: () => quitApp(),
+		},
+		{
+			label: "Quit Superset Completely",
+			toolTip: "Quit and stop all background services (host-service, daemon)",
+			click: () => quitAppCompletely(),
 		},
 	]);
 

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import {
 	app,
+	dialog,
 	Menu,
 	type MenuItemConstructorOptions,
 	nativeImage,
@@ -81,6 +82,22 @@ function createTrayIcon(): Electron.NativeImage | null {
 function openSettings(): void {
 	focusMainWindow();
 	menuEmitter.emit("open-settings");
+}
+
+async function confirmAndQuitCompletely(): Promise<void> {
+	const { response } = await dialog.showMessageBox({
+		type: "warning",
+		buttons: ["Quit Completely", "Cancel"],
+		defaultId: 1,
+		cancelId: 1,
+		title: "Quit Superset Completely",
+		message: "Quit Superset and stop all background services?",
+		detail:
+			"All open terminal sessions will be killed and any running host-services will be stopped. Use “Close Superset” instead if you want services to keep running for the next launch.",
+	});
+	if (response === 0) {
+		quitAppCompletely();
+	}
 }
 
 interface HostInfo {
@@ -229,13 +246,15 @@ async function updateTrayMenu(): Promise<void> {
 		},
 		{ type: "separator" },
 		{
-			label: "Quit Superset",
+			label: "Close Superset",
 			click: () => quitApp(),
 		},
 		{
 			label: "Quit Superset Completely",
 			toolTip: "Quit and stop all background services (host-service, daemon)",
-			click: () => quitAppCompletely(),
+			click: () => {
+				void confirmAndQuitCompletely();
+			},
 		},
 	]);
 

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -253,9 +253,9 @@ async function updateTrayMenu(): Promise<void> {
 			label: "Close Superset",
 			click: () => quitApp(),
 		},
+		{ type: "separator" },
 		{
 			label: "Quit Superset Completely",
-			toolTip: "Quit and stop all background services (host-service, daemon)",
 			click: () => {
 				void confirmAndQuitCompletely();
 			},

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -85,18 +85,22 @@ function openSettings(): void {
 }
 
 async function confirmAndQuitCompletely(): Promise<void> {
-	const { response } = await dialog.showMessageBox({
-		type: "warning",
-		buttons: ["Quit Completely", "Cancel"],
-		defaultId: 1,
-		cancelId: 1,
-		title: "Quit Superset Completely",
-		message: "Quit Superset and stop all background services?",
-		detail:
-			"All open terminal sessions will be killed and any running host-services will be stopped. Use “Close Superset” instead if you want services to keep running for the next launch.",
-	});
-	if (response === 0) {
-		quitAppCompletely();
+	try {
+		const { response } = await dialog.showMessageBox({
+			type: "warning",
+			buttons: ["Quit Completely", "Cancel"],
+			defaultId: 1,
+			cancelId: 1,
+			title: "Quit Superset Completely",
+			message: "Quit Superset and stop all background services?",
+			detail:
+				"All open terminal sessions will be killed and any running host-services will be stopped. Use “Close Superset” instead if you want services to keep running for the next launch.",
+		});
+		if (response === 0) {
+			quitAppCompletely();
+		}
+	} catch (error) {
+		console.error("[Tray] Quit-completely confirmation failed:", error);
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a new macOS tray entry **"Quit Superset Completely"** that nukes everything: the Electron app, all running host-services, and the pty-daemon/terminal-host.
- The existing **"Quit Superset"** remains a soft quit — services keep running so the next launch re-adopts them via manifest. Auto-update behavior is unchanged.
- Reuses the existing `runDevQuitCleanup()` shutdown sequence (`coordinator.stopAll()` + `terminalHostClient.shutdownIfRunning({ killSessions: true })`) by gating it on a new `forceFullCleanup` flag inside the `before-quit` handler.

## Test plan

- [ ] Dev: `bun dev` in `apps/desktop`, sign in to an org, click tray → **Quit Superset**. App and services exit cleanly (no regression).
- [ ] Packaged build, **Quit Superset Completely**: confirm `pgrep -f host-service` is empty and the pty-daemon socket is gone after quit.
- [ ] Packaged build, **Quit Superset** (soft): host-service PID survives Electron exit and is re-adopted on next launch.
- [ ] Tray **Host Service → Restart** / **Stop** still flips status correctly.
- [ ] Auto-update swap does not tear down host-service / pty-daemon.
- [ ] `bun run lint` and `bun run typecheck` exit 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a macOS tray option “Quit Superset Completely” to fully shut down the app and all background services, with a confirmation prompt. The soft path is now “Close Superset” and keeps services running for re-adoption.

- **New Features**
  - Adds “Quit Superset Completely” via `quitAppCompletely()` + `forceFullCleanup`, reusing `runDevQuitCleanup()` to stop host-service(s) and the pty-daemon/terminal-host.
  - Shows a warning dialog before full shutdown (Cancel default) and catches dialog errors; adds a separator before the action and removes an unused tray tooltip.
  - Renames soft quit to “Close Superset”; behavior unchanged and auto-update still leaves services running.

<sup>Written for commit 45f9d2b19095e155181255865a0c43e50c57c8cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Quit Superset Completely" menu/tray option that performs a full cleanup of background services and resources before exiting.
  * The existing quit option is now labeled "Close Superset" to distinguish it from the full-quit behavior.
  * The full-quit option shows a confirmation prompt ("Quit Superset Completely") before proceeding to prevent accidental full shutdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->