### PR TITLE
fix(desktop): drop LigaturesAddon + add Korean editor fallback (macOS rendering)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -155,7 +155,6 @@
 		"@xterm/addon-clipboard": "0.3.0-beta.197",
 		"@xterm/addon-fit": "0.12.0-beta.197",
 		"@xterm/addon-image": "0.10.0-beta.197",
-		"@xterm/addon-ligatures": "0.11.0-beta.197",
 		"@xterm/addon-progress": "0.3.0-beta.197",
 		"@xterm/addon-search": "0.17.0-beta.197",
 		"@xterm/addon-serialize": "0.15.0-beta.197",

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -1,5 +1,4 @@
 import { ClipboardAddon } from "@xterm/addon-clipboard";
-import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { ProgressAddon } from "@xterm/addon-progress";
 import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
@@ -33,10 +32,10 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 	const progressAddon = new ProgressAddon();
 	terminal.loadAddon(progressAddon);
 
-	try {
-		terminal.loadAddon(new LigaturesAddon());
-	} catch {}
-
+	// LigaturesAddon intentionally omitted: when combined with the WebGL renderer
+	// it corrupts the glyph atlas — styled cells (italic/color) bleed glyphs
+	// into adjacent cells and the corruption survives resize. macOS surfaced
+	// this most reliably; ligature support (==, =>, !==) is the trade-off.
 	const webglAddon = loadTerminalWebglAddon(terminal);
 
 	return {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/constants.ts
@@ -1,3 +1,21 @@
-export const DEFAULT_CODE_EDITOR_FONT_FAMILY =
-	"ui-monospace, Menlo, Consolas, Liberation Mono, monospace";
+// "Apple SD Gothic Neo" lets macOS shape NFD-normalized Hangul (jamo decomposed
+// into U+11xx) correctly via AAT — without it, Latin-only monospace fonts like
+// Menlo leak each jamo to a separate fallback glyph and the syllable breaks
+// apart. "Malgun Gothic" mirrors the same role on Windows.
+const CJK_FONT_FALLBACK = '"Apple SD Gothic Neo", "Malgun Gothic"';
+
+export const DEFAULT_CODE_EDITOR_FONT_FAMILY = `ui-monospace, Menlo, Consolas, ${CJK_FONT_FALLBACK}, Liberation Mono, monospace`;
 export const DEFAULT_CODE_EDITOR_FONT_SIZE = 13;
+
+/**
+ * Append CJK fallback to a user-provided font stack so NFD Hangul still shapes
+ * correctly. Skipped when the stack already references a Korean fallback.
+ */
+export function withCjkFallback(fontFamily: string | undefined): string {
+	if (!fontFamily) return DEFAULT_CODE_EDITOR_FONT_FAMILY;
+	const lower = fontFamily.toLowerCase();
+	if (lower.includes("apple sd gothic") || lower.includes("malgun gothic")) {
+		return fontFamily;
+	}
+	return `${fontFamily}, ${CJK_FONT_FALLBACK}, monospace`;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/createCodeMirrorTheme/createCodeMirrorTheme.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/createCodeMirrorTheme/createCodeMirrorTheme.ts
@@ -1,9 +1,6 @@
 import { EditorView } from "@codemirror/view";
 import { getEditorTheme, type Theme, withAlpha } from "shared/themes";
-import {
-	DEFAULT_CODE_EDITOR_FONT_FAMILY,
-	DEFAULT_CODE_EDITOR_FONT_SIZE,
-} from "../constants";
+import { DEFAULT_CODE_EDITOR_FONT_SIZE, withCjkFallback } from "../constants";
 
 interface CodeEditorFontSettings {
 	fontFamily?: string;
@@ -28,7 +25,7 @@ export function createCodeMirrorTheme(
 				height: fillHeight ? "100%" : "auto",
 				backgroundColor: editorTheme.colors.background,
 				color: editorTheme.colors.foreground,
-				fontFamily: fontSettings.fontFamily ?? DEFAULT_CODE_EDITOR_FONT_FAMILY,
+				fontFamily: withCjkFallback(fontSettings.fontFamily),
 				fontSize: `${fontSize}px`,
 			},
 			".cm-scroller": {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -1,7 +1,6 @@
 import { toast } from "@superset/ui/sonner";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
-import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import type { ITheme } from "@xterm/xterm";
@@ -112,12 +111,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	xterm.loadAddon(unicode11Addon);
 	xterm.loadAddon(imageAddon);
 
-	try {
-		xterm.loadAddon(new LigaturesAddon());
-	} catch {
-		// Ligatures not supported by current font
-	}
-
+	// LigaturesAddon intentionally omitted — see terminal-addons.ts for context.
 	const webglAddon = loadTerminalWebglAddon(xterm);
 
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/constants.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/constants.ts
@@ -1,3 +1,21 @@
-export const DEFAULT_CODE_EDITOR_FONT_FAMILY =
-	"ui-monospace, Menlo, Consolas, Liberation Mono, monospace";
+// "Apple SD Gothic Neo" lets macOS shape NFD-normalized Hangul (jamo decomposed
+// into U+11xx) correctly via AAT — without it, Latin-only monospace fonts like
+// Menlo leak each jamo to a separate fallback glyph and the syllable breaks
+// apart. "Malgun Gothic" mirrors the same role on Windows.
+const CJK_FONT_FALLBACK = '"Apple SD Gothic Neo", "Malgun Gothic"';
+
+export const DEFAULT_CODE_EDITOR_FONT_FAMILY = `ui-monospace, Menlo, Consolas, ${CJK_FONT_FALLBACK}, Liberation Mono, monospace`;
 export const DEFAULT_CODE_EDITOR_FONT_SIZE = 13;
+
+/**
+ * Append CJK fallback to a user-provided font stack so NFD Hangul still shapes
+ * correctly. Skipped when the stack already references a Korean fallback.
+ */
+export function withCjkFallback(fontFamily: string | undefined): string {
+	if (!fontFamily) return DEFAULT_CODE_EDITOR_FONT_FAMILY;
+	const lower = fontFamily.toLowerCase();
+	if (lower.includes("apple sd gothic") || lower.includes("malgun gothic")) {
+		return fontFamily;
+	}
+	return `${fontFamily}, ${CJK_FONT_FALLBACK}, monospace`;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createCodeMirrorTheme.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createCodeMirrorTheme.ts
@@ -1,9 +1,6 @@
 import { EditorView } from "@codemirror/view";
 import { getEditorTheme, type Theme } from "shared/themes";
-import {
-	DEFAULT_CODE_EDITOR_FONT_FAMILY,
-	DEFAULT_CODE_EDITOR_FONT_SIZE,
-} from "./constants";
+import { DEFAULT_CODE_EDITOR_FONT_SIZE, withCjkFallback } from "./constants";
 
 interface CodeEditorFontSettings {
 	fontFamily?: string;
@@ -25,7 +22,7 @@ export function createCodeMirrorTheme(
 				height: fillHeight ? "100%" : "auto",
 				backgroundColor: editorTheme.colors.background,
 				color: editorTheme.colors.foreground,
-				fontFamily: fontSettings.fontFamily ?? DEFAULT_CODE_EDITOR_FONT_FAMILY,
+				fontFamily: withCjkFallback(fontSettings.fontFamily),
 				fontSize: `${fontSize}px`,
 			},
 			".cm-scroller": {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/diff-viewer-style.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/diff-viewer-style.ts
@@ -1,8 +1,8 @@
 import type { CSSProperties } from "react";
 import { getEditorTheme, type Theme } from "shared/themes";
 import {
-	DEFAULT_CODE_EDITOR_FONT_FAMILY,
 	DEFAULT_CODE_EDITOR_FONT_SIZE,
+	withCjkFallback,
 } from "../../components/CodeEditor/constants";
 
 interface CodeThemeFontSettings {
@@ -14,7 +14,7 @@ export function getDiffViewerStyle(
 	theme: Theme,
 	fontSettings: CodeThemeFontSettings,
 ): CSSProperties {
-	const fontFamily = fontSettings.fontFamily ?? DEFAULT_CODE_EDITOR_FONT_FAMILY;
+	const fontFamily = withCjkFallback(fontSettings.fontFamily);
 	const fontSize = fontSettings.fontSize ?? DEFAULT_CODE_EDITOR_FONT_SIZE;
 	const lineHeight = Math.round(fontSize * 1.5);
 	const editorTheme = getEditorTheme(theme);

--- a/bun.lock
+++ b/bun.lock
@@ -229,7 +229,6 @@
         "@xterm/addon-clipboard": "0.3.0-beta.197",
         "@xterm/addon-fit": "0.12.0-beta.197",
         "@xterm/addon-image": "0.10.0-beta.197",
-        "@xterm/addon-ligatures": "0.11.0-beta.197",
         "@xterm/addon-progress": "0.3.0-beta.197",
         "@xterm/addon-search": "0.17.0-beta.197",
         "@xterm/addon-serialize": "0.15.0-beta.197",
@@ -3190,8 +3189,6 @@
 
     "@xterm/addon-image": ["@xterm/addon-image@0.10.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-31oIqBm+Yk3xyYGjBhhp308gDyFywv3JJAWBflycgqZFbvfZ2ju4IvHmvKJhp8qC+0ac6SRAA7XBKGqtoZjcsA=="],
 
-    "@xterm/addon-ligatures": ["@xterm/addon-ligatures@0.11.0-beta.197", "", { "dependencies": { "lru-cache": "^6.0.0", "opentype.js": "^0.8.0" }, "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-76arq3li5i71YP8RMatAsE7H79FvRV/gaLF/iwgxeQgIXurVt3bEuwta64JlMe+BchelmoVv22T4yQjFo2pOkQ=="],
-
     "@xterm/addon-progress": ["@xterm/addon-progress@0.3.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-ZvWE78sIBu0rAjpvycuKZqBVWLcm5ePO/oH4tBIwJLIY3g2FpRKKorBGPN9raBHw3Bfxzg7tZAFqv6iuDZxEIw=="],
 
     "@xterm/addon-search": ["@xterm/addon-search@0.17.0-beta.197", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.197" } }, "sha512-F2hAFAheDDElC/25UcacZTx65JYnjoD6hhMVcLBbXrYhf0io1mtOZTVG5oxeitx1vpdLH1JGMmwFpHUSPspZzQ=="],
@@ -5030,8 +5027,6 @@
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
-    "opentype.js": ["opentype.js@0.8.0", "", { "dependencies": { "tiny-inflate": "^1.0.2" }, "bin": { "ot": "./bin/ot" } }, "sha512-FQHR4oGP+a0m/f6yHoRpBOIbn/5ZWxKd4D/djHVJu8+KpBTYrJda0b7mLcgDEMWXE9xBCJm+qb0yv6FcvPjukg=="],
-
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
     "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
@@ -5864,8 +5859,6 @@
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
-    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
-
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
@@ -6178,7 +6171,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
@@ -6679,8 +6672,6 @@
     "@wdio/utils/@puppeteer/browsers": ["@puppeteer/browsers@2.13.0", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA=="],
 
     "@wdio/utils/decamelize": ["decamelize@6.0.1", "", {}, "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ=="],
-
-    "@xterm/addon-ligatures/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "@xyflow/react/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
@@ -7207,8 +7198,6 @@
     "supertap/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
-
-    "tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "teen_process/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
@@ -7914,6 +7903,8 @@
 
     "fastembed/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
 
+    "fastembed/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "friendly-words/express/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
@@ -7941,6 +7932,8 @@
     "friendly-words/express/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "friendly-words/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "fumadocs-mdx/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
@@ -8004,6 +7997,8 @@
 
     "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "iconv-corefoundation/cli-truncate/slice-ansi": ["slice-ansi@3.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ=="],
 
     "iconv-corefoundation/cli-truncate/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -8063,6 +8058,12 @@
     "metro/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
 
     "metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-sized/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 


### PR DESCRIPTION

  Fixes two macOS-specific text rendering regressions in Superset desktop:

  - Terminal glyph ghosting — styled cells (italic / color) leak glyphs into adjacent cells in the xterm WebGL renderer, and the corruption survives
  resize.
  - Editor Hangul shaping — NFD-normalized Korean text renders as disconnected jamo instead of composed syllables in both the v1 WorkspaceView editor and
   the v2-workspace route.

  Root causes:
  1. @xterm/addon-ligatures hooks into the WebGL renderer's glyph cache; combined with styled cells it corrupts atlas slot assignment so an italic a can
  paint over a different cell's b. Removing the addon eliminates the class of bugs.
  2. The default editor font stack (ui-monospace, Menlo, Consolas, Liberation Mono, monospace) has no font with AAT shaping for Hangul jamo at U+11xx.
  The browser falls back per-codepoint without composition, breaking syllables apart. Injecting Apple SD Gothic Neo (macOS) / Malgun Gothic (Windows)
  restores shaping via AAT morx tables.

  Related Issues

  Type of Change

  - Bug fix
  - New feature
  - Documentation
  - Refactor
  - Other (please describe):

  Testing

  Automated
  - bun run typecheck — passes
  - bun run lint — passes (Biome warning 0)
  - bun test apps/desktop/src/renderer/lib/terminal — 232 / 232 pass
  - bun test apps/desktop/src/lib/trpc/routers/settings/font-settings.test.ts — 18 / 18 pass

  Manual (recommended for reviewer)
  - Terminal: Run a styled stream — ls --color, vim with italic comments, an italic shell prompt — then type / scroll / resize. Expect no glyph ghosts.
  - Editor (v1 + v2): Open a file containing NFD-normalized Hangul. Quick repro:
  python3 -c 'import sys, unicodedata; sys.stdout.write(unicodedata.normalize("NFD", "한글 테스트"))' > nfd.txt
  - Open nfd.txt in both v1 WorkspaceView and the v2-workspace route. Expect syllables to compose.

  Screenshots (if applicable)

  Additional Notes

  Trade-offs
  - Ligatures lost (==, =>, !==). Re-adding them would require patching xterm's WebGL renderer or shipping a custom DOM renderer — out of scope. Removing
   the addon is the simplest safe path to ending atlas corruption.
  - No user toggle. A blanket removal is simpler and avoids gating a known-broken code path behind a setting.
  - Windows / Linux untouched. Apple SD Gothic Neo is macOS-only; the Malgun Gothic entry covers Windows. Linux relies on monospace generic fallback,
  unchanged.

  Files changed

  Terminal
  - apps/desktop/src/renderer/lib/terminal/terminal-addons.ts — drop LigaturesAddon from the v2 runtime loader.
  - apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts — drop LigaturesAddon from v1
  createTerminalInWrapper.
  - apps/desktop/package.json + bun.lock — remove @xterm/addon-ligatures dependency.

  Editor (v1 — WorkspaceView)
  - …/WorkspaceView/components/CodeEditor/constants.ts — add CJK fallback to the default editor font; export withCjkFallback() for user-configured fonts.
  - …/WorkspaceView/components/CodeEditor/createCodeMirrorTheme.ts — route fontSettings.fontFamily through withCjkFallback().
  - …/WorkspaceView/utils/code-theme/diff-viewer-style.ts — same wrapping so diff viewers shape Hangul like editors.

  Editor (v2 — v2-workspace route)
  - …/v2-workspace/$workspaceId/.../CodeView/components/CodeEditor/constants.ts — same CJK fallback + withCjkFallback() helper.
  - …/v2-workspace/$workspaceId/.../CodeView/components/CodeEditor/createCodeMirrorTheme/createCodeMirrorTheme.ts — route fontSettings.fontFamily through
   withCjkFallback().


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed ligatures from terminal

* **Refactor**
  * Enhanced CJK font fallback logic in code editors with dedicated constants

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4561)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->