### PR TITLE
feat(cli): add `projects create` command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",
@@ -684,7 +684,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",
@@ -780,7 +780,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
         "@hono/node-ws": "^1.3.0",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.12";
+const VERSION = "0.2.13";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/cli/src/commands/projects/create/command.ts
+++ b/packages/cli/src/commands/projects/create/command.ts
@@ -1,0 +1,78 @@
+import { boolean, CLIError, string } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { requireHostTarget, resolveHostTarget } from "../../../lib/host-target";
+
+export default command({
+	description: "Create a project on a host",
+	options: {
+		host: string().desc("Target host machineId"),
+		local: boolean().desc("Target this machine"),
+		name: string().required().desc("Project name"),
+		clone: string().desc(
+			"Git remote URL to clone (requires --parent-dir). Mutually exclusive with --import",
+		),
+		parentDir: string().desc(
+			"Parent directory the cloned repo lands in (required with --clone)",
+		),
+		import: string().desc(
+			"Existing local repo path on the target host. Mutually exclusive with --clone",
+		),
+	},
+	run: async ({ ctx, options }) => {
+		const organizationId = ctx.config.organizationId;
+		if (!organizationId) {
+			throw new CLIError("No active organization", "Run: superset auth login");
+		}
+
+		if (Boolean(options.clone) === Boolean(options.import)) {
+			throw new CLIError(
+				"Specify exactly one of --clone or --import",
+				"Use --clone <url> --parent-dir <path> or --import <path>",
+			);
+		}
+		if (options.clone && !options.parentDir) {
+			throw new CLIError(
+				"--clone requires --parent-dir",
+				"Pass --parent-dir <path> alongside --clone",
+			);
+		}
+		if (options.import && options.parentDir) {
+			throw new CLIError(
+				"--parent-dir cannot be used with --import",
+				"--import takes the full repo path",
+			);
+		}
+
+		const hostId = requireHostTarget({
+			host: options.host ?? undefined,
+			local: options.local ?? undefined,
+		});
+
+		const target = resolveHostTarget({
+			requestedHostId: hostId,
+			organizationId,
+			userJwt: ctx.bearer,
+		});
+
+		const mode = options.clone
+			? {
+					kind: "clone" as const,
+					parentDir: options.parentDir as string,
+					url: options.clone,
+				}
+			: {
+					kind: "importLocal" as const,
+					repoPath: options.import as string,
+				};
+
+		const result = await target.client.project.create.mutate({
+			name: options.name,
+			mode,
+		});
+
+		return {
+			data: result,
+			message: `Created project "${options.name}" on host ${target.hostId}`,
+		};
+	},
+});


### PR DESCRIPTION
## Summary

Adds `superset projects create` so the CLI can bootstrap a project on a target host. Without this, remote-host workflows had no CLI path to create the project a workspace needs — users had to use the desktop app first.

Mirrors `workspaces create`'s flag pattern: required `--host`/`--local`, mutually-exclusive mode flags.

```
superset projects create --name <name> (--host <id> | --local) (--clone <url> --parent-dir <path> | --import <path>)
```

Two modes only:
- `--clone <url>` (+ `--parent-dir`) — clone a remote and register the project
- `--import <path>` — register an existing folder on the host

Empty + template are intentionally left to desktop — empty is niche from a CLI, and template IDs aren't something users memorize.

The host-service `project.create` saga is unchanged — this PR is purely the CLI front door for it (clone/import → local DB → cloud `v2Project.create` with slug retry → main workspace).

Bumps cli `0.2.12` → `0.2.13`. Release cut still happens as a separate `release(cli): cut v0.2.13` commit per existing convention.

## Test plan

- [ ] `superset projects create --local --name foo --clone https://github.com/<x>/<y> --parent-dir ~/code` creates a project and main workspace on the local host
- [ ] `superset projects create --local --name foo --import ~/code/existing-repo` registers an existing folder
- [ ] `superset projects create --host <remote> --name foo --clone <url> --parent-dir <path>` works through the relay against a remote host
- [ ] Validation errors fire correctly: missing `--host`/`--local`; both `--clone` and `--import`; `--clone` without `--parent-dir`; `--parent-dir` with `--import`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `superset projects create` to bootstrap a project on a local or remote host from the CLI. Supports cloning a repo or importing an existing folder, so remote-host workflows no longer need the desktop app.

- **New Features**
  - Command: `superset projects create --name <name> (--host <id> | --local) (--clone <url> --parent-dir <path> | --import <path>)`
  - Validates flags: require `--host` or `--local`; exactly one of `--clone` or `--import`; `--clone` needs `--parent-dir`; `--import` cannot use `--parent-dir`
  - Calls existing host-service `project.create`; no backend changes; empty/template modes remain desktop-only

- **Dependencies**
  - Bump `@superset/cli` to `0.2.13`

<sup>Written for commit 9b4c2d2ffbced894edf74275126e3ee4e10f1e24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI command to create projects on a specified host with options for cloning existing repositories or importing from a path.

* **Chores**
  * Bumped CLI version to 0.2.13.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4355)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->