### PR TITLE
perf(desktop): adaptive refetch interval on v2 git status query

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
@@ -2,6 +2,11 @@ import { workspaceTrpc } from "@superset/workspace-client";
 import { useCallback } from "react";
 import { useWorkspaceEvent } from "../useWorkspaceEvent";
 
+const STATUS_REFETCH_INTERVAL_MS = 2_500;
+const LARGE_CHANGESET_REFETCH_INTERVAL_MS = 10_000;
+const LARGE_CHANGESET_THRESHOLD = 200;
+const STATUS_QUERY_STALE_TIME_MS = 2_000;
+
 /**
  * Fetches workspace git status and keeps it live against server events.
  *
@@ -11,7 +16,9 @@ import { useWorkspaceEvent } from "../useWorkspaceEvent";
  *
  * `git:changed` is already debounced server-side in `GitWatcher` and covers
  * both `.git/` metadata writes and worktree file edits — no client-side
- * debounce needed.
+ * debounce needed. The polling `refetchInterval` is a safety net for missed
+ * events (suspend/resume, FS watcher edge cases) and backs off on large
+ * changesets to avoid sustained git overhead.
  */
 export function useGitStatus(workspaceId: string) {
 	const utils = workspaceTrpc.useUtils();
@@ -24,7 +31,20 @@ export function useGitStatus(workspaceId: string) {
 
 	const query = workspaceTrpc.git.getStatus.useQuery(
 		{ workspaceId, baseBranch: baseBranch ?? undefined },
-		{ refetchOnWindowFocus: true, enabled: Boolean(workspaceId) },
+		{
+			enabled: Boolean(workspaceId),
+			refetchOnWindowFocus: true,
+			staleTime: STATUS_QUERY_STALE_TIME_MS,
+			refetchInterval: (query) => {
+				const data = query.state.data;
+				if (!data) return STATUS_REFETCH_INTERVAL_MS;
+				const total =
+					data.againstBase.length + data.staged.length + data.unstaged.length;
+				return total >= LARGE_CHANGESET_THRESHOLD
+					? LARGE_CHANGESET_REFETCH_INTERVAL_MS
+					: STATUS_REFETCH_INTERVAL_MS;
+			},
+		},
 	);
 
 	const invalidate = useCallback(() => {


### PR DESCRIPTION
## Summary
- v2 `getStatus` query had no `refetchInterval` — liveness depended entirely on the server-pushed `git:changed` event, with no fallback when events are missed (suspend/resume, FS watcher edge cases).
- Adds a polling safety net mirroring v1's `useGitChangesStatus`: 2.5s default, 10s when `againstBase + staged + unstaged ≥ 200` to avoid sustained git overhead on large repos.
- Adds `staleTime: 2000ms` to coalesce burst-y refetches.

This is the first of three small PRs porting the load-time wins from the v1 changes view into v2 (the other two: list virtualization, lazy commits fetch).

## Test plan
- [ ] Open a v2 workspace with a small changeset (<200 files); confirm status updates within ~2.5s when files change externally
- [ ] Open a v2 workspace with a large changeset (≥200 files); confirm refetch backs off to ~10s and the UI stays responsive
- [ ] Background the app for a few minutes, foreground it; confirm status reflects external changes (window-focus refetch still fires)
- [ ] Edit a file in the worktree; confirm the existing `git:changed` event-driven invalidation still updates status promptly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an adaptive polling safety net to the v2 `getStatus` query so status stays fresh when `git:changed` events are missed. Poll every 2.5s by default, back off to 10s for ≥200-file changesets, and set `staleTime` to 2s to coalesce bursty refetches.

<sup>Written for commit 22b7c9786b527878bec8bc8ceaf75ce047a6ad91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced git status polling with adaptive refresh intervals based on changeset size, improving responsiveness and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->