### PR TITLE
harden(host-service): connect-phase deadline + reconnect-guaranteed onclose

### DIFF
--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -11,6 +11,7 @@ const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
 const INBOUND_SILENCE_TIMEOUT_MS = 75_000;
 const WATCHDOG_INTERVAL_MS = 10_000;
+const CONNECT_TIMEOUT_MS = 20_000;
 
 export interface TunnelClientOptions {
 	relayUrl: string;
@@ -59,15 +60,32 @@ export class TunnelClient {
 		}
 		this.connecting = true;
 
+		let timedOut = false;
+		const deadline = setTimeout(() => {
+			if (this.closed) return;
+			timedOut = true;
+			console.warn(
+				`[host-service:tunnel] connect did not complete within ${CONNECT_TIMEOUT_MS}ms, forcing retry`,
+			);
+			try {
+				this.socket?.close(4001, "Connect timeout");
+			} catch {}
+			this.socket = null;
+			this.connecting = false;
+			this.scheduleReconnect();
+		}, CONNECT_TIMEOUT_MS);
+
 		// An unhandled rejection here (e.g. DNS failure inside getAuthToken on
 		// wake from sleep) crashes host-service and orphans every PTY.
 		try {
 			const token = await this.getAuthToken();
-			if (this.closed) {
-				this.connecting = false;
+			if (timedOut || this.closed) {
+				clearTimeout(deadline);
+				if (this.closed) this.connecting = false;
 				return;
 			}
 			if (!token) {
+				clearTimeout(deadline);
 				console.warn("[host-service:tunnel] no auth token available, retrying");
 				this.connecting = false;
 				this.scheduleReconnect();
@@ -84,6 +102,7 @@ export class TunnelClient {
 			this.lastInboundAt = Date.now();
 
 			socket.onopen = () => {
+				clearTimeout(deadline);
 				this.reconnectAttempts = 0;
 				this.connecting = false;
 				this.lastInboundAt = Date.now();
@@ -99,28 +118,34 @@ export class TunnelClient {
 			};
 
 			socket.onclose = (event) => {
-				const wasOurSocket = this.socket === socket;
-				if (!wasOurSocket) return;
-
-				this.socket = null;
-				this.connecting = false;
-				this.stopWatchdog();
-				this.cleanupChannels();
-
-				if (this.closed) return;
-
-				if (event.code === 1008) {
+				if (this.socket !== socket) return;
+				clearTimeout(deadline);
+				try {
+					this.socket = null;
+					this.connecting = false;
+					this.stopWatchdog();
+					this.cleanupChannels();
+					if (event.code === 1008) {
+						console.warn(
+							`[host-service:tunnel] relay rejected connection (code=${event.code}, reason=${event.reason ?? ""}); retrying`,
+						);
+					}
+				} catch (err) {
 					console.warn(
-						`[host-service:tunnel] relay rejected connection (code=${event.code}, reason=${event.reason ?? ""}); retrying`,
+						"[host-service:tunnel] error during onclose cleanup",
+						err,
 					);
+				} finally {
+					if (!this.closed) this.scheduleReconnect();
 				}
-				this.scheduleReconnect();
 			};
 
 			socket.onerror = (event) => {
 				console.error("[host-service:tunnel] socket error:", event);
 			};
 		} catch (error) {
+			clearTimeout(deadline);
+			if (timedOut) return;
 			const message = error instanceof Error ? error.message : String(error);
 			console.error(`[host-service:tunnel] connect failed: ${message}`);
 			this.socket = null;


### PR DESCRIPTION
## Summary

Follow-up to #4537. That PR fixed the one known stuck-state path (1001 close code throwing inside `cleanupChannels`). This closes two more paths to the same `socket=null, connecting=true, reconnectTimer=null` wedge:

- **`getAuthToken()` hangs without an upstream timeout.** The `await` sits forever, `connecting` stays `true`, every subsequent `connect()` call early-returns on the `if (this.connecting) return;` guard. No retry ever scheduled. Permanent stuck.
- **WebSocket stalls in `CONNECTING`.** Captive portal, NAT rebind mid-handshake, dead server — `onopen`/`onclose`/`onerror` never fire. Watchdog can't help because it's only started inside `onopen`. Same wedge.

Both collapse into one mechanism: a **20s connect-phase deadline**. On timeout we force-close any in-flight socket (code 4001, application-reserved), reset state, and schedule a reconnect. The stale `onclose` for the abandoned socket no-ops via the existing `this.socket !== socket` identity check, so no double-scheduling.

Also wraps the `onclose` body in `try/finally` so any future throw inside it still routes through `scheduleReconnect()` — defense-in-depth against the class of bug we just fixed (synchronous throw inside the close handler that bypasses the retry call).

## What's left unaddressed

The multi-boolean state (`closed` / `connecting` / `socket` / `reconnectTimer` / `watchdogTimer`) is the canonical setup for these bugs. A single `state` enum (`'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed'`) with explicit transitions would prevent whole classes of wedge — that's the "robust WebSocket client" refactor pattern. Out of scope for this PR; worth a follow-up if anyone feels like a from-scratch rewrite.

## Test plan

- [x] `bun run --filter=@superset/host-service typecheck` passes
- [x] `bun run lint` clean
- [ ] In a desktop canary: run host-service offline, confirm `[host-service:tunnel] connect did not complete within 20000ms, forcing retry` appears every ~20s in `~/.superset/host/<org>/host-service.log` and `[host-service:tunnel] reconnecting in Xms (attempt N)` follows each one
- [ ] In a desktop canary: connect normally, confirm `connected to relay for host ...` appears within ~3s (deadline cleared in `onopen`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the tunnel client from getting stuck in “connecting” by adding a 20s connect-phase deadline and guaranteeing a reconnect even if `onclose` cleanup throws. On timeout, we force-close the socket (4001), reset state, and schedule a retry.

- **Bug Fixes**
  - Added a 20s connect deadline to cover hanging `getAuthToken()` and stalled WebSocket handshakes; on timeout, close with 4001, reset, and reconnect.
  - Clear the deadline in all paths (`onopen`, auth failure, `onclose`, and catch) and ignore stale `onclose` via socket identity check.
  - Wrapped `onclose` cleanup in try/finally so `scheduleReconnect()` always runs; also stops the watchdog and cleans up channels safely.

<sup>Written for commit 7d9b7ec2e2504a3cf7f15ee81f0ebd88d449729c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added connection timeout enforcement for tunnel establishment to prevent hanging connections.
  * Improved socket cleanup and reconnection handling during connection failures.
  * Enhanced logging for better visibility into connection timeout events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4539)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->