### PR TITLE
chore(desktop): rename open-links setting to inapp browser

### DIFF
--- a/apps/desktop/src/renderer/lib/clickPolicy/actionLabel.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/actionLabel.ts
@@ -7,9 +7,9 @@ const FILE_LABELS: Record<LinkAction, string> = {
 };
 
 const URL_LABELS: Record<LinkAction, string> = {
-	pane: "Open in Superset browser",
+	pane: "Open in in-app browser",
 	newTab: "Open in new browser tab",
-	external: "Open in external browser",
+	external: "Open in default browser",
 };
 
 export function actionLabel(action: LinkAction, surface: Surface): string {
@@ -31,9 +31,9 @@ const SHORT_FILE_LABELS: Record<LinkAction, string> = {
 };
 
 const SHORT_URL_LABELS: Record<LinkAction, string> = {
-	pane: "Superset browser",
+	pane: "in-app browser",
 	newTab: "new tab",
-	external: "external browser",
+	external: "default browser",
 };
 
 export function shortActionLabel(action: LinkAction, surface: Surface): string {

--- a/apps/desktop/src/renderer/lib/clickPolicy/actionLabel.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/actionLabel.ts
@@ -7,9 +7,9 @@ const FILE_LABELS: Record<LinkAction, string> = {
 };
 
 const URL_LABELS: Record<LinkAction, string> = {
-	pane: "Open in browser",
+	pane: "Open in Superset browser",
 	newTab: "Open in new browser tab",
-	external: "Open in system browser",
+	external: "Open in external browser",
 };
 
 export function actionLabel(action: LinkAction, surface: Surface): string {
@@ -31,9 +31,9 @@ const SHORT_FILE_LABELS: Record<LinkAction, string> = {
 };
 
 const SHORT_URL_LABELS: Record<LinkAction, string> = {
-	pane: "browser",
+	pane: "Superset browser",
 	newTab: "new tab",
-	external: "system browser",
+	external: "external browser",
 };
 
 export function shortActionLabel(action: LinkAction, surface: Surface): string {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -210,11 +210,11 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 								htmlFor="open-links-in-app"
 								className="text-sm font-medium"
 							>
-								Open links in Superset browser
+								Open links in the in-app browser
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Open links from chat and terminal in the Superset browser
-								instead of an external browser
+								Open links from chat and terminal in the in-app browser instead
+								of your default browser
 							</p>
 						</div>
 						<Switch

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -210,11 +210,11 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 								htmlFor="open-links-in-app"
 								className="text-sm font-medium"
 							>
-								Open links in app browser
+								Open links in Superset browser
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Open links from chat and terminal in the built-in browser
-								instead of your default browser
+								Open links from chat and terminal in the Superset browser
+								instead of an external browser
 							</p>
 						</div>
 						<Switch

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -606,9 +606,9 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 	{
 		id: SETTING_ITEM_ID.BEHAVIOR_OPEN_LINKS_IN_APP,
 		section: "behavior",
-		title: "Open links in Superset browser",
+		title: "Open links in the in-app browser",
 		description:
-			"Open links from chat and terminal in the Superset browser instead of an external browser",
+			"Open links from chat and terminal in the in-app browser instead of your default browser",
 		keywords: [
 			"browser",
 			"links",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -606,9 +606,9 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 	{
 		id: SETTING_ITEM_ID.BEHAVIOR_OPEN_LINKS_IN_APP,
 		section: "behavior",
-		title: "Open links in app browser",
+		title: "Open links in Superset browser",
 		description:
-			"Open links from chat and terminal in the built-in browser instead of your default browser",
+			"Open links from chat and terminal in the Superset browser instead of an external browser",
 		keywords: [
 			"browser",
 			"links",


### PR DESCRIPTION
## Summary
- Renamed the Behavior setting label "Open links in app browser" → "Open links in the in-app browser"
- Updated its description to "Open links from chat and terminal in the in-app browser instead of your default browser"
- Renamed URL right-click action labels: "Open in browser" → "Open in in-app browser"; "Open in system browser" → "Open in default browser" (long labels and short tooltip labels)
- Updated the settings search index title/description so the item still surfaces under "browser"

## Test plan
- [ ] Open Settings > Behavior and confirm the new label/description render
- [ ] Search settings for "browser" and confirm the item still surfaces
- [ ] Right-click a URL in chat/terminal and confirm the menu shows "Open in in-app browser" / "Open in default browser"