### PR TITLE
[codex] Fix pty daemon cleanup for background process groups

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -208,9 +208,9 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).toContain("SUPERSET_HOOK_DEBUG_LOG");
 		expect(wrapper).toContain("tail -n +1 -F");
 		expect(wrapper).toContain("_superset_cleanup_session_watcher");
-		expect(wrapper).toContain(
-			'pkill -TERM -P "$SUPERSET_CODEX_SESSION_WATCHER_PID"',
-		);
+		expect(wrapper).toContain("_superset_child_pids_for");
+		expect(wrapper).toContain('kill -TERM "$_superset_child_pid"');
+		expect(wrapper).toContain('kill -KILL "$_superset_watcher_pid"');
 		expect(wrapper).not.toContain("mkfifo");
 		expect(wrapper).not.toContain(
 			"SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH",

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -207,6 +207,8 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).not.toContain("$" + "{CODEX_HOME:-$HOME/.codex}");
 		expect(wrapper).toContain("SUPERSET_HOOK_DEBUG_LOG");
 		expect(wrapper).toContain("tail -n +1 -F");
+		expect(wrapper).toContain("_superset_cleanup_session_watcher");
+		expect(wrapper).toContain("mkfifo");
 		expect(wrapper).toContain('"UserTurn"');
 		expect(wrapper).toContain("_approval_request");
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -208,7 +208,10 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).toContain("SUPERSET_HOOK_DEBUG_LOG");
 		expect(wrapper).toContain("tail -n +1 -F");
 		expect(wrapper).toContain("_superset_cleanup_session_watcher");
-		expect(wrapper).toContain("mkfifo");
+		expect(wrapper).not.toContain("mkfifo");
+		expect(wrapper).not.toContain(
+			"SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH",
+		);
 		expect(wrapper).toContain('"UserTurn"');
 		expect(wrapper).toContain("_approval_request");
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -208,6 +208,9 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).toContain("SUPERSET_HOOK_DEBUG_LOG");
 		expect(wrapper).toContain("tail -n +1 -F");
 		expect(wrapper).toContain("_superset_cleanup_session_watcher");
+		expect(wrapper).toContain(
+			'pkill -TERM -P "$SUPERSET_CODEX_SESSION_WATCHER_PID"',
+		);
 		expect(wrapper).not.toContain("mkfifo");
 		expect(wrapper).not.toContain(
 			"SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH",

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -13,11 +13,30 @@ _superset_notify_path="{{NOTIFY_PATH}}"
 _superset_debug_log="${SUPERSET_HOOK_DEBUG_LOG:-/tmp/superset-codex-hooks.log}"
 _superset_has_superset_context="0"
 [ -n "$SUPERSET_TERMINAL_ID$SUPERSET_TAB_ID$SUPERSET_PANE_ID" ] && _superset_has_superset_context="1"
+SUPERSET_CODEX_SESSION_WATCHER_PID=""
 
 _superset_debug() {
   [ "$_superset_debug_enabled" = "1" ] || return 0
   printf '%s [codex-wrapper] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" "$*" >> "$_superset_debug_log" 2>/dev/null || true
 }
+
+_superset_cleanup_session_watcher() {
+  if [ -n "$SUPERSET_CODEX_SESSION_WATCHER_PID" ]; then
+    kill "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
+    wait "$SUPERSET_CODEX_SESSION_WATCHER_PID" 2>/dev/null || true
+    _superset_debug "session watcher stopped pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"
+    SUPERSET_CODEX_SESSION_WATCHER_PID=""
+  fi
+}
+
+_superset_exit_trap() {
+  _superset_status=$?
+  trap - EXIT HUP INT TERM
+  _superset_cleanup_session_watcher
+  exit "$_superset_status"
+}
+
+trap _superset_exit_trap EXIT HUP INT TERM
 
 if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" ]; then
   export CODEX_TUI_RECORD_SESSION="${CODEX_TUI_RECORD_SESSION:-1}"
@@ -27,12 +46,31 @@ if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" 
   (
     _superset_notify="$_superset_notify_path"
     _superset_session_log="$CODEX_TUI_SESSION_LOG_PATH"
+    _superset_watcher_fifo="${TMPDIR:-/tmp}/superset-codex-watcher-$$_${RANDOM:-0}.fifo"
+    _superset_tail_pid=""
 
     _superset_emit_event() {
       _superset_payload=$(printf '{"hook_event_name":"%s"}' "$1")
       _superset_debug "emitting $1 via $_superset_notify"
       bash "$_superset_notify" "$_superset_payload" >/dev/null 2>&1 || true
     }
+
+    _superset_stop_tail() {
+      if [ -n "$_superset_tail_pid" ]; then
+        kill "$_superset_tail_pid" >/dev/null 2>&1 || true
+        wait "$_superset_tail_pid" 2>/dev/null || true
+        _superset_tail_pid=""
+      fi
+      rm -f "$_superset_watcher_fifo" >/dev/null 2>&1 || true
+    }
+
+    _superset_watcher_exit() {
+      trap - EXIT HUP INT TERM
+      _superset_stop_tail
+      exit 0
+    }
+
+    trap _superset_watcher_exit EXIT HUP INT TERM
 
     _superset_i=0
     while [ ! -f "$_superset_session_log" ] && [ "$_superset_i" -lt 200 ]; do
@@ -45,12 +83,20 @@ if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" 
     fi
     _superset_debug "watching session=$_superset_session_log"
 
-    tail -n +1 -F "$_superset_session_log" 2>/dev/null | while IFS= read -r _superset_line; do
+    if ! mkfifo "$_superset_watcher_fifo" 2>/dev/null; then
+      _superset_debug "failed to create watcher fifo path=$_superset_watcher_fifo"
+      exit 0
+    fi
+
+    tail -n +1 -F "$_superset_session_log" > "$_superset_watcher_fifo" 2>/dev/null &
+    _superset_tail_pid=$!
+
+    while IFS= read -r _superset_line; do
       case "$_superset_line" in
         *'"dir":"from_tui"'*'"kind":"op"'*'"UserTurn"'*) _superset_emit_event "Start" ;;
         *'_approval_request"'*) _superset_emit_event "PermissionRequest" ;;
       esac
-    done
+    done < "$_superset_watcher_fifo"
   ) &
   SUPERSET_CODEX_SESSION_WATCHER_PID=$!
   _superset_debug "session watcher pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"
@@ -66,10 +112,7 @@ fi
 SUPERSET_CODEX_STATUS=$?
 _superset_debug "codex exited status=$SUPERSET_CODEX_STATUS"
 
-if [ -n "$SUPERSET_CODEX_SESSION_WATCHER_PID" ]; then
-  kill "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
-  wait "$SUPERSET_CODEX_SESSION_WATCHER_PID" 2>/dev/null || true
-  _superset_debug "session watcher stopped pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"
-fi
+_superset_cleanup_session_watcher
 
+trap - EXIT HUP INT TERM
 exit "$SUPERSET_CODEX_STATUS"

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -14,6 +14,7 @@ _superset_debug_log="${SUPERSET_HOOK_DEBUG_LOG:-/tmp/superset-codex-hooks.log}"
 _superset_has_superset_context="0"
 [ -n "$SUPERSET_TERMINAL_ID$SUPERSET_TAB_ID$SUPERSET_PANE_ID" ] && _superset_has_superset_context="1"
 SUPERSET_CODEX_SESSION_WATCHER_PID=""
+SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH=""
 
 _superset_debug() {
   [ "$_superset_debug_enabled" = "1" ] || return 0
@@ -28,6 +29,30 @@ _superset_pid_is_zombie() {
   esac
 }
 
+_superset_kill_pid_with_timeout() {
+  _superset_kill_pid="$1"
+  case "$_superset_kill_pid" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  kill "$_superset_kill_pid" >/dev/null 2>&1 || true
+  _superset_kill_i=0
+  while kill -0 "$_superset_kill_pid" >/dev/null 2>&1 && ! _superset_pid_is_zombie "$_superset_kill_pid" && [ "$_superset_kill_i" -lt 20 ]; do
+    _superset_kill_i=$((_superset_kill_i + 1))
+    sleep 0.05
+  done
+  if kill -0 "$_superset_kill_pid" >/dev/null 2>&1 && ! _superset_pid_is_zombie "$_superset_kill_pid"; then
+    kill -9 "$_superset_kill_pid" >/dev/null 2>&1 || true
+  fi
+}
+
+_superset_cleanup_session_watcher_tail() {
+  if [ -n "$SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH" ]; then
+    _superset_tail_pid_from_file=$(cat "$SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH" 2>/dev/null || true)
+    _superset_kill_pid_with_timeout "$_superset_tail_pid_from_file"
+    rm -f "$SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH" >/dev/null 2>&1 || true
+  fi
+}
+
 _superset_cleanup_session_watcher() {
   if [ -n "$SUPERSET_CODEX_SESSION_WATCHER_PID" ]; then
     kill "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
@@ -39,8 +64,10 @@ _superset_cleanup_session_watcher() {
     if _superset_pid_is_zombie "$SUPERSET_CODEX_SESSION_WATCHER_PID" || ! kill -0 "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1; then
       wait "$SUPERSET_CODEX_SESSION_WATCHER_PID" 2>/dev/null || true
     else
+      _superset_cleanup_session_watcher_tail
       kill -9 "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
     fi
+    _superset_cleanup_session_watcher_tail
     _superset_debug "session watcher stopped pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"
     SUPERSET_CODEX_SESSION_WATCHER_PID=""
   fi
@@ -58,11 +85,13 @@ trap _superset_exit_trap EXIT HUP INT TERM
 if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" ]; then
   export CODEX_TUI_RECORD_SESSION="${CODEX_TUI_RECORD_SESSION:-1}"
   export CODEX_TUI_SESSION_LOG_PATH="${TMPDIR:-/tmp}/superset-codex-session-$$_$(date +%s).jsonl"
+  SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH="${TMPDIR:-/tmp}/superset-codex-watcher-tail-$$_$(date +%s).pid"
   _superset_debug "session watcher starting terminalId=$SUPERSET_TERMINAL_ID tabId=$SUPERSET_TAB_ID paneId=$SUPERSET_PANE_ID log=$CODEX_TUI_SESSION_LOG_PATH notify=$_superset_notify_path"
 
   (
     _superset_notify="$_superset_notify_path"
     _superset_session_log="$CODEX_TUI_SESSION_LOG_PATH"
+    _superset_tail_pid_path="$SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH"
     _superset_watcher_fifo="${TMPDIR:-/tmp}/superset-codex-watcher-$$_${RANDOM:-0}.fifo"
     _superset_tail_pid=""
 
@@ -88,6 +117,7 @@ if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" 
         _superset_tail_pid=""
       fi
       rm -f "$_superset_watcher_fifo" >/dev/null 2>&1 || true
+      rm -f "$_superset_tail_pid_path" >/dev/null 2>&1 || true
     }
 
     _superset_watcher_exit() {
@@ -116,6 +146,7 @@ if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" 
 
     tail -n +1 -F "$_superset_session_log" > "$_superset_watcher_fifo" 2>/dev/null &
     _superset_tail_pid=$!
+    printf '%s\n' "$_superset_tail_pid" > "$_superset_tail_pid_path" 2>/dev/null || true
 
     while IFS= read -r _superset_line; do
       case "$_superset_line" in

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -14,60 +14,16 @@ _superset_debug_log="${SUPERSET_HOOK_DEBUG_LOG:-/tmp/superset-codex-hooks.log}"
 _superset_has_superset_context="0"
 [ -n "$SUPERSET_TERMINAL_ID$SUPERSET_TAB_ID$SUPERSET_PANE_ID" ] && _superset_has_superset_context="1"
 SUPERSET_CODEX_SESSION_WATCHER_PID=""
-SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH=""
 
 _superset_debug() {
   [ "$_superset_debug_enabled" = "1" ] || return 0
   printf '%s [codex-wrapper] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" "$*" >> "$_superset_debug_log" 2>/dev/null || true
 }
 
-_superset_pid_is_zombie() {
-  _superset_pid_state=$(ps -p "$1" -o stat= 2>/dev/null || true)
-  case "$_superset_pid_state" in
-    *Z*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-_superset_kill_pid_with_timeout() {
-  _superset_kill_pid="$1"
-  case "$_superset_kill_pid" in
-    ''|*[!0-9]*) return 0 ;;
-  esac
-  kill "$_superset_kill_pid" >/dev/null 2>&1 || true
-  _superset_kill_i=0
-  while kill -0 "$_superset_kill_pid" >/dev/null 2>&1 && ! _superset_pid_is_zombie "$_superset_kill_pid" && [ "$_superset_kill_i" -lt 20 ]; do
-    _superset_kill_i=$((_superset_kill_i + 1))
-    sleep 0.05
-  done
-  if kill -0 "$_superset_kill_pid" >/dev/null 2>&1 && ! _superset_pid_is_zombie "$_superset_kill_pid"; then
-    kill -9 "$_superset_kill_pid" >/dev/null 2>&1 || true
-  fi
-}
-
-_superset_cleanup_session_watcher_tail() {
-  if [ -n "$SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH" ]; then
-    _superset_tail_pid_from_file=$(cat "$SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH" 2>/dev/null || true)
-    _superset_kill_pid_with_timeout "$_superset_tail_pid_from_file"
-    rm -f "$SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH" >/dev/null 2>&1 || true
-  fi
-}
-
 _superset_cleanup_session_watcher() {
   if [ -n "$SUPERSET_CODEX_SESSION_WATCHER_PID" ]; then
     kill "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
-    _superset_wait_i=0
-    while kill -0 "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 && ! _superset_pid_is_zombie "$SUPERSET_CODEX_SESSION_WATCHER_PID" && [ "$_superset_wait_i" -lt 20 ]; do
-      _superset_wait_i=$((_superset_wait_i + 1))
-      sleep 0.05
-    done
-    if _superset_pid_is_zombie "$SUPERSET_CODEX_SESSION_WATCHER_PID" || ! kill -0 "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1; then
-      wait "$SUPERSET_CODEX_SESSION_WATCHER_PID" 2>/dev/null || true
-    else
-      _superset_cleanup_session_watcher_tail
-      kill -9 "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
-    fi
-    _superset_cleanup_session_watcher_tail
+    wait "$SUPERSET_CODEX_SESSION_WATCHER_PID" 2>/dev/null || true
     _superset_debug "session watcher stopped pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"
     SUPERSET_CODEX_SESSION_WATCHER_PID=""
   fi
@@ -85,48 +41,17 @@ trap _superset_exit_trap EXIT HUP INT TERM
 if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" ]; then
   export CODEX_TUI_RECORD_SESSION="${CODEX_TUI_RECORD_SESSION:-1}"
   export CODEX_TUI_SESSION_LOG_PATH="${TMPDIR:-/tmp}/superset-codex-session-$$_$(date +%s).jsonl"
-  SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH="${TMPDIR:-/tmp}/superset-codex-watcher-tail-$$_$(date +%s).pid"
   _superset_debug "session watcher starting terminalId=$SUPERSET_TERMINAL_ID tabId=$SUPERSET_TAB_ID paneId=$SUPERSET_PANE_ID log=$CODEX_TUI_SESSION_LOG_PATH notify=$_superset_notify_path"
 
   (
     _superset_notify="$_superset_notify_path"
     _superset_session_log="$CODEX_TUI_SESSION_LOG_PATH"
-    _superset_tail_pid_path="$SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH"
-    _superset_watcher_fifo="${TMPDIR:-/tmp}/superset-codex-watcher-$$_${RANDOM:-0}.fifo"
-    _superset_tail_pid=""
 
     _superset_emit_event() {
       _superset_payload=$(printf '{"hook_event_name":"%s"}' "$1")
       _superset_debug "emitting $1 via $_superset_notify"
       bash "$_superset_notify" "$_superset_payload" >/dev/null 2>&1 || true
     }
-
-    _superset_stop_tail() {
-      if [ -n "$_superset_tail_pid" ]; then
-        kill "$_superset_tail_pid" >/dev/null 2>&1 || true
-        _superset_tail_wait_i=0
-        while kill -0 "$_superset_tail_pid" >/dev/null 2>&1 && ! _superset_pid_is_zombie "$_superset_tail_pid" && [ "$_superset_tail_wait_i" -lt 20 ]; do
-          _superset_tail_wait_i=$((_superset_tail_wait_i + 1))
-          sleep 0.05
-        done
-        if _superset_pid_is_zombie "$_superset_tail_pid" || ! kill -0 "$_superset_tail_pid" >/dev/null 2>&1; then
-          wait "$_superset_tail_pid" 2>/dev/null || true
-        else
-          kill -9 "$_superset_tail_pid" >/dev/null 2>&1 || true
-        fi
-        _superset_tail_pid=""
-      fi
-      rm -f "$_superset_watcher_fifo" >/dev/null 2>&1 || true
-      rm -f "$_superset_tail_pid_path" >/dev/null 2>&1 || true
-    }
-
-    _superset_watcher_exit() {
-      trap - EXIT HUP INT TERM
-      _superset_stop_tail
-      exit 0
-    }
-
-    trap _superset_watcher_exit EXIT HUP INT TERM
 
     _superset_i=0
     while [ ! -f "$_superset_session_log" ] && [ "$_superset_i" -lt 200 ]; do
@@ -139,21 +64,12 @@ if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" 
     fi
     _superset_debug "watching session=$_superset_session_log"
 
-    if ! mkfifo "$_superset_watcher_fifo" 2>/dev/null; then
-      _superset_debug "failed to create watcher fifo path=$_superset_watcher_fifo"
-      exit 0
-    fi
-
-    tail -n +1 -F "$_superset_session_log" > "$_superset_watcher_fifo" 2>/dev/null &
-    _superset_tail_pid=$!
-    printf '%s\n' "$_superset_tail_pid" > "$_superset_tail_pid_path" 2>/dev/null || true
-
-    while IFS= read -r _superset_line; do
+    tail -n +1 -F "$_superset_session_log" 2>/dev/null | while IFS= read -r _superset_line; do
       case "$_superset_line" in
         *'"dir":"from_tui"'*'"kind":"op"'*'"UserTurn"'*) _superset_emit_event "Start" ;;
         *'_approval_request"'*) _superset_emit_event "PermissionRequest" ;;
       esac
-    done < "$_superset_watcher_fifo"
+    done
   ) &
   SUPERSET_CODEX_SESSION_WATCHER_PID=$!
   _superset_debug "session watcher pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -20,14 +20,29 @@ _superset_debug() {
   printf '%s [codex-wrapper] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" "$*" >> "$_superset_debug_log" 2>/dev/null || true
 }
 
+_superset_child_pids_for() {
+  if command -v pgrep >/dev/null 2>&1; then
+    pgrep -P "$1" 2>/dev/null || true
+    return 0
+  fi
+  ps -axo pid=,ppid= 2>/dev/null | awk -v ppid="$1" '$2 == ppid { print $1 }' 2>/dev/null || true
+}
+
 _superset_cleanup_session_watcher() {
   if [ -n "$SUPERSET_CODEX_SESSION_WATCHER_PID" ]; then
-    if command -v pkill >/dev/null 2>&1; then
-      pkill -TERM -P "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
-    fi
-    kill "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
-    wait "$SUPERSET_CODEX_SESSION_WATCHER_PID" 2>/dev/null || true
-    _superset_debug "session watcher stopped pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"
+    _superset_watcher_pid="$SUPERSET_CODEX_SESSION_WATCHER_PID"
+    _superset_child_pids="$(_superset_child_pids_for "$_superset_watcher_pid" | tr '\n' ' ')"
+    for _superset_child_pid in $_superset_child_pids; do
+      kill -TERM "$_superset_child_pid" >/dev/null 2>&1 || true
+    done
+    kill -TERM "$_superset_watcher_pid" >/dev/null 2>&1 || true
+    sleep 0.2
+    _superset_child_pids="$_superset_child_pids $(_superset_child_pids_for "$_superset_watcher_pid" | tr '\n' ' ')"
+    for _superset_child_pid in $_superset_child_pids; do
+      kill -KILL "$_superset_child_pid" >/dev/null 2>&1 || true
+    done
+    kill -KILL "$_superset_watcher_pid" >/dev/null 2>&1 || true
+    _superset_debug "session watcher cleanup signaled pid=$_superset_watcher_pid"
     SUPERSET_CODEX_SESSION_WATCHER_PID=""
   fi
 }

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -22,6 +22,9 @@ _superset_debug() {
 
 _superset_cleanup_session_watcher() {
   if [ -n "$SUPERSET_CODEX_SESSION_WATCHER_PID" ]; then
+    if command -v pkill >/dev/null 2>&1; then
+      pkill -TERM -P "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
+    fi
     kill "$SUPERSET_CODEX_SESSION_WATCHER_PID" >/dev/null 2>&1 || true
     wait "$SUPERSET_CODEX_SESSION_WATCHER_PID" 2>/dev/null || true
     _superset_debug "session watcher stopped pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"
@@ -70,7 +73,7 @@ if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" 
         *'_approval_request"'*) _superset_emit_event "PermissionRequest" ;;
       esac
     done
-  ) &
+  ) 2>/dev/null &
   SUPERSET_CODEX_SESSION_WATCHER_PID=$!
   _superset_debug "session watcher pid=$SUPERSET_CODEX_SESSION_WATCHER_PID"
 else

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -9,7 +9,7 @@
  * - Event streaming
  */
 
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
@@ -26,6 +26,10 @@ import {
 import { connect, type Socket } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+	isPositiveInteger,
+	signalProcessTreeAndGroups,
+} from "@superset/pty-daemon/process-tree";
 import { app } from "electron";
 import { SUPERSET_DIR_NAME } from "shared/constants";
 import { throwIfAborted } from "../terminal/abort";
@@ -508,35 +512,7 @@ export class TerminalHostClient extends EventEmitter {
 	): void {
 		if (!isPositiveInteger(pid)) return;
 		if (!this.isPidAlive(pid)) return;
-
-		const table = readProcessTable();
-		const currentPgid = getProcessGroupId(process.pid, table);
-		const pids = collectProcessTree(pid, table);
-		const pgids = new Set<number>();
-
-		for (const targetPid of pids) {
-			const info = table.find((row) => row.pid === targetPid);
-			if (!info) continue;
-			if (info.pgid <= 1) continue;
-			if (currentPgid !== null && info.pgid === currentPgid) continue;
-			pgids.add(info.pgid);
-		}
-
-		for (const pgid of pgids) {
-			try {
-				process.kill(-pgid, signal);
-			} catch {
-				// Process group may have already exited.
-			}
-		}
-
-		for (const targetPid of pids) {
-			try {
-				process.kill(targetPid, signal);
-			} catch {
-				// Best-effort; PID may be stale or process already exited.
-			}
-		}
+		signalProcessTreeAndGroups(pid, signal);
 	}
 
 	private async waitForPidExit(
@@ -1670,64 +1646,6 @@ export class TerminalHostClient extends EventEmitter {
 		this.disconnect();
 		this.removeAllListeners();
 	}
-}
-
-interface ProcessInfo {
-	pid: number;
-	ppid: number;
-	pgid: number;
-}
-
-function readProcessTable(): ProcessInfo[] {
-	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid="], {
-		encoding: "utf8",
-	});
-	if (result.error || result.status !== 0) return [];
-
-	return result.stdout
-		.split("\n")
-		.map((line) => line.trim())
-		.filter(Boolean)
-		.flatMap((line) => {
-			const [pid, ppid, pgid] = line.split(/\s+/).map(Number);
-			if (!isPositiveInteger(pid) || !Number.isInteger(ppid) || ppid < 0) {
-				return [];
-			}
-			if (!isPositiveInteger(pgid)) return [];
-			return [{ pid, ppid, pgid }];
-		});
-}
-
-function collectProcessTree(
-	rootPid: number,
-	table: ProcessInfo[],
-): Set<number> {
-	const pids = new Set<number>([rootPid]);
-	const childrenByParent = new Map<number, ProcessInfo[]>();
-	for (const row of table) {
-		const children = childrenByParent.get(row.ppid) ?? [];
-		children.push(row);
-		childrenByParent.set(row.ppid, children);
-	}
-
-	const queue = [rootPid];
-	for (const pid of queue) {
-		for (const child of childrenByParent.get(pid) ?? []) {
-			if (pids.has(child.pid)) continue;
-			pids.add(child.pid);
-			queue.push(child.pid);
-		}
-	}
-
-	return pids;
-}
-
-function getProcessGroupId(pid: number, table: ProcessInfo[]): number | null {
-	return table.find((row) => row.pid === pid)?.pgid ?? null;
-}
-
-function isPositiveInteger(value: unknown): value is number {
-	return typeof value === "number" && Number.isInteger(value) && value > 0;
 }
 
 // =============================================================================

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -9,7 +9,7 @@
  * - Event streaming
  */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
@@ -494,7 +494,7 @@ export class TerminalHostClient extends EventEmitter {
 		try {
 			const raw = readFileSync(PID_PATH, "utf-8").trim();
 			const pid = Number.parseInt(raw, 10);
-			if (isPositiveInteger(pid)) {
+			if (isPositiveInteger(pid) && this.isTerminalHostDaemonPid(pid)) {
 				this.signalDaemonProcessTreeAndGroups(pid, "SIGTERM");
 				if (!(await this.waitForPidExit(pid, 1500))) {
 					this.signalDaemonProcessTreeAndGroups(pid, "SIGKILL");
@@ -504,6 +504,18 @@ export class TerminalHostClient extends EventEmitter {
 		} catch {
 			// Best-effort.
 		}
+	}
+
+	private isTerminalHostDaemonPid(pid: number): boolean {
+		if (!isPositiveInteger(pid)) return false;
+		const result = spawnSync("ps", ["-p", String(pid), "-o", "command="], {
+			encoding: "utf8",
+		});
+		if (result.error || result.status !== 0) return false;
+		const command = result.stdout.trim();
+		if (!command) return false;
+		const daemonScript = this.getDaemonScriptPath();
+		return command.includes(daemonScript) || command.includes("terminal-host");
 	}
 
 	private signalDaemonProcessTreeAndGroups(

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -9,7 +9,7 @@
  * - Event streaming
  */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
@@ -364,7 +364,7 @@ export class TerminalHostClient extends EventEmitter {
 					);
 				}
 				this.resetConnectionState({ emitDisconnected: false });
-				this.killDaemonFromPidFile();
+				await this.killDaemonFromPidFile();
 				await this.waitForDaemonShutdown();
 			}
 
@@ -390,7 +390,7 @@ export class TerminalHostClient extends EventEmitter {
 						);
 					}
 					this.resetConnectionState({ emitDisconnected: false });
-					this.killDaemonFromPidFile();
+					await this.killDaemonFromPidFile();
 					await this.waitForDaemonShutdown();
 					await this.spawnDaemon();
 					continue;
@@ -409,7 +409,15 @@ export class TerminalHostClient extends EventEmitter {
 							);
 						}
 						this.resetConnectionState({ emitDisconnected: false });
-						await this.shutdownLegacyDaemon();
+						try {
+							await this.shutdownLegacyDaemon();
+						} catch (shutdownError) {
+							console.warn(
+								"[TerminalHostClient] Legacy daemon shutdown failed, falling back to PID kill:",
+								shutdownError,
+							);
+							await this.killDaemonFromPidFile();
+						}
 						await this.waitForDaemonShutdown();
 						await this.spawnDaemon();
 						continue;
@@ -476,21 +484,78 @@ export class TerminalHostClient extends EventEmitter {
 		}
 	}
 
-	private killDaemonFromPidFile(): void {
+	private async killDaemonFromPidFile(): Promise<void> {
 		if (!existsSync(PID_PATH)) return;
 
 		try {
 			const raw = readFileSync(PID_PATH, "utf-8").trim();
 			const pid = Number.parseInt(raw, 10);
 			if (!Number.isNaN(pid)) {
-				try {
-					process.kill(pid, "SIGTERM");
-				} catch {
-					// Best-effort; PID may be stale or process already exited.
+				this.signalDaemonProcessTreeAndGroups(pid, "SIGTERM");
+				if (!(await this.waitForPidExit(pid, 1500))) {
+					this.signalDaemonProcessTreeAndGroups(pid, "SIGKILL");
+					await this.waitForPidExit(pid, 500);
 				}
 			}
 		} catch {
 			// Best-effort.
+		}
+	}
+
+	private signalDaemonProcessTreeAndGroups(
+		pid: number,
+		signal: NodeJS.Signals,
+	): void {
+		if (!this.isPidAlive(pid)) return;
+
+		const table = readProcessTable();
+		const currentPgid = getProcessGroupId(process.pid, table);
+		const pids = collectProcessTree(pid, table);
+		const pgids = new Set<number>();
+
+		for (const targetPid of pids) {
+			const info = table.find((row) => row.pid === targetPid);
+			if (!info) continue;
+			if (info.pgid <= 1) continue;
+			if (currentPgid !== null && info.pgid === currentPgid) continue;
+			pgids.add(info.pgid);
+		}
+
+		for (const pgid of pgids) {
+			try {
+				process.kill(-pgid, signal);
+			} catch {
+				// Process group may have already exited.
+			}
+		}
+
+		for (const targetPid of pids) {
+			try {
+				process.kill(targetPid, signal);
+			} catch {
+				// Best-effort; PID may be stale or process already exited.
+			}
+		}
+	}
+
+	private async waitForPidExit(
+		pid: number,
+		timeoutMs: number,
+	): Promise<boolean> {
+		const startTime = Date.now();
+		while (Date.now() - startTime < timeoutMs) {
+			if (!this.isPidAlive(pid)) return true;
+			await this.sleep(50);
+		}
+		return !this.isPidAlive(pid);
+	}
+
+	private isPidAlive(pid: number): boolean {
+		try {
+			process.kill(pid, 0);
+			return true;
+		} catch (error) {
+			return (error as NodeJS.ErrnoException).code === "EPERM";
 		}
 	}
 
@@ -1116,6 +1181,10 @@ export class TerminalHostClient extends EventEmitter {
 		// This handles the case where daemon crashed and PID was reused
 		if (existsSync(PID_PATH)) {
 			if (DEBUG_CLIENT) {
+				console.log("[TerminalHostClient] Killing daemon from stale PID file");
+			}
+			await this.killDaemonFromPidFile();
+			if (DEBUG_CLIENT) {
 				console.log("[TerminalHostClient] Removing stale PID file");
 			}
 			try {
@@ -1600,6 +1669,64 @@ export class TerminalHostClient extends EventEmitter {
 		this.disconnect();
 		this.removeAllListeners();
 	}
+}
+
+interface ProcessInfo {
+	pid: number;
+	ppid: number;
+	pgid: number;
+}
+
+function readProcessTable(): ProcessInfo[] {
+	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+		encoding: "utf8",
+	});
+	if (result.error || result.status !== 0) return [];
+
+	return result.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.flatMap((line) => {
+			const [pid, ppid, pgid] = line.split(/\s+/).map(Number);
+			if (!isPositiveInteger(pid) || !Number.isInteger(ppid) || ppid < 0) {
+				return [];
+			}
+			if (!isPositiveInteger(pgid)) return [];
+			return [{ pid, ppid, pgid }];
+		});
+}
+
+function collectProcessTree(
+	rootPid: number,
+	table: ProcessInfo[],
+): Set<number> {
+	const pids = new Set<number>([rootPid]);
+	const childrenByParent = new Map<number, ProcessInfo[]>();
+	for (const row of table) {
+		const children = childrenByParent.get(row.ppid) ?? [];
+		children.push(row);
+		childrenByParent.set(row.ppid, children);
+	}
+
+	const queue = [rootPid];
+	for (const pid of queue) {
+		for (const child of childrenByParent.get(pid) ?? []) {
+			if (pids.has(child.pid)) continue;
+			pids.add(child.pid);
+			queue.push(child.pid);
+		}
+	}
+
+	return pids;
+}
+
+function getProcessGroupId(pid: number, table: ProcessInfo[]): number | null {
+	return table.find((row) => row.pid === pid)?.pgid ?? null;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0;
 }
 
 // =============================================================================

--- a/apps/desktop/src/main/terminal-host/pty-subprocess.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess.ts
@@ -8,8 +8,11 @@
  * to avoid JSON escaping overhead on escape-sequence-heavy PTY output.
  */
 
-import { spawnSync } from "node:child_process";
 import { write as fsWrite } from "node:fs";
+import {
+	type ProcessSignalError,
+	signalProcessTreeAndGroups,
+} from "@superset/pty-daemon/process-tree";
 import type { IPty } from "node-pty";
 import * as pty from "node-pty";
 import treeKill from "tree-kill";
@@ -258,88 +261,24 @@ function flush(): void {
 	flushing = false;
 }
 
-interface ProcessInfo {
-	pid: number;
-	ppid: number;
-	pgid: number;
-}
-
-function signalProcessTreeGroups(rootPid: number, signal: string): void {
-	const table = readProcessTable();
-	const currentPgid = getProcessGroupId(process.pid, table);
-	const pids = collectProcessTree(rootPid, table);
-	const pgids = new Set<number>();
-
-	for (const pid of pids) {
-		const info = table.find((row) => row.pid === pid);
-		if (!info) continue;
-		if (info.pgid <= 1) continue;
-		if (currentPgid !== null && info.pgid === currentPgid) continue;
-		pgids.add(info.pgid);
-	}
-
-	for (const pgid of pgids) {
-		try {
-			process.kill(-pgid, signal as NodeJS.Signals);
-		} catch (err) {
-			if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
-				console.error(
-					`[pty-subprocess] Failed to ${signal} process group ${pgid}:`,
-					err,
-				);
-			}
-		}
-	}
-}
-
-function readProcessTable(): ProcessInfo[] {
-	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid="], {
-		encoding: "utf8",
-	});
-	if (result.error || result.status !== 0) return [];
-
-	return result.stdout
-		.split("\n")
-		.map((line) => line.trim())
-		.filter(Boolean)
-		.flatMap((line) => {
-			const [pid, ppid, pgid] = line.split(/\s+/).map(Number);
-			if (!isPositiveInteger(pid) || !isPositiveInteger(ppid)) return [];
-			if (!isPositiveInteger(pgid)) return [];
-			return [{ pid, ppid, pgid }];
-		});
-}
-
-function collectProcessTree(
+function signalProcessTreeGroups(
 	rootPid: number,
-	table: ProcessInfo[],
-): Set<number> {
-	const pids = new Set<number>([rootPid]);
-	const childrenByParent = new Map<number, ProcessInfo[]>();
-	for (const row of table) {
-		const children = childrenByParent.get(row.ppid) ?? [];
-		children.push(row);
-		childrenByParent.set(row.ppid, children);
-	}
-
-	const queue = [rootPid];
-	for (const pid of queue) {
-		for (const child of childrenByParent.get(pid) ?? []) {
-			if (pids.has(child.pid)) continue;
-			pids.add(child.pid);
-			queue.push(child.pid);
-		}
-	}
-
-	return pids;
+	signal: NodeJS.Signals,
+): void {
+	signalProcessTreeAndGroups(rootPid, signal, {
+		signalPids: false,
+		onSignalError: logProcessSignalError,
+	});
 }
 
-function getProcessGroupId(pid: number, table: ProcessInfo[]): number | null {
-	return table.find((row) => row.pid === pid)?.pgid ?? null;
-}
+function logProcessSignalError(event: ProcessSignalError): void {
+	if ((event.error as NodeJS.ErrnoException).code === "ESRCH") return;
 
-function isPositiveInteger(value: unknown): value is number {
-	return typeof value === "number" && Number.isInteger(value) && value > 0;
+	const label = event.target === "pgid" ? "process group" : "pid";
+	console.error(
+		`[pty-subprocess] Failed to ${event.signal} ${label} ${event.id}:`,
+		event.error,
+	);
 }
 
 // =============================================================================
@@ -444,7 +383,9 @@ function handleResize(payload: Buffer): void {
 }
 
 function handleKill(payload: Buffer): void {
-	const signal = payload.length > 0 ? payload.toString("utf8") : "SIGHUP";
+	const signal = (
+		payload.length > 0 ? payload.toString("utf8") : "SIGHUP"
+	) as NodeJS.Signals;
 
 	if (!ptyProcess) {
 		return;

--- a/apps/desktop/src/main/terminal-host/pty-subprocess.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess.ts
@@ -8,6 +8,7 @@
  * to avoid JSON escaping overhead on escape-sequence-heavy PTY output.
  */
 
+import { spawnSync } from "node:child_process";
 import { write as fsWrite } from "node:fs";
 import type { IPty } from "node-pty";
 import * as pty from "node-pty";
@@ -257,6 +258,90 @@ function flush(): void {
 	flushing = false;
 }
 
+interface ProcessInfo {
+	pid: number;
+	ppid: number;
+	pgid: number;
+}
+
+function signalProcessTreeGroups(rootPid: number, signal: string): void {
+	const table = readProcessTable();
+	const currentPgid = getProcessGroupId(process.pid, table);
+	const pids = collectProcessTree(rootPid, table);
+	const pgids = new Set<number>();
+
+	for (const pid of pids) {
+		const info = table.find((row) => row.pid === pid);
+		if (!info) continue;
+		if (info.pgid <= 1) continue;
+		if (currentPgid !== null && info.pgid === currentPgid) continue;
+		pgids.add(info.pgid);
+	}
+
+	for (const pgid of pgids) {
+		try {
+			process.kill(-pgid, signal as NodeJS.Signals);
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+				console.error(
+					`[pty-subprocess] Failed to ${signal} process group ${pgid}:`,
+					err,
+				);
+			}
+		}
+	}
+}
+
+function readProcessTable(): ProcessInfo[] {
+	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+		encoding: "utf8",
+	});
+	if (result.error || result.status !== 0) return [];
+
+	return result.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.flatMap((line) => {
+			const [pid, ppid, pgid] = line.split(/\s+/).map(Number);
+			if (!isPositiveInteger(pid) || !isPositiveInteger(ppid)) return [];
+			if (!isPositiveInteger(pgid)) return [];
+			return [{ pid, ppid, pgid }];
+		});
+}
+
+function collectProcessTree(
+	rootPid: number,
+	table: ProcessInfo[],
+): Set<number> {
+	const pids = new Set<number>([rootPid]);
+	const childrenByParent = new Map<number, ProcessInfo[]>();
+	for (const row of table) {
+		const children = childrenByParent.get(row.ppid) ?? [];
+		children.push(row);
+		childrenByParent.set(row.ppid, children);
+	}
+
+	const queue = [rootPid];
+	for (const pid of queue) {
+		for (const child of childrenByParent.get(pid) ?? []) {
+			if (pids.has(child.pid)) continue;
+			pids.add(child.pid);
+			queue.push(child.pid);
+		}
+	}
+
+	return pids;
+}
+
+function getProcessGroupId(pid: number, table: ProcessInfo[]): number | null {
+	return table.find((row) => row.pid === pid)?.pgid ?? null;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
 // =============================================================================
 // Message Handlers
 // =============================================================================
@@ -359,13 +444,14 @@ function handleResize(payload: Buffer): void {
 }
 
 function handleKill(payload: Buffer): void {
-	const signal = payload.length > 0 ? payload.toString("utf8") : "SIGTERM";
+	const signal = payload.length > 0 ? payload.toString("utf8") : "SIGHUP";
 
 	if (!ptyProcess) {
 		return;
 	}
 
 	const pid = ptyProcess.pid;
+	signalProcessTreeGroups(pid, signal);
 
 	// Step 1: Kill the process tree using tree-kill
 	// tree-kill traverses by PPID to find all descendants
@@ -380,6 +466,7 @@ function handleKill(payload: Buffer): void {
 	const escalationTimer = setTimeout(() => {
 		if (!ptyProcess) return; // Already exited via onExit
 
+		signalProcessTreeGroups(pid, "SIGKILL");
 		treeKill(pid, "SIGKILL", (err) => {
 			if (err) {
 				console.error("[pty-subprocess] Failed to SIGKILL process tree:", err);
@@ -444,6 +531,7 @@ function handleDispose(): void {
 		const pid = ptyProcess.pid;
 		ptyProcess = null;
 
+		signalProcessTreeGroups(pid, "SIGKILL");
 		// tree-kill spawns child processes (ps/pgrep) to discover descendants,
 		// so we must wait for the callback before exiting.
 		treeKill(pid, "SIGKILL", (err) => {

--- a/apps/desktop/src/main/terminal-host/pty-subprocess.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess.ts
@@ -11,6 +11,8 @@
 import { write as fsWrite } from "node:fs";
 import {
 	type ProcessSignalError,
+	type ProcessSignalTarget,
+	signalProcessTargets,
 	signalProcessTreeAndGroups,
 } from "@superset/pty-daemon/process-tree";
 import type { IPty } from "node-pty";
@@ -264,8 +266,8 @@ function flush(): void {
 function signalProcessTreeGroups(
 	rootPid: number,
 	signal: NodeJS.Signals,
-): void {
-	signalProcessTreeAndGroups(rootPid, signal, {
+): ProcessSignalTarget[] {
+	return signalProcessTreeAndGroups(rootPid, signal, {
 		signalPids: false,
 		onSignalError: logProcessSignalError,
 	});
@@ -392,7 +394,7 @@ function handleKill(payload: Buffer): void {
 	}
 
 	const pid = ptyProcess.pid;
-	signalProcessTreeGroups(pid, signal);
+	const escalationTargets = signalProcessTreeGroups(pid, signal);
 
 	// Step 1: Signal descendants and process groups. tree-kill keeps legacy
 	// PPID traversal behavior for direct children.
@@ -407,7 +409,7 @@ function handleKill(payload: Buffer): void {
 	const escalationTimer = setTimeout(() => {
 		if (!ptyProcess) return; // Already exited via onExit
 
-		signalProcessTreeGroups(pid, "SIGKILL");
+		signalProcessTargets(escalationTargets, "SIGKILL", logProcessSignalError);
 		treeKill(pid, "SIGKILL", (err) => {
 			if (err) {
 				console.error("[pty-subprocess] Failed to SIGKILL process tree:", err);

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -942,7 +942,7 @@ export class Session {
 	 * Marks the session as terminating immediately (idempotent).
 	 * The actual PTY termination is async - use isTerminating to check state.
 	 */
-	kill(signal: string = "SIGTERM"): void {
+	kill(signal: string = "SIGHUP"): void {
 		// Idempotent: if already terminating, don't send another signal
 		if (this.terminatingAt !== null) {
 			return;

--- a/bun.lock
+++ b/bun.lock
@@ -919,7 +919,7 @@
     },
     "packages/pty-daemon": {
       "name": "@superset/pty-daemon",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "pty-daemon": "./src/main.ts",
       },

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -15,6 +15,10 @@ import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	isPositiveInteger,
+	signalProcessTreeAndGroups,
+} from "@superset/pty-daemon/process-tree";
+import {
 	CURRENT_PROTOCOL_VERSION,
 	encodeFrame,
 	FrameDecoder,
@@ -50,6 +54,7 @@ const SOCKET_READY_TIMEOUT_MS = 5_000;
 const VERSION_PROBE_TIMEOUT_MS = 1_500;
 const HANDOFF_PREDECESSOR_EXIT_TIMEOUT_MS = 3_000;
 const HANDOFF_PROBE_TOTAL_TIMEOUT_MS = 3_000;
+const DAEMON_TERMINATE_TIMEOUT_MS = 1_000;
 
 /**
  * Crash supervision parameters. If the daemon for an organization crashes
@@ -273,16 +278,29 @@ export class DaemonSupervisor {
 
 		// Gate the probe on predecessor exit — see waitForPidExit's docstring
 		// for the race it guards against.
-		const predecessorExited = await waitForPidExit(
+		let predecessorExited = await waitForPidExit(
 			instance.pid,
 			HANDOFF_PREDECESSOR_EXIT_TIMEOUT_MS,
 		);
 		if (!predecessorExited) {
-			restoreOnFailure();
-			return {
-				ok: false,
-				reason: `predecessor pid ${instance.pid} did not exit within ${HANDOFF_PREDECESSOR_EXIT_TIMEOUT_MS}ms after handoff ack`,
-			};
+			logEvent("pty_daemon_update_predecessor_escalate", {
+				organizationId,
+				predecessorPid: instance.pid,
+				successorPid: result.successorPid,
+				timeoutMs: HANDOFF_PREDECESSOR_EXIT_TIMEOUT_MS,
+			});
+			terminatePidOnly(instance.pid, "SIGKILL");
+			predecessorExited = await waitForPidExit(
+				instance.pid,
+				DAEMON_TERMINATE_TIMEOUT_MS,
+			);
+			if (!predecessorExited) {
+				restoreOnFailure();
+				return {
+					ok: false,
+					reason: `predecessor pid ${instance.pid} did not exit within ${HANDOFF_PREDECESSOR_EXIT_TIMEOUT_MS + DAEMON_TERMINATE_TIMEOUT_MS}ms after handoff ack`,
+				};
+			}
 		}
 
 		const probedVersion = await probeDaemonVersionWithRetry(
@@ -406,11 +424,7 @@ export class DaemonSupervisor {
 		this.stopAdoptedLivenessCheck(organizationId);
 		if (!instance) return;
 		this.stopping.add(organizationId);
-		try {
-			process.kill(instance.pid, "SIGTERM");
-		} catch {
-			// Already dead.
-		}
+		await terminateProcessTreeAndGroups(instance.pid, "SIGTERM");
 		removePtyDaemonManifest(organizationId);
 	}
 
@@ -520,23 +534,7 @@ export class DaemonSupervisor {
 		console.log(
 			`[pty-daemon:${organizationId}] DEV: killing leftover daemon pid=${manifest.pid} (started ${Math.round((Date.now() - manifest.startedAt) / 1000)}s ago) so the next bootstrap picks up fresh bundle code`,
 		);
-		try {
-			process.kill(manifest.pid, "SIGTERM");
-		} catch {
-			// Already dead between our check and the kill.
-		}
-		const deadline = Date.now() + 1000;
-		while (Date.now() < deadline) {
-			if (!isProcessAlive(manifest.pid)) break;
-			await new Promise((r) => setTimeout(r, 50));
-		}
-		if (isProcessAlive(manifest.pid)) {
-			try {
-				process.kill(manifest.pid, "SIGKILL");
-			} catch {
-				// Already dead.
-			}
-		}
+		await terminateProcessTreeAndGroups(manifest.pid, "SIGTERM");
 		removePtyDaemonManifest(organizationId);
 	}
 
@@ -623,11 +621,7 @@ export class DaemonSupervisor {
 		const reachable = await isSocketConnectable(manifest.socketPath, 1000);
 		if (!reachable) {
 			// PID alive but socket gone — daemon is wedged. Kill and respawn.
-			try {
-				process.kill(manifest.pid, "SIGTERM");
-			} catch {
-				// Already dead.
-			}
+			await terminateProcessTreeAndGroups(manifest.pid, "SIGTERM");
 			removePtyDaemonManifest(organizationId);
 			return null;
 		}
@@ -737,11 +731,7 @@ export class DaemonSupervisor {
 
 		const ready = await waitForSocket(socketPath, SOCKET_READY_TIMEOUT_MS);
 		if (!ready) {
-			try {
-				child.kill("SIGTERM");
-			} catch {
-				// best-effort
-			}
+			await terminateProcessTreeAndGroups(childPid, "SIGTERM");
 			let logTail = "";
 			try {
 				const buf = fs.readFileSync(logPath, "utf-8");
@@ -983,6 +973,26 @@ async function probeDaemonVersionWithRetry(
 		await new Promise((r) => setTimeout(r, 50));
 	}
 	return null;
+}
+
+function terminatePidOnly(pid: number, signal: NodeJS.Signals): void {
+	if (!isPositiveInteger(pid)) return;
+	try {
+		process.kill(pid, signal);
+	} catch {
+		// Already dead or not ours.
+	}
+}
+
+async function terminateProcessTreeAndGroups(
+	pid: number,
+	signal: NodeJS.Signals,
+): Promise<void> {
+	if (!isPositiveInteger(pid)) return;
+	signalProcessTreeAndGroups(pid, signal);
+	if (await waitForPidExit(pid, DAEMON_TERMINATE_TIMEOUT_MS)) return;
+	signalProcessTreeAndGroups(pid, "SIGKILL");
+	await waitForPidExit(pid, DAEMON_TERMINATE_TIMEOUT_MS);
 }
 
 /**

--- a/packages/host-service/src/runtime/teardown/teardown.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.ts
@@ -118,7 +118,7 @@ export async function runTeardown({
 			timedOut = true;
 			appendTail(`\n[teardown timed out after ${timeoutMs}ms]\n`);
 			try {
-				session.pty.kill();
+				void session.pty.kill().catch(() => {});
 			} catch {
 				// PTY may already be dead
 			}

--- a/packages/host-service/src/terminal/DaemonClient/DaemonClient.node-test.ts
+++ b/packages/host-service/src/terminal/DaemonClient/DaemonClient.node-test.ts
@@ -7,6 +7,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { after, before, test } from "node:test";
 import { Server } from "@superset/pty-daemon";
+import { CURRENT_PROTOCOL_VERSION } from "@superset/pty-daemon/protocol";
 import { DaemonClient } from "./DaemonClient.ts";
 
 const sockPath = path.join(
@@ -31,7 +32,7 @@ test("connect + handshake exposes daemon version", async () => {
 	const c = new DaemonClient({ socketPath: sockPath });
 	await c.connect();
 	assert.equal(c.version, "0.0.0-host-test");
-	assert.equal(c.protocol, 1);
+	assert.equal(c.protocol, CURRENT_PROTOCOL_VERSION);
 	assert.ok(c.isConnected);
 	await c.dispose();
 });

--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import * as os from "node:os";
+import { signalProcessTreeAndGroups } from "@superset/pty-daemon/process-tree";
 
 const SHELL_ENV_TIMEOUT_MS = 8_000;
 const CACHE_TTL_MS = 60_000;
@@ -134,10 +135,14 @@ function spawnCleanShellEnv(): Promise<Record<string, string>> {
 		child.stderr?.on("data", (data: Buffer) => stderrBuffers.push(data));
 
 		const timeout = setTimeout(() => {
-			try {
-				child.kill("SIGKILL");
-			} catch {
-				// Already exited.
+			if (child.pid) {
+				signalProcessTreeAndGroups(child.pid, "SIGKILL");
+			} else {
+				try {
+					child.kill("SIGKILL");
+				} catch {
+					// Already exited.
+				}
 			}
 
 			reject(

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -14,11 +14,15 @@ import {
 } from "@superset/shared/terminal-title-scanner";
 import { and, eq, ne } from "drizzle-orm";
 import type { Hono } from "hono";
+import { isProcessAlive, readPtyDaemonManifest } from "../daemon/manifest.ts";
 import type { HostDb } from "../db/index.ts";
 import { projects, terminalSessions, workspaces } from "../db/schema.ts";
 import type { EventBus } from "../events/index.ts";
 import { portManager } from "../ports/port-manager.ts";
-import type { DaemonClient } from "./DaemonClient/index.ts";
+import {
+	DaemonClient,
+	type Signal as DaemonSignal,
+} from "./DaemonClient/index.ts";
 import {
 	getDaemonClient,
 	onDaemonDisconnect,
@@ -53,7 +57,7 @@ interface DaemonPty {
 	pid: number;
 	write(data: string): void;
 	resize(cols: number, rows: number): void;
-	kill(signal?: NodeJS.Signals): void;
+	kill(signal?: NodeJS.Signals): Promise<void>;
 	onData(cb: (data: string) => void): PtyDataDisposer;
 	onExit(
 		cb: (info: { exitCode: number; signal: number }) => void,
@@ -78,14 +82,7 @@ function makeDaemonPty(
 			}
 		},
 		kill(signal) {
-			daemon
-				.close(
-					sessionId,
-					(signal as "SIGTERM" | "SIGKILL" | "SIGINT" | "SIGHUP") ?? "SIGHUP",
-				)
-				.catch(() => {
-					// Already gone or daemon disconnected — no-op.
-				});
+			return daemon.close(sessionId, toDaemonSignal(signal));
 		},
 		onData(cb) {
 			// StringDecoder buffers partial UTF-8 sequences across chunks.
@@ -518,6 +515,69 @@ function queueInitialCommand(
 	});
 }
 
+interface DaemonCloseResult {
+	attempted: boolean;
+	succeeded: boolean;
+	error?: unknown;
+}
+
+export interface DisposeSessionResult {
+	terminalId: string;
+	daemonCloseAttempted: boolean;
+	daemonCloseSucceeded: boolean;
+}
+
+function toDaemonSignal(signal?: NodeJS.Signals): DaemonSignal {
+	switch (signal) {
+		case "SIGINT":
+		case "SIGTERM":
+		case "SIGKILL":
+		case "SIGHUP":
+			return signal;
+		default:
+			return "SIGHUP";
+	}
+}
+
+function isUnknownDaemonSessionError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	return error.message.includes("unknown session:");
+}
+
+function reachableDaemonSocketPath(): string | null {
+	const explicitSocket = process.env.SUPERSET_PTY_DAEMON_SOCKET;
+	if (explicitSocket) return explicitSocket;
+
+	const organizationId = process.env.ORGANIZATION_ID;
+	if (!organizationId) return null;
+
+	const manifest = readPtyDaemonManifest(organizationId);
+	if (!manifest || !isProcessAlive(manifest.pid)) return null;
+	return manifest.socketPath;
+}
+
+async function closeDaemonSessionById(
+	terminalId: string,
+	signal: DaemonSignal = "SIGHUP",
+): Promise<DaemonCloseResult> {
+	const socketPath = reachableDaemonSocketPath();
+	if (!socketPath) return { attempted: false, succeeded: true };
+
+	const daemon = new DaemonClient({ socketPath, connectTimeoutMs: 1000 });
+	try {
+		await daemon.connect();
+		await daemon.close(terminalId, signal);
+		return { attempted: true, succeeded: true };
+	} catch (error) {
+		if (isUnknownDaemonSessionError(error)) {
+			return { attempted: true, succeeded: true };
+		}
+		return { attempted: true, succeeded: false, error };
+	} finally {
+		await daemon.dispose().catch(() => {});
+	}
+}
+
 /**
  * Kills the PTY (if live) and marks the DB row disposed. Safe to call even
  * when there's no in-memory session — e.g. for zombie `active` rows left
@@ -525,7 +585,25 @@ function queueInitialCommand(
  * transient teardown session.
  */
 export function disposeSession(terminalId: string, db: HostDb) {
+	void disposeSessionAndWait(terminalId, db)
+		.then((result) => {
+			if (!result.daemonCloseSucceeded) {
+				console.warn("[terminal] disposeSession daemon close failed", {
+					terminalId,
+				});
+			}
+		})
+		.catch((error) => {
+			console.warn("[terminal] disposeSession failed", { terminalId, error });
+		});
+}
+
+export async function disposeSessionAndWait(
+	terminalId: string,
+	db: HostDb,
+): Promise<DisposeSessionResult> {
 	const session = sessions.get(terminalId);
+	let closePromise: Promise<DaemonCloseResult> | null = null;
 
 	if (session) {
 		if (session.shellReadyTimeoutId) {
@@ -538,9 +616,21 @@ export function disposeSession(terminalId: string, db: HostDb) {
 		session.sockets.clear();
 		if (!session.exited) {
 			try {
-				session.pty.kill();
-			} catch {
-				// PTY may already be dead
+				closePromise = session.pty.kill().then(
+					() =>
+						({ attempted: true, succeeded: true }) satisfies DaemonCloseResult,
+					(error) => ({
+						attempted: true,
+						succeeded: isUnknownDaemonSessionError(error),
+						error,
+					}),
+				);
+			} catch (error) {
+				closePromise = Promise.resolve({
+					attempted: true,
+					succeeded: isUnknownDaemonSessionError(error),
+					error,
+				});
 			}
 		}
 		// Stop receiving daemon callbacks for this session.
@@ -558,6 +648,8 @@ export function disposeSession(terminalId: string, db: HostDb) {
 			// best-effort
 		}
 		sessions.delete(terminalId);
+	} else {
+		closePromise = closeDaemonSessionById(terminalId, "SIGHUP");
 	}
 
 	portManager.unregisterSession(terminalId);
@@ -566,16 +658,25 @@ export function disposeSession(terminalId: string, db: HostDb) {
 		.set({ status: "disposed", endedAt: Date.now() })
 		.where(eq(terminalSessions.id, terminalId))
 		.run();
+
+	const closeResult = closePromise
+		? await closePromise
+		: { attempted: false, succeeded: true };
+	return {
+		terminalId,
+		daemonCloseAttempted: closeResult.attempted,
+		daemonCloseSucceeded: closeResult.succeeded,
+	};
 }
 
 /**
  * Dispose every active session belonging to the given workspace.
  * Returns counts so callers (e.g. workspaceCleanup.destroy) can surface warnings.
  */
-export function disposeSessionsByWorkspaceId(
+export async function disposeSessionsByWorkspaceId(
 	workspaceId: string,
 	db: HostDb,
-): { terminated: number; failed: number } {
+): Promise<{ terminated: number; failed: number }> {
 	const rows = db
 		.select({ id: terminalSessions.id })
 		.from(terminalSessions)
@@ -591,7 +692,11 @@ export function disposeSessionsByWorkspaceId(
 	let failed = 0;
 	for (const row of rows) {
 		try {
-			disposeSession(row.id, db);
+			const result = await disposeSessionAndWait(row.id, db);
+			if (!result.daemonCloseSucceeded) {
+				failed += 1;
+				continue;
+			}
 			terminated += 1;
 		} catch {
 			failed += 1;

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -5,7 +5,7 @@ import { getSupervisor, waitForDaemonReady } from "../../../daemon";
 import { terminalSessions, workspaces } from "../../../db/schema";
 import {
 	createTerminalSessionInternal,
-	disposeSession,
+	disposeSessionAndWait,
 	listTerminalSessions,
 	parseThemeType,
 } from "../../../terminal/terminal";
@@ -122,7 +122,7 @@ export const terminalRouter = router({
 				workspaceId: z.string(),
 			}),
 		)
-		.mutation(({ ctx, input }) => {
+		.mutation(async ({ ctx, input }) => {
 			const workspace = ctx.db.query.workspaces
 				.findFirst({ where: eq(workspaces.id, input.workspaceId) })
 				.sync();
@@ -152,7 +152,7 @@ export const terminalRouter = router({
 				});
 			}
 
-			disposeSession(input.terminalId, ctx.db);
+			await disposeSessionAndWait(input.terminalId, ctx.db);
 			return { terminalId: input.terminalId, status: "disposed" as const };
 		}),
 

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -255,7 +255,10 @@ async function runDestroy(ctx: HostServiceContext, input: DestroyInput) {
 
 	// 3a. PTYs
 	try {
-		const killed = disposeSessionsByWorkspaceId(input.workspaceId, ctx.db);
+		const killed = await disposeSessionsByWorkspaceId(
+			input.workspaceId,
+			ctx.db,
+		);
 		if (killed.failed > 0) {
 			warnings.push(`${killed.failed} terminal(s) may still be running`);
 		}

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -91,14 +91,11 @@ describe("terminal router integration", () => {
 		let workspaceCleanupHelperPid: number | null = null;
 
 		try {
-			const daemonEntryPath = fileURLToPath(
-				new URL("../../../pty-daemon/src/main.ts", import.meta.url),
+			const daemonBundlePath = fileURLToPath(
+				new URL("../../../pty-daemon/dist/pty-daemon.js", import.meta.url),
 			);
-			const daemonArgs = [
-				"--experimental-strip-types",
-				daemonEntryPath,
-				`--socket=${socketPath}`,
-			];
+			ensureDaemonBundle(daemonBundlePath);
+			const daemonArgs = [daemonBundlePath, `--socket=${socketPath}`];
 			daemonProcess = spawn("node", daemonArgs, {
 				stdio: ["ignore", "pipe", "pipe"],
 				env: {
@@ -323,6 +320,30 @@ function detachedHelperScript(pidPath: string): string {
 		`echo "$helper_pid" > ${shellQuote(pidPath)}`,
 		"sleep 60",
 	].join("; ");
+}
+
+function ensureDaemonBundle(bundlePath: string): void {
+	const packageDir = fileURLToPath(
+		new URL("../../../pty-daemon", import.meta.url),
+	);
+	const result = spawnSync("bun", ["run", "build:daemon"], {
+		cwd: packageDir,
+		encoding: "utf8",
+	});
+	if (result.status === 0) {
+		if (!existsSync(bundlePath)) {
+			throw new Error(`pty-daemon bundle was not created: ${bundlePath}`);
+		}
+		return;
+	}
+	throw new Error(
+		[
+			"failed to build pty-daemon bundle for integration test",
+			`exitCode: ${result.status}`,
+			`stdout:\n${result.stdout}`,
+			`stderr:\n${result.stderr}`,
+		].join("\n"),
+	);
 }
 
 function readPositivePidFile(filePath: string): number | null {

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -1,13 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import {
-	existsSync,
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,7 +15,10 @@ import {
 	resetTerminalBaseEnvForTests,
 } from "../../src/terminal/env";
 import { listTerminalResourceSessions } from "../../src/terminal/resource-sessions";
-import { __resetSessionsForTesting } from "../../src/terminal/terminal";
+import {
+	__resetSessionsForTesting,
+	disposeSessionsByWorkspaceId,
+} from "../../src/terminal/terminal";
 import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
 import { seedTerminalSession } from "../helpers/seed";
 
@@ -79,18 +76,19 @@ describe("terminal router integration", () => {
 		).rejects.toBeInstanceOf(TRPCClientError);
 	});
 
-	test("killSession cleans up background process groups from a real daemon session", async () => {
+	test("terminal disposal cleans up background process groups from real daemon sessions", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "host-service-terminal-pgrp-"));
 		const socketPath = join(tmp, "pty-daemon.sock");
-		const logPath = join(tmp, "superset-codex-session.jsonl");
-		const pidPath = join(tmp, "tail.pid");
+		const pidPath = join(tmp, "detached-helper.pid");
+		const workspaceCleanupPidPath = join(tmp, "workspace-detached-helper.pid");
 		const terminalId = randomUUID();
+		const workspaceCleanupTerminalId = randomUUID();
 		let daemonProcess: ChildProcess | null = null;
 		let daemonStdout = "";
 		let daemonStderr = "";
 		let daemonSpawnError = "";
-		let tailPid: number | null = null;
-		writeFileSync(logPath, "");
+		let helperPid: number | null = null;
+		let workspaceCleanupHelperPid: number | null = null;
 
 		try {
 			const daemonEntryPath = fileURLToPath(
@@ -137,13 +135,6 @@ describe("terminal router integration", () => {
 			process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
 			process.env.SUPERSET_HOME_DIR = tmp;
 
-			const backgroundScript = [
-				"set -m",
-				`tail -n +1 -F ${shellQuote(logPath)} >/dev/null 2>&1 & tail_pid=$!`,
-				`echo "$tail_pid" > ${shellQuote(pidPath)}`,
-				"sleep 60",
-			].join("; ");
-
 			await scenario.host.trpc.terminal.createSession.mutate({
 				workspaceId: scenario.workspaceId,
 				terminalId,
@@ -151,24 +142,69 @@ describe("terminal router integration", () => {
 			const daemon = await getDaemonClient();
 			daemon.input(
 				terminalId,
-				Buffer.from(`/bin/bash -lc ${shellQuote(backgroundScript)}\n`),
+				Buffer.from(
+					`/bin/bash -lc ${shellQuote(detachedHelperScript(pidPath))}\n`,
+				),
 			);
 
 			await waitFor(() => readPositivePidFile(pidPath) !== null, 3000);
-			tailPid = readPositivePidFile(pidPath);
-			expect(tailPid).not.toBeNull();
-			expect(isPidAlive(tailPid as number)).toBe(true);
+			helperPid = readPositivePidFile(pidPath);
+			expect(helperPid).not.toBeNull();
+			expect(isPidAlive(helperPid as number)).toBe(true);
 
 			await scenario.host.trpc.terminal.killSession.mutate({
 				workspaceId: scenario.workspaceId,
 				terminalId,
 			});
 
-			await waitFor(() => !isPidAlive(tailPid as number), 3000);
+			await waitFor(() => !isPidAlive(helperPid as number), 3000);
+
+			await scenario.host.trpc.terminal.createSession.mutate({
+				workspaceId: scenario.workspaceId,
+				terminalId: workspaceCleanupTerminalId,
+			});
+			daemon.input(
+				workspaceCleanupTerminalId,
+				Buffer.from(
+					`/bin/bash -lc ${shellQuote(detachedHelperScript(workspaceCleanupPidPath))}\n`,
+				),
+			);
+
+			await waitFor(
+				() => readPositivePidFile(workspaceCleanupPidPath) !== null,
+				3000,
+			);
+			workspaceCleanupHelperPid = readPositivePidFile(workspaceCleanupPidPath);
+			expect(workspaceCleanupHelperPid).not.toBeNull();
+			expect(isPidAlive(workspaceCleanupHelperPid as number)).toBe(true);
+
+			__resetSessionsForTesting();
+			const disposed = await disposeSessionsByWorkspaceId(
+				scenario.workspaceId,
+				scenario.host.db,
+			);
+			expect(disposed.failed).toBe(0);
+			expect(disposed.terminated).toBeGreaterThanOrEqual(1);
+
+			await waitFor(
+				() => !isPidAlive(workspaceCleanupHelperPid as number),
+				3000,
+			);
 		} finally {
-			if (tailPid !== null && tailPid > 0 && isPidAlive(tailPid)) {
+			if (helperPid !== null && helperPid > 0 && isPidAlive(helperPid)) {
 				try {
-					process.kill(tailPid, "SIGKILL");
+					process.kill(helperPid, "SIGKILL");
+				} catch {
+					// Already gone.
+				}
+			}
+			if (
+				workspaceCleanupHelperPid !== null &&
+				workspaceCleanupHelperPid > 0 &&
+				isPidAlive(workspaceCleanupHelperPid)
+			) {
+				try {
+					process.kill(workspaceCleanupHelperPid, "SIGKILL");
 				} catch {
 					// Already gone.
 				}
@@ -278,6 +314,15 @@ describe("terminal router integration", () => {
 
 function shellQuote(value: string): string {
 	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function detachedHelperScript(pidPath: string): string {
+	return [
+		"set -m",
+		`${shellQuote(process.execPath)} -e ${shellQuote("process.on('SIGHUP', () => {}); process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);")} >/dev/null 2>&1 & helper_pid=$!`,
+		`echo "$helper_pid" > ${shellQuote(pidPath)}`,
+		"sleep 60",
+	].join("; ");
 }
 
 function readPositivePidFile(filePath: string): number | null {

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { TRPCClientError } from "@trpc/client";
 import {
 	disposeDaemonClient,
@@ -85,33 +86,53 @@ describe("terminal router integration", () => {
 		const pidPath = join(tmp, "tail.pid");
 		const terminalId = randomUUID();
 		let daemonProcess: ChildProcess | null = null;
+		let daemonStdout = "";
 		let daemonStderr = "";
+		let daemonSpawnError = "";
 		let tailPid: number | null = null;
 		writeFileSync(logPath, "");
 
 		try {
-			daemonProcess = spawn(
-				"node",
-				[
-					"--experimental-strip-types",
-					join(process.cwd(), "packages/pty-daemon/src/main.ts"),
-					`--socket=${socketPath}`,
-				],
-				{
-					stdio: ["ignore", "ignore", "pipe"],
-					env: {
-						...process.env,
-						SUPERSET_PTY_DAEMON_VERSION: "0.0.0-host-service-terminal-test",
-					},
-				},
+			const daemonEntryPath = fileURLToPath(
+				new URL("../../../pty-daemon/src/main.ts", import.meta.url),
 			);
+			const daemonArgs = [
+				"--experimental-strip-types",
+				daemonEntryPath,
+				`--socket=${socketPath}`,
+			];
+			daemonProcess = spawn("node", daemonArgs, {
+				stdio: ["ignore", "pipe", "pipe"],
+				env: {
+					...process.env,
+					SUPERSET_PTY_DAEMON_VERSION: "0.0.0-host-service-terminal-test",
+				},
+			});
+			daemonProcess.stdout?.on("data", (chunk) => {
+				daemonStdout += chunk.toString();
+			});
 			daemonProcess.stderr?.on("data", (chunk) => {
 				daemonStderr += chunk.toString();
+			});
+			daemonProcess.once("error", (error) => {
+				daemonSpawnError =
+					error instanceof Error
+						? (error.stack ?? error.message)
+						: String(error);
 			});
 			await waitFor(
 				() => existsSync(socketPath),
 				3000,
-				() => `pty-daemon did not create socket; stderr:\n${daemonStderr}`,
+				() =>
+					[
+						"pty-daemon did not create socket",
+						`args: node ${daemonArgs.join(" ")}`,
+						`exitCode: ${daemonProcess?.exitCode ?? "null"}`,
+						`signalCode: ${daemonProcess?.signalCode ?? "null"}`,
+						`spawnError:\n${daemonSpawnError}`,
+						`stdout:\n${daemonStdout}`,
+						`stderr:\n${daemonStderr}`,
+					].join("\n"),
 			);
 			process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
 			process.env.SUPERSET_HOME_DIR = tmp;

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -1,16 +1,45 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { TRPCClientError } from "@trpc/client";
+import {
+	disposeDaemonClient,
+	getDaemonClient,
+} from "../../src/terminal/daemon-client-singleton";
+import {
+	initTerminalBaseEnv,
+	resetTerminalBaseEnvForTests,
+} from "../../src/terminal/env";
+import { __resetSessionsForTesting } from "../../src/terminal/terminal";
 import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
 
 describe("terminal router integration", () => {
 	let scenario: BasicScenario;
 
 	beforeEach(async () => {
+		initTerminalBaseEnv({
+			PATH: process.env.PATH ?? "/usr/bin:/bin",
+			HOME: process.env.HOME ?? tmpdir(),
+			SHELL: "/bin/sh",
+		});
 		scenario = await createBasicScenario();
 	});
 
 	afterEach(async () => {
+		__resetSessionsForTesting();
+		await disposeDaemonClient();
+		resetTerminalBaseEnvForTests();
+		delete process.env.SUPERSET_PTY_DAEMON_SOCKET;
+		delete process.env.SUPERSET_HOME_DIR;
 		await scenario?.dispose();
 	});
 
@@ -46,4 +75,139 @@ describe("terminal router integration", () => {
 			}),
 		).rejects.toBeInstanceOf(TRPCClientError);
 	});
+
+	test("killSession cleans up background process groups from a real daemon session", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "host-service-terminal-pgrp-"));
+		const socketPath = join(tmp, "pty-daemon.sock");
+		const logPath = join(tmp, "superset-codex-session.jsonl");
+		const pidPath = join(tmp, "tail.pid");
+		const terminalId = randomUUID();
+		let daemonProcess: ChildProcess | null = null;
+		let daemonStderr = "";
+		let tailPid: number | null = null;
+		writeFileSync(logPath, "");
+
+		try {
+			daemonProcess = spawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					join(process.cwd(), "packages/pty-daemon/src/main.ts"),
+					`--socket=${socketPath}`,
+				],
+				{
+					stdio: ["ignore", "ignore", "pipe"],
+					env: {
+						...process.env,
+						SUPERSET_PTY_DAEMON_VERSION: "0.0.0-host-service-terminal-test",
+					},
+				},
+			);
+			daemonProcess.stderr?.on("data", (chunk) => {
+				daemonStderr += chunk.toString();
+			});
+			await waitFor(
+				() => existsSync(socketPath),
+				3000,
+				() => `pty-daemon did not create socket; stderr:\n${daemonStderr}`,
+			);
+			process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
+			process.env.SUPERSET_HOME_DIR = tmp;
+
+			const backgroundScript = [
+				"set -m",
+				`tail -n +1 -F ${shellQuote(logPath)} >/dev/null 2>&1 & tail_pid=$!`,
+				`echo "$tail_pid" > ${shellQuote(pidPath)}`,
+				"sleep 60",
+			].join("; ");
+
+			await scenario.host.trpc.terminal.createSession.mutate({
+				workspaceId: scenario.workspaceId,
+				terminalId,
+			});
+			const daemon = await getDaemonClient();
+			daemon.input(
+				terminalId,
+				Buffer.from(`/bin/bash -lc ${shellQuote(backgroundScript)}\n`),
+			);
+
+			await waitFor(() => existsSync(pidPath), 3000);
+			tailPid = Number(readFileSync(pidPath, "utf8").trim());
+			expect(isPidAlive(tailPid)).toBe(true);
+
+			await scenario.host.trpc.terminal.killSession.mutate({
+				workspaceId: scenario.workspaceId,
+				terminalId,
+			});
+
+			await waitFor(() => !isPidAlive(tailPid as number), 3000);
+		} finally {
+			if (tailPid !== null && isPidAlive(tailPid)) {
+				try {
+					process.kill(tailPid, "SIGKILL");
+				} catch {
+					// Already gone.
+				}
+			}
+			await disposeDaemonClient();
+			await stopDaemonProcess(daemonProcess);
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
 });
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs: number,
+	message?: () => string,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error(message?.() ?? `condition timed out after ${timeoutMs}ms`);
+}
+
+async function stopDaemonProcess(child: ChildProcess | null): Promise<void> {
+	if (!child || child.exitCode !== null || child.signalCode !== null) return;
+	child.kill("SIGTERM");
+	if (await waitForProcessExit(child, 1000)) return;
+	child.kill("SIGKILL");
+	await waitForProcessExit(child, 1000);
+}
+
+async function waitForProcessExit(
+	child: ChildProcess,
+	timeoutMs: number,
+): Promise<boolean> {
+	if (child.exitCode !== null || child.signalCode !== null) return true;
+	return new Promise((resolve) => {
+		const timeout = setTimeout(() => {
+			cleanup();
+			resolve(false);
+		}, timeoutMs);
+		const onExit = () => {
+			cleanup();
+			resolve(true);
+		};
+		const cleanup = () => {
+			clearTimeout(timeout);
+			child.off("exit", onExit);
+		};
+		child.once("exit", onExit);
+	});
+}

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/pty-daemon",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"private": true,
 	"type": "module",
 	"exports": {

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -12,6 +12,10 @@
 			"types": "./src/protocol/index.ts",
 			"default": "./src/protocol/index.ts"
 		},
+		"./process-tree": {
+			"types": "./src/process-tree.ts",
+			"default": "./src/process-tree.ts"
+		},
 		"./package.json": "./package.json"
 	},
 	"bin": {

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -3,6 +3,8 @@ import * as fs from "node:fs";
 import * as nodePty from "node-pty";
 import type { SessionMeta } from "../protocol/index.ts";
 
+const KILL_ESCALATION_TIMEOUT_MS = 1000;
+
 export type PtyOnData = (data: Buffer) => void;
 export type PtyOnExit = (info: {
 	code: number | null;
@@ -36,6 +38,8 @@ class NodePtyAdapter implements Pty {
 	readonly pid: number;
 	meta: SessionMeta;
 	private term: nodePty.IPty;
+	private exited = false;
+	private killEscalationTimer: NodeJS.Timeout | null = null;
 
 	constructor(term: nodePty.IPty, meta: SessionMeta) {
 		this.term = term;
@@ -71,7 +75,10 @@ class NodePtyAdapter implements Pty {
 	}
 
 	kill(signal?: NodeJS.Signals): void {
-		this.term.kill(signal);
+		const killSignal = signal ?? "SIGHUP";
+		signalProcessTreeAndGroups(this.pid, killSignal, { includeRoot: false });
+		this.term.kill(killSignal);
+		this.scheduleKillEscalation(killSignal);
 	}
 
 	onData(cb: PtyOnData): void {
@@ -82,8 +89,25 @@ class NodePtyAdapter implements Pty {
 
 	onExit(cb: PtyOnExit): void {
 		this.term.onExit(({ exitCode, signal }) => {
+			this.exited = true;
+			if (this.killEscalationTimer) {
+				clearTimeout(this.killEscalationTimer);
+				this.killEscalationTimer = null;
+			}
 			cb({ code: exitCode ?? null, signal: signal ?? null });
 		});
+	}
+
+	private scheduleKillEscalation(signal: NodeJS.Signals): void {
+		if (signal === "SIGKILL" || this.exited || this.killEscalationTimer) return;
+
+		this.killEscalationTimer = setTimeout(() => {
+			this.killEscalationTimer = null;
+			if (this.exited) return;
+			signalProcessTreeAndGroups(this.pid, "SIGKILL", { includeRoot: false });
+			this.term.kill("SIGKILL");
+		}, KILL_ESCALATION_TIMEOUT_MS);
+		this.killEscalationTimer.unref();
 	}
 }
 
@@ -169,6 +193,7 @@ class AdoptedPty implements Pty {
 	private readonly writer: fs.WriteStream;
 	private exitFired = false;
 	private livenessTimer: NodeJS.Timeout | null = null;
+	private killEscalationTimer: NodeJS.Timeout | null = null;
 	private exitCallbacks: PtyOnExit[] = [];
 
 	constructor(fd: number, pid: number, meta: SessionMeta) {
@@ -188,6 +213,7 @@ class AdoptedPty implements Pty {
 			if (this.exitFired) return;
 			this.exitFired = true;
 			if (this.livenessTimer) clearInterval(this.livenessTimer);
+			if (this.killEscalationTimer) clearTimeout(this.killEscalationTimer);
 			// Close the read/write streams so the inherited fd doesn't keep
 			// the event loop alive after the shell exits. We use
 			// `autoClose: false` (so handoff-time refcounting works), which
@@ -253,11 +279,9 @@ class AdoptedPty implements Pty {
 	}
 
 	kill(signal?: NodeJS.Signals): void {
-		try {
-			process.kill(this.pid, signal ?? "SIGHUP");
-		} catch {
-			// Already dead; idempotent kill.
-		}
+		const killSignal = signal ?? "SIGHUP";
+		signalProcessTreeAndGroups(this.pid, killSignal);
+		this.scheduleKillEscalation(killSignal);
 	}
 
 	onData(cb: PtyOnData): void {
@@ -269,6 +293,18 @@ class AdoptedPty implements Pty {
 	onExit(cb: PtyOnExit): void {
 		this.exitCallbacks.push(cb);
 	}
+
+	private scheduleKillEscalation(signal: NodeJS.Signals): void {
+		if (signal === "SIGKILL" || this.exitFired || this.killEscalationTimer)
+			return;
+
+		this.killEscalationTimer = setTimeout(() => {
+			this.killEscalationTimer = null;
+			if (this.exitFired) return;
+			signalProcessTreeAndGroups(this.pid, "SIGKILL");
+		}, KILL_ESCALATION_TIMEOUT_MS);
+		this.killEscalationTimer.unref();
+	}
 }
 
 function isPidAlive(pid: number): boolean {
@@ -279,6 +315,120 @@ function isPidAlive(pid: number): boolean {
 		// EPERM means the pid exists but isn't ours — count as alive.
 		return (err as NodeJS.ErrnoException).code === "EPERM";
 	}
+}
+
+interface ProcessInfo {
+	pid: number;
+	ppid: number;
+	pgid: number;
+}
+
+function signalProcessTreeAndGroups(
+	rootPid: number,
+	signal: NodeJS.Signals,
+	options: { includeRoot?: boolean } = {},
+): void {
+	const includeRoot = options.includeRoot ?? true;
+	const table = readProcessTable();
+	const currentPgid = getProcessGroupId(process.pid, table);
+	const rootPgid = getProcessGroupId(rootPid, table);
+	const pids = collectProcessTree(rootPid, table);
+	const pgids = new Set<number>();
+
+	for (const pid of pids) {
+		if (!includeRoot && pid === rootPid) continue;
+		const info = table.find((row) => row.pid === pid);
+		if (!info) continue;
+		if (info.pgid <= 1) continue;
+		if (currentPgid !== null && info.pgid === currentPgid) continue;
+		if (!includeRoot && rootPgid !== null && info.pgid === rootPgid) {
+			continue;
+		}
+		pgids.add(info.pgid);
+	}
+
+	for (const pgid of pgids) {
+		signalProcessGroup(pgid, signal);
+	}
+
+	for (const pid of pids) {
+		if (!includeRoot && pid === rootPid) continue;
+		signalPid(pid, signal);
+	}
+}
+
+function readProcessTable(): ProcessInfo[] {
+	const result = childProcess.spawnSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+		encoding: "utf8",
+	});
+	if (result.error || result.status !== 0) return [];
+
+	return result.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.flatMap((line) => {
+			const [pid, ppid, pgid] = line.split(/\s+/).map(Number);
+			if (!isPositiveInteger(pid) || !isPositiveInteger(ppid)) return [];
+			if (!isPositiveInteger(pgid)) return [];
+			return [{ pid, ppid, pgid }];
+		});
+}
+
+function collectProcessTree(
+	rootPid: number,
+	table: ProcessInfo[],
+): Set<number> {
+	const pids = new Set<number>([rootPid]);
+	const childrenByParent = new Map<number, ProcessInfo[]>();
+	for (const row of table) {
+		const children = childrenByParent.get(row.ppid) ?? [];
+		children.push(row);
+		childrenByParent.set(row.ppid, children);
+	}
+
+	const queue = [rootPid];
+	for (const pid of queue) {
+		for (const child of childrenByParent.get(pid) ?? []) {
+			if (pids.has(child.pid)) continue;
+			pids.add(child.pid);
+			queue.push(child.pid);
+		}
+	}
+
+	return pids;
+}
+
+function getProcessGroupId(pid: number, table: ProcessInfo[]): number | null {
+	return table.find((row) => row.pid === pid)?.pgid ?? null;
+}
+
+function signalProcessGroup(pgid: number, signal: NodeJS.Signals): void {
+	try {
+		process.kill(-pgid, signal);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+			process.stderr.write(
+				`[pty-daemon] failed to ${signal} process group ${pgid}: ${(err as Error).message}\n`,
+			);
+		}
+	}
+}
+
+function signalPid(pid: number, signal: NodeJS.Signals): void {
+	try {
+		process.kill(pid, signal);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+			process.stderr.write(
+				`[pty-daemon] failed to ${signal} pid ${pid}: ${(err as Error).message}\n`,
+			);
+		}
+	}
+}
+
+function isPositiveInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0;
 }
 
 export interface AdoptOptions {

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -1,6 +1,10 @@
 import * as childProcess from "node:child_process";
 import * as fs from "node:fs";
 import * as nodePty from "node-pty";
+import {
+	type ProcessSignalError,
+	signalProcessTreeAndGroups,
+} from "../process-tree.ts";
 import type { SessionMeta } from "../protocol/index.ts";
 
 const KILL_ESCALATION_TIMEOUT_MS = 1000;
@@ -76,7 +80,10 @@ class NodePtyAdapter implements Pty {
 
 	kill(signal?: NodeJS.Signals): void {
 		const killSignal = signal ?? "SIGHUP";
-		signalProcessTreeAndGroups(this.pid, killSignal, { includeRoot: false });
+		signalProcessTreeAndGroups(this.pid, killSignal, {
+			includeRoot: false,
+			onSignalError: logProcessSignalError,
+		});
 		this.term.kill(killSignal);
 		this.scheduleKillEscalation(killSignal);
 	}
@@ -104,7 +111,10 @@ class NodePtyAdapter implements Pty {
 		this.killEscalationTimer = setTimeout(() => {
 			this.killEscalationTimer = null;
 			if (this.exited) return;
-			signalProcessTreeAndGroups(this.pid, "SIGKILL", { includeRoot: false });
+			signalProcessTreeAndGroups(this.pid, "SIGKILL", {
+				includeRoot: false,
+				onSignalError: logProcessSignalError,
+			});
 			this.term.kill("SIGKILL");
 		}, KILL_ESCALATION_TIMEOUT_MS);
 		this.killEscalationTimer.unref();
@@ -280,7 +290,9 @@ class AdoptedPty implements Pty {
 
 	kill(signal?: NodeJS.Signals): void {
 		const killSignal = signal ?? "SIGHUP";
-		signalProcessTreeAndGroups(this.pid, killSignal);
+		signalProcessTreeAndGroups(this.pid, killSignal, {
+			onSignalError: logProcessSignalError,
+		});
 		this.scheduleKillEscalation(killSignal);
 	}
 
@@ -301,7 +313,9 @@ class AdoptedPty implements Pty {
 		this.killEscalationTimer = setTimeout(() => {
 			this.killEscalationTimer = null;
 			if (this.exitFired) return;
-			signalProcessTreeAndGroups(this.pid, "SIGKILL");
+			signalProcessTreeAndGroups(this.pid, "SIGKILL", {
+				onSignalError: logProcessSignalError,
+			});
 		}, KILL_ESCALATION_TIMEOUT_MS);
 		this.killEscalationTimer.unref();
 	}
@@ -317,120 +331,13 @@ function isPidAlive(pid: number): boolean {
 	}
 }
 
-interface ProcessInfo {
-	pid: number;
-	ppid: number;
-	pgid: number;
-}
+function logProcessSignalError(event: ProcessSignalError): void {
+	if ((event.error as NodeJS.ErrnoException).code === "ESRCH") return;
 
-function signalProcessTreeAndGroups(
-	rootPid: number,
-	signal: NodeJS.Signals,
-	options: { includeRoot?: boolean } = {},
-): void {
-	// includeRoot=false lets node-pty deliver the signal to its own child after
-	// we have separately signalled descendants and detached process groups.
-	const includeRoot = options.includeRoot ?? true;
-	const table = readProcessTable();
-	const currentPgid = getProcessGroupId(process.pid, table);
-	const rootPgid = getProcessGroupId(rootPid, table);
-	const pids = collectProcessTree(rootPid, table);
-	const pgids = new Set<number>();
-
-	for (const pid of pids) {
-		if (!includeRoot && pid === rootPid) continue;
-		const info = table.find((row) => row.pid === pid);
-		if (!info) continue;
-		if (info.pgid <= 1) continue;
-		if (currentPgid !== null && info.pgid === currentPgid) continue;
-		if (!includeRoot && rootPgid !== null && info.pgid === rootPgid) {
-			continue;
-		}
-		pgids.add(info.pgid);
-	}
-
-	for (const pgid of pgids) {
-		signalProcessGroup(pgid, signal);
-	}
-
-	for (const pid of pids) {
-		if (!includeRoot && pid === rootPid) continue;
-		signalPid(pid, signal);
-	}
-}
-
-function readProcessTable(): ProcessInfo[] {
-	const result = childProcess.spawnSync("ps", ["-axo", "pid=,ppid=,pgid="], {
-		encoding: "utf8",
-	});
-	if (result.error || result.status !== 0) return [];
-
-	return result.stdout
-		.split("\n")
-		.map((line) => line.trim())
-		.filter(Boolean)
-		.flatMap((line) => {
-			const [pid, ppid, pgid] = line.split(/\s+/).map(Number);
-			if (!isPositiveInteger(pid) || !isPositiveInteger(ppid)) return [];
-			if (!isPositiveInteger(pgid)) return [];
-			return [{ pid, ppid, pgid }];
-		});
-}
-
-function collectProcessTree(
-	rootPid: number,
-	table: ProcessInfo[],
-): Set<number> {
-	const pids = new Set<number>([rootPid]);
-	const childrenByParent = new Map<number, ProcessInfo[]>();
-	for (const row of table) {
-		const children = childrenByParent.get(row.ppid) ?? [];
-		children.push(row);
-		childrenByParent.set(row.ppid, children);
-	}
-
-	const queue = [rootPid];
-	for (const pid of queue) {
-		for (const child of childrenByParent.get(pid) ?? []) {
-			if (pids.has(child.pid)) continue;
-			pids.add(child.pid);
-			queue.push(child.pid);
-		}
-	}
-
-	return pids;
-}
-
-function getProcessGroupId(pid: number, table: ProcessInfo[]): number | null {
-	return table.find((row) => row.pid === pid)?.pgid ?? null;
-}
-
-function signalProcessGroup(pgid: number, signal: NodeJS.Signals): void {
-	try {
-		process.kill(-pgid, signal);
-	} catch (err) {
-		if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
-			process.stderr.write(
-				`[pty-daemon] failed to ${signal} process group ${pgid}: ${(err as Error).message}\n`,
-			);
-		}
-	}
-}
-
-function signalPid(pid: number, signal: NodeJS.Signals): void {
-	try {
-		process.kill(pid, signal);
-	} catch (err) {
-		if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
-			process.stderr.write(
-				`[pty-daemon] failed to ${signal} pid ${pid}: ${(err as Error).message}\n`,
-			);
-		}
-	}
-}
-
-function isPositiveInteger(value: unknown): value is number {
-	return typeof value === "number" && Number.isInteger(value) && value > 0;
+	const label = event.target === "pgid" ? "process group" : "pid";
+	process.stderr.write(
+		`[pty-daemon] failed to ${event.signal} ${label} ${event.id}: ${(event.error as Error).message}\n`,
+	);
 }
 
 export interface AdoptOptions {

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -46,11 +46,20 @@ class NodePtyAdapter implements Pty {
 	private term: nodePty.IPty;
 	private exited = false;
 	private killEscalationTimer: NodeJS.Timeout | null = null;
+	private exitInfo: { code: number | null; signal: number | null } | null =
+		null;
+	private exitCallbacks: PtyOnExit[] = [];
 
 	constructor(term: nodePty.IPty, meta: SessionMeta) {
 		this.term = term;
 		this.pid = term.pid;
 		this.meta = meta;
+		this.term.onExit(({ exitCode, signal }) => {
+			if (this.exited) return;
+			this.exited = true;
+			this.exitInfo = { code: exitCode ?? null, signal: signal ?? null };
+			for (const cb of this.exitCallbacks) cb(this.exitInfo);
+		});
 	}
 
 	getMasterFd(): number {
@@ -97,10 +106,11 @@ class NodePtyAdapter implements Pty {
 	}
 
 	onExit(cb: PtyOnExit): void {
-		this.term.onExit(({ exitCode, signal }) => {
-			this.exited = true;
-			cb({ code: exitCode ?? null, signal: signal ?? null });
-		});
+		if (this.exitInfo) {
+			cb(this.exitInfo);
+			return;
+		}
+		this.exitCallbacks.push(cb);
 	}
 
 	private scheduleKillEscalation(

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -3,6 +3,8 @@ import * as fs from "node:fs";
 import * as nodePty from "node-pty";
 import {
 	type ProcessSignalError,
+	type ProcessSignalTarget,
+	signalProcessTargets,
 	signalProcessTreeAndGroups,
 } from "../process-tree.ts";
 import type { SessionMeta } from "../protocol/index.ts";
@@ -80,12 +82,12 @@ class NodePtyAdapter implements Pty {
 
 	kill(signal?: NodeJS.Signals): void {
 		const killSignal = signal ?? "SIGHUP";
-		signalProcessTreeAndGroups(this.pid, killSignal, {
+		const escalationTargets = signalProcessTreeAndGroups(this.pid, killSignal, {
 			includeRoot: false,
 			onSignalError: logProcessSignalError,
 		});
 		this.term.kill(killSignal);
-		this.scheduleKillEscalation(killSignal);
+		this.scheduleKillEscalation(killSignal, escalationTargets);
 	}
 
 	onData(cb: PtyOnData): void {
@@ -97,25 +99,24 @@ class NodePtyAdapter implements Pty {
 	onExit(cb: PtyOnExit): void {
 		this.term.onExit(({ exitCode, signal }) => {
 			this.exited = true;
-			if (this.killEscalationTimer) {
-				clearTimeout(this.killEscalationTimer);
-				this.killEscalationTimer = null;
-			}
 			cb({ code: exitCode ?? null, signal: signal ?? null });
 		});
 	}
 
-	private scheduleKillEscalation(signal: NodeJS.Signals): void {
+	private scheduleKillEscalation(
+		signal: NodeJS.Signals,
+		targets: ProcessSignalTarget[],
+	): void {
 		if (signal === "SIGKILL" || this.exited || this.killEscalationTimer) return;
 
 		this.killEscalationTimer = setTimeout(() => {
 			this.killEscalationTimer = null;
-			if (this.exited) return;
-			signalProcessTreeAndGroups(this.pid, "SIGKILL", {
-				includeRoot: false,
-				onSignalError: logProcessSignalError,
-			});
-			this.term.kill("SIGKILL");
+			signalProcessTargets(targets, "SIGKILL", logProcessSignalError);
+			try {
+				this.term.kill("SIGKILL");
+			} catch {
+				// PTY root may have already exited; detached targets still matter.
+			}
 		}, KILL_ESCALATION_TIMEOUT_MS);
 		this.killEscalationTimer.unref();
 	}
@@ -223,7 +224,6 @@ class AdoptedPty implements Pty {
 			if (this.exitFired) return;
 			this.exitFired = true;
 			if (this.livenessTimer) clearInterval(this.livenessTimer);
-			if (this.killEscalationTimer) clearTimeout(this.killEscalationTimer);
 			// Close the read/write streams so the inherited fd doesn't keep
 			// the event loop alive after the shell exits. We use
 			// `autoClose: false` (so handoff-time refcounting works), which
@@ -290,10 +290,10 @@ class AdoptedPty implements Pty {
 
 	kill(signal?: NodeJS.Signals): void {
 		const killSignal = signal ?? "SIGHUP";
-		signalProcessTreeAndGroups(this.pid, killSignal, {
+		const escalationTargets = signalProcessTreeAndGroups(this.pid, killSignal, {
 			onSignalError: logProcessSignalError,
 		});
-		this.scheduleKillEscalation(killSignal);
+		this.scheduleKillEscalation(killSignal, escalationTargets);
 	}
 
 	onData(cb: PtyOnData): void {
@@ -306,16 +306,16 @@ class AdoptedPty implements Pty {
 		this.exitCallbacks.push(cb);
 	}
 
-	private scheduleKillEscalation(signal: NodeJS.Signals): void {
+	private scheduleKillEscalation(
+		signal: NodeJS.Signals,
+		targets: ProcessSignalTarget[],
+	): void {
 		if (signal === "SIGKILL" || this.exitFired || this.killEscalationTimer)
 			return;
 
 		this.killEscalationTimer = setTimeout(() => {
 			this.killEscalationTimer = null;
-			if (this.exitFired) return;
-			signalProcessTreeAndGroups(this.pid, "SIGKILL", {
-				onSignalError: logProcessSignalError,
-			});
+			signalProcessTargets(targets, "SIGKILL", logProcessSignalError);
 		}, KILL_ESCALATION_TIMEOUT_MS);
 		this.killEscalationTimer.unref();
 	}

--- a/packages/pty-daemon/src/process-tree.ts
+++ b/packages/pty-daemon/src/process-tree.ts
@@ -13,7 +13,17 @@ export interface ProcessSignalError {
 	error: unknown;
 }
 
+export interface ProcessSignalTarget {
+	target: "pid" | "pgid";
+	id: number;
+}
+
 export interface SignalProcessTreeAndGroupsOptions {
+	/**
+	 * When false, skip the root pid and its process group. node-pty will
+	 * deliver the signal to its own child separately; we only need to handle
+	 * descendants and any detached process groups they spawned.
+	 */
 	includeRoot?: boolean;
 	signalGroups?: boolean;
 	signalPids?: boolean;
@@ -25,8 +35,17 @@ export function signalProcessTreeAndGroups(
 	rootPid: number,
 	signal: NodeJS.Signals,
 	options: SignalProcessTreeAndGroupsOptions = {},
-): void {
-	if (!isPositiveInteger(rootPid)) return;
+): ProcessSignalTarget[] {
+	const targets = collectProcessSignalTargets(rootPid, options);
+	signalProcessTargets(targets, signal, options.onSignalError);
+	return targets;
+}
+
+export function collectProcessSignalTargets(
+	rootPid: number,
+	options: SignalProcessTreeAndGroupsOptions = {},
+): ProcessSignalTarget[] {
+	if (!isPositiveInteger(rootPid)) return [];
 
 	const includeRoot = options.includeRoot ?? true;
 	const signalGroups = options.signalGroups ?? true;
@@ -39,6 +58,7 @@ export function signalProcessTreeAndGroups(
 	const rootPgid = getProcessGroupId(rootPid, table);
 	const pids = collectProcessTree(rootPid, table);
 	const pgids = new Set<number>();
+	const targets: ProcessSignalTarget[] = [];
 
 	for (const pid of pids) {
 		if (!includeRoot && pid === rootPid) continue;
@@ -54,15 +74,27 @@ export function signalProcessTreeAndGroups(
 
 	if (signalGroups) {
 		for (const pgid of pgids) {
-			signalTarget("pgid", pgid, signal, options.onSignalError);
+			targets.push({ target: "pgid", id: pgid });
 		}
 	}
 
 	if (signalPids) {
 		for (const pid of pids) {
 			if (!includeRoot && pid === rootPid) continue;
-			signalTarget("pid", pid, signal, options.onSignalError);
+			targets.push({ target: "pid", id: pid });
 		}
+	}
+
+	return targets;
+}
+
+export function signalProcessTargets(
+	targets: ProcessSignalTarget[],
+	signal: NodeJS.Signals,
+	onSignalError?: (error: ProcessSignalError) => void,
+): void {
+	for (const { target, id } of targets) {
+		signalTarget(target, id, signal, onSignalError);
 	}
 }
 

--- a/packages/pty-daemon/src/process-tree.ts
+++ b/packages/pty-daemon/src/process-tree.ts
@@ -1,0 +1,145 @@
+import { spawnSync } from "node:child_process";
+
+export interface ProcessInfo {
+	pid: number;
+	ppid: number;
+	pgid: number;
+}
+
+export interface ProcessSignalError {
+	target: "pid" | "pgid";
+	id: number;
+	signal: NodeJS.Signals;
+	error: unknown;
+}
+
+export interface SignalProcessTreeAndGroupsOptions {
+	includeRoot?: boolean;
+	signalGroups?: boolean;
+	signalPids?: boolean;
+	excludeCurrentProcessGroup?: boolean;
+	onSignalError?: (error: ProcessSignalError) => void;
+}
+
+export function signalProcessTreeAndGroups(
+	rootPid: number,
+	signal: NodeJS.Signals,
+	options: SignalProcessTreeAndGroupsOptions = {},
+): void {
+	if (!isPositiveInteger(rootPid)) return;
+
+	const includeRoot = options.includeRoot ?? true;
+	const signalGroups = options.signalGroups ?? true;
+	const signalPids = options.signalPids ?? true;
+	const excludeCurrentProcessGroup = options.excludeCurrentProcessGroup ?? true;
+	const table = readProcessTable();
+	const currentPgid = excludeCurrentProcessGroup
+		? getProcessGroupId(process.pid, table)
+		: null;
+	const rootPgid = getProcessGroupId(rootPid, table);
+	const pids = collectProcessTree(rootPid, table);
+	const pgids = new Set<number>();
+
+	for (const pid of pids) {
+		if (!includeRoot && pid === rootPid) continue;
+		const info = table.find((row) => row.pid === pid);
+		if (!info) continue;
+		if (info.pgid <= 1) continue;
+		if (currentPgid !== null && info.pgid === currentPgid) continue;
+		if (!includeRoot && rootPgid !== null && info.pgid === rootPgid) {
+			continue;
+		}
+		pgids.add(info.pgid);
+	}
+
+	if (signalGroups) {
+		for (const pgid of pgids) {
+			signalTarget("pgid", pgid, signal, options.onSignalError);
+		}
+	}
+
+	if (signalPids) {
+		for (const pid of pids) {
+			if (!includeRoot && pid === rootPid) continue;
+			signalTarget("pid", pid, signal, options.onSignalError);
+		}
+	}
+}
+
+export function readProcessTable(): ProcessInfo[] {
+	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+		encoding: "utf8",
+	});
+	if (result.error || result.status !== 0) return [];
+
+	return result.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.flatMap((line) => {
+			const [pidText, ppidText, pgidText] = line.split(/\s+/);
+			if (
+				pidText === undefined ||
+				ppidText === undefined ||
+				pgidText === undefined
+			) {
+				return [];
+			}
+			const pid = Number(pidText);
+			const ppid = Number(ppidText);
+			const pgid = Number(pgidText);
+			if (!isPositiveInteger(pid) || !Number.isInteger(ppid) || ppid < 0) {
+				return [];
+			}
+			if (!isPositiveInteger(pgid)) return [];
+			return [{ pid, ppid, pgid }];
+		});
+}
+
+export function collectProcessTree(
+	rootPid: number,
+	table: ProcessInfo[],
+): Set<number> {
+	const pids = new Set<number>([rootPid]);
+	const childrenByParent = new Map<number, ProcessInfo[]>();
+	for (const row of table) {
+		const children = childrenByParent.get(row.ppid) ?? [];
+		children.push(row);
+		childrenByParent.set(row.ppid, children);
+	}
+
+	const queue = [rootPid];
+	for (const pid of queue) {
+		for (const child of childrenByParent.get(pid) ?? []) {
+			if (pids.has(child.pid)) continue;
+			pids.add(child.pid);
+			queue.push(child.pid);
+		}
+	}
+
+	return pids;
+}
+
+export function getProcessGroupId(
+	pid: number,
+	table: ProcessInfo[],
+): number | null {
+	return table.find((row) => row.pid === pid)?.pgid ?? null;
+}
+
+export function isPositiveInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function signalTarget(
+	target: "pid" | "pgid",
+	id: number,
+	signal: NodeJS.Signals,
+	onSignalError: SignalProcessTreeAndGroupsOptions["onSignalError"],
+): void {
+	try {
+		process.kill(target === "pgid" ? -id : id, signal);
+	} catch (error) {
+		onSignalError?.({ target, id, signal, error });
+	}
+}

--- a/packages/pty-daemon/src/process-tree.ts
+++ b/packages/pty-daemon/src/process-tree.ts
@@ -57,12 +57,13 @@ export function collectProcessSignalTargets(
 		: null;
 	const rootPgid = getProcessGroupId(rootPid, table);
 	const pids = collectProcessTree(rootPid, table);
+	const infoByPid = new Map(table.map((row) => [row.pid, row]));
 	const pgids = new Set<number>();
 	const targets: ProcessSignalTarget[] = [];
 
 	for (const pid of pids) {
 		if (!includeRoot && pid === rootPid) continue;
-		const info = table.find((row) => row.pid === pid);
+		const info = infoByPid.get(pid);
 		if (!info) continue;
 		if (info.pgid <= 1) continue;
 		if (currentPgid !== null && info.pgid === currentPgid) continue;

--- a/packages/pty-daemon/test/control-plane.test.ts
+++ b/packages/pty-daemon/test/control-plane.test.ts
@@ -8,13 +8,7 @@
 // Runs under Node (`node --experimental-strip-types --test`).
 
 import { strict as assert } from "node:assert";
-import {
-	existsSync,
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { after, before, describe, test } from "node:test";
@@ -238,20 +232,18 @@ describe("session lifecycle", () => {
 		await c.close();
 	});
 
-	test("default close kills background jobs in separate process groups", async () => {
+	test("default close kills detached background process groups", async () => {
 		const c = await connectAndHello(sockPath);
 		const id = uniqueId("background-pgrp");
 		const tmp = mkdtempSync(path.join(os.tmpdir(), "pty-daemon-pgrp-"));
-		const logPath = path.join(tmp, "superset-codex-session.jsonl");
-		const pidPath = path.join(tmp, "tail.pid");
-		let tailPid: number | null = null;
-		writeFileSync(logPath, "");
+		const pidPath = path.join(tmp, "detached-helper.pid");
+		let helperPid: number | null = null;
 
 		try {
 			const script = [
 				"set -m",
-				`tail -n +1 -F ${shellQuote(logPath)} >/dev/null 2>&1 & tail_pid=$!`,
-				`echo "$tail_pid" > ${shellQuote(pidPath)}`,
+				`${shellQuote(process.execPath)} -e ${shellQuote("process.on('SIGHUP', () => {}); process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);")} >/dev/null 2>&1 & helper_pid=$!`,
+				`echo "$helper_pid" > ${shellQuote(pidPath)}`,
 				"sleep 60",
 			].join("; ");
 
@@ -268,19 +260,19 @@ describe("session lifecycle", () => {
 			c.send({ type: "subscribe", id, replay: false });
 			await waitForCondition(() => readPositivePidFile(pidPath) !== null);
 
-			tailPid = readPositivePidFile(pidPath);
-			assert.notEqual(tailPid, null);
-			assert.equal(isPidAlive(tailPid as number), true);
+			helperPid = readPositivePidFile(pidPath);
+			assert.notEqual(helperPid, null);
+			assert.equal(isPidAlive(helperPid as number), true);
 
 			c.send({ type: "close", id });
 			await c.waitFor((m) => m.type === "closed" && m.id === id);
 			await c.waitFor((m) => m.type === "exit" && m.id === id, 3000);
 
-			await waitForCondition(() => !isPidAlive(tailPid as number), 3000);
+			await waitForCondition(() => !isPidAlive(helperPid as number), 3000);
 		} finally {
-			if (tailPid !== null && tailPid > 0 && isPidAlive(tailPid)) {
+			if (helperPid !== null && helperPid > 0 && isPidAlive(helperPid)) {
 				try {
-					process.kill(tailPid, "SIGKILL");
+					process.kill(helperPid, "SIGKILL");
 				} catch {
 					// Already gone.
 				}

--- a/packages/pty-daemon/test/control-plane.test.ts
+++ b/packages/pty-daemon/test/control-plane.test.ts
@@ -8,6 +8,13 @@
 // Runs under Node (`node --experimental-strip-types --test`).
 
 import { strict as assert } from "node:assert";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { after, before, describe, test } from "node:test";
@@ -49,6 +56,31 @@ const baseMeta = {
 
 function uniqueId(prefix: string): string {
 	return `${prefix}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function waitForCondition(
+	predicate: () => boolean,
+	timeoutMs = 3000,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error(`condition timed out after ${timeoutMs}ms`);
 }
 
 // ---------------- Handshake ----------------
@@ -196,6 +228,57 @@ describe("session lifecycle", () => {
 		// returned (the bug), this waitFor would timeout.
 		await c.waitFor((m) => m.type === "exit" && m.id === id, 3000);
 		await c.close();
+	});
+
+	test("default close kills background jobs in separate process groups", async () => {
+		const c = await connectAndHello(sockPath);
+		const id = uniqueId("background-pgrp");
+		const tmp = mkdtempSync(path.join(os.tmpdir(), "pty-daemon-pgrp-"));
+		const logPath = path.join(tmp, "superset-codex-session.jsonl");
+		const pidPath = path.join(tmp, "tail.pid");
+		let tailPid: number | null = null;
+		writeFileSync(logPath, "");
+
+		try {
+			const script = [
+				"set -m",
+				`tail -n +1 -F ${shellQuote(logPath)} >/dev/null 2>&1 & tail_pid=$!`,
+				`echo "$tail_pid" > ${shellQuote(pidPath)}`,
+				"sleep 60",
+			].join("; ");
+
+			c.send({
+				type: "open",
+				id,
+				meta: {
+					...baseMeta,
+					shell: "/bin/bash",
+					argv: ["-c", script],
+				},
+			});
+			await c.waitFor((m) => m.type === "open-ok" && m.id === id);
+			c.send({ type: "subscribe", id, replay: false });
+			await waitForCondition(() => existsSync(pidPath));
+
+			tailPid = Number(readFileSync(pidPath, "utf8").trim());
+			assert.equal(isPidAlive(tailPid), true);
+
+			c.send({ type: "close", id });
+			await c.waitFor((m) => m.type === "closed" && m.id === id);
+			await c.waitFor((m) => m.type === "exit" && m.id === id, 3000);
+
+			await waitForCondition(() => !isPidAlive(tailPid as number), 3000);
+		} finally {
+			if (tailPid !== null && isPidAlive(tailPid)) {
+				try {
+					process.kill(tailPid, "SIGKILL");
+				} catch {
+					// Already gone.
+				}
+			}
+			rmSync(tmp, { recursive: true, force: true });
+			await c.close();
+		}
 	});
 });
 

--- a/scripts/smoke-pty-daemon-cleanup.mjs
+++ b/scripts/smoke-pty-daemon-cleanup.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for stale PTY child processes.
+ *
+ * Usage:
+ *   node scripts/smoke-pty-daemon-cleanup.mjs [repo-root]
+ *
+ * The script starts the target worktree's real pty-daemon under Node, opens a
+ * bash PTY that backgrounds `tail -F` in its own process group, closes the
+ * daemon session, and fails if the background tail survives.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const HEADER_BYTES = 4;
+const INNER_JSON_LEN_BYTES = 4;
+const MAX_FRAME_BYTES = 8 * 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 5000;
+
+function parseArgs(rawArgs) {
+	const parsed = {
+		production: false,
+		repoRoot: undefined,
+		socketPath: undefined,
+		orgId: undefined,
+	};
+	for (let i = 0; i < rawArgs.length; i += 1) {
+		const arg = rawArgs[i];
+		if (arg === "--help" || arg === "-h") {
+			printUsageAndExit();
+		}
+		if (arg === "--production" || arg === "--prod") {
+			parsed.production = true;
+			continue;
+		}
+		if (arg === "--socket") {
+			parsed.socketPath = rawArgs[i + 1];
+			parsed.production = true;
+			i += 1;
+			continue;
+		}
+		if (arg?.startsWith("--socket=")) {
+			parsed.socketPath = arg.slice("--socket=".length);
+			parsed.production = true;
+			continue;
+		}
+		if (arg === "--org" || arg === "--organization") {
+			parsed.orgId = rawArgs[i + 1];
+			parsed.production = true;
+			i += 1;
+			continue;
+		}
+		if (arg?.startsWith("--org=")) {
+			parsed.orgId = arg.slice("--org=".length);
+			parsed.production = true;
+			continue;
+		}
+		if (arg === "--repo" || arg === "--repo-root") {
+			parsed.repoRoot = rawArgs[i + 1];
+			i += 1;
+			continue;
+		}
+		if (arg?.startsWith("--repo=")) {
+			parsed.repoRoot = arg.slice("--repo=".length);
+			continue;
+		}
+		if (!arg?.startsWith("-") && parsed.repoRoot === undefined) {
+			parsed.repoRoot = arg;
+			continue;
+		}
+		throw new Error(`unknown argument: ${arg}`);
+	}
+	return parsed;
+}
+
+function printUsageAndExit() {
+	console.log(`Usage:
+  node scripts/smoke-pty-daemon-cleanup.mjs [repo-root]
+  node scripts/smoke-pty-daemon-cleanup.mjs --repo /path/to/worktree
+  node scripts/smoke-pty-daemon-cleanup.mjs --production
+  node scripts/smoke-pty-daemon-cleanup.mjs --production --org <organizationId>
+  node scripts/smoke-pty-daemon-cleanup.mjs --socket /path/to/pty-daemon.sock`);
+	process.exit(0);
+}
+
+class PtyDaemonClient {
+	static async connect(socketPath) {
+		const socket = await new Promise((resolve, reject) => {
+			const sock = net.createConnection({ path: socketPath });
+			const timer = setTimeout(() => {
+				sock.destroy();
+				reject(new Error("connect timed out"));
+			}, DEFAULT_TIMEOUT_MS);
+			sock.once("connect", () => {
+				clearTimeout(timer);
+				resolve(sock);
+			});
+			sock.once("error", (error) => {
+				clearTimeout(timer);
+				reject(error);
+			});
+		});
+
+		const client = new PtyDaemonClient(socket);
+		const ack = await client.request({
+			type: "hello",
+			protocols: [2, 1],
+			clientVersion: "cleanup-smoke",
+		});
+		if (ack.type !== "hello-ack") {
+			throw new Error(`handshake failed: ${JSON.stringify(ack)}`);
+		}
+		client.protocol = ack.protocol;
+		client.daemonVersion = ack.daemonVersion;
+		return client;
+	}
+
+	constructor(socket) {
+		this.socket = socket;
+		this.buffer = Buffer.alloc(0);
+		this.waiters = [];
+		this.protocol = null;
+		this.daemonVersion = "";
+		socket.on("data", (chunk) => this.onData(chunk));
+		socket.on("close", () => this.rejectAll(new Error("socket closed")));
+		socket.on("error", (error) => this.rejectAll(error));
+	}
+
+	request(message) {
+		this.socket.write(encodeFrame(message));
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.waiters = this.waiters.filter(
+					(waiter) => waiter.resolve !== resolve,
+				);
+				reject(new Error(`timed out waiting for ${message.type}`));
+			}, DEFAULT_TIMEOUT_MS);
+			this.waiters.push({
+				resolve: (frame) => {
+					clearTimeout(timer);
+					resolve(frame.message);
+				},
+				reject: (error) => {
+					clearTimeout(timer);
+					reject(error);
+				},
+			});
+		});
+	}
+
+	async dispose() {
+		if (this.socket.destroyed) return;
+		await new Promise((resolve) => {
+			this.socket.end(() => resolve());
+			setTimeout(() => {
+				if (!this.socket.destroyed) this.socket.destroy();
+				resolve();
+			}, 200);
+		});
+	}
+
+	onData(chunk) {
+		this.buffer =
+			this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+		for (const frame of drainFrames(this)) {
+			const waiter = this.waiters.shift();
+			if (waiter) waiter.resolve(frame);
+		}
+	}
+
+	rejectAll(error) {
+		const waiters = this.waiters.splice(0);
+		for (const waiter of waiters) {
+			waiter.reject(error);
+		}
+	}
+}
+
+function encodeFrame(message, payload) {
+	const jsonBytes = Buffer.from(JSON.stringify(message), "utf8");
+	const payloadLen = payload?.byteLength ?? 0;
+	const totalLen = INNER_JSON_LEN_BYTES + jsonBytes.byteLength + payloadLen;
+	const out = Buffer.alloc(HEADER_BYTES + totalLen);
+	out.writeUInt32BE(totalLen, 0);
+	out.writeUInt32BE(jsonBytes.byteLength, HEADER_BYTES);
+	jsonBytes.copy(out, HEADER_BYTES + INNER_JSON_LEN_BYTES);
+	if (payloadLen > 0) {
+		out.set(
+			payload,
+			HEADER_BYTES + INNER_JSON_LEN_BYTES + jsonBytes.byteLength,
+		);
+	}
+	return out;
+}
+
+function drainFrames(client) {
+	const frames = [];
+	while (client.buffer.length >= HEADER_BYTES) {
+		const totalLen = client.buffer.readUInt32BE(0);
+		if (totalLen > MAX_FRAME_BYTES) {
+			throw new Error(`frame too large: ${totalLen}`);
+		}
+		if (totalLen < INNER_JSON_LEN_BYTES) {
+			throw new Error(`frame too small: ${totalLen}`);
+		}
+		if (client.buffer.length < HEADER_BYTES + totalLen) break;
+
+		const jsonLen = client.buffer.readUInt32BE(HEADER_BYTES);
+		if (jsonLen > totalLen - INNER_JSON_LEN_BYTES) {
+			throw new Error(`invalid json length: ${jsonLen}`);
+		}
+
+		const jsonStart = HEADER_BYTES + INNER_JSON_LEN_BYTES;
+		const payloadStart = jsonStart + jsonLen;
+		const frameEnd = HEADER_BYTES + totalLen;
+		const message = JSON.parse(
+			client.buffer.subarray(jsonStart, payloadStart).toString("utf8"),
+		);
+		const payload =
+			payloadStart < frameEnd
+				? client.buffer.subarray(payloadStart, frameEnd)
+				: null;
+		frames.push({ message, payload });
+		client.buffer = client.buffer.subarray(frameEnd);
+	}
+	return frames;
+}
+
+async function waitFor(predicate, timeoutMs, message) {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (predicate()) return true;
+		await sleep(25);
+	}
+	if (message) throw new Error(message());
+	return false;
+}
+
+async function stopProcess(child) {
+	if (!child || child.exitCode !== null || child.signalCode !== null) return;
+	child.kill("SIGTERM");
+	if (await waitForProcessExit(child, 1000)) return;
+	child.kill("SIGKILL");
+	await waitForProcessExit(child, 1000);
+}
+
+function waitForProcessExit(child, timeoutMs) {
+	if (child.exitCode !== null || child.signalCode !== null) return true;
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => {
+			child.off("exit", onExit);
+			resolve(false);
+		}, timeoutMs);
+		const onExit = () => {
+			clearTimeout(timer);
+			resolve(true);
+		};
+		child.once("exit", onExit);
+	});
+}
+
+function fileExists(filePath) {
+	return existsSync(filePath);
+}
+
+function isPidAlive(pid) {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return error?.code === "EPERM";
+	}
+}
+
+function killPid(pid, signal) {
+	try {
+		process.kill(pid, signal);
+	} catch {
+		// Already gone.
+	}
+}
+
+function processRow(pid) {
+	const result = spawnSync(
+		"ps",
+		["-p", String(pid), "-o", "pid=,ppid=,pgid=,tty=,stat=,command="],
+		{ encoding: "utf8" },
+	);
+	const row = result.stdout.trim();
+	return row.length > 0 ? row : null;
+}
+
+function shellQuote(value) {
+	return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function stringEnv(env) {
+	const out = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (typeof value === "string") out[key] = value;
+	}
+	return out;
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const tmpDir = mkdtempSync(path.join(os.tmpdir(), "superset-pty-cleanup-"));
+	const launchedSocketPath = path.join(tmpDir, "pty-daemon.sock");
+	const sessionLogPath = path.join(tmpDir, "superset-codex-session.jsonl");
+	const tailPidPath = path.join(tmpDir, "tail.pid");
+	const sessionId = `cleanup-smoke-${process.pid}-${Date.now()}`;
+
+	let repoRoot = null;
+	let daemonProcess = null;
+	let daemonStderr = "";
+	let client = null;
+	let tailPid = null;
+
+	try {
+		writeFileSync(sessionLogPath, "");
+
+		let socketPath;
+		if (args.production || args.socketPath) {
+			const target = args.socketPath
+				? {
+						socketPath: path.resolve(args.socketPath),
+						pid: null,
+						organizationId: "manual-socket",
+						startedAt: null,
+					}
+				: await findProductionDaemon(args.orgId);
+			socketPath = target.socketPath;
+			repoRoot = process.cwd();
+			console.log("[smoke] mode: production");
+			console.log(`[smoke] organization: ${target.organizationId}`);
+			console.log(`[smoke] daemon pid: ${target.pid ?? "(manual socket)"}`);
+			console.log(`[smoke] socket: ${socketPath}`);
+		} else {
+			repoRoot = path.resolve(args.repoRoot ?? process.cwd());
+			const daemonEntry = path.join(
+				repoRoot,
+				"packages/pty-daemon/src/main.ts",
+			);
+			socketPath = launchedSocketPath;
+			console.log("[smoke] mode: source");
+			console.log(`[smoke] repo: ${repoRoot}`);
+			console.log(`[smoke] daemon: ${daemonEntry}`);
+
+			daemonProcess = spawn(
+				"node",
+				["--experimental-strip-types", daemonEntry, `--socket=${socketPath}`],
+				{
+					cwd: repoRoot,
+					stdio: ["ignore", "ignore", "pipe"],
+					env: {
+						...process.env,
+						SUPERSET_PTY_DAEMON_VERSION: "cleanup-smoke",
+					},
+				},
+			);
+			daemonProcess.stderr?.on("data", (chunk) => {
+				daemonStderr += chunk.toString();
+			});
+
+			await waitFor(
+				() => fileExists(socketPath),
+				DEFAULT_TIMEOUT_MS,
+				() => `daemon did not create socket\n${daemonStderr}`,
+			);
+		}
+
+		client = await PtyDaemonClient.connect(socketPath);
+		console.log(
+			`[smoke] connected: protocol=${client.protocol} daemon=${client.daemonVersion}`,
+		);
+
+		const script = [
+			"set -m",
+			`tail -n +1 -F ${shellQuote(sessionLogPath)} >/dev/null 2>&1 & tail_pid=$!`,
+			`echo "$tail_pid" > ${shellQuote(tailPidPath)}`,
+			"sleep 60",
+		].join("; ");
+
+		const open = await client.request({
+			type: "open",
+			id: sessionId,
+			meta: {
+				shell: "/bin/bash",
+				argv: ["-c", script],
+				cwd: repoRoot,
+				cols: 80,
+				rows: 24,
+				env: {
+					...stringEnv(process.env),
+					TERM: "xterm-256color",
+				},
+			},
+		});
+		if (open.type !== "open-ok") {
+			throw new Error(`open failed: ${JSON.stringify(open)}`);
+		}
+		console.log(`[smoke] shell pid: ${open.pid}`);
+
+		await waitFor(
+			() => fileExists(tailPidPath),
+			DEFAULT_TIMEOUT_MS,
+			() => `tail pid file was not written; daemon stderr:\n${daemonStderr}`,
+		);
+		tailPid = Number(readFileSync(tailPidPath, "utf8").trim());
+		if (!Number.isInteger(tailPid) || tailPid <= 0) {
+			throw new Error(`invalid tail pid: ${readFileSync(tailPidPath, "utf8")}`);
+		}
+		console.log(`[smoke] background tail pid: ${tailPid}`);
+		console.log(`[smoke] before close: ${processRow(tailPid) ?? "missing"}`);
+
+		const closed = await client.request({ type: "close", id: sessionId });
+		if (closed.type !== "closed") {
+			throw new Error(`close failed: ${JSON.stringify(closed)}`);
+		}
+
+		const cleaned = await waitFor(
+			() => !isPidAlive(tailPid),
+			DEFAULT_TIMEOUT_MS,
+		);
+		if (!cleaned) {
+			console.error(`[smoke] after close: ${processRow(tailPid) ?? "missing"}`);
+			console.error("[smoke] FAIL: background tail survived terminal close");
+			process.exitCode = 1;
+		} else {
+			console.log("[smoke] PASS: background tail was reaped");
+		}
+	} catch (error) {
+		console.error(
+			`[smoke] ERROR: ${error instanceof Error ? error.stack : error}`,
+		);
+		process.exitCode = 1;
+	} finally {
+		if (tailPid !== null && isPidAlive(tailPid)) {
+			console.error(`[smoke] cleanup: killing leaked test tail pid ${tailPid}`);
+			killPid(tailPid, "SIGKILL");
+		}
+		await client?.dispose().catch(() => {});
+		await stopProcess(daemonProcess);
+		rmSync(tmpDir, { recursive: true, force: true });
+	}
+}
+
+await main();
+
+async function findProductionDaemon(orgId) {
+	const manifests = listProductionDaemonManifests().filter((manifest) => {
+		if (orgId && manifest.organizationId !== orgId) return false;
+		if (!isPidAlive(manifest.pid)) return false;
+		if (!fileExists(manifest.socketPath)) return false;
+		return true;
+	});
+
+	const connectable = [];
+	for (const manifest of manifests) {
+		if (await canConnect(manifest.socketPath)) {
+			connectable.push(manifest);
+		}
+	}
+
+	if (connectable.length === 0) {
+		const suffix = orgId ? ` for org ${orgId}` : "";
+		throw new Error(`no running production pty-daemon manifest found${suffix}`);
+	}
+
+	connectable.sort((a, b) => b.startedAt - a.startedAt);
+	if (connectable.length > 1 && !orgId) {
+		console.log("[smoke] multiple production daemons found; using newest:");
+		for (const manifest of connectable) {
+			console.log(
+				`[smoke] candidate org=${manifest.organizationId} pid=${manifest.pid} startedAt=${new Date(manifest.startedAt).toISOString()} socket=${manifest.socketPath}`,
+			);
+		}
+	}
+
+	return connectable[0];
+}
+
+function listProductionDaemonManifests() {
+	const home =
+		process.env.SUPERSET_HOME_DIR || path.join(os.homedir(), ".superset");
+	const hostDir = path.join(home, "host");
+	if (!existsSync(hostDir)) return [];
+
+	const manifests = [];
+	for (const entry of readdirSync(hostDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const filePath = path.join(hostDir, entry.name, "pty-daemon-manifest.json");
+		if (!existsSync(filePath)) continue;
+		try {
+			const data = JSON.parse(readFileSync(filePath, "utf8"));
+			if (
+				typeof data.pid !== "number" ||
+				typeof data.socketPath !== "string" ||
+				typeof data.startedAt !== "number" ||
+				typeof data.organizationId !== "string"
+			) {
+				continue;
+			}
+			manifests.push({
+				pid: data.pid,
+				socketPath: data.socketPath,
+				startedAt: data.startedAt,
+				organizationId: data.organizationId,
+			});
+		} catch {
+			// Ignore invalid or concurrently-written manifests.
+		}
+	}
+	return manifests;
+}
+
+function canConnect(socketPath) {
+	return new Promise((resolve) => {
+		const socket = net.createConnection({ path: socketPath });
+		const timer = setTimeout(() => {
+			socket.destroy();
+			resolve(false);
+		}, 1000);
+		socket.once("connect", () => {
+			clearTimeout(timer);
+			socket.end();
+			resolve(true);
+		});
+		socket.once("error", () => {
+			clearTimeout(timer);
+			resolve(false);
+		});
+	});
+}

--- a/scripts/smoke-pty-daemon-cleanup.mjs
+++ b/scripts/smoke-pty-daemon-cleanup.mjs
@@ -6,8 +6,8 @@
  *   node scripts/smoke-pty-daemon-cleanup.mjs [repo-root]
  *
  * The script starts the target worktree's real pty-daemon under Node, opens a
- * bash PTY that backgrounds `tail -F` in its own process group, closes the
- * daemon session, and fails if the background tail survives.
+ * bash PTY that backgrounds a generic long-running helper in its own process
+ * group, closes the daemon session, and fails if the helper survives.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -17,7 +17,6 @@ import {
 	readdirSync,
 	readFileSync,
 	rmSync,
-	writeFileSync,
 } from "node:fs";
 import net from "node:net";
 import os from "node:os";
@@ -283,6 +282,14 @@ function isPidAlive(pid) {
 	}
 }
 
+function readPositivePidFile(filePath) {
+	if (!existsSync(filePath)) return null;
+	const raw = readFileSync(filePath, "utf8").trim();
+	if (!/^\d+$/.test(raw)) return null;
+	const pid = Number(raw);
+	return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
 function killPid(pid, signal) {
 	try {
 		process.kill(pid, signal);
@@ -321,19 +328,16 @@ async function main() {
 	const args = parseArgs(process.argv.slice(2));
 	const tmpDir = mkdtempSync(path.join(os.tmpdir(), "superset-pty-cleanup-"));
 	const launchedSocketPath = path.join(tmpDir, "pty-daemon.sock");
-	const sessionLogPath = path.join(tmpDir, "superset-codex-session.jsonl");
-	const tailPidPath = path.join(tmpDir, "tail.pid");
+	const helperPidPath = path.join(tmpDir, "detached-helper.pid");
 	const sessionId = `cleanup-smoke-${process.pid}-${Date.now()}`;
 
 	let repoRoot = null;
 	let daemonProcess = null;
 	let daemonStderr = "";
 	let client = null;
-	let tailPid = null;
+	let helperPid = null;
 
 	try {
-		writeFileSync(sessionLogPath, "");
-
 		let socketPath;
 		if (args.production || args.socketPath) {
 			const target = args.socketPath
@@ -391,8 +395,8 @@ async function main() {
 
 		const script = [
 			"set -m",
-			`tail -n +1 -F ${shellQuote(sessionLogPath)} >/dev/null 2>&1 & tail_pid=$!`,
-			`echo "$tail_pid" > ${shellQuote(tailPidPath)}`,
+			`${shellQuote(process.execPath)} -e ${shellQuote("process.on('SIGHUP', () => {}); process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);")} >/dev/null 2>&1 & helper_pid=$!`,
+			`echo "$helper_pid" > ${shellQuote(helperPidPath)}`,
 			"sleep 60",
 		].join("; ");
 
@@ -417,16 +421,18 @@ async function main() {
 		console.log(`[smoke] shell pid: ${open.pid}`);
 
 		await waitFor(
-			() => fileExists(tailPidPath),
+			() => readPositivePidFile(helperPidPath) !== null,
 			DEFAULT_TIMEOUT_MS,
-			() => `tail pid file was not written; daemon stderr:\n${daemonStderr}`,
+			() => `helper pid file was not written; daemon stderr:\n${daemonStderr}`,
 		);
-		tailPid = Number(readFileSync(tailPidPath, "utf8").trim());
-		if (!Number.isInteger(tailPid) || tailPid <= 0) {
-			throw new Error(`invalid tail pid: ${readFileSync(tailPidPath, "utf8")}`);
+		helperPid = readPositivePidFile(helperPidPath);
+		if (!Number.isInteger(helperPid) || helperPid <= 0) {
+			throw new Error(
+				`invalid helper pid: ${readFileSync(helperPidPath, "utf8")}`,
+			);
 		}
-		console.log(`[smoke] background tail pid: ${tailPid}`);
-		console.log(`[smoke] before close: ${processRow(tailPid) ?? "missing"}`);
+		console.log(`[smoke] background helper pid: ${helperPid}`);
+		console.log(`[smoke] before close: ${processRow(helperPid) ?? "missing"}`);
 
 		const closed = await client.request({ type: "close", id: sessionId });
 		if (closed.type !== "closed") {
@@ -434,15 +440,17 @@ async function main() {
 		}
 
 		const cleaned = await waitFor(
-			() => !isPidAlive(tailPid),
+			() => !isPidAlive(helperPid),
 			DEFAULT_TIMEOUT_MS,
 		);
 		if (!cleaned) {
-			console.error(`[smoke] after close: ${processRow(tailPid) ?? "missing"}`);
-			console.error("[smoke] FAIL: background tail survived terminal close");
+			console.error(
+				`[smoke] after close: ${processRow(helperPid) ?? "missing"}`,
+			);
+			console.error("[smoke] FAIL: background helper survived terminal close");
 			process.exitCode = 1;
 		} else {
-			console.log("[smoke] PASS: background tail was reaped");
+			console.log("[smoke] PASS: background helper was reaped");
 		}
 	} catch (error) {
 		console.error(
@@ -450,9 +458,11 @@ async function main() {
 		);
 		process.exitCode = 1;
 	} finally {
-		if (tailPid !== null && isPidAlive(tailPid)) {
-			console.error(`[smoke] cleanup: killing leaked test tail pid ${tailPid}`);
-			killPid(tailPid, "SIGKILL");
+		if (helperPid !== null && isPidAlive(helperPid)) {
+			console.error(
+				`[smoke] cleanup: killing leaked test helper pid ${helperPid}`,
+			);
+			killPid(helperPid, "SIGKILL");
 		}
 		await client?.dispose().catch(() => {});
 		await stopProcess(daemonProcess);


### PR DESCRIPTION
## Summary

Fixes stale PTY child processes that survive terminal/session close after moving into separate process groups. Cleanup is now generic: the daemon snapshots descendant PIDs/process groups before the PTY root exits, sends the requested signal, then reuses that same target set for SIGKILL escalation so detached helpers cannot escape after being reparented to pid 1.

The same process-tree/group cleanup is shared across the daemon, adopted PTY sessions, the v1 desktop terminal-host subprocess, host-service daemon lifecycle paths, and stale PID-file cleanup.

## Root Cause

The close path killed the shell/PTY root, but background jobs in their own process group could survive long enough to be reparented to pid 1 and detach from the terminal (`tty=??`). Once that happened, later PPID-tree cleanup could no longer find them.

The stricter smoke test now uses a generic long-running Node helper that ignores `SIGHUP`/`SIGTERM`, not a Codex or `tail` fixture. That reproduced the exact failure: first signal kills the shell, the helper becomes `ppid=1 tty=??`, and cleanup must still reap it.

## What Changed

- Default PTY close uses `SIGHUP`, signals descendant process groups/trees, then escalates to `SIGKILL` against the original target snapshot.
- Host-service `killSession` and workspace deletion now await daemon session close, including sessions that only exist in the daemon after host-service lost its in-memory map.
- Workspace delete, pane/tab close, teardown timeout, daemon restart/dev cleanup, wedged-daemon adoption cleanup, and upgrade predecessor cleanup all route through generic process cleanup.
- Upgrade handoff escalates only the predecessor daemon pid if handoff succeeds but the predecessor fails to exit.
- V1 terminal-host stale PID-file cleanup validates the pid still looks like terminal-host before signaling.
- Codex wrapper session-log watching remains only as a small compatibility bridge for older Codex TUI events; bespoke FIFO/tail PID/zombie cleanup was removed so process reaping stays in the generic PTY layer.
- `@superset/pty-daemon` is bumped from `0.2.0` to `0.2.1`.

## Validation

- `node scripts/smoke-pty-daemon-cleanup.mjs`
- `bun test packages/host-service/test/integration/terminal.integration.test.ts`
- `node --experimental-strip-types --test packages/pty-daemon/test/control-plane.test.ts --test-name-pattern "detached background"`
- `bun run --cwd packages/pty-daemon test`
- `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`
- `bun run --cwd packages/pty-daemon typecheck`
- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd apps/desktop typecheck`
- `bun run lint`

Also checked after local smoke/integration runs that no test helper processes remained.
