### PR TITLE
chore(cli): bump version to 0.2.19

### DIFF
--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.18";
+const VERSION = "0.2.19";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.18",
+	"version": "0.2.19",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Bumps `@superset/cli` to 0.2.19.

First CLI release that carries the in-band relay drain handler from #4594 — the host-service recognizes the `{type:"drain"}` message the relay sends before a SIGINT shutdown and reconnects immediately, instead of sitting out the ~75s inbound-silence watchdog on every relay deploy.

`cli-v0.2.18` is already tagged, so the drain-capable build ships as 0.2.19.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4642">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@superset/cli` to 0.2.19. This release adds the in-band relay drain handler so the host service reconnects immediately on relay deploys, avoiding the ~75s inbound-silence watchdog.

<sup>Written for commit 684fd8ae9d803d3e9c53d610665478b2be8a4740. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4642?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.2.19

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->