### PR TITLE
fix(cli-framework): show global options in subcommand --help

### DIFF
--- a/packages/cli-framework/src/help.ts
+++ b/packages/cli-framework/src/help.ts
@@ -64,7 +64,7 @@ export function generateGroupHelp(
 	name: string,
 	path: string[],
 	node: CommandNode,
-	_globals?: Record<string, ProcessedBuilderConfig>,
+	globals?: Record<string, ProcessedBuilderConfig>,
 ): string {
 	const lines: string[] = [];
 	const fullPath = [name, ...path].join(" ");
@@ -89,6 +89,14 @@ export function generateGroupHelp(
 		lines.push("");
 	}
 
+	if (globals && Object.keys(globals).length > 0) {
+		lines.push("Global options:");
+		lines.push(...formatOptions(globals));
+		lines.push("");
+	}
+
+	lines.push("  --help, -h       Show help");
+
 	return lines.join("\n");
 }
 
@@ -96,7 +104,7 @@ export function generateCommandHelp(
 	name: string,
 	path: string[],
 	node: CommandNode,
-	_globals?: Record<string, ProcessedBuilderConfig>,
+	globals?: Record<string, ProcessedBuilderConfig>,
 ): string {
 	const lines: string[] = [];
 	const fullPath = [name, ...path].join(" ");
@@ -144,6 +152,14 @@ export function generateCommandHelp(
 		lines.push(...formatOptions(node.options));
 		lines.push("");
 	}
+
+	if (globals && Object.keys(globals).length > 0) {
+		lines.push("Global options:");
+		lines.push(...formatOptions(globals));
+		lines.push("");
+	}
+
+	lines.push("  --help, -h       Show help");
 
 	return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- `--json`, `--quiet`, and `--api-key` were declared as globals in `cli.config.ts` but only rendered under `superset --help` — `superset <group> --help` and `superset <group> <cmd> --help` silently dropped them because `generateGroupHelp` / `generateCommandHelp` took `_globals` (underscored, unused).
- Render the globals section (and a `--help, -h` line) in both group and command help, matching the root help format.

## Test plan
- [x] `superset --help` still shows Global options (unchanged behavior)
- [x] `superset auth --help` now lists `--json`, `--quiet`, `--api-key`
- [x] `superset auth login --help` now lists them
- [x] `superset tasks list --help` now lists them
- [x] `bun run lint` clean
- [x] `bun run typecheck --filter @superset/cli-framework` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI help so global options show for subcommands. `superset <group> --help` and `superset <group> <cmd> --help` now display the Global options section (`--json`, `--quiet`, `--api-key`) and a `--help, -h` line, matching the root help.

<sup>Written for commit d65e84772ffb9419fdb8d35a328a47dd8fa0e6ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced CLI command help text to conditionally display available global options, providing clearer documentation and improving command discovery for users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4424)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->