### PR TITLE
[codex] Fix teardown shell exit command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.9",
+      "version": "1.9.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -785,7 +785,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@hono/node-server": "1.19.11",
         "@hono/node-ws": "1.3.0",

--- a/packages/host-service/src/runtime/teardown/teardown.test.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildTeardownInitialCommand } from "./teardown";
+
+function isFishAvailable(): boolean {
+	const result = spawnSync("fish", ["-c", "exit 0"], { stdio: "ignore" });
+	return result.status === 0;
+}
+
+describe("teardown initial command", () => {
+	test("uses exec instead of shell-specific exit status syntax", () => {
+		const command = buildTeardownInitialCommand(
+			"/tmp/worktree/.superset/teardown.sh",
+		);
+
+		expect(command).toBe("exec bash '/tmp/worktree/.superset/teardown.sh'");
+		expect(command).not.toContain("$?");
+	});
+
+	test("exits fish with the teardown script status", () => {
+		if (!isFishAvailable()) return;
+
+		const root = mkdtempSync(join(tmpdir(), "host-service-teardown-"));
+		const dirWithQuote = join(root, "quote's dir");
+		const scriptPath = join(dirWithQuote, "teardown.sh");
+
+		try {
+			mkdirSync(dirWithQuote, { recursive: true });
+			writeFileSync(scriptPath, "#!/usr/bin/env bash\nexit 7\n", {
+				mode: 0o755,
+			});
+			chmodSync(scriptPath, 0o755);
+
+			const result = spawnSync("fish", [
+				"-c",
+				buildTeardownInitialCommand(scriptPath),
+			]);
+
+			expect(result.status).toBe(7);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/host-service/src/runtime/teardown/teardown.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.ts
@@ -53,8 +53,7 @@ export async function runTeardown({
 	if (!existsSync(scriptPath)) return { status: "skipped" };
 
 	const terminalId = randomUUID();
-	// Single-quoted so no shell interpolation is possible on the path.
-	const initialCommand = `bash ${singleQuote(scriptPath)} ; exit $?`;
+	const initialCommand = buildTeardownInitialCommand(scriptPath);
 
 	const session = await createTerminalSessionInternal({
 		terminalId,
@@ -136,6 +135,13 @@ export async function runTeardown({
 		}, timeoutMs);
 		timer.unref();
 	});
+}
+
+export function buildTeardownInitialCommand(scriptPath: string): string {
+	// `exec` replaces the user's login shell with the teardown process. That
+	// avoids shell-specific exit-status syntax like `$?`, which breaks in fish
+	// and leaves the hidden teardown terminal open until timeout.
+	return `exec bash ${singleQuote(scriptPath)}`;
 }
 
 /** POSIX single-quote escape: safe for any byte sequence in a path. */

--- a/packages/host-service/test/integration/teardown.integration.test.ts
+++ b/packages/host-service/test/integration/teardown.integration.test.ts
@@ -104,6 +104,8 @@ function createFishLikePtySpawner(
 			| null = null;
 
 		queueMicrotask(() => {
+			// OSC 133;A — shell-integration prompt-start marker the terminal
+			// session waits for before sending the initial command.
 			dataCallback?.(Buffer.from("\x1b]133;A\x07"));
 		});
 

--- a/packages/host-service/test/integration/teardown.integration.test.ts
+++ b/packages/host-service/test/integration/teardown.integration.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Server, type ServerOptions } from "@superset/pty-daemon";
+import { runTeardown } from "../../src/runtime/teardown";
+import { disposeDaemonClient } from "../../src/terminal/daemon-client-singleton";
+import {
+	initTerminalBaseEnv,
+	resetTerminalBaseEnvForTests,
+} from "../../src/terminal/env";
+import { __resetSessionsForTesting } from "../../src/terminal/terminal";
+import { __setAccountShellForTesting } from "../../src/terminal/user-shell";
+import { type BasicScenario, createBasicScenario } from "../helpers/scenarios";
+
+describe("runTeardown integration", () => {
+	let scenario: BasicScenario | null = null;
+	let server: Server | null = null;
+	let tmp: string | null = null;
+
+	afterEach(async () => {
+		__resetSessionsForTesting();
+		await disposeDaemonClient();
+		resetTerminalBaseEnvForTests();
+		__setAccountShellForTesting(undefined);
+		delete process.env.SUPERSET_PTY_DAEMON_SOCKET;
+		delete process.env.SUPERSET_HOME_DIR;
+		if (server) {
+			await server.close().catch(() => {});
+			server = null;
+		}
+		if (scenario) {
+			await scenario.dispose();
+			scenario = null;
+		}
+		if (tmp) {
+			rmSync(tmp, { recursive: true, force: true });
+			tmp = null;
+		}
+	});
+
+	test("hidden teardown terminal exits under fish instead of timing out", async () => {
+		tmp = mkdtempSync(join(tmpdir(), "host-service-teardown-it-"));
+		const socketPath = join(tmp, "pty-daemon.sock");
+		const writes: string[] = [];
+		server = new Server({
+			socketPath,
+			daemonVersion: "0.0.0-teardown-integration-test",
+			spawnPty: createFishLikePtySpawner(writes),
+		});
+		await server.listen();
+
+		process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
+		process.env.SUPERSET_HOME_DIR = tmp;
+		__setAccountShellForTesting("/bin/fish");
+		initTerminalBaseEnv({
+			HOME: process.env.HOME ?? tmp,
+			LANG: "en_US.UTF-8",
+			PATH: process.env.PATH ?? "/usr/bin:/bin",
+			SHELL: "/bin/bash",
+		});
+
+		scenario = await createBasicScenario();
+		const scriptDir = join(scenario.repo.repoPath, ".superset");
+		const markerPath = join(scenario.repo.repoPath, "teardown-marker.txt");
+		mkdirSync(scriptDir, { recursive: true });
+		writeFileSync(
+			join(scriptDir, "teardown.sh"),
+			`#!/usr/bin/env bash\nprintf ran > ${shellQuote(markerPath)}\n`,
+			{ mode: 0o755 },
+		);
+
+		const startedAt = Date.now();
+		const result = await runTeardown({
+			db: scenario.host.db,
+			workspaceId: scenario.workspaceId,
+			worktreePath: scenario.repo.repoPath,
+			timeoutMs: 3_000,
+		});
+
+		expect(Date.now() - startedAt).toBeLessThan(3_000);
+		expect(result.status).toBe("ok");
+		expect(writes).toHaveLength(1);
+		expect(writes[0]).toStartWith("exec bash ");
+		expect(writes[0]).not.toContain("$?");
+		expect(existsSync(markerPath)).toBe(true);
+	});
+});
+
+function createFishLikePtySpawner(
+	writes: string[],
+): NonNullable<ServerOptions["spawnPty"]> {
+	return ({ meta }) => {
+		let dataCallback: ((data: Buffer) => void) | null = null;
+		let exitCallback:
+			| ((info: { code: number | null; signal: number | null }) => void)
+			| null = null;
+
+		queueMicrotask(() => {
+			dataCallback?.(Buffer.from("\x1b]133;A\x07"));
+		});
+
+		return {
+			pid: 42,
+			meta,
+			write(data) {
+				const command = data.toString("utf8").trim();
+				writes.push(command);
+				if (command.includes("$?")) {
+					dataCallback?.(
+						Buffer.from(
+							"fish: $? is not the exit status. In fish, please use $status.\n",
+						),
+					);
+					return;
+				}
+
+				const child = spawnSync("/bin/sh", ["-c", command], {
+					cwd: meta.cwd,
+					env: meta.env,
+				});
+				if (child.stdout.byteLength > 0) dataCallback?.(child.stdout);
+				if (child.stderr.byteLength > 0) dataCallback?.(child.stderr);
+				exitCallback?.({ code: child.status ?? 1, signal: null });
+			},
+			resize(cols, rows) {
+				meta.cols = cols;
+				meta.rows = rows;
+			},
+			kill(signal) {
+				exitCallback?.({ code: null, signal: signal === "SIGKILL" ? 9 : 1 });
+			},
+			onData(cb) {
+				dataCallback = cb;
+			},
+			onExit(cb) {
+				exitCallback = cb;
+			},
+			getMasterFd() {
+				return 0;
+			},
+		};
+	};
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}


### PR DESCRIPTION
## Summary

Fixes SUPER-487 by changing the hidden teardown terminal command from `bash <script>; exit $?` to `exec bash <script>`.

## Root Cause

Teardown commands are queued into the user login shell. Fish does not support `$?`, so the command could fail before exiting the hidden terminal. That left teardown waiting for the timeout path, which made workspace teardown take about 60 seconds.

## Impact

The teardown process now replaces the login shell with the bash teardown script, so completion and exit status propagation no longer depend on shell-specific syntax. This should work for fish, zsh, bash, and sh while preserving safe single-quote escaping for script paths.

## Validation

- `bun test packages/host-service/src/runtime/teardown/teardown.test.ts packages/host-service/test/integration/teardown.integration.test.ts`
- `bun run lint`
- `bun run --cwd packages/host-service typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the teardown shell command with an exec-based call so the hidden terminal exits reliably across shells and propagates the script status. Addresses SUPER-487 and removes the ~60s timeout seen with fish.

- **Bug Fixes**
  - Switch to `exec bash <script>` via new `buildTeardownInitialCommand()` in `@superset/host-service`.
  - Works with fish, zsh, bash, and sh; preserves safe single-quote escaping for script paths.
  - Added unit tests and a fish-like PTY integration test to confirm exit status propagation and no timeout.

<sup>Written for commit d4aa217a262c6821f93ade23e86a71b058798f20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of teardown operations by ensuring teardown processes reliably propagate exit codes in fish-like shells.
  * Prevented hidden teardown terminals from remaining open longer than necessary, so teardowns complete promptly.

* **Tests**
  * Added tests to validate shell compatibility and quoting behavior for teardown execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4478)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->