### PR TITLE
release(cli): cut v0.2.16

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -685,7 +685,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.15";
+const VERSION = "0.2.16";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.15",
+	"version": "0.2.16",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Changes since v0.2.15:

- workspaces: `superset workspaces list` table now shows the workspace ID column. (#4463)
- docs: VHS demo walkthrough recording added under `packages/cli/demo/`. (#4461)
- auth: `superset auth login --api-key sk_live_…` stores an API key at `~/.superset/config.json` instead of running the OAuth flow; `whoami` and `logout` updated to recognize stored keys. (#4472)
- hosts: `superset hosts list` shows `local` for the host machine you're invoking from, distinct from `online`/`no`. (#4476)
- automations: `--agent` is now the host agent instance/preset id (e.g. `claude`, `codex`, `superset`) and is resolved live from the host on every run. The `--agent-config-file` flag is removed; create/update rename `agentConfig` -> `agent` end-to-end. (#4481)

## Test plan

- [ ] CI green
- [ ] After merge, push `cli-v0.2.16` tag to fire the release pipeline (Release CLI workflow → builds linux-x64 / darwin-arm64 / linux-arm64 and updates the rolling `cli-latest` pointer)
- [ ] Smoke install via `cli-latest` once the release is published

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut `@superset/cli` v0.2.16. Adds API key login, clearer host labeling, workspace IDs in lists, and a simplified `--agent` flag (removes `--agent-config-file`).

- **New Features**
  - Workspaces: `superset workspaces list` now shows the workspace ID column.
  - Auth: `superset auth login --api-key ...` stores the key in `~/.superset/config.json`; `whoami` and `logout` use stored keys.
  - Hosts: `superset hosts list` now marks the current machine as `local`.
  - Automations: `--agent` is now a host agent ID (e.g., `claude`, `codex`, `superset`) resolved at run time.

- **Migration**
  - Replace `--agent-config-file` with `--agent`.
  - Update configs and payloads from `agentConfig` to `agent`.

<sup>Written for commit 9cd1a3745de477400104c8e18d728702426dd240. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI package version from 0.2.15 to 0.2.16.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4494)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->