### PR TITLE
fix(host-service): accept unknown mediaType on attachment upload

### DIFF
--- a/packages/host-service/src/trpc/router/attachments/attachments.test.ts
+++ b/packages/host-service/src/trpc/router/attachments/attachments.test.ts
@@ -84,14 +84,30 @@ describe("attachmentsRouter.upload", () => {
 		}
 	});
 
-	it("rejects unrecognized media type", async () => {
+	it("falls back to application/octet-stream for unrecognized media type", async () => {
 		const caller = createCaller();
-		await expect(
-			caller.upload({
-				data: { kind: "base64", data: PNG_BASE64 },
-				mediaType: "application/x-totally-fake",
-			}),
-		).rejects.toThrow(/unrecognized media type/i);
+		const result = await caller.upload({
+			data: { kind: "base64", data: PNG_BASE64 },
+			mediaType: "application/x-totally-fake",
+			originalFilename: "racetrack.bmad",
+		});
+		expect(result.mediaType).toBe("application/octet-stream");
+		const filePath = getAttachmentFilePath(
+			result.attachmentId,
+			"application/octet-stream",
+		);
+		expect(filePath).toMatch(/\.bin$/);
+		expect(existsSync(filePath)).toBe(true);
+	});
+
+	it("falls back to application/octet-stream for empty media type", async () => {
+		const caller = createCaller();
+		const result = await caller.upload({
+			data: { kind: "base64", data: PNG_BASE64 },
+			mediaType: "",
+			originalFilename: "racetrack.bmad",
+		});
+		expect(result.mediaType).toBe("application/octet-stream");
 	});
 
 	it("accepts a single decoded byte", async () => {

--- a/packages/host-service/src/trpc/router/attachments/attachments.ts
+++ b/packages/host-service/src/trpc/router/attachments/attachments.ts
@@ -15,9 +15,11 @@ const uploadInputSchema = z.object({
 		kind: z.literal("base64"),
 		data: z.string().min(1),
 	}),
-	mediaType: z.string().min(1),
+	mediaType: z.string(),
 	originalFilename: z.string().optional(),
 });
+
+const FALLBACK_MEDIA_TYPE = "application/octet-stream";
 
 /**
  * Cheap size estimate from a base64 string without allocating the
@@ -36,12 +38,9 @@ export const attachmentsRouter = router({
 	 * renderer never sees the on-disk path.
 	 */
 	upload: protectedProcedure.input(uploadInputSchema).mutation(({ input }) => {
-		if (!mimeTypes.extension(input.mediaType)) {
-			throw new TRPCError({
-				code: "BAD_REQUEST",
-				message: `Unrecognized media type: ${input.mediaType}`,
-			});
-		}
+		const mediaType = mimeTypes.extension(input.mediaType)
+			? input.mediaType
+			: FALLBACK_MEDIA_TYPE;
 
 		// Reject before allocating the decoded buffer so a 1GB base64
 		// payload doesn't spike host memory only to be rejected at the end.
@@ -65,7 +64,7 @@ export const attachmentsRouter = router({
 
 		const metadata: AttachmentMetadata = {
 			attachmentId: randomUUID(),
-			mediaType: input.mediaType,
+			mediaType,
 			originalFilename: input.originalFilename,
 			sizeBytes: bytes.length,
 			createdAt: Date.now(),


### PR DESCRIPTION
## Summary
- Users uploading files with custom extensions (e.g. a `.bmad` Fortran lattice file for accelerator simulations) hit `Too small: expected string to have >=1 characters` on `mediaType` because browsers report empty `File.type` for unknown extensions.
- Even with a non-empty mediaType, the upload handler then threw `Unrecognized media type` for anything `mime-types` didn't know.
- Now the upload handler falls back to `application/octet-stream` when the mediaType is empty or unknown. Original filename is still preserved in metadata, and the agent receives the file via its on-disk path (with `.bin` extension) plus the original filename.

## Test plan
- [x] Existing attachment tests still pass (14/14)
- [x] New test: unknown mediaType (`application/x-totally-fake`) is accepted and stored as `.bin`
- [x] New test: empty mediaType is accepted and stored as octet-stream
- [x] Typecheck + biome lint clean
- [ ] Manual: drop `/tmp/sample.bmad` into the new-workspace modal and confirm it uploads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes attachment uploads failing for unknown file types by accepting empty or unrecognized `mediaType` so custom extensions (e.g. .bmad) upload successfully.

- **Bug Fixes**
  - Relaxed `attachments.upload` input to allow empty `mediaType`.
  - If `mime-types` can’t resolve the type, save as `application/octet-stream` with a `.bin` path and keep the original filename in metadata; added tests for unknown and empty `mediaType`.

<sup>Written for commit d9fcadb72735700dfc7fdfb0437a785dfe4b0c10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File uploads with unrecognized media types are now accepted and automatically handled with a fallback format instead of being rejected.

* **Bug Fixes**
  * Improved handling of edge cases in file upload validation to support broader file type compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4439)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->