### PR TITLE
fix(auth): unblock OAuth signups by supplying slug for auto-default team

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -259,6 +259,21 @@ export const auth = betterAuth({
 				enabled: true,
 				maximumTeams: 25,
 				allowRemovingAllTeams: false,
+				defaultTeam: {
+					enabled: true,
+					customCreateDefaultTeam: async (organization) => {
+						const [team] = await db
+							.insert(authSchema.teams)
+							.values({
+								name: "Default Team",
+								slug: "DEFAULT",
+								organizationId: organization.id,
+							})
+							.returning();
+						if (!team) throw new Error("Failed to create default team");
+						return { ...team, updatedAt: team.updatedAt ?? undefined };
+					},
+				},
 			},
 			schema: {
 				team: {
@@ -341,12 +356,6 @@ export const auth = betterAuth({
 						.where(eq(authSchema.organizations.id, organization.id));
 
 					await seedDefaultStatuses(organization.id);
-
-					await db.insert(authSchema.teams).values({
-						name: organization.name,
-						slug: organization.slug,
-						organizationId: organization.id,
-					});
 				},
 
 				beforeRemoveMember: async ({ member, organization }) => {


### PR DESCRIPTION
## Summary
- P0: every new Google OAuth signup since #4403 deployed was failing at `/api/auth/callback/google` with `unable_to_create_user`.
- Better Auth's organization plugin auto-creates a default team during `createOrganization` (`crud-org.mjs:106-136`) and hard-codes `teamData = { organizationId, name, createdAt }` — no `slug`. Our `auth.teams.slug` is `NOT NULL` with no default, so the insert aborted with a constraint violation, rolling back the whole signup transaction.
- Use `teams.defaultTeam.customCreateDefaultTeam` to own the auto-team insert and supply a constant `"DEFAULT"` slug. Drop the now-duplicate `db.insert(teams)` from `afterCreateOrganization`.

## Why this hook (and not `beforeCreateTeam` / `afterCreateOrganization`)
- `beforeCreateTeam` fires on both the auto-default path *and* user-initiated `createTeam` calls from the Settings → Teams UI (`crud-team.mjs:107`). Unconditionally returning `{ slug: "DEFAULT" }` would clobber user-chosen slugs.
- `afterCreateOrganization` runs at line 137 — *after* the broken auto-team insert at line 126. The transaction already aborts before we'd get there.
- `customCreateDefaultTeam` is the dedicated callback consulted only on the auto-default path.

## Existing orgs
Untouched. They keep the team backfilled by migration `0049` (slug = org slug). Only orgs created after this deploys get `slug="DEFAULT"`.

## Test plan
- [ ] Sign in via Google with a fresh email whose domain is not on any org's `allowedDomains`. Confirm signup completes and lands in `/`.
- [ ] In the DB, verify the new org has exactly one row in `auth.teams` with `name='Default Team'`, `slug='DEFAULT'`, and exactly one matching row in `auth.team_members` for the new user.
- [ ] Create a second team via Settings → Teams with a custom name/slug. Confirm it is created with the user-supplied values (no clobbering from this hook).
- [ ] Smoke-test domain auto-enroll: sign up with an email whose domain matches an org's `allowedDomains` and confirm the user lands in that org (no new org / default team created).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks OAuth signups by ensuring the auto-created default team gets a slug. This removes the NOT NULL violation on `auth.teams.slug` during org creation.

- **Bug Fixes**
  - Create the default team via `teams.defaultTeam.customCreateDefaultTeam` with name "Default Team" and `slug="DEFAULT"`.
  - Remove the redundant team insert in `afterCreateOrganization`.
  - Only affects the auto-default team path; user-created teams keep user-chosen slugs.

<sup>Written for commit 8eb30559251359f53fc17d0649ac711683fe2f1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized default team creation during organization setup to use consistent naming conventions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4435)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->