### PR TITLE
fix(desktop): restore recently-viewed dropdown + tighten topbar chrome

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -214,12 +214,12 @@ export function DashboardSidebarHeader({
 			    horizontal inset — keeps traffic-light alignment matching the
 			    TopBar's 80px pad regardless of parent padding changes. */}
 			<div
-				className="drag -mx-2 flex h-8 items-center gap-1.5"
+				className="drag -mx-2 flex h-8 items-center gap-1.5 pr-2"
 				style={{ paddingLeft: isMac ? "80px" : "8px" }}
 			>
 				<SidebarToggle />
-				<NavigationControls showHistoryDropdown={false} />
-				<ResourceConsumption surface="v2" />
+				<NavigationControls />
+				<ResourceConsumption surface="v2" className="ml-auto" />
 			</div>
 			<OrganizationDropdown variant="expanded" />
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/NavigationControls.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/NavigationControls.tsx
@@ -5,13 +5,7 @@ import { LuArrowLeft, LuArrowRight } from "react-icons/lu";
 import { HotkeyLabel, useHotkey } from "renderer/hotkeys";
 import { HistoryDropdown } from "./components/HistoryDropdown";
 
-interface NavigationControlsProps {
-	showHistoryDropdown?: boolean;
-}
-
-export function NavigationControls({
-	showHistoryDropdown = true,
-}: NavigationControlsProps = {}) {
+export function NavigationControls() {
 	const router = useRouter();
 	const location = useLocation();
 
@@ -70,7 +64,7 @@ export function NavigationControls({
 				</TooltipContent>
 			</Tooltip>
 
-			{showHistoryDropdown && <HistoryDropdown />}
+			<HistoryDropdown />
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/components/HistoryDropdown/HistoryDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/components/HistoryDropdown/HistoryDropdown.tsx
@@ -296,6 +296,7 @@ export function HistoryDropdown() {
 			return (v2WorkspaceData ?? []).some((w) => w.id === entry.entityId);
 		}
 		if (entry.type === "automation") {
+			if (!isV2CloudEnabled) return false;
 			return (automationData ?? []).some((a) => a.id === entry.entityId);
 		}
 		return (taskData ?? []).some(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/components/HistoryDropdown/HistoryDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/components/HistoryDropdown/HistoryDropdown.tsx
@@ -11,7 +11,9 @@ import { cn } from "@superset/ui/utils";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useLocation, useNavigate } from "@tanstack/react-router";
-import { LuHistory } from "react-icons/lu";
+import { LuCpu, LuGitBranch, LuHistory } from "react-icons/lu";
+import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	StatusIcon,
@@ -71,6 +73,94 @@ function WorkspaceRow({
 					</span>
 				</>
 			)}
+		</DropdownMenuItem>
+	);
+}
+
+function V2WorkspaceRow({
+	entry,
+	isCurrent,
+	v2WorkspaceData,
+	onSelect,
+}: {
+	entry: RecentlyViewedEntry;
+	isCurrent: boolean;
+	v2WorkspaceData: {
+		id: string;
+		projectName: string;
+		branch: string;
+	}[];
+	onSelect: () => void;
+}) {
+	const ws = v2WorkspaceData.find((w) => w.id === entry.entityId);
+
+	return (
+		<DropdownMenuItem
+			className={cn("gap-2.5", isCurrent && "bg-accent/50")}
+			onSelect={onSelect}
+		>
+			<span className="text-muted-foreground text-xs shrink-0 w-20 text-left line-clamp-1">
+				{ws ? ws.projectName : "Workspace"}
+			</span>
+			<span className="flex items-center justify-center w-4 shrink-0">
+				<LuGitBranch
+					className="size-3 text-muted-foreground"
+					strokeWidth={1.5}
+				/>
+			</span>
+			<span
+				className={cn(
+					"truncate text-xs font-normal flex-1 min-w-0",
+					!ws && "text-muted-foreground",
+				)}
+			>
+				{ws ? ws.branch : "Unknown"}
+			</span>
+		</DropdownMenuItem>
+	);
+}
+
+function AutomationRow({
+	entry,
+	isCurrent,
+	automationData,
+	onSelect,
+}: {
+	entry: RecentlyViewedEntry;
+	isCurrent: boolean;
+	automationData: {
+		id: string;
+		name: string;
+		agentId: string;
+	}[];
+	onSelect: () => void;
+}) {
+	const automation = automationData.find((a) => a.id === entry.entityId);
+	const presetIcon = usePresetIcon(automation?.agentId ?? "");
+
+	return (
+		<DropdownMenuItem
+			className={cn("gap-2.5", isCurrent && "bg-accent/50")}
+			onSelect={onSelect}
+		>
+			<span className="text-muted-foreground text-xs shrink-0 w-20 text-left line-clamp-1">
+				Automation
+			</span>
+			<span className="flex items-center justify-center w-4 shrink-0">
+				{presetIcon ? (
+					<img src={presetIcon} alt="" className="size-3.5 object-contain" />
+				) : (
+					<LuCpu className="size-3 text-muted-foreground" strokeWidth={1.5} />
+				)}
+			</span>
+			<span
+				className={cn(
+					"truncate text-xs font-normal flex-1 min-w-0",
+					!automation && "text-muted-foreground",
+				)}
+			>
+				{automation ? automation.name : "Unknown"}
+			</span>
 		</DropdownMenuItem>
 	);
 }
@@ -138,6 +228,7 @@ export function HistoryDropdown() {
 	const recentEntries = useRecentlyViewed(20);
 	const currentPath = useLocation({ select: (loc) => loc.pathname });
 	const collections = useCollections();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	const { data: groups } = electronTrpc.workspaces.getAllGrouped.useQuery();
 	const workspaceData = (groups ?? []).flatMap((group) =>
@@ -147,6 +238,34 @@ export function HistoryDropdown() {
 			projectColor: group.project.color,
 			branch: ws.branch ?? ws.name,
 		})),
+	);
+
+	const { data: v2WorkspaceData } = useLiveQuery(
+		(q) =>
+			q
+				.from({ workspaces: collections.v2Workspaces })
+				.innerJoin(
+					{ projects: collections.v2Projects },
+					({ workspaces, projects }) => eq(workspaces.projectId, projects.id),
+				)
+				.select(({ workspaces, projects }) => ({
+					id: workspaces.id,
+					projectName: projects.name,
+					branch: workspaces.branch,
+				})),
+		[collections],
+	);
+
+	const { data: automationData } = useLiveQuery(
+		(q) =>
+			q
+				.from({ automations: collections.automations })
+				.select(({ automations }) => ({
+					id: automations.id,
+					name: automations.name,
+					agentId: automations.agentConfig.id,
+				})),
+		[collections],
 	);
 
 	const { data: taskData } = useLiveQuery(
@@ -169,7 +288,15 @@ export function HistoryDropdown() {
 
 	const filteredEntries = recentEntries.filter((entry) => {
 		if (entry.type === "workspace") {
+			if (isV2CloudEnabled) return false;
 			return workspaceData.some((w) => w.id === entry.entityId);
+		}
+		if (entry.type === "v2-workspace") {
+			if (!isV2CloudEnabled) return false;
+			return (v2WorkspaceData ?? []).some((w) => w.id === entry.entityId);
+		}
+		if (entry.type === "automation") {
+			return (automationData ?? []).some((a) => a.id === entry.entityId);
 		}
 		return (taskData ?? []).some(
 			(t) => t.id === entry.entityId || t.slug === entry.entityId,
@@ -211,16 +338,41 @@ export function HistoryDropdown() {
 			<DropdownMenuContent align="start" className="w-80">
 				<DropdownMenuLabel>Recently Viewed</DropdownMenuLabel>
 				<DropdownMenuSeparator />
-				{filteredEntries.map((entry) =>
-					entry.type === "task" ? (
-						<TaskRow
-							key={entry.path}
-							entry={entry}
-							isCurrent={entry.path === currentPath}
-							taskData={taskData ?? []}
-							onSelect={() => navigate({ to: entry.path })}
-						/>
-					) : (
+				{filteredEntries.map((entry) => {
+					if (entry.type === "task") {
+						return (
+							<TaskRow
+								key={entry.path}
+								entry={entry}
+								isCurrent={entry.path === currentPath}
+								taskData={taskData ?? []}
+								onSelect={() => navigate({ to: entry.path })}
+							/>
+						);
+					}
+					if (entry.type === "v2-workspace") {
+						return (
+							<V2WorkspaceRow
+								key={entry.path}
+								entry={entry}
+								isCurrent={entry.path === currentPath}
+								v2WorkspaceData={v2WorkspaceData ?? []}
+								onSelect={() => navigate({ to: entry.path })}
+							/>
+						);
+					}
+					if (entry.type === "automation") {
+						return (
+							<AutomationRow
+								key={entry.path}
+								entry={entry}
+								isCurrent={entry.path === currentPath}
+								automationData={automationData ?? []}
+								onSelect={() => navigate({ to: entry.path })}
+							/>
+						);
+					}
+					return (
 						<WorkspaceRow
 							key={entry.path}
 							entry={entry}
@@ -228,8 +380,8 @@ export function HistoryDropdown() {
 							workspaceData={workspaceData}
 							onSelect={() => navigate({ to: entry.path })}
 						/>
-					),
-				)}
+					);
+				})}
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/components/HistoryDropdown/hooks/useRecentlyViewed/useRecentlyViewed.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/components/HistoryDropdown/hooks/useRecentlyViewed/useRecentlyViewed.ts
@@ -4,29 +4,54 @@ import { persistentHistory } from "renderer/lib/persistent-hash-history";
 
 export interface RecentlyViewedEntry {
 	path: string;
-	type: "workspace" | "task";
+	type: "workspace" | "v2-workspace" | "task" | "automation";
 	entityId: string;
 	timestamp: number;
+}
+
+function pathnameOf(href: string): string {
+	const queryIndex = href.indexOf("?");
+	const hashIndex = href.indexOf("#");
+	const cutoffs = [queryIndex, hashIndex].filter((i) => i >= 0);
+	return cutoffs.length === 0 ? href : href.substring(0, Math.min(...cutoffs));
 }
 
 function parseResourceEntry(entry: {
 	path: string;
 	timestamp: number;
 }): RecentlyViewedEntry | null {
-	const wsMatch = entry.path.match(/^\/workspace\/(.+)$/);
+	const pathname = pathnameOf(entry.path);
+
+	const v2WsMatch = pathname.match(/^\/v2-workspace\/([^/]+)/);
+	if (v2WsMatch?.[1])
+		return {
+			path: `/v2-workspace/${v2WsMatch[1]}`,
+			type: "v2-workspace",
+			entityId: v2WsMatch[1],
+			timestamp: entry.timestamp,
+		};
+	const wsMatch = pathname.match(/^\/workspace\/([^/]+)/);
 	if (wsMatch?.[1])
 		return {
-			path: entry.path,
+			path: `/workspace/${wsMatch[1]}`,
 			type: "workspace",
 			entityId: wsMatch[1],
 			timestamp: entry.timestamp,
 		};
-	const taskMatch = entry.path.match(/^\/tasks\/(.+)$/);
+	const taskMatch = pathname.match(/^\/tasks\/([^/]+)/);
 	if (taskMatch?.[1])
 		return {
-			path: entry.path,
+			path: `/tasks/${taskMatch[1]}`,
 			type: "task",
 			entityId: taskMatch[1],
+			timestamp: entry.timestamp,
+		};
+	const automationMatch = pathname.match(/^\/automations\/([^/]+)/);
+	if (automationMatch?.[1])
+		return {
+			path: `/automations/${automationMatch[1]}`,
+			type: "automation",
+			entityId: automationMatch[1],
 			timestamp: entry.timestamp,
 		};
 	return null;
@@ -41,10 +66,10 @@ export function useRecentlyViewed(limit = 20): RecentlyViewedEntry[] {
 
 	for (let i = allEntries.length - 1; i >= 0; i--) {
 		const entry = allEntries[i];
-		if (!entry || seen.has(entry.path)) continue;
+		if (!entry) continue;
 		const resource = parseResourceEntry(entry);
-		if (resource) {
-			seen.set(entry.path, resource);
+		if (resource && !seen.has(resource.path)) {
+			seen.set(resource.path, resource);
 		}
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -54,8 +54,7 @@ export function TopBar() {
 				{!sidebarHostsChrome && (
 					<>
 						<SidebarToggle />
-						<NavigationControls showHistoryDropdown={false} />
-						<ResourceConsumption surface={isV2CloudEnabled ? "v2" : "v1"} />
+						<NavigationControls />
 					</>
 				)}
 			</div>
@@ -85,6 +84,9 @@ export function TopBar() {
 			)}
 
 			<div className="flex items-center gap-3 h-full pr-4 shrink-0">
+				{!sidebarHostsChrome && (
+					<ResourceConsumption surface={isV2CloudEnabled ? "v2" : "v1"} />
+				)}
 				{!isOnline && (
 					<div className="no-drag flex items-center gap-1.5 text-xs text-muted-foreground bg-muted px-2 py-1 rounded">
 						<HiOutlineWifi className="size-3.5" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
@@ -1,4 +1,5 @@
 import type { WorkspaceState } from "@superset/panes";
+import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -90,10 +91,12 @@ function getTerminalTitleOverrides(
 
 interface ResourceConsumptionProps {
 	surface?: "v1" | "v2";
+	className?: string;
 }
 
 export function ResourceConsumption({
 	surface = "v1",
+	className,
 }: ResourceConsumptionProps) {
 	const [open, setOpen] = useState(false);
 	const [sortOption, setSortOption] = useState<SortOption>("memory");
@@ -344,40 +347,32 @@ export function ResourceConsumption({
 			<Tooltip delayDuration={150}>
 				<TooltipTrigger asChild>
 					<PopoverTrigger asChild>
-						<button
-							type="button"
-							className="no-drag inline-flex items-center gap-1.5 h-6 px-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+						<Button
+							variant="ghost"
+							size="icon-xs"
 							aria-label="Resource consumption"
-						>
-							<span className="relative flex items-center">
-								<HiOutlineCpuChip className="h-3.5 w-3.5 shrink-0" />
-								{triggerDotColorClass && (
-									<span
-										className={cn(
-											"absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-2 ring-background",
-											triggerDotColorClass,
-										)}
-									/>
-								)}
-							</span>
-							{normalizedSnapshot && (
-								<span className="text-xs font-medium tabular-nums tracking-tight hidden md:inline">
-									{formatMemory(normalizedSnapshot.totalMemory)}
-								</span>
+							className={cn(
+								"no-drag relative text-muted-foreground hover:text-foreground",
+								className,
 							)}
-						</button>
+						>
+							<HiOutlineCpuChip className="size-3.5" />
+							{triggerDotColorClass && (
+								<span
+									className={cn(
+										"absolute top-0.5 right-0.5 size-1.5 rounded-full ring-2 ring-background",
+										triggerDotColorClass,
+									)}
+								/>
+							)}
+						</Button>
 					</PopoverTrigger>
 				</TooltipTrigger>
-				{normalizedSnapshot && (
-					<TooltipContent
-						side="bottom"
-						sideOffset={6}
-						showArrow={false}
-						className="md:hidden"
-					>
-						{formatMemory(normalizedSnapshot.totalMemory)}
-					</TooltipContent>
-				)}
+				<TooltipContent side="bottom" sideOffset={6} showArrow={false}>
+					{normalizedSnapshot
+						? `Resources · ${formatMemory(normalizedSnapshot.totalMemory)}`
+						: "Resources"}
+				</TooltipContent>
 			</Tooltip>
 
 			<PopoverContent align="start" className="w-[28rem] p-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- Recently-viewed was rendering as a permanently-disabled icon in v2 because the path matcher only knew `/workspace/$id` (v1) and the slug capture greedily ate search params and nested subroutes — so `/v2-workspace/$id` never matched and `/tasks/SUP-123?tab=…` never resolved to a slug. Now matches `/v2-workspace/$id` and `/automations/$id`, strips `?…`/`#…`, anchors to the first path segment, and dedupes by the canonical path.
- Filter cross-version workspace entries so clicking a v1 entry from v2 mode (or vice versa) doesn't drop the user on `CrossVersionMismatchState` ("Pick a workspace").
- Re-show the dropdown trigger in both topbar and v2 sidebar header (#4314 hardcoded `showHistoryDropdown={false}` because the regex was broken and it was always rendering as the disabled icon — fixing the underlying matcher means we can drop the prop).
- Resource monitor trigger collapsed to an icon-only ghost button and floated to the far right of its row in both surfaces (right-side cluster in the topbar, `ml-auto` + `pr-2` in the v2 sidebar header).

## Test plan
- [ ] In v2 mode, visit a v2 workspace, a task, and an automation — open the clock dropdown and confirm all three appear with the correct project/agent labels.
- [ ] Visit `/tasks/SUP-XYZ?tab=…` and `/tasks/SUP-XYZ/issue/123` — confirm the dropdown collapses both into a single `/tasks/SUP-XYZ` entry.
- [ ] In v1 mode (toggle off v2 cloud), confirm v2-workspace entries are hidden; v1 entries still work.
- [ ] In v2 mode, confirm v1 workspace entries are hidden (no cross-version mismatch screen on click).
- [ ] Confirm resource monitor icon sits on the far right in both the topbar (sidebar closed/collapsed) and the v2 sidebar header (sidebar open).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Recently Viewed dropdown in v2 by fixing route matching and adding support for v2 workspaces and automations. Also tightens topbar chrome by making the resource monitor an icon-only button aligned to the right.

- **Bug Fixes**
  - Parse paths correctly: strip query/hash, anchor to first segment, and dedupe by canonical path (e.g., collapse `/tasks/KEY?tab=x` to `/tasks/KEY`).
  - Add `v2-workspace` and `automation` resource types with correct labels/icons; include v2 project/branch and automation agent metadata.
  - Respect the v2 Cloud toggle: hide v2 entries (including automations) when v1 is active and hide v1 entries in v2 to avoid the mismatch screen.
  - Re-enable the History dropdown in both the topbar and v2 sidebar header; remove the `showHistoryDropdown` prop.

- **UI Improvements**
  - Resource monitor is now an icon-only `ghost` button with a status dot and clearer tooltip; floated to the far right in the topbar and v2 sidebar header.

<sup>Written for commit 301bd5a513ba7f34338b05ea350bd8d68f2c25ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * History dropdown now includes V2 workspaces and automations in recently viewed items.
  * History dropdown is shown by default in navigation controls.

* **Style**
  * Resource consumption button restyled to use the shared button and accepts positioning classes.
  * Simplified resource tooltip content and adjusted header/sidebar control layout.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4370)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->