### PR TITLE
feat(desktop): show template gallery on empty Mine automations tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -49,7 +49,6 @@ import {
 	LuSearchX,
 	LuSparkles,
 	LuTrash2,
-	LuZap,
 } from "react-icons/lu";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
@@ -275,7 +274,8 @@ function AutomationsPage() {
 			</header>
 
 			<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-				{!automationsReady ? null : automations.length === 0 ? (
+				{!automationsReady ? null : visible.length === 0 &&
+					(automations.length === 0 || scope === "mine") ? (
 					<div className="flex-1 overflow-y-auto px-8 py-8">
 						<AutomationsEmptyState onSelectTemplate={handleSelectTemplate} />
 					</div>
@@ -286,17 +286,11 @@ function AutomationsPage() {
 								variant="icon"
 								className="size-14 [&_svg:not([class*='size-'])]:size-7"
 							>
-								{scope === "mine" ? <LuZap /> : <LuSearchX />}
+								<LuSearchX />
 							</EmptyMedia>
-							<EmptyTitle>
-								{scope === "mine"
-									? "No automations yet"
-									: "No team automations"}
-							</EmptyTitle>
+							<EmptyTitle>No team automations</EmptyTitle>
 							<EmptyDescription>
-								{scope === "mine"
-									? "Create one to run an agent on a schedule."
-									: "Nobody on your team has shared automations yet."}
+								Nobody on your team has shared automations yet.
 							</EmptyDescription>
 						</EmptyHeader>
 					</Empty>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -274,8 +274,7 @@ function AutomationsPage() {
 			</header>
 
 			<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-				{!automationsReady ? null : visible.length === 0 &&
-					(automations.length === 0 || scope === "mine") ? (
+				{!automationsReady ? null : visible.length === 0 && scope === "mine" ? (
 					<div className="flex-1 overflow-y-auto px-8 py-8">
 						<AutomationsEmptyState onSelectTemplate={handleSelectTemplate} />
 					</div>


### PR DESCRIPTION
## Summary
- On the Automations page, the Mine tab now shows the template gallery (`AutomationsEmptyState`) when the user has no automations of their own, even if their team has automations.
- Previously this state showed a generic "No automations yet" message, requiring users to click "New automation" to see templates.
- The Team tab still shows its dedicated "No team automations" empty state.

## Test plan
- [ ] Open Automations with zero automations → template gallery shows on Mine tab.
- [ ] Have a teammate's automation but none of your own → switching to Mine still shows the template gallery; Team shows the team list.
- [ ] Have at least one of your own automations → Mine shows the list as before.
- [ ] Team tab with no shared automations still shows the "No team automations" empty state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the template gallery on the Mine tab when you have no personal automations, so you can start from a template without extra clicks. The Team tab keeps its dedicated “No team automations” empty state.

- **Bug Fixes**
  - Prevent the template gallery from showing on the Team tab when there are zero automations; keep the Team empty state instead.

<sup>Written for commit 8119c9065503e272b6a8435311bf282f4d40d3c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refined the automations dashboard empty-state experience to be scope- and visibility-aware. When viewing "Mine" with no visible automations, a personal empty state appears; when viewing "Team" (or other cases with zero visible items), a fixed "No team automations" panel and team-specific visual are shown, providing clearer, context-specific messaging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4425)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->