### PR TITLE
fix(desktop): stop folder import on cloud lookup errors

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const hostUrl = "http://host-service";
+const repoPath = "/repos/octocat";
+const setupResult = {
+	repoPath,
+	mainWorkspaceId: "workspace-1",
+};
+const cloudError = {
+	url: "https://github.com/octocat/hello.git",
+	message: "cloud-down",
+};
+const localCandidate = { id: "local-project", name: "octocat" };
+
+const selectDirectoryMock = mock(async () => ({
+	canceled: false,
+	path: repoPath,
+}));
+const findByPathMock = mock(async () => ({
+	candidates: [] as (typeof localCandidate)[],
+	cloudErrors: [] as (typeof cloudError)[],
+}));
+const setupMock = mock(async () => setupResult);
+const createMock = mock(async () => ({
+	projectId: "created-project",
+	repoPath,
+	mainWorkspaceId: "workspace-created",
+}));
+const finalizeSetupMock = mock(() => undefined);
+
+mock.module("react", () => ({
+	useCallback: <T extends (...args: never[]) => unknown>(callback: T) =>
+		callback,
+}));
+
+mock.module("renderer/lib/electron-trpc", () => ({
+	electronTrpc: {
+		window: {
+			selectDirectory: {
+				useMutation: () => ({ mutateAsync: selectDirectoryMock }),
+			},
+		},
+	},
+}));
+
+mock.module("renderer/lib/host-service-client", () => ({
+	getHostServiceClientByUrl: () => ({
+		project: {
+			findByPath: { query: findByPathMock },
+			setup: { mutate: setupMock },
+			create: { mutate: createMock },
+		},
+	}),
+}));
+
+mock.module("renderer/react-query/projects", () => ({
+	useFinalizeProjectSetup: () => finalizeSetupMock,
+}));
+
+mock.module(
+	"renderer/routes/_authenticated/providers/LocalHostServiceProvider",
+	() => ({
+		useLocalHostService: () => ({ activeHostUrl: hostUrl }),
+	}),
+);
+
+const { useFolderFirstImport } = await import("./useFolderFirstImport");
+
+describe("useFolderFirstImport", () => {
+	beforeEach(() => {
+		for (const fn of [
+			selectDirectoryMock,
+			findByPathMock,
+			setupMock,
+			createMock,
+			finalizeSetupMock,
+		]) {
+			fn.mockClear();
+		}
+		findByPathMock.mockResolvedValue({ candidates: [], cloudErrors: [] });
+	});
+
+	it("reports cloud lookup errors instead of creating a duplicate local import when no candidates exist", async () => {
+		findByPathMock.mockResolvedValue({
+			candidates: [],
+			cloudErrors: [cloudError],
+		});
+		const onError = mock(() => undefined);
+
+		const result = await useFolderFirstImport({ onError }).start();
+
+		expect(result).toBeNull();
+		expect(findByPathMock).toHaveBeenCalledWith({ repoPath });
+		expect(onError).toHaveBeenCalledWith(
+			"Couldn't reach cloud for https://github.com/octocat/hello.git: cloud-down",
+		);
+		expect(createMock).not.toHaveBeenCalled();
+		expect(setupMock).not.toHaveBeenCalled();
+		expect(finalizeSetupMock).not.toHaveBeenCalled();
+	});
+
+	it("keeps folder-first candidate import flowing even when the lookup response includes cloud errors", async () => {
+		findByPathMock.mockResolvedValue({
+			candidates: [localCandidate],
+			cloudErrors: [cloudError],
+		});
+		const onError = mock(() => undefined);
+
+		const result = await useFolderFirstImport({ onError }).start();
+
+		expect(result).toEqual({
+			projectId: "local-project",
+			repoPath: "/repos/octocat",
+			mainWorkspaceId: "workspace-1",
+		});
+		expect(setupMock).toHaveBeenCalledWith({
+			projectId: "local-project",
+			mode: { kind: "import", repoPath },
+		});
+		expect(createMock).not.toHaveBeenCalled();
+		expect(onError).not.toHaveBeenCalled();
+		expect(finalizeSetupMock).toHaveBeenCalledWith(hostUrl, {
+			projectId: "local-project",
+			repoPath,
+			mainWorkspaceId: "workspace-1",
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
@@ -10,14 +10,13 @@ const cloudError = {
 	url: "https://github.com/octocat/hello.git",
 	message: "cloud-down",
 };
-const localCandidate = { id: "local-project", name: "octocat" };
 
 const selectDirectoryMock = mock(async () => ({
 	canceled: false,
 	path: repoPath,
 }));
 const findByPathMock = mock(async () => ({
-	candidates: [] as (typeof localCandidate)[],
+	candidates: [] as { id: string; name: string }[],
 	cloudErrors: [] as (typeof cloudError)[],
 }));
 const setupMock = mock(async () => setupResult);
@@ -97,32 +96,5 @@ describe("useFolderFirstImport", () => {
 		expect(createMock).not.toHaveBeenCalled();
 		expect(setupMock).not.toHaveBeenCalled();
 		expect(finalizeSetupMock).not.toHaveBeenCalled();
-	});
-
-	it("keeps folder-first candidate import flowing even when the lookup response includes cloud errors", async () => {
-		findByPathMock.mockResolvedValue({
-			candidates: [localCandidate],
-			cloudErrors: [cloudError],
-		});
-		const onError = mock(() => undefined);
-
-		const result = await useFolderFirstImport({ onError }).start();
-
-		expect(result).toEqual({
-			projectId: "local-project",
-			repoPath: "/repos/octocat",
-			mainWorkspaceId: "workspace-1",
-		});
-		expect(setupMock).toHaveBeenCalledWith({
-			projectId: "local-project",
-			mode: { kind: "import", repoPath },
-		});
-		expect(createMock).not.toHaveBeenCalled();
-		expect(onError).not.toHaveBeenCalled();
-		expect(finalizeSetupMock).toHaveBeenCalledWith(hostUrl, {
-			projectId: "local-project",
-			repoPath,
-			mainWorkspaceId: "workspace-1",
-		});
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.ts
@@ -51,11 +51,7 @@ export function useFolderFirstImport(options?: {
 			candidates = response.candidates;
 			if (candidates.length === 0 && response.cloudErrors.length > 0) {
 				const first = response.cloudErrors[0];
-				onError?.(
-					first
-						? `Couldn't reach cloud for ${first.url}: ${first.message}`
-						: "Couldn't reach cloud",
-				);
+				onError?.(`Couldn't reach cloud for ${first.url}: ${first.message}`);
 				return null;
 			}
 		} catch (err) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.ts
@@ -49,6 +49,15 @@ export function useFolderFirstImport(options?: {
 		try {
 			const response = await client.project.findByPath.query({ repoPath });
 			candidates = response.candidates;
+			if (candidates.length === 0 && response.cloudErrors.length > 0) {
+				const first = response.cloudErrors[0];
+				onError?.(
+					first
+						? `Couldn't reach cloud for ${first.url}: ${first.message}`
+						: "Couldn't reach cloud",
+				);
+				return null;
+			}
 		} catch (err) {
 			onError?.(err instanceof Error ? err.message : String(err));
 			return null;


### PR DESCRIPTION
## Summary
- stop folder-first import when cloud lookup returns errors and there are no local candidates
- surface the first cloud lookup error instead of creating a new local import while lookup state is indeterminate
- keep candidate import flowing when candidates exist, even if the response also includes cloud errors

## Note
Duplicate GitHub remotes are still allowed. This only blocks the no-candidate + cloud-error fallback that could create an unintended new project when existing-project discovery failed.

## QA
- bun --cwd apps/desktop test src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
- bun --cwd apps/desktop typecheck
- bun run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder-first imports now stop and surface a clear cloud-specific error message when a cloud lookup returns no candidates but reports cloud errors, preventing unintended setup.

* **Tests**
  * Added a test verifying folder-first import is blocked and reports cloud errors when a cloud lookup returns errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->