### PR TITLE
release(cli): cut v0.2.17

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -686,7 +686,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.16";
+const VERSION = "0.2.17";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.16",
+	"version": "0.2.17",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Cut CLI v0.2.17.

Changes since v0.2.16 (bundled via `lib/host-service.js` + the standalone CLI dist):

- **host-service**: connect-phase deadline + reconnect-guaranteed `onclose` so the tunnel can't get stranded mid-handshake; failed connects always schedule a retry. (#4539)
- **host-service**: unstrand tunnel reconnect path and wire relay Sentry so reconnect failures surface instead of silently looping. (#4537)
- **build**: bundle `@mastra/duckdb` and the `@duckdb/node-bindings-*` natives across darwin-arm64 / darwin-x64 / linux-x64 / linux-arm64 targets so duckdb-backed code paths work in the standalone CLI bundle.

Relay-side fix #4491 (cache `host.checkAccess` by userId) ships via `apps/relay` Fly deploy, not this tag.

After this merges, push `cli-v0.2.17` to fire `release-cli.yml`.

## Test plan

- [ ] CI green
- [ ] Merge, then push `cli-v0.2.17` and verify the Release CLI workflow publishes the draft release + refreshes the `cli-latest` rolling pointer
- [ ] Smoke: `superset hosts list` from a freshly downloaded `cli-latest` build survives a relay restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI package version to 0.2.17.
  * Updated the CLI's exported build-time version used by downstream builds and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->