### PR TITLE
fix(desktop): persist tasks-view project selection across refresh

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -24,7 +24,10 @@ import { NavigationControls } from "renderer/routes/_authenticated/_dashboard/co
 import { SidebarToggle } from "renderer/routes/_authenticated/_dashboard/components/SidebarToggle";
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
 import { ResourceConsumption } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption";
-import { useTasksFilterStore } from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
+import {
+	tasksSearchFromFilters,
+	useTasksFilterStore,
+} from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
 import { STROKE_WIDTH_THICK } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import { useOpenNewProjectModal } from "renderer/stores/add-repository-modal";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
@@ -91,13 +94,16 @@ export function DashboardSidebarHeader({
 
 	const handleTasksClick = () => {
 		gateFeature(GATED_FEATURES.TASKS, () => {
-			const search: Record<string, string> = {};
-			if (lastTab !== "all") search.tab = lastTab;
-			if (lastAssignee) search.assignee = lastAssignee;
-			if (lastSearch) search.search = lastSearch;
-			if (lastTypeTab !== "tasks") search.type = lastTypeTab;
-			if (lastProjectFilter) search.project = lastProjectFilter;
-			navigate({ to: "/tasks", search });
+			navigate({
+				to: "/tasks",
+				search: tasksSearchFromFilters({
+					tab: lastTab,
+					assignee: lastAssignee,
+					search: lastSearch,
+					typeTab: lastTypeTab,
+					projectFilter: lastProjectFilter,
+				}),
+			});
 		});
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/page.tsx
@@ -15,6 +15,7 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { Route as TasksLayoutRoute } from "../layout";
+import { tasksSearchFromFilters } from "../stores/tasks-filter-state";
 import { ActivitySection } from "./components/ActivitySection";
 import { EditableTitle } from "./components/EditableTitle";
 import { PropertiesSidebar } from "./components/PropertiesSidebar";
@@ -35,7 +36,13 @@ type TaskDetailRecord = SelectTask & {
 
 function TaskDetailPage() {
 	const { taskId } = Route.useParams();
-	const { tab, assignee, search } = TasksLayoutRoute.useSearch();
+	const {
+		tab,
+		assignee,
+		search: searchQuery,
+		type,
+		project,
+	} = TasksLayoutRoute.useSearch();
 	const navigate = useNavigate();
 	const collections = useCollections();
 	const { tasks: taskActions } = useOptimisticCollectionActions();
@@ -45,12 +52,14 @@ function TaskDetailPage() {
 		);
 
 	const backSearch = useMemo(() => {
-		const s: Record<string, string> = {};
-		if (tab) s.tab = tab;
-		if (assignee) s.assignee = assignee;
-		if (search) s.search = search;
-		return s;
-	}, [tab, assignee, search]);
+		return tasksSearchFromFilters({
+			tab: tab ?? "all",
+			assignee: assignee ?? null,
+			search: searchQuery ?? "",
+			typeTab: type ?? "tasks",
+			projectFilter: project ?? null,
+		});
+	}, [tab, assignee, searchQuery, type, project]);
 	useEscapeToNavigate("/tasks", { search: backSearch });
 
 	// Support both UUID and slug lookups

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -8,7 +8,10 @@ import {
 	useState,
 } from "react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import { useTasksFilterStore } from "../../stores/tasks-filter-state";
+import {
+	tasksSearchFromFilters,
+	useTasksFilterStore,
+} from "../../stores/tasks-filter-state";
 import { BoardContent } from "./components/BoardContent";
 import { GitHubIssuesContent } from "./components/GitHubIssuesContent";
 import { LinearCTA } from "./components/LinearCTA";
@@ -60,24 +63,18 @@ export function TasksView({
 			search?: string;
 			type?: "tasks" | "prs" | "issues";
 			project?: string | null;
-		}) => {
-			const tab = overrides.tab ?? currentTab;
-			const assignee =
-				overrides.assignee !== undefined ? overrides.assignee : assigneeFilter;
-			const query =
-				overrides.search !== undefined ? overrides.search : searchQuery;
-			const type = overrides.type ?? typeTab;
-			const project =
-				overrides.project !== undefined ? overrides.project : projectFilter;
-
-			const search: Record<string, string> = {};
-			if (tab !== "all") search.tab = tab;
-			if (assignee) search.assignee = assignee;
-			if (query) search.search = query;
-			if (type !== "tasks") search.type = type;
-			if (project) search.project = project;
-			return search;
-		},
+		}) =>
+			tasksSearchFromFilters({
+				tab: overrides.tab ?? currentTab,
+				assignee:
+					overrides.assignee !== undefined
+						? overrides.assignee
+						: assigneeFilter,
+				search: overrides.search !== undefined ? overrides.search : searchQuery,
+				typeTab: overrides.type ?? typeTab,
+				projectFilter:
+					overrides.project !== undefined ? overrides.project : projectFilter,
+			}),
 		[currentTab, assigneeFilter, searchQuery, typeTab, projectFilter],
 	);
 
@@ -146,8 +143,9 @@ export function TasksView({
 	);
 
 	useEffect(() => {
-		if (projectFilter) return;
-		const firstProject = v2Projects?.[0];
+		if (!v2Projects) return;
+		if (projectFilter && v2Projects.some((p) => p.id === projectFilter)) return;
+		const firstProject = v2Projects[0];
 		if (!firstProject) return;
 		navigate({
 			to: "/tasks",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.ts
@@ -1,16 +1,18 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 export type ViewMode = "table" | "board";
 export type TypeTab = "tasks" | "prs" | "issues";
+export type FilterTab = "all" | "active" | "backlog";
 
 interface TasksFilterState {
-	tab: "all" | "active" | "backlog";
+	tab: FilterTab;
 	assignee: string | null;
 	search: string;
 	viewMode: ViewMode;
 	typeTab: TypeTab;
 	projectFilter: string | null;
-	setTab: (tab: "all" | "active" | "backlog") => void;
+	setTab: (tab: FilterTab) => void;
 	setAssignee: (assignee: string | null) => void;
 	setSearch: (search: string) => void;
 	setViewMode: (viewMode: ViewMode) => void;
@@ -18,17 +20,51 @@ interface TasksFilterState {
 	setProjectFilter: (projectFilter: string | null) => void;
 }
 
-export const useTasksFilterStore = create<TasksFilterState>()((set) => ({
-	tab: "all",
-	assignee: null,
-	search: "",
-	viewMode: "table",
-	typeTab: "tasks",
-	projectFilter: null,
-	setTab: (tab) => set({ tab }),
-	setAssignee: (assignee) => set({ assignee }),
-	setSearch: (search) => set({ search }),
-	setViewMode: (viewMode) => set({ viewMode }),
-	setTypeTab: (typeTab) => set({ typeTab }),
-	setProjectFilter: (projectFilter) => set({ projectFilter }),
-}));
+export const useTasksFilterStore = create<TasksFilterState>()(
+	persist(
+		(set) => ({
+			tab: "all",
+			assignee: null,
+			search: "",
+			viewMode: "table",
+			typeTab: "tasks",
+			projectFilter: null,
+			setTab: (tab) => set({ tab }),
+			setAssignee: (assignee) => set({ assignee }),
+			setSearch: (search) => set({ search }),
+			setViewMode: (viewMode) => set({ viewMode }),
+			setTypeTab: (typeTab) => set({ typeTab }),
+			setProjectFilter: (projectFilter) => set({ projectFilter }),
+		}),
+		{
+			name: "tasks-filter-state",
+			version: 1,
+			partialize: (state) => ({
+				projectFilter: state.projectFilter,
+				tab: state.tab,
+				typeTab: state.typeTab,
+				viewMode: state.viewMode,
+			}),
+		},
+	),
+);
+
+export interface TasksFilters {
+	tab: FilterTab;
+	assignee: string | null;
+	search: string;
+	typeTab: TypeTab;
+	projectFilter: string | null;
+}
+
+export function tasksSearchFromFilters(
+	filters: TasksFilters,
+): Record<string, string> {
+	const out: Record<string, string> = {};
+	if (filters.tab !== "all") out.tab = filters.tab;
+	if (filters.assignee) out.assignee = filters.assignee;
+	if (filters.search) out.search = filters.search;
+	if (filters.typeTab !== "tasks") out.type = filters.typeTab;
+	if (filters.projectFilter) out.project = filters.projectFilter;
+	return out;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -4,7 +4,10 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { HiOutlineClipboardDocumentList } from "react-icons/hi2";
 import { LuLayers } from "react-icons/lu";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
-import { useTasksFilterStore } from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
+import {
+	tasksSearchFromFilters,
+	useTasksFilterStore,
+} from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
 import { STROKE_WIDTH } from "../constants";
 import { NewWorkspaceButton } from "./NewWorkspaceButton";
 
@@ -41,13 +44,16 @@ export function WorkspaceSidebarHeader({
 
 	const handleTasksClick = () => {
 		gateFeature(GATED_FEATURES.TASKS, () => {
-			const search: Record<string, string> = {};
-			if (lastTab !== "all") search.tab = lastTab;
-			if (lastAssignee) search.assignee = lastAssignee;
-			if (lastSearch) search.search = lastSearch;
-			if (lastTypeTab !== "tasks") search.type = lastTypeTab;
-			if (lastProjectFilter) search.project = lastProjectFilter;
-			navigate({ to: "/tasks", search });
+			navigate({
+				to: "/tasks",
+				search: tasksSearchFromFilters({
+					tab: lastTab,
+					assignee: lastAssignee,
+					search: lastSearch,
+					typeTab: lastTypeTab,
+					projectFilter: lastProjectFilter,
+				}),
+			});
 		});
 	};
 


### PR DESCRIPTION
## Summary

- Selecting a project on `/tasks`, navigating elsewhere, refreshing, then clicking the sidebar's Tasks link reset the filter to the first v2 project. The selection lived in the URL (preserved by refresh), but the sidebar rebuilt the URL from an **in-memory** Zustand store that didn't survive a reload, so it navigated to `/tasks` with no `project` param and the auto-default snapped to `v2Projects[0]`.
- Wraps `useTasksFilterStore` in `persist()` with a `partialize` allowlist (`projectFilter`, `tab`, `typeTab`, `viewMode`) and `version: 1`. Skips `search` (re-applying a typed query later is confusing) and `assignee` (silent persisted filtering is a foot-gun).
- Tightens the auto-default in `TasksView` so it also fires when the persisted `projectFilter` no longer exists in `v2Projects` (stale/deleted ID).
- Extracts a shared `tasksSearchFromFilters(filters)` helper used by `TasksView.buildSearch` and both sidebar headers (`WorkspaceSidebarHeader`, `DashboardSidebarHeader`) so they can't drift on which params get written.

## Test plan

- [ ] On `/tasks`, switch the project filter to one that isn't first in the list, navigate to a workspace, hard-refresh, click Tasks in the sidebar — the previously selected project is still selected.
- [ ] Same flow but quit/relaunch the app instead of refreshing — selection still restored.
- [ ] Manually edit `localStorage["tasks-filter-state"]` to a `projectFilter` ID that doesn't exist, then load `/tasks` — falls back to `v2Projects[0]` instead of getting stuck.
- [ ] Tab / view mode / type tab persist across refresh; search query and assignee filter do NOT (intentional).
- [ ] Sidebar Tasks link from both `WorkspaceSidebar` and `DashboardSidebar` lands on the same URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted Tasks view filters across refreshes and relaunches. Sidebar Tasks and task-detail back now return to the same project/type, with a safe fallback if the saved project no longer exists.

- **Bug Fixes**
  - Wrapped `useTasksFilterStore` with `persist()` (v1); allowlisted `projectFilter`, `tab`, `typeTab`, `viewMode`; skipped `search` and `assignee`.
  - Unified URL building with `tasksSearchFromFilters()` in `TasksView`, both sidebar headers, and task-detail back navigation to preserve `project` and `type`.
  - Tightened `TasksView` defaulting: waits for projects; if `projectFilter` is missing or not in `v2Projects`, falls back to the first project.

<sup>Written for commit 0a14bd1928785022f8a9e734e7dbbd6d73900037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task filters (project selection, active tab, filter type, and view mode) are now persisted and restored across sessions.

* **Improvements**
  * Unified helper introduced to consistently build Tasks route query parameters; sidebar, workspace header, task list, and task page now use it.
  * Project-selection sync now waits for project data and selects the first valid project when needed to avoid premature navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4526)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->