### PR TITLE
chore(agents): add ticket-format skill

### DIFF
--- a/.agents/skills/ticket-format/SKILL.md
+++ b/.agents/skills/ticket-format/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: ticket-format
+description: Use when creating, drafting, or grooming a Linear or Superset ticket in this repo. Defines the canonical three-section structure.
+---
+
+# Ticket Format
+
+## Context
+2–4 sentences. What's broken or wanted, and why. Outcome-focused, not solution-focused.
+
+## References
+Where the ticket came from. Omit section if none.
+
+| Source | Who | Link | Date |
+|--------|-----|------|------|
+| Slack #feedback | @alice | [thread](…) | 2026-05-10 |
+
+## Implementation notes
+Agent-groomed. Leave empty if you don't have codebase context — a later grooming pass will fill it in. When you do fill it in, use these sub-headings and skip what doesn't apply:
+
+- `### Files` — `path:line` + why relevant
+- `### Approach` — one paragraph
+- `### Related code` — similar patterns in the repo
+- `### Gotchas` — constraints, prior incidents

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,12 @@ bun run clean:workspaces   # Clean all workspace node_modules
 ## Agent Rules
 1. **Type safety** - avoid `any` unless necessary
 2. **Prefer `gh` CLI** - when performing git operations (PRs, issues, checkout, etc.), prefer the GitHub CLI (`gh`) over raw `git` commands where possible
-3. **Shared command source** - keep command definitions in `.agents/commands/` only. `.claude/commands` and `.cursor/commands` should be symlinks to `../.agents/commands`. (`packages/chat` discovers slash commands from `.claude/commands`.)
+3. **Shared command and skill source** - keep command definitions in `.agents/commands/` and skill definitions in `.agents/skills/`. `.claude/commands` and `.cursor/commands` should be symlinks to `../.agents/commands`; `.claude/skills` should be a symlink to `../.agents/skills`. (`packages/chat` discovers slash commands from `.claude/commands`.) Skills aren't a cross-agent format yet, so non-Claude agents (Codex, Cursor, OpenCode) should read the relevant `.agents/skills/*/SKILL.md` file directly when its description matches the task.
 4. **Workspace MCP config** - keep shared MCP servers in `.mcp.json`; `.cursor/mcp.json` should link to `../.mcp.json`. Codex uses `.codex/config.toml` (run with `CODEX_HOME=.codex codex ...`). OpenCode uses `opencode.json` and should mirror the same MCP set using OpenCode's `remote`/`local` schema.
 5. **Mastra dependencies** - use the published upstream `mastracode` and `@mastra/*` packages. Do not add fork tarball overrides or custom patch steps unless explicitly requested.
 6. **Plan & doc placement** - implementation plans go in `plans/` (cross-cutting) or `apps/<app>/plans/` (app-scoped); shipped plans move to `plans/done/`. Architecture/reference docs go in `<app>/docs/`. Never drop `*_PLAN.md` at an app root or inside `src/`.
 7. **Always fix lint warnings before pushing** - CI fails on Biome warnings, not just errors (the lint script treats warnings as errors). Run `bun run lint:fix` after edits and verify `bun run lint` exits 0 before `git push`. Never push code that produces lint output, even auto-fixable formatting.
+8. **Linear ticket format** - all tickets (creation, drafting, grooming) follow `.agents/skills/ticket-format/SKILL.md`. Read that file before creating or grooming a ticket.
 
 
 ---


### PR DESCRIPTION
## Summary
- Adds `.agents/skills/ticket-format/SKILL.md` defining the canonical three-section ticket structure: **Context**, **References** (table with Source/Who/Link/Date), **Implementation notes** (agent-groomed, can be left empty for a later pass).
- Symlinks `.claude/skills` → `../.agents/skills` so Claude Code auto-invokes when creating/grooming tickets.
- `AGENTS.md` rule 3 extended to cover skills; new rule 8 points non-Claude agents (Codex, Cursor, OpenCode) at the SKILL.md file since the skill format isn't cross-agent yet.

## Test plan
- [ ] `ls .claude/skills/ticket-format/` resolves through the symlink and shows `SKILL.md`
- [ ] Open a fresh Claude Code session and ask it to create a Linear ticket — verify the skill triggers and produces the three-section format
- [ ] Spot-check Codex/Cursor by asking them to draft a ticket and confirm they read `.agents/skills/ticket-format/SKILL.md` via the AGENTS.md reference

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ticket-format` skill to standardize Linear and Superset tickets with three sections: Context, References (table), and Implementation notes. Symlink `.claude/skills` to `../.agents/skills` so Claude Code auto-invokes the skill, and update `AGENTS.md` to document shared skills and require this format; non-Claude agents are directed to `.agents/skills/ticket-format/SKILL.md`.

<sup>Written for commit 03e7291c792dd5b057b5965c3136b5afb4a978a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced standardized ticket format guidance for Linear and Superset tickets with defined sections (Context, References, Implementation notes)
  * Updated agent rules to include shared skill definitions and symlink requirements
  * Established mandatory ticket format compliance across all workflows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4469)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->