### PR TITLE
[codex] test(desktop): isolate host-service coordinator mocks

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
@@ -27,7 +35,9 @@ const removeManifestMock = mock(() => {
 });
 const isProcessAliveMock = mock(() => true);
 
+const realHostServiceManifest = await import("./host-service-manifest");
 mock.module("./host-service-manifest", () => ({
+	...realHostServiceManifest,
 	readManifest: readManifestMock,
 	removeManifest: removeManifestMock,
 	isProcessAlive: isProcessAliveMock,
@@ -37,7 +47,9 @@ mock.module("./host-service-manifest", () => ({
 
 const pollHealthCheckMock = mock(() => Promise.resolve(true));
 
+const realHostServiceUtils = await import("./host-service-utils");
 mock.module("./host-service-utils", () => ({
+	...realHostServiceUtils,
 	HEALTH_POLL_TIMEOUT_MS: 10_000,
 	MAX_HOST_LOG_BYTES: 1024,
 	findFreePort: mock(() => Promise.resolve(40000)),
@@ -61,28 +73,16 @@ mock.module("electron-log/main", () => ({
 	},
 }));
 
-mock.module("@superset/local-db", () => ({ settings: {} }));
+const realHostInfo = await import("@superset/shared/host-info");
 mock.module("@superset/shared/host-info", () => ({
+	...realHostInfo,
 	getHostId: () => "host-1",
 	getHostName: () => "host",
-}));
-mock.module("main/env.main", () => ({
-	env: { NEXT_PUBLIC_API_URL: "", RELAY_URL: "" },
-}));
-mock.module("shared/env.shared", () => ({
-	env: { DESKTOP_VITE_PORT: 3000, DESKTOP_NOTIFICATIONS_PORT: 4000 },
-}));
-mock.module("./app-environment", () => ({
-	SUPERSET_HOME_DIR: "/tmp/superset",
 }));
 mock.module("./local-db", () => ({
 	localDb: {
 		select: () => ({ from: () => ({ get: () => null }) }),
 	},
-}));
-mock.module("./terminal/env", () => ({ HOOK_PROTOCOL_VERSION: "1" }));
-mock.module("../../lib/trpc/routers/workspaces/utils/shell-env", () => ({
-	getProcessEnvWithShellPath: async (e: Record<string, string>) => e,
 }));
 
 const { HostServiceCoordinator } = await import("./host-service-coordinator");
@@ -289,4 +289,8 @@ describe("HostServiceCoordinator.reset", () => {
 		expect(spawnMock).toHaveBeenCalledTimes(1);
 		expect(conn.port).toBe(60000);
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });


### PR DESCRIPTION
## Summary

Follow-up to #4395. The host-service coordinator test used broad Bun `mock.module` replacements that leaked through Bun's process-global mock registry into unrelated desktop tests.

This narrows the mocks by preserving real exports for partially mocked modules, removes unused broad mocks, and restores Bun mocks in `afterAll`.

## Impact

Desktop tests can run in the same Bun process without unrelated modules observing incomplete mock exports or test-only environment values.

## Validation

- `bun test apps/desktop/src/main/lib/host-service-coordinator.test.ts`
- `bunx biome check apps/desktop/src/main/lib/host-service-coordinator.test.ts`
- `bun run lint:fix`
- `bun run lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated and cleaned up Bun mocks in the host-service coordinator tests to stop leaking partial module exports and test-only env into other desktop tests. Partially mock only what’s needed and restore mocks after the suite.

- **Bug Fixes**
  - Preserve real exports when mocking `./host-service-manifest`, `./host-service-utils`, and `@superset/shared/host-info`.
  - Remove broad, unused mocks for `main/env.main`, `shared/env.shared`, `./app-environment`, `./terminal/env`, and `../../lib/trpc/routers/workspaces/utils/shell-env`.
  - Restore Bun’s mock registry in `afterAll` via `mock.restore()`.

<sup>Written for commit 64c5c95f2ca456c5f4c09b22f65f3c0c21a204cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup and mock management for more reliable testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4448)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->