### PR TITLE
[codex] restore escape from top-level settings

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -10,6 +10,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	type SettingsSection,
 	useSetSettingsSearchQuery,
+	useSettingsOriginRoute,
 	useSettingsSearchQuery,
 } from "renderer/stores/settings-state";
 import { NavigationControls } from "../_dashboard/components/NavigationControls";
@@ -106,6 +107,7 @@ function SettingsLayout() {
 	const isMac = platform === undefined || platform === "darwin";
 	const searchQuery = useSettingsSearchQuery();
 	const setSearchQuery = useSetSettingsSearchQuery();
+	const originRoute = useSettingsOriginRoute();
 	const location = useLocation();
 	const navigate = useNavigate();
 	const normalizedSearchQuery = searchQuery.trim();
@@ -141,16 +143,17 @@ function SettingsLayout() {
 		(event) => {
 			if (document.querySelector('[data-state="open"]')) return;
 			const segments = location.pathname.split("/").filter(Boolean);
-			// Peel one segment, but only if we're deeper than a top-of-section
-			// route like /settings/teams. Esc at the top is a no-op so users don't
-			// get yanked out of settings unexpectedly.
-			if (segments.length <= 2) return;
 			event.preventDefault();
+			if (segments.length <= 2) {
+				navigate({ to: originRoute });
+				return;
+			}
+
 			const parent = `/${segments.slice(0, -1).join("/")}`;
 			navigate({ to: parent });
 		},
 		{ enableOnFormTags: false, enableOnContentEditable: false },
-		[navigate, location.pathname],
+		[navigate, location.pathname, originRoute],
 	);
 
 	const usesInnerSidebar =


### PR DESCRIPTION
## Summary
- Restore Escape key behavior so top-level settings routes exit back to the stored origin route.
- Preserve nested settings behavior where Escape moves up one settings route segment.

## Root cause
PR #4403 changed the Escape handler to only peel nested settings segments and return at top-level settings pages, which made Escape a no-op on routes like `/settings/account`.

## Validation
- `bunx biome check --write --unsafe apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx`
- `bun run lint:fix`
- `bun run lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Escape behavior in Settings: top-level pages now exit back to the saved origin route, while nested pages still step up one level. Fixes the regression where Escape did nothing on routes like `/settings/account`.

- **Bug Fixes**
  - Top-level settings: Escape now navigates to the saved `originRoute` via `useSettingsOriginRoute`.
  - Nested settings: Escape still moves up one settings path segment.

<sup>Written for commit eacfa4a0a9da83677cf5594767c71e7031a429ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Escape key behavior in the settings section. When pressing Escape at the top level of settings, users are now automatically navigated back to their previous location instead of remaining in the settings area.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4445)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->