### PR TITLE
fix(desktop): keep New Workspace label on one line at min sidebar width

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -265,17 +265,19 @@ export function DashboardSidebarHeader({
 				<span className="flex-1 text-left">Tasks</span>
 			</button>
 
-			<div className="flex items-center gap-1">
+			<div className="flex items-center gap-0">
 				<button
 					type="button"
 					onClick={() => openModal()}
-					className="group flex flex-1 min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+					className="group flex flex-1 min-w-0 items-center gap-1.5 rounded-md px-2 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
 				>
 					<LuPlus
 						className="size-4 shrink-0"
 						strokeWidth={STROKE_WIDTH_THICK}
 					/>
-					<span className="flex-1 text-left">New Workspace</span>
+					<span className="flex-1 truncate text-left whitespace-nowrap">
+						New Workspace
+					</span>
 					<span
 						className={cn(
 							"shrink-0 text-[10px] font-mono tabular-nums text-muted-foreground/60",


### PR DESCRIPTION
## Summary
- Tighten the inner gap inside the **New Workspace** button (`gap-2` → `gap-1.5`) and collapse the gap between it and the adjacent **Add repository** button (`gap-1` → `gap-0`) so the label doesn't wrap when the sidebar shrinks.
- Add `truncate whitespace-nowrap` on the label so it ellipsizes gracefully if the sidebar still gets tighter.

## Test plan
- [ ] Open the dashboard sidebar, drag it down to its min width, confirm "New Workspace" stays on one line.
- [ ] Hover the button — keyboard shortcut still appears, layout doesn't shift.
- [ ] Verify the collapsed sidebar (icon-only) is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the “New Workspace” label on one line at the sidebar’s minimum width by tightening the button’s internal spacing and removing the gap to the adjacent “Add repository” button. Added text truncation (`truncate whitespace-nowrap`) so it ellipsizes instead of wrapping, with no change to the collapsed sidebar or hover shortcut behavior.

<sup>Written for commit b05aeb198a01dacab160a23f44007e07a2b0bf9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the "New Workspace" button layout in the sidebar with improved spacing and text handling for better visual presentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4382)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->