### PR TITLE
fix(auth): bump MCP OAuth access token TTL to 7d

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -202,6 +202,7 @@ export const auth = betterAuth({
 			consentPage: `${env.NEXT_PUBLIC_WEB_URL}/oauth/consent`,
 			allowDynamicClientRegistration: true,
 			allowUnauthenticatedClientRegistration: true,
+			accessTokenExpiresIn: 60 * 60 * 24 * 7,
 			validAudiences: [
 				env.NEXT_PUBLIC_API_URL,
 				`${env.NEXT_PUBLIC_API_URL}/`,


### PR DESCRIPTION
## Summary

- `oauthProvider` was using the better-auth default `accessTokenExpiresIn` of 1h. MCP clients that don't request `offline_access` (or whose refresh-token storage flakes) end up re-auth'ing multiple times a day. Set it to 7d.

## Background

This is the same problem we fixed client-side in #4069 for the Superset CLI ("the 1h access-token TTL plus no refresh path meant the CLI forced re-login multiple times per day"). The CLI fix added `offline_access` + a refresh handler, but for third-party MCP clients (Claude Desktop, Cursor, ChatGPT Connectors, etc.) we can't dictate scopes — we have to make the server tolerant.

7d was picked to cover a typical work week so a single refresh hiccup doesn't bounce someone out, while keeping the blast radius of a leaked token finite.

## Why not "fix it properly" upstream

Two real issues live in `@better-auth/oauth-provider` and are still present in latest (1.6.10) and 1.7.0-beta.3:

1. **Refresh-token grant doesn't preserve audience** (RFC 8707 §2.2 says it SHOULD). `checkResource` reads `ctx.body.resource` fresh on every request — if a client refreshes without sending `resource`, the issued token is opaque, and our MCP route only verifies JWTs. Our route → 401 → forced re-auth.
2. **Refresh-token reuse detection is aggressive**: a single replay of a rotated refresh token `deleteMany`'s every refresh token for that user+client.

The MCP TS SDK does pass `resource` on refresh so (1) doesn't bite SDK-using clients today, and (2) is hard to relax without security tradeoffs. Not changing better-auth versions in this PR — pinning 1.6.5 across the board for now.

## Test plan

- [ ] Deploy and confirm a fresh MCP login from Claude Code / Cursor stays authenticated past 1h
- [ ] Existing tokens in the wild still expire on their original 1h schedule — verify by inspecting `oauth_access_tokens.expires_at` for tokens issued before vs. after deploy
- [ ] No regression in CLI auth (CLI already refreshes proactively, but it should now refresh less often)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase MCP OAuth access token TTL from 1 hour to 7 days to prevent frequent re-auth for clients without `offline_access` or flaky refresh storage. Makes the server more tolerant of third‑party MCP clients while keeping risk bounded.

- **Bug Fixes**
  - Set `accessTokenExpiresIn` to 7 days in the OAuth provider.
  - Existing tokens keep their 1h expiry; new tokens get 7d.
  - No dependency changes; known `@better-auth/oauth-provider` refresh-audience issue remains.

<sup>Written for commit 679f658d9ea18262e2990e8c2688caea64e8027b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth access token expiration to 7 days

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4365)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->