### PR TITLE
[codex] Hide sidebar diff stats on hover

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -254,13 +254,13 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 						</span>
 					)}
 
-					<div className="col-start-2 row-start-1 flex h-5 shrink-0 items-center justify-end gap-1.5">
+					<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center justify-items-end [&>*]:col-start-1 [&>*]:row-start-1">
 						{creationStatusText ? (
 							<span
 								className={cn(
-									"text-[11px] transition-opacity",
+									"text-[11px]",
 									creationStatus === "failed"
-										? "text-destructive group-hover:opacity-0 group-hover:hidden"
+										? "text-destructive group-hover:hidden"
 										: "text-muted-foreground",
 								)}
 							>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
@@ -10,7 +10,7 @@ export function DashboardSidebarWorkspaceDiffStats({
 	isActive,
 }: DashboardSidebarWorkspaceDiffStatsProps) {
 	return (
-		<div className="flex h-5 w-fit shrink-0 items-center justify-self-end text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible">
+		<div className="flex h-5 w-fit shrink-0 items-center justify-self-end font-mono text-[10px] tabular-nums group-hover:hidden">
 			<div className="flex items-center gap-1.5 leading-none">
 				<span
 					className={isActive ? "text-emerald-500/90" : "text-muted-foreground"}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
@@ -14,7 +14,7 @@ export function WorkspaceDiffStats({
 	return (
 		<div
 			className={cn(
-				"flex h-5 shrink-0 items-center rounded px-1.5 text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible",
+				"flex h-5 shrink-0 items-center rounded px-1.5 font-mono text-[10px] tabular-nums group-hover:hidden",
 				isActive ? "bg-foreground/10" : "bg-muted/50",
 			)}
 		>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -403,7 +403,7 @@ export function WorkspaceListItem({
 										isActive={isActive}
 									/>
 								)}
-								<div className="flex items-center justify-end gap-1.5 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-[opacity,visibility]">
+								<div className="hidden items-center justify-end gap-1.5 group-hover:flex">
 									{shortcutIndex !== undefined &&
 										shortcutIndex < MAX_KEYBOARD_SHORTCUT_INDEX && (
 											<span className="text-[10px] text-muted-foreground font-mono tabular-nums shrink-0">


### PR DESCRIPTION
## Summary

- Hide left sidebar diff stats with `group-hover:hidden` instead of opacity/visibility on hover.
- Treat the trailing sidebar metadata/actions area as a replacement slot so hover actions do not sit beside hidden diff counters.
- Apply the same behavior to the legacy workspace sidebar row for consistency.

## Why

The diff counters were previously opacity-hidden on hover, which kept their reserved width and caused hover actions to appear offset or make the row feel like it was shifting. Removing them from layout on hover makes the metadata-to-actions transition cleaner and closer to Linear-style sidebar interactions.

## Validation

- `bun run lint:fix`
- `bun run lint`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide sidebar diff stats on hover by removing them from layout so actions replace them cleanly. This prevents layout shift and makes sidebar interactions feel smoother.

- **Refactors**
  - Switched diff stats to `group-hover:hidden` (from opacity/visibility) in dashboard and legacy workspace sidebars.
  - Made the trailing metadata/actions area a single replacement slot using a grid wrapper and `group-hover:flex` for actions.
  - Simplified related classes to keep behavior consistent across both sidebars.

<sup>Written for commit 23f1bdcfb01e918c5d5a14f7469e0ab1ee727991. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined workspace sidebar hover interactions with improved visual consistency and responsiveness.
  * Updated workspace stats displays and action controls styling for smoother, more reactive user interactions.
  * Enhanced layout styling in workspace components for better performance and cleaner visual feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4344)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->