### PR TITLE
feat(automations): server-side telemetry for lifecycle + dispatch

### DIFF
--- a/apps/api/src/app/api/automations/dispatch/[id]/route.ts
+++ b/apps/api/src/app/api/automations/dispatch/[id]/route.ts
@@ -63,6 +63,8 @@ export async function POST(
 		automation,
 		scheduledFor: new Date(parsed.data.scheduledFor),
 		relayUrl: env.RELAY_URL,
+		surface: "scheduler",
+		trigger: "scheduled",
 	});
 
 	return Response.json({ ok: true, outcome });

--- a/apps/api/src/app/api/automations/run-failed/route.ts
+++ b/apps/api/src/app/api/automations/run-failed/route.ts
@@ -4,8 +4,8 @@ import { automationRuns, automations } from "@superset/db/schema";
 import { Receiver } from "@upstash/qstash";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-
 import { env } from "@/env";
+import { posthog } from "@/lib/analytics";
 
 export const dynamic = "force-dynamic";
 
@@ -77,6 +77,7 @@ export async function POST(request: Request): Promise<Response> {
 	const [automation] = await dbWs
 		.select({
 			organizationId: automations.organizationId,
+			ownerUserId: automations.ownerUserId,
 			name: automations.name,
 		})
 		.from(automations)
@@ -89,7 +90,7 @@ export async function POST(request: Request): Promise<Response> {
 
 	const errorText = `delivery failed after retries (status ${parsed.data.status}): ${parsed.data.error ?? "unknown"}`;
 
-	await dbWs
+	const [run] = await dbWs
 		.insert(automationRuns)
 		.values({
 			automationId,
@@ -102,7 +103,26 @@ export async function POST(request: Request): Promise<Response> {
 		.onConflictDoUpdate({
 			target: [automationRuns.automationId, automationRuns.scheduledFor],
 			set: { status: "dispatch_failed", error: errorText },
-		});
+		})
+		.returning({ id: automationRuns.id });
+
+	posthog.capture({
+		distinctId: automation.ownerUserId,
+		event: "automation_run_dispatched",
+		properties: {
+			automation_id: automationId,
+			organization_id: automation.organizationId,
+			owner_user_id: automation.ownerUserId,
+			surface: "scheduler",
+			trigger: "scheduled",
+			outcome: "dispatch_failed",
+			run_id: run?.id ?? null,
+			session_kind: null,
+			error: errorText,
+			qstash_status: parsed.data.status,
+		},
+		groups: { organization: automation.organizationId },
+	});
 
 	Sentry.captureException(
 		new Error(`automation dispatch failed: ${automationId}`),

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -4,6 +4,7 @@ import type { TRPCClient } from "@trpc/client";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import SuperJSON from "superjson";
 import { getApiUrl } from "./config";
+import { env } from "./env";
 
 export type ApiClient = TRPCClient<AppRouter>;
 
@@ -26,6 +27,9 @@ export function createApiClient(opts: {
 					)
 						? { "x-api-key": opts.bearer }
 						: { Authorization: `Bearer ${opts.bearer}` };
+					// Server-side telemetry uses `session.userAgent` to attribute
+					// the request surface (web/mcp/cli) — see surfaceFromSession.
+					headers["User-Agent"] = `superset-cli/${env.VERSION}`;
 					if (opts.organizationId) {
 						headers[ORGANIZATION_HEADER] = opts.organizationId;
 					}

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -21,6 +21,7 @@ import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, desc, eq, getTableColumns, ilike } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "../../env";
+import { posthog } from "../../lib/analytics";
 import { protectedProcedure } from "../../trpc";
 import {
 	requireActiveOrgMembership,
@@ -31,6 +32,7 @@ import {
 	getAutomationForUser,
 	promptSourceFromSession,
 	recordPromptVersion,
+	surfaceFromSession,
 } from "./helpers";
 import {
 	createAutomationSchema,
@@ -43,6 +45,31 @@ import { automationVersionsRouter } from "./versions";
 
 function escapeLikePattern(value: string): string {
 	return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+function captureAutomationLifecycle(
+	ctx: {
+		session: {
+			user: { id: string };
+			session: { userAgent: string | null };
+		};
+	},
+	event: string,
+	automation: { id: string; organizationId: string; ownerUserId: string },
+	extras: Record<string, unknown> = {},
+): void {
+	posthog.capture({
+		distinctId: ctx.session.user.id,
+		event,
+		properties: {
+			automation_id: automation.id,
+			organization_id: automation.organizationId,
+			owner_user_id: automation.ownerUserId,
+			surface: surfaceFromSession(ctx.session),
+			...extras,
+		},
+		groups: { organization: automation.organizationId },
+	});
 }
 
 function requirePaidSubscription(subscription: SelectSubscription | null) {
@@ -298,6 +325,13 @@ export const automationRouter = {
 				return row;
 			});
 
+			captureAutomationLifecycle(ctx, "automation_created", created, {
+				has_workspace: created.v2WorkspaceId !== null,
+				has_host: created.targetHostId !== null,
+				agent_kind: created.agentConfig.kind,
+				timezone: created.timezone,
+			});
+
 			return { ...created, scheduleText: safeDescribeRrule(created) };
 		}),
 
@@ -361,6 +395,25 @@ export const automationRouter = {
 				.where(eq(automations.id, input.id))
 				.returning();
 
+			if (updated) {
+				const fieldsChanged = (
+					[
+						"name",
+						"agentConfig",
+						"targetHostId",
+						"v2ProjectId",
+						"v2WorkspaceId",
+						"rrule",
+						"dtstart",
+						"timezone",
+						"mcpScope",
+					] as const
+				).filter((key) => input[key] !== undefined);
+				captureAutomationLifecycle(ctx, "automation_updated", updated, {
+					fields_changed: fieldsChanged,
+				});
+			}
+
 			return { ...updated, scheduleText: safeDescribeRrule(updated) };
 		}),
 
@@ -414,6 +467,10 @@ export const automationRouter = {
 				return row;
 			});
 
+			captureAutomationLifecycle(ctx, "automation_updated", updated, {
+				fields_changed: ["prompt"],
+			});
+
 			return { ...updated, scheduleText: safeDescribeRrule(updated) };
 		}),
 
@@ -421,9 +478,15 @@ export const automationRouter = {
 		.input(z.object({ id: z.string().uuid() }))
 		.mutation(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
-			await getAutomationForUser(ctx.session.user.id, organizationId, input.id);
+			const existing = await getAutomationForUser(
+				ctx.session.user.id,
+				organizationId,
+				input.id,
+			);
 
 			await dbWs.delete(automations).where(eq(automations.id, input.id));
+
+			captureAutomationLifecycle(ctx, "automation_deleted", existing);
 
 			return { ok: true };
 		}),
@@ -462,6 +525,12 @@ export const automationRouter = {
 				.where(eq(automations.id, input.id))
 				.returning();
 
+			if (updated && existing.enabled !== input.enabled) {
+				captureAutomationLifecycle(ctx, "automation_enabled_toggled", updated, {
+					enabled: input.enabled,
+				});
+			}
+
 			return { ...updated, scheduleText: safeDescribeRrule(updated) };
 		}),
 
@@ -481,6 +550,9 @@ export const automationRouter = {
 				automation,
 				scheduledFor: new Date(),
 				relayUrl: env.RELAY_URL,
+				surface: surfaceFromSession(ctx.session),
+				trigger: "manual",
+				actorUserId: ctx.session.user.id,
 			});
 
 			if (outcome.status === "conflict") {

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -27,6 +27,8 @@ import {
 	slugifyForBranch,
 } from "@superset/shared/workspace-launch";
 import { and, desc, eq, inArray } from "drizzle-orm";
+import { posthog } from "../../lib/analytics";
+import type { AutomationSurface } from "./helpers";
 import { RelayDispatchError, relayMutation } from "./relay-client";
 
 export type DispatchOutcome =
@@ -36,10 +38,55 @@ export type DispatchOutcome =
 	| { status: "dispatch_failed"; runId: string | null; error: string }
 	| { status: "conflict" };
 
+export type DispatchTrigger = "scheduled" | "manual";
+
 export interface DispatchOptions {
 	automation: SelectAutomation;
 	scheduledFor: Date;
 	relayUrl: string;
+	/** How the request reached this dispatcher — drives the `surface` event prop. */
+	surface: AutomationSurface;
+	/** "scheduled" for cron-driven runs, "manual" for runNow. */
+	trigger: DispatchTrigger;
+	/**
+	 * The user who initiated this dispatch. For manual runs, the invoker;
+	 * for scheduled runs, the automation owner is used as a fallback.
+	 */
+	actorUserId?: string;
+}
+
+interface RunCaptureExtras {
+	outcome: DispatchOutcome["status"];
+	runId: string | null;
+	sessionKind?: "chat" | "terminal" | null;
+	hostId?: string | null;
+	error?: string;
+	startedAt: number;
+}
+
+function captureRunDispatched(
+	opts: DispatchOptions,
+	extras: RunCaptureExtras,
+): void {
+	const { automation, surface, trigger, actorUserId } = opts;
+	posthog.capture({
+		distinctId: actorUserId ?? automation.ownerUserId,
+		event: "automation_run_dispatched",
+		properties: {
+			automation_id: automation.id,
+			organization_id: automation.organizationId,
+			owner_user_id: automation.ownerUserId,
+			surface,
+			trigger,
+			outcome: extras.outcome,
+			run_id: extras.runId,
+			session_kind: extras.sessionKind ?? null,
+			host_id: extras.hostId ?? automation.targetHostId ?? null,
+			error: extras.error,
+			latency_ms: Date.now() - extras.startedAt,
+		},
+		groups: { organization: automation.organizationId },
+	});
 }
 
 /**
@@ -53,11 +100,19 @@ export async function dispatchAutomation(
 	opts: DispatchOptions,
 ): Promise<DispatchOutcome> {
 	const { automation, scheduledFor, relayUrl } = opts;
+	const startedAt = Date.now();
 
 	const resolved = await resolveTargetHost(automation);
 	if (!resolved) {
 		const error = "no host available";
 		const inserted = await recordSkipped(automation, scheduledFor, null, error);
+		captureRunDispatched(opts, {
+			outcome: "skipped_offline",
+			runId: inserted?.id ?? null,
+			error,
+			hostId: null,
+			startedAt,
+		});
 		return { status: "skipped_offline", runId: inserted?.id ?? null, error };
 	}
 	const { host, paidPlan } = resolved;
@@ -66,11 +121,15 @@ export async function dispatchAutomation(
 	// SELECT and dispatch. Bail without writing a run row to avoid muddying
 	// dashboards with paywall blocks under the offline metric.
 	if (!paidPlan) {
-		return {
-			status: "skipped_unpaid",
+		const error = "automations require a Pro plan";
+		captureRunDispatched(opts, {
+			outcome: "skipped_unpaid",
 			runId: null,
-			error: "automations require a Pro plan",
-		};
+			error,
+			hostId: host.machineId,
+			startedAt,
+		});
+		return { status: "skipped_unpaid", runId: null, error };
 	}
 	if (!host.isOnline) {
 		const error = "target host offline";
@@ -80,6 +139,13 @@ export async function dispatchAutomation(
 			host.machineId,
 			error,
 		);
+		captureRunDispatched(opts, {
+			outcome: "skipped_offline",
+			runId: inserted?.id ?? null,
+			error,
+			hostId: host.machineId,
+			startedAt,
+		});
 		return { status: "skipped_offline", runId: inserted?.id ?? null, error };
 	}
 
@@ -101,6 +167,7 @@ export async function dispatchAutomation(
 	if (!run) return { status: "conflict" };
 
 	let workspaceId: string | null = null;
+	let sessionKind: "chat" | "terminal" | null = null;
 	try {
 		const [owner] = await dbWs
 			.select({ email: users.email })
@@ -171,6 +238,7 @@ export async function dispatchAutomation(
 					dispatchedAt: new Date(),
 				})
 				.where(eq(automationRuns.id, run.id));
+			sessionKind = "chat";
 		} else {
 			const command = buildTerminalCommand({
 				prompt: automation.prompt,
@@ -194,6 +262,7 @@ export async function dispatchAutomation(
 					dispatchedAt: new Date(),
 				})
 				.where(eq(automationRuns.id, run.id));
+			sessionKind = "terminal";
 		}
 	} catch (err) {
 		const error = describeError(err, "dispatch");
@@ -205,9 +274,23 @@ export async function dispatchAutomation(
 				error,
 			})
 			.where(eq(automationRuns.id, run.id));
+		captureRunDispatched(opts, {
+			outcome: "dispatch_failed",
+			runId: run.id,
+			error,
+			hostId: host.machineId,
+			startedAt,
+		});
 		return { status: "dispatch_failed", runId: run.id, error };
 	}
 
+	captureRunDispatched(opts, {
+		outcome: "dispatched",
+		runId: run.id,
+		sessionKind,
+		hostId: host.machineId,
+		startedAt,
+	});
 	return { status: "dispatched", runId: run.id };
 }
 

--- a/packages/trpc/src/router/automation/helpers.ts
+++ b/packages/trpc/src/router/automation/helpers.ts
@@ -24,6 +24,17 @@ export function promptSourceFromSession(session: {
 	return session.session.userAgent === "mcp-v2" ? "agent" : "human";
 }
 
+export type AutomationSurface = "web" | "mcp" | "cli" | "scheduler";
+
+export function surfaceFromSession(session: {
+	session: { userAgent: string | null };
+}): Exclude<AutomationSurface, "scheduler"> {
+	const ua = session.session.userAgent;
+	if (ua === "mcp-v2") return "mcp";
+	if (ua?.startsWith("superset-cli/")) return "cli";
+	return "web";
+}
+
 export type AutomationDbExecutor =
 	| typeof dbWs
 	| Parameters<Parameters<typeof dbWs.transaction>[0]>[0];


### PR DESCRIPTION
## Summary

The MCP & CLI Usage dashboard (PostHog dashboard 1566665) showed automations being used by ~6 users via `mcp_tool_called`. A direct query against prod Neon told a different story: **13 owners across 12 orgs created 36 automations and produced 250 dispatched runs in ~3 weeks**. Roughly half of automation creators go through the web UI, which currently emits zero telemetry — the automation tRPC router has no `posthog.capture` calls anywhere, the dispatcher is silent, and run terminal state is not tracked at all.

Adds 5 events fired **server-side** from the tRPC router or dispatcher. Every entry point (web, MCP, CLI, scheduler) routes through these mutations, so one capture per mutation gives full coverage with no client-side work.

### Events

**Lifecycle (4):**
- `automation_created` — fired in `automation.create` after insert + `recordPromptVersion` succeed.
- `automation_updated` — fired in `automation.update` and `automation.setPrompt`. Includes `fields_changed: string[]` so we don't fragment per-field.
- `automation_enabled_toggled` — split out from `update` because pause/resume is the highest-signal lifecycle action.
- `automation_deleted`.

**Run dispatcher (1):**
- `automation_run_dispatched` — fired once per dispatch attempt at every return path of `dispatchAutomation()` plus from the QStash failure callback. Properties: `outcome` (`dispatched | dispatch_failed | skipped_offline | skipped_unpaid`), `trigger` (`scheduled | manual`), `session_kind`, `host_id`, `error?`, `latency_ms`, `run_id?`.

### Surface detection

`surfaceFromSession(session)` (added next to existing `promptSourceFromSession`):
- `userAgent === "mcp-v2"` → `"mcp"`
- `userAgent?.startsWith("superset-cli/")` → `"cli"`
- else → `"web"`

The scheduler dispatch route explicitly passes `surface: "scheduler"` since it has no session. The CLI api-client now sets `User-Agent: superset-cli/<version>` so it's distinguishable from web traffic.

### Why one `automation_run_dispatched` instead of dispatched + completed

The `automation_run_status` enum has only `dispatching | dispatched | skipped_offline | dispatch_failed` — no `succeeded` or `failed`. The dispatcher writes `dispatched` and the run becomes fire-and-forget; the agent finishes asynchronously on the host with no callback. Adding terminal state requires an enum migration plus host-side write-back, which is **out of scope** for this PR. We collapse both into a single dispatch-time event for now; the follow-up PR introduces `automation_run_completed`.

## Test plan

- [ ] `bun dev`, create an automation in the desktop UI → `automation_created` lands in PostHog Live Events with `surface: "web"`
- [ ] Invoke `automations_create` via Claude Code MCP → `surface: "mcp"`
- [ ] `bunx superset automations create ...` → `surface: "cli"` (validates the User-Agent change)
- [ ] `automation.runNow` via UI → `automation_run_dispatched` with `trigger: "manual"`, `outcome: "dispatched"`
- [ ] Trigger `/api/automations/evaluate` (or wait for cron) → event with `surface: "scheduler"`, `trigger: "scheduled"`
- [ ] Force a dispatch failure (host offline) → `outcome: "skipped_offline"` event with `error` populated
- [ ] `bun run lint && bun run typecheck` — both clean

## Follow-ups (separate PRs)

- Add `succeeded` / `failed` enum values to `automation_run_status` + host-side write-back so we can introduce `automation_run_completed`
- Extend dashboard 1566665 with Automations tiles (events/day, dispatch outcome breakdown, surface mix)
- The current 54% `dispatch_failed` rate visible in the prod data is worth digging into separately

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server-side telemetry for automation lifecycle and run dispatch so every entry point (web, MCP, CLI, scheduler) is tracked without client work. Emits consistent PostHog events and adds surface detection; CLI now sets a `User-Agent`.

- **New Features**
  - Lifecycle events from the tRPC router: `automation_created`, `automation_updated` (with `fields_changed`), `automation_enabled_toggled`, `automation_deleted`.
  - Dispatch event: `automation_run_dispatched` from the dispatcher and QStash failure callback with props: `outcome` (`dispatched | dispatch_failed | skipped_offline | skipped_unpaid`), `trigger` (`scheduled | manual`), `surface` (`web | mcp | cli | scheduler`), `session_kind`, `host_id`, `run_id`, `error`, `latency_ms`.
  - Surface detection via `session.userAgent`: `"mcp-v2"` → `mcp`, `"superset-cli/<version>"` → `cli`, else `web`; scheduler passes `surface: "scheduler"`. The CLI now sends `User-Agent: superset-cli/<version>`.
  - Note: terminal run status (succeeded/failed) is not included yet and will ship in a follow-up.

<sup>Written for commit bdc00bf9a82480a74e9fce25f58aa4816d29e6a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive analytics tracking for automation lifecycle events (creation, updates, deletion, status toggling) and dispatch outcomes to provide better insights into system usage and behavior.

* **Chores**
  * Enhanced error diagnostics for failed automation runs with detailed event capture and metadata.
  * Added explicit user-agent identification for CLI requests to improve request tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4372)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->