### PR TITLE
feat(desktop): let host owners rename devices

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
@@ -99,6 +99,11 @@ export function useOptimisticCollectionActions() {
 			mutation: () => PersistableTransaction,
 		) => runMutation("optimistic.v2UsersHosts", failureTitle, mutation);
 
+		const runHostsMutation = (
+			failureTitle: string,
+			mutation: () => PersistableTransaction,
+		) => runMutation("optimistic.v2Hosts", failureTitle, mutation);
+
 		return {
 			tasks: {
 				updateTitle: (taskId: string, title: string) =>
@@ -201,6 +206,14 @@ export function useOptimisticCollectionActions() {
 						collections.chatSessions.delete(sessionId),
 					);
 				},
+			},
+			v2Hosts: {
+				renameHost: (hostId: string, name: string) =>
+					runHostsMutation("Failed to rename host", () =>
+						collections.v2Hosts.update(hostId, (draft) => {
+							draft.name = name;
+						}),
+					),
 			},
 			v2UsersHosts: {
 				addMember: (input: {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -319,6 +319,17 @@ function createOrgCollections(organizationId: string): OrgCollections {
 			// Composite PK on (organization_id, machine_id); within an
 			// org-scoped collection, machineId alone is unique.
 			getKey: (item) => item.machineId,
+			onUpdate: async ({ transaction }) => {
+				const { original, changes } = transaction.mutations[0];
+				if (changes.name === undefined) {
+					throw new Error("Only name updates are supported on v2_hosts");
+				}
+				const result = await apiClient.v2Host.rename.mutate({
+					hostId: original.machineId,
+					name: changes.name,
+				});
+				return { txid: result.txid };
+			},
 		}),
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
@@ -159,6 +159,7 @@ export function HostSettings({ hostId }: HostSettingsProps) {
 				name={host.name}
 				isOnline={host.isOnline}
 				machineId={host.machineId}
+				canRename={isOwner}
 			/>
 
 			<section className="space-y-3">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostHeader/HostHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostHeader/HostHeader.tsx
@@ -1,12 +1,52 @@
 import { cn } from "@superset/ui/utils";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { LuPencil } from "react-icons/lu";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 
 interface HostHeaderProps {
 	name: string;
 	isOnline: boolean;
 	machineId: string;
+	canRename: boolean;
 }
 
-export function HostHeader({ name, isOnline, machineId }: HostHeaderProps) {
+export function HostHeader({
+	name,
+	isOnline,
+	machineId,
+	canRename,
+}: HostHeaderProps) {
+	const { v2Hosts: hostActions } = useOptimisticCollectionActions();
+	const [isEditing, setIsEditing] = useState(false);
+	const [draft, setDraft] = useState(name);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (!isEditing) setDraft(name);
+	}, [name, isEditing]);
+
+	useLayoutEffect(() => {
+		if (isEditing) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [isEditing]);
+
+	const commit = () => {
+		const trimmed = draft.trim();
+		setIsEditing(false);
+		if (!trimmed || trimmed === name) {
+			setDraft(name);
+			return;
+		}
+		hostActions.renameHost(machineId, trimmed);
+	};
+
+	const cancel = () => {
+		setDraft(name);
+		setIsEditing(false);
+	};
+
 	return (
 		<div className="mb-8">
 			<div className="flex items-center gap-2">
@@ -16,7 +56,46 @@ export function HostHeader({ name, isOnline, machineId }: HostHeaderProps) {
 						isOnline ? "bg-emerald-500" : "bg-muted-foreground/40",
 					)}
 				/>
-				<h2 className="text-xl font-semibold">{name}</h2>
+				{isEditing ? (
+					<label className="inline-grid text-xl font-semibold -my-px leading-[1.6875rem]">
+						<span
+							aria-hidden
+							className="invisible col-start-1 row-start-1 whitespace-pre"
+						>
+							{draft || " "}
+						</span>
+						<input
+							ref={inputRef}
+							size={1}
+							className="col-start-1 row-start-1 bg-transparent border-b border-border outline-none focus:border-foreground w-full p-0"
+							value={draft}
+							onChange={(e) => setDraft(e.target.value)}
+							onBlur={commit}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									commit();
+								}
+								if (e.key === "Escape") {
+									e.preventDefault();
+									cancel();
+								}
+							}}
+						/>
+					</label>
+				) : canRename ? (
+					<button
+						type="button"
+						onClick={() => setIsEditing(true)}
+						className="flex items-center gap-2 text-left hover:text-foreground"
+						title="Rename host"
+					>
+						<h2 className="text-xl font-semibold">{name}</h2>
+						<LuPencil className="size-4 text-muted-foreground" />
+					</button>
+				) : (
+					<h2 className="text-xl font-semibold">{name}</h2>
+				)}
 			</div>
 			<p className="text-sm text-muted-foreground mt-1">
 				{isOnline ? "Online" : "Offline"} ·{" "}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostHeader/HostHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostHeader/HostHeader.tsx
@@ -20,6 +20,7 @@ export function HostHeader({
 	const [isEditing, setIsEditing] = useState(false);
 	const [draft, setDraft] = useState(name);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const cancelledRef = useRef(false);
 
 	useEffect(() => {
 		if (!isEditing) setDraft(name);
@@ -27,12 +28,17 @@ export function HostHeader({
 
 	useLayoutEffect(() => {
 		if (isEditing) {
+			cancelledRef.current = false;
 			inputRef.current?.focus();
 			inputRef.current?.select();
 		}
 	}, [isEditing]);
 
 	const commit = () => {
+		if (cancelledRef.current) {
+			cancelledRef.current = false;
+			return;
+		}
 		const trimmed = draft.trim();
 		setIsEditing(false);
 		if (!trimmed || trimmed === name) {
@@ -43,6 +49,7 @@ export function HostHeader({
 	};
 
 	const cancel = () => {
+		cancelledRef.current = true;
 		setDraft(name);
 		setIsEditing(false);
 	};
@@ -66,6 +73,7 @@ export function HostHeader({
 						</span>
 						<input
 							ref={inputRef}
+							aria-label="Host name"
 							size={1}
 							className="col-start-1 row-start-1 bg-transparent border-b border-border outline-none focus:border-foreground w-full p-0"
 							value={draft}

--- a/packages/trpc/src/router/host/host.ts
+++ b/packages/trpc/src/router/host/host.ts
@@ -74,7 +74,7 @@ export const hostRouter = {
 				});
 			}
 
-			const [host] = await dbWs
+			const [inserted] = await dbWs
 				.insert(v2Hosts)
 				.values({
 					organizationId: input.organizationId,
@@ -82,13 +82,19 @@ export const hostRouter = {
 					name: input.name,
 					createdByUserId: ctx.userId,
 				})
-				.onConflictDoUpdate({
+				.onConflictDoNothing({
 					target: [v2Hosts.organizationId, v2Hosts.machineId],
-					set: {
-						name: input.name,
-					},
 				})
 				.returning();
+
+			const host =
+				inserted ??
+				(await db.query.v2Hosts.findFirst({
+					where: and(
+						eq(v2Hosts.organizationId, input.organizationId),
+						eq(v2Hosts.machineId, input.machineId),
+					),
+				}));
 
 			if (!host) {
 				throw new TRPCError({

--- a/packages/trpc/src/router/v2-host/v2-host.ts
+++ b/packages/trpc/src/router/v2-host/v2-host.ts
@@ -65,6 +65,33 @@ async function requireOrgMember(userId: string, organizationId: string) {
 }
 
 export const v2HostRouter = {
+	rename: protectedProcedure
+		.input(
+			z.object({
+				hostId: z.string().min(1),
+				name: z.string().min(1).max(120),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const organizationId = requireActiveOrgId(ctx);
+			await requireHostOwner(ctx.session.user.id, input.hostId, organizationId);
+
+			const txid = await dbWs.transaction(async (tx) => {
+				await tx
+					.update(v2Hosts)
+					.set({ name: input.name })
+					.where(
+						and(
+							eq(v2Hosts.organizationId, organizationId),
+							eq(v2Hosts.machineId, input.hostId),
+						),
+					);
+				return await getCurrentTxid(tx);
+			});
+
+			return { success: true, txid };
+		}),
+
 	addMember: protectedProcedure
 		.input(
 			z.object({

--- a/packages/trpc/src/router/v2-host/v2-host.ts
+++ b/packages/trpc/src/router/v2-host/v2-host.ts
@@ -69,7 +69,11 @@ export const v2HostRouter = {
 		.input(
 			z.object({
 				hostId: z.string().min(1),
-				name: z.string().min(1).max(120),
+				name: z
+					.string()
+					.max(120)
+					.transform((value) => value.trim())
+					.pipe(z.string().min(1, "Host name cannot be empty")),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary
- `host.ensure` was overwriting the stored host name on every call (each tunnel reconnect / workspace create), so any user-chosen name was clobbered by the OS hostname. Switched to `onConflictDoNothing` so the name is only set on first insert.
- Added a `v2Host.rename` mutation (owner-only, mirrors the other `v2Host` permissioning) and wired it through the `v2Hosts` tanstack collection (`onUpdate`) and a `v2Hosts.renameHost` optimistic action.
- Host settings header (`/settings/hosts/$hostId`) now shows a pencil affordance next to the name for owners; click to swap into an auto-sized inline input. Enter commits, Escape cancels, blur commits.

## Test plan
- [ ] Open host settings as an owner, click the pencil, rename the host, hit Enter — name persists and survives a host-service reconnect.
- [ ] Restart the host service / create a new workspace afterwards — name is not reverted to the OS hostname.
- [ ] Open host settings as a non-owner member — no pencil, no input.
- [ ] Try renaming to an empty string — input snaps back to the previous name.
- [ ] Try Escape during edit — draft is discarded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let host owners rename devices inline from the host settings page, and keep user-chosen names across reconnects.

- **New Features**
  - Inline rename for owners in host settings (pencil icon). Enter/blur commits, Escape cancels.
  - Added `v2Host.rename` (owner-only) and wired it through the `v2Hosts` collection for optimistic updates.

- **Bug Fixes**
  - Switched `host.ensure` to `onConflictDoNothing` so the stored name is only set on first insert and not reset on reconnect/workspace create.
  - Rename UX: Escape now cancels without committing; input has an accessible label; server trims and rejects whitespace-only names in `v2Host.rename`.

<sup>Written for commit 49c945903439548e8c5fd2528d5aab0fcd176c85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Owners can rename hosts from settings with inline editing, auto-focus, full-text select, Enter to confirm, Escape to cancel
  * Renames apply immediately with optimistic updates and surface failure toasts if they fail
* **Bug Fixes**
  * More reliable host creation/conflict handling and server-side rename processing for consistent results

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4468)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->