### PR TITLE
chore(api): drop redundant matcher entry from CORS proxy

### DIFF
--- a/apps/api/src/proxy.ts
+++ b/apps/api/src/proxy.ts
@@ -67,6 +67,5 @@ export default function proxy(req: NextRequest) {
 export const config = {
 	matcher: [
 		"/((?!_next|ingest|monitoring|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-		"/(api|trpc)(.*)",
 	],
 };


### PR DESCRIPTION
## Summary

`apps/api/src/proxy.ts` had two matcher entries:

\`\`\`ts
matcher: [
  "/((?!_next|ingest|monitoring|<asset-exts>).*)",
  "/(api|trpc)(.*)",  // ← fully covered by the line above
],
\`\`\`

The second is redundant — the first wildcard already matches everything not in its exclusion list, including `/api/*` and `/trpc/*`. Next dedupes overlapping matchers so behaviour is identical, it's just dead config.

Dropping it leaves a single readable pattern.

## Scope

- No CORS or routing behaviour change.
- Originally this PR also added negative-lookahead exclusions for server-to-server endpoints (jwks, token, webhooks) to skip middleware on them and trim Vercel log volume. Pulled that back: chat-attachments turned out to be local-only per Avi's follow-up, so the matcher doesn't need finer-grained scoping right now. The /api log cleanup can come back later if the volume matters once #4490 + #4491 deploy.

## Test plan

- [ ] CI green
- [ ] Browser sign-in / tRPC still works from `app.superset.sh`, `admin.superset.sh`, desktop renderer (CORS unchanged)
- [ ] GitHub + Linear webhooks still deliver (still match the matcher exactly as before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed middleware routing so proxy/CORS middleware applies to the correct set of requests while explicitly skipping internal Next.js paths, ingest/monitoring routes, and common static assets.

* **Performance**
  * Reduced unnecessary middleware execution on excluded paths to improve overall request handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4492)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->