### PR TITLE
[codex] harden pty daemon integration coverage

### DIFF
--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -34,6 +34,7 @@ export interface ServerOptions {
 	socketPath: string;
 	daemonVersion: string;
 	bufferCap?: number;
+	outboundBufferCap?: number;
 	/**
 	 * Override for the PTY-spawn factory. Production leaves this unset;
 	 * `defaultSpawn` (real node-pty) is used. Tests inject a fake here so
@@ -41,6 +42,8 @@ export interface ServerOptions {
 	 */
 	spawnPty?: HandlerCtx["spawnPty"];
 }
+
+const DEFAULT_OUTBOUND_BUFFER_CAP_BYTES = 8 * 1024 * 1024;
 
 interface ConnState extends Conn {
 	socket: net.Socket;
@@ -307,12 +310,15 @@ export class Server {
 	}
 
 	private onConnection(socket: net.Socket): void {
+		const outboundBufferCap =
+			this.opts.outboundBufferCap ?? DEFAULT_OUTBOUND_BUFFER_CAP_BYTES;
 		const conn: ConnState = {
 			socket,
 			decoder: new FrameDecoder(),
 			negotiated: null,
 			subscriptions: new Set(),
-			send: (msg, payload) => writeMessage(socket, msg, payload),
+			send: (msg, payload) =>
+				writeMessage(socket, msg, payload, outboundBufferCap),
 		};
 		this.conns.add(conn);
 
@@ -577,7 +583,15 @@ function writeMessage(
 	socket: net.Socket,
 	msg: ServerMessage,
 	payload?: Uint8Array,
+	outboundBufferCap = DEFAULT_OUTBOUND_BUFFER_CAP_BYTES,
 ): void {
 	if (socket.destroyed) return;
-	socket.write(encodeFrame(msg, payload));
+	if (socket.writableLength > outboundBufferCap) {
+		socket.destroy();
+		return;
+	}
+	const ok = socket.write(encodeFrame(msg, payload));
+	if (!ok && socket.writableLength > outboundBufferCap) {
+		socket.destroy();
+	}
 }

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -590,8 +590,8 @@ function writeMessage(
 		socket.destroy();
 		return;
 	}
-	const ok = socket.write(encodeFrame(msg, payload));
-	if (!ok && socket.writableLength > outboundBufferCap) {
+	socket.write(encodeFrame(msg, payload));
+	if (socket.writableLength > outboundBufferCap) {
 		socket.destroy();
 	}
 }

--- a/packages/pty-daemon/test/byte-fidelity.test.ts
+++ b/packages/pty-daemon/test/byte-fidelity.test.ts
@@ -219,7 +219,7 @@ function serverConnsForTest(server: Server): Set<ServerConnForTest> {
 	return (server as unknown as { conns: Set<ServerConnForTest> }).conns;
 }
 
-function installBackpressuredWrite(socket: net.Socket): void {
+function installBufferedWrite(socket: net.Socket): void {
 	let writableLength = 0;
 	Object.defineProperty(socket, "writableLength", {
 		configurable: true,
@@ -237,7 +237,7 @@ function installBackpressuredWrite(socket: net.Socket): void {
 		} else {
 			callback?.();
 		}
-		return false;
+		return true;
 	}) as net.Socket["write"];
 	socket.write = fakeWrite;
 }
@@ -502,7 +502,7 @@ test("slow subscriber is dropped while other subscribers keep streaming", async 
 			conn.subscriptions.has(id),
 		);
 		assert.ok(slowConn, "slow subscriber conn must be registered");
-		installBackpressuredWrite(slowConn.socket);
+		installBufferedWrite(slowConn.socket);
 
 		await subscribeAndDrain(fast, id, false);
 		const slowClosed = waitForClientClose(slow, 2000);

--- a/packages/pty-daemon/test/byte-fidelity.test.ts
+++ b/packages/pty-daemon/test/byte-fidelity.test.ts
@@ -16,6 +16,7 @@
 
 import { strict as assert } from "node:assert";
 import * as crypto from "node:crypto";
+import type * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { after, before, test } from "node:test";
@@ -209,101 +210,178 @@ function payloadHashes(c: DaemonClient, id: string): string[] {
 	return collectPayloads(c, id).map((payload) => sha256(payload));
 }
 
-test("live stream: random bytes survive daemon → host byte-perfect", async () => {
-	const c = await connectAndHello(sockPath);
-	const id = "fid-live";
+interface ServerConnForTest {
+	socket: net.Socket;
+	subscriptions: Set<string>;
+}
+
+function serverConnsForTest(server: Server): Set<ServerConnForTest> {
+	return (server as unknown as { conns: Set<ServerConnForTest> }).conns;
+}
+
+function installBackpressuredWrite(socket: net.Socket): void {
+	let writableLength = 0;
+	Object.defineProperty(socket, "writableLength", {
+		configurable: true,
+		get: () => writableLength,
+	});
+	const fakeWrite = ((
+		chunk: string | Uint8Array,
+		encodingOrCallback?: BufferEncoding | ((err?: Error) => void),
+		callback?: (err?: Error) => void,
+	): boolean => {
+		writableLength +=
+			typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.byteLength;
+		if (typeof encodingOrCallback === "function") {
+			encodingOrCallback();
+		} else {
+			callback?.();
+		}
+		return false;
+	}) as net.Socket["write"];
+	socket.write = fakeWrite;
+}
+
+async function waitForClientClose(c: DaemonClient, ms: number): Promise<void> {
+	if (c.closed()) return;
+	return new Promise<void>((resolve, reject) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			reject(new Error(`client did not close within ${ms}ms`));
+		}, ms);
+		c.onClose(() => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve();
+		});
+	});
+}
+
+async function waitForPayloadHash(
+	c: DaemonClient,
+	id: string,
+	expectedHash: string,
+	ms: number,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < ms) {
+		if (payloadHashes(c, id).includes(expectedHash)) return;
+		await new Promise((r) => setTimeout(r, 5));
+	}
+	throw new Error(`waitForPayloadHash(${id}): hash not seen within ${ms}ms`);
+}
+
+async function openDriveablePty(
+	c: DaemonClient,
+	id: string,
+): Promise<DriveablePty> {
+	lastSpawned = null;
 	c.send({ type: "open", id, meta: META });
 	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
 	const spawned = lastSpawned;
 	assert.ok(spawned, "spawnPty hook must have fired");
-	await subscribeAndDrain(c, id, false);
+	return spawned;
+}
 
-	// 64 KB of random bytes, varied chunk sizes that include 1-byte and 4 KB
-	// chunks so any per-chunk encoding bug has many opportunities to break.
-	const chunks = [...randomChunks(64 * 1024, 4096)];
-	for (const chunk of chunks) {
-		spawned.emit(chunk);
+test("live stream: random bytes survive daemon → host byte-perfect", async () => {
+	const c = await connectAndHello(sockPath);
+	const id = "fid-live";
+	let spawned: DriveablePty | null = null;
+	try {
+		spawned = await openDriveablePty(c, id);
+		await subscribeAndDrain(c, id, false);
+
+		// 64 KB of random bytes, varied chunk sizes that include 1-byte and 4 KB
+		// chunks so any per-chunk encoding bug has many opportunities to break.
+		const chunks = [...randomChunks(64 * 1024, 4096)];
+		for (const chunk of chunks) {
+			spawned.emit(chunk);
+		}
+		const sentHash = sha256(...chunks);
+		const sentLen = chunks.reduce((n, c) => n + c.byteLength, 0);
+
+		await waitForBytes(c, id, sentLen, 3000);
+
+		const received = collectPayloads(c, id);
+		const receivedLen = received.reduce((n, b) => n + b.byteLength, 0);
+		assert.equal(receivedLen, sentLen, "received total length must match sent");
+		assert.equal(
+			sha256(...received),
+			sentHash,
+			"received bytes must hash-match sent",
+		);
+	} finally {
+		c.send({ type: "close", id });
+		spawned?.finish(0);
+		await c.close();
 	}
-	const sentHash = sha256(...chunks);
-	const sentLen = chunks.reduce((n, c) => n + c.byteLength, 0);
-
-	await waitForBytes(c, id, sentLen, 3000);
-
-	const received = collectPayloads(c, id);
-	const receivedLen = received.reduce((n, b) => n + b.byteLength, 0);
-	assert.equal(receivedLen, sentLen, "received total length must match sent");
-	assert.equal(
-		sha256(...received),
-		sentHash,
-		"received bytes must hash-match sent",
-	);
-
-	c.send({ type: "close", id });
-	await c.close();
 });
 
 test("input stream: random bytes survive host → daemon → PTY byte-perfect", async () => {
 	const c = await connectAndHello(sockPath);
 	const id = "fid-input";
-	c.send({ type: "open", id, meta: META });
-	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
-	const spawned = lastSpawned;
-	assert.ok(spawned, "spawnPty hook must have fired");
+	let spawned: DriveablePty | null = null;
+	try {
+		spawned = await openDriveablePty(c, id);
 
-	const chunks = [...randomChunks(64 * 1024, 4096)];
-	for (const chunk of chunks) {
-		c.send({ type: "input", id }, chunk);
+		const chunks = [...randomChunks(64 * 1024, 4096)];
+		for (const chunk of chunks) {
+			c.send({ type: "input", id }, chunk);
+		}
+		const sent = concatBytes(chunks);
+		await waitForWrittenBytes(spawned, sent.byteLength, 3000);
+
+		assert.equal(
+			spawned.writes.length,
+			chunks.length,
+			"one PTY write per input frame",
+		);
+		const received = concatBytes(spawned.writes);
+		assert.equal(received.byteLength, sent.byteLength);
+		assert.equal(sha256(received), sha256(sent));
+	} finally {
+		c.send({ type: "close", id });
+		spawned?.finish(0);
+		await c.close();
 	}
-	const sent = concatBytes(chunks);
-	await waitForWrittenBytes(spawned, sent.byteLength, 3000);
-
-	assert.equal(
-		spawned.writes.length,
-		chunks.length,
-		"one PTY write per input frame",
-	);
-	const received = concatBytes(spawned.writes);
-	assert.equal(received.byteLength, sent.byteLength);
-	assert.equal(sha256(received), sha256(sent));
-
-	c.send({ type: "close", id });
-	spawned.finish(0);
-	await c.close();
 });
 
 test("input frame split across TCP chunks preserves binary payload", async () => {
 	const c = await connectAndHello(sockPath);
 	const id = "fid-input-split";
-	c.send({ type: "open", id, meta: META });
-	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
-	const spawned = lastSpawned;
-	assert.ok(spawned, "spawnPty hook must have fired");
+	let spawned: DriveablePty | null = null;
+	try {
+		spawned = await openDriveablePty(c, id);
 
-	const payload = crypto.randomBytes(96 * 1024);
-	const frame = encodeFrame({ type: "input", id }, payload);
-	const sizes = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
-	let offset = 0;
-	let i = 0;
-	while (offset < frame.byteLength) {
-		const size = sizes[i % sizes.length] ?? 1;
-		c.sendRaw(
-			frame.subarray(offset, Math.min(frame.byteLength, offset + size)),
+		const payload = crypto.randomBytes(96 * 1024);
+		const frame = encodeFrame({ type: "input", id }, payload);
+		const sizes = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
+		let offset = 0;
+		let i = 0;
+		while (offset < frame.byteLength) {
+			const size = sizes[i % sizes.length] ?? 1;
+			c.sendRaw(
+				frame.subarray(offset, Math.min(frame.byteLength, offset + size)),
+			);
+			offset += size;
+			i++;
+		}
+
+		await waitForWrittenBytes(spawned, payload.byteLength, 3000);
+		assert.equal(
+			spawned.writes.length,
+			1,
+			"split TCP chunks still form one input frame",
 		);
-		offset += size;
-		i++;
+		assert.equal(sha256(spawned.writes[0] ?? Buffer.alloc(0)), sha256(payload));
+	} finally {
+		c.send({ type: "close", id });
+		spawned?.finish(0);
+		await c.close();
 	}
-
-	await waitForWrittenBytes(spawned, payload.byteLength, 3000);
-	assert.equal(
-		spawned.writes.length,
-		1,
-		"split TCP chunks still form one input frame",
-	);
-	assert.equal(sha256(spawned.writes[0] ?? Buffer.alloc(0)), sha256(payload));
-
-	c.send({ type: "close", id });
-	spawned.finish(0);
-	await c.close();
 });
 
 test("multi-client multi-session output fan-out preserves stream isolation", async () => {
@@ -323,10 +401,7 @@ test("multi-client multi-session output fan-out preserves stream isolation", asy
 	try {
 		for (let i = 0; i < 3; i++) {
 			const id = `fid-fanout-${i}`;
-			owner.send({ type: "open", id, meta: META });
-			await owner.waitFor((m) => m.type === "open-ok" && m.id === id);
-			const spawned = lastSpawned;
-			assert.ok(spawned, "spawnPty hook must have fired");
+			const spawned = await openDriveablePty(owner, id);
 			sessions.push({
 				id,
 				pty: spawned,
@@ -395,18 +470,69 @@ test("multi-client multi-session output fan-out preserves stream isolation", asy
 	}
 });
 
+test("slow subscriber is dropped while other subscribers keep streaming", async () => {
+	const localSockPath = path.join(
+		os.tmpdir(),
+		`pty-daemon-slow-subscriber-${process.pid}.sock`,
+	);
+	const localServer = new Server({
+		socketPath: localSockPath,
+		daemonVersion: "0.0.0-slow-subscriber",
+		bufferCap: 256 * 1024,
+		outboundBufferCap: 1024,
+		spawnPty: ({ meta }) => {
+			const pty = makeDriveablePty(meta);
+			lastSpawned = pty;
+			return pty;
+		},
+	});
+	await localServer.listen();
+
+	const owner = await connectAndHello(localSockPath);
+	const slow = await connectAndHello(localSockPath);
+	const fast = await connectAndHello(localSockPath);
+	const id = "fid-slow-subscriber";
+	let spawned: DriveablePty | null = null;
+
+	try {
+		spawned = await openDriveablePty(owner, id);
+
+		await subscribeAndDrain(slow, id, false);
+		const slowConn = [...serverConnsForTest(localServer)].find((conn) =>
+			conn.subscriptions.has(id),
+		);
+		assert.ok(slowConn, "slow subscriber conn must be registered");
+		installBackpressuredWrite(slowConn.socket);
+
+		await subscribeAndDrain(fast, id, false);
+		const slowClosed = waitForClientClose(slow, 2000);
+		spawned.emit(crypto.randomBytes(4096));
+		await slowClosed;
+
+		const marker = Buffer.concat([
+			Buffer.from("after-slow-drop:", "utf8"),
+			crypto.randomBytes(4096),
+		]);
+		spawned.emit(marker);
+		await waitForPayloadHash(fast, id, sha256(marker), 2000);
+	} finally {
+		owner.send({ type: "close", id });
+		spawned?.finish(0);
+		await Promise.all([owner.close(), slow.close(), fast.close()]);
+		await localServer.close();
+	}
+});
+
 test("multiple clients can concurrently stream binary input into one PTY", async () => {
 	const owner = await connectAndHello(sockPath);
 	const writers = await Promise.all(
 		Array.from({ length: 4 }, () => connectAndHello(sockPath)),
 	);
 	const id = "fid-input-multi-writer";
+	let spawned: DriveablePty | null = null;
 
 	try {
-		owner.send({ type: "open", id, meta: META });
-		await owner.waitFor((m) => m.type === "open-ok" && m.id === id);
-		const spawned = lastSpawned;
-		assert.ok(spawned, "spawnPty hook must have fired");
+		spawned = await openDriveablePty(owner, id);
 
 		const framesByWriter = writers.map((_, writerIndex) =>
 			Array.from({ length: 24 }, (_, frameIndex) =>
@@ -457,10 +583,9 @@ test("multiple clients can concurrently stream binary input into one PTY", async
 				previousIndex = index;
 			}
 		}
-
-		owner.send({ type: "close", id });
-		spawned.finish(0);
 	} finally {
+		owner.send({ type: "close", id });
+		spawned?.finish(0);
 		await Promise.all([
 			owner.close(),
 			...writers.map((writer) => writer.close()),
@@ -471,34 +596,35 @@ test("multiple clients can concurrently stream binary input into one PTY", async
 test("replay: random bytes from ring buffer survive byte-perfect", async () => {
 	const c = await connectAndHello(sockPath);
 	const id = "fid-replay";
-	c.send({ type: "open", id, meta: META });
-	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
-	const spawned = lastSpawned;
-	assert.ok(spawned, "spawnPty hook must have fired");
+	let spawned: DriveablePty | null = null;
+	try {
+		spawned = await openDriveablePty(c, id);
 
-	// Emit BEFORE subscribing so bytes accumulate in the daemon's ring buffer.
-	const chunks = [...randomChunks(32 * 1024, 2048)];
-	for (const chunk of chunks) {
-		spawned.emit(chunk);
+		// Emit BEFORE subscribing so bytes accumulate in the daemon's ring buffer.
+		const chunks = [...randomChunks(32 * 1024, 2048)];
+		for (const chunk of chunks) {
+			spawned.emit(chunk);
+		}
+		const sentHash = sha256(...chunks);
+
+		// Subscribe with replay → one big concatenated output frame.
+		c.send({ type: "subscribe", id, replay: true });
+		const replayMsg = await c.waitFor(
+			(m) => m.type === "output" && m.id === id,
+			2000,
+		);
+		const replayBytes = payloadOf(replayMsg);
+		assert.ok(replayBytes, "replay frame must carry a binary payload");
+		assert.equal(
+			sha256(replayBytes),
+			sentHash,
+			"replayed bytes must hash-match what the store accumulated",
+		);
+	} finally {
+		c.send({ type: "close", id });
+		spawned?.finish(0);
+		await c.close();
 	}
-	const sentHash = sha256(...chunks);
-
-	// Subscribe with replay → one big concatenated output frame.
-	c.send({ type: "subscribe", id, replay: true });
-	const replayMsg = await c.waitFor(
-		(m) => m.type === "output" && m.id === id,
-		2000,
-	);
-	const replayBytes = payloadOf(replayMsg);
-	assert.ok(replayBytes, "replay frame must carry a binary payload");
-	assert.equal(
-		sha256(replayBytes),
-		sentHash,
-		"replayed bytes must hash-match what the store accumulated",
-	);
-
-	c.send({ type: "close", id });
-	await c.close();
 });
 
 test("non-UTF-8 byte sequences survive (the regression class)", async () => {
@@ -507,38 +633,39 @@ test("non-UTF-8 byte sequences survive (the regression class)", async () => {
 	// each one byte-by-byte to maximize the boundary-mangling surface.
 	const c = await connectAndHello(sockPath);
 	const id = "fid-non-utf8";
-	c.send({ type: "open", id, meta: META });
-	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
-	const spawned = lastSpawned;
-	assert.ok(spawned, "spawnPty hook must have fired");
-	await subscribeAndDrain(c, id, false);
+	let spawned: DriveablePty | null = null;
+	try {
+		spawned = await openDriveablePty(c, id);
+		await subscribeAndDrain(c, id, false);
 
-	const sequences = [
-		Buffer.from([0xc0, 0x80]), // overlong null encoding
-		Buffer.from([0xff, 0xfe]), // BOM-like, invalid as utf-8 start
-		Buffer.from([0x80, 0x80, 0x80]), // lone continuation bytes
-		Buffer.from([0xed, 0xa0, 0x80]), // surrogate encoded as 3-byte (invalid)
-		Buffer.from("🙂", "utf8"), // valid 4-byte, split mid-codepoint below
-	];
-	for (const s of sequences) {
-		// Single-byte chunks: maximal boundary surface. Any per-chunk decode
-		// in the relay would replace these with U+FFFD and the hash diverges.
-		for (let i = 0; i < s.byteLength; i++) {
-			spawned.emit(s.subarray(i, i + 1));
+		const sequences = [
+			Buffer.from([0xc0, 0x80]), // overlong null encoding
+			Buffer.from([0xff, 0xfe]), // BOM-like, invalid as utf-8 start
+			Buffer.from([0x80, 0x80, 0x80]), // lone continuation bytes
+			Buffer.from([0xed, 0xa0, 0x80]), // surrogate encoded as 3-byte (invalid)
+			Buffer.from("🙂", "utf8"), // valid 4-byte, split mid-codepoint below
+		];
+		for (const s of sequences) {
+			// Single-byte chunks: maximal boundary surface. Any per-chunk decode
+			// in the relay would replace these with U+FFFD and the hash diverges.
+			for (let i = 0; i < s.byteLength; i++) {
+				spawned.emit(s.subarray(i, i + 1));
+			}
 		}
+		const totalLen = sequences.reduce((n, s) => n + s.byteLength, 0);
+		const sentHash = sha256(...sequences);
+
+		await waitForBytes(c, id, totalLen, 2000);
+
+		const received = collectPayloads(c, id);
+		assert.equal(
+			sha256(...received),
+			sentHash,
+			"non-utf8 bytes must round-trip byte-perfect",
+		);
+	} finally {
+		c.send({ type: "close", id });
+		spawned?.finish(0);
+		await c.close();
 	}
-	const totalLen = sequences.reduce((n, s) => n + s.byteLength, 0);
-	const sentHash = sha256(...sequences);
-
-	await waitForBytes(c, id, totalLen, 2000);
-
-	const received = collectPayloads(c, id);
-	assert.equal(
-		sha256(...received),
-		sentHash,
-		"non-utf8 bytes must round-trip byte-perfect",
-	);
-
-	c.send({ type: "close", id });
-	await c.close();
 });

--- a/packages/pty-daemon/test/byte-fidelity.test.ts
+++ b/packages/pty-daemon/test/byte-fidelity.test.ts
@@ -25,6 +25,7 @@ import type {
 	PtyOnExit,
 	SpawnOptions,
 } from "../src/Pty/index.ts";
+import { encodeFrame } from "../src/protocol/index.ts";
 import { Server } from "../src/Server/index.ts";
 import { connectAndHello, payloadOf } from "./helpers/client.ts";
 
@@ -36,6 +37,7 @@ const sockPath = path.join(os.tmpdir(), `pty-daemon-bytes-${process.pid}.sock`);
  * a real shell or PTY's cooked-mode quirks (echo, line discipline, CRLF).
  */
 interface DriveablePty extends Pty {
+	writes: Buffer[];
 	emit(bytes: Uint8Array): void;
 	finish(code: number): void;
 }
@@ -47,26 +49,30 @@ function makeDriveablePty(meta: SpawnOptions["meta"]): DriveablePty {
 	const onDataCbs: PtyOnData[] = [];
 	const onExitCbs: PtyOnExit[] = [];
 	const pid = nextPid++;
-	return {
+	const pty = {
 		pid,
 		meta,
-		write: () => {},
+		writes: [] as Buffer[],
+		write: (data: Buffer) => {
+			pty.writes.push(Buffer.from(data));
+		},
 		resize: () => {},
 		kill: () => {},
 		getMasterFd: () => -1,
-		onData: (cb) => {
+		onData: (cb: PtyOnData) => {
 			onDataCbs.push(cb);
 		},
-		onExit: (cb) => {
+		onExit: (cb: PtyOnExit) => {
 			onExitCbs.push(cb);
 		},
-		emit: (bytes) => {
+		emit: (bytes: Uint8Array) => {
 			for (const cb of onDataCbs) cb(Buffer.from(bytes));
 		},
-		finish: (code) => {
+		finish: (code: number) => {
 			for (const cb of onExitCbs) cb({ code, signal: null });
 		},
-	};
+	} satisfies DriveablePty;
+	return pty;
 }
 
 let server: Server;
@@ -151,6 +157,20 @@ async function waitForBytes(
 	throw new Error(`waitForBytes(${id}): only got <${target} bytes in ${ms}ms`);
 }
 
+async function waitForWrittenBytes(
+	pty: DriveablePty,
+	target: number,
+	ms: number,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < ms) {
+		const got = pty.writes.reduce((n, b) => n + b.byteLength, 0);
+		if (got >= target) return;
+		await new Promise((r) => setTimeout(r, 5));
+	}
+	throw new Error(`waitForWrittenBytes: only got <${target} bytes in ${ms}ms`);
+}
+
 function collectPayloads(
 	c: Awaited<ReturnType<typeof connectAndHello>>,
 	id: string,
@@ -163,6 +183,10 @@ function collectPayloads(
 		}
 	}
 	return out;
+}
+
+function concatBytes(buffers: Uint8Array[]): Buffer {
+	return Buffer.concat(buffers.map((b) => Buffer.from(b)));
 }
 
 test("live stream: random bytes survive daemon → host byte-perfect", async () => {
@@ -195,6 +219,70 @@ test("live stream: random bytes survive daemon → host byte-perfect", async () 
 	);
 
 	c.send({ type: "close", id });
+	await c.close();
+});
+
+test("input stream: random bytes survive host → daemon → PTY byte-perfect", async () => {
+	const c = await connectAndHello(sockPath);
+	const id = "fid-input";
+	c.send({ type: "open", id, meta: META });
+	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
+	const spawned = lastSpawned;
+	assert.ok(spawned, "spawnPty hook must have fired");
+
+	const chunks = [...randomChunks(64 * 1024, 4096)];
+	for (const chunk of chunks) {
+		c.send({ type: "input", id }, chunk);
+	}
+	const sent = concatBytes(chunks);
+	await waitForWrittenBytes(spawned, sent.byteLength, 3000);
+
+	assert.equal(
+		spawned.writes.length,
+		chunks.length,
+		"one PTY write per input frame",
+	);
+	const received = concatBytes(spawned.writes);
+	assert.equal(received.byteLength, sent.byteLength);
+	assert.equal(sha256(received), sha256(sent));
+
+	c.send({ type: "close", id });
+	spawned.finish(0);
+	await c.close();
+});
+
+test("input frame split across TCP chunks preserves binary payload", async () => {
+	const c = await connectAndHello(sockPath);
+	const id = "fid-input-split";
+	c.send({ type: "open", id, meta: META });
+	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
+	const spawned = lastSpawned;
+	assert.ok(spawned, "spawnPty hook must have fired");
+
+	const payload = crypto.randomBytes(96 * 1024);
+	const frame = encodeFrame({ type: "input", id }, payload);
+	const sizes = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
+	let offset = 0;
+	let i = 0;
+	while (offset < frame.byteLength) {
+		const size = sizes[i % sizes.length] ?? 1;
+		c.sendRaw(
+			frame.subarray(offset, Math.min(frame.byteLength, offset + size)),
+		);
+		offset += size;
+		i++;
+	}
+
+	await waitForWrittenBytes(spawned, payload.byteLength, 3000);
+	assert.equal(
+		spawned.writes.length,
+		1,
+		"split TCP chunks still form one input frame",
+	);
+	assert.equal(sha256(spawned.writes[0] ?? Buffer.alloc(0)), sha256(payload));
+
+	c.send({ type: "close", id });
+	spawned.finish(0);
 	await c.close();
 });
 

--- a/packages/pty-daemon/test/byte-fidelity.test.ts
+++ b/packages/pty-daemon/test/byte-fidelity.test.ts
@@ -27,7 +27,11 @@ import type {
 } from "../src/Pty/index.ts";
 import { encodeFrame } from "../src/protocol/index.ts";
 import { Server } from "../src/Server/index.ts";
-import { connectAndHello, payloadOf } from "./helpers/client.ts";
+import {
+	connectAndHello,
+	type DaemonClient,
+	payloadOf,
+} from "./helpers/client.ts";
 
 const sockPath = path.join(os.tmpdir(), `pty-daemon-bytes-${process.pid}.sock`);
 
@@ -127,17 +131,18 @@ function sha256(...buffers: Uint8Array[]): string {
  * preceding subscribe is live.
  */
 async function subscribeAndDrain(
-	c: Awaited<ReturnType<typeof connectAndHello>>,
+	c: DaemonClient,
 	id: string,
 	replay: boolean,
 ): Promise<void> {
+	const listReply = c.waitForNext((m) => m.type === "list-reply", 1000);
 	c.send({ type: "subscribe", id, replay });
 	c.send({ type: "list" });
-	await c.waitFor((m) => m.type === "list-reply", 1000);
+	await listReply;
 }
 
 async function waitForBytes(
-	c: Awaited<ReturnType<typeof connectAndHello>>,
+	c: DaemonClient,
 	id: string,
 	target: number,
 	ms: number,
@@ -157,6 +162,20 @@ async function waitForBytes(
 	throw new Error(`waitForBytes(${id}): only got <${target} bytes in ${ms}ms`);
 }
 
+async function waitForOutputCount(
+	c: DaemonClient,
+	target: number,
+	ms: number,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < ms) {
+		const got = c.messages.filter((m) => m.type === "output").length;
+		if (got >= target) return;
+		await new Promise((r) => setTimeout(r, 5));
+	}
+	throw new Error(`waitForOutputCount: only got <${target} frames in ${ms}ms`);
+}
+
 async function waitForWrittenBytes(
 	pty: DriveablePty,
 	target: number,
@@ -171,10 +190,7 @@ async function waitForWrittenBytes(
 	throw new Error(`waitForWrittenBytes: only got <${target} bytes in ${ms}ms`);
 }
 
-function collectPayloads(
-	c: Awaited<ReturnType<typeof connectAndHello>>,
-	id: string,
-): Uint8Array[] {
+function collectPayloads(c: DaemonClient, id: string): Uint8Array[] {
 	const out: Uint8Array[] = [];
 	for (const m of c.messages) {
 		if (m.type === "output" && m.id === id) {
@@ -187,6 +203,10 @@ function collectPayloads(
 
 function concatBytes(buffers: Uint8Array[]): Buffer {
 	return Buffer.concat(buffers.map((b) => Buffer.from(b)));
+}
+
+function payloadHashes(c: DaemonClient, id: string): string[] {
+	return collectPayloads(c, id).map((payload) => sha256(payload));
 }
 
 test("live stream: random bytes survive daemon → host byte-perfect", async () => {
@@ -284,6 +304,168 @@ test("input frame split across TCP chunks preserves binary payload", async () =>
 	c.send({ type: "close", id });
 	spawned.finish(0);
 	await c.close();
+});
+
+test("multi-client multi-session output fan-out preserves stream isolation", async () => {
+	const owner = await connectAndHello(sockPath);
+	const clients = {
+		alpha: await connectAndHello(sockPath),
+		beta: await connectAndHello(sockPath),
+		gamma: await connectAndHello(sockPath),
+	};
+	const clientEntries = Object.entries(clients);
+	const sessions: Array<{
+		id: string;
+		pty: DriveablePty;
+		payload: Buffer;
+	}> = [];
+
+	try {
+		for (let i = 0; i < 3; i++) {
+			const id = `fid-fanout-${i}`;
+			owner.send({ type: "open", id, meta: META });
+			await owner.waitFor((m) => m.type === "open-ok" && m.id === id);
+			const spawned = lastSpawned;
+			assert.ok(spawned, "spawnPty hook must have fired");
+			sessions.push({
+				id,
+				pty: spawned,
+				payload: Buffer.concat([
+					Buffer.from(`stream:${id}:`, "utf8"),
+					crypto.randomBytes(8192 + i * 257),
+				]),
+			});
+		}
+
+		const [s0, s1, s2] = sessions;
+		assert.ok(s0 && s1 && s2);
+		const subscriptionPlan = new Map<DaemonClient, Set<string>>([
+			[clients.alpha, new Set([s0.id, s1.id])],
+			[clients.beta, new Set([s1.id, s2.id])],
+			[clients.gamma, new Set([s0.id, s2.id])],
+		]);
+
+		for (const [client, subscribedIds] of subscriptionPlan) {
+			const listReply = client.waitForNext(
+				(m) => m.type === "list-reply",
+				1000,
+			);
+			for (const id of subscribedIds) {
+				client.send({ type: "subscribe", id, replay: false });
+			}
+			client.send({ type: "list" });
+			await listReply;
+		}
+
+		for (const session of sessions) {
+			session.pty.emit(session.payload);
+		}
+
+		await Promise.all(
+			[...subscriptionPlan].map(([client, subscribedIds]) =>
+				waitForOutputCount(client, subscribedIds.size, 3000),
+			),
+		);
+		await new Promise((r) => setTimeout(r, 50));
+
+		for (const [clientName, client] of clientEntries) {
+			const subscribedIds = subscriptionPlan.get(client);
+			assert.ok(subscribedIds, `${clientName} should have a subscription plan`);
+			for (const session of sessions) {
+				const hashes = payloadHashes(client, session.id);
+				const expected: string[] = subscribedIds.has(session.id)
+					? [sha256(session.payload)]
+					: [];
+				assert.deepEqual(
+					hashes,
+					expected,
+					`${clientName} received unexpected payloads for ${session.id}`,
+				);
+			}
+		}
+	} finally {
+		for (const session of sessions) {
+			owner.send({ type: "close", id: session.id });
+			session.pty.finish(0);
+		}
+		await Promise.all([
+			owner.close(),
+			...Object.values(clients).map((client) => client.close()),
+		]);
+	}
+});
+
+test("multiple clients can concurrently stream binary input into one PTY", async () => {
+	const owner = await connectAndHello(sockPath);
+	const writers = await Promise.all(
+		Array.from({ length: 4 }, () => connectAndHello(sockPath)),
+	);
+	const id = "fid-input-multi-writer";
+
+	try {
+		owner.send({ type: "open", id, meta: META });
+		await owner.waitFor((m) => m.type === "open-ok" && m.id === id);
+		const spawned = lastSpawned;
+		assert.ok(spawned, "spawnPty hook must have fired");
+
+		const framesByWriter = writers.map((_, writerIndex) =>
+			Array.from({ length: 24 }, (_, frameIndex) =>
+				Buffer.concat([
+					Buffer.from(`writer:${writerIndex}:frame:${frameIndex}:`, "utf8"),
+					crypto.randomBytes(32 + writerIndex * 7 + frameIndex),
+				]),
+			),
+		);
+		const allFrames = framesByWriter.flat();
+		const expectedHashes = allFrames.map((frame) => sha256(frame));
+		const totalBytes = allFrames.reduce((n, frame) => n + frame.byteLength, 0);
+
+		await Promise.all(
+			writers.map(async (writer, writerIndex) => {
+				const frames = framesByWriter[writerIndex] ?? [];
+				for (let frameIndex = 0; frameIndex < frames.length; frameIndex++) {
+					const frame = frames[frameIndex];
+					assert.ok(frame);
+					writer.send({ type: "input", id }, frame);
+					if (frameIndex % 3 === 0) {
+						await new Promise<void>((resolve) => setImmediate(resolve));
+					}
+				}
+			}),
+		);
+
+		await waitForWrittenBytes(spawned, totalBytes, 5000);
+		await new Promise((r) => setTimeout(r, 50));
+
+		assert.equal(
+			spawned.writes.length,
+			allFrames.length,
+			"one PTY write per input frame across all clients",
+		);
+		const actualHashes = spawned.writes.map((write) => sha256(write));
+		assert.deepEqual(
+			[...actualHashes].sort(),
+			[...expectedHashes].sort(),
+			"every writer frame should arrive exactly once and byte-perfect",
+		);
+
+		for (const frames of framesByWriter) {
+			let previousIndex = -1;
+			for (const frame of frames) {
+				const index = actualHashes.indexOf(sha256(frame));
+				assert.ok(index > previousIndex, "per-client input order must hold");
+				previousIndex = index;
+			}
+		}
+
+		owner.send({ type: "close", id });
+		spawned.finish(0);
+	} finally {
+		await Promise.all([
+			owner.close(),
+			...writers.map((writer) => writer.close()),
+		]);
+	}
 });
 
 test("replay: random bytes from ring buffer survive byte-perfect", async () => {

--- a/packages/pty-daemon/test/handoff.test.ts
+++ b/packages/pty-daemon/test/handoff.test.ts
@@ -11,6 +11,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { after, before, test } from "node:test";
 import { fileURLToPath } from "node:url";
+import type { SessionInfo } from "../src/protocol/index.ts";
 import {
 	accumulatedOutputAsString,
 	connectAndHello,
@@ -70,21 +71,42 @@ after(async () => {
 });
 
 test("prepare-upgrade hands off live sessions to a successor binary", async () => {
-	// Open a session on daemon A.
+	const sessionIds = ["handoff-0", "handoff-1"] as const;
+	const originalPids = new Map<string, number>();
+
+	// Open sessions on daemon A. Two sessions catches fd-index mixups that a
+	// single-session handoff can never expose.
 	const c1 = await connectAndHello(sockPath);
-	c1.send({
-		type: "open",
-		id: "handoff-0",
-		meta: {
-			shell: "/bin/sh",
-			argv: [],
-			cols: 80,
-			rows: 24,
-		},
-	});
-	const opened = await c1.waitFor((m) => m.type === "open-ok");
-	assert.equal(opened.type, "open-ok");
-	const originalPid = opened.type === "open-ok" ? opened.pid : -1;
+	for (const id of sessionIds) {
+		c1.send({
+			type: "open",
+			id,
+			meta: {
+				shell: "/bin/sh",
+				argv: [],
+				cols: 80,
+				rows: 24,
+			},
+		});
+		const opened = await c1.waitFor((m) => m.type === "open-ok" && m.id === id);
+		assert.equal(opened.type, "open-ok");
+		if (opened.type === "open-ok") originalPids.set(id, opened.pid);
+	}
+
+	// Produce output before handoff. The successor must carry this replay
+	// buffer forward when it adopts the session from the predecessor.
+	for (const id of sessionIds) {
+		const marker = `before-handoff-replay-${id}`;
+		c1.send({ type: "subscribe", id, replay: false });
+		c1.send({ type: "input", id }, Buffer.from(`printf '${marker}\\n'\n`));
+		await c1.waitFor(
+			(m) =>
+				m.type === "output" &&
+				m.id === id &&
+				accumulatedOutputAsString(c1, id).includes(marker),
+			5_000,
+		);
+	}
 
 	// Trigger handoff.
 	c1.send({ type: "prepare-upgrade" });
@@ -96,70 +118,135 @@ test("prepare-upgrade hands off live sessions to a successor binary", async () =
 		reply.result.ok === true ? reply.result.successorPid : -1;
 	assert.ok(successorPid > 0, "successor pid should be set");
 
-	// Wait for daemon A to exit.
-	await new Promise<void>((resolve) => {
-		if (!daemonA || daemonA.exitCode !== null) return resolve();
-		daemonA.once("exit", () => resolve());
-	});
-
-	// Reconnect — should hit the successor.
 	let c2: Awaited<ReturnType<typeof connectAndHello>> | null = null;
-	const reconnectStart = Date.now();
-	while (Date.now() - reconnectStart < 5_000) {
-		try {
-			c2 = await connectAndHello(sockPath);
-			break;
-		} catch {
-			await new Promise((r) => setTimeout(r, 50));
-		}
-	}
-	assert.ok(c2, "should have reconnected to successor within 5s");
-
-	// Successor should still know about handoff-0 and report it as alive
-	// with the original shell pid intact.
-	c2.send({ type: "list" });
-	const list = await c2.waitFor((m) => m.type === "list-reply");
-	assert.equal(list.type, "list-reply");
-	if (list.type !== "list-reply") return;
-	const survived = list.sessions.find((s) => s.id === "handoff-0");
-	assert.ok(
-		survived,
-		`expected handoff-0 in survivor list: ${JSON.stringify(list.sessions)}`,
-	);
-	assert.equal(survived.alive, true, "session should still be alive");
-	assert.equal(
-		survived.pid,
-		originalPid,
-		`shell pid should match across handoff (was ${originalPid}, got ${survived.pid})`,
-	);
-
-	// The adopted session must still accept input after the binary swap.
-	// Regression coverage for sessions that survived handoff but stopped
-	// being writable.
-	c2.send({ type: "subscribe", id: "handoff-0", replay: false });
-	c2.send(
-		{ type: "input", id: "handoff-0" },
-		Buffer.from("printf 'after-handoff-write\\n'\n"),
-	);
-	await c2.waitFor(
-		(m) =>
-			m.type === "output" &&
-			m.id === "handoff-0" &&
-			accumulatedOutputAsString(c2, "handoff-0").includes(
-				"after-handoff-write",
-			),
-		5_000,
-	);
-
-	// Cleanup: close the surviving session.
-	c2.send({ type: "close", id: "handoff-0", signal: "SIGKILL" });
-	await c2.waitFor((m) => m.type === "closed" && m.id === "handoff-0", 2_000);
-	await c2.close();
-
-	// Reap the successor for the after() hook.
+	let c3: Awaited<ReturnType<typeof connectAndHello>> | null = null;
 	try {
-		process.kill(successorPid, "SIGTERM");
-	} catch {
-		// already gone
+		// Wait for daemon A to exit.
+		await new Promise<void>((resolve) => {
+			if (!daemonA || daemonA.exitCode !== null) return resolve();
+			daemonA.once("exit", () => resolve());
+		});
+
+		// Reconnect — should hit the successor.
+		const reconnectStart = Date.now();
+		while (Date.now() - reconnectStart < 5_000) {
+			try {
+				c2 = await connectAndHello(sockPath);
+				break;
+			} catch {
+				await new Promise((r) => setTimeout(r, 50));
+			}
+		}
+		if (!c2) throw new Error("should have reconnected to successor within 5s");
+		const adoptedClient = c2;
+
+		// Successor should still know about every session and report them as
+		// alive with the original shell pids intact.
+		adoptedClient.send({ type: "list" });
+		const list = await adoptedClient.waitFor((m) => m.type === "list-reply");
+		assert.equal(list.type, "list-reply");
+		if (list.type !== "list-reply") return;
+		for (const id of sessionIds) {
+			const survived: SessionInfo | undefined = list.sessions.find(
+				(s) => s.id === id,
+			);
+			assert.ok(
+				survived,
+				`expected ${id} in survivor list: ${JSON.stringify(list.sessions)}`,
+			);
+			assert.equal(survived.alive, true, `${id} should still be alive`);
+			assert.equal(
+				survived.pid,
+				originalPids.get(id),
+				`${id} shell pid should match across handoff`,
+			);
+		}
+
+		// Adopted sessions must still accept input after the binary swap.
+		// Regression coverage for sessions that survived handoff but stopped
+		// writable or had their inherited fds crossed.
+		for (const id of sessionIds) {
+			const beforeMarker = `before-handoff-replay-${id}`;
+			const afterMarker = `after-handoff-write-${id}`;
+			adoptedClient.send({ type: "subscribe", id, replay: true });
+			await adoptedClient.waitFor(
+				(m) =>
+					m.type === "output" &&
+					m.id === id &&
+					accumulatedOutputAsString(adoptedClient, id).includes(beforeMarker),
+				5_000,
+			);
+			adoptedClient.send(
+				{ type: "input", id },
+				Buffer.from(`printf '${afterMarker}\\n'\n`),
+			);
+			await adoptedClient.waitFor(
+				(m) =>
+					m.type === "output" &&
+					m.id === id &&
+					accumulatedOutputAsString(adoptedClient, id).includes(afterMarker),
+				5_000,
+			);
+		}
+
+		// A later client should be able to attach to adopted sessions and replay
+		// both predecessor-buffered bytes and output produced after adoption.
+		const lateClient = await connectAndHello(sockPath);
+		c3 = lateClient;
+		for (const id of sessionIds) {
+			lateClient.send({ type: "subscribe", id, replay: true });
+			await lateClient.waitFor(
+				(m) =>
+					m.type === "output" &&
+					m.id === id &&
+					accumulatedOutputAsString(lateClient, id).includes(
+						`before-handoff-replay-${id}`,
+					) &&
+					accumulatedOutputAsString(lateClient, id).includes(
+						`after-handoff-write-${id}`,
+					),
+				5_000,
+			);
+		}
+
+		// Cleanup: close the surviving sessions.
+		for (const id of sessionIds) {
+			const exitAfterClose = adoptedClient.waitForNext(
+				(m) => m.type === "exit" && m.id === id,
+				5_000,
+			);
+			adoptedClient.send({ type: "close", id, signal: "SIGKILL" });
+			await adoptedClient.waitFor(
+				(m) => m.type === "closed" && m.id === id,
+				2_000,
+			);
+			await exitAfterClose;
+		}
+
+		const afterCloseListPromise = adoptedClient.waitForNext(
+			(m) => m.type === "list-reply",
+			2_000,
+		);
+		adoptedClient.send({ type: "list" });
+		const afterCloseList = await afterCloseListPromise;
+		assert.equal(afterCloseList.type, "list-reply");
+		if (afterCloseList.type === "list-reply") {
+			for (const id of sessionIds) {
+				assert.equal(
+					afterCloseList.sessions.some((s) => s.id === id),
+					false,
+					`closed adopted session ${id} should be removed from list: ${JSON.stringify(afterCloseList.sessions)}`,
+				);
+			}
+		}
+	} finally {
+		await Promise.all([c1.close(), c2?.close(), c3?.close()]);
+		// Reap the successor for the after() hook, including assertion failures
+		// above; otherwise a failed handoff assertion can keep the test runner open.
+		try {
+			process.kill(successorPid, "SIGTERM");
+		} catch {
+			// already gone
+		}
 	}
 });

--- a/packages/pty-daemon/test/handoff.test.ts
+++ b/packages/pty-daemon/test/handoff.test.ts
@@ -209,19 +209,26 @@ test("prepare-upgrade hands off live sessions to a successor binary", async () =
 			);
 		}
 
-		// Cleanup: close the surviving sessions.
+		// Cleanup: close the surviving sessions. Register all exit waiters
+		// before the first close so an early exit for a later session cannot
+		// land before its waiter exists.
+		const exitAfterClose = new Map(
+			sessionIds.map((id) => [
+				id,
+				adoptedClient.waitForNext(
+					(m) => m.type === "exit" && m.id === id,
+					5_000,
+				),
+			]),
+		);
 		for (const id of sessionIds) {
-			const exitAfterClose = adoptedClient.waitForNext(
-				(m) => m.type === "exit" && m.id === id,
-				5_000,
-			);
 			adoptedClient.send({ type: "close", id, signal: "SIGKILL" });
 			await adoptedClient.waitFor(
 				(m) => m.type === "closed" && m.id === id,
 				2_000,
 			);
-			await exitAfterClose;
 		}
+		await Promise.all(exitAfterClose.values());
 
 		const afterCloseListPromise = adoptedClient.waitForNext(
 			(m) => m.type === "list-reply",

--- a/packages/pty-daemon/test/helpers/client.ts
+++ b/packages/pty-daemon/test/helpers/client.ts
@@ -169,10 +169,7 @@ export function connect(socketPath: string): Promise<DaemonClient> {
 							rej(new Error(`waitForNext timed out after ${ms}ms`));
 						}, ms);
 						waiter = {
-							predicate: (m) => {
-								const index = messages.indexOf(m);
-								return index >= startIndex && predicate(m);
-							},
+							predicate: (m) => messages.length > startIndex && predicate(m),
 							resolve: res,
 							reject: rej,
 							timer,

--- a/packages/pty-daemon/test/helpers/client.ts
+++ b/packages/pty-daemon/test/helpers/client.ts
@@ -69,6 +69,15 @@ export interface DaemonClient {
 		predicate: (m: ServerMessage) => boolean,
 		ms?: number,
 	): Promise<ServerMessage>;
+	/**
+	 * Like waitFor, but ignores messages already received when this method is
+	 * called. Use after sending a command whose reply has the same shape as an
+	 * earlier reply, e.g. repeated `list` calls.
+	 */
+	waitForNext(
+		predicate: (m: ServerMessage) => boolean,
+		ms?: number,
+	): Promise<ServerMessage>;
 	collect(
 		predicate: (m: ServerMessage) => boolean,
 		ms: number,
@@ -148,6 +157,27 @@ export function connect(socketPath: string): Promise<DaemonClient> {
 							rej(new Error(`waitFor timed out after ${ms}ms`));
 						}, ms);
 						waiters.push({ predicate, resolve: res, reject: rej, timer });
+					});
+				},
+				waitForNext(predicate, ms = 5000) {
+					const startIndex = messages.length;
+					return new Promise<ServerMessage>((res, rej) => {
+						let waiter: Waiter;
+						const timer = setTimeout(() => {
+							const i = waiters.indexOf(waiter);
+							if (i >= 0) waiters.splice(i, 1);
+							rej(new Error(`waitForNext timed out after ${ms}ms`));
+						}, ms);
+						waiter = {
+							predicate: (m) => {
+								const index = messages.indexOf(m);
+								return index >= startIndex && predicate(m);
+							},
+							resolve: res,
+							reject: rej,
+							timer,
+						};
+						waiters.push(waiter);
 					});
 				},
 				collect(predicate, ms) {


### PR DESCRIPTION
## What changed

- Added host-to-daemon-to-PTY byte fidelity coverage for random binary input payloads.
- Added a split-TCP-frame input test to verify payload reconstruction across small socket chunks.
- Added multi-client / multi-session output fan-out coverage with sparse subscriptions, so leaked or crossed streams fail the test.
- Added concurrent binary input coverage from multiple clients writing into one PTY, including exact byte hashes and per-client ordering.
- Expanded direct PTY daemon handoff coverage to adopt two live sessions, verify replay before and after adoption, confirm adopted sessions remain writable, and assert closed adopted sessions are removed from `list`.
- Added `waitForNext` to the daemon test client so repeated replies like `list-reply` and `exit` cannot falsely match stale messages.

## Why

The direct PTY daemon needs stronger reliability coverage around binary streaming, many-client fan-out, concurrent input, and live-session adoption. While hardening these tests, the existing helper showed a false-positive risk: `waitFor` could resolve against previously received messages when a test needed a fresh reply.

## Validation

- `bunx biome check --write --unsafe packages/pty-daemon/test/handoff.test.ts packages/pty-daemon/test/helpers/client.ts packages/pty-daemon/test/byte-fidelity.test.ts`
- `node --experimental-strip-types --test test/byte-fidelity.test.ts` in `packages/pty-daemon`
- `bun run typecheck` in `packages/pty-daemon`
- `bun run test` in `packages/pty-daemon`
- `bun run test:integration` in `packages/pty-daemon`
- `bun run build:daemon` in `packages/pty-daemon`
- `bun run lint`
- `node scripts/smoke-pty-daemon-cleanup.mjs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive byte-fidelity runtime tests and helpers to verify exact binary I/O, fragmented-frame reassembly, multi-client fan-out, backpressure behavior, replay correctness, and non‑UTF‑8 round trips.
* **Handoff**
  * Expanded handoff validation to confirm two concurrent sessions survive upgrades with preserved PIDs, buffered replay, and continued I/O for new and late subscribers.
* **Tests — Helpers**
  * Added a client helper to await the next matching server message with timeout handling.
* **Bug Fixes**
  * Bounded per-connection outbound buffering to improve stability under high output and backpressure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4458)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->