### PR TITLE
release(cli): cut v0.2.15

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -686,7 +686,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.14";
+const VERSION = "0.2.15";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.14",
+	"version": "0.2.15",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Bumps `@superset/cli` from 0.2.14 → 0.2.15. After merge, push `cli-v0.2.15` against the resulting commit on `main` to fire `.github/workflows/release-cli.yml`.

## Changes since v0.2.14

- workspaces: `superset workspaces list` now accepts `--project` and `--search` filters, matching the desktop list view. (#4455)
- cli-framework: `--help` on a subcommand now shows the global options (e.g. `--json`, `--quiet`, `--api-key`) instead of hiding them. (#4424)
- host-service: attachment upload no longer rejects unknown `mediaType` values returned by some hosts. (#4439)
- host-service: PR fetch is now per-branch, avoiding 504s on repos with large numbers of open PRs. (#4268)

## Test plan

- [ ] CI green on this PR
- [ ] After merge, push `cli-v0.2.15` and confirm `Release CLI` workflow builds all three targets (linux-x64, darwin-arm64, linux-arm64)
- [ ] Verify draft release + `cli-latest` rolling tag are updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut `@superset/cli` v0.2.15 with improvements to workspace filtering, clearer help output, and more reliable host-service behavior on large repos.

- **New Features**
  - `superset workspaces list` now supports `--project` and `--search`.
  - Subcommand `--help` shows global options from `@superset/cli-framework` (e.g., `--json`, `--quiet`, `--api-key`).

- **Bug Fixes**
  - Attachment uploads accept unknown `mediaType` values from some hosts.
  - PR fetching is per-branch to avoid 504s on repos with many open PRs.

<sup>Written for commit 4c7d0027839e2f67dd5b06784d3b82ccaa53bcc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI version to 0.2.15

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4462)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->