### PR TITLE
fix(desktop): skip post-delete navigation when active workspace changed

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -35,11 +35,7 @@ export function useDestroyDialogState({
 }: UseDestroyDialogStateOptions) {
 	const { destroy, inspect, hostTarget } = useDestroyWorkspace(workspaceId);
 	const { markDeleting, clearDeleting } = useDeletingWorkspaces();
-	const {
-		getNavigationTargetAfterRemoval,
-		isWorkspaceRouteActive,
-		navigateToRemovalTarget,
-	} = useNavigateAwayFromWorkspace();
+	const { navigateAwayFromWorkspace } = useNavigateAwayFromWorkspace();
 
 	const { preferences, setDeleteLocalBranch: setDeleteBranch } =
 		useV2UserPreferences();
@@ -114,15 +110,12 @@ export function useDestroyDialogState({
 			if (inFlight.current) return;
 			inFlight.current = true;
 
-			// Snapshot the next-sibling target now so we preserve sidebar order
-			// (collections may evict the workspace by the time destroy resolves).
-			// We re-check the active route at apply time to avoid hijacking the
-			// user if they navigated elsewhere during the delete.
-			const navigationTarget = getNavigationTargetAfterRemoval(workspaceId);
-
 			setError(null);
 			onOpenChange(false);
 			markDeleting(workspaceId);
+			// Navigate up-front: no-ops if the deleted workspace isn't the
+			// active route, so a later user navigation won't be hijacked.
+			navigateAwayFromWorkspace(workspaceId);
 			toast(`Deleting "${workspaceName}"...`);
 
 			try {
@@ -144,9 +137,6 @@ export function useDestroyDialogState({
 					}
 				}
 				for (const warning of result.warnings) toast.warning(warning);
-				if (isWorkspaceRouteActive(workspaceId)) {
-					navigateToRemovalTarget(navigationTarget);
-				}
 				onDeleted?.();
 			} catch (err) {
 				const e = err as DestroyWorkspaceError;
@@ -174,9 +164,7 @@ export function useDestroyDialogState({
 			onDeleted,
 			markDeleting,
 			clearDeleting,
-			getNavigationTargetAfterRemoval,
-			isWorkspaceRouteActive,
-			navigateToRemovalTarget,
+			navigateAwayFromWorkspace,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -111,8 +111,6 @@ export function useDestroyDialogState({
 			if (inFlight.current) return;
 			inFlight.current = true;
 
-			const navigationTarget = getNavigationTargetAfterRemoval(workspaceId);
-
 			setError(null);
 			onOpenChange(false);
 			markDeleting(workspaceId);
@@ -137,7 +135,7 @@ export function useDestroyDialogState({
 					}
 				}
 				for (const warning of result.warnings) toast.warning(warning);
-				navigateToRemovalTarget(navigationTarget);
+				navigateToRemovalTarget(getNavigationTargetAfterRemoval(workspaceId));
 				onDeleted?.();
 			} catch (err) {
 				const e = err as DestroyWorkspaceError;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -35,8 +35,11 @@ export function useDestroyDialogState({
 }: UseDestroyDialogStateOptions) {
 	const { destroy, inspect, hostTarget } = useDestroyWorkspace(workspaceId);
 	const { markDeleting, clearDeleting } = useDeletingWorkspaces();
-	const { getNavigationTargetAfterRemoval, navigateToRemovalTarget } =
-		useNavigateAwayFromWorkspace();
+	const {
+		getNavigationTargetAfterRemoval,
+		isWorkspaceRouteActive,
+		navigateToRemovalTarget,
+	} = useNavigateAwayFromWorkspace();
 
 	const { preferences, setDeleteLocalBranch: setDeleteBranch } =
 		useV2UserPreferences();
@@ -111,6 +114,12 @@ export function useDestroyDialogState({
 			if (inFlight.current) return;
 			inFlight.current = true;
 
+			// Snapshot the next-sibling target now so we preserve sidebar order
+			// (collections may evict the workspace by the time destroy resolves).
+			// We re-check the active route at apply time to avoid hijacking the
+			// user if they navigated elsewhere during the delete.
+			const navigationTarget = getNavigationTargetAfterRemoval(workspaceId);
+
 			setError(null);
 			onOpenChange(false);
 			markDeleting(workspaceId);
@@ -135,7 +144,9 @@ export function useDestroyDialogState({
 					}
 				}
 				for (const warning of result.warnings) toast.warning(warning);
-				navigateToRemovalTarget(getNavigationTargetAfterRemoval(workspaceId));
+				if (isWorkspaceRouteActive(workspaceId)) {
+					navigateToRemovalTarget(navigationTarget);
+				}
 				onDeleted?.();
 			} catch (err) {
 				const e = err as DestroyWorkspaceError;
@@ -164,6 +175,7 @@ export function useDestroyDialogState({
 			markDeleting,
 			clearDeleting,
 			getNavigationTargetAfterRemoval,
+			isWorkspaceRouteActive,
 			navigateToRemovalTarget,
 		],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
@@ -4,20 +4,17 @@ import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 import { getFlattenedV2WorkspaceIds } from "../../utils/getFlattenedV2WorkspaceIds";
-import {
-	resolveWorkspaceRemovalNavigationTarget,
-	type WorkspaceRemovalNavigationTarget,
-} from "./navigationTarget";
+import { resolveWorkspaceRemovalNavigationTarget } from "./navigationTarget";
 
 function reportRemovalNavigationError(error: unknown) {
 	console.error("[useNavigateAwayFromWorkspace] navigation failed", error);
 }
 
 /**
- * If the user is viewing the workspace about to be removed, resolve a
- * valid next visible workspace sibling (or home). Destructive deletes use
- * the resolver after `workspaceCleanup.destroy` succeeds; non-destructive
- * sidebar removals can navigate immediately.
+ * If the user is viewing the workspace about to be removed, navigate to a
+ * valid next visible workspace sibling (or home). No-ops when the active
+ * route is a different workspace, so callers can fire this up-front without
+ * hijacking the user if they've already moved on.
  */
 export function useNavigateAwayFromWorkspace() {
 	const navigate = useNavigate();
@@ -25,43 +22,23 @@ export function useNavigateAwayFromWorkspace() {
 	const collections = useCollections();
 	const { isDeleting } = useDeletingWorkspaces();
 
-	const getNavigationTargetAfterRemoval = useCallback(
-		(workspaceId: string): WorkspaceRemovalNavigationTarget | null => {
+	const navigateAwayFromWorkspace = useCallback(
+		(workspaceId: string) => {
 			const workspaceMatch = matchRoute({
 				to: "/v2-workspace/$workspaceId",
 				fuzzy: true,
 			});
 			const activeWorkspaceId =
 				workspaceMatch !== false ? workspaceMatch.workspaceId : null;
-			const orderedWorkspaceIds = getFlattenedV2WorkspaceIds(collections);
-
-			return resolveWorkspaceRemovalNavigationTarget({
+			const target = resolveWorkspaceRemovalNavigationTarget({
 				activeWorkspaceId,
 				removedWorkspaceId: workspaceId,
-				orderedWorkspaceIds,
+				orderedWorkspaceIds: getFlattenedV2WorkspaceIds(collections),
 				isWorkspaceValid: (id) =>
 					collections.v2Workspaces.get(id) !== undefined,
 				isWorkspaceDeleting: (id) => isDeleting(id),
 			});
-		},
-		[collections, isDeleting, matchRoute],
-	);
 
-	const isWorkspaceRouteActive = useCallback(
-		(workspaceId: string) => {
-			const workspaceMatch = matchRoute({
-				to: "/v2-workspace/$workspaceId",
-				fuzzy: true,
-			});
-			return (
-				workspaceMatch !== false && workspaceMatch.workspaceId === workspaceId
-			);
-		},
-		[matchRoute],
-	);
-
-	const navigateToRemovalTarget = useCallback(
-		(target: WorkspaceRemovalNavigationTarget | null) => {
 			if (!target) return;
 			if (target.kind === "workspace") {
 				void navigateToV2Workspace(target.workspaceId, navigate, {
@@ -73,20 +50,8 @@ export function useNavigateAwayFromWorkspace() {
 				reportRemovalNavigationError,
 			);
 		},
-		[navigate],
+		[collections, isDeleting, matchRoute, navigate],
 	);
 
-	const navigateAwayFromWorkspace = useCallback(
-		(workspaceId: string) => {
-			navigateToRemovalTarget(getNavigationTargetAfterRemoval(workspaceId));
-		},
-		[getNavigationTargetAfterRemoval, navigateToRemovalTarget],
-	);
-
-	return {
-		getNavigationTargetAfterRemoval,
-		isWorkspaceRouteActive,
-		navigateAwayFromWorkspace,
-		navigateToRemovalTarget,
-	};
+	return { navigateAwayFromWorkspace };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
@@ -47,6 +47,19 @@ export function useNavigateAwayFromWorkspace() {
 		[collections, isDeleting, matchRoute],
 	);
 
+	const isWorkspaceRouteActive = useCallback(
+		(workspaceId: string) => {
+			const workspaceMatch = matchRoute({
+				to: "/v2-workspace/$workspaceId",
+				fuzzy: true,
+			});
+			return (
+				workspaceMatch !== false && workspaceMatch.workspaceId === workspaceId
+			);
+		},
+		[matchRoute],
+	);
+
 	const navigateToRemovalTarget = useCallback(
 		(target: WorkspaceRemovalNavigationTarget | null) => {
 			if (!target) return;
@@ -72,6 +85,7 @@ export function useNavigateAwayFromWorkspace() {
 
 	return {
 		getNavigationTargetAfterRemoval,
+		isWorkspaceRouteActive,
 		navigateAwayFromWorkspace,
 		navigateToRemovalTarget,
 	};


### PR DESCRIPTION
## Summary
- Resolve the workspace-removal navigation target *after* `destroy()` succeeds in `useDestroyDialogState.run`, instead of capturing it before the destroy starts.
- If the user navigates to a different workspace while the delete is in flight, `resolveWorkspaceRemovalNavigationTarget` now returns `null` and `navigateToRemovalTarget` no-ops — they stay on the workspace they switched to.
- Only re-navigates when the deleted workspace is still the active route at completion time.

## Test plan
- [ ] Delete the currently-active workspace → still navigates to the next visible sibling (or home).
- [ ] Open delete dialog on workspace A, confirm, then switch to workspace B before destroy completes → user remains on workspace B (no redirect).
- [ ] Delete a non-active workspace from the sidebar context menu → active route unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent unwanted redirects after deleting a workspace. We now navigate immediately on delete only if the deleted workspace is the active route; otherwise it no-ops.

- **Bug Fixes**
  - Navigate up-front to the next visible sibling (or home) when deleting the currently viewed workspace; skip when another workspace is active.

- **Refactors**
  - Simplified `useNavigateAwayFromWorkspace` to a single `navigateAwayFromWorkspace` function, removing the snapshot/apply flow.

<sup>Written for commit 114712dc6d66dcf35cf0bf8bb15793d2112ae406. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified workspace-removal navigation so the app resolves and performs the redirect as part of the removal flow.
* **Bug Fixes**
  * Navigates away immediately when initiating a workspace delete (no-op if not active) and stops doing an additional post-delete redirect to avoid redundant route changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4392)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->