### PR TITLE
feat(desktop): always-on network logging for Electric bug reports

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -49,6 +49,7 @@ import {
 	getTerminalHostClient,
 } from "./lib/terminal-host/client";
 import { disposeTray, initTray } from "./lib/tray";
+import { startNetworkLogger, stopNetworkLogger } from "./network-logger";
 import { MainWindow } from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
@@ -231,6 +232,7 @@ app.on("before-quit", async (event) => {
 		}
 		shutdownTanstackDbPersistence();
 		disposeTray();
+		await stopNetworkLogger();
 	} catch (error) {
 		console.error("[main] Cleanup during quit failed:", error);
 	}
@@ -269,7 +271,9 @@ if (process.env.NODE_ENV === "development") {
 		if (signalHandled) return;
 		signalHandled = true;
 		console.log(`[main] Received ${signal}, quitting...`);
-		void runDevQuitCleanup().finally(() => app.exit(0));
+		void Promise.allSettled([runDevQuitCleanup(), stopNetworkLogger()]).finally(
+			() => app.exit(0),
+		);
 	};
 
 	process.on("SIGTERM", () => handleTerminationSignal("SIGTERM"));
@@ -387,6 +391,12 @@ if (!gotTheLock) {
 		initSentry();
 		await initAppState();
 		initTanstackDbPersistence();
+
+		try {
+			await startNetworkLogger();
+		} catch (error) {
+			console.error("[main] Failed to start network logger:", error);
+		}
 
 		await loadWebviewBrowserExtension();
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -232,9 +232,10 @@ app.on("before-quit", async (event) => {
 		}
 		shutdownTanstackDbPersistence();
 		disposeTray();
-		await stopNetworkLogger();
 	} catch (error) {
 		console.error("[main] Cleanup during quit failed:", error);
+	} finally {
+		await stopNetworkLogger();
 	}
 	app.exit(0);
 });

--- a/apps/desktop/src/main/network-logger/index.ts
+++ b/apps/desktop/src/main/network-logger/index.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+import { app, session } from "electron";
+
+const PARTITION = "persist:superset";
+const CURRENT_FILE = "current.json";
+const SESSION_PREFIX = "session-";
+const SESSION_SUFFIX = ".json";
+const MAX_FILE_BYTES = 1024 * 1024 * 1024;
+const MAX_RETAINED_SESSIONS = 3;
+
+let started = false;
+
+function logsDir(): string {
+	const dir = path.join(app.getPath("userData"), "network-logs");
+	fs.mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function archivePreviousSession(): void {
+	const dir = logsDir();
+	const currentPath = path.join(dir, CURRENT_FILE);
+	if (!fs.existsSync(currentPath)) return;
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+	const archivedPath = path.join(
+		dir,
+		`${SESSION_PREFIX}${stamp}${SESSION_SUFFIX}`,
+	);
+	fs.renameSync(currentPath, archivedPath);
+	finalizeIfNeeded(archivedPath);
+}
+
+function finalizeIfNeeded(filePath: string): void {
+	const stats = fs.statSync(filePath);
+	if (stats.size < 4) return;
+	const tailWindow = Math.min(stats.size, 8 * 1024);
+	const buffer = Buffer.alloc(tailWindow);
+	const fd = fs.openSync(filePath, "r+");
+	try {
+		fs.readSync(fd, buffer, 0, tailWindow, stats.size - tailWindow);
+		const tail = buffer.toString("utf8");
+		if (tail.trimEnd().endsWith("]}")) return;
+		const lastBoundary = tail.lastIndexOf("},\n");
+		if (lastBoundary === -1) return;
+		const truncateAt = stats.size - tailWindow + lastBoundary + 1;
+		fs.ftruncateSync(fd, truncateAt);
+		fs.writeSync(fd, "\n]}", truncateAt);
+	} finally {
+		fs.closeSync(fd);
+	}
+}
+
+function pruneOldSessions(): void {
+	const dir = logsDir();
+	const files = fs
+		.readdirSync(dir)
+		.filter(
+			(name) =>
+				name.startsWith(SESSION_PREFIX) && name.endsWith(SESSION_SUFFIX),
+		)
+		.map((name) => ({
+			name,
+			mtimeMs: fs.statSync(path.join(dir, name)).mtimeMs,
+		}))
+		.sort((a, b) => b.mtimeMs - a.mtimeMs);
+	for (const stale of files.slice(MAX_RETAINED_SESSIONS)) {
+		try {
+			fs.unlinkSync(path.join(dir, stale.name));
+		} catch {
+			// Best-effort
+		}
+	}
+}
+
+export async function startNetworkLogger(): Promise<void> {
+	if (started) return;
+	archivePreviousSession();
+	pruneOldSessions();
+	const logPath = path.join(logsDir(), CURRENT_FILE);
+	await session.fromPartition(PARTITION).netLog.startLogging(logPath, {
+		captureMode: "includeSensitive",
+		maxFileSize: MAX_FILE_BYTES,
+	});
+	started = true;
+	console.log("[network-logger] recording to", logPath);
+}
+
+export async function stopNetworkLogger(): Promise<void> {
+	if (!started) return;
+	started = false;
+	try {
+		await session.fromPartition(PARTITION).netLog.stopLogging();
+	} catch (error) {
+		console.warn("[network-logger] stopLogging failed:", error);
+	}
+}

--- a/apps/desktop/src/main/network-logger/index.ts
+++ b/apps/desktop/src/main/network-logger/index.ts
@@ -30,6 +30,10 @@ function archivePreviousSession(): void {
 	finalizeIfNeeded(archivedPath);
 }
 
+const EVENT_ARRAY_MARKER = Buffer.from('"events":[');
+const EVENT_BOUNDARY = Buffer.from("},\n");
+const CLOSING = Buffer.from("\n]}");
+
 function finalizeIfNeeded(filePath: string): void {
 	const stats = fs.statSync(filePath);
 	if (stats.size < 4) return;
@@ -38,13 +42,14 @@ function finalizeIfNeeded(filePath: string): void {
 	const fd = fs.openSync(filePath, "r+");
 	try {
 		fs.readSync(fd, buffer, 0, tailWindow, stats.size - tailWindow);
-		const tail = buffer.toString("utf8");
-		if (tail.trimEnd().endsWith("]}")) return;
-		const lastBoundary = tail.lastIndexOf("},\n");
+		if (buffer.toString("utf8").trimEnd().endsWith("]}")) return;
+		const lastBoundary = buffer.lastIndexOf(EVENT_BOUNDARY);
 		if (lastBoundary === -1) return;
+		const eventsMarker = buffer.indexOf(EVENT_ARRAY_MARKER);
+		if (eventsMarker !== -1 && lastBoundary < eventsMarker) return;
 		const truncateAt = stats.size - tailWindow + lastBoundary + 1;
 		fs.ftruncateSync(fd, truncateAt);
-		fs.writeSync(fd, "\n]}", truncateAt);
+		fs.writeSync(fd, CLOSING, 0, CLOSING.length, truncateAt);
 	} finally {
 		fs.closeSync(fd);
 	}
@@ -87,9 +92,9 @@ export async function startNetworkLogger(): Promise<void> {
 
 export async function stopNetworkLogger(): Promise<void> {
 	if (!started) return;
-	started = false;
 	try {
 		await session.fromPartition(PARTITION).netLog.stopLogging();
+		started = false;
 	} catch (error) {
 		console.warn("[network-logger] stopLogging failed:", error);
 	}


### PR DESCRIPTION
## Summary

- Starts Chromium NetLog on app ready against `session.fromPartition("persist:superset")` with `captureMode: "includeSensitive"`, so per-request response headers (incl. Electric's `electric-handle` / `electric-offset` / `electric-up-to-date` cursors) end up in the log
- Always-on, no in-product UI. On next launch the prior session's data is stitched, archived as `session-<ISO>.json`, repaired if the previous shutdown truncated mid-event, then pruned to the 3 most recent
- Dev SIGTERM/SIGINT now also flush the log before exit; the rename-on-launch repair handles crash/force-quit cases

## Support flow

When a user reports an Electric sync issue:

1. **Quit Superset** (required — `current.json` while running is just a placeholder; the real data lives in a temp dir until `stopLogging()` stitches it)
2. Send us the newest `session-*.json` file in:
   - macOS: `~/Library/Application Support/Superset/network-logs/`
   - Windows: `%APPDATA%\Superset\network-logs\`
   - Linux: `~/.config/Superset/network-logs/`
3. Load it into <https://netlog-viewer.appspot.com>

**Privacy:** files contain `Authorization: Bearer …` headers. Share via private channel; revoke the token after.

## What's captured / not

| | Default mode | This PR (`includeSensitive`) | `everything` |
| - | - | - | - |
| URL + status + timing | ✓ | ✓ | ✓ |
| Standard headers | ✓ | ✓ | ✓ |
| `electric-handle` / `electric-offset` | ✗ | ✓ | ✓ |
| `Authorization` / `Cookie` values | redacted | ✓ | ✓ |
| Request / response bodies | ✗ | ✗ | ✓ |

Verified against real captured sessions on the dev build: 272k events, `electric-handle: <id>` and `electric-offset: 0_inf` present in response header arrays; resume requests (`v1/shape?handle=…&offset=0_inf&...`) browsable.

## Caveats

- 1GB per-file cap. Past that, Chromium silently stops appending — fine for almost any bug repro window, but worth knowing
- `current.json` during recording is a placeholder pointing at a temp dir (Chromium streams chunks there and stitches on `stopLogging()`). Users must quit the app to materialize the file
- No response bodies: useful for "shape stream is slow / not resuming / handshake failing", less so for "row X never arrived"

## Test plan

- [x] Typecheck + lint clean
- [x] Captured session contains `electric-handle` / `electric-offset` response headers (verified via grep on real file)
- [x] Repair logic produces parseable JSON from a mid-event-truncated file (tested against a real broken file produced before the SIGTERM fix landed)
- [x] After SIGTERM + repair fixes landed, a fresh archived session is valid JSON with 272k events end-to-end
- [ ] Smoke test: load a finalized `session-*.json` into <https://netlog-viewer.appspot.com> and confirm shape requests + headers are browsable in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network activity logging integrated into the desktop app for improved diagnostics.
  * Logging starts on app launch and is stopped during shutdown to ensure proper cleanup.
  * Automatic log rotation and archival with retention of recent sessions to manage disk usage.

* **Bug Fixes**
  * Graceful handling of incomplete or corrupted archived logs during startup so archives remain readable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4585)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->