### PR TITLE
fix(trpc): prevent last-owner removal/demotion race condition via advisory lock

### DIFF
--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -1,5 +1,5 @@
 import { stripeClient } from "@superset/auth/stripe";
-import { db } from "@superset/db/client";
+import { db, dbWs } from "@superset/db/client";
 import { members, organizations } from "@superset/db/schema";
 import {
 	sessions as authSessions,
@@ -16,6 +16,19 @@ import { generateImagePathname, uploadImage } from "../../lib/upload";
 import { jwtProcedure, protectedProcedure, publicProcedure } from "../../trpc";
 import { verifyOrgAdmin } from "../integration/utils";
 import { organizationMembersRouter } from "./members";
+
+type DbWsTransaction = Parameters<Parameters<typeof dbWs.transaction>[0]>[0];
+async function withOwnerMutationLock<T>(
+	organizationId: string,
+	fn: (tx: DbWsTransaction) => Promise<T>,
+): Promise<T> {
+	return dbWs.transaction(async (tx: DbWsTransaction) => {
+		await tx.execute(
+			sql`SELECT pg_advisory_xact_lock(hashtextextended(${organizationId}::text, 0))`,
+		);
+		return fn(tx);
+	});
+}
 
 async function getInvitationById(invitationId: string) {
 	const invitation = await db.query.invitations.findFirst({
@@ -464,13 +477,51 @@ export const organizationRouter = {
 				});
 			}
 
-			await ctx.auth.api.removeMember({
-				body: {
-					organizationId: input.organizationId,
-					memberIdOrEmail: targetMember.id, // Use member ID, not user ID
-				},
-				headers: ctx.headers,
-			});
+			if (targetMember.role === "owner") {
+				await withOwnerMutationLock(input.organizationId, async (tx) => {
+					const targetUnderLock = await tx
+						.select({ role: members.role })
+						.from(members)
+						.where(eq(members.id, targetMember.id))
+						.limit(1);
+
+					// Already removed or demoted by a concurrent request — nothing to do.
+					if (targetUnderLock[0]?.role !== "owner") return;
+
+					const [{ count }] = await tx
+						.select({ count: sql<number>`count(*)::int` })
+						.from(members)
+						.where(
+							and(
+								eq(members.organizationId, input.organizationId),
+								eq(members.role, "owner"),
+							),
+						);
+
+					if (count <= 1) {
+						throw new TRPCError({
+							code: "FORBIDDEN",
+							message: "Cannot remove the last owner. Transfer ownership first.",
+						});
+					}
+
+					await ctx.auth.api.removeMember({
+						body: {
+							organizationId: input.organizationId,
+							memberIdOrEmail: targetMember.id,
+						},
+						headers: ctx.headers,
+					});
+				});
+			} else {
+				await ctx.auth.api.removeMember({
+					body: {
+						organizationId: input.organizationId,
+						memberIdOrEmail: targetMember.id,
+					},
+					headers: ctx.headers,
+				});
+			}
 
 			return { success: true };
 		}),
@@ -496,16 +547,64 @@ export const organizationRouter = {
 				});
 			}
 
-			const leaveResult = await ctx.auth.api.leaveOrganization({
-				body: { organizationId: input.organizationId },
-				headers: ctx.headers,
-			});
+			if (membership.role === "owner") {
+				await withOwnerMutationLock(input.organizationId, async (tx) => {
+					// Re-read under the lock: role may have changed since the initial fetch.
+					const memberUnderLock = await tx
+						.select({ role: members.role })
+						.from(members)
+						.where(
+							and(
+								eq(members.organizationId, input.organizationId),
+								eq(members.userId, ctx.session.user.id),
+							),
+						)
+						.limit(1);
 
-			if (!leaveResult) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "Failed to leave organization",
+					if (memberUnderLock[0]?.role === "owner") {
+						const [{ count }] = await tx
+							.select({ count: sql<number>`count(*)::int` })
+							.from(members)
+							.where(
+								and(
+									eq(members.organizationId, input.organizationId),
+									eq(members.role, "owner"),
+								),
+							);
+
+						if (count <= 1) {
+							throw new TRPCError({
+								code: "FORBIDDEN",
+								message:
+									"Cannot leave as the last owner. Transfer ownership first.",
+							});
+						}
+					}
+
+					const leaveResult = await ctx.auth.api.leaveOrganization({
+						body: { organizationId: input.organizationId },
+						headers: ctx.headers,
+					});
+
+					if (!leaveResult) {
+						throw new TRPCError({
+							code: "INTERNAL_SERVER_ERROR",
+							message: "Failed to leave organization",
+						});
+					}
 				});
+			} else {
+				const leaveResult = await ctx.auth.api.leaveOrganization({
+					body: { organizationId: input.organizationId },
+					headers: ctx.headers,
+				});
+
+				if (!leaveResult) {
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message: "Failed to leave organization",
+					});
+				}
 			}
 
 			const otherMembership = await db.query.members.findFirst({
@@ -566,7 +665,6 @@ export const organizationRouter = {
 
 			const actorRole = actorMembership.role as OrganizationRole;
 			const targetRole = targetMember.role as OrganizationRole;
-			const ownerCount = allMembers.filter((m) => m.role === "owner").length;
 
 			if (actorRole === "admin" && targetRole === "owner") {
 				throw new TRPCError({
@@ -589,25 +687,56 @@ export const organizationRouter = {
 				});
 			}
 
-			if (
-				targetRole === "owner" &&
-				ownerCount === 1 &&
-				input.role !== "owner"
-			) {
-				throw new TRPCError({
-					code: "FORBIDDEN",
-					message: "Cannot demote the last owner. Promote someone else first.",
+			const isDemotingOwner = targetRole === "owner" && input.role !== "owner";
+
+			if (isDemotingOwner) {
+				await withOwnerMutationLock(input.organizationId, async (tx) => {
+					const targetUnderLock = await tx
+						.select({ role: members.role })
+						.from(members)
+						.where(eq(members.id, input.memberId))
+						.limit(1);
+
+					// Re-check under lock in case a concurrent request already demoted them.
+					if (targetUnderLock[0]?.role === "owner") {
+						const [{ count }] = await tx
+							.select({ count: sql<number>`count(*)::int` })
+							.from(members)
+							.where(
+								and(
+									eq(members.organizationId, input.organizationId),
+									eq(members.role, "owner"),
+								),
+							);
+
+						if (count <= 1) {
+							throw new TRPCError({
+								code: "FORBIDDEN",
+								message:
+									"Cannot demote the last owner. Promote someone else first.",
+							});
+						}
+					}
+
+					await ctx.auth.api.updateMemberRole({
+						body: {
+							organizationId: input.organizationId,
+							memberId: input.memberId,
+							role: [input.role],
+						},
+						headers: ctx.headers,
+					});
+				});
+			} else {
+				await ctx.auth.api.updateMemberRole({
+					body: {
+						organizationId: input.organizationId,
+						memberId: input.memberId,
+						role: [input.role],
+					},
+					headers: ctx.headers,
 				});
 			}
-
-			await ctx.auth.api.updateMemberRole({
-				body: {
-					organizationId: input.organizationId,
-					memberId: input.memberId,
-					role: [input.role],
-				},
-				headers: ctx.headers,
-			});
 
 			const updatedMember = await db.query.members.findFirst({
 				where: eq(members.id, input.memberId),


### PR DESCRIPTION
## Problem  
## Solves Issue #4297 

Three organization mutation endpoints — `removeMember`, `leaveOrganization`, and `updateMemberRole` — each checked the owner count **before** performing the destructive operation, but without holding any lock. Two concurrent requests could both pass the count check and then both succeed, leaving the organization with zero owners.

## Solution

Introduce a `withOwnerMutationLock` helper that wraps the critical section in a PostgreSQL advisory transaction lock (`pg_advisory_xact_lock`). The lock key is derived from the organization ID via `hashtextextended`, making it org-scoped so concurrent mutations to **different** orgs are never serialized.

Under the lock, the member's role is re-read from the database before the count check, so a concurrent request that already demoted/removed the member is correctly handled without an error.

### Changes

- **`packages/trpc/src/router/organization/organization.ts`**
  - Import `dbWs` (the write-side Drizzle client) alongside the existing `db`.
  - Add `withOwnerMutationLock<T>(organizationId, fn)` — runs `fn` inside a transaction protected by a per-org advisory lock.
  - `removeMember`: wrap owner-removal path in `withOwnerMutationLock`; re-read role under lock before checking count; non-owners are removed on the fast path (no lock needed).
  - `leaveOrganization`: same pattern — owner path acquires lock and re-reads membership before the count check.
  - `updateMemberRole`: same pattern for demoting an owner — lock acquired only when `isDemotingOwner` is true; re-reads role under lock before count check.
  - Remove the now-redundant pre-lock `ownerCount` variable from `updateMemberRole`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents orgs from losing their last owner during concurrent member changes by guarding owner-sensitive mutations with a per-org PostgreSQL advisory lock. Applies to `removeMember`, `leaveOrganization`, and `updateMemberRole`.

- **Bug Fixes**
  - Add `withOwnerMutationLock(orgId, fn)` using `pg_advisory_xact_lock` in a transaction via `dbWs` from `@superset/db/client`.
  - Re-read membership under the lock before counting owners; block actions that would remove or demote the last owner.
  - Use lock only on owner paths; non-owner paths stay fast.
  - Lock key is derived from org ID, so different orgs don’t block each other.

<sup>Written for commit 75b07eb89b0629ba95a8e3498fc94299d7f15c6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced organization member management to reliably prevent removal or demotion of the last owner during concurrent operations.
  * Improved validation when members leave an organization to ensure the operation succeeds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4296)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->