### PR TITLE
fix(desktop): add Cmd+F search to v2 markdown preview

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -147,6 +147,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 					document={document}
 					filePath={filePath}
 					workspaceId={workspaceId}
+					isActive={context.isActive}
 					onChangeView={handleChangeView}
 					onForceView={handleForceView}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/types.ts
@@ -34,6 +34,7 @@ export interface ViewProps {
 	document: SharedFileDocument;
 	filePath: string;
 	workspaceId: string;
+	isActive: boolean;
 	onChangeView: (viewId: string) => void;
 	onForceView: (viewId: string) => void;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/MarkdownPreviewView/MarkdownPreviewView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/MarkdownPreviewView/MarkdownPreviewView.tsx
@@ -1,14 +1,39 @@
+import { useRef } from "react";
 import { TipTapMarkdownRenderer } from "renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer";
+import { MarkdownSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/MarkdownSearch";
+import { useMarkdownSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useMarkdownSearch";
 import type { ViewProps } from "../../types";
 
-export function MarkdownPreviewView({ document }: ViewProps) {
+export function MarkdownPreviewView({ document, filePath }: ViewProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const search = useMarkdownSearch({
+		containerRef,
+		isFocused: true,
+		isRenderedMode: true,
+		filePath,
+	});
+
 	if (document.content.kind !== "text") {
 		return null;
 	}
 
 	return (
-		<div className="h-full overflow-auto p-4">
-			<TipTapMarkdownRenderer value={document.content.value} />
+		<div className="relative h-full">
+			<MarkdownSearch
+				isOpen={search.isSearchOpen}
+				query={search.query}
+				caseSensitive={search.caseSensitive}
+				matchCount={search.matchCount}
+				activeMatchIndex={search.activeMatchIndex}
+				onQueryChange={search.setQuery}
+				onCaseSensitiveChange={search.setCaseSensitive}
+				onFindNext={search.findNext}
+				onFindPrevious={search.findPrevious}
+				onClose={search.closeSearch}
+			/>
+			<div ref={containerRef} className="h-full overflow-auto p-4">
+				<TipTapMarkdownRenderer value={document.content.value} />
+			</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/MarkdownPreviewView/MarkdownPreviewView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/MarkdownPreviewView/MarkdownPreviewView.tsx
@@ -4,11 +4,15 @@ import { MarkdownSearch } from "renderer/screens/main/components/WorkspaceView/C
 import { useMarkdownSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useMarkdownSearch";
 import type { ViewProps } from "../../types";
 
-export function MarkdownPreviewView({ document, filePath }: ViewProps) {
+export function MarkdownPreviewView({
+	document,
+	filePath,
+	isActive,
+}: ViewProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const search = useMarkdownSearch({
 		containerRef,
-		isFocused: true,
+		isFocused: isActive,
 		isRenderedMode: true,
 		filePath,
 	});


### PR DESCRIPTION
## Summary
- Wires the existing `useMarkdownSearch` hook + `MarkdownSearch` component into v2's `MarkdownPreviewView`, so Cmd+F now opens the same inline search bar that v1 has had — match highlighting, count, next/prev (Enter/Shift+Enter), case-sensitive toggle, Esc-to-close.
- Single-file change: `MarkdownPreviewView.tsx` now renders the search overlay above a ref'd scroll container and calls the v1 hook with `isFocused: true` / `isRenderedMode: true`.
- No new shared package — v2 chat search already imports `useTextSearch` from the v1 tree, so this PR follows the same cross-tree convention to avoid churn.

Closes SUPER-630.

## Test plan
- [ ] Open a `.md` file in a v2 workspace, confirm the preview renders as before.
- [ ] Press Cmd+F inside the preview — inline search bar appears in the top-right.
- [ ] Type a query — matches highlight, count shows `N of M`, Enter / Shift+Enter cycle next/prev, scroll follows the active match.
- [ ] Toggle case-sensitive button — match set updates.
- [ ] Press Esc — search closes, highlights clear.
- [ ] Switch to a different markdown file — search state resets cleanly.
- [ ] Verify v1 markdown preview search still works (no regression).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cmd+F search to the v2 Markdown preview, mirroring v1, using `useMarkdownSearch` and `MarkdownSearch` with a ref’d scroll container for highlights, N/M count, next/prev (Enter/Shift+Enter), case sensitivity, and Esc-to-close (SUPER-630). Also gates the find hotkey to the active pane by threading `isActive` through `ViewProps`, so only the focused preview responds in split view.

<sup>Written for commit e2cb21de2a9c175d72561d750fefe0293ec22e87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-view markdown search UI to markdown previews for finding and navigating matches.
  * View renderers now receive an active/inactive state so previews can adjust behavior when a pane is active or not.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4475)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->