### PR TITLE
fix(api): pass connected set as array literal in sync-presence

### DIFF
--- a/apps/api/src/app/api/hosts/jobs/sync-presence/route.ts
+++ b/apps/api/src/app/api/hosts/jobs/sync-presence/route.ts
@@ -72,6 +72,12 @@ export async function POST(request: Request): Promise<Response> {
 		});
 	}
 
+	// Pass the connected set as a single Postgres array-literal parameter
+	// rather than letting drizzle expand the JS array into N placeholders
+	// (`($1, $2, ...)::text[]` is a row-cast, not an array). Routing keys are
+	// `${uuid}:${32-char-hex}` so the unquoted `{a,b,c}` literal is safe.
+	const connectedArrayLiteral = `{${connected.join(",")}}`;
+
 	let rows: Array<{
 		organization_id: string;
 		machine_id: string;
@@ -87,7 +93,7 @@ export async function POST(request: Request): Promise<Response> {
 				SELECT
 					organization_id,
 					machine_id,
-					(organization_id::text || ':' || machine_id) = ANY(${connected}::text[]) AS expected
+					(organization_id::text || ':' || machine_id) = ANY(${connectedArrayLiteral}::text[]) AS expected
 				FROM v2_hosts
 			)
 			UPDATE v2_hosts h


### PR DESCRIPTION
## Summary

The reconciler from #4476 has been 502-ing every QStash tick since merge. Verified via Vercel logs — the actual error:

\`\`\`
Error: Failed query: ... ANY(($1, $2, $3, ..., $57)::text[])
\`\`\`

Drizzle's \`sql\` template was expanding the JS \`connected: string[]\` as N positional placeholders, producing a Postgres **row-constructor cast to text[]** rather than an array. That's not valid SQL syntax for membership testing.

## Fix

Build a single Postgres array literal (\`{a,b,c}\`) from the connected set and pass it as one text parameter. The routing keys are \`\${uuid}:\${32-char-hex}\` — they contain only \`[0-9a-f-]\` plus a single \`:\`, no characters that would conflict with the unquoted array literal format, so no per-element quoting needed.

## Test plan

- [ ] After merge + Vercel deploy, watch the next QStash tick in vercel logs — should return 200 with \`{connected, flippedOn, flippedOff}\` counts instead of 502.
- [ ] Confirm a known stuck-online host (the sandbox on satya-sprite, killed earlier) flips to \`is_online = false\` after one reconciler run.

## Notes

- Caught this while running the original E2E test: killed the staging relay machine, waited for the directory TTL to expire, expected the reconciler to flip my row to offline — instead it 502-ed every minute. The \`try/catch\` from the hardening commit (a8c83b6 in the merged PR) is what made it diagnosable rather than a generic 500.
- The local repro confirmed shape of the error too (\`db.execute\` throws \`NeonDbError\` with the same expanded SQL).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the sync-presence job by passing the connected set as a single Postgres array literal (`{a,b,c}`) instead of letting `drizzle` expand the JS array into N placeholders that became a row-cast and caused 502s. Membership checks now work, so hosts flip online/offline as expected.

<sup>Written for commit 4f515d20d0deaf9b2c8d70314cabd6adecc0f3d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal database query construction for presence synchronization endpoints. No changes to user-facing functionality, behavior, or response formats.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4483)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->