### PR TITLE
feat(desktop): confirm before removing workspace from sidebar

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/modules/workspace/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/workspace/commands.tsx
@@ -61,6 +61,7 @@ export const workspaceProvider: CommandProvider = {
 				run: () =>
 					useRemoveFromSidebarIntent.getState().request({
 						workspaceId: workspace.id,
+						workspaceName: workspace.name,
 						projectId: workspace.projectId ?? "",
 						isMain,
 					}),

--- a/apps/desktop/src/renderer/commandPalette/ui/RemoveFromSidebarMount/RemoveFromSidebarMount.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/RemoveFromSidebarMount/RemoveFromSidebarMount.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useRef } from "react";
+import {
+	AlertDialog,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { useCallback } from "react";
 import { useNavigateAwayFromWorkspace } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useRemoveFromSidebarIntent } from "renderer/stores/remove-workspace-from-sidebar-intent";
@@ -9,11 +18,16 @@ export function RemoveFromSidebarMount() {
 	const { hideWorkspaceInSidebar, removeWorkspaceFromSidebar } =
 		useDashboardSidebarState();
 	const { navigateAwayFromWorkspace } = useNavigateAwayFromWorkspace();
-	const lastTickRef = useRef(0);
 
-	useEffect(() => {
-		if (!target || target.tick === lastTickRef.current) return;
-		lastTickRef.current = target.tick;
+	const handleOpenChange = useCallback(
+		(open: boolean) => {
+			if (!open) clear();
+		},
+		[clear],
+	);
+
+	const handleConfirm = useCallback(() => {
+		if (!target) return;
 		navigateAwayFromWorkspace(target.workspaceId);
 		if (target.isMain) {
 			hideWorkspaceInSidebar(target.workspaceId, target.projectId);
@@ -29,5 +43,37 @@ export function RemoveFromSidebarMount() {
 		clear,
 	]);
 
-	return null;
+	return (
+		<AlertDialog open={!!target} onOpenChange={handleOpenChange}>
+			<AlertDialogContent className="max-w-[360px] gap-0 p-0">
+				<AlertDialogHeader className="px-4 pt-4 pb-2">
+					<AlertDialogTitle className="font-medium">
+						Remove "{target?.workspaceName ?? "workspace"}" from sidebar?
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						The workspace itself isn't deleted — you can always add it back from
+						the Workspaces page.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={() => handleOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={handleConfirm}
+					>
+						Remove
+					</Button>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -5,10 +5,10 @@ import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useDashboardSidebarSectionRename } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSectionRenameContext";
-import { useNavigateAwayFromWorkspace } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useRemoveFromSidebarIntent } from "renderer/stores/remove-workspace-from-sidebar-intent";
 import {
 	useV2NotificationStore,
 	useV2WorkspaceIsUnread,
@@ -31,7 +31,6 @@ export function useDashboardSidebarWorkspaceItemActions({
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
-	const { navigateAwayFromWorkspace } = useNavigateAwayFromWorkspace();
 	const { activeHostUrl } = useLocalHostService();
 	const { copyToClipboard } = useCopyToClipboard();
 	const { v2Workspaces: workspaceActions } = useOptimisticCollectionActions();
@@ -41,12 +40,8 @@ export function useDashboardSidebarWorkspaceItemActions({
 	);
 	const setManualUnread = useV2NotificationStore((s) => s.setManualUnread);
 	const isUnread = useV2WorkspaceIsUnread(workspaceId);
-	const {
-		createSection,
-		hideWorkspaceInSidebar,
-		moveWorkspaceToSection,
-		removeWorkspaceFromSidebar,
-	} = useDashboardSidebarState();
+	const { createSection, moveWorkspaceToSection, removeWorkspaceFromSidebar } =
+		useDashboardSidebarState();
 
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [renameValue, setRenameValue] = useState(workspaceName);
@@ -89,12 +84,12 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleRemoveFromSidebar = () => {
-		navigateAwayFromWorkspace(workspaceId);
-		if (isMainWorkspace) {
-			hideWorkspaceInSidebar(workspaceId, projectId);
-			return;
-		}
-		removeWorkspaceFromSidebar(workspaceId);
+		useRemoveFromSidebarIntent.getState().request({
+			workspaceId,
+			workspaceName,
+			projectId,
+			isMain: isMainWorkspace,
+		});
 	};
 
 	const handleCreateSection = () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -30,6 +30,7 @@ import type {
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { PRIcon } from "renderer/screens/main/components/PRIcon/PRIcon";
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
+import { useRemoveFromSidebarIntent } from "renderer/stores/remove-workspace-from-sidebar-intent";
 import { V2_WORKSPACES_ROW_GRID } from "../../constants";
 
 interface V2WorkspaceRowProps {
@@ -47,11 +48,7 @@ export function V2WorkspaceRow({
 }: V2WorkspaceRowProps) {
 	const navigate = useNavigate();
 	const { gateFeature } = usePaywall();
-	const {
-		ensureWorkspaceInSidebar,
-		hideWorkspaceInSidebar,
-		removeWorkspaceFromSidebar,
-	} = useDashboardSidebarState();
+	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const isMainWorkspace = workspace.type === "main";
 
 	const HostIcon = hostIconFor(workspace.hostType);
@@ -95,18 +92,18 @@ export function V2WorkspaceRow({
 				event.preventDefault();
 				return;
 			}
-			if (isMainWorkspace) {
-				hideWorkspaceInSidebar(workspace.id, workspace.projectId);
-				return;
-			}
-			removeWorkspaceFromSidebar(workspace.id);
+			useRemoveFromSidebarIntent.getState().request({
+				workspaceId: workspace.id,
+				workspaceName: workspace.name,
+				projectId: workspace.projectId,
+				isMain: isMainWorkspace,
+			});
 		},
 		[
-			hideWorkspaceInSidebar,
 			isCurrentRoute,
 			isMainWorkspace,
-			removeWorkspaceFromSidebar,
 			workspace.id,
+			workspace.name,
 			workspace.projectId,
 		],
 	);

--- a/apps/desktop/src/renderer/stores/remove-workspace-from-sidebar-intent.ts
+++ b/apps/desktop/src/renderer/stores/remove-workspace-from-sidebar-intent.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 export interface RemoveFromSidebarTarget {
 	workspaceId: string;
+	workspaceName: string;
 	projectId: string;
 	isMain: boolean;
 	tick: number;


### PR DESCRIPTION
## Summary
- Routes every "Remove from sidebar" entry point (sidebar row minus button, sidebar context menu, command palette, Workspaces page row) through the shared `useRemoveFromSidebarIntent` store.
- Converts `RemoveFromSidebarMount` from an auto-executing effect into an `AlertDialog` that warns the user and notes the workspace can be re-added from the Workspaces page.
- Adds `workspaceName` to the intent target so the dialog can name what's being removed.

## Test plan
- [ ] Sidebar row hover → click minus icon → confirm dialog appears, "Remove" hides/removes, "Cancel" leaves sidebar untouched.
- [ ] Sidebar row right-click → "Remove from Sidebar" → same dialog flow.
- [ ] `⌘K` command palette → "Remove from sidebar" → same dialog flow.
- [ ] Workspaces page → minus button on a sidebar-pinned row → dialog flow; the current-route row still shows the disabled tooltip and is not removable.
- [ ] Main workspace (always-shown) removal still routes through `hideWorkspaceInSidebar`; non-main routes through `removeWorkspaceFromSidebar`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a confirmation dialog before removing a workspace from the sidebar and route all remove actions through a shared intent store. This prevents accidental removals and keeps behavior consistent across the sidebar, context menu, command palette, and Workspaces page.

- **New Features**
  - All “Remove from sidebar” entry points now use `useRemoveFromSidebarIntent`.
  - Converted the auto-executing mount to an `AlertDialog` (`@superset/ui/alert-dialog`, `@superset/ui/button`) that names the workspace and notes it can be re-added from the Workspaces page.
  - Intent target now includes `workspaceName`; main workspaces still call `hideWorkspaceInSidebar`, others call `removeWorkspaceFromSidebar`.

<sup>Written for commit 38646bbda46ce25749df81f1ce600c2eaa1e4d52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a confirmation dialog when removing a workspace from the sidebar, providing users with an additional safety measure before the action is completed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4524)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->