### PR TITLE
fix(slack-agent): surface Retry-After in 429 message instead of static fallback

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -148,9 +148,9 @@ export async function formatErrorForSlack(error: unknown): Promise<string> {
 	} catch {
 		// Haiku itself failed (possibly also rate limited) — use static fallback
 		if (error instanceof Anthropic.APIError && error.status === 429) {
-			const retryAfter = (error.headers as Record<string, string>)?.['retry-after'];
+			const retryAfter = error.headers?.get('retry-after');
 			const seconds = retryAfter ? parseInt(retryAfter, 10) : null;
-			const waitMsg = seconds && !isNaN(seconds)
+			const waitMsg = seconds !== null && !isNaN(seconds) && seconds > 0
 				? `Please try again in ${seconds} seconds.`
 				: "Please try again in a moment.";
 			return `I'm a bit overloaded right now — ${waitMsg}`;

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -148,7 +148,12 @@ export async function formatErrorForSlack(error: unknown): Promise<string> {
 	} catch {
 		// Haiku itself failed (possibly also rate limited) — use static fallback
 		if (error instanceof Anthropic.APIError && error.status === 429) {
-			return "I'm a bit overloaded right now — please try again in a moment.";
+			const retryAfter = (error.headers as Record<string, string>)?.['retry-after'];
+			const seconds = retryAfter ? parseInt(retryAfter, 10) : null;
+			const waitMsg = seconds && !isNaN(seconds)
+				? `Please try again in ${seconds} seconds.`
+				: "Please try again in a moment.";
+			return `I'm a bit overloaded right now — ${waitMsg}`;
 		}
 		return "Sorry, something went wrong. Please try again.";
 	}


### PR DESCRIPTION
Closes superset-sh#4104

The 429 handler in `formatErrorForSlack()` returned a static message regardless of the provider's Retry-After header.

When Anthropic returns `Retry-After: 60`, the user now sees "Please try again in 60 seconds" instead of a generic message.

Falls back to "Please try again in a moment" when Retry-After is absent or unparseable.

4 lines changed. No other behavior modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the `Retry-After` header value in Slack 429 error messages so users know exactly how long to wait (e.g., “Please try again in 60 seconds.”). Keeps the existing overload prefix and falls back to “Please try again in a moment” when the header is missing or invalid; no other behavior changed.

<sup>Written for commit 122c6af1114ad7405279f18cd55fbd32f553baa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rate-limit error messages now show specific "try again in X seconds" timing when available from the service; otherwise they fall back to a generic "try again in a moment" message.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4373)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->