### PR TITLE
ux(mobile): apply Laws of UX to workspace/project/pane flow

### DIFF
--- a/apps/mobile/DESIGN.md
+++ b/apps/mobile/DESIGN.md
@@ -1,0 +1,108 @@
+# Mobile UX Redesign — Laws of UX Pass
+
+Branch: `ux/mobile-flow-laws-of-ux`
+Scope: `apps/mobile/` only. No upstream package changes. No new routes.
+
+## 1. Current Flow (as of branch base `7f6876f`)
+
+```
+RootLayout
+└── (authenticated)             Stack + native TabBar (SwiftUI)
+    ├── (home)                  Stack
+    │   ├── index               WorkspacesScreen   (placeholder card)
+    │   └── workspaces/[id]     WorkspaceDetailScreen (3 hard-coded cards)
+    ├── (tasks)                 Stack
+    │   ├── index               TasksScreen         (placeholder)
+    │   └── [id]                TaskDetailScreen    (placeholder)
+    └── (more)                  Stack
+        ├── index               MoreMenuScreen      (org switch + nav)
+        └── settings            SettingsScreen      (3 placeholder cards)
+```
+
+Tab bar: native SwiftUI view (`@superset/tab-bar`) with 3 visible items
+(Home / Tasks / More-menu). Org switcher lives both in More and as a header
+button on the Workspaces screen (sheet).
+
+Note: the brief mentions `panes/[paneId]`, but that route does not exist on
+mobile yet. Within this branch it is reinterpreted as "the cards (panes)
+shown inside `workspaces/[id]`" — we improve their structure without
+adding new routes.
+
+## 2. Identified Violations
+
+| Law                    | Violation                                                                                  |
+|------------------------|--------------------------------------------------------------------------------------------|
+| Hick's Law             | Tab count is fine (3). But Workspaces screen has zero scaffolding to filter when populated.|
+| Fitts's Law            | Custom back chevrons (`<Pressable className="p-1">`) on Workspace/Task/Settings ~24x24 pt — far below 44pt target. |
+| Jakob's Law            | Workspace and Task detail screens pad with `insets.top` instead of using the Stack header → no swipe-back affordance, no native large-title behavior. RefreshControl exists on home but is a no-op. |
+| Miller's Law           | No grouping in Workspaces list. Once data arrives we'd dump N items in one viewport.        |
+| Tesler's Law           | Org switching is duplicated (header sheet + More tab). Two affordances for one action.      |
+| Aesthetic-Usability    | Hard-coded `hsl()` color in `OrganizationHeaderButton` chevron instead of token.            |
+| Doherty Threshold      | No skeletons; on first paint the screen is blank text "will appear here". No optimistic UI. |
+| Goal-Gradient          | No progress indicator while collections sync.                                               |
+| Peak-End               | Pane (workspace card) "open" moment is unstyled — straight to a generic ScrollView.         |
+| Serial Position        | Action lists in More are unranked; "Sign out" sits at end (good) but "Settings" is buried alone. |
+
+## 3. Proposed Flow (same routes, new structure)
+
+```
+(home) WorkspacesScreen
+├── Sticky header (Stack header — Jakob)
+│   └── OrgHeaderButton (pressable 44pt, opens switcher sheet — Tesler dedupe)
+├── ScrollView (RefreshControl wired to collection.refetch — Doherty)
+│   ├── Section "Active"     (Miller — projects with non-archived status)
+│   │   └── ProjectGroup
+│   │       └── WorkspaceCard[] (≤7 visible, "see more" expander)
+│   ├── Section "Recent"     (Serial Position — middle de-emphasised)
+│   └── Section "Archived"   (collapsed by default — Tesler)
+└── Loading: SkeletonList (Goal-Gradient + Aesthetic-Usability)
+
+(home) workspaces/[id]  WorkspaceDetailScreen
+├── Stack header (title from data, native back swipe — Jakob/Fitts)
+└── ScrollView
+    └── PaneCard[]   (Peak-End: subtle scale-in + spacing rhythm)
+
+(tasks) TasksScreen
+├── Stack header
+└── ScrollView with same Active/Recent grouping pattern
+
+(more) MoreMenuScreen
+└── Order anchored: Org → primary actions → Sign out (Serial Position)
+```
+
+## 4. Concrete Changes (one commit each)
+
+1. **fix(mobile/nav): native back + 44pt targets on detail screens** — drop manual `Pressable` back chevrons; rely on Stack header. Where a custom button is kept (e.g. settings deep-link), bump to `min-h-[44px] min-w-[44px]`. Removes Fitts/Jakob violations on `WorkspaceDetailScreen`, `TaskDetailScreen`, `SettingsScreen`.
+2. **feat(mobile/workspaces): chunk projects with skeleton + sections** — render Active / Archived sections from `collections.projects`. Reusable `<SectionHeader>` and `<WorkspaceCard>` components in the screen folder. `<SkeletonList>` while data is loading. Caps each section to 7 visible items with "Show all" reveal (Miller). Wires RefreshControl to refetch the collection.
+3. **fix(mobile/workspaces): use token color in OrgHeaderButton chevron** — replace `hsl(240 5% 64.9%)` with `useTheme().mutedForeground` (Aesthetic-Usability).
+4. **feat(mobile/workspace-detail): real header + pane cards** — drive `Stack.Screen` title from project name via `Stack.Screen options`. Add `PaneCard` component grouping the three info sections with consistent spacing (Peak-End). Skeletons while project loads.
+5. **feat(mobile/more): re-order and tighten More menu** — anchor Org at top, Settings + Help row in middle, Sign out at bottom (Serial Position). Single tap targets at 44pt.
+
+Each commit is independently typecheckable and reversible. No deletes
+without `bun run typecheck` clean.
+
+## 5. Tradeoffs
+
+- **No new dependencies.** Animations stay in `react-native-reanimated`
+  (already a dep). No haptics lib (would be a nice Peak-End boost but
+  out-of-scope under "no new deps").
+- **Sections are component-local**, not a generic primitive. Promoting
+  to `components/ui/section.tsx` would be premature abstraction for
+  two consumers.
+- **`panes/[paneId]` route not introduced.** Brief mentioned it, but
+  creating it would conflict with "no new routes". The "pane" concept
+  is realised as `<PaneCard>` within `workspaces/[id]`.
+- **Native TabBar untouched.** It's already at 3 items (Hick OK) and
+  changing the SwiftUI module is out of scope for this branch.
+- **Org-switcher duplication is reduced** by collapsing the per-screen
+  header sheet *only* when the user has a single org; multi-org users
+  still get the quick header switch (this is a smaller change than
+  removing it outright and avoids a regression for power users).
+
+## 6. Out of Scope (honest)
+
+- Real data wiring beyond what `useLiveQuery` already gives us.
+- Search, command-palette, or filters beyond section chunking.
+- iPad/web layout. Mobile portrait only.
+- Tests — there is no test harness in `apps/mobile` today; adding one
+  is its own PR.

--- a/apps/mobile/DESIGN.md
+++ b/apps/mobile/DESIGN.md
@@ -76,7 +76,8 @@ adding new routes.
 2. **feat(mobile/workspaces): chunk projects with skeleton + sections** — render Active / Archived sections from `collections.projects`. Reusable `<SectionHeader>` and `<WorkspaceCard>` components in the screen folder. `<SkeletonList>` while data is loading. Caps each section to 7 visible items with "Show all" reveal (Miller). Wires RefreshControl to refetch the collection.
 3. **fix(mobile/workspaces): use token color in OrgHeaderButton chevron** — replace `hsl(240 5% 64.9%)` with `useTheme().mutedForeground` (Aesthetic-Usability).
 4. **feat(mobile/workspace-detail): real header + pane cards** — drive `Stack.Screen` title from project name via `Stack.Screen options`. Add `PaneCard` component grouping the three info sections with consistent spacing (Peak-End). Skeletons while project loads.
-5. **feat(mobile/more): re-order and tighten More menu** — anchor Org at top, Settings + Help row in middle, Sign out at bottom (Serial Position). Single tap targets at 44pt.
+5. **fix(mobile/more): re-order and tighten More menu** — anchor Org at top, Settings + Help row in middle, Sign out at bottom (Serial Position). Single tap targets at 44pt.
+6. **feat(mobile/tasks): chunk by status type with skeletons** — same chunking pattern as Workspaces, but driven by `task_statuses.type` so Active / Backlog / Done show as separate sections; Done collapses by default (Tesler).
 
 Each commit is independently typecheckable and reversible. No deletes
 without `bun run typecheck` clean.

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/WorkspacesScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/WorkspacesScreen.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCallback, useMemo, useState } from "react";
 import {
 	RefreshControl,
 	ScrollView,
@@ -7,19 +8,64 @@ import {
 } from "react-native";
 import { Text } from "@/components/ui/text";
 import { useOrganizations } from "@/screens/(authenticated)/hooks/useOrganizations";
+import { useCollections } from "@/screens/(authenticated)/providers/CollectionsProvider";
 import { OrganizationHeaderButton } from "./components/OrganizationHeaderButton";
 import { OrganizationSwitcherSheet } from "./components/OrganizationSwitcherSheet";
+import { ProjectSection } from "./components/ProjectSection";
+import type { WorkspaceCardProps } from "./components/WorkspaceCard";
+import { WorkspacesSkeleton } from "./components/WorkspacesSkeleton";
+
+const ACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
 
 export function WorkspacesScreen() {
 	const [refreshing, setRefreshing] = useState(false);
 	const [sheetOpen, setSheetOpen] = useState(false);
 	const { width } = useWindowDimensions();
+	const collections = useCollections();
 	const {
 		organizations,
 		activeOrganization,
 		activeOrganizationId,
 		switchOrganization,
 	} = useOrganizations();
+
+	const { data: projects, isLoading } = useLiveQuery(
+		(q) => q.from({ projects: collections.projects }),
+		[collections],
+	);
+
+	// Miller's Law — chunk into Active / Recent buckets so the user
+	// is never scanning more than one cognitive group at a time.
+	const { active, recent } = useMemo(() => {
+		const now = Date.now();
+		const cutoff = now - ACTIVE_THRESHOLD_MS;
+		const buckets: {
+			active: WorkspaceCardProps[];
+			recent: WorkspaceCardProps[];
+		} = { active: [], recent: [] };
+
+		const sorted = [...(projects ?? [])].sort((a, b) => {
+			const aTs = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+			const bTs = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+			return bTs - aTs;
+		});
+
+		for (const project of sorted) {
+			const updatedTs = project.updatedAt
+				? new Date(project.updatedAt).getTime()
+				: 0;
+			const card: WorkspaceCardProps = {
+				id: project.id,
+				name: project.name,
+				repoLabel: `${project.repoOwner}/${project.repoName}`,
+				branch: project.defaultBranch,
+			};
+			if (updatedTs >= cutoff) buckets.active.push(card);
+			else buckets.recent.push(card);
+		}
+
+		return buckets;
+	}, [projects]);
 
 	const handleSwitchOrganization = (organizationId: string) => {
 		setSheetOpen(false);
@@ -28,8 +74,18 @@ export function WorkspacesScreen() {
 
 	const onRefresh = useCallback(async () => {
 		setRefreshing(true);
-		setRefreshing(false);
-	}, []);
+		try {
+			// Electric collections sync in real-time, so a hard refetch isn't
+			// exposed. preload() at minimum re-attaches the shape if it was
+			// idle — and the RefreshControl gives the user a Doherty-friendly
+			// "I heard you" tactile signal.
+			await collections.projects.preload();
+		} finally {
+			setRefreshing(false);
+		}
+	}, [collections]);
+
+	const isEmpty = !isLoading && (projects?.length ?? 0) === 0;
 
 	return (
 		<>
@@ -45,12 +101,29 @@ export function WorkspacesScreen() {
 					<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
 				}
 			>
-				<View className="p-6">
-					<View className="items-center justify-center py-20">
-						<Text className="text-center text-muted-foreground">
-							Workspaces grouped by project will appear here
-						</Text>
-					</View>
+				<View className="px-4 pb-8 pt-2 gap-6">
+					{isLoading ? (
+						<WorkspacesSkeleton />
+					) : isEmpty ? (
+						<View className="items-center justify-center py-20">
+							<Text className="text-center text-muted-foreground">
+								No workspaces yet — create one to get started
+							</Text>
+						</View>
+					) : (
+						<>
+							{active.length > 0 ? (
+								<ProjectSection title="Active" items={active} />
+							) : null}
+							{recent.length > 0 ? (
+								<ProjectSection
+									title="Recent"
+									items={recent}
+									defaultCollapsed={active.length > 0}
+								/>
+							) : null}
+						</>
+					)}
 				</View>
 			</ScrollView>
 			<OrganizationSwitcherSheet

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/OrganizationHeaderButton/OrganizationHeaderButton.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/OrganizationHeaderButton/OrganizationHeaderButton.tsx
@@ -1,6 +1,7 @@
 import { Stack } from "expo-router";
 import { ChevronsUpDown } from "lucide-react-native";
 import { Pressable } from "react-native";
+import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import { OrganizationAvatar } from "../OrganizationSwitcherSheet/components/OrganizationAvatar";
 
@@ -17,12 +18,21 @@ export function OrganizationHeaderButton({
 		<>
 			<Stack.Toolbar placement="left">
 				<Stack.Toolbar.View hidesSharedBackground>
-					<Pressable onPress={onPress} className="flex-row items-center gap-2">
+					<Pressable
+						onPress={onPress}
+						className="flex-row items-center gap-2"
+						style={{ minHeight: 44 }}
+						accessibilityRole="button"
+						accessibilityLabel={`${name ?? "Organization"} — switch organization`}
+					>
 						<OrganizationAvatar name={name} logo={logo} size={28} />
 						<Text className="text-xl font-semibold text-foreground">
 							{name ?? "Organization"}
 						</Text>
-						<ChevronsUpDown size={14} color="hsl(240 5% 64.9%)" />
+						<Icon
+							as={ChevronsUpDown}
+							className="text-muted-foreground size-3.5"
+						/>
 					</Pressable>
 				</Stack.Toolbar.View>
 			</Stack.Toolbar>

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/ProjectSection/ProjectSection.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/ProjectSection/ProjectSection.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { WorkspaceCard, type WorkspaceCardProps } from "../WorkspaceCard";
+
+const VISIBLE_LIMIT = 7; // Miller's Law — chunk to ≤7 per viewport.
+
+export interface ProjectSectionProps {
+	title: string;
+	count?: number;
+	items: WorkspaceCardProps[];
+	defaultCollapsed?: boolean;
+}
+
+/**
+ * Section header + chunked list of workspace cards.
+ * - Caps at 7 visible (Miller's Law) with a "Show all" reveal.
+ * - `defaultCollapsed` lets us hide low-priority sections (Tesler's Law).
+ */
+export function ProjectSection({
+	title,
+	count,
+	items,
+	defaultCollapsed = false,
+}: ProjectSectionProps) {
+	const [collapsed, setCollapsed] = useState(defaultCollapsed);
+	const [expanded, setExpanded] = useState(false);
+
+	const total = count ?? items.length;
+	const visible = expanded ? items : items.slice(0, VISIBLE_LIMIT);
+	const hasMore = items.length > VISIBLE_LIMIT;
+
+	return (
+		<View className="gap-2">
+			<Pressable
+				onPress={() => setCollapsed((c) => !c)}
+				className="flex-row items-center justify-between px-2"
+				style={{ minHeight: 44 }}
+				accessibilityRole="button"
+				accessibilityLabel={`${title}, ${total} items, ${collapsed ? "collapsed" : "expanded"}`}
+			>
+				<Text className="text-xs font-medium text-muted-foreground uppercase">
+					{title}
+				</Text>
+				<Text className="text-xs text-muted-foreground">
+					{collapsed ? `Show ${total}` : total}
+				</Text>
+			</Pressable>
+			{collapsed ? null : (
+				<View className="gap-1.5">
+					{visible.map((item) => (
+						<WorkspaceCard key={item.id} {...item} />
+					))}
+					{hasMore && !expanded ? (
+						<Pressable
+							onPress={() => setExpanded(true)}
+							className="items-center justify-center rounded-xl py-3 active:opacity-70"
+							style={{ minHeight: 44 }}
+						>
+							<Text className="text-sm font-medium text-muted-foreground">
+								Show all {items.length}
+							</Text>
+						</Pressable>
+					) : null}
+				</View>
+			)}
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/ProjectSection/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/ProjectSection/index.ts
@@ -1,0 +1,2 @@
+export type { ProjectSectionProps } from "./ProjectSection";
+export { ProjectSection } from "./ProjectSection";

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspaceCard/WorkspaceCard.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspaceCard/WorkspaceCard.tsx
@@ -1,0 +1,56 @@
+import { Link } from "expo-router";
+import { ChevronRight, GitBranch } from "lucide-react-native";
+import { Pressable, View } from "react-native";
+import { Icon } from "@/components/ui/icon";
+import { Text } from "@/components/ui/text";
+
+export interface WorkspaceCardProps {
+	id: string;
+	name: string;
+	repoLabel?: string;
+	branch?: string;
+}
+
+/**
+ * Tap target is min 44pt high (Fitts's Law). Single-line truncation keeps
+ * the card scannable (Aesthetic-Usability). Pressed state gives the
+ * "pane opened" peak moment a clear acknowledgement.
+ */
+export function WorkspaceCard({
+	id,
+	name,
+	repoLabel,
+	branch,
+}: WorkspaceCardProps) {
+	return (
+		<Link href={`/(authenticated)/(home)/workspaces/${id}`} asChild>
+			<Pressable
+				className="flex-row items-center gap-3 rounded-xl bg-card px-4 py-3 active:opacity-70"
+				style={{ minHeight: 44 }}
+			>
+				<View className="flex-1 gap-0.5">
+					<Text
+						className="text-base font-semibold text-foreground"
+						numberOfLines={1}
+					>
+						{name}
+					</Text>
+					{repoLabel || branch ? (
+						<View className="flex-row items-center gap-1.5">
+							{branch ? (
+								<Icon
+									as={GitBranch}
+									className="text-muted-foreground size-3.5"
+								/>
+							) : null}
+							<Text className="text-xs text-muted-foreground" numberOfLines={1}>
+								{[repoLabel, branch].filter(Boolean).join(" · ")}
+							</Text>
+						</View>
+					) : null}
+				</View>
+				<Icon as={ChevronRight} className="text-muted-foreground size-5" />
+			</Pressable>
+		</Link>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspaceCard/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspaceCard/index.ts
@@ -1,0 +1,2 @@
+export type { WorkspaceCardProps } from "./WorkspaceCard";
+export { WorkspaceCard } from "./WorkspaceCard";

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspacesSkeleton/WorkspacesSkeleton.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspacesSkeleton/WorkspacesSkeleton.tsx
@@ -1,0 +1,38 @@
+import { View } from "react-native";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const SKELETON_ROWS = 5;
+
+/**
+ * Doherty Threshold + Goal-Gradient: showing structure on first paint
+ * tells the user "your data is on its way" instead of an empty stage.
+ */
+export function WorkspacesSkeleton() {
+	return (
+		<View className="gap-6">
+			{[0, 1].map((section) => (
+				<View key={section} className="gap-2">
+					<View className="px-2">
+						<Skeleton className="h-3 w-20" />
+					</View>
+					<View className="gap-1.5">
+						{Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+							<View
+								// biome-ignore lint/suspicious/noArrayIndexKey: static count
+								key={i}
+								className="flex-row items-center gap-3 rounded-xl bg-card px-4 py-3"
+								style={{ minHeight: 44 }}
+							>
+								<View className="flex-1 gap-1.5">
+									<Skeleton className="h-4 w-2/3" />
+									<Skeleton className="h-3 w-1/2" />
+								</View>
+								<Skeleton className="h-4 w-4 rounded-full" />
+							</View>
+						))}
+					</View>
+				</View>
+			))}
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspacesSkeleton/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspacesSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { WorkspacesSkeleton } from "./WorkspacesSkeleton";

--- a/apps/mobile/screens/(authenticated)/(more)/MoreMenuScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(more)/MoreMenuScreen.tsx
@@ -17,6 +17,9 @@ import { useSignOut } from "@/hooks/useSignOut";
 import { authClient } from "@/lib/auth/client";
 import { useCollections } from "@/screens/(authenticated)/providers/CollectionsProvider";
 
+// Every row in the menu honors a 44pt minimum tap target (Fitts's Law).
+const ROW_MIN_HEIGHT = 44;
+
 export function MoreMenuScreen() {
 	const router = useRouter();
 	const insets = useSafeAreaInsets();
@@ -49,19 +52,26 @@ export function MoreMenuScreen() {
 		}
 	};
 
+	// Serial-Position Effect:
+	//   anchor "Organization" at the top (most context-rich)
+	//   anchor "Log out" at the bottom (most consequential)
+	//   keep secondary General actions in the middle.
 	return (
 		<ScrollView
 			className="flex-1 bg-background"
 			contentContainerStyle={{ paddingTop: insets.top + 16 }}
 		>
 			<View className="px-4 gap-6">
-				{/* Org section */}
+				{/* Org section (TOP anchor) */}
 				<View className="gap-2">
 					<Text className="text-xs font-medium text-muted-foreground uppercase px-2">
 						Organization
 					</Text>
 					<View className="rounded-xl bg-card">
-						<View className="flex-row items-center gap-3 px-4 py-3">
+						<View
+							className="flex-row items-center gap-3 px-4 py-3"
+							style={{ minHeight: ROW_MIN_HEIGHT }}
+						>
 							<Avatar
 								alt={activeOrg?.name ?? "Organization"}
 								className="size-9"
@@ -85,7 +95,10 @@ export function MoreMenuScreen() {
 										key={org.id}
 										onPress={() => handleSwitchOrg(org.id)}
 										disabled={switching}
-										className="flex-row items-center gap-3 px-4 py-3"
+										className="flex-row items-center gap-3 px-4 py-3 active:opacity-70"
+										style={{ minHeight: ROW_MIN_HEIGHT }}
+										accessibilityRole="button"
+										accessibilityLabel={`Switch to ${org.name}`}
 									>
 										<Icon
 											as={ArrowLeftRight}
@@ -101,7 +114,7 @@ export function MoreMenuScreen() {
 					</View>
 				</View>
 
-				{/* Menu items */}
+				{/* General section (MIDDLE — de-emphasised by Serial Position) */}
 				<View className="gap-2">
 					<Text className="text-xs font-medium text-muted-foreground uppercase px-2">
 						General
@@ -109,7 +122,10 @@ export function MoreMenuScreen() {
 					<View className="rounded-xl bg-card">
 						<Pressable
 							onPress={() => router.push("/(authenticated)/(more)/settings")}
-							className="flex-row items-center gap-3 px-4 py-3"
+							className="flex-row items-center gap-3 px-4 py-3 active:opacity-70"
+							style={{ minHeight: ROW_MIN_HEIGHT }}
+							accessibilityRole="button"
+							accessibilityLabel="Settings"
 						>
 							<Icon as={Settings} className="text-foreground size-5" />
 							<Text className="text-base flex-1">Settings</Text>
@@ -121,12 +137,15 @@ export function MoreMenuScreen() {
 					</View>
 				</View>
 
-				{/* Sign out */}
+				{/* Sign out (BOTTOM anchor — terminal action) */}
 				<View className="gap-2">
 					<View className="rounded-xl bg-card">
 						<Pressable
 							onPress={signOut}
-							className="flex-row items-center gap-3 px-4 py-3"
+							className="flex-row items-center gap-3 px-4 py-3 active:opacity-70"
+							style={{ minHeight: ROW_MIN_HEIGHT }}
+							accessibilityRole="button"
+							accessibilityLabel="Log out"
 						>
 							<Icon as={LogOut} className="text-destructive size-5" />
 							<Text className="text-base text-destructive">Log out</Text>

--- a/apps/mobile/screens/(authenticated)/(more)/settings/SettingsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(more)/settings/SettingsScreen.tsx
@@ -1,28 +1,17 @@
-import { useRouter } from "expo-router";
-import { ChevronLeft } from "lucide-react-native";
-import { Pressable, ScrollView, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ScrollView, View } from "react-native";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 
 export function SettingsScreen() {
-	const router = useRouter();
-	const insets = useSafeAreaInsets();
-
+	// Parent (more)/_layout.tsx already provides the native Stack header
+	// with title "Settings" — that gives us swipe-back + a 44pt back button
+	// for free (Jakob's + Fitts's Law). No custom chevron needed.
 	return (
 		<ScrollView
 			className="flex-1 bg-background"
-			contentContainerStyle={{ paddingTop: insets.top }}
+			contentInsetAdjustmentBehavior="automatic"
 		>
 			<View className="p-6 gap-4">
-				<View className="flex-row items-center gap-2">
-					<Pressable onPress={() => router.back()} className="p-1">
-						<Icon as={ChevronLeft} className="text-foreground size-6" />
-					</Pressable>
-					<Text className="text-2xl font-bold">Settings</Text>
-				</View>
-
 				<Card>
 					<CardHeader>
 						<CardTitle>Account</CardTitle>

--- a/apps/mobile/screens/(authenticated)/(tasks)/tasks/TasksScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(tasks)/tasks/TasksScreen.tsx
@@ -1,29 +1,116 @@
-import { useCallback, useState } from "react";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCallback, useMemo, useState } from "react";
 import { RefreshControl, ScrollView, View } from "react-native";
 import { Text } from "@/components/ui/text";
+import { useCollections } from "@/screens/(authenticated)/providers/CollectionsProvider";
+import type { TaskCardProps } from "./components/TaskCard";
+import { TasksSection } from "./components/TasksSection";
+import { TasksSkeleton } from "./components/TasksSkeleton";
+
+// task_statuses.type values: "backlog" | "unstarted" | "started" | "completed" | "canceled"
+const ACTIVE_TYPES = new Set(["started", "unstarted"]);
+const DONE_TYPES = new Set(["completed", "canceled"]);
 
 export function TasksScreen() {
 	const [refreshing, setRefreshing] = useState(false);
+	const collections = useCollections();
+
+	const { data: tasks, isLoading: tasksLoading } = useLiveQuery(
+		(q) => q.from({ tasks: collections.tasks }),
+		[collections],
+	);
+	const { data: statuses, isLoading: statusesLoading } = useLiveQuery(
+		(q) => q.from({ statuses: collections.taskStatuses }),
+		[collections],
+	);
+
+	const isLoading = tasksLoading || statusesLoading;
+
+	// Miller's Law — bucket into Active / Backlog / Done so the user
+	// scans one cognitive group at a time. Done collapses by default
+	// (Tesler — push less-relevant complexity behind a tap).
+	const sections = useMemo(() => {
+		const statusById = new Map(statuses?.map((s) => [s.id, s]) ?? []);
+		const buckets: Record<"active" | "backlog" | "done", TaskCardProps[]> = {
+			active: [],
+			backlog: [],
+			done: [],
+		};
+
+		const sorted = [...(tasks ?? [])].sort((a, b) => {
+			const aTs = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+			const bTs = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+			return bTs - aTs;
+		});
+
+		for (const task of sorted) {
+			const status = statusById.get(task.statusId);
+			const card: TaskCardProps = {
+				id: task.id,
+				title: task.title,
+				slug: task.slug,
+				statusName: status?.name,
+				statusColor: status?.color,
+			};
+			if (status && ACTIVE_TYPES.has(status.type)) buckets.active.push(card);
+			else if (status && DONE_TYPES.has(status.type)) buckets.done.push(card);
+			else buckets.backlog.push(card);
+		}
+		return buckets;
+	}, [tasks, statuses]);
 
 	const onRefresh = useCallback(async () => {
 		setRefreshing(true);
-		// TODO: refresh task data
-		setRefreshing(false);
-	}, []);
+		try {
+			await Promise.all([
+				collections.tasks.preload(),
+				collections.taskStatuses.preload(),
+			]);
+		} finally {
+			setRefreshing(false);
+		}
+	}, [collections]);
+
+	const isEmpty = !isLoading && (tasks?.length ?? 0) === 0;
 
 	return (
 		<ScrollView
 			className="flex-1 bg-background"
+			contentInsetAdjustmentBehavior="automatic"
 			refreshControl={
 				<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
 			}
 		>
-			<View className="p-6">
-				<View className="items-center justify-center py-20">
-					<Text className="text-muted-foreground text-center">
-						Tasks synced via Electric will appear here
-					</Text>
-				</View>
+			<View className="px-4 pb-8 pt-2 gap-6">
+				{isLoading ? (
+					<TasksSkeleton />
+				) : isEmpty ? (
+					<View className="items-center justify-center py-20">
+						<Text className="text-muted-foreground text-center">
+							No tasks yet — they'll appear here as they sync
+						</Text>
+					</View>
+				) : (
+					<>
+						{sections.active.length > 0 ? (
+							<TasksSection title="Active" items={sections.active} />
+						) : null}
+						{sections.backlog.length > 0 ? (
+							<TasksSection
+								title="Backlog"
+								items={sections.backlog}
+								defaultCollapsed={sections.active.length > 0}
+							/>
+						) : null}
+						{sections.done.length > 0 ? (
+							<TasksSection
+								title="Done"
+								items={sections.done}
+								defaultCollapsed
+							/>
+						) : null}
+					</>
+				)}
 			</View>
 		</ScrollView>
 	);

--- a/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TaskCard/TaskCard.tsx
+++ b/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TaskCard/TaskCard.tsx
@@ -1,0 +1,57 @@
+import { Link } from "expo-router";
+import { ChevronRight } from "lucide-react-native";
+import { Pressable, View } from "react-native";
+import { Icon } from "@/components/ui/icon";
+import { Text } from "@/components/ui/text";
+
+export interface TaskCardProps {
+	id: string;
+	title: string;
+	slug?: string;
+	statusName?: string;
+	statusColor?: string;
+}
+
+/**
+ * Compact, scannable task row. Status dot uses the user-configured colour
+ * straight from the task_statuses table — keeps brand consistency
+ * (Aesthetic-Usability) without inventing new tokens.
+ */
+export function TaskCard({
+	id,
+	title,
+	slug,
+	statusName,
+	statusColor,
+}: TaskCardProps) {
+	return (
+		<Link href={`/(authenticated)/(tasks)/${id}`} asChild>
+			<Pressable
+				className="flex-row items-center gap-3 rounded-xl bg-card px-4 py-3 active:opacity-70"
+				style={{ minHeight: 44 }}
+			>
+				{statusColor ? (
+					<View
+						className="size-2.5 rounded-full"
+						style={{ backgroundColor: statusColor }}
+						accessibilityLabel={statusName ?? "status"}
+					/>
+				) : null}
+				<View className="flex-1 gap-0.5">
+					<Text
+						className="text-base font-medium text-foreground"
+						numberOfLines={1}
+					>
+						{title}
+					</Text>
+					{slug || statusName ? (
+						<Text className="text-xs text-muted-foreground" numberOfLines={1}>
+							{[slug, statusName].filter(Boolean).join(" · ")}
+						</Text>
+					) : null}
+				</View>
+				<Icon as={ChevronRight} className="text-muted-foreground size-5" />
+			</Pressable>
+		</Link>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TaskCard/index.ts
+++ b/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TaskCard/index.ts
@@ -1,0 +1,2 @@
+export type { TaskCardProps } from "./TaskCard";
+export { TaskCard } from "./TaskCard";

--- a/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TasksSection/TasksSection.tsx
+++ b/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TasksSection/TasksSection.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { TaskCard, type TaskCardProps } from "../TaskCard";
+
+const VISIBLE_LIMIT = 7; // Miller's Law.
+
+export interface TasksSectionProps {
+	title: string;
+	items: TaskCardProps[];
+	defaultCollapsed?: boolean;
+}
+
+export function TasksSection({
+	title,
+	items,
+	defaultCollapsed = false,
+}: TasksSectionProps) {
+	const [collapsed, setCollapsed] = useState(defaultCollapsed);
+	const [expanded, setExpanded] = useState(false);
+
+	const visible = expanded ? items : items.slice(0, VISIBLE_LIMIT);
+	const hasMore = items.length > VISIBLE_LIMIT;
+
+	return (
+		<View className="gap-2">
+			<Pressable
+				onPress={() => setCollapsed((c) => !c)}
+				className="flex-row items-center justify-between px-2"
+				style={{ minHeight: 44 }}
+				accessibilityRole="button"
+				accessibilityLabel={`${title}, ${items.length} tasks`}
+			>
+				<Text className="text-xs font-medium text-muted-foreground uppercase">
+					{title}
+				</Text>
+				<Text className="text-xs text-muted-foreground">
+					{collapsed ? `Show ${items.length}` : items.length}
+				</Text>
+			</Pressable>
+			{collapsed ? null : (
+				<View className="gap-1.5">
+					{visible.map((item) => (
+						<TaskCard key={item.id} {...item} />
+					))}
+					{hasMore && !expanded ? (
+						<Pressable
+							onPress={() => setExpanded(true)}
+							className="items-center justify-center rounded-xl py-3 active:opacity-70"
+							style={{ minHeight: 44 }}
+						>
+							<Text className="text-sm font-medium text-muted-foreground">
+								Show all {items.length}
+							</Text>
+						</Pressable>
+					) : null}
+				</View>
+			)}
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TasksSection/index.ts
+++ b/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TasksSection/index.ts
@@ -1,0 +1,2 @@
+export type { TasksSectionProps } from "./TasksSection";
+export { TasksSection } from "./TasksSection";

--- a/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TasksSkeleton/TasksSkeleton.tsx
+++ b/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TasksSkeleton/TasksSkeleton.tsx
@@ -1,0 +1,34 @@
+import { View } from "react-native";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const SKELETON_ROWS = 5;
+
+export function TasksSkeleton() {
+	return (
+		<View className="gap-6">
+			{[0, 1].map((section) => (
+				<View key={section} className="gap-2">
+					<View className="px-2">
+						<Skeleton className="h-3 w-24" />
+					</View>
+					<View className="gap-1.5">
+						{Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+							<View
+								// biome-ignore lint/suspicious/noArrayIndexKey: static count
+								key={i}
+								className="flex-row items-center gap-3 rounded-xl bg-card px-4 py-3"
+								style={{ minHeight: 44 }}
+							>
+								<Skeleton className="h-2.5 w-2.5 rounded-full" />
+								<View className="flex-1 gap-1.5">
+									<Skeleton className="h-4 w-3/4" />
+									<Skeleton className="h-3 w-1/3" />
+								</View>
+							</View>
+						))}
+					</View>
+				</View>
+			))}
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TasksSkeleton/index.ts
+++ b/apps/mobile/screens/(authenticated)/(tasks)/tasks/components/TasksSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { TasksSkeleton } from "./TasksSkeleton";

--- a/apps/mobile/screens/(authenticated)/tasks/[id]/TaskDetailScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/tasks/[id]/TaskDetailScreen.tsx
@@ -1,36 +1,28 @@
-import { useLocalSearchParams, useRouter } from "expo-router";
-import { ChevronLeft } from "lucide-react-native";
-import { Pressable, ScrollView, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Icon } from "@/components/ui/icon";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { ScrollView, View } from "react-native";
 import { Text } from "@/components/ui/text";
 
 export function TaskDetailScreen() {
 	const { id } = useLocalSearchParams<{ id: string }>();
-	const router = useRouter();
-	const insets = useSafeAreaInsets();
 
+	// Native Stack header → swipe-back + 44pt back button (Jakob's + Fitts's Law).
 	return (
-		<ScrollView
-			className="flex-1 bg-background"
-			contentContainerStyle={{ paddingTop: insets.top }}
-		>
-			<View className="p-6 gap-4">
-				<View className="flex-row items-center gap-2">
-					<Pressable onPress={() => router.back()} className="p-1">
-						<Icon as={ChevronLeft} className="text-foreground size-6" />
-					</Pressable>
-					<Text className="text-2xl font-bold">Task</Text>
-				</View>
+		<>
+			<Stack.Screen options={{ title: "Task" }} />
+			<ScrollView
+				className="flex-1 bg-background"
+				contentInsetAdjustmentBehavior="automatic"
+			>
+				<View className="p-6 gap-4">
+					<Text className="text-muted-foreground">ID: {id}</Text>
 
-				<Text className="text-muted-foreground">ID: {id}</Text>
-
-				<View className="items-center justify-center py-20">
-					<Text className="text-muted-foreground text-center">
-						Task content will appear here
-					</Text>
+					<View className="items-center justify-center py-20">
+						<Text className="text-muted-foreground text-center">
+							Task content will appear here
+						</Text>
+					</View>
 				</View>
-			</View>
-		</ScrollView>
+			</ScrollView>
+		</>
 	);
 }

--- a/apps/mobile/screens/(authenticated)/workspaces/[id]/WorkspaceDetailScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspaces/[id]/WorkspaceDetailScreen.tsx
@@ -1,64 +1,59 @@
-import { useLocalSearchParams, useRouter } from "expo-router";
-import { ChevronLeft } from "lucide-react-native";
-import { Pressable, ScrollView, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { ScrollView, View } from "react-native";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 
 export function WorkspaceDetailScreen() {
 	const { id } = useLocalSearchParams<{ id: string }>();
-	const router = useRouter();
-	const insets = useSafeAreaInsets();
 
+	// Native Stack header gives us:
+	// - swipe-back gesture (Jakob's Law)
+	// - hit-tested back button at 44pt by default (Fitts's Law)
+	// - large-title behavior + safe-area handling for free
 	return (
-		<ScrollView
-			className="flex-1 bg-background"
-			contentContainerStyle={{ paddingTop: insets.top }}
-		>
-			<View className="p-6 gap-4">
-				<View className="flex-row items-center gap-2">
-					<Pressable onPress={() => router.back()} className="p-1">
-						<Icon as={ChevronLeft} className="text-foreground size-6" />
-					</Pressable>
-					<Text className="text-2xl font-bold">Workspace</Text>
+		<>
+			<Stack.Screen options={{ title: "Workspace" }} />
+			<ScrollView
+				className="flex-1 bg-background"
+				contentInsetAdjustmentBehavior="automatic"
+			>
+				<View className="p-6 gap-4">
+					<Text className="text-muted-foreground">ID: {id}</Text>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Branch Info</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<Text className="text-muted-foreground">
+								Branch details will appear here
+							</Text>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Claude Session</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<Text className="text-muted-foreground">
+								Active Claude session info will appear here
+							</Text>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Terminal</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<Text className="text-muted-foreground">
+								Terminal output will appear here
+							</Text>
+						</CardContent>
+					</Card>
 				</View>
-
-				<Text className="text-muted-foreground">ID: {id}</Text>
-
-				<Card>
-					<CardHeader>
-						<CardTitle>Branch Info</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<Text className="text-muted-foreground">
-							Branch details will appear here
-						</Text>
-					</CardContent>
-				</Card>
-
-				<Card>
-					<CardHeader>
-						<CardTitle>Claude Session</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<Text className="text-muted-foreground">
-							Active Claude session info will appear here
-						</Text>
-					</CardContent>
-				</Card>
-
-				<Card>
-					<CardHeader>
-						<CardTitle>Terminal</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<Text className="text-muted-foreground">
-							Terminal output will appear here
-						</Text>
-					</CardContent>
-				</Card>
-			</View>
-		</ScrollView>
+			</ScrollView>
+		</>
 	);
 }

--- a/apps/mobile/screens/(authenticated)/workspaces/[id]/WorkspaceDetailScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspaces/[id]/WorkspaceDetailScreen.tsx
@@ -1,57 +1,69 @@
+import { useLiveQuery } from "@tanstack/react-db";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { ScrollView, View } from "react-native";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Text } from "@/components/ui/text";
+import { useCollections } from "@/screens/(authenticated)/providers/CollectionsProvider";
+import { PaneCard } from "./components/PaneCard";
+import { WorkspaceDetailSkeleton } from "./components/WorkspaceDetailSkeleton";
 
 export function WorkspaceDetailScreen() {
 	const { id } = useLocalSearchParams<{ id: string }>();
+	const collections = useCollections();
 
-	// Native Stack header gives us:
-	// - swipe-back gesture (Jakob's Law)
-	// - hit-tested back button at 44pt by default (Fitts's Law)
-	// - large-title behavior + safe-area handling for free
+	const { data: projects, isLoading } = useLiveQuery(
+		(q) => q.from({ projects: collections.projects }),
+		[collections],
+	);
+
+	const project = projects?.find((p) => p.id === id);
+	const title = project?.name ?? "Workspace";
+	const repoLabel = project
+		? `${project.repoOwner}/${project.repoName}`
+		: undefined;
+
 	return (
 		<>
-			<Stack.Screen options={{ title: "Workspace" }} />
+			{/* Native Stack header → swipe-back + 44pt back button (Jakob/Fitts). */}
+			<Stack.Screen options={{ title }} />
 			<ScrollView
 				className="flex-1 bg-background"
 				contentInsetAdjustmentBehavior="automatic"
 			>
-				<View className="p-6 gap-4">
-					<Text className="text-muted-foreground">ID: {id}</Text>
-
-					<Card>
-						<CardHeader>
-							<CardTitle>Branch Info</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<Text className="text-muted-foreground">
-								Branch details will appear here
-							</Text>
-						</CardContent>
-					</Card>
-
-					<Card>
-						<CardHeader>
-							<CardTitle>Claude Session</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<Text className="text-muted-foreground">
-								Active Claude session info will appear here
-							</Text>
-						</CardContent>
-					</Card>
-
-					<Card>
-						<CardHeader>
-							<CardTitle>Terminal</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<Text className="text-muted-foreground">
-								Terminal output will appear here
-							</Text>
-						</CardContent>
-					</Card>
+				<View className="p-4 gap-4">
+					{isLoading ? (
+						<WorkspaceDetailSkeleton />
+					) : (
+						<>
+							{repoLabel ? (
+								<Text className="text-sm text-muted-foreground px-2">
+									{repoLabel} · {project?.defaultBranch}
+								</Text>
+							) : null}
+							<PaneCard
+								index={0}
+								title="Branch Info"
+								description="Working branch and recent commits"
+							>
+								<Text className="text-muted-foreground">
+									Branch details will appear here
+								</Text>
+							</PaneCard>
+							<PaneCard
+								index={1}
+								title="Claude Session"
+								description="Live agent activity"
+							>
+								<Text className="text-muted-foreground">
+									Active Claude session info will appear here
+								</Text>
+							</PaneCard>
+							<PaneCard index={2} title="Terminal" description="Output stream">
+								<Text className="text-muted-foreground">
+									Terminal output will appear here
+								</Text>
+							</PaneCard>
+						</>
+					)}
 				</View>
 			</ScrollView>
 		</>

--- a/apps/mobile/screens/(authenticated)/workspaces/[id]/components/PaneCard/PaneCard.tsx
+++ b/apps/mobile/screens/(authenticated)/workspaces/[id]/components/PaneCard/PaneCard.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import Animated, {
+	useAnimatedStyle,
+	useSharedValue,
+	withDelay,
+	withTiming,
+} from "react-native-reanimated";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+
+export interface PaneCardProps {
+	title: string;
+	description?: string;
+	/** 0-based index drives the staggered fade-in (Peak-End). */
+	index?: number;
+	children: ReactNode;
+}
+
+const STAGGER_MS = 60;
+const DURATION_MS = 220; // Below the Doherty 400ms threshold.
+
+/**
+ * A single "pane" inside a workspace. The subtle staggered fade-in is the
+ * Peak-End moment — opening a workspace feels alive without crossing the
+ * Doherty threshold.
+ */
+export function PaneCard({
+	title,
+	description,
+	index = 0,
+	children,
+}: PaneCardProps) {
+	const opacity = useSharedValue(0);
+	const translateY = useSharedValue(8);
+
+	useEffect(() => {
+		const delay = index * STAGGER_MS;
+		opacity.value = withDelay(delay, withTiming(1, { duration: DURATION_MS }));
+		translateY.value = withDelay(
+			delay,
+			withTiming(0, { duration: DURATION_MS }),
+		);
+	}, [index, opacity, translateY]);
+
+	const style = useAnimatedStyle(() => ({
+		opacity: opacity.value,
+		transform: [{ translateY: translateY.value }],
+	}));
+
+	return (
+		<Animated.View style={style}>
+			<Card>
+				<CardHeader>
+					<CardTitle>{title}</CardTitle>
+					{description ? (
+						<CardDescription>{description}</CardDescription>
+					) : null}
+				</CardHeader>
+				<CardContent>{children}</CardContent>
+			</Card>
+		</Animated.View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/workspaces/[id]/components/PaneCard/index.ts
+++ b/apps/mobile/screens/(authenticated)/workspaces/[id]/components/PaneCard/index.ts
@@ -1,0 +1,2 @@
+export type { PaneCardProps } from "./PaneCard";
+export { PaneCard } from "./PaneCard";

--- a/apps/mobile/screens/(authenticated)/workspaces/[id]/components/WorkspaceDetailSkeleton/WorkspaceDetailSkeleton.tsx
+++ b/apps/mobile/screens/(authenticated)/workspaces/[id]/components/WorkspaceDetailSkeleton/WorkspaceDetailSkeleton.tsx
@@ -1,0 +1,22 @@
+import { View } from "react-native";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const PANE_COUNT = 3;
+
+export function WorkspaceDetailSkeleton() {
+	return (
+		<View className="gap-4">
+			{Array.from({ length: PANE_COUNT }).map((_, i) => (
+				<View
+					// biome-ignore lint/suspicious/noArrayIndexKey: static count
+					key={i}
+					className="rounded-xl bg-card p-4 gap-3"
+				>
+					<Skeleton className="h-5 w-1/3" />
+					<Skeleton className="h-4 w-2/3" />
+					<Skeleton className="h-16 w-full" />
+				</View>
+			))}
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/workspaces/[id]/components/WorkspaceDetailSkeleton/index.ts
+++ b/apps/mobile/screens/(authenticated)/workspaces/[id]/components/WorkspaceDetailSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceDetailSkeleton } from "./WorkspaceDetailSkeleton";


### PR DESCRIPTION
## Summary

Restructures `apps/mobile/` navigation and screen content along Jon Yablonski's Laws of UX. No new routes, no upstream package changes, no new dependencies.

Full rationale and per-Law audit lives in [`apps/mobile/DESIGN.md`](./apps/mobile/DESIGN.md).

### Changes (one logical commit each)

1. `fix(mobile/nav)` — drop manual `<ChevronLeft>` back buttons on Workspace/Task/Settings detail; rely on the native Stack header so we get swipe-back **and** a 44pt hit target for free (Jakob's + Fitts's).
2. `feat(mobile/workspaces)` — `useLiveQuery(collections.projects)` chunked into **Active** (touched in last 7 days) / **Recent** sections, capped at 7 visible per section with a "Show all" reveal (Miller). `<WorkspacesSkeleton>` covers first paint (Doherty / Goal-Gradient). Pull-to-refresh wired to `collection.preload()`.
3. `fix(mobile/workspaces)` — replace hard-coded `hsl(...)` chevron color in `OrganizationHeaderButton` with the `text-muted-foreground` token; bump the org switcher pressable to 44pt + `accessibilityLabel` (Aesthetic-Usability + Fitts).
4. `feat(mobile/workspace-detail)` — drive `Stack.Screen` title from the live project name; new `<PaneCard>` wraps the three info panes with a sub-Doherty (220ms) staggered fade-in for the Peak-End moment. Skeleton while data loads.
5. `fix(mobile/more)` — re-anchored: Organization at the top, Settings in the middle, Log out at the bottom (Serial Position). Every row enforced to 44pt with `accessibilityRole`/`accessibilityLabel`.
6. `feat(mobile/tasks)` — same chunking pattern as Workspaces, but driven by `task_statuses.type`: **Active** (started/unstarted) / **Backlog** / **Done**. Done collapses by default (Tesler).

### Verification

- `bun run typecheck` — clean
- `bun run lint` (biome) — clean
- TypeScript strict, no `any`, no new deps

## Test plan

- [ ] Cold-launch on iOS — Workspaces shows skeletons then groups; pull-to-refresh closes within ~400ms.
- [ ] Tap a workspace card → header title is the project name; back swipe works; PaneCards stagger in <300ms.
- [ ] Tap a task → native back button + swipe-back work; no double-header.
- [ ] More tab → Org row top, Sign out bottom, every row ≥44pt.
- [ ] Empty-state copy renders when there are zero projects / zero tasks.
- [ ] Multi-org account: header switcher sheet still opens; "Switch to X" rows in More menu still work.

## Out of scope (called out in DESIGN.md)

- `panes/[paneId]` route — brief mentioned it but creating it would violate "no new routes". The "pane" idea is realised as `<PaneCard>` inside `workspaces/[id]`.
- Native SwiftUI tab bar (`@superset/tab-bar`) is untouched — already 3 items.
- Real data wiring beyond what `useLiveQuery` already gives us (search, command palette, etc.).
- Tests — `apps/mobile` has no test harness today; that's its own PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks mobile flows around the Laws of UX to make navigation faster, lists easier to scan, and tap targets accessible. Adds sectioned lists with skeletons and a refined workspace detail experience—no new routes or dependencies.

- **New Features**
  - Workspaces: Active/Recent sections (max 7 visible with “Show all”), skeleton on first paint, pull-to-refresh.
  - Tasks: Active/Backlog/Done sections (Done collapsed by default), skeletons, pull-to-refresh.
  - Workspace detail: title from live project name; new PaneCards with subtle staggered fade-in; loading skeleton.

- **Bug Fixes**
  - Navigation: removed custom back chevrons; use native Stack headers for swipe-back and 44pt targets on detail screens and settings.
  - More tab: Organization pinned to top; Settings in middle; Log out at bottom; all rows ≥44pt with accessibility labels.
  - Org header button: chevron uses `text-muted-foreground` token and adds an accessibility label.

<sup>Written for commit 2cf67105ad9502ec0c33450c7315274b1f61d41b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

