### PR TITLE
feat(desktop): add File menu, rename Add Repository options

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/menu.ts
+++ b/apps/desktop/src/lib/trpc/routers/menu.ts
@@ -9,7 +9,8 @@ import { publicProcedure, router } from "..";
 
 type MenuEvent =
 	| { type: "open-settings"; data: OpenSettingsEvent }
-	| { type: "open-workspace"; data: OpenWorkspaceEvent };
+	| { type: "open-workspace"; data: OpenWorkspaceEvent }
+	| { type: "open-project" };
 
 export const createMenuRouter = () => {
 	return router({
@@ -23,12 +24,18 @@ export const createMenuRouter = () => {
 					emit.next({ type: "open-workspace", data: { workspaceId } });
 				};
 
+				const onOpenProject = () => {
+					emit.next({ type: "open-project" });
+				};
+
 				menuEmitter.on("open-settings", onOpenSettings);
 				menuEmitter.on("open-workspace", onOpenWorkspace);
+				menuEmitter.on("open-project", onOpenProject);
 
 				return () => {
 					menuEmitter.off("open-settings", onOpenSettings);
 					menuEmitter.off("open-workspace", onOpenWorkspace);
+					menuEmitter.off("open-project", onOpenProject);
 				};
 			});
 		}),

--- a/apps/desktop/src/main/lib/menu.ts
+++ b/apps/desktop/src/main/lib/menu.ts
@@ -18,6 +18,20 @@ export function createApplicationMenu() {
 
 	const template: Electron.MenuItemConstructorOptions[] = [
 		{
+			label: "File",
+			submenu: [
+				{
+					label: "Open Repo...",
+					accelerator: "CmdOrCtrl+O",
+					click: () => {
+						menuEmitter.emit("open-project");
+					},
+				},
+				{ type: "separator" },
+				{ label: "Close Window", role: "close" },
+			],
+		},
+		{
 			label: "Edit",
 			submenu: [
 				{ role: "undo" },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -196,11 +196,11 @@ export function DashboardSidebarHeader({
 					>
 						<DropdownMenuItem onSelect={() => openNewProject()}>
 							<HiMiniPlus className="size-4" />
-							Create new project
+							Clone from URL
 						</DropdownMenuItem>
 						<DropdownMenuItem onSelect={handleImportFolder}>
 							<LuFolderInput className="size-4" />
-							Import project
+							Open from folder
 						</DropdownMenuItem>
 					</DropdownMenuContent>
 				</DropdownMenu>
@@ -306,11 +306,11 @@ export function DashboardSidebarHeader({
 					>
 						<DropdownMenuItem onSelect={() => openNewProject()}>
 							<HiMiniPlus className="size-4" />
-							Create new project
+							Clone from URL
 						</DropdownMenuItem>
 						<DropdownMenuItem onSelect={handleImportFolder}>
 							<LuFolderInput className="size-4" />
-							Import project
+							Open from folder
 						</DropdownMenuItem>
 					</DropdownMenuContent>
 				</DropdownMenu>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/ProjectPickerPill/ProjectPickerPill.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/ProjectPickerPill/ProjectPickerPill.tsx
@@ -124,11 +124,11 @@ export function ProjectPickerPill({
 					<CommandGroup forceMount>
 						<CommandItem forceMount onSelect={handleCreateNewProject}>
 							<HiMiniPlus className="size-4" />
-							Create new project
+							Clone from URL
 						</CommandItem>
 						<CommandItem forceMount onSelect={handleImportProject}>
 							<LuFolderInput className="size-4" />
-							Import project
+							Open from folder
 						</CommandItem>
 					</CommandGroup>
 				</Command>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/FileMenuListener/FileMenuListener.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/FileMenuListener/FileMenuListener.tsx
@@ -1,0 +1,34 @@
+import { toast } from "@superset/ui/sonner";
+import { useNavigate } from "@tanstack/react-router";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
+
+export function FileMenuListener() {
+	const navigate = useNavigate();
+	const folderImport = useFolderFirstImport({
+		onError: (message) => {
+			toast.error(`Import failed: ${message}`);
+		},
+		onMultipleProjects: ({ candidates }) => {
+			toast.error("Import failed", {
+				description: `Multiple projects use this repository (${candidates.length}). Choose the project in settings to set it up on this device.`,
+				action: {
+					label: "Open Projects",
+					onClick: () => navigate({ to: "/settings/projects" }),
+				},
+			});
+		},
+	});
+
+	electronTrpc.menu.subscribe.useSubscription(undefined, {
+		onData: async (event) => {
+			if (event.type !== "open-project") return;
+			const result = await folderImport.start();
+			if (result) {
+				toast.success("Project ready — open it from the sidebar.");
+			}
+		},
+	});
+
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/FileMenuListener/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/FileMenuListener/index.ts
@@ -1,0 +1,1 @@
+export { FileMenuListener } from "./FileMenuListener";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -32,6 +32,7 @@ import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import { MOCK_ORG_ID, NOTIFICATION_EVENTS } from "shared/constants";
 import { AgentHooks } from "./components/AgentHooks";
+import { FileMenuListener } from "./components/FileMenuListener";
 import { GlobalBrowserLifecycle } from "./components/GlobalBrowserLifecycle";
 import { TeardownLogsDialog } from "./components/TeardownLogsDialog";
 import { V2NotificationController } from "./components/V2NotificationController";
@@ -207,6 +208,7 @@ function AuthenticatedLayout() {
 							highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}
 						>
 							<AgentHooks />
+							<FileMenuListener />
 							<V2NotificationController />
 							<Outlet />
 							<V1ImportModal />


### PR DESCRIPTION
## Summary
- Adds an application **File** menu with **Open Repo…** (`Cmd/Ctrl+O`, runs the same flow as the sidebar's open-from-folder import) and **Close Window** (`Cmd/Ctrl+W`, Electron `close` role).
- Renames the sidebar **Add repository** dropdown items from "Create new project" / "Import project" → **Clone from URL** / **Open from folder** so each option's behavior is obvious from the label. Updated in both the dashboard sidebar and the new-workspace `ProjectPickerPill`.
- Wires the menu through `menuEmitter` → `electronTrpc.menu.subscribe`. Open Repo handling lives in a new `FileMenuListener` component mounted inside `LocalHostServiceProvider` (since `useFolderFirstImport` requires that context).

## Test plan
- [ ] Open the app — File menu appears in the menu bar with **Open Repo…** and **Close Window**.
- [ ] `Cmd+O` (or File → Open Repo…) opens the native folder picker; selecting a git repo registers it as a project (toast: "Project ready — open it from the sidebar.").
- [ ] Selecting a folder that matches multiple existing projects shows the "Open Projects" toast linking to `/settings/projects`.
- [ ] `Cmd+W` (or File → Close Window) closes the focused window.
- [ ] Sidebar **Add repository** dropdown now reads **Clone from URL** / **Open from folder**; both flows still work end-to-end.
- [ ] `ProjectPickerPill` in the new-workspace modal shows the new labels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a File menu with “Open Repo…” (Cmd/Ctrl+O) and “Close Window”, and renames “Add repository” options to clarify actions. “Open Repo…” runs the same open-from-folder import flow and shows success/error toasts.

- **New Features**
  - Added File menu with “Open Repo…” and “Close Window”; wired to emit `open-project`.
  - Introduced `FileMenuListener` to handle `electronTrpc.menu.subscribe` and start folder import; shows toasts for success, errors, and multi-project cases.
  - Renamed labels to “Clone from URL” and “Open from folder” in the dashboard sidebar and new-workspace `ProjectPickerPill`.

<sup>Written for commit 19cf87f316930b2e3a710856d8f600285c6f6092. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a File menu with "Open Repo..." option to the desktop application.
  * Updated project action labels for clarity: "Clone from URL" and "Open from folder" now appear across relevant menu areas.
  * Integrated menu-driven project opening workflow that directly initiates folder-based imports with user-friendly feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4383)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->