### PR TITLE
feat(cli): add --project and --search filters to workspaces list

### DIFF
--- a/packages/cli/src/commands/workspaces/list/command.ts
+++ b/packages/cli/src/commands/workspaces/list/command.ts
@@ -2,11 +2,18 @@ import { boolean, CLIError, string, table } from "@superset/cli-framework";
 import { command } from "../../../lib/command";
 import { resolveHostFilter } from "../../../lib/host-target";
 
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export default command({
 	description: "List workspaces accessible to you in the active organization",
 	options: {
 		host: string().desc("Filter to a specific host (machineId)"),
 		local: boolean().desc("Filter to this machine"),
+		project: string().desc("Filter by project name (case-insensitive) or id"),
+		search: string()
+			.alias("s")
+			.desc("Search by workspace name or branch substring"),
 	},
 	display: (data) =>
 		table(
@@ -26,8 +33,19 @@ export default command({
 			local: options.local ?? undefined,
 		});
 
+		const projectInput = options.project ?? undefined;
+		const projectId =
+			projectInput && UUID_RE.test(projectInput) ? projectInput : undefined;
+		const projectName = projectInput && !projectId ? projectInput : undefined;
+
 		const [workspaces, hosts] = await Promise.all([
-			ctx.api.v2Workspace.list.query({ organizationId, hostId }),
+			ctx.api.v2Workspace.list.query({
+				organizationId,
+				hostId,
+				projectId,
+				projectName,
+				search: options.search ?? undefined,
+			}),
 			ctx.api.host.list.query({ organizationId }),
 		]);
 		const hostNameById = new Map(hosts.map((host) => [host.id, host.name]));

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -144,6 +144,12 @@ export type WorkspaceListResponse = Array<Workspace>;
 export interface WorkspaceListParams {
 	/** Restrict the listing to workspaces on a single host machineId. */
 	hostId?: string;
+	/** Restrict the listing to a single project by UUID. */
+	projectId?: string;
+	/** Restrict the listing by project name (case-insensitive exact match). */
+	projectName?: string;
+	/** Substring match against workspace name or branch. */
+	search?: string;
 }
 
 export interface WorkspaceCreateParams {

--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -10,7 +10,7 @@ import {
 import { getCurrentTxid } from "@superset/db/utils";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
-import { and, eq, ilike, inArray, or } from "drizzle-orm";
+import { and, eq, ilike, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { posthog } from "../../lib/analytics";
 import { jwtProcedure, protectedProcedure } from "../../trpc";
@@ -127,7 +127,11 @@ export const v2WorkspaceRouter = {
 				});
 			}
 
-			const searchPattern = input.search ? `%${input.search}%` : null;
+			const escapeLike = (value: string) =>
+				value.replace(/[\\%_]/g, (char) => `\\${char}`);
+			const searchPattern = input.search
+				? `%${escapeLike(input.search)}%`
+				: null;
 			const searchMatch = searchPattern
 				? or(
 						ilike(v2Workspaces.name, searchPattern),
@@ -162,7 +166,7 @@ export const v2WorkspaceRouter = {
 							? eq(v2Workspaces.projectId, input.projectId)
 							: undefined,
 						input.projectName
-							? ilike(v2Projects.name, input.projectName)
+							? sql`lower(${v2Projects.name}) = lower(${input.projectName})`
 							: undefined,
 						searchMatch,
 					),

--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -10,7 +10,7 @@ import {
 import { getCurrentTxid } from "@superset/db/utils";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, ilike, inArray, or } from "drizzle-orm";
 import { z } from "zod";
 import { posthog } from "../../lib/analytics";
 import { jwtProcedure, protectedProcedure } from "../../trpc";
@@ -114,6 +114,9 @@ export const v2WorkspaceRouter = {
 			z.object({
 				organizationId: z.string().uuid(),
 				hostId: z.string().min(1).optional(),
+				projectId: z.string().uuid().optional(),
+				projectName: z.string().min(1).optional(),
+				search: z.string().min(1).optional(),
 			}),
 		)
 		.query(async ({ ctx, input }) => {
@@ -123,6 +126,14 @@ export const v2WorkspaceRouter = {
 					message: "Not a member of this organization",
 				});
 			}
+
+			const searchPattern = input.search ? `%${input.search}%` : null;
+			const searchMatch = searchPattern
+				? or(
+						ilike(v2Workspaces.name, searchPattern),
+						ilike(v2Workspaces.branch, searchPattern),
+					)
+				: undefined;
 
 			const rows = await db
 				.select({
@@ -147,6 +158,13 @@ export const v2WorkspaceRouter = {
 						eq(v2Workspaces.organizationId, input.organizationId),
 						eq(v2UsersHosts.userId, ctx.userId),
 						input.hostId ? eq(v2Workspaces.hostId, input.hostId) : undefined,
+						input.projectId
+							? eq(v2Workspaces.projectId, input.projectId)
+							: undefined,
+						input.projectName
+							? ilike(v2Projects.name, input.projectName)
+							: undefined,
+						searchMatch,
 					),
 				);
 


### PR DESCRIPTION
## Summary
- `superset workspaces list` was getting long once you've accumulated workspaces across multiple projects.
- Adds `--project <name|uuid>` — case-insensitive exact name match, UUID-shape input routed to `projectId`. Project slugs aren't surfaced anywhere in the UI, so name (as shown in the desktop sidebar) is the natural ergonomic key.
- Adds `--search <substring>` / `-s` — matches workspace name OR branch as `%pattern%`, same shape as the existing `tasks list --search`.
- Extends `v2Workspace.list` tRPC input and `@superset/sdk` `WorkspaceListParams` in lockstep so the SDK keeps mirroring the CLI 1:1.

## Test plan
Verified against the local API with three projects (Superset, openclaw, mastra-superset) and ~30 workspaces:
- [x] `--project openclaw` → only the 1 openclaw row
- [x] `--project SUPERSET` (uppercase) → Superset rows (case-insensitive name match)
- [x] `--project 9ee3c9b7-…` (UUID) → routed to `projectId`, returned the openclaw row
- [x] `--search cli` → 3 workspaces, all matching name or branch substring (`cli-deep-links`, `cli-filtering-options`, `align-sdk-cli-mcp-…`)
- [x] `--project Superset --search cli` → AND-composes correctly
- [x] `--project DoesNotExist` / `--search xyzqqzxyz` → `[]`
- [x] `bun run lint`, `bun run typecheck` both clean across the monorepo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--project` and `--search` filters to `superset workspaces list` to quickly narrow workspaces. Also hardens server-side filtering to ensure exact project-name matches and safe substring search.

- **New Features**
  - `--project <name|uuid>` filters by project; case-insensitive exact name match, or UUID routed to `projectId`.
  - `--search <substring>` / `-s` matches workspace name or branch and composes with `--host`/`--local`.
  - Added `projectId`, `projectName`, and `search` to `v2Workspace.list` and `@superset/sdk` `WorkspaceListParams`.

- **Bug Fixes**
  - Escape `\`, `%`, and `_` in `search` before `ILIKE` to prevent unintended wildcards.
  - Use `lower(name) = lower(input)` for `projectName` to enforce true exact match.

<sup>Written for commit 1004a0caf34a3cf263ef32b1ff26212ad20ca2a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace filtering: filter by project ID (UUID), project name, or perform text searches across workspace names and branches.
  * CLI improvements: the --project option now accepts either a UUID (treated as project ID) or a name (treated as project name), and a --search option is supported for substring matches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4455)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->