### PR TITLE
style(desktop): show workspace + branch in v2 top bar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -13,6 +13,7 @@ import { ResourceConsumption } from "./components/ResourceConsumption";
 import { RightSidebarToggle } from "./components/RightSidebarToggle";
 import { SearchBarTrigger } from "./components/SearchBarTrigger";
 import { V2WorkspaceOpenInButton } from "./components/V2WorkspaceOpenInButton";
+import { V2WorkspaceTitle } from "./components/V2WorkspaceTitle";
 import { WindowControls } from "./components/WindowControls";
 
 export function TopBar() {
@@ -57,6 +58,12 @@ export function TopBar() {
 					</>
 				)}
 				{!isV2CloudEnabled && <ResourceConsumption />}
+			</div>
+
+			<div className="flex min-w-0 flex-1 items-center justify-start">
+				{isV2WorkspaceRoute && v2WorkspaceId && (
+					<V2WorkspaceTitle workspaceId={v2WorkspaceId} />
+				)}
 			</div>
 
 			{!isV2WorkspaceRoute && workspaceId && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2OpenInMenuButton/V2OpenInMenuButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2OpenInMenuButton/V2OpenInMenuButton.tsx
@@ -5,6 +5,7 @@ import {
 	DropdownMenuShortcut,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { OverflowFadeText } from "@superset/ui/overflow-fade-text";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
@@ -108,13 +109,13 @@ export function V2OpenInMenuButton({
 							/>
 						)}
 						{branch && (
-							<span className="hidden lg:inline text-muted-foreground truncate max-w-[140px] tabular-nums">
+							<OverflowFadeText
+								className="hidden lg:inline-block max-w-[140px] text-muted-foreground tabular-nums"
+								title={branch}
+							>
 								/{branch}
-							</span>
+							</OverflowFadeText>
 						)}
-						<span className="hidden sm:inline text-foreground font-medium">
-							Open
-						</span>
 					</button>
 				</TooltipTrigger>
 				<TooltipContent side="bottom" sideOffset={6}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceTitle/V2WorkspaceTitle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceTitle/V2WorkspaceTitle.tsx
@@ -1,0 +1,79 @@
+import { OverflowFadeText } from "@superset/ui/overflow-fade-text";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { GitBranch } from "lucide-react";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useWorkspaceCreatesStore } from "renderer/stores/workspace-creates";
+
+interface V2WorkspaceTitleProps {
+	workspaceId: string;
+}
+
+export function V2WorkspaceTitle({ workspaceId }: V2WorkspaceTitleProps) {
+	const collections = useCollections();
+	const { data: workspaces = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ workspaces: collections.v2Workspaces })
+				.where(({ workspaces }) => eq(workspaces.id, workspaceId))
+				.select(({ workspaces }) => ({
+					name: workspaces.name,
+					branch: workspaces.branch,
+				})),
+		[collections, workspaceId],
+	);
+	const syncedWorkspace = workspaces[0] ?? null;
+	const inFlight = useWorkspaceCreatesStore((store) =>
+		store.entries.find((entry) => entry.snapshot.id === workspaceId),
+	);
+	const name =
+		syncedWorkspace?.name ??
+		inFlight?.cloudRow?.name ??
+		inFlight?.snapshot.name ??
+		null;
+	const branch =
+		syncedWorkspace?.branch ??
+		inFlight?.cloudRow?.branch ??
+		inFlight?.snapshot.branch ??
+		null;
+
+	if (!name && !branch) {
+		return null;
+	}
+
+	return (
+		<div className="flex min-w-0 max-w-full items-center gap-1.5">
+			{name && (
+				<OverflowFadeText
+					className="text-[13px] font-medium text-foreground tracking-tight"
+					title={name}
+				>
+					{name}
+				</OverflowFadeText>
+			)}
+			{name && branch && (
+				<span
+					className="shrink-0 text-muted-foreground/50 text-xs select-none"
+					aria-hidden="true"
+				>
+					/
+				</span>
+			)}
+			{branch && (
+				<span
+					className="flex min-w-0 items-center gap-1 rounded-md bg-muted/60 px-1.5 py-0.5 text-muted-foreground ring-1 ring-inset ring-border/50"
+					title={branch}
+				>
+					<GitBranch
+						className="size-3 shrink-0 opacity-70"
+						strokeWidth={2}
+						aria-hidden="true"
+					/>
+					<OverflowFadeText className="font-mono text-[11px] leading-none tracking-tight">
+						{branch}
+					</OverflowFadeText>
+				</span>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceTitle/V2WorkspaceTitle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceTitle/V2WorkspaceTitle.tsx
@@ -1,7 +1,7 @@
 import { OverflowFadeText } from "@superset/ui/overflow-fade-text";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { GitBranch } from "lucide-react";
+import { ChevronRight, GitBranch } from "lucide-react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useWorkspaceCreatesStore } from "renderer/stores/workspace-creates";
 
@@ -42,26 +42,22 @@ export function V2WorkspaceTitle({ workspaceId }: V2WorkspaceTitleProps) {
 	}
 
 	return (
-		<div className="flex min-w-0 max-w-full items-center gap-1.5">
+		<div className="flex min-w-0 max-w-full items-center gap-1.5 text-[13px] tracking-tight">
 			{name && (
-				<OverflowFadeText
-					className="text-[13px] font-medium text-foreground tracking-tight"
-					title={name}
-				>
+				<OverflowFadeText className="font-medium text-foreground" title={name}>
 					{name}
 				</OverflowFadeText>
 			)}
 			{name && branch && (
-				<span
-					className="shrink-0 text-muted-foreground/50 text-xs select-none"
+				<ChevronRight
+					className="size-3 shrink-0 text-muted-foreground/40"
+					strokeWidth={2}
 					aria-hidden="true"
-				>
-					/
-				</span>
+				/>
 			)}
 			{branch && (
 				<span
-					className="flex min-w-0 items-center gap-1 rounded-md bg-muted/60 px-1.5 py-0.5 text-muted-foreground ring-1 ring-inset ring-border/50"
+					className="flex min-w-0 items-center gap-1 text-muted-foreground"
 					title={branch}
 				>
 					<GitBranch
@@ -69,9 +65,7 @@ export function V2WorkspaceTitle({ workspaceId }: V2WorkspaceTitleProps) {
 						strokeWidth={2}
 						aria-hidden="true"
 					/>
-					<OverflowFadeText className="font-mono text-[11px] leading-none tracking-tight">
-						{branch}
-					</OverflowFadeText>
+					<OverflowFadeText>{branch}</OverflowFadeText>
 				</span>
 			)}
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceTitle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceTitle/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspaceTitle } from "./V2WorkspaceTitle";

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.5",
+      "version": "1.8.8",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Add a workspace title to the v2 top bar that shows `<workspace name> › ⎇ <branch>` aligned to the start, so users always know which workspace/branch they are in without opening a menu.
- Style it as a flat Linear-style breadcrumb (no pill/ring, single 13px size, chevron separator) and use the existing `OverflowFadeText` so long names/branches fade out at the right edge instead of hard-truncating.
- Apply the same fade to the `/branch` label inside the Open-in button and drop the redundant "Open" text — the editor icon already conveys the action and frees space for the branch.

## Why / Context
The v2 top bar previously had no in-window indication of the active workspace or branch. The Open-in button was the only place the branch surfaced, and it hard-truncated with an ellipsis at 140px. This change gives the active workspace its own anchored breadcrumb and unifies the truncation behavior with the tab title fade pattern already used elsewhere.

## How It Works
- `V2WorkspaceTitle` reads `name` + `branch` from the v2 workspace collection (with an in-flight workspace-create fallback) and renders a flat row in the TopBar's center column, now `justify-start`.
- Both the name and branch use `OverflowFadeText` (`@superset/ui/overflow-fade-text`) which applies a `mask-image` linear gradient on the right edge when the text overflows its container — same hook (`useOverflowFade`) the tab titles use.
- `V2OpenInMenuButton` swaps its `truncate max-w-[140px]` span for `OverflowFadeText` with the same width cap, so the branch fades instead of ellipsizing, and removes the trailing "Open" word.

## Manual QA Checklist
- [ ] Open a v2 workspace — name and branch render at the start of the top bar with a chevron separator.
- [ ] Long workspace name fades out at the right edge instead of showing an ellipsis.
- [ ] Long branch name in the title fades out the same way.
- [ ] Open-in button shows `/branch` next to the editor icon at lg+ widths and fades on overflow; no "Open" text.
- [ ] Hovering name or branch shows the full value via `title` tooltip.
- [ ] In-flight workspace creates (before sync) still render the title from the snapshot/cloud row.
- [ ] No layout shift when toggling sidebar open/closed/collapsed (TopBar padding still correct on macOS).
- [ ] Non-v2 workspace routes are unaffected (search bar trigger still centered).

## Testing
- `bun run lint`
- `bun run typecheck` (desktop)
- Manual testing in dev mode

## Design Decisions
- **Flat breadcrumb over pill**: A boxed pill around the branch felt heavy in the chrome; Linear-style breadcrumbs read as navigation rather than a tag and match the rest of the top bar density.
- **Reuse `OverflowFadeText` over a custom truncation**: The fade hook is already battle-tested for tab titles and respects parent resize via `ResizeObserver`, so the title and Open-in branch get consistent overflow behavior for free.

## Follow-ups
- None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the active workspace and branch in the v2 top bar and make long names fade instead of hard-truncating. Improves clarity and keeps the Open-in button compact.

- New Features
  - Adds a left-aligned breadcrumb: "<workspace> › ⎇ <branch>" in the v2 top bar.
  - Uses `@superset/ui/overflow-fade-text` so long names/branches fade; title tooltips show full values.
  - Open-in button shows "/branch" with the same fade and drops the redundant "Open" label.
  - No changes on non-v2 routes.

<sup>Written for commit 6382823989e10507b66c94d2ff5cb1893920eb76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace title display in the top bar for v2 workspaces, showing workspace name and branch information with improved visual indicators.

* **Style**
  * Improved branch name rendering with better overflow handling, replacing truncation with a fade effect for cleaner display on smaller screens.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4321)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->