### PR TITLE
fix(desktop): even row height between Mine and Team in automations

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -357,7 +357,7 @@ function AutomationsPage() {
 										}}
 										className={cn(
 											rowGrid,
-											"group/row min-w-0 cursor-pointer border-b border-border/50 px-4 py-2.5 text-sm outline-none transition-colors hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
+											"group/row h-10 min-w-0 cursor-pointer border-b border-border/50 px-4 text-sm outline-none transition-colors hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
 										)}
 									>
 										<span className="flex min-w-0 items-center gap-2">


### PR DESCRIPTION
## Summary
- Pin automation list rows to `h-10` so Mine and Team scopes render identically (Owner column and pause badge no longer drift row height).

## Test plan
- [ ] Open Automations, toggle Mine ↔ Team — rows are visually the same height.
- [ ] Confirm a paused automation (with the "paused" badge) keeps the row at the same height.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a fixed h-10 height for automation list rows so Mine and Team views render identically. Prevents the Owner column and paused badge from changing row height.

<sup>Written for commit 801db1354d057f25127d2f4a51a37eb169719e93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined automation table row styling with fixed height sizing for improved visual consistency and better layout alignment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4402)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->