### PR TITLE
fix(desktop): enable v2 create pull request action

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -16,11 +16,6 @@ import { usePRFlowState } from "./hooks/usePRFlowState";
 import { useReviewTab } from "./hooks/useReviewTab";
 import type { SidebarTabDefinition } from "./types";
 
-// Gates the "Create PR" button only — the chat-driven create flow doesn't
-// exist in v2 yet. The PR status group (link + merge dropdown for an open PR)
-// always renders so users can see PR state and merge once a PR exists.
-const CREATE_PR_BUTTON_ENABLED = false;
-
 type SidebarTabId = "changes" | "files" | "review";
 
 const VALID_TAB_IDS: readonly SidebarTabId[] = ["changes", "files", "review"];
@@ -183,7 +178,6 @@ export function WorkspaceSidebar({
 				state={flowState}
 				dispatch={dispatch}
 				onRetry={onRetry}
-				createPREnabled={CREATE_PR_BUTTON_ENABLED}
 			/>
 			<SidebarHeader
 				tabs={tabs}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -384,6 +384,7 @@ function V2WorkspaceContent({
 							onSelectFile={openFilePaneFromTreeClick}
 							onSelectDiffFile={openDiffPane}
 							onOpenComment={openCommentPane}
+							onOpenChat={addChatTab}
 							onSearch={handleQuickOpen}
 							selectedFilePath={selectedFilePath}
 							pendingReveal={pendingReveal}


### PR DESCRIPTION
## Summary
- wire the V2 workspace sidebar PR action to the chat tab launcher
- remove the stale Create PR feature gate so documented V2 Create PR flow opens /pr/create-pr with pr-context.md

## QA
- bun --cwd apps/desktop test 'src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/usePRFlowDispatch/usePRFlowDispatch.test.ts' 'src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/utils/getPRFlowState/getPRFlowState.test.ts'
- bun --cwd apps/desktop typecheck
- bun run lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the V2 “Create Pull Request” action in the workspace sidebar and hook it into the chat-driven flow. Removes the stale feature gate so starting a PR opens /pr/create-pr with pr-context.md, and wires the action to launch a chat tab.

<sup>Written for commit 98201e0a985c085e39b857bb02fb31c44f14a9a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

