### PR TITLE
fix(desktop): auto-name v2 workspaces from prompt when no agent is selected

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -101,6 +101,7 @@ export function useSubmitWorkspace(
 			? draft.linkedPR?.title || `PR #${draft.linkedPR?.prNumber}`
 			: undefined;
 
+		const trimmedPrompt = draft.prompt.trim();
 		const workspaceId = crypto.randomUUID();
 		const snapshot = {
 			id: workspaceId,
@@ -111,6 +112,10 @@ export function useSubmitWorkspace(
 			baseBranch: draft.baseBranch ?? undefined,
 			taskId: linkedTaskId,
 			agents,
+			namingPrompt:
+				!isPrCheckout && !wantAgent && trimmedPrompt
+					? trimmedPrompt
+					: undefined,
 		};
 
 		closeAndResetDraft();

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -67,7 +67,7 @@ const createInputSchema = z
 		baseBranch: z.string().min(1).optional(),
 		taskId: z.string().uuid().optional(),
 		agents: z.array(agentLaunchSchema).optional(),
-		namingPrompt: z.string().optional(),
+		namingPrompt: z.string().min(1).optional(),
 		id: z.string().uuid().optional(),
 		// Adopt the worktree git already has at this path instead of
 		// inferring the path from `branch`. When present, `branch` is

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -67,6 +67,7 @@ const createInputSchema = z
 		baseBranch: z.string().min(1).optional(),
 		taskId: z.string().uuid().optional(),
 		agents: z.array(agentLaunchSchema).optional(),
+		namingPrompt: z.string().optional(),
 		id: z.string().uuid().optional(),
 		// Adopt the worktree git already has at this path instead of
 		// inferring the path from `branch`. When present, `branch` is
@@ -506,7 +507,8 @@ export const workspacesRouter = router({
 			// resolution, so by the time we need the resolved values for
 			// `worktree add` they're already in hand. PR path skips entirely
 			// — PR title + derived branch are already meaningful.
-			const composerPrompt = input.agents?.[0]?.prompt?.trim() ?? "";
+			const composerPrompt =
+				input.agents?.[0]?.prompt?.trim() || input.namingPrompt?.trim() || "";
 			const wantAi =
 				input.pr === undefined &&
 				(input.branch === undefined || input.name === undefined) &&


### PR DESCRIPTION
## Summary
- In v2, the composer prompt only reached the host via `agents[0].prompt`, so the "No agent" submit silently dropped it and the workspace landed with a friendly-random name (v1 behavior was to auto-name from the prompt regardless of agent).
- Pass the prompt as a top-level `namingPrompt` on the no-agent path; host falls back to it when `agents[0].prompt` is empty.
- CLI/SDK/MCP whitelist the fields they forward to `workspaces.create`, so the new optional field stays internal to the desktop modal.

## Test plan
- [ ] v2 modal: pick a project, leave agent as "No agent", type a prompt, submit → workspace + branch are renamed from the prompt (not `happy-balloon`).
- [ ] v2 modal: pick an agent, type a prompt → still renames from the agent's prompt (unchanged path).
- [ ] v2 modal: PR checkout path is unaffected (PR title still wins).
- [ ] `superset workspaces create` from the CLI still works with no schema surprise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-name v2 workspaces from the composer prompt even when “No agent” is selected. Adds a `namingPrompt` fallback used by the host with non-empty validation; agent path remains unchanged.

- **Bug Fixes**
  - Desktop (v2 modal): send trimmed prompt as `namingPrompt` when “No agent” is chosen.
  - Host (`packages/host-service`): prefer `agents[0].prompt`, else use trimmed `namingPrompt`; reject empty `namingPrompt`.
  - PR checkout still names from the PR title.
  - CLI/SDK/MCP forwarding unchanged; `namingPrompt` remains internal to the desktop flow.

<sup>Written for commit 15c2612874d8c58444074292b44db68fffbc7d53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace creation accepts an optional naming prompt for AI-powered name suggestions.

* **Improvements**
  * Naming prompt input is now whitespace-trimmed before use.
  * AI naming will use a provided trimmed naming prompt even if no agent prompt is present; snapshot naming now reflects the trimmed user prompt.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4404)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->