### PR TITLE
fix(desktop): force GIT_PAGER=cat to dodge Apple Git 2.50+ block

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
@@ -181,18 +181,30 @@ export async function getProcessEnvWithShellPath(
 	const env = await getProcessEnvWithShellEnv(baseEnv, shellEnvResult);
 
 	const shellPath = shellEnvResult.PATH || shellEnvResult.Path;
-	if (!shellPath) {
-		return env;
+	if (shellPath) {
+		env.PATH = shellPath;
+		if (
+			process.platform === "win32" ||
+			"Path" in baseEnv ||
+			"Path" in shellEnvResult
+		) {
+			env.Path = shellPath;
+		}
 	}
 
-	env.PATH = shellPath;
-	if (
-		process.platform === "win32" ||
-		"Path" in baseEnv ||
-		"Path" in shellEnvResult
-	) {
-		env.Path = shellPath;
-	}
+	// Git ≥ 2.50 refuses to honor an *inherited* `PAGER` or `GIT_PAGER`
+	// env var on non-interactive callers ("Use of \"PAGER\" is not
+	// permitted without enabling allowUnsafePager"), which simple-git
+	// surfaces as GitPluginError and breaks workspace creation, status
+	// reads, worktree prune, etc.
+	//
+	// Strip both. Programmatic git invocations have piped stdout (not a
+	// TTY), so git skips paging entirely — no replacement value is needed.
+	// User-facing terminals get their own PAGER/GIT_PAGER from the
+	// interactive shell, so this only affects the host-service / desktop
+	// main process's own git children.
+	delete env.PAGER;
+	delete env.GIT_PAGER;
 
 	return env;
 }


### PR DESCRIPTION
## Summary

Apple Git 2.50 (shipped in macOS Sequoia 15.5+ and current Homebrew) refuses to honor an inherited `PAGER` env var on non-interactive callers, erroring with:

\`\`\`
Use of "PAGER" is not permitted without enabling allowUnsafePager
\`\`\`

`simple-git` wraps that stderr as `GitPluginError`, which breaks every git read path used by workspace creation — `git status`, `git worktree list`, `git worktree prune`, `git for-each-ref` — and bubbles up to the renderer as "Couldn't create workspace".

## Fix

One-liner in `getProcessEnvWithShellPath` (`apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts`), which is the single env builder used by both:

- desktop's simple-git wrapper (`getSimpleGitWithShellPath`)
- the host-service child spawn (`host-service-coordinator.ts:515`)

Setting `GIT_PAGER=cat` cascades to all simple-git calls in desktop main + the host-service's `process.env` → inherited by every `simpleGit()` call inside host-service (13 callsites, mostly without explicit `.env()` overrides).

`GIT_PAGER` takes precedence over `PAGER` for git, so users' interactive terminals still see their preferred pager (delta, less, etc.). Only git inside non-interactive helpers is silenced — pagers are useless in programmatic git invocations anyway.

## Test plan

- [ ] CI green
- [ ] On macOS with Apple Git 2.50+ and `PAGER` set in login shell: open Canary → New Workspace → workspace creates without error
- [ ] `~/.superset/host/<org>/host-service.log` no longer shows `GitPluginError: Use of "PAGER" is not permitted...` lines
- [ ] Terminal sessions still respect user's `PAGER` for non-git tools

## Background log evidence (Satya's local Canary)

\`\`\`
[git/getBranchSyncStatus] git.status() failed; treating working tree as clean for this read GitPluginError: Use of "PAGER" is not permitted without enabling allowUnsafePager
[workspace-creation] git worktree list failed: GitPluginError: Use of "PAGER" is not permitted without enabling allowUnsafePager
[workspaceCreation.searchBranches] git for-each-ref failed: GitPluginError: Use of "PAGER" is not permitted without enabling allowUnsafePager
[workspaces.create] worktree prune failed: GitPluginError: Use of "PAGER" is not permitted without enabling allowUnsafePager
\`\`\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip `PAGER` and `GIT_PAGER` from the env for all desktop and host-service `git` calls to avoid Apple Git 2.50+ blocking inherited pager vars in non-interactive runs. This restores workspace creation and other git reads while leaving interactive terminals unchanged.

- **Bug Fixes**
  - Remove `PAGER` and `GIT_PAGER` in `getProcessEnvWithShellPath`, cascading to all `simple-git` calls and host-service spawns (fixes `git status`, worktree ops, and ref listing).
  - Only set `PATH`/`Path` when `shellPath` is present.

<sup>Written for commit 2570c929d894947717bd726205fbb59d199e5e5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented non-interactive git commands from using host paging so output appears consistently without unexpected pagers.
  * Improved environment PATH handling so the app only adopts shell PATH when one is actually provided, avoiding accidental overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4568)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->