### PR TITLE
fix(desktop): filter themes by query in command palette theme submenu

### DIFF
--- a/apps/desktop/src/main/lib/auto-updater.test.ts
+++ b/apps/desktop/src/main/lib/auto-updater.test.ts
@@ -36,6 +36,18 @@ mock.module("main/index", () => ({
 	setSkipQuitConfirmation: mock(() => {}),
 }));
 
+// host-service-coordinator.test.ts mocks electron-log/main without transports;
+// mock.module leaks across files in bun's CI runner, so install a complete
+// shape here defensively to avoid order-dependent breakage.
+mock.module("electron-log/main", () => ({
+	default: {
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		transports: { file: { level: "info" } },
+	},
+}));
+
 // auto-updater short-circuits setupAutoUpdater on non-mac/linux hosts, so
 // pin the platform here to keep the tests portable across CI runners.
 mock.module("shared/constants", () => ({

--- a/apps/desktop/src/renderer/commandPalette/ui/ThemeFrame/ThemeFrame.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/ThemeFrame/ThemeFrame.tsx
@@ -59,6 +59,26 @@ export function ThemeFrame() {
 
 	const showSystem = matchesQuery(`System ${SYSTEM_THEME_ID}`, query);
 
+	const visibleLight = filterThemes(
+		lightThemes.filter((t) => !t.isCustom),
+		"Light",
+		query,
+	);
+	const visibleDark = filterThemes(
+		darkThemes.filter((t) => !t.isCustom),
+		"Dark",
+		query,
+	);
+	const visibleCustom = filterThemes(
+		[...customLight, ...customDark],
+		"Custom",
+		query,
+	);
+	const hasThemeGroup =
+		visibleLight.length > 0 ||
+		visibleDark.length > 0 ||
+		visibleCustom.length > 0;
+
 	return (
 		<CommandList>
 			<CommandEmpty>No themes found.</CommandEmpty>
@@ -81,34 +101,39 @@ export function ThemeFrame() {
 				</CommandGroup>
 			)}
 
-			{showSystem && <CommandSeparator />}
+			{showSystem && hasThemeGroup && <CommandSeparator />}
 
 			<ThemeGroup
 				heading="Light"
-				themes={lightThemes.filter((t) => !t.isCustom)}
+				themes={visibleLight}
 				activeId={activeThemeId}
 				onSelect={pickTheme}
-				query={query}
 			/>
 
 			<ThemeGroup
 				heading="Dark"
-				themes={darkThemes.filter((t) => !t.isCustom)}
+				themes={visibleDark}
 				activeId={activeThemeId}
 				onSelect={pickTheme}
-				query={query}
 			/>
 
-			{(customLight.length > 0 || customDark.length > 0) && (
-				<ThemeGroup
-					heading="Custom"
-					themes={[...customLight, ...customDark]}
-					activeId={activeThemeId}
-					onSelect={pickTheme}
-					query={query}
-				/>
-			)}
+			<ThemeGroup
+				heading="Custom"
+				themes={visibleCustom}
+				activeId={activeThemeId}
+				onSelect={pickTheme}
+			/>
 		</CommandList>
+	);
+}
+
+function filterThemes(
+	themes: Theme[],
+	heading: string,
+	query: string,
+): Theme[] {
+	return themes.filter((theme) =>
+		matchesQuery(`${heading} ${theme.name} ${theme.id}`, query),
 	);
 }
 
@@ -117,23 +142,13 @@ interface ThemeGroupProps {
 	themes: Theme[];
 	activeId: string;
 	onSelect: (themeId: string) => void;
-	query: string;
 }
 
-function ThemeGroup({
-	heading,
-	themes,
-	activeId,
-	onSelect,
-	query,
-}: ThemeGroupProps) {
-	const visible = themes.filter((theme) =>
-		matchesQuery(`${heading} ${theme.name} ${theme.id}`, query),
-	);
-	if (visible.length === 0) return null;
+function ThemeGroup({ heading, themes, activeId, onSelect }: ThemeGroupProps) {
+	if (themes.length === 0) return null;
 	return (
 		<CommandGroup heading={heading}>
-			{visible.map((theme) => (
+			{themes.map((theme) => (
 				<CommandItem
 					key={`${heading}:${theme.id}`}
 					value={`${heading} ${theme.name} ${theme.id}`}

--- a/apps/desktop/src/renderer/commandPalette/ui/ThemeFrame/ThemeFrame.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/ThemeFrame/ThemeFrame.tsx
@@ -21,6 +21,12 @@ import {
 	type Theme,
 } from "shared/themes";
 import { useFrameStackStore } from "../../core/frames";
+import { useCommandPaletteQuery } from "../CommandPalette/CommandPalette";
+
+function matchesQuery(haystack: string, query: string): boolean {
+	if (!query) return true;
+	return haystack.toLowerCase().includes(query.toLowerCase().trim());
+}
 
 export function ThemeFrame() {
 	const activeThemeId = useThemeId();
@@ -29,6 +35,7 @@ export function ThemeFrame() {
 	const systemLightThemeId = useSystemLightThemeId();
 	const systemDarkThemeId = useSystemDarkThemeId();
 	const setOpen = useFrameStackStore((s) => s.setOpen);
+	const query = useCommandPaletteQuery();
 
 	const allThemes = [...builtInThemes, ...customThemes];
 	const lightThemes = allThemes.filter((t) => t.type === "light");
@@ -50,33 +57,38 @@ export function ThemeFrame() {
 		setOpen(false);
 	};
 
+	const showSystem = matchesQuery(`System ${SYSTEM_THEME_ID}`, query);
+
 	return (
 		<CommandList>
 			<CommandEmpty>No themes found.</CommandEmpty>
 
-			<CommandGroup>
-				<CommandItem
-					value={`system ${SYSTEM_THEME_ID}`}
-					onSelect={() => pickTheme(SYSTEM_THEME_ID)}
-				>
-					<div className="flex shrink-0 -space-x-1">
-						<ThemeSwatch theme={systemLightTheme} />
-						<ThemeSwatch theme={systemDarkTheme} />
-					</div>
-					<span>System</span>
-					{activeThemeId === SYSTEM_THEME_ID ? (
-						<span className="ml-auto text-xs text-muted-foreground">✓</span>
-					) : null}
-				</CommandItem>
-			</CommandGroup>
+			{showSystem && (
+				<CommandGroup>
+					<CommandItem
+						value={`system ${SYSTEM_THEME_ID}`}
+						onSelect={() => pickTheme(SYSTEM_THEME_ID)}
+					>
+						<div className="flex shrink-0 -space-x-1">
+							<ThemeSwatch theme={systemLightTheme} />
+							<ThemeSwatch theme={systemDarkTheme} />
+						</div>
+						<span>System</span>
+						{activeThemeId === SYSTEM_THEME_ID ? (
+							<span className="ml-auto text-xs text-muted-foreground">✓</span>
+						) : null}
+					</CommandItem>
+				</CommandGroup>
+			)}
 
-			<CommandSeparator />
+			{showSystem && <CommandSeparator />}
 
 			<ThemeGroup
 				heading="Light"
 				themes={lightThemes.filter((t) => !t.isCustom)}
 				activeId={activeThemeId}
 				onSelect={pickTheme}
+				query={query}
 			/>
 
 			<ThemeGroup
@@ -84,6 +96,7 @@ export function ThemeFrame() {
 				themes={darkThemes.filter((t) => !t.isCustom)}
 				activeId={activeThemeId}
 				onSelect={pickTheme}
+				query={query}
 			/>
 
 			{(customLight.length > 0 || customDark.length > 0) && (
@@ -92,6 +105,7 @@ export function ThemeFrame() {
 					themes={[...customLight, ...customDark]}
 					activeId={activeThemeId}
 					onSelect={pickTheme}
+					query={query}
 				/>
 			)}
 		</CommandList>
@@ -103,13 +117,23 @@ interface ThemeGroupProps {
 	themes: Theme[];
 	activeId: string;
 	onSelect: (themeId: string) => void;
+	query: string;
 }
 
-function ThemeGroup({ heading, themes, activeId, onSelect }: ThemeGroupProps) {
-	if (themes.length === 0) return null;
+function ThemeGroup({
+	heading,
+	themes,
+	activeId,
+	onSelect,
+	query,
+}: ThemeGroupProps) {
+	const visible = themes.filter((theme) =>
+		matchesQuery(`${heading} ${theme.name} ${theme.id}`, query),
+	);
+	if (visible.length === 0) return null;
 	return (
 		<CommandGroup heading={heading}>
-			{themes.map((theme) => (
+			{visible.map((theme) => (
 				<CommandItem
 					key={`${heading}:${theme.id}`}
 					value={`${heading} ${theme.name} ${theme.id}`}


### PR DESCRIPTION
## Summary
- Typing in the command palette did nothing once inside the Theme submenu — the input was visible but never narrowed the list.
- `CommandPalette` disables cmdk's built-in filter for any frame using `renderFrame` (frames are expected to filter themselves, like `LinkTaskFrame` does via `useHybridSearch`). `ThemeFrame` never read the query, so search silently broke.
- `ThemeFrame` now reads `useCommandPaletteQuery()` and substring-matches against heading + theme name + theme id, so "dark", "solar", or an id all work. `<CommandEmpty>` still fires when nothing matches.

## Test plan
- [ ] Open command palette, navigate into Theme submenu, type "dark" — only dark themes show
- [ ] Type "solar" (or any theme name) — only matching themes show
- [ ] Type "system" — System row shows; type gibberish — "No themes found." renders
- [ ] Clear the input — full list comes back

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken search in the command palette Theme submenu. Typing now filters themes by name, id, and group heading, including the System option.

- **Bug Fixes**
  - `ThemeFrame` reads `useCommandPaletteQuery()` and filters with a case-insensitive substring match.
  - Matches heading + theme name + theme id; includes "System".
  - Hides non-matching items; shows the empty state; separator only when "System" and a group are visible.
  - Stabilized `auto-updater.test.ts` with a self-contained `electron-log/main` mock to avoid CI order flakiness.

<sup>Written for commit 02b2e3a738f633b407ad3fe8d8d8874a2a95185b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette theme selection now supports search-aware filtering: Light, Dark, Custom, and System entries are shown or hidden based on your query (case-insensitive substring matching). The System option appears only when relevant, and separators adjust for a cleaner list while searching.

* **Tests**
  * Improved auto-updater tests with a defensive logger mock to prevent CI flakiness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4573)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->