### PR TITLE
fix(desktop): stabilize workspace create and delete navigation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -35,7 +35,8 @@ export function useDestroyDialogState({
 }: UseDestroyDialogStateOptions) {
 	const { destroy, inspect, hostTarget } = useDestroyWorkspace(workspaceId);
 	const { markDeleting, clearDeleting } = useDeletingWorkspaces();
-	const navigateAway = useNavigateAwayFromWorkspace();
+	const { getNavigationTargetAfterRemoval, navigateToRemovalTarget } =
+		useNavigateAwayFromWorkspace();
 
 	const { preferences, setDeleteLocalBranch: setDeleteBranch } =
 		useV2UserPreferences();
@@ -110,9 +111,7 @@ export function useDestroyDialogState({
 			if (inFlight.current) return;
 			inFlight.current = true;
 
-			// Navigate off the doomed workspace FIRST. Closing the dialog
-			// and hiding the row were swallowing the nav otherwise.
-			navigateAway(workspaceId);
+			const navigationTarget = getNavigationTargetAfterRemoval(workspaceId);
 
 			setError(null);
 			onOpenChange(false);
@@ -138,6 +137,7 @@ export function useDestroyDialogState({
 					}
 				}
 				for (const warning of result.warnings) toast.warning(warning);
+				navigateToRemovalTarget(navigationTarget);
 				onDeleted?.();
 			} catch (err) {
 				const e = err as DestroyWorkspaceError;
@@ -165,7 +165,8 @@ export function useDestroyDialogState({
 			onDeleted,
 			markDeleting,
 			clearDeleting,
-			navigateAway,
+			getNavigationTargetAfterRemoval,
+			navigateToRemovalTarget,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -31,7 +31,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
-	const navigateAway = useNavigateAwayFromWorkspace();
+	const { navigateAwayFromWorkspace } = useNavigateAwayFromWorkspace();
 	const { activeHostUrl } = useLocalHostService();
 	const { copyToClipboard } = useCopyToClipboard();
 	const { v2Workspaces: workspaceActions } = useOptimisticCollectionActions();
@@ -89,7 +89,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleRemoveFromSidebar = () => {
-		navigateAway(workspaceId);
+		navigateAwayFromWorkspace(workspaceId);
 		if (isMainWorkspace) {
 			hideWorkspaceInSidebar(workspaceId, projectId);
 			return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/navigationTarget.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/navigationTarget.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { resolveWorkspaceRemovalNavigationTarget } from "./navigationTarget";
+
+describe("resolveWorkspaceRemovalNavigationTarget", () => {
+	test("does nothing when the removed workspace is not active", () => {
+		expect(
+			resolveWorkspaceRemovalNavigationTarget({
+				activeWorkspaceId: "workspace-a",
+				removedWorkspaceId: "workspace-b",
+				orderedWorkspaceIds: ["workspace-a", "workspace-b"],
+			}),
+		).toBeNull();
+	});
+
+	test("chooses the next workspace in sidebar order", () => {
+		expect(
+			resolveWorkspaceRemovalNavigationTarget({
+				activeWorkspaceId: "workspace-b",
+				removedWorkspaceId: "workspace-b",
+				orderedWorkspaceIds: ["workspace-a", "workspace-b", "workspace-c"],
+			}),
+		).toEqual({ kind: "workspace", workspaceId: "workspace-c" });
+	});
+
+	test("falls back to the previous workspace at the end of the list", () => {
+		expect(
+			resolveWorkspaceRemovalNavigationTarget({
+				activeWorkspaceId: "workspace-c",
+				removedWorkspaceId: "workspace-c",
+				orderedWorkspaceIds: ["workspace-a", "workspace-b", "workspace-c"],
+			}),
+		).toEqual({ kind: "workspace", workspaceId: "workspace-b" });
+	});
+
+	test("skips stale and deleting workspaces", () => {
+		expect(
+			resolveWorkspaceRemovalNavigationTarget({
+				activeWorkspaceId: "workspace-a",
+				removedWorkspaceId: "workspace-a",
+				orderedWorkspaceIds: [
+					"workspace-a",
+					"stale-workspace",
+					"deleting-workspace",
+					"workspace-b",
+				],
+				isWorkspaceValid: (workspaceId) => workspaceId !== "stale-workspace",
+				isWorkspaceDeleting: (workspaceId) =>
+					workspaceId === "deleting-workspace",
+			}),
+		).toEqual({ kind: "workspace", workspaceId: "workspace-b" });
+	});
+
+	test("uses the first valid workspace when the removed id is no longer ordered", () => {
+		expect(
+			resolveWorkspaceRemovalNavigationTarget({
+				activeWorkspaceId: "workspace-a",
+				removedWorkspaceId: "workspace-a",
+				orderedWorkspaceIds: ["stale-workspace", "workspace-b"],
+				isWorkspaceValid: (workspaceId) => workspaceId !== "stale-workspace",
+			}),
+		).toEqual({ kind: "workspace", workspaceId: "workspace-b" });
+	});
+
+	test("falls back home when no valid workspace remains", () => {
+		expect(
+			resolveWorkspaceRemovalNavigationTarget({
+				activeWorkspaceId: "workspace-a",
+				removedWorkspaceId: "workspace-a",
+				orderedWorkspaceIds: ["workspace-a", "stale-workspace"],
+				isWorkspaceValid: (workspaceId) => workspaceId !== "stale-workspace",
+			}),
+		).toEqual({ kind: "home" });
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/navigationTarget.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/navigationTarget.ts
@@ -1,0 +1,38 @@
+import { getActiveIdAfterRemoval } from "@superset/panes";
+
+export type WorkspaceRemovalNavigationTarget =
+	| { kind: "workspace"; workspaceId: string }
+	| { kind: "home" };
+
+interface ResolveWorkspaceRemovalNavigationTargetArgs {
+	activeWorkspaceId: string | null | undefined;
+	removedWorkspaceId: string;
+	orderedWorkspaceIds: readonly string[];
+	isWorkspaceValid?: (workspaceId: string) => boolean;
+	isWorkspaceDeleting?: (workspaceId: string) => boolean;
+}
+
+export function resolveWorkspaceRemovalNavigationTarget({
+	activeWorkspaceId,
+	removedWorkspaceId,
+	orderedWorkspaceIds,
+	isWorkspaceValid = () => true,
+	isWorkspaceDeleting = () => false,
+}: ResolveWorkspaceRemovalNavigationTargetArgs): WorkspaceRemovalNavigationTarget | null {
+	if (activeWorkspaceId !== removedWorkspaceId) return null;
+
+	const navigableIds = orderedWorkspaceIds.filter(
+		(workspaceId) =>
+			workspaceId === removedWorkspaceId ||
+			(isWorkspaceValid(workspaceId) && !isWorkspaceDeleting(workspaceId)),
+	);
+	const nextWorkspaceId = getActiveIdAfterRemoval(
+		navigableIds,
+		removedWorkspaceId,
+		removedWorkspaceId,
+	);
+
+	return nextWorkspaceId
+		? { kind: "workspace", workspaceId: nextWorkspaceId }
+		: { kind: "home" };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
@@ -1,33 +1,78 @@
-import { getActiveIdAfterRemoval } from "@superset/panes";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 import { getFlattenedV2WorkspaceIds } from "../../utils/getFlattenedV2WorkspaceIds";
+import {
+	resolveWorkspaceRemovalNavigationTarget,
+	type WorkspaceRemovalNavigationTarget,
+} from "./navigationTarget";
+
+function reportRemovalNavigationError(error: unknown) {
+	console.error("[useNavigateAwayFromWorkspace] navigation failed", error);
+}
 
 /**
- * If the user is viewing the workspace about to be removed, jump to the
- * next visible sidebar sibling (or home). No-op otherwise. Called
- * directly at the callsite — not via a callback prop — because
- * plumbing this through dialog onDeleting was silently dropping the nav.
+ * If the user is viewing the workspace about to be removed, resolve a
+ * valid next visible workspace sibling (or home). Destructive deletes use
+ * the resolver after `workspaceCleanup.destroy` succeeds; non-destructive
+ * sidebar removals can navigate immediately.
  */
 export function useNavigateAwayFromWorkspace() {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
 	const collections = useCollections();
+	const { isDeleting } = useDeletingWorkspaces();
 
-	return (workspaceId: string) => {
-		const isViewingWorkspace = !!matchRoute({
-			to: "/v2-workspace/$workspaceId",
-			params: { workspaceId },
-			fuzzy: true,
-		});
-		if (!isViewingWorkspace) return;
-		const ids = getFlattenedV2WorkspaceIds(collections);
-		const next = getActiveIdAfterRemoval(ids, workspaceId, workspaceId);
-		if (next) {
-			void navigateToV2Workspace(next, navigate);
-		} else {
-			void navigate({ to: "/" });
-		}
+	const getNavigationTargetAfterRemoval = useCallback(
+		(workspaceId: string): WorkspaceRemovalNavigationTarget | null => {
+			const workspaceMatch = matchRoute({
+				to: "/v2-workspace/$workspaceId",
+				fuzzy: true,
+			});
+			const activeWorkspaceId =
+				workspaceMatch !== false ? workspaceMatch.workspaceId : null;
+			const orderedWorkspaceIds = getFlattenedV2WorkspaceIds(collections);
+
+			return resolveWorkspaceRemovalNavigationTarget({
+				activeWorkspaceId,
+				removedWorkspaceId: workspaceId,
+				orderedWorkspaceIds,
+				isWorkspaceValid: (id) =>
+					collections.v2Workspaces.get(id) !== undefined,
+				isWorkspaceDeleting: (id) => isDeleting(id),
+			});
+		},
+		[collections, isDeleting, matchRoute],
+	);
+
+	const navigateToRemovalTarget = useCallback(
+		(target: WorkspaceRemovalNavigationTarget | null) => {
+			if (!target) return;
+			if (target.kind === "workspace") {
+				void navigateToV2Workspace(target.workspaceId, navigate, {
+					replace: true,
+				}).catch(reportRemovalNavigationError);
+				return;
+			}
+			void navigate({ to: "/", replace: true }).catch(
+				reportRemovalNavigationError,
+			);
+		},
+		[navigate],
+	);
+
+	const navigateAwayFromWorkspace = useCallback(
+		(workspaceId: string) => {
+			navigateToRemovalTarget(getNavigationTargetAfterRemoval(workspaceId));
+		},
+		[getNavigationTargetAfterRemoval, navigateToRemovalTarget],
+	);
+
+	return {
+		getNavigationTargetAfterRemoval,
+		navigateAwayFromWorkspace,
+		navigateToRemovalTarget,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -1,5 +1,5 @@
 import { toast } from "@superset/ui/sonner";
-import { useNavigate } from "@tanstack/react-router";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { authClient } from "renderer/lib/auth-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -23,6 +23,7 @@ export function useSubmitWorkspace(
 	promptContext: NewWorkspacePromptContextApi,
 ) {
 	const navigate = useNavigate();
+	const matchRoute = useMatchRoute();
 	const { closeAndResetDraft, draft } = useDashboardNewWorkspaceDraft();
 	const { submit } = useWorkspaceCreates();
 	const { machineId } = useLocalHostService();
@@ -113,12 +114,57 @@ export function useSubmitWorkspace(
 		};
 
 		closeAndResetDraft();
-		void navigate({ to: `/v2-workspace/${workspaceId}` as string });
-		void submit({ hostId, snapshot });
+		void navigate({
+			to: "/v2-workspace/$workspaceId",
+			params: { workspaceId },
+		}).catch((error) => {
+			console.error("[useSubmitWorkspace] failed to open workspace", error);
+		});
+
+		const isViewingOptimisticWorkspace = () => {
+			const workspaceMatch = matchRoute({
+				to: "/v2-workspace/$workspaceId",
+			});
+			return (
+				workspaceMatch !== false && workspaceMatch.workspaceId === workspaceId
+			);
+		};
+
+		void submit({ hostId, snapshot })
+			.then((result) => {
+				if (!result.ok) {
+					if (isViewingOptimisticWorkspace()) {
+						toast.error("Workspace creation failed");
+					}
+					return;
+				}
+				if (result.workspaceId === workspaceId) return;
+				if (!isViewingOptimisticWorkspace()) return;
+				void navigate({
+					to: "/v2-workspace/$workspaceId",
+					params: { workspaceId: result.workspaceId },
+					replace: true,
+				}).catch((error) => {
+					console.error(
+						"[useSubmitWorkspace] failed to redirect workspace",
+						error,
+					);
+				});
+			})
+			.catch((error) => {
+				console.error(
+					"[useSubmitWorkspace] workspace creation failed unexpectedly",
+					error,
+				);
+				if (isViewingOptimisticWorkspace()) {
+					toast.error("Workspace creation failed");
+				}
+			});
 	}, [
 		activeOrganizationId,
 		closeAndResetDraft,
 		draft,
+		matchRoute,
 		machineId,
 		navigate,
 		projectId,


### PR DESCRIPTION
## Summary
- Redirect PR workspace creation from the optimistic UUID to the canonical workspace id returned by `workspaces.create`.
- Move destructive delete navigation until after `workspaceCleanup.destroy` succeeds.
- Resolve delete fallback navigation from valid visible workspaces, skipping stale local rows and workspaces already being deleted.
- Include auto-visible local main workspaces in the delete fallback order and add regression coverage.

## Root Cause
The create modal navigated immediately to a locally generated workspace id even when the host returned an existing canonical workspace id. The delete flow also navigated before destroy completed and chose candidates from local sidebar state alone, which could include rows that were not backed by a live `v2Workspaces` record.

## Validation
- `bun run lint:fix`
- `bun run lint`
- `bun test apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/navigationTarget.test.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/getFlattenedV2WorkspaceIds.test.ts`
- `bun run typecheck --filter=@superset/desktop`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes workspace navigation during create and delete to prevent flicker and wrong routes. On delete, we resolve the next target first, then navigate with history replace only after cleanup succeeds.

- **Bug Fixes**
  - Creation: redirect from the optimistic id to the canonical id returned by `workspaces.create` (history replace); show an error toast if creation fails while viewing the optimistic workspace.
  - Deletion: compute the target via `getNavigationTargetAfterRemoval`, then call `navigateToRemovalTarget` after `workspaceCleanup.destroy` succeeds; skip stale and deleting rows, fall back to home (history replace).
  - Navigation hook: `useNavigateAwayFromWorkspace` now exposes `getNavigationTargetAfterRemoval`, `navigateToRemovalTarget`, and `navigateAwayFromWorkspace`; target resolution is in `resolveWorkspaceRemovalNavigationTarget` (uses `@superset/panes`); sidebar “remove” uses `navigateAwayFromWorkspace` immediately.
  - Sidebar order: include auto-visible local main workspaces for the active machine; ignore hidden ones.
  - Tests: added coverage for removal target resolution and flattened workspace ordering.

<sup>Written for commit 0fe1ba3cacd7fc022954672cf248fd7f531b5836. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved workspace-removal navigation so deleting a workspace reliably navigates to the next valid workspace (or home) and centralizes navigation behavior.
  * Tightened workspace creation flow so post-submit navigation, error reporting, and conditional redirects/toasts occur only when the optimistic workspace route is active.

* **Tests**
  * Added tests covering workspace-removal navigation scenarios, including wrapping, skipping invalid/deleting workspaces, and fallback to home.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4316)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->