### PR TITLE
fix(terminal): drop BASH_FUNC_* keys from captured shell env

### DIFF
--- a/packages/host-service/src/terminal/clean-shell-env.test.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { parseEnvOutput } from "./clean-shell-env.ts";
+
+const DELIMITER = "__SUPERSET_SHELL_ENV__";
+
+function withDelimiters(body: string): string {
+	return `${DELIMITER}\n${body}\n${DELIMITER}`;
+}
+
+describe("parseEnvOutput", () => {
+	test("parses standard KEY=value lines", () => {
+		const result = parseEnvOutput(
+			withDelimiters("HOME=/Users/test\nPATH=/usr/bin\nSHELL=/bin/zsh"),
+		);
+		expect(result).toEqual({
+			HOME: "/Users/test",
+			PATH: "/usr/bin",
+			SHELL: "/bin/zsh",
+		});
+	});
+
+	test("drops exported bash function definitions (BASH_FUNC_*)", () => {
+		const body = [
+			"HOME=/home/ec2-user",
+			"BASH_FUNC_which%%=() {  (alias; eval declare -f) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot $@",
+			"}",
+			"PATH=/usr/local/bin:/usr/bin",
+		].join("\n");
+		const result = parseEnvOutput(withDelimiters(body));
+		expect(result).toEqual({
+			HOME: "/home/ec2-user",
+			PATH: "/usr/local/bin:/usr/bin",
+		});
+		expect(Object.keys(result)).not.toContain("BASH_FUNC_which%%");
+	});
+
+	test("ignores continuation lines that contain '='", () => {
+		const body = [
+			"HOME=/home/x",
+			"BASH_FUNC_foo%%=() {  local x=1",
+			"  local y=2",
+			"}",
+			"USER=x",
+		].join("\n");
+		const result = parseEnvOutput(withDelimiters(body));
+		expect(result).toEqual({ HOME: "/home/x", USER: "x" });
+	});
+
+	test("throws when delimiter is missing", () => {
+		expect(() => parseEnvOutput("HOME=/x")).toThrow("delimiter not found");
+	});
+
+	test("throws when section parses to empty", () => {
+		expect(() => parseEnvOutput(withDelimiters(""))).toThrow("returned empty");
+	});
+});

--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -68,18 +68,19 @@ function resolveShellForEnv(): string {
 	return resolveConfiguredShell(process.env);
 }
 
-function parseEnvOutput(stdout: string): Record<string, string> {
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+export function parseEnvOutput(stdout: string): Record<string, string> {
 	const envSection = stdout.split(DELIMITER)[1];
 	if (!envSection) {
 		throw new Error("Failed to parse shell env output - delimiter not found");
 	}
 
 	const result: Record<string, string> = {};
-	for (const line of envSection.split("\n").filter(Boolean)) {
+	for (const line of envSection.split("\n")) {
+		if (!ENV_KEY_RE.test(line)) continue;
 		const idx = line.indexOf("=");
-		if (idx > 0) {
-			result[line.slice(0, idx)] = line.slice(idx + 1);
-		}
+		result[line.slice(0, idx)] = line.slice(idx + 1);
 	}
 
 	if (Object.keys(result).length === 0) {


### PR DESCRIPTION
## Summary
- `parseEnvOutput` in `clean-shell-env.ts` split `command env` output line-by-line, which truncated exported bash function entries (`BASH_FUNC_<name>%%=() { … \n }`) to just the first line. That malformed value propagated into every spawned pty.
- Result: every nested bash printed `bash: which: line 1: syntax error: unexpected end of file` and `error importing function definition for 'which'`. Cosmetic (bash falls back to `/usr/bin/which`), but loud on Amazon Linux EC2 where `/etc/profile.d/which2.sh` ships `export -f which`.
- Fix: require `^[A-Za-z_][A-Za-z0-9_]*=` before treating a captured line as a key/value, so `BASH_FUNC_*%%` keys and function-body continuation lines are skipped. VS Code's `resolveShellEnv` does the same thing for the same reason.

## Test plan
- [x] `bun test src/terminal/clean-shell-env.test.ts` — 5 new tests pass
- [x] `bun test src/terminal/env.test.ts` — existing 39 tests still pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [ ] Manual: open a v2 terminal on an Amazon Linux EC2 host and verify the `which` import error no longer prints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops importing exported bash functions from captured shell env by ignoring `BASH_FUNC_*%%` lines. This removes noisy “error importing function definition” messages in nested bash shells (common on Amazon Linux where `which` is exported).

- **Bug Fixes**
  - Updated env parser to only accept lines matching `^[A-Za-z_][A-Za-z0-9_]*=`; skips `BASH_FUNC_*%%` and continuation lines.
  - Added tests for standard keys, dropped functions, continuation lines, and delimiter errors; existing tests still pass.

<sup>Written for commit 7ce1b25cf4aba24a5d37d2cd7fcc8f6bef0c9362. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for environment variable parsing, including edge cases with bash functions and continuation lines.

* **Bug Fixes**
  * Improved environment variable parsing with enhanced validation and more robust handling of special cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4477)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->