### PR TITLE
feat(relay): per-user relay-url-override flag; sjc-only deploy script

### DIFF
--- a/apps/desktop/src/main/lib/analytics/index.ts
+++ b/apps/desktop/src/main/lib/analytics/index.ts
@@ -21,6 +21,14 @@ function getClient(): PostHog | null {
 	return posthog;
 }
 
+export function getPosthogClient(): PostHog | null {
+	return getClient();
+}
+
+export function getUserId(): string | null {
+	return userId;
+}
+
 function isTelemetryEnabled(): boolean {
 	return DEFAULT_TELEMETRY_ENABLED;
 }

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -7,7 +7,6 @@ import { settings } from "@superset/local-db";
 import { getHostId, getHostName } from "@superset/shared/host-info";
 import { app } from "electron";
 import log from "electron-log/main";
-import { env } from "main/env.main";
 import { env as sharedEnv } from "shared/env.shared";
 import { getProcessEnvWithShellPath } from "../../lib/trpc/routers/workspaces/utils/shell-env";
 import { SUPERSET_HOME_DIR } from "./app-environment";
@@ -27,6 +26,7 @@ import {
 	pollHealthCheck,
 } from "./host-service-utils";
 import { localDb } from "./local-db";
+import { getRelayUrl } from "./relay-url";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
 
 export type HostServiceStatus = "starting" | "running" | "stopped";
@@ -541,9 +541,13 @@ export class HostServiceCoordinator extends EventEmitter {
 
 		// `getProcessEnvWithShellPath` merges in the user's interactive shell env,
 		// which in dev has `RELAY_URL` set. Enforce the toggle *after* that merge
-		// so the child definitely doesn't see a relay URL when disabled.
-		if (exposeViaRelay && env.RELAY_URL) {
-			childEnv.RELAY_URL = env.RELAY_URL;
+		// so the child definitely doesn't see a relay URL when disabled. The
+		// effective URL comes from the PostHog `relay-url-override` flag with
+		// `env.RELAY_URL` as fallback (see main/lib/relay-url) so we can A/B-test
+		// alternate relay deployments per-user.
+		const effectiveRelayUrl = await getRelayUrl();
+		if (exposeViaRelay && effectiveRelayUrl) {
+			childEnv.RELAY_URL = effectiveRelayUrl;
 		} else {
 			delete childEnv.RELAY_URL;
 		}

--- a/apps/desktop/src/main/lib/relay-url/index.ts
+++ b/apps/desktop/src/main/lib/relay-url/index.ts
@@ -1,0 +1,1 @@
+export { getRelayUrl } from "./relay-url";

--- a/apps/desktop/src/main/lib/relay-url/relay-url.ts
+++ b/apps/desktop/src/main/lib/relay-url/relay-url.ts
@@ -1,0 +1,34 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { env } from "main/env.main";
+import { getPosthogClient, getUserId } from "main/lib/analytics";
+
+interface RelayUrlPayload {
+	url?: string;
+}
+
+/**
+ * Returns the relay base URL the host-service should tunnel to. Reads the
+ * `relay-url-override` PostHog flag payload for the current user; falls back
+ * to `env.RELAY_URL` when PostHog is unavailable, the user isn't identified
+ * yet, the flag is off, or the payload is malformed.
+ *
+ * Mirrors the renderer-side `useRelayUrl` hook so the tunnel and client WS
+ * opens land on the same URL.
+ */
+export async function getRelayUrl(): Promise<string | undefined> {
+	const fallback = env.RELAY_URL;
+	const client = getPosthogClient();
+	const userId = getUserId();
+	if (!client || !userId) return fallback;
+	try {
+		const payload = (await client.getFeatureFlagPayload(
+			FEATURE_FLAGS.RELAY_URL_OVERRIDE,
+			userId,
+		)) as RelayUrlPayload | undefined | null;
+		const override = payload?.url;
+		if (typeof override === "string" && override.length > 0) return override;
+	} catch (err) {
+		console.warn("[relay-url] PostHog payload fetch failed:", err);
+	}
+	return fallback;
+}

--- a/apps/desktop/src/renderer/hooks/host-service/useHostTargetUrl/resolveHostUrl.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useHostTargetUrl/resolveHostUrl.ts
@@ -1,10 +1,13 @@
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import { env } from "renderer/env.renderer";
 
 /**
  * Pure resolver: hostId + machineId + activeHostUrl + organizationId → URL.
  * Hosts other than the local machine are reached via relay; the local
  * machine is reached directly via electronTrpc through `activeHostUrl`.
+ *
+ * Callers fetch `relayUrl` from `useRelayUrl()` so the PostHog override is
+ * applied consistently between the renderer's hook-based and store-based
+ * call sites.
  *
  * Guaranteed-non-null inputs are typed as required because callers inside
  * `_authenticated/` get organizationId from the route guard. A null at call
@@ -15,8 +18,9 @@ export function resolveHostUrl(args: {
 	machineId: string | null;
 	activeHostUrl: string | null;
 	organizationId: string;
+	relayUrl: string;
 }): string | null {
 	if (args.hostId === args.machineId) return args.activeHostUrl;
 	const routingKey = buildHostRoutingKey(args.organizationId, args.hostId);
-	return `${env.RELAY_URL}/hosts/${routingKey}`;
+	return `${args.relayUrl}/hosts/${routingKey}`;
 }

--- a/apps/desktop/src/renderer/hooks/host-service/useHostTargetUrl/useHostTargetUrl.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useHostTargetUrl/useHostTargetUrl.ts
@@ -1,6 +1,6 @@
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import { useMemo } from "react";
-import { env } from "renderer/env.renderer";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { authClient } from "renderer/lib/auth-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 
@@ -13,12 +13,13 @@ export function useHostUrl(hostId: string | null | undefined): string | null {
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const { data: session } = authClient.useSession();
 	const activeOrganizationId = session?.session?.activeOrganizationId ?? null;
+	const relayUrl = useRelayUrl();
 
 	return useMemo(() => {
 		if (hostId === undefined) return null;
 		if (hostId === null || hostId === machineId) return activeHostUrl;
 		if (!activeOrganizationId) return null;
 		const routingKey = buildHostRoutingKey(activeOrganizationId, hostId);
-		return `${env.RELAY_URL}/hosts/${routingKey}`;
-	}, [hostId, machineId, activeOrganizationId, activeHostUrl]);
+		return `${relayUrl}/hosts/${routingKey}`;
+	}, [hostId, machineId, activeOrganizationId, activeHostUrl, relayUrl]);
 }

--- a/apps/desktop/src/renderer/hooks/host-service/useWorkspaceHostUrl/useWorkspaceHostUrl.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useWorkspaceHostUrl/useWorkspaceHostUrl.ts
@@ -2,7 +2,7 @@ import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
-import { env } from "renderer/env.renderer";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 
@@ -24,6 +24,7 @@ export function useWorkspaceHostTarget(
 ): WorkspaceHostTarget {
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
+	const relayUrl = useRelayUrl();
 
 	const { data: workspaceRows = [], isReady } = useLiveQuery(
 		(q) =>
@@ -58,9 +59,9 @@ export function useWorkspaceHostTarget(
 			status: "ready",
 			kind: "remote",
 			hostId: match.hostId,
-			url: `${env.RELAY_URL}/hosts/${routingKey}`,
+			url: `${relayUrl}/hosts/${routingKey}`,
 		};
-	}, [workspaceId, isReady, match, machineId, activeHostUrl]);
+	}, [workspaceId, isReady, match, machineId, activeHostUrl, relayUrl]);
 }
 
 /**

--- a/apps/desktop/src/renderer/hooks/useRelayUrl/index.ts
+++ b/apps/desktop/src/renderer/hooks/useRelayUrl/index.ts
@@ -1,0 +1,1 @@
+export { useRelayUrl } from "./useRelayUrl";

--- a/apps/desktop/src/renderer/hooks/useRelayUrl/useRelayUrl.ts
+++ b/apps/desktop/src/renderer/hooks/useRelayUrl/useRelayUrl.ts
@@ -1,0 +1,23 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagPayload } from "posthog-js/react";
+import { env } from "renderer/env.renderer";
+
+interface RelayUrlPayload {
+	url?: string;
+}
+
+/**
+ * Returns the relay base URL the renderer should use for client-side WS opens
+ * (terminal, eventBus). Reads the `relay-url-override` PostHog flag payload
+ * and falls back to `env.RELAY_URL` when the flag is off or the payload is
+ * malformed. Pairs with the main-side helper used at host-service spawn so
+ * the tunnel and the client open against the same URL.
+ */
+export function useRelayUrl(): string {
+	const payload = useFeatureFlagPayload(FEATURE_FLAGS.RELAY_URL_OVERRIDE) as
+		| RelayUrlPayload
+		| undefined;
+	const override = payload?.url;
+	if (typeof override === "string" && override.length > 0) return override;
+	return env.RELAY_URL;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.ts
@@ -5,7 +5,7 @@ import {
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
-import { env } from "renderer/env.renderer";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceWsToken } from "renderer/lib/host-service-auth";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -36,6 +36,7 @@ export function useDashboardSidebarPortsData(): {
 	const collections = useCollections();
 	const queryClient = useQueryClient();
 	const { activeHostUrl, machineId } = useLocalHostService();
+	const relayUrl = useRelayUrl();
 
 	const { data: hosts = [] } = useLiveQuery(
 		(q) =>
@@ -65,10 +66,10 @@ export function useDashboardSidebarPortsData(): {
 				activeHostUrl,
 				hosts,
 				machineId,
-				relayUrl: env.RELAY_URL,
+				relayUrl,
 				workspaces,
 			}),
-		[activeHostUrl, hosts, machineId, workspaces],
+		[activeHostUrl, hosts, machineId, relayUrl, workspaces],
 	);
 
 	const queries = useQueries({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -2,7 +2,7 @@ import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef } from "react";
-import { env } from "renderer/env.renderer";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -129,6 +129,7 @@ function useStableDashboardSidebarProjects(
 export function useDashboardSidebarData() {
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
+	const relayUrl = useRelayUrl();
 	const { toggleProjectCollapsed } = useDashboardSidebarState();
 	const queryClient = useQueryClient();
 
@@ -361,10 +362,10 @@ export function useDashboardSidebarData() {
 				activeHostUrl,
 				hosts,
 				machineId,
-				relayUrl: env.RELAY_URL,
+				relayUrl,
 				workspaces: visibleSidebarWorkspaces,
 			}),
-		[activeHostUrl, hosts, machineId, visibleSidebarWorkspaces],
+		[activeHostUrl, hosts, machineId, relayUrl, visibleSidebarWorkspaces],
 	);
 
 	const pullRequestQueries = useQueries({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -4,7 +4,7 @@ import { MIN_HOST_SERVICE_VERSION } from "@superset/shared/host-version";
 import { and, eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQuery } from "@tanstack/react-query";
-import { env } from "renderer/env.renderer";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -28,6 +28,7 @@ export function useRemoteHostStatus(
 ): RemoteHostStatus {
 	const collections = useCollections();
 	const { machineId } = useLocalHostService();
+	const relayUrl = useRelayUrl();
 	const organizationId = workspace?.organizationId ?? "";
 	const hostId = workspace?.hostId ?? "";
 	const isLocal =
@@ -51,7 +52,7 @@ export function useRemoteHostStatus(
 	);
 	const hostRow = hostRows[0] ?? null;
 
-	const hostUrl = `${env.RELAY_URL}/hosts/${buildHostRoutingKey(
+	const hostUrl = `${relayUrl}/hosts/${buildHostRoutingKey(
 		organizationId,
 		hostId,
 	)}`;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
@@ -1,7 +1,7 @@
 import type { SelectV2Workspace } from "@superset/db/schema";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import { createContext, type ReactNode, useContext } from "react";
-import { env } from "renderer/env.renderer";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import {
 	getHostServiceHeaders,
 	getHostServiceWsToken,
@@ -24,10 +24,11 @@ export function WorkspaceProvider({
 	children: ReactNode;
 }) {
 	const { machineId, activeHostUrl } = useLocalHostService();
+	const relayUrl = useRelayUrl();
 	const hostUrl =
 		workspace.hostId === machineId
 			? activeHostUrl
-			: `${env.RELAY_URL}/hosts/${buildHostRoutingKey(
+			: `${relayUrl}/hosts/${buildHostRoutingKey(
 					workspace.organizationId,
 					workspace.hostId,
 				)}`;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -25,6 +25,7 @@ import { LinkedIssuePill } from "renderer/components/Chat/ChatInterface/componen
 import { IssueLinkCommand } from "renderer/components/Chat/ChatInterface/components/IssueLinkCommand";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
 import { PLATFORM } from "renderer/hotkeys";
 import { authClient } from "renderer/lib/auth-client";
@@ -76,6 +77,7 @@ export function PromptGroup({
 	const navigate = useNavigate();
 	const attachments = useProviderAttachments();
 	const { activeHostUrl, machineId } = useLocalHostService();
+	const relayUrl = useRelayUrl();
 	const { data: session } = authClient.useSession();
 	const activeOrganizationId = session?.session?.activeOrganizationId;
 	const needsSetup = selectedProject?.needsSetup === true;
@@ -126,9 +128,10 @@ export function PromptGroup({
 				machineId,
 				activeHostUrl,
 				organizationId: activeOrganizationId,
+				relayUrl,
 			}) ?? null
 		);
-	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId]);
+	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
 	const { agents: v2Agents, isFetched: v2AgentsFetched } =
 		useV2AgentChoices(launchHostUrl);
 	const selectableAgentIds = useMemo(
@@ -214,9 +217,10 @@ export function PromptGroup({
 				machineId,
 				activeHostUrl,
 				organizationId: activeOrganizationId,
+				relayUrl,
 			}) ?? null
 		);
-	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId]);
+	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
 	const uploadAttachments = useUploadAttachments({
 		files: attachments.files,
 		hostUrl: uploadHostUrl,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
@@ -2,7 +2,7 @@ import type { WorkspaceState } from "@superset/panes";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
-import { env } from "renderer/env.renderer";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -34,6 +34,7 @@ interface HostNotificationSubscriberGroup {
 export function V2NotificationController() {
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
+	const relayUrl = useRelayUrl();
 	const { data: workspaceHosts = [] } = useLiveQuery(
 		(q) =>
 			q
@@ -62,8 +63,9 @@ export function V2NotificationController() {
 				localWorkspaceRows,
 				machineId,
 				activeHostUrl,
+				relayUrl,
 			}),
-		[workspaceHosts, localWorkspaceRows, machineId, activeHostUrl],
+		[workspaceHosts, localWorkspaceRows, machineId, activeHostUrl, relayUrl],
 	);
 
 	return (
@@ -84,6 +86,7 @@ function groupWorkspacesByHostUrl({
 	localWorkspaceRows,
 	machineId,
 	activeHostUrl,
+	relayUrl,
 }: {
 	workspaceHosts: WorkspaceHostRow[];
 	localWorkspaceRows: Array<{
@@ -92,6 +95,7 @@ function groupWorkspacesByHostUrl({
 	}>;
 	machineId: string | null;
 	activeHostUrl: string | null;
+	relayUrl: string;
 }): HostNotificationSubscriberGroup[] {
 	const paneLayoutsByWorkspaceId = new Map(
 		localWorkspaceRows.map((row) => [
@@ -107,6 +111,7 @@ function groupWorkspacesByHostUrl({
 			hostId: workspace.hostId,
 			machineId,
 			activeHostUrl,
+			relayUrl,
 		});
 		if (!hostUrl) continue;
 
@@ -129,14 +134,16 @@ function getHostUrlForWorkspace({
 	hostId,
 	machineId,
 	activeHostUrl,
+	relayUrl,
 }: {
 	organizationId: string;
 	hostId: string;
 	machineId: string | null;
 	activeHostUrl: string | null;
+	relayUrl: string;
 }): string | null {
 	if (machineId && hostId === machineId) {
 		return activeHostUrl;
 	}
-	return `${env.RELAY_URL}/hosts/${buildHostRoutingKey(organizationId, hostId)}`;
+	return `${relayUrl}/hosts/${buildHostRoutingKey(organizationId, hostId)}`;
 }

--- a/apps/desktop/src/renderer/stores/new-workspace-prompt-context/useNewWorkspacePromptContext.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-prompt-context/useNewWorkspacePromptContext.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { authClient } from "renderer/lib/auth-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import type {
@@ -33,6 +34,7 @@ export function useNewWorkspacePromptContext(args: {
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const { data: session } = authClient.useSession();
 	const activeOrganizationId = session?.session?.activeOrganizationId ?? null;
+	const relayUrl = useRelayUrl();
 
 	const hostUrl = useMemo(() => {
 		const id = hostId ?? machineId;
@@ -42,8 +44,9 @@ export function useNewWorkspacePromptContext(args: {
 			machineId,
 			activeHostUrl,
 			organizationId: activeOrganizationId,
+			relayUrl,
 		});
-	}, [hostId, machineId, activeHostUrl, activeOrganizationId]);
+	}, [hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
 
 	useEffect(() => {
 		if (!projectId || !hostUrl) return;

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceState } from "@superset/panes";
 import { useCallback } from "react";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { authClient } from "renderer/lib/auth-client";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
@@ -39,6 +40,7 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 	const { data: session } = authClient.useSession();
 	const organizationId = session?.session?.activeOrganizationId;
 	const collections = useCollections();
+	const relayUrl = useRelayUrl();
 
 	const dispatch = useCallback(
 		async (args: SubmitArgs): Promise<SubmitResult> => {
@@ -58,6 +60,7 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 				machineId,
 				activeHostUrl,
 				organizationId,
+				relayUrl,
 			});
 			if (!hostUrl) {
 				const error = "Host service not available";
@@ -143,7 +146,7 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 				return { ok: false, error };
 			}
 		},
-		[machineId, activeHostUrl, organizationId, collections],
+		[machineId, activeHostUrl, organizationId, collections, relayUrl],
 	);
 
 	const submit = useCallback(

--- a/apps/desktop/test-setup.ts
+++ b/apps/desktop/test-setup.ts
@@ -159,6 +159,9 @@ mock.module("main/lib/analytics", () => ({
 	track: mock(() => {}),
 	clearUserCache: mock(() => {}),
 	shutdown: mock(() => Promise.resolve()),
+	getPosthogClient: mock(() => null),
+	getUserId: mock(() => null),
+	setUserId: mock(() => {}),
 }));
 
 // =============================================================================

--- a/apps/relay/fly.toml
+++ b/apps/relay/fly.toml
@@ -1,3 +1,9 @@
+# Region topology is NOT in this file — fly.toml has no per-region count syntax.
+# The fleet shape is asserted by `apps/relay/scripts/deploy.sh`, which runs
+# `fly scale count` after `fly deploy`. Current target: 6 machines, 1 per region:
+#   sjc (primary), iad, fra, nrt, sin, gru.
+# Update the REGIONS array in scripts/deploy.sh to change the topology.
+
 app = "superset-relay"
 primary_region = "sjc"
 
@@ -12,8 +18,6 @@ primary_region = "sjc"
   force_https = true
   auto_stop_machines = "off"
   auto_start_machines = true
-  min_machines_running = 2
-  max_machines_running = 8
 
 [http_service.concurrency]
   type = "connections"
@@ -28,6 +32,6 @@ primary_region = "sjc"
   path = "/health"
 
 [[vm]]
-  memory = "1gb"
-  cpu_kind = "shared"
-  cpus = 1
+  memory = "4gb"
+  cpu_kind = "performance"
+  cpus = 2

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "bun run --env-file=../../.env --hot src/index.ts",
 		"start": "bun run src/index.ts",
+		"deploy": "./scripts/deploy.sh",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {

--- a/apps/relay/scripts/deploy.sh
+++ b/apps/relay/scripts/deploy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP=superset-relay
+REGIONS=(sjc iad fra nrt sin gru)
+COUNT=${#REGIONS[@]}
+REGION_LIST=$(IFS=, ; echo "${REGIONS[*]}")
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "==> fly deploy"
+fly deploy \
+  --config apps/relay/fly.toml \
+  --dockerfile apps/relay/Dockerfile \
+  --app "$APP" \
+  .
+
+echo "==> fly scale count: $COUNT machines, 1 per region across $REGION_LIST"
+fly scale count "app=$COUNT" \
+  --region "$REGION_LIST" \
+  --max-per-region 1 \
+  --app "$APP" \
+  --yes
+
+echo "==> Status"
+fly status --app "$APP"

--- a/apps/relay/scripts/deploy.sh
+++ b/apps/relay/scripts/deploy.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 APP=superset-relay
-REGIONS=(sjc iad fra nrt sin gru)
+REGIONS=(sjc)
 COUNT=${#REGIONS[@]}
 REGION_LIST=$(IFS=, ; echo "${REGIONS[*]}")
 

--- a/packages/cli/src/commands/start/command.ts
+++ b/packages/cli/src/commands/start/command.ts
@@ -31,6 +31,7 @@ export default command({
 			const result = await spawnHostService({
 				organizationId: organization.id,
 				sessionToken: ctx.bearer,
+				api: ctx.api,
 				port: options.port,
 				daemon: options.daemon ?? false,
 			});

--- a/packages/cli/src/lib/host/relay-url.ts
+++ b/packages/cli/src/lib/host/relay-url.ts
@@ -1,0 +1,30 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import type { ApiClient } from "../api-client";
+import { env } from "../env";
+
+interface RelayUrlPayload {
+	url?: string;
+}
+
+/**
+ * Resolves the relay base URL the host service should tunnel to. Asks the
+ * server for the `relay-url-override` PostHog flag payload for the current
+ * user and falls back to `env.RELAY_URL` whenever the flag is off, the
+ * payload is malformed, or the API call fails. Mirrors the desktop main
+ * helper (`apps/desktop/src/main/lib/relay-url`) so the override applies
+ * consistently across both spawn paths.
+ */
+export async function getRelayUrl(api: ApiClient): Promise<string> {
+	const fallback = env.RELAY_URL;
+	try {
+		const payload = (await api.analytics.featureFlagPayload.query({
+			key: FEATURE_FLAGS.RELAY_URL_OVERRIDE,
+		})) as RelayUrlPayload | null | undefined;
+		const override = payload?.url;
+		if (typeof override === "string" && override.length > 0) return override;
+	} catch {
+		// Best-effort — fall back to env if the server is unreachable or
+		// returned an unexpected shape.
+	}
+	return fallback;
+}

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -3,12 +3,14 @@ import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { createServer } from "node:net";
 import { dirname, join } from "node:path";
+import type { ApiClient } from "../api-client";
 import { env } from "../env";
 import {
 	type HostServiceManifest,
 	hostDbPath,
 	writeManifest,
 } from "./manifest";
+import { getRelayUrl } from "./relay-url";
 
 const HEALTH_POLL_INTERVAL_MS = 200;
 const HEALTH_POLL_TIMEOUT_MS = 10_000;
@@ -16,6 +18,7 @@ const HEALTH_POLL_TIMEOUT_MS = 10_000;
 export interface SpawnHostOptions {
 	organizationId: string;
 	sessionToken: string;
+	api: ApiClient;
 	port?: number;
 	daemon: boolean;
 }
@@ -98,6 +101,7 @@ export async function spawnHostService(
 	const port = options.port ?? (await findFreePort());
 	const secret = randomBytes(32).toString("hex");
 	const migrationsFolder = resolveMigrationsFolder();
+	const relayUrl = await getRelayUrl(options.api);
 
 	const child = spawn(hostBin, [], {
 		stdio: options.daemon ? "ignore" : "inherit",
@@ -107,7 +111,7 @@ export async function spawnHostService(
 			ORGANIZATION_ID: options.organizationId,
 			AUTH_TOKEN: options.sessionToken,
 			SUPERSET_API_URL: env.SUPERSET_API_URL,
-			RELAY_URL: env.RELAY_URL,
+			RELAY_URL: relayUrl,
 			PORT: String(port),
 			HOST_SERVICE_PORT: String(port),
 			HOST_SERVICE_SECRET: secret,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -85,4 +85,13 @@ export const FEATURE_FLAGS = {
 	 * the credential), so this only controls who can START a session.
 	 */
 	WEB_REMOTE_CONTROL_ACCESS: "web-remote-control-access",
+	/**
+	 * Per-user override for the relay base URL. Payload shape:
+	 * `{ "url": "https://..." }`. When set, both the host-service tunnel and
+	 * the desktop renderer's client-side WS opens route through this URL
+	 * instead of `env.RELAY_URL`. Lets us A/B-test alternative relay
+	 * implementations (e.g. Cloudflare Durable Objects) without changing
+	 * defaults for other users.
+	 */
+	RELAY_URL_OVERRIDE: "relay-url-override",
 } as const;

--- a/packages/trpc/src/router/analytics/analytics.ts
+++ b/packages/trpc/src/router/analytics/analytics.ts
@@ -83,6 +83,24 @@ export const analyticsRouter = {
 			return { ok: true };
 		}),
 
+	// Server-side feature-flag payload lookup for the authenticated user. Lets
+	// clients without a PostHog SDK (e.g. the CLI binary) evaluate flags
+	// without us baking the PostHog project key into their build. Returns
+	// `null` when the flag is off or has no payload configured.
+	featureFlagPayload: protectedProcedure
+		.input(z.object({ key: z.string().min(1).max(100) }))
+		.query(async ({ ctx, input }) => {
+			try {
+				const payload = await posthog.getFeatureFlagPayload(
+					input.key,
+					ctx.session.user.id,
+				);
+				return payload ?? null;
+			} catch {
+				return null;
+			}
+		}),
+
 	getActivationFunnel: adminProcedure
 		.input(
 			z


### PR DESCRIPTION
## Summary

Two things, ordered by size of diff:

1. **`relay-url-override` PostHog flag.** Per-user override for the relay base URL so we can A/B alternate relay deployments (e.g. Cloudflare Durable Objects) without changing the default (`env.RELAY_URL`). Payload shape `{ "url": "https://..." }`. Wired through:
   - Desktop main: `getRelayUrl()` resolves the flag before host-service spawn (`host-service-coordinator.ts`).
   - Desktop renderer: `useRelayUrl()` hook replaces `env.RELAY_URL` at every WS/tRPC call site (terminal, eventBus, sidebar queries, `V2NotificationController`, workspace provider, etc).
   - CLI: `packages/cli/src/lib/host/relay-url.ts` fetches the override via a new tRPC procedure (`analytics.featureFlagPayload`) so we don't bake the PostHog project key into the CLI binary.

2. **Relay deploy script + `fly.toml` cleanup.**
   - `apps/relay/scripts/deploy.sh` is idempotent: `fly deploy` from repo root + `fly scale count` with `--max-per-region 1`. `REGIONS=(sjc)` for now — single-region while we debug Fly's cross-region WS routing (May 9 incident). Update the array to re-expand to `iad, fra, nrt, sin, gru` once resolved.
   - `fly.toml`: VM back to `performance-2x/4GB` (matches live; the May 5 attempt to downsize to `shared-cpu-1x/1GB` was rolled back). Dropped `min_machines_running` (no-op under `auto_stop_machines = "off"`) and `max_machines_running` (not a real Fly setting — undocumented, ignored).
   - Header comment in `fly.toml` points at the deploy script as the source of truth for region topology.
   - Exposed `bun run --filter=@superset/relay deploy`.

## What happens when this is deployed
Relay fleet stays single-region (sjc). No new machines provisioned. Existing tunnels survive. The `relay-url-override` flag is opt-in per-user via PostHog — defaults to `env.RELAY_URL` for everyone until we explicitly set the flag.

## Region choice (for when we re-expand)
PostHog active-workspace-user data over the last 30d (events: `workspace_opened`, `workspace_initialized`, `terminal_opened`, `terminal_warm_attached`, `desktop_opened`):

| continent | active users | covered by |
|---|---|---|
| AS | 12,645 | nrt (JP/KR/TW) + sin (SEA + India fallback) |
| NA | 9,846 | sjc + iad |
| EU | 7,763 | fra |
| SA | 1,465 | **gru** (60% Brazil) |
| OC | 833 | (skip — nrt covers at ~120ms) |
| AF | 367 | (skip — too small) |

Skipping `bom` (India 1.4k but `sin` is ~30ms), `syd`, `jnb` until those continents grow.

## Upstash KV
Already added `us-east-1`, `ap-southeast-1`, `sa-east-1` read replicas out-of-band so every Fly region is <10ms from a directory replica. `directory.lookup()` runs in `authMiddleware` on every cross-machine request, so these replicas materially cut tail latency for iad/sin/gru when we re-expand.

## Test plan
- [ ] `bun run --filter=@superset/relay deploy` lands a single sjc machine, no extra regions
- [ ] Flip `relay-url-override` to a test URL for one user → desktop main spawns host-service with `RELAY_URL=<override>`, renderer WS opens target the override
- [ ] Flag off → both fall back to `env.RELAY_URL`
- [ ] CLI `superset start --daemon` reads the override via the tRPC procedure
- [ ] Watch `fly logs -a superset-relay` post-deploy — no cross-region replay loops, no Upstash timeouts