### PR TITLE
[codex] Use skip permissions for v2 Claude preset

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentDetail/AgentDetail.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentDetail/AgentDetail.tsx
@@ -166,7 +166,7 @@ export function AgentDetail({
 							value={commandText}
 							onChange={(e) => setCommandText(e.target.value)}
 							onBlur={handleCommandBlur}
-							placeholder="claude --permission-mode acceptEdits"
+							placeholder="claude --dangerously-skip-permissions"
 						/>
 					</StackedField>
 

--- a/apps/docs/content/docs/terminal-presets.mdx
+++ b/apps/docs/content/docs/terminal-presets.mdx
@@ -41,10 +41,10 @@ Presets are parallel by default.
 
 ## Quick-Add Templates
 
-Pre-configured presets for popular AI agents. Defaults mirror the bundled Superset launch settings for each agent. Codex uses its most permissive bypass flag; edit any preset to change its permission mode.
+Pre-configured presets for popular AI agents. Defaults mirror the bundled Superset launch settings for each agent. Claude and Codex use their most permissive bypass flags; edit any preset to change its permission mode.
 
 - **amp** - `amp` (built-in permission rules auto-deny destructive ops)
-- **claude** - `claude --permission-mode acceptEdits`
+- **claude** - `claude --dangerously-skip-permissions`
 - **codex** - `codex --dangerously-bypass-approvals-and-sandbox` (most permissive)
 - **gemini** - `gemini --approval-mode=auto_edit`
 - **copilot** - `copilot --allow-tool=write`

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -58,6 +58,14 @@ describe("agentConfigsRouter", () => {
 			expect(result.find((row) => row.presetId === "superset")).toBeUndefined();
 		});
 
+		it("seeds Claude with its most permissive flag", async () => {
+			const caller = createCaller();
+			const result = await caller.list();
+			const claude = result.find((row) => row.presetId === "claude");
+
+			expect(claude?.args).toEqual(["--dangerously-skip-permissions"]);
+		});
+
 		it("seeds Codex with its most permissive flag", async () => {
 			const caller = createCaller();
 			const result = await caller.list();

--- a/packages/shared/src/host-agent-presets.ts
+++ b/packages/shared/src/host-agent-presets.ts
@@ -37,7 +37,7 @@ export const HOST_AGENT_PRESETS = [
 		description:
 			"Anthropic's coding agent for reading code, editing files, and running terminal workflows.",
 		command: "claude",
-		args: ["--permission-mode", "acceptEdits"],
+		args: ["--dangerously-skip-permissions"],
 		promptTransport: "argv",
 		promptArgs: [],
 		env: {},


### PR DESCRIPTION
## Summary

Updates the v2 Claude host-agent preset to launch with `claude --dangerously-skip-permissions` instead of `--permission-mode acceptEdits`.

Also updates the v2 agent settings placeholder and terminal preset docs so the UI and docs match the new bundled launch behavior, and adds host-service coverage for the seeded Claude args.

## Impact

Newly seeded v2 Claude host-agent configs will default to Claude's most permissive permission mode. Existing persisted host-agent rows are not rewritten by this change.

## Validation

- `bun test packages/host-service/src/trpc/router/settings/agent-configs.test.ts`
- `bun run lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the v2 Claude host-agent preset to use `claude --dangerously-skip-permissions` instead of `--permission-mode acceptEdits`, and updates the settings placeholder and terminal presets docs to match. Adds a host-service test to cover the new seeded args; existing saved configs are unchanged.

<sup>Written for commit c6c34b25dbbdd2eeb94b1341a188a1f0a1159d8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Claude agent preset command with a new permission flag.

* **Documentation**
  * Updated Quick-Add Templates documentation to reflect the new Claude preset configuration.

* **Tests**
  * Added test assertion to verify the Claude preset includes the updated flag.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4440)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->