### PR TITLE
fix(desktop): keep sidebar from sticking on "creating" when Electric is slow

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -134,12 +134,17 @@ export function useDashboardSidebarData() {
 
 	// In-flight workspace.create operations. These don't have a backing DB row
 	// — they're kept in renderer memory until the real v2Workspaces row arrives
-	// via Electric sync (or until error/dismiss).
+	// via Electric sync (or until error/dismiss). Entries that have already
+	// resolved on the host service carry `cloudRow`; those are surfaced as
+	// real synced rows below so the sidebar doesn't stick on "creating" when
+	// Electric is slow.
 	const inFlightEntries = useWorkspaceCreatesStore((store) => store.entries);
 	const inFlightSidebarRows = useMemo(
 		() =>
 			inFlightEntries
 				.filter((entry) => entry.snapshot.id !== undefined)
+				// Entries with a cloudRow are rendered via the synced fallback below.
+				.filter((entry) => !(entry.state === "creating" && entry.cloudRow))
 				.map((entry) => ({
 					id: entry.snapshot.id as string,
 					projectId: entry.snapshot.projectId,
@@ -287,6 +292,44 @@ export function useDashboardSidebarData() {
 		[collections],
 	);
 
+	// Cloud-row fallback: when workspaces.create has resolved on the host
+	// service but Electric hasn't yet delivered the v2Workspaces row, surface
+	// the cloud row cached on the in-flight entry so the sidebar renders the
+	// workspace as fully synced. Manager.tsx removes the entry once Electric
+	// catches up, at which point the live query takes over seamlessly.
+	const cloudRowFallbackWorkspaces = useMemo(() => {
+		if (inFlightEntries.length === 0) return [];
+		const hostByMachineId = new Map(
+			hosts.map((host) => [host.machineId, host]),
+		);
+		const rows = inFlightEntries.flatMap((entry) => {
+			const cloudRow = entry.cloudRow;
+			if (!cloudRow) return [];
+			// Electric already delivered; let the live query own this row.
+			if (localStateWorkspaceIds.has(cloudRow.id)) return [];
+			const localState = collections.v2WorkspaceLocalState.get(cloudRow.id);
+			const host = hostByMachineId.get(cloudRow.hostId);
+			return [
+				{
+					id: cloudRow.id,
+					projectId: localState?.sidebarState.projectId ?? cloudRow.projectId,
+					hostId: cloudRow.hostId,
+					type: cloudRow.type,
+					hostIsOnline: host?.isOnline ?? false,
+					name: cloudRow.name,
+					branch: cloudRow.branch,
+					createdAt: cloudRow.createdAt,
+					updatedAt: cloudRow.updatedAt,
+					tabOrder:
+						localState?.sidebarState.tabOrder ?? PENDING_WORKSPACE_TAB_ORDER,
+					sectionId: localState?.sidebarState.sectionId ?? null,
+					isHidden: localState?.sidebarState.isHidden ?? false,
+				},
+			];
+		});
+		return getVisibleSidebarWorkspaces(rows);
+	}, [collections, hosts, inFlightEntries, localStateWorkspaceIds]);
+
 	const visibleSidebarWorkspaces = useMemo(() => {
 		const sidebarProjectIds = new Set(
 			sidebarProjects.map((project) => project.id),
@@ -298,8 +341,13 @@ export function useDashboardSidebarData() {
 				sidebarProjectIds.has(workspace.projectId),
 		);
 
-		return [...autoLocalMainWorkspaces, ...sidebarWorkspaces];
+		return [
+			...autoLocalMainWorkspaces,
+			...sidebarWorkspaces,
+			...cloudRowFallbackWorkspaces,
+		];
 	}, [
+		cloudRowFallbackWorkspaces,
 		localMainWorkspaces,
 		localStateWorkspaceIds,
 		machineId,


### PR DESCRIPTION
## Summary
- Mirrors the workspace-details fix from #4141 for the sidebar. After `workspaces.create` resolves on the host service, the sidebar's live query inner-joins `v2WorkspaceLocalState ∩ v2Workspaces ∩ v2Hosts` — if Electric stalls on `v2Workspaces`, the inner join drops the row, the in-flight entry stays in `state: "creating"`, and the pending row sticks forever (until refresh clears the in-memory store and Electric reconnects).
- `useDashboardSidebarData` now synthesizes a synced sidebar workspace from each in-flight entry's `cloudRow` (already cached by #4141) when the row hasn't been delivered by Electric yet, using the local state row that `useWorkspaceCreates.dispatch` inserts for `projectId` / `tabOrder` / `sectionId`. The pending "creating" row is filtered out for those entries to avoid double-render. `Manager.tsx` still removes the in-flight entry once Electric catches up — seamless handoff.
- Closes SUPER-610 / #4387.

## Test plan
- [ ] Create a workspace with Electric reachable — sidebar row appears as synced immediately (no creating badge), no flicker when Electric delivers.
- [ ] Throttle / disconnect Electric (devtools or block the shape URL), create a workspace — sidebar transitions from "creating" → synced row as soon as `workspaces.create` resolves, instead of sticking on "creating".
- [ ] Reconnect Electric — synced fallback row is replaced by the live-query row, in-flight entry is removed, no duplicate.
- [ ] Force `workspaces.create` to error — pending failed row still renders and can be dismissed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the dashboard sidebar from sticking on “creating” when Electric is slow by rendering a synced fallback from each in‑flight entry’s `cloudRow` until the live `v2Workspaces` row arrives. Seamless handoff with no duplicates or flicker; addresses SUPER-610.

- **Bug Fixes**
  - Filter in‑flight entries so “creating” rows with a `cloudRow` don’t render twice.
  - Synthesize a visible sidebar row from the cached `cloudRow` plus local sidebar state (`projectId`, `tabOrder`, `sectionId`) until sync delivers.
  - Allow `Manager.tsx` to remove the in‑flight entry once Electric catches up so the live query takes over.

<sup>Written for commit f9ae618f2fca541aa1d7118685360b66eca57ec8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard sidebar to display newly created workspaces immediately, even before cloud synchronization completes, providing a seamless workspace management experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4390)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->