### PR TITLE
fix(desktop): persist tasks-view project filter across navigation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -74,6 +74,8 @@ export function DashboardSidebarHeader({
 		tab: lastTab,
 		assignee: lastAssignee,
 		search: lastSearch,
+		typeTab: lastTypeTab,
+		projectFilter: lastProjectFilter,
 	} = useTasksFilterStore();
 
 	const handleWorkspacesClick = () => {
@@ -92,6 +94,8 @@ export function DashboardSidebarHeader({
 			if (lastTab !== "all") search.tab = lastTab;
 			if (lastAssignee) search.assignee = lastAssignee;
 			if (lastSearch) search.search = lastSearch;
+			if (lastTypeTab !== "tasks") search.type = lastTypeTab;
+			if (lastProjectFilter) search.project = lastProjectFilter;
 			navigate({ to: "/tasks", search });
 		});
 	};

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -35,6 +35,8 @@ export function WorkspaceSidebarHeader({
 		tab: lastTab,
 		assignee: lastAssignee,
 		search: lastSearch,
+		typeTab: lastTypeTab,
+		projectFilter: lastProjectFilter,
 	} = useTasksFilterStore();
 
 	const handleTasksClick = () => {
@@ -43,6 +45,8 @@ export function WorkspaceSidebarHeader({
 			if (lastTab !== "all") search.tab = lastTab;
 			if (lastAssignee) search.assignee = lastAssignee;
 			if (lastSearch) search.search = lastSearch;
+			if (lastTypeTab !== "tasks") search.type = lastTypeTab;
+			if (lastProjectFilter) search.project = lastProjectFilter;
 			navigate({ to: "/tasks", search });
 		});
 	};


### PR DESCRIPTION
## Summary
- Sidebar Tasks click handlers (v1 + v2) restored `tab`/`assignee`/`search` from the tasks filter store but dropped `projectFilter` and `typeTab`
- Result: clicking away and back to Tasks reset the URL params, and the auto-select effect in `TasksView` snapped the project filter to the first project
- Fix: include `project` and `type` in the search params built by both sidebar handlers, matching the rest of the store

## Test plan
- [ ] Open Tasks view, select a non-default project → navigate to a workspace → click Tasks again → selected project persists
- [ ] Same flow on v2 dashboard sidebar
- [ ] Same flow on v1 workspace sidebar
- [ ] Switch type tab to PRs/Issues, navigate away, click Tasks → type tab persists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the selected project and type tab in the Tasks view when navigating from the dashboard or workspace sidebar, so your choices don’t reset.

- **Bug Fixes**
  - Sidebar Tasks handlers now include `project` and `type` in the `/tasks` URL from the tasks filter store.
  - Stops the auto-select from snapping to the first project when returning to Tasks.

<sup>Written for commit 77f70b444a33fd55e515d2fdc0ac122f89e6251e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar navigation to the Tasks section now properly preserves task filter preferences, including task type and project selections. Filter state persistence is now consistent across both dashboard and workspace sidebars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->