### PR TITLE
feat(desktop): respawn host-service on every Electron auto-update

### DIFF
--- a/apps/desktop/plans/20260507-host-service-bundled-version-pin.md
+++ b/apps/desktop/plans/20260507-host-service-bundled-version-pin.md
@@ -1,0 +1,52 @@
+# Pin host-service adoption to bundled version
+
+## Problem
+
+Today `host-service-coordinator.tryAdopt()` adopts any running host-service whose version satisfies `>= MIN_HOST_SERVICE_VERSION` — a manually-bumped floor in `packages/shared/src/host-version.ts`. After an Electron auto-update, the new desktop happily adopts a stale host-service as long as it clears the floor, so non-breaking host-service changes (patches, additive features) never reach users until someone remembers to bump the floor.
+
+We want auto-updated desktops to always end up running the host-service binary that shipped with them.
+
+## Why respawn is safe
+
+Pty-daemon — the only process holding durable session state — has its own manifest + supervisor (`packages/host-service/src/daemon/DaemonSupervisor.ts`) and is adopted independently. Killing host-service drops only:
+
+- tunnel-client WebSockets (auto-reconnect)
+- the in-memory terminal sessions Map (rebuilt on re-attach via daemon-client)
+- cached env
+
+Real PTY state stays in the daemon across the swap.
+
+## Change
+
+Replace the floor check with an equality check against the host-service bundled into this Electron build. Reuse the existing kill+respawn path.
+
+1. Inject `BUNDLED_HOST_SERVICE_VERSION` into the desktop main bundle at build time (read `packages/host-service/package.json` version), mirroring the `EXPECTED_DAEMON_VERSION` pattern at `packages/host-service/src/daemon/expected-version.ts`.
+2. In `apps/desktop/src/main/lib/host-service-coordinator.ts:289-308`, replace
+   ```ts
+   !semver.satisfies(version, `>=${MIN_HOST_SERVICE_VERSION}`)
+   ```
+   with
+   ```ts
+   version !== BUNDLED_HOST_SERVICE_VERSION
+   ```
+   (or `!semver.gte(version, BUNDLED_HOST_SERVICE_VERSION)` if we want a newer dev daemon to win — see open question).
+3. Keep `MIN_HOST_SERVICE_VERSION` only for the renderer-side **remote** host gate at `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts:91`. We can't kill remote hosts — a floor is still the right shape there.
+
+Everything else is unchanged: `detached: true` spawn, manifest re-adoption on next start, crash circuit breaker, daemon lifecycle.
+
+## Behavior after change
+
+- **Auto-update ships new host-service version** → next Electron launch: adoption check fails, manifest PID gets SIGTERM, fresh host-service spawns from the bundled binary. One brief tunnel reconnect.
+- **Auto-update ships same host-service version** → adoption succeeds, no respawn.
+- **Pty-daemon** → never killed by this path; survives across host-service swaps as designed.
+
+## Open questions
+
+- **Strict equality vs `>=bundled`?** Strict equality means a dev build pointing at a locally newer host-service would get killed on Electron start. `>=bundled` avoids that but lets a hand-rolled newer daemon stick around indefinitely. Default to strict equality unless dev-flow friction shows up.
+- **Drain before SIGTERM?** Today line 304 is a hard kill. If respawn cadence becomes user-visible (tunnel reconnect storms), add a short drain — stop accepting new connections, wait N seconds — before SIGTERM. Not needed in v1.
+
+## Out of scope
+
+- Pty-daemon version pinning (already handled by `DaemonSupervisor` + `EXPECTED_DAEMON_VERSION`).
+- Changing `MIN_HOST_SERVICE_VERSION` semantics for the remote-host renderer gate.
+- Any auto-update lifecycle changes — host-service and pty-daemon still must not be torn down by the auto-updater itself; the respawn happens on the *next* launch via the existing adoption path.

--- a/apps/desktop/plans/20260507-host-service-bundled-version-pin.md
+++ b/apps/desktop/plans/20260507-host-service-bundled-version-pin.md
@@ -25,11 +25,11 @@ Replace the floor check with an equality check against the host-service bundled 
    ```ts
    !semver.satisfies(version, `>=${MIN_HOST_SERVICE_VERSION}`)
    ```
-   with
+   with strict equality:
    ```ts
    version !== BUNDLED_HOST_SERVICE_VERSION
    ```
-   (or `!semver.gte(version, BUNDLED_HOST_SERVICE_VERSION)` if we want a newer dev daemon to win — see open question).
+   The Electron build is the source of truth for which host-service runs against it. Any drift — older or newer — gets killed and respawned from the bundled binary. This keeps the cloud/desktop deploy contract tight (only one host-service version is ever live alongside a given desktop) and avoids the "hand-rolled newer daemon sticks around indefinitely" failure mode.
 3. Keep `MIN_HOST_SERVICE_VERSION` only for the renderer-side **remote** host gate at `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts:91`. We can't kill remote hosts — a floor is still the right shape there.
 
 Everything else is unchanged: `detached: true` spawn, manifest re-adoption on next start, crash circuit breaker, daemon lifecycle.
@@ -38,11 +38,11 @@ Everything else is unchanged: `detached: true` spawn, manifest re-adoption on ne
 
 - **Auto-update ships new host-service version** → next Electron launch: adoption check fails, manifest PID gets SIGTERM, fresh host-service spawns from the bundled binary. One brief tunnel reconnect.
 - **Auto-update ships same host-service version** → adoption succeeds, no respawn.
+- **Dev: locally newer host-service** → killed and replaced with the bundled version. If you need to test against a newer daemon in dev, point the desktop at a build that bundles it; don't hand-roll the running process.
 - **Pty-daemon** → never killed by this path; survives across host-service swaps as designed.
 
 ## Open questions
 
-- **Strict equality vs `>=bundled`?** Strict equality means a dev build pointing at a locally newer host-service would get killed on Electron start. `>=bundled` avoids that but lets a hand-rolled newer daemon stick around indefinitely. Default to strict equality unless dev-flow friction shows up.
 - **Drain before SIGTERM?** Today line 304 is a hard kill. If respawn cadence becomes user-visible (tunnel reconnect storms), add a short drain — stop accepting new connections, wait N seconds — before SIGTERM. Not needed in v1.
 
 ## Out of scope

--- a/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
+++ b/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
@@ -20,7 +20,7 @@ Real PTY state stays in the daemon across the swap.
 
 Replace the floor check with an equality check against the host-service bundled into this Electron build. Reuse the existing kill+respawn path.
 
-1. Inject `BUNDLED_HOST_SERVICE_VERSION` into the desktop main bundle at build time (read `packages/host-service/package.json` version), mirroring the `EXPECTED_DAEMON_VERSION` pattern at `packages/host-service/src/daemon/expected-version.ts`.
+1. Promote the host-service version to `HOST_SERVICE_VERSION` in `packages/shared/src/host-version.ts` as the single source of truth. Both `host.info` (runtime, returned to the desktop on adoption probe) and the desktop coordinator (compile-time import as `BUNDLED_HOST_SERVICE_VERSION`) read from this constant — so the value the desktop checks against is the same value the bundled host-service reports. Drift between this constant and `packages/host-service/package.json#version` is a manual concern; the auto-derive-from-package.json approach (mirroring `EXPECTED_DAEMON_VERSION` at `packages/host-service/src/daemon/expected-version.ts`) was deferred because host-service's package.json has historically lagged the runtime-reported version (`packages/host-service/src/trpc/router/host/host.ts` previously hardcoded "0.8.0" while `package.json` was still at "0.1.0"); reconciling that is its own change.
 2. In `apps/desktop/src/main/lib/host-service-coordinator.ts:289-308`, replace
    ```ts
    !semver.satisfies(version, `>=${MIN_HOST_SERVICE_VERSION}`)
@@ -29,7 +29,7 @@ Replace the floor check with an equality check against the host-service bundled 
    ```ts
    version !== BUNDLED_HOST_SERVICE_VERSION
    ```
-   The Electron build is the source of truth for which host-service runs against it. Any drift — older or newer — gets killed and respawned from the bundled binary. This keeps the cloud/desktop deploy contract tight (only one host-service version is ever live alongside a given desktop) and avoids the "hand-rolled newer daemon sticks around indefinitely" failure mode.
+   The Electron build is the source of truth for which host-service runs against it. Any drift — older or newer — gets killed and respawned from the bundled binary. This keeps the cloud/desktop deploy contract tight (only one host-service version is ever live alongside a given desktop) and avoids the "hand-rolled newer host-service sticks around indefinitely" failure mode.
 3. Keep `MIN_HOST_SERVICE_VERSION` only for the renderer-side **remote** host gate at `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts:91`. We can't kill remote hosts — a floor is still the right shape there.
 
 Everything else is unchanged: `detached: true` spawn, manifest re-adoption on next start, crash circuit breaker, daemon lifecycle.

--- a/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
+++ b/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
@@ -55,13 +55,17 @@ Everything else is unchanged: `detached: true` spawn, manifest re-adoption on ne
 
 ## Outcomes & Retrospective
 
+The plan above describes a host-service version pin (steps 2–3). That approach was implemented and then **simplified out** — see the retrospective below for what actually shipped.
+
 **Shipped:**
-- `packages/host-service/package.json#version` is now the single source of truth. Bumped `0.1.0` → `0.8.0` to reconcile with the previously hard-coded value, then `0.8.0` → `0.8.1` so existing installs respawn once on next launch. Added `"./package.json": "./package.json"` to its `exports` map so consumers can import it (same pattern as `packages/pty-daemon/package.json`).
-- `host.info` (`packages/host-service/src/trpc/router/host/host.ts`) imports the package.json with `with { type: "json" }` and returns `pkg.version` — no more hard-coded constant.
-- Desktop coordinator (`apps/desktop/src/main/lib/host-service-coordinator.ts`) imports the same package.json as `BUNDLED_HOST_SERVICE_VERSION`. Adoption now requires strict equality — `version !== BUNDLED_HOST_SERVICE_VERSION` triggers kill + respawn.
-- **App-version pin (belt + suspenders).** Added `spawnedByAppVersion` to the host-service manifest; the child writes it from `SUPERSET_APP_VERSION` (passed by the coordinator from `app.getVersion()`). On adoption the coordinator additionally requires `manifest.spawnedByAppVersion === app.getVersion()`. Either pin mismatching triggers respawn — so every desktop auto-update guarantees a fresh host-service even if someone forgets to bump the host-service version on a host-service code change. Pre-existing manifests without the field are coerced to empty string and naturally trip the pin on first launch.
-- `MIN_HOST_SERVICE_VERSION` retained for the **remote**-host renderer gate (`useRemoteHostStatus.ts`) where a floor is still the right shape.
+- **App-version pin in `tryAdopt`.** The host-service manifest gains `spawnedByAppVersion`; the child writes it from `SUPERSET_APP_VERSION` (passed by the coordinator from `app.getVersion()`). On adoption the coordinator requires `manifest.spawnedByAppVersion === app.getVersion()` — any mismatch kills the manifest PID and falls through to `spawn()` from the bundled binary. Pre-existing manifests without the field are coerced to empty string by `readManifest` so the old PID is still found and killed (no orphan).
+- **Why app-version, not host-service version.** Host-service ships with the desktop, so `app.getVersion()` strictly subsumes the host-service version pin for the auto-update use case. Bumping the host-service version on a host-service code change is no longer load-bearing for adoption.
+- **Host-service version still flows through `host.info`** (`packages/host-service/src/trpc/router/host/host.ts`), now derived from `packages/host-service/package.json` via a `with { type: "json" }` import — kept for telemetry/debugging and because the renderer-side **remote**-host gate (`useRemoteHostStatus`) still compares it against `MIN_HOST_SERVICE_VERSION`.
+- `packages/host-service/package.json` was bumped `0.1.0` → `0.8.0` (reconciles the historical drift where `host.info` hard-coded `"0.8.0"` while `package.json` lagged) and then `0.8.0` → `0.8.1`. Added `"./package.json": "./package.json"` to its `exports` so the import works cross-package.
 - `semver` import dropped from the coordinator — no longer needed there.
+
+**Tried and removed:**
+- A `BUNDLED_HOST_SERVICE_VERSION` pin in `tryAdopt` (compile-time read of `@superset/host-service/package.json#version`, strict-equality check against `host.info.version`). Implemented, but redundant once the app-version pin landed: in our build flow host-service ships with the desktop, so the app-version pin catches every case the host-service version pin caught — plus the case where someone forgets to bump the host-service version on a host-service code change. Removed to avoid carrying a second concept and a per-adoption HTTP probe that no longer mattered.
 
 **Deferred:**
 - Drain-before-SIGTERM. The hard kill is unchanged; revisit if respawn cadence becomes user-visible.

--- a/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
+++ b/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
@@ -56,9 +56,10 @@ Everything else is unchanged: `detached: true` spawn, manifest re-adoption on ne
 ## Outcomes & Retrospective
 
 **Shipped:**
-- `packages/host-service/package.json#version` is now the single source of truth. Bumped `0.1.0` → `0.8.0` to reconcile with the previously hard-coded value, and added `"./package.json": "./package.json"` to its `exports` map so consumers can import it (same pattern as `packages/pty-daemon/package.json`).
+- `packages/host-service/package.json#version` is now the single source of truth. Bumped `0.1.0` → `0.8.0` to reconcile with the previously hard-coded value, then `0.8.0` → `0.8.1` so existing installs respawn once on next launch. Added `"./package.json": "./package.json"` to its `exports` map so consumers can import it (same pattern as `packages/pty-daemon/package.json`).
 - `host.info` (`packages/host-service/src/trpc/router/host/host.ts`) imports the package.json with `with { type: "json" }` and returns `pkg.version` — no more hard-coded constant.
 - Desktop coordinator (`apps/desktop/src/main/lib/host-service-coordinator.ts`) imports the same package.json as `BUNDLED_HOST_SERVICE_VERSION`. Adoption now requires strict equality — `version !== BUNDLED_HOST_SERVICE_VERSION` triggers kill + respawn.
+- **App-version pin (belt + suspenders).** Added `spawnedByAppVersion` to the host-service manifest; the child writes it from `SUPERSET_APP_VERSION` (passed by the coordinator from `app.getVersion()`). On adoption the coordinator additionally requires `manifest.spawnedByAppVersion === app.getVersion()`. Either pin mismatching triggers respawn — so every desktop auto-update guarantees a fresh host-service even if someone forgets to bump the host-service version on a host-service code change. Pre-existing manifests without the field are coerced to empty string and naturally trip the pin on first launch.
 - `MIN_HOST_SERVICE_VERSION` retained for the **remote**-host renderer gate (`useRemoteHostStatus.ts`) where a floor is still the right shape.
 - `semver` import dropped from the coordinator — no longer needed there.
 

--- a/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
+++ b/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
@@ -20,7 +20,9 @@ Real PTY state stays in the daemon across the swap.
 
 Replace the floor check with an equality check against the host-service bundled into this Electron build. Reuse the existing kill+respawn path.
 
-1. Promote the host-service version to `HOST_SERVICE_VERSION` in `packages/shared/src/host-version.ts` as the single source of truth. Both `host.info` (runtime, returned to the desktop on adoption probe) and the desktop coordinator (compile-time import as `BUNDLED_HOST_SERVICE_VERSION`) read from this constant — so the value the desktop checks against is the same value the bundled host-service reports. Drift between this constant and `packages/host-service/package.json#version` is a manual concern; the auto-derive-from-package.json approach (mirroring `EXPECTED_DAEMON_VERSION` at `packages/host-service/src/daemon/expected-version.ts`) was deferred because host-service's package.json has historically lagged the runtime-reported version (`packages/host-service/src/trpc/router/host/host.ts` previously hardcoded "0.8.0" while `package.json` was still at "0.1.0"); reconciling that is its own change.
+1. `packages/host-service/package.json#version` is the single source of truth, mirroring the `EXPECTED_DAEMON_VERSION` pattern at `packages/host-service/src/daemon/expected-version.ts`. Both `host.info` (runtime, returned to the desktop on adoption probe) and the desktop coordinator import the package.json directly with `with { type: "json" }` and read `.version`. Bumping `packages/host-service/package.json` automatically bumps both — no shared constant to keep in sync.
+
+   To enable the cross-package import on the desktop side, `packages/host-service/package.json` adds `"./package.json": "./package.json"` to its `exports` map (same as `packages/pty-daemon/package.json`). The package.json version is also bumped from `0.1.0` to `0.8.0` to reconcile a pre-existing drift: `host.info` had been hard-coding `"0.8.0"` for several breaking-change ratchets while `package.json` was never bumped past `0.1.0`. After this PR, `package.json` becomes load-bearing — bumping it kills every running host-service on the next launch.
 2. In `apps/desktop/src/main/lib/host-service-coordinator.ts:289-308`, replace
    ```ts
    !semver.satisfies(version, `>=${MIN_HOST_SERVICE_VERSION}`)
@@ -54,8 +56,9 @@ Everything else is unchanged: `detached: true` spawn, manifest re-adoption on ne
 ## Outcomes & Retrospective
 
 **Shipped:**
-- Promoted the host-service version constant to `HOST_SERVICE_VERSION` in `packages/shared/src/host-version.ts` (single source of truth). `host.info` now reads from there, replacing the previously hardcoded `HOST_SERVICE_VERSION = "0.8.0"` in `packages/host-service/src/trpc/router/host/host.ts`.
-- Desktop coordinator (`apps/desktop/src/main/lib/host-service-coordinator.ts`) imports it as `BUNDLED_HOST_SERVICE_VERSION`. Adoption now requires strict equality — `version !== BUNDLED_HOST_SERVICE_VERSION` triggers kill + respawn.
+- `packages/host-service/package.json#version` is now the single source of truth. Bumped `0.1.0` → `0.8.0` to reconcile with the previously hard-coded value, and added `"./package.json": "./package.json"` to its `exports` map so consumers can import it (same pattern as `packages/pty-daemon/package.json`).
+- `host.info` (`packages/host-service/src/trpc/router/host/host.ts`) imports the package.json with `with { type: "json" }` and returns `pkg.version` — no more hard-coded constant.
+- Desktop coordinator (`apps/desktop/src/main/lib/host-service-coordinator.ts`) imports the same package.json as `BUNDLED_HOST_SERVICE_VERSION`. Adoption now requires strict equality — `version !== BUNDLED_HOST_SERVICE_VERSION` triggers kill + respawn.
 - `MIN_HOST_SERVICE_VERSION` retained for the **remote**-host renderer gate (`useRemoteHostStatus.ts`) where a floor is still the right shape.
 - `semver` import dropped from the coordinator — no longer needed there.
 

--- a/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
+++ b/apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md
@@ -50,3 +50,14 @@ Everything else is unchanged: `detached: true` spawn, manifest re-adoption on ne
 - Pty-daemon version pinning (already handled by `DaemonSupervisor` + `EXPECTED_DAEMON_VERSION`).
 - Changing `MIN_HOST_SERVICE_VERSION` semantics for the remote-host renderer gate.
 - Any auto-update lifecycle changes — host-service and pty-daemon still must not be torn down by the auto-updater itself; the respawn happens on the *next* launch via the existing adoption path.
+
+## Outcomes & Retrospective
+
+**Shipped:**
+- Promoted the host-service version constant to `HOST_SERVICE_VERSION` in `packages/shared/src/host-version.ts` (single source of truth). `host.info` now reads from there, replacing the previously hardcoded `HOST_SERVICE_VERSION = "0.8.0"` in `packages/host-service/src/trpc/router/host/host.ts`.
+- Desktop coordinator (`apps/desktop/src/main/lib/host-service-coordinator.ts`) imports it as `BUNDLED_HOST_SERVICE_VERSION`. Adoption now requires strict equality — `version !== BUNDLED_HOST_SERVICE_VERSION` triggers kill + respawn.
+- `MIN_HOST_SERVICE_VERSION` retained for the **remote**-host renderer gate (`useRemoteHostStatus.ts`) where a floor is still the right shape.
+- `semver` import dropped from the coordinator — no longer needed there.
+
+**Deferred:**
+- Drain-before-SIGTERM. The hard kill is unchanged; revisit if respawn cadence becomes user-visible.

--- a/apps/desktop/src/main/host-service/env.ts
+++ b/apps/desktop/src/main/host-service/env.ts
@@ -12,6 +12,7 @@ export const env = createEnv({
 		ORGANIZATION_ID: z.string().min(1),
 		DESKTOP_VITE_PORT: z.coerce.number().int().positive(),
 		RELAY_URL: z.string().url().optional(),
+		SUPERSET_APP_VERSION: z.string().min(1),
 	},
 	runtimeEnv: process.env,
 	emptyStringAsUndefined: true,

--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -74,6 +74,7 @@ async function main(): Promise<void> {
 						authToken: env.HOST_SERVICE_SECRET,
 						startedAt,
 						organizationId: env.ORGANIZATION_ID,
+						spawnedByAppVersion: env.SUPERSET_APP_VERSION,
 					});
 				} catch (error) {
 					console.error("[host-service] Failed to write manifest:", error);

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -3,9 +3,6 @@ import { randomBytes } from "node:crypto";
 import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import path from "node:path";
-import hostServicePackageJson from "@superset/host-service/package.json" with {
-	type: "json",
-};
 import { settings } from "@superset/local-db";
 import { getHostId, getHostName } from "@superset/shared/host-info";
 import { app } from "electron";
@@ -30,10 +27,6 @@ import {
 } from "./host-service-utils";
 import { localDb } from "./local-db";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
-
-// Bundled at compile time — kept in lockstep with what `host.info` reports
-// because both sides read the same package.json.
-const BUNDLED_HOST_SERVICE_VERSION: string = hostServicePackageJson.version;
 
 export type HostServiceStatus = "starting" | "running" | "stopped";
 
@@ -306,24 +299,6 @@ export class HostServiceCoordinator extends EventEmitter {
 			return null;
 		}
 
-		const version = await this.fetchHostVersion(
-			manifest.endpoint,
-			manifest.authToken,
-		);
-		if (!version || version !== BUNDLED_HOST_SERVICE_VERSION) {
-			const reason = version
-				? `version ${version} != bundled ${BUNDLED_HOST_SERVICE_VERSION}`
-				: "version unknown";
-			console.log(
-				`[host-service:${organizationId}] Adopted service ${reason}, killing`,
-			);
-			try {
-				process.kill(manifest.pid, "SIGTERM");
-			} catch {}
-			removeManifest(organizationId);
-			return null;
-		}
-
 		this.instances.set(organizationId, {
 			pid: manifest.pid,
 			port,
@@ -337,27 +312,6 @@ export class HostServiceCoordinator extends EventEmitter {
 		);
 		this.emitStatus(organizationId, "running", null);
 		return { port, secret: manifest.authToken, machineId: this.machineId };
-	}
-
-	private async fetchHostVersion(
-		endpoint: string,
-		secret: string,
-	): Promise<string | null> {
-		try {
-			const controller = new AbortController();
-			const timeout = setTimeout(() => controller.abort(), 3_000);
-			const response = await fetch(`${endpoint}/trpc/host.info`, {
-				signal: controller.signal,
-				headers: { Authorization: `Bearer ${secret}` },
-			});
-			clearTimeout(timeout);
-			if (!response.ok) return null;
-			const data = await response.json();
-			const result = data?.result?.data;
-			return result?.json?.version ?? result?.version ?? null;
-		} catch {
-			return null;
-		}
 	}
 
 	private readAndValidateManifest(

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -3,9 +3,11 @@ import { randomBytes } from "node:crypto";
 import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import path from "node:path";
+import hostServicePackageJson from "@superset/host-service/package.json" with {
+	type: "json",
+};
 import { settings } from "@superset/local-db";
 import { getHostId, getHostName } from "@superset/shared/host-info";
-import { HOST_SERVICE_VERSION as BUNDLED_HOST_SERVICE_VERSION } from "@superset/shared/host-version";
 import { app } from "electron";
 import { env } from "main/env.main";
 import { env as sharedEnv } from "shared/env.shared";
@@ -28,6 +30,10 @@ import {
 } from "./host-service-utils";
 import { localDb } from "./local-db";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
+
+// Bundled at compile time — kept in lockstep with what `host.info` reports
+// because both sides read the same package.json.
+const BUNDLED_HOST_SERVICE_VERSION: string = hostServicePackageJson.version;
 
 export type HostServiceStatus = "starting" | "running" | "stopped";
 

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -291,6 +291,21 @@ export class HostServiceCoordinator extends EventEmitter {
 		const url = new URL(manifest.endpoint);
 		const port = Number(url.port);
 
+		const currentAppVersion = app.getVersion();
+		if (manifest.spawnedByAppVersion !== currentAppVersion) {
+			const reason = manifest.spawnedByAppVersion
+				? `spawned by app ${manifest.spawnedByAppVersion} != current ${currentAppVersion}`
+				: "no recorded app version (pre-upgrade manifest)";
+			console.log(
+				`[host-service:${organizationId}] Adopted service ${reason}, killing`,
+			);
+			try {
+				process.kill(manifest.pid, "SIGTERM");
+			} catch {}
+			removeManifest(organizationId);
+			return null;
+		}
+
 		const version = await this.fetchHostVersion(
 			manifest.endpoint,
 			manifest.authToken,
@@ -494,6 +509,7 @@ export class HostServiceCoordinator extends EventEmitter {
 			SUPERSET_HOME_DIR: SUPERSET_HOME_DIR,
 			SUPERSET_AGENT_HOOK_PORT: String(sharedEnv.DESKTOP_NOTIFICATIONS_PORT),
 			SUPERSET_AGENT_HOOK_VERSION: HOOK_PROTOCOL_VERSION,
+			SUPERSET_APP_VERSION: app.getVersion(),
 			AUTH_TOKEN: config.authToken,
 			SUPERSET_API_URL: config.cloudApiUrl,
 		});

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -5,10 +5,9 @@ import * as fs from "node:fs";
 import path from "node:path";
 import { settings } from "@superset/local-db";
 import { getHostId, getHostName } from "@superset/shared/host-info";
-import { MIN_HOST_SERVICE_VERSION } from "@superset/shared/host-version";
+import { HOST_SERVICE_VERSION as BUNDLED_HOST_SERVICE_VERSION } from "@superset/shared/host-version";
 import { app } from "electron";
 import { env } from "main/env.main";
-import semver from "semver";
 import { env as sharedEnv } from "shared/env.shared";
 import { getProcessEnvWithShellPath } from "../../lib/trpc/routers/workspaces/utils/shell-env";
 import { SUPERSET_HOME_DIR } from "./app-environment";
@@ -290,12 +289,9 @@ export class HostServiceCoordinator extends EventEmitter {
 			manifest.endpoint,
 			manifest.authToken,
 		);
-		if (
-			!version ||
-			!semver.satisfies(version, `>=${MIN_HOST_SERVICE_VERSION}`)
-		) {
+		if (!version || version !== BUNDLED_HOST_SERVICE_VERSION) {
 			const reason = version
-				? `version ${version} < ${MIN_HOST_SERVICE_VERSION}`
+				? `version ${version} != bundled ${BUNDLED_HOST_SERVICE_VERSION}`
 				: "version unknown";
 			console.log(
 				`[host-service:${organizationId}] Adopted service ${reason}, killing`,

--- a/apps/desktop/src/main/lib/host-service-manifest.ts
+++ b/apps/desktop/src/main/lib/host-service-manifest.ts
@@ -15,6 +15,15 @@ export interface HostServiceManifest {
 	authToken: string;
 	startedAt: number;
 	organizationId: string;
+	/**
+	 * Desktop app version that spawned this host-service. Compared against
+	 * the current `app.getVersion()` on adoption — any mismatch triggers a
+	 * kill + respawn so every Electron auto-update lands on a freshly
+	 * spawned host-service, even when the host-service version pin alone
+	 * would have allowed adoption (e.g. host-service code changed but its
+	 * `package.json#version` was not bumped).
+	 */
+	spawnedByAppVersion: string;
 }
 
 export function manifestDir(organizationId: string): string {
@@ -58,6 +67,14 @@ export function readManifest(
 			typeof data.organizationId !== "string"
 		) {
 			return null;
+		}
+
+		// `spawnedByAppVersion` is required going forward, but pre-existing
+		// manifests on upgraded users won't have it. Coerce to empty string so
+		// `tryAdopt` still finds the old PID, then trip the app-version pin
+		// (current version !== "") so the stale daemon gets killed and respawned.
+		if (typeof data.spawnedByAppVersion !== "string") {
+			data.spawnedByAppVersion = "";
 		}
 
 		return data as HostServiceManifest;

--- a/bun.lock
+++ b/bun.lock
@@ -775,7 +775,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.1.0",
+      "version": "0.8.1",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
         "@hono/node-ws": "^1.3.0",

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "0.1.0",
+	"version": "0.8.0",
 	"private": true,
 	"type": "module",
 	"exports": {
@@ -39,7 +39,8 @@
 		"./attachments": {
 			"types": "./src/trpc/router/attachments/index.ts",
 			"default": "./src/trpc/router/attachments/index.ts"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"scripts": {
 		"clean": "git clean -xdf .cache .turbo dist node_modules",

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"private": true,
 	"type": "module",
 	"exports": {

--- a/packages/host-service/src/trpc/router/host/host.ts
+++ b/packages/host-service/src/trpc/router/host/host.ts
@@ -1,9 +1,16 @@
 import os from "node:os";
+import hostServicePackageJson from "@superset/host-service/package.json" with {
+	type: "json",
+};
 import { getHostId, getHostName } from "@superset/shared/host-info";
-import { HOST_SERVICE_VERSION } from "@superset/shared/host-version";
 import { TRPCError } from "@trpc/server";
 import type { ApiClient } from "../../../types";
 import { protectedProcedure, router } from "../../index";
+
+// Auto-derived from this package's package.json so a host-service version
+// bump automatically flows through to `host.info` and the desktop's
+// strict-equality adoption check (see host-service-coordinator.tryAdopt).
+const HOST_SERVICE_VERSION: string = hostServicePackageJson.version;
 
 const ORGANIZATION_CACHE_TTL_MS = 60 * 60 * 1000;
 

--- a/packages/host-service/src/trpc/router/host/host.ts
+++ b/packages/host-service/src/trpc/router/host/host.ts
@@ -1,30 +1,10 @@
 import os from "node:os";
 import { getHostId, getHostName } from "@superset/shared/host-info";
+import { HOST_SERVICE_VERSION } from "@superset/shared/host-version";
 import { TRPCError } from "@trpc/server";
 import type { ApiClient } from "../../../types";
 import { protectedProcedure, router } from "../../index";
 
-// 0.4.0: terminal launch moved from `terminal.ensureSession` to
-// `terminal.launchSession` plus WebSocket attach params.
-// 0.3.0: cloud `device.*` router renamed to `host.*`; `device.ensureV2Host`
-// is now `host.ensure`, host registrations are keyed on (orgId, machineId)
-// composite, and `targetHostId`/`v2_workspaces.host_id` are machineId text
-// not uuid. Older host-service binaries call the now-removed `device.*`
-// procedures and fail at registration.
-// 0.2.0: `workspaceCreation.adopt` accepts optional `worktreePath`.
-// 0.5.0: pty-daemon supervision moved into host-service. New
-// `terminal.daemon` tRPC namespace; existing 0.4.x host-services
-// don't expose it, so the desktop coordinator must refuse to adopt
-// them on upgrade and respawn with the new bundle. Adopting in
-// place would leave the new desktop talking to old code with no
-// `terminal.daemon.*` routes, breaking Settings → Manage daemon.
-// 0.7.0: canonical `workspaces.create` flow + `settings.hostAgentConfigs`
-// router (PR1, #3893). 0.6.x host-services don't expose either, so
-// adopting one in place would break new-project creation and the
-// agent-config settings UI.
-// 0.8.0: terminal creation moved to `terminal.createSession`; WebSocket
-// `/terminal/:terminalId` is attach-only.
-const HOST_SERVICE_VERSION = "0.8.0";
 const ORGANIZATION_CACHE_TTL_MS = 60 * 60 * 1000;
 
 let cachedOrganization: {

--- a/packages/shared/src/host-version.ts
+++ b/packages/shared/src/host-version.ts
@@ -1,22 +1,9 @@
 /**
- * Canonical version of host-service in this checkout. Reported by
- * `host.info` at runtime, and bundled into the desktop main process as
- * the version the Electron build expects to run against. Bump on every
- * host-service change shipping a new build.
- *
- * The desktop coordinator pins adoption to this exact value: if a running
- * host-service reports a different version (older or newer), it is killed
- * and respawned from the bundled binary. Pty-daemon — which holds durable
- * session state — has its own manifest + supervisor and survives the swap.
- */
-export const HOST_SERVICE_VERSION = "0.8.0";
-
-/**
  * Minimum host-service version a v2 workspace UI can work with against a
  * **remote** host whose binary we don't control (gates renderer mounting
  * via `useRemoteHostStatus`). For the local host-service we bundle, the
- * desktop coordinator pins to `HOST_SERVICE_VERSION` exactly — this floor
- * does not apply.
+ * desktop coordinator pins to the bundled version exactly (read from
+ * `@superset/host-service/package.json`) — this floor does not apply.
  *
  * 0.4.0: terminal launch moved from `terminal.ensureSession` to
  * `terminal.launchSession` plus WebSocket attach params.

--- a/packages/shared/src/host-version.ts
+++ b/packages/shared/src/host-version.ts
@@ -1,8 +1,22 @@
 /**
- * Minimum host-service version this app can work with. Bumping this forces
- * the desktop coordinator to kill + respawn any adopted local service older
- * than this, and gates v2 workspace UIs from mounting against a remote host
- * whose CLI is still on an older version.
+ * Canonical version of host-service in this checkout. Reported by
+ * `host.info` at runtime, and bundled into the desktop main process as
+ * the version the Electron build expects to run against. Bump on every
+ * host-service change shipping a new build.
+ *
+ * The desktop coordinator pins adoption to this exact value: if a running
+ * host-service reports a different version (older or newer), it is killed
+ * and respawned from the bundled binary. Pty-daemon — which holds durable
+ * session state — has its own manifest + supervisor and survives the swap.
+ */
+export const HOST_SERVICE_VERSION = "0.8.0";
+
+/**
+ * Minimum host-service version a v2 workspace UI can work with against a
+ * **remote** host whose binary we don't control (gates renderer mounting
+ * via `useRemoteHostStatus`). For the local host-service we bundle, the
+ * desktop coordinator pins to `HOST_SERVICE_VERSION` exactly — this floor
+ * does not apply.
  *
  * 0.4.0: terminal launch moved from `terminal.ensureSession` to
  * `terminal.launchSession` plus WebSocket attach params.
@@ -13,17 +27,12 @@
  *
  * 0.5.0 — pty-daemon supervision migrated into host-service. New
  * `terminal.daemon` tRPC namespace; older 0.4.x host-services don't
- * expose it. Adopting one in place would leave the new desktop
- * talking to old code: Settings → Manage daemon would silently
- * fail, and the v2 PTY survival promise is broken.
+ * expose it.
  *
  * 0.7.0 — canonical `workspaces.create` flow + `settings.hostAgentConfigs`
- * router (PR1, #3893). Older 0.6.x host-services don't expose either,
- * so adopting one in place would break new-project creation and the
- * agent-config settings UI.
+ * router (PR1, #3893). Older 0.6.x host-services don't expose either.
  *
  * 0.8.0 — v2 terminal creation moved to `terminal.createSession`; the
- * WebSocket route is attach-only by `terminalId`. Older host-services would
- * reject the renderer's creation call and still expect socket-side startup.
+ * WebSocket route is attach-only by `terminalId`.
  */
 export const MIN_HOST_SERVICE_VERSION = "0.8.0";


### PR DESCRIPTION
**Plan:** `apps/desktop/plans/done/20260507-host-service-bundled-version-pin.md`

## Summary
- Auto-updated desktops now always end up running a freshly spawned host-service. The coordinator pins host-service adoption to the desktop's `app.getVersion()`: if a running host-service was spawned by a different desktop version, it's killed (SIGTERM) and respawned from the bundled binary on the next Electron launch.
- Pty-daemon — the durable session-state holder — has its own manifest + supervisor and is unaffected, so terminal sessions survive the host-service swap.
- `MIN_HOST_SERVICE_VERSION` is retained for the renderer-side **remote**-host gate (`useRemoteHostStatus`) where we can't kill the remote process and a floor is still the right shape.

## Why / Context
Previously, `tryAdopt` accepted any local host-service satisfying `>= MIN_HOST_SERVICE_VERSION` — a manually-bumped floor. After auto-update, a stale host-service that cleared the floor stuck around indefinitely; non-breaking host-service changes never reached users until someone remembered to bump the floor.

### Why "kill on Electron update" is OK here
Host-service has two deployment modes, and they want different things:
- **Bundled with Electron (this PR's path).** Host-service ships in the desktop binary. Co-deployed → freshness wins → killing on next-launch adoption is fine.
- **Standalone CLI on a remote machine** (consumed by the desktop via the renderer remote-host flow). Has its own update cadence independent of any one Electron build → lifecycle preservation matters there. **Unchanged by this PR**: the desktop never reads or writes that machine's manifest; the renderer-side `useRemoteHostStatus` floor gate is the only contract.

The detached/manifest/fd-handoff machinery exists primarily for the standalone case. Repurposing the bundled-local manifest for "always fresh" is deliberate now that the standalone case is structurally separated.

User-visible cost is small: pty-daemon (`packages/host-service/src/daemon/DaemonSupervisor.ts`) has its own manifest+adoption lifecycle, so killing host-service drops only tunnel-client WebSockets (auto-reconnect) and the in-memory terminal sessions Map (rebuilt on re-attach via daemon-client). Real PTY state stays in the daemon.

We still **do not** kill host-service in the auto-updater path itself (no `stopBackendAndWaitForExit`-style step before `quitAndInstall`). The kill happens on the *next* Electron launch via `tryAdopt` — single code path that handles auto-update, crash recovery, and manual restart uniformly.

## How It Works
- `HostServiceManifest` gains `spawnedByAppVersion: string`. The host-service child writes it from a new `SUPERSET_APP_VERSION` env var. The coordinator sets that env from `app.getVersion()` when spawning.
- `tryAdopt`:
  ```ts
  if (manifest.spawnedByAppVersion !== app.getVersion()) {
      // SIGTERM the old PID, drop the manifest, fall through to spawn()
  }
  ```
- Pre-existing manifests (without the field) are coerced to `""` by `readManifest` so the old PID is still found and killed — no orphan. Result: every existing user respawns host-service exactly once on first launch after this ships.

### Why app-version, not host-service version
A host-service version pin was implemented and then removed. In our build flow host-service ships with the desktop, so the app-version pin strictly subsumes it for the auto-update use case — plus it catches the case where someone forgets to bump the host-service version on a host-service code change. The removed pin only added value for a hand-rolled binary in dev.

### Side cleanup
- `packages/host-service/package.json#version` was previously stuck at `0.1.0` while `host.info` hard-coded `"0.8.0"`. Reconciled: `host.info` now reads `pkg.version` via `with { type: "json" }` (mirrors `EXPECTED_DAEMON_VERSION`), and the package.json was bumped `0.1.0` → `0.8.1`. Added `"./package.json": "./package.json"` to the exports map. The renderer-side remote-host gate still uses `MIN_HOST_SERVICE_VERSION = "0.8.0"` against this reported value.
- `semver` import dropped from the coordinator (no longer needed there).

## Manual QA Checklist

### App-version pin (the main behavior)
- [ ] Fresh launch with no manifest → host-service spawns, manifest written with `spawnedByAppVersion: app.getVersion()`.
- [ ] Same Electron version restarts → adoption succeeds, no respawn (no "killing" log).
- [ ] Simulate auto-update: change `apps/desktop/package.json` version (or run a different packaged build), restart → coordinator logs `Adopted service spawned by app X.X.X != current Y.Y.Y, killing`, SIGTERMs the old PID, spawns fresh.
- [ ] Pre-existing manifest (no `spawnedByAppVersion`) → logs `no recorded app version (pre-upgrade manifest), killing` once, then settles.

### Pty-daemon survives the swap
- [ ] Open a v2 workspace terminal, type some text.
- [ ] Trigger a host-service respawn (via the version-mismatch path above).
- [ ] After Electron relaunches, the terminal session re-attaches to the same daemon-side PTY and shows the prior buffer (no fresh shell).

### Tunnel reconnect
- [ ] Brief tunnel reconnect on host-service respawn is acceptable (no permanent disconnect, no error toast loop).
- [ ] Trigger a respawn while a workspace is mid-render — renderer recovers cleanly without manual reload.

### Remote-host gate untouched
- [ ] `useRemoteHostStatus` still uses `MIN_HOST_SERVICE_VERSION`; connecting to a remote host below the floor still surfaces the existing "host CLI too old" UI.
- [ ] Connecting to a remote on `0.8.0` works (floor = 0.8.0, satisfies). Connecting to a remote on `0.8.1` works (satisfies floor).

## Testing
- `bun run typecheck` — pass.
- `bun run lint` — pass.
- `bun turbo run build --filter=@superset/desktop --filter=@superset/host-service` — pass. Verified packaged ASAR bundles `host-service@0.8.1` and that `SUPERSET_APP_VERSION = electron.app.getVersion(...)` is wired through to `manifest.spawnedByAppVersion`.

## Risks / Rollout
- **One-time forced respawn** for every existing user on first launch after this ships (their manifest lacks `spawnedByAppVersion`). In-flight tRPC requests during the kill window fail; renderer reconnect handles it. Pty-daemon is unaffected — terminal sessions survive.
- **Hard SIGTERM, no drain.** Same as before this PR. Respawn cadence is now "every desktop update" instead of "every host-service version bump." If users notice tunnel blips after auto-updates, drain-before-SIGTERM is the lever to revisit (deferred in the plan).
- **Rollback:** revert this PR. The previous `>= MIN_HOST_SERVICE_VERSION` floor returns; running host-services are again adopted as long as they clear it.

## Follow-ups
- Drain-before-SIGTERM if respawn cadence becomes user-visible.
