### PR TITLE
fix(host-service): split PR sidebar GraphQL query to avoid 504s on busy repos

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -6,7 +6,10 @@ import type { HostDb } from "../../db";
 import { projects, pullRequests, workspaces } from "../../db/schema";
 import type { GitWatcher } from "../../events/git-watcher";
 import type { GitFactory } from "../git";
-import { fetchRepositoryPullRequests } from "./utils/github-query";
+import {
+	fetchPullRequestChecks,
+	fetchRepositoryPullRequests,
+} from "./utils/github-query";
 import type { GraphQLPullRequestNode } from "./utils/github-query/types";
 import {
 	type ChecksStatus,
@@ -896,10 +899,37 @@ export class PullRequestRuntimeManager {
 		const keyToRow = new Map<string, { id: string }>();
 		const now = Date.now();
 
+		// Fetch checks per-PR only for the PRs we care about. Issue #4246:
+		// bundling `statusCheckRollup` into the listing query 504s on busy
+		// repos. `wantedKeys.size` is bounded by distinct workspace upstreams
+		// in this project — typically a handful — so the fan-out stays small.
+		const octokit = await this.github();
+		const checksByPrNumber = new Map<
+			number,
+			Awaited<ReturnType<typeof fetchPullRequestChecks>>
+		>();
+		await Promise.all(
+			[...latestByKey.values()].map(async (node) => {
+				try {
+					const checks = await fetchPullRequestChecks(
+						octokit,
+						repo,
+						node.number,
+					);
+					checksByPrNumber.set(node.number, checks);
+				} catch (error) {
+					console.warn(
+						"[host-service:pull-request-runtime] Failed to fetch PR checks",
+						{ projectId, prNumber: node.number, error },
+					);
+				}
+			}),
+		);
+
 		for (const [key, node] of latestByKey) {
 			const existing = this.findPullRequestRow(repo, node.number);
 			const checks = parseCheckContexts(
-				node.statusCheckRollup?.contexts?.nodes ?? [],
+				checksByPrNumber.get(node.number) ?? [],
 			);
 			const rowId = this.upsertPullRequestRow({
 				existing,

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import {
+	fetchPullRequestChecks,
+	fetchRepositoryPullRequests,
+} from "./github-query";
+
+// Issue #4246: GitHub's GraphQL endpoint returns HTTP 504 when the bulk
+// PR-listing query also materializes statusCheckRollup.contexts(first: 50)
+// for ~100 PRs against a busy repo. The fetcher must not bundle check
+// rollups into the listing query; checks have to be fetched separately,
+// per-PR, only for the PRs the caller actually cares about.
+describe("github-query (large-repo timeout reproduction for #4246)", () => {
+	test("listing query does not request statusCheckRollup", async () => {
+		const queries: string[] = [];
+		const octokit = {
+			graphql: async (query: string) => {
+				queries.push(query);
+				return { repository: { pullRequests: { nodes: [] } } };
+			},
+		};
+
+		await fetchRepositoryPullRequests(octokit as never, {
+			owner: "owner",
+			name: "repo",
+		});
+
+		expect(queries).toHaveLength(1);
+		expect(queries[0]).not.toContain("statusCheckRollup");
+	});
+
+	test("listing succeeds even when bulk-rollup queries would 504", async () => {
+		const octokit = {
+			graphql: async (query: string) => {
+				if (
+					query.includes("pullRequests(") &&
+					query.includes("statusCheckRollup")
+				) {
+					const error = new Error("GraphQL request failed: 504") as Error & {
+						status?: number;
+					};
+					error.status = 504;
+					throw error;
+				}
+				return {
+					repository: {
+						pullRequests: {
+							nodes: [
+								{
+									number: 1,
+									title: "feature",
+									url: "https://github.com/owner/repo/pull/1",
+									state: "OPEN",
+									isDraft: false,
+									headRefName: "feature",
+									headRefOid: "abc",
+									isCrossRepository: false,
+									headRepositoryOwner: { login: "owner" },
+									headRepository: { name: "repo" },
+									reviewDecision: null,
+									updatedAt: "2026-01-01T00:00:00Z",
+								},
+							],
+						},
+					},
+				};
+			},
+		};
+
+		const nodes = await fetchRepositoryPullRequests(octokit as never, {
+			owner: "owner",
+			name: "repo",
+		});
+
+		expect(nodes).toHaveLength(1);
+		expect(nodes[0]?.number).toBe(1);
+	});
+
+	test("fetchPullRequestChecks fetches statusCheckRollup for a single PR", async () => {
+		const captured: { query: string; variables: unknown }[] = [];
+		const octokit = {
+			graphql: async (query: string, variables: unknown) => {
+				captured.push({ query, variables });
+				return {
+					repository: {
+						pullRequest: {
+							statusCheckRollup: {
+								contexts: {
+									nodes: [
+										{
+											__typename: "CheckRun",
+											name: "ci",
+											conclusion: "SUCCESS",
+											detailsUrl: "https://example.com/ci",
+											status: "COMPLETED",
+											startedAt: null,
+											completedAt: null,
+											checkSuite: null,
+										},
+									],
+								},
+							},
+						},
+					},
+				};
+			},
+		};
+
+		const checks = await fetchPullRequestChecks(
+			octokit as never,
+			{ owner: "owner", name: "repo" },
+			42,
+		);
+
+		expect(checks).toHaveLength(1);
+		expect(captured[0]?.query).toContain("statusCheckRollup");
+		expect(captured[0]?.query).not.toContain("pullRequests(");
+		const vars = captured[0]?.variables as { number: number };
+		expect(vars.number).toBe(42);
+	});
+});

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -1,7 +1,9 @@
 import type { Octokit } from "@octokit/rest";
-import { PULL_REQUESTS_QUERY } from "./query";
+import { PULL_REQUEST_CHECKS_QUERY, PULL_REQUESTS_QUERY } from "./query";
 import type {
+	GraphQLCheckContextNode,
 	GraphQLPullRequestNode,
+	PullRequestChecksGraphQLResult,
 	PullRequestsGraphQLResult,
 } from "./types";
 
@@ -22,5 +24,27 @@ export async function fetchRepositoryPullRequests(
 
 	return (result.repository?.pullRequests?.nodes ?? []).filter(
 		(node): node is GraphQLPullRequestNode => node !== null,
+	);
+}
+
+export async function fetchPullRequestChecks(
+	octokit: Octokit,
+	repository: {
+		owner: string;
+		name: string;
+	},
+	prNumber: number,
+): Promise<GraphQLCheckContextNode[]> {
+	const result = await octokit.graphql<PullRequestChecksGraphQLResult>(
+		PULL_REQUEST_CHECKS_QUERY,
+		{
+			owner: repository.owner,
+			repo: repository.name,
+			number: prNumber,
+		},
+	);
+
+	return (
+		result.repository?.pullRequest?.statusCheckRollup?.contexts?.nodes ?? []
 	);
 }

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/index.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/index.ts
@@ -1,4 +1,7 @@
-export { fetchRepositoryPullRequests } from "./github-query";
+export {
+	fetchPullRequestChecks,
+	fetchRepositoryPullRequests,
+} from "./github-query";
 export type {
 	GraphQLCheckContextNode,
 	GraphQLPullRequestNode,

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/query.ts
@@ -1,3 +1,9 @@
+// Listing intentionally omits `statusCheckRollup`. Issue #4246: GitHub's
+// GraphQL endpoint returns HTTP 504 when this query also materializes
+// `statusCheckRollup.contexts(first: 50)` across 100 PRs on a busy repo
+// (the per-request deadline is exceeded for the 100×50 nested fetch).
+// Checks are fetched separately, per-PR, only for PRs the caller cares
+// about — see `PULL_REQUEST_CHECKS_QUERY`.
 export const PULL_REQUESTS_QUERY = `
 	query PullRequestsForSidebar($owner: String!, $repo: String!) {
 		repository(owner: $owner, name: $repo) {
@@ -15,29 +21,38 @@ export const PULL_REQUESTS_QUERY = `
 					headRepository { name }
 					reviewDecision
 					updatedAt
-					statusCheckRollup {
-						contexts(first: 50) {
-							nodes {
-								__typename
-								... on CheckRun {
-									name
-									conclusion
-									detailsUrl
-									status
-									startedAt
-									completedAt
-									checkSuite {
-										workflowRun {
-											databaseId
-										}
+				}
+			}
+		}
+	}
+`;
+
+export const PULL_REQUEST_CHECKS_QUERY = `
+	query PullRequestChecksForSidebar($owner: String!, $repo: String!, $number: Int!) {
+		repository(owner: $owner, name: $repo) {
+			pullRequest(number: $number) {
+				statusCheckRollup {
+					contexts(first: 50) {
+						nodes {
+							__typename
+							... on CheckRun {
+								name
+								conclusion
+								detailsUrl
+								status
+								startedAt
+								completedAt
+								checkSuite {
+									workflowRun {
+										databaseId
 									}
 								}
-								... on StatusContext {
-									context
-									state
-									targetUrl
-									createdAt
-								}
+							}
+							... on StatusContext {
+								context
+								state
+								targetUrl
+								createdAt
 							}
 						}
 					}

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
@@ -39,11 +39,6 @@ export interface GraphQLPullRequestNode {
 	headRepository: { name: string } | null;
 	reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
 	updatedAt: string;
-	statusCheckRollup: {
-		contexts: {
-			nodes: GraphQLCheckContextNode[];
-		} | null;
-	} | null;
 }
 
 export interface PullRequestsGraphQLResult {
@@ -51,5 +46,17 @@ export interface PullRequestsGraphQLResult {
 		pullRequests?: {
 			nodes?: Array<GraphQLPullRequestNode | null>;
 		};
+	} | null;
+}
+
+export interface PullRequestChecksGraphQLResult {
+	repository?: {
+		pullRequest?: {
+			statusCheckRollup: {
+				contexts: {
+					nodes: GraphQLCheckContextNode[];
+				} | null;
+			} | null;
+		} | null;
 	} | null;
 }


### PR DESCRIPTION
## Summary
- Closes #4246. Drops `statusCheckRollup` from the bulk `PullRequestsForSidebar` listing — that 100×50 nested materialization was timing out (504) on large repos, and the failed promise was cached for 60s, so the sidebar PR badge never resolved.
- Adds `PULL_REQUEST_CHECKS_QUERY` and `fetchPullRequestChecks` to fetch `statusCheckRollup` per PR. `performProjectRefresh` calls it via `Promise.all` only for the small set of PRs that match the project's workspace upstreams (typically a handful), not all 100.
- New `github-query.test.ts` pins the contract: listing query has no `statusCheckRollup`; listing still works when a hypothetical bulk-rollup query 504s; per-PR checks query carries the PR number variable.

## Test plan
- [x] `bun run typecheck` — 29/29 packages pass
- [x] `bun test packages/host-service` — 571 pass, 0 fail
- [x] `bun run lint` — clean
- [ ] Manual: open a workspace tracking a large/active repo, confirm PR badge appears in `DashboardSidebarWorkspaceItem` and `host.db.pull_requests` populates
- [ ] Verify no regression on small repos (badge still resolves quickly, no extra latency from per-PR check fan-out)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4246 by splitting the PR sidebar GraphQL queries to avoid 504s on busy repos. Removes check rollups from the bulk listing and fetches per-PR checks only for relevant PRs, so the sidebar badge resolves consistently.

- **Bug Fixes**
  - Dropped `statusCheckRollup` from the `PullRequestsForSidebar` listing to prevent timeouts from 100×50 nested materialization.
  - Added `PULL_REQUEST_CHECKS_QUERY` and `fetchPullRequestChecks`; `performProjectRefresh` fans out checks only for workspace-relevant PRs.
  - Updated types/exports and added tests to pin the contract (listing omits rollups; per-PR checks query uses the PR number).

<sup>Written for commit 85edfedd77515ac444a85d38208271da3e37fd36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of pull request status check loading by fetching checks individually per PR, preventing GitHub API timeouts that occurred when processing repositories with many status checks.

* **Tests**
  * Added test coverage to verify proper handling of status check queries and prevent regression of timeout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->