### PR TITLE
chore(cli): bump version to 0.2.18

### DIFF
--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.17";
+const VERSION = "0.2.18";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bump `@superset/cli` to `0.2.18` (`cli.config.ts` `VERSION` + `package.json`) to cut the next stable CLI release.

## Why / Context
The published `cli-latest` (`0.2.17`) is broken on Linux — `superset start` crashes on a missing `@mastra/core`, and `superset update` fails with `EXDEV`. The fixes are in **#4635**.

Re-releasing under `0.2.17` would not reach affected users: `superset update` short-circuits when `current === target`, so anyone stuck on the broken `0.2.17` would just see "already up to date." The version must bump for the fix to propagate.

## ⚠️ Merge ordering
This PR only bumps the version — it does **not** contain the fixes. Before tagging `cli-v0.2.18`:

1. Merge **#4635** (the actual Linux bundle fixes) into `main`.
2. Merge this PR.
3. Push tag `cli-v0.2.18` → `release-cli.yml` builds all 3 targets and repoints `cli-latest`.

If `cli-v0.2.18` is tagged before #4635 lands, the release ships `0.2.18` **without** the fixes.

## Testing
- Trivial version-string change; no behavior change. CI covers build.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4637">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@superset/cli` to 0.2.18 to ship the Linux fixes (missing `@mastra/core`; `EXDEV` on `superset update`). This PR only updates the version so affected users can receive the fix.

- **Migration**
  - Merge #4635 into `main`.
  - Merge this PR.
  - Tag `cli-v0.2.18` to build all targets and repoint `cli-latest`. Do not tag before #4635 lands.

<sup>Written for commit df4e81c68ec28f8e0473a4bf30ee484192b3ce44. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4637?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI version from 0.2.17 to 0.2.18

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->