### PR TITLE
feat(cli): show workspace id in `workspaces list` default table

### DIFF
--- a/packages/cli/src/commands/workspaces/list/command.ts
+++ b/packages/cli/src/commands/workspaces/list/command.ts
@@ -18,8 +18,8 @@ export default command({
 	display: (data) =>
 		table(
 			data as Record<string, unknown>[],
-			["name", "branch", "projectName", "hostName"],
-			["NAME", "BRANCH", "PROJECT", "HOST"],
+			["name", "branch", "projectName", "hostName", "id"],
+			["NAME", "BRANCH", "PROJECT", "HOST", "ID"],
 			30,
 		),
 	run: async ({ ctx, options }) => {


### PR DESCRIPTION
## Summary
- `superset workspaces open` requires a UUID, but the default `workspaces list` table didn't include the ID — forcing users through `--json` to copy it.
- Add `ID` as the trailing column, matching the convention used by `projects list`, `agents list`, and `hosts list`.

## Test plan
- [ ] `superset workspaces list` shows the `ID` column
- [ ] `superset workspaces list --json` output is unchanged
- [ ] Copy an `ID` from the list and run `superset workspaces open <id>`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the workspace ID as the trailing column in the default `superset workspaces list` output. This makes it easy to copy the UUID for `superset workspaces open <id>` and matches `projects list`, `agents list`, and `hosts list`.

<sup>Written for commit 18c0a67ddc4ad5734ca4f9d39ec5492e8a4ce8a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The workspace list command now displays the workspace ID column in the output table, positioned alongside the existing name, branch, project name, and hostname columns. This provides users with a complete view of workspace identifiers when listing workspaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4463)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->