### PR TITLE
docs(cli): document `projects create` + `setup` and dedup story

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -339,54 +339,93 @@ superset org switch org_…
 
 ### projects
 
-Projects are checked-out repos that live on a specific host. The host
-clones (or registers) the repo, creates the cloud record, and makes it
-available to every machine in the organization.
+A project is a repository registered with your organization. It carries
+a cloud record (one per repo, shared across the org) and one or more
+host-side checkouts. Workspaces branch off a host's checkout.
 
 <Command
 	name="superset projects list"
-	options={[
-		{ flag: "--host <id>", description: "Target host. Defaults to the local machine." },
-	]}
 	output={`Array<{
   id: string;
-  repoOwner: string;
-  repoName: string;
-  repoPath: string;
+  name: string;
+  slug: string;
+  repoCloneUrl: string | null;
+  githubRepositoryId: string | null;
 }>`}
-	humanColumns={["ID", "OWNER", "REPO", "PATH"]}
+	humanColumns={["NAME", "SLUG", "REPO", "ID"]}
 	quiet="project IDs"
 >
-List projects on the target host.
+List projects in the active organization. Org-wide; not host-scoped.
 </Command>
 
 <Command
 	name="superset projects create"
 	options={[
 		{ flag: "--name <name>", required: true, description: "Display name for the project." },
-		{ flag: "--url <url>", description: "Clone from a Git URL. Mutually exclusive with `--path`." },
-		{ flag: "--parent-dir <path>", description: "Where to clone into. Required with `--url`." },
-		{ flag: "--path <path>", description: "Import an existing local repo. Mutually exclusive with `--url`." },
-		{ flag: "--host <id>", description: "Target host. Defaults to the local machine." },
+		{ flag: "--host <id>", description: "Target host machineId. Mutually exclusive with `--local`; one is required." },
+		{ flag: "--local", description: "Target this machine. Mutually exclusive with `--host`; one is required." },
+		{ flag: "--clone <url>", description: "Clone from a Git URL. Mutually exclusive with `--import`." },
+		{ flag: "--parent-dir <path>", description: "Parent directory the cloned repo lands in. Required with `--clone`." },
+		{ flag: "--import <path>", description: "Existing repo path on the target host. Mutually exclusive with `--clone`." },
 	]}
 	output={`{
   projectId: string;
   repoPath: string;
+  mainWorkspaceId: string;
+}`}
+>
+Create a fresh project on a host. Two modes:
+
+- **Clone** — pass `--clone <url>` and `--parent-dir`. The host clones the
+  repo into `<parent-dir>/<derived-name>/`.
+- **Import** — pass `--import <path>` to register a repo that already exists
+  on disk.
+
+Either way, a new cloud project record is created and the host's main
+workspace is ensured.
+
+`create` always creates a new cloud project, even if your org already has
+one for the same Git URL. Use [`projects setup`](#superset-projects-setup-id)
+when adopting an existing project on a fresh machine.
+
+```bash
+superset projects create --name "my-app" --local --clone https://github.com/org/my-app.git --parent-dir ~/code
+superset projects create --name "my-app" --local --import ~/code/my-app
+```
+</Command>
+
+<Command
+	name="superset projects setup <id>"
+	args={[
+		{ name: "id", required: true, description: "Project UUID to adopt." },
+	]}
+	options={[
+		{ flag: "--host <id>", description: "Target host machineId. Mutually exclusive with `--local`; one is required." },
+		{ flag: "--local", description: "Target this machine. Mutually exclusive with `--host`; one is required." },
+		{ flag: "--parent-dir <path>", description: "Parent directory to clone the project's repo into (clone mode). The URL comes from the cloud project, so no `--clone <url>` is needed." },
+		{ flag: "--import <path>", description: "Existing repo path on the target host (import mode)." },
+		{ flag: "--allow-relocate", description: "Permit re-importing at a different path if the project is already set up here. `--import` only." },
+	]}
+	output={`{
+  repoPath: string;
   mainWorkspaceId: string | null;
 }`}
 >
-Register a project on a host. Two modes:
+Adopt an existing project onto a host without creating a duplicate cloud
+record. Counterpart to [`create`](#superset-projects-create) for the
+"new machine, repo already in the org" case.
 
-- **Clone** — pass `--url` and `--parent-dir`. The host clones the repo
-  into `<parent-dir>/<derived-name>/`.
-- **Import** — pass `--path` to register a repo that already exists on disk.
+Find the project ID via [`projects list`](#superset-projects-list).
 
-Either way, the cloud project row is created and the host's main workspace
-is ensured.
+Idempotent: re-running against a project that's already set up at the same
+path is a no-op that returns the existing `mainWorkspaceId`.
 
 ```bash
-superset projects create --name "my-app" --url https://github.com/org/my-app.git --parent-dir ~/code
-superset projects create --name "my-app" --path ~/code/my-app
+# Pick an ID from `superset projects list`, then clone it onto this machine
+superset projects setup 47c31b04-… --local --parent-dir ~/code
+
+# Or register an existing local checkout
+superset projects setup 47c31b04-… --local --import ~/code/my-app
 ```
 </Command>
 
@@ -456,7 +495,8 @@ List workspaces on the target host.
 		{ flag: "--project <projectId>", required: true, description: "Project ID." },
 		{ flag: "--name <name>", required: true, description: "Workspace name." },
 		{ flag: "--branch <branch>", required: true, description: "Workspace branch." },
-		{ flag: "--host <id>", description: "Defaults to the local machine." },
+		{ flag: "--host <id>", description: "Target host machineId. Mutually exclusive with `--local`; one is required." },
+		{ flag: "--local", description: "Target this machine. Mutually exclusive with `--host`; one is required." },
 	]}
 	output="Workspace"
 >
@@ -466,7 +506,8 @@ Create a workspace on the target host.
 superset workspaces create \
   --project prj_… \
   --name "fix-login-bug" \
-  --branch fix/login-bug
+  --branch fix/login-bug \
+  --local
 ```
 </Command>
 

--- a/apps/docs/content/docs/cli/getting-started.mdx
+++ b/apps/docs/content/docs/cli/getting-started.mdx
@@ -66,20 +66,40 @@ Auth: Session (expires in 32 min)
 
 ## Run your first commands
 
-List workspaces on the local machine:
-
-```bash
-superset workspaces list
-```
-
-Create one against an existing project:
+List the projects in your organization:
 
 ```bash
 superset projects list
+```
+
+If your repo isn't there yet, register it on this machine — clone from a
+Git URL or import an existing checkout:
+
+```bash
+# Clone from a URL
+superset projects create --name "my-app" --local \
+  --clone https://github.com/org/my-app.git \
+  --parent-dir ~/code
+
+# Or register an existing local checkout
+superset projects create --name "my-app" --local --import ~/code/my-app
+```
+
+If the project already exists in your org but isn't on this machine,
+attach to it instead of creating a duplicate:
+
+```bash
+superset projects setup <id-from-projects-list> --local --parent-dir ~/code
+```
+
+Then create a workspace against it:
+
+```bash
 superset workspaces create \
   --project prj_… \
   --name "fix-login-bug" \
-  --branch fix/login-bug
+  --branch fix/login-bug \
+  --local
 ```
 
 Trigger an automation immediately:
@@ -112,20 +132,20 @@ output unless you pass `--quiet`.
 
 ## Local vs. remote hosts
 
-`workspaces`, `projects`, and `automations create/update` accept a
-`--host <id>` flag to pick which host handles the request. When omitted,
-the CLI targets the local machine, talks directly to the host server over
-loopback, and works offline.
-
-To target a different host:
+Commands that touch a host accept `--host <id>` to pick which host handles
+the request, or `--local` for this machine. Local-targeted calls go
+straight to the host server over loopback (offline-friendly); remote
+calls route through the cloud API and the relay.
 
 ```bash
 superset hosts list
 superset workspaces list --host h_…
 ```
 
-Remote calls go through the cloud API and the relay; behavior is otherwise
-identical.
+Mutating host commands (`projects create`, `projects setup`,
+`workspaces create`) require an explicit `--host` or `--local` — there's
+no default. Read-only host queries (`workspaces list`) default to the
+local machine.
 
 ## Where state lives
 

--- a/apps/docs/content/docs/cli/host-server.mdx
+++ b/apps/docs/content/docs/cli/host-server.mdx
@@ -61,32 +61,62 @@ superset status
 
 ## Getting started
 
-### Create a project
+### Create or adopt a project
 
-A workspace branches off a project — a checked-out repo registered with
-Superset. Clone a remote repo or import an existing local one:
+A workspace branches off a project — a repo registered with Superset.
+
+Each repo gets one cloud project record, shared across the organization.
+The first machine to register the repo runs `projects create`; every
+machine after that uses `projects setup` to attach to the existing
+project instead of creating a duplicate.
+
+Start by checking what's already in your org:
+
+```bash
+superset projects list
+```
+
+#### First machine — `projects create`
+
+If the project doesn't exist yet, clone a remote repo or import an
+existing local one:
 
 ```bash
 # Clone from a Git URL
 superset projects create \
   --name "My Project" \
-  --url https://github.com/org/repo.git \
+  --local \
+  --clone https://github.com/org/repo.git \
   --parent-dir ~/code
 
 # Or import a repo that's already on disk
 superset projects create \
   --name "My Project" \
-  --path ~/code/existing-repo
+  --local \
+  --import ~/code/existing-repo
 ```
 
 The host server clones (or registers) the repo, creates the cloud project
-record, and ensures the main workspace. Project records are shared across
-the organization, so once it exists, any machine in the org can host
-worktrees of it:
+record, and ensures the main workspace.
+
+#### Subsequent machines — `projects setup <id>`
+
+If a teammate (or a previous machine of yours) already created the project,
+adopt it instead of running `create` again — `create` would make a duplicate
+cloud project pointing at the same repo. Pick the ID from `projects list`,
+then:
 
 ```bash
-superset projects list
+# Clone the project's repo onto this machine
+superset projects setup 47c31b04-… --local --parent-dir ~/code
+
+# Or attach to an existing local checkout
+superset projects setup 47c31b04-… --local --import ~/code/repo
 ```
+
+The URL for clone mode comes from the cloud project record, so `setup`
+doesn't need `--clone <url>`. `setup` is idempotent: re-running against a
+project that's already set up here is a no-op.
 
 ### Create your first workspace
 


### PR DESCRIPTION
## Summary

Updates the CLI docs for the new `projects create` (#4355) and `projects setup` (#4356) commands, plus a few drive-by corrections that were already wrong before this work.

### `cli-reference.mdx` — `projects` section
- `projects list` was documented as host-scoped with `repoOwner/repoName/repoPath`. Actual command is org-wide returning `name/slug/repoCloneUrl/id`. Fixed.
- `projects create` flag list updated to the shipped surface: `--clone <url>` (was `--url`), `--import <path>` (was `--path`), and `--host`/`--local` are now required (one of).
- New `projects setup <id>` block documenting the dedup-aware adoption path.

### `host-server.mdx` — Create or adopt a project
Rewrote the walkthrough so the dedup story is explicit: first machine runs `create`; subsequent machines run `setup <id>` to attach to the existing cloud project instead of duplicating it. Updated all flag examples.

### `getting-started.mdx`
- The "Run your first commands" section assumed a project already existed. Now shows how to bootstrap one via `create` or attach via `setup`.
- "Local vs. remote hosts" tightened: mutating host commands (`projects create`, `projects setup`, `workspaces create`) require explicit `--host`/`--local`; read-only host queries default to local.

### Drive-by
`workspaces create` flag table also said `--host` defaults to local — it doesn't. Fixed alongside.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` in `apps/docs` succeeds
- [ ] Visually scan the rendered `/cli/cli-reference`, `/cli/getting-started`, `/cli/host-server` pages on Vercel preview

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for `projects create` and the new `projects setup`, and clarifies the create-vs-setup flow so teams don’t create duplicate cloud projects. Also fixes `projects list` output and host-targeting flags across the CLI docs.

- **New Features**
  - Document `projects setup <id>` to adopt existing cloud projects on a new machine (clone/import modes, idempotent, no `--clone` needed).
  - Update `projects create` to the shipped surface: `--clone`, `--import`, and required `--host` or `--local`; add concise examples.
  - Rewrite host-server and getting-started guides to show when to use `create` vs `setup`.

- **Bug Fixes**
  - Correct `projects list`: org-wide scope, columns `NAME/SLUG/REPO/ID`, and output shape.
  - Fix `workspaces create` table and host-targeting docs: mutating commands require explicit `--host` or `--local`; read-only lists default to local.

<sup>Written for commit 85004a2ee9e36601645450af772c9dfcaaa26e18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference documentation for `projects` and `workspaces` commands with refined options and output formats.
  * Introduced `projects setup` command for adopting existing projects on new hosts.
  * Reorganized getting started guide to follow a project-first workflow.
  * Clarified host targeting requirements (explicit `--host` or `--local` selection for mutating commands).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4357)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->