### PR TITLE
feat(desktop): add copy actions and tighten layout for diff comment threads fix linking on comments

### DIFF
--- a/apps/desktop/src/renderer/components/CommentMarkdown/CommentMarkdown.tsx
+++ b/apps/desktop/src/renderer/components/CommentMarkdown/CommentMarkdown.tsx
@@ -1,4 +1,12 @@
-import type { ComponentProps, ReactNode } from "react";
+import {
+	type ComponentProps,
+	type MouseEvent,
+	type ReactNode,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { LuCheck, LuCopy } from "react-icons/lu";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
@@ -9,6 +17,54 @@ import { CommentCodeBlock } from "./components/CommentCodeBlock";
 type ReactMarkdownComponents = ComponentProps<
 	typeof ReactMarkdown
 >["components"];
+
+function CopyableDetails({
+	children,
+	open,
+}: {
+	children?: ReactNode;
+	open?: boolean;
+}) {
+	const ref = useRef<HTMLDetailsElement>(null);
+	const [isCopied, setIsCopied] = useState(false);
+	useEffect(() => {
+		if (!isCopied) return;
+		const timer = setTimeout(() => setIsCopied(false), 2000);
+		return () => clearTimeout(timer);
+	}, [isCopied]);
+	const handleCopy = (e: MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		if (!ref.current) return;
+		const clone = ref.current.cloneNode(true) as HTMLDetailsElement;
+		for (const el of clone.querySelectorAll("summary")) el.remove();
+		navigator.clipboard
+			.writeText((clone.textContent ?? "").trim())
+			.then(() => setIsCopied(true))
+			.catch((err) => {
+				console.error("[CommentMarkdown/copyDetails] Failed to copy:", err);
+			});
+	};
+	return (
+		<div className="relative">
+			<button
+				type="button"
+				onClick={handleCopy}
+				className="absolute right-1 top-1 z-10 rounded bg-card/80 p-1 text-muted-foreground/70 backdrop-blur-sm transition-colors hover:bg-accent hover:text-foreground"
+				aria-label={isCopied ? "Copied" : "Copy contents"}
+			>
+				{isCopied ? (
+					<LuCheck className="size-3 text-green-500" />
+				) : (
+					<LuCopy className="size-3" />
+				)}
+			</button>
+			<details ref={ref} open={open}>
+				{children}
+			</details>
+		</div>
+	);
+}
 
 const baseComponents = {
 	code: ({
@@ -31,6 +87,7 @@ const baseComponents = {
 			{children}
 		</a>
 	),
+	details: CopyableDetails,
 } satisfies ReactMarkdownComponents;
 
 interface CommentMarkdownProps {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
@@ -184,21 +184,6 @@ export function CommentThread({
 }
 
 function CommentRow({ comment }: { comment: Comment }) {
-	const [isCopied, setIsCopied] = useState(false);
-	useEffect(() => {
-		if (!isCopied) return;
-		const timer = setTimeout(() => setIsCopied(false), 2000);
-		return () => clearTimeout(timer);
-	}, [isCopied]);
-	const handleCopy = () => {
-		navigator.clipboard
-			.writeText(comment.body)
-			.then(() => setIsCopied(true))
-			.catch((err) => {
-				console.error("[CommentRow/copy] Failed to copy:", err);
-				toast.error("Couldn't copy comment");
-			});
-	};
 	return (
 		<li className="flex gap-2 px-2.5 py-2">
 			<Avatar className="mt-0.5 size-5 shrink-0">
@@ -222,18 +207,6 @@ function CommentRow({ comment }: { comment: Comment }) {
 							{formatRelative(comment.createdAt)}
 						</time>
 					)}
-					<button
-						type="button"
-						onClick={handleCopy}
-						className="ml-auto shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
-						aria-label={isCopied ? "Copied" : "Copy comment"}
-					>
-						{isCopied ? (
-							<LuCheck className="size-3 text-green-500" />
-						) : (
-							<LuCopy className="size-3" />
-						)}
-					</button>
 				</div>
 				<div className="diff-comment-body mt-1">
 					<CommentMarkdown body={comment.body} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
@@ -9,7 +9,13 @@ import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useEffect, useState } from "react";
-import { LuChevronRight, LuExternalLink, LuLoaderCircle } from "react-icons/lu";
+import {
+	LuCheck,
+	LuChevronRight,
+	LuCopy,
+	LuExternalLink,
+	LuLoaderCircle,
+} from "react-icons/lu";
 import { CommentMarkdown } from "renderer/components/CommentMarkdown";
 import "./comment-thread.css";
 
@@ -43,6 +49,23 @@ export function CommentThread({
 	focusTick,
 }: CommentThreadProps) {
 	const [open, setOpen] = useState(!isResolved && !isOutdated);
+	const [isLinkCopied, setIsLinkCopied] = useState(false);
+	useEffect(() => {
+		if (!isLinkCopied) return;
+		const timer = setTimeout(() => setIsLinkCopied(false), 2000);
+		return () => clearTimeout(timer);
+	}, [isLinkCopied]);
+	const handleCopyLink = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		if (!url) return;
+		navigator.clipboard
+			.writeText(url)
+			.then(() => setIsLinkCopied(true))
+			.catch((err) => {
+				console.error("[CommentThread/copyLink] Failed to copy:", err);
+				toast.error("Couldn't copy link");
+			});
+	};
 	// Auto-collapse on resolve/outdated (matches GitHub).
 	useEffect(() => {
 		if (isResolved || isOutdated) setOpen(false);
@@ -71,7 +94,7 @@ export function CommentThread({
 			open={open}
 			onOpenChange={setOpen}
 			className={cn(
-				"diff-comment my-1 overflow-hidden rounded-md border border-border bg-card text-card-foreground",
+				"diff-comment mx-3 my-1 overflow-hidden rounded-md border border-border bg-card text-card-foreground",
 				isResolved && "opacity-70",
 			)}
 		>
@@ -103,16 +126,30 @@ export function CommentThread({
 					)}
 				</CollapsibleTrigger>
 				{url && (
-					<a
-						href={url}
-						target="_blank"
-						rel="noreferrer"
-						onClick={(e) => e.stopPropagation()}
-						className="shrink-0 text-muted-foreground hover:text-foreground"
-						aria-label="Open on GitHub"
-					>
-						<LuExternalLink className="size-3" />
-					</a>
+					<>
+						<button
+							type="button"
+							onClick={handleCopyLink}
+							className="shrink-0 text-muted-foreground hover:text-foreground"
+							aria-label={isLinkCopied ? "Copied" : "Copy link"}
+						>
+							{isLinkCopied ? (
+								<LuCheck className="size-3 text-green-500" />
+							) : (
+								<LuCopy className="size-3" />
+							)}
+						</button>
+						<a
+							href={url}
+							target="_blank"
+							rel="noreferrer"
+							onClick={(e) => e.stopPropagation()}
+							className="shrink-0 text-muted-foreground hover:text-foreground"
+							aria-label="Open on GitHub"
+						>
+							<LuExternalLink className="size-3" />
+						</a>
+					</>
 				)}
 			</div>
 			<CollapsibleContent className="overflow-hidden border-t border-border data-[state=closed]:animate-none">
@@ -147,6 +184,21 @@ export function CommentThread({
 }
 
 function CommentRow({ comment }: { comment: Comment }) {
+	const [isCopied, setIsCopied] = useState(false);
+	useEffect(() => {
+		if (!isCopied) return;
+		const timer = setTimeout(() => setIsCopied(false), 2000);
+		return () => clearTimeout(timer);
+	}, [isCopied]);
+	const handleCopy = () => {
+		navigator.clipboard
+			.writeText(comment.body)
+			.then(() => setIsCopied(true))
+			.catch((err) => {
+				console.error("[CommentRow/copy] Failed to copy:", err);
+				toast.error("Couldn't copy comment");
+			});
+	};
 	return (
 		<li className="flex gap-2 px-2.5 py-2">
 			<Avatar className="mt-0.5 size-5 shrink-0">
@@ -170,6 +222,18 @@ function CommentRow({ comment }: { comment: Comment }) {
 							{formatRelative(comment.createdAt)}
 						</time>
 					)}
+					<button
+						type="button"
+						onClick={handleCopy}
+						className="ml-auto shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+						aria-label={isCopied ? "Copied" : "Copy comment"}
+					>
+						{isCopied ? (
+							<LuCheck className="size-3 text-green-500" />
+						) : (
+							<LuCopy className="size-3" />
+						)}
+					</button>
 				</div>
 				<div className="diff-comment-body mt-1">
 					<CommentMarkdown body={comment.body} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
@@ -49,21 +49,24 @@ export function CommentThread({
 	focusTick,
 }: CommentThreadProps) {
 	const [open, setOpen] = useState(!isResolved && !isOutdated);
-	const [isLinkCopied, setIsLinkCopied] = useState(false);
+	const [isCopied, setIsCopied] = useState(false);
 	useEffect(() => {
-		if (!isLinkCopied) return;
-		const timer = setTimeout(() => setIsLinkCopied(false), 2000);
+		if (!isCopied) return;
+		const timer = setTimeout(() => setIsCopied(false), 2000);
 		return () => clearTimeout(timer);
-	}, [isLinkCopied]);
-	const handleCopyLink = (e: React.MouseEvent) => {
+	}, [isCopied]);
+	const handleCopy = (e: React.MouseEvent) => {
 		e.stopPropagation();
-		if (!url) return;
+		const text =
+			comments.length === 1
+				? comments[0].body
+				: comments.map((c) => `@${c.authorLogin}:\n${c.body}`).join("\n\n");
 		navigator.clipboard
-			.writeText(url)
-			.then(() => setIsLinkCopied(true))
+			.writeText(text)
+			.then(() => setIsCopied(true))
 			.catch((err) => {
-				console.error("[CommentThread/copyLink] Failed to copy:", err);
-				toast.error("Couldn't copy link");
+				console.error("[CommentThread/copy] Failed to copy:", err);
+				toast.error("Couldn't copy comment");
 			});
 	};
 	// Auto-collapse on resolve/outdated (matches GitHub).
@@ -125,31 +128,35 @@ export function CommentThread({
 						</span>
 					)}
 				</CollapsibleTrigger>
+				<button
+					type="button"
+					onClick={handleCopy}
+					className="shrink-0 text-muted-foreground hover:text-foreground"
+					aria-label={
+						isCopied
+							? "Copied"
+							: comments.length === 1
+								? "Copy comment"
+								: "Copy comments"
+					}
+				>
+					{isCopied ? (
+						<LuCheck className="size-3 text-green-500" />
+					) : (
+						<LuCopy className="size-3" />
+					)}
+				</button>
 				{url && (
-					<>
-						<button
-							type="button"
-							onClick={handleCopyLink}
-							className="shrink-0 text-muted-foreground hover:text-foreground"
-							aria-label={isLinkCopied ? "Copied" : "Copy link"}
-						>
-							{isLinkCopied ? (
-								<LuCheck className="size-3 text-green-500" />
-							) : (
-								<LuCopy className="size-3" />
-							)}
-						</button>
-						<a
-							href={url}
-							target="_blank"
-							rel="noreferrer"
-							onClick={(e) => e.stopPropagation()}
-							className="shrink-0 text-muted-foreground hover:text-foreground"
-							aria-label="Open on GitHub"
-						>
-							<LuExternalLink className="size-3" />
-						</a>
-					</>
+					<a
+						href={url}
+						target="_blank"
+						rel="noreferrer"
+						onClick={(e) => e.stopPropagation()}
+						className="shrink-0 text-muted-foreground hover:text-foreground"
+						aria-label="Open on GitHub"
+					>
+						<LuExternalLink className="size-3" />
+					</a>
 				)}
 			</div>
 			<CollapsibleContent className="overflow-hidden border-t border-border data-[state=closed]:animate-none">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/comment-thread.css
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/comment-thread.css
@@ -1,7 +1,6 @@
 .diff-comment {
 	display: block;
-	width: 100%;
-	max-width: 100%;
+	max-width: min(100%, 720px);
 	min-width: 0;
 	box-sizing: border-box;
 	overflow-wrap: anywhere;


### PR DESCRIPTION
## Summary

- Cap the diff comment thread card at `max-width: min(100%, 720px)` with `mx-3` margin so long review comments stay readable in wide diff columns
- Add a copy button to each individual comment that copies the comment body to the clipboard
- Add a copy-link button next to the existing "Open on GitHub" button in the thread header that copies the thread URL

## Test plan

- [ ] Open a PR with review comments in the v2 workspace diff pane
- [ ] Verify thread cards no longer stretch the full content column width and are inset from both edges
- [ ] Click the copy icon on a comment row → body is in clipboard; icon flips to green check for ~2s
- [ ] Click the copy-link icon on the thread header → thread URL is in clipboard; icon flips to green check for ~2s
- [ ] External-link icon still opens GitHub in a new tab

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds copy actions for diff comments and markdown details. Tightens thread width for better readability.

- **New Features**
  - Cap thread cards at `max-width: min(100%, 720px)` with `mx-3`.
  - Header copy button copies the comment body (or all with author prefixes) with a short success check; "Open on GitHub" still shows when available.
  - Markdown details blocks now have a small copy button that copies their inner content (excluding the summary).

- **Refactors**
  - Remove the per-comment copy button; the header action covers this.

<sup>Written for commit eb735a20ed77206d40c0fbcb387837882a371775. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "copy comment(s)" control to comment threads with a short visual confirmation when copying succeeds.
  * Added copy-to-clipboard for expandable Markdown "details" blocks, with a brief checkmark confirmation on success.

* **Style**
  * Capped comment display width (max 720px) to improve layout and readability across viewports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4389)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->