### PR TITLE
[codex] add context to v2 macOS notifications

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
@@ -15,6 +15,8 @@ interface WorkspaceHostRow {
 	workspaceId: string;
 	organizationId: string;
 	hostId: string;
+	name: string;
+	branch: string;
 }
 
 interface HostNotificationSubscriberGroup {
@@ -43,6 +45,8 @@ export function V2NotificationController() {
 					workspaceId: v2Workspaces.id,
 					organizationId: v2Workspaces.organizationId,
 					hostId: v2Workspaces.hostId,
+					name: v2Workspaces.name,
+					branch: v2Workspaces.branch,
 				})),
 		[collections],
 	);
@@ -118,6 +122,10 @@ function groupWorkspacesByHostUrl({
 		const group = groups.get(hostUrl) ?? [];
 		group.push({
 			workspaceId: workspace.workspaceId,
+			workspaceName:
+				workspace.name.trim() ||
+				workspace.branch.trim() ||
+				workspace.workspaceId,
 			paneLayout: paneLayoutsByWorkspaceId.get(workspace.workspaceId) ?? null,
 		});
 		groups.set(hostUrl, group);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
@@ -123,9 +123,7 @@ function groupWorkspacesByHostUrl({
 		group.push({
 			workspaceId: workspace.workspaceId,
 			workspaceName:
-				workspace.name.trim() ||
-				workspace.branch.trim() ||
-				workspace.workspaceId,
+				workspace.name.trim() || workspace.branch.trim() || "Workspace",
 			paneLayout: paneLayoutsByWorkspaceId.get(workspace.workspaceId) ?? null,
 		});
 		groups.set(hostUrl, group);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/components/HostNotificationSubscriber/HostNotificationSubscriber.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/components/HostNotificationSubscriber/HostNotificationSubscriber.tsx
@@ -16,6 +16,7 @@ import {
 
 export interface HostNotificationWorkspaceState {
 	workspaceId: string;
+	workspaceName: string;
 	paneLayout: WorkspaceState<PaneViewerData> | null;
 }
 
@@ -53,6 +54,7 @@ export function HostNotificationSubscriber({
 			if (!workspace) return;
 			handleV2AgentLifecycleEvent({
 				workspaceId,
+				workspaceName: workspace.workspaceName,
 				payload,
 				paneLayout: workspace.paneLayout,
 				volume,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/lifecycleEvents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/lifecycleEvents.ts
@@ -4,6 +4,7 @@ import type {
 	TerminalLifecyclePayload,
 } from "@superset/workspace-client";
 import { playRingtone } from "renderer/lib/ringtones/play";
+import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useRingtoneStore } from "renderer/stores/ringtone";
@@ -12,6 +13,7 @@ import {
 	useV2NotificationStore,
 	type V2NotificationSourceInput,
 } from "renderer/stores/v2-notifications";
+import { getV2NativeNotificationContent } from "./notificationContent";
 import {
 	isV2NotificationTargetVisible,
 	resolveV2NotificationTarget,
@@ -27,12 +29,14 @@ import { resolveV2AgentStatusTransition } from "./statusTransitions";
  */
 export function handleV2AgentLifecycleEvent({
 	workspaceId,
+	workspaceName,
 	payload,
 	paneLayout,
 	volume,
 	muted,
 }: {
 	workspaceId: string;
+	workspaceName: string;
 	payload: AgentLifecyclePayload;
 	paneLayout: WorkspaceState<PaneViewerData> | null | undefined;
 	volume: number;
@@ -61,7 +65,13 @@ export function handleV2AgentLifecycleEvent({
 	const ringtoneId = useRingtoneStore.getState().selectedRingtoneId;
 	void playRingtone({ ringtoneId, volume, muted });
 
-	showNativeNotification({ payload, workspaceId, target });
+	showNativeNotification({
+		payload,
+		workspaceId,
+		workspaceName,
+		target,
+		paneLayout,
+	});
 }
 
 export function handleV2TerminalLifecycleEvent({
@@ -134,17 +144,27 @@ function shouldSuppress(
 function showNativeNotification({
 	payload,
 	workspaceId,
+	workspaceName,
 	target,
+	paneLayout,
 }: {
 	payload: AgentLifecyclePayload;
 	workspaceId: string;
+	workspaceName: string;
 	target: V2NotificationTarget;
+	paneLayout: WorkspaceState<PaneViewerData> | null | undefined;
 }): void {
-	const isPermission = payload.eventType === "PermissionRequest";
-	const title = isPermission ? "Awaiting Response" : "Agent Complete";
-	const body = isPermission
-		? "Your agent needs input"
-		: "Your agent has finished";
+	const terminalTitle =
+		terminalRuntimeRegistry
+			.getTitle(target.terminalId, target.paneId)
+			?.trim() || terminalRuntimeRegistry.getTitle(target.terminalId)?.trim();
+	const { title, body } = getV2NativeNotificationContent({
+		workspaceName,
+		payload,
+		target,
+		paneLayout,
+		terminalTitle,
+	});
 
 	void electronTrpcClient.notifications.showNative
 		.mutate({

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/lifecycleEvents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/lifecycleEvents.ts
@@ -4,7 +4,6 @@ import type {
 	TerminalLifecyclePayload,
 } from "@superset/workspace-client";
 import { playRingtone } from "renderer/lib/ringtones/play";
-import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useRingtoneStore } from "renderer/stores/ringtone";
@@ -70,7 +69,6 @@ export function handleV2AgentLifecycleEvent({
 		workspaceId,
 		workspaceName,
 		target,
-		paneLayout,
 	});
 }
 
@@ -146,24 +144,15 @@ function showNativeNotification({
 	workspaceId,
 	workspaceName,
 	target,
-	paneLayout,
 }: {
 	payload: AgentLifecyclePayload;
 	workspaceId: string;
 	workspaceName: string;
 	target: V2NotificationTarget;
-	paneLayout: WorkspaceState<PaneViewerData> | null | undefined;
 }): void {
-	const terminalTitle =
-		terminalRuntimeRegistry
-			.getTitle(target.terminalId, target.paneId)
-			?.trim() || terminalRuntimeRegistry.getTitle(target.terminalId)?.trim();
 	const { title, body } = getV2NativeNotificationContent({
 		workspaceName,
 		payload,
-		target,
-		paneLayout,
-		terminalTitle,
 	});
 
 	void electronTrpcClient.notifications.showNative

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import type { WorkspaceState } from "@superset/panes";
+import type { AgentLifecyclePayload } from "@superset/workspace-client";
+import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { getV2NativeNotificationContent } from "./notificationContent";
+
+const layout: WorkspaceState<PaneViewerData> = {
+	version: 1,
+	activeTabId: "tab-1",
+	tabs: [
+		{
+			id: "tab-1",
+			titleOverride: "Backend",
+			createdAt: 1,
+			activePaneId: "pane-1",
+			layout: { type: "pane", paneId: "pane-1" },
+			panes: {
+				"pane-1": {
+					id: "pane-1",
+					kind: "terminal",
+					titleOverride: "Test runner",
+					data: { terminalId: "terminal-1" },
+				},
+			},
+		},
+	],
+};
+
+function payload(
+	overrides: Partial<AgentLifecyclePayload>,
+): AgentLifecyclePayload {
+	return {
+		eventType: "Stop",
+		terminalId: "terminal-1",
+		occurredAt: 1,
+		...overrides,
+	};
+}
+
+describe("getV2NativeNotificationContent", () => {
+	it("includes agent, workspace, pane, and tab labels for completion", () => {
+		expect(
+			getV2NativeNotificationContent({
+				workspaceName: "Improve notifications",
+				payload: payload({
+					agent: { agentId: "codex", sessionId: "session-1" },
+				}),
+				target: {
+					workspaceId: "workspace-1",
+					tabId: "tab-1",
+					paneId: "pane-1",
+					terminalId: "terminal-1",
+				},
+				paneLayout: layout,
+			}),
+		).toEqual({
+			title: "Codex Complete - Improve notifications",
+			body: "Pane: Test runner | Tab: Backend",
+		});
+	});
+
+	it("uses needs-input copy for permission requests", () => {
+		expect(
+			getV2NativeNotificationContent({
+				workspaceName: "Improve notifications",
+				payload: payload({
+					eventType: "PermissionRequest",
+					agent: { agentId: "claude" },
+				}),
+				target: {
+					workspaceId: "workspace-1",
+					tabId: "tab-1",
+					paneId: "pane-1",
+					terminalId: "terminal-1",
+				},
+				paneLayout: layout,
+			}),
+		).toMatchObject({
+			title: "Claude Needs Input - Improve notifications",
+			body: "Pane: Test runner | Tab: Backend",
+		});
+	});
+
+	it("falls back to runtime terminal title and short terminal id", () => {
+		expect(
+			getV2NativeNotificationContent({
+				workspaceName: " ",
+				payload: payload({ agent: { agentId: "droid" } }),
+				target: {
+					workspaceId: "workspace-1",
+					terminalId: "terminal-long-id",
+				},
+				paneLayout: null,
+				terminalTitle: "deploy script",
+			}),
+		).toEqual({
+			title: "Droid Complete - Workspace",
+			body: "Pane: deploy script",
+		});
+
+		expect(
+			getV2NativeNotificationContent({
+				workspaceName: "",
+				payload: payload({ agent: undefined }),
+				target: {
+					workspaceId: "workspace-1",
+					terminalId: "terminal-long-id",
+				},
+				paneLayout: null,
+			}),
+		).toMatchObject({
+			title: "Agent Complete - Workspace",
+			body: "Pane: Terminal long-id",
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
@@ -24,7 +24,7 @@ describe("getV2NativeNotificationContent", () => {
 			}),
 		).toEqual({
 			title: "Agent Complete - Codex",
-			body: "Workspace: Improve notifications",
+			body: "Improve notifications",
 		});
 	});
 
@@ -39,7 +39,7 @@ describe("getV2NativeNotificationContent", () => {
 			}),
 		).toMatchObject({
 			title: "Agent Needs Input - Claude",
-			body: "Workspace: Improve notifications",
+			body: "Improve notifications",
 		});
 	});
 
@@ -51,7 +51,7 @@ describe("getV2NativeNotificationContent", () => {
 			}),
 		).toEqual({
 			title: "Agent Complete - Droid",
-			body: "Workspace: Workspace",
+			body: "Workspace",
 		});
 
 		expect(
@@ -61,7 +61,7 @@ describe("getV2NativeNotificationContent", () => {
 			}),
 		).toMatchObject({
 			title: "Agent Complete",
-			body: "Workspace: Workspace",
+			body: "Workspace",
 		});
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
@@ -23,12 +23,12 @@ describe("getV2NativeNotificationContent", () => {
 				}),
 			}),
 		).toEqual({
-			title: "Agent Complete - Codex",
+			title: "Codex - Complete",
 			body: "Improve notifications",
 		});
 	});
 
-	it("uses needs-input copy for permission requests", () => {
+	it("uses needs-attention copy for permission requests", () => {
 		expect(
 			getV2NativeNotificationContent({
 				workspaceName: "Improve notifications",
@@ -38,7 +38,7 @@ describe("getV2NativeNotificationContent", () => {
 				}),
 			}),
 		).toMatchObject({
-			title: "Agent Needs Input - Claude",
+			title: "Claude - Needs Attention",
 			body: "Improve notifications",
 		});
 	});
@@ -50,7 +50,7 @@ describe("getV2NativeNotificationContent", () => {
 				payload: payload({ agent: { agentId: "droid" } }),
 			}),
 		).toEqual({
-			title: "Agent Complete - Droid",
+			title: "Droid - Complete",
 			body: "Workspace",
 		});
 
@@ -60,7 +60,7 @@ describe("getV2NativeNotificationContent", () => {
 				payload: payload({ agent: undefined }),
 			}),
 		).toMatchObject({
-			title: "Agent Complete",
+			title: "Agent - Complete",
 			body: "Workspace",
 		});
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
@@ -1,30 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import type { WorkspaceState } from "@superset/panes";
 import type { AgentLifecyclePayload } from "@superset/workspace-client";
-import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { getV2NativeNotificationContent } from "./notificationContent";
-
-const layout: WorkspaceState<PaneViewerData> = {
-	version: 1,
-	activeTabId: "tab-1",
-	tabs: [
-		{
-			id: "tab-1",
-			titleOverride: "Backend",
-			createdAt: 1,
-			activePaneId: "pane-1",
-			layout: { type: "pane", paneId: "pane-1" },
-			panes: {
-				"pane-1": {
-					id: "pane-1",
-					kind: "terminal",
-					titleOverride: "Test runner",
-					data: { terminalId: "terminal-1" },
-				},
-			},
-		},
-	],
-};
 
 function payload(
 	overrides: Partial<AgentLifecyclePayload>,
@@ -38,24 +14,17 @@ function payload(
 }
 
 describe("getV2NativeNotificationContent", () => {
-	it("includes agent, workspace, pane, and tab labels for completion", () => {
+	it("uses the agent label in the title and workspace label in the body", () => {
 		expect(
 			getV2NativeNotificationContent({
 				workspaceName: "Improve notifications",
 				payload: payload({
 					agent: { agentId: "codex", sessionId: "session-1" },
 				}),
-				target: {
-					workspaceId: "workspace-1",
-					tabId: "tab-1",
-					paneId: "pane-1",
-					terminalId: "terminal-1",
-				},
-				paneLayout: layout,
 			}),
 		).toEqual({
 			title: "Agent Complete - Codex",
-			body: "Workspace: Improve notifications | Pane: Test runner | Tab: Backend",
+			body: "Workspace: Improve notifications",
 		});
 	});
 
@@ -67,50 +36,32 @@ describe("getV2NativeNotificationContent", () => {
 					eventType: "PermissionRequest",
 					agent: { agentId: "claude" },
 				}),
-				target: {
-					workspaceId: "workspace-1",
-					tabId: "tab-1",
-					paneId: "pane-1",
-					terminalId: "terminal-1",
-				},
-				paneLayout: layout,
 			}),
 		).toMatchObject({
 			title: "Agent Needs Input - Claude",
-			body: "Workspace: Improve notifications | Pane: Test runner | Tab: Backend",
+			body: "Workspace: Improve notifications",
 		});
 	});
 
-	it("falls back to runtime terminal title and short terminal id", () => {
+	it("falls back to generic labels", () => {
 		expect(
 			getV2NativeNotificationContent({
 				workspaceName: " ",
 				payload: payload({ agent: { agentId: "droid" } }),
-				target: {
-					workspaceId: "workspace-1",
-					terminalId: "terminal-long-id",
-				},
-				paneLayout: null,
-				terminalTitle: "deploy script",
 			}),
 		).toEqual({
 			title: "Agent Complete - Droid",
-			body: "Workspace: Workspace | Pane: deploy script",
+			body: "Workspace: Workspace",
 		});
 
 		expect(
 			getV2NativeNotificationContent({
 				workspaceName: "",
 				payload: payload({ agent: undefined }),
-				target: {
-					workspaceId: "workspace-1",
-					terminalId: "terminal-long-id",
-				},
-				paneLayout: null,
 			}),
 		).toMatchObject({
 			title: "Agent Complete",
-			body: "Workspace: Workspace | Pane: Terminal long-id",
+			body: "Workspace: Workspace",
 		});
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
@@ -54,8 +54,8 @@ describe("getV2NativeNotificationContent", () => {
 				paneLayout: layout,
 			}),
 		).toEqual({
-			title: "Codex Complete - Improve notifications",
-			body: "Pane: Test runner | Tab: Backend",
+			title: "Agent Complete - Codex",
+			body: "Workspace: Improve notifications | Pane: Test runner | Tab: Backend",
 		});
 	});
 
@@ -76,8 +76,8 @@ describe("getV2NativeNotificationContent", () => {
 				paneLayout: layout,
 			}),
 		).toMatchObject({
-			title: "Claude Needs Input - Improve notifications",
-			body: "Pane: Test runner | Tab: Backend",
+			title: "Agent Needs Input - Claude",
+			body: "Workspace: Improve notifications | Pane: Test runner | Tab: Backend",
 		});
 	});
 
@@ -94,8 +94,8 @@ describe("getV2NativeNotificationContent", () => {
 				terminalTitle: "deploy script",
 			}),
 		).toEqual({
-			title: "Droid Complete - Workspace",
-			body: "Pane: deploy script",
+			title: "Agent Complete - Droid",
+			body: "Workspace: Workspace | Pane: deploy script",
 		});
 
 		expect(
@@ -109,8 +109,8 @@ describe("getV2NativeNotificationContent", () => {
 				paneLayout: null,
 			}),
 		).toMatchObject({
-			title: "Agent Complete - Workspace",
-			body: "Pane: Terminal long-id",
+			title: "Agent Complete",
+			body: "Workspace: Workspace | Pane: Terminal long-id",
 		});
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -1,0 +1,136 @@
+import type { Pane, Tab, WorkspaceState } from "@superset/panes";
+import {
+	BUILTIN_AGENT_LABELS,
+	type BuiltinAgentId,
+} from "@superset/shared/agent-catalog";
+import type {
+	AgentIdentity,
+	AgentLifecyclePayload,
+} from "@superset/workspace-client";
+import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import type { V2NotificationTarget } from "./resolveV2NotificationTarget";
+
+interface V2NativeNotificationContentOptions {
+	workspaceName: string;
+	payload: AgentLifecyclePayload;
+	target: V2NotificationTarget;
+	paneLayout: WorkspaceState<PaneViewerData> | null | undefined;
+	terminalTitle?: string | null;
+}
+
+interface ResolvedPaneLocation {
+	tab?: Tab<PaneViewerData>;
+	pane?: Pane<PaneViewerData>;
+}
+
+const PANE_KIND_LABELS: Record<string, string> = {
+	browser: "Browser",
+	chat: "Chat",
+	comment: "Comment",
+	devtools: "DevTools",
+	diff: "Changes",
+	file: "File",
+	terminal: "Terminal",
+};
+
+export function getV2NativeNotificationContent({
+	workspaceName,
+	payload,
+	target,
+	paneLayout,
+	terminalTitle,
+}: V2NativeNotificationContentOptions): { title: string; body: string } {
+	const agentLabel = getAgentLabel(payload.agent);
+	const action =
+		payload.eventType === "PermissionRequest" ? "Needs Input" : "Complete";
+	const workspaceLabel = cleanLabel(workspaceName) ?? "Workspace";
+	const location = resolvePaneLocation({ paneLayout, target });
+	const paneLabel = getPaneLabel({
+		pane: location.pane,
+		target,
+		terminalTitle,
+	});
+	const tabLabel = getTabLabel(location.tab, paneLayout);
+	const bodyParts = [
+		`Pane: ${paneLabel}`,
+		tabLabel ? `Tab: ${tabLabel}` : null,
+	].filter((part): part is string => Boolean(part));
+
+	return {
+		title: `${agentLabel} ${action} - ${workspaceLabel}`,
+		body: bodyParts.join(" | "),
+	};
+}
+
+function getAgentLabel(agent: AgentIdentity | undefined): string {
+	const agentId = cleanLabel(agent?.agentId);
+	if (!agentId) return "Agent";
+	if (agentId in BUILTIN_AGENT_LABELS) {
+		return BUILTIN_AGENT_LABELS[agentId as BuiltinAgentId];
+	}
+	return humanizeIdentifier(agentId);
+}
+
+function resolvePaneLocation({
+	paneLayout,
+	target,
+}: {
+	paneLayout: WorkspaceState<PaneViewerData> | null | undefined;
+	target: V2NotificationTarget;
+}): ResolvedPaneLocation {
+	const tab = target.tabId
+		? paneLayout?.tabs.find((candidate) => candidate.id === target.tabId)
+		: undefined;
+	const pane = target.paneId ? tab?.panes[target.paneId] : undefined;
+	return { tab, pane };
+}
+
+function getPaneLabel({
+	pane,
+	target,
+	terminalTitle,
+}: {
+	pane: Pane<PaneViewerData> | undefined;
+	target: V2NotificationTarget;
+	terminalTitle?: string | null;
+}): string {
+	return (
+		cleanLabel(pane?.titleOverride) ??
+		cleanLabel(terminalTitle) ??
+		(pane ? PANE_KIND_LABELS[pane.kind] : undefined) ??
+		`Terminal ${shortId(target.terminalId)}`
+	);
+}
+
+function getTabLabel(
+	tab: Tab<PaneViewerData> | undefined,
+	paneLayout: WorkspaceState<PaneViewerData> | null | undefined,
+): string | null {
+	if (!tab) return null;
+	const explicitTitle = cleanLabel(tab.titleOverride);
+	if (explicitTitle) return explicitTitle;
+	const index = paneLayout?.tabs.indexOf(tab);
+	return typeof index === "number" && index >= 0 ? `Tab ${index + 1}` : null;
+}
+
+function cleanLabel(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function humanizeIdentifier(value: string): string {
+	const words = value
+		.replace(/^custom:/, "")
+		.split(/[-_:\s]+/)
+		.filter(Boolean);
+	if (words.length === 0) return "Agent";
+	return words
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+}
+
+function shortId(value: string): string {
+	const withoutTerminalPrefix = value.replace(/^terminal[-_:]?/i, "");
+	const candidate = withoutTerminalPrefix || value;
+	return candidate.length > 8 ? candidate.slice(0, 8) : candidate;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -26,7 +26,7 @@ export function getV2NativeNotificationContent({
 			agentLabel === "Agent"
 				? `Agent ${action}`
 				: `Agent ${action} - ${agentLabel}`,
-		body: `Workspace: ${workspaceLabel}`,
+		body: workspaceLabel,
 	};
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -1,4 +1,3 @@
-import type { Pane, Tab, WorkspaceState } from "@superset/panes";
 import {
 	BUILTIN_AGENT_LABELS,
 	type BuiltinAgentId,
@@ -7,62 +6,27 @@ import type {
 	AgentIdentity,
 	AgentLifecyclePayload,
 } from "@superset/workspace-client";
-import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
-import type { V2NotificationTarget } from "./resolveV2NotificationTarget";
 
 interface V2NativeNotificationContentOptions {
 	workspaceName: string;
 	payload: AgentLifecyclePayload;
-	target: V2NotificationTarget;
-	paneLayout: WorkspaceState<PaneViewerData> | null | undefined;
-	terminalTitle?: string | null;
 }
-
-interface ResolvedPaneLocation {
-	tab?: Tab<PaneViewerData>;
-	pane?: Pane<PaneViewerData>;
-}
-
-const PANE_KIND_LABELS: Record<string, string> = {
-	browser: "Browser",
-	chat: "Chat",
-	comment: "Comment",
-	devtools: "DevTools",
-	diff: "Changes",
-	file: "File",
-	terminal: "Terminal",
-};
 
 export function getV2NativeNotificationContent({
 	workspaceName,
 	payload,
-	target,
-	paneLayout,
-	terminalTitle,
 }: V2NativeNotificationContentOptions): { title: string; body: string } {
 	const agentLabel = getAgentLabel(payload.agent);
 	const action =
 		payload.eventType === "PermissionRequest" ? "Needs Input" : "Complete";
 	const workspaceLabel = cleanLabel(workspaceName) ?? "Workspace";
-	const location = resolvePaneLocation({ paneLayout, target });
-	const paneLabel = getPaneLabel({
-		pane: location.pane,
-		target,
-		terminalTitle,
-	});
-	const tabLabel = getTabLabel(location.tab, paneLayout);
-	const bodyParts = [
-		`Workspace: ${workspaceLabel}`,
-		`Pane: ${paneLabel}`,
-		tabLabel ? `Tab: ${tabLabel}` : null,
-	].filter((part): part is string => Boolean(part));
 
 	return {
 		title:
 			agentLabel === "Agent"
 				? `Agent ${action}`
 				: `Agent ${action} - ${agentLabel}`,
-		body: bodyParts.join(" | "),
+		body: `Workspace: ${workspaceLabel}`,
 	};
 }
 
@@ -73,48 +37,6 @@ function getAgentLabel(agent: AgentIdentity | undefined): string {
 		return BUILTIN_AGENT_LABELS[agentId as BuiltinAgentId];
 	}
 	return humanizeIdentifier(agentId);
-}
-
-function resolvePaneLocation({
-	paneLayout,
-	target,
-}: {
-	paneLayout: WorkspaceState<PaneViewerData> | null | undefined;
-	target: V2NotificationTarget;
-}): ResolvedPaneLocation {
-	const tab = target.tabId
-		? paneLayout?.tabs.find((candidate) => candidate.id === target.tabId)
-		: undefined;
-	const pane = target.paneId ? tab?.panes[target.paneId] : undefined;
-	return { tab, pane };
-}
-
-function getPaneLabel({
-	pane,
-	target,
-	terminalTitle,
-}: {
-	pane: Pane<PaneViewerData> | undefined;
-	target: V2NotificationTarget;
-	terminalTitle?: string | null;
-}): string {
-	return (
-		cleanLabel(pane?.titleOverride) ??
-		cleanLabel(terminalTitle) ??
-		(pane ? PANE_KIND_LABELS[pane.kind] : undefined) ??
-		`Terminal ${shortId(target.terminalId)}`
-	);
-}
-
-function getTabLabel(
-	tab: Tab<PaneViewerData> | undefined,
-	paneLayout: WorkspaceState<PaneViewerData> | null | undefined,
-): string | null {
-	if (!tab) return null;
-	const explicitTitle = cleanLabel(tab.titleOverride);
-	if (explicitTitle) return explicitTitle;
-	const index = paneLayout?.tabs.indexOf(tab);
-	return typeof index === "number" && index >= 0 ? `Tab ${index + 1}` : null;
 }
 
 function cleanLabel(value: string | null | undefined): string | null {
@@ -131,10 +53,4 @@ function humanizeIdentifier(value: string): string {
 	return words
 		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 		.join(" ");
-}
-
-function shortId(value: string): string {
-	const withoutTerminalPrefix = value.replace(/^terminal[-_:]?/i, "");
-	const candidate = withoutTerminalPrefix || value;
-	return candidate.length > 8 ? candidate.slice(0, 8) : candidate;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -18,14 +18,11 @@ export function getV2NativeNotificationContent({
 }: V2NativeNotificationContentOptions): { title: string; body: string } {
 	const agentLabel = getAgentLabel(payload.agent);
 	const action =
-		payload.eventType === "PermissionRequest" ? "Needs Input" : "Complete";
+		payload.eventType === "PermissionRequest" ? "Needs Attention" : "Complete";
 	const workspaceLabel = cleanLabel(workspaceName) ?? "Workspace";
 
 	return {
-		title:
-			agentLabel === "Agent"
-				? `Agent ${action}`
-				: `Agent ${action} - ${agentLabel}`,
+		title: `${agentLabel} - ${action}`,
 		body: workspaceLabel,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -52,12 +52,16 @@ export function getV2NativeNotificationContent({
 	});
 	const tabLabel = getTabLabel(location.tab, paneLayout);
 	const bodyParts = [
+		`Workspace: ${workspaceLabel}`,
 		`Pane: ${paneLabel}`,
 		tabLabel ? `Tab: ${tabLabel}` : null,
 	].filter((part): part is string => Boolean(part));
 
 	return {
-		title: `${agentLabel} ${action} - ${workspaceLabel}`,
+		title:
+			agentLabel === "Agent"
+				? `Agent ${action}`
+				: `Agent ${action} - ${agentLabel}`,
 		body: bodyParts.join(" | "),
 	};
 }


### PR DESCRIPTION
## Summary

Adds richer native macOS notification content for v2 workspace agent lifecycle events. Instead of generic `Agent Complete` / `Your agent has finished` copy, notifications now include the agent label, workspace name, pane label, and tab label when available.

## Why

The v2 notification pipeline already receives agent identity and can resolve workspace/pane layout context, but the native notification copy only used generic text. That made it hard to tell which agent, pane, or workspace finished when multiple agents were running.

## Changes

- Threads workspace display names into the v2 host notification subscriber.
- Adds a focused notification content formatter for agent, workspace, pane, tab, terminal title, and fallback labels.
- Uses the formatter when showing native notifications from v2 lifecycle events.
- Adds unit coverage for completion, permission request, and fallback notification content.

## Validation

- `bun test apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/resolveV2NotificationTarget.test.ts apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/statusTransitions.test.ts`
- `bun run lint`
- `bun run --cwd apps/desktop typecheck`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4614">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches v2 macOS notifications to agent‑first titles and a simpler body. Titles are “{Agent} - Complete/Needs Attention”; the body shows only the workspace name.

- **New Features**
  - Title format: “{Agent} - Complete” or “Needs Attention” for permission requests.
  - Body: “{WorkspaceName}” (trimmed; falls back to `name` → `branch` → “Workspace”).
  - Agent labels resolve via `@superset/shared/agent-catalog` or humanized ids; threaded `workspaceName` through and added unit tests.

<sup>Written for commit d20323939873af96cf75333fdced90ce92360695. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4614?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now display a cleaned workspace name (trimmed, falling back to branch or generic "Workspace") and use concise native notification titles combining agent label + action.
* **Bug Fixes**
  * Removed noisy/ambiguous label content and simplified title selection for clearer notifications.
* **Tests**
  * Added tests for notification title/body generation, permission-request wording, and fallback labeling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->