### PR TITLE
fix(desktop): restore v2 sidebar LOC indicator

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
@@ -1,42 +1,44 @@
-import { workspaceTrpc } from "@superset/workspace-client";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useWorkspaceEvent } from "../useWorkspaceEvent";
+import { useWorkspaceHostUrl } from "../useWorkspaceHostUrl";
 
 export interface DiffStats {
 	additions: number;
 	deletions: number;
 }
 
-/**
- * Diff stats for a single workspace, derived from the shared `git.getStatus`
- * query cache. Subscribes to `git:changed` and invalidates the query — React
- * Query collapses concurrent invalidations from sibling consumers (e.g.
- * `useGitStatus`, multiple sidebar tiles) into a single refetch.
- */
 export function useDiffStats(workspaceId: string): DiffStats | null {
-	const utils = workspaceTrpc.useUtils();
-	const { data: status } = workspaceTrpc.git.getStatus.useQuery(
-		{ workspaceId },
-		{
-			enabled: Boolean(workspaceId),
-			// Match the pre-RQ behavior: only update on `git:changed`, never
-			// on focus. Multiple sidebar tiles each have their own query key,
-			// so focus refetch would re-fan out the very work this hook is
-			// supposed to consolidate.
-			refetchOnWindowFocus: false,
-		},
+	const hostUrl = useWorkspaceHostUrl(workspaceId);
+	const queryClient = useQueryClient();
+	const queryKey = useMemo(
+		() => ["diff-stats", hostUrl, workspaceId] as const,
+		[hostUrl, workspaceId],
 	);
 
+	const { data: status } = useQuery({
+		queryKey,
+		enabled: Boolean(workspaceId) && Boolean(hostUrl),
+		queryFn: () => {
+			if (!hostUrl) return null;
+			return getHostServiceClientByUrl(hostUrl).git.getStatus.query({
+				workspaceId,
+			});
+		},
+		refetchOnWindowFocus: false,
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+
 	const invalidate = useCallback(() => {
-		void utils.git.getStatus.invalidate({ workspaceId });
-	}, [utils, workspaceId]);
+		void queryClient.invalidateQueries({ queryKey });
+	}, [queryClient, queryKey]);
 
 	useWorkspaceEvent("git:changed", workspaceId, invalidate);
 
 	return useMemo<DiffStats | null>(() => {
 		if (!status) return null;
 
-		// Deduplicate by path — a file can appear in multiple categories.
 		const byPath = new Map<string, { additions: number; deletions: number }>();
 		for (const file of status.againstBase) byPath.set(file.path, file);
 		for (const file of status.staged) byPath.set(file.path, file);


### PR DESCRIPTION
## Summary

- #4160 rewrote \`useDiffStats\` from imperative \`client.git.getStatus.query()\` to \`workspaceTrpc.git.getStatus.useQuery()\`. This broke the v2 dashboard sidebar's LOC indicator — \`workspaceTrpc.Provider\` only mounts inside \`v2-workspace/\$workspaceId\`, but the sidebar is a sibling of that \`<Outlet />\`, so its tRPC hooks had no provider above them. Even when one provider was present, it points at a single hostUrl and can't fan out to sidebar workspaces living on different hosts (local vs remote vs cloud).
- Resolve hostUrl per-workspaceId via \`useWorkspaceHostUrl\`, call the imperative \`getHostServiceClientByUrl(hostUrl).git.getStatus.query(...)\` inside a react-query \`queryFn\` keyed on \`(hostUrl, workspaceId)\`. Concurrent callers for the same workspace (sidebar tile + hover overlay) still dedup through the global \`QueryClient\` — same end-state perf #4160 intended, without the broken Provider assumption.
- \`staleTime: Number.POSITIVE_INFINITY\` since \`git:changed\` is push-authoritative — sidebar tile remounts (virtualization, route changes) reuse the cached value.

## Test plan

- [ ] Open desktop app on a project with multiple v2 workspaces, confirm \`+N −N\` chip appears on tiles with local changes
- [ ] Edit a file in a workspace, confirm chip updates without manual refresh
- [ ] Hover a workspace, confirm hover-card LOC matches the tile (no double-fetch in network panel)
- [ ] Verify chip works for both local-device and remote-device workspaces in the same sidebar

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the v2 sidebar LOC (+N/−N) indicator by fetching diff stats per workspace without relying on a `workspaceTrpc` provider. Works across local, remote, and cloud workspaces.

- **Bug Fixes**
  - Switched to `@tanstack/react-query` `useQuery` with `getHostServiceClientByUrl(hostUrl).git.getStatus.query(...)`.
  - Resolve `hostUrl` per `workspaceId` via `useWorkspaceHostUrl`; cache key: `["diff-stats", hostUrl, workspaceId]`.
  - Invalidate on `git:changed`; `staleTime: Infinity`; `refetchOnWindowFocus: false`; dedup concurrent fetches via the global `QueryClient`.

<sup>Written for commit 3a454140960ab54907e444c32a24adeb9a5d12f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal infrastructure for diff statistics tracking to enhance performance and maintainability. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->