### PR TITLE
feat(desktop): allow relay-backup.superset.sh in renderer CSP

### DIFF
--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -11,13 +11,13 @@
       - default-src 'self': Only allow resources from same origin
       - script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com: Allow scripts from same origin + WebAssembly (for xterm ImageAddon) + PostHog
       - style-src 'self' 'unsafe-inline': Allow styles from same origin + inline (needed for CSS-in-JS)
-      - connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc: Allow WebSocket + API + Electric proxy + PostHog + Sentry + data URIs (file attachment upload via data URL) + blob URIs + local host-service (127.0.0.1) + relay
+      - connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc: Allow WebSocket + API + Electric proxy + PostHog + Sentry + data URIs (file attachment upload via data URL) + blob URIs + local host-service (127.0.0.1) + relay + relay override target (for staging/failover via PostHog flag)
       - img-src 'self' data: blob: https: http:: Allow images from any source (needed for favicons, browser pane webview content, and file attachment previews)
       - font-src 'self': Allow fonts from same origin
       - frame-src https: http: data: blob:: Allow webview browser pane to load any URL
       - child-src 'self' blob:: Allow workers from same origin + blob workers
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: blob: https: http:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: blob: https: http:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary

- Adds `https://relay-backup.superset.sh` as a pre-allowed `connect-src` entry in the desktop renderer's CSP, alongside the existing `%RELAY_URL%` (which is replaced with `https://relay.superset.sh` at build time).
- This is a stable secondary relay URL we can repoint via DNS (CNAME) or via the existing `relay-url-override` PostHog flag payload, so we can route a user's host-service / desktop renderer at a non-prod relay (staging, failover) without cutting a new desktop release each time the override target changes.
- Today's CSP only allows `%RELAY_URL%` substituted at build time, so any override URL gets blocked by `connect-src` for HTTPS requests (the `wss:` scheme-only entry already lets WS through, which is why CLI tunneling works against any host).

## Test plan

- [ ] Build the desktop renderer; confirm the resulting `index.html` contains `https://relay-backup.superset.sh` in the `connect-src` directive.
- [ ] With the `relay-url-override` flag set to `{"url": "https://relay-backup.superset.sh"}` for a test user, the desktop renderer can issue HTTPS trpc requests to the relay (workspace creates, port queries) without CSP violations in DevTools console.
- [ ] Without the flag (or for users outside the cohort), behavior is unchanged — renderer still uses `relay.superset.sh`.

## Notes

- `relay-backup.superset.sh` resolves via CNAME to the staging Fly app today; we can re-CNAME it elsewhere (failover, new staging env) without redeploying desktop.
- No change to the host-service (main process) — it has no CSP, so any override URL has always worked there. This PR closes the renderer-side gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds https://relay-backup.superset.sh to the desktop renderer CSP (`connect-src`) so the `relay-url-override` flag can route HTTPS requests to a staging/failover relay without shipping a new desktop build. `%RELAY_URL%` remains the primary host; behavior is unchanged for users not in the flag cohort.

<sup>Written for commit f55aea8f7f53f4fc0b50f0b3085d13103cae0fa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security connectivity configuration to allow connections to an additional backup relay endpoint.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4473)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->