### PR TITLE
chore(dev): add dev:desktop script that skips web app

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"scripts": {
 		"dev": "turbo run dev dev:caddy --filter=@superset/api --filter=@superset/web --filter=@superset/desktop --filter=electric-proxy --filter=//",
 		"dev:all": "turbo dev",
+		"dev:desktop": "turbo run dev dev:caddy --filter=@superset/api --filter=@superset/desktop --filter=electric-proxy --filter=//",
 		"dev:caddy": "dotenv -- caddy run --config Caddyfile",
 		"dev:docs": "turbo dev --filter=@superset/docs",
 		"dev:marketing": "turbo dev --filter=@superset/marketing --filter=@superset/docs",


### PR DESCRIPTION
## Summary
- Adds `bun dev:desktop` to root `package.json`, running api + desktop + electric-proxy + caddy but skipping `@superset/web`
- Useful for desktop-focused work where the second Next.js dev server (web) is dead weight — it's typically the biggest memory consumer after electron-vite, easily 1.5–3 GB once HMR warms up

## Test plan
- [ ] `bun dev:desktop` starts api, desktop, electric-proxy, caddy
- [ ] `@superset/web` does not start
- [ ] `bun dev` still runs everything as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `bun dev:desktop` to start `@superset/api`, `@superset/desktop`, `electric-proxy`, and `caddy` while skipping `@superset/web` for desktop-focused development. Reduces local memory use and keeps `bun dev` behavior unchanged.

<sup>Written for commit f421947ab5bf97eba4aa7fc7872ce9f3c47935d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development scripts to streamline setup and execution for local development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4578)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->