### PR TITLE
release(sdk): cut alpha.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -921,7 +921,7 @@
     },
     "packages/sdk": {
       "name": "@superset/sdk",
-      "version": "0.0.1-alpha.9",
+      "version": "0.0.1-alpha.10",
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "bun-types": "1.3.11",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/sdk",
-	"version": "0.0.1-alpha.9",
+	"version": "0.0.1-alpha.10",
 	"description": "TypeScript SDK for the Superset API",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## Summary

Changes since alpha.9:

- `workspaces.list` accepts `projectId`, `projectName`, and `search` to filter the listing — matches the desktop list view. (#4455)
- chore(deps): pin exact dev versions (`bun-types` 1.3.11, `typescript` 5.9.3). (#4436)
- **BREAKING**: `automations.create` / `automations.update` / `AutomationSummary` rename `agentConfig` -> `agent` (string id of a host agent instance or preset, e.g. `claude`, `codex`, `superset`). The `AgentConfig` type is removed from the public surface. The host now resolves the live agent config on every run, so client-side snapshots no longer drift from `Settings → Agents` edits. (#4481)

## Test plan

- [ ] CI green
- [ ] After merge: `cd packages/sdk && bun run build && cd dist && npm publish --access public`
- [ ] Verify `@superset_sh/sdk@0.0.1-alpha.10` resolves on npm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/sdk` 0.0.1-alpha.10. Adds workspace list filters and a breaking rename for automation agents; also pins dev deps `bun-types@1.3.11` and `typescript@5.9.3`.

- **New Features**
  - `workspaces.list` now supports `projectId`, `projectName`, and `search` filters to match the desktop list view.

- **Migration**
  - Rename `agentConfig` to `agent` in `automations.create`, `automations.update`, and `AutomationSummary`. Use a string id (e.g., `claude`, `codex`, `superset`). The `AgentConfig` type is removed; the host resolves the live agent config on each run.

<sup>Written for commit 56d56be92e2186607f583477b1061b2d301c9ff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK package version to `0.0.1-alpha.10`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4495)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->