### PR TITLE
feat(desktop): add "Open in Browser" to browser overflow menu

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
@@ -10,6 +10,7 @@ import {
 	TbClock,
 	TbCopy,
 	TbDots,
+	TbExternalLink,
 	TbReload,
 	TbTrash,
 } from "react-icons/tb";
@@ -42,6 +43,12 @@ export function BrowserOverflowMenu({
 	const handleCopyUrl = () => {
 		if (currentUrl) {
 			copyToClipboard(currentUrl);
+		}
+	};
+
+	const handleOpenExternal = () => {
+		if (currentUrl) {
+			electronTrpcClient.external.openUrl.mutate(currentUrl).catch(() => {});
 		}
 	};
 
@@ -95,6 +102,14 @@ export function BrowserOverflowMenu({
 				>
 					<TbCopy className="size-4" />
 					Copy URL
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					onClick={handleOpenExternal}
+					disabled={!hasPage}
+					className="gap-2"
+				>
+					<TbExternalLink className="size-4" />
+					Open in Browser
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem onClick={handleClearHistory} className="gap-2">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
@@ -10,6 +10,7 @@ import {
 	TbClock,
 	TbCopy,
 	TbDots,
+	TbExternalLink,
 	TbReload,
 	TbTrash,
 } from "react-icons/tb";
@@ -32,6 +33,7 @@ export function BrowserOverflowMenu({
 	const clearBrowsingDataMutation =
 		electronTrpc.browser.clearBrowsingData.useMutation();
 	const clearHistoryMutation = electronTrpc.browserHistory.clear.useMutation();
+	const openExternalMutation = electronTrpc.external.openUrl.useMutation();
 	const currentUrl = useTabsStore((s) => s.panes[paneId]?.browser?.currentUrl);
 
 	const handleScreenshot = () => {
@@ -47,6 +49,12 @@ export function BrowserOverflowMenu({
 	const handleCopyUrl = () => {
 		if (currentUrl) {
 			copyToClipboard(currentUrl);
+		}
+	};
+
+	const handleOpenExternal = () => {
+		if (currentUrl) {
+			openExternalMutation.mutate(currentUrl);
 		}
 	};
 
@@ -96,6 +104,14 @@ export function BrowserOverflowMenu({
 				>
 					<TbCopy className="size-4" />
 					Copy URL
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					onClick={handleOpenExternal}
+					disabled={!hasPage}
+					className="gap-2"
+				>
+					<TbExternalLink className="size-4" />
+					Open in Browser
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem onClick={handleClearHistory} className="gap-2">


### PR DESCRIPTION
## Summary
- Adds an "Open in Browser" item to the in-app browser's "..." overflow menu that opens the current URL in the user's default external browser
- Reuses the existing `external.openUrl` tRPC route (which goes through `shell.openExternal` with URL-scheme safety checks)
- Wired into both the v1 and v2 BrowserOverflowMenu components so it shows up regardless of which workspace shell is active

## Test plan
- [ ] Navigate to a real page in the in-app browser, open the "..." menu, click "Open in Browser" — URL opens in the system default browser
- [ ] Verify the item is disabled when no real page is loaded (about:blank)
- [ ] Repeat in v2 workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Open in Browser” to the in-app browser overflow menu to open the current page in the system’s default browser. The item is disabled when no real page is loaded and uses the existing `external.openUrl` route; available in both v1 and v2 overflow menus.

<sup>Written for commit 420abbfa4aa1258b157822041781df1200384d28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an "Open in Browser" option to the menu, allowing you to open the current page in your external browser application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->