### PR TITLE
feat(v2): lock new accounts to v2 and capture project_opened

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -1,6 +1,19 @@
+import { isV2OnlyUser } from "@superset/shared/v2-only-user";
+import { authClient } from "renderer/lib/auth-client";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+
+/**
+ * True for accounts created on/after V2_ONLY_USER_CUTOFF — these users
+ * never see the v1↔v2 switch.
+ */
+export function useIsV2OnlyUser(): boolean {
+	const { data: session } = authClient.useSession();
+	return isV2OnlyUser(session?.user?.createdAt);
+}
 
 /** Returns whether v2 is currently active for this user. */
 export function useIsV2CloudEnabled(): boolean {
-	return useV2LocalOverrideStore((s) => s.optInV2 === true);
+	const v2Only = useIsV2OnlyUser();
+	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
+	return v2Only || optInV2 === true;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -13,7 +13,10 @@ import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
 import { Switch } from "@superset/ui/switch";
 import { useNavigate } from "@tanstack/react-router";
-import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import {
+	useIsV2CloudEnabled,
+	useIsV2OnlyUser,
+} from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { STEP_ROUTES, useOnboardingStore } from "renderer/stores/onboarding";
 import { useOpenV1ImportModal } from "renderer/stores/v1-import-modal";
@@ -44,6 +47,7 @@ export function ExperimentalSettings({
 		visibleItems,
 	);
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const isV2OnlyUser = useIsV2OnlyUser();
 	const setOptInV2 = useV2LocalOverrideStore((state) => state.setOptInV2);
 	const resetOnboarding = useOnboardingStore((state) => state.reset);
 	const openV1ImportModal = useOpenV1ImportModal();
@@ -64,7 +68,7 @@ export function ExperimentalSettings({
 			</div>
 
 			<div className="space-y-6">
-				{showSupersetV2 && (
+				{showSupersetV2 && !isV2OnlyUser && (
 					<div className="flex items-center justify-between gap-6">
 						<div className="min-w-0 flex-1 space-y-0.5">
 							<Label htmlFor="superset-v2" className="text-sm font-medium">
@@ -87,7 +91,7 @@ export function ExperimentalSettings({
 						/>
 					</div>
 				)}
-				{showV1Migration && (
+				{showV1Migration && !isV2OnlyUser && (
 					<div className="flex items-center justify-between gap-6">
 						<div className="min-w-0 flex-1 space-y-0.5">
 							<Label className="text-sm font-medium">Import from v1</Label>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,10 @@
 			"types": "./src/constants.ts",
 			"default": "./src/constants.ts"
 		},
+		"./v2-only-user": {
+			"types": "./src/v2-only-user.ts",
+			"default": "./src/v2-only-user.ts"
+		},
 		"./names": {
 			"types": "./src/names/index.ts",
 			"default": "./src/names/index.ts"

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -58,6 +58,13 @@ export const TEARDOWN_TIMEOUT_MS = 60_000;
 // PostHog
 export const POSTHOG_COOKIE_NAME = "superset";
 
+// Users whose account was created at or after this instant are v2-only:
+// the v1↔v2 surface switch is hidden and v2 cloud is forced on. Pre-cutoff
+// users keep the existing opt-in toggle. Stored as an ISO string so the
+// value is identical on server, desktop renderer, web, and admin.
+// 2026-05-15 14:00 UTC = Fri 07:00 PDT / 10:00 EDT.
+export const V2_ONLY_USER_CUTOFF = "2026-05-15T14:00:00.000Z";
+
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */
 	ELECTRIC_TASKS_ACCESS: "electric-tasks-access",

--- a/packages/shared/src/v2-only-user.ts
+++ b/packages/shared/src/v2-only-user.ts
@@ -1,0 +1,13 @@
+import { V2_ONLY_USER_CUTOFF } from "./constants";
+
+export function isV2OnlyUser(
+	createdAt: Date | string | number | null | undefined,
+): boolean {
+	if (createdAt == null) return false;
+	const created =
+		createdAt instanceof Date
+			? createdAt.getTime()
+			: new Date(createdAt).getTime();
+	if (Number.isNaN(created)) return false;
+	return created >= new Date(V2_ONLY_USER_CUTOFF).getTime();
+}

--- a/packages/trpc/src/router/v2-project/v2-project.test.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.test.ts
@@ -157,6 +157,10 @@ mock.module("@vercel/blob", () => ({
 	put: mock(),
 }));
 
+mock.module("../../lib/analytics", () => ({
+	posthog: { capture: mock(() => {}) },
+}));
+
 mock.module("../../lib/github-avatar", () => ({
 	fetchAndStoreGitHubAvatar: fetchAndStoreGitHubAvatarMock,
 }));

--- a/packages/trpc/src/router/v2-project/v2-project.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.ts
@@ -11,6 +11,7 @@ import { TRPCError } from "@trpc/server";
 import { del } from "@vercel/blob";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
+import { posthog } from "../../lib/analytics";
 import { fetchAndStoreGitHubAvatar } from "../../lib/github-avatar";
 import { generateImagePathname, uploadImage } from "../../lib/upload";
 import { jwtProcedure, protectedProcedure } from "../../trpc";
@@ -259,6 +260,17 @@ export const v2ProjectRouter = {
 					message: "Failed to create project",
 				});
 			}
+
+			posthog.capture({
+				distinctId: ctx.userId,
+				event: "project_opened",
+				properties: {
+					project_id: project.id,
+					organization_id: project.organizationId,
+					method: input.repoCloneUrl ? "github" : "empty",
+					surface: "v2",
+				},
+			});
 
 			if (githubOwner) {
 				const owner = githubOwner;


### PR DESCRIPTION
## Summary

- Accounts created on/after **2026-05-15 14:00 UTC** (Fri 07:00 PDT / 10:00 EDT) are locked to v2: the v1↔v2 toggle in Experimental Settings and the "Import from v1" button are hidden, and `useIsV2CloudEnabled()` returns `true` regardless of the local opt-in. Pre-cutoff users keep the existing toggle behavior.
- Single shared constant `V2_ONLY_USER_CUTOFF` in `packages/shared/src/constants.ts` (no DB column, no PostHog flag — `users.created_at` is server-set, so no race or backfill).
- New `project_opened` capture in `v2-project.create` so the existing activation funnel (`packages/trpc/src/router/analytics/analytics.ts`) works for the v2 cohort. v1 vs v2 differentiation in PostHog is already handled by the `surface` super-property from `PostHogSurfaceTagger`.

## Test plan

- [ ] Sign in as an existing (pre-cutoff) account → "Try Superset v2" Switch and "Import from v1" button are still visible in Settings → Experimental; toggle still flips between v1 and v2.
- [ ] Temporarily lower `V2_ONLY_USER_CUTOFF` to a past date, reload → both controls disappear, app boots into v2, V2AvailableBanner is gone. Restore the cutoff.
- [ ] Offline test: log in pre-cutoff while online, go offline, restart → behavior unchanged (offline branch in `_authenticated/layout.tsx` still triggers when applicable).
- [ ] After deploy: confirm `project_opened` events with `surface: "v2"` start landing in PostHog (currently zero v2-tagged ones), and the activation funnel for v2 users no longer drops at step 3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock new accounts (created on/after 2026-05-15 14:00 UTC) to v2 and capture `project_opened` during v2 project creation. This forces v2 for new users and unblocks the v2 activation funnel.

- **New Features**
  - V2-only cohort: hide the v1↔v2 switch and “Import from v1”; `useIsV2CloudEnabled()` is always true; pre-cutoff users keep the toggle.
  - Shared cutoff/util: add `V2_ONLY_USER_CUTOFF` and `isV2OnlyUser` in `packages/shared` (exported as `@superset/shared/v2-only-user`); used by `ExperimentalSettings.tsx` and `useIsV2CloudEnabled.ts`.
  - Analytics: `v2-project.create` emits `project_opened` with `surface: "v2"` and `method` (“github” | “empty”); tests mock `posthog` to avoid env validation.

<sup>Written for commit 567a0b2f7bac684aedbc5f581693eb55c29a033c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic v2 access for users created on/after a cutoff date.
  * Project creation now emits analytics events for tracking.

* **Behavior Changes**
  * Experimental settings hide the “Try v2” and “Import from v1” options for v2-only users.
  * V2 availability now respects both automatic v2-only status and explicit opt-in.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4538)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->