### PR TITLE
[codex] Move tab indicator into close slot

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
@@ -247,10 +247,12 @@ export function GroupItem({
 								<span className="text-sm truncate flex-1 text-left">
 									{displayName}
 								</span>
-								{status && status !== "idle" && (
-									<StatusIndicator status={status} />
-								)}
 							</button>
+							{status && status !== "idle" && (
+								<div className="pointer-events-none absolute right-1 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center group-hover:hidden">
+									<StatusIndicator status={status} />
+								</div>
+							)}
 							<div className="absolute right-1 top-1/2 -translate-y-1/2 hidden items-center gap-0.5 group-hover:flex">
 								<Tooltip delayDuration={500}>
 									<TooltipTrigger asChild>

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -159,21 +159,23 @@ export function TabItem<TData>({
 										<OverflowFadeText className="flex-1">
 											{title}
 										</OverflowFadeText>
-										{accessory && (
-											<span className="shrink-0 leading-none">{accessory}</span>
-										)}
 									</button>
 								</TooltipTrigger>
 								<TooltipContent side="bottom" showArrow={false}>
 									{title}
 								</TooltipContent>
 							</Tooltip>
-							<div className="flex h-full w-7 shrink-0 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+							<div className="relative flex h-full w-7 shrink-0 items-center justify-center">
+								{accessory && (
+									<span className="pointer-events-none absolute inset-0 flex items-center justify-center leading-none opacity-100 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+										{accessory}
+									</span>
+								)}
 								<Tooltip delayDuration={500}>
 									<TooltipTrigger asChild>
 										<Button
 											className={cn(
-												"size-5 cursor-pointer text-current",
+												"pointer-events-none size-5 cursor-pointer text-current opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
 												isActive ? "hover:bg-foreground/10" : "hover:bg-muted",
 											)}
 											onClick={(event) => {


### PR DESCRIPTION
## Summary

- Moves tab accessory indicators into the close-button slot so running/status icons occupy the right edge of tabs.
- Swaps the indicator for the close X on hover/focus without shifting the close button position.
- Applies the same behavior to the shared pane tab bar and the legacy desktop group strip.

## Validation

- `bunx biome check --write --unsafe packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx`
- `bun run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved tab status/accessory indicators into the close-button slot so status icons stay on the far right without layout shift. On hover or focus, the close button replaces the indicator; applied to both the shared pane TabBar and the desktop GroupStrip.

<sup>Written for commit 8ba994d47f842cc1dfa8e52e3ff14790b6a75806. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tab interface rendering to improve visual presentation and interactive behavior during hover and focus states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4446)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->