### PR TITLE
feat(desktop): background terminal sessions in v2 tab bar + restore move-to-background button

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx
@@ -1,0 +1,151 @@
+import type { WorkspaceStore } from "@superset/panes";
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { Archive, ChevronDown, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
+import { useStore } from "zustand";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData, TerminalPaneData } from "../../types";
+
+interface BackgroundTerminalsButtonProps {
+	workspaceId: string;
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+}
+
+/**
+ * Tab-bar control that surfaces running terminal daemon sessions for the
+ * workspace that have no pane attached (e.g. moved to background via the
+ * terminal pane header). Renders nothing when there are none; otherwise a
+ * single button with a dropdown to re-open or kill each background session.
+ */
+export function BackgroundTerminalsButton({
+	workspaceId,
+	store,
+}: BackgroundTerminalsButtonProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const tabs = useStore(store, (s) => s.tabs);
+	const utils = workspaceTrpc.useUtils();
+	const killSession = workspaceTrpc.terminal.killSession.useMutation();
+	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
+		{ workspaceId },
+		{ refetchInterval: isOpen ? 2_000 : 5_000, refetchOnWindowFocus: true },
+	);
+
+	const attachedTerminalIds = useMemo(() => {
+		const ids = new Set<string>();
+		for (const tab of tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				if (pane.kind !== "terminal") continue;
+				const data = pane.data as Partial<TerminalPaneData>;
+				if (data.terminalId) ids.add(data.terminalId);
+			}
+		}
+		return ids;
+	}, [tabs]);
+
+	const backgroundSessions = useMemo(() => {
+		const sessions = sessionsQuery.data?.sessions ?? [];
+		return sessions
+			.filter((session) => !attachedTerminalIds.has(session.terminalId))
+			.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+	}, [sessionsQuery.data?.sessions, attachedTerminalIds]);
+
+	if (backgroundSessions.length === 0) return null;
+
+	const label = `${backgroundSessions.length} background terminal session${
+		backgroundSessions.length === 1 ? "" : "s"
+	}`;
+
+	const handleAdopt = (terminalId: string) => {
+		store.getState().addTab({
+			panes: [
+				{
+					kind: "terminal",
+					data: { terminalId } as TerminalPaneData,
+				},
+			],
+		});
+		void utils.terminal.listSessions.invalidate({ workspaceId });
+		setIsOpen(false);
+	};
+
+	const handleKill = async (terminalId: string) => {
+		try {
+			await killSession.mutateAsync({ terminalId, workspaceId });
+		} catch (error) {
+			console.error(
+				"[BackgroundTerminalsButton] Failed to kill session:",
+				error,
+			);
+			toast.error("Failed to close terminal session");
+		} finally {
+			void utils.terminal.listSessions.invalidate({ workspaceId });
+		}
+	};
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button
+					className="h-7 gap-1 rounded-md border border-border/60 bg-muted/30 px-2 text-xs text-muted-foreground shadow-none hover:bg-accent/60 hover:text-foreground"
+					size="sm"
+					type="button"
+					variant="ghost"
+				>
+					<Archive className="size-3.5" />
+					<span>{label}</span>
+					<ChevronDown className="size-3" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-80">
+				<DropdownMenuLabel className="text-xs">
+					Background terminal sessions
+				</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				<div className="max-h-80 overflow-y-auto">
+					{backgroundSessions.map((session) => (
+						<DropdownMenuItem
+							key={session.terminalId}
+							className="group flex items-center gap-2"
+							onSelect={() => handleAdopt(session.terminalId)}
+						>
+							<Archive className="size-3.5 shrink-0 text-muted-foreground" />
+							<span className="min-w-0 flex-1 truncate text-xs">
+								{session.title ?? "Terminal"}
+							</span>
+							{session.createdAt > 0 && (
+								<span className="shrink-0 text-xs text-muted-foreground/70">
+									{getRelativeTime(session.createdAt, { format: "compact" })}
+								</span>
+							)}
+							<button
+								type="button"
+								aria-label="Close terminal session"
+								title="Close terminal session"
+								disabled={killSession.isPending}
+								className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
+								onClick={(event) => {
+									event.preventDefault();
+									event.stopPropagation();
+									void handleKill(session.terminalId);
+								}}
+							>
+								<Trash2 className="size-3" />
+							</button>
+						</DropdownMenuItem>
+					))}
+				</div>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx
@@ -132,7 +132,10 @@ export function BackgroundTerminalsButton({
 								type="button"
 								aria-label="Close terminal session"
 								title="Close terminal session"
-								disabled={killSession.isPending}
+								disabled={
+									killSession.isPending &&
+									killSession.variables?.terminalId === session.terminalId
+								}
 								className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
 								onClick={(event) => {
 									event.preventDefault();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/index.ts
@@ -1,0 +1,1 @@
+export { BackgroundTerminalsButton } from "./BackgroundTerminalsButton";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/TerminalHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/TerminalHeaderExtras.tsx
@@ -1,4 +1,7 @@
 import type { RendererContext } from "@superset/panes";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { Archive } from "lucide-react";
+import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
 import type {
 	PaneViewerData,
 	TerminalPaneData,
@@ -19,6 +22,11 @@ export function TerminalHeaderExtras({
 
 	const data = context.pane.data as TerminalPaneData;
 
+	const handleMoveToBackground = () => {
+		markTerminalForBackground(data.terminalId);
+		void context.actions.close();
+	};
+
 	return (
 		<div className="flex items-center gap-0.5">
 			<TerminalRemoteControlButton
@@ -29,6 +37,24 @@ export function TerminalHeaderExtras({
 				terminalId={data.terminalId}
 				terminalInstanceId={context.pane.id}
 			/>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="Move terminal to background"
+						onClick={(event) => {
+							event.stopPropagation();
+							handleMoveToBackground();
+						}}
+						className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+					>
+						<Archive className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					Move terminal to background
+				</TooltipContent>
+			</Tooltip>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -10,6 +10,7 @@ import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel"
 import { getV2NotificationSourcesForTab } from "renderer/stores/v2-notifications";
 import { useWorkspace } from "../providers/WorkspaceProvider";
 import { AddTabMenu } from "./components/AddTabMenu";
+import { BackgroundTerminalsButton } from "./components/BackgroundTerminalsButton";
 import { V2NotificationStatusIndicator } from "./components/V2NotificationStatusIndicator";
 import { V2PresetsBar } from "./components/V2PresetsBar";
 import { V2WorkspaceRunButton } from "./components/V2WorkspaceRunButton";
@@ -273,6 +274,12 @@ function V2WorkspaceContent() {
 								onAddBrowser={addBrowserTab}
 								showPresetsBar={showPresetsBar}
 								onToggleShowPresetsBar={setShowPresetsBar}
+							/>
+						)}
+						renderTabBarTrailing={() => (
+							<BackgroundTerminalsButton
+								workspaceId={workspaceId}
+								store={store}
 							/>
 						)}
 						renderEmptyState={() => (

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -15,6 +15,7 @@ export function Workspace<TData>({
 	renderTabIcon,
 	renderEmptyState,
 	renderAddTabMenu,
+	renderTabBarTrailing,
 	renderBelowTabBar,
 	onBeforeCloseTab,
 	onAfterCloseTab,
@@ -96,6 +97,7 @@ export function Workspace<TData>({
 				}
 				renderTabIcon={renderTabIcon}
 				renderAddTabMenu={renderAddTabMenu}
+				renderTabBarTrailing={renderTabBarTrailing}
 				renderTabAccessory={renderTabAccessory}
 			/>
 			{renderBelowTabBar?.()}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -33,6 +33,7 @@ interface TabBarProps<TData> {
 	onMovePaneToNewTab: (paneId: string, toIndex: number) => void;
 	renderTabIcon?: (tab: Tab<TData>) => ReactNode;
 	renderAddTabMenu?: () => ReactNode;
+	renderTabBarTrailing?: () => ReactNode;
 	renderTabAccessory?: (tab: Tab<TData>) => ReactNode;
 }
 
@@ -82,6 +83,7 @@ export function TabBar<TData>({
 	onMovePaneToNewTab,
 	renderTabIcon,
 	renderAddTabMenu,
+	renderTabBarTrailing,
 	renderTabAccessory,
 }: TabBarProps<TData>) {
 	const tabsTrackRef = useRef<HTMLDivElement>(null);
@@ -173,6 +175,11 @@ export function TabBar<TData>({
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 				<div className="flex min-w-0 flex-1 items-stretch" />
+				{renderTabBarTrailing && (
+					<div className="flex h-full shrink-0 items-center px-1">
+						{renderTabBarTrailing()}
+					</div>
+				)}
 			</div>
 		);
 	}
@@ -226,6 +233,11 @@ export function TabBar<TData>({
 			{hasHorizontalOverflow && (
 				<div className="flex h-full w-10 shrink-0 items-center justify-center bg-background">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
+				</div>
+			)}
+			{renderTabBarTrailing && (
+				<div className="flex h-full shrink-0 items-center px-1">
+					{renderTabBarTrailing()}
 				</div>
 			)}
 		</div>

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -105,6 +105,8 @@ export interface WorkspaceProps<TData> {
 	renderTabIcon?: (tab: Tab<TData>) => ReactNode;
 	renderEmptyState?: () => ReactNode;
 	renderAddTabMenu?: () => ReactNode;
+	/** Rendered at the trailing (right) edge of the tab bar row. */
+	renderTabBarTrailing?: () => ReactNode;
 	renderBelowTabBar?: () => ReactNode;
 	onBeforeClosePane?: (
 		pane: Pane<TData>,


### PR DESCRIPTION
## What

- **New `BackgroundTerminalsButton` in the v2-workspace tab bar.** Surfaces running terminal daemon sessions for the workspace that have no pane attached. Renders nothing when there are none; otherwise a single button — *"N background terminal session(s)"* — with a dropdown. Selecting an entry re-opens it as a new terminal tab (re-attaches to the existing `terminalId`); the hover trash icon kills the session.
- **Restored the "Move terminal to background" archive button** in the v2 terminal pane header (it was removed in #3888). Calls `markTerminalForBackground(terminalId)` then `context.actions.close()`, so the pane closes but the daemon session keeps running — that's how you produce a background session in the first place.
- **`@superset/panes`:** new `renderTabBarTrailing` render-prop on `<Workspace>`, threaded into `TabBar` and rendered at the trailing edge of the tab-bar row.

## Notes

- Background sessions get their name from the host-service-tracked OSC title (`listSessions` → `session.title`), falling back to "Terminal" when the shell never emitted one — same as a paned terminal would show.

## Test plan

- Open a v2 workspace, click the archive icon in a terminal pane header → pane closes, session keeps running.
- Within ~5s the "1 background terminal session" button appears at the right of the tab bar.
- Click it → dropdown lists the session; click the entry → re-opens as a tab and re-attaches (scrollback intact).
- Trash icon → session killed, button disappears.
- `bun run typecheck` and `bun run lint` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces background terminal sessions in the v2 workspace tab bar and restores the “move to background” control to manage running terminals. Adds a `renderTabBarTrailing` slot to `@superset/panes` to host the new button.

- **New Features**
  - New BackgroundTerminalsButton in the v2 tab bar: shows “N background terminal session(s)”, dropdown to reopen as a new tab (re-attaches to existing `terminalId`), and a trash icon to kill sessions.
  - Restored “Move terminal to background” button in the terminal pane header: calls `markTerminalForBackground(terminalId)` and closes the pane, keeping the daemon running.
  - `@superset/panes`: added `renderTabBarTrailing` render-prop on `<Workspace>` (threaded into `TabBar`) to render trailing tab bar content.

- **Bug Fixes**
  - Kill button disabled state is scoped per session row while a kill is pending, not for the whole list.

<sup>Written for commit 609c2a484d46c5d42096cf38376a724ad0e183b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Move terminal sessions to the background for later use.
  * Background terminals menu in the workspace tab bar showing session titles and relative creation times.
  * Re-open (adopt) or kill background terminals from the menu.
  * Tab bar now supports custom trailing content, allowing the background terminals button to be shown.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4459)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->