### PR TITLE
docs(agents): clarify Superset workspace context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Superset Monorepo Guide
 
+You're running inside a Superset workspace — an isolated git-worktree copy of this repo. "Workspace" in any user message refers to this, not VS Code/editor workspaces.
+
 ## Question Tool
 
 When you need to ask the user ANY question — including simple yes/no, confirmations, and clarifications — ALWAYS use the `ask_user` tool. Never ask questions in plain text. The Superset UI renders `ask_user` calls as an interactive overlay with clickable option buttons; plain-text questions will not be surfaced to the user in the same way.

--- a/skills/superset/SKILL.md
+++ b/skills/superset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superset
-description: Drives the Superset CLI to orchestrate coding agents across devices. Use when the user wants to spawn an agent, create or manage workspaces, schedule automations, or interact with Superset projects, hosts, or tasks from the terminal.
+description: Create workspaces, spawn agents, schedule automations, and manage Superset projects/tasks/hosts via the `superset` CLI. Use to orchestrate coding agents across devices from the terminal.
 allowed-tools: Bash(superset:*)
 ---
 


### PR DESCRIPTION
## Summary
- Add a one-line note to AGENTS.md explaining that agents run inside an isolated Superset workspace (git-worktree copy of the repo), so "workspace" in user messages refers to this — not editor workspaces.

## Test plan
- [x] AGENTS.md renders cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that agents run inside an isolated Superset workspace (git-worktree copy of the repo), not an editor workspace, and front-loads verbs in the `superset` skill description for clearer intent and better trigger matching.

<sup>Written for commit 10b8cb7bc9cf29579dd426027ce37b94b807446c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that "workspace" refers to the isolated Superset git-worktree context in AGENTS docs.
  * Reworded the Superset skill description for improved clarity; workflow and usage details unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4405)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->