### PR TITLE
feat(marketing): serve agent-skills discovery at superset.sh

### DIFF
--- a/apps/marketing/src/app/.well-known/agent-skills/index.json/route.ts
+++ b/apps/marketing/src/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
+export const dynamic = "force-static";
+
+const SKILL_PATH = path.join(process.cwd(), "../../skills/superset/SKILL.md");
+
+export function GET() {
+	const content = fs.readFileSync(SKILL_PATH, "utf-8");
+	const { data } = matter(content);
+	const digest = createHash("sha256").update(content).digest("hex");
+	const name = data.name as string;
+
+	return Response.json({
+		$schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+		skills: [
+			{
+				name,
+				type: "skill-md",
+				description: data.description,
+				url: `/.well-known/agent-skills/${name}/SKILL.md`,
+				files: ["SKILL.md"],
+				digest: `sha256:${digest}`,
+			},
+		],
+	});
+}

--- a/apps/marketing/src/app/.well-known/agent-skills/superset/SKILL.md/route.ts
+++ b/apps/marketing/src/app/.well-known/agent-skills/superset/SKILL.md/route.ts
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const dynamic = "force-static";
+
+const SKILL_PATH = path.join(process.cwd(), "../../skills/superset/SKILL.md");
+
+export function GET() {
+	const content = fs.readFileSync(SKILL_PATH, "utf-8");
+	return new Response(content, {
+		headers: { "content-type": "text/markdown; charset=utf-8" },
+	});
+}


### PR DESCRIPTION
## Summary
- Adds `.well-known/agent-skills` endpoints to the marketing app so `npx skills add https://superset.sh` resolves the Superset CLI skill via the [Vercel skills CLI well-known protocol](https://github.com/vercel-labs/skills/blob/main/src/providers/wellknown.ts), matching how conductor.build publishes their skill.
- Routes are `force-static` and read from `skills/superset/SKILL.md` at build time — single source of truth, no duplication.
- Two endpoints:
  - `/.well-known/agent-skills/index.json` — agentskills.io 0.2.0 discovery JSON with sha256 digest
  - `/.well-known/agent-skills/superset/SKILL.md` — the SKILL.md content as `text/markdown`

## Test plan
- [x] `curl /.well-known/agent-skills/index.json` returns valid discovery JSON with correct schema, name, description, files, and digest
- [x] `curl /.well-known/agent-skills/superset/SKILL.md` returns the SKILL.md content with `content-type: text/markdown; charset=utf-8`
- [x] `npx skills add http://localhost:3998 --list` (the published Vercel skills CLI) successfully discovers and lists the `superset` skill
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [ ] After deploy: `npx skills add https://superset.sh --list` works against production

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve Agent Skills discovery from superset.sh so the `skills` CLI can install the Superset skill via well-known endpoints. Uses the monorepo SKILL.md as the single source of truth.

- **New Features**
  - /.well-known/agent-skills/index.json — agentskills.io 0.2.0 discovery JSON with sha256 digest
  - /.well-known/agent-skills/superset/SKILL.md — serves SKILL.md as text/markdown
  - Routes are force-static and read skills/superset/SKILL.md at build time

<sup>Written for commit 0fd8ed98820407bfb0c2a293aea0b7fb6acbb213. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new endpoints for agent skills discovery that expose skill metadata (name, description, digest) and serve skill documentation files in markdown format through standardized APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->