### PR TITLE
style(desktop): gray terminal log button instead of amber

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalLogsButton/TerminalLogsButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalLogsButton/TerminalLogsButton.tsx
@@ -52,7 +52,7 @@ export function TerminalLogsButton({
 								"rounded p-1 transition-colors",
 								hasError
 									? "text-destructive/70 hover:text-destructive"
-									: "text-amber-500/70 hover:text-amber-500",
+									: "text-muted-foreground hover:text-foreground",
 							)}
 						>
 							<AlertTriangle className="size-3.5" />


### PR DESCRIPTION
## Summary
- Switch the non-error state of the terminal connection-log button from amber to muted gray (`text-muted-foreground hover:text-foreground`).
- Error state (`text-destructive`) and per-row warn coloring inside the popover are unchanged.

## Test plan
- [ ] Open a v2 workspace terminal pane that surfaces a connection log entry and confirm the button renders gray instead of orange.
- [ ] Trigger an error-level log entry and confirm the button still renders red.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use muted gray for the terminal connection-log button in non-error state to reduce visual noise, replacing amber with `text-muted-foreground hover:text-foreground`.
Error state (`text-destructive`) and warn row colors inside the popover are unchanged.

<sup>Written for commit fa2ed5319b425cc459484f38c98654c4f9eb4c20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Terminal Logs Button visual styling to better distinguish between log types. Non-error entries now display with muted colors, while error states maintain their distinctive red styling for clearer visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->