### PR TITLE
fix(host-service): load headless xterm in terminal tracker

### DIFF
--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -13,7 +13,18 @@
 // Pattern adapted from VSCode's XtermSerializer
 // (src/vs/platform/terminal/node/ptyService.ts).
 
-import { Terminal as HeadlessTerminal } from "@xterm/headless";
+import type {
+	Terminal as HeadlessTerminalInstance,
+	ITerminalInitOnlyOptions,
+	ITerminalOptions,
+} from "@xterm/headless";
+import headlessModule from "@xterm/headless";
+
+const { Terminal: HeadlessTerminal } = headlessModule as unknown as {
+	Terminal: new (
+		options: ITerminalOptions & ITerminalInitOnlyOptions,
+	) => HeadlessTerminalInstance;
+};
 
 export interface ModeTracker {
 	feed(bytes: Uint8Array): void;

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -3,6 +3,7 @@ import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
 	existsSync,
+	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
@@ -150,6 +151,7 @@ describe("terminal router integration", () => {
 		const socketPath = join(tmp, "pty-daemon.sock");
 		const pidPath = join(tmp, "detached-helper.pid");
 		const workspaceCleanupPidPath = join(tmp, "workspace-detached-helper.pid");
+		const shellPath = createDeterministicTestShell(tmp);
 		const terminalId = randomUUID();
 		const workspaceCleanupTerminalId = randomUUID();
 		let daemonProcess: ChildProcess | null = null;
@@ -200,6 +202,7 @@ describe("terminal router integration", () => {
 			);
 			process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
 			process.env.SUPERSET_HOME_DIR = tmp;
+			__setAccountShellForTesting(shellPath);
 
 			await scenario.host.trpc.terminal.createSession.mutate({
 				workspaceId: scenario.workspaceId,
@@ -389,6 +392,24 @@ function detachedHelperScript(pidPath: string): string {
 		`echo "$helper_pid" > ${shellQuote(pidPath)}`,
 		"sleep 60",
 	].join("; ");
+}
+
+function createDeterministicTestShell(tmp: string): string {
+	const shellPath = join(tmp, "sh");
+	mkdirSync(tmp, { recursive: true });
+	writeFileSync(
+		shellPath,
+		[
+			"#!/bin/sh",
+			'if [ "$#" -gt 0 ] && [ "$1" = "-l" ]; then',
+			"  shift",
+			"fi",
+			'exec /bin/sh "$@"',
+			"",
+		].join("\n"),
+		{ mode: 0o755 },
+	);
+	return shellPath;
 }
 
 function createFakePty(


### PR DESCRIPTION
## Summary
- load @xterm/headless through its default module shape so terminal mode tracker tests and runtime imports work under Bun
- make the real-daemon terminal cleanup integration test use a deterministic test shell instead of the user's shell startup behavior

## QA
- bun --cwd packages/host-service test src/terminal/terminal-mode-tracker.test.ts
- bun --cwd packages/host-service test test/integration/terminal.integration.test.ts --test-name-pattern "terminal disposal"
- bun --cwd packages/host-service test src/terminal/terminal-mode-tracker.test.ts src/trpc/router/terminal src/terminal test/integration/terminal.integration.test.ts
- bun --cwd packages/host-service typecheck
- bun run lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bun compatibility for the terminal mode tracker by loading `@xterm/headless` via its default export. Stabilizes terminal cleanup integration tests by using a deterministic test shell instead of the user’s shell.

- **Bug Fixes**
  - Load `@xterm/headless` through its default module and extract the `Terminal` constructor with types so runtime and tests work under Bun.
  - Use a simple shim shell for tests to avoid user startup scripts, making the terminal disposal and daemon cleanup flow reliable.

<sup>Written for commit 4d4e0fa517909bb9ae137b138bae732480b2ec9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

