### PR TITLE
feat(desktop): restore Create organization in org switcher

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -19,6 +19,7 @@ import {
 	HiChevronUpDown,
 	HiOutlineArrowRightOnRectangle,
 	HiOutlineCog6Tooth,
+	HiOutlinePlus,
 } from "react-icons/hi2";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
 import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
@@ -147,7 +148,7 @@ export function OrganizationDropdown({
 					<FiUsers className="h-4 w-4" />
 					<span>Manage members</span>
 				</DropdownMenuItem>
-				{organizations && organizations.length > 1 && (
+				{organizations && organizations.length > 0 && (
 					<DropdownMenuSub>
 						<DropdownMenuSubTrigger className="gap-2">
 							<span>Switch organization</span>
@@ -178,6 +179,13 @@ export function OrganizationDropdown({
 									)}
 								</DropdownMenuItem>
 							))}
+							<DropdownMenuSeparator />
+							<DropdownMenuItem
+								onSelect={() => navigate({ to: "/create-organization" })}
+							>
+								<HiOutlinePlus className="h-4 w-4" />
+								<span>Create organization</span>
+							</DropdownMenuItem>
 						</DropdownMenuSubContent>
 					</DropdownMenuSub>
 				)}

--- a/apps/desktop/src/renderer/routes/create-organization/page.tsx
+++ b/apps/desktop/src/renderer/routes/create-organization/page.tsx
@@ -157,16 +157,24 @@ export function CreateOrganization() {
 		return <Navigate to="/sign-in" replace />;
 	}
 
-	if (activeOrganizationId) {
-		return <Navigate to="/" replace />;
-	}
+	const hasActiveOrganization = !!activeOrganizationId;
 
 	return (
 		<div className="relative flex min-h-screen items-center justify-center bg-background p-4">
 			<div className="absolute top-4 right-4">
-				<Button variant="ghost" onClick={handleSignOut} type="button">
-					Sign Out
-				</Button>
+				{hasActiveOrganization ? (
+					<Button
+						variant="ghost"
+						onClick={() => navigate({ to: "/" })}
+						type="button"
+					>
+						Cancel
+					</Button>
+				) : (
+					<Button variant="ghost" onClick={handleSignOut} type="button">
+						Sign Out
+					</Button>
+				)}
 			</div>
 
 			<Card className="w-full max-w-md">


### PR DESCRIPTION
## Summary
- Adds a "Create organization" item inside the Switch organization submenu in the desktop topbar/sidebar org dropdown, separated from the org list.
- Lets the existing `/create-organization` route be entered when an active organization is already set; swaps the top-right "Sign Out" for a "Cancel" button in that case so users can back out without logging out.
- Shows the Switch organization submenu when the user has ≥1 org (was ≥2), so Create organization is always reachable.

## Test plan
- [ ] Open the org dropdown with a single organization — Switch organization submenu is visible and contains the org + Create organization.
- [ ] Open the org dropdown with multiple organizations — orgs list renders, separator, then Create organization at the bottom.
- [ ] Click Create organization → lands on `/create-organization` with a Cancel button (top-right) that returns to `/`.
- [ ] Submit the form → new org is created and set active; user lands on `/`.
- [ ] Onboarding flow (no active org) still shows Sign Out instead of Cancel and redirects post-create.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores “Create organization” in the org switcher and makes the create flow available even when an org is active, with a clear Cancel option for quick exit.

- **New Features**
  - Adds “Create organization” to the Switch organization submenu (with a separator); navigates to `/create-organization`.
  - On `/create-organization`, shows “Cancel” (returns to `/`) when an org is active; keeps “Sign Out” for onboarding.
  - Shows the Switch organization submenu when the user has at least one org (was two), so “Create organization” is always reachable.

<sup>Written for commit 39c1438e49c6328e8887a1a9735bff9607a96396. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now create a new organization directly from the organization dropdown menu.
  * The create organization page displays a Cancel button when an active organization exists, enabling quick navigation back to the dashboard.

* **Improvements**
  * The "Switch organization" submenu now appears when you have at least one organization instead of requiring more than one.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4471)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->