### PR TITLE
fix(relay): cache host.checkAccess by userId, not token

### DIFF
--- a/apps/relay/src/access.ts
+++ b/apps/relay/src/access.ts
@@ -1,17 +1,38 @@
+import { parseHostRoutingKey } from "@superset/shared/host-routing";
 import { LRUCache } from "lru-cache";
 import { createApiClient } from "./api-client";
+import type { AuthContext } from "./auth";
 
+const ALLOWED_TTL_MS = 15 * 60 * 1000;
+const DENIED_TTL_MS = 30 * 1000;
+
+// Cache by (userId, hostId), not (token, hostId). Tokens rotate on every JWT
+// refresh while the underlying user→host authorization is stable, so a
+// token-keyed cache effectively expires with each refresh and burns
+// host.checkAccess calls on the API for no reason.
 const allowedCache = new LRUCache<string, true>({
 	max: 50_000,
-	ttl: 5 * 60 * 1000,
+	ttl: ALLOWED_TTL_MS,
+});
+const deniedCache = new LRUCache<string, true>({
+	max: 10_000,
+	ttl: DENIED_TTL_MS,
 });
 
 export async function checkHostAccess(
+	auth: AuthContext,
 	token: string,
 	hostId: string,
 ): Promise<boolean> {
-	const key = `${token}:${hostId}`;
+	// Short-circuit "not in org" locally: the API does this same check from
+	// the JWT before hitting the DB, so the round trip is wasted.
+	const parsed = parseHostRoutingKey(hostId);
+	if (!parsed) return false;
+	if (!auth.organizationIds.includes(parsed.organizationId)) return false;
+
+	const key = `${auth.sub}:${hostId}`;
 	if (allowedCache.has(key)) return true;
+	if (deniedCache.has(key)) return false;
 
 	try {
 		const client = createApiClient(token);
@@ -19,6 +40,8 @@ export async function checkHostAccess(
 		const ok = result.allowed && result.paidPlan;
 		if (ok) {
 			allowedCache.set(key, true);
+		} else {
+			deniedCache.set(key, true);
 		}
 		return ok;
 	} catch {

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -108,7 +108,7 @@ const authMiddleware: MiddlewareHandler<AppContext> = async (c, next) => {
 		return c.json({ error: "Host not connected" }, 503);
 	}
 
-	const hasAccess = await checkHostAccess(token, hostId);
+	const hasAccess = await checkHostAccess(auth, token, hostId);
 	if (!hasAccess) return c.json({ error: "Forbidden" }, 403);
 
 	c.set("auth", auth);
@@ -140,7 +140,7 @@ app.get(
 					return;
 				}
 
-				const hasAccess = await checkHostAccess(token, hostId);
+				const hasAccess = await checkHostAccess(auth, token, hostId);
 				if (!hasAccess) {
 					ws.close(1008, "Forbidden");
 					return;


### PR DESCRIPTION
## Summary

`host.checkAccess` was accounting for ~29% of `/api` log volume on Vercel. The relay caches results in an LRU, but the cache key was `\`\${token}:\${hostId}\`` — and JWTs rotate every hour or so. Every refresh invalidated the cache entry even though the underlying user→host authorization hadn't changed, so active desktops were re-hitting the API roughly every JWT lifetime regardless of the 5-minute LRU TTL.

## Changes

- **Cache key**: `(userId, hostId)` via verified `auth.sub`. Stable across token refreshes.
- **Allowed TTL**: 5m → 15m. Org/host membership changes maybe a few times a day per user; a 15m worst-case stale-allow window is fine.
- **Negative cache**: 30s for denied. Prevents a misconfigured client with a bad token from hammering the API.
- **Local short-circuit**: if the host's `organizationId` isn't in `auth.organizationIds`, return false without an API call. The API does this exact check from the JWT before its DB query, so the round trip was wasted.

## Expected impact

~80% drop in `host.checkAccess` calls = ~23% of total `/api` log volume.

Follow-up to #4490 (deleted `device.heartbeat`, ~10% of volume).

## Test plan

- [ ] CI green
- [ ] Watch Vercel `/api` `host.checkAccess` request count drop within an hour of staging deploy
- [ ] Spot-check that revoking a user from an org still bounces them within 15 minutes (the new allowed-TTL)
- [ ] Confirm no spike in 403 Forbidden after deploy (would indicate the negative cache is being too aggressive)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache `host.checkAccess` by userId instead of token to stop cache busting on JWT refresh. Adds a local org check and tuned TTLs to cut API calls by ~80% (~23% of `/api` volume).

- **Refactors**
  - Cache key: `auth.sub + hostId` (stable across token rotation).
  - TTLs: allowed 15m; denied 30s.
  - Local short-circuit: return false if host org not in `auth.organizationIds` (no API call).
  - Signature change: `checkHostAccess(auth, token, hostId)`; call sites updated.

<sup>Written for commit 2d5c787151c4ae338a1225b3cc1c6f329af8da67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved access authorization efficiency with enhanced caching strategy for host access validation.
  * Optimized authorization flow to reduce repeated API checks and provide faster access decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4491)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->