### PR TITLE
fix(desktop): hide resource monitor severity dot on v2 sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
@@ -357,7 +357,7 @@ export function ResourceConsumption({
 							)}
 						>
 							<HiOutlineCpuChip className="size-3.5" />
-							{triggerDotColorClass && (
+							{!isV2 && triggerDotColorClass && (
 								<span
 									className={cn(
 										"absolute top-0.5 right-0.5 size-1.5 rounded-full ring-2 ring-background",


### PR DESCRIPTION
## Summary
- Scopes the colored severity dot on the resource monitor CPU icon to the v1 TopBar only — the v2 sidebar header no longer renders the red/amber indicator on top of the trigger.
- The severity badges inside the popover (per-workspace/app rows) are unchanged.

## Test plan
- [ ] Open the desktop app on the v2 surface and confirm no colored dot appears on the CPU icon in the sidebar header, even under elevated/high host memory pressure.
- [ ] Confirm the v1 TopBar still shows the red/amber dot when applicable.
- [ ] Open the resource monitor popover on v2 and confirm the per-row severity badges still render.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the resource monitor severity dot on the CPU icon in the v2 sidebar header. Keep the dot on the v1 TopBar and leave popover row badges unchanged.

<sup>Written for commit 3e17b6e170c06f2b25bccfc86d151a20bed9047f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the resource monitor visual indicator to display appropriately based on interface version, enhancing consistency across different UI surfaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4391)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->