### PR TITLE
fix(desktop): scope workspace prompt context by project

### DIFF
--- a/apps/desktop/src/renderer/stores/new-workspace-prompt-context/buildSubmitPrompt.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-prompt-context/buildSubmitPrompt.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { buildSubmitPrompt } from "./buildSubmitPrompt";
+import {
+	makePromptContextKey,
+	useNewWorkspacePromptContextStore,
+} from "./store";
+
+describe("buildSubmitPrompt", () => {
+	beforeEach(() => {
+		useNewWorkspacePromptContextStore.setState({ entries: new Map() });
+	});
+
+	test("scopes linked GitHub issue bodies by project and host context", async () => {
+		const store = useNewWorkspacePromptContextStore.getState();
+		store.register(makePromptContextKey("github-issue", 7, "project-a"), () =>
+			Promise.resolve({ text: "body from project A" }),
+		);
+		store.register(makePromptContextKey("github-issue", 7, "project-b"), () =>
+			Promise.resolve({ text: "body from project B" }),
+		);
+		await store.awaitPending(1000);
+
+		const prompt = buildSubmitPrompt({
+			userPrompt: "",
+			linkedPR: null,
+			contextScope: "project-b",
+			linkedIssues: [
+				{
+					source: "github",
+					slug: "gh-7",
+					title: "Issue 7",
+					number: 7,
+					url: "https://example.com/issues/7",
+				},
+			],
+		});
+
+		expect(prompt).toContain("body from project B");
+		expect(prompt).not.toContain("body from project A");
+	});
+});

--- a/apps/desktop/src/renderer/stores/new-workspace-prompt-context/buildSubmitPrompt.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-prompt-context/buildSubmitPrompt.test.ts
@@ -2,40 +2,92 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { buildSubmitPrompt } from "./buildSubmitPrompt";
 import {
 	makePromptContextKey,
+	makePromptContextScope,
 	useNewWorkspacePromptContextStore,
 } from "./store";
+
+const SHARED_ISSUE_NUMBER = 7;
+const SHARED_PR_NUMBER = 17;
+
+const sameNumberContextFixtures = [
+	{
+		projectId: "project-alpha",
+		hostUrl: "https://host-one.superset.test",
+		issueBody: "fixture issue body: alpha on host one",
+		prBody: "fixture PR body: alpha on host one",
+	},
+	{
+		projectId: "project-alpha",
+		hostUrl: "https://host-two.superset.test",
+		issueBody: "fixture issue body: alpha on host two",
+		prBody: "fixture PR body: alpha on host two",
+	},
+	{
+		projectId: "project-beta",
+		hostUrl: "https://host-one.superset.test",
+		issueBody: "fixture issue body: beta on host one",
+		prBody: "fixture PR body: beta on host one",
+	},
+	{
+		projectId: "project-beta",
+		hostUrl: "https://host-two.superset.test",
+		issueBody: "fixture issue body: beta on host two",
+		prBody: "fixture PR body: beta on host two",
+	},
+] as const;
 
 describe("buildSubmitPrompt", () => {
 	beforeEach(() => {
 		useNewWorkspacePromptContextStore.setState({ entries: new Map() });
 	});
 
-	test("scopes linked GitHub issue bodies by project and host context", async () => {
+	test("scopes same-number GitHub issue and PR bodies by project and host fixtures", async () => {
 		const store = useNewWorkspacePromptContextStore.getState();
-		store.register(makePromptContextKey("github-issue", 7, "project-a"), () =>
-			Promise.resolve({ text: "body from project A" }),
-		);
-		store.register(makePromptContextKey("github-issue", 7, "project-b"), () =>
-			Promise.resolve({ text: "body from project B" }),
-		);
+		for (const fixture of sameNumberContextFixtures) {
+			const contextScope = makePromptContextScope(
+				fixture.projectId,
+				fixture.hostUrl,
+			);
+			store.register(
+				makePromptContextKey("github-issue", SHARED_ISSUE_NUMBER, contextScope),
+				() => Promise.resolve({ text: fixture.issueBody }),
+			);
+			store.register(
+				makePromptContextKey("pr", SHARED_PR_NUMBER, contextScope),
+				() => Promise.resolve({ text: fixture.prBody }),
+			);
+		}
 		await store.awaitPending(1000);
 
-		const prompt = buildSubmitPrompt({
-			userPrompt: "",
-			linkedPR: null,
-			contextScope: "project-b",
-			linkedIssues: [
-				{
-					source: "github",
-					slug: "gh-7",
-					title: "Issue 7",
-					number: 7,
-					url: "https://example.com/issues/7",
+		for (const target of sameNumberContextFixtures) {
+			const prompt = buildSubmitPrompt({
+				userPrompt: "Start from the linked context.",
+				linkedPR: {
+					prNumber: SHARED_PR_NUMBER,
+					title: "Shared PR number",
+					url: `https://github.com/superset-sh/${target.projectId}/pull/${SHARED_PR_NUMBER}`,
+					state: "open",
 				},
-			],
-		});
+				contextScope: makePromptContextScope(target.projectId, target.hostUrl),
+				linkedIssues: [
+					{
+						source: "github",
+						slug: `gh-${SHARED_ISSUE_NUMBER}`,
+						title: "Shared issue number",
+						number: SHARED_ISSUE_NUMBER,
+						url: `https://github.com/superset-sh/${target.projectId}/issues/${SHARED_ISSUE_NUMBER}`,
+					},
+				],
+			});
 
-		expect(prompt).toContain("body from project B");
-		expect(prompt).not.toContain("body from project A");
+			expect(prompt).toContain(target.issueBody);
+			expect(prompt).toContain(target.prBody);
+
+			for (const other of sameNumberContextFixtures) {
+				if (other === target) continue;
+				expect(prompt).not.toContain(other.issueBody);
+				expect(prompt).not.toContain(other.prBody);
+			}
+		}
 	});
 });

--- a/apps/desktop/src/renderer/stores/new-workspace-prompt-context/buildSubmitPrompt.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-prompt-context/buildSubmitPrompt.ts
@@ -2,12 +2,16 @@ import type {
 	LinkedIssue,
 	LinkedPR,
 } from "renderer/stores/new-workspace-draft";
-import { useNewWorkspacePromptContextStore } from "./store";
+import {
+	makePromptContextKey,
+	useNewWorkspacePromptContextStore,
+} from "./store";
 
 export interface BuildSubmitPromptArgs {
 	userPrompt: string;
 	linkedPR: LinkedPR | null;
 	linkedIssues: LinkedIssue[];
+	contextScope?: string | null;
 }
 
 function readBody(key: string): string | null {
@@ -21,14 +25,18 @@ export function buildSubmitPrompt(args: BuildSubmitPromptArgs): string {
 
 	for (const issue of args.linkedIssues) {
 		if (issue.source !== "internal" || !issue.taskId) continue;
-		const body = readBody(`task:${issue.taskId}`);
+		const body = readBody(
+			makePromptContextKey("task", issue.taskId, args.contextScope),
+		);
 		const header = `## Linked task — ${issue.slug}: ${issue.title}`;
 		linkedSections.push(body ? `${header}\n${body}` : header);
 	}
 
 	for (const issue of args.linkedIssues) {
 		if (issue.source !== "github" || issue.number == null) continue;
-		const body = readBody(`github-issue:${issue.number}`);
+		const body = readBody(
+			makePromptContextKey("github-issue", issue.number, args.contextScope),
+		);
 		const headerLines = [
 			`## Linked GitHub issue — #${issue.number}: ${issue.title}`,
 		];
@@ -38,7 +46,9 @@ export function buildSubmitPrompt(args: BuildSubmitPromptArgs): string {
 	}
 
 	if (args.linkedPR) {
-		const body = readBody(`pr:${args.linkedPR.prNumber}`);
+		const body = readBody(
+			makePromptContextKey("pr", args.linkedPR.prNumber, args.contextScope),
+		);
 		const header = `## Linked PR — #${args.linkedPR.prNumber}: ${args.linkedPR.title}\n${args.linkedPR.url}`;
 		linkedSections.push(body ? `${header}\n\n${body}` : header);
 	}

--- a/apps/desktop/src/renderer/stores/new-workspace-prompt-context/store.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-prompt-context/store.ts
@@ -2,10 +2,21 @@ import { create } from "zustand";
 
 export type PromptContextBody = { text: string };
 
+type PromptContextKind = "github-issue" | "pr" | "task";
+
 export type PromptContextEntry =
 	| { state: "loading"; promise: Promise<PromptContextBody | null> }
 	| { state: "ready"; body: PromptContextBody }
 	| { state: "failed" };
+
+export function makePromptContextKey(
+	kind: PromptContextKind,
+	id: string | number,
+	scope?: string | null,
+): string {
+	const base = `${kind}:${id}`;
+	return scope ? `${scope}|${base}` : base;
+}
 
 interface PromptContextState {
 	entries: Map<string, PromptContextEntry>;

--- a/apps/desktop/src/renderer/stores/new-workspace-prompt-context/store.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-prompt-context/store.ts
@@ -18,6 +18,14 @@ export function makePromptContextKey(
 	return scope ? `${scope}|${base}` : base;
 }
 
+export function makePromptContextScope(
+	projectId: string | null,
+	hostUrl: string | null,
+): string | null {
+	if (!projectId || !hostUrl) return null;
+	return `${projectId}|${hostUrl}`;
+}
+
 interface PromptContextState {
 	entries: Map<string, PromptContextEntry>;
 	register: (

--- a/apps/desktop/src/renderer/stores/new-workspace-prompt-context/useNewWorkspacePromptContext.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-prompt-context/useNewWorkspacePromptContext.ts
@@ -13,7 +13,10 @@ import {
 	fetchInternalTaskBody,
 	fetchPrBody,
 } from "./fetchers";
-import { useNewWorkspacePromptContextStore } from "./store";
+import {
+	makePromptContextKey,
+	useNewWorkspacePromptContextStore,
+} from "./store";
 
 export interface NewWorkspacePromptContextApi {
 	build: (args: {
@@ -48,13 +51,18 @@ export function useNewWorkspacePromptContext(args: {
 		});
 	}, [hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
 
+	const contextScope = useMemo(() => {
+		if (!projectId || !hostUrl) return null;
+		return `${projectId}|${hostUrl}`;
+	}, [projectId, hostUrl]);
+
 	useEffect(() => {
-		if (!projectId || !hostUrl) return;
+		if (!projectId || !hostUrl || !contextScope) return;
 		const store = useNewWorkspacePromptContextStore.getState();
 
 		if (linkedPR) {
 			const prNumber = linkedPR.prNumber;
-			store.register(`pr:${prNumber}`, () =>
+			store.register(makePromptContextKey("pr", prNumber, contextScope), () =>
 				fetchPrBody({ prNumber, projectId, hostUrl }),
 			);
 		}
@@ -62,17 +70,18 @@ export function useNewWorkspacePromptContext(args: {
 		for (const issue of linkedIssues) {
 			if (issue.source === "github" && issue.number != null) {
 				const issueNumber = issue.number;
-				store.register(`github-issue:${issueNumber}`, () =>
-					fetchGitHubIssueBody({ issueNumber, projectId, hostUrl }),
+				store.register(
+					makePromptContextKey("github-issue", issueNumber, contextScope),
+					() => fetchGitHubIssueBody({ issueNumber, projectId, hostUrl }),
 				);
 			} else if (issue.source === "internal" && issue.taskId) {
 				const taskId = issue.taskId;
-				store.register(`task:${taskId}`, () =>
+				store.register(makePromptContextKey("task", taskId, contextScope), () =>
 					fetchInternalTaskBody({ taskId }),
 				);
 			}
 		}
-	}, [projectId, hostUrl, linkedPR, linkedIssues]);
+	}, [projectId, hostUrl, contextScope, linkedPR, linkedIssues]);
 
 	return useMemo<NewWorkspacePromptContextApi>(
 		() => ({
@@ -84,9 +93,10 @@ export function useNewWorkspacePromptContext(args: {
 					userPrompt: buildArgs.userPrompt,
 					linkedPR: buildArgs.linkedPR,
 					linkedIssues: buildArgs.linkedIssues,
+					contextScope,
 				});
 			},
 		}),
-		[],
+		[contextScope],
 	);
 }

--- a/apps/desktop/src/renderer/stores/new-workspace-prompt-context/useNewWorkspacePromptContext.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-prompt-context/useNewWorkspacePromptContext.ts
@@ -15,6 +15,7 @@ import {
 } from "./fetchers";
 import {
 	makePromptContextKey,
+	makePromptContextScope,
 	useNewWorkspacePromptContextStore,
 } from "./store";
 
@@ -51,10 +52,10 @@ export function useNewWorkspacePromptContext(args: {
 		});
 	}, [hostId, machineId, activeHostUrl, activeOrganizationId, relayUrl]);
 
-	const contextScope = useMemo(() => {
-		if (!projectId || !hostUrl) return null;
-		return `${projectId}|${hostUrl}`;
-	}, [projectId, hostUrl]);
+	const contextScope = useMemo(
+		() => makePromptContextScope(projectId, hostUrl),
+		[projectId, hostUrl],
+	);
 
 	useEffect(() => {
 		if (!projectId || !hostUrl || !contextScope) return;


### PR DESCRIPTION
## Summary
- key cached linked issue, PR, and task bodies by project and host context
- prevent same-number GitHub issues or PRs from another repo leaking stale context into a new workspace prompt
- add regression coverage for scoped prompt body lookup

## QA
- bun --cwd apps/desktop test src/renderer/stores/new-workspace-prompt-context/buildSubmitPrompt.test.ts src/renderer/stores/new-workspace-prompt-context src/shared/context
- bun --cwd apps/desktop typecheck
- bun run lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the workspace prompt context by project and host to prevent cross-repo leaks of cached issue/PR/task bodies. Fixes cases where same-number GitHub issues or PRs pulled in stale content from another repo.

- **Bug Fixes**
  - Added scoped cache keys that include project and host, used for `github-issue`, `pr`, and `task` bodies.
  - Introduced `makePromptContextKey` and `makePromptContextScope`; updated store registration and prompt builder to use scoped keys and pass `contextScope`.
  - Added regression test covering same-number GitHub issues and PRs across different projects/hosts.

<sup>Written for commit 2148bb2609e09e122780f5c2062e903a6414fe17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt context is now properly scoped by project and host URL, ensuring that only relevant context is included in generated prompts and preventing unintended mixing of context across different projects and hosts.

* **Tests**
  * Added comprehensive test coverage validating proper context scoping behavior across multiple project and host URL combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->