### PR TITLE
fix(desktop): auto-refresh diff view when external files change

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -323,6 +323,23 @@ export function ChangesView({
 		};
 	}, []);
 
+	// Reset the debounce buffer when the active workspace/worktree changes —
+	// otherwise paths queued for workspace A could be replayed against
+	// workspace B's `worktreePath` after a switch, triggering unnecessary
+	// invalidations in the new workspace.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on workspace change
+	useEffect(() => {
+		if (refreshTimerRef.current) {
+			clearTimeout(refreshTimerRef.current);
+			refreshTimerRef.current = null;
+		}
+		pendingRefreshRef.current = {
+			invalidateBranches: false,
+			invalidateAllDiffs: false,
+			changedAbsolutePaths: new Set<string>(),
+		};
+	}, [workspaceId, worktreePath]);
+
 	useWorkspaceFileEvents(
 		workspaceId ?? "",
 		(event) => {
@@ -384,6 +401,15 @@ export function ChangesView({
 					// the currently-selected one — so the inline diffs in the
 					// expanded `ChangesContent` view also refresh when an
 					// external process (e.g. an AI coding agent) edits a file.
+					//
+					// `oldAbsolutePath` is only threaded through for the selected
+					// file, where the rename's prior path is known. For non-
+					// selected renames it stays `undefined`; this still matches
+					// the cached query because React Query's `stableStringify`
+					// drops `undefined` fields from the cache key, so an entry
+					// stored with a concrete `oldAbsolutePath` is invalidated by
+					// our prefix-only call. `collectEventPaths` already returns
+					// both sides of a rename, so both diffs get refreshed.
 					const renamedSelectedOldPath = selectedFileState?.file.oldPath
 						? toAbsoluteWorkspacePath(
 								worktreePath,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -16,13 +16,8 @@ import {
 import { useBranchSyncInvalidation } from "renderer/screens/main/hooks/useBranchSyncInvalidation";
 import { useGitChangesStatus } from "renderer/screens/main/hooks/useGitChangesStatus";
 import { useChangesStore } from "renderer/stores/changes";
-import {
-	pathsMatch,
-	retargetAbsolutePath,
-	toAbsoluteWorkspacePath,
-} from "shared/absolute-paths";
+import { pathsMatch, toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import type { ChangeCategory, ChangedFile } from "shared/changes-types";
-import type { FileSystemChangeEvent } from "shared/file-tree-types";
 import { sidebarHeaderTabTriggerClassName } from "../headerTabStyles";
 import { CategorySection } from "./components/CategorySection";
 import { ChangesHeader } from "./components/ChangesHeader";
@@ -30,7 +25,11 @@ import { CommitInput } from "./components/CommitInput";
 import { DiscardConfirmDialog } from "./components/DiscardConfirmDialog";
 import { ReviewPanel } from "./components/ReviewPanel";
 import { useOrderedSections } from "./hooks";
-import { getPRActionState, shouldAutoCreatePRAfterPublish } from "./utils";
+import {
+	collectEventPaths,
+	getPRActionState,
+	shouldAutoCreatePRAfterPublish,
+} from "./utils";
 
 interface ChangesViewProps {
 	onFileOpen?: (
@@ -46,36 +45,11 @@ const INACTIVE_BRANCH_REFETCH_INTERVAL_MS = 10_000;
 
 interface PendingChangesRefresh {
 	invalidateBranches: boolean;
-	invalidateSelectedFile: boolean;
+	invalidateAllDiffs: boolean;
+	changedAbsolutePaths: Set<string>;
 }
 
 type ChangesSidebarTab = "diffs" | "review";
-
-function eventTargetsSelectedFile(
-	event: FileSystemChangeEvent,
-	selectedAbsolutePath: string | null,
-): boolean {
-	if (!selectedAbsolutePath) {
-		return false;
-	}
-
-	if (event.type === "overflow") {
-		return true;
-	}
-
-	if (event.type === "rename" && event.absolutePath && event.oldAbsolutePath) {
-		return (
-			retargetAbsolutePath(
-				selectedAbsolutePath,
-				event.oldAbsolutePath,
-				event.absolutePath,
-				Boolean(event.isDirectory),
-			) !== null
-		);
-	}
-
-	return event.absolutePath === selectedAbsolutePath;
-}
 
 export function ChangesView({
 	onFileOpen,
@@ -264,7 +238,8 @@ export function ChangesView({
 	const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const pendingRefreshRef = useRef<PendingChangesRefresh>({
 		invalidateBranches: false,
-		invalidateSelectedFile: false,
+		invalidateAllDiffs: false,
+		changedAbsolutePaths: new Set<string>(),
 	});
 	const {
 		data: githubComments = [],
@@ -355,11 +330,12 @@ export function ChangesView({
 				return;
 			}
 
-			const selectedAbsolutePath = selectedFileState?.absolutePath ?? null;
-			pendingRefreshRef.current.invalidateBranches ||=
-				event.type === "overflow";
-			pendingRefreshRef.current.invalidateSelectedFile ||=
-				eventTargetsSelectedFile(event, selectedAbsolutePath);
+			const collected = collectEventPaths(event);
+			pendingRefreshRef.current.invalidateBranches ||= collected.isOverflow;
+			pendingRefreshRef.current.invalidateAllDiffs ||= collected.isOverflow;
+			for (const changedPath of collected.paths) {
+				pendingRefreshRef.current.changedAbsolutePaths.add(changedPath);
+			}
 
 			if (refreshTimerRef.current) {
 				clearTimeout(refreshTimerRef.current);
@@ -370,7 +346,8 @@ export function ChangesView({
 				const pending = pendingRefreshRef.current;
 				pendingRefreshRef.current = {
 					invalidateBranches: false,
-					invalidateSelectedFile: false,
+					invalidateAllDiffs: false,
+					changedAbsolutePaths: new Set<string>(),
 				};
 
 				const invalidations: Promise<unknown>[] = [
@@ -386,32 +363,61 @@ export function ChangesView({
 					);
 				}
 
-				if (pending.invalidateSelectedFile && selectedFileState) {
-					const oldAbsPath = selectedFileState.file.oldPath
+				if (pending.invalidateAllDiffs) {
+					// Watcher overflowed — we don't know which files changed, so
+					// invalidate every diff query for this worktree. tRPC's
+					// invalidator matches on input prefix, so omitting
+					// `absolutePath` clears all per-file entries.
+					invalidations.push(
+						trpcUtils.changes.getGitFileContents.invalidate({ worktreePath }),
+						trpcUtils.changes.getGitOriginalContent.invalidate({
+							worktreePath,
+						}),
+					);
+					if (workspaceId) {
+						invalidations.push(
+							trpcUtils.filesystem.readFile.invalidate({ workspaceId }),
+						);
+					}
+				} else {
+					// Invalidate diff queries for every changed file — not just
+					// the currently-selected one — so the inline diffs in the
+					// expanded `ChangesContent` view also refresh when an
+					// external process (e.g. an AI coding agent) edits a file.
+					const renamedSelectedOldPath = selectedFileState?.file.oldPath
 						? toAbsoluteWorkspacePath(
 								worktreePath,
 								selectedFileState.file.oldPath,
 							)
 						: undefined;
-					invalidations.push(
-						trpcUtils.changes.getGitFileContents.invalidate({
-							worktreePath,
-							absolutePath: selectedFileState.absolutePath,
-							oldAbsolutePath: oldAbsPath,
-						}),
-						trpcUtils.changes.getGitOriginalContent.invalidate({
-							worktreePath,
-							absolutePath: selectedFileState.absolutePath,
-							oldAbsolutePath: oldAbsPath,
-						}),
-					);
-					if (workspaceId) {
+
+					for (const changedPath of pending.changedAbsolutePaths) {
+						const oldAbsolutePath =
+							selectedFileState?.absolutePath &&
+							pathsMatch(selectedFileState.absolutePath, changedPath)
+								? renamedSelectedOldPath
+								: undefined;
+
 						invalidations.push(
-							trpcUtils.filesystem.readFile.invalidate({
-								workspaceId,
-								absolutePath: selectedFileState.absolutePath,
+							trpcUtils.changes.getGitFileContents.invalidate({
+								worktreePath,
+								absolutePath: changedPath,
+								oldAbsolutePath,
+							}),
+							trpcUtils.changes.getGitOriginalContent.invalidate({
+								worktreePath,
+								absolutePath: changedPath,
+								oldAbsolutePath,
 							}),
 						);
+						if (workspaceId) {
+							invalidations.push(
+								trpcUtils.filesystem.readFile.invalidate({
+									workspaceId,
+									absolutePath: changedPath,
+								}),
+							);
+						}
 					}
 				}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/collect-event-paths.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/collect-event-paths.test.ts
@@ -74,4 +74,12 @@ describe("collectEventPaths", () => {
 		expect(result.isOverflow).toBe(false);
 		expect(result.paths).toEqual(["/ws/src/gone.ts"]);
 	});
+
+	test("supports create events", () => {
+		const result = collectEventPaths(
+			makeEvent({ type: "create", absolutePath: "/ws/src/new.ts" }),
+		);
+		expect(result.isOverflow).toBe(false);
+		expect(result.paths).toEqual(["/ws/src/new.ts"]);
+	});
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/collect-event-paths.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/collect-event-paths.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import type { FileSystemChangeEvent } from "shared/file-tree-types";
+import { collectEventPaths } from "./collect-event-paths";
+
+function makeEvent(
+	overrides: Partial<FileSystemChangeEvent> = {},
+): FileSystemChangeEvent {
+	return { type: "update", revision: 0, ...overrides };
+}
+
+describe("collectEventPaths", () => {
+	test("returns isOverflow for overflow events without paths", () => {
+		const result = collectEventPaths(makeEvent({ type: "overflow" }));
+		expect(result.isOverflow).toBe(true);
+		expect(result.paths).toEqual([]);
+	});
+
+	test("returns the absolute path for an update event", () => {
+		const result = collectEventPaths(
+			makeEvent({ type: "update", absolutePath: "/ws/src/file.ts" }),
+		);
+		expect(result.isOverflow).toBe(false);
+		expect(result.paths).toEqual(["/ws/src/file.ts"]);
+	});
+
+	test("returns both old and new paths for rename events", () => {
+		const result = collectEventPaths(
+			makeEvent({
+				type: "rename",
+				absolutePath: "/ws/src/new.ts",
+				oldAbsolutePath: "/ws/src/old.ts",
+			}),
+		);
+		expect(result.isOverflow).toBe(false);
+		expect(result.paths.sort()).toEqual(
+			["/ws/src/new.ts", "/ws/src/old.ts"].sort(),
+		);
+	});
+
+	test("does not duplicate when rename event reports the same old and new path", () => {
+		const result = collectEventPaths(
+			makeEvent({
+				type: "rename",
+				absolutePath: "/ws/src/file.ts",
+				oldAbsolutePath: "/ws/src/file.ts",
+			}),
+		);
+		expect(result.paths).toEqual(["/ws/src/file.ts"]);
+	});
+
+	test("returns empty paths when create/update event has no absolutePath", () => {
+		const result = collectEventPaths(
+			makeEvent({ type: "update", absolutePath: undefined }),
+		);
+		expect(result.isOverflow).toBe(false);
+		expect(result.paths).toEqual([]);
+	});
+
+	test("returns the old path even if the new path is missing", () => {
+		const result = collectEventPaths(
+			makeEvent({
+				type: "rename",
+				absolutePath: undefined,
+				oldAbsolutePath: "/ws/src/old.ts",
+			}),
+		);
+		expect(result.paths).toEqual(["/ws/src/old.ts"]);
+	});
+
+	test("supports delete events", () => {
+		const result = collectEventPaths(
+			makeEvent({ type: "delete", absolutePath: "/ws/src/gone.ts" }),
+		);
+		expect(result.isOverflow).toBe(false);
+		expect(result.paths).toEqual(["/ws/src/gone.ts"]);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/collect-event-paths.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/collect-event-paths.ts
@@ -1,0 +1,45 @@
+import type { FileSystemChangeEvent } from "shared/file-tree-types";
+
+export interface CollectedEventPaths {
+	/**
+	 * Specific absolute paths affected by the event. Empty when the event is
+	 * an `overflow` (watcher lost track) — callers should fall back to a
+	 * worktree-wide invalidation in that case.
+	 */
+	paths: string[];
+	/**
+	 * True when the event is `overflow`, signalling the watcher lost track of
+	 * one or more changes. Callers should invalidate every diff query for the
+	 * affected worktree because the specific paths are unknown.
+	 */
+	isOverflow: boolean;
+}
+
+/**
+ * Extracts the absolute paths affected by a file system event so callers can
+ * invalidate cached queries keyed by `absolutePath`.
+ *
+ * For renames both the old and new path are returned because consumers may
+ * have queries keyed by either side (e.g. inline diffs of a renamed file).
+ */
+export function collectEventPaths(
+	event: FileSystemChangeEvent,
+): CollectedEventPaths {
+	if (event.type === "overflow") {
+		return { paths: [], isOverflow: true };
+	}
+
+	const paths: string[] = [];
+	if (event.absolutePath) {
+		paths.push(event.absolutePath);
+	}
+	if (
+		event.type === "rename" &&
+		event.oldAbsolutePath &&
+		event.oldAbsolutePath !== event.absolutePath
+	) {
+		paths.push(event.oldAbsolutePath);
+	}
+
+	return { paths, isOverflow: false };
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/index.ts
@@ -1,4 +1,5 @@
 export { shouldAutoCreatePRAfterPublish } from "./auto-create-pr-after-publish";
+export { collectEventPaths } from "./collect-event-paths";
 export { formatRelativeDate } from "./date";
 export { getPRActionState } from "./pr-action-state";
 export { getStatusColor, getStatusIndicator } from "./status";


### PR DESCRIPTION
## Description

The Changes view only invalidated diff content queries for the
*currently-selected* file when a file system event arrived. Inline diffs in
the expanded \`ChangesContent\` view (\`FileDiffSection\` for each changed
file) therefore never refreshed when an external process — typically an AI
coding agent — edited those files. Users had to close and reopen each diff
to see the new state, defeating real-time review of agent edits.

**Fix:**

1. Track every changed absolute path in the existing 75 ms debounce buffer
   instead of a single \`invalidateSelectedFile\` flag.
2. Invalidate the three diff-content queries (\`changes.getGitFileContents\`,
   \`changes.getGitOriginalContent\`, \`filesystem.readFile\`) for each
   changed path so every visible inline diff refreshes, not just the
   selected one.
3. On \`overflow\` events (watcher lost track), invalidate all diff queries
   for the worktree by omitting the \`absolutePath\` filter — this matches
   every per-file entry under the \`worktreePath\` prefix.
4. Extract event-path collection into a small \`collectEventPaths\` util
   (with rename-aware old/new path expansion) and cover it with unit tests.

## Related Issues

Closes #2753

PRs #2754 and #2755 previously proposed similar fixes but were closed by a
maintainer in the 2026-05-06 stale-PR audit (\"re-attempt from a fresh
branch if a fix is still wanted\"). This change adapts the same approach to
the current codebase, scoped tighter (no \`pathsMatch\` rewrite of
\`eventTargetsSelectedFile\` — that helper is removed entirely since we now
react to *all* changed paths regardless of selection).

## Type of Change

- [x] Bug fix

## Testing

- New unit tests for \`collectEventPaths\` (7 cases — overflow, update,
  rename old+new, no-op rename, missing absolutePath, delete events).
- \`bun run lint\` ✅
- \`bun run typecheck\` (in \`apps/desktop\`) ✅
- \`bun test src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView\` ✅ — 29 pass

Manual verification (recommended for the reviewer):

1. Open a workspace with several uncommitted changes.
2. Expand the inline diff view for two or more files.
3. From a terminal or AI agent, edit one of the files that is **not**
   the currently-selected one in the sidebar.
4. The corresponding inline diff should refresh within ~75 ms without any
   user action.
5. Repeat with a rapid sequence of edits across multiple files to confirm
   the debounce batches them correctly.

## Screenshots (if applicable)

_No UI changes; only invalidation behavior. Hard to screenshot a
non-stale diff — manual verification covers it._

## Additional Notes

- I considered porting solomon23's \`eventTargetsFile\` + \`pathsMatch\`
  refactor from #2755 but kept the diff smaller: now that we invalidate
  *all* changed paths (not just the selected one), the path-comparison
  helper isn't on the hot path. tRPC's invalidator already matches
  by structural input equality.
- The \`invalidateBranches\` flag stays gated on \`overflow\` events,
  preserving the existing \`getBranches\` refetch policy.
- Disclosure: I am the same contributor who recently filed #4293 and
  PR #4294 against the desktop Files View. Let me know if a different
  approach (e.g. moving invalidation into \`ChangesContent\` itself, à la
  #2754) is preferred and I can rework.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-refreshes inline diffs in the Changes view when external edits occur by tracking all changed paths and invalidating their diff queries, with a worktree-wide fallback on watcher overflow. Also clears the debounce buffer on workspace/worktree switches to prevent cross-workspace invalidations (closes #2753).

- **Bug Fixes**
  - Track every changed absolute path in the 75 ms debounce window.
  - Invalidate `changes.getGitFileContents`, `changes.getGitOriginalContent`, and `filesystem.readFile` per changed path; on overflow, invalidate all diff queries for the worktree.
  - Reset the pending refresh buffer and timer on `[workspaceId, worktreePath]` change.
  - Add `collectEventPaths` (rename-aware old/new path expansion) with unit tests, including create events.

<sup>Written for commit 1ed4beb9528685c2955a6b8815552eb1b3f55fae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changes view now uses path-based tracking for filesystem changes, improving accuracy for renames, creates, updates, and deletes and avoiding stale pending-change state across workspaces.
  * Better handling of overflow events to ensure full refresh when needed.

* **Tests**
  * Added unit tests covering event-path collection and edge cases (rename, overflow, missing paths).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4298)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->