### PR TITLE
feat(desktop): require single project selection in tasks view

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -133,6 +133,22 @@ export function TasksView({
 		[collections],
 	);
 
+	const { data: v2Projects } = useLiveQuery(
+		(q) => q.from({ projects: collections.v2Projects }),
+		[collections],
+	);
+
+	useEffect(() => {
+		if (projectFilter) return;
+		const firstProject = v2Projects?.[0];
+		if (!firstProject) return;
+		navigate({
+			to: "/tasks",
+			search: buildSearch({ project: firstProject.id }),
+			replace: true,
+		});
+	}, [projectFilter, v2Projects, navigate, buildSearch]);
+
 	const isLinearConnected =
 		integrations?.some((i) => i.provider === "linear") ?? false;
 
@@ -152,7 +168,7 @@ export function TasksView({
 		navigate({ to: "/tasks", search: buildSearch({ type }), replace: true });
 	};
 
-	const handleProjectFilterChange = (project: string | null) => {
+	const handleProjectFilterChange = (project: string) => {
 		navigate({ to: "/tasks", search: buildSearch({ project }), replace: true });
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
@@ -39,7 +39,7 @@ interface TasksTopBarProps {
 	typeTab: TypeTab;
 	onTypeTabChange: (typeTab: TypeTab) => void;
 	projectFilter: string | null;
-	onProjectFilterChange: (projectId: string | null) => void;
+	onProjectFilterChange: (projectId: string) => void;
 }
 
 const TYPE_TABS = [

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/ProjectFilter/ProjectFilter.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/ProjectFilter/ProjectFilter.tsx
@@ -16,7 +16,7 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 
 interface ProjectFilterProps {
 	value: string | null;
-	onChange: (value: string | null) => void;
+	onChange: (value: string) => void;
 }
 
 export function ProjectFilter({ value, onChange }: ProjectFilterProps) {
@@ -42,7 +42,7 @@ export function ProjectFilter({ value, onChange }: ProjectFilterProps) {
 		return projects.filter((p) => p.name.toLowerCase().includes(q));
 	}, [projects, search]);
 
-	const handleSelect = (id: string | null) => {
+	const handleSelect = (id: string) => {
 		onChange(id);
 		setOpen(false);
 		setSearch("");
@@ -87,12 +87,6 @@ export function ProjectFilter({ value, onChange }: ProjectFilterProps) {
 						onValueChange={setSearch}
 					/>
 					<CommandList className="max-h-80">
-						<CommandGroup>
-							<CommandItem onSelect={() => handleSelect(null)}>
-								<span className="text-sm">All projects</span>
-								{value === null && <HiCheck className="ml-auto size-3.5" />}
-							</CommandItem>
-						</CommandGroup>
 						{filtered.length === 0 && search && (
 							<CommandEmpty>No projects found.</CommandEmpty>
 						)}


### PR DESCRIPTION
## Summary
- Removes the "All projects" option from the project filter dropdown in the tasks view
- Auto-selects the first available v2 project when none is set, so PRs and issues always have a concrete project to query
- Tightens `onChange` / `onProjectFilterChange` signatures to `(string) => void`

## Test plan
- [ ] Open the tasks view with no `?project=` in the URL — verify the URL is replaced to include the first v2 project
- [ ] Open the project filter dropdown — verify "All projects" no longer appears
- [ ] Select a different project — verify the URL updates and PRs/Issues tabs reflect the new project
- [ ] Switch between Tasks / PRs / Issues tabs — verify the project stays selected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the tasks view project filter single-select by removing “All projects.” If no project is set, auto-select the first v2 project and update the URL so PRs/Issues always target a specific project; also tighten `onProjectFilterChange`/`onChange` to accept a string only.

<sup>Written for commit 08280f933988b536bacbda6d4ff63f147f1f4196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed automatic project selection in Tasks view to navigate to the first available project when no project filter is set.

* **Refactor**
  * Removed "All projects" option from project filter; users must now select a specific project to view tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->