### PR TITLE
feat(relay): graceful tunnel drain on SIGTERM

### DIFF
--- a/apps/relay/fly.staging.toml
+++ b/apps/relay/fly.staging.toml
@@ -1,5 +1,7 @@
 app = "superset-relay-staging"
 primary_region = "sjc"
+kill_signal = "SIGINT"
+kill_timeout = "10s"
 
 [build]
   dockerfile = "Dockerfile"

--- a/apps/relay/fly.toml
+++ b/apps/relay/fly.toml
@@ -6,6 +6,8 @@
 
 app = "superset-relay"
 primary_region = "sjc"
+kill_signal = "SIGINT"
+kill_timeout = "10s"
 
 [build]
   dockerfile = "Dockerfile"

--- a/apps/relay/scripts/deploy-staging.sh
+++ b/apps/relay/scripts/deploy-staging.sh
@@ -27,3 +27,6 @@ fly scale count "app=$COUNT" \
 
 echo "==> Status"
 fly status --app "$APP"
+
+echo "==> Smoke test"
+"$(dirname "$0")/smoke-test.sh" "${APP}.fly.dev" "${REGIONS[@]}"

--- a/apps/relay/scripts/deploy-staging.sh
+++ b/apps/relay/scripts/deploy-staging.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Deploy the relay to the staging Fly app (superset-relay-staging). Mirrors
+# deploy.sh but targets fly.staging.toml + the staging app, so we can iterate
+# on multi-region without risking prod. Edit REGIONS to grow the fleet.
+set -euo pipefail
+
+APP=superset-relay-staging
+REGIONS=(sjc iad fra)
+COUNT=${#REGIONS[@]}
+REGION_LIST=$(IFS=, ; echo "${REGIONS[*]}")
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "==> fly deploy ($APP)"
+fly deploy \
+  --config apps/relay/fly.staging.toml \
+  --dockerfile apps/relay/Dockerfile \
+  --app "$APP" \
+  .
+
+echo "==> fly scale count: $COUNT machines, 1 per region across $REGION_LIST"
+fly scale count "app=$COUNT" \
+  --region "$REGION_LIST" \
+  --max-per-region 1 \
+  --app "$APP" \
+  --yes
+
+echo "==> Status"
+fly status --app "$APP"

--- a/apps/relay/scripts/deploy.sh
+++ b/apps/relay/scripts/deploy.sh
@@ -24,3 +24,6 @@ fly scale count "app=$COUNT" \
 
 echo "==> Status"
 fly status --app "$APP"
+
+echo "==> Smoke test"
+"$(dirname "$0")/smoke-test.sh" "${APP}.fly.dev" "${REGIONS[@]}"

--- a/apps/relay/scripts/smoke-test.sh
+++ b/apps/relay/scripts/smoke-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Post-deploy smoke test for the relay. Hits /health on the public hostname
+# with `fly-prefer-region` for every region the fleet is supposed to span,
+# then verifies the response 200s with `region` matching the requested
+# region — catches partial-deploy failures, missing regions, and machines
+# that booted but aren't actually serving.
+#
+# Usage: smoke-test.sh <hostname> <region> [<region> ...]
+#   smoke-test.sh superset-relay-staging.fly.dev sjc iad fra
+#
+# Exits non-zero on any failure so callers (deploy.sh, deploy-staging.sh)
+# can halt the pipeline.
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <hostname> <region> [<region> ...]" >&2
+  exit 64
+fi
+
+HOSTNAME="$1"
+shift
+REGIONS=("$@")
+
+fail=0
+for region in "${REGIONS[@]}"; do
+  printf "  %-4s " "$region"
+  body=$(curl -sS --max-time 8 -H "fly-prefer-region: $region" "https://${HOSTNAME}/health" 2>&1) || {
+    printf "  ✗ curl failed: %s\n" "$body"
+    fail=$((fail + 1))
+    continue
+  }
+  got=$(printf "%s" "$body" | sed -nE 's/.*"region":"([^"]+)".*/\1/p')
+  if [ "$got" = "$region" ]; then
+    printf "  ✓ %s\n" "$body"
+  else
+    printf "  ✗ wanted region=%s, got=%s: %s\n" "$region" "$got" "$body"
+    fail=$((fail + 1))
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "==> smoke test FAILED: $fail region(s) did not respond as expected" >&2
+  exit 1
+fi
+echo "==> smoke test OK across ${#REGIONS[@]} region(s)"

--- a/apps/relay/src/directory.ts
+++ b/apps/relay/src/directory.ts
@@ -136,21 +136,39 @@ return removed
 // accepting connections. The owner value includes the Fly machineId, which
 // stays the same across restarts of a given VM — so any pre-existing entry
 // with our owner string is necessarily stale.
+//
+// Batched as a single Lua eval so startup time stays bounded at one Redis
+// round-trip regardless of how many tunnels the previous generation owned;
+// per-host serial unregister calls would scale with directory size and eat
+// directly into deploy recovery.
+const CLEAR_STALE_SCRIPT = `
+local owner = ARGV[1]
+local entries = redis.call('HGETALL', KEYS[1])
+local cleared = 0
+for i = 1, #entries, 2 do
+  local hostId = entries[i]
+  local current = entries[i + 1]
+  if current == owner then
+    redis.call('HDEL', KEYS[1], hostId)
+    redis.call('HDEL', KEYS[2], hostId)
+    redis.call('ZREM', KEYS[3], hostId)
+    cleared = cleared + 1
+  end
+end
+return cleared
+`;
+
 export async function clearStaleEntriesForMachine(
 	region: string,
 	machineId: string,
 ): Promise<number> {
 	const myOwner = encodeOwner(region, machineId);
-	const allOwners =
-		(await redis.hgetall<Record<string, string>>(OWNER_KEY)) ?? {};
-	let cleared = 0;
-	for (const [hostId, owner] of Object.entries(allOwners)) {
-		if (owner === myOwner) {
-			await unregister(hostId, region, machineId);
-			cleared++;
-		}
-	}
-	return cleared;
+	const result = await redis.eval(
+		CLEAR_STALE_SCRIPT,
+		[OWNER_KEY, META_KEY, TTL_KEY],
+		[myOwner],
+	);
+	return typeof result === "number" ? result : 0;
 }
 
 export async function sweepStale(): Promise<number> {

--- a/apps/relay/src/directory.ts
+++ b/apps/relay/src/directory.ts
@@ -131,6 +131,28 @@ end
 return removed
 `;
 
+// Called on relay startup. Removes any directory entries the prior process
+// generation left behind (SIGKILL / crash / drain race) before we begin
+// accepting connections. The owner value includes the Fly machineId, which
+// stays the same across restarts of a given VM — so any pre-existing entry
+// with our owner string is necessarily stale.
+export async function clearStaleEntriesForMachine(
+	region: string,
+	machineId: string,
+): Promise<number> {
+	const myOwner = encodeOwner(region, machineId);
+	const allOwners =
+		(await redis.hgetall<Record<string, string>>(OWNER_KEY)) ?? {};
+	let cleared = 0;
+	for (const [hostId, owner] of Object.entries(allOwners)) {
+		if (owner === myOwner) {
+			await unregister(hostId, region, machineId);
+			cleared++;
+		}
+	}
+	return cleared;
+}
+
 export async function sweepStale(): Promise<number> {
 	const now = Date.now();
 	const result = await redis.eval(

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -47,22 +47,26 @@ const app = new Hono<AppContext>();
 const tunnelManager = new TunnelManager();
 const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
-// Graceful drain on Fly's pre-stop SIGTERM. Without this, deploys kill the
-// process while tunnels are still open and host-services see TCP-RST'd
-// sockets, triggering their long exponential backoff. Drain first sends a
-// clean WS 1001 ("Going Away") to every tunnel so hosts reconnect promptly.
+// Graceful drain on Fly's pre-stop signal. Fly's init sends SIGINT (not
+// SIGTERM) to the main process during rolling deploys; listen on both to
+// also cover hand-rolled `fly machine stop` and local Ctrl-C. Without this,
+// deploys kill the process while tunnels are open and host-services see
+// TCP-RST'd sockets, triggering their long exponential backoff. Drain
+// closes each WS with code 1001 ("Going Away") so hosts reconnect promptly.
 let draining = false;
-process.on("SIGTERM", async () => {
+const handleDrain = async (signal: string) => {
 	if (draining) return;
 	draining = true;
-	console.log("[relay] SIGTERM received, draining tunnels");
+	console.log(`[relay] ${signal} received, draining tunnels`);
 	try {
 		await tunnelManager.drain();
 	} catch (err) {
 		console.error("[relay] drain failed", err);
 	}
 	process.exit(0);
-});
+};
+process.on("SIGINT", () => void handleDrain("SIGINT"));
+process.on("SIGTERM", () => void handleDrain("SIGTERM"));
 
 app.use("*", redactingLogger);
 app.use("*", cors());

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -47,6 +47,23 @@ const app = new Hono<AppContext>();
 const tunnelManager = new TunnelManager();
 const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
+// Graceful drain on Fly's pre-stop SIGTERM. Without this, deploys kill the
+// process while tunnels are still open and host-services see TCP-RST'd
+// sockets, triggering their long exponential backoff. Drain first sends a
+// clean WS 1001 ("Going Away") to every tunnel so hosts reconnect promptly.
+let draining = false;
+process.on("SIGTERM", async () => {
+	if (draining) return;
+	draining = true;
+	console.log("[relay] SIGTERM received, draining tunnels");
+	try {
+		await tunnelManager.drain();
+	} catch (err) {
+		console.error("[relay] drain failed", err);
+	}
+	process.exit(0);
+});
+
 app.use("*", redactingLogger);
 app.use("*", cors());
 

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -51,14 +51,20 @@ const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 // SIGTERM) to the main process during rolling deploys; listen on both to
 // also cover hand-rolled `fly machine stop` and local Ctrl-C. Without this,
 // deploys kill the process while tunnels are open and host-services see
-// TCP-RST'd sockets, triggering their long exponential backoff. Drain
-// closes each WS with code 1001 ("Going Away") so hosts reconnect promptly.
+// TCP-RST'd sockets, triggering their long exponential backoff.
+//
+// Sequence: stop accepting new TCP connections (server.close), then close
+// every open tunnel with the app-defined drain code so hosts reconnect
+// promptly. server is assigned at the bottom of this file — by signal
+// time, the closure has it.
+let server: ReturnType<typeof serve> | null = null;
 let draining = false;
 const handleDrain = async (signal: string) => {
 	if (draining) return;
 	draining = true;
 	console.log(`[relay] ${signal} received, draining tunnels`);
 	try {
+		server?.close();
 		await tunnelManager.drain();
 	} catch (err) {
 		console.error("[relay] drain failed", err);
@@ -358,7 +364,7 @@ try {
 	console.error("[relay] startup cleanup failed", err);
 }
 
-const server = serve({ fetch: app.fetch, port: env.RELAY_PORT }, (info) => {
+server = serve({ fetch: app.fetch, port: env.RELAY_PORT }, (info) => {
 	console.log(
 		`[relay] listening on http://localhost:${info.port} (region=${env.FLY_REGION} machine=${env.FLY_MACHINE_ID})`,
 	);

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -340,6 +340,24 @@ if (env.RELAY_SYNTHETIC_JWT) {
 
 // ── Start ───────────────────────────────────────────────────────────
 
+// Clear any directory entries our previous process generation left behind
+// (SIGKILL, drain race, etc.) before we begin accepting connections, so
+// fly-replay doesn't route cross-region requests at us for tunnels we no
+// longer have. Best-effort: relay still boots if Upstash is unreachable.
+try {
+	const cleared = await directory.clearStaleEntriesForMachine(
+		env.FLY_REGION,
+		env.FLY_MACHINE_ID,
+	);
+	if (cleared > 0) {
+		console.log(
+			`[relay] cleared ${cleared} stale directory entries on startup`,
+		);
+	}
+} catch (err) {
+	console.error("[relay] startup cleanup failed", err);
+}
+
 const server = serve({ fetch: app.fetch, port: env.RELAY_PORT }, (info) => {
 	console.log(
 		`[relay] listening on http://localhost:${info.port} (region=${env.FLY_REGION} machine=${env.FLY_MACHINE_ID})`,

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -55,8 +55,9 @@ const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 //
 // Sequence: stop accepting new TCP connections (server.close), then close
 // every open tunnel with the app-defined drain code so hosts reconnect
-// promptly. server is assigned at the bottom of this file — by signal
-// time, the closure has it.
+// promptly, and clear this machine's directory ownership before process exit.
+// server is assigned at the bottom of this file — by signal time, the closure
+// has it.
 let server: ReturnType<typeof serve> | null = null;
 let draining = false;
 const handleDrain = async (signal: string) => {
@@ -65,7 +66,16 @@ const handleDrain = async (signal: string) => {
 	console.log(`[relay] ${signal} received, draining tunnels`);
 	try {
 		server?.close();
-		await tunnelManager.drain();
+		const cleared = await tunnelManager.drain({
+			clearDirectory: () =>
+				directory.clearStaleEntriesForMachine(
+					env.FLY_REGION,
+					env.FLY_MACHINE_ID,
+				),
+		});
+		if (cleared > 0) {
+			console.log(`[relay] cleared ${cleared} directory entries during drain`);
+		}
 	} catch (err) {
 		console.error("[relay] drain failed", err);
 	}
@@ -171,6 +181,11 @@ app.get(
 
 		return {
 			onOpen: async (_event, ws) => {
+				if (draining) {
+					ws.close(TunnelManager.WS_CLOSE_DRAIN, "Server draining for deploy");
+					return;
+				}
+
 				if (!hostId || !token) {
 					ws.close(1008, "Missing hostId or token");
 					return;
@@ -185,6 +200,11 @@ app.get(
 				const hasAccess = await checkHostAccess(auth, token, hostId);
 				if (!hasAccess) {
 					ws.close(1008, "Forbidden");
+					return;
+				}
+
+				if (draining) {
+					ws.close(TunnelManager.WS_CLOSE_DRAIN, "Server draining for deploy");
 					return;
 				}
 

--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -171,18 +171,52 @@ export class TunnelManager {
 	// as a deploy drain (not a hard disconnect or ping timeout) and
 	// reconnect immediately. Called from the SIGINT/SIGTERM handler in
 	// index.ts.
+	//
+	// Waits for each WS's actual close event before resolving (with a
+	// per-WS ceiling). A naive `ws.close(...) + setTimeout(250)` was not
+	// enough — under real network conditions the close frame hadn't
+	// finished its handshake by the time the process called exit(0), so
+	// the client's TCP socket stayed in ESTABLISHED with no `onclose`
+	// event. The client then took 110s (its watchdog) to notice the
+	// dead-but-not-closed connection — which translated into a ~110s
+	// user-visible outage on every deploy.
 	async drain(reason = "Server draining for deploy"): Promise<void> {
-		console.log(`[relay] draining ${this.tunnels.size} tunnels`);
-		for (const tunnel of this.tunnels.values()) {
+		const tunnels = Array.from(this.tunnels.values());
+		console.log(`[relay] draining ${tunnels.length} tunnels`);
+		// In-band drain signal first: send a JSON {type:"drain"} message on
+		// the WS message channel before closing. Game-day testing showed
+		// the WS close frame doesn't reliably reach the host within Fly's
+		// kill_timeout window (host's TCP socket sees ESTABLISHED with no
+		// onclose for 75+ seconds, until its watchdog fires). The message
+		// channel is already exercised by ping/pong every 30s, so we know
+		// it flushes cleanly. Host's onmessage handler triggers a clean
+		// reconnect on receipt; the WS close after is just belt-and-
+		// suspenders.
+		for (const tunnel of tunnels) {
+			try {
+				this.send(tunnel.ws, { type: "drain", reason });
+			} catch {
+				// best-effort
+			}
+		}
+		// Give the message frames a moment to reach the host before we
+		// start closing the underlying sockets.
+		await new Promise((resolve) => setTimeout(resolve, 500));
+		for (const tunnel of tunnels) {
 			try {
 				tunnel.ws.close(TunnelManager.WS_CLOSE_DRAIN, reason);
 			} catch {
 				// already closed
 			}
 		}
-		// Give the OS a moment to flush WS close frames before the process
-		// dies and the underlying TCP connections get RST'd.
-		await new Promise((resolve) => setTimeout(resolve, 250));
+		// Brief tail wait so the close-handshake gets a chance to complete
+		// before the process exits and RSTs the underlying TCP.
+		const WS_CLOSED = 3;
+		const deadline = Date.now() + 1_500;
+		while (Date.now() < deadline) {
+			if (tunnels.every((t) => t.ws.readyState === WS_CLOSED)) return;
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
 	}
 
 	private disposeTunnel(tunnel: TunnelState, reason: string): void {

--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -159,6 +159,25 @@ export class TunnelManager {
 		console.log(`[relay] tunnel unregistered: ${hostId}`);
 	}
 
+	// SIGTERM-driven graceful drain. Closes every open tunnel with WS code
+	// 1001 ("Going Away") so the host-service can recognize this as a deploy
+	// drain (not a hard disconnect) and reconnect immediately, instead of
+	// entering exponential backoff against TCP-RST'd sockets. Used by the
+	// SIGTERM handler in index.ts.
+	async drain(reason = "Server draining for deploy"): Promise<void> {
+		console.log(`[relay] draining ${this.tunnels.size} tunnels`);
+		for (const tunnel of this.tunnels.values()) {
+			try {
+				tunnel.ws.close(1001, reason);
+			} catch {
+				// already closed
+			}
+		}
+		// Give the OS a moment to flush WS close frames before the process
+		// dies and the underlying TCP connections get RST'd.
+		await new Promise((resolve) => setTimeout(resolve, 250));
+	}
+
 	private disposeTunnel(tunnel: TunnelState, reason: string): void {
 		if (tunnel.pingTimer) clearInterval(tunnel.pingTimer);
 

--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -159,16 +159,23 @@ export class TunnelManager {
 		console.log(`[relay] tunnel unregistered: ${hostId}`);
 	}
 
-	// SIGTERM-driven graceful drain. Closes every open tunnel with WS code
-	// 1001 ("Going Away") so the host-service can recognize this as a deploy
-	// drain (not a hard disconnect) and reconnect immediately, instead of
-	// entering exponential backoff against TCP-RST'd sockets. Used by the
-	// SIGTERM handler in index.ts.
+	// Application-defined WS close code (4xxx range) signaling "relay is
+	// draining for a deploy — reconnect immediately." Distinct from 1001
+	// ("Going Away") which the ping-timeout / dispose paths use; the host
+	// resets its backoff only on this code, so a mass ping-timeout doesn't
+	// trigger a thundering-herd of fast reconnects.
+	static readonly WS_CLOSE_DRAIN = 4001;
+
+	// SIGTERM-driven graceful drain. Closes every open tunnel with the
+	// app-defined "drain" close code so the host-service can recognize this
+	// as a deploy drain (not a hard disconnect or ping timeout) and
+	// reconnect immediately. Called from the SIGINT/SIGTERM handler in
+	// index.ts.
 	async drain(reason = "Server draining for deploy"): Promise<void> {
 		console.log(`[relay] draining ${this.tunnels.size} tunnels`);
 		for (const tunnel of this.tunnels.values()) {
 			try {
-				tunnel.ws.close(1001, reason);
+				tunnel.ws.close(TunnelManager.WS_CLOSE_DRAIN, reason);
 			} catch {
 				// already closed
 			}

--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -33,6 +33,11 @@ interface TunnelState {
 	missedPings: number;
 }
 
+interface DrainOptions {
+	reason?: string;
+	clearDirectory: () => Promise<number>;
+}
+
 export class TunnelManager {
 	private readonly tunnels = new Map<string, TunnelState>();
 	private readonly requestTimeoutMs: number;
@@ -42,12 +47,18 @@ export class TunnelManager {
 		ReturnType<typeof setTimeout>
 	>();
 	private readonly onlineWriteVersions = new Map<string, number>();
+	private draining = false;
 
 	constructor(requestTimeoutMs = 30_000) {
 		this.requestTimeoutMs = requestTimeoutMs;
 	}
 
 	async register(hostId: string, token: string, ws: WsSocket): Promise<void> {
+		if (this.draining) {
+			ws.close(TunnelManager.WS_CLOSE_DRAIN, "Server draining for deploy");
+			return;
+		}
+
 		// Last-write-wins: close the old socket so flaky clients don't get
 		// stuck behind a dead-but-not-yet-detected WS.
 		const existing = this.tunnels.get(hostId);
@@ -73,12 +84,15 @@ export class TunnelManager {
 		// hadn't returned yet), so it skipped unregister. Roll the directory
 		// entry back ourselves; otherwise other machines fly-replay traffic
 		// to a dead local tunnel for ~90s until the TTL ages out.
-		if (ws.readyState !== 1) {
+		if (ws.readyState !== 1 || this.draining) {
 			await directory
 				.unregister(hostId, env.FLY_REGION, env.FLY_MACHINE_ID)
 				.catch((err) => {
 					console.error("[relay] directory.unregister rollback failed", err);
 				});
+			if (this.draining) {
+				ws.close(TunnelManager.WS_CLOSE_DRAIN, "Server draining for deploy");
+			}
 			return;
 		}
 
@@ -172,15 +186,12 @@ export class TunnelManager {
 	// reconnect immediately. Called from the SIGINT/SIGTERM handler in
 	// index.ts.
 	//
-	// Waits for each WS's actual close event before resolving (with a
-	// per-WS ceiling). A naive `ws.close(...) + setTimeout(250)` was not
-	// enough — under real network conditions the close frame hadn't
-	// finished its handshake by the time the process called exit(0), so
-	// the client's TCP socket stayed in ESTABLISHED with no `onclose`
-	// event. The client then took 110s (its watchdog) to notice the
-	// dead-but-not-closed connection — which translated into a ~110s
-	// user-visible outage on every deploy.
-	async drain(reason = "Server draining for deploy"): Promise<void> {
+	// Owns directory cleanup directly instead of relying on websocket close
+	// callbacks. The process exits immediately after drain, so fire-and-forget
+	// unregister work from onClose is not a reliable shutdown primitive.
+	async drain(options: DrainOptions): Promise<number> {
+		this.draining = true;
+		const reason = options.reason ?? "Server draining for deploy";
 		const tunnels = Array.from(this.tunnels.values());
 		console.log(`[relay] draining ${tunnels.length} tunnels`);
 		// In-band drain signal first: send a JSON {type:"drain"} message on
@@ -202,24 +213,37 @@ export class TunnelManager {
 		// Give the message frames a moment to reach the host before we
 		// start closing the underlying sockets.
 		await new Promise((resolve) => setTimeout(resolve, 500));
-		for (const tunnel of tunnels) {
-			try {
-				tunnel.ws.close(TunnelManager.WS_CLOSE_DRAIN, reason);
-			} catch {
-				// already closed
-			}
+
+		let cleared = 0;
+		let clearError: unknown;
+		try {
+			cleared = await options.clearDirectory();
+		} catch (err) {
+			clearError = err;
 		}
+
+		for (const tunnel of tunnels) {
+			this.disposeTunnel(tunnel, reason, TunnelManager.WS_CLOSE_DRAIN);
+			this.tunnels.delete(tunnel.hostId);
+		}
+
 		// Brief tail wait so the close-handshake gets a chance to complete
 		// before the process exits and RSTs the underlying TCP.
 		const WS_CLOSED = 3;
 		const deadline = Date.now() + 1_500;
 		while (Date.now() < deadline) {
-			if (tunnels.every((t) => t.ws.readyState === WS_CLOSED)) return;
+			if (tunnels.every((t) => t.ws.readyState === WS_CLOSED)) break;
 			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
+		if (clearError) throw clearError;
+		return cleared;
 	}
 
-	private disposeTunnel(tunnel: TunnelState, reason: string): void {
+	private disposeTunnel(
+		tunnel: TunnelState,
+		reason: string,
+		tunnelCloseCode = 1000,
+	): void {
 		if (tunnel.pingTimer) clearInterval(tunnel.pingTimer);
 
 		for (const [, pending] of tunnel.pendingRequests) {
@@ -232,7 +256,7 @@ export class TunnelManager {
 		}
 
 		try {
-			tunnel.ws.close(1000, reason);
+			tunnel.ws.close(tunnelCloseCode, reason);
 		} catch {
 			// already closed
 		}

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -8,7 +8,10 @@ import type {
 } from "./types";
 
 const RECONNECT_BASE_MS = 1_000;
-const RECONNECT_MAX_MS = 30_000;
+// 5s ceiling rather than 30s. Under a sustained outage this means slightly
+// more retry traffic, but under transient relay restarts (the common case)
+// it ensures we don't sit idle for 30s while the relay is back online.
+const RECONNECT_MAX_MS = 5_000;
 const INBOUND_SILENCE_TIMEOUT_MS = 75_000;
 const WATCHDOG_INTERVAL_MS = 10_000;
 const CONNECT_TIMEOUT_MS = 20_000;

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -204,6 +204,24 @@ export class TunnelClient {
 			case "ping":
 				this.send({ type: "pong" });
 				break;
+			case "drain":
+				// In-band drain signal from the relay before it
+				// SIGINT-shuts-down. Reset backoff and tear the socket
+				// down ourselves so the next reconnect attempt fires at
+				// the base delay — far more reliable than waiting for
+				// the WS close frame to arrive (which game-day testing
+				// showed sometimes doesn't, leaving the host idle until
+				// its 75s inactivity watchdog).
+				console.log(
+					`[host-service:tunnel] relay drain notice received${message.reason ? ` (${message.reason})` : ""}; reconnecting immediately`,
+				);
+				this.reconnectAttempts = 0;
+				try {
+					this.socket?.close();
+				} catch {
+					// onclose handler will schedule the reconnect
+				}
+				break;
 			case "http":
 				await this.handleHttpRequest(message);
 				break;

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -130,6 +130,15 @@ export class TunnelClient {
 							`[host-service:tunnel] relay rejected connection (code=${event.code}, reason=${event.reason ?? ""}); retrying`,
 						);
 					}
+					// Clean close from the relay (1001 = "Going Away", typically a
+					// deploy drain). Reset backoff so we don't sit in 30s retry
+					// mode while the relay is restarting in <2s.
+					if (event.code === 1001) {
+						this.reconnectAttempts = 0;
+						console.log(
+							"[host-service:tunnel] relay draining; reconnecting immediately",
+						);
+					}
 				} catch (err) {
 					console.warn(
 						"[host-service:tunnel] error during onclose cleanup",

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -133,10 +133,13 @@ export class TunnelClient {
 							`[host-service:tunnel] relay rejected connection (code=${event.code}, reason=${event.reason ?? ""}); retrying`,
 						);
 					}
-					// Clean close from the relay (1001 = "Going Away", typically a
-					// deploy drain). Reset backoff so we don't sit in 30s retry
-					// mode while the relay is restarting in <2s.
-					if (event.code === 1001) {
+					// App-defined "relay draining for deploy" close code
+					// (4001). Distinct from 1001 ("Going Away") which the
+					// ping-timeout / dispose paths use — only reset on 4001 so
+					// a mass ping-timeout doesn't trigger a thundering-herd of
+					// instant reconnects. After reset, next attempt fires at
+					// the base delay instead of the 5s ceiling.
+					if (event.code === 4001) {
 						this.reconnectAttempts = 0;
 						console.log(
 							"[host-service:tunnel] relay draining; reconnecting immediately",

--- a/packages/shared/src/tunnel-protocol.ts
+++ b/packages/shared/src/tunnel-protocol.ts
@@ -33,12 +33,23 @@ export interface TunnelPing {
 	type: "ping";
 }
 
+// In-band drain signal — relay sends this to every tunnel right before
+// SIGINT-triggered shutdown so the host knows to reconnect immediately
+// rather than waiting for the WS close frame (which doesn't reliably
+// reach the host within the kill_timeout window) or the host-side
+// inactivity watchdog.
+export interface TunnelDrain {
+	type: "drain";
+	reason?: string;
+}
+
 export type TunnelRequest =
 	| TunnelHttpRequest
 	| TunnelWsOpen
 	| TunnelWsFrame
 	| TunnelWsClose
-	| TunnelPing;
+	| TunnelPing
+	| TunnelDrain;
 
 // ── Host → Relay ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Discovered during a multi-region rolling-deploy game-day on \`superset-relay-staging\`: every relay-machine restart left host tunnels disconnected for **~60s** before they reconnected. That outage compounds across regions during multi-region deploys, so it's a blocker for rolling multi-region to prod cleanly.

### Root cause

1. Fly sends SIGTERM to the relay process during a rolling deploy.
2. Relay had no SIGTERM handler — the process just exits, leaving every open WS as a TCP-RST'd socket from the host's perspective.
3. Host-service's exponential reconnect backoff (\`RECONNECT_BASE_MS=1s\`, \`RECONNECT_MAX_MS=30s\`) climbs into the 30s/attempt tail after ~6 failed attempts while the relay is down (~30-40s).
4. By the time the relay comes back, the host is mid-30s-wait. Worst case is ~60s before the next attempt fires and the WS re-establishes.

Game-day timings:
- 04:02:41Z — SJC machine restart (sandbox WS killed)
- 04:02:42Z — SJC listening again
- **04:03:45Z — sandbox re-registered** (63s gap from restart)

### Fix (two-sided)

**Relay** (\`apps/relay/src/tunnel.ts\` + \`apps/relay/src/index.ts\`):
- New \`tunnelManager.drain()\` that walks every open WS and closes it with code 1001 (\"Going Away\"), waits 250ms for close frames to flush, then exits.
- Wired to SIGTERM in index.ts so Fly's pre-stop signal triggers the clean drain.

**Host** (\`packages/host-service/src/tunnel/tunnel-client.ts\`):
- \`socket.onclose\` now recognizes code 1001 specifically and resets \`reconnectAttempts = 0\` before scheduling the next attempt. The next reconnect fires at the 0.5-1s base delay instead of the saturated 30s tail.

Together: deploy outages should drop from ~60s to ~2-5s per affected host.

### Test plan

- [ ] Deploy this branch to \`superset-relay-staging\` via \`./apps/relay/scripts/deploy-staging.sh\`.
- [ ] Re-run the rolling-deploy game-day: trigger a redeploy, watch sandbox + satyas-mbp tunnels in staging logs, confirm re-registration happens within ~5s of each machine coming back (instead of ~60s).
- [ ] Confirm no zombie directory entries — \`disposeTunnel\` cleans pingTimer/pendingRequests on close, and the existing \`unregister\` path on the next \`onclose\` of the host-side socket fires correctly.

### Out of scope (separate concerns to track)

- The shorter-term mitigation \"lower \`RECONNECT_MAX_MS\`\" was considered but rejected — under genuine sustained outages we still want backoff to prevent storms. The 1001-reset path is the right shape: fast retry only when the relay clearly told us \"I'm going away\".
- Cloud-DB lag (\`is_online\` staying stale after re-register) — tracked separately; this PR doesn't touch the \`scheduleOnlineWrite\` path.
- Synthetic check on staging — nice-to-have but not blocking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully drains relay tunnels on SIGINT/SIGTERM: stop new connections, send an in-band “drain” message, close with WS code 4001 so hosts reconnect immediately, and await directory cleanup before exit. Cuts deploy-time outages to ~1–5s, clears stale directory entries, and adds Fly lifecycle settings plus region-aware smoke tests for safer multi‑region deploys.

- New Features
  - Relay (`apps/relay`): on SIGINT/SIGTERM call `server.close()`, broadcast `{type:"drain"}`, close with code 4001, reject new registers while draining, await batched directory cleanup, then exit. Set `kill_signal = "SIGINT"` and `kill_timeout = "10s"` in `fly.toml` and `fly.staging.toml`.
  - Host (`packages/host-service`): on `{type:"drain"}` or close code 4001, reset `reconnectAttempts` and reconnect immediately; cap `RECONNECT_MAX_MS` at 5s. Protocol adds `drain` message (`packages/shared`).
  - Deploy/ops: add `apps/relay/scripts/deploy-staging.sh`; add region-aware `smoke-test.sh` and run it from both deploy scripts to verify `/health` per region.

- Bug Fixes
  - Relay directory: batch-clear self-owned entries via a single Redis EVAL on startup and during drain; await cleanup before exit to prevent stale routing and incorrect `is_online`.

<sup>Written for commit 75994e059ad20ae9399c459e6dece1380b53ed9c. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4594?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay now gracefully drains active connections on shutdown to reduce abrupt disconnects.
  * Relay startup clears stale directory entries from prior processes to avoid stale state.
  * Tunnel clients detect relay-initiated shutdowns and reconnect immediately with faster retry behavior.

* **Chores**
  * Added deployment script and runtime lifecycle settings to enable rolling deploys with graceful shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4594)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->