### PR TITLE
fix(host-service): unstrand tunnel reconnect; wire relay Sentry

### DIFF
--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -28,6 +28,15 @@ const redactingLogger = logger((message, ...rest) => {
 
 initSentry();
 
+process.on("uncaughtException", (err) => {
+	captureSentryException(err, { source: "uncaughtException" });
+	console.error("[relay] uncaughtException (suppressed)", err);
+});
+process.on("unhandledRejection", (reason) => {
+	captureSentryException(reason, { source: "unhandledRejection" });
+	console.error("[relay] unhandledRejection (suppressed)", reason);
+});
+
 type AppContext = {
 	Variables: {
 		auth: AuthContext;
@@ -42,6 +51,14 @@ const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
 app.use("*", redactingLogger);
 app.use("*", cors());
+
+app.onError((err, c) => {
+	captureSentryException(err, {
+		op: "hono.onError",
+		path: new URL(c.req.url).pathname,
+	});
+	return c.json({ error: "Internal server error" }, 500);
+});
 
 app.get("/health", (c) => c.json({ ok: true, region: env.FLY_REGION }));
 

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -29,11 +29,9 @@ const redactingLogger = logger((message, ...rest) => {
 initSentry();
 
 process.on("uncaughtException", (err) => {
-	captureSentryException(err, { source: "uncaughtException" });
 	console.error("[relay] uncaughtException (suppressed)", err);
 });
 process.on("unhandledRejection", (reason) => {
-	captureSentryException(reason, { source: "unhandledRejection" });
 	console.error("[relay] unhandledRejection (suppressed)", reason);
 });
 

--- a/apps/relay/src/sentry.ts
+++ b/apps/relay/src/sentry.ts
@@ -11,6 +11,15 @@ export function initSentry(): void {
 		release: process.env.FLY_IMAGE_REF,
 		environment: process.env.FLY_APP_NAME ?? "relay-local",
 		tracesSampleRate: 0,
+		_experiments: { enableLogs: true },
+		integrations: [
+			Sentry.consoleLoggingIntegration({
+				levels: ["log", "info", "warn", "error"],
+			}),
+			Sentry.onUncaughtExceptionIntegration({
+				exitEvenIfOtherHandlersAreRegistered: false,
+			}),
+		],
 		initialScope: {
 			tags: {
 				region: env.FLY_REGION,

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -302,7 +302,9 @@ export class TunnelClient {
 
 	private cleanupChannels(): void {
 		for (const channel of this.localChannels.values()) {
-			channel.ws.close(1001, "Tunnel disconnected");
+			try {
+				channel.ws.close(1000, "Tunnel disconnected");
+			} catch {}
 		}
 		this.localChannels.clear();
 	}

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -304,7 +304,12 @@ export class TunnelClient {
 		for (const channel of this.localChannels.values()) {
 			try {
 				channel.ws.close(1000, "Tunnel disconnected");
-			} catch {}
+			} catch (err) {
+				console.warn(
+					"[host-service:tunnel] error closing local channel ws",
+					err,
+				);
+			}
 		}
 		this.localChannels.clear();
 	}


### PR DESCRIPTION
## Summary

Investigating why my hosts stopped reconnecting after a relay deploy, found two issues — one a real bug, one missing observability.

**Bug fix: host tunnel never reconnects after relay drops it (when active local channels exist).**
`TunnelClient.cleanupChannels` calls `channel.ws.close(1001, ...)`. 1001 is server-reserved per the WHATWG WebSocket spec; Undici (Node's built-in WebSocket) throws `InvalidAccessError` when clients send it. The throw bubbled out of `socket.onclose` before `scheduleReconnect()` ran, leaving the TunnelClient in a permanent dead state — `socket=null`, `connecting=false`, `reconnectTimer=null`, `closed=false`. Only relaunching the desktop app (= fresh `connectRelay()`) recovered it. Only hits hosts with active local channels at disconnect time, which is why idle hosts in the relay logs looked fine.

Caught via a real `[host-service] uncaughtException — staying up { DOMException [InvalidAccessError]: invalid code }` in `~/.superset/host/<org>/host-service.log` after the deploy.

**Observability: wire relay Sentry.**
Relay had `@sentry/node` initialized but `RELAY_SENTRY_DSN` was never set in Fly secrets, so two recent crashes (`exit_code=1`, not OOM) left no stack trace. Adds:
- `consoleLoggingIntegration` so every `console.*` (including Hono request log lines, with tokens already redacted by `redactingLogger`) ships to Sentry Logs.
- `onUncaughtExceptionIntegration({ exitEvenIfOtherHandlersAreRegistered: false })` + top-level `process.on('uncaughtException'|'unhandledRejection')` handlers — log + suppress instead of exiting, so a single uncaught throw doesn't drop every active tunnel.
- `app.onError()` Hono hook to capture errors thrown out of route handlers (Hono swallows these into a default 500 otherwise).

`RELAY_SENTRY_DSN` has been staged + deployed to `superset-relay` already.

## Test plan

- [x] `bun run --filter=@superset/relay typecheck` passes
- [x] `bun run --filter=@superset/host-service typecheck` passes
- [x] `bun run lint` clean
- [x] Relay v24 deployed; `/health` returns 200 in ~70ms; no Sentry init errors in fresh logs
- [ ] Cut a desktop canary with this fix and verify: trigger a relay restart, confirm host with active terminal sessions reconnects automatically (host-service.log should show `[host-service:tunnel] reconnecting in Xms` followed by `connected to relay for host ...`)

## Adjacent finds (not in this PR)

- `apps/relay/src/tunnel.ts:171` has the same `clientWs.close(1001, reason)` pattern. Relay uses the `ws` npm package via `@hono/node-ws`, which is more permissive than Undici, so it likely doesn't throw — but worth verifying.
- Single-machine relay topology (sjc only). `fly.toml` comments reference a 6-region scale-out but actual state is one machine, so every relay deploy is a 100% outage window.
- Defense-in-depth alternative: wrap the entire `socket.onclose` body in try/catch so any future throw inside it can't strand the client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a host reconnect bug and wires relay Sentry to keep tunnels stable and errors observable. Hosts now reconnect after relay restarts, and relay errors are captured without taking the process down.

- **Bug Fixes**
  - Host tunnel cleanup now uses WebSocket close code 1000 with a try/catch, preventing a throw that blocked `scheduleReconnect()`.
  - Logs unexpected channel close errors so they surface in Sentry Logs.

- **New Features**
  - Wired `@sentry/node` with console logging and uncaught-exception integrations; added Hono `app.onError` to capture route errors.
  - Process `uncaughtException`/`unhandledRejection` handlers now log only (avoids double-capture); relay stays up. Enabled `RELAY_SENTRY_DSN` on `superset-relay`.

<sup>Written for commit 9827893be599b9f94121b9c2d62d44d56eb0a7ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized handling of unexpected process and request errors with standardized JSON 500 responses.
  * More robust WebSocket cleanup with graceful close and suppressed errors on failure.

* **Improvements**
  * Improved error reporting and monitoring configuration.
  * Added console logging integration for clearer runtime visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4537)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->