### PR TITLE
Revert "fix(slack): route mentions/DMs by user team for Slack Connect"

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
@@ -39,8 +39,6 @@ interface SlackAssistantMessageEvent {
 	event_ts: string;
 	thread_ts?: string;
 	files?: SlackEventFile[];
-	team?: string;
-	user_team?: string;
 }
 
 interface ProcessAssistantMessageParams {
@@ -54,15 +52,9 @@ export async function processAssistantMessage({
 	teamId,
 	eventId,
 }: ProcessAssistantMessageParams): Promise<void> {
-	// Slack Connect DMs deliver the bot's team in the envelope but the user's
-	// home team on the event itself. Route by the user's team so the user's
-	// own org's connection responds.
-	const userTeam = event.user_team ?? event.team ?? teamId;
-
 	console.log("[slack/process-assistant-message] Processing message:", {
 		eventId,
 		teamId,
-		userTeam,
 		channel: event.channel,
 		user: event.user,
 	});
@@ -70,7 +62,7 @@ export async function processAssistantMessage({
 	const connection = await db.query.integrationConnections.findFirst({
 		where: and(
 			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, userTeam),
+			eq(integrationConnections.externalOrgId, teamId),
 			isNull(integrationConnections.disconnectedAt),
 		),
 		orderBy: [
@@ -82,7 +74,7 @@ export async function processAssistantMessage({
 	if (!connection) {
 		console.error(
 			"[slack/process-assistant-message] No connection found for team:",
-			userTeam,
+			teamId,
 		);
 		return;
 	}
@@ -94,7 +86,7 @@ export async function processAssistantMessage({
 			? db.query.usersSlackUsers.findFirst({
 					where: and(
 						eq(usersSlackUsers.slackUserId, event.user),
-						eq(usersSlackUsers.teamId, userTeam),
+						eq(usersSlackUsers.teamId, teamId),
 					),
 					columns: { userId: true, modelPreference: true },
 				})
@@ -159,7 +151,7 @@ export async function processAssistantMessage({
 		});
 		const connectUrl = generateConnectUrl({
 			slackUserId: event.user,
-			teamId: userTeam,
+			teamId,
 		});
 		await slack.chat.postMessage({
 			channel: event.channel,

--- a/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
@@ -38,8 +38,6 @@ interface SlackAppMentionEvent {
 	event_ts: string;
 	thread_ts?: string;
 	files?: SlackEventFile[];
-	user_team?: string;
-	team?: string;
 }
 
 interface ProcessMentionParams {
@@ -53,15 +51,9 @@ export async function processSlackMention({
 	teamId,
 	eventId,
 }: ProcessMentionParams): Promise<void> {
-	// In Slack Connect (shared) channels the envelope team_id is the team of the
-	// bot that received the event, which can be a different org than the user.
-	// Route by the user's home team so the user's own org's connection responds.
-	const userTeam = event.user_team ?? event.team ?? teamId;
-
 	console.log("[slack/process-mention] Processing mention:", {
 		eventId,
 		teamId,
-		userTeam,
 		channel: event.channel,
 		user: event.user,
 	});
@@ -69,7 +61,7 @@ export async function processSlackMention({
 	const connection = await db.query.integrationConnections.findFirst({
 		where: and(
 			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, userTeam),
+			eq(integrationConnections.externalOrgId, teamId),
 			isNull(integrationConnections.disconnectedAt),
 		),
 		orderBy: [
@@ -81,7 +73,7 @@ export async function processSlackMention({
 	if (!connection) {
 		console.error(
 			"[slack/process-mention] No connection found for team:",
-			userTeam,
+			teamId,
 		);
 		return;
 	}
@@ -93,7 +85,7 @@ export async function processSlackMention({
 			? db.query.usersSlackUsers.findFirst({
 					where: and(
 						eq(usersSlackUsers.slackUserId, event.user),
-						eq(usersSlackUsers.teamId, userTeam),
+						eq(usersSlackUsers.teamId, teamId),
 					),
 					columns: { userId: true, modelPreference: true },
 				})
@@ -158,7 +150,7 @@ export async function processSlackMention({
 		});
 		const connectUrl = generateConnectUrl({
 			slackUserId: event.user,
-			teamId: userTeam,
+			teamId,
 		});
 		await slack.chat.postMessage({
 			channel: event.channel,


### PR DESCRIPTION
Reverts #4528.

## Why
That PR routed `app_mention` / DM events by `event.user_team` / `event.team` on the assumption that Slack would carry the user's home team there in Slack Connect channels. Real prod payloads don't — both fields are absent on the mention I tested. More importantly, the underlying premise was wrong: per [Slack's own docs](https://docs.slack.dev/apis/slack-connect/using-slack-connect-api-methods/), `app_mention` is intentionally routed only to the installing team's installation, and "external" users from another workspace are *meant* to be unauthorized for that install. Trying to silently respond on behalf of a different installation is non-idiomatic and confusing UX (the bot you @-mentioned stays silent while a different bot answers).

Reverting puts us back at the pre-#4528 behavior so we can ship the correct fix (smarter gate message when the user is linked under a different team) on a clean base.

## Test plan
- [ ] Existing Slack mention / DM flow in a non-Connect channel keeps working unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Slack Connect routing change so mentions and DMs are handled by the installing team's `teamId` again. This prevents cross-org replies and matches Slack’s expected behavior in Connect channels.

- **Bug Fixes**
  - Look up connections and user mappings by `teamId` only.
  - Removed `user_team`/`team` fields from event types; updated logging and connect URL usage accordingly.

<sup>Written for commit 266424d0ecf3dfca87b03aad29212579400b7de2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack integration connection handling for more consistent team ID routing and account linking across shared-channel events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4531)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->