### PR TITLE
feat(cli): add `projects setup` command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -684,7 +684,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.13";
+const VERSION = "0.2.14";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/cli/src/commands/projects/setup/command.ts
+++ b/packages/cli/src/commands/projects/setup/command.ts
@@ -1,0 +1,74 @@
+import { boolean, CLIError, positional, string } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { requireHostTarget, resolveHostTarget } from "../../../lib/host-target";
+
+export default command({
+	description:
+		"Adopt an existing project on a host (clone its repo or import a folder)",
+	args: [positional("id").required().desc("Project UUID to adopt")],
+	options: {
+		host: string().desc("Target host machineId"),
+		local: boolean().desc("Target this machine"),
+		parentDir: string().desc(
+			"Parent directory to clone the project's repo into (clone mode)",
+		),
+		import: string().desc(
+			"Existing local repo path on the target host (import mode)",
+		),
+		allowRelocate: boolean().desc(
+			"Permit re-importing at a different path if the project is already set up here",
+		),
+	},
+	run: async ({ ctx, args, options }) => {
+		const projectId = args.id as string;
+		const organizationId = ctx.config.organizationId;
+		if (!organizationId) {
+			throw new CLIError("No active organization", "Run: superset auth login");
+		}
+
+		if (Boolean(options.parentDir) === Boolean(options.import)) {
+			throw new CLIError(
+				"Specify exactly one of --parent-dir or --import",
+				"Use --parent-dir <path> to clone, or --import <path> to register an existing folder",
+			);
+		}
+		if (options.allowRelocate && !options.import) {
+			throw new CLIError(
+				"--allow-relocate only applies to --import",
+				"Drop --allow-relocate, or switch to --import <path>",
+			);
+		}
+
+		const hostId = requireHostTarget({
+			host: options.host ?? undefined,
+			local: options.local ?? undefined,
+		});
+
+		const target = resolveHostTarget({
+			requestedHostId: hostId,
+			organizationId,
+			userJwt: ctx.bearer,
+		});
+
+		const mode = options.parentDir
+			? {
+					kind: "clone" as const,
+					parentDir: options.parentDir,
+				}
+			: {
+					kind: "import" as const,
+					repoPath: options.import as string,
+					allowRelocate: options.allowRelocate ?? false,
+				};
+
+		const result = await target.client.project.setup.mutate({
+			projectId,
+			mode,
+		});
+
+		return {
+			data: result,
+			message: `Set up project ${projectId} on host ${target.hostId}`,
+		};
+	},
+});


### PR DESCRIPTION
## Summary

Adopt an existing v2 project on a host without creating a duplicate — the dedup counterpart to `projects create`. Without this, anyone setting up Superset on a new machine and reaching for the CLI would always create a fresh cloud project, even if their org already has one for the same repo.

```
superset projects setup <id> (--host <id> | --local) (--parent-dir <path> | --import <path> [--allow-relocate])
```

- Positional `<id>` is the cloud project UUID (find it via `superset projects list`).
- `--parent-dir <path>` triggers clone mode — URL comes from the cloud project, so no `--clone <url>` needed.
- `--import <path>` registers an existing folder.
- `--allow-relocate` permits re-importing at a different path when the project is already set up here.

Wraps host-service `project.setup`, which already handles the no-op-when-already-set-up case and the `linkRepoCloneUrl` write-back when an imported folder has a remote the cloud project doesn't yet know about.

Pairs with `projects create` to mirror the desktop's two-button UX (Create vs Import).

Bumps cli `0.2.13` → `0.2.14`.

## Test plan

- [x] `--help` and validation cases (mutex, `--allow-relocate` requires `--import`)
- [x] Live: `superset projects setup <id> --local --import <path>` against a project already set up returned the existing `mainWorkspaceId` (idempotent)
- [ ] `superset projects setup <id> --local --parent-dir <path>` clones a fresh checkout for a project with `repoCloneUrl`
- [ ] `superset projects setup <id> --local --import <path>` for a project with no `repoCloneUrl` writes back via `linkRepoCloneUrl` if the folder has a remote
- [ ] `superset projects setup <id> --host <remote> --parent-dir <path>` works against a remote host through the relay

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `superset projects setup` to attach an existing cloud project to a target host without creating a duplicate. Supports clone or import modes and is idempotent.

- New Features
  - New command: `superset projects setup <id>` targeting `--host <id>` or `--local`.
  - Modes: clone with `--parent-dir <path>`, or import with `--import <path>`; `--allow-relocate` permits re-import at a new path.
  - Validation: require exactly one of `--parent-dir`/`--import`; `--allow-relocate` only with `--import`.
  - Uses host-service `project.setup`; no-op if already set up and writes back missing repo URL when importing.

- Dependencies
  - Bump `@superset/cli` from 0.2.13 to 0.2.14.

<sup>Written for commit 58f2b93f9b1d61a0ef17ef72a0903c26cce2a746. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced project adoption command with support for clone and import modes, configurable host targets, and relocation options.

* **Chores**
  * CLI version updated to 0.2.14.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4356)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->