### PR TITLE
fix(desktop): stable Adopt button + Adopt-all on v1 workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -322,12 +322,12 @@ export function ImportWorkspacesPage({
 				void adoptAll();
 			}}
 			disabled={isAdoptingAll || pendingEntries.length === 0}
-			className="shrink-0 gap-1.5"
+			className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px] font-medium tabular-nums"
 		>
-			{isAdoptingAll && <Spinner className="size-3.5" />}
+			{isAdoptingAll && <Spinner className="size-3" />}
 			{isAdoptingAll && adoptAllProgress
 				? `Adopting ${adoptAllProgress.current + 1}/${adoptAllProgress.total}`
-				: `Adopt all (${pendingEntries.length})`}
+				: `Adopt all · ${pendingEntries.length}`}
 		</Button>
 	) : null;
 
@@ -365,9 +365,9 @@ export function ImportWorkspacesPage({
 			headerAction={headerAction}
 		>
 			{Array.from(grouped.entries()).map(([projectV1Id, group]) => (
-				<div key={projectV1Id} className="mb-2 flex min-w-0 flex-col">
+				<div key={projectV1Id} className="mb-1.5 flex min-w-0 flex-col">
 					<div
-						className="truncate px-3 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+						className="truncate px-2.5 pt-2.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70"
 						title={group.projectName}
 					>
 						{group.projectName}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -29,7 +29,7 @@ function trpcCode(err: unknown): string | null {
 type AdoptStatus =
 	| { kind: "idle" }
 	| { kind: "running" }
-	| { kind: "imported"; v2WorkspaceId: string }
+	| { kind: "imported" }
 	| { kind: "error"; message: string };
 
 const IDLE: AdoptStatus = { kind: "idle" };
@@ -218,7 +218,7 @@ export function ImportWorkspacesPage({
 	);
 
 	const adoptWorkspace = useCallback(
-		async (entry: VisibleWorkspace): Promise<boolean> => {
+		async (entry: VisibleWorkspace) => {
 			const { workspace, v2ProjectId, worktreePath, baseBranch } = entry;
 			updateAdoptStatus(workspace.id, { kind: "running" });
 			try {
@@ -246,14 +246,10 @@ export function ImportWorkspacesPage({
 				}
 
 				ensureWorkspaceInSidebar(result.workspace.id, v2ProjectId);
-				updateAdoptStatus(workspace.id, {
-					kind: "imported",
-					v2WorkspaceId: result.workspace.id,
-				});
+				updateAdoptStatus(workspace.id, { kind: "imported" });
 				await queryClient.invalidateQueries({
 					queryKey: WORKSPACE_CLOUD_LIST_KEY,
 				});
-				return true;
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				updateAdoptStatus(workspace.id, { kind: "error", message });
@@ -264,7 +260,6 @@ export function ImportWorkspacesPage({
 					organizationId,
 					err,
 				});
-				return false;
 			}
 		},
 		[
@@ -297,7 +292,6 @@ export function ImportWorkspacesPage({
 			return status.kind === "idle" || status.kind === "error";
 		});
 		if (queue.length === 0) return;
-		setAdoptAllProgress({ current: 0, total: queue.length });
 		try {
 			for (let i = 0; i < queue.length; i++) {
 				const entry = queue[i];

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -296,6 +296,10 @@ export function ImportWorkspacesPage({
 			for (let i = 0; i < queue.length; i++) {
 				const entry = queue[i];
 				if (!entry) continue;
+				const current = adoptStatesRef.current.get(entry.workspace.id) ?? IDLE;
+				if (current.kind === "running" || current.kind === "imported") {
+					continue;
+				}
 				setAdoptAllProgress({ current: i, total: queue.length });
 				await adoptWorkspace(entry);
 			}
@@ -318,8 +322,8 @@ export function ImportWorkspacesPage({
 			disabled={isAdoptingAll || pendingEntries.length === 0}
 			className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px] font-medium tabular-nums"
 		>
-			{isAdoptingAll && <Spinner className="size-3" />}
-			{isAdoptingAll && adoptAllProgress
+			{adoptAllProgress && <Spinner className="size-3" />}
+			{adoptAllProgress
 				? `Adopting ${adoptAllProgress.current + 1}/${adoptAllProgress.total}`
 				: `Adopt all · ${pendingEntries.length}`}
 		</Button>
@@ -404,7 +408,9 @@ function WorkspaceRow({ entry, status, disabled, onAdopt }: WorkspaceRowProps) {
 			return { kind: "imported" };
 		}
 		if (status.kind === "error") {
-			return { kind: "error", message: status.message, onRetry: onAdopt };
+			return disabled
+				? { kind: "running", label: "Queued" }
+				: { kind: "error", message: status.message, onRetry: onAdopt };
 		}
 		return {
 			kind: "ready",

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -1,5 +1,7 @@
+import { Button } from "@superset/ui/button";
+import { Spinner } from "@superset/ui/spinner";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { LuLayoutGrid } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -24,11 +26,20 @@ function trpcCode(err: unknown): string | null {
 	return typeof code === "string" ? code : null;
 }
 
+type AdoptStatus =
+	| { kind: "idle" }
+	| { kind: "running" }
+	| { kind: "imported"; v2WorkspaceId: string }
+	| { kind: "error"; message: string };
+
+const IDLE: AdoptStatus = { kind: "idle" };
+
 export function ImportWorkspacesPage({
 	organizationId,
 	activeHostUrl,
 }: ImportWorkspacesPageProps) {
 	const queryClient = useQueryClient();
+	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const projectsQuery = electronTrpc.migration.readV1Projects.useQuery();
 	const workspacesQuery = electronTrpc.migration.readV1Workspaces.useQuery();
 	const worktreesQuery = electronTrpc.migration.readV1Worktrees.useQuery();
@@ -156,6 +167,8 @@ export function ImportWorkspacesPage({
 		workspace: (typeof allWorkspaces)[number];
 		v2ProjectId: string;
 		alreadyImported: boolean;
+		worktreePath: string | undefined;
+		baseBranch: string | null;
 	};
 	const visibleWorkspaces: VisibleWorkspace[] = [];
 	for (const workspace of allWorkspaces) {
@@ -171,8 +184,152 @@ export function ImportWorkspacesPage({
 				continue;
 			}
 		}
-		visibleWorkspaces.push({ workspace, v2ProjectId, alreadyImported });
+		const worktree = workspace.worktreeId
+			? worktreesById.get(workspace.worktreeId)
+			: undefined;
+		visibleWorkspaces.push({
+			workspace,
+			v2ProjectId,
+			alreadyImported,
+			worktreePath: worktree?.path,
+			baseBranch: worktree?.baseBranch ?? null,
+		});
 	}
+
+	const [adoptStates, setAdoptStates] = useState<Map<string, AdoptStatus>>(
+		() => new Map(),
+	);
+	const adoptStatesRef = useRef(adoptStates);
+	adoptStatesRef.current = adoptStates;
+
+	const updateAdoptStatus = useCallback(
+		(workspaceId: string, status: AdoptStatus) => {
+			setAdoptStates((prev) => {
+				const next = new Map(prev);
+				if (status.kind === "idle") {
+					next.delete(workspaceId);
+				} else {
+					next.set(workspaceId, status);
+				}
+				return next;
+			});
+		},
+		[],
+	);
+
+	const adoptWorkspace = useCallback(
+		async (entry: VisibleWorkspace): Promise<boolean> => {
+			const { workspace, v2ProjectId, worktreePath, baseBranch } = entry;
+			updateAdoptStatus(workspace.id, { kind: "running" });
+			try {
+				const client = getHostServiceClientByUrl(activeHostUrl);
+				const adoptArgs = {
+					projectId: v2ProjectId,
+					workspaceName: workspace.name,
+					branch: workspace.branch,
+					baseBranch: baseBranch ?? undefined,
+				};
+				let result: Awaited<
+					ReturnType<typeof client.workspaceCreation.adopt.mutate>
+				>;
+				try {
+					result = await client.workspaceCreation.adopt.mutate({
+						...adoptArgs,
+						worktreePath,
+					});
+				} catch (err) {
+					if (worktreePath && trpcCode(err) === "NOT_FOUND") {
+						result = await client.workspaceCreation.adopt.mutate(adoptArgs);
+					} else {
+						throw err;
+					}
+				}
+
+				ensureWorkspaceInSidebar(result.workspace.id, v2ProjectId);
+				updateAdoptStatus(workspace.id, {
+					kind: "imported",
+					v2WorkspaceId: result.workspace.id,
+				});
+				await queryClient.invalidateQueries({
+					queryKey: WORKSPACE_CLOUD_LIST_KEY,
+				});
+				return true;
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				updateAdoptStatus(workspace.id, { kind: "error", message });
+				console.error("[v1-import] workspace adopt failed", {
+					v1WorkspaceId: workspace.id,
+					v2ProjectId,
+					branch: workspace.branch,
+					organizationId,
+					err,
+				});
+				return false;
+			}
+		},
+		[
+			activeHostUrl,
+			ensureWorkspaceInSidebar,
+			organizationId,
+			queryClient,
+			updateAdoptStatus,
+		],
+	);
+
+	const [adoptAllProgress, setAdoptAllProgress] = useState<{
+		current: number;
+		total: number;
+	} | null>(null);
+
+	const pendingEntries = visibleWorkspaces.filter((entry) => {
+		if (entry.alreadyImported) return false;
+		const status = adoptStates.get(entry.workspace.id) ?? IDLE;
+		return status.kind === "idle" || status.kind === "error";
+	});
+
+	const visibleWorkspacesRef = useRef(visibleWorkspaces);
+	visibleWorkspacesRef.current = visibleWorkspaces;
+
+	const adoptAll = useCallback(async () => {
+		const queue = visibleWorkspacesRef.current.filter((entry) => {
+			if (entry.alreadyImported) return false;
+			const status = adoptStatesRef.current.get(entry.workspace.id) ?? IDLE;
+			return status.kind === "idle" || status.kind === "error";
+		});
+		if (queue.length === 0) return;
+		setAdoptAllProgress({ current: 0, total: queue.length });
+		try {
+			for (let i = 0; i < queue.length; i++) {
+				const entry = queue[i];
+				if (!entry) continue;
+				setAdoptAllProgress({ current: i, total: queue.length });
+				await adoptWorkspace(entry);
+			}
+		} finally {
+			setAdoptAllProgress(null);
+		}
+	}, [adoptWorkspace]);
+
+	const isAdoptingAll = adoptAllProgress !== null;
+	const showAdoptAll = pendingEntries.length > 0 || isAdoptingAll;
+
+	const headerAction = showAdoptAll ? (
+		<Button
+			type="button"
+			size="sm"
+			variant="default"
+			onClick={() => {
+				void adoptAll();
+			}}
+			disabled={isAdoptingAll || pendingEntries.length === 0}
+			className="shrink-0 gap-1.5"
+		>
+			{isAdoptingAll && <Spinner className="size-3.5" />}
+			{isAdoptingAll && adoptAllProgress
+				? `Adopting ${adoptAllProgress.current + 1}/${adoptAllProgress.total}`
+				: `Adopt all (${pendingEntries.length})`}
+		</Button>
+	) : null;
 
 	const grouped = new Map<
 		string,
@@ -205,6 +362,7 @@ export function ImportWorkspacesPage({
 			}
 			onRefresh={refresh}
 			isRefreshing={isRefreshing}
+			headerAction={headerAction}
 		>
 			{Array.from(grouped.entries()).map(([projectV1Id, group]) => (
 				<div key={projectV1Id} className="mb-2 flex min-w-0 flex-col">
@@ -214,25 +372,15 @@ export function ImportWorkspacesPage({
 					>
 						{group.projectName}
 					</div>
-					{group.items.map(({ workspace, v2ProjectId, alreadyImported }) => (
+					{group.items.map((entry) => (
 						<WorkspaceRow
-							key={workspace.id}
-							workspace={workspace}
-							worktreePath={
-								workspace.worktreeId
-									? worktreesById.get(workspace.worktreeId)?.path
-									: undefined
-							}
-							baseBranch={
-								workspace.worktreeId
-									? (worktreesById.get(workspace.worktreeId)?.baseBranch ??
-										null)
-									: null
-							}
-							v2ProjectId={v2ProjectId}
-							alreadyImported={alreadyImported}
-							organizationId={organizationId}
-							activeHostUrl={activeHostUrl}
+							key={entry.workspace.id}
+							entry={entry}
+							status={adoptStates.get(entry.workspace.id) ?? IDLE}
+							disabled={isAdoptingAll}
+							onAdopt={() => {
+								void adoptWorkspace(entry);
+							}}
 						/>
 					))}
 				</div>
@@ -242,92 +390,34 @@ export function ImportWorkspacesPage({
 }
 
 interface WorkspaceRowProps {
-	workspace: {
-		id: string;
-		name: string;
-		branch: string;
-		projectId: string;
+	entry: {
+		workspace: { id: string; name: string; branch: string };
+		alreadyImported: boolean;
 	};
-	worktreePath: string | undefined;
-	baseBranch: string | null;
-	v2ProjectId: string;
-	alreadyImported: boolean;
-	organizationId: string;
-	activeHostUrl: string;
+	status: AdoptStatus;
+	disabled: boolean;
+	onAdopt: () => void;
 }
 
-function WorkspaceRow({
-	workspace,
-	worktreePath,
-	baseBranch,
-	v2ProjectId,
-	alreadyImported,
-	organizationId,
-	activeHostUrl,
-}: WorkspaceRowProps) {
-	const queryClient = useQueryClient();
-	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
-	const [running, setRunning] = useState(false);
-	const [errorMessage, setErrorMessage] = useState<string | null>(null);
-	const [adoptedV2Id, setAdoptedV2Id] = useState<string | null>(null);
-
-	const isImported = alreadyImported || !!adoptedV2Id;
-
-	const runImport = async () => {
-		setRunning(true);
-		setErrorMessage(null);
-		try {
-			const client = getHostServiceClientByUrl(activeHostUrl);
-			const adoptArgs = {
-				projectId: v2ProjectId,
-				workspaceName: workspace.name,
-				branch: workspace.branch,
-				baseBranch: baseBranch ?? undefined,
-				existingWorkspaceId: adoptedV2Id ?? undefined,
-			};
-			let result: Awaited<
-				ReturnType<typeof client.workspaceCreation.adopt.mutate>
-			>;
-			try {
-				result = await client.workspaceCreation.adopt.mutate({
-					...adoptArgs,
-					worktreePath,
-				});
-			} catch (err) {
-				if (worktreePath && trpcCode(err) === "NOT_FOUND") {
-					result = await client.workspaceCreation.adopt.mutate(adoptArgs);
-				} else {
-					throw err;
-				}
-			}
-
-			ensureWorkspaceInSidebar(result.workspace.id, v2ProjectId);
-			setAdoptedV2Id(result.workspace.id);
-			await queryClient.invalidateQueries({
-				queryKey: WORKSPACE_CLOUD_LIST_KEY,
-			});
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			setErrorMessage(message);
-			console.error("[v1-import] workspace adopt failed", {
-				v1WorkspaceId: workspace.id,
-				v2ProjectId,
-				branch: workspace.branch,
-				organizationId,
-				err,
-			});
-		} finally {
-			setRunning(false);
-		}
-	};
+function WorkspaceRow({ entry, status, disabled, onAdopt }: WorkspaceRowProps) {
+	const { workspace, alreadyImported } = entry;
 
 	const action: RowAction = (() => {
-		if (running) return { kind: "running" };
-		if (isImported) return { kind: "imported" };
-		if (errorMessage) {
-			return { kind: "error", message: errorMessage, onRetry: runImport };
+		if (status.kind === "running") {
+			return { kind: "running", label: "Adopting…" };
 		}
-		return { kind: "ready", label: "Adopt", onClick: runImport };
+		if (alreadyImported || status.kind === "imported") {
+			return { kind: "imported" };
+		}
+		if (status.kind === "error") {
+			return { kind: "error", message: status.message, onRetry: onAdopt };
+		}
+		return {
+			kind: "ready",
+			label: "Adopt",
+			onClick: onAdopt,
+			disabled,
+		};
 	})();
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
@@ -91,12 +91,13 @@ export function V1ImportModal() {
 					)}
 				</div>
 
-				<div className="box-border flex shrink-0 items-center justify-between gap-3 border-t bg-background px-5 py-4">
+				<div className="box-border flex shrink-0 items-center justify-between gap-3 border-t border-border/60 bg-background px-5 py-3">
 					{previousPage ? (
 						<Button
-							variant="outline"
+							variant="ghost"
+							size="sm"
 							onClick={() => setPage(previousPage)}
-							className="shrink-0"
+							className="h-8 shrink-0 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground"
 						>
 							Back
 						</Button>
@@ -104,11 +105,19 @@ export function V1ImportModal() {
 						<div />
 					)}
 					{nextPage ? (
-						<Button onClick={() => setPage(nextPage)} className="shrink-0">
+						<Button
+							size="sm"
+							onClick={() => setPage(nextPage)}
+							className="h-8 shrink-0 px-3 text-[13px] font-medium"
+						>
 							{page === "welcome" ? "Get started" : "Next"}
 						</Button>
 					) : (
-						<Button onClick={close} className="shrink-0">
+						<Button
+							size="sm"
+							onClick={close}
+							className="h-8 shrink-0 px-3 text-[13px] font-medium"
+						>
 							Done
 						</Button>
 					)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportPageShell/ImportPageShell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportPageShell/ImportPageShell.tsx
@@ -28,18 +28,18 @@ export function ImportPageShell({
 }: ImportPageShellProps) {
 	return (
 		<div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-			<div className="flex items-start gap-3 border-b px-8 py-5 pr-20">
+			<div className="flex items-center gap-3 border-b border-border/60 px-6 py-3.5 pr-16">
 				<div className="min-w-0 flex-1">
-					<div className="truncate text-lg font-semibold text-foreground">
+					<div className="truncate text-[14px] font-medium tracking-tight text-foreground">
 						{title}
 					</div>
 					{description && (
-						<p className="mt-1 truncate text-xs text-muted-foreground">
+						<p className="mt-0.5 truncate text-[12px] text-muted-foreground">
 							{description}
 						</p>
 					)}
 				</div>
-				<div className="flex shrink-0 items-center gap-2">
+				<div className="flex shrink-0 items-center gap-1">
 					{headerAction}
 					{onRefresh && (
 						<Button
@@ -49,7 +49,7 @@ export function ImportPageShell({
 							onClick={onRefresh}
 							disabled={isRefreshing}
 							aria-label="Refresh"
-							className="h-7 w-7 shrink-0"
+							className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
 						>
 							<LuRefreshCw
 								className={`size-3.5${isRefreshing ? " animate-spin" : ""}`}
@@ -59,13 +59,13 @@ export function ImportPageShell({
 					)}
 				</div>
 			</div>
-			<div className="flex min-h-0 min-w-0 flex-1 flex-col gap-0.5 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-3">
+			<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto overscroll-contain px-2 py-2">
 				{isLoading ? (
 					<div className="flex flex-1 items-center justify-center">
-						<Spinner className="size-5" />
+						<Spinner className="size-4 text-muted-foreground" />
 					</div>
 				) : itemCount === 0 ? (
-					<div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+					<div className="flex flex-1 items-center justify-center px-6 text-center text-[13px] text-muted-foreground">
 						{emptyMessage ?? "Nothing to import."}
 					</div>
 				) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportPageShell/ImportPageShell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportPageShell/ImportPageShell.tsx
@@ -11,6 +11,7 @@ interface ImportPageShellProps {
 	itemCount: number;
 	onRefresh?: () => void;
 	isRefreshing?: boolean;
+	headerAction?: ReactNode;
 	children: ReactNode;
 }
 
@@ -22,6 +23,7 @@ export function ImportPageShell({
 	itemCount,
 	onRefresh,
 	isRefreshing,
+	headerAction,
 	children,
 }: ImportPageShellProps) {
 	return (
@@ -37,22 +39,25 @@ export function ImportPageShell({
 						</p>
 					)}
 				</div>
-				{onRefresh && (
-					<Button
-						type="button"
-						variant="ghost"
-						size="icon"
-						onClick={onRefresh}
-						disabled={isRefreshing}
-						aria-label="Refresh"
-						className="h-7 w-7 shrink-0"
-					>
-						<LuRefreshCw
-							className={`size-3.5${isRefreshing ? " animate-spin" : ""}`}
-							strokeWidth={2}
-						/>
-					</Button>
-				)}
+				<div className="flex shrink-0 items-center gap-2">
+					{headerAction}
+					{onRefresh && (
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							onClick={onRefresh}
+							disabled={isRefreshing}
+							aria-label="Refresh"
+							className="h-7 w-7 shrink-0"
+						>
+							<LuRefreshCw
+								className={`size-3.5${isRefreshing ? " animate-spin" : ""}`}
+								strokeWidth={2}
+							/>
+						</Button>
+					)}
+				</div>
 			</div>
 			<div className="flex min-h-0 min-w-0 flex-1 flex-col gap-0.5 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-3">
 				{isLoading ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
@@ -125,7 +125,7 @@ function RowActionView({ action }: { action: RowAction }) {
 					className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px] font-medium"
 				>
 					<Spinner className="size-3" />
-					{action.label ?? null}
+					{action.label}
 				</Button>
 			);
 		case "imported":

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
@@ -52,22 +52,22 @@ export function ImportRow({
 	action,
 }: ImportRowProps) {
 	return (
-		<div className="flex w-full min-w-0 max-w-full items-center gap-3 overflow-hidden px-3 py-2">
+		<div className="group flex w-full min-w-0 max-w-full items-center gap-3 overflow-hidden rounded-md px-2.5 py-1.5 transition-colors hover:bg-accent/40">
 			{icon && (
-				<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+				<div className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
 					{icon}
 				</div>
 			)}
 			<div className="flex min-w-0 flex-1 flex-col">
 				<span
-					className="truncate text-sm font-medium text-foreground"
+					className="truncate text-[13px] font-medium leading-tight text-foreground"
 					title={primary}
 				>
 					{primary}
 				</span>
 				{secondary && (
 					<span
-						className="truncate font-mono text-[11px] text-muted-foreground"
+						className="mt-0.5 truncate font-mono text-[11px] leading-tight text-muted-foreground"
 						title={secondary}
 					>
 						{secondary}
@@ -75,7 +75,7 @@ export function ImportRow({
 				)}
 				{action.kind === "error" && (
 					<span
-						className="select-text cursor-text truncate text-[11px] text-destructive"
+						className="mt-0.5 select-text cursor-text truncate text-[11px] leading-tight text-destructive"
 						title={action.message}
 					>
 						{action.message}
@@ -83,14 +83,14 @@ export function ImportRow({
 				)}
 				{action.kind === "blocked" && (
 					<span
-						className="truncate text-[11px] text-muted-foreground"
+						className="mt-0.5 truncate text-[11px] leading-tight text-muted-foreground"
 						title={action.reason}
 					>
 						{action.reason}
 					</span>
 				)}
 				{action.kind === "confirm" && (
-					<span className="select-text cursor-text text-[11px] text-muted-foreground [overflow-wrap:anywhere]">
+					<span className="mt-0.5 select-text cursor-text text-[11px] leading-tight text-muted-foreground [overflow-wrap:anywhere]">
 						{action.message}
 					</span>
 				)}
@@ -110,7 +110,7 @@ function RowActionView({ action }: { action: RowAction }) {
 					variant="outline"
 					onClick={action.onClick}
 					disabled={action.disabled}
-					className="shrink-0"
+					className="h-7 shrink-0 px-2.5 text-[12px] font-medium"
 				>
 					{action.label}
 				</Button>
@@ -122,9 +122,9 @@ function RowActionView({ action }: { action: RowAction }) {
 					size="sm"
 					variant="outline"
 					disabled
-					className="shrink-0 gap-1.5"
+					className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px] font-medium"
 				>
-					<Spinner className="size-3.5" />
+					<Spinner className="size-3" />
 					{action.label ?? null}
 				</Button>
 			);
@@ -132,7 +132,7 @@ function RowActionView({ action }: { action: RowAction }) {
 			return (
 				<div
 					className={cn(
-						"flex shrink-0 items-center gap-1 text-xs font-medium",
+						"flex shrink-0 items-center gap-1 text-[12px] font-medium",
 						"text-emerald-600 dark:text-emerald-400",
 					)}
 				>
@@ -142,7 +142,7 @@ function RowActionView({ action }: { action: RowAction }) {
 			);
 		case "blocked":
 			return (
-				<div className="shrink-0 text-[11px] uppercase tracking-wide text-muted-foreground">
+				<div className="shrink-0 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
 					Blocked
 				</div>
 			);
@@ -153,7 +153,7 @@ function RowActionView({ action }: { action: RowAction }) {
 					size="sm"
 					variant="outline"
 					onClick={action.onRetry}
-					className="shrink-0 gap-1.5"
+					className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px] font-medium"
 				>
 					<LuTriangle className="size-3 text-destructive" strokeWidth={2.5} />
 					Retry
@@ -165,8 +165,9 @@ function RowActionView({ action }: { action: RowAction }) {
 					<Button
 						type="button"
 						size="sm"
-						variant="outline"
+						variant="ghost"
 						onClick={action.onCancel}
+						className="h-7 px-2.5 text-[12px] font-medium"
 					>
 						{action.cancelLabel ?? "Cancel"}
 					</Button>
@@ -175,6 +176,7 @@ function RowActionView({ action }: { action: RowAction }) {
 						size="sm"
 						variant="default"
 						onClick={action.onConfirm}
+						className="h-7 px-2.5 text-[12px] font-medium"
 					>
 						{action.confirmLabel}
 					</Button>
@@ -188,7 +190,7 @@ function RowActionView({ action }: { action: RowAction }) {
 							type="button"
 							size="sm"
 							variant="outline"
-							className="shrink-0 gap-1.5"
+							className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px] font-medium"
 						>
 							{action.label}
 							<LuChevronDown className="size-3" strokeWidth={2} />
@@ -202,7 +204,7 @@ function RowActionView({ action }: { action: RowAction }) {
 								className="flex flex-col items-start gap-0.5"
 							>
 								<div className="flex w-full items-center gap-2">
-									<span className="truncate text-sm">{candidate.name}</span>
+									<span className="truncate text-[13px]">{candidate.name}</span>
 									{candidate.matchesExpected && (
 										<span className="ml-auto shrink-0 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
 											matches v1

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
@@ -19,7 +19,7 @@ export interface PickCandidate {
 
 export type RowAction =
 	| { kind: "ready"; label: string; onClick: () => void; disabled?: boolean }
-	| { kind: "running" }
+	| { kind: "running"; label?: string }
 	| { kind: "imported"; label?: string }
 	| { kind: "blocked"; reason: string }
 	| { kind: "error"; message: string; onRetry: () => void }
@@ -117,9 +117,16 @@ function RowActionView({ action }: { action: RowAction }) {
 			);
 		case "running":
 			return (
-				<div className="flex h-8 w-[68px] shrink-0 items-center justify-center text-muted-foreground">
+				<Button
+					type="button"
+					size="sm"
+					variant="outline"
+					disabled
+					className="shrink-0 gap-1.5"
+				>
 					<Spinner className="size-3.5" />
-				</div>
+					{action.label ?? null}
+				</Button>
 			);
 		case "imported":
 			return (


### PR DESCRIPTION
## Summary
- The v1 → v2 migration modal scrolled to the top of the list when you clicked Adopt, because the row swapped its `<Button>` for a `<div>` mid-flight; Radix Dialog then re-focused the dialog root. The adopting state is now a *disabled* button (with spinner + "Adopting…") so focus stays on the row.
- Added an **Adopt all (N)** button in the workspaces page header. It runs sequentially and shows live progress ("Adopting 3/12"); individual rows are disabled while it's running.
- Lifted per-row adoption state into `ImportWorkspacesPage` so Adopt-all and per-row clicks share one state machine.

## Test plan
- [ ] Open the v1 import modal → Workspaces tab with a long list; click Adopt on a workspace far down → list does not scroll, row shows "Adopting…", then "Imported".
- [ ] Click **Adopt all** with multiple pending workspaces → sequential adopt, header shows progress, individual Adopt buttons disabled.
- [ ] Trigger an adopt failure (e.g., force NOT_FOUND) → row shows error + Retry; Adopt-all still completes the rest.
- [ ] Already-imported rows still render as Imported and aren't re-adopted by Adopt-all.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Adopt button and adds Adopt‑all with progress in the v1→v2 import modal, with a cleaner Linear‑style UI. Prevents duplicate adopts during bulk runs and ensures adopted workspaces appear in the sidebar.

- **Bug Fixes**
  - Keep the adopting state as a disabled button with spinner and “Adopting…”, stopping dialog refocus/scroll.
  - Prevent double‑adopt in Adopt‑all by showing “Queued” instead of Retry on errors and skipping entries already running/imported.

- **New Features**
  - “Adopt all (N)” runs sequentially with live progress (“Adopting X/Y”), disables row actions while running, skips already‑imported items, continues on errors with per‑row Retry; adoption state is centralized in `ImportWorkspacesPage`; sidebar updates and the cloud list is invalidated after adoption.
  - Linear‑style polish: smaller header/footer buttons (h‑8, 13px), 13px row text with flat icons and subtle hover, 10px uppercase section labels, and tabular‑nums in “Adopt all · N”.

<sup>Written for commit e89a621b25b1315fde1dfd520654b2e6ab248db2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Adopt all" now runs selected imports sequentially with progress tracking and disables per-row actions while running.

* **Improvements**
  * Per-workspace import statuses (idle, running, imported, error) surface clearer row actions and enable retry.
  * Row action visuals refined (running state may show a label; clearer imported/error states).
  * Page header accepts an optional header action; modal footer and navigation buttons use consistent sizing and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->