### PR TITLE
chore(desktop): default Changes view diff to inline

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -108,21 +108,14 @@ export const FileRow = memo(function FileRow({
 			>
 				<FileIcon fileName={basename} className="size-3.5 shrink-0" />
 				<span className="flex min-w-0 flex-1 items-baseline overflow-hidden">
-					{dir && (
-						<span
-							className="min-w-0 truncate text-muted-foreground"
-							style={{ direction: "rtl", textAlign: "left" }}
-						>
-							<bdi>{dir}</bdi>
-						</span>
-					)}
+					{dir && <span className="truncate text-muted-foreground">{dir}</span>}
 					{oldBasename && (
 						<span className="truncate text-muted-foreground">
 							{oldBasename}
 							<span className="px-1">→</span>
 						</span>
 					)}
-					<span className="shrink-0 truncate font-medium text-foreground">
+					<span className="min-w-[120px] truncate font-medium text-foreground">
 						{basename}
 					</span>
 				</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -63,8 +63,8 @@ export const FileRow = memo(function FileRow({
 	onOpenFile,
 	onOpenInEditor,
 }: FileRowProps) {
-	const { dir: fullDir, basename } = splitPath(file.path);
-	const dir = hideDir ? "" : fullDir;
+	const { basename } = splitPath(file.path);
+	const displayPath = hideDir ? basename : file.path;
 	const oldBasename =
 		file.oldPath && (file.status === "renamed" || file.status === "copied")
 			? splitPath(file.oldPath).basename
@@ -108,15 +108,17 @@ export const FileRow = memo(function FileRow({
 			>
 				<FileIcon fileName={basename} className="size-3.5 shrink-0" />
 				<span className="flex min-w-0 flex-1 items-baseline overflow-hidden">
-					{dir && <span className="truncate text-muted-foreground">{dir}</span>}
 					{oldBasename && (
-						<span className="truncate text-muted-foreground">
+						<span className="shrink-0 text-muted-foreground">
 							{oldBasename}
 							<span className="px-1">→</span>
 						</span>
 					)}
-					<span className="min-w-[120px] truncate font-medium text-foreground">
-						{basename}
+					<span
+						className="min-w-0 flex-1 truncate text-foreground"
+						style={{ direction: "rtl", textAlign: "left" }}
+					>
+						<bdi>{displayPath}</bdi>
 					</span>
 				</span>
 				<span className="ml-auto flex shrink-0 items-center gap-1.5 group-hover:invisible">
@@ -216,7 +218,9 @@ export const FileRow = memo(function FileRow({
 				<ContextMenuTrigger asChild>
 					<TooltipTrigger asChild>{rowButton}</TooltipTrigger>
 				</ContextMenuTrigger>
-				<TooltipContent side="right">{policy.hint}</TooltipContent>
+				<TooltipContent side="right">
+					<span className="font-mono text-[10px]">{file.path}</span>
+				</TooltipContent>
 			</Tooltip>
 			<ContextMenuContent className="w-64">
 				<ContextMenuItem onSelect={() => onSelect?.(file.path)}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -108,14 +108,21 @@ export const FileRow = memo(function FileRow({
 			>
 				<FileIcon fileName={basename} className="size-3.5 shrink-0" />
 				<span className="flex min-w-0 flex-1 items-baseline overflow-hidden">
-					{dir && <span className="truncate text-muted-foreground">{dir}</span>}
+					{dir && (
+						<span
+							className="min-w-0 truncate text-muted-foreground"
+							style={{ direction: "rtl", textAlign: "left" }}
+						>
+							<bdi>{dir}</bdi>
+						</span>
+					)}
 					{oldBasename && (
 						<span className="truncate text-muted-foreground">
 							{oldBasename}
 							<span className="px-1">→</span>
 						</span>
 					)}
-					<span className="min-w-[120px] truncate font-medium text-foreground">
+					<span className="shrink-0 truncate font-medium text-foreground">
 						{basename}
 					</span>
 				</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -44,13 +44,6 @@ export function DiffFileHeader({
 	const { copyToClipboard, copied } = useCopyToClipboard();
 	const policy = useSidebarFilePolicy();
 
-	// Split into directory + basename so the basename stays visible when the
-	// header is narrow — the directory truncates with ellipsis first, and the
-	// basename truncates only as a fallback (very narrow pane or no directory).
-	const lastSlash = path.lastIndexOf("/");
-	const dir = lastSlash >= 0 ? path.slice(0, lastSlash + 1) : "";
-	const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
-
 	return (
 		<div className="group/diff-file-header @container/diff-file-header sticky top-0 z-10 flex min-w-0 flex-nowrap items-center gap-1 bg-card px-3 py-2">
 			<button
@@ -80,18 +73,16 @@ export function DiffFileHeader({
 						className="flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded px-1 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
 						<FileIcon fileName={path} className="size-3.5 shrink-0" />
-						<span className="flex min-w-0 items-baseline font-mono text-xs">
-							{dir && (
-								<span className="min-w-0 shrink-[1000] truncate text-muted-foreground">
-									{dir}
-								</span>
-							)}
-							<span className="min-w-0 truncate text-foreground">{name}</span>
+						<span
+							className="min-w-0 flex-1 truncate font-mono text-xs text-foreground"
+							style={{ direction: "rtl", textAlign: "left" }}
+						>
+							<bdi>{path}</bdi>
 						</span>
 					</button>
 				</TooltipTrigger>
 				<TooltipContent side="bottom" showArrow={false}>
-					{policy.hint}
+					<span className="font-mono text-[10px]">{path}</span>
 				</TooltipContent>
 			</Tooltip>
 			<Tooltip>

--- a/apps/desktop/src/renderer/stores/changes/store.ts
+++ b/apps/desktop/src/renderer/stores/changes/store.ts
@@ -66,7 +66,7 @@ interface ChangesState {
 const initialState = {
 	selectedFiles: {} as Record<string, SelectedFileState | null>,
 	activeTab: "diffs" as ChangesSidebarTab,
-	viewMode: "side-by-side" as DiffViewMode,
+	viewMode: "inline" as DiffViewMode,
 	fileListViewMode: "grouped" as FileListViewMode,
 	expandedSections: {
 		"against-base": true,
@@ -231,7 +231,7 @@ export const useChangesStore = create<ChangesState>()(
 			}),
 			{
 				name: "changes-store",
-				version: 5,
+				version: 6,
 				migrate: (persisted, version) => {
 					const state = persisted as Record<string, unknown>;
 					if (version < 2) {
@@ -245,6 +245,9 @@ export const useChangesStore = create<ChangesState>()(
 					}
 					if (version < 5) {
 						state.activeTab = "diffs";
+					}
+					if (version < 6) {
+						state.viewMode = "inline";
 					}
 					state.sectionOrder = normalizeChangeSectionOrder(
 						state.sectionOrder as ChangeCategory[] | undefined,

--- a/apps/desktop/src/renderer/stores/settings.ts
+++ b/apps/desktop/src/renderer/stores/settings.ts
@@ -13,10 +13,20 @@ interface SettingsStore extends Settings {
 export const useSettings = create<SettingsStore>()(
 	persist(
 		(set) => ({
-			diffStyle: "split",
+			diffStyle: "unified",
 			showDiffComments: true,
 			update: (key, value) => set({ [key]: value }),
 		}),
-		{ name: "settings" },
+		{
+			name: "settings",
+			version: 1,
+			migrate: (persisted, version) => {
+				const state = (persisted ?? {}) as Record<string, unknown>;
+				if (version < 1) {
+					state.diffStyle = "unified";
+				}
+				return state as unknown as SettingsStore;
+			},
+		},
 	),
 );


### PR DESCRIPTION
## Summary
- Flip the persisted default for the Changes view diff mode from side-by-side to inline.
- Bump the persist version (5 → 6) and add a migration that resets `viewMode` to `"inline"` so existing users on the old default get migrated.
- Toolbar toggle in `DiffToolbar` and the split/unified mapping in `LightDiffViewer` are unchanged; users can still switch back.

Linear: [SUPER-687](https://linear.app/superset-sh/issue/SUPER-687/chore-default-diff-view-in-changes-view-to-inline-instead-of-side-by)

## Test plan
- [ ] Fresh install (or cleared `changes-store` localStorage): Changes view opens with the inline diff selected.
- [ ] Existing install with persisted `viewMode: "side-by-side"`: after upgrade, Changes view opens with inline selected (migration ran).
- [ ] Toggle in `DiffToolbar` still flips between inline and side-by-side, and the choice persists across reload.
- [ ] v1 file viewer (`FileViewerPane`) reflects the new default since it reads the same store.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default diff is now inline in the Changes view and unified in the v2 diff pane (SUPER-687). Existing users are migrated (`changes-store` v6 sets `viewMode: "inline"`, `settings` v1 sets `diffStyle: "unified"`); toggles still persist, the v1 file viewer reflects the new default, and file paths in the v2 Changes list and diff header use GitHub‑style left-ellipsis truncation to keep filenames visible with a tooltip that shows the full path.

<sup>Written for commit 9491377fdc49aaf099ea3e59f4b3f0576249c4d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Default change diff view switched from side-by-side to inline; existing preferences are migrated to this new default.
  * Default diff rendering switched from split to unified; persisted settings are migrated to the new default.

* **Style**
  * Improved file path and filename display across the UI for better RTL/long-path handling and updated tooltips to show full paths in monospace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4497)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->