### PR TITLE
fix(relay): harden host-relay websocket connection retries

### DIFF
--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -12,6 +12,10 @@ type WsSocket = {
 const PING_INTERVAL_MS = 30_000;
 const PING_TIMEOUT_MISSED = 3;
 const ONLINE_DEBOUNCE_MS = 250;
+const SET_ONLINE_RETRY_BASE_MS = 500;
+const SET_ONLINE_RETRY_MAX_MS = 8_000;
+const SET_ONLINE_MAX_ATTEMPTS = 3;
+const MAX_PENDING_REQUESTS_PER_TUNNEL = 1_000;
 
 interface PendingRequest {
 	resolve: (response: TunnelHttpResponse) => void;
@@ -37,6 +41,7 @@ export class TunnelManager {
 		string,
 		ReturnType<typeof setTimeout>
 	>();
+	private readonly onlineWriteVersions = new Map<string, number>();
 
 	constructor(requestTimeoutMs = 30_000) {
 		this.requestTimeoutMs = requestTimeoutMs;
@@ -185,24 +190,62 @@ export class TunnelManager {
 				clearTimeout(pending);
 				this.onlineDebounce.delete(hostId);
 			}
+			this.onlineWriteVersions.set(
+				hostId,
+				(this.onlineWriteVersions.get(hostId) ?? 0) + 1,
+			);
 			return;
 		}
 		const pending = this.onlineDebounce.get(hostId);
 		if (pending) clearTimeout(pending);
+		const version = (this.onlineWriteVersions.get(hostId) ?? 0) + 1;
+		this.onlineWriteVersions.set(hostId, version);
 		const timer = setTimeout(() => {
 			this.onlineDebounce.delete(hostId);
-			if (this.onlineState.get(hostId) === isOnline) return;
-			this.onlineState.set(hostId, isOnline);
-			void createApiClient(token)
-				.host.setOnline.mutate({ hostId, isOnline })
-				.catch((err) => {
-					console.error("[relay] setOnline mutate failed", err);
-				});
-			// Drop the entry after a definitive offline write so onlineState
-			// doesn't accumulate one boolean per historical hostId.
-			if (!isOnline) this.onlineState.delete(hostId);
+			void this.attemptOnlineWrite(hostId, token, isOnline, version);
 		}, ONLINE_DEBOUNCE_MS);
 		this.onlineDebounce.set(hostId, timer);
+	}
+
+	private async attemptOnlineWrite(
+		hostId: string,
+		token: string,
+		isOnline: boolean,
+		version: number,
+	): Promise<void> {
+		for (let attempt = 0; attempt < SET_ONLINE_MAX_ATTEMPTS; attempt++) {
+			if (this.onlineWriteVersions.get(hostId) !== version) return;
+			try {
+				await createApiClient(token).host.setOnline.mutate({
+					hostId,
+					isOnline,
+				});
+				if (this.onlineWriteVersions.get(hostId) !== version) return;
+				this.onlineState.set(hostId, isOnline);
+				if (!isOnline) this.onlineState.delete(hostId);
+				if (this.onlineWriteVersions.get(hostId) === version) {
+					this.onlineWriteVersions.delete(hostId);
+				}
+				return;
+			} catch (err) {
+				if (this.onlineWriteVersions.get(hostId) !== version) return;
+				if (attempt === SET_ONLINE_MAX_ATTEMPTS - 1) {
+					console.error(
+						`[relay] setOnline(${isOnline}) failed for ${hostId} after ${SET_ONLINE_MAX_ATTEMPTS} attempts`,
+						err,
+					);
+					if (this.onlineWriteVersions.get(hostId) === version) {
+						this.onlineWriteVersions.delete(hostId);
+					}
+					return;
+				}
+				const delay = Math.min(
+					SET_ONLINE_RETRY_BASE_MS * 2 ** attempt,
+					SET_ONLINE_RETRY_MAX_MS,
+				);
+				await new Promise((r) => setTimeout(r, delay));
+			}
+		}
 	}
 
 	hasTunnel(hostId: string): boolean {
@@ -220,6 +263,10 @@ export class TunnelManager {
 	): Promise<TunnelHttpResponse> {
 		const tunnel = this.tunnels.get(hostId);
 		if (!tunnel) throw new Error("Host not connected");
+
+		if (tunnel.pendingRequests.size >= MAX_PENDING_REQUESTS_PER_TUNNEL) {
+			throw new Error("Host overloaded (pending request queue full)");
+		}
 
 		const id = crypto.randomUUID();
 

--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -221,8 +221,11 @@ export class TunnelManager {
 					isOnline,
 				});
 				if (this.onlineWriteVersions.get(hostId) !== version) return;
-				this.onlineState.set(hostId, isOnline);
-				if (!isOnline) this.onlineState.delete(hostId);
+				if (isOnline) {
+					this.onlineState.set(hostId, true);
+				} else {
+					this.onlineState.delete(hostId);
+				}
 				if (this.onlineWriteVersions.get(hostId) === version) {
 					this.onlineWriteVersions.delete(hostId);
 				}
@@ -234,6 +237,7 @@ export class TunnelManager {
 						`[relay] setOnline(${isOnline}) failed for ${hostId} after ${SET_ONLINE_MAX_ATTEMPTS} attempts`,
 						err,
 					);
+					this.onlineState.delete(hostId);
 					if (this.onlineWriteVersions.get(hostId) === version) {
 						this.onlineWriteVersions.delete(hostId);
 					}

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -63,6 +63,10 @@ export class TunnelClient {
 		// wake from sleep) crashes host-service and orphans every PTY.
 		try {
 			const token = await this.getAuthToken();
+			if (this.closed) {
+				this.connecting = false;
+				return;
+			}
 			if (!token) {
 				console.warn("[host-service:tunnel] no auth token available, retrying");
 				this.connecting = false;

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -9,6 +9,8 @@ import type {
 
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
+const INBOUND_SILENCE_TIMEOUT_MS = 75_000;
+const WATCHDOG_INTERVAL_MS = 10_000;
 
 export interface TunnelClientOptions {
 	relayUrl: string;
@@ -18,6 +20,11 @@ export interface TunnelClientOptions {
 	hostServiceSecret: string;
 }
 
+interface LocalChannel {
+	ws: WebSocket;
+	pendingFrames: string[];
+}
+
 export class TunnelClient {
 	private readonly relayUrl: string;
 	private readonly hostId: string;
@@ -25,10 +32,13 @@ export class TunnelClient {
 	private readonly localPort: number;
 	private readonly hostServiceSecret: string;
 	private socket: WebSocket | null = null;
-	private localChannels = new Map<string, WebSocket>();
+	private localChannels = new Map<string, LocalChannel>();
 	private reconnectAttempts = 0;
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private watchdogTimer: ReturnType<typeof setInterval> | null = null;
+	private lastInboundAt = 0;
 	private closed = false;
+	private connecting = false;
 
 	constructor(options: TunnelClientOptions) {
 		this.relayUrl = options.relayUrl;
@@ -40,6 +50,14 @@ export class TunnelClient {
 
 	async connect(): Promise<void> {
 		if (this.closed) return;
+		if (this.connecting) return;
+		if (
+			this.socket?.readyState === WebSocket.CONNECTING ||
+			this.socket?.readyState === WebSocket.OPEN
+		) {
+			return;
+		}
+		this.connecting = true;
 
 		// An unhandled rejection here (e.g. DNS failure inside getAuthToken on
 		// wake from sleep) crashes host-service and orphans every PTY.
@@ -47,6 +65,7 @@ export class TunnelClient {
 			const token = await this.getAuthToken();
 			if (!token) {
 				console.warn("[host-service:tunnel] no auth token available, retrying");
+				this.connecting = false;
 				this.scheduleReconnect();
 				return;
 			}
@@ -58,24 +77,40 @@ export class TunnelClient {
 
 			const socket = new WebSocket(url.toString());
 			this.socket = socket;
+			this.lastInboundAt = Date.now();
 
 			socket.onopen = () => {
 				this.reconnectAttempts = 0;
+				this.connecting = false;
+				this.lastInboundAt = Date.now();
+				this.startWatchdog();
 				console.log(
 					`[host-service:tunnel] connected to relay for host ${this.hostId}`,
 				);
 			};
 
 			socket.onmessage = (event) => {
+				this.lastInboundAt = Date.now();
 				void this.handleMessage(event.data);
 			};
 
-			socket.onclose = () => {
+			socket.onclose = (event) => {
+				const wasOurSocket = this.socket === socket;
+				if (!wasOurSocket) return;
+
 				this.socket = null;
+				this.connecting = false;
+				this.stopWatchdog();
 				this.cleanupChannels();
-				if (!this.closed) {
-					this.scheduleReconnect();
+
+				if (this.closed) return;
+
+				if (event.code === 1008) {
+					console.warn(
+						`[host-service:tunnel] relay rejected connection (code=${event.code}, reason=${event.reason ?? ""}); retrying`,
+					);
 				}
+				this.scheduleReconnect();
 			};
 
 			socket.onerror = (event) => {
@@ -85,12 +120,14 @@ export class TunnelClient {
 			const message = error instanceof Error ? error.message : String(error);
 			console.error(`[host-service:tunnel] connect failed: ${message}`);
 			this.socket = null;
+			this.connecting = false;
 			this.scheduleReconnect();
 		}
 	}
 
 	close(): void {
 		this.closed = true;
+		this.stopWatchdog();
 		if (this.reconnectTimer) {
 			clearTimeout(this.reconnectTimer);
 			this.reconnectTimer = null;
@@ -193,6 +230,18 @@ export class TunnelClient {
 		const localWs = new WebSocket(wsUrl.toString());
 		localWs.binaryType = "arraybuffer";
 
+		const channel: LocalChannel = {
+			ws: localWs,
+			pendingFrames: [],
+		};
+
+		localWs.onopen = () => {
+			for (const frame of channel.pendingFrames) {
+				localWs.send(frame);
+			}
+			channel.pendingFrames.length = 0;
+		};
+
 		localWs.onmessage = (event) => {
 			const data = event.data;
 			if (typeof data === "string") {
@@ -222,38 +271,71 @@ export class TunnelClient {
 			);
 		};
 
-		this.localChannels.set(request.id, localWs);
+		this.localChannels.set(request.id, channel);
 	}
 
 	private handleWsFrame(message: TunnelWsFrame): void {
-		const localWs = this.localChannels.get(message.id);
-		if (localWs?.readyState === WebSocket.OPEN) {
-			localWs.send(message.data);
+		const channel = this.localChannels.get(message.id);
+		if (!channel) return;
+		if (channel.ws.readyState === WebSocket.OPEN) {
+			channel.ws.send(message.data);
+			return;
+		}
+		if (channel.ws.readyState === WebSocket.CONNECTING) {
+			if (channel.pendingFrames.length < 256) {
+				channel.pendingFrames.push(message.data);
+			}
 		}
 	}
 
 	private handleWsClose(message: TunnelWsClose): void {
-		const localWs = this.localChannels.get(message.id);
-		if (localWs) {
+		const channel = this.localChannels.get(message.id);
+		if (channel) {
 			this.localChannels.delete(message.id);
-			localWs.close(message.code ?? 1000);
+			channel.ws.close(message.code ?? 1000);
 		}
 	}
 
 	private cleanupChannels(): void {
-		for (const ws of this.localChannels.values()) {
-			ws.close(1001, "Tunnel disconnected");
+		for (const channel of this.localChannels.values()) {
+			channel.ws.close(1001, "Tunnel disconnected");
 		}
 		this.localChannels.clear();
+	}
+
+	private startWatchdog(): void {
+		this.stopWatchdog();
+		this.watchdogTimer = setInterval(() => {
+			if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+			const silentFor = Date.now() - this.lastInboundAt;
+			if (silentFor > INBOUND_SILENCE_TIMEOUT_MS) {
+				console.warn(
+					`[host-service:tunnel] no inbound traffic for ${silentFor}ms, forcing reconnect`,
+				);
+				try {
+					this.socket.close(4002, "Inbound silence timeout");
+				} catch {
+					// already closed
+				}
+			}
+		}, WATCHDOG_INTERVAL_MS);
+	}
+
+	private stopWatchdog(): void {
+		if (this.watchdogTimer) {
+			clearInterval(this.watchdogTimer);
+			this.watchdogTimer = null;
+		}
 	}
 
 	private scheduleReconnect(): void {
 		if (this.closed || this.reconnectTimer) return;
 
-		const delay = Math.min(
+		const baseDelay = Math.min(
 			RECONNECT_BASE_MS * 2 ** this.reconnectAttempts,
 			RECONNECT_MAX_MS,
 		);
+		const delay = Math.floor(baseDelay * (0.5 + Math.random() * 0.5));
 		this.reconnectAttempts++;
 
 		console.log(


### PR DESCRIPTION
## Summary

Local reliability fixes for the host↔relay tunnel. Targets the "host shows online but unreachable" symptom without taking on cross-machine liveness reconciliation (deferred).

**Host (`TunnelClient`)**
- Overlap guard on `connect()` so a pending reconnect timer can't race a manual reconnect
- Watchdog forces reconnect after 75s of inbound silence (catches half-open TCP from sleep/NAT timeout without waiting for the relay's 90s missed-ping window)
- Stale `onclose` for an already-replaced socket no longer tears down the new socket's watchdog/channels
- Jittered exponential reconnect backoff (breaks thundering-herd on relay redeploys)
- Buffer `ws:frame` messages that arrive before the local WS reaches `OPEN` (cap 256) so the first frame after `ws:open` isn't dropped
- Relay 1008 closes now retry instead of permanently stopping (1008 is sent for both Unauthorized and Forbidden, and `checkHostAccess` can fail transiently)

**Relay (`TunnelManager`)**
- Bounded retry-with-version for `host.setOnline` so a transient API failure doesn't desync the in-memory cache; flap-mid-retry cancels stale loops via a monotonic version counter
- Per-tunnel pending HTTP request cap (1000) for backpressure against a stuck host filling memory

**Not in this PR (deferred):** sweep-driven DB reconciliation, SIGTERM drain, heartbeat resurrection, self-eviction in `maybeReplay`. These need connection-epoch IDs and tests for multi-machine failure modes before they're safe to add — earlier draft of those had race conditions when the sweeping machine wasn't the owning machine.

## Test plan

- [ ] Disconnect host laptop network mid-session → host should reconnect within ~75s instead of waiting for relay's missed-ping timeout
- [ ] Kill and restart relay → all hosts reconnect with jittered offsets (not synchronized waves)
- [ ] Trigger a transient API 5xx during register → host stays connected, `isOnline=true` write retries up to 3× before giving up
- [ ] Trigger relay auth failure (e.g. revoked JWT mid-test) → host receives 1008, logs warning, retries with backoff (does NOT permanently stop)
- [ ] Tunnel a workspace request that opens a WS to host-service → frames sent immediately after `ws:open` arrive intact
- [ ] `bun run lint` + `bun --bun turbo run typecheck` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves reliability of the host↔relay WebSocket tunnel to reduce “online but unreachable” cases. Hosts recover faster from half-open connections, and the relay avoids stale `isOnline` state and memory pressure.

- **Bug Fixes**
  - Host (`TunnelClient`): guard overlapping connects; re-check `closed` after token fetch to avoid post-close connects; ignore stale `onclose`; jittered exponential reconnect backoff; watchdog forces reconnect after 75s of inbound silence; buffer early `ws:frame` until local WS is OPEN (cap 256); retry after relay 1008 closes.
  - Relay (`TunnelManager`): retry `host.setOnline` with bounded backoff and versioning to keep the cache consistent; clear cached `isOnline` on terminal failure so the next write isn’t suppressed; cap pending HTTP requests per tunnel at 1,000 for backpressure.

<sup>Written for commit e43be46c12eab479a1e107f0574bf99c62f6fa82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel/relay stability with an inbound-traffic watchdog that detects stalls and triggers reconnection.
  * Prevented connection race conditions and added safer reconnect/backoff with jitter.
  * More robust online/offline synchronization: debounced, versioned writes with bounded retries to avoid stale updates.
  * Added a hard cap on per-tunnel pending HTTP requests to fail fast when overloaded.


[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4427)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->