### PR TITLE
chore(slack): log raw event payload for Slack Connect diagnosis

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/route.ts
+++ b/apps/api/src/app/api/integrations/slack/events/route.ts
@@ -77,6 +77,13 @@ export async function POST(request: Request) {
 			return Response.json({ error: "Invalid payload shape" }, { status: 400 });
 		}
 
+		if (event.type === "app_mention" || event.type === "message") {
+			console.log(
+				"[slack/events] Raw payload for diagnostic:",
+				JSON.stringify(payload),
+			);
+		}
+
 		if (event.type === "app_mention") {
 			try {
 				await qstash.publishJSON({


### PR DESCRIPTION
## Summary
- Adds a one-off `console.log` of the full Slack event envelope on `app_mention` / `message` events, so we can see what Slack is actually sending in a Slack Connect channel.
- Background: PR #4528 routed by `event.user_team`/`event.team`, but a real Connect-channel mention (`Ev0B3L4JB353`) showed both fields were absent. We need to see the full envelope (especially `authorizations[]`, `context_team_id`, `is_ext_shared_channel`) before picking the right routing key.

## Plan after this lands
- User reproduces the bug, I read the logged payload, then ship a real fix and revert this log.

## Test plan
- [ ] After deploy, trigger an @mention in the shared channel; confirm a `[slack/events] Raw payload for diagnostic:` line shows up in Vercel logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily log the full Slack event payload for `app_mention` and `message` events to debug Slack Connect routing when `event.user_team` and `event.team` are missing. This exposes fields like `authorizations[]`, `context_team_id`, and `is_ext_shared_channel` in logs to pick the correct routing key.

<sup>Written for commit a236ae83081c902ea68373dc33698e9b21e29a1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Slack integration diagnostics by adding console logging for event debugging purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4530)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->