### PR TITLE
fix(web): allow relay WSS origin in CSP for canary/prod

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -313,6 +313,7 @@ jobs:
           SLACK_BILLING_WEBHOOK_URL: ${{ secrets.SLACK_BILLING_WEBHOOK_URL }}
           SECRETS_ENCRYPTION_KEY: ${{ secrets.SECRETS_ENCRYPTION_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RELAY_URL: ${{ secrets.RELAY_URL }}
         run: |
           vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
           vercel build --token=$VERCEL_TOKEN

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -234,6 +234,7 @@ jobs:
           SLACK_BILLING_WEBHOOK_URL: ${{ secrets.SLACK_BILLING_WEBHOOK_URL }}
           SECRETS_ENCRYPTION_KEY: ${{ secrets.SECRETS_ENCRYPTION_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RELAY_URL: ${{ secrets.RELAY_URL }}
         run: |
           vercel pull --yes --environment=production --token=$VERCEL_TOKEN
           vercel build --prod --token=$VERCEL_TOKEN

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -18,10 +18,14 @@ const apiOrigin = process.env.NEXT_PUBLIC_API_URL
 	: null;
 // Remote-control viewers open a WebSocket to the relay. In dev the blanket
 // `ws:`/`wss:` below covers it; in prod we need to allow the relay origin
-// explicitly so `connect-src` doesn't block `wss://relay…`.
+// explicitly so `connect-src` doesn't block `wss://relay…`. The hard-coded
+// prod fallback keeps the header correct even if RELAY_URL isn't plumbed
+// into the build env.
 const relayWsOrigin = process.env.RELAY_URL
 	? new URL(process.env.RELAY_URL).origin.replace(/^http/, "ws")
-	: null;
+	: isProduction
+		? "wss://relay.superset.sh"
+		: null;
 
 const contentSecurityPolicy = [
 	"default-src 'self'",


### PR DESCRIPTION
## Summary
- Remote-control terminals were broken in canary because the CSP `connect-src` directive didn't include the relay WSS origin. Root cause: `RELAY_URL` wasn't plumbed into the `deploy-web` build env, so `process.env.RELAY_URL` was undefined when `next.config.ts` computed the CSP, and the browser blocked `wss://relay.superset.sh`.
- Add `RELAY_URL` to the `deploy-web` env in both `deploy-preview.yml` and `deploy-production.yml`.
- Add a `wss://relay.superset.sh` production fallback in `apps/web/next.config.ts` so the header stays correct even if the env isn't plumbed in the future.

## Test plan
- [ ] Wait for preview deploy and inspect the response `Content-Security-Policy` header on the web app — `connect-src` should include `wss://relay.superset.sh`.
- [ ] Open a remote-control terminal session against the preview/canary web build and confirm the WSS connection opens (no CSP violation in the browser console).
- [ ] Sanity-check production CSP after the next prod deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CSP to allow the relay WebSocket origin in canary and production, restoring remote-control terminals. Adds env wiring and a safe production fallback so the header stays correct.

- **Bug Fixes**
  - Pass `RELAY_URL` into `deploy-web` for preview and production builds in `.github/workflows/deploy-preview.yml` and `.github/workflows/deploy-production.yml`.
  - In `apps/web/next.config.ts`, set `relayWsOrigin` with a production fallback to `wss://relay.superset.sh` so `connect-src` always allows the relay.

<sup>Written for commit f390b17dcabf87ba9d493fec44c5f4d3a5205aa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment and application configuration to support configurable relay server endpoints. Production deployments now include a default relay server fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4577)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->