### PR TITLE
fix(desktop): keep projects in sidebar after closing last workspace

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -173,6 +173,8 @@ function upsertProject(mainRepoPath: string, defaultBranch: string): Project {
 }
 
 async function ensureMainWorkspace(project: Project): Promise<void> {
+	activateProject(project);
+
 	const existingBranchWorkspace = getBranchWorkspace(project.id);
 
 	if (existingBranchWorkspace) {
@@ -240,8 +242,6 @@ async function ensureMainWorkspace(project: Project): Promise<void> {
 	setLastActiveWorkspace(workspace.id);
 
 	if (!wasExisting) {
-		activateProject(project);
-
 		track("workspace_opened", {
 			workspace_id: workspace.id,
 			project_id: project.id,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -569,6 +569,8 @@ export const createCreateProcedures = () => {
 					await safeCheckoutBranch(project.mainRepoPath, input.branch);
 				}
 
+				activateProject(project);
+
 				const existing = getBranchWorkspace(input.projectId);
 
 				if (existing) {
@@ -637,8 +639,6 @@ export const createCreateProcedures = () => {
 				setLastActiveWorkspace(workspace.id);
 
 				if (!wasExisting) {
-					activateProject(project);
-
 					track("workspace_opened", {
 						workspace_id: workspace.id,
 						project_id: project.id,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -16,7 +16,6 @@ import {
 	getProject,
 	getWorkspace,
 	getWorktree,
-	hideProjectIfNoWorkspaces,
 	markWorkspaceAsDeleting,
 	updateActiveWorkspaceIfRemoved,
 } from "../utils/db-helpers";
@@ -331,10 +330,6 @@ export const createDeleteProcedures = () => {
 					deleteWorktreeRecord(worktree.id);
 				}
 
-				if (project) {
-					hideProjectIfNoWorkspaces(workspace.projectId);
-				}
-
 				const terminalWarning =
 					terminalResult.failed > 0
 						? `${terminalResult.failed} terminal process(es) may still be running`
@@ -361,7 +356,6 @@ export const createDeleteProcedures = () => {
 					.terminal.killByWorkspaceId(input.id);
 
 				deleteWorkspace(input.id);
-				hideProjectIfNoWorkspaces(workspace.projectId);
 				updateActiveWorkspaceIfRemoved(input.id);
 
 				const terminalWarning =
@@ -560,7 +554,6 @@ export const createDeleteProcedures = () => {
 				}
 
 				deleteWorktreeRecord(input.worktreeId);
-				hideProjectIfNoWorkspaces(worktree.projectId);
 
 				track("worktree_deleted", { worktree_id: input.worktreeId });
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/db-helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/db-helpers.ts
@@ -90,37 +90,6 @@ export function activateProject(project: SelectProject): void {
 }
 
 /**
- * Hide a project from the sidebar by setting tabOrder to null.
- * Called when the last workspace in a project is deleted/closed.
- */
-export function hideProject(projectId: string): void {
-	localDb
-		.update(projects)
-		.set({ tabOrder: null })
-		.where(eq(projects.id, projectId))
-		.run();
-}
-
-/**
- * Check if a project has any remaining workspaces.
- * If not, hide it from the sidebar.
- *
- * Note: We check for ANY workspaces (including those being deleted) to avoid
- * prematurely hiding the project when multiple workspaces are being deleted
- * concurrently. The project should only be hidden when all deletions complete.
- */
-export function hideProjectIfNoWorkspaces(projectId: string): void {
-	const remainingWorkspaces = localDb
-		.select()
-		.from(workspaces)
-		.where(eq(workspaces.projectId, projectId))
-		.all();
-	if (remainingWorkspaces.length === 0) {
-		hideProject(projectId);
-	}
-}
-
-/**
  * Select the next active workspace after the current one is removed.
  * Returns the ID of the next workspace to activate, or null if none.
  * Selects the most recently opened workspace from VISIBLE projects only


### PR DESCRIPTION
## Summary
- The v2 sidebar query filters projects by `tab_order IS NOT NULL`. `workspaces.close`, `workspaces.delete`, and `workspaces.deleteWorktree` all called `hideProjectIfNoWorkspaces`, which nulled `tab_order` whenever the last workspace was removed — silently abandoning the project even though "Close" reads as reversible to users.
- Stop auto-hiding. Empty projects stay in the sidebar; users remove a project explicitly via the project header (which already deletes the project row).
- Defensively call `activateProject` unconditionally in `ensureMainWorkspace` and `openMainRepoWorkspace`, so re-opening a project from disk always re-surfaces it if `tab_order` ever ends up NULL.

## How I confirmed the bug
On my own machine, 7 of 9 projects were already hidden — every one of them had 0 workspaces, matching the close/delete-last-workspace path exactly. None had the inconsistent (NULL `tab_order` + workspaces still present) state, so this single fix covers the live regression.

## Test plan
- [ ] In v2 sidebar: create a project with a single workspace, right-click → **Close** the workspace. The workspace section disappears but the project header remains in the sidebar.
- [ ] Same flow with **Delete**: workspace gone, project still listed.
- [ ] Click `+` on the now-empty project header → can create a new workspace; project still in original sidebar position.
- [ ] Re-open an existing project via "Open Folder" / drag-drop → still surfaces normally; `lastOpenedAt` updates.
- [ ] To remove a project entirely: project header context menu → "Close project" still deletes the project row and all its workspaces.
- [ ] (Recovery, manual) For users with already-hidden projects, run `UPDATE projects SET tab_order = ... WHERE tab_order IS NULL` to bring them back.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep projects visible in the v2 sidebar after closing or deleting the last workspace. Removes auto-hiding and always reactivates projects when reopened so they don't disappear.

- **Bug Fixes**
  - Removed `hideProjectIfNoWorkspaces` and its calls in delete/close paths; empty projects remain listed.
  - Call `activateProject` unconditionally in `ensureMainWorkspace` and workspace open/create flows to restore `tab_order` if it’s `NULL`.
  - Explicit “Close project” still deletes the project row as before.

<sup>Written for commit 6859e2811e988f695b7579edab213aa41f0cc8b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project activation timing to occur consistently across workspace creation and management scenarios
  * Projects will no longer automatically be hidden from the sidebar when their workspaces are deleted

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4333)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->