### PR TITLE
fix(host-service): unblock v2Project.create slug exhaustion

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
@@ -50,6 +50,8 @@ export function NewProjectModal({
 
 	const [parentDir, setParentDir] = useState("");
 	const [url, setUrl] = useState("");
+	const [name, setName] = useState("");
+	const [nameTouched, setNameTouched] = useState(false);
 	const [working, setWorking] = useState(false);
 
 	useEffect(() => {
@@ -57,8 +59,15 @@ export function NewProjectModal({
 		setParentDir(`${homeDir}/.superset/projects`);
 	}, [homeDir, parentDir]);
 
+	useEffect(() => {
+		if (nameTouched) return;
+		setName(deriveProjectNameFromUrl(url));
+	}, [url, nameTouched]);
+
 	const reset = () => {
 		setUrl("");
+		setName("");
+		setNameTouched(false);
 		setWorking(false);
 	};
 
@@ -97,9 +106,9 @@ export function NewProjectModal({
 			toast.error("Please select a project location");
 			return;
 		}
-		const name = deriveProjectNameFromUrl(trimmedUrl);
-		if (!name) {
-			toast.error("Could not derive a project name from the URL or path");
+		const trimmedName = name.trim() || deriveProjectNameFromUrl(trimmedUrl);
+		if (!trimmedName) {
+			toast.error("Please enter a project name");
 			return;
 		}
 
@@ -107,7 +116,7 @@ export function NewProjectModal({
 		try {
 			const client = getHostServiceClientByUrl(activeHostUrl);
 			const result = await client.project.create.mutate({
-				name,
+				name: trimmedName,
 				mode: { kind: "clone", parentDir: trimmedParent, url: trimmedUrl },
 			});
 			finalizeSetup(activeHostUrl, result);
@@ -158,6 +167,22 @@ export function NewProjectModal({
 								}
 							}}
 							autoFocus
+						/>
+					</div>
+
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="project-name" className="text-xs">
+							Project name
+						</Label>
+						<Input
+							id="project-name"
+							value={name}
+							onChange={(e) => {
+								setName(e.target.value);
+								setNameTouched(true);
+							}}
+							placeholder="my-project"
+							disabled={working}
 						/>
 					</div>
 

--- a/packages/host-service/src/trpc/router/project/handlers.ts
+++ b/packages/host-service/src/trpc/router/project/handlers.ts
@@ -66,32 +66,16 @@ async function createCloudProjectWithSlugRetry(
 	args: { id: string; name: string; repoCloneUrl?: string },
 ) {
 	const baseSlug = slugifyProjectName(args.name);
-
-	// Ask the cloud for a slug it knows is currently free, so the common
-	// case is one round-trip. The retry loop below is only there to handle
-	// races (another device claiming the same slug between proposal and
-	// insert) — those retries jump straight to random hex suffixes since
-	// any sequential `${baseSlug}-${N}` we'd try is already known taken.
-	let firstSlug = baseSlug;
-	try {
-		const proposed = await ctx.api.v2Project.proposeSlug.query({
-			organizationId: ctx.organizationId,
-			baseSlug,
-		});
-		firstSlug = proposed.slug;
-	} catch (err) {
-		console.warn("[project.create] proposeSlug failed, using baseSlug", {
-			err: err instanceof Error ? err.message : String(err),
-		});
-	}
-
 	let lastError: unknown;
-	const maxAttempts = 50;
+	// 1 attempt at the bare baseSlug + 9 random-hex retries. With 6 hex
+	// chars (16M options), a per-attempt collision needs ~thousands of
+	// existing slugs sharing the base before risk shows up.
+	const maxAttempts = 10;
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
 		const slug =
 			attempt === 0
-				? firstSlug
-				: `${baseSlug}-${randomBytes(2).toString("hex")}`;
+				? baseSlug
+				: `${baseSlug}-${randomBytes(3).toString("hex")}`;
 		try {
 			return await ctx.api.v2Project.create.mutate({
 				organizationId: ctx.organizationId,

--- a/packages/host-service/src/trpc/router/project/handlers.ts
+++ b/packages/host-service/src/trpc/router/project/handlers.ts
@@ -1,4 +1,4 @@
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { rmSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
@@ -67,15 +67,9 @@ async function createCloudProjectWithSlugRetry(
 ) {
 	const baseSlug = slugifyProjectName(args.name);
 	let lastError: unknown;
-	// 1 attempt at the bare baseSlug + 9 random-hex retries. With 6 hex
-	// chars (16M options), a per-attempt collision needs ~thousands of
-	// existing slugs sharing the base before risk shows up.
-	const maxAttempts = 10;
+	const maxAttempts = 100;
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
-		const slug =
-			attempt === 0
-				? baseSlug
-				: `${baseSlug}-${randomBytes(3).toString("hex")}`;
+		const slug = attempt === 0 ? baseSlug : `${baseSlug}-${attempt + 1}`;
 		try {
 			return await ctx.api.v2Project.create.mutate({
 				organizationId: ctx.organizationId,

--- a/packages/host-service/src/trpc/router/project/handlers.ts
+++ b/packages/host-service/src/trpc/router/project/handlers.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { rmSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
@@ -50,10 +50,6 @@ interface CreateResult {
 	mainWorkspaceId: string;
 }
 
-function slugWithSuffix(baseSlug: string, attempt: number): string {
-	return attempt === 0 ? baseSlug : `${baseSlug}-${attempt + 1}`;
-}
-
 // Cloud v2Project.create catches v2_projects_org_slug_unique and re-throws
 // as TRPCError CONFLICT with this exact message — kept stable so the slug
 // retry below can detect it. If you change the cloud message, change this
@@ -70,10 +66,32 @@ async function createCloudProjectWithSlugRetry(
 	args: { id: string; name: string; repoCloneUrl?: string },
 ) {
 	const baseSlug = slugifyProjectName(args.name);
+
+	// Ask the cloud for a slug it knows is currently free, so the common
+	// case is one round-trip. The retry loop below is only there to handle
+	// races (another device claiming the same slug between proposal and
+	// insert) — those retries jump straight to random hex suffixes since
+	// any sequential `${baseSlug}-${N}` we'd try is already known taken.
+	let firstSlug = baseSlug;
+	try {
+		const proposed = await ctx.api.v2Project.proposeSlug.query({
+			organizationId: ctx.organizationId,
+			baseSlug,
+		});
+		firstSlug = proposed.slug;
+	} catch (err) {
+		console.warn("[project.create] proposeSlug failed, using baseSlug", {
+			err: err instanceof Error ? err.message : String(err),
+		});
+	}
+
 	let lastError: unknown;
-	const maxAttempts = 10;
+	const maxAttempts = 50;
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
-		const slug = slugWithSuffix(baseSlug, attempt);
+		const slug =
+			attempt === 0
+				? firstSlug
+				: `${baseSlug}-${randomBytes(2).toString("hex")}`;
 		try {
 			return await ctx.api.v2Project.create.mutate({
 				organizationId: ctx.organizationId,
@@ -95,7 +113,7 @@ async function createCloudProjectWithSlugRetry(
 	}
 	throw new TRPCError({
 		code: "CONFLICT",
-		message: `Could not allocate a unique slug for "${args.name}" after ${maxAttempts} attempts`,
+		message: `Could not allocate a unique slug for "${args.name}" after ${maxAttempts} attempts. Try a different project name.`,
 		cause: lastError,
 	});
 }

--- a/packages/trpc/src/router/v2-project/v2-project.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.ts
@@ -122,56 +122,6 @@ export const v2ProjectRouter = {
 			return row;
 		}),
 
-	// Returns a slug that is currently free for this org, derived from
-	// `baseSlug`. Either `baseSlug` itself, or `${baseSlug}-${N}` where N
-	// is one greater than the highest existing numeric suffix.
-	//
-	// Best-effort hint, not a reservation — a concurrent create can still
-	// claim the same slug between proposeSlug and v2Project.create. The
-	// host service retries on conflict; this endpoint just makes the
-	// common case a single round-trip.
-	proposeSlug: jwtProcedure
-		.input(
-			z.object({
-				organizationId: z.string().uuid(),
-				baseSlug: z.string().min(1),
-			}),
-		)
-		.query(async ({ ctx, input }) => {
-			if (!ctx.organizationIds.includes(input.organizationId)) {
-				throw new TRPCError({
-					code: "FORBIDDEN",
-					message: "Not a member of this organization",
-				});
-			}
-			const escaped = input.baseSlug.replace(/[\\%_]/g, (m) => `\\${m}`);
-			const rows = await dbWs
-				.select({ slug: v2Projects.slug })
-				.from(v2Projects)
-				.where(
-					and(
-						eq(v2Projects.organizationId, input.organizationId),
-						sql`${v2Projects.slug} ILIKE ${`${escaped}%`} ESCAPE '\\'`,
-					),
-				);
-			const taken = new Set(rows.map((r) => r.slug));
-			if (!taken.has(input.baseSlug)) {
-				return { slug: input.baseSlug };
-			}
-			const suffixPattern = new RegExp(
-				`^${input.baseSlug.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-(\\d+)$`,
-			);
-			let highest = 1;
-			for (const slug of taken) {
-				const match = slug.match(suffixPattern);
-				if (match) {
-					const n = Number.parseInt(match[1] ?? "0", 10);
-					if (n > highest) highest = n;
-				}
-			}
-			return { slug: `${input.baseSlug}-${highest + 1}` };
-		}),
-
 	findByGitHubRemote: jwtProcedure
 		.input(
 			z.object({

--- a/packages/trpc/src/router/v2-project/v2-project.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.ts
@@ -122,6 +122,56 @@ export const v2ProjectRouter = {
 			return row;
 		}),
 
+	// Returns a slug that is currently free for this org, derived from
+	// `baseSlug`. Either `baseSlug` itself, or `${baseSlug}-${N}` where N
+	// is one greater than the highest existing numeric suffix.
+	//
+	// Best-effort hint, not a reservation — a concurrent create can still
+	// claim the same slug between proposeSlug and v2Project.create. The
+	// host service retries on conflict; this endpoint just makes the
+	// common case a single round-trip.
+	proposeSlug: jwtProcedure
+		.input(
+			z.object({
+				organizationId: z.string().uuid(),
+				baseSlug: z.string().min(1),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			if (!ctx.organizationIds.includes(input.organizationId)) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Not a member of this organization",
+				});
+			}
+			const escaped = input.baseSlug.replace(/[\\%_]/g, (m) => `\\${m}`);
+			const rows = await dbWs
+				.select({ slug: v2Projects.slug })
+				.from(v2Projects)
+				.where(
+					and(
+						eq(v2Projects.organizationId, input.organizationId),
+						sql`${v2Projects.slug} ILIKE ${`${escaped}%`} ESCAPE '\\'`,
+					),
+				);
+			const taken = new Set(rows.map((r) => r.slug));
+			if (!taken.has(input.baseSlug)) {
+				return { slug: input.baseSlug };
+			}
+			const suffixPattern = new RegExp(
+				`^${input.baseSlug.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-(\\d+)$`,
+			);
+			let highest = 1;
+			for (const slug of taken) {
+				const match = slug.match(suffixPattern);
+				if (match) {
+					const n = Number.parseInt(match[1] ?? "0", 10);
+					if (n > highest) highest = n;
+				}
+			}
+			return { slug: `${input.baseSlug}-${highest + 1}` };
+		}),
+
 	findByGitHubRemote: jwtProcedure
 		.input(
 			z.object({


### PR DESCRIPTION
## Summary

The cloud `v2Project.create` flow only tried 10 sequential `${name}-${N}` slugs before throwing `CONFLICT: Could not allocate a unique slug` ([handlers.ts:74](https://github.com/superset-sh/superset/blob/main/packages/host-service/src/trpc/router/project/handlers.ts)). Any org that had used a popular base name (e.g. `main`) more than 10 times could no longer create new projects with that name. Org `11e5053b-fb52-4be4-aba3-e287f259610e` hit this 60+ times in 3 hours.

Three layered fixes:

- **`v2Project.proposeSlug` query** — single DB round-trip that returns either `baseSlug` (if free) or `${baseSlug}-${N+1}` where N is the highest existing numeric suffix in the org. Used by the host service to seed the retry loop, so the common case is one create attempt instead of N collisions.
- **Random-hex retry** — if `proposeSlug`'s pick loses a race, retries jump straight to `${baseSlug}-${4-char-hex}` (skipping sequential `-N` slugs which are guaranteed taken once we know the proposed slug lost). Cap raised 10 → 50.
- **Editable Project name field in `NewProjectModal`** — defaults to the URL-derived name but lets users override, so on the (now near-impossible) exhaustion error they have a direct path to retry with a different name. Error message also updated to advise the same.

## Test plan

- [ ] `bun run lint` and `bun run typecheck` pass locally (verified)
- [ ] Manual: create a project from the desktop modal — name field defaults from URL, can be edited
- [ ] Manual: in an org with `main` already taken, create another project named `main` — should succeed with slug `main-2` (and not require any retries)
- [ ] Manual: simulate a race by creating two projects named `main` near-simultaneously — second one resolves via random-hex retry

Closes the slug-exhaustion incident affecting org `11e5053b-fb52-4be4-aba3-e287f259610e`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes slug exhaustion in cloud `v2Project.create` by trying the base slug first, then sequential `${baseSlug}-${N}` with a higher cap (100). Also makes the project name editable in the creation modal.

- **Bug Fixes**
  - Dropped `v2Project.proposeSlug`. Now tries `baseSlug` once, then `${baseSlug}-${N}` for up to 99 retries (100 total).
  - Improved conflict error to suggest trying a different name.

- **New Features**
  - `NewProjectModal`: added an editable Project name field that defaults from the URL.

<sup>Written for commit af8a21bb670354f495bcb64bef09d2aa95fa053e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project name field is now editable during repository cloning, auto-populated from the repository URL until the user edits it.

* **Improvements**
  * Project slug collision handling now retries more aggressively using numeric suffixes and returns a clearer error suggesting trying a different project name when allocation fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4586)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->