### PR TITLE
fix(slack): route mentions/DMs by user team for Slack Connect

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
@@ -39,6 +39,8 @@ interface SlackAssistantMessageEvent {
 	event_ts: string;
 	thread_ts?: string;
 	files?: SlackEventFile[];
+	team?: string;
+	user_team?: string;
 }
 
 interface ProcessAssistantMessageParams {
@@ -52,9 +54,15 @@ export async function processAssistantMessage({
 	teamId,
 	eventId,
 }: ProcessAssistantMessageParams): Promise<void> {
+	// Slack Connect DMs deliver the bot's team in the envelope but the user's
+	// home team on the event itself. Route by the user's team so the user's
+	// own org's connection responds.
+	const userTeam = event.user_team ?? event.team ?? teamId;
+
 	console.log("[slack/process-assistant-message] Processing message:", {
 		eventId,
 		teamId,
+		userTeam,
 		channel: event.channel,
 		user: event.user,
 	});
@@ -62,7 +70,7 @@ export async function processAssistantMessage({
 	const connection = await db.query.integrationConnections.findFirst({
 		where: and(
 			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, teamId),
+			eq(integrationConnections.externalOrgId, userTeam),
 			isNull(integrationConnections.disconnectedAt),
 		),
 		orderBy: [
@@ -74,7 +82,7 @@ export async function processAssistantMessage({
 	if (!connection) {
 		console.error(
 			"[slack/process-assistant-message] No connection found for team:",
-			teamId,
+			userTeam,
 		);
 		return;
 	}
@@ -86,7 +94,7 @@ export async function processAssistantMessage({
 			? db.query.usersSlackUsers.findFirst({
 					where: and(
 						eq(usersSlackUsers.slackUserId, event.user),
-						eq(usersSlackUsers.teamId, teamId),
+						eq(usersSlackUsers.teamId, userTeam),
 					),
 					columns: { userId: true, modelPreference: true },
 				})
@@ -151,7 +159,7 @@ export async function processAssistantMessage({
 		});
 		const connectUrl = generateConnectUrl({
 			slackUserId: event.user,
-			teamId,
+			teamId: userTeam,
 		});
 		await slack.chat.postMessage({
 			channel: event.channel,

--- a/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
@@ -38,6 +38,8 @@ interface SlackAppMentionEvent {
 	event_ts: string;
 	thread_ts?: string;
 	files?: SlackEventFile[];
+	user_team?: string;
+	team?: string;
 }
 
 interface ProcessMentionParams {
@@ -51,9 +53,15 @@ export async function processSlackMention({
 	teamId,
 	eventId,
 }: ProcessMentionParams): Promise<void> {
+	// In Slack Connect (shared) channels the envelope team_id is the team of the
+	// bot that received the event, which can be a different org than the user.
+	// Route by the user's home team so the user's own org's connection responds.
+	const userTeam = event.user_team ?? event.team ?? teamId;
+
 	console.log("[slack/process-mention] Processing mention:", {
 		eventId,
 		teamId,
+		userTeam,
 		channel: event.channel,
 		user: event.user,
 	});
@@ -61,7 +69,7 @@ export async function processSlackMention({
 	const connection = await db.query.integrationConnections.findFirst({
 		where: and(
 			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, teamId),
+			eq(integrationConnections.externalOrgId, userTeam),
 			isNull(integrationConnections.disconnectedAt),
 		),
 		orderBy: [
@@ -73,7 +81,7 @@ export async function processSlackMention({
 	if (!connection) {
 		console.error(
 			"[slack/process-mention] No connection found for team:",
-			teamId,
+			userTeam,
 		);
 		return;
 	}
@@ -85,7 +93,7 @@ export async function processSlackMention({
 			? db.query.usersSlackUsers.findFirst({
 					where: and(
 						eq(usersSlackUsers.slackUserId, event.user),
-						eq(usersSlackUsers.teamId, teamId),
+						eq(usersSlackUsers.teamId, userTeam),
 					),
 					columns: { userId: true, modelPreference: true },
 				})
@@ -150,7 +158,7 @@ export async function processSlackMention({
 		});
 		const connectUrl = generateConnectUrl({
 			slackUserId: event.user,
-			teamId,
+			teamId: userTeam,
 		});
 		await slack.chat.postMessage({
 			channel: event.channel,


### PR DESCRIPTION
## Summary
- In Slack Connect shared channels / Connect DMs, the events endpoint was looking up `integrationConnections` and `usersSlackUsers` by the envelope `team_id` — which is the team of the **bot** that received the event, not the user. With two Superset bots in a Connect channel (one per side), this routed mentions/DMs to the wrong org or returned "Slack not connected".
- `process-mention` and `process-assistant-message` now derive `userTeam = event.user_team ?? event.team ?? teamId` and use that for the connection lookup, user-link lookup, and connect-account link token. Behavior outside Slack Connect is unchanged (those fields are absent on regular events).
- `process-link-shared`, `process-entity-details`, and `process-app-home-opened` are intentionally left as-is — they aren't user-initiated mentions and should act on behalf of the bot that received the event.

## Test plan
- [ ] In a Slack Connect channel with both orgs' Superset bots, @mention either bot — the user's own org's Superset replies and the user-link gate no longer fires when the user is linked under their home team.
- [ ] In a regular (non-Connect) channel, @mentions still route to the team's connection as before.
- [ ] DM the bot in a Slack Connect DM scenario and confirm the user's own org's connection answers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Slack Connect mentions and assistant DMs by the user's home team instead of the bot's team so replies come from the correct org and user linking works. Behavior outside Slack Connect is unchanged.

- **Bug Fixes**
  - In `process-mention` and `process-assistant-message`, derive `userTeam = event.user_team ?? event.team ?? teamId`.
  - Use `userTeam` for `integrationConnections` and `usersSlackUsers` lookups and for the connect-account URL token.
  - Leave `process-link-shared`, `process-entity-details`, and `process-app-home-opened` as-is to act as the receiving bot.

<sup>Written for commit 55d787745c16d72547d9ec39f492d3fb5862c6da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack event routing to correctly identify and process assistant messages and mentions from the appropriate team context
  * Fixed account linking and subscription verification accuracy for users in multi-team Slack workspaces

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4528)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->