### PR TITLE
fix(auth): disable promo codes on annual checkout

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -814,7 +814,11 @@ export const auth = betterAuth({
 					}
 				},
 
-				getCheckoutSessionParams: async ({ user, plan, subscription }) => {
+				getCheckoutSessionParams: async (
+					{ user, plan, subscription },
+					_request,
+					ctx,
+				) => {
 					if (plan.name === "enterprise") {
 						throw new Error(
 							"Enterprise subscriptions are managed by admins. Contact founders@superset.sh.",
@@ -828,10 +832,14 @@ export const auth = betterAuth({
 						),
 					});
 
+					const annual = Boolean(
+						(ctx?.body as { annual?: boolean } | undefined)?.annual,
+					);
+
 					return {
 						params: {
 							customer: org?.stripeCustomerId ?? undefined,
-							allow_promotion_codes: true,
+							allow_promotion_codes: !annual,
 							billing_address_collection: "required",
 							metadata: {
 								organizationId: org?.id ?? "",


### PR DESCRIPTION
## Summary

Stripe Pro monthly and yearly share the same Product, so `coupon.applies_to.products` cannot restrict a coupon to monthly-only. Defense has to live in our checkout.

Read `ctx.body.annual` in `getCheckoutSessionParams` and set `allow_promotion_codes: !annual`. Yearly checkouts no longer show the promo code field; monthly is unchanged.

## Why

A Stripe coupon configured `percent_off: 100, duration: repeating, duration_in_months: 1` discounts every invoice issued within the next calendar month. When the customer picks the yearly price, the first (and only) invoice for the next 12 months falls in that window, so 100% comes off the full annual amount. We saw one redemption that gave a customer a full year free instead of one month (Inversion Semi, invoice `in_1TWOGw...`).

Companion changes (out of band, in Stripe):
- New coupon `XfyAZQKE` "First Month Free" replaces the per-partner "1 Month Free" pattern.
- Existing active promotion codes deactivated in the Stripe dashboard (a few open partner codes kept alive).

## Test plan
- [ ] Hit Pro upgrade with `annual: true` — no "have a code?" link in Stripe Checkout.
- [ ] Hit Pro upgrade with `annual: false` — promo code field still appears, monthly redemption of `First Month Free` works as expected.
- [ ] Enterprise path still throws unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable promotion codes during annual checkout to prevent “first month free” coupons from discounting a full yearly invoice. Monthly checkout is unchanged.

- **Bug Fixes**
  - In `packages/auth`, `getCheckoutSessionParams` reads `ctx.body.annual` and sets Stripe Checkout `allow_promotion_codes: !annual`.
  - Annual sessions no longer show the promo code field.

<sup>Written for commit 88b83cc1ce92fd76cfe717c48ba78fbe0c3c01fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined checkout session configuration to intelligently manage promotion code availability based on customer preferences. Promotional codes are now conditionally offered depending on the customer's selected billing cycle type (annual or standard monthly), ensuring consistent and appropriate promotional pricing strategies across all subscription plans and tiers while maintaining existing security measures and enterprise plan protections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4470)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->