### PR TITLE
feat(desktop): remove automations-access feature flag

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -1,4 +1,3 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -9,7 +8,6 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { HiMiniPlus, HiOutlineClipboardDocumentList } from "react-icons/hi2";
 import {
 	LuClock,
@@ -71,10 +69,6 @@ export function DashboardSidebarHeader({
 	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
 	const isTasksOpen = !!matchRoute({ to: "/tasks", fuzzy: true });
 	const isAutomationsOpen = !!matchRoute({ to: "/automations", fuzzy: true });
-
-	const showAutomations = useFeatureFlagEnabled(
-		FEATURE_FLAGS.AUTOMATIONS_ACCESS,
-	);
 
 	const {
 		tab: lastTab,
@@ -143,25 +137,23 @@ export function DashboardSidebarHeader({
 					<TooltipContent side="right">Tasks</TooltipContent>
 				</Tooltip>
 
-				{showAutomations && (
-					<Tooltip delayDuration={300}>
-						<TooltipTrigger asChild>
-							<button
-								type="button"
-								onClick={handleAutomationsClick}
-								className={cn(
-									"flex size-8 items-center justify-center rounded-md transition-colors",
-									isAutomationsOpen
-										? "bg-accent text-foreground"
-										: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-								)}
-							>
-								<LuClock className="size-4" />
-							</button>
-						</TooltipTrigger>
-						<TooltipContent side="right">Automations</TooltipContent>
-					</Tooltip>
-				)}
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={handleAutomationsClick}
+							className={cn(
+								"flex size-8 items-center justify-center rounded-md transition-colors",
+								isAutomationsOpen
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+							)}
+						>
+							<LuClock className="size-4" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Automations</TooltipContent>
+				</Tooltip>
 
 				<Tooltip delayDuration={300}>
 					<TooltipTrigger asChild>
@@ -239,21 +231,19 @@ export function DashboardSidebarHeader({
 				<span className="flex-1 text-left">Workspaces</span>
 			</button>
 
-			{showAutomations && (
-				<button
-					type="button"
-					onClick={handleAutomationsClick}
-					className={cn(
-						"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
-						isAutomationsOpen
-							? "bg-accent text-foreground"
-							: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-					)}
-				>
-					<LuClock className="size-4 shrink-0" />
-					<span className="flex-1 text-left">Automations</span>
-				</button>
-			)}
+			<button
+				type="button"
+				onClick={handleAutomationsClick}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
+					isAutomationsOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<LuClock className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Automations</span>
+			</button>
 
 			<button
 				type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -123,24 +123,6 @@ export function DashboardSidebarHeader({
 					<TooltipTrigger asChild>
 						<button
 							type="button"
-							onClick={handleTasksClick}
-							className={cn(
-								"flex size-8 items-center justify-center rounded-md transition-colors",
-								isTasksOpen
-									? "bg-accent text-foreground"
-									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-							)}
-						>
-							<HiOutlineClipboardDocumentList className="size-4" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="right">Tasks</TooltipContent>
-				</Tooltip>
-
-				<Tooltip delayDuration={300}>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
 							onClick={handleAutomationsClick}
 							className={cn(
 								"flex size-8 items-center justify-center rounded-md transition-colors",
@@ -153,6 +135,24 @@ export function DashboardSidebarHeader({
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="right">Automations</TooltipContent>
+				</Tooltip>
+
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={handleTasksClick}
+							className={cn(
+								"flex size-8 items-center justify-center rounded-md transition-colors",
+								isTasksOpen
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+							)}
+						>
+							<HiOutlineClipboardDocumentList className="size-4" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Tasks</TooltipContent>
 				</Tooltip>
 
 				<Tooltip delayDuration={300}>

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -72,13 +72,6 @@ export const FEATURE_FLAGS = {
 	/** When enabled, blocks remote agent execution on the desktop (e.g., for enterprise orgs). */
 	DISABLE_REMOTE_AGENT: "disable-remote-agent",
 	/**
-	 * Gates the Automations feature in the UI (sidebar entry, routes, create
-	 * flow). Complementary to the subscriptions.plan paid-tier check —
-	 * server-side procedures still enforce paid plan; this flag controls
-	 * UI visibility and staged rollout.
-	 */
-	AUTOMATIONS_ACCESS: "automations-access",
-	/**
 	 * Routes the Slack agent to the v2 MCP server (`@superset/mcp-v2`)
 	 * instead of v1 (`@superset/mcp`). Evaluated against the linking
 	 * user's id (the Superset user behind the Slack mention) so it


### PR DESCRIPTION
## Summary
- Drops the `automations-access` PostHog flag — Automations is now visible in the sidebar for everyone
- Paid-plan paywall (`GATED_FEATURES.AUTOMATIONS`) still gates actual access via the route + click handler

## Test plan
- [ ] Sidebar shows Automations entry for users without the flag set
- [ ] Clicking Automations on a free plan triggers the paywall
- [ ] Clicking Automations on a paid plan navigates to `/automations`

Note: the `automations-access` flag in PostHog (Production) is left in place for now and can be deleted separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Automations visible in the desktop sidebar for all users by removing the `automations-access` feature flag; access is still enforced by `GATED_FEATURES.AUTOMATIONS` (free plans see the paywall; paid plans go to `/automations`). Also aligns the collapsed sidebar order with the expanded view (Automations before Tasks).

- **Refactors**
  - Removed `FEATURE_FLAGS.AUTOMATIONS_ACCESS` from `@superset/shared/constants`.
  - Dropped `useFeatureFlagEnabled` gating in `DashboardSidebarHeader`; the Automations button always renders and the click handler enforces paywall/navigation.

- **Bug Fixes**
  - Collapsed sidebar order now matches expanded: Automations appears before Tasks.

<sup>Written for commit 7f39fbfcdc866550d93ba1d29c4f07b01eee383c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Automations sidebar entry is now always visible in both collapsed and expanded layouts; users can see the Automations option at all times. Access to Automations functionality remains restricted and is enforced when attempting to navigate to it, so only permitted users can enter the feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->