### PR TITLE
[codex] Fix changes pane scroll to file headers

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -37,12 +37,15 @@ function ScrollToFile({
 			const scrollContainer = v.getScrollContainerElement();
 			if (!scrollContainer) return;
 
-			const target = scrollContainer.querySelector(
+			const entry = scrollContainer.querySelector(
 				`[data-diff-path="${CSS.escape(path)}"]`,
-			);
-			if (!target) return;
+			) as HTMLElement | null;
+			const header = scrollContainer.querySelector(
+				`[data-diff-entry-header-path="${CSS.escape(path)}"]`,
+			) as HTMLElement | null;
+			if (!entry || !header) return;
 
-			const offset = v.getOffsetInScrollContainer(target as HTMLElement);
+			const offset = v.getOffsetInScrollContainer(header);
 			scrollContainer.scrollTo({ top: offset });
 			lastScrolledPath.current = path;
 			if (focusTick != null) lastFocusTick.current = focusTick;
@@ -54,7 +57,7 @@ function ScrollToFile({
 				// few frames so the annotation slot has time to render.
 				let attempts = 0;
 				const tryScroll = () => {
-					const lineEl = findLineElement(target as HTMLElement, focusLine);
+					const lineEl = findLineElement(entry, focusLine);
 					if (lineEl) {
 						lineEl.scrollIntoView({ block: "center" });
 						return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
@@ -184,6 +184,23 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 	}
 
 	const shouldMount = reason ? showFullDiff : hasBeenNearRef.current;
+	const header = (
+		<DiffFileHeader
+			path={file.path}
+			status={file.status}
+			additions={file.additions}
+			deletions={file.deletions}
+			expandUnchanged={expandUnchanged}
+			onToggleExpandUnchanged={handleToggleExpandUnchanged}
+			collapsed={collapsed}
+			onToggleCollapsed={handleToggleCollapsed}
+			viewed={viewed}
+			onToggleViewed={handleToggleViewed}
+			onOpenFile={handleOpenFile}
+			onOpenInExternalEditor={handleOpenInExternalEditor}
+			onDiscard={requestDiscard}
+		/>
+	);
 
 	return (
 		<div
@@ -193,24 +210,15 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 				minHeight: collapsed ? COLLAPSED_HEIGHT_PX : expandedHeight(file),
 			}}
 		>
+			{header}
 			{shouldMount ? (
 				<WorkspaceDiff
 					workspaceId={workspaceId}
 					path={file.path}
-					status={file.status}
 					source={file.source}
-					additions={file.additions}
-					deletions={file.deletions}
 					diffStyle={diffStyle}
 					expandUnchanged={expandUnchanged}
-					onToggleExpandUnchanged={handleToggleExpandUnchanged}
 					collapsed={collapsed}
-					onToggleCollapsed={handleToggleCollapsed}
-					viewed={viewed}
-					onToggleViewed={handleToggleViewed}
-					onOpenFile={handleOpenFile}
-					onOpenInExternalEditor={handleOpenInExternalEditor}
-					onDiscard={requestDiscard}
 					focusLine={focusLine}
 					focusTick={focusTick}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -52,7 +52,10 @@ export function DiffFileHeader({
 	const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
 
 	return (
-		<div className="group/diff-file-header @container/diff-file-header sticky top-0 z-10 flex min-w-0 flex-nowrap items-center gap-1 bg-card px-3 py-2">
+		<div
+			data-diff-entry-header-path={path}
+			className="group/diff-file-header @container/diff-file-header sticky top-0 z-10 flex min-w-0 flex-nowrap items-center gap-1 bg-card px-3 py-2"
+		>
 			<button
 				type="button"
 				onClick={onToggleCollapsed}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -10,7 +10,6 @@ import {
 import { useResolvedTheme, useTerminalTheme } from "renderer/stores/theme";
 import type { DiffFileSource } from "../../../../../useChangeset";
 import { CommentThread } from "../CommentThread";
-import { DiffFileHeader } from "../DiffFileHeader";
 import {
 	type DiffCommentThread,
 	useDiffAnnotations,
@@ -19,20 +18,10 @@ import {
 interface WorkspaceDiffProps {
 	workspaceId: string;
 	path: string;
-	status: string;
 	source: DiffFileSource;
-	additions: number;
-	deletions: number;
 	diffStyle: "split" | "unified";
 	expandUnchanged: boolean;
-	onToggleExpandUnchanged: () => void;
 	collapsed: boolean;
-	onToggleCollapsed: () => void;
-	viewed: boolean;
-	onToggleViewed: () => void;
-	onOpenFile?: (openInNewTab?: boolean) => void;
-	onOpenInExternalEditor?: () => void;
-	onDiscard?: () => void;
 	focusLine?: number;
 	focusTick?: number;
 }
@@ -40,20 +29,10 @@ interface WorkspaceDiffProps {
 export const WorkspaceDiff = memo(function WorkspaceDiff({
 	workspaceId,
 	path,
-	status,
 	source,
-	additions,
-	deletions,
 	diffStyle,
 	expandUnchanged,
-	onToggleExpandUnchanged,
 	collapsed,
-	onToggleCollapsed,
-	viewed,
-	onToggleViewed,
-	onOpenFile,
-	onOpenInExternalEditor,
-	onDiscard,
 	focusLine,
 	focusTick,
 }: WorkspaceDiffProps) {
@@ -132,21 +111,6 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 
 	return (
 		<div className="flex flex-col">
-			<DiffFileHeader
-				path={path}
-				status={status}
-				additions={additions}
-				deletions={deletions}
-				expandUnchanged={expandUnchanged}
-				onToggleExpandUnchanged={onToggleExpandUnchanged}
-				collapsed={collapsed}
-				onToggleCollapsed={onToggleCollapsed}
-				viewed={viewed}
-				onToggleViewed={onToggleViewed}
-				onOpenFile={onOpenFile}
-				onOpenInExternalEditor={onOpenInExternalEditor}
-				onDiscard={onDiscard}
-			/>
 			{diffQuery.data ? (
 				<MultiFileDiff<DiffCommentThread>
 					oldFile={diffQuery.data.oldFile}


### PR DESCRIPTION
## Summary
- Scroll changes-pane file jumps to the diff entry header anchor instead of the whole entry wrapper.
- Keep the file header rendered by `DiffFileEntry` even before the lazy diff body mounts.
- Simplify `WorkspaceDiff` so it only owns the diff body and comment annotations.

## Root Cause
The changes pane click path selected the file entry wrapper as the scroll target. When comment annotations or lazy-mounted diff content changed the entry layout, the jump could land relative to the comment/body area instead of consistently landing on the file entry header.

## Impact
Clicking a file in the changes pane now consistently lands at that file's header. Comment-focused jumps still use the entry root for line lookup after the header jump.

## Validation
- `bunx biome check` on the touched diff-pane files
- `bun run --cwd apps/desktop typecheck`
- `bun run lint:fix`
- `bun run lint`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4615">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scroll jumps from the changes pane now land on each file’s header for stable positioning, even when diff content or comments mount later. The file header always renders; `WorkspaceDiff` now only renders the diff body and annotations.

- **Bug Fixes**
  - Use the header element (`[data-diff-entry-header-path]`) as the scroll target instead of the entry wrapper.
  - After snapping to the header, focus-on-line still centers the target line to keep comment jumps working.

- **Refactors**
  - Render `DiffFileHeader` unconditionally in `DiffFileEntry`; lazy‑mount only the diff body.
  - Remove header-related props and rendering from `WorkspaceDiff`.

<sup>Written for commit 4bdc0ed8566414e094a04df7564ac933e867dea7. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4615?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll-to-file behavior and line-focusing alignment in the diff viewer to correctly target the appropriate DOM elements within virtualized diffs.

* **Refactor**
  * Restructured the diff display architecture to improve separation of concerns between headers and content rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->