### PR TITLE
fix(cli): unbreak superset start and superset update on Linux

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -97,6 +97,16 @@ jobs:
               console.log(m, "OK");
             }
           '
+          # @mastra/duckdb ships unbundled and is imported as ESM by
+          # host-service.js, which loads @mastra/core (a peer dep) from disk.
+          # ESM ignores NODE_PATH, so resolution is by directory walk — run
+          # the check from a script inside lib/ to mirror host-service.js.
+          cat > "$DIST/lib/_smoke.mjs" <<'EOF'
+          await import("@mastra/duckdb");
+          console.log("@mastra/duckdb OK");
+          EOF
+          "$DIST/lib/node" "$DIST/lib/_smoke.mjs"
+          rm "$DIST/lib/_smoke.mjs"
           # Actually spawn a PTY against the bundled Node + bundled prebuild.
           # Catches the runtime failures `require()` can't see — spawn-helper
           # exec bit, pty.node ABI mismatch, arch mismatch, etc. Asserts

--- a/packages/cli/scripts/build-dist-linux-docker.sh
+++ b/packages/cli/scripts/build-dist-linux-docker.sh
@@ -77,6 +77,16 @@ docker run --rm --platform "$PLATFORM" \
         console.log(m, \"OK\");
       }
     "
+    # @mastra/duckdb ships unbundled and is imported as ESM by host-service.js,
+    # which loads @mastra/core (a peer dep) from disk. ESM ignores NODE_PATH, so
+    # resolution is by directory walk — run the check from a script inside lib/
+    # to mirror host-service.js exactly.
+    cat > "$DIST/lib/_smoke.mjs" <<EOF
+await import("@mastra/duckdb");
+console.log("@mastra/duckdb OK");
+EOF
+    "$DIST/lib/node" "$DIST/lib/_smoke.mjs"
+    rm "$DIST/lib/_smoke.mjs"
     NODE_PATH="$DIST/lib/node_modules" DIST="$DIST" "$DIST/lib/node" -e "
       const resolved = require.resolve(\"node-pty/lib/unixTerminal\");
       if (!resolved.startsWith(process.env.DIST)) {

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -251,28 +251,42 @@ function copyPackageWithDeps(
 	repoRoot: string,
 	destModules: string,
 	copied: Set<string>,
+	optional = false,
 ): void {
 	if (copied.has(packageName)) return;
-	copied.add(packageName);
 
 	const sourcePath = findPackagePath(packageName, startDir, repoRoot);
 	if (!sourcePath) {
+		if (optional) {
+			console.warn(
+				`[build-dist]   skipping peer dep not installed: ${packageName}`,
+			);
+			return;
+		}
 		throw new Error(
 			`Package not found: ${packageName}. Run 'bun install' first.`,
 		);
 	}
+	copied.add(packageName);
 
 	const destPath = join(destModules, packageName);
 	mkdirSync(dirname(destPath), { recursive: true });
 	cpSync(sourcePath, destPath, { recursive: true, dereference: true });
 
-	// Recursively copy runtime dependencies
 	const packageJsonPath = join(sourcePath, "package.json");
 	if (existsSync(packageJsonPath)) {
 		const pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-		const deps = Object.keys(pkg.dependencies ?? {});
-		for (const dep of deps) {
+		for (const dep of Object.keys(pkg.dependencies ?? {})) {
 			copyPackageWithDeps(dep, sourcePath, repoRoot, destModules, copied);
+		}
+		// Packages we ship unbundled (e.g. @mastra/duckdb) load their peer
+		// deps from disk at module init — a bundled consumer's inlined copy
+		// is invisible to them. Walk non-optional peers best-effort: one the
+		// installer didn't materialize is skipped rather than failing the build.
+		const peerMeta = pkg.peerDependenciesMeta ?? {};
+		for (const dep of Object.keys(pkg.peerDependencies ?? {})) {
+			if (peerMeta[dep]?.optional) continue;
+			copyPackageWithDeps(dep, sourcePath, repoRoot, destModules, copied, true);
 		}
 	}
 }

--- a/packages/cli/src/commands/update/command.ts
+++ b/packages/cli/src/commands/update/command.ts
@@ -9,7 +9,6 @@ import {
 	rmSync,
 	statSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -186,7 +185,10 @@ export default command({
 		}
 
 		const installRoot = resolveInstallRoot();
-		const tempDir = mkdtempSync(join(tmpdir(), "superset-update-"));
+		// Stage as a sibling of the install root so the final renameSync()
+		// is an intra-filesystem move. tmpdir() is frequently a separate
+		// mount (tmpfs on Linux) — renaming across it fails with EXDEV.
+		const tempDir = mkdtempSync(`${installRoot}.update-`);
 
 		try {
 			await downloadAndExtract(tarballUrl(target, pinnedVersion), tempDir);


### PR DESCRIPTION
## Summary
- **`superset start`** — ship `@mastra/core` (peer dependency of the unbundled `@mastra/duckdb`) into the CLI bundle; fresh installs were crashing at host-service boot with `ERR_MODULE_NOT_FOUND`.
- **`superset update`** — stage the download on the install filesystem so the final `rename` doesn't fail with `EXDEV` when `/tmp` is a separate mount (the common Linux case).
- Harden the Linux build smoke tests to actually exercise `@mastra/duckdb`, so this class of bug can't ship undetected again.

## Why / Context
Two regressions made the standalone CLI unusable on Linux after the recent CLI port.

**`superset start` crash.** `@mastra/duckdb` ships unbundled (its native bindings can't be inlined into `host-service.js`) and declares `@mastra/core` as a `peerDependency`. `build-dist.ts`'s `copyPackageWithDeps` only walked `dependencies`, so `@mastra/core` and its transitive closure never landed in `lib/node_modules`. Every fresh install crashed on the first `superset start`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@mastra/core'
  imported from .../lib/node_modules/@mastra/duckdb/dist/index.js
```

**`superset update` crash.** The updater staged the new release via `mkdtempSync(tmpdir())` then `renameSync()`'d it onto the install root. On Linux `/tmp` is typically a separate mount (tmpfs), so the cross-filesystem rename failed:

```
Error: EXDEV: cross-device link not permitted, rename '/tmp/superset-update-XXX' -> '/home/user/superset'
```

## How It Works
- **`build-dist.ts`** — `copyPackageWithDeps` now also walks non-optional `peerDependencies`, recursively. A package shipped unbundled must have its peers resolvable from disk at runtime (a bundled consumer's inlined copy is invisible to it). Peers the installer didn't materialize are skipped best-effort; `dependencies` stay fatal-if-missing.
- **`update/command.ts`** — the staging temp dir is created as a sibling of the install root (`mkdtempSync(\`${installRoot}.update-\`)`) instead of in `tmpdir()`, so the final `renameSync` is always an intra-filesystem move.
- **Smoke tests** (`build-dist-linux-docker.sh` + `build-cli.yml`) — after building, they now `import("@mastra/duckdb")` as ESM from a script placed inside `lib/`, mirroring how `host-service.js` resolves it. The previous smoke test only `require()`'d four native packages and never touched the host-service runtime imports — which is exactly why bug 1 shipped.

## Manual QA Checklist
- [x] Docker `linux-x64` build passes the hardened smoke test (`@mastra/duckdb OK`)
- [x] Docker `linux-arm64` build passes the hardened smoke test
- [x] `superset update` EXDEV — reproduced the old failure with the published `0.2.17` binary under a separate-device `/tmp`, confirmed the patched binary succeeds
- [x] Fixed build's host service boots end-to-end on a real Linux host (Fly machine) — `listening` + `health.check` OK
- [x] A real mastra chat conversation works against the fixed build's host service

## Testing
- `bun run typecheck`
- `bun run lint`
- Docker builds for both Linux targets via `packages/cli/scripts/build-dist-linux-docker.sh` (mirrors CI)

## Known Limitations
- Separate, pre-existing issue (not addressed here): the host service holds a static auth token, so the relay tunnel can't re-authenticate once it expires. A ticket is being drafted for that.
- The `@mastra/core` fix overlaps with commit `056771967` on `feat-relay-graceful-drain` (a simpler `NATIVE_PACKAGES` one-liner); whichever lands second should drop the duplicate. The peer-dependency walk here is the more general fix.

## Risks / Rollout
- Risk: low — build-script + CLI-command changes only; no schema or API surface. The peer-dep walk only *adds* packages to the bundle (the tarball grows because `@mastra/core`'s tree now ships, as required).
- Rollback: revert the two commits; the next CLI release returns to the prior `build-dist.ts` / `update` behavior.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4635">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux failures in superset start and superset update. Bundles the missing `@mastra/core` peer for `@mastra/duckdb` and stages updates on the install filesystem to avoid EXDEV errors.

- **Bug Fixes**
  - Bundle non-optional peerDependencies for unbundled packages; ensures `@mastra/core` is present for `@mastra/duckdb` (prevents ERR_MODULE_NOT_FOUND on fresh installs).
  - Stage downloads as a sibling of the install root and rename in-place; avoids cross-device rename (EXDEV) when `/tmp` is a separate mount.

- **Tests**
  - Hardened Linux smoke test to import `@mastra/duckdb` as ESM from inside `lib/`, mirroring host-service resolution.

<sup>Written for commit 35cfe5fedfcc48f932a8fb7748d4febd1441c979. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4635?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved update process stability by optimizing temporary directory placement to prevent cross-filesystem operation failures.

* **Chores**
  * Upgraded build system to gracefully handle optional peer dependencies.
  * Enhanced smoke tests to verify DuckDB compatibility across different module resolution scenarios in CI and Docker builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->