### PR TITLE
feat(desktop): gray out .git and gitignored entries in Files View

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
@@ -3,6 +3,7 @@ import { observable } from "@trpc/server/observable";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { getServiceForWorkspace } from "../workspace-fs-service";
+import { getIgnoredEntries } from "./utils/get-ignored-entries";
 
 function isClosedStreamError(error: unknown): boolean {
 	return (
@@ -39,9 +40,24 @@ export const createFilesystemRouter = () => {
 			)
 			.query(async ({ input }) => {
 				const service = getServiceForWorkspace(input.workspaceId);
-				return await service.listDirectory({
+				const result = await service.listDirectory({
 					absolutePath: input.absolutePath,
 				});
+
+				const ignoredNames = await getIgnoredEntries(
+					input.absolutePath,
+					result.entries.map((entry) => entry.name),
+				);
+
+				// `.git` is always treated as ignored regardless of gitignore
+				// rules so that the git directory and nested submodule git
+				// directories render muted alongside `.gitignore` matches.
+				return {
+					entries: result.entries.map((entry) => ({
+						...entry,
+						isIgnored: entry.name === ".git" || ignoredNames.has(entry.name),
+					})),
+				};
 			}),
 
 		readFile: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import {
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getIgnoredEntries } from "./get-ignored-entries";
+
+const TEST_ROOT = mkdtempSync(
+	join(realpathSync(tmpdir()), "superset-ignored-entries-"),
+);
+
+function makeRepo(name: string): string {
+	const repoPath = join(TEST_ROOT, name);
+	mkdirSync(repoPath, { recursive: true });
+	execSync("git init", { cwd: repoPath, stdio: "ignore" });
+	execSync("git config user.email 'test@example.com'", {
+		cwd: repoPath,
+		stdio: "ignore",
+	});
+	execSync("git config user.name 'Test'", { cwd: repoPath, stdio: "ignore" });
+	return repoPath;
+}
+
+afterAll(() => {
+	rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe("getIgnoredEntries", () => {
+	test("returns empty set for empty input", async () => {
+		const result = await getIgnoredEntries("/tmp", []);
+		expect(result.size).toBe(0);
+	});
+
+	test("flags entries matching .gitignore", async () => {
+		const repo = makeRepo("flags-ignored");
+		writeFileSync(join(repo, ".gitignore"), "node_modules\n*.log\n");
+		mkdirSync(join(repo, "node_modules"));
+		writeFileSync(join(repo, "node_modules", "x.js"), "");
+		writeFileSync(join(repo, "debug.log"), "");
+		writeFileSync(join(repo, "src.ts"), "");
+
+		const result = await getIgnoredEntries(repo, [
+			"node_modules",
+			"debug.log",
+			"src.ts",
+		]);
+		expect(result.has("node_modules")).toBe(true);
+		expect(result.has("debug.log")).toBe(true);
+		expect(result.has("src.ts")).toBe(false);
+	});
+
+	test("does not flag tracked files even if they match a pattern", async () => {
+		const repo = makeRepo("tracked-not-flagged");
+		writeFileSync(join(repo, "keep.log"), "kept");
+		execSync("git add keep.log && git commit -m 'init'", {
+			cwd: repo,
+			stdio: "ignore",
+		});
+		writeFileSync(join(repo, ".gitignore"), "*.log\n");
+
+		const result = await getIgnoredEntries(repo, ["keep.log"]);
+		expect(result.has("keep.log")).toBe(false);
+	});
+
+	test("returns empty set in non-git directory", async () => {
+		const dir = join(TEST_ROOT, "not-a-repo");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "a.txt"), "");
+
+		const result = await getIgnoredEntries(dir, ["a.txt"]);
+		expect(result.size).toBe(0);
+	});
+
+	test("respects nested .gitignore files", async () => {
+		const repo = makeRepo("nested-gitignore");
+		writeFileSync(join(repo, ".gitignore"), "*.tmp\n");
+		mkdirSync(join(repo, "sub"));
+		writeFileSync(join(repo, "sub", ".gitignore"), "secret.txt\n");
+		writeFileSync(join(repo, "sub", "secret.txt"), "");
+		writeFileSync(join(repo, "sub", "shared.tmp"), "");
+		writeFileSync(join(repo, "sub", "kept.md"), "");
+
+		const result = await getIgnoredEntries(join(repo, "sub"), [
+			"secret.txt",
+			"shared.tmp",
+			"kept.md",
+		]);
+		expect(result.has("secret.txt")).toBe(true);
+		expect(result.has("shared.tmp")).toBe(true);
+		expect(result.has("kept.md")).toBe(false);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.test.ts
@@ -77,6 +77,19 @@ describe("getIgnoredEntries", () => {
 		expect(result.size).toBe(0);
 	});
 
+	test("preserves filenames with leading whitespace", async () => {
+		const repo = makeRepo("space-names");
+		// gitignore strips trailing whitespace from patterns unless escaped,
+		// so we only assert leading-space round-trip via NUL-delimited I/O.
+		writeFileSync(join(repo, ".gitignore"), " spaced.log\n");
+		writeFileSync(join(repo, " spaced.log"), "");
+		writeFileSync(join(repo, "normal.log"), "");
+
+		const result = await getIgnoredEntries(repo, [" spaced.log", "normal.log"]);
+		expect(result.has(" spaced.log")).toBe(true);
+		expect(result.has("normal.log")).toBe(false);
+	});
+
 	test("respects nested .gitignore files", async () => {
 		const repo = makeRepo("nested-gitignore");
 		writeFileSync(join(repo, ".gitignore"), "*.tmp\n");

--- a/apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.ts
@@ -1,0 +1,93 @@
+import { spawn } from "node:child_process";
+import { getProcessEnvWithShellPath } from "../../workspaces/utils/shell-env";
+
+const GIT_CHECK_IGNORE_TIMEOUT_MS = 5_000;
+
+/**
+ * Returns the subset of `names` that `git check-ignore` reports as ignored
+ * within `dirAbsolutePath`. Returns an empty set when the directory is not
+ * inside a git work tree, when git is unavailable, or on any other failure —
+ * callers should treat ignored detection as a best-effort signal.
+ *
+ * Tracked files are intentionally NOT reported as ignored (we omit
+ * `--no-index`), matching git's standard semantics.
+ */
+export async function getIgnoredEntries(
+	dirAbsolutePath: string,
+	names: string[],
+): Promise<Set<string>> {
+	if (names.length === 0) {
+		return new Set();
+	}
+
+	let env: NodeJS.ProcessEnv;
+	try {
+		env = await getProcessEnvWithShellPath();
+	} catch {
+		env = process.env;
+	}
+
+	return await new Promise<Set<string>>((resolve) => {
+		let stdout = "";
+		let settled = false;
+		const settle = (value: Set<string>) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeoutId);
+			resolve(value);
+		};
+
+		const child = spawn(
+			"git",
+			["-C", dirAbsolutePath, "check-ignore", "--stdin"],
+			{
+				env,
+				windowsHide: true,
+			},
+		);
+
+		const timeoutId = setTimeout(() => {
+			child.kill();
+			settle(new Set());
+		}, GIT_CHECK_IGNORE_TIMEOUT_MS);
+
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString("utf8");
+		});
+
+		child.stdout.on("error", () => {
+			settle(new Set());
+		});
+
+		child.stdin.on("error", () => {
+			// git exits early when not in a repo; ignore EPIPE so the close
+			// handler can resolve based on exit code.
+		});
+
+		child.on("error", () => {
+			settle(new Set());
+		});
+
+		child.on("close", (code) => {
+			// Exit codes per `git check-ignore`:
+			//   0  — at least one path matched
+			//   1  — no paths matched
+			//  128 — fatal (e.g. not a git repository)
+			if (code === 0) {
+				const matched = stdout
+					.split("\n")
+					.map((line) => line.trim())
+					.filter(Boolean);
+				settle(new Set(matched));
+				return;
+			}
+			settle(new Set());
+		});
+
+		for (const name of names) {
+			if (!child.stdin.writable) break;
+			child.stdin.write(`${name}\n`);
+		}
+		child.stdin.end();
+	});
+}

--- a/apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.ts
@@ -37,9 +37,12 @@ export async function getIgnoredEntries(
 			resolve(value);
 		};
 
+		// `-z` switches both stdin and stdout to NUL-terminated paths,
+		// preserving filenames with leading/trailing spaces or other
+		// characters that line-based parsing would mangle.
 		const child = spawn(
 			"git",
-			["-C", dirAbsolutePath, "check-ignore", "--stdin"],
+			["-C", dirAbsolutePath, "check-ignore", "-z", "--stdin"],
 			{
 				env,
 				windowsHide: true,
@@ -74,10 +77,7 @@ export async function getIgnoredEntries(
 			//   1  — no paths matched
 			//  128 — fatal (e.g. not a git repository)
 			if (code === 0) {
-				const matched = stdout
-					.split("\n")
-					.map((line) => line.trim())
-					.filter(Boolean);
+				const matched = stdout.split("\0").filter(Boolean);
 				settle(new Set(matched));
 				return;
 			}
@@ -86,7 +86,7 @@ export async function getIgnoredEntries(
 
 		for (const name of names) {
 			if (!child.stdin.writable) break;
-			child.stdin.write(`${name}\n`);
+			child.stdin.write(`${name}\0`);
 		}
 		child.stdin.end();
 	});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -221,6 +221,7 @@ export function FilesView() {
 						path: entry.absolutePath,
 						relativePath: getEntryRelativePath(currentPath, entry.absolutePath),
 						isDirectory: entry.kind === "directory",
+						isIgnored: entry.isIgnored ?? false,
 					}));
 					for (const entry of nextEntries) {
 						entryCacheRef.current.set(entry.path, entry);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -59,6 +59,21 @@ function getPathSegmentSeparator(absolutePath: string): string {
 	return absolutePath.includes("\\") ? "\\" : "/";
 }
 
+function getBasename(absolutePath: string): string {
+	const trimmedPath = absolutePath.replace(/[\\/]+$/, "");
+	const lastSeparatorIndex = Math.max(
+		trimmedPath.lastIndexOf("/"),
+		trimmedPath.lastIndexOf("\\"),
+	);
+	return lastSeparatorIndex === -1
+		? trimmedPath
+		: trimmedPath.slice(lastSeparatorIndex + 1);
+}
+
+function affectsIgnoreState(absolutePath: string): boolean {
+	return getBasename(absolutePath) === ".gitignore";
+}
+
 function getParentPath(absolutePath: string): string {
 	const trimmedPath = absolutePath.replace(/[\\/]+$/, "");
 	const lastSeparatorIndex = Math.max(
@@ -290,7 +305,14 @@ export function FilesView() {
 			if (event) {
 				pendingRefreshRef.current.invalidateSearch = true;
 
-				if (event.type === "overflow" || !currentRoot) {
+				// `.gitignore` edits change the `isIgnored` state of every
+				// descendant of the file's directory. The cheapest correct
+				// option is a full refresh — gitignore edits are infrequent.
+				const gitignoreChanged =
+					(event.absolutePath && affectsIgnoreState(event.absolutePath)) ||
+					(event.oldAbsolutePath && affectsIgnoreState(event.oldAbsolutePath));
+
+				if (event.type === "overflow" || !currentRoot || gitignoreChanged) {
 					pendingRefreshRef.current.fullRefresh = true;
 				} else if (
 					event.type === "rename" &&

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -55,6 +55,7 @@ export function FileTreeItem({
 	const isFolder = entry.isDirectory;
 	const isExpanded = item.isExpanded();
 	const level = item.getItemMeta().level;
+	const isIgnored = entry.isIgnored ?? false;
 
 	const parentPath = isFolder
 		? entry.path
@@ -123,6 +124,7 @@ export function FileTreeItem({
 				"flex items-center gap-1 px-1 cursor-pointer select-none",
 				"hover:bg-accent/50 transition-colors",
 				item.isSelected() && "bg-accent",
+				isIgnored && "opacity-50",
 			)}
 			onClick={handleClick}
 			onDoubleClick={handleDoubleClick}

--- a/apps/desktop/src/shared/file-tree-types.ts
+++ b/apps/desktop/src/shared/file-tree-types.ts
@@ -24,4 +24,5 @@ export interface DirectoryEntry {
 	path: string;
 	relativePath: string;
 	isDirectory: boolean;
+	isIgnored?: boolean;
 }


### PR DESCRIPTION
## Description

Adds visual de-emphasis (50% opacity) to entries in the Files View that are
either the `.git` directory or matched by `.gitignore` (and the rest of git's
ignore stack — `.git/info/exclude`, parent `.gitignore` files, global
gitignore).

Implementation follows the path the auto-triage bot suggested on #4293, but
keeps the git logic at the desktop tRPC layer rather than inside the platform-
agnostic `@superset/workspace-fs` package:

1. New util `apps/desktop/src/lib/trpc/routers/filesystem/utils/get-ignored-entries.ts`
   that runs `git -C <dir> check-ignore --stdin` against the entries returned by
   `service.listDirectory`. Errors (non-git workspace, git not on PATH, timeout)
   degrade gracefully to "nothing ignored".
2. The `filesystem.listDirectory` tRPC procedure annotates each entry with
   `isIgnored: boolean`, with `.git` always treated as ignored regardless of
   gitignore rules so submodule git directories also render muted.
3. `DirectoryEntry` (`apps/desktop/src/shared/file-tree-types.ts`) gains an
   optional `isIgnored?: boolean`, threaded through `FilesView.tsx`'s
   `dataLoader` into `FileTreeItem.tsx`, which applies `opacity-50` when set.

Tracked files are intentionally **not** flagged as ignored (we omit
`--no-index`), matching git's standard semantics — gitignore rules don't
apply to files already in the index.

## Related Issues

Closes #4293

## Type of Change

- [x] New feature

## Testing

- New unit tests in `get-ignored-entries.test.ts` cover:
  - empty input
  - entries matched by `.gitignore`
  - tracked files NOT being flagged even if they match a pattern
  - non-git directories returning an empty set
  - nested `.gitignore` files at subdirectory level
- `bun run lint` ✅
- `bun run typecheck` (in `apps/desktop`) ✅
- `bun test src/lib/trpc/routers/filesystem` (in `apps/desktop`) ✅ — 5/5

Manual verification: open a workspace with `node_modules`, `.env`, and `.git`
in the Files View — those entries render at 50% opacity while tracked files
keep full emphasis.

## Screenshots (if applicable)

_Will attach a before/after screenshot of the Files View once a maintainer
spins up the desktop app — happy to add inline if preferred._

## Additional Notes

- `git check-ignore` is invoked once per directory listing with a 5s timeout
  and `--stdin` to avoid `ARG_MAX` issues on large directories.
- A potential follow-up is to skip the git call entirely when descending into
  an already-ignored parent directory (the current implementation always runs
  it, which is correct but slightly wasteful inside `node_modules/foo/bar`).
- The hide-vs-gray-out toggle suggested in #4293 is intentionally deferred —
  default gray-out covers the primary use case and a settings UI is a larger
  scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gray out `.git` and gitignored files in the Files View to reduce visual noise. The view now auto-refreshes on `.gitignore` edits and preserves filenames with leading spaces.

- **New Features**
  - `filesystem.listDirectory` annotates entries with `isIgnored` via `getIgnoredEntries` (runs `git -C <dir> check-ignore -z --stdin`; no-ops in non-git or error cases). `.git` is always ignored; tracked files are not flagged.
  - The file tree applies `opacity-50` to `isIgnored` entries; git logic stays in the desktop tRPC layer (no changes to `@superset/workspace-fs`).

- **Bug Fixes**
  - Files View performs a full refresh when `.gitignore` is created, updated, renamed, or deleted to keep `isIgnored` accurate.
  - Switched to NUL-delimited I/O in `getIgnoredEntries` to correctly handle names with leading spaces.

<sup>Written for commit ccb20b7ec087aee2347b310d2546816c94a6581e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Files and directories matching ignore patterns are now flagged and visually dimmed in the file browser.
  * Directory listings include an ignore-state flag so ignored items are tracked consistently.

* **Improvements**
  * Changes to ignore files trigger a full visible-directory refresh to keep listings up to date.

* **Tests**
  * Added tests covering ignore detection, nested ignore files, tracked vs. ignored entries, and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4294)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->