### PR TITLE
feat(desktop): migrate version check to tRPC; deprecate REST endpoint

### DIFF
--- a/apps/api/src/app/api/desktop/version/route.ts
+++ b/apps/api/src/app/api/desktop/version/route.ts
@@ -1,8 +1,14 @@
 const MINIMUM_DESKTOP_VERSION = "1.5.0";
 
 /**
- * Used to force the desktop app to update, in cases where we can't support
- * multiple versions of the desktop app easily.
+ * @deprecated Use the `desktop.minimumVersion` tRPC procedure
+ * (`packages/trpc/src/router/desktop/desktop.ts`) instead. Kept here so older
+ * shipped desktop builds — whose `useVersionCheck` hook still calls this REST
+ * path — keep getting a sane response. Remove once the install base below
+ * v1.5.0 has aged out and Vercel logs show no traffic on this path.
+ *
+ * Keep `MINIMUM_DESKTOP_VERSION` in sync with the tRPC procedure's constant
+ * while both exist.
  */
 export async function GET() {
 	return Response.json({

--- a/apps/desktop/src/renderer/hooks/useVersionCheck/useVersionCheck.ts
+++ b/apps/desktop/src/renderer/hooks/useVersionCheck/useVersionCheck.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { env } from "renderer/env.renderer";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { lt } from "semver";
 
 interface VersionRequirements {
@@ -32,22 +32,7 @@ export function useVersionCheck(): UseVersionCheckResult {
 		}
 
 		try {
-			const response = await fetch(
-				`${env.NEXT_PUBLIC_API_URL}/api/desktop/version`,
-			);
-
-			if (!response.ok) {
-				// Fail open - if API is down, don't block users
-				setState({
-					isLoading: false,
-					isBlocked: false,
-					requirements: null,
-					error: null,
-				});
-				return;
-			}
-
-			const requirements: VersionRequirements = await response.json();
+			const requirements = await apiTrpcClient.desktop.minimumVersion.query();
 			const currentVersion = window.App.appVersion;
 			const isBlocked = lt(currentVersion, requirements.minimumVersion);
 
@@ -59,7 +44,7 @@ export function useVersionCheck(): UseVersionCheckResult {
 				error: null,
 			});
 		} catch (error) {
-			// Fail open on network errors
+			// Fail open on network/tRPC errors so a flaky API can't block users.
 			setState({
 				isLoading: false,
 				isBlocked: false,

--- a/packages/trpc/src/root.ts
+++ b/packages/trpc/src/root.ts
@@ -7,6 +7,7 @@ import { apiKeyRouter } from "./router/api-key";
 import { automationRouter } from "./router/automation";
 import { billingRouter } from "./router/billing";
 import { chatRouter } from "./router/chat";
+import { desktopRouter } from "./router/desktop";
 import { deviceRouter } from "./router/device";
 import { hostRouter } from "./router/host";
 import { integrationRouter } from "./router/integration";
@@ -31,6 +32,7 @@ export const appRouter = createTRPCRouter({
 	automation: automationRouter,
 	billing: billingRouter,
 	chat: chatRouter,
+	desktop: desktopRouter,
 	device: deviceRouter,
 	host: hostRouter,
 	integration: integrationRouter,

--- a/packages/trpc/src/router/desktop/desktop.ts
+++ b/packages/trpc/src/router/desktop/desktop.ts
@@ -1,0 +1,21 @@
+import type { TRPCRouterRecord } from "@trpc/server";
+import { publicProcedure } from "../../trpc";
+
+const MINIMUM_DESKTOP_VERSION = "1.5.0";
+
+const UPDATE_REQUIRED_MESSAGE =
+	"Please update to the latest version to continue.";
+
+export const desktopRouter = {
+	/**
+	 * Minimum desktop version the cloud will accept. The renderer's
+	 * `useVersionCheck` polls this and gates the app behind the
+	 * UpdateRequiredPage when the running version is below this floor.
+	 *
+	 * Public so the check can run before the user authenticates.
+	 */
+	minimumVersion: publicProcedure.query(() => ({
+		minimumVersion: MINIMUM_DESKTOP_VERSION,
+		message: UPDATE_REQUIRED_MESSAGE,
+	})),
+} satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/desktop/index.ts
+++ b/packages/trpc/src/router/desktop/index.ts
@@ -1,0 +1,1 @@
+export { desktopRouter } from "./desktop";


### PR DESCRIPTION
## Summary

`/api/desktop/version` was the only non-tRPC endpoint the desktop renderer called cross-origin. Move it onto tRPC so the desktop ↔ API surface is uniform.

- Add `desktop.minimumVersion` `publicProcedure` to the API tRPC router (`packages/trpc/src/router/desktop/desktop.ts`). Public because the gate must run before the user authenticates.
- Switch `useVersionCheck` hook to call `apiTrpcClient.desktop.minimumVersion.query()` instead of `fetch`. Fail-open behaviour preserved.
- Mark the REST handler `@deprecated` with a pointer to the tRPC procedure. Keep it alive so older shipped builds — whose bundled `useVersionCheck` still hits the REST path — continue getting a sane response. Retire once the install base below v1.5.0 has aged out and Vercel shows no traffic on the path.

## Drive-by note

`useVersionCheck` and `UpdateRequiredPage` are **orphaned on `main`** — they're exported but not imported by any current renderer code. An earlier routing refactor (`apps/desktop/plans/done/ROUTING_REFACTOR_PLAN.md`) stopped wiring them up, so new builds ship with no version-floor gate. This PR migrates the hook to tRPC but doesn't fix the orphan; rewiring at the root route is a follow-up.

## Test plan

- [ ] CI green
- [ ] In dev, run `apiTrpcClient.desktop.minimumVersion.query()` from the renderer console — returns `{ minimumVersion: "1.5.0", message: "..." }`
- [ ] Old shipped builds (pre-rewire) continue to receive `{ minimumVersion, message }` via the deprecated REST endpoint (manual: hit `https://api.superset.sh/api/desktop/version`)
- [ ] When the gate is rewired in a future PR, the new build doesn't preflight to the REST path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the desktop version check to tRPC and deprecated the `/api/desktop/version` REST endpoint to unify the desktop ↔ API surface while keeping older builds working.

- **Refactors**
  - Added public tRPC procedure `desktop.minimumVersion` returning `{ minimumVersion: "1.5.0", message }`.
  - Registered the `desktop` router in `appRouter` and exported it from `packages/trpc`.
  - Updated `useVersionCheck` to call `apiTrpcClient.desktop.minimumVersion.query()` and kept fail-open behavior.
  - Marked the REST route as `@deprecated`; kept it for backward compatibility and noted to keep version constants in sync.

- **Migration**
  - No action required. Remove the REST endpoint once usage from builds below v1.5.0 drops.

<sup>Written for commit 751616047266018d0e96374efc67fca58bc90237. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Minimum desktop app version requirement updated to 1.5.0.
  * Desktop version checking infrastructure improved for enhanced reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4498)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->