### PR TITLE
[codex] Fix nonblocking worktree status refresh

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -75,8 +75,10 @@ function V2WorkspacePage() {
 	const workspaceStatusQuery = workspaceTrpc.workspace.get.useQuery(
 		{ id: workspace.id },
 		{
-			refetchOnWindowFocus: true,
+			refetchOnMount: "always",
+			refetchOnWindowFocus: "always",
 			retry: false,
+			staleTime: 0,
 		},
 	);
 
@@ -95,7 +97,7 @@ function V2WorkspacePage() {
 		);
 	}
 
-	return <V2WorkspaceContent />;
+	return <V2WorkspaceContent key={workspace.id} />;
 }
 
 function V2WorkspaceContent() {


### PR DESCRIPTION
## Summary
- Force the nonblocking worktree status query to refetch on mount and window focus instead of relying on the workspace-client stale cache.
- Keep workspace content nonblocking, but remount the workspace content when the workspace id changes.

## Root cause
The follow-up that made `workspace.get` nonblocking still inherited the workspace client's default `staleTime`, so a recently cached `worktreeExists: true` could prevent the fresh check that should switch to the missing-worktree page. Removing the pending gate also removed an implicit remount point for workspace content.

## Validation
- `bun run lint`
- `bun run typecheck` in `apps/desktop`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale worktree status by forcing a fresh check and remounting workspace content when switching workspaces. Users now see the missing-worktree page immediately when the worktree is gone.

- **Bug Fixes**
  - Always refetch status on mount and on window focus; set `staleTime: 0`.
  - Keep nonblocking; maintain `retry: false`.
  - Remount workspace view with `key={workspace.id}` to reset state on workspace change.

<sup>Written for commit 87489c7da9de07691ca98e677b285e77396d2c77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace status data refresh behavior to ensure you always see the most current information when accessing the workspace.
  * Fixed workspace content reset when switching between different workspaces to prevent stale data display.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4347)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->