### PR TITLE
feat(desktop): roomier v2 workspace pickers + clearer branch actions

### DIFF
--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/IssueLinkCommand/IssueLinkCommand.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/IssueLinkCommand/IssueLinkCommand.tsx
@@ -155,7 +155,7 @@ export function IssueLinkCommand({
 				<TooltipContent side="bottom">{tooltipLabel}</TooltipContent>
 			</Tooltip>
 			<PopoverContent
-				className="w-80 p-0"
+				className="w-[440px] p-0"
 				align="start"
 				side="bottom"
 				onWheel={(event) => event.stopPropagation()}
@@ -179,7 +179,7 @@ export function IssueLinkCommand({
 							Show closed
 						</label>
 					</div>
-					<CommandList className="max-h-[280px]">
+					<CommandList className="max-h-[420px]">
 						{filteredTasks.length === 0 && (
 							<CommandEmpty>
 								{showClosed ? "No issues found." : "No open issues found."}
@@ -211,25 +211,35 @@ export function IssueLinkCommand({
 													task.externalUrl ?? undefined,
 												)
 											}
-											className="group"
+											className="group items-start gap-3 rounded-md px-2.5 py-2"
 										>
-											{status ? (
-												<StatusIcon
-													type={status.type}
-													color={status.color}
-													progress={status.progressPercent ?? undefined}
-												/>
-											) : (
-												<span className="size-3.5 shrink-0 rounded-full border border-muted-foreground/40" />
-											)}
-											<span className="max-w-24 shrink-0 truncate font-mono text-xs text-muted-foreground">
-												{task.slug}
+											<span className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
+												{status ? (
+													<StatusIcon
+														type={status.type}
+														color={status.color}
+														progress={status.progressPercent ?? undefined}
+													/>
+												) : (
+													<span className="size-3.5 rounded-full border border-muted-foreground/40" />
+												)}
 											</span>
-											<span className="min-w-0 flex-1 truncate text-xs">
-												{task.title}
-											</span>
-											<span className="shrink-0 hidden text-xs text-muted-foreground group-data-[selected=true]:inline">
-												Link ↵
+											<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+												<span className="truncate text-sm leading-snug">
+													{task.title}
+												</span>
+												<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+													<span className="font-mono">{task.slug}</span>
+													{status ? (
+														<>
+															<span aria-hidden>·</span>
+															<span className="capitalize">{status.type}</span>
+														</>
+													) : null}
+												</span>
+											</div>
+											<span className="ml-2 hidden shrink-0 self-center text-[11px] text-muted-foreground group-data-[selected=true]:inline">
+												↵
 											</span>
 										</CommandItem>
 									);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -8,8 +8,9 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
 import { useEffect, useRef, useState } from "react";
-import { GoGitBranch } from "react-icons/go";
+import { GoGitBranch, GoGlobe } from "react-icons/go";
 import { HiCheck, HiChevronUpDown } from "react-icons/hi2";
+import { LuFolderOpen } from "react-icons/lu";
 import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
 import type { BranchFilter, BranchRow } from "../../../hooks/useBranchContext";
 import { FormPickerTrigger } from "../FormPickerTrigger";
@@ -166,7 +167,13 @@ export function CompareBaseBranchPicker({
 									}}
 									className="group items-start gap-3 rounded-md px-2.5 py-2"
 								>
-									<GoGitBranch className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+									{isWorktree ? (
+										<LuFolderOpen className="mt-0.5 size-4 shrink-0 text-primary/80" />
+									) : isRemoteOnly ? (
+										<GoGlobe className="mt-0.5 size-4 shrink-0 text-muted-foreground/60" />
+									) : (
+										<GoGitBranch className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+									)}
 									<div className="flex min-w-0 flex-1 flex-col gap-0.5">
 										<span className="truncate text-sm leading-snug">
 											{branch.name}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -32,19 +32,10 @@ interface CompareBaseBranchPickerProps {
 		branchName: string,
 		source: "local" | "remote-tracking",
 	) => void;
-	onCheckoutBranch: (branchName: string) => void;
-	onOpenExisting: (branchName: string) => void;
-	// Adopts a worktree git knows about but Superset doesn't yet track as a
-	// workspace (e.g. created outside Superset). The server-side
-	// `workspaces.create` already detects and adopts; this handler awaits the
-	// returned canonical workspace id before navigating, since the optimistic
-	// snapshot id won't match the existing row.
-	onAdoptForeignWorktree: (branchName: string) => void;
-	// Authoritative (cloud-synced) answer to "does a workspace row exist for
-	// this branch on this host?". Computed from the v2Workspaces collection
-	// so it stays in sync with soft-deletes. Trumps any server-side
-	// `hasWorkspace` snapshot, which can be stale after deletion.
-	hasWorkspaceForBranch: (branchName: string) => boolean;
+	// Single unified action: "go to a workspace for this branch". The server's
+	// `workspaces.create` resolves which path to take (open tracked / adopt
+	// foreign worktree / create fresh) so the client doesn't have to.
+	onOpenWorkspace: (branchName: string) => void;
 }
 
 export function CompareBaseBranchPicker({
@@ -61,10 +52,7 @@ export function CompareBaseBranchPicker({
 	hasNextPage,
 	onLoadMore,
 	onSelectCompareBaseBranch,
-	onCheckoutBranch,
-	onOpenExisting,
-	onAdoptForeignWorktree,
-	hasWorkspaceForBranch,
+	onOpenWorkspace,
 }: CompareBaseBranchPickerProps) {
 	const [open, setOpen] = useState(false);
 	const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -212,60 +200,18 @@ export function CompareBaseBranchPicker({
 										</span>
 									</div>
 									<span className="ml-2 flex shrink-0 items-center gap-1.5 self-center">
-										{(() => {
-											// Three states drive the row's CTA, each named after
-											// what it actually does:
-											//   1. Tracked workspace exists  → "Open workspace"
-											//      (jump to it; cloud-collection lookup).
-											//   2. Foreign worktree but no   → "Open workspace"
-											//      tracked workspace yet         (server adopts the
-											//                                     existing worktree;
-											//                                     awaits canonical
-											//                                     id before nav).
-											//   3. No worktree at all         → "Create workspace"
-											//      (fresh `git worktree add`).
-											const canOpenTracked = hasWorkspaceForBranch(branch.name);
-											const isForeignWorktree =
-												!canOpenTracked && Boolean(branch.worktreePath);
-											return (
-												<span className="hidden items-center gap-1.5 group-hover:inline-flex group-focus-within:inline-flex">
-													{canOpenTracked ? (
-														<button
-															type="button"
-															className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
-															onClick={(e) => {
-																e.stopPropagation();
-																onOpenExisting(branch.name);
-															}}
-														>
-															Open workspace
-														</button>
-													) : isForeignWorktree ? (
-														<button
-															type="button"
-															className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
-															onClick={(e) => {
-																e.stopPropagation();
-																onAdoptForeignWorktree(branch.name);
-															}}
-														>
-															Open workspace
-														</button>
-													) : (
-														<button
-															type="button"
-															className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
-															onClick={(e) => {
-																e.stopPropagation();
-																onCheckoutBranch(branch.name);
-															}}
-														>
-															Create workspace
-														</button>
-													)}
-												</span>
-											);
-										})()}
+										<span className="hidden items-center gap-1.5 group-hover:inline-flex group-focus-within:inline-flex">
+											<button
+												type="button"
+												className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
+												onClick={(e) => {
+													e.stopPropagation();
+													onOpenWorkspace(branch.name);
+												}}
+											>
+												Open workspace
+											</button>
+										</span>
 										{effectiveCompareBaseBranch === branch.name && (
 											<HiCheck className="size-4 text-primary group-hover:hidden group-focus-within:hidden" />
 										)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -35,9 +35,8 @@ interface CompareBaseBranchPickerProps {
 		branchName: string,
 		source: "local" | "remote-tracking",
 	) => void;
-	// Single unified action: "go to a workspace for this branch". The server's
-	// `workspaces.create` resolves which path to take (open tracked / adopt
-	// foreign worktree / create fresh) so the client doesn't have to.
+	// Server's workspaces.create resolves between open-tracked, adopt-foreign-
+	// worktree, and fresh-create — the picker doesn't decide.
 	onOpenWorkspace: (branchName: string) => void;
 }
 
@@ -58,9 +57,7 @@ export function CompareBaseBranchPicker({
 	onOpenWorkspace,
 }: CompareBaseBranchPickerProps) {
 	const [open, setOpen] = useState(false);
-	// Mirror cmdk's selected-row value so a Mod+Enter keydown can resolve it
-	// to the branch name without traversing DOM. Without this, keyboard users
-	// have no path to `onOpenWorkspace`.
+	// Mirror cmdk's selected row so Mod+Enter can resolve it without DOM lookup.
 	const [selectedValue, setSelectedValue] = useState("");
 	const sentinelRef = useRef<HTMLDivElement | null>(null);
 
@@ -132,10 +129,8 @@ export function CompareBaseBranchPicker({
 					value={selectedValue}
 					onValueChange={setSelectedValue}
 					onKeyDown={(e) => {
-						// Keyboard parity with the hover-only "Open workspace" button.
-						// cmdk arrow-keys leave focus on the input, so the per-row
-						// button is unreachable; Mod+Enter on the active row routes to
-						// the same handler.
+						// cmdk leaves focus on the input, so the per-row button is
+						// pointer-only — Mod+Enter is the keyboard path to it.
 						if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
 							if (!selectedValue) return;
 							e.preventDefault();
@@ -224,24 +219,22 @@ export function CompareBaseBranchPicker({
 										</span>
 									</div>
 									<span className="ml-2 flex shrink-0 items-center gap-1.5 self-center">
-										<span className="hidden items-center gap-1.5 group-hover:inline-flex group-data-[selected=true]:inline-flex">
-											<button
-												type="button"
-												className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
-												onClick={(e) => {
-													e.stopPropagation();
-													onOpenWorkspace(branch.name);
-													setOpen(false);
-												}}
-											>
-												Open workspace
-												<span className="ml-1.5 text-[10px] opacity-70">
-													{MOD_KEY}↵
-												</span>
-											</button>
-										</span>
+										<button
+											type="button"
+											className="hidden items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20 group-hover:inline-flex group-data-[selected=true]:inline-flex"
+											onClick={(e) => {
+												e.stopPropagation();
+												onOpenWorkspace(branch.name);
+												setOpen(false);
+											}}
+										>
+											Open workspace
+											<span className="ml-1.5 text-[10px] opacity-70">
+												{MOD_KEY}↵
+											</span>
+										</button>
 										{effectiveCompareBaseBranch === branch.name && (
-											<HiCheck className="size-4 text-primary group-hover:hidden group-focus-within:hidden" />
+											<HiCheck className="size-4 text-primary group-hover:hidden group-data-[selected=true]:hidden" />
 										)}
 									</span>
 								</CommandItem>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -168,7 +168,7 @@ export function CompareBaseBranchPicker({
 								>
 									<GoGitBranch className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
 									<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-										<span className="truncate font-mono text-sm leading-snug">
+										<span className="truncate text-sm leading-snug">
 											{branch.name}
 										</span>
 										<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -11,9 +11,12 @@ import { useEffect, useRef, useState } from "react";
 import { GoGitBranch, GoGlobe } from "react-icons/go";
 import { HiCheck, HiChevronUpDown } from "react-icons/hi2";
 import { LuFolderOpen } from "react-icons/lu";
+import { PLATFORM } from "renderer/hotkeys";
 import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
 import type { BranchFilter, BranchRow } from "../../../hooks/useBranchContext";
 import { FormPickerTrigger } from "../FormPickerTrigger";
+
+const MOD_KEY = PLATFORM === "mac" ? "⌘" : "Ctrl";
 
 interface CompareBaseBranchPickerProps {
 	effectiveCompareBaseBranch: string | null;
@@ -55,6 +58,10 @@ export function CompareBaseBranchPicker({
 	onOpenWorkspace,
 }: CompareBaseBranchPickerProps) {
 	const [open, setOpen] = useState(false);
+	// Mirror cmdk's selected-row value so a Mod+Enter keydown can resolve it
+	// to the branch name without traversing DOM. Without this, keyboard users
+	// have no path to `onOpenWorkspace`.
+	const [selectedValue, setSelectedValue] = useState("");
 	const sentinelRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
@@ -120,7 +127,24 @@ export function CompareBaseBranchPicker({
 				align="start"
 				onWheel={(event) => event.stopPropagation()}
 			>
-				<Command shouldFilter={false}>
+				<Command
+					shouldFilter={false}
+					value={selectedValue}
+					onValueChange={setSelectedValue}
+					onKeyDown={(e) => {
+						// Keyboard parity with the hover-only "Open workspace" button.
+						// cmdk arrow-keys leave focus on the input, so the per-row
+						// button is unreachable; Mod+Enter on the active row routes to
+						// the same handler.
+						if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+							if (!selectedValue) return;
+							e.preventDefault();
+							e.stopPropagation();
+							onOpenWorkspace(selectedValue);
+							setOpen(false);
+						}
+					}}
+				>
 					<CommandInput
 						placeholder="Search branches..."
 						value={branchSearch}
@@ -200,16 +224,20 @@ export function CompareBaseBranchPicker({
 										</span>
 									</div>
 									<span className="ml-2 flex shrink-0 items-center gap-1.5 self-center">
-										<span className="hidden items-center gap-1.5 group-hover:inline-flex group-focus-within:inline-flex">
+										<span className="hidden items-center gap-1.5 group-hover:inline-flex group-data-[selected=true]:inline-flex">
 											<button
 												type="button"
 												className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
 												onClick={(e) => {
 													e.stopPropagation();
 													onOpenWorkspace(branch.name);
+													setOpen(false);
 												}}
 											>
 												Open workspace
+												<span className="ml-1.5 text-[10px] opacity-70">
+													{MOD_KEY}↵
+												</span>
 											</button>
 										</span>
 										{effectiveCompareBaseBranch === branch.name && (

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -7,12 +7,6 @@ import {
 } from "@superset/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "@superset/ui/tooltip";
 import { useEffect, useRef, useState } from "react";
 import { GoGitBranch } from "react-icons/go";
 import { HiCheck, HiChevronUpDown } from "react-icons/hi2";
@@ -113,16 +107,20 @@ export function CompareBaseBranchPicker({
 					<GoGitBranch className="size-3 shrink-0" />
 					{isBranchesLoading && branches.length === 0 ? (
 						<span className="h-2.5 w-14 rounded-sm bg-muted-foreground/15 animate-pulse" />
-					) : (
+					) : effectiveCompareBaseBranch ? (
 						<span className="font-mono truncate">
-							{effectiveCompareBaseBranch || "..."}
+							{effectiveCompareBaseBranch}
+						</span>
+					) : (
+						<span className="truncate text-muted-foreground/80">
+							Select base branch…
 						</span>
 					)}
 					<HiChevronUpDown className="size-3 shrink-0" />
 				</FormPickerTrigger>
 			</PopoverTrigger>
 			<PopoverContent
-				className="w-96 p-0"
+				className="w-[440px] p-0"
 				align="start"
 				onWheel={(event) => event.stopPropagation()}
 			>
@@ -146,134 +144,106 @@ export function CompareBaseBranchPicker({
 							</TabsTrigger>
 						</TabsList>
 					</Tabs>
-					<TooltipProvider delayDuration={300}>
-						<CommandList className="max-h-[400px]">
-							{!isBranchesLoading && branches.length === 0 && (
-								<CommandEmpty>No branches found</CommandEmpty>
-							)}
-							{branches.map((branch) => {
-								const isRemoteOnly = branch.isRemote && !branch.isLocal;
-								const isWorktree = Boolean(branch.worktreePath);
-								return (
-									<CommandItem
-										key={branch.name}
-										value={branch.name}
-										onSelect={() => {
-											// Carry the row's locality through so the server doesn't
-											// re-resolve and risk picking a stale cached remote ref.
-											onSelectCompareBaseBranch(
-												branch.name,
-												branch.isLocal ? "local" : "remote-tracking",
-											);
-											setOpen(false);
-										}}
-										className="group h-11 flex items-center justify-between gap-3 px-3"
-									>
-										<span className="flex items-center gap-2.5 truncate flex-1 min-w-0">
-											<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
-											<span className="truncate font-mono text-xs">
-												{branch.name}
-											</span>
-											<span className="flex items-center gap-1.5 shrink-0">
-												{branch.name === defaultBranch && (
-													<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-														default
-													</span>
-												)}
-												{isRemoteOnly && (
-													<span className="text-[10px] text-muted-foreground/60 bg-muted/60 px-1.5 py-0.5 rounded">
-														remote
-													</span>
-												)}
-												{isWorktree && (
-													<span className="text-[10px] text-primary/80 bg-primary/10 px-1.5 py-0.5 rounded">
-														worktree
-													</span>
-												)}
-											</span>
+					<CommandList className="max-h-[420px]">
+						{!isBranchesLoading && branches.length === 0 && (
+							<CommandEmpty>No branches found</CommandEmpty>
+						)}
+						{branches.map((branch) => {
+							const isRemoteOnly = branch.isRemote && !branch.isLocal;
+							const isWorktree = Boolean(branch.worktreePath);
+							return (
+								<CommandItem
+									key={branch.name}
+									value={branch.name}
+									onSelect={() => {
+										// Carry the row's locality through so the server doesn't
+										// re-resolve and risk picking a stale cached remote ref.
+										onSelectCompareBaseBranch(
+											branch.name,
+											branch.isLocal ? "local" : "remote-tracking",
+										);
+										setOpen(false);
+									}}
+									className="group h-11 flex items-center justify-between gap-3 px-3"
+								>
+									<span className="flex items-center gap-2.5 truncate flex-1 min-w-0">
+										<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+										<span className="truncate font-mono text-xs">
+											{branch.name}
 										</span>
-										<span className="flex items-center gap-2 shrink-0">
-											{branch.lastCommitDate > 0 && (
-												<span className="text-[11px] text-muted-foreground/70 group-hover:hidden">
-													{formatRelativeTime(branch.lastCommitDate * 1000)}
+										<span className="flex items-center gap-1.5 shrink-0">
+											{branch.name === defaultBranch && (
+												<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+													default
 												</span>
 											)}
-											{isWorktree ? (
-												(() => {
-													// Authoritative check against the cloud-synced
-													// collection — a `server hasWorkspace:true` row
-													// may be stale after a delete.
-													const hasWorkspace = hasWorkspaceForBranch(
-														branch.name,
-													);
-													return (
-														<button
-															type="button"
-															className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
-															onClick={(e) => {
-																e.stopPropagation();
-																if (hasWorkspace) {
-																	onOpenExisting(branch.name);
-																} else {
-																	onCheckoutBranch(branch.name);
-																}
-															}}
-														>
-															{hasWorkspace ? "Open" : "Create"}
-														</button>
-													);
-												})()
-											) : branch.isCheckedOut ? (
-												<Tooltip>
-													<TooltipTrigger asChild>
-														{/*
-															Use aria-disabled, NOT the native `disabled` attribute.
-															Native disabled buttons don't fire pointer events, so the
-															Tooltip never sees hover/focus and never opens — defeating
-															the purpose of explaining why the button is unavailable.
-														*/}
-														<button
-															type="button"
-															aria-disabled="true"
-															className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center rounded-sm bg-muted px-2 py-0.5 text-[11px] text-muted-foreground/70 cursor-not-allowed"
-															onClick={(e) => e.stopPropagation()}
-														>
-															Check out
-														</button>
-													</TooltipTrigger>
-													<TooltipContent side="left">
-														Already checked out in another worktree
-													</TooltipContent>
-												</Tooltip>
-											) : (
-												<button
-													type="button"
-													className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
-													onClick={(e) => {
-														e.stopPropagation();
-														onCheckoutBranch(branch.name);
-													}}
-												>
-													Check out
-												</button>
+											{isRemoteOnly && (
+												<span className="text-[10px] text-muted-foreground/60 bg-muted/60 px-1.5 py-0.5 rounded">
+													remote
+												</span>
 											)}
-											{effectiveCompareBaseBranch === branch.name && (
-												<HiCheck className="size-4 text-primary" />
+											{isWorktree && (
+												<span className="text-[10px] text-primary/80 bg-primary/10 px-1.5 py-0.5 rounded">
+													worktree
+												</span>
 											)}
 										</span>
-									</CommandItem>
-								);
-							})}
-							{hasNextPage && (
-								<div
-									ref={sentinelRef}
-									className="py-2 text-center text-[11px] text-muted-foreground/60"
-								>
-									{isFetchingNextPage ? "Loading more..." : ""}
-								</div>
-							)}
-						</CommandList>
-					</TooltipProvider>
+									</span>
+									<span className="flex items-center gap-2 shrink-0">
+										{branch.lastCommitDate > 0 && (
+											<span className="text-[11px] text-muted-foreground/70 group-hover:hidden">
+												{formatRelativeTime(branch.lastCommitDate * 1000)}
+											</span>
+										)}
+										{(() => {
+											// Authoritative check against the cloud-synced
+											// collection — a server `hasWorkspace:true` row
+											// may be stale after a delete.
+											const canOpen = hasWorkspaceForBranch(branch.name);
+											return (
+												<span className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center gap-1.5">
+													{canOpen ? (
+														<button
+															type="button"
+															className="inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
+															onClick={(e) => {
+																e.stopPropagation();
+																onOpenExisting(branch.name);
+															}}
+														>
+															Open workspace
+														</button>
+													) : (
+														<button
+															type="button"
+															className="inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
+															onClick={(e) => {
+																e.stopPropagation();
+																onCheckoutBranch(branch.name);
+															}}
+														>
+															Create workspace
+														</button>
+													)}
+												</span>
+											);
+										})()}
+										{effectiveCompareBaseBranch === branch.name && (
+											<HiCheck className="size-4 text-primary" />
+										)}
+									</span>
+								</CommandItem>
+							);
+						})}
+						{hasNextPage && (
+							<div
+								ref={sentinelRef}
+								className="py-2 text-center text-[11px] text-muted-foreground/60"
+							>
+								{isFetchingNextPage ? "Loading more..." : ""}
+							</div>
+						)}
+					</CommandList>
 				</Command>
 			</PopoverContent>
 		</Popover>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -34,6 +34,12 @@ interface CompareBaseBranchPickerProps {
 	) => void;
 	onCheckoutBranch: (branchName: string) => void;
 	onOpenExisting: (branchName: string) => void;
+	// Adopts a worktree git knows about but Superset doesn't yet track as a
+	// workspace (e.g. created outside Superset). The server-side
+	// `workspaces.create` already detects and adopts; this handler awaits the
+	// returned canonical workspace id before navigating, since the optimistic
+	// snapshot id won't match the existing row.
+	onAdoptForeignWorktree: (branchName: string) => void;
 	// Authoritative (cloud-synced) answer to "does a workspace row exist for
 	// this branch on this host?". Computed from the v2Workspaces collection
 	// so it stays in sync with soft-deletes. Trumps any server-side
@@ -57,6 +63,7 @@ export function CompareBaseBranchPicker({
 	onSelectCompareBaseBranch,
 	onCheckoutBranch,
 	onOpenExisting,
+	onAdoptForeignWorktree,
 	hasWorkspaceForBranch,
 }: CompareBaseBranchPickerProps) {
 	const [open, setOpen] = useState(false);
@@ -206,19 +213,40 @@ export function CompareBaseBranchPicker({
 									</div>
 									<span className="ml-2 flex shrink-0 items-center gap-1.5 self-center">
 										{(() => {
-											// Authoritative check against the cloud-synced
-											// collection — a server `hasWorkspace:true` row
-											// may be stale after a delete.
-											const canOpen = hasWorkspaceForBranch(branch.name);
+											// Three states drive the row's CTA, each named after
+											// what it actually does:
+											//   1. Tracked workspace exists  → "Open workspace"
+											//      (jump to it; cloud-collection lookup).
+											//   2. Foreign worktree but no   → "Open workspace"
+											//      tracked workspace yet         (server adopts the
+											//                                     existing worktree;
+											//                                     awaits canonical
+											//                                     id before nav).
+											//   3. No worktree at all         → "Create workspace"
+											//      (fresh `git worktree add`).
+											const canOpenTracked = hasWorkspaceForBranch(branch.name);
+											const isForeignWorktree =
+												!canOpenTracked && Boolean(branch.worktreePath);
 											return (
 												<span className="hidden items-center gap-1.5 group-hover:inline-flex group-focus-within:inline-flex">
-													{canOpen ? (
+													{canOpenTracked ? (
 														<button
 															type="button"
 															className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
 															onClick={(e) => {
 																e.stopPropagation();
 																onOpenExisting(branch.name);
+															}}
+														>
+															Open workspace
+														</button>
+													) : isForeignWorktree ? (
+														<button
+															type="button"
+															className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
+															onClick={(e) => {
+																e.stopPropagation();
+																onAdoptForeignWorktree(branch.name);
 															}}
 														>
 															Open workspace

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -164,48 +164,51 @@ export function CompareBaseBranchPicker({
 										);
 										setOpen(false);
 									}}
-									className="group h-11 flex items-center justify-between gap-3 px-3"
+									className="group items-start gap-3 rounded-md px-2.5 py-2"
 								>
-									<span className="flex items-center gap-2.5 truncate flex-1 min-w-0">
-										<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
-										<span className="truncate font-mono text-xs">
+									<GoGitBranch className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+									<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+										<span className="truncate font-mono text-sm leading-snug">
 											{branch.name}
 										</span>
-										<span className="flex items-center gap-1.5 shrink-0">
-											{branch.name === defaultBranch && (
-												<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-													default
+										<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+											{branch.lastCommitDate > 0 && (
+												<span>
+													{formatRelativeTime(branch.lastCommitDate * 1000)}
 												</span>
+											)}
+											{branch.name === defaultBranch && (
+												<>
+													<span aria-hidden>·</span>
+													<span>default</span>
+												</>
 											)}
 											{isRemoteOnly && (
-												<span className="text-[10px] text-muted-foreground/60 bg-muted/60 px-1.5 py-0.5 rounded">
-													remote
-												</span>
+												<>
+													<span aria-hidden>·</span>
+													<span>remote</span>
+												</>
 											)}
 											{isWorktree && (
-												<span className="text-[10px] text-primary/80 bg-primary/10 px-1.5 py-0.5 rounded">
-													worktree
-												</span>
+												<>
+													<span aria-hidden>·</span>
+													<span className="text-primary/80">worktree</span>
+												</>
 											)}
 										</span>
-									</span>
-									<span className="flex items-center gap-2 shrink-0">
-										{branch.lastCommitDate > 0 && (
-											<span className="text-[11px] text-muted-foreground/70 group-hover:hidden">
-												{formatRelativeTime(branch.lastCommitDate * 1000)}
-											</span>
-										)}
+									</div>
+									<span className="ml-2 flex shrink-0 items-center gap-1.5 self-center">
 										{(() => {
 											// Authoritative check against the cloud-synced
 											// collection — a server `hasWorkspace:true` row
 											// may be stale after a delete.
 											const canOpen = hasWorkspaceForBranch(branch.name);
 											return (
-												<span className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center gap-1.5">
+												<span className="hidden items-center gap-1.5 group-hover:inline-flex group-focus-within:inline-flex">
 													{canOpen ? (
 														<button
 															type="button"
-															className="inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
+															className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
 															onClick={(e) => {
 																e.stopPropagation();
 																onOpenExisting(branch.name);
@@ -216,7 +219,7 @@ export function CompareBaseBranchPicker({
 													) : (
 														<button
 															type="button"
-															className="inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
+															className="inline-flex items-center rounded-sm bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20"
 															onClick={(e) => {
 																e.stopPropagation();
 																onCheckoutBranch(branch.name);
@@ -229,7 +232,7 @@ export function CompareBaseBranchPicker({
 											);
 										})()}
 										{effectiveCompareBaseBranch === branch.name && (
-											<HiCheck className="size-4 text-primary" />
+											<HiCheck className="size-4 text-primary group-hover:hidden group-focus-within:hidden" />
 										)}
 									</span>
 								</CommandItem>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/GitHubIssueLinkCommand/GitHubIssueLinkCommand.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/GitHubIssueLinkCommand/GitHubIssueLinkCommand.tsx
@@ -129,7 +129,7 @@ export function GitHubIssueLinkCommand({
 				<TooltipContent side="bottom">{tooltipLabel}</TooltipContent>
 			</Tooltip>
 			<PopoverContent
-				className="w-80 p-0"
+				className="w-[440px] p-0"
 				align="start"
 				side="bottom"
 				onWheel={(event) => event.stopPropagation()}
@@ -153,7 +153,7 @@ export function GitHubIssueLinkCommand({
 							Show closed
 						</label>
 					</div>
-					<CommandList className="max-h-[280px]">
+					<CommandList className="max-h-[420px]">
 						{searchResults.length === 0 && (
 							<CommandEmpty>
 								{isLoading ? (
@@ -191,28 +191,37 @@ export function GitHubIssueLinkCommand({
 											: "Open issues"
 								}
 							>
-								{searchResults.map((issue) => (
-									<CommandItem
-										key={issue.issueNumber}
-										value={`${issue.issueNumber}-${issue.title}`}
-										onSelect={() => handleSelect(issue)}
-										className="group"
-									>
-										<IssueIcon
-											state={normalizeIssueState(issue.state)}
-											className="size-3.5 shrink-0"
-										/>
-										<span className="shrink-0 font-mono text-xs text-muted-foreground">
-											#{issue.issueNumber}
-										</span>
-										<span className="min-w-0 flex-1 truncate text-xs">
-											{issue.title}
-										</span>
-										<span className="shrink-0 hidden text-xs text-muted-foreground group-data-[selected=true]:inline">
-											Link ↵
-										</span>
-									</CommandItem>
-								))}
+								{searchResults.map((issue) => {
+									const state = normalizeIssueState(issue.state);
+									return (
+										<CommandItem
+											key={issue.issueNumber}
+											value={`${issue.issueNumber}-${issue.title}`}
+											onSelect={() => handleSelect(issue)}
+											className="group items-start gap-3 rounded-md px-2.5 py-2"
+										>
+											<IssueIcon
+												state={state}
+												className="mt-0.5 size-4 shrink-0"
+											/>
+											<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+												<span className="truncate text-sm leading-snug">
+													{issue.title}
+												</span>
+												<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+													<span className="font-mono">
+														#{issue.issueNumber}
+													</span>
+													<span aria-hidden>·</span>
+													<span className="capitalize">{state}</span>
+												</span>
+											</div>
+											<span className="ml-2 hidden shrink-0 self-center text-[11px] text-muted-foreground group-data-[selected=true]:inline">
+												↵
+											</span>
+										</CommandItem>
+									);
+								})}
 							</CommandGroup>
 						)}
 					</CommandList>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/PRLinkCommand/PRLinkCommand.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/PRLinkCommand/PRLinkCommand.tsx
@@ -131,7 +131,7 @@ export function PRLinkCommand({
 				<TooltipContent side="bottom">{tooltipLabel}</TooltipContent>
 			</Tooltip>
 			<PopoverContent
-				className="w-80 p-0"
+				className="w-[440px] p-0"
 				align="start"
 				side="bottom"
 				onWheel={(event) => event.stopPropagation()}
@@ -155,7 +155,7 @@ export function PRLinkCommand({
 							Show closed
 						</label>
 					</div>
-					<CommandList className="max-h-[280px]">
+					<CommandList className="max-h-[420px]">
 						{pullRequests.length === 0 && (
 							<CommandEmpty>
 								{isLoading ? (
@@ -193,28 +193,35 @@ export function PRLinkCommand({
 											: "Open PRs"
 								}
 							>
-								{pullRequests.map((pr) => (
-									<CommandItem
-										key={pr.prNumber}
-										value={`${pr.prNumber}-${pr.title}`}
-										onSelect={() => handleSelect(pr)}
-										className="group"
-									>
-										<PRIcon
-											state={normalizeState(pr.state, pr.isDraft) as PRState}
-											className="size-3.5 shrink-0"
-										/>
-										<span className="shrink-0 font-mono text-xs text-muted-foreground">
-											#{pr.prNumber}
-										</span>
-										<span className="min-w-0 flex-1 truncate text-xs">
-											{pr.title}
-										</span>
-										<span className="shrink-0 hidden text-xs text-muted-foreground group-data-[selected=true]:inline">
-											Link ↵
-										</span>
-									</CommandItem>
-								))}
+								{pullRequests.map((pr) => {
+									const state = normalizeState(pr.state, pr.isDraft) as PRState;
+									return (
+										<CommandItem
+											key={pr.prNumber}
+											value={`${pr.prNumber}-${pr.title}`}
+											onSelect={() => handleSelect(pr)}
+											className="group items-start gap-3 rounded-md px-2.5 py-2"
+										>
+											<PRIcon
+												state={state}
+												className="mt-0.5 size-4 shrink-0"
+											/>
+											<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+												<span className="truncate text-sm leading-snug">
+													{pr.title}
+												</span>
+												<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+													<span className="font-mono">#{pr.prNumber}</span>
+													<span aria-hidden>·</span>
+													<span className="capitalize">{state}</span>
+												</span>
+											</div>
+											<span className="ml-2 hidden shrink-0 self-center text-[11px] text-muted-foreground group-data-[selected=true]:inline">
+												↵
+											</span>
+										</CommandItem>
+									);
+								})}
 							</CommandGroup>
 						)}
 					</CommandList>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
@@ -1,8 +1,6 @@
 import { toast } from "@superset/ui/sonner";
-import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useMemo, useState } from "react";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useCallback, useState } from "react";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import type { BaseBranchSource } from "../../../../../DashboardNewWorkspaceDraftContext";
@@ -29,9 +27,9 @@ export interface UseBranchPickerControllerArgs {
 
 /**
  * Owns all state + handlers for the branch picker: the search/filter inputs,
- * the branch-context query, the host-id resolution that gates Open/Create
- * dispatch, and the per-row action callbacks. Returns a single `pickerProps`
- * object ready to spread into `<CompareBaseBranchPicker />`.
+ * the branch-context query, the host-id resolution that gates dispatch, and
+ * the per-row action callbacks. Returns a single `pickerProps` object ready
+ * to spread into `<CompareBaseBranchPicker />`.
  */
 export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 	const {
@@ -44,7 +42,6 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 	} = args;
 
 	const navigate = useNavigate();
-	const collections = useCollections();
 	const { machineId } = useLocalHostService();
 	const { submit } = useWorkspaceCreates();
 
@@ -67,34 +64,6 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 
 	const effectiveCompareBaseBranch = baseBranch || defaultBranch || null;
 
-	// Authoritative "does a workspace already exist for this (project, branch,
-	// host)?" — driven by the cloud-synced collection rather than the server's
-	// per-row hasWorkspace snapshot, which can be stale after a delete.
-	const { data: projectWorkspaces } = useLiveQuery(
-		(q) => q.from({ workspaces: collections.v2Workspaces }),
-		[collections],
-	);
-
-	const workspaceByBranch = useMemo(() => {
-		const map = new Map<string, string>();
-		if (!projectId || !projectWorkspaces || !resolvedHostId) return map;
-		for (const w of projectWorkspaces) {
-			if (
-				w.projectId === projectId &&
-				w.hostId === resolvedHostId &&
-				w.branch
-			) {
-				map.set(w.branch, w.id);
-			}
-		}
-		return map;
-	}, [projectId, projectWorkspaces, resolvedHostId]);
-
-	const hasWorkspaceForBranch = useCallback(
-		(name: string) => workspaceByBranch.has(name),
-		[workspaceByBranch],
-	);
-
 	// Picker actions bypass the modal's submit, so they don't get the
 	// `resolveNames` pass — fall back to the branch name when the user hasn't
 	// typed a workspace name.
@@ -103,64 +72,15 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 		[typedWorkspaceName],
 	);
 
-	const onCheckoutBranch = useCallback(
-		(branchName: string) => {
-			if (!projectId) {
-				toast.error("Select a project first");
-				return;
-			}
-			if (!resolvedHostId) {
-				toast.error("No active host");
-				return;
-			}
-			const workspaceId = crypto.randomUUID();
-			const workspaceName = resolveActionWorkspaceName(branchName);
-			closeModal();
-			void navigate({ to: `/v2-workspace/${workspaceId}` as string });
-			void submit({
-				hostId: resolvedHostId,
-				snapshot: {
-					id: workspaceId,
-					projectId,
-					name: workspaceName,
-					branch: branchName,
-				},
-			});
-		},
-		[
-			projectId,
-			resolvedHostId,
-			resolveActionWorkspaceName,
-			submit,
-			closeModal,
-			navigate,
-		],
-	);
-
-	const onOpenExisting = useCallback(
-		(branchName: string) => {
-			const workspaceId = workspaceByBranch.get(branchName);
-			if (!workspaceId) {
-				toast.error("Could not find existing workspace for this branch");
-				return;
-			}
-			closeModal();
-			void navigate({
-				to: "/v2-workspace/$workspaceId",
-				params: { workspaceId },
-			});
-		},
-		[workspaceByBranch, closeModal, navigate],
-	);
-
-	// Foreign worktree = git knows about the worktree (`branch.worktreePath` is
-	// set) but no v2 workspace row exists for it. The server's workspaces.create
-	// procedure already adopts in this case; the only client-side wrinkle is
-	// that adoption returns a *different* canonical id than our optimistic
-	// snapshot id, so we have to await the submit and navigate to the resolved
-	// id rather than the random UUID. (onCheckoutBranch's fast-path nav would
-	// land the user on a 404.)
-	const onAdoptForeignWorktree = useCallback(
+	// Single "go to a workspace for this branch" path. The server's
+	// `workspaces.create` already covers all three cases:
+	//   - Tracked workspace exists       → returns canonical row (alreadyExists)
+	//   - Foreign worktree, no row yet   → adopts via adoptExistingWorktree
+	//   - No worktree at all             → fresh `git worktree add`
+	// Awaiting the result + navigating to the canonical id avoids the 404 you'd
+	// hit by optimistically navigating to the snapshot id (server can return a
+	// different id for the existing-row + adoption paths).
+	const onOpenWorkspace = useCallback(
 		async (branchName: string) => {
 			if (!projectId) {
 				toast.error("Select a project first");
@@ -224,10 +144,7 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 		hasNextPage: hasNextPage ?? false,
 		onLoadMore,
 		onSelectCompareBaseBranch,
-		onCheckoutBranch,
-		onOpenExisting,
-		onAdoptForeignWorktree,
-		hasWorkspaceForBranch,
+		onOpenWorkspace,
 	};
 
 	return { pickerProps };

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
@@ -107,6 +107,12 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 					to: "/v2-workspace/$workspaceId",
 					params: { workspaceId: result.workspaceId },
 				});
+			} else {
+				// `submit` tracks the failure via `markError`, but the in-flight
+				// manager doesn't toast — without this, a rejected open closes
+				// the modal silently and the user has no feedback that anything
+				// failed.
+				toast.error(result.error || "Failed to open workspace");
 			}
 		},
 		[

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
@@ -153,6 +153,52 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 		[workspaceByBranch, closeModal, navigate],
 	);
 
+	// Foreign worktree = git knows about the worktree (`branch.worktreePath` is
+	// set) but no v2 workspace row exists for it. The server's workspaces.create
+	// procedure already adopts in this case; the only client-side wrinkle is
+	// that adoption returns a *different* canonical id than our optimistic
+	// snapshot id, so we have to await the submit and navigate to the resolved
+	// id rather than the random UUID. (onCheckoutBranch's fast-path nav would
+	// land the user on a 404.)
+	const onAdoptForeignWorktree = useCallback(
+		async (branchName: string) => {
+			if (!projectId) {
+				toast.error("Select a project first");
+				return;
+			}
+			if (!resolvedHostId) {
+				toast.error("No active host");
+				return;
+			}
+			const snapshotId = crypto.randomUUID();
+			const workspaceName = resolveActionWorkspaceName(branchName);
+			closeModal();
+			const result = await submit({
+				hostId: resolvedHostId,
+				snapshot: {
+					id: snapshotId,
+					projectId,
+					name: workspaceName,
+					branch: branchName,
+				},
+			});
+			if (result.ok) {
+				void navigate({
+					to: "/v2-workspace/$workspaceId",
+					params: { workspaceId: result.workspaceId },
+				});
+			}
+		},
+		[
+			projectId,
+			resolvedHostId,
+			resolveActionWorkspaceName,
+			submit,
+			closeModal,
+			navigate,
+		],
+	);
+
 	const onSelectCompareBaseBranch = useCallback(
 		(branch: string, source: BaseBranchSource) => {
 			onBaseBranchChange(branch, source);
@@ -180,6 +226,7 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 		onSelectCompareBaseBranch,
 		onCheckoutBranch,
 		onOpenExisting,
+		onAdoptForeignWorktree,
 		hasWorkspaceForBranch,
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
@@ -25,12 +25,7 @@ export interface UseBranchPickerControllerArgs {
 	closeModal: () => void;
 }
 
-/**
- * Owns all state + handlers for the branch picker: the search/filter inputs,
- * the branch-context query, the host-id resolution that gates dispatch, and
- * the per-row action callbacks. Returns a single `pickerProps` object ready
- * to spread into `<CompareBaseBranchPicker />`.
- */
+/** Returns a `pickerProps` object ready to spread into `<CompareBaseBranchPicker />`. */
 export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 	const {
 		projectId,
@@ -45,8 +40,8 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 	const { machineId } = useLocalHostService();
 	const { submit } = useWorkspaceCreates();
 
-	// `null` means "local active machine" — pin to the device's own machineId
-	// so workspace lookups (which key by hostId) resolve against the right host.
+	// `null` hostId means "local active machine"; pin to the device's machineId
+	// so workspace lookups (keyed by hostId) hit the right host.
 	const resolvedHostId = hostId ?? machineId;
 
 	const [branchSearch, setBranchSearch] = useState("");
@@ -64,22 +59,17 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 
 	const effectiveCompareBaseBranch = baseBranch || defaultBranch || null;
 
-	// Picker actions bypass the modal's submit, so they don't get the
-	// `resolveNames` pass — fall back to the branch name when the user hasn't
-	// typed a workspace name.
+	// Picker actions bypass the modal's submit pipeline (and its `resolveNames`
+	// pass), so we mirror its branch-name fallback here.
 	const resolveActionWorkspaceName = useCallback(
 		(branchName: string) => typedWorkspaceName.trim() || branchName,
 		[typedWorkspaceName],
 	);
 
-	// Single "go to a workspace for this branch" path. The server's
-	// `workspaces.create` already covers all three cases:
-	//   - Tracked workspace exists       → returns canonical row (alreadyExists)
-	//   - Foreign worktree, no row yet   → adopts via adoptExistingWorktree
-	//   - No worktree at all             → fresh `git worktree add`
-	// Awaiting the result + navigating to the canonical id avoids the 404 you'd
-	// hit by optimistically navigating to the snapshot id (server can return a
-	// different id for the existing-row + adoption paths).
+	// Server's `workspaces.create` resolves all three cases (open tracked,
+	// adopt foreign worktree, fresh create). Await + navigate to the canonical
+	// id — the existing-row and adoption paths can return an id different from
+	// the optimistic snapshot id, which would otherwise 404.
 	const onOpenWorkspace = useCallback(
 		async (branchName: string) => {
 			if (!projectId) {
@@ -108,10 +98,8 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 					params: { workspaceId: result.workspaceId },
 				});
 			} else {
-				// `submit` tracks the failure via `markError`, but the in-flight
-				// manager doesn't toast — without this, a rejected open closes
-				// the modal silently and the user has no feedback that anything
-				// failed.
+				// `submit` records the failure for the in-flight tracker but
+				// doesn't toast; surface it here so the closed modal isn't silent.
 				toast.error(result.error || "Failed to open workspace");
 			}
 		},


### PR DESCRIPTION
## Summary
- Widen the v2 Create-Workspace pickers (PR / GitHub issue / task) from `w-80` to `w-[440px]` and reformat each row as a Linear-style two-line item (title on top, mono id · state below) so long titles aren't clipped.
- Match the branch picker to the new width, add a `Select base branch…` placeholder, drop the disabled `Check out` tooltip + `TooltipProvider`.
- Replace the per-row `Open` / `Create` / `Check out` mix with exactly one action that names what it does:
  - `hasWorkspaceForBranch(branch)` → **Open workspace** (`onOpenExisting`)
  - otherwise → **Create workspace** (`onCheckoutBranch`)
- Every branch row is now actionable; row click still sets compare base.

## Notes
- v1 (`apps/desktop/src/renderer/components/NewWorkspaceModal/...`) is untouched per the v1-sunset rule.
- Keyboard-shortcut hints (`↵`, `⌘↵`) were removed — they weren't actually wired to a keydown handler, so showing them was misleading.
- Edge case to watch: `onCheckoutBranch` will be invoked for branches that have a worktree elsewhere (`branch.isCheckedOut`). The handler is expected to surface a toast on failure rather than silently no-op.

## Test plan
- [ ] Open the v2 dashboard → New Workspace modal; PR/Issue/Task pickers render at the wider size with two-line items.
- [ ] Branch picker: trigger placeholder reads `Select base branch…` when no base is selected.
- [ ] Hover any branch row: exactly one button — `Open workspace` if a workspace exists for that branch, else `Create workspace`.
- [ ] Click `Open workspace` → jumps to the existing workspace.
- [ ] Click `Create workspace` on a branch without a worktree → workspace is created and opened.
- [ ] Click `Create workspace` on a branch already checked out elsewhere → handler surfaces an error toast (no silent failure).
- [ ] Row click (anywhere outside the action button) still sets the compare base and closes the picker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the v2 pickers with two-line rows and unified branch rows to one “Open workspace” action resolved on the server (open/adopt/create). Adds keyboard activation, better error handling, and a small polish to selected-row icon behavior.

- **New Features**
  - PR/GitHub issue/task pickers: popovers 440px, lists 420px, two-line items (title; monospace id + state).
  - Branch picker: 440px width, “Select base branch…” placeholder, per‑state icons (worktree/remote/local) with a meta strip, and one CTA — Open workspace. Row click still sets the compare base. The button is visible on the selected row, and Mod+Enter triggers it.

- **Bug Fixes**
  - Await the canonical workspace id and show a toast on submit failure to avoid 404s and silent closes when opening/adopting worktrees.
  - Align the selected-base check icon with button visibility to prevent brief overlap on active rows.

<sup>Written for commit 7028914f762b7c450a6ffabc7f13359ea5057445. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Wider, more readable dropdowns and taller lists across branch, issue, PR, and GitHub issue pickers.
  * Reworked list items with clearer hierarchy: title, metadata (number/state), status indicator, and keyboard affordance.

* **Refactor**
  * Consolidated per-row actions into a single, consistent "Open workspace" flow for branch rows.

* **New Features**
  * Keyboard shortcut support to open the focused row's workspace (Mod/Ctrl+Enter).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->