### PR TITLE
fix(desktop): show PR status icon on collapsed v2 sidebar items

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -37,6 +37,7 @@ export function DashboardSidebarWorkspaceItem({
 		name,
 		branch,
 		creationStatus,
+		pullRequest,
 	} = workspace;
 	const isMainWorkspace = workspace.type === "main";
 	const diffStats = useDiffStats(id);
@@ -142,6 +143,7 @@ export function DashboardSidebarWorkspaceItem({
 					workspaceStatus={workspaceStatus}
 					onClick={handleClick}
 					creationStatus={creationStatus}
+					pullRequestState={pullRequest?.state ?? null}
 					aria-label={
 						creationStatus ? `Creating workspace: ${name}` : undefined
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -3,6 +3,7 @@ import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import type { ActivePaneStatus } from "shared/tabs-types";
 import type {
 	DashboardSidebarWorkspaceHostType,
+	DashboardSidebarWorkspacePullRequest,
 	DashboardSidebarWorkspaceType,
 } from "../../../../types";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
@@ -15,6 +16,7 @@ interface DashboardSidebarCollapsedWorkspaceButtonProps
 	isActive: boolean;
 	workspaceStatus?: ActivePaneStatus | null;
 	creationStatus?: "preparing" | "generating-branch" | "creating" | "failed";
+	pullRequestState?: DashboardSidebarWorkspacePullRequest["state"] | null;
 }
 
 export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
@@ -29,6 +31,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 			isActive,
 			workspaceStatus = null,
 			creationStatus,
+			pullRequestState = null,
 			className,
 			...props
 		},
@@ -54,6 +57,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 					variant="collapsed"
 					workspaceStatus={workspaceStatus}
 					creationStatus={creationStatus}
+					pullRequestState={pullRequestState}
 				/>
 			</button>
 		);


### PR DESCRIPTION
## Summary
- The v2 collapsed workspace button rendered only the workspace-type icon (laptop/dot/cloud) regardless of PR state, while the expanded row swaps the same icon for the colored PR-state icon (open/merged/closed/draft) inside `DashboardSidebarWorkspaceIcon`.
- `DashboardSidebarCollapsedWorkspaceButton` now accepts a `pullRequestState` prop and forwards it to the icon, and `DashboardSidebarWorkspaceItem` passes `pullRequest?.state ?? null` through from the workspace data.

## Test plan
- [ ] Collapse the v2 left sidebar on a project with open / merged / closed / draft PRs; confirm each workspace's button shows the matching colored PR icon (green open / purple merged / red closed / muted draft) instead of the laptop/dot/cloud.
- [ ] Workspaces without a PR still show the workspace-type icon.
- [ ] Workspaces in the `working` / `creating` / `failed` state still show their spinner / warning overlay (PR state shouldn't override those).
- [ ] Expand the sidebar — expanded rows are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show PR status icons on collapsed v2 sidebar workspace buttons to match the expanded view. Pass `pullRequest.state` from `DashboardSidebarWorkspaceItem` into `DashboardSidebarCollapsedWorkspaceButton` and through to the icon.

- **Bug Fixes**
  - Collapsed buttons now show green/purple/red/muted PR icons when a PR exists.
  - Workspaces without a PR still show the workspace-type icon.
  - Spinner/warning overlays for working/creating/failed states still take priority.

<sup>Written for commit 4662ce1be34f0980a80b19b57f3a455582c19297. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced workspace sidebar components to handle pull request state information in the collapsed view.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4426)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->