### PR TITLE
fix(desktop): mirror v1 agent-preset overrides into v2 host-service store

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -78,6 +78,7 @@ import {
 	shouldPersistNormalizedTerminalPresets,
 } from "./preset-execution-mode";
 import { getPresetsForTriggerField } from "./preset-trigger-selection";
+import { buildLegacyHostAgentMirrorPlan } from "./v2-host-agent-mirror";
 
 function isValidRingtoneId(ringtoneId: string): boolean {
 	if (isBuiltInRingtoneId(ringtoneId)) {
@@ -269,6 +270,24 @@ export const createSettingsRouter = () => {
 			return getNormalizedTerminalPresets();
 		}),
 		getAgentPresets: publicProcedure.query(() => getResolvedAgentPresets()),
+		/**
+		 * Returns the per-host-agent-row mirror plan derived from the v1
+		 * `agentPresetOverrides` envelope. Used once per host-service from the
+		 * renderer to call `agentConfigs.mirrorLegacyOverrides`, repairing the
+		 * v2 store for users who applied the pre-#3546 YOLO migration on v1
+		 * but never had it propagated to host-service `host_agent_configs`.
+		 * See issue #4195.
+		 *
+		 * Returns split `{ presetId, command, args }` entries — only for builtin
+		 * agent IDs that have an override `command` in the envelope. Idempotent
+		 * to compute (pure read).
+		 */
+		getV2HostAgentMirrorPlan: publicProcedure.query(() => {
+			runAgentPresetPermissionsMigration();
+			const row = getSettings();
+			const envelope = readAgentPresetOverrides(row.agentPresetOverrides);
+			return buildLegacyHostAgentMirrorPlan(envelope);
+		}),
 		createCustomAgent: publicProcedure
 			.input(createCustomAgentInputSchema)
 			.mutation(({ input }) => {

--- a/apps/desktop/src/lib/trpc/routers/settings/v2-host-agent-mirror.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/v2-host-agent-mirror.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { applyLegacyPermissionsOverrides } from "@superset/shared/agent-permissions-migration";
+import { buildLegacyHostAgentMirrorPlan } from "./v2-host-agent-mirror";
+
+describe("buildLegacyHostAgentMirrorPlan", () => {
+	it("returns an empty plan for an envelope with no overrides", () => {
+		expect(buildLegacyHostAgentMirrorPlan({ version: 1, presets: [] })).toEqual(
+			[],
+		);
+	});
+
+	it("translates a claude `--dangerously-skip-permissions` v1 override into split form", () => {
+		const envelope = applyLegacyPermissionsOverrides({
+			version: 1,
+			presets: [],
+		});
+		const plan = buildLegacyHostAgentMirrorPlan(envelope);
+
+		const claude = plan.find((entry) => entry.presetId === "claude");
+		expect(claude).toBeDefined();
+		expect(claude?.command).toBe("claude");
+		expect(claude?.args).toEqual(["--dangerously-skip-permissions"]);
+	});
+
+	it("includes codex / gemini / copilot when their override commands are set", () => {
+		const envelope = applyLegacyPermissionsOverrides({
+			version: 1,
+			presets: [],
+		});
+		const plan = buildLegacyHostAgentMirrorPlan(envelope);
+		const ids = plan.map((entry) => entry.presetId).sort();
+		expect(ids).toContain("claude");
+		expect(ids).toContain("codex");
+		expect(ids).toContain("gemini");
+		expect(ids).toContain("copilot");
+	});
+
+	it("preserves user-customized v1 overrides over legacy defaults", () => {
+		const envelope = applyLegacyPermissionsOverrides({
+			version: 1,
+			presets: [{ id: "claude", command: "claude --my-custom-flag" }],
+		});
+		const plan = buildLegacyHostAgentMirrorPlan(envelope);
+		const claude = plan.find((entry) => entry.presetId === "claude");
+		expect(claude?.command).toBe("claude");
+		expect(claude?.args).toEqual(["--my-custom-flag"]);
+	});
+
+	it("skips agents whose override has no command field", () => {
+		const plan = buildLegacyHostAgentMirrorPlan({
+			version: 1,
+			presets: [{ id: "cursor-agent", promptCommandSuffix: "--yolo" }],
+		});
+		expect(
+			plan.find((entry) => entry.presetId === "cursor-agent"),
+		).toBeUndefined();
+	});
+
+	it("ignores overrides for non-builtin agent IDs", () => {
+		const plan = buildLegacyHostAgentMirrorPlan({
+			version: 1,
+			presets: [{ id: "custom:abc-123", command: "my-custom" }],
+		});
+		expect(plan).toEqual([]);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/settings/v2-host-agent-mirror.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/v2-host-agent-mirror.ts
@@ -1,0 +1,39 @@
+import type { AgentPresetOverrideEnvelope } from "@superset/local-db";
+import { LEGACY_BUILTIN_TERMINAL_AGENT_OVERRIDES } from "@superset/shared/agent-permissions-migration";
+import { parseCommandString } from "shared/argv";
+
+export interface LegacyHostAgentMirrorEntry {
+	presetId: string;
+	command: string;
+	args: string[];
+}
+
+/**
+ * Translate the v1 `agent_preset_overrides` envelope into the per-host-agent
+ * mirror plan that gets sent to host-service `agentConfigs.mirrorLegacyOverrides`.
+ *
+ * For each builtin terminal agent that has a legacy override `command` string
+ * in the envelope (i.e. the user benefited from `runAgentPresetPermissionsMigration`),
+ * we parse the v1 single-string command into `{ command, args }` so the host-service
+ * — which stores the launch shape split — can apply it idempotently. See #4195.
+ *
+ * Pure function: no DB or IPC. Only tests for presence + valid parse; the host
+ * service is responsible for the seed-default-still-matches idempotence check.
+ */
+export function buildLegacyHostAgentMirrorPlan(
+	envelope: AgentPresetOverrideEnvelope,
+): LegacyHostAgentMirrorEntry[] {
+	const overridesById = new Map(
+		envelope.presets.map((preset) => [preset.id, preset]),
+	);
+	const plan: LegacyHostAgentMirrorEntry[] = [];
+	for (const presetId of Object.keys(LEGACY_BUILTIN_TERMINAL_AGENT_OVERRIDES)) {
+		const override = overridesById.get(presetId);
+		const commandString = override?.command;
+		if (!commandString) continue;
+		const { command, args } = parseCommandString(commandString);
+		if (!command) continue;
+		plan.push({ presetId, command, args });
+	}
+	return plan;
+}

--- a/apps/desktop/src/renderer/hooks/useV2HostAgentMirror/index.ts
+++ b/apps/desktop/src/renderer/hooks/useV2HostAgentMirror/index.ts
@@ -1,0 +1,1 @@
+export { useV2HostAgentMirror } from "./useV2HostAgentMirror";

--- a/apps/desktop/src/renderer/hooks/useV2HostAgentMirror/useV2HostAgentMirror.ts
+++ b/apps/desktop/src/renderer/hooks/useV2HostAgentMirror/useV2HostAgentMirror.ts
@@ -1,0 +1,52 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { V2_AGENT_CONFIGS_QUERY_KEY } from "renderer/hooks/useV2AgentConfigs";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+
+/**
+ * Once per `hostUrl` (per renderer session), pulls the legacy v1 agent-preset
+ * mirror plan from desktop main and applies it to the host-service's
+ * `host_agent_configs`. Fixes #4195 — pre-#3546 users whose `--dangerously-skip-permissions`
+ * was applied to the v1 envelope but never reached the host-service store.
+ *
+ * Idempotent on the host-service side: each entry only writes when the row
+ * still matches the seed default exactly. Calling repeatedly is safe.
+ */
+export function useV2HostAgentMirror(hostUrl: string | null) {
+	const queryClient = useQueryClient();
+	const planQuery = electronTrpc.settings.getV2HostAgentMirrorPlan.useQuery(
+		undefined,
+		{ staleTime: Number.POSITIVE_INFINITY },
+	);
+	const ranForHostUrlRef = useRef<Set<string>>(new Set());
+
+	useEffect(() => {
+		if (!hostUrl) return;
+		if (!planQuery.data) return;
+		if (ranForHostUrlRef.current.has(hostUrl)) return;
+		const plan = planQuery.data;
+		ranForHostUrlRef.current.add(hostUrl);
+		if (plan.length === 0) return;
+
+		void (async () => {
+			try {
+				const result = await getHostServiceClientByUrl(
+					hostUrl,
+				).settings.agentConfigs.mirrorLegacyOverrides.mutate({
+					overrides: plan,
+				});
+				if (result.applied.length > 0) {
+					await queryClient.invalidateQueries({
+						queryKey: [...V2_AGENT_CONFIGS_QUERY_KEY, hostUrl],
+					});
+				}
+			} catch (err) {
+				// Don't retry on this attempt — the per-hostUrl ref already advanced.
+				// User can restart the app to retry; or any v2-side edit invalidates
+				// the seed-default-match check anyway.
+				console.warn("[useV2HostAgentMirror] mirror failed", err);
+			}
+		})();
+	}, [hostUrl, planQuery.data, queryClient]);
+}

--- a/apps/desktop/src/renderer/lib/argv.ts
+++ b/apps/desktop/src/renderer/lib/argv.ts
@@ -1,47 +1,6 @@
-import { parse, quote } from "shell-quote";
-
-/**
- * Format a command + argv array as an editable shell-style string.
- * Round-trips through `parseCommandString` losslessly: the command
- * and every argv element are quoted (when needed) so paths with
- * spaces and explicit empty strings survive the round trip.
- */
-export function joinCommandArgs(command: string, args: string[]): string {
-	const tokens = command.length === 0 ? args : [command, ...args];
-	if (tokens.length === 0) return "";
-	return quote(tokens);
-}
-
-/**
- * Parse a shell-style string into `command` (first token) and the rest as
- * `args`. Drops control operators (`|`, `>`, etc.) — this is a launch
- * spec, not a shell invocation. Empty quoted args (`""`) and tokens with
- * embedded spaces are preserved exactly.
- */
-export function parseCommandString(input: string): {
-	command: string;
-	args: string[];
-} {
-	const tokens = parse(input).filter(
-		(token): token is string => typeof token === "string",
-	);
-	if (tokens.length === 0) return { command: "", args: [] };
-	const [command, ...args] = tokens;
-	return { command: command ?? "", args };
-}
-
-/** Format a bare argv array (no leading executable). */
-export function joinArgs(args: string[]): string {
-	if (args.length === 0) return "";
-	return quote(args);
-}
-
-/**
- * Parse a bare argv array (no leading executable). Preserves empty
- * quoted args; drops only shell control operators.
- */
-export function parseArgs(input: string): string[] {
-	return parse(input).filter(
-		(token): token is string => typeof token === "string",
-	);
-}
+export {
+	joinArgs,
+	joinCommandArgs,
+	parseArgs,
+	parseCommandString,
+} from "shared/argv";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -9,6 +9,7 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { getPresetLaunchPlan } from "renderer/stores/tabs/preset-launch";
+import { parseCommandString } from "shared/argv";
 import { filterMatchingPresetsForProject } from "shared/preset-project-targeting";
 import type { StoreApi } from "zustand/vanilla";
 import type { PaneViewerData, TerminalPaneData } from "../../types";
@@ -54,7 +55,8 @@ export function useV2PresetExecution({
 	// /settings/agents page, so user edits there propagate here. The hook is
 	// already invalidated by mutations in the agents settings page.
 	const { activeHostUrl } = useLocalHostService();
-	const { data: agents = [] } = useV2AgentConfigs(activeHostUrl);
+	const configsQuery = useV2AgentConfigs(activeHostUrl);
+	const agents = configsQuery.data ?? [];
 
 	// Map presetId → command (first match wins if the user has multiple
 	// host configs for the same preset).
@@ -68,23 +70,82 @@ export function useV2PresetExecution({
 		return map;
 	}, [agents]);
 
+	// Map command-executable basename → presetId. Used as a fallback overlay
+	// key when a preset row has no `agentId` (e.g. it was imported from a
+	// renamed v1 builtin preset and `linkedAgentId` resolution missed it).
+	// First match wins. See issue #4195.
+	const presetIdByCommandBasename = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const agent of agents) {
+			const command = agent.command.trim();
+			if (command.length === 0) continue;
+			const basename = command.split(/[\\/]/).pop() ?? command;
+			if (map.has(basename)) continue;
+			map.set(basename, agent.presetId);
+		}
+		return map;
+	}, [agents]);
+
 	const matchedPresets = useMemo(
 		() => filterMatchingPresetsForProject(allPresets, projectId),
 		[allPresets, projectId],
 	);
 
+	const inferAgentIdFromCommands = useCallback(
+		(commands: string[]): string | undefined => {
+			const first = commands[0];
+			if (!first) return undefined;
+			const { command } = parseCommandString(first);
+			if (!command) return undefined;
+			const basename = command.split(/[\\/]/).pop() ?? command;
+			return presetIdByCommandBasename.get(basename);
+		},
+		[presetIdByCommandBasename],
+	);
+
 	const resolvePresetCommands = useCallback(
 		(preset: V2TerminalPresetRow): string[] => {
-			if (!preset.agentId) return preset.commands;
-			const live = agentCommandsById.get(preset.agentId);
-			if (live) return [live];
+			const explicitId = preset.agentId;
+			if (explicitId) {
+				const live = agentCommandsById.get(explicitId);
+				if (live) return [live];
+				if (configsQuery.data) {
+					console.warn(
+						"[useV2PresetExecution] preset.agentId set but no live host-agent config found",
+						{ presetId: preset.id, agentId: explicitId },
+					);
+				}
+				return preset.commands;
+			}
+			// Fallback: snapshot's first command basename matches a known
+			// host-agent — overlay anyway so renamed v1-imported presets don't
+			// silently run a stranded snapshot. See issue #4195.
+			const inferredId = inferAgentIdFromCommands(preset.commands);
+			if (inferredId) {
+				const live = agentCommandsById.get(inferredId);
+				if (live) return [live];
+			}
 			return preset.commands;
 		},
-		[agentCommandsById],
+		[agentCommandsById, configsQuery.data, inferAgentIdFromCommands],
 	);
 
 	const executePreset = useCallback(
 		async (preset: V2TerminalPresetRow) => {
+			// Block launches before host-service is reachable or before the
+			// agent-configs query has resolved at least once. Without this guard
+			// `agents` is `[]` and any preset with `agentId` falls through to its
+			// stale `commands` snapshot — exactly the regression reported in #4195.
+			if (!activeHostUrl) {
+				toast.error("Host service is not ready yet — try again in a moment.");
+				return;
+			}
+			if (configsQuery.isLoading || configsQuery.isPending) {
+				toast.error(
+					"Agent configurations are still loading — try again in a moment.",
+				);
+				return;
+			}
 			const state = store.getState();
 			const activeTabId = state.activeTabId;
 			const target = resolveTarget(preset.executionMode);
@@ -180,7 +241,14 @@ export function useV2PresetExecution({
 				});
 			}
 		},
-		[store, launcher, resolvePresetCommands],
+		[
+			store,
+			launcher,
+			resolvePresetCommands,
+			activeHostUrl,
+			configsQuery.isLoading,
+			configsQuery.isPending,
+		],
 	);
 
 	return { matchedPresets, executePreset };

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { inferImportedAgentId } from "./ImportPresetsPage";
+
+describe("inferImportedAgentId", () => {
+	it("matches when name is a builtin agent ID", () => {
+		expect(inferImportedAgentId({ name: "claude", commands: ["claude"] })).toBe(
+			"claude",
+		);
+	});
+
+	it("matches a renamed preset by command basename — pre-#3546 yolo", () => {
+		expect(
+			inferImportedAgentId({
+				name: "Yolo Claude",
+				commands: ["claude --dangerously-skip-permissions"],
+			}),
+		).toBe("claude");
+	});
+
+	it("matches a renamed preset by command basename — current default", () => {
+		expect(
+			inferImportedAgentId({
+				name: "My Claude",
+				commands: ["claude --permission-mode acceptEdits"],
+			}),
+		).toBe("claude");
+	});
+
+	it("matches when the command includes a leading directory path", () => {
+		expect(
+			inferImportedAgentId({
+				name: "Custom",
+				commands: ["/Users/me/bin/codex --sandbox workspace-write"],
+			}),
+		).toBe("codex");
+	});
+
+	it("returns undefined when neither name nor command basename match", () => {
+		expect(
+			inferImportedAgentId({
+				name: "My Special Tool",
+				commands: ["my-special-tool --flag"],
+			}),
+		).toBeUndefined();
+	});
+
+	it("returns undefined for empty commands", () => {
+		expect(
+			inferImportedAgentId({ name: "Custom", commands: [] }),
+		).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
@@ -10,6 +10,7 @@ import { LuTerminal } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { parseCommandString } from "shared/argv";
 import { ImportPageShell } from "../components/ImportPageShell";
 import { ImportRow, type RowAction } from "../components/ImportRow";
 
@@ -18,6 +19,33 @@ interface ImportPresetsPageProps {
 }
 
 const BUILTIN_AGENT_IDS = new Set<string>(AGENT_TYPES);
+
+/**
+ * Resolve the v2 `agentId` for an imported v1 preset. We try (in order):
+ * 1. The preset's `name` directly — covers untouched builtin presets.
+ * 2. The basename of the first command's executable — covers renamed
+ *    presets (e.g. user changed name to "Yolo Claude") whose commands
+ *    still start with `claude` / `claude --dangerously-skip-permissions`.
+ *    Without this, the v2 row imports with `agentId: undefined`, the
+ *    `useV2PresetExecution` overlay short-circuits, and the launch is
+ *    permanently pinned to the v1 snapshot. See issue #4195.
+ */
+export function inferImportedAgentId(
+	preset: Pick<TerminalPreset, "name" | "commands">,
+): AgentType | undefined {
+	if (BUILTIN_AGENT_IDS.has(preset.name)) {
+		return preset.name as AgentType;
+	}
+	const firstCommand = preset.commands?.[0];
+	if (!firstCommand) return undefined;
+	const { command } = parseCommandString(firstCommand);
+	if (!command) return undefined;
+	const basename = command.split(/[\\/]/).pop() ?? command;
+	if (BUILTIN_AGENT_IDS.has(basename)) {
+		return basename as AgentType;
+	}
+	return undefined;
+}
 
 export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 	const collections = useCollections();
@@ -61,9 +89,7 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 			isRefreshing={isRefreshing}
 		>
 			{presets.map((preset, index) => {
-				const linkedAgentId = BUILTIN_AGENT_IDS.has(preset.name)
-					? (preset.name as AgentType)
-					: undefined;
+				const linkedAgentId = inferImportedAgentId(preset);
 				const v2Name = linkedAgentId
 					? AGENT_LABELS[linkedAgentId]
 					: preset.name;

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -7,6 +7,7 @@ import {
 	useMemo,
 } from "react";
 import { env } from "renderer/env.renderer";
+import { useV2HostAgentMirror } from "renderer/hooks/useV2HostAgentMirror";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { setHostServiceSecret } from "renderer/lib/host-service-auth";
@@ -77,6 +78,10 @@ export function LocalHostServiceProvider({
 
 		return { machineId, activeHostUrl };
 	}, [machineIdData, activeConnection]);
+
+	// Mirror legacy v1 agent-preset overrides into the v2 host-service store
+	// once the host URL is known. See useV2HostAgentMirror for details (#4195).
+	useV2HostAgentMirror(value?.activeHostUrl ?? null);
 
 	if (!value) return null;
 

--- a/apps/desktop/src/shared/argv.ts
+++ b/apps/desktop/src/shared/argv.ts
@@ -1,0 +1,47 @@
+import { parse, quote } from "shell-quote";
+
+/**
+ * Format a command + argv array as an editable shell-style string.
+ * Round-trips through `parseCommandString` losslessly: the command
+ * and every argv element are quoted (when needed) so paths with
+ * spaces and explicit empty strings survive the round trip.
+ */
+export function joinCommandArgs(command: string, args: string[]): string {
+	const tokens = command.length === 0 ? args : [command, ...args];
+	if (tokens.length === 0) return "";
+	return quote(tokens);
+}
+
+/**
+ * Parse a shell-style string into `command` (first token) and the rest as
+ * `args`. Drops control operators (`|`, `>`, etc.) — this is a launch
+ * spec, not a shell invocation. Empty quoted args (`""`) and tokens with
+ * embedded spaces are preserved exactly.
+ */
+export function parseCommandString(input: string): {
+	command: string;
+	args: string[];
+} {
+	const tokens = parse(input).filter(
+		(token): token is string => typeof token === "string",
+	);
+	if (tokens.length === 0) return { command: "", args: [] };
+	const [command, ...args] = tokens;
+	return { command: command ?? "", args };
+}
+
+/** Format a bare argv array (no leading executable). */
+export function joinArgs(args: string[]): string {
+	if (args.length === 0) return "";
+	return quote(args);
+}
+
+/**
+ * Parse a bare argv array (no leading executable). Preserves empty
+ * quoted args; drops only shell control operators.
+ */
+export function parseArgs(input: string): string[] {
+	return parse(input).filter(
+		(token): token is string => typeof token === "string",
+	);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.5",
+      "version": "1.8.8",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -300,6 +300,125 @@ describe("agentConfigsRouter", () => {
 		});
 	});
 
+	describe("mirrorLegacyOverrides()", () => {
+		it("rewrites a seed-default row whose v1 override differs", async () => {
+			const caller = createCaller();
+			await caller.list();
+
+			const result = await caller.mirrorLegacyOverrides({
+				overrides: [
+					{
+						presetId: "claude",
+						command: "claude",
+						args: ["--dangerously-skip-permissions"],
+					},
+				],
+			});
+
+			expect(result.applied).toEqual(["claude"]);
+			const claude = (await caller.list()).find(
+				(row) => row.presetId === "claude",
+			);
+			expect(claude?.command).toBe("claude");
+			expect(claude?.args).toEqual(["--dangerously-skip-permissions"]);
+		});
+
+		it("is idempotent — second call applies nothing", async () => {
+			const caller = createCaller();
+			await caller.list();
+
+			const overrides = [
+				{
+					presetId: "claude",
+					command: "claude",
+					args: ["--dangerously-skip-permissions"],
+				},
+			];
+			const first = await caller.mirrorLegacyOverrides({ overrides });
+			const second = await caller.mirrorLegacyOverrides({ overrides });
+
+			expect(first.applied).toEqual(["claude"]);
+			expect(second.applied).toEqual([]);
+			expect(second.skipped.find((s) => s.presetId === "claude")?.reason).toBe(
+				"user-customized",
+			);
+		});
+
+		it("does not clobber a v2-side customization", async () => {
+			const caller = createCaller();
+			const claude = (await caller.list()).find(
+				(row) => row.presetId === "claude",
+			);
+			if (!claude) throw new Error("expected claude row");
+			// User customizes the v2 row first.
+			await caller.update({
+				id: claude.id,
+				patch: { command: "claude", args: ["--my-flag"] },
+			});
+
+			const result = await caller.mirrorLegacyOverrides({
+				overrides: [
+					{
+						presetId: "claude",
+						command: "claude",
+						args: ["--dangerously-skip-permissions"],
+					},
+				],
+			});
+
+			expect(result.applied).toEqual([]);
+			const after = (await caller.list()).find(
+				(row) => row.presetId === "claude",
+			);
+			expect(after?.args).toEqual(["--my-flag"]);
+		});
+
+		it("seeds defaults if the table was empty", async () => {
+			const caller = createCaller();
+			// No prior list() — table is empty.
+			const result = await caller.mirrorLegacyOverrides({
+				overrides: [
+					{
+						presetId: "claude",
+						command: "claude",
+						args: ["--dangerously-skip-permissions"],
+					},
+				],
+			});
+			expect(result.applied).toEqual(["claude"]);
+			const rows = await caller.list();
+			expect(rows.map((r) => r.presetId)).toEqual(DEFAULT_PRESET_IDS);
+		});
+
+		it("skips presetIds that are not installed", async () => {
+			const caller = createCaller();
+			await caller.list();
+			const result = await caller.mirrorLegacyOverrides({
+				overrides: [{ presetId: "pi", command: "pi", args: ["--legacy"] }],
+			});
+			expect(result.applied).toEqual([]);
+			expect(result.skipped[0]?.reason).toBe("not-installed");
+		});
+
+		it("skips when the override matches the current row exactly", async () => {
+			const caller = createCaller();
+			const seeded = await caller.list();
+			const claude = seeded.find((r) => r.presetId === "claude");
+			if (!claude) throw new Error("expected claude row");
+			const result = await caller.mirrorLegacyOverrides({
+				overrides: [
+					{
+						presetId: "claude",
+						command: claude.command,
+						args: claude.args,
+					},
+				],
+			});
+			expect(result.applied).toEqual([]);
+			expect(result.skipped[0]?.reason).toBe("no-op");
+		});
+	});
+
 	describe("resetToDefaults()", () => {
 		it("replaces current configs with bundled defaults", async () => {
 			const caller = createCaller();

--- a/packages/host-service/src/trpc/router/settings/agent-configs.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.ts
@@ -154,6 +154,16 @@ const addInputSchema = z.object({
 	presetId: z.string().trim().min(1).optional(),
 });
 
+const mirrorLegacyOverrideEntrySchema = z.object({
+	presetId: z.string().trim().min(1),
+	command: z.string().trim().min(1),
+	args: argvSchema,
+});
+
+const mirrorLegacyOverridesInputSchema = z.object({
+	overrides: z.array(mirrorLegacyOverrideEntrySchema),
+});
+
 export const agentConfigsRouter = router({
 	/**
 	 * List configured host agents in persisted order. Seeds bundled defaults
@@ -320,6 +330,74 @@ export const agentConfigsRouter = router({
 				});
 			});
 			return listOrdered(ctx.db).map(toOutput);
+		}),
+
+	/**
+	 * Mirror legacy v1 agent-preset overrides into this host-service's
+	 * `host_agent_configs` table. For each override, the row matching
+	 * `presetId` is updated only when its `command + args` still match the
+	 * bundled seed default exactly — which means the user has not edited
+	 * the v2 row yet, so applying the legacy override can't clobber a v2-side
+	 * customization. Idempotent: a second call after the first is a no-op
+	 * because the row no longer matches the seed default. See issue #4195
+	 * and `runAgentPresetPermissionsMigration` in the desktop settings router.
+	 */
+	mirrorLegacyOverrides: protectedProcedure
+		.input(mirrorLegacyOverridesInputSchema)
+		.mutation(({ ctx, input }) => {
+			seedDefaultsIfEmpty(ctx.db);
+			const rows = listOrdered(ctx.db);
+			const rowsByPresetId = new Map(rows.map((row) => [row.presetId, row]));
+			const seedByPresetId = new Map(
+				getDefaultSeedPresets().map((preset) => [preset.presetId, preset]),
+			);
+
+			const applied: string[] = [];
+			const skipped: { presetId: string; reason: string }[] = [];
+			const now = Date.now();
+			for (const override of input.overrides) {
+				const row = rowsByPresetId.get(override.presetId);
+				if (!row) {
+					skipped.push({
+						presetId: override.presetId,
+						reason: "not-installed",
+					});
+					continue;
+				}
+				const seed = seedByPresetId.get(override.presetId);
+				if (!seed) {
+					skipped.push({ presetId: override.presetId, reason: "not-a-seed" });
+					continue;
+				}
+				const seedArgsJson = JSON.stringify(seed.args);
+				if (row.command !== seed.command || row.argsJson !== seedArgsJson) {
+					skipped.push({
+						presetId: override.presetId,
+						reason: "user-customized",
+					});
+					continue;
+				}
+				const overrideArgsJson = JSON.stringify(override.args);
+				if (
+					override.command === row.command &&
+					overrideArgsJson === row.argsJson
+				) {
+					skipped.push({ presetId: override.presetId, reason: "no-op" });
+					continue;
+				}
+				ctx.db
+					.update(hostAgentConfigs)
+					.set({
+						command: override.command,
+						argsJson: overrideArgsJson,
+						updatedAt: now,
+					})
+					.where(eq(hostAgentConfigs.id, row.id))
+					.run();
+				applied.push(override.presetId);
+			}
+
+			return { applied, skipped };
 		}),
 
 	/**

--- a/plans/4195-v2-stranded-permission-mode-fix.md
+++ b/plans/4195-v2-stranded-permission-mode-fix.md
@@ -1,0 +1,99 @@
+# 4195 — v2 launches Claude with stale `--permission-mode acceptEdits`
+
+## Root cause
+
+There are two parallel agent-command stores with no sync between them:
+
+| | V1 store | V2 store |
+|---|---|---|
+| Backing | desktop main `settings.agentPresetOverrides` (file-backed) | host-service SQLite `host_agent_configs` |
+| Edits | `V1AgentsSettings` | `V2AgentsSettings` |
+| Read by | v1 launch paths | `useV2AgentConfigs` → `useV2PresetExecution` |
+
+`runAgentPresetPermissionsMigration` (`apps/desktop/src/lib/trpc/routers/settings/index.ts:135-165`) restores YOLO defaults (`claude --dangerously-skip-permissions`) for pre-#3546 users — but writes ONLY to `settings.agentPresetOverrides` (v1). The host-service `host_agent_configs` table is freshly seeded with `claude` + `["--permission-mode","acceptEdits"]` from `getDefaultSeedPresets()` and never receives the v1 override.
+
+`useV2PresetExecution.ts` overlays the live host-service config on top of the v2 row's snapshot. Live wins. So v2 launches always run `acceptEdits`, silently overriding the user's `--dangerously-skip-permissions` preference.
+
+Three additional sub-bugs identified:
+
+1. **Renamed v1 preset on import.** `ImportPresetsPage.tsx` only sets `linkedAgentId` when `preset.name` is in `AGENT_TYPES`. A user-renamed v1 Claude preset (e.g. "Yolo Claude") imports with `agentId: undefined`, so the overlay short-circuits and the launch is the snapshot forever.
+2. **Stale snapshot on import.** Even with `agentId` set, `commands` is copied verbatim from v1. If the user customized the v1 terminal-preset commands (not the agent-preset overrides), the v2 row carries those forever and only the live overlay can correct it — which loops back to the host-service-store-was-never-migrated problem.
+3. **Empty `useV2AgentConfigs` at execute time.** `staleTime: Infinity` + `enabled: !!hostUrl`. If `activeHostUrl` is null at the moment of `executePreset`, `agents` is `[]`, every preset with `agentId` falls through to its stale `preset.commands` snapshot.
+
+## Fix
+
+### Primary: mirror v1 envelope into the v2 host-service store
+
+A renderer-driven mirror, fired once per `activeHostUrl` per session.
+
+**Host-service: idempotent migration mutation.**
+`mirrorLegacyOverrides` (`packages/host-service/src/trpc/router/settings/agent-configs.ts`) takes `{ presetId, command, args }[]` and writes to a row only if its `command + args` still match the bundled seed default exactly. Idempotent by design — no marker column needed: the second invocation no longer matches the seed default, so it's a no-op. Critically, this means a user who has already customized a row in `V2AgentsSettings` is never clobbered, and the migration can run on every connect with zero risk.
+
+**Desktop main: build the mirror plan.**
+`buildLegacyHostAgentMirrorPlan` (`apps/desktop/src/lib/trpc/routers/settings/v2-host-agent-mirror.ts`) reads the v1 `agentPresetOverrides` envelope and translates each legacy override `command` string (like `"claude --dangerously-skip-permissions"`) into split `{ command, args }` form using `shell-quote`. Exposed as the tRPC query `settings.getV2HostAgentMirrorPlan`.
+
+**Renderer hook.**
+`useV2HostAgentMirror` (`apps/desktop/src/renderer/hooks/useV2HostAgentMirror`) fires the mirror once per `hostUrl` (per renderer session, deduped via a ref) when both the plan and `hostUrl` are known. On success, invalidates `V2_AGENT_CONFIGS_QUERY_KEY` so the v2 settings page and `useV2PresetExecution` see the new commands immediately.
+
+Wired into `LocalHostServiceProvider` so the mirror runs as soon as the local host-service is reachable.
+
+Why renderer-driven, not main-driven: keeping the migration in renderer-trpc-land means the desktop main process doesn't take a new dependency on the host-service tRPC client, and the host-service stays stateless about who its caller is. The mirror is a one-shot per session — if it fails, the user can restart the app or any v2-side edit invalidates the seed-default-match check anyway, so fancier retry logic is unnecessary.
+
+### Sub-bug fixes
+
+**Renamed v1 preset.** `inferImportedAgentId` in `ImportPresetsPage.tsx` now matches first by `name` (preserving existing behavior) and falls back to the basename of the first command's executable. So a renamed `"Yolo Claude"` preset whose first command is `"claude --dangerously-skip-permissions"` correctly links to `agentId: "claude"` on import.
+
+**Overlay fallback in `useV2PresetExecution`.** When a preset's `agentId` is unset, the resolver now also tries to match the snapshot's first-command basename against `presetIdByCommandBasename` (built from `agents`). If a known builtin matches, the live overlay wins — so legacy v1-imported rows with no `agentId` still pick up the user's current v2 settings. If `agentId` is set but the lookup misses, we log a `console.warn` rather than silently snapshotting.
+
+**Empty configs at execute.** `executePreset` in `useV2PresetExecution` now blocks when `!activeHostUrl` or when the configs query is still pending/loading, surfacing a toast instead of silently launching from the snapshot. By the time the user sees the v2 UI, `LocalHostServiceProvider` has already established the host URL — this guard catches the genuinely-not-yet-ready case.
+
+### v1 surgery avoided
+
+Per the user's preference to fix forward in v2 and not evolve v1 code, all changes are in v2 paths or in shared/v1-immutable boundaries. The v1 `runAgentPresetPermissionsMigration` and `applyLegacyPermissionsOverrides` are reused untouched.
+
+## Tests
+
+- `packages/host-service/src/trpc/router/settings/agent-configs.test.ts` — six new cases for `mirrorLegacyOverrides`:
+  - rewrites a seed-default row when the v1 override differs (the core regression);
+  - is idempotent on second call;
+  - does not clobber a v2-side customization (skips with `user-customized`);
+  - seeds defaults if the table was empty;
+  - skips presetIds that are not installed;
+  - skips with `no-op` when the override matches the current row exactly.
+- `apps/desktop/src/lib/trpc/routers/settings/v2-host-agent-mirror.test.ts` — six cases for the v1-envelope → mirror-plan translation:
+  - empty envelope → empty plan;
+  - end-to-end: feed `applyLegacyPermissionsOverrides` output through `buildLegacyHostAgentMirrorPlan` and verify `claude` becomes `{ command: "claude", args: ["--dangerously-skip-permissions"] }` (this is the regression test the user called out);
+  - includes codex / gemini / copilot;
+  - preserves user-customized v1 overrides;
+  - skips agents whose override has only `promptCommandSuffix`;
+  - ignores overrides for non-builtin agent IDs.
+- `apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.test.ts` — six cases for `inferImportedAgentId`:
+  - matches by name when name is a builtin agent ID;
+  - matches a renamed preset with the pre-#3546 yolo command;
+  - matches a renamed preset with the current default command;
+  - matches when the command includes a leading directory path;
+  - returns undefined when neither name nor basename match;
+  - returns undefined for empty commands.
+
+The end-to-end regression chain (pre-#3546 user → v1 envelope override → v2 launch with `--dangerously-skip-permissions`) is covered by chaining `applyLegacyPermissionsOverrides` → `buildLegacyHostAgentMirrorPlan` → `mirrorLegacyOverrides`. Each link is unit-tested.
+
+## Files touched
+
+Added:
+- `apps/desktop/src/shared/argv.ts` — moved from `renderer/lib/argv.ts` so main can use `parseCommandString` too.
+- `apps/desktop/src/lib/trpc/routers/settings/v2-host-agent-mirror.ts` + `.test.ts`.
+- `apps/desktop/src/renderer/hooks/useV2HostAgentMirror/{useV2HostAgentMirror.ts,index.ts}`.
+- `apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.test.ts`.
+
+Modified:
+- `apps/desktop/src/renderer/lib/argv.ts` → re-exports from `shared/argv`.
+- `apps/desktop/src/lib/trpc/routers/settings/index.ts` → added `getV2HostAgentMirrorPlan` query.
+- `apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx` → exported `inferImportedAgentId`, used for `linkedAgentId`.
+- `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts` → command-basename overlay fallback + execute-time host/configs guard.
+- `apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx` → invokes `useV2HostAgentMirror`.
+- `packages/host-service/src/trpc/router/settings/agent-configs.ts` → new `mirrorLegacyOverrides` mutation + tests.
+
+## Known limitations / follow-ups
+
+- The mirror only translates the v1 `command` field into the v2 launch shape. v1's `promptCommand` and `promptCommandSuffix` (codex's trailing `--`, copilot's `-i`, etc.) don't have a clean 1:1 mapping into the v2 split `{ command, args, promptArgs }` shape — for now they remain v2-default. This matches the reported regression scope; the prompt-side variants can be addressed separately if reports come in.
+- The renderer-driven mirror runs after `LocalHostServiceProvider` has the host URL, which is "good enough" since the v2 UI doesn't render before then. A theoretical race exists where a launch fires in the same tick the host URL resolves; the new `executePreset` host/loading guard catches it.


### PR DESCRIPTION
## Summary

- Closes #4195. Pre-#3546 users whose v1 envelope had `claude --dangerously-skip-permissions` were stranded: the v2 host-service `host_agent_configs` seeded with `claude --permission-mode acceptEdits` and never received the v1 override, so v2 launches silently ran `acceptEdits` against the user's explicit preference.
- Adds an idempotent `mirrorLegacyOverrides` host-service mutation that only writes when a row still matches the seed default (v2-side edits are never clobbered), wired up via a desktop-side plan builder + a renderer hook fired once per host URL.
- Fixes three sub-bugs the same diagnostic surfaced: renamed v1 builtins now resolve `linkedAgentId` by command basename on import; `useV2PresetExecution`'s overlay falls back to command basename when `agentId` is unset; `executePreset` blocks with a toast when host-service or configs aren't ready instead of silently snapshotting.

See `plans/4195-v2-stranded-permission-mode-fix.md` for the full writeup.

## Test plan

- [x] `bun test packages/host-service/src/trpc/router/settings/agent-configs.test.ts` — 6 new cases covering the rewrite, idempotence, the don't-clobber-v2-edits guarantee, empty-table seeding, not-installed skip, and no-op skip.
- [x] `bun test apps/desktop/src/lib/trpc/routers/settings/v2-host-agent-mirror.test.ts` — 6 cases including the end-to-end `applyLegacyPermissionsOverrides` → `buildLegacyHostAgentMirrorPlan` → `{ command: "claude", args: ["--dangerously-skip-permissions"] }` regression for #4195.
- [x] `bun test apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.test.ts` — 6 cases for the renamed-preset basename match (yolo command, current default, leading directory path, miss case, empty commands).
- [x] `bun run lint` clean.
- [x] `bun run typecheck` clean across all 29 packages.
- [ ] Manual: as a pre-#3546 user, upgrade to v2, confirm v2 settings shows `claude --dangerously-skip-permissions` and that running the Claude preset spawns with that argv.
- [ ] Manual: rename the v1 Claude preset to something like "Yolo Claude", import to v2, confirm `linkedAgentId` resolves and the live overlay applies.
- [ ] Manual: edit the Claude command in v2 settings to something custom, confirm a subsequent app boot does NOT clobber the customization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4195 by mirroring v1 agent-preset permission overrides into the v2 host-service store so pre-#3546 users keep their intended flags (e.g., claude --dangerously-skip-permissions). Adds an idempotent sync that runs once per host and never overwrites v2 edits.

- **Bug Fixes**
  - Added `agentConfigs.mirrorLegacyOverrides` to update rows only when they still match the seeded default.
  - Added `settings.getV2HostAgentMirrorPlan` and a renderer hook `useV2HostAgentMirror` to apply the plan once per host URL and refresh configs.
  - Importing renamed v1 built-ins now resolves `linkedAgentId` by command basename.
  - `useV2PresetExecution` falls back to command basename when `agentId` is unset and blocks launches until host service and configs are ready.

<sup>Written for commit 170f0f5722bc234e8ec955d4aa5ec2169b85aeac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent permission mode settings from v1 being ignored in v2 preset execution.
  * Improved detection of imported presets when agent names have been customized.

* **Improvements**
  * Enhanced reliability of agent configuration handling when host service data isn't immediately available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->