### PR TITLE
[codex] fix v2 port visibility

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
@@ -197,7 +197,32 @@ describe("deriveHostPortQueryTargets", () => {
 				machineId: "local-machine",
 				hostType: "local-device",
 				hostUrl: "http://127.0.0.1:4567",
-				workspaceIds: ["workspace-a", "workspace-b"],
+				workspaceIds: ["workspace-a", "workspace-b", "workspace-c"],
+			},
+		]);
+	});
+
+	it("queries the active local host for all workspaces when host mapping is stale", () => {
+		const targets = deriveHostPortQueryTargets({
+			activeHostUrl: "http://127.0.0.1:4567",
+			hosts: [],
+			machineId: "local-machine",
+			relayUrl: "https://relay.example.com",
+			workspaces: [
+				{
+					id: "workspace-stale",
+					name: "Stale Local Workspace",
+					hostId: "old-host-id",
+				},
+			],
+		});
+
+		expect(targets).toEqual([
+			{
+				machineId: "local-machine",
+				hostType: "local-device",
+				hostUrl: "http://127.0.0.1:4567",
+				workspaceIds: ["workspace-stale"],
 			},
 		]);
 	});
@@ -279,7 +304,6 @@ describe("groupDashboardSidebarPorts", () => {
 					],
 				},
 			],
-			machineId: "host-1",
 			workspaces: [
 				{
 					id: "workspace-b",
@@ -302,13 +326,13 @@ describe("groupDashboardSidebarPorts", () => {
 		expect(groups[0]?.hostType).toBe("local-device");
 	});
 
-	it("drops ports whose workspace belongs to another host", () => {
+	it("trusts the host that returned a port when workspace host mapping is stale", () => {
 		const groups = groupDashboardSidebarPorts({
 			hostPortResults: [
 				{
 					hostId: "host-1",
-					hostType: "remote-device",
-					hostUrl: "https://relay.example.com/hosts/host-1",
+					hostType: "local-device",
+					hostUrl: "http://127.0.0.1:4567",
 					ports: [
 						{
 							port: 5173,
@@ -323,7 +347,6 @@ describe("groupDashboardSidebarPorts", () => {
 					],
 				},
 			],
-			machineId: "machine-1",
 			workspaces: [
 				{
 					id: "workspace-1",
@@ -333,6 +356,16 @@ describe("groupDashboardSidebarPorts", () => {
 			],
 		});
 
-		expect(groups).toEqual([]);
+		expect(groups).toHaveLength(1);
+		expect(groups[0]).toMatchObject({
+			workspaceId: "workspace-1",
+			workspaceName: "Workspace",
+			hostType: "local-device",
+		});
+		expect(groups[0]?.ports[0]).toMatchObject({
+			hostId: "host-1",
+			hostType: "local-device",
+			port: 5173,
+		});
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.ts
@@ -153,10 +153,9 @@ export function useDashboardSidebarPortsData(): {
 		() =>
 			groupDashboardSidebarPorts({
 				hostPortResults: queries.map((query) => query.data),
-				machineId,
 				workspaces,
 			}),
-		[queries, machineId, workspaces],
+		[queries, workspaces],
 	);
 
 	const totalPortCount = workspacePortGroups.reduce(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
@@ -74,6 +74,13 @@ function getPortCacheKey(
 	return `${port.workspaceId}:${port.terminalId}:${port.port}`;
 }
 
+function mergeSortedWorkspaceIds(
+	left: readonly string[],
+	right: readonly string[],
+): string[] {
+	return Array.from(new Set([...left, ...right])).sort();
+}
+
 export function applyPortEventsToHostPortsResult(
 	result: HostPortsResult | undefined,
 	events: PortChangedPayload[],
@@ -137,6 +144,9 @@ export function deriveHostPortQueryTargets({
 	for (const workspaceIds of workspaceIdsByHostId.values()) {
 		workspaceIds.sort();
 	}
+	const allWorkspaceIds = workspaces
+		.map((workspace) => workspace.id)
+		.sort((a, b) => a.localeCompare(b));
 
 	const targets = hosts.flatMap((host) => {
 		const workspaceIds = workspaceIdsByHostId.get(host.machineId);
@@ -162,22 +172,30 @@ export function deriveHostPortQueryTargets({
 		];
 	});
 
-	// If the local v2Hosts row hasn't synced via Electric, the loop above won't
-	// include the local machine — which would hide its ports. Synthesize a
-	// local target from machineId + activeHostUrl whenever workspaces with
-	// hostId === machineId exist.
-	if (
-		machineId &&
-		activeHostUrl &&
-		!targets.some((target) => target.machineId === machineId)
-	) {
-		const localWorkspaceIds = workspaceIdsByHostId.get(machineId);
-		if (localWorkspaceIds && localWorkspaceIds.length > 0) {
+	// v1 asked the local port manager for every tracked port. Keep v2's host
+	// fan-out for remote ports, but make the active local host tolerant of
+	// stale/missing Electric host mappings by allowing every known workspace id.
+	if (machineId && activeHostUrl && allWorkspaceIds.length > 0) {
+		const localTargetIndex = targets.findIndex(
+			(target) => target.machineId === machineId,
+		);
+		if (localTargetIndex >= 0) {
+			const localTarget = targets[localTargetIndex];
+			if (localTarget) {
+				targets[localTargetIndex] = {
+					...localTarget,
+					workspaceIds: mergeSortedWorkspaceIds(
+						localTarget.workspaceIds,
+						allWorkspaceIds,
+					),
+				};
+			}
+		} else {
 			targets.push({
 				machineId,
 				hostType: "local-device",
 				hostUrl: activeHostUrl,
-				workspaceIds: localWorkspaceIds,
+				workspaceIds: allWorkspaceIds,
 			});
 		}
 	}
@@ -187,11 +205,9 @@ export function deriveHostPortQueryTargets({
 
 export function groupDashboardSidebarPorts({
 	hostPortResults,
-	machineId,
 	workspaces,
 }: {
 	hostPortResults: Array<HostPortsResult | undefined>;
-	machineId: string | null;
 	workspaces: DashboardSidebarWorkspaceRow[];
 }): DashboardSidebarPortGroup[] {
 	const workspacesById = new Map(
@@ -199,11 +215,6 @@ export function groupDashboardSidebarPorts({
 			workspace.id,
 			{
 				name: workspace.name,
-				hostId: workspace.hostId,
-				hostType:
-					workspace.hostId === machineId
-						? ("local-device" as const)
-						: ("remote-device" as const),
 			},
 		]),
 	);
@@ -215,7 +226,6 @@ export function groupDashboardSidebarPorts({
 		for (const port of result.ports) {
 			const workspace = workspacesById.get(port.workspaceId);
 			if (!workspace) continue;
-			if (workspace.hostId !== result.hostId) continue;
 
 			const dashboardPort: DashboardSidebarPort = {
 				...port,
@@ -231,7 +241,7 @@ export function groupDashboardSidebarPorts({
 				groupMap.set(port.workspaceId, {
 					workspaceId: port.workspaceId,
 					workspaceName: workspace.name,
-					hostType: workspace.hostType,
+					hostType: result.hostType,
 					ports: [dashboardPort],
 				});
 			}

--- a/packages/port-scanner/src/port-manager.test.ts
+++ b/packages/port-scanner/src/port-manager.test.ts
@@ -196,6 +196,23 @@ describe("PortManager — #3372 concurrency (at most one lsof in flight)", () =>
 });
 
 describe("PortManager — port identity updates", () => {
+	it("keeps common development service ports", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+
+		listeningPorts = [
+			{ port: 5432, pid: 1000, address: "127.0.0.1", processName: "postgres" },
+			{ port: 6379, pid: 1001, address: "127.0.0.1", processName: "redis" },
+		];
+		await manager.forceScan();
+
+		expect(
+			manager
+				.getAllPorts()
+				.map((port) => port.port)
+				.sort(),
+		).toEqual([5432, 6379]);
+	});
+
 	it("emits an update when an existing port rebinds to a new address", async () => {
 		const added: DetectedPort[] = [];
 		const removed: DetectedPort[] = [];

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -12,8 +12,8 @@ const SCAN_INTERVAL_MS = 2500;
 /** Delay before scanning after a port hint is detected (in ms) */
 const HINT_SCAN_DELAY_MS = 500;
 
-/** Ports to ignore (common system ports that are usually not dev servers) */
-const IGNORED_PORTS = new Set([22, 80, 443, 5432, 3306, 6379, 27017]);
+/** Ports to ignore (common privileged/system ports that are usually not dev servers) */
+const IGNORED_PORTS = new Set([22, 80, 443]);
 
 const PORT_HINT_PATTERNS = [
 	/listening\s+on\s+(?:port\s+)?(\d+)/i,


### PR DESCRIPTION
## Summary

Fix v2 Ports visibility regressions compared with v1:

- Query the active local host with all known workspace IDs so local ports still surface when Electric host/workspace mapping is stale or delayed.
- Trust the host-service result that returned a port when grouping, instead of dropping the row because the synced workspace host mapping disagrees.
- Narrow ignored scanner ports to only privileged/system ports (`22`, `80`, `443`) so common dev services like Postgres, MySQL, Redis, and Mongo can appear again.

## Root Cause

v1 grouped every detected local port returned by the local port manager. v2 added a per-host workspace allowlist from synced `v2Hosts`/`v2Workspaces`, then dropped returned ports whose host did not match the synced workspace row. Users with stale host IDs or delayed Electric host sync could have local ports hidden. Separately, the shared scanner ignored common database/service ports that users expect to see in dev workflows.

## Validation

- `bun test packages/port-scanner/src/port-manager.test.ts`
- `bun test apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts`
- `bun run --cwd packages/port-scanner typecheck`
- `bun run --cwd apps/desktop typecheck`
- `bun run lint`

Manual repro fixture: a Bun server on `3306` appears in the fixed branch and stays hidden on `main`, as expected before this fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 dashboard port visibility so local dev ports show again and grouping uses the host that actually returned the port. Keeps system ports filtered while allowing common databases to appear.

- **Bug Fixes**
  - Query the active local host with all workspace IDs when host mapping is stale, so local ports still surface (`apps/desktop`).
  - Trust the host-service result when grouping ports and use its `hostType`; don’t drop ports due to mismatched workspace host mapping (`apps/desktop`).
  - Limit ignored scanner ports to `22`, `80`, `443` so ports like `5432`, `3306`, `6379`, `27017` appear again (`packages/port-scanner`).
  - Updated tests to cover these cases.

<sup>Written for commit cba63308d1df7e170c199b2a94266a3577079dec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Common database and service ports (PostgreSQL, Redis, MongoDB, MySQL) are now detected and displayed in the dashboard.

* **Bug Fixes**
  * Improved handling of stale workspace and host mappings to ensure accurate port grouping and display in the sidebar.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4326)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->