### PR TITLE
feat(cli): add --issue <num> to workspaces create

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
@@ -6,6 +6,7 @@ import {
 	getFallbackAgentId,
 	indexResolvedAgentConfigs,
 } from "@superset/shared/agent-settings";
+import { deriveBranchName } from "@superset/shared/workspace-launch";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -25,7 +26,6 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCreateWorkspace } from "renderer/react-query/workspaces";
 import { ProjectThumbnail } from "renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail";
 import type { TaskWithStatus } from "../../../../../components/TasksView/hooks/useTasksTable";
-import { deriveBranchName } from "../../../../utils/deriveBranchName";
 
 type TaskLaunchAgent = AgentDefinitionId | "none";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
@@ -1,3 +1,4 @@
+import { deriveBranchName } from "@superset/shared/workspace-launch";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -26,7 +27,6 @@ import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import { MOCK_ORG_ID } from "shared/constants";
 import type { TaskWithStatus } from "../../../../../components/TasksView/hooks/useTasksTable";
-import { deriveBranchName } from "../../../../utils/deriveBranchName";
 
 const AGENT_STORAGE_KEY = "lastSelectedV2TaskAgent";
 const NONE = "none" as const;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx
@@ -6,6 +6,7 @@ import {
 	getFallbackAgentId,
 	indexResolvedAgentConfigs,
 } from "@superset/shared/agent-settings";
+import { deriveBranchName } from "@superset/shared/workspace-launch";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -28,7 +29,6 @@ import { launchAgentSession } from "renderer/lib/agent-session-orchestrator";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCreateWorkspace } from "renderer/react-query/workspaces";
 import { ProjectThumbnail } from "renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail";
-import { deriveBranchName } from "../../../../../../$taskId/utils/deriveBranchName";
 import type { TaskWithStatus } from "../../../../hooks/useTasksTable";
 
 type TaskStatus = "pending" | "creating" | "done" | "failed";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
@@ -1,3 +1,4 @@
+import { deriveBranchName } from "@superset/shared/workspace-launch";
 import { Button } from "@superset/ui/button";
 import {
 	Command,
@@ -28,7 +29,6 @@ import { useLocalHostService } from "renderer/routes/_authenticated/providers/Lo
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import { MOCK_ORG_ID } from "shared/constants";
-import { deriveBranchName } from "../../../../../../$taskId/utils/deriveBranchName";
 import type { TaskWithStatus } from "../../../../hooks/useTasksTable";
 
 const AGENT_STORAGE_KEY = "lastSelectedV2TaskBatchAgent";

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -42,7 +42,9 @@ export default command({
 		}
 
 		const sourceCount =
-			(options.branch ? 1 : 0) + (options.pr ? 1 : 0) + (options.issue ? 1 : 0);
+			(options.branch != null ? 1 : 0) +
+			(options.pr != null ? 1 : 0) +
+			(options.issue != null ? 1 : 0);
 		if (sourceCount !== 1) {
 			throw new CLIError(
 				"Specify exactly one of --branch, --pr, or --issue",

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -1,4 +1,5 @@
 import { boolean, CLIError, number, string } from "@superset/cli-framework";
+import { deriveBranchName } from "@superset/shared/workspace-launch";
 import { command } from "../../../lib/command";
 import { requireHostTarget, resolveHostTarget } from "../../../lib/host-target";
 import { uploadAttachments } from "../../../lib/upload-attachments";
@@ -9,9 +10,16 @@ export default command({
 		host: string().desc("Target host machineId"),
 		local: boolean().desc("Target this machine"),
 		project: string().required().desc("Project ID"),
-		name: string().required().desc("Workspace name"),
-		branch: string().desc("Git branch (required unless --pr is set)"),
+		name: string().desc(
+			"Workspace name (defaults to the derived branch name when --issue is set)",
+		),
+		branch: string().desc(
+			"Git branch (use exactly one of --branch | --pr | --issue)",
+		),
 		pr: number().desc("PR number — derives branch via gh pr checkout"),
+		issue: number().desc(
+			"GitHub issue number — derives branch from `issue-<num>` + issue title",
+		),
 		baseBranch: string().desc(
 			"Branch to fork from when `branch` does not exist (defaults to project default)",
 		),
@@ -19,7 +27,7 @@ export default command({
 			"Agent to spawn after creation. Preset id (`claude`, `codex`, …), HostAgentConfig instance UUID, or `superset`",
 		),
 		prompt: string().desc(
-			"Initial prompt the agent starts with. Required when --agent is set",
+			"Initial prompt the agent starts with. Required when --agent is set, unless --issue is also set (then defaults to issue title + body + URL)",
 		),
 		attachment: string()
 			.variadic()
@@ -33,10 +41,12 @@ export default command({
 			throw new CLIError("No active organization", "Run: superset auth login");
 		}
 
-		if (Boolean(options.branch) === Boolean(options.pr)) {
+		const sourceCount =
+			(options.branch ? 1 : 0) + (options.pr ? 1 : 0) + (options.issue ? 1 : 0);
+		if (sourceCount !== 1) {
 			throw new CLIError(
-				"Specify exactly one of --branch or --pr",
-				"Use --branch <name> or --pr <number>",
+				"Specify exactly one of --branch, --pr, or --issue",
+				"Use --branch <name>, --pr <number>, or --issue <number>",
 			);
 		}
 
@@ -46,10 +56,10 @@ export default command({
 				"Pass --agent <id> alongside --prompt",
 			);
 		}
-		if (options.agent && !options.prompt) {
+		if (options.agent && !options.prompt && !options.issue) {
 			throw new CLIError(
 				"--agent requires --prompt",
-				"Pass --prompt <text> alongside --agent",
+				"Pass --prompt <text>, or use --issue <num> to default the prompt to the issue",
 			);
 		}
 		if (options.attachment && options.attachment.length > 0 && !options.agent) {
@@ -70,16 +80,37 @@ export default command({
 			userJwt: ctx.bearer,
 		});
 
+		let resolvedBranch = options.branch;
+		let resolvedName = options.name;
+		let resolvedPrompt = options.prompt;
+
+		if (options.issue) {
+			const issue = await target.client.workspaceCreation.getIssue.query({
+				projectId: options.project,
+				issueNumber: options.issue,
+			});
+			resolvedBranch = deriveBranchName({
+				slug: `issue-${issue.issueNumber}`,
+				title: issue.title,
+			});
+			if (!resolvedName) {
+				resolvedName = resolvedBranch;
+			}
+			if (options.agent && !resolvedPrompt) {
+				resolvedPrompt = `${issue.title}\n\n${issue.body}\n\n${issue.url}`;
+			}
+		}
+
 		const attachmentIds = options.attachment
 			? await uploadAttachments(target.client, options.attachment)
 			: [];
 
 		const agents =
-			options.agent && options.prompt
+			options.agent && resolvedPrompt
 				? [
 						{
 							agent: options.agent,
-							prompt: options.prompt,
+							prompt: resolvedPrompt,
 							...(attachmentIds.length > 0 ? { attachmentIds } : {}),
 						},
 					]
@@ -87,8 +118,8 @@ export default command({
 
 		const result = await target.client.workspaces.create.mutate({
 			projectId: options.project,
-			name: options.name,
-			branch: options.branch,
+			name: resolvedName,
+			branch: resolvedBranch,
 			pr: options.pr,
 			baseBranch: options.baseBranch,
 			agents,

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -11,7 +11,7 @@ export default command({
 		local: boolean().desc("Target this machine"),
 		project: string().required().desc("Project ID"),
 		name: string().desc(
-			"Workspace name (defaults to the derived branch name when --issue is set)",
+			"Workspace name (optional; defaults to the derived branch name when --issue is set, or a server-generated name otherwise)",
 		),
 		branch: string().desc(
 			"Git branch (use exactly one of --branch | --pr | --issue)",

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/get-issue.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/get-issue.ts
@@ -1,0 +1,92 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { protectedProcedure } from "../../../index";
+import { resolveGithubRepo } from "../shared/project-helpers";
+
+interface IssueDetail {
+	issueNumber: number;
+	title: string;
+	body: string;
+	url: string;
+	state: string;
+	authorLogin: string | null;
+}
+
+const ghIssueViewSchema = z.object({
+	number: z.number(),
+	title: z.string(),
+	body: z.string().nullable().optional(),
+	url: z.string(),
+	state: z.string(),
+	author: z.object({ login: z.string() }).nullable().optional(),
+});
+
+const ISSUE_VIEW_FIELDS = "number,title,body,url,state,author";
+
+const getIssueInputSchema = z.object({
+	projectId: z.string(),
+	issueNumber: z.number().int().positive(),
+});
+
+export const getIssue = protectedProcedure
+	.input(getIssueInputSchema)
+	.query(async ({ ctx, input }): Promise<IssueDetail> => {
+		const repo = await resolveGithubRepo(ctx, input.projectId);
+
+		try {
+			const raw = await ctx.execGh(
+				[
+					"issue",
+					"view",
+					String(input.issueNumber),
+					"--repo",
+					`${repo.owner}/${repo.name}`,
+					"--json",
+					ISSUE_VIEW_FIELDS,
+				],
+				{ cwd: repo.repoPath ?? undefined },
+			);
+			const issue = ghIssueViewSchema.parse(raw);
+			if (issue.url.includes("/pull/")) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `#${input.issueNumber} is a pull request, not an issue`,
+				});
+			}
+			return {
+				issueNumber: issue.number,
+				title: issue.title,
+				body: issue.body ?? "",
+				url: issue.url,
+				state: issue.state.toLowerCase(),
+				authorLogin: issue.author?.login ?? null,
+			};
+		} catch (ghErr) {
+			if (ghErr instanceof TRPCError) throw ghErr;
+			console.warn(
+				"[workspaceCreation.getIssue] gh path failed; falling back to Octokit",
+				ghErr,
+			);
+		}
+
+		const octokit = await ctx.github();
+		const { data: issue } = await octokit.issues.get({
+			owner: repo.owner,
+			repo: repo.name,
+			issue_number: input.issueNumber,
+		});
+		if (issue.pull_request) {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: `#${input.issueNumber} is a pull request, not an issue`,
+			});
+		}
+		return {
+			issueNumber: issue.number,
+			title: issue.title,
+			body: issue.body ?? "",
+			url: issue.html_url,
+			state: issue.state.toLowerCase(),
+			authorLogin: issue.user?.login ?? null,
+		};
+	});

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/get-issue.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/get-issue.ts
@@ -69,24 +69,30 @@ export const getIssue = protectedProcedure
 			);
 		}
 
-		const octokit = await ctx.github();
-		const { data: issue } = await octokit.issues.get({
-			owner: repo.owner,
-			repo: repo.name,
-			issue_number: input.issueNumber,
-		});
-		if (issue.pull_request) {
-			throw new TRPCError({
-				code: "NOT_FOUND",
-				message: `#${input.issueNumber} is a pull request, not an issue`,
+		try {
+			const octokit = await ctx.github();
+			const { data: issue } = await octokit.issues.get({
+				owner: repo.owner,
+				repo: repo.name,
+				issue_number: input.issueNumber,
 			});
+			if (issue.pull_request) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `#${input.issueNumber} is a pull request, not an issue`,
+				});
+			}
+			return {
+				issueNumber: issue.number,
+				title: issue.title,
+				body: issue.body ?? "",
+				url: issue.html_url,
+				state: issue.state.toLowerCase(),
+				authorLogin: issue.user?.login ?? null,
+			};
+		} catch (err) {
+			if (err instanceof TRPCError) throw err;
+			console.warn("[workspaceCreation.getIssue] octokit fallback failed", err);
+			throw err;
 		}
-		return {
-			issueNumber: issue.number,
-			title: issue.title,
-			body: issue.body ?? "",
-			url: issue.html_url,
-			state: issue.state.toLowerCase(),
-			authorLogin: issue.user?.login ?? null,
-		};
 	});

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/get-issue.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/get-issue.ts
@@ -92,6 +92,17 @@ export const getIssue = protectedProcedure
 			};
 		} catch (err) {
 			if (err instanceof TRPCError) throw err;
+			if (
+				typeof err === "object" &&
+				err !== null &&
+				"status" in err &&
+				(err as { status: unknown }).status === 404
+			) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `Issue #${input.issueNumber} not found in ${repo.owner}/${repo.name}`,
+				});
+			}
 			console.warn("[workspaceCreation.getIssue] octokit fallback failed", err);
 			throw err;
 		}

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/index.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/index.ts
@@ -1,4 +1,5 @@
 export { adopt } from "./adopt";
+export { getIssue } from "./get-issue";
 export { listProjectWorktrees } from "./list-project-worktrees";
 export { searchBranches } from "./search-branches";
 export { searchGitHubIssues } from "./search-github-issues";

--- a/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
@@ -1,6 +1,7 @@
 import { router } from "../../index";
 import {
 	adopt,
+	getIssue,
 	listProjectWorktrees,
 	searchBranches,
 	searchGitHubIssues,
@@ -10,6 +11,7 @@ import {
 export const workspaceCreationRouter = router({
 	searchBranches,
 	adopt,
+	getIssue,
 	listProjectWorktrees,
 	searchGitHubIssues,
 	searchPullRequests,

--- a/packages/shared/src/workspace-launch/derive-branch-name.ts
+++ b/packages/shared/src/workspace-launch/derive-branch-name.ts
@@ -1,4 +1,4 @@
-import { sanitizeSegment } from "@superset/shared/workspace-launch";
+import { sanitizeSegment } from "./branch";
 
 export function deriveBranchName({
 	slug,

--- a/packages/shared/src/workspace-launch/index.ts
+++ b/packages/shared/src/workspace-launch/index.ts
@@ -1,4 +1,5 @@
 export * from "./branch";
+export * from "./derive-branch-name";
 export * from "./friendly-branch-name";
 export * from "./slug";
 export * from "./workspace-naming";


### PR DESCRIPTION
Closes #4428

## Summary
- Add `--issue <num>` to `superset workspaces create`, symmetric to the existing `--pr <num>`. The CLI resolves the issue into branch name (`issue-<num>-<slug>`), workspace name, and (when `--agent` is set) a default prompt, then hands off to the existing workspace creation path.
- Lift `deriveBranchName` from `apps/desktop` into `@superset/shared/workspace-launch` so desktop and CLI share one branch-shape source of truth.
- Add a focused `workspaceCreation.getIssue` host-service procedure that returns the issue body (the existing `searchGitHubIssues` direct-lookup path doesn't include `body`).

## Why / Context
`--pr <num>` already covers *work in flight*. The missing counterpart for *work to do* is the more common starting point: an issue exists, hand an agent the title/body, let it produce a PR. Today the equivalent requires hand-composing `gh issue view ... --json title,body` into `--prompt`. This PR makes the pairing first-class.

## How It Works
1. CLI validates `exactly one of --branch | --pr | --issue` (replacing the previous two-way check).
2. When `--issue` is set, the CLI calls `target.client.workspaceCreation.getIssue.query({ projectId, issueNumber })`.
3. CLI derives `branch = deriveBranchName({ slug: "issue-<n>", title: issue.title })` using the shared helper.
4. `--name` defaults to the derived branch when omitted (also made optional for `--branch`/`--pr` paths since the server already handles a missing name).
5. When `--agent` is set without `--prompt`, the prompt defaults to `${title}\n\n${body}\n\n${url}`.
6. Everything downstream — host selection, branch creation, agent spawn, attachments, `alreadyExists` reuse — is unchanged.

`workspaceCreation.getIssue` mirrors the `gh issue view → Octokit fallback` pattern from `searchGitHubIssues`, including the `/pull/` URL guard against `gh issue view` returning a PR for a PR number.

## Manual QA Checklist

### CLI surface
- [ ] `superset workspaces create --help` lists `--issue <number>` and `--name` is no longer marked required.
- [ ] `superset workspaces create --project <id>` (no source flag) errors: "Specify exactly one of --branch, --pr, or --issue".
- [ ] `superset workspaces create --project <id> --branch x --issue 1` errors with the same message.
- [ ] `superset workspaces create --project <id> --pr 1 --issue 1` errors with the same message.

### Issue resolution
- [ ] `superset workspaces create --project <id> --issue <num>` creates a workspace with branch `issue-<num>-<slug-of-title>` and name equal to the derived branch.
- [ ] `--name my-name --issue <num>` keeps the explicit name and still derives the branch from the issue.
- [ ] `--issue <num>` pointed at a PR number errors with "#N is a pull request, not an issue".
- [ ] `--issue <num>` for a non-existent issue errors with a clear NOT_FOUND.

### Agent + prompt defaults
- [ ] `--issue <num> --agent claude` (no `--prompt`) spawns the agent with prompt `${title}\n\n${body}\n\n${url}`.
- [ ] `--issue <num> --agent claude --prompt "custom"` uses the explicit prompt verbatim.
- [ ] `--agent claude` without `--prompt` and without `--issue` still errors (existing behavior).
- [ ] `--prompt "x"` without `--agent` still errors (existing behavior).

### Regression — existing flows
- [ ] `--branch <name>` and `--pr <num>` still work (with or without `--name`).
- [ ] `alreadyExists` reuse still triggers on repeat invocations.

### Desktop (no behavior change expected — `deriveBranchName` lifted to shared)
- [ ] "Open in workspace" / "Run in workspace" flows on task pages still produce the same branch names they did before.

## Testing
- `bun run lint` (passes)
- `bun run typecheck` on `packages/shared`, `packages/host-service`, `packages/cli` (passes)
- Manual: `node packages/cli/dist/index.js workspaces create --help` confirms the new flag and updated descriptions
- No automated tests added (per scope — this PR wires existing primitives)

## Design Decisions
- **New `getIssue` procedure instead of extending `searchGitHubIssues`**: the search procedure deliberately omits `body` from its response shape. Adding `body` to every search hit would bloat list payloads; a focused single-issue procedure is cleaner.
- **Derive branch client-side instead of server-side**: keeps the `--issue` path symmetric with `--branch` (CLI provides the branch name; server creates it). The asymmetry with `--pr` (server picks branch via `gh pr checkout`) is intentional — PRs already have a remote branch, issues don't.
- **`--name` made optional globally, not just for `--issue`**: the server schema has accepted optional `name` for a while; the CLI was stricter than the server. Help text now documents the new default.

## Known Limitations
- The default prompt uses raw issue body. Markdown formatting in the body is preserved verbatim — agents see the same Markdown a human reader would.
- `getIssue` returns `state` and `authorLogin` for symmetry with `searchGitHubIssues` even though the CLI doesn't currently consume them.

## Follow-ups
- None planned. The change is intentionally minimal — no new naming primitives, no new git logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--issue <num>` to `superset workspaces create` to spin up a workspace from a GitHub issue, deriving a sensible branch/name and defaulting the agent prompt. Also tightens validation and improves error messages when issue lookups fail.

- New Features
  - CLI accepts `--issue <num>` and derives the branch via `deriveBranchName({ slug: issue-<n>, title })`; `--name` defaults to the branch when omitted.
  - Enforces exactly one of `--branch | --pr | --issue`.
  - With `--agent` and no `--prompt`, the prompt auto-fills with issue title, body, and URL.
  - Host service adds `workspaceCreation.getIssue` to fetch issue details and rejects PR numbers.

- Bug Fixes
  - Map Octokit 404s to `TRPCError.NOT_FOUND` in `workspaceCreation.getIssue` for clearer errors when `gh` is unavailable.
  - Flag validation uses `!= null` so `--issue 0`/`--pr 0` aren’t treated as missing and reach the server’s `positive()` guard.

<sup>Written for commit 36379988ad0cac5f634c286e406be4662b1175bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create workspaces from GitHub issues via the workspace creation command (`--issue`), auto-deriving branch/name/prompt from issue details.
  * Added backend support to fetch and normalize GitHub issue details for workspace creation.

* **Chores**
  * Centralized branch-name derivation used across workspace launch flows for more consistent naming.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4429)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->