### PR TITLE
feat(desktop): expose copyable organization ID in org settings

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/organization/components/OrganizationSettings/OrganizationSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/organization/components/OrganizationSettings/OrganizationSettings.tsx
@@ -17,9 +17,15 @@ import {
 	TableHeader,
 	TableRow,
 } from "@superset/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useState } from "react";
+import {
+	HiOutlineClipboardDocument,
+	HiOutlineClipboardDocumentCheck,
+} from "react-icons/hi2";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -105,6 +111,8 @@ export function OrganizationSettings({
 		SETTING_ITEM_ID.ORGANIZATION_SLUG,
 		visibleItems,
 	);
+	const showId = isItemVisible(SETTING_ITEM_ID.ORGANIZATION_ID, visibleItems);
+	const { copyToClipboard, copied } = useCopyToClipboard();
 	const showMembersList = isItemVisible(
 		SETTING_ITEM_ID.ORGANIZATION_MEMBERS_LIST,
 		visibleItems,
@@ -231,7 +239,7 @@ export function OrganizationSettings({
 		);
 	}
 
-	const showOrgSettings = showLogo || showName || showSlug;
+	const showOrgSettings = showLogo || showName || showSlug || showId;
 	const showMembersSection =
 		showMembersList ||
 		isItemVisible(SETTING_ITEM_ID.ORGANIZATION_MEMBERS_INVITE, visibleItems) ||
@@ -313,6 +321,43 @@ export function OrganizationSettings({
 											}`}
 											disabled={!isOwner}
 										/>
+									</SettingsRow>
+								)}
+
+								{showId && (
+									<SettingsRow
+										label="ID"
+										hint="Use this when calling the Superset API."
+										htmlFor="org-id"
+									>
+										<button
+											type="button"
+											id="org-id"
+											onClick={() => copyToClipboard(organization.id)}
+											aria-label="Copy organization ID"
+											className="group relative block w-72 cursor-pointer rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+										>
+											<Input
+												value={organization.id}
+												readOnly
+												tabIndex={-1}
+												className="w-full font-mono text-xs pr-10 select-none caret-transparent cursor-pointer pointer-events-none group-hover:bg-accent"
+											/>
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<span className="absolute right-1 top-1 inline-flex h-7 w-7 items-center justify-center rounded-md bg-secondary text-secondary-foreground group-hover:bg-secondary/80">
+														{copied ? (
+															<HiOutlineClipboardDocumentCheck className="h-4 w-4" />
+														) : (
+															<HiOutlineClipboardDocument className="h-4 w-4" />
+														)}
+													</span>
+												</TooltipTrigger>
+												<TooltipContent>
+													{copied ? "Copied!" : "Copy"}
+												</TooltipContent>
+											</Tooltip>
+										</button>
 									</SettingsRow>
 								)}
 							</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -7,6 +7,7 @@ export const SETTING_ITEM_ID = {
 	ORGANIZATION_LOGO: "organization-logo",
 	ORGANIZATION_NAME: "organization-name",
 	ORGANIZATION_SLUG: "organization-slug",
+	ORGANIZATION_ID: "organization-id",
 	ORGANIZATION_MEMBERS_LIST: "organization-members-list",
 	ORGANIZATION_MEMBERS_INVITE: "organization-members-invite",
 	ORGANIZATION_MEMBERS_PENDING_INVITATIONS:
@@ -114,6 +115,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.ORGANIZATION_LOGO]: "shared",
 	[SETTING_ITEM_ID.ORGANIZATION_NAME]: "shared",
 	[SETTING_ITEM_ID.ORGANIZATION_SLUG]: "shared",
+	[SETTING_ITEM_ID.ORGANIZATION_ID]: "shared",
 	[SETTING_ITEM_ID.ORGANIZATION_MEMBERS_LIST]: "shared",
 	[SETTING_ITEM_ID.ORGANIZATION_MEMBERS_INVITE]: "shared",
 	[SETTING_ITEM_ID.ORGANIZATION_MEMBERS_PENDING_INVITATIONS]: "shared",
@@ -275,6 +277,21 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"subdomain",
 			"link",
 			"unique",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.ORGANIZATION_ID,
+		section: "organization",
+		title: "Organization ID",
+		description: "Your organization's unique identifier",
+		keywords: [
+			"organization",
+			"id",
+			"identifier",
+			"uuid",
+			"unique",
+			"copy",
+			"api",
 		],
 	},
 	{


### PR DESCRIPTION
## Summary
- Adds an "ID" row to the Organization settings page so users can grab their org ID for Superset API calls
- The entire row is a click target (copies on click), with a tooltip on the icon affordance that switches between "Copy" and "Copied!"; the ID itself is rendered non-selectable so the whole control feels like one button
- Registers the new item in `settings-search` so it surfaces for queries like "id", "uuid", "identifier"

## Test plan
- [ ] Open Settings → Organization, confirm the new ID row appears below Slug
- [ ] Click anywhere on the input (left or icon side) and confirm the org ID is on the clipboard
- [ ] Hover the icon and confirm the tooltip shows "Copy", then "Copied!" after click
- [ ] Try to highlight the ID text — it should not be selectable
- [ ] Search settings for "id" / "uuid" and confirm the row matches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copyable Organization ID row in Settings → Organization to help users grab the ID for Superset API calls. The whole row copies on click and is discoverable via settings search.

- **New Features**
  - Added “ID” row below Slug; the entire row is clickable to copy the org ID, and the ID text is non-selectable.
  - Clipboard icon toggles between copy and copied states, with a tooltip showing “Copy” → “Copied!”.
  - Registered “Organization ID” in settings search with keywords like id, uuid, identifier, and api.

<sup>Written for commit e126c43bebe8cd47f87a8b2f17610f57bf72ffdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to view and copy your organization ID from the settings page with a single click
  * Organization ID is now searchable within settings for easier access

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4437)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->