### PR TITLE
fix(api): pass email as personProperty in featureFlagPayload

### DIFF
--- a/packages/trpc/src/router/analytics/analytics.ts
+++ b/packages/trpc/src/router/analytics/analytics.ts
@@ -91,9 +91,19 @@ export const analyticsRouter = {
 		.input(z.object({ key: z.string().min(1).max(100) }))
 		.query(async ({ ctx, input }) => {
 			try {
+				// Pass email as a personProperty so PostHog evaluates email-based
+				// targeting against what we know about the authenticated user,
+				// not against PostHog's person store (which may not have a row
+				// keyed by ctx.session.user.id with email backfilled).
 				const payload = await posthog.getFeatureFlagPayload(
 					input.key,
 					ctx.session.user.id,
+					undefined,
+					{
+						personProperties: {
+							email: ctx.session.user.email ?? "",
+						},
+					},
 				);
 				return payload ?? null;
 			} catch {


### PR DESCRIPTION
## Summary

The \`relay-url-override\` PostHog flag — which we rely on to canary individual users at a non-prod relay (staging, failover) — has been silently returning \`null\` for affected users. Discovered while trying to route my sandbox host at \`superset-relay-staging\` for multi-region game-day testing: the flag was set up correctly (email = satya@superset.sh, payload = staging URL), but \`analytics.featureFlagPayload\` returned null and the CLI fell back to the baked-in prod URL.

## Root cause

\`analytics.featureFlagPayload\` calls PostHog with only \`ctx.session.user.id\` as the distinctId:

\`\`\`ts
posthog.getFeatureFlagPayload(input.key, ctx.session.user.id)
\`\`\`

PostHog has to find a person row keyed by that distinctId, then read \`email\` from their stored properties to evaluate an email-based filter. If the user's Better Auth UUID isn't on a person record (no \`identify\` event linking it) — which is the case for users that the cloud only \`capture\`s server-side without identifying — the lookup returns no email and the filter fails. Flag returns null, all the targeting we'd configured is moot.

## Fix

Pass \`personProperties: { email: ctx.session.user.email }\` as the options arg so PostHog evaluates filters against the properties we supply, not what's in its person store. One file, +10 LOC.

## Why this matters beyond the immediate sandbox issue

The whole rollout strategy for multi-region relay depends on per-user PostHog targeting working reliably:

1. Set the \`relay-url-override\` flag on prod to route a small set of test users at a canary relay.
2. Observe their experience.
3. If clean, expand the cohort.
4. Eventually flip the default and remove the flag.

If \`featureFlagPayload\` doesn't reliably match users by email, none of that works. This fix is a prerequisite for safe multi-region rollout to production users.

## Test plan

- [ ] After merge + Vercel deploy, hit \`https://api.superset.sh/api/trpc/analytics.featureFlagPayload?input={"json":{"key":"relay-url-override"}}\` with a valid auth token and confirm it returns the configured payload (was returning \`null\`).
- [ ] Restart sandbox daemon on satya-sprite, confirm process env has the staging URL (was prod).
- [ ] Confirm sandbox tunnel appears in staging relay logs in one of sjc/iad/fra.

## Notes

- Email comes from \`ctx.session.user.email\` which Better Auth sets on protected procedures. Defaulted to \`""\` for type safety — PostHog will simply not match the email filter if the user happens to have a null email, which is the right behavior.
- No PostHog flag changes needed; the existing \`relay-url-override\` flag (id 674202) already targets \`email = satya@superset.sh\` correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes email-targeted PostHog flags by passing the authenticated user's email as `personProperties` to `posthog.getFeatureFlagPayload`. This makes `relay-url-override` (and similar flags) return the configured payload instead of null, restoring per-user canary routing for multi-region rollout.

<sup>Written for commit 19616b268a4cae2117843f53c35618853aa373ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature flag targeting reliability by enabling email-based identification when the default user identifier is unavailable. This ensures feature flags are properly applied to all authenticated users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4592)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->