### PR TITLE
feat(api): reconcile host online status from relay directory

### DIFF
--- a/apps/api/src/app/api/hosts/jobs/sync-presence/route.ts
+++ b/apps/api/src/app/api/hosts/jobs/sync-presence/route.ts
@@ -1,0 +1,86 @@
+import { db } from "@superset/db/client";
+import { Receiver } from "@upstash/qstash";
+import { Redis } from "@upstash/redis";
+import { sql } from "drizzle-orm";
+
+import { env } from "@/env";
+
+export const dynamic = "force-dynamic";
+
+const receiver = new Receiver({
+	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
+	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
+});
+
+const redis = new Redis({
+	url: env.KV_REST_API_URL,
+	token: env.KV_REST_API_TOKEN,
+});
+
+// Key shape owned by apps/relay/src/directory.ts — must match.
+const RELAY_TTL_KEY = "relay:tunnel-ttl";
+
+export async function POST(request: Request): Promise<Response> {
+	const body = await request.text();
+	const signature = request.headers.get("upstash-signature");
+	const isDev = env.NODE_ENV === "development";
+
+	if (!isDev) {
+		if (!signature) {
+			return Response.json({ error: "Missing signature" }, { status: 401 });
+		}
+		const valid = await receiver
+			.verify({
+				body,
+				signature,
+				url: `${env.NEXT_PUBLIC_API_URL}/api/hosts/jobs/sync-presence`,
+			})
+			.catch(() => false);
+		if (!valid) {
+			return Response.json({ error: "Invalid signature" }, { status: 401 });
+		}
+	}
+
+	let connected: string[];
+	try {
+		connected = await redis.zrange<string[]>(
+			RELAY_TTL_KEY,
+			Date.now(),
+			"+inf",
+			{ byScore: true },
+		);
+	} catch (error) {
+		console.error("[sync-presence] redis read failed:", error);
+		return Response.json({ error: "Directory read failed" }, { status: 502 });
+	}
+
+	const result = await db.execute<{
+		organization_id: string;
+		machine_id: string;
+		is_online: boolean;
+	}>(sql`
+		WITH desired AS (
+			SELECT
+				organization_id,
+				machine_id,
+				(organization_id::text || ':' || machine_id) = ANY(${connected}::text[]) AS expected
+			FROM v2_hosts
+		)
+		UPDATE v2_hosts h
+		SET is_online = d.expected
+		FROM desired d
+		WHERE h.organization_id = d.organization_id
+			AND h.machine_id = d.machine_id
+			AND h.is_online IS DISTINCT FROM d.expected
+		RETURNING h.organization_id, h.machine_id, h.is_online
+	`);
+
+	const flippedOn = result.rows.filter((r) => r.is_online === true).length;
+	const flippedOff = result.rows.filter((r) => r.is_online === false).length;
+
+	return Response.json({
+		connected: connected.length,
+		flippedOn,
+		flippedOff,
+	});
+}

--- a/apps/api/src/app/api/hosts/jobs/sync-presence/route.ts
+++ b/apps/api/src/app/api/hosts/jobs/sync-presence/route.ts
@@ -35,7 +35,10 @@ export async function POST(request: Request): Promise<Response> {
 				signature,
 				url: `${env.NEXT_PUBLIC_API_URL}/api/hosts/jobs/sync-presence`,
 			})
-			.catch(() => false);
+			.catch((error) => {
+				console.error("[sync-presence] signature verify failed:", error);
+				return false;
+			});
 		if (!valid) {
 			return Response.json({ error: "Invalid signature" }, { status: 401 });
 		}
@@ -54,29 +57,55 @@ export async function POST(request: Request): Promise<Response> {
 		return Response.json({ error: "Directory read failed" }, { status: 502 });
 	}
 
-	const result = await db.execute<{
+	// Refuse to mass-flip when the directory comes back empty — most likely a
+	// misconfigured KV credential or a wiped key, not a real zero-host state.
+	// The relay's event-driven setOnline writes still cover genuine disconnects.
+	if (connected.length === 0) {
+		console.warn(
+			"[sync-presence] empty connected set; skipping reconcile to avoid mass-flip",
+		);
+		return Response.json({
+			connected: 0,
+			flippedOn: 0,
+			flippedOff: 0,
+			skipped: true,
+		});
+	}
+
+	let rows: Array<{
 		organization_id: string;
 		machine_id: string;
 		is_online: boolean;
-	}>(sql`
-		WITH desired AS (
-			SELECT
-				organization_id,
-				machine_id,
-				(organization_id::text || ':' || machine_id) = ANY(${connected}::text[]) AS expected
-			FROM v2_hosts
-		)
-		UPDATE v2_hosts h
-		SET is_online = d.expected
-		FROM desired d
-		WHERE h.organization_id = d.organization_id
-			AND h.machine_id = d.machine_id
-			AND h.is_online IS DISTINCT FROM d.expected
-		RETURNING h.organization_id, h.machine_id, h.is_online
-	`);
+	}>;
+	try {
+		const result = await db.execute<{
+			organization_id: string;
+			machine_id: string;
+			is_online: boolean;
+		}>(sql`
+			WITH desired AS (
+				SELECT
+					organization_id,
+					machine_id,
+					(organization_id::text || ':' || machine_id) = ANY(${connected}::text[]) AS expected
+				FROM v2_hosts
+			)
+			UPDATE v2_hosts h
+			SET is_online = d.expected
+			FROM desired d
+			WHERE h.organization_id = d.organization_id
+				AND h.machine_id = d.machine_id
+				AND h.is_online IS DISTINCT FROM d.expected
+			RETURNING h.organization_id, h.machine_id, h.is_online
+		`);
+		rows = result.rows;
+	} catch (error) {
+		console.error("[sync-presence] reconcile UPDATE failed:", error);
+		return Response.json({ error: "Reconcile write failed" }, { status: 502 });
+	}
 
-	const flippedOn = result.rows.filter((r) => r.is_online === true).length;
-	const flippedOff = result.rows.filter((r) => r.is_online === false).length;
+	const flippedOn = rows.filter((r) => r.is_online === true).length;
+	const flippedOff = rows.filter((r) => r.is_online === false).length;
 
 	return Response.json({
 		connected: connected.length,

--- a/apps/relay/fly.staging.toml
+++ b/apps/relay/fly.staging.toml
@@ -1,0 +1,31 @@
+app = "superset-relay-staging"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  RELAY_PORT = "8080"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+
+[http_service.concurrency]
+  type = "connections"
+  soft_limit = 2000
+  hard_limit = 5000
+
+[[http_service.checks]]
+  interval = "10s"
+  timeout = "2s"
+  grace_period = "20s"
+  method = "GET"
+  path = "/health"
+
+[[vm]]
+  memory = "4gb"
+  cpu_kind = "performance"
+  cpus = 2

--- a/packages/cli/src/commands/hosts/list/command.ts
+++ b/packages/cli/src/commands/hosts/list/command.ts
@@ -1,4 +1,5 @@
 import { CLIError, table } from "@superset/cli-framework";
+import { getHostId } from "@superset/shared/host-info";
 import { command } from "../../../lib/command";
 
 export default command({
@@ -16,10 +17,11 @@ export default command({
 		}
 
 		const rows = await ctx.api.host.list.query({ organizationId });
+		const localHostId = getHostId();
 		return rows.map((row) => ({
 			id: row.id,
 			name: row.name,
-			online: row.online ? "yes" : "no",
+			online: row.online ? "yes" : row.id === localHostId ? "local" : "no",
 		}));
 	},
 });


### PR DESCRIPTION
## Summary

Adds a safety net for stale `v2_hosts.is_online` rows. Today the boolean is written event-driven by the relay calling `host.setOnline` on tunnel open/close (3-retry, then silently dropped). When the relay crashes or `host.setOnline` exhausts its retries, the DB stays `is_online = true` indefinitely with no self-healing — and automation dispatch (`packages/trpc/src/router/automation/dispatch.ts`), the desktop popovers, port scans, PR target derivation, and host badges all gate behavior on this boolean. Agents then route work at unreachable hosts and get confused, which is the user-visible bug this addresses.

### Approach

The relay already maintains the ground-truth connected set in Upstash (`relay:tunnel-ttl` sorted set, refreshed on every pong, evicted by `sweepStale` after a 90s grace window — see `apps/relay/src/directory.ts`). The new reconciler is a QStash-triggered route at `POST /api/hosts/jobs/sync-presence` that:

1. Reads `relay:tunnel-ttl` directly from the same Upstash the relay uses (API already has the credentials).
2. Diffs against `v2_hosts.is_online` in a single CTE-driven `UPDATE ... IS DISTINCT FROM` using `ANY(\$1::text[])` for membership.
3. Returns counts of `flippedOn` / `flippedOff` for observability.

A QStash schedule fires this every minute. Combined with the relay's existing 90s TTL + 30s sweep, a stuck row corrects within ~3 minutes worst case.

The existing event-driven `host.setOnline` write stays in place — it handles the common-case sub-second transition. The reconciler only catches the failure modes (relay crash, API write failures).

### Why direct-Upstash instead of a new relay endpoint

Earlier in the design we considered adding a `GET /internal/presence` to the relay with a shared-secret auth. Dropped because:
- The API already has matching `KV_REST_API_URL` / `KV_REST_API_TOKEN` env vars (used by `apps/api/src/app/api/chat/tools/web-search/route.ts` for rate limiting).
- One fewer network hop, one fewer env var to manage across two services, no shared secret to provision.
- The coupling cost (knowing the key shape `relay:tunnel-ttl`) is small and documented inline.

### Other changes in this PR

- **`packages/cli/src/commands/hosts/list/command.ts`** — relabels offline rows as `local` when `row.id` matches `getHostId()`. Gives users running the daemon on the same machine a clearer "running but not relay-connected" signal versus a generic `no`. Other clients still see `no` for that host, which is the correct answer for them — they genuinely can't reach it.
- **`apps/relay/fly.staging.toml`** — config for a parallel staging Fly app (`superset-relay-staging`). Already deployed, targeted at individual users via the existing `relay-url-override` PostHog flag (CSP allows `https://relay-backup.superset.sh` after #4473). Documents the staging setup so future test infra is reproducible.

## Test plan

- [x] Staging relay deployed (`superset-relay-staging.fly.dev`), sandbox host registered there via the PostHog `relay-url-override` flag.
- [ ] After merge, watch the first QStash run via the Upstash dashboard or Vercel logs — confirm 2xx response and reasonable `connected` count.
- [ ] Force-kill the staging relay machine to manufacture stuck-online entries; confirm next reconciler run flips them to `false` (`flippedOff` > 0 in the response).
- [ ] Inspect a sample of `v2_hosts` rows for known-offline hosts to confirm they converge.

## Out of scope

- No schema changes. `v2_hosts.is_online` stays a boolean; the reconciler keeps the value honest.
- No Electric/desktop reactive changes — reconciler updates flow through the normal Electric WAL fan-out, which is already at scale-acceptable volume since drift corrections are rare in steady state.
- All consumers (`dispatch.ts`, popovers, port scans, badges) keep reading `is_online` unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scheduled reconciler to sync host online status with the relay’s Upstash directory, fixing stuck-online rows and adding guardrails to avoid mass flips. This self-heals drift so routing, automation, and UI stop targeting unreachable machines.

- **Bug Fixes**
  - QStash-triggered `POST /api/hosts/jobs/sync-presence` reads Upstash `relay:tunnel-ttl` and diffs into `v2_hosts.is_online`; returns `connected`, `flippedOn`, `flippedOff`.
  - Reliability: skip writes when the directory is empty to avoid mass-offline; wrap the reconcile `UPDATE` in try/catch and log; log on signature-verify failures.
  - Runs every minute; with the relay’s 90s TTL + sweep, drift corrects in ~3 minutes.
  - Keeps event-driven `host.setOnline` as primary; this job repairs relay/API failure cases.

- **New Features**
  - CLI `hosts list`: offline rows show `local` when `row.id` matches `getHostId()`.
  - Added `apps/relay/fly.staging.toml` for a staging relay app (`superset-relay-staging`) used via the `relay-url-override` flag.

<sup>Written for commit c4ad01364c3a8799bcbcc2c3c6ec5d20c1026a27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host presence sync endpoint to reconcile online/offline status with connected tunnels, including signature verification and safety checks to avoid mass-flips.
  * CLI hosts list now marks the current machine as "local" instead of "no".

* **Chores**
  * Added staging deployment configuration for the relay service.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4476)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->