### PR TITLE
chore(release): patch-bump host-service on each desktop release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -51,6 +51,25 @@ jobs:
           echo "Current tag: ${CURRENT_TAG}"
           echo "Previous tag: ${PREVIOUS_TAG:-none}"
 
+      - name: Verify host-service version was bumped
+        if: steps.prev_tag.outputs.previous_tag != ''
+        run: |
+          PREVIOUS_TAG="${{ steps.prev_tag.outputs.previous_tag }}"
+          CURRENT_TAG="${{ steps.prev_tag.outputs.current_tag }}"
+          PREV_HS=$(git show "${PREVIOUS_TAG}:packages/host-service/package.json" | jq -r .version)
+          CURR_HS=$(git show "${CURRENT_TAG}:packages/host-service/package.json" | jq -r .version)
+          echo "host-service @ ${PREVIOUS_TAG}: ${PREV_HS}"
+          echo "host-service @ ${CURRENT_TAG}: ${CURR_HS}"
+          if [ "${PREV_HS}" = "${CURR_HS}" ]; then
+            echo "::error::host-service version was not bumped between ${PREVIOUS_TAG} and ${CURRENT_TAG} (still ${CURR_HS}). Run apps/desktop/create-release.sh to bump both, or bump packages/host-service/package.json manually before re-tagging."
+            exit 1
+          fi
+          HIGHER=$(printf '%s\n%s\n' "${PREV_HS}" "${CURR_HS}" | sort -V | tail -1)
+          if [ "${HIGHER}" != "${CURR_HS}" ]; then
+            echo "::error::host-service version regressed: ${PREV_HS} -> ${CURR_HS}"
+            exit 1
+          fi
+
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -51,25 +51,6 @@ jobs:
           echo "Current tag: ${CURRENT_TAG}"
           echo "Previous tag: ${PREVIOUS_TAG:-none}"
 
-      - name: Verify host-service version was bumped
-        if: steps.prev_tag.outputs.previous_tag != ''
-        run: |
-          PREVIOUS_TAG="${{ steps.prev_tag.outputs.previous_tag }}"
-          CURRENT_TAG="${{ steps.prev_tag.outputs.current_tag }}"
-          PREV_HS=$(git show "${PREVIOUS_TAG}:packages/host-service/package.json" | jq -r .version)
-          CURR_HS=$(git show "${CURRENT_TAG}:packages/host-service/package.json" | jq -r .version)
-          echo "host-service @ ${PREVIOUS_TAG}: ${PREV_HS}"
-          echo "host-service @ ${CURRENT_TAG}: ${CURR_HS}"
-          if [ "${PREV_HS}" = "${CURR_HS}" ]; then
-            echo "::error::host-service version was not bumped between ${PREVIOUS_TAG} and ${CURRENT_TAG} (still ${CURR_HS}). Run apps/desktop/create-release.sh to bump both, or bump packages/host-service/package.json manually before re-tagging."
-            exit 1
-          fi
-          HIGHER=$(printf '%s\n%s\n' "${PREV_HS}" "${CURR_HS}" | sort -V | tail -1)
-          if [ "${HIGHER}" != "${CURR_HS}" ]; then
-            echo "::error::host-service version regressed: ${PREV_HS} -> ${CURR_HS}"
-            exit 1
-          fi
-
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/apps/desktop/create-release.sh
+++ b/apps/desktop/create-release.sh
@@ -92,7 +92,7 @@ bump_host_service_patch() {
     local repo_root="$1"
     local pkg="${repo_root}/packages/host-service/package.json"
     local current new tmp
-    current=$(node -p "require('${pkg}').version")
+    current=$(jq -r .version "${pkg}")
     new=$(increment_patch "${current}")
     tmp=$(mktemp)
     jq ".version = \"${new}\"" "${pkg}" > "${tmp}" && mv "${tmp}" "${pkg}"
@@ -318,7 +318,7 @@ if [ -n "$COMMIT_INPUT" ]; then
         TMP_FILE=$(mktemp)
         jq ".version = \"${VERSION}\"" "${DESKTOP_DIR}/package.json" > "${TMP_FILE}" && mv "${TMP_FILE}" "${DESKTOP_DIR}/package.json"
         bunx biome format --write "${DESKTOP_DIR}/package.json"
-        HOST_SERVICE_OLD=$(node -p "require('./packages/host-service/package.json').version")
+        HOST_SERVICE_OLD=$(jq -r .version "packages/host-service/package.json")
         HOST_SERVICE_NEW=$(bump_host_service_patch "${WORKTREE_DIR}")
         git add "${DESKTOP_DIR}/package.json" "packages/host-service/package.json"
         git commit -m "chore(desktop): bump version to ${VERSION} (host-service ${HOST_SERVICE_OLD} -> ${HOST_SERVICE_NEW})"
@@ -355,7 +355,7 @@ else
         # Patch-bump host-service alongside the desktop bump so detached
         # host-service auto-updates ship with each desktop release.
         REPO_ROOT_FOR_HS=$(git rev-parse --show-toplevel)
-        HOST_SERVICE_OLD=$(node -p "require('${REPO_ROOT_FOR_HS}/packages/host-service/package.json').version")
+        HOST_SERVICE_OLD=$(jq -r .version "${REPO_ROOT_FOR_HS}/packages/host-service/package.json")
         HOST_SERVICE_NEW=$(bump_host_service_patch "${REPO_ROOT_FOR_HS}")
         success "Updated host-service from ${HOST_SERVICE_OLD} to ${HOST_SERVICE_NEW}"
 

--- a/apps/desktop/create-release.sh
+++ b/apps/desktop/create-release.sh
@@ -87,6 +87,19 @@ increment_major() {
     echo "$((major + 1)).0.0"
 }
 
+# Patch-bump packages/host-service/package.json under the given repo root, echo new version.
+bump_host_service_patch() {
+    local repo_root="$1"
+    local pkg="${repo_root}/packages/host-service/package.json"
+    local current new tmp
+    current=$(node -p "require('${pkg}').version")
+    new=$(increment_patch "${current}")
+    tmp=$(mktemp)
+    jq ".version = \"${new}\"" "${pkg}" > "${tmp}" && mv "${tmp}" "${pkg}"
+    (cd "${repo_root}" && bunx biome format --write "packages/host-service/package.json" >/dev/null)
+    echo "${new}"
+}
+
 # Parse arguments
 VERSION=""
 COMMIT_INPUT=""
@@ -305,9 +318,11 @@ if [ -n "$COMMIT_INPUT" ]; then
         TMP_FILE=$(mktemp)
         jq ".version = \"${VERSION}\"" "${DESKTOP_DIR}/package.json" > "${TMP_FILE}" && mv "${TMP_FILE}" "${DESKTOP_DIR}/package.json"
         bunx biome format --write "${DESKTOP_DIR}/package.json"
-        git add "${DESKTOP_DIR}/package.json"
-        git commit -m "chore(desktop): bump version to ${VERSION}"
-        success "Committed version bump ${WORKTREE_VERSION} -> ${VERSION} on top of ${SHORT_SHA}"
+        HOST_SERVICE_OLD=$(node -p "require('./packages/host-service/package.json').version")
+        HOST_SERVICE_NEW=$(bump_host_service_patch "${WORKTREE_DIR}")
+        git add "${DESKTOP_DIR}/package.json" "packages/host-service/package.json"
+        git commit -m "chore(desktop): bump version to ${VERSION} (host-service ${HOST_SERVICE_OLD} -> ${HOST_SERVICE_NEW})"
+        success "Committed version bump ${WORKTREE_VERSION} -> ${VERSION} (host-service ${HOST_SERVICE_OLD} -> ${HOST_SERVICE_NEW}) on top of ${SHORT_SHA}"
     fi
 
     info "Pushing temp branch ${TEMP_BRANCH}..."
@@ -337,9 +352,16 @@ else
         bunx biome format --write package.json
         success "Updated package.json from ${CURRENT_VERSION} to ${VERSION}"
 
+        # Patch-bump host-service alongside the desktop bump so detached
+        # host-service auto-updates ship with each desktop release.
+        REPO_ROOT_FOR_HS=$(git rev-parse --show-toplevel)
+        HOST_SERVICE_OLD=$(node -p "require('${REPO_ROOT_FOR_HS}/packages/host-service/package.json').version")
+        HOST_SERVICE_NEW=$(bump_host_service_patch "${REPO_ROOT_FOR_HS}")
+        success "Updated host-service from ${HOST_SERVICE_OLD} to ${HOST_SERVICE_NEW}"
+
         # Commit the version change
-        git add package.json
-        git commit -m "chore(desktop): bump version to ${VERSION}"
+        git add package.json "${REPO_ROOT_FOR_HS}/packages/host-service/package.json"
+        git commit -m "chore(desktop): bump version to ${VERSION} (host-service ${HOST_SERVICE_OLD} -> ${HOST_SERVICE_NEW})"
         success "Committed version change"
     fi
 


### PR DESCRIPTION
## Summary
- `apps/desktop/create-release.sh` now patch-bumps `packages/host-service/package.json` in the same commit as the desktop version bump (e.g. `0.8.1` → `0.8.2`). Wired into both the normal release path and the commit-based (canary-style) worktree path.
- `.github/workflows/release-desktop.yml` adds a "Verify host-service version was bumped" step that compares `packages/host-service/package.json` between the previous and current `desktop-v*` tag and fails if it wasn't bumped (or regressed). Skipped when there's no previous tag.
- Each desktop release now ships a fresh host-service version, so detached host-service auto-updates pick up the latest code.

## Test plan
- [ ] Dry-run `./apps/desktop/create-release.sh <next-version>` locally and confirm the resulting commit modifies both `apps/desktop/package.json` and `packages/host-service/package.json`, with a patch bump on host-service.
- [ ] Same for the commit-based path (`./apps/desktop/create-release.sh <version> <sha>`) — confirm host-service is bumped inside the temp worktree commit.
- [ ] Verify the `release-desktop` workflow fails on a tag that doesn't bump host-service (e.g. push a test tag from a commit where host-service wasn't touched) and passes when it does.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-patch bumps `packages/host-service` on every desktop release via the release script. Drops the CI guardrail and relies on the script to keep detached host-service updates in sync.

- **New Features**
  - `apps/desktop/create-release.sh` patch-bumps `packages/host-service/package.json` in the same commit as the desktop version for both standard and worktree releases.

- **Refactors**
  - Removed the host-service bump check in `.github/workflows/release-desktop.yml`, and switched version reads/updates to `jq` with formatting via `biome`.

<sup>Written for commit ecb05eaa7cb874b124c6b7d8fc1fea376d3672cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release process to automatically synchronize host-service versioning alongside desktop app releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->