### PR TITLE
feat(desktop): wire Link task command to v2 workspaces

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/ui/LinkTask/LinkTaskFrame.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/LinkTask/LinkTaskFrame.tsx
@@ -6,13 +6,35 @@ import {
 } from "@superset/ui/command";
 import { toast } from "@superset/ui/sonner";
 import { useLiveQuery } from "@tanstack/react-db";
-import Fuse from "fuse.js";
-import { useMemo } from "react";
+import { useDeferredValue, useMemo } from "react";
+import {
+	StatusIcon,
+	type StatusType,
+} from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/StatusIcon";
+import { useHybridSearch } from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useHybridSearch";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useFrameStackStore } from "../../core/frames";
 import { useCommandPaletteQuery } from "../CommandPalette/CommandPalette";
 
 const MAX_RESULTS = 25;
+
+// Matches tasks list view ordering: in progress → todo → backlog → done → canceled.
+const STATUS_TYPE_ORDER: Record<string, number> = {
+	started: 0,
+	unstarted: 1,
+	backlog: 2,
+	completed: 3,
+	canceled: 4,
+};
+
+const PRIORITY_ORDER: Record<string, number> = {
+	urgent: 0,
+	high: 1,
+	medium: 2,
+	low: 3,
+	none: 4,
+};
 
 interface LinkTaskFrameProps {
 	workspaceId: string;
@@ -21,7 +43,9 @@ interface LinkTaskFrameProps {
 export function LinkTaskFrame({ workspaceId }: LinkTaskFrameProps) {
 	const collections = useCollections();
 	const query = useCommandPaletteQuery();
+	const deferredQuery = useDeferredValue(query);
 	const setOpen = useFrameStackStore((s) => s.setOpen);
+	const { v2Workspaces } = useOptimisticCollectionActions();
 
 	const { data: tasks = [] } = useLiveQuery(
 		(q) =>
@@ -29,68 +53,130 @@ export function LinkTaskFrame({ workspaceId }: LinkTaskFrameProps) {
 				id: t.id,
 				slug: t.slug,
 				title: t.title,
+				description: t.description,
+				labels: t.labels,
+				statusId: t.statusId,
+				priority: t.priority,
 				externalUrl: t.externalUrl,
 				updatedAt: t.updatedAt,
 			})),
 		[collections.tasks],
 	);
 
-	const fuse = useMemo(
-		() =>
-			new Fuse(tasks, {
-				keys: [
-					{ name: "slug", weight: 3 },
-					{ name: "title", weight: 2 },
-				],
-				threshold: 0.4,
-				ignoreLocation: true,
-			}),
-		[tasks],
+	const { data: statuses = [] } = useLiveQuery(
+		(q) =>
+			q.from({ s: collections.taskStatuses }).select(({ s }) => ({
+				id: s.id,
+				type: s.type,
+				color: s.color,
+				position: s.position,
+				progressPercent: s.progressPercent,
+			})),
+		[collections.taskStatuses],
 	);
 
+	const statusMap = useMemo(() => {
+		const map = new Map<
+			string,
+			{
+				type: StatusType;
+				color: string;
+				position: number;
+				progressPercent: number | null;
+			}
+		>();
+		for (const s of statuses) {
+			map.set(s.id, {
+				type: s.type as StatusType,
+				color: s.color,
+				position: s.position,
+				progressPercent: s.progressPercent,
+			});
+		}
+		return map;
+	}, [statuses]);
+
+	const { search } = useHybridSearch(tasks);
+
 	const filtered = useMemo(() => {
-		if (!query) {
+		if (!deferredQuery) {
 			return [...tasks]
-				.sort(
-					(a, b) =>
-						new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-				)
+				.sort((a, b) => {
+					const statusA = a.statusId ? statusMap.get(a.statusId) : undefined;
+					const statusB = b.statusId ? statusMap.get(b.statusId) : undefined;
+					const typeOrderA =
+						STATUS_TYPE_ORDER[statusA?.type ?? ""] ?? Number.MAX_SAFE_INTEGER;
+					const typeOrderB =
+						STATUS_TYPE_ORDER[statusB?.type ?? ""] ?? Number.MAX_SAFE_INTEGER;
+					if (typeOrderA !== typeOrderB) return typeOrderA - typeOrderB;
+					const positionA = statusA?.position ?? Number.MAX_SAFE_INTEGER;
+					const positionB = statusB?.position ?? Number.MAX_SAFE_INTEGER;
+					if (positionA !== positionB) return positionA - positionB;
+					const priorityOrderA =
+						PRIORITY_ORDER[a.priority] ?? Number.MAX_SAFE_INTEGER;
+					const priorityOrderB =
+						PRIORITY_ORDER[b.priority] ?? Number.MAX_SAFE_INTEGER;
+					return priorityOrderA - priorityOrderB;
+				})
 				.slice(0, MAX_RESULTS);
 		}
-		return fuse.search(query, { limit: MAX_RESULTS }).map((r) => r.item);
-	}, [query, fuse, tasks]);
+		return search(deferredQuery)
+			.slice(0, MAX_RESULTS)
+			.map((r) => r.item);
+	}, [deferredQuery, search, tasks, statusMap]);
 
 	const handleSelect = (taskId: string, slug: string) => {
+		v2Workspaces.updateWorkspace(workspaceId, { taskId });
 		toast.success(`Linked ${slug} to workspace`);
-		void linkTaskToWorkspace(taskId, workspaceId);
 		setOpen(false);
 	};
 
 	return (
 		<CommandList className="max-h-[400px]">
 			<CommandEmpty>No tasks found.</CommandEmpty>
-			<CommandGroup heading={query ? "Results" : "Recent tasks"}>
-				{filtered.map((task) => (
-					<RawCommandItem
-						key={task.id}
-						value={`${task.slug} ${task.title}`}
-						onSelect={() => handleSelect(task.id, task.slug)}
-					>
-						<span className="text-xs font-mono text-muted-foreground">
-							{task.slug}
-						</span>
-						<span className="truncate">{task.title}</span>
-					</RawCommandItem>
-				))}
-			</CommandGroup>
+			{filtered.length > 0 && (
+				<CommandGroup heading={deferredQuery ? "Results" : "Tasks"}>
+					{filtered.map((task) => {
+						const status = task.statusId
+							? statusMap.get(task.statusId)
+							: undefined;
+						return (
+							<RawCommandItem
+								key={task.id}
+								value={`${task.slug} ${task.title}`}
+								onSelect={() => handleSelect(task.id, task.slug)}
+								className="group items-start gap-3 rounded-md px-2.5 py-2"
+							>
+								<span className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
+									{status ? (
+										<StatusIcon
+											type={status.type}
+											color={status.color}
+											progress={status.progressPercent ?? undefined}
+										/>
+									) : (
+										<span className="size-3.5 rounded-full border border-muted-foreground/40" />
+									)}
+								</span>
+								<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+									<span className="truncate text-sm leading-snug">
+										{task.title}
+									</span>
+									<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+										<span className="font-mono">{task.slug}</span>
+										{status ? (
+											<>
+												<span aria-hidden>·</span>
+												<span className="capitalize">{status.type}</span>
+											</>
+										) : null}
+									</span>
+								</div>
+							</RawCommandItem>
+						);
+					})}
+				</CommandGroup>
+			)}
 		</CommandList>
 	);
-}
-
-async function linkTaskToWorkspace(
-	taskId: string,
-	workspaceId: string,
-): Promise<void> {
-	void taskId;
-	void workspaceId;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/DashboardSidebarWorkspaceHoverCardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/DashboardSidebarWorkspaceHoverCardContent.tsx
@@ -13,6 +13,7 @@ import { useHotkeyDisplay } from "renderer/hotkeys";
 import type { DashboardSidebarWorkspace } from "../../../../types";
 import { ChecksList } from "./components/ChecksList";
 import { ChecksSummary } from "./components/ChecksSummary";
+import { LinkedTaskSection } from "./components/LinkedTaskSection";
 import { PullRequestStatusBadge } from "./components/PullRequestStatusBadge";
 import { ReviewStatus } from "./components/ReviewStatus";
 
@@ -37,6 +38,7 @@ export function DashboardSidebarWorkspaceHoverCardContent({
 		needsRebase,
 		behindCount,
 		createdAt,
+		taskId,
 	} = workspace;
 	const { keys: openPRDisplay } = useHotkeyDisplay("OPEN_PR");
 	const hasOpenPRShortcut = !(
@@ -102,6 +104,8 @@ export function DashboardSidebarWorkspaceHoverCardContent({
 					{formatDistanceToNow(createdAt, { addSuffix: true })}
 				</span>
 			</div>
+
+			{taskId && <LinkedTaskSection taskId={taskId} />}
 
 			{needsRebase && (
 				<div className="flex items-center gap-2 text-amber-500 text-xs bg-amber-500/10 px-2 py-1.5 rounded-md">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/LinkedTaskSection/LinkedTaskSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/LinkedTaskSection/LinkedTaskSection.tsx
@@ -1,0 +1,84 @@
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { Link } from "@tanstack/react-router";
+import { LuExternalLink } from "react-icons/lu";
+import {
+	StatusIcon,
+	type StatusType,
+} from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/StatusIcon";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+interface LinkedTaskSectionProps {
+	taskId: string;
+}
+
+export function LinkedTaskSection({ taskId }: LinkedTaskSectionProps) {
+	const collections = useCollections();
+
+	const { data: rows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ t: collections.tasks })
+				.leftJoin({ s: collections.taskStatuses }, ({ t, s }) =>
+					eq(t.statusId, s.id),
+				)
+				.where(({ t }) => eq(t.id, taskId))
+				.select(({ t, s }) => ({
+					id: t.id,
+					slug: t.slug,
+					title: t.title,
+					externalUrl: t.externalUrl,
+					statusType: s?.type ?? null,
+					statusColor: s?.color ?? null,
+					statusProgress: s?.progressPercent ?? null,
+				})),
+		[collections, taskId],
+	);
+
+	const task = rows[0];
+	if (!task) return null;
+
+	return (
+		<div className="pt-2 border-t border-border space-y-0.5">
+			<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+				Task
+			</span>
+			<div className="flex items-center gap-1.5">
+				<Link
+					to="/tasks/$taskId"
+					params={{ taskId: task.id }}
+					className="group/task flex min-w-0 flex-1 items-center gap-1.5 text-left hover:text-foreground"
+					title={task.title}
+				>
+					<span className="flex size-3.5 shrink-0 items-center justify-center">
+						{task.statusType ? (
+							<StatusIcon
+								type={task.statusType as StatusType}
+								color={task.statusColor ?? "#9ca3af"}
+								progress={task.statusProgress ?? undefined}
+							/>
+						) : (
+							<span className="size-3 rounded-full border border-muted-foreground/40" />
+						)}
+					</span>
+					<span className="font-mono text-xs text-muted-foreground shrink-0">
+						{task.slug}
+					</span>
+					<span className="truncate text-xs">{task.title}</span>
+				</Link>
+				{task.externalUrl && (
+					<a
+						href={task.externalUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="shrink-0 text-muted-foreground hover:text-foreground"
+						title="Open task externally"
+						onClick={(e) => e.stopPropagation()}
+					>
+						<LuExternalLink className="size-3" />
+					</a>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/LinkedTaskSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/LinkedTaskSection/index.ts
@@ -1,0 +1,1 @@
+export { LinkedTaskSection } from "./LinkedTaskSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -250,6 +250,7 @@ export function useDashboardSidebarData() {
 					hostIsOnline: hosts.isOnline,
 					name: workspaces.name,
 					branch: workspaces.branch,
+					taskId: workspaces.taskId,
 					createdAt: workspaces.createdAt,
 					updatedAt: workspaces.updatedAt,
 					tabOrder: sidebarWorkspaces.sidebarState.tabOrder,
@@ -285,6 +286,7 @@ export function useDashboardSidebarData() {
 					hostIsOnline: hosts.isOnline,
 					name: workspaces.name,
 					branch: workspaces.branch,
+					taskId: workspaces.taskId,
 					createdAt: workspaces.createdAt,
 					updatedAt: workspaces.updatedAt,
 					tabOrder: MAIN_WORKSPACE_TAB_ORDER,
@@ -319,6 +321,7 @@ export function useDashboardSidebarData() {
 					hostIsOnline: host?.isOnline ?? false,
 					name: cloudRow.name,
 					branch: cloudRow.branch,
+					taskId: cloudRow.taskId,
 					createdAt: cloudRow.createdAt,
 					updatedAt: cloudRow.updatedAt,
 					tabOrder:
@@ -491,6 +494,7 @@ export function useDashboardSidebarData() {
 				behindCount: null,
 				createdAt: workspace.createdAt,
 				updatedAt: workspace.updatedAt,
+				taskId: workspace.taskId,
 			};
 
 			if (workspace.sectionId) {
@@ -541,6 +545,7 @@ export function useDashboardSidebarData() {
 				behindCount: null,
 				createdAt: new Date(),
 				updatedAt: new Date(),
+				taskId: null,
 				creationStatus: pw.status,
 			};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -40,6 +40,7 @@ export interface DashboardSidebarWorkspace {
 	behindCount: number | null;
 	createdAt: Date;
 	updatedAt: Date;
+	taskId: string | null;
 	creationStatus?: "preparing" | "generating-branch" | "creating" | "failed";
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -1,6 +1,12 @@
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	useCallback,
+	useDeferredValue,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useTasksFilterStore } from "../../stores/tasks-filter-state";
 import { BoardContent } from "./components/BoardContent";
@@ -30,6 +36,7 @@ export function TasksView({
 	const collections = useCollections();
 	const currentTab: TabValue = initialTab ?? "all";
 	const [searchQuery, setSearchQuery] = useState(initialSearch ?? "");
+	const deferredSearchQuery = useDeferredValue(searchQuery);
 	const assigneeFilter = initialAssignee ?? null;
 	const typeTab = initialType ?? "tasks";
 	const projectFilter = initialProject ?? null;
@@ -231,14 +238,14 @@ export function TasksView({
 						(viewMode === "board" ? (
 							<BoardContent
 								filterTab={currentTab}
-								searchQuery={searchQuery}
+								searchQuery={deferredSearchQuery}
 								assigneeFilter={assigneeFilter}
 								onTaskClick={handleTaskClick}
 							/>
 						) : (
 							<TableContent
 								filterTab={currentTab}
-								searchQuery={searchQuery}
+								searchQuery={deferredSearchQuery}
 								assigneeFilter={assigneeFilter}
 								onTaskClick={handleTaskClick}
 								onSelectionChange={handleSelectionChange}
@@ -247,13 +254,13 @@ export function TasksView({
 					{showPRs && (
 						<PullRequestsContent
 							projectFilter={projectFilter}
-							searchQuery={searchQuery}
+							searchQuery={deferredSearchQuery}
 						/>
 					)}
 					{showIssues && (
 						<GitHubIssuesContent
 							projectFilter={projectFilter}
-							searchQuery={searchQuery}
+							searchQuery={deferredSearchQuery}
 						/>
 					)}
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
@@ -21,6 +21,7 @@ interface V2WorkspacePatch {
 	name?: string;
 	branch?: string;
 	hostId?: string;
+	taskId?: string | null;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -188,6 +189,9 @@ export function useOptimisticCollectionActions() {
 							}
 							if (patch.hostId !== undefined) {
 								draft.hostId = patch.hostId;
+							}
+							if (patch.taskId !== undefined) {
+								draft.taskId = patch.taskId;
 							}
 						}),
 					),

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -411,12 +411,13 @@ function createOrgCollections(organizationId: string): OrgCollections {
 			getKey: (item) => item.id,
 			onUpdate: async ({ transaction }) => {
 				const { original, changes } = transaction.mutations[0];
-				const { branch, hostId, name } = changes;
+				const { branch, hostId, name, taskId } = changes;
 				const result = await apiClient.v2Workspace.update.mutate({
 					id: original.id,
 					branch,
 					hostId,
 					name,
+					taskId,
 				});
 				return { txid: result.txid };
 			},

--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -396,6 +396,7 @@ export const v2WorkspaceRouter = {
 				name: z.string().min(1).optional(),
 				branch: z.string().min(1).optional(),
 				hostId: z.string().min(1).optional(),
+				taskId: z.string().uuid().nullable().optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -412,10 +413,30 @@ export const v2WorkspaceRouter = {
 				await getScopedHost(workspace.organizationId, input.hostId);
 			}
 
+			if (input.taskId) {
+				const found = await dbWs.query.tasks.findFirst({
+					columns: { id: true, organizationId: true },
+					where: eq(tasks.id, input.taskId),
+				});
+				if (!found) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "taskId not found",
+					});
+				}
+				if (found.organizationId !== workspace.organizationId) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message: "taskId must belong to the workspace's organization",
+					});
+				}
+			}
+
 			const data = {
 				branch: input.branch,
 				hostId: input.hostId,
 				name: input.name,
+				taskId: input.taskId,
 			};
 			if (
 				Object.keys(data).every(


### PR DESCRIPTION
## Summary

Closes [SUPER-685](https://linear.app/superset-sh/issue/SUPER-685).

- **Link task command actually links.** The command palette picker now writes `taskId` to the current v2 workspace via `useOptimisticCollectionActions().v2Workspaces.updateWorkspace`; the `v2WorkspacePatch` and the collection's `onUpdate` handler both carry `taskId` end-to-end. `v2Workspace.update` trpc accepts `taskId` (uuid, nullable, optional) and validates it belongs to the workspace's org (mirroring `create`). `null` is the unlink path.
- **Linked task surfaces in the v2 sidebar hover card.** New `LinkedTaskSection` renders a "Task" row with `StatusIcon`, slug, truncated title, an in-app `<Link to="/tasks/$taskId">`, and an external-link icon when `externalUrl` is set. `taskId` is projected through all three sidebar workspace query/build sites in `useDashboardSidebarData`.
- **Picker UI matches `IssueLinkCommand`.** `StatusIcon` + two-line title/slug+status layout. The `Show closed` checkbox was dropped in favor of sorting in Linear list-view order (`started → unstarted → backlog → completed → canceled`, then `status.position`, then priority) — closed tasks naturally fall to the bottom and remain searchable.
- **Search quality + responsiveness.** Picker now uses the shared `useHybridSearch` hook (exact on slug/labels, fuzzy on title/description) instead of a single permissive Fuse. Both the picker and the main `TasksView` use `useDeferredValue` on the search query so heavy re-renders yield to keystrokes.

## Test plan

- [ ] Open command palette inside a v2 workspace → `Link task` → pick a task → workspace gets `taskId`, sidebar hover card shows it.
- [ ] Hover the workspace → click the linked task slug → navigates to `/tasks/$taskId`; external-link icon opens the Linear URL when present.
- [ ] Confirm closed/canceled tasks sort to the bottom in the picker; search "contact us" no longer matches "Context menus for panes".
- [ ] Type fast in the picker and in the tasks list search input — input stays responsive, results catch up when paused.
- [ ] `bun run typecheck` and `bun run lint` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links tasks to v2 workspaces from the command palette and shows the linked task in the sidebar hover card. Closes SUPER-685 and aligns the picker UI and search with the tasks list.

- **New Features**
  - Linking writes `taskId` to the current v2 workspace via `useOptimisticCollectionActions().v2Workspaces.updateWorkspace`; passing `null` unlinks.
  - `v2Workspace.update` now accepts `taskId` (uuid, nullable, optional) and validates it belongs to the workspace’s org.
  - Sidebar hover card displays the linked task with `StatusIcon`, slug, truncated title, an in-app link to `/tasks/$taskId`, and an external link when `externalUrl` exists. Picker UI matches `IssueLinkCommand`.

- **Performance**
  - Picker uses `useHybridSearch` and tasks list sort order (started → unstarted → backlog → completed → canceled, then status.position, then priority); closed tasks naturally sink but stay searchable.
  - Both the picker and `TasksView` use `useDeferredValue` for smoother typing under heavy re-renders.

<sup>Written for commit cf223da3c6a51c29fc3c456b53fb32915e5b7fe9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Link tasks to workspaces and view linked task details in workspace hover cards
  * Display task status, slug, and external links within linked task sections
  * Improved hybrid search functionality for better task discovery and filtering

* **Improvements**
  * Enhanced search performance with deferred query handling
  * Task lists now display with status icons and priority information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4493)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->