### PR TITLE
fix(desktop): mute terminal connection-log icon color

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalLogsButton/TerminalLogsButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalLogsButton/TerminalLogsButton.tsx
@@ -52,7 +52,7 @@ export function TerminalLogsButton({
 								"rounded p-1 transition-colors",
 								hasError
 									? "text-destructive/70 hover:text-destructive"
-									: "text-amber-500/70 hover:text-amber-500",
+									: "text-muted-foreground hover:text-foreground",
 							)}
 						>
 							<AlertTriangle className="size-3.5" />


### PR DESCRIPTION
## Summary
- The warning-level AlertTriangle icon in the terminal pane header was rendered in `text-amber-500`, which drew the eye even when nothing was wrong.
- Switch the non-error state to `text-muted-foreground` so it blends with the header; errors still render in `text-destructive`.

## Test plan
- [ ] Open a terminal that emits warn/info connection log entries; confirm the AlertTriangle icon renders muted instead of orange.
- [ ] Trigger an error-level connection event; confirm the icon still renders in destructive red.
- [ ] Open the popover; confirm the `warn` level label inside still uses amber for level differentiation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Muted the AlertTriangle icon in the terminal header for non-error connection logs so it blends with the header; errors still render in destructive red. Replaces the amber warning color with a muted foreground and neutral hover to reduce visual noise.

<sup>Written for commit 99f7904382529ac4d3ccf19da44c8ba856f42561. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the terminal logs button's error indicator to use a more prominent destructive style for error states instead of the previous amber styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->