### PR TITLE
fix(desktop): make v2 changes sidebar scrollable

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -787,7 +787,7 @@ export function ChangesView({
 						</div>
 					) : (
 						<div
-							className="flex-1 overflow-y-auto"
+							className="min-h-0 flex-1 overflow-y-auto"
 							data-changes-scroll-container
 						>
 							{orderedSections


### PR DESCRIPTION
## Summary
- The v2 Changes sidebar's diffs list wasn't scrolling — long file lists overflowed past the viewport instead of becoming a scroll area.
- Root cause: the scroll container at `ChangesView.tsx:790` had `flex-1 overflow-y-auto` but no `min-h-0`. In a flex column, the default `min-height: auto` lets the item grow to fit its content, defeating `overflow-y-auto`.
- Fix: add `min-h-0` so the container is actually constrained by its parent and can scroll.

## Test plan
- [ ] Open a v2 workspace with enough changed files to overflow the sidebar
- [ ] Confirm the Diffs tab scrolls within the sidebar (not the whole panel)
- [ ] Confirm the Review tab still renders correctly
- [ ] Confirm the empty "No changes detected" state still centers correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix v2 Changes sidebar so long diff lists scroll within the sidebar instead of overflowing. Added `min-h-0` to the scroll container to constrain it in the flex column and make `overflow-y-auto` take effect.

<sup>Written for commit f552d9b8ba9fccbb071c64c26c40144611ae1a82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout sizing behavior in the changes view panel to ensure the diffs list displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->