### PR TITLE
[codex] fix v2 terminal shell resolution

### DIFF
--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import * as os from "node:os";
 import { signalProcessTreeAndGroups } from "@superset/pty-daemon/process-tree";
+import { resolveConfiguredShell } from "./user-shell.ts";
 
 const SHELL_ENV_TIMEOUT_MS = 8_000;
 const CACHE_TTL_MS = 60_000;
@@ -64,10 +65,7 @@ function buildMinimalEnv(): Record<string, string> {
 }
 
 function resolveShellForEnv(): string {
-	if (process.platform === "win32") {
-		return process.env.COMSPEC || "cmd.exe";
-	}
-	return process.env.SHELL || "/bin/sh";
+	return resolveConfiguredShell(process.env);
 }
 
 function parseEnvOutput(stdout: string): Record<string, string> {
@@ -103,6 +101,11 @@ function spawnCleanShellEnv(): Promise<Record<string, string>> {
 	return new Promise((resolve, reject) => {
 		const shell = resolveShellForEnv();
 		const env = buildMinimalEnv();
+		if (process.platform === "win32") {
+			env.COMSPEC = shell;
+		} else {
+			env.SHELL = shell;
+		}
 		const command = `echo -n "${DELIMITER}"; command env; echo -n "${DELIMITER}"; exit`;
 
 		// Anchor at $HOME so the snapshot shell doesn't inherit a cwd

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -14,18 +14,34 @@ import {
 // ── resolveLaunchShell ───────────────────────────────────────────────
 
 describe("resolveLaunchShell", () => {
-	test("returns SHELL from base env on non-Windows", () => {
-		expect(resolveLaunchShell({ SHELL: "/usr/local/bin/fish" })).toBe(
-			"/usr/local/bin/fish",
-		);
+	test("prefers the configured account shell over inherited SHELL", () => {
+		expect(
+			resolveLaunchShell(
+				{ SHELL: "/bin/bash" },
+				{ accountShell: "/opt/homebrew/bin/fish", platform: "darwin" },
+			),
+		).toBe("/opt/homebrew/bin/fish");
+	});
+
+	test("falls back to SHELL from base env when account shell is unavailable", () => {
+		expect(
+			resolveLaunchShell(
+				{ SHELL: "/usr/local/bin/fish" },
+				{ accountShell: null, platform: "darwin" },
+			),
+		).toBe("/usr/local/bin/fish");
 	});
 
 	test("falls back to /bin/sh when SHELL is absent", () => {
-		expect(resolveLaunchShell({})).toBe("/bin/sh");
+		expect(
+			resolveLaunchShell({}, { accountShell: null, platform: "darwin" }),
+		).toBe("/bin/sh");
 	});
 
 	test("does not default to /bin/zsh", () => {
-		expect(resolveLaunchShell({})).not.toBe("/bin/zsh");
+		expect(
+			resolveLaunchShell({}, { accountShell: null, platform: "darwin" }),
+		).not.toBe("/bin/zsh");
 	});
 });
 
@@ -406,7 +422,17 @@ describe("buildV2TerminalEnv", () => {
 			SUPERSET_AGENT_HOOK_VERSION: "2",
 		});
 		expect(env.TERM_PROGRAM).toBe("kitty");
+		expect(env.SHELL).toBe("/bin/zsh");
 		expect(env.LANG).toContain("UTF-8");
+	});
+
+	test("sets SHELL to the selected launch shell even when base env was stale", () => {
+		const env = buildV2TerminalEnv({
+			...baseParams,
+			baseEnv: { ...baseParams.baseEnv, SHELL: "/bin/bash" },
+			shell: "/opt/homebrew/bin/fish",
+		});
+		expect(env.SHELL).toBe("/opt/homebrew/bin/fish");
 	});
 
 	test("allows empty root path and alternate Superset env without breaking the contract", () => {

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -169,6 +169,7 @@ export function buildV2TerminalEnv(
 	Object.assign(env, getShellBootstrapEnv({ shell, baseEnv, supersetHomeDir }));
 
 	env.TERM = "xterm-256color";
+	env.SHELL = shell;
 	// claude-code and similar chat TUIs only parse kitty CSI-u (e.g. Shift+Enter
 	// → \x1b[13;2u) when TERM_PROGRAM ∈ {ghostty, kitty, iTerm.app, WezTerm,
 	// WarpTerminal}. xterm.js already emits the right bytes — claim kitty so

--- a/packages/host-service/src/terminal/shell-launch.ts
+++ b/packages/host-service/src/terminal/shell-launch.ts
@@ -10,13 +10,17 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import {
+	type ResolveConfiguredShellOptions,
+	resolveConfiguredShell,
+} from "./user-shell.ts";
 
 /** Does not default to /bin/zsh — falls back to /bin/sh (POSIX-guaranteed). */
-export function resolveLaunchShell(baseEnv: Record<string, string>): string {
-	if (process.platform === "win32") {
-		return baseEnv.COMSPEC || "cmd.exe";
-	}
-	return baseEnv.SHELL || "/bin/sh";
+export function resolveLaunchShell(
+	baseEnv: Record<string, string>,
+	options?: ResolveConfiguredShellOptions,
+): string {
+	return resolveConfiguredShell(baseEnv, options);
 }
 
 export function getSupersetShellPaths(supersetHomeDir: string): {

--- a/packages/host-service/src/terminal/user-shell.ts
+++ b/packages/host-service/src/terminal/user-shell.ts
@@ -1,0 +1,66 @@
+import os from "node:os";
+
+type ShellEnvSource = Record<string, string | undefined>;
+
+export interface ResolveConfiguredShellOptions {
+	platform?: NodeJS.Platform;
+	/**
+	 * Test override. `undefined` probes the OS account; `null` simulates an
+	 * unavailable account shell and falls back to env.
+	 */
+	accountShell?: string | null;
+}
+
+function normalizeShellPath(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: null;
+}
+
+export function getAccountShell(
+	platform: NodeJS.Platform = process.platform,
+): string | null {
+	if (platform === "win32") return null;
+
+	try {
+		const shell = (os.userInfo() as { shell?: unknown }).shell;
+		return normalizeShellPath(shell);
+	} catch {
+		return null;
+	}
+}
+
+let accountShellForTesting: string | null | undefined;
+
+export function __setAccountShellForTesting(
+	shell: string | null | undefined,
+): void {
+	accountShellForTesting = shell;
+}
+
+/**
+ * Resolve the shell Superset should launch for user terminals.
+ *
+ * Desktop-launched helper processes can inherit a generic SHELL such as
+ * /bin/bash even when the user's configured login shell is fish. Prefer the
+ * OS account shell to match normal terminal-app behavior and the old v1 path.
+ */
+export function resolveConfiguredShell(
+	env: ShellEnvSource,
+	options: ResolveConfiguredShellOptions = {},
+): string {
+	const platform = options.platform ?? process.platform;
+
+	if (platform === "win32") {
+		return normalizeShellPath(env.COMSPEC) ?? "cmd.exe";
+	}
+
+	const accountShell =
+		options.accountShell === undefined
+			? accountShellForTesting === undefined
+				? getAccountShell(platform)
+				: normalizeShellPath(accountShellForTesting)
+			: normalizeShellPath(options.accountShell);
+
+	return accountShell ?? normalizeShellPath(env.SHELL) ?? "/bin/sh";
+}

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { Server } from "@superset/pty-daemon";
 import { TRPCClientError } from "@trpc/client";
 import {
 	disposeDaemonClient,
@@ -19,6 +26,7 @@ import {
 	__resetSessionsForTesting,
 	disposeSessionsByWorkspaceId,
 } from "../../src/terminal/terminal";
+import { __setAccountShellForTesting } from "../../src/terminal/user-shell.ts";
 import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
 import { seedTerminalSession } from "../helpers/seed";
 
@@ -38,6 +46,7 @@ describe("terminal router integration", () => {
 		__resetSessionsForTesting();
 		await disposeDaemonClient();
 		resetTerminalBaseEnvForTests();
+		__setAccountShellForTesting(undefined);
 		delete process.env.SUPERSET_PTY_DAEMON_SOCKET;
 		delete process.env.SUPERSET_HOME_DIR;
 		await scenario?.dispose();
@@ -74,6 +83,66 @@ describe("terminal router integration", () => {
 				workspaceId: scenario.workspaceId,
 			}),
 		).rejects.toBeInstanceOf(TRPCClientError);
+	});
+
+	test("createSession sends the configured shell to the daemon instead of inherited bash", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "host-service-terminal-shell-"));
+		const socketPath = join(tmp, "pty-daemon.sock");
+		const fakeFishPath = join(tmp, "fish");
+		const terminalId = randomUUID();
+		const spawned: Array<{
+			meta: {
+				shell: string;
+				argv: string[];
+				env?: Record<string, string>;
+			};
+		}> = [];
+		const server = new Server({
+			socketPath,
+			daemonVersion: "0.0.0-terminal-shell-test",
+			spawnPty: ({ meta }) => {
+				spawned.push({ meta });
+				return createFakePty(4200 + spawned.length, meta);
+			},
+		});
+
+		writeFileSync(fakeFishPath, "#!/bin/sh\n", { mode: 0o755 });
+
+		try {
+			await server.listen();
+			process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
+			process.env.SUPERSET_HOME_DIR = tmp;
+			__setAccountShellForTesting(fakeFishPath);
+			resetTerminalBaseEnvForTests();
+			initTerminalBaseEnv({
+				PATH: `${tmp}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+				HOME: process.env.HOME ?? tmp,
+				SHELL: "/bin/bash",
+			});
+
+			await scenario.host.trpc.terminal.createSession.mutate({
+				workspaceId: scenario.workspaceId,
+				terminalId,
+			});
+
+			expect(spawned).toHaveLength(1);
+			const [{ meta }] = spawned;
+			expect(meta.shell).toBe(fakeFishPath);
+			expect(meta.argv[0]).toBe("-l");
+			expect(meta.argv[1]).toBe("--init-command");
+			expect(meta.env?.SHELL).toBe(fakeFishPath);
+			expect(meta.env?.SUPERSET_TERMINAL_ID).toBe(terminalId);
+		} finally {
+			await scenario.host.trpc.terminal.killSession
+				.mutate({
+					workspaceId: scenario.workspaceId,
+					terminalId,
+				})
+				.catch(() => {});
+			await disposeDaemonClient();
+			await server.close();
+			rmSync(tmp, { recursive: true, force: true });
+		}
 	});
 
 	test("terminal disposal cleans up background process groups from real daemon sessions", async () => {
@@ -320,6 +389,48 @@ function detachedHelperScript(pidPath: string): string {
 		`echo "$helper_pid" > ${shellQuote(pidPath)}`,
 		"sleep 60",
 	].join("; ");
+}
+
+function createFakePty(
+	pid: number,
+	meta: {
+		shell: string;
+		argv: string[];
+		cwd?: string;
+		env?: Record<string, string>;
+		cols: number;
+		rows: number;
+	},
+) {
+	let currentMeta = meta;
+	const exitCallbacks: Array<
+		(info: { code: number | null; signal: number | null }) => void
+	> = [];
+
+	return {
+		pid,
+		get meta() {
+			return currentMeta;
+		},
+		write() {},
+		resize(cols: number, rows: number) {
+			currentMeta = { ...currentMeta, cols, rows };
+		},
+		kill() {
+			for (const callback of exitCallbacks.splice(0)) {
+				callback({ code: null, signal: null });
+			}
+		},
+		onData() {},
+		onExit(
+			callback: (info: { code: number | null; signal: number | null }) => void,
+		) {
+			exitCallbacks.push(callback);
+		},
+		getMasterFd() {
+			return 0;
+		},
+	};
 }
 
 function ensureDaemonBundle(bundlePath: string): void {


### PR DESCRIPTION
## What changed

- Added host-service shell resolution that prefers the user's configured account shell over inherited `SHELL`.
- Used that resolver for v2 terminal shell launch and clean shell env probing.
- Set the PTY `SHELL` env var to the actual selected launch shell.
- Added unit and integration coverage for stale inherited `/bin/bash` with a configured fish shell.

## Why

Superset v2 terminals could open in bash for fish users because desktop-launched host-service processes can inherit a generic `SHELL=/bin/bash`. v2 trusted that inherited value when selecting the PTY shell, unlike v1 behavior that followed the user's configured shell.

## Related

- Related fish terminal issue: #2292

## Validation

- `bun test packages/host-service/test/integration/terminal.integration.test.ts`
- `bun run --filter @superset/host-service typecheck`
- `bun run --filter @superset/host-service test`
- `bun run lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 terminal shell selection to use the user's configured login shell instead of an inherited `SHELL`, preventing fish users from launching into bash.

- **Bug Fixes**
  - Added `resolveConfiguredShell` in `user-shell.ts` to prefer the OS account shell; falls back to `SHELL` or `/bin/sh` (`COMSPEC`/`cmd.exe` on Windows).
  - Used the resolver for v2 terminal launch and clean-env probing; PTY env now sets `SHELL`/`COMSPEC` to the selected shell.
  - Added unit and integration tests validating stale `/bin/bash` with a configured fish and ensuring `SHELL` matches the launch shell.

<sup>Written for commit d86046da445284a344c2cc217ff5d4cb66f3f9dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal environment variables (SHELL/COMSPEC) are now correctly set based on configured shell preferences.
  * Shell preferences are reliably honored when launching terminal sessions across platforms.
  * Terminal sessions now use configured shell settings instead of inherited values.

* **Refactor**
  * Centralized shell resolution logic with improved platform-specific preference handling and fallback behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4465)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
