### PR TITLE
fix(cli): skip browser auto-open in SSH / headless contexts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,6 +10,7 @@
 		"build:linux-x64": "cli-framework build --target=bun-linux-x64 --outfile=./dist/superset-linux-x64",
 		"build:all": "bun run build:darwin-arm64 && bun run build:linux-x64",
 		"build:dist": "bun run scripts/build-dist.ts",
+		"test": "bun test --pass-with-no-tests",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/cli/src/commands/auth/login/LoginUI.tsx
+++ b/packages/cli/src/commands/auth/login/LoginUI.tsx
@@ -6,6 +6,7 @@ export type LoginStatus = "starting" | "waiting" | "exchanging" | "done";
 export interface LoginUIProps {
 	url: string | null;
 	status: LoginStatus;
+	noBrowser?: boolean;
 	onSubmit: (code: string) => void;
 	onCancel: () => void;
 	onCopy: () => Promise<boolean>;
@@ -14,6 +15,7 @@ export interface LoginUIProps {
 export function LoginUI({
 	url,
 	status,
+	noBrowser,
 	onSubmit,
 	onCancel,
 	onCopy,
@@ -96,7 +98,11 @@ export function LoginUI({
 			<Text bold>superset auth login</Text>
 			<Text> </Text>
 			<Box flexDirection="row">
-				<Text>Browser didn't open? Use the url below to sign in </Text>
+				<Text>
+					{noBrowser
+						? "Open this URL on a machine with a browser to sign in "
+						: "Browser didn't open? Use the url below to sign in "}
+				</Text>
 				<Text dimColor>(press c to copy)</Text>
 			</Box>
 			<Text> </Text>

--- a/packages/cli/src/commands/auth/login/command.ts
+++ b/packages/cli/src/commands/auth/login/command.ts
@@ -1,9 +1,9 @@
 import * as p from "@clack/prompts";
-import { CLIError, string } from "@superset/cli-framework";
+import { boolean, CLIError, string } from "@superset/cli-framework";
 import { render } from "ink";
 import { createElement } from "react";
 import { createApiClient } from "../../../lib/api-client";
-import { login } from "../../../lib/auth";
+import { detectHeadlessReason, login } from "../../../lib/auth";
 import { command } from "../../../lib/command";
 import { readConfig, writeConfig } from "../../../lib/config";
 import { copyToClipboard } from "./copyToClipboard";
@@ -16,9 +16,19 @@ export default command({
 		organization: string().desc(
 			"Organization id or slug — required for non-TTY logins when you belong to multiple orgs",
 		),
+		"no-browser": boolean().desc(
+			"Print the auth URL instead of opening a browser. Auto-enabled in SSH / headless contexts.",
+		),
 	},
 	run: async (opts) => {
 		const config = readConfig();
+		const headlessReason = detectHeadlessReason({
+			isTTY: Boolean(process.stdout.isTTY),
+			platform: process.platform,
+			env: process.env,
+		});
+		const noBrowser =
+			opts.options["no-browser"] === true || headlessReason !== null;
 		const useInk =
 			process.stdout.isTTY && process.stdin.isTTY && !process.env.CI;
 
@@ -32,6 +42,7 @@ export default command({
 		let currentProps: LoginUIProps = {
 			url: null,
 			status: "starting",
+			noBrowser,
 			onSubmit: (code) => pasteResolve?.(code),
 			onCancel: () => pasteReject?.(new CLIError("Login cancelled")),
 			onCopy: async () => false,
@@ -54,6 +65,7 @@ export default command({
 		let cancelled = false;
 		try {
 			result = await login(opts.signal, {
+				noBrowser,
 				onAuthorizationUrl: (url) => {
 					if (inkInstance) {
 						update({
@@ -62,7 +74,11 @@ export default command({
 							onCopy: () => copyToClipboard(url),
 						});
 					} else {
-						p.log.message("Browser didn't open? Use the url below to sign in");
+						p.log.message(
+							noBrowser
+								? "Open this URL on a machine with a browser to sign in:"
+								: "Browser didn't open? Use the url below to sign in",
+						);
 						p.log.message(url);
 					}
 				},

--- a/packages/cli/src/lib/auth.test.ts
+++ b/packages/cli/src/lib/auth.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import { buildAuthorizeUrl, detectHeadlessReason } from "./auth";
+
+describe("detectHeadlessReason", () => {
+	const base = {
+		isTTY: true,
+		platform: "darwin" as NodeJS.Platform,
+		env: {} as NodeJS.ProcessEnv,
+	};
+
+	test("returns null for interactive macOS terminal", () => {
+		expect(detectHeadlessReason(base)).toBeNull();
+	});
+
+	test("returns null for interactive Linux terminal with DISPLAY", () => {
+		expect(
+			detectHeadlessReason({
+				...base,
+				platform: "linux",
+				env: { DISPLAY: ":0" },
+			}),
+		).toBeNull();
+	});
+
+	test("returns null for Linux with WAYLAND_DISPLAY", () => {
+		expect(
+			detectHeadlessReason({
+				...base,
+				platform: "linux",
+				env: { WAYLAND_DISPLAY: "wayland-0" },
+			}),
+		).toBeNull();
+	});
+
+	test("blocks when stdout is not a TTY", () => {
+		expect(detectHeadlessReason({ ...base, isTTY: false })).toBe("no TTY");
+	});
+
+	test("blocks in CI", () => {
+		expect(detectHeadlessReason({ ...base, env: { CI: "true" } })).toBe(
+			"CI environment",
+		);
+	});
+
+	test("blocks when SSH_CONNECTION is set", () => {
+		expect(
+			detectHeadlessReason({
+				...base,
+				env: { SSH_CONNECTION: "10.0.0.1 12345 10.0.0.2 22" },
+			}),
+		).toBe("SSH session");
+	});
+
+	test("blocks when SSH_CLIENT is set (Daniel's EC2 case)", () => {
+		expect(
+			detectHeadlessReason({
+				...base,
+				env: { SSH_CLIENT: "10.0.0.1 12345 22" },
+			}),
+		).toBe("SSH session");
+	});
+
+	test("blocks when SSH_TTY is set", () => {
+		expect(
+			detectHeadlessReason({
+				...base,
+				env: { SSH_TTY: "/dev/pts/0" },
+			}),
+		).toBe("SSH session");
+	});
+
+	test("blocks on Linux with no DISPLAY and no WAYLAND_DISPLAY", () => {
+		expect(detectHeadlessReason({ ...base, platform: "linux", env: {} })).toBe(
+			"no display",
+		);
+	});
+
+	test("blocks on FreeBSD with no DISPLAY", () => {
+		expect(
+			detectHeadlessReason({ ...base, platform: "freebsd", env: {} }),
+		).toBe("no display");
+	});
+
+	test("does NOT block on macOS without DISPLAY (always has Aqua)", () => {
+		expect(
+			detectHeadlessReason({ ...base, platform: "darwin", env: {} }),
+		).toBeNull();
+	});
+
+	test("does NOT block on Windows without DISPLAY", () => {
+		expect(
+			detectHeadlessReason({ ...base, platform: "win32", env: {} }),
+		).toBeNull();
+	});
+
+	test("blocks in a Superset remote workspace", () => {
+		expect(
+			detectHeadlessReason({
+				...base,
+				env: { SUPERSET_REMOTE_WORKSPACE: "1" },
+			}),
+		).toBe("remote workspace");
+	});
+
+	test("blocks in a Docker container", () => {
+		expect(
+			detectHeadlessReason({ ...base, env: { CONTAINER: "docker" } }),
+		).toBe("container");
+	});
+
+	test("blocks in a Kubernetes pod", () => {
+		expect(
+			detectHeadlessReason({
+				...base,
+				env: { KUBERNETES_SERVICE_HOST: "10.0.0.1" },
+			}),
+		).toBe("container");
+	});
+});
+
+describe("buildAuthorizeUrl", () => {
+	const fixture = {
+		apiUrl: "https://api.superset.sh",
+		redirectUri: "https://app.superset.sh/cli/auth/code",
+		codeChallenge: "EXAMPLE_CHALLENGE",
+		state: "EXAMPLE_STATE",
+	};
+
+	test("targets the better-auth oauth2 authorize endpoint", () => {
+		const url = buildAuthorizeUrl(fixture);
+		expect(url.origin).toBe("https://api.superset.sh");
+		expect(url.pathname).toBe("/api/auth/oauth2/authorize");
+	});
+
+	test("always sets response_type=code (the value the server requires)", () => {
+		const url = buildAuthorizeUrl(fixture);
+		expect(url.searchParams.get("response_type")).toBe("code");
+		expect(url.searchParams.getAll("response_type")).toEqual(["code"]);
+	});
+
+	test("uses PKCE S256 challenge method", () => {
+		const url = buildAuthorizeUrl(fixture);
+		expect(url.searchParams.get("code_challenge")).toBe("EXAMPLE_CHALLENGE");
+		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+	});
+
+	test("preserves the chosen redirect_uri verbatim", () => {
+		const loopback = buildAuthorizeUrl({
+			...fixture,
+			redirectUri: "http://127.0.0.1:51789/callback",
+		});
+		expect(loopback.searchParams.get("redirect_uri")).toBe(
+			"http://127.0.0.1:51789/callback",
+		);
+	});
+
+	test("requests openid + offline_access scopes", () => {
+		const url = buildAuthorizeUrl(fixture);
+		const scope = url.searchParams.get("scope") ?? "";
+		expect(scope.split(" ").sort()).toEqual(
+			["email", "offline_access", "openid", "profile"].sort(),
+		);
+	});
+
+	test("ties the request to the API resource", () => {
+		const url = buildAuthorizeUrl(fixture);
+		expect(url.searchParams.get("resource")).toBe(fixture.apiUrl);
+	});
+
+	test("URL round-trip through string parses back to the same params", () => {
+		const url = buildAuthorizeUrl(fixture);
+		const parsed = new URL(url.toString());
+		expect(parsed.searchParams.get("response_type")).toBe("code");
+		expect(parsed.searchParams.get("client_id")).toBe("superset-cli");
+		expect(parsed.searchParams.get("state")).toBe(fixture.state);
+	});
+});

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -18,6 +18,7 @@ export interface LoginResult {
 export interface LoginCallbacks {
 	onAuthorizationUrl?: (url: string) => void;
 	promptForPastedCode: (signal: AbortSignal) => Promise<string>;
+	noBrowser?: boolean;
 }
 
 function base64url(buffer: Buffer): string {
@@ -54,11 +55,41 @@ export function getWebUrl(): string {
 	return env.SUPERSET_WEB_URL;
 }
 
+export interface BrowserOpenEnvironment {
+	isTTY: boolean;
+	platform: NodeJS.Platform;
+	env: NodeJS.ProcessEnv;
+}
+
+export function detectHeadlessReason(
+	environment: BrowserOpenEnvironment,
+): string | null {
+	const { isTTY, platform, env } = environment;
+	if (!isTTY) return "no TTY";
+	if (env.CI) return "CI environment";
+	if (env.SSH_CONNECTION || env.SSH_TTY || env.SSH_CLIENT) return "SSH session";
+	if (env.SUPERSET_REMOTE_WORKSPACE) return "remote workspace";
+	if (env.CONTAINER === "docker" || env.KUBERNETES_SERVICE_HOST)
+		return "container";
+	if (
+		platform !== "darwin" &&
+		platform !== "win32" &&
+		!env.DISPLAY &&
+		!env.WAYLAND_DISPLAY
+	) {
+		return "no display";
+	}
+	return null;
+}
+
 function shouldOpenBrowser(): boolean {
-	if (!process.stdout.isTTY) return false;
-	if (process.env.CI) return false;
-	if (process.env.SSH_CONNECTION || process.env.SSH_TTY) return false;
-	return true;
+	return (
+		detectHeadlessReason({
+			isTTY: Boolean(process.stdout.isTTY),
+			platform: process.platform,
+			env: process.env,
+		}) === null
+	);
 }
 
 async function bindLoopbackServer(): Promise<{
@@ -173,7 +204,7 @@ function parsePastedCode(input: string): { code: string; state: string } {
 	return { code, state };
 }
 
-function buildAuthorizeUrl({
+export function buildAuthorizeUrl({
 	apiUrl,
 	redirectUri,
 	codeChallenge,
@@ -317,7 +348,7 @@ export async function login(
 
 	callbacks.onAuthorizationUrl?.(pasteAuthorizeUrl);
 
-	if (shouldOpenBrowser()) {
+	if (!callbacks.noBrowser && shouldOpenBrowser()) {
 		void openBrowser(browserAuthorizeUrl);
 	}
 


### PR DESCRIPTION
## Summary

`superset auth login` over-eagerly shelled out to `xdg-open` on any TTY where `CI` / `SSH_CONNECTION` / `SSH_TTY` were unset. In real-world headless boxes that gap meant:

- **`SSH_CLIENT` was ignored.** openssh sets `SSH_CLIENT` but skips `SSH_CONNECTION` under certain PAM stacks / `UseDNS no` configs. A user SSH'd into an EC2 instance hit the auto-open path and ended up with a mangled URL pasted into their local Chrome — which then failed with `[query.response_type] Invalid input: expected "code"` against better-auth's Zod schema.
- **Linux + no DISPLAY / WAYLAND_DISPLAY → `xdg-open` is a no-op.** Same outcome: the URL gets thrown at the terminal in whatever shape the launcher prints it.
- **No `--no-browser` escape hatch** for users who want a clean paste flow even in a "headed" terminal.

## What changed

- Extracted browser-eligibility into `detectHeadlessReason(env)` — pure, returns a reason string or `null`. New checks: `SSH_CLIENT`, container env (`CONTAINER=docker`, `KUBERNETES_SERVICE_HOST`), Superset remote workspaces (`SUPERSET_REMOTE_WORKSPACE`), and Linux/BSD without `DISPLAY`/`WAYLAND_DISPLAY`. macOS and Windows still skip the display check (OS-level URL handlers).
- Added `--no-browser` flag to `superset auth login`.
- LoginUI swaps the prompt from `Browser didn't open?` to `Open this URL on a machine with a browser to sign in` when we already know the browser was never going to open.
- Added regression-guard tests on `buildAuthorizeUrl` confirming `response_type=code` is always set (the value the server's better-auth Zod schema requires).

## Why this fixes the SSH paste error too

Curl'ing the live URL builds verifies the API accepts the params as the CLI generates them. The validation error in the Slack thread was the symptom of a URL that got copy-paste-mangled out of an SSH terminal — auto-open chose `xdg-open` (which can't reach a browser on a remote box), the URL was dumped onto the terminal in whatever encoding the launcher emitted, and the user pasted a clipped copy into their local Chrome. Skipping auto-open on SSH means the URL is printed cleanly via clack/Ink (which we control), so the paste works.

Slack thread: user (Daniel) SSH'd into `ec2-user@ip-172-31-24-214`, ran `superset auth login`.

## Test plan

- [x] `bun --filter=@superset/cli test` — 22 new tests pass
- [x] `bun --filter=@superset/cli typecheck` clean
- [x] `bun run lint` clean
- [ ] Manual: `ssh` into a Linux box, run `superset auth login` from a fresh build, confirm browser is not launched and the URL is printed
- [ ] Manual: `superset auth login --no-browser` on macOS prints URL without opening Safari
- [ ] Manual: vanilla `superset auth login` on macOS still opens the browser

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip opening a browser for `superset auth login` in SSH/headless environments to prevent broken copy-paste URLs, and add a `--no-browser` flag. The UI now shows a clearer message when auto-open is disabled.

- **Bug Fixes**
  - Skip browser launch in SSH (`SSH_CLIENT`/`SSH_CONNECTION`/`SSH_TTY`), CI/no TTY, containers, and Linux/BSD without `DISPLAY`/`WAYLAND_DISPLAY`; avoids `xdg-open` no-ops and mangled URLs.
  - Add tests for headless detection and for `buildAuthorizeUrl` to ensure `response_type=code` is always set.

- **New Features**
  - `--no-browser` flag for `superset auth login`; auto-enabled in headless/SSH contexts.
  - Login UI updates its prompt to “Open this URL on a machine with a browser” when auto-open is skipped.

<sup>Written for commit dd2f311586d58b24ee92cd9b316b0a4bfb943f47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-browser` flag to the `auth login` command to suppress automatic browser launching
  * Automatic detection of headless environments and non-TTY contexts to prevent browser opening attempts

* **Tests**
  * Added comprehensive test coverage for authentication detection and authorization utilities

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4474)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->