### PR TITLE
Revert "Make worktree status check nonblocking"

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceStatusUnavailableState/WorkspaceStatusUnavailableState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceStatusUnavailableState/WorkspaceStatusUnavailableState.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@superset/ui/button";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, RefreshCw, TriangleAlert } from "lucide-react";
+
+interface WorkspaceStatusUnavailableStateProps {
+	onRefresh: () => void;
+	isRefreshing?: boolean;
+}
+
+export function WorkspaceStatusUnavailableState({
+	onRefresh,
+	isRefreshing = false,
+}: WorkspaceStatusUnavailableStateProps) {
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div className="flex w-full max-w-md flex-col items-start gap-5">
+				<div className="grid size-10 place-items-center rounded-lg border border-border/60 bg-muted/30">
+					<TriangleAlert
+						className="size-[18px] text-muted-foreground"
+						strokeWidth={1.5}
+						aria-hidden="true"
+					/>
+				</div>
+
+				<div className="flex flex-col gap-1.5">
+					<h1 className="select-text cursor-text text-[15px] font-medium tracking-tight text-foreground">
+						Workspace status unavailable
+					</h1>
+					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
+						Superset could not confirm whether this workspace is available on
+						the host. Refresh after the host is reachable again.
+					</p>
+				</div>
+
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-7 gap-1.5 px-2 text-[13px] font-medium"
+						onClick={onRefresh}
+						disabled={isRefreshing}
+					>
+						<RefreshCw
+							className="size-3.5"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
+						Refresh
+					</Button>
+					<Button
+						asChild
+						size="sm"
+						variant="ghost"
+						className="h-7 gap-1.5 px-2 text-[13px] font-medium"
+					>
+						<Link to="/v2-workspaces">
+							Browse workspaces
+							<ArrowRight
+								className="size-3.5"
+								strokeWidth={2}
+								aria-hidden="true"
+							/>
+						</Link>
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceStatusUnavailableState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceStatusUnavailableState/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceStatusUnavailableState } from "./WorkspaceStatusUnavailableState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -16,6 +16,7 @@ import { V2WorkspaceRunButton } from "./components/V2WorkspaceRunButton";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
 import { WorkspaceMissingWorktreeState } from "./components/WorkspaceMissingWorktreeState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
+import { WorkspaceStatusUnavailableState } from "./components/WorkspaceStatusUnavailableState";
 import { useBrowserShellInteractionPassthrough } from "./hooks/useBrowserShellInteractionPassthrough";
 import { useClearActivePaneAttention } from "./hooks/useClearActivePaneAttention";
 import { useConsumeAutomationRunLink } from "./hooks/useConsumeAutomationRunLink";
@@ -79,6 +80,21 @@ function V2WorkspacePage() {
 			retry: false,
 		},
 	);
+
+	if (workspaceStatusQuery.isPending) {
+		return <div className="flex h-full w-full" />;
+	}
+
+	if (workspaceStatusQuery.isError) {
+		return (
+			<WorkspaceStatusUnavailableState
+				onRefresh={() => {
+					void workspaceStatusQuery.refetch();
+				}}
+				isRefreshing={workspaceStatusQuery.isFetching}
+			/>
+		);
+	}
 
 	if (workspaceStatusQuery.data?.worktreeExists === false) {
 		return (


### PR DESCRIPTION
## Summary
- Reverts #4346 / `d988f24b` (`Make worktree status check nonblocking`).
- Restores the blocking workspace status check before mounting v2 workspace content.
- Restores the `WorkspaceStatusUnavailableState` fallback component.

## Reason
The nonblocking follow-up regressed workspace switching/missing-worktree behavior. Reverting returns the route to the known pre-#4346 behavior.

## Validation
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck` in `apps/desktop`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revert the nonblocking worktree status check and restore the previous blocking behavior in the v2 workspace route. This fixes workspace switching and missing-worktree regressions and brings back the “status unavailable” fallback.

- **Bug Fixes**
  - Block mounting v2 workspace content until the status query resolves.
  - Show `WorkspaceStatusUnavailableState` on status errors with Refresh and “Browse workspaces” actions.
  - Restore missing worktree handling to the pre-#4346 behavior.

<sup>Written for commit a008b2e9a919e16c1654e5bfae0eeb03596a0916. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace status error handling with a new unavailable state UI
  * Added the ability to refresh workspace status from the error state
  * Navigation link to workspace list now available when status is unavailable
  * Loading state now displays while fetching workspace information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4348)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->