### PR TITLE
fix(cost): remove deprecated device.heartbeat tRPC route

### DIFF
--- a/packages/trpc/src/router/device/device.ts
+++ b/packages/trpc/src/router/device/device.ts
@@ -11,54 +11,6 @@ import { protectedProcedure } from "../../trpc";
  */
 export const deviceRouter = {
 	/**
-	 * @deprecated Kept for backwards compat with shipped desktop/mobile clients
-	 * that still call heartbeat on a 30s interval. Same logic as registerDevice.
-	 */
-	heartbeat: protectedProcedure
-		.input(
-			z.object({
-				deviceId: z.string().min(1),
-				deviceName: z.string().min(1),
-				deviceType: z.enum(deviceTypeValues),
-			}),
-		)
-		.mutation(async ({ ctx, input }) => {
-			const organizationId = ctx.activeOrganizationId;
-			if (!organizationId) {
-				throw new TRPCError({
-					code: "BAD_REQUEST",
-					message: "No active organization selected",
-				});
-			}
-
-			const userId = ctx.session.user.id;
-			const now = new Date();
-
-			await db
-				.insert(devicePresence)
-				.values({
-					userId,
-					organizationId,
-					deviceId: input.deviceId,
-					deviceName: input.deviceName,
-					deviceType: input.deviceType,
-					lastSeenAt: now,
-					createdAt: now,
-				})
-				.onConflictDoUpdate({
-					target: [devicePresence.userId, devicePresence.deviceId],
-					set: {
-						deviceName: input.deviceName,
-						deviceType: input.deviceType,
-						lastSeenAt: now,
-						organizationId,
-					},
-				});
-
-			return { success: true };
-		}),
-
-	/**
 	 * Register device presence (called once on app startup).
 	 * Upserts a row so MCP can verify device ownership.
 	 */


### PR DESCRIPTION
## Summary

Removes `device.heartbeat`, accounting for ~10% of `/api` log volume on Vercel.

The renderer caller was removed in #2904 (2026-03-28). `MINIMUM_DESKTOP_VERSION = "1.5.0"` (released 2026-04-11) blocks every client that predates the caller removal from using the app — those clients hit the `UpdateRequiredPage` gate. The endpoint was kept "for backwards compat with shipped clients", but the only clients still polling are stuck behind that gate, and their heartbeat traffic has no downstream consumer.

`heartbeat` only updates `device_presence.last_seen_at`, which is purely cosmetic (used for `ORDER BY` in the MCP `list-devices` tool). After this change, stale-build calls return a silent tRPC `NOT_FOUND` — no UI affordance, no breakage.

`registerDevice` stays untouched — MCP's `executeOnDevice` still uses the `device_presence` row for ownership verification.

## Test plan

- [ ] CI green
- [ ] Spot-check Vercel `/api` log volume drops by ~10% within an hour of deploy
- [ ] Confirm no spike in tRPC `NOT_FOUND` errors in app code (only stale binaries should hit it)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed deprecated `device.heartbeat` tRPC route to eliminate unused polling and cut cost, keeping `registerDevice` for MCP ownership checks. Expect ~10% drop in Vercel `/api` log volume; stale clients are already blocked and now get tRPC NOT_FOUND.

<sup>Written for commit f216c1ece39d2471ccd392402b5e4fa71cf45534. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated device synchronization procedure that was previously maintained for compatibility with older application versions. Core device registration functionality remains fully available and operational. Applications currently using this removed procedure will require code updates to maintain full compatibility and proper connectivity with the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4490)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->