### PR TITLE
test: pin PATH

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -55,7 +55,7 @@ function isZshAvailable(): boolean {
 function writeBashProfilePath(homeDir: string, pathValue: string): void {
 	writeFileSync(
 		path.join(homeDir, ".bash_profile"),
-		`export PATH="${pathValue}"\n`,
+		`export PATH=${quoteShellLiteral(pathValue)}\n`,
 	);
 }
 

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -52,6 +52,13 @@ function isZshAvailable(): boolean {
 	}
 }
 
+function writeBashProfilePath(homeDir: string, pathValue: string): void {
+	writeFileSync(
+		path.join(homeDir, ".bash_profile"),
+		`export PATH="${pathValue}"\n`,
+	);
+}
+
 describe("shell-wrappers", () => {
 	beforeEach(() => {
 		mkdirSync(TEST_BIN_DIR, { recursive: true });
@@ -280,10 +287,7 @@ fi
 		mkdirSync(homeDir, { recursive: true });
 		mkdirSync(systemBinDir, { recursive: true });
 
-		writeFileSync(
-			path.join(homeDir, ".bash_profile"),
-			`export PATH="${systemBinDir}:/usr/bin:/bin"\n`,
-		);
+		writeBashProfilePath(homeDir, `${systemBinDir}:/usr/bin:/bin`);
 
 		writeFileSync(
 			path.join(systemBinDir, "claude"),
@@ -320,6 +324,7 @@ echo wrapper
 		const missingBinDir = path.join(integrationRoot, "missing-bin");
 		mkdirSync(homeDir, { recursive: true });
 		mkdirSync(systemBinDir, { recursive: true });
+		writeBashProfilePath(homeDir, `${systemBinDir}:/usr/bin:/bin`);
 
 		writeFileSync(
 			path.join(systemBinDir, "claude"),
@@ -359,6 +364,7 @@ echo system
 		mkdirSync(homeDir, { recursive: true });
 		mkdirSync(systemBinDir, { recursive: true });
 		mkdirSync(wrapperBinDir, { recursive: true });
+		writeBashProfilePath(homeDir, `${systemBinDir}:/usr/bin:/bin`);
 
 		writeFileSync(
 			path.join(systemBinDir, "claude"),


### PR DESCRIPTION
## Description

  Pins the bash startup `PATH` in the shell-wrapper fallback tests by writing a fixture `.bash_profile`. 
  These tests create fake managed-command binaries, such as `claude`, inside temporary test directories. Without pinning `PATH` through bash startup, a developer machine with a real `claude` CLI installed can resolve the system binary instead of the test fixture. This makes the fallback tests environment dependent.
  
   ## Type of Change

  - [x] Bug fix
  
  ## Testing

  - `bun test src/main/lib/agent-setup/shell-wrappers.test.ts`
  - `bun run lint`
  
  ## Additional Notes

  This only changes test fixture setup. Product code is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned and shell-quoted the bash startup PATH in shell-wrapper fallback tests by writing a `.bash_profile` fixture via a small helper, so test binaries resolve from temp dirs instead of real system CLIs like `claude`. This makes the tests deterministic across machines; product code is unchanged.

<sup>Written for commit 374b22c2b23e719da6e91985fb08e40725e00608. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test maintainability by introducing a reusable test helper to set up a user bash profile PATH, reducing duplicated setup across three integration tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4447)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->