### PR TITLE
fix(host-service): bake NODE_ENV=production into release bundle

### DIFF
--- a/packages/host-service/build.ts
+++ b/packages/host-service/build.ts
@@ -17,6 +17,9 @@ const result = await Bun.build({
 	outdir,
 	naming: "host-service.js",
 	format: "esm",
+	define: {
+		"process.env.NODE_ENV": JSON.stringify("production"),
+	},
 	external: [
 		"better-sqlite3",
 		"node-pty",


### PR DESCRIPTION
## Summary

- Pass `define: { "process.env.NODE_ENV": JSON.stringify("production") }` to `Bun.build()` in `packages/host-service/build.ts` so shipped CLI bundles constant-fold to production-mode.
- Without this, Bun substitutes `process.env.NODE_ENV` using the build host's env. CI doesn't set it → bundle bakes in `"development"` → dev-only branches run unconditionally in production binaries (`cli-v0.2.14`–`cli-v0.2.17` all affected).

## Verified against shipped `cli-v0.2.16` linux-x64 bundle

Before (`lib/host-service.js`):
- `const isProductionEnv = (process == null ? undefined : "development") === "production";`
- `console.log(\`[host-service] starting (… NODE_ENV=${"development"})\`);`
- serve.ts devShutdown branch: `const isDev2 = true;` → registers SIGTERM/SIGINT handlers that kill the daemon on every supervised restart
- DaemonSupervisor spawn branch: `const isDev2 = true;` → `detached: false`, `stdio: ["ignore", "pipe", "pipe"]` → daemon dies with parent, rotating log file never written

After (rebuilt locally with this patch):
- `"production" === "production"` → true
- Startup log prints `NODE_ENV=production`
- Both `isDev2 = false` → daemon detached + rotating log fd opened, devShutdown handlers not registered

Only `process.env.NODE_ENV` is auto-substituted by Bun (special case for React-style tree-shaking); the bundle's other ~80 `process.env.X` references survive as runtime reads, so this is the only env leak that needed fixing.

## Test plan
- [x] Local rebuild of `packages/host-service` produces a bundle with `NODE_ENV=production` constant-folded into all three sites (serve.ts:55, DaemonSupervisor.ts:910, startup log)
- [x] `bun run lint packages/host-service/build.ts` clean
- [ ] Cut `cli-v0.2.18`; verify `journalctl -u superset | grep "host-service.*starting"` reports `NODE_ENV=production`
- [ ] Verify `~/.superset/host/<org>/pty-daemon.log` is created and rotates
- [ ] Verify `systemctl restart superset` no longer logs the `dev-mode SIGTERM` message

Closes #4563.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force production mode in the `host-service` release bundle by defining `process.env.NODE_ENV="production"` at build time. Fixes dev-only behavior in shipped CLI builds, ensuring the daemon runs correctly (fixes #4563).

- **Bug Fixes**
  - Add `define: { "process.env.NODE_ENV": JSON.stringify("production") }` to `Bun.build()` in `packages/host-service/build.ts` to constant-fold production paths.
  - Result: daemon runs detached with rotating logs; dev SIGTERM/SIGINT handlers are not registered in production.

<sup>Written for commit f6075bbcd1481a9e6c6d5fd70bfae1c831573969. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the host service to ensure proper environment handling in production deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4590)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->