### PR TITLE
[codex] Handle missing workspace worktrees

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/WorkspaceMissingWorktreeState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/WorkspaceMissingWorktreeState.tsx
@@ -36,10 +36,10 @@ export function WorkspaceMissingWorktreeState({
 				</div>
 
 				<div className="flex flex-col gap-1.5">
-					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+					<h1 className="select-text cursor-text text-[15px] font-medium tracking-tight text-foreground">
 						Worktree missing
 					</h1>
-					<p className="text-[13px] leading-relaxed text-muted-foreground">
+					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
 						This workspace record still exists, but its worktree folder is no
 						longer on this host. Terminals and file actions are unavailable.
 					</p>
@@ -51,7 +51,7 @@ export function WorkspaceMissingWorktreeState({
 							Path
 						</span>
 						<code
-							className="min-w-0 truncate font-mono text-[11px] text-muted-foreground"
+							className="select-text cursor-text min-w-0 truncate font-mono text-[11px] text-muted-foreground"
 							title={worktreePath}
 						>
 							{worktreePath}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/WorkspaceMissingWorktreeState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/WorkspaceMissingWorktreeState.tsx
@@ -47,15 +47,17 @@ export function WorkspaceMissingWorktreeState({
 
 				{worktreePath ? (
 					<div className="flex w-full items-center gap-2 rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5">
-						<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+						<span className="shrink-0 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
 							Path
 						</span>
-						<code
-							className="select-text cursor-text min-w-0 truncate font-mono text-[11px] text-muted-foreground"
-							title={worktreePath}
-						>
-							{worktreePath}
-						</code>
+						<div className="min-w-0 flex-1 overflow-x-auto">
+							<code
+								className="inline-block min-w-max select-text cursor-text whitespace-nowrap font-mono text-[11px] text-muted-foreground"
+								title={worktreePath}
+							>
+								{worktreePath}
+							</code>
+						</div>
 					</div>
 				) : null}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/WorkspaceMissingWorktreeState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/WorkspaceMissingWorktreeState.tsx
@@ -1,0 +1,112 @@
+import { Button } from "@superset/ui/button";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, FolderX, RefreshCw, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { DashboardSidebarDeleteDialog } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog";
+
+interface WorkspaceMissingWorktreeStateProps {
+	workspaceId: string;
+	workspaceName: string;
+	branch: string;
+	worktreePath?: string;
+	onRefresh: () => void;
+	isRefreshing?: boolean;
+}
+
+export function WorkspaceMissingWorktreeState({
+	workspaceId,
+	workspaceName,
+	branch,
+	worktreePath,
+	onRefresh,
+	isRefreshing = false,
+}: WorkspaceMissingWorktreeStateProps) {
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const displayName = workspaceName || branch;
+
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div className="flex w-full max-w-md flex-col items-start gap-5">
+				<div className="grid size-10 place-items-center rounded-lg border border-destructive/20 bg-destructive/10">
+					<FolderX
+						className="size-[18px] text-destructive"
+						strokeWidth={1.5}
+						aria-hidden="true"
+					/>
+				</div>
+
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Worktree missing
+					</h1>
+					<p className="text-[13px] leading-relaxed text-muted-foreground">
+						This workspace record still exists, but its worktree folder is no
+						longer on this host. Terminals and file actions are unavailable.
+					</p>
+				</div>
+
+				{worktreePath ? (
+					<div className="flex w-full items-center gap-2 rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5">
+						<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+							Path
+						</span>
+						<code
+							className="min-w-0 truncate font-mono text-[11px] text-muted-foreground"
+							title={worktreePath}
+						>
+							{worktreePath}
+						</code>
+					</div>
+				) : null}
+
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						size="sm"
+						variant="destructive"
+						className="h-7 gap-1.5 px-2.5 text-[13px]"
+						onClick={() => setDeleteDialogOpen(true)}
+					>
+						<Trash2 className="size-3.5" strokeWidth={2} aria-hidden="true" />
+						Delete workspace
+					</Button>
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-7 gap-1.5 px-2 text-[13px] font-medium"
+						onClick={onRefresh}
+						disabled={isRefreshing}
+					>
+						<RefreshCw
+							className="size-3.5"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+						Refresh
+					</Button>
+					<Button
+						asChild
+						size="sm"
+						variant="ghost"
+						className="h-7 gap-1.5 px-2 text-[13px] font-medium"
+					>
+						<Link to="/v2-workspaces">
+							Browse workspaces
+							<ArrowRight
+								className="size-3.5"
+								strokeWidth={2}
+								aria-hidden="true"
+							/>
+						</Link>
+					</Button>
+				</div>
+
+				<DashboardSidebarDeleteDialog
+					workspaceId={workspaceId}
+					workspaceName={displayName}
+					open={deleteDialogOpen}
+					onOpenChange={setDeleteDialogOpen}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceMissingWorktreeState/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceMissingWorktreeState } from "./WorkspaceMissingWorktreeState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceStatusUnavailableState/WorkspaceStatusUnavailableState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceStatusUnavailableState/WorkspaceStatusUnavailableState.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@superset/ui/button";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, RefreshCw, TriangleAlert } from "lucide-react";
+
+interface WorkspaceStatusUnavailableStateProps {
+	onRefresh: () => void;
+	isRefreshing?: boolean;
+}
+
+export function WorkspaceStatusUnavailableState({
+	onRefresh,
+	isRefreshing = false,
+}: WorkspaceStatusUnavailableStateProps) {
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div className="flex w-full max-w-md flex-col items-start gap-5">
+				<div className="grid size-10 place-items-center rounded-lg border border-border/60 bg-muted/30">
+					<TriangleAlert
+						className="size-[18px] text-muted-foreground"
+						strokeWidth={1.5}
+						aria-hidden="true"
+					/>
+				</div>
+
+				<div className="flex flex-col gap-1.5">
+					<h1 className="select-text cursor-text text-[15px] font-medium tracking-tight text-foreground">
+						Workspace status unavailable
+					</h1>
+					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
+						Superset could not confirm whether this workspace is available on
+						the host. Refresh after the host is reachable again.
+					</p>
+				</div>
+
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-7 gap-1.5 px-2 text-[13px] font-medium"
+						onClick={onRefresh}
+						disabled={isRefreshing}
+					>
+						<RefreshCw
+							className="size-3.5"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+						Refresh
+					</Button>
+					<Button
+						asChild
+						size="sm"
+						variant="ghost"
+						className="h-7 gap-1.5 px-2 text-[13px] font-medium"
+					>
+						<Link to="/v2-workspaces">
+							Browse workspaces
+							<ArrowRight
+								className="size-3.5"
+								strokeWidth={2}
+								aria-hidden="true"
+							/>
+						</Link>
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceStatusUnavailableState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceStatusUnavailableState/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceStatusUnavailableState } from "./WorkspaceStatusUnavailableState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -16,6 +16,7 @@ import { V2WorkspaceRunButton } from "./components/V2WorkspaceRunButton";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
 import { WorkspaceMissingWorktreeState } from "./components/WorkspaceMissingWorktreeState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
+import { WorkspaceStatusUnavailableState } from "./components/WorkspaceStatusUnavailableState";
 import { useBrowserShellInteractionPassthrough } from "./hooks/useBrowserShellInteractionPassthrough";
 import { useClearActivePaneAttention } from "./hooks/useClearActivePaneAttention";
 import { useConsumeAutomationRunLink } from "./hooks/useConsumeAutomationRunLink";
@@ -84,10 +85,18 @@ function V2WorkspacePage() {
 		return <div className="flex h-full w-full" />;
 	}
 
-	if (
-		workspaceStatusQuery.isError ||
-		workspaceStatusQuery.data.worktreeExists === false
-	) {
+	if (workspaceStatusQuery.isError) {
+		return (
+			<WorkspaceStatusUnavailableState
+				onRefresh={() => {
+					void workspaceStatusQuery.refetch();
+				}}
+				isRefreshing={workspaceStatusQuery.isFetching}
+			/>
+		);
+	}
+
+	if (workspaceStatusQuery.data?.worktreeExists === false) {
 		return (
 			<WorkspaceMissingWorktreeState
 				workspaceId={workspace.id}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,4 +1,5 @@
 import { Workspace } from "@superset/panes";
+import { workspaceTrpc } from "@superset/workspace-client";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
@@ -13,6 +14,7 @@ import { V2NotificationStatusIndicator } from "./components/V2NotificationStatus
 import { V2PresetsBar } from "./components/V2PresetsBar";
 import { V2WorkspaceRunButton } from "./components/V2WorkspaceRunButton";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
+import { WorkspaceMissingWorktreeState } from "./components/WorkspaceMissingWorktreeState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { useBrowserShellInteractionPassthrough } from "./hooks/useBrowserShellInteractionPassthrough";
 import { useClearActivePaneAttention } from "./hooks/useClearActivePaneAttention";
@@ -69,6 +71,41 @@ export const Route = createFileRoute(
 });
 
 function V2WorkspacePage() {
+	const { workspace } = useWorkspace();
+	const workspaceStatusQuery = workspaceTrpc.workspace.get.useQuery(
+		{ id: workspace.id },
+		{
+			refetchOnWindowFocus: true,
+			retry: false,
+		},
+	);
+
+	if (workspaceStatusQuery.isPending) {
+		return <div className="flex h-full w-full" />;
+	}
+
+	if (
+		workspaceStatusQuery.isError ||
+		workspaceStatusQuery.data.worktreeExists === false
+	) {
+		return (
+			<WorkspaceMissingWorktreeState
+				workspaceId={workspace.id}
+				workspaceName={workspace.name}
+				branch={workspace.branch}
+				worktreePath={workspaceStatusQuery.data?.worktreePath}
+				onRefresh={() => {
+					void workspaceStatusQuery.refetch();
+				}}
+				isRefreshing={workspaceStatusQuery.isFetching}
+			/>
+		);
+	}
+
+	return <V2WorkspaceContent />;
+}
+
+function V2WorkspaceContent() {
 	const {
 		terminalId,
 		chatSessionId,

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -690,8 +690,13 @@ export async function createTerminalSessionInternal({
 		.findFirst({ where: eq(workspaces.id, workspaceId) })
 		.sync();
 
-	if (!workspace || !existsSync(workspace.worktreePath)) {
-		return { error: "Workspace worktree not found" };
+	if (!workspace) {
+		return { error: "Workspace not found" };
+	}
+	if (!existsSync(workspace.worktreePath)) {
+		return {
+			error: `Workspace worktree no longer exists: ${workspace.worktreePath}`,
+		};
 	}
 
 	// Derive root path from the workspace's project

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -284,23 +283,9 @@ async function runDestroy(ctx: HostServiceContext, input: DestroyInput) {
 		}
 
 		if (git) {
-			if (!existsSync(local.worktreePath)) {
-				try {
-					await git.raw(["worktree", "prune"]);
-					worktreeRemoved = true;
-				} catch (err) {
-					const message = err instanceof Error ? err.message : String(err);
-					warnings.push(
-						`Failed to prune missing worktree metadata for ${local.worktreePath}: ${message}`,
-					);
-				}
-			}
-
 			try {
-				if (!worktreeRemoved) {
-					await git.raw(["worktree", "remove", "--force", local.worktreePath]);
-					worktreeRemoved = true;
-				}
+				await git.raw(["worktree", "remove", "--force", local.worktreePath]);
+				worktreeRemoved = true;
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				if (

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -283,14 +284,29 @@ async function runDestroy(ctx: HostServiceContext, input: DestroyInput) {
 		}
 
 		if (git) {
+			if (!existsSync(local.worktreePath)) {
+				try {
+					await git.raw(["worktree", "prune"]);
+					worktreeRemoved = true;
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					warnings.push(
+						`Failed to prune missing worktree metadata for ${local.worktreePath}: ${message}`,
+					);
+				}
+			}
+
 			try {
-				await git.raw(["worktree", "remove", "--force", local.worktreePath]);
-				worktreeRemoved = true;
+				if (!worktreeRemoved) {
+					await git.raw(["worktree", "remove", "--force", local.worktreePath]);
+					worktreeRemoved = true;
+				}
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				if (
 					message.includes("is not a working tree") ||
 					message.includes("No such file or directory") ||
+					message.includes("does not exist") ||
 					message.includes("ENOENT")
 				) {
 					worktreeRemoved = true;

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -20,7 +21,10 @@ export const workspaceRouter = router({
 				});
 			}
 
-			return localWorkspace;
+			return {
+				...localWorkspace,
+				worktreeExists: existsSync(localWorkspace.worktreePath),
+			};
 		}),
 
 	cloudList: protectedProcedure.query(async ({ ctx }) => {

--- a/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
@@ -141,7 +141,7 @@ describe("workspaceCleanup.destroy integration", () => {
 		expect(branches.all).not.toContain(scenario.branch);
 	});
 
-	test("missing worktree is pruned and can still delete the branch", async () => {
+	test("missing worktree is removed and can still delete the branch", async () => {
 		rmSync(scenario.worktreePath, { recursive: true, force: true });
 
 		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
@@ -154,6 +154,42 @@ describe("workspaceCleanup.destroy integration", () => {
 
 		const branches = await scenario.repo.git.branchLocal();
 		expect(branches.all).not.toContain(scenario.branch);
+	});
+
+	test("missing worktree cleanup does not prune unrelated stale worktree metadata", async () => {
+		const otherBranch = "feature/other-missing";
+		const otherWorktreePath = join(
+			scenario.repo.repoPath,
+			".worktrees",
+			"feature-other-missing",
+		);
+		await scenario.repo.git.raw([
+			"worktree",
+			"add",
+			"-b",
+			otherBranch,
+			otherWorktreePath,
+		]);
+		seedWorkspace(scenario.host, {
+			projectId: scenario.projectId,
+			worktreePath: otherWorktreePath,
+			branch: otherBranch,
+		});
+		rmSync(scenario.worktreePath, { recursive: true, force: true });
+		rmSync(otherWorktreePath, { recursive: true, force: true });
+
+		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
+			workspaceId: scenario.featureWorkspaceId,
+		});
+		expect(result.worktreeRemoved).toBe(true);
+
+		const worktreeList = await scenario.repo.git.raw([
+			"worktree",
+			"list",
+			"--porcelain",
+		]);
+		expect(worktreeList).not.toContain(scenario.worktreePath);
+		expect(worktreeList).toContain(otherWorktreePath);
 	});
 
 	test("returns success when no local workspace row exists, still calls cloud delete", async () => {

--- a/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { writeFileSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { TRPCClientError } from "@trpc/client";
 import { eq } from "drizzle-orm";
@@ -135,6 +135,21 @@ describe("workspaceCleanup.destroy integration", () => {
 			workspaceId: scenario.featureWorkspaceId,
 			deleteBranch: true,
 		});
+		expect(result.branchDeleted).toBe(true);
+
+		const branches = await scenario.repo.git.branchLocal();
+		expect(branches.all).not.toContain(scenario.branch);
+	});
+
+	test("missing worktree is pruned and can still delete the branch", async () => {
+		rmSync(scenario.worktreePath, { recursive: true, force: true });
+
+		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
+			workspaceId: scenario.featureWorkspaceId,
+			deleteBranch: true,
+		});
+		expect(result.success).toBe(true);
+		expect(result.worktreeRemoved).toBe(true);
 		expect(result.branchDeleted).toBe(true);
 
 		const branches = await scenario.repo.git.branchLocal();

--- a/packages/host-service/test/integration/workspace.integration.test.ts
+++ b/packages/host-service/test/integration/workspace.integration.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { writeFileSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
+import {
+	type BasicScenario,
+	createBasicScenario,
+	createFeatureWorktreeScenario,
+} from "../helpers/scenarios";
 
 describe("workspace router integration", () => {
 	let scenario: BasicScenario;
@@ -20,6 +24,22 @@ describe("workspace router integration", () => {
 		});
 		expect(ws.id).toBe(scenario.workspaceId);
 		expect(ws.branch).toBe("main");
+		expect(ws.worktreeExists).toBe(true);
+	});
+
+	test("get reports when the worktree path no longer exists", async () => {
+		const featureScenario = await createFeatureWorktreeScenario();
+		try {
+			rmSync(featureScenario.worktreePath, { recursive: true, force: true });
+
+			const ws = await featureScenario.host.trpc.workspace.get.query({
+				id: featureScenario.featureWorkspaceId,
+			});
+			expect(ws.worktreePath).toBe(featureScenario.worktreePath);
+			expect(ws.worktreeExists).toBe(false);
+		} finally {
+			await featureScenario.dispose();
+		}
 	});
 
 	test("get throws NOT_FOUND for missing workspace", async () => {


### PR DESCRIPTION
## Summary

Adds first-class handling for v2 workspaces whose local worktree directory has been removed outside Superset.

- Exposes `worktreeExists` from host-service workspace lookup.
- Shows a dedicated missing-worktree state in the desktop workspace page instead of mounting terminal/file workflows that cannot work.
- Keeps delete available from that state and makes cleanup prune stale git worktree metadata so optional branch deletion still works.
- Improves terminal creation errors when the workspace row exists but the worktree path does not.

## Impact

Users get a clear indicator when a workspace record remains but its worktree directory is gone. They can refresh, browse other workspaces, or delete the stale workspace record without terminal creation failing silently or generically.

## Validation

- `bun run lint`
- `bun run typecheck` in `packages/host-service`
- `bun run typecheck` in `apps/desktop`
- `bun test packages/host-service/test/integration/workspace.integration.test.ts packages/host-service/test/integration/workspace-cleanup.integration.test.ts`
- `bun test packages/host-service/test/workspace-cleanup.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles v2 workspaces whose local worktree folder was removed and adds a fallback when the host is unreachable. The desktop shows clear states, and the host service reports status to prevent broken terminals and enable safe cleanup.

- **New Features**
  - `workspace.get` now returns `worktreeExists` (and the UI queries it) to show a dedicated “Worktree missing” state with path (horizontally scrollable), Refresh, Browse, and Delete actions.
  - Added a “Workspace status unavailable” state for host connectivity issues with Refresh and Browse actions.

- **Bug Fixes**
  - Terminal creation now returns specific errors for “Workspace not found” vs. “Worktree no longer exists”.
  - Cleanup prunes only metadata for the missing worktree, so deleting a workspace or its branch still works and unrelated worktrees aren’t pruned.

<sup>Written for commit 5c8dcb527381449a2c18b64d4e87f3d443b07971. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New empty-state UIs for "Worktree missing" and "Workspace status unavailable" with refresh, delete, and browse actions; path shown when available.
  * Workspace status now reports whether the local worktree exists, enabling conditional UI.

* **Bug Fixes**
  * More specific terminal error when a worktree path is missing vs workspace not found.
  * Cleanup treats already-missing worktrees as removed instead of failing.

* **Tests**
  * Integration tests added/updated to cover missing worktree scenarios and reporting of worktree existence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4343)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->