### PR TITLE
perf(desktop): virtualize the v2 changes file list

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from "react";
 import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { ChangesSection } from "./components/ChangesSection";
-import { FileRow } from "./components/FileRow";
+import { VirtualizedFileList } from "./components/VirtualizedFileList";
 
 interface ChangesFileListProps {
 	files: ChangesetFile[];
@@ -68,7 +68,7 @@ export const ChangesFileList = memo(function ChangesFileList({
 	}
 
 	return (
-		<div className="min-h-0 flex-1 overflow-y-auto">
+		<div>
 			{GROUP_ORDER.map((key) => {
 				const groupFiles = grouped[key];
 				if (groupFiles.length === 0) return null;
@@ -84,17 +84,14 @@ export const ChangesFileList = memo(function ChangesFileList({
 								: undefined
 						}
 					>
-						{groupFiles.map((file) => (
-							<FileRow
-								key={`${file.source.kind}:${file.path}`}
-								file={file}
-								workspaceId={workspaceId}
-								worktreePath={worktreePath}
-								onSelect={onSelectFile}
-								onOpenFile={onOpenFile}
-								onOpenInEditor={onOpenInEditor}
-							/>
-						))}
+						<VirtualizedFileList
+							files={groupFiles}
+							workspaceId={workspaceId}
+							worktreePath={worktreePath}
+							onSelectFile={onSelectFile}
+							onOpenFile={onOpenFile}
+							onOpenInEditor={onOpenInEditor}
+						/>
 					</ChangesSection>
 				);
 			})}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/VirtualizedFileList/VirtualizedFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/VirtualizedFileList/VirtualizedFileList.tsx
@@ -1,0 +1,74 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useRef } from "react";
+import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+import { FileRow } from "../FileRow";
+
+const ESTIMATED_ROW_HEIGHT = 28;
+const OVERSCAN = 10;
+
+interface VirtualizedFileListProps {
+	files: ChangesetFile[];
+	workspaceId: string;
+	worktreePath?: string;
+	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
+	onOpenInEditor?: (path: string) => void;
+}
+
+export function VirtualizedFileList({
+	files,
+	workspaceId,
+	worktreePath,
+	onSelectFile,
+	onOpenFile,
+	onOpenInEditor,
+}: VirtualizedFileListProps) {
+	const listRef = useRef<HTMLDivElement>(null);
+
+	const virtualizer = useVirtualizer({
+		count: files.length,
+		getScrollElement: () =>
+			listRef.current?.closest(
+				"[data-changes-scroll-container]",
+			) as HTMLElement | null,
+		estimateSize: () => ESTIMATED_ROW_HEIGHT,
+		overscan: OVERSCAN,
+		scrollMargin: listRef.current?.offsetTop ?? 0,
+	});
+
+	const items = virtualizer.getVirtualItems();
+
+	return (
+		<div ref={listRef}>
+			<div
+				className="relative w-full"
+				style={{ height: virtualizer.getTotalSize() }}
+			>
+				{items.map((virtualRow) => {
+					const file = files[virtualRow.index];
+					if (!file) return null;
+					return (
+						<div
+							key={`${file.source.kind}:${file.path}`}
+							data-index={virtualRow.index}
+							ref={virtualizer.measureElement}
+							className="absolute left-0 w-full"
+							style={{
+								top: virtualRow.start - (virtualizer.options.scrollMargin ?? 0),
+							}}
+						>
+							<FileRow
+								file={file}
+								workspaceId={workspaceId}
+								worktreePath={worktreePath}
+								onSelect={onSelectFile}
+								onOpenFile={onOpenFile}
+								onOpenInEditor={onOpenInEditor}
+							/>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/VirtualizedFileList/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/VirtualizedFileList/index.ts
@@ -1,0 +1,1 @@
+export { VirtualizedFileList } from "./VirtualizedFileList";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -90,7 +90,10 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 				onRenameBranch={onRenameBranch}
 				canRename={canRenameBranch}
 			/>
-			<div className="min-h-0 flex-1 overflow-y-auto">
+			<div
+				data-changes-scroll-container
+				className="min-h-0 flex-1 overflow-y-auto"
+			>
 				<ChangesFileList
 					files={files}
 					workspaceId={workspaceId}


### PR DESCRIPTION
## Summary
- Wraps each section's rows in `useVirtualizer` so only visible rows render. Mirrors v1's `CommitListVirtualized` pattern; `@tanstack/react-virtual` is already a dep.
- Fixes a latent nested-overflow: `ChangesFileList` had its own `overflow-y-auto` inside `ChangesTabContent`'s real scroll container, leaving the inner element as a no-op scroller. Marks the parent with `data-changes-scroll-container` so the virtualizer can find the real scroll element, and drops the inner overflow.

Largest of the v1→v2 perf wins for the changes view. Workspaces with 50+ changed files previously paid the full DOM cost on every status update; this drops it to the visible window (~10–20 rows + overscan).

## Test plan
- [ ] Open a v2 workspace with a small changeset (≤10 files); confirm the list renders correctly with no layout shift, virtualization is invisible to the eye
- [ ] Open a v2 workspace with a large changeset (≥100 files); scroll smoothly, no overlapping rows, no missing rows at section boundaries
- [ ] Hover a row, open the dropdown menu (⋯), open the right-click context menu — confirm both work after rows have been recycled by scrolling
- [ ] Toggle each section (Unstaged / Staged / Against base / Committed) collapsed and expanded; rows should re-flow with correct positions
- [ ] Stage / unstage / discard a file; confirm the list updates and selection isn't lost
- [ ] Resize the sidebar; confirm rows re-measure correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Virtualizes the v2 Changes file list so only visible rows render using `@tanstack/react-virtual`, reducing DOM work and improving scroll performance on large changesets. Also fixes a nested overflow by marking the real scroll container with `data-changes-scroll-container` and removing the inner `overflow-y-auto` to ensure the virtualizer uses the correct element.

<sup>Written for commit d383fe2be2ae3bca4734ec357dbecf834340ee5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized file list rendering in the workspace changes tab to efficiently handle large numbers of modified files.
  * Enhanced scrolling performance for smoother navigation when viewing file changes in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->