### PR TITLE
feat(desktop): show loader while fetching tasks PRs and issues

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/GitHubIssuesContent/GitHubIssuesContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/GitHubIssuesContent/GitHubIssuesContent.tsx
@@ -220,7 +220,12 @@ export function GitHubIssuesContent({
 					</div>
 				)}
 
-				{totalCount === 0 && !isFetching && !error ? (
+				{isInitialLoad ? (
+					<div className="flex h-full items-center justify-center gap-2 p-8 text-muted-foreground">
+						<LuRefreshCw className="size-4 animate-spin" />
+						<span className="text-sm">Loading issues…</span>
+					</div>
+				) : totalCount === 0 && !isFetching && !error ? (
 					<div className="flex h-full items-center justify-center p-8">
 						<span className="text-sm text-muted-foreground">
 							{showClosed ? "No issues found." : "No open issues."}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/PullRequestsContent/PullRequestsContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/PullRequestsContent/PullRequestsContent.tsx
@@ -221,7 +221,12 @@ export function PullRequestsContent({
 					</div>
 				)}
 
-				{totalCount === 0 && !isFetching && !error ? (
+				{isInitialLoad ? (
+					<div className="flex h-full items-center justify-center gap-2 p-8 text-muted-foreground">
+						<LuRefreshCw className="size-4 animate-spin" />
+						<span className="text-sm">Loading pull requests…</span>
+					</div>
+				) : totalCount === 0 && !isFetching && !error ? (
 					<div className="flex h-full items-center justify-center p-8">
 						<span className="text-sm text-muted-foreground">
 							{showClosed


### PR DESCRIPTION
## Summary
- Add a centered spinner + "Loading…" message in the scrollable area of `PullRequestsContent` and `GitHubIssuesContent` while the initial fetch is in flight
- Distinguishes "still loading" from the empty-result state, which previously rendered as a blank pane until data arrived
- Reuses the already-imported `LuRefreshCw` icon, no new dependencies

## Test plan
- [ ] Open the unified tasks view, switch to the **PRs** tab on a project with many PRs — confirm the spinner appears during the first fetch, then is replaced by the list
- [ ] Toggle "Show closed / merged" — confirm the spinner does **not** flash (subsequent fetches keep using the inline header indicator since data is already on screen)
- [ ] Repeat for the **Issues** tab
- [ ] Confirm the "No open pull requests." / "No open issues." empty state still renders when a project genuinely has none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a centered loader during the first fetch in the Tasks view PRs and Issues tabs to clearly distinguish loading from an empty state. Reduces confusion from a blank pane on initial load.

- New Features
  - Centered spinner with “Loading…” text on initial load in PRs and Issues.
  - Reuses `LuRefreshCw`; no new dependencies.
  - Empty states unchanged; no spinner flash on subsequent fetches.

<sup>Written for commit 8f483f48a7b08f321ee55d55f6ef2d5d03f7c7b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- GitHub issues view now displays a loading spinner with "Loading issues…" message during initial data fetch
- Pull requests view now shows a loading indicator with "Loading pull requests…" message during initial load
- Improved clarity between data-fetching and empty-result states for better user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->