### PR TITLE
[codex] fix simple-git unsafe env handling

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	SIMPLE_GIT_UNSAFE_OPTION_FLAGS,
+	USER_GIT_ENV_SIMPLE_GIT_OPTIONS,
+} from "@superset/shared/simple-git-options";
+import simpleGit, { type SimpleGit } from "simple-git";
+
+function makeBlockedGitEnv(workRoot: string): Record<string, string> {
+	const globalConfig = join(workRoot, "global.gitconfig");
+	const systemConfig = join(workRoot, "system.gitconfig");
+	const configFile = join(workRoot, "gitconfig");
+	const templateDir = join(workRoot, "template");
+	mkdirSync(templateDir);
+	writeFileSync(globalConfig, "");
+	writeFileSync(systemConfig, "");
+	writeFileSync(configFile, "");
+
+	return {
+		EDITOR: "true",
+		GIT_ASKPASS: "/bin/echo",
+		GIT_CONFIG: configFile,
+		GIT_CONFIG_COUNT: "0",
+		GIT_CONFIG_GLOBAL: globalConfig,
+		GIT_CONFIG_SYSTEM: systemConfig,
+		GIT_EDITOR: "true",
+		GIT_EXEC_PATH: execSync("git --exec-path", { encoding: "utf8" }).trim(),
+		GIT_EXTERNAL_DIFF: "true",
+		GIT_PAGER: "cat",
+		GIT_PROXY_COMMAND: "true",
+		GIT_SEQUENCE_EDITOR: "true",
+		GIT_SSH: "ssh",
+		GIT_SSH_COMMAND: "ssh",
+		GIT_TEMPLATE_DIR: templateDir,
+		PAGER: "cat",
+		PREFIX: workRoot,
+		SSH_ASKPASS: "/bin/echo",
+	};
+}
+
+async function expectUnsafeEnvRejected(git: SimpleGit): Promise<void> {
+	try {
+		await git.raw(["status", "--short"]);
+	} catch (err) {
+		expect(String(err)).toContain("not permitted without enabling allowUnsafe");
+		return;
+	}
+
+	throw new Error("Expected simple-git to reject unsafe git environment");
+}
+
+describe("simple-git user env options", () => {
+	let workRoot: string;
+
+	beforeEach(() => {
+		workRoot = mkdtempSync(join(tmpdir(), "superset-git-client-"));
+	});
+
+	afterEach(() => {
+		rmSync(workRoot, { recursive: true, force: true });
+	});
+
+	test("enables every simple-git unsafe compatibility flag", () => {
+		for (const flag of SIMPLE_GIT_UNSAFE_OPTION_FLAGS) {
+			expect(USER_GIT_ENV_SIMPLE_GIT_OPTIONS.unsafe[flag]).toBe(true);
+		}
+	});
+
+	test("rejects the same env without the unsafe allow-list", async () => {
+		const repoPath = join(workRoot, "repo");
+		mkdirSync(repoPath);
+		execSync("git init", { cwd: repoPath, stdio: "ignore" });
+
+		await expectUnsafeEnvRejected(
+			simpleGit(repoPath).env(makeBlockedGitEnv(workRoot)),
+		);
+	});
+
+	test("allows user git env variables that simple-git blocks by default", async () => {
+		const repoPath = join(workRoot, "repo");
+		mkdirSync(repoPath);
+		execSync("git init", { cwd: repoPath, stdio: "ignore" });
+
+		const git = simpleGit(repoPath, USER_GIT_ENV_SIMPLE_GIT_OPTIONS).env(
+			makeBlockedGitEnv(workRoot),
+		);
+
+		const status = await git.raw(["status", "--short"]);
+		expect(status).toBe("");
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
@@ -3,15 +3,28 @@ import {
 	execFile,
 } from "node:child_process";
 import { promisify } from "node:util";
-import simpleGit, { type SimpleGit } from "simple-git";
+import { USER_GIT_ENV_SIMPLE_GIT_OPTIONS } from "@superset/shared/simple-git-options";
+import simpleGit, { type SimpleGit, type SimpleGitOptions } from "simple-git";
 import { getProcessEnvWithShellPath } from "./shell-env";
 
 const execFileAsync = promisify(execFile);
 
+// Superset is a local Git client, so inherited user Git config/env is expected
+// behavior. simple-git 3.36 blocks these hooks by default; allow them centrally
+// instead of deleting individual env vars and changing Git semantics.
+const SIMPLE_GIT_OPTIONS =
+	USER_GIT_ENV_SIMPLE_GIT_OPTIONS satisfies Partial<SimpleGitOptions>;
+
+function createUserSimpleGit(repoPath?: string): SimpleGit {
+	return repoPath
+		? simpleGit(repoPath, SIMPLE_GIT_OPTIONS)
+		: simpleGit(SIMPLE_GIT_OPTIONS);
+}
+
 export async function getSimpleGitWithShellPath(
 	repoPath?: string,
 ): Promise<SimpleGit> {
-	const git = repoPath ? simpleGit(repoPath) : simpleGit();
+	const git = createUserSimpleGit(repoPath);
 	git.env(await getProcessEnvWithShellPath());
 	return git;
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.test.ts
@@ -8,7 +8,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { applyShellEnvToProcess, getProcessEnvWithShellEnv } from "./shell-env";
+import {
+	applyShellEnvToProcess,
+	getProcessEnvWithShellEnv,
+	getProcessEnvWithShellPath,
+} from "./shell-env";
 
 describe("shell env merging", () => {
 	test("getProcessEnvWithShellEnv fills in missing shell variables", async () => {
@@ -53,6 +57,23 @@ describe("shell env merging", () => {
 		await applyShellEnvToProcess(targetEnv, {});
 
 		expect(targetEnv).toEqual({});
+	});
+});
+
+describe("getProcessEnvWithShellPath preserves user git env vars", () => {
+	test("keeps pager and editor variables in the returned env", async () => {
+		const env = await getProcessEnvWithShellPath({
+			PATH: "/usr/bin:/bin",
+			EDITOR: "vim",
+			GIT_EDITOR: "vim",
+			PAGER: "less",
+			GIT_PAGER: "less",
+		});
+
+		expect(env.EDITOR).toBe("vim");
+		expect(env.GIT_EDITOR).toBe("vim");
+		expect(env.PAGER).toBe("less");
+		expect(env.GIT_PAGER).toBe("less");
 	});
 });
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
@@ -192,20 +192,6 @@ export async function getProcessEnvWithShellPath(
 		}
 	}
 
-	// Git ≥ 2.50 refuses to honor an *inherited* `PAGER` or `GIT_PAGER`
-	// env var on non-interactive callers ("Use of \"PAGER\" is not
-	// permitted without enabling allowUnsafePager"), which simple-git
-	// surfaces as GitPluginError and breaks workspace creation, status
-	// reads, worktree prune, etc.
-	//
-	// Strip both. Programmatic git invocations have piped stdout (not a
-	// TTY), so git skips paging entirely — no replacement value is needed.
-	// User-facing terminals get their own PAGER/GIT_PAGER from the
-	// interactive shell, so this only affects the host-service / desktop
-	// main process's own git children.
-	delete env.PAGER;
-	delete env.GIT_PAGER;
-
 	return env;
 }
 

--- a/packages/host-service/src/runtime/git/git.ts
+++ b/packages/host-service/src/runtime/git/git.ts
@@ -1,12 +1,11 @@
-import simpleGit from "simple-git";
-
+import { createUserSimpleGit } from "./simple-git";
 import type { GitCredentialProvider, GitFactory } from "./types";
 import { getRemoteUrl } from "./utils";
 
 export function createGitFactory(provider: GitCredentialProvider): GitFactory {
 	return async (repoPath: string) => {
 		const initialCredentials = await provider.getCredentials(null);
-		const git = simpleGit(repoPath).env(initialCredentials.env);
+		const git = createUserSimpleGit(repoPath).env(initialCredentials.env);
 		const remoteUrl = await getRemoteUrl(git);
 		const credentials = await provider.getCredentials(remoteUrl);
 

--- a/packages/host-service/src/runtime/git/simple-git.test.ts
+++ b/packages/host-service/src/runtime/git/simple-git.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	SIMPLE_GIT_UNSAFE_OPTION_FLAGS,
+	USER_GIT_ENV_SIMPLE_GIT_OPTIONS,
+} from "@superset/shared/simple-git-options";
+import simpleGit, { type SimpleGit } from "simple-git";
+import { createUserSimpleGit } from "./simple-git";
+
+function makeBlockedGitEnv(workRoot: string): Record<string, string> {
+	const globalConfig = join(workRoot, "global.gitconfig");
+	const systemConfig = join(workRoot, "system.gitconfig");
+	const configFile = join(workRoot, "gitconfig");
+	const templateDir = join(workRoot, "template");
+	mkdirSync(templateDir);
+	writeFileSync(globalConfig, "");
+	writeFileSync(systemConfig, "");
+	writeFileSync(configFile, "");
+
+	return {
+		EDITOR: "true",
+		GIT_ASKPASS: "/bin/echo",
+		GIT_CONFIG: configFile,
+		GIT_CONFIG_COUNT: "0",
+		GIT_CONFIG_GLOBAL: globalConfig,
+		GIT_CONFIG_SYSTEM: systemConfig,
+		GIT_EDITOR: "true",
+		GIT_EXEC_PATH: execSync("git --exec-path", { encoding: "utf8" }).trim(),
+		GIT_EXTERNAL_DIFF: "true",
+		GIT_PAGER: "cat",
+		GIT_PROXY_COMMAND: "true",
+		GIT_SEQUENCE_EDITOR: "true",
+		GIT_SSH: "ssh",
+		GIT_SSH_COMMAND: "ssh",
+		GIT_TEMPLATE_DIR: templateDir,
+		PAGER: "cat",
+		PREFIX: workRoot,
+		SSH_ASKPASS: "/bin/echo",
+	};
+}
+
+async function expectUnsafeEnvRejected(git: SimpleGit): Promise<void> {
+	try {
+		await git.raw(["status", "--short"]);
+	} catch (err) {
+		expect(String(err)).toContain("not permitted without enabling allowUnsafe");
+		return;
+	}
+
+	throw new Error("Expected simple-git to reject unsafe git environment");
+}
+
+describe("createUserSimpleGit", () => {
+	let workRoot: string;
+
+	beforeEach(() => {
+		workRoot = mkdtempSync(join(tmpdir(), "superset-host-simple-git-"));
+	});
+
+	afterEach(() => {
+		rmSync(workRoot, { recursive: true, force: true });
+	});
+
+	test("enables every simple-git unsafe compatibility flag", () => {
+		for (const flag of SIMPLE_GIT_UNSAFE_OPTION_FLAGS) {
+			expect(USER_GIT_ENV_SIMPLE_GIT_OPTIONS.unsafe[flag]).toBe(true);
+		}
+	});
+
+	test("rejects the same env without the unsafe allow-list", async () => {
+		const repoPath = join(workRoot, "repo");
+		mkdirSync(repoPath);
+		execSync("git init", { cwd: repoPath, stdio: "ignore" });
+
+		await expectUnsafeEnvRejected(
+			simpleGit(repoPath).env(makeBlockedGitEnv(workRoot)),
+		);
+	});
+
+	test("allows user git env variables that simple-git blocks by default", async () => {
+		const repoPath = join(workRoot, "repo");
+		mkdirSync(repoPath);
+		execSync("git init", { cwd: repoPath, stdio: "ignore" });
+
+		const git = createUserSimpleGit(repoPath).env(makeBlockedGitEnv(workRoot));
+
+		const status = await git.raw(["status", "--short"]);
+		expect(status).toBe("");
+	});
+});

--- a/packages/host-service/src/runtime/git/simple-git.ts
+++ b/packages/host-service/src/runtime/git/simple-git.ts
@@ -1,0 +1,14 @@
+import { USER_GIT_ENV_SIMPLE_GIT_OPTIONS } from "@superset/shared/simple-git-options";
+import simpleGit, { type SimpleGit, type SimpleGitOptions } from "simple-git";
+
+// Superset is a local Git client, so inherited user Git config/env is expected
+// behavior. simple-git 3.36 blocks these hooks by default; allow them centrally
+// instead of deleting individual env vars and changing Git semantics.
+const SIMPLE_GIT_OPTIONS =
+	USER_GIT_ENV_SIMPLE_GIT_OPTIONS satisfies Partial<SimpleGitOptions>;
+
+export function createUserSimpleGit(baseDir?: string): SimpleGit {
+	return baseDir
+		? simpleGit(baseDir, SIMPLE_GIT_OPTIONS)
+		: simpleGit(SIMPLE_GIT_OPTIONS);
+}

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -8,8 +8,9 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
-import simpleGit, { type SimpleGit } from "simple-git";
+import type { SimpleGit } from "simple-git";
 import { resolveUpstream } from "../../../../runtime/git/refs";
+import { createUserSimpleGit } from "../../../../runtime/git/simple-git";
 import type { Branch, ChangedFile, FileStatus } from "../types";
 
 // Skip line counting for files larger than this — anything over a MB
@@ -335,7 +336,7 @@ export async function detectUnstagedRenames(
 		const tempIndex = join(tempDir, "index");
 		await copyFile(indexPath, tempIndex);
 
-		const tempGit = simpleGit(worktreePath).env({
+		const tempGit = createUserSimpleGit(worktreePath).env({
 			...process.env,
 			GIT_INDEX_FILE: tempIndex,
 		});

--- a/packages/host-service/src/trpc/router/project/project.ts
+++ b/packages/host-service/src/trpc/router/project/project.ts
@@ -5,9 +5,9 @@ import {
 } from "@superset/shared/github-remote";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import simpleGit from "simple-git";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
+import { createUserSimpleGit } from "../../../runtime/git/simple-git";
 import { protectedProcedure, router } from "../../index";
 import {
 	createFromClone,
@@ -179,7 +179,7 @@ export const projectRouter = router({
 			}
 
 			// walkAllRemotes branch — v1→v2 importer.
-			const allRemotes = await getGitHubRemotes(simpleGit(gitRoot));
+			const allRemotes = await getGitHubRemotes(createUserSimpleGit(gitRoot));
 
 			const urlsToQuery = new Map<string, ParsedGitHubRemote>();
 			for (const parsed of allRemotes.values()) {

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { join, resolve as resolvePath } from "node:path";
 import { parseGitHubRemote } from "@superset/shared/github-remote";
 import { TRPCError } from "@trpc/server";
-import simpleGit from "simple-git";
+import { createUserSimpleGit } from "../../../../runtime/git/simple-git";
 import {
 	findMatchingRemote,
 	getGitHubRemotes,
@@ -87,7 +87,7 @@ function asInitialCommitTrpcError(err: unknown): TRPCError {
 
 /** `git init --initial-branch=main` with a fallback for older git versions. */
 async function gitInitMainBranch(targetPath: string): Promise<void> {
-	const git = simpleGit(targetPath);
+	const git = createUserSimpleGit(targetPath);
 	try {
 		await git.init(["--initial-branch=main"]);
 	} catch {
@@ -97,7 +97,9 @@ async function gitInitMainBranch(targetPath: string): Promise<void> {
 
 async function revParseGitRoot(path: string): Promise<string> {
 	try {
-		return (await simpleGit(path).revparse(["--show-toplevel"])).trim();
+		return (
+			await createUserSimpleGit(path).revparse(["--show-toplevel"])
+		).trim();
 	} catch {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
@@ -116,7 +118,7 @@ export async function resolveLocalRepo(
 ): Promise<ResolvedRepo> {
 	validateDirectoryPath(repoPath, "Path");
 	const gitRoot = await revParseGitRoot(repoPath);
-	const remotes = await getGitHubRemotes(simpleGit(gitRoot));
+	const remotes = await getGitHubRemotes(createUserSimpleGit(gitRoot));
 	const originParsed = remotes.get("origin");
 	if (originParsed) {
 		return { repoPath: gitRoot, remoteName: "origin", parsed: originParsed };
@@ -142,7 +144,7 @@ export async function resolveMatchingSlug(
 ): Promise<ResolvedGitHubRepo> {
 	validateDirectoryPath(repoPath, "Path");
 	const gitRoot = await revParseGitRoot(repoPath);
-	const remotes = await getGitHubRemotes(simpleGit(gitRoot));
+	const remotes = await getGitHubRemotes(createUserSimpleGit(gitRoot));
 	const remoteName = findMatchingRemote(remotes, expectedSlug);
 	if (!remoteName) {
 		const found = [...remotes.entries()]
@@ -191,7 +193,7 @@ export async function initEmptyRepo(
 	try {
 		await gitInitMainBranch(targetPath);
 		try {
-			await simpleGit(targetPath).raw([
+			await createUserSimpleGit(targetPath).raw([
 				"commit",
 				"--allow-empty",
 				"-m",
@@ -232,11 +234,11 @@ export async function cloneTemplateInto(
 
 	try {
 		// --depth=1 since we're throwing away the template's history anyway.
-		await simpleGit().clone(templateUrl, targetPath, ["--depth=1"]);
+		await createUserSimpleGit().clone(templateUrl, targetPath, ["--depth=1"]);
 		rmSync(join(targetPath, ".git"), { recursive: true, force: true });
 
 		await gitInitMainBranch(targetPath);
-		const git = simpleGit(targetPath);
+		const git = createUserSimpleGit(targetPath);
 		await git.add(".");
 		try {
 			await git.raw(["commit", "-m", "Initial commit"]);
@@ -290,7 +292,7 @@ export async function cloneRepoInto(
 	claimEmptyTargetDir(targetPath);
 
 	try {
-		await simpleGit().clone(repoCloneUrl, targetPath);
+		await createUserSimpleGit().clone(repoCloneUrl, targetPath);
 	} catch (err) {
 		rmSync(targetPath, { recursive: true, force: true });
 		throw new TRPCError({

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/project-helpers.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/project-helpers.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import simpleGit from "simple-git";
 import { projects } from "../../../../db/schema";
+import { createUserSimpleGit } from "../../../../runtime/git/simple-git";
 import type { HostServiceContext } from "../../../../types";
 import type { ProjectNotSetupCause } from "../../../error-types";
 import { getGitHubRemotes } from "../../project/utils/git-remote";
@@ -50,7 +50,7 @@ export async function resolveGithubRepo(
 	let gitRoot: string;
 	try {
 		gitRoot = (
-			await simpleGit(local.repoPath).revparse(["--show-toplevel"])
+			await createUserSimpleGit(local.repoPath).revparse(["--show-toplevel"])
 		).trim();
 	} catch (err) {
 		throw new TRPCError({
@@ -60,7 +60,7 @@ export async function resolveGithubRepo(
 		});
 	}
 
-	const remotes = await getGitHubRemotes(simpleGit(gitRoot));
+	const remotes = await getGitHubRemotes(createUserSimpleGit(gitRoot));
 	const preferred =
 		(local.remoteName ? remotes.get(local.remoteName) : undefined) ??
 		remotes.get("origin") ??

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -112,6 +112,10 @@
 			"types": "./src/github-remote.ts",
 			"default": "./src/github-remote.ts"
 		},
+		"./simple-git-options": {
+			"types": "./src/simple-git-options.ts",
+			"default": "./src/simple-git-options.ts"
+		},
 		"./shell-ready-scanner": {
 			"types": "./src/shell-ready-scanner.ts",
 			"default": "./src/shell-ready-scanner.ts"

--- a/packages/shared/src/simple-git-options.test.ts
+++ b/packages/shared/src/simple-git-options.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+	SIMPLE_GIT_UNSAFE_OPTION_FLAGS,
+	USER_GIT_ENV_SIMPLE_GIT_OPTIONS,
+} from "./simple-git-options";
+
+const EXPECTED_SIMPLE_GIT_UNSAFE_OPTION_FLAGS = [
+	"allowUnsafeAlias",
+	"allowUnsafeAskPass",
+	"allowUnsafeConfigEnvCount",
+	"allowUnsafeConfigPaths",
+	"allowUnsafeCredentialHelper",
+	"allowUnsafeCustomBinary",
+	"allowUnsafeDiffExternal",
+	"allowUnsafeDiffTextConv",
+	"allowUnsafeEditor",
+	"allowUnsafeFilter",
+	"allowUnsafeFsMonitor",
+	"allowUnsafeGitProxy",
+	"allowUnsafeGpgProgram",
+	"allowUnsafeHooksPath",
+	"allowUnsafeMergeDriver",
+	"allowUnsafePack",
+	"allowUnsafePager",
+	"allowUnsafeProtocolOverride",
+	"allowUnsafeSshCommand",
+	"allowUnsafeTemplateDir",
+] as const;
+
+describe("simple-git unsafe options", () => {
+	test("keeps the full simple-git unsafe option list explicit", () => {
+		expect(SIMPLE_GIT_UNSAFE_OPTION_FLAGS).toEqual(
+			EXPECTED_SIMPLE_GIT_UNSAFE_OPTION_FLAGS,
+		);
+	});
+
+	test("enables every simple-git unsafe option", () => {
+		expect(Object.keys(USER_GIT_ENV_SIMPLE_GIT_OPTIONS.unsafe)).toEqual([
+			...EXPECTED_SIMPLE_GIT_UNSAFE_OPTION_FLAGS,
+		]);
+		for (const flag of EXPECTED_SIMPLE_GIT_UNSAFE_OPTION_FLAGS) {
+			expect(USER_GIT_ENV_SIMPLE_GIT_OPTIONS.unsafe[flag]).toBe(true);
+		}
+	});
+});

--- a/packages/shared/src/simple-git-options.ts
+++ b/packages/shared/src/simple-git-options.ts
@@ -1,0 +1,33 @@
+export const SIMPLE_GIT_UNSAFE_OPTION_FLAGS = [
+	"allowUnsafeAlias",
+	"allowUnsafeAskPass",
+	"allowUnsafeConfigEnvCount",
+	"allowUnsafeConfigPaths",
+	"allowUnsafeCredentialHelper",
+	"allowUnsafeCustomBinary",
+	"allowUnsafeDiffExternal",
+	"allowUnsafeDiffTextConv",
+	"allowUnsafeEditor",
+	"allowUnsafeFilter",
+	"allowUnsafeFsMonitor",
+	"allowUnsafeGitProxy",
+	"allowUnsafeGpgProgram",
+	"allowUnsafeHooksPath",
+	"allowUnsafeMergeDriver",
+	"allowUnsafePack",
+	"allowUnsafePager",
+	"allowUnsafeProtocolOverride",
+	"allowUnsafeSshCommand",
+	"allowUnsafeTemplateDir",
+] as const;
+
+export type SimpleGitUnsafeOptionFlag =
+	(typeof SIMPLE_GIT_UNSAFE_OPTION_FLAGS)[number];
+
+export const USER_GIT_ENV_SIMPLE_GIT_OPTIONS = {
+	unsafe: Object.fromEntries(
+		SIMPLE_GIT_UNSAFE_OPTION_FLAGS.map((flag) => [flag, true]),
+	),
+} as {
+	unsafe: Record<SimpleGitUnsafeOptionFlag, true>;
+};

--- a/scripts/check-simple-git-usage.sh
+++ b/scripts/check-simple-git-usage.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+failures=0
+
+report_violation() {
+	local message="$1"
+	local pattern="$2"
+	shift 2
+
+	local output
+	if output=$(rg -n -U --pcre2 "$pattern" apps packages "$@" 2>/dev/null); then
+		echo "$message"
+		echo "$output"
+		echo
+		failures=1
+	fi
+}
+
+COMMON_EXCLUDES=(
+	--glob '!**/*.test.ts'
+	--glob '!**/*.bench.ts'
+	--glob '!**/test/**'
+	--glob '!apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts'
+	--glob '!packages/host-service/src/runtime/git/simple-git.ts'
+)
+
+report_violation \
+	"[simple-git] Direct runtime imports from simple-git are forbidden. Use apps/desktop git-client.ts or packages/host-service runtime/git/simple-git.ts." \
+	"(?s)import(?!\\s+type\\b)[^;]*from\\s*['\"]simple-git['\"]" \
+	"${COMMON_EXCLUDES[@]}"
+
+report_violation \
+	"[simple-git] require(\"simple-git\") is forbidden outside tests and approved wrappers." \
+	"\\brequire\\(\\s*['\"]simple-git['\"]\\s*\\)" \
+	"${COMMON_EXCLUDES[@]}"
+
+report_violation \
+	"[simple-git] Direct simpleGit(...) construction is forbidden outside tests and approved wrappers." \
+	"\\bsimpleGit\\(" \
+	"${COMMON_EXCLUDES[@]}"
+
+if [[ "$failures" -ne 0 ]]; then
+	exit 1
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -13,5 +13,6 @@ fi
 
 ./scripts/check-desktop-git-env.sh
 ./scripts/check-git-ref-strings.sh
+bash ./scripts/check-simple-git-usage.sh
 
 exit $exit_code


### PR DESCRIPTION
Fixes #4599
Supersedes #4600

## What changed

- Replaces the shell-env `PAGER`/`GIT_PAGER` stripping workaround with a simple-git configuration that explicitly allows the user's Git environment/config hooks.
- Centralizes the simple-git unsafe allow-list in `@superset/shared/simple-git-options` so desktop and host-service use the same policy.
- Routes host-service production simple-git construction through one wrapper and adds a lint guard to prevent future direct production `simpleGit(...)` usage outside approved wrappers.
- Adds regression coverage proving default simple-git rejects the blocked env while our configured client accepts it.

## Why

The `allowUnsafeEditor` / `allowUnsafePager` failures are thrown by `simple-git@3.36.0`, not by Git itself. Superset is a local Git client, so honoring the user's local Git environment is expected. Deleting individual env vars treated one symptom and changed user Git semantics.

## Validation

- `bun test packages/shared/src/simple-git-options.test.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.test.ts packages/host-service/src/runtime/git/simple-git.test.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.test.ts`
- `bun run lint`
- `bun run typecheck` in `packages/shared`
- `bun run typecheck` in `packages/host-service`
- `bun run typecheck` in `apps/desktop`
- Mutation-checked the regression tests by temporarily removing `allowUnsafeEditor` and `allowUnsafeAlias`; both cases failed as expected before restoration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `simple-git` unsafe env errors by allowing user Git env/config and centralizing options to honor local Git behavior. Removes the `PAGER` stripping workaround and routes production Git usage through approved wrappers.

- **Bug Fixes**
  - Enable all `simple-git@3.36` unsafe flags via `@superset/shared/simple-git-options` so editor/pager/hooks work as expected.
  - Preserve `PAGER`/`GIT_PAGER` in desktop shell env.
  - Add tests covering the explicit unsafe flag list and acceptance of user env vs default rejection.

- **Refactors**
  - Add `createUserSimpleGit` wrapper (host-service) and use shared options in desktop and host-service.
  - Replace direct `simple-git` usage with wrappers in production paths.
  - Add `scripts/check-simple-git-usage.sh` and run it in `scripts/lint.sh` to forbid direct imports/constructors outside tests and approved wrappers.

<sup>Written for commit cdfe2fc895f8244fba5f21f846f763dd0faf8f88. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4602?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Git integration with centralized configuration for safer, more reliable Git operations across the application.
  * Enhanced environment variable preservation for Git-related settings (editor, pager configurations).

* **Bug Fixes**
  * Resolved issues with Git hook handling by implementing consistent Git client initialization.

* **Tests**
  * Added comprehensive test coverage for Git client configuration and environment variable handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4602)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->