### PR TITLE
fix(desktop): clarify workspace hierarchy and CJK terminal fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ superset-dev-data/
 
 # Local-only plans (not tracked)
 plans/local/
+.ace-tool/

--- a/apps/desktop/src/main/lib/terminal-host/headless-emulator.test.ts
+++ b/apps/desktop/src/main/lib/terminal-host/headless-emulator.test.ts
@@ -45,6 +45,7 @@ const EXIT_ALT_SCREEN = `${CSI}?1049l`;
 // Cursor movement
 const MOVE_CURSOR = (row: number, col: number) => `${CSI}${row};${col}H`;
 const CLEAR_SCREEN = `${CSI}2J`;
+const UNICODE_11_WIDE_SYMBOL = String.fromCodePoint(0x231a);
 
 // OSC-7 CWD reporting - format is file://hostname/path (path is NOT URL-encoded)
 const OSC7_CWD = (path: string) => `${OSC}7;file://localhost${path}${BEL}`;
@@ -64,6 +65,21 @@ describe("HeadlessEmulator", () => {
 		test("should initialize with default modes", () => {
 			const modes = emulator.getModes();
 			expect(modesEqual(modes, DEFAULT_MODES)).toBe(true);
+		});
+
+		test("should use Unicode 11 widths for wide symbol layout", async () => {
+			const narrowEmulator = new HeadlessEmulator({
+				cols: 2,
+				rows: 1,
+				scrollback: 1000,
+			});
+
+			try {
+				await narrowEmulator.writeSync(`${UNICODE_11_WIDE_SYMBOL}A`);
+				expect(narrowEmulator.getScrollbackLines()).toBe(2);
+			} finally {
+				narrowEmulator.dispose();
+			}
 		});
 
 		test("should write text to terminal", async () => {

--- a/apps/desktop/src/main/lib/terminal-host/headless-emulator.ts
+++ b/apps/desktop/src/main/lib/terminal-host/headless-emulator.ts
@@ -9,6 +9,7 @@
 
 import "../../terminal-host/xterm-env-polyfill";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { Terminal } from "@xterm/headless";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import {
@@ -92,6 +93,12 @@ export class HeadlessEmulator {
 
 		this.serializeAddon = new SerializeAddon();
 		this.terminal.loadAddon(this.serializeAddon);
+		this.terminal.loadAddon(
+			new Unicode11Addon() as unknown as Parameters<
+				typeof this.terminal.loadAddon
+			>[0],
+		);
+		this.terminal.unicode.activeVersion = "11";
 
 		// Initialize mode state
 		this.modes = { ...DEFAULT_MODES };

--- a/apps/desktop/src/main/lib/terminal/session.test.ts
+++ b/apps/desktop/src/main/lib/terminal/session.test.ts
@@ -7,8 +7,14 @@ if (typeof window === "undefined") {
 
 const { SerializeAddon } = await import("@xterm/addon-serialize");
 const { Terminal: HeadlessTerminal } = await import("@xterm/headless");
-const { flushSession, getSerializedScrollback, recoverScrollback } =
-	await import("./session");
+const {
+	createHeadlessTerminal,
+	flushSession,
+	getSerializedScrollback,
+	recoverScrollback,
+} = await import("./session");
+
+const UNICODE_11_WIDE_SYMBOL = String.fromCodePoint(0x231a);
 
 function createTestHeadless() {
 	const headless = new HeadlessTerminal({
@@ -25,6 +31,23 @@ function createTestHeadless() {
 }
 
 describe("session", () => {
+	describe("createHeadlessTerminal", () => {
+		it("uses Unicode 11 widths for restored scrollback layout", async () => {
+			const { headless } = createHeadlessTerminal({
+				cols: 2,
+				rows: 1,
+				scrollback: 1000,
+			});
+
+			await new Promise<void>((resolve) => {
+				headless.write(`${UNICODE_11_WIDE_SYMBOL}A`, resolve);
+			});
+
+			expect(headless.buffer.active.length).toBe(2);
+			headless.dispose();
+		});
+	});
+
 	describe("recoverScrollback", () => {
 		it("should write existing scrollback to headless and return true", async () => {
 			const { headless, serializer } = createTestHeadless();

--- a/apps/desktop/src/main/lib/terminal/session.ts
+++ b/apps/desktop/src/main/lib/terminal/session.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import "../../terminal-host/xterm-env-polyfill";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { Terminal as HeadlessTerminal } from "@xterm/headless";
 import * as pty from "node-pty";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
@@ -37,6 +38,10 @@ export function createHeadlessTerminal(params: {
 	headless.loadAddon(
 		serializer as unknown as Parameters<typeof headless.loadAddon>[0],
 	);
+	headless.loadAddon(
+		new Unicode11Addon() as unknown as Parameters<typeof headless.loadAddon>[0],
+	);
+	headless.unicode.activeVersion = "11";
 
 	return { headless, serializer };
 }

--- a/apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
 	DEFAULT_TERMINAL_FONT_FAMILY,
 	sanitizeTerminalFontFamily,
+	TERMINAL_CJK_FALLBACK_FONT_FAMILIES,
 } from "./index";
 
 type MeasureFn = (text: string) => { width: number };
@@ -47,6 +48,9 @@ const proportionalWidths: MeasureFn = (text) => {
 	for (const ch of text) width += ch === "M" ? 16 : 6;
 	return { width };
 };
+const serializedCjkFallbacks = TERMINAL_CJK_FALLBACK_FONT_FAMILIES.map(
+	(family) => `"${family}"`,
+).join(", ");
 
 describe("sanitizeTerminalFontFamily", () => {
 	let restore: (() => void) | null = null;
@@ -108,7 +112,7 @@ describe("sanitizeTerminalFontFamily", () => {
 	test("passes a monospace font through when the stack already ends with monospace", () => {
 		restore = stubCanvas(() => equalWidths);
 		expect(sanitizeTerminalFontFamily('"JetBrains Mono", monospace')).toBe(
-			'"JetBrains Mono", monospace',
+			`"JetBrains Mono", ${serializedCjkFallbacks}, monospace`,
 		);
 	});
 
@@ -117,9 +121,11 @@ describe("sanitizeTerminalFontFamily", () => {
 		// proportional default — appending "monospace" forces OS monospace.
 		restore = stubCanvas(() => equalWidths);
 		expect(sanitizeTerminalFontFamily('"JetBrains Mono"')).toBe(
-			'"JetBrains Mono", monospace',
+			`"JetBrains Mono", ${serializedCjkFallbacks}, monospace`,
 		);
-		expect(sanitizeTerminalFontFamily("Menlo")).toBe("Menlo, monospace");
+		expect(sanitizeTerminalFontFamily("Menlo")).toBe(
+			`"Menlo", ${serializedCjkFallbacks}, monospace`,
+		);
 	});
 
 	test("falls back to default for a proportional primary family (quoted)", () => {
@@ -143,7 +149,7 @@ describe("sanitizeTerminalFontFamily", () => {
 		// Use a unique family so the module-level monospace cache doesn't mask
 		// the canvas error path.
 		expect(sanitizeTerminalFontFamily('"UnmeasurableFont-ABC-123"')).toBe(
-			'"UnmeasurableFont-ABC-123", monospace',
+			`"UnmeasurableFont-ABC-123", ${serializedCjkFallbacks}, monospace`,
 		);
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
@@ -39,6 +39,15 @@ function serializeFontFamilyList(families: string[]): string {
 		.join(", ");
 }
 
+export const TERMINAL_CJK_FALLBACK_FONT_FAMILIES = [
+	"Noto Sans Mono CJK SC",
+	"Source Han Mono SC",
+	"PingFang SC",
+	"Hiragino Sans GB",
+	"Microsoft YaHei",
+	"Noto Sans CJK SC",
+] as const;
+
 export const DEFAULT_TERMINAL_FONT_FAMILIES = [
 	"JetBrains Mono",
 	"JetBrainsMono Nerd Font",
@@ -52,6 +61,7 @@ export const DEFAULT_TERMINAL_FONT_FAMILIES = [
 	"Menlo",
 	"Monaco",
 	"Courier New",
+	...TERMINAL_CJK_FALLBACK_FONT_FAMILIES,
 	"monospace",
 ] as const;
 
@@ -90,6 +100,34 @@ function parseFontFamilyList(cssValue: string): string[] {
 
 const monospaceCheckCache = new Map<string, boolean>();
 
+function appendTerminalFallbacks(families: string[]): string {
+	const cjkFallbackKeys = new Set(
+		TERMINAL_CJK_FALLBACK_FONT_FAMILIES.map((family) => family.toLowerCase()),
+	);
+	const result = families.filter(
+		(family) => !cjkFallbackKeys.has(family.toLowerCase()),
+	);
+	const firstGenericIndex = result.findIndex((family) =>
+		GENERIC_FONT_FAMILIES.has(family.toLowerCase()),
+	);
+	let insertIndex =
+		firstGenericIndex === -1 ? result.length : firstGenericIndex;
+
+	for (const fallback of TERMINAL_CJK_FALLBACK_FONT_FAMILIES) {
+		result.splice(insertIndex, 0, fallback);
+		insertIndex += 1;
+	}
+
+	const hasMonospaceFallback = result.some((family) =>
+		MONOSPACE_GENERIC_FAMILIES.has(family.toLowerCase()),
+	);
+	if (!hasMonospaceFallback) {
+		result.push("monospace");
+	}
+
+	return serializeFontFamilyList(result);
+}
+
 /**
  * Heuristically decide whether `family` is a monospace font using canvas
  * measurement — monospace fonts render narrow ("iiiiii") and wide ("MMMMMM")
@@ -123,7 +161,7 @@ function isFontFamilyMonospace(family: string): boolean {
 
 /**
  * Guard against a persisted terminal font that would break xterm rendering
- * (e.g. a proportional font like "Inter"). Returns the raw CSS value when
+ * (e.g. a proportional font like "Inter"). Returns a sanitized CSS stack when
  * the primary family is monospace; otherwise falls back to the bundled
  * default so a poisoned setting can never blank the app on startup.
  *
@@ -159,14 +197,10 @@ export function sanitizeTerminalFontFamily(
 		);
 		return DEFAULT_TERMINAL_FONT_FAMILY;
 	}
-	// Ensure a generic monospace tail — if the configured primary isn't
-	// installed on this machine, the browser falls back to the OS monospace
-	// generic instead of a proportional default (mirrors VS Code's behavior
-	// in src/vs/workbench/contrib/terminal/browser/terminalConfigurationService.ts).
-	const hasMonoTail = families.some((f) =>
-		MONOSPACE_GENERIC_FAMILIES.has(f.toLowerCase()),
-	);
-	return hasMonoTail ? cssValue : `${cssValue}, monospace`;
+	// Ensure CJK coverage and a generic monospace tail. If the configured
+	// primary is Latin-only or not installed, the browser still gets explicit
+	// terminal-safe fallbacks before reaching the generic family.
+	return appendTerminalFallbacks(families);
 }
 
 /** Reads localStorage theme cache for flash-free first paint. */

--- a/apps/desktop/src/renderer/lib/terminal/appearance/terminal-cjk-font-fallback.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/terminal-cjk-font-fallback.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+	DEFAULT_TERMINAL_FONT_FAMILY,
+	sanitizeTerminalFontFamily,
+	TERMINAL_CJK_FALLBACK_FONT_FAMILIES,
+} from "./index";
+
+type MeasureFn = (text: string) => { width: number };
+
+function stubCanvas(measureForFont: (font: string) => MeasureFn) {
+	const originalCreate = document.createElement;
+	// biome-ignore lint/suspicious/noExplicitAny: bun:test `mock` wraps arbitrary fns
+	(document as any).createElement = mock((tag: string) => {
+		if (tag !== "canvas") {
+			// biome-ignore lint/suspicious/noExplicitAny: delegating stub accepts any tag
+			return (originalCreate as any).call(document, tag);
+		}
+		let currentFont = "";
+		return {
+			getContext: (kind: string) => {
+				if (kind !== "2d") return null;
+				return {
+					set font(value: string) {
+						currentFont = value;
+					},
+					get font() {
+						return currentFont;
+					},
+					measureText: (text: string) => measureForFont(currentFont)(text),
+				};
+			},
+		};
+	});
+	return () => {
+		// biome-ignore lint/suspicious/noExplicitAny: restoring stubbed method
+		(document as any).createElement = originalCreate;
+	};
+}
+
+const equalWidths: MeasureFn = (text) => ({ width: text.length * 10 });
+
+describe("terminal CJK font fallback", () => {
+	let restore: (() => void) | null = null;
+
+	afterEach(() => {
+		restore?.();
+		restore = null;
+	});
+
+	test("keeps CJK fallbacks ahead of generic monospace for Source Code Pro", () => {
+		restore = stubCanvas(() => equalWidths);
+
+		const result = sanitizeTerminalFontFamily('"Source Code Pro", monospace');
+
+		for (const family of TERMINAL_CJK_FALLBACK_FONT_FAMILIES) {
+			expect(result).toContain(`"${family}"`);
+		}
+		expect(result).toMatch(
+			/^"Source Code Pro", "Noto Sans Mono CJK SC".*, monospace$/,
+		);
+	});
+
+	test("does not duplicate an existing CJK fallback", () => {
+		restore = stubCanvas(() => equalWidths);
+
+		const result = sanitizeTerminalFontFamily(
+			'"Source Code Pro", "PingFang SC", monospace',
+		);
+
+		expect(result.match(/"PingFang SC"/g)?.length).toBe(1);
+	});
+
+	test("keeps CJK fallbacks before proportional generic fallbacks", () => {
+		restore = stubCanvas(() => equalWidths);
+
+		const result = sanitizeTerminalFontFamily('"Source Code Pro", sans-serif');
+
+		expect(result.indexOf('"Noto Sans Mono CJK SC"')).toBeLessThan(
+			result.indexOf("sans-serif"),
+		);
+	});
+
+	test("default terminal stack includes explicit CJK fallbacks", () => {
+		for (const family of TERMINAL_CJK_FALLBACK_FONT_FAMILIES) {
+			expect(DEFAULT_TERMINAL_FONT_FAMILY).toContain(`"${family}"`);
+		}
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { TERMINAL_RENDERING_OPTIONS } from "./xterm-options";
+
+describe("terminal runtime rendering options", () => {
+	test("rescales overlapping fallback glyphs in renderer terminals", () => {
+		expect(TERMINAL_RENDERING_OPTIONS.rescaleOverlappingGlyphs).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -9,6 +9,7 @@ import { loadAddons } from "./terminal-addons";
 import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
+import { TERMINAL_RENDERING_OPTIONS } from "./xterm-options";
 
 const SERIALIZE_SCROLLBACK = 1000;
 const STORAGE_KEY_PREFIX = "terminal-buffer:";
@@ -59,6 +60,7 @@ function createTerminal(
 		cursorInactiveStyle: "outline",
 		vtExtensions: { kittyKeyboard: true },
 		scrollbar: { showScrollbar: false },
+		...TERMINAL_RENDERING_OPTIONS,
 	});
 	terminal.loadAddon(fitAddon);
 	terminal.loadAddon(serializeAddon);

--- a/apps/desktop/src/renderer/lib/terminal/xterm-options.ts
+++ b/apps/desktop/src/renderer/lib/terminal/xterm-options.ts
@@ -1,0 +1,5 @@
+import type { ITerminalOptions } from "@xterm/xterm";
+
+export const TERMINAL_RENDERING_OPTIONS = {
+	rescaleOverlappingGlyphs: true,
+} satisfies Pick<ITerminalOptions, "rescaleOverlappingGlyphs">;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -11,6 +11,7 @@ import type { DashboardSidebarProjectChild } from "../../../../types";
 import { SidebarDragOverlay } from "../../../SidebarDragOverlay";
 import { SortableSectionHeader } from "../../../SortableSectionHeader";
 import { SortableWorkspaceItem } from "../../../SortableWorkspaceItem";
+import { DASHBOARD_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME } from "./hierarchy";
 
 interface DashboardSidebarExpandedProjectContentProps {
 	projectId: string;
@@ -60,7 +61,7 @@ export function DashboardSidebarExpandedProjectContent({
 					transition={{ duration: 0.15, ease: "easeOut" }}
 					className="overflow-hidden"
 				>
-					<div className="pb-1">
+					<div className={DASHBOARD_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME}>
 						<DndContext
 							sensors={sensors}
 							collisionDetection={collisionDetection}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/hierarchy.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/hierarchy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { DASHBOARD_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME } from "./hierarchy";
+
+describe("dashboard sidebar project child hierarchy", () => {
+	test("indents project children and draws a parent relationship line", () => {
+		expect(DASHBOARD_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME).toContain(
+			"ml-4",
+		);
+		expect(DASHBOARD_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME).toContain(
+			"border-l",
+		);
+		expect(DASHBOARD_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME).toContain(
+			"pl-1",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/hierarchy.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/hierarchy.ts
@@ -1,0 +1,2 @@
+export const DASHBOARD_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME =
+	"pb-1 ml-4 border-l border-border/70 pl-1";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -20,6 +20,12 @@ import type {
 import { getCreationStatusText } from "../../utils/getCreationStatusText";
 import { DashboardSidebarWorkspaceDiffStats } from "../DashboardSidebarWorkspaceDiffStats";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
+import {
+	DASHBOARD_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME,
+	DASHBOARD_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME,
+	DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME,
+	DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME,
+} from "./hierarchy";
 
 const PR_STATE_LABEL: Record<
 	DashboardSidebarWorkspacePullRequest["state"],
@@ -109,6 +115,9 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 		const workspaceKindDescription = isMainWorkspace
 			? "Uses the repository checkout on this host"
 			: "Isolated copy for parallel development";
+		const hierarchyConnectorClassName = isInSection
+			? DASHBOARD_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME
+			: DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME;
 
 		return (
 			// biome-ignore lint/a11y/noStaticElementInteractions: Mirrors the legacy sidebar row UI, which includes nested action buttons.
@@ -131,7 +140,9 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				onDoubleClick={onDoubleClick}
 				className={cn(
 					"relative flex w-full items-center pr-2 text-left text-sm",
-					isInSection ? "pl-7" : "pl-5",
+					isInSection
+						? DASHBOARD_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME
+						: DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME,
 					onClick &&
 						(isActive
 							? "cursor-pointer hover:bg-muted"
@@ -149,6 +160,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 						style={{ backgroundColor: "var(--color-foreground)" }}
 					/>
 				)}
+				<div aria-hidden="true" className={hierarchyConnectorClassName} />
 
 				<Tooltip delayDuration={500}>
 					<TooltipTrigger asChild>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/hierarchy.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/hierarchy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+	DASHBOARD_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME,
+	DASHBOARD_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME,
+	DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME,
+	DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME,
+} from "./hierarchy";
+
+describe("dashboard sidebar expanded workspace row hierarchy", () => {
+	test("indents top-level workspace rows below project rows and draws a connector", () => {
+		expect(DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME).toContain(
+			"pl-10",
+		);
+		expect(
+			DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME,
+		).toContain("absolute");
+		expect(
+			DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME,
+		).toContain("w-10");
+		expect(DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME).not.toContain(
+			"before:",
+		);
+	});
+
+	test("keeps section workspace rows deeper than top-level workspace rows", () => {
+		expect(DASHBOARD_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME).toContain(
+			"pl-12",
+		);
+		expect(DASHBOARD_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME).toContain(
+			"w-11",
+		);
+		expect(DASHBOARD_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME).not.toContain(
+			"before:",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/hierarchy.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/hierarchy.ts
@@ -1,0 +1,9 @@
+export const DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME = "pl-10";
+
+export const DASHBOARD_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME =
+	"pointer-events-none absolute -left-1 top-1/2 h-px w-10 -translate-y-1/2 bg-border/80";
+
+export const DASHBOARD_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME = "pl-12";
+
+export const DASHBOARD_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME =
+	"pointer-events-none absolute -left-2 top-1/2 h-px w-11 -translate-y-1/2 bg-border/70";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -11,6 +11,7 @@ import { useSectionDropZone } from "../hooks";
 import type { SidebarSection, SidebarWorkspace } from "../types";
 import { WorkspaceListItem } from "../WorkspaceListItem";
 import { WorkspaceSection } from "../WorkspaceSection";
+import { WORKSPACE_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME } from "./hierarchy";
 import { ProjectHeader } from "./ProjectHeader";
 
 const PROJECT_TYPE = "PROJECT";
@@ -361,7 +362,7 @@ export function ProjectSection({
 						transition={{ duration: 0.15, ease: "easeOut" }}
 						className="overflow-hidden"
 					>
-						<div className="pb-1">
+						<div className={WORKSPACE_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME}>
 							{showRootDropZones && topLevelChildren.length === 0 && (
 								<div
 									{...topUngroupedDropZone.handlers}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/hierarchy.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/hierarchy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { WORKSPACE_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME } from "./hierarchy";
+
+describe("workspace sidebar project child hierarchy", () => {
+	test("indents project children and draws a parent relationship line", () => {
+		expect(WORKSPACE_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME).toContain(
+			"ml-4",
+		);
+		expect(WORKSPACE_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME).toContain(
+			"border-l",
+		);
+		expect(WORKSPACE_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME).toContain(
+			"pl-1",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/hierarchy.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/hierarchy.ts
@@ -1,0 +1,2 @@
+export const WORKSPACE_SIDEBAR_PROJECT_CHILDREN_TREE_CLASS_NAME =
+	"pb-1 ml-4 border-l border-border/70 pl-1";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -26,6 +26,12 @@ import {
 	GITHUB_STATUS_STALE_TIME,
 	MAX_KEYBOARD_SHORTCUT_INDEX,
 } from "./constants";
+import {
+	WORKSPACE_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME,
+	WORKSPACE_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME,
+	WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME,
+	WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME,
+} from "./hierarchy";
 import { useWorkspaceDnD } from "./useWorkspaceDnD";
 import { WorkspaceAheadBehind } from "./WorkspaceAheadBehind";
 import { WorkspaceContextMenu } from "./WorkspaceContextMenu";
@@ -257,6 +263,13 @@ export function WorkspaceListItem({
 			: null);
 
 	const showBranchSubtitle = isBranchWorkspace || (!!name && name !== branch);
+	const isInSection = sectionId !== null;
+	const hierarchyRowClassName = isInSection
+		? WORKSPACE_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME
+		: WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME;
+	const hierarchyConnectorClassName = isInSection
+		? WORKSPACE_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME
+		: WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME;
 
 	if (isCollapsed) {
 		return (
@@ -302,7 +315,8 @@ export function WorkspaceListItem({
 			onMouseEnter={handleMouseEnter}
 			onDoubleClick={isBranchWorkspace ? undefined : rename.startRename}
 			className={cn(
-				"flex w-full pl-3 pr-2 text-sm",
+				"flex w-full pr-2 text-sm",
+				hierarchyRowClassName,
 				"transition-colors text-left cursor-pointer",
 				isActive ? "hover:bg-muted" : "hover:bg-muted/50",
 				"group relative",
@@ -316,6 +330,7 @@ export function WorkspaceListItem({
 			{isActive && (
 				<div className="absolute left-0 top-0 bottom-0 w-0.5 bg-primary rounded-r" />
 			)}
+			<div aria-hidden="true" className={hierarchyConnectorClassName} />
 
 			<div
 				className={cn(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/hierarchy.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/hierarchy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+	WORKSPACE_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME,
+	WORKSPACE_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME,
+	WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME,
+	WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME,
+} from "./hierarchy";
+
+describe("workspace sidebar expanded workspace row hierarchy", () => {
+	test("indents top-level workspace rows below project rows and draws a connector", () => {
+		expect(WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME).toContain(
+			"pl-8",
+		);
+		expect(
+			WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME,
+		).toContain("absolute");
+		expect(
+			WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME,
+		).toContain("w-8");
+	});
+
+	test("keeps section workspace rows deeper than top-level workspace rows", () => {
+		expect(WORKSPACE_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME).toContain(
+			"pl-10",
+		);
+		expect(WORKSPACE_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME).toContain(
+			"w-10",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/hierarchy.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/hierarchy.ts
@@ -1,0 +1,9 @@
+export const WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_ROW_CLASS_NAME = "pl-8";
+
+export const WORKSPACE_SIDEBAR_TOP_LEVEL_WORKSPACE_CONNECTOR_CLASS_NAME =
+	"pointer-events-none absolute -left-1 top-1/2 h-px w-8 -translate-y-1/2 bg-border/80";
+
+export const WORKSPACE_SIDEBAR_SECTION_WORKSPACE_ROW_CLASS_NAME = "pl-10";
+
+export const WORKSPACE_SIDEBAR_SECTION_WORKSPACE_CONNECTOR_CLASS_NAME =
+	"pointer-events-none absolute -left-2 top-1/2 h-px w-10 -translate-y-1/2 bg-border/70";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { TERMINAL_OPTIONS } from "./config";
+
+describe("legacy terminal config", () => {
+	test("rescales overlapping fallback glyphs", () => {
+		expect(TERMINAL_OPTIONS.rescaleOverlappingGlyphs).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_TERMINAL_FONT_FAMILY as SHARED_DEFAULT_TERMINAL_FONT_FAMILY,
 	DEFAULT_TERMINAL_FONT_SIZE as SHARED_DEFAULT_TERMINAL_FONT_SIZE,
 } from "renderer/lib/terminal/appearance";
+import { TERMINAL_RENDERING_OPTIONS } from "renderer/lib/terminal/xterm-options";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 
 // Use user's theme
@@ -35,6 +36,7 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
 	cursorInactiveStyle: "outline",
 	vtExtensions: { kittyKeyboard: true },
 	screenReaderMode: false,
+	...TERMINAL_RENDERING_OPTIONS,
 	// xterm's fit addon permanently reserves scrollbar width from usable columns.
 	// Hide the built-in scrollbar so terminal content can use the full pane width.
 	scrollbar: {


### PR DESCRIPTION
## Description

This PR improves two desktop UI/runtime issues:

- Makes the repository-to-workspace hierarchy clearer in both desktop sidebar implementations by adding child indentation and explicit connector lines.
- Adds explicit CJK fallback fonts to terminal font stacks so Latin-only fonts such as Source Code Pro still render Chinese text reliably.
- Enables xterm's overlapping glyph rescaling in both desktop terminal renderer paths to prevent fallback glyphs from painting into adjacent cells.
- Activates Unicode 11 width handling in both headless terminal emulators so serialized/restored scrollback uses the same wide-character layout as the renderer.

## Related Issues

No linked issue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- [x] `npm exec --yes --package bun@1.3.11 -- bun run lint`
- [x] `npm exec --yes --package bun@1.3.11 -- bun test ./src/renderer/lib/terminal/terminal-runtime.test.ts ./src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.test.ts ./src/main/lib/terminal/session.test.ts ./src/main/lib/terminal-host/headless-emulator.test.ts ./src/renderer/lib/terminal/appearance/appearance.test.ts ./src/renderer/lib/terminal/appearance/terminal-cjk-font-fallback.test.ts ./src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/hierarchy.test.ts ./src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/hierarchy.test.ts ./src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/hierarchy.test.ts ./src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/hierarchy.test.ts`
- [x] `npm exec --yes --package bun@1.3.11 -- bun run build` from `apps/desktop`

## Screenshots

<img width="576" height="500" alt="image" src="https://github.com/user-attachments/assets/b17a4366-885b-4dd5-9b86-9dd428c7357b" />

## Additional Notes

The hierarchy treatment is applied to both the V2 DashboardSidebar and the legacy WorkspaceSidebar so the visual relationship is consistent regardless of the active sidebar path.

For terminal rendering, the browser renderer and the headless scrollback emulators are updated together. This prevents live CJK/fallback glyph overlap and avoids reintroducing incorrect wide-character layout when restoring terminal snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CJK font fallback added to terminal for improved East Asian text rendering
  * Unicode 11 enabled in terminal and overlapping-glyph rescaling turned on

* **UI Enhancements**
  * Sidebar hierarchy styling refined for clearer indentation and connector visuals across workspace/project lists

* **Tests**
  * Added tests for CJK fallback, Unicode width handling, rendering options

* **Chores**
  * Ignored local tooling directory in VCS

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4510)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->