### PR TITLE
[codex] Fix changes sidebar modifier click behavior

### DIFF
--- a/apps/desktop/src/renderer/lib/clickPolicy/index.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/index.ts
@@ -9,11 +9,18 @@ export { ShadowClickHint } from "./components/ShadowClickHint";
 export { buildHint, UNBOUND_HINT } from "./hint";
 export { modifierLabel } from "./modifierLabel";
 export {
+	buildChangesSidebarFileHint,
+	type ChangesSidebarFileIntent,
+	resolveChangesSidebarFileIntent,
+	tierForChangesSidebarFileIntent,
+} from "./policies/changesSidebarFilePolicy";
+export {
 	type FolderIntent,
 	folderIntentFor,
 	folderIntentLabel,
 } from "./policies/folderPolicy";
 export type { ClickPolicy } from "./policies/policy";
+export { useChangesSidebarFilePolicy } from "./policies/useChangesSidebarFilePolicy";
 export { useInlineFilePolicy } from "./policies/useInlineFilePolicy";
 export { useInlineUrlPolicy } from "./policies/useInlineUrlPolicy";
 export { useSidebarFilePolicy } from "./policies/useSidebarFilePolicy";
@@ -29,4 +36,5 @@ export type {
 	Surface,
 	TierMode,
 } from "./types";
+export { usePierreChangesSidebarRowClickPolicy } from "./usePierreChangesSidebarRowClickPolicy";
 export { usePierreRowClickPolicy } from "./usePierreRowClickPolicy";

--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
@@ -67,6 +67,19 @@ describe("changes sidebar file policy", () => {
 		).toBe("external");
 	});
 
+	it("returns null for unbound tiers", () => {
+		expect(
+			resolveChangesSidebarFileIntent(
+				{ ...map, meta: null },
+				{
+					metaKey: true,
+					ctrlKey: false,
+					shiftKey: false,
+				},
+			),
+		).toBeNull();
+	});
+
 	it("finds shortcuts for menu items from the same map", () => {
 		expect(tierForChangesSidebarFileIntent(map, "diffNewTab")).toBe("shift");
 		expect(tierForChangesSidebarFileIntent(map, "file")).toBe("meta");

--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import type { LinkTierMap } from "../types";
+import {
+	resolveChangesSidebarFileIntent,
+	tierForChangesSidebarFileIntent,
+} from "./changesSidebarFilePolicy";
+
+const map: LinkTierMap = {
+	plain: "pane",
+	shift: "newTab",
+	meta: "pane",
+	metaShift: "external",
+};
+
+describe("changes sidebar file policy", () => {
+	it("keeps plain click on the diff", () => {
+		expect(
+			resolveChangesSidebarFileIntent(map, {
+				metaKey: false,
+				ctrlKey: false,
+				shiftKey: false,
+			}),
+		).toBe("diff");
+	});
+
+	it("maps shift-click through the settings map", () => {
+		expect(
+			resolveChangesSidebarFileIntent(map, {
+				metaKey: false,
+				ctrlKey: false,
+				shiftKey: true,
+			}),
+		).toBe("diffNewTab");
+	});
+
+	it("maps cmd/ctrl-click to the file when the settings action is pane", () => {
+		expect(
+			resolveChangesSidebarFileIntent(map, {
+				metaKey: true,
+				ctrlKey: false,
+				shiftKey: false,
+			}),
+		).toBe("file");
+		expect(
+			resolveChangesSidebarFileIntent(map, {
+				metaKey: false,
+				ctrlKey: true,
+				shiftKey: false,
+			}),
+		).toBe("file");
+	});
+
+	it("maps cmd/ctrl-shift-click to the external editor", () => {
+		expect(
+			resolveChangesSidebarFileIntent(map, {
+				metaKey: true,
+				ctrlKey: false,
+				shiftKey: true,
+			}),
+		).toBe("external");
+		expect(
+			resolveChangesSidebarFileIntent(map, {
+				metaKey: false,
+				ctrlKey: true,
+				shiftKey: true,
+			}),
+		).toBe("external");
+	});
+
+	it("finds shortcuts for menu items from the same map", () => {
+		expect(tierForChangesSidebarFileIntent(map, "diffNewTab")).toBe("shift");
+		expect(tierForChangesSidebarFileIntent(map, "file")).toBe("meta");
+		expect(tierForChangesSidebarFileIntent(map, "external")).toBe("metaShift");
+	});
+});

--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.ts
@@ -1,0 +1,59 @@
+import { modifierLabel } from "../modifierLabel";
+import { tierFor } from "../tiers";
+import type {
+	LinkAction,
+	LinkTier,
+	LinkTierMap,
+	ModifierEvent,
+} from "../types";
+
+export type ChangesSidebarFileIntent =
+	| "diff"
+	| "diffNewTab"
+	| "file"
+	| "external";
+
+const MODIFIER_TIERS: LinkTier[] = ["shift", "meta", "metaShift"];
+
+function intentFor(
+	tier: LinkTier,
+	action: LinkAction | null,
+): ChangesSidebarFileIntent | null {
+	if (action === null) return null;
+	if (action === "external") return "external";
+	if (action === "newTab") return "diffNewTab";
+	return tier === "plain" ? "diff" : "file";
+}
+
+function shortIntentLabel(intent: ChangesSidebarFileIntent): string {
+	if (intent === "diff") return "diff";
+	if (intent === "diffNewTab") return "diff in new tab";
+	if (intent === "file") return "open file";
+	return "editor";
+}
+
+export function resolveChangesSidebarFileIntent(
+	map: LinkTierMap,
+	event: ModifierEvent,
+): ChangesSidebarFileIntent | null {
+	const tier = tierFor(event, "4-tier");
+	return intentFor(tier, map[tier]);
+}
+
+export function tierForChangesSidebarFileIntent(
+	map: LinkTierMap,
+	intent: ChangesSidebarFileIntent,
+): LinkTier | null {
+	for (const tier of MODIFIER_TIERS) {
+		if (intentFor(tier, map[tier]) === intent) return tier;
+	}
+	return null;
+}
+
+export function buildChangesSidebarFileHint(map: LinkTierMap): string {
+	return MODIFIER_TIERS.flatMap((tier) => {
+		const intent = intentFor(tier, map[tier]);
+		if (intent === null) return [];
+		return `${modifierLabel(tier)}: ${shortIntentLabel(intent)}`;
+	}).join(" · ");
+}

--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/useChangesSidebarFilePolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/useChangesSidebarFilePolicy.ts
@@ -1,0 +1,29 @@
+import { useCallback, useMemo } from "react";
+import {
+	buildChangesSidebarFileHint,
+	type ChangesSidebarFileIntent,
+	resolveChangesSidebarFileIntent,
+	tierForChangesSidebarFileIntent,
+} from "./changesSidebarFilePolicy";
+import { useSidebarFilePolicy } from "./useSidebarFilePolicy";
+
+export function useChangesSidebarFilePolicy() {
+	const policy = useSidebarFilePolicy();
+
+	const getIntent = useCallback(
+		(event: Parameters<typeof resolveChangesSidebarFileIntent>[1]) =>
+			resolveChangesSidebarFileIntent(policy.map, event),
+		[policy.map],
+	);
+	const tierForIntent = useCallback(
+		(intent: ChangesSidebarFileIntent) =>
+			tierForChangesSidebarFileIntent(policy.map, intent),
+		[policy.map],
+	);
+	const hint = useMemo(
+		() => buildChangesSidebarFileHint(policy.map),
+		[policy.map],
+	);
+
+	return { ...policy, getIntent, tierForIntent, hint };
+}

--- a/apps/desktop/src/renderer/lib/clickPolicy/usePierreChangesSidebarRowClickPolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/usePierreChangesSidebarRowClickPolicy.ts
@@ -55,10 +55,12 @@ export function usePierreChangesSidebarRowClickPolicy({
 				return;
 			}
 
+			const intent = getFileIntent(e);
+			if (intent === null) return;
+
 			e.preventDefault();
 			e.stopPropagation();
 
-			const intent = getFileIntent(e);
 			if (intent === "external") openInExternalEditor(trimmed);
 			else if (intent === "file") onOpenFile(trimmed, false);
 			else if (intent === "diffNewTab") onSelectDiff(trimmed, true);

--- a/apps/desktop/src/renderer/lib/clickPolicy/usePierreChangesSidebarRowClickPolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/usePierreChangesSidebarRowClickPolicy.ts
@@ -1,0 +1,71 @@
+import { useCallback } from "react";
+import type { ChangesSidebarFileIntent } from "./policies/changesSidebarFilePolicy";
+import { folderIntentFor } from "./policies/folderPolicy";
+import type { ModifierEvent } from "./types";
+
+interface UsePierreChangesSidebarRowClickPolicyOptions {
+	getFileIntent: (event: ModifierEvent) => ChangesSidebarFileIntent | null;
+	onSelectDiff: (relativePath: string, openInNewTab?: boolean) => void;
+	onOpenFile: (relativePath: string, openInNewTab?: boolean) => void;
+	openInExternalEditor: (relativePath: string) => void;
+}
+
+interface UsePierreChangesSidebarRowClickPolicyResult {
+	onClickCapture: (e: React.MouseEvent<HTMLDivElement>) => void;
+	findFileRow: (e: React.MouseEvent) => HTMLElement | null;
+}
+
+export function usePierreChangesSidebarRowClickPolicy({
+	getFileIntent,
+	onSelectDiff,
+	onOpenFile,
+	openInExternalEditor,
+}: UsePierreChangesSidebarRowClickPolicyOptions): UsePierreChangesSidebarRowClickPolicyResult {
+	const findRow = useCallback((e: React.MouseEvent): HTMLElement | null => {
+		const path = e.nativeEvent.composedPath();
+		for (const node of path) {
+			if (!(node instanceof HTMLElement)) continue;
+			if (node.getAttribute("data-item-path")) return node;
+		}
+		return null;
+	}, []);
+
+	const findFileRow = useCallback(
+		(e: React.MouseEvent): HTMLElement | null => {
+			const row = findRow(e);
+			const itemPath = row?.getAttribute("data-item-path");
+			if (!row || !itemPath || itemPath.endsWith("/")) return null;
+			return row;
+		},
+		[findRow],
+	);
+
+	const onClickCapture = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			const treePath = findRow(e)?.getAttribute("data-item-path");
+			if (!treePath) return;
+			const trimmed = treePath.endsWith("/") ? treePath.slice(0, -1) : treePath;
+
+			if (treePath.endsWith("/")) {
+				const intent = folderIntentFor(e);
+				if (intent === null) return;
+				e.preventDefault();
+				e.stopPropagation();
+				if (intent === "external") openInExternalEditor(trimmed);
+				return;
+			}
+
+			e.preventDefault();
+			e.stopPropagation();
+
+			const intent = getFileIntent(e);
+			if (intent === "external") openInExternalEditor(trimmed);
+			else if (intent === "file") onOpenFile(trimmed, false);
+			else if (intent === "diffNewTab") onSelectDiff(trimmed, true);
+			else if (intent === "diff") onSelectDiff(trimmed, false);
+		},
+		[findRow, getFileIntent, onSelectDiff, onOpenFile, openInExternalEditor],
+	);
+
+	return { onClickCapture, findFileRow };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
@@ -16,8 +16,8 @@ import { Undo2 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	ShadowClickHint,
-	usePierreRowClickPolicy,
-	useSidebarFilePolicy,
+	useChangesSidebarFilePolicy,
+	usePierreChangesSidebarRowClickPolicy,
 } from "renderer/lib/clickPolicy";
 import { useFallthroughIcons } from "renderer/lib/fileIcons";
 import {
@@ -29,7 +29,10 @@ import {
 import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
 import { PierreRowContextMenu } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PierreRowContextMenu";
 import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
-import { toRelativeWorkspacePath } from "shared/absolute-paths";
+import {
+	toAbsoluteWorkspacePath,
+	toRelativeWorkspacePath,
+} from "shared/absolute-paths";
 import type { FoldSignal } from "../../ChangesFileList";
 import { FileRowContextMenuItems } from "./components/FileRowContextMenuItems";
 import { FolderContextMenuItems } from "./components/FolderContextMenuItems";
@@ -75,7 +78,7 @@ interface ChangesTreeViewProps {
  *  - `renderContextMenu`: file-row actions matching `FileRow`; folder-row
  *    actions (open in editor, copy path)
  *  - hover actions overlay (Discard on unstaged + more-actions ⌄ dropdown)
- *  - `usePierreRowClickPolicy` for settings-driven click routing
+ *  - `useChangesSidebarFilePolicy` for settings-driven click routing
  *  - selection echo: when the diff pane's file is in this section, focus it
  *
  * The discard confirm dialog lives here, not in the per-row menus: Pierre
@@ -212,15 +215,21 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 		return text ? { text } : null;
 	};
 
-	const filePolicy = useSidebarFilePolicy();
-	const { onClickCapture, findFileRow } = usePierreRowClickPolicy({
-		filePolicy,
-		onSelectFile: (rel, openInNewTab) => {
-			lastUserSelectRef.current = rel;
-			onSelectFile?.(rel, openInNewTab);
+	const filePolicy = useChangesSidebarFilePolicy();
+	const { onClickCapture, findFileRow } = usePierreChangesSidebarRowClickPolicy(
+		{
+			getFileIntent: filePolicy.getIntent,
+			onSelectDiff: (rel, openInNewTab) => {
+				lastUserSelectRef.current = rel;
+				onSelectFile?.(rel, openInNewTab);
+			},
+			onOpenFile: (rel, openInNewTab) => {
+				if (!worktreePath) return;
+				onOpenFile?.(toAbsoluteWorkspacePath(worktreePath, rel), openInNewTab);
+			},
+			openInExternalEditor: (rel) => onOpenInEditor?.(rel),
 		},
-		openInExternalEditor: (rel) => onOpenInEditor?.(rel),
-	});
+	);
 
 	// Hoisted so the dialog outlives the menu/hover overlay that triggers it.
 	const [discardTarget, setDiscardTarget] = useState<ChangesetFile | null>(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
@@ -11,7 +11,10 @@ import {
 	Trash2,
 	Undo2,
 } from "lucide-react";
-import { modifierLabel, useSidebarFilePolicy } from "renderer/lib/clickPolicy";
+import {
+	modifierLabel,
+	useChangesSidebarFilePolicy,
+} from "renderer/lib/clickPolicy";
 import { PathActionsMenuItems } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PathActionsMenuItems";
 import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
@@ -52,9 +55,10 @@ export function FileRowContextMenuItems({
 	const canDiscard = sectionKind === "unstaged";
 	const isDeleteAction = file.status === "untracked" || file.status === "added";
 
-	const policy = useSidebarFilePolicy();
-	const newTabTier = policy.tierForAction("newTab");
-	const externalTier = policy.tierForAction("external");
+	const policy = useChangesSidebarFilePolicy();
+	const diffNewTabTier = policy.tierForIntent("diffNewTab");
+	const fileTier = policy.tierForIntent("file");
+	const externalTier = policy.tierForIntent("external");
 
 	return (
 		<>
@@ -65,9 +69,9 @@ export function FileRowContextMenuItems({
 			<DropdownMenuItem onSelect={() => onSelectFile?.(file.path, true)}>
 				<SquarePlus />
 				Open Diff in New Tab
-				{newTabTier && (
+				{diffNewTabTier && (
 					<DropdownMenuShortcut>
-						{modifierLabel(newTabTier)}
+						{modifierLabel(diffNewTabTier)}
 					</DropdownMenuShortcut>
 				)}
 			</DropdownMenuItem>
@@ -77,6 +81,9 @@ export function FileRowContextMenuItems({
 			>
 				<FileText />
 				Open File
+				{fileTier && (
+					<DropdownMenuShortcut>{modifierLabel(fileTier)}</DropdownMenuShortcut>
+				)}
 			</DropdownMenuItem>
 			<DropdownMenuItem
 				onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -26,7 +26,10 @@ import {
 	Undo2,
 } from "lucide-react";
 import { memo, useState } from "react";
-import { modifierLabel, useSidebarFilePolicy } from "renderer/lib/clickPolicy";
+import {
+	modifierLabel,
+	useChangesSidebarFilePolicy,
+} from "renderer/lib/clickPolicy";
 import { FileIcon } from "renderer/lib/fileIcons";
 import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
@@ -90,9 +93,10 @@ export const FileRow = memo(function FileRow({
 		discardMutation.mutate({ workspaceId, filePath: file.path });
 	};
 
-	const policy = useSidebarFilePolicy();
-	const newTabTier = policy.tierForAction("newTab");
-	const externalTier = policy.tierForAction("external");
+	const policy = useChangesSidebarFilePolicy();
+	const diffNewTabTier = policy.tierForIntent("diffNewTab");
+	const fileTier = policy.tierForIntent("file");
+	const externalTier = policy.tierForIntent("external");
 
 	const rowButton = (
 		<div className="group relative">
@@ -100,10 +104,12 @@ export const FileRow = memo(function FileRow({
 				type="button"
 				className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
 				onClick={(e) => {
-					const action = policy.getAction(e);
-					if (action === "external") onOpenInEditor?.(file.path);
-					else if (action === "newTab") onSelect?.(file.path, true);
-					else if (action === "pane") onSelect?.(file.path, false);
+					const intent = policy.getIntent(e);
+					if (intent === "external") onOpenInEditor?.(file.path);
+					else if (intent === "file" && absolutePath)
+						onOpenFile?.(absolutePath, false);
+					else if (intent === "diffNewTab") onSelect?.(file.path, true);
+					else if (intent === "diff") onSelect?.(file.path, false);
 				}}
 			>
 				<FileIcon fileName={basename} className="size-3.5 shrink-0" />
@@ -172,9 +178,9 @@ export const FileRow = memo(function FileRow({
 						<DropdownMenuItem onSelect={() => onSelect?.(file.path, true)}>
 							<SquarePlus />
 							Open Diff in New Tab
-							{newTabTier && (
+							{diffNewTabTier && (
 								<DropdownMenuShortcut>
-									{modifierLabel(newTabTier)}
+									{modifierLabel(diffNewTabTier)}
 								</DropdownMenuShortcut>
 							)}
 						</DropdownMenuItem>
@@ -184,6 +190,11 @@ export const FileRow = memo(function FileRow({
 						>
 							<FileText />
 							Open File
+							{fileTier && (
+								<DropdownMenuShortcut>
+									{modifierLabel(fileTier)}
+								</DropdownMenuShortcut>
+							)}
 						</DropdownMenuItem>
 						<DropdownMenuItem
 							onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}
@@ -226,9 +237,9 @@ export const FileRow = memo(function FileRow({
 				<ContextMenuItem onSelect={() => onSelect?.(file.path, true)}>
 					<SquarePlus />
 					Open Diff in New Tab
-					{newTabTier && (
+					{diffNewTabTier && (
 						<ContextMenuShortcut>
-							{modifierLabel(newTabTier)}
+							{modifierLabel(diffNewTabTier)}
 						</ContextMenuShortcut>
 					)}
 				</ContextMenuItem>
@@ -238,6 +249,9 @@ export const FileRow = memo(function FileRow({
 				>
 					<FileText />
 					Open File
+					{fileTier && (
+						<ContextMenuShortcut>{modifierLabel(fileTier)}</ContextMenuShortcut>
+					)}
 				</ContextMenuItem>
 				<ContextMenuItem
 					onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -70,6 +70,21 @@ describe("healV2UserPreferences", () => {
 			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks.metaShift,
 		);
 	});
+
+	it("migrates the legacy sidebar file link default to the current default", () => {
+		const healed = healV2UserPreferences({
+			sidebarFileLinks: {
+				plain: "pane",
+				shift: "newTab",
+				meta: "external",
+				metaShift: "external",
+			},
+		});
+
+		expect(healed.sidebarFileLinks).toEqual(
+			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
+		);
+	});
 });
 
 describe("healWorkspaceLocalState", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -195,12 +195,39 @@ const DEFAULT_LINK_TIER_MAP: LinkTierMap = {
 	metaShift: "external",
 };
 
-const DEFAULT_SIDEBAR_FILE_LINKS: LinkTierMap = {
+const LEGACY_SIDEBAR_FILE_LINKS: LinkTierMap = {
 	plain: "pane",
 	shift: "newTab",
 	meta: "external",
 	metaShift: "external",
 };
+
+const DEFAULT_SIDEBAR_FILE_LINKS: LinkTierMap = {
+	plain: "pane",
+	shift: "newTab",
+	meta: "pane",
+	metaShift: "external",
+};
+
+function isSameLinkTierMap(a: LinkTierMap, b: LinkTierMap): boolean {
+	return (
+		a.plain === b.plain &&
+		a.shift === b.shift &&
+		a.meta === b.meta &&
+		a.metaShift === b.metaShift
+	);
+}
+
+function isCompleteLinkTierMap(
+	value: Partial<LinkTierMap>,
+): value is LinkTierMap {
+	return (
+		"plain" in value &&
+		"shift" in value &&
+		"meta" in value &&
+		"metaShift" in value
+	);
+}
 
 export const v2UserPreferencesSchema = z.object({
 	id: z.literal("preferences"),
@@ -273,14 +300,23 @@ export function healV2UserPreferences(raw: unknown): V2UserPreferencesRow {
 	const r = (
 		raw && typeof raw === "object" ? raw : {}
 	) as Partial<V2UserPreferencesRow>;
+	const sidebarFileLinks = r.sidebarFileLinks
+		? {
+				...DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
+				...r.sidebarFileLinks,
+			}
+		: DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks;
+	const shouldMigrateLegacySidebarFileLinks =
+		r.sidebarFileLinks &&
+		isCompleteLinkTierMap(r.sidebarFileLinks) &&
+		isSameLinkTierMap(r.sidebarFileLinks, LEGACY_SIDEBAR_FILE_LINKS);
 	return {
 		...DEFAULT_V2_USER_PREFERENCES,
 		...r,
 		fileLinks: { ...DEFAULT_V2_USER_PREFERENCES.fileLinks, ...r.fileLinks },
 		urlLinks: { ...DEFAULT_V2_USER_PREFERENCES.urlLinks, ...r.urlLinks },
-		sidebarFileLinks: {
-			...DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
-			...r.sidebarFileLinks,
-		},
+		sidebarFileLinks: shouldMigrateLegacySidebarFileLinks
+			? DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks
+			: sidebarFileLinks,
 	};
 }


### PR DESCRIPTION
## Summary

- Add a centralized changes-sidebar click policy that translates the existing sidebar file-link settings into changes-specific intents.
- Update grouped and tree changes rows so Cmd/Ctrl-click opens the actual file pane, while Cmd/Ctrl-Shift-click opens the external editor.
- Update sidebar file-link defaults and read-time preference healing so users on the old default get the corrected Cmd/Ctrl behavior without losing custom mappings.

## Impact

Plain clicks still open diffs, Shift-click still opens diffs in a new tab, and existing settings remain the source of truth for modifier behavior. Menu shortcut labels and hover hints now come from the same centralized policy.

## Validation

- `bun test apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts`
- `bun run typecheck --filter=@superset/desktop`
- `bun run lint:fix`
- `bun run lint`
- `git diff --check`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4644">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the changes sidebar click policy and updated the tree and row components to use it. Hover hints and menu shortcuts now come from one source, and unbound tiers are respected.

- **Bug Fixes**
  - Plain click opens the diff. Shift-click opens the diff in a new tab.
  - Cmd/Ctrl-click opens the file pane. Cmd/Ctrl-Shift-click opens the external editor.
  - Unbound modifier tiers do nothing.

- **Migration**
  - Auto-heals legacy `sidebarFileLinks` defaults to the new default (`meta: pane`, `metaShift: external`) without changing custom mappings.

<sup>Written for commit 7324c93d9c06dd92cc3ed0bbd8c76aab2be21c52. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4644?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced changes sidebar click routing: modifier keys (Shift, Cmd/Ctrl) now control opening diffs, files, or external editor; keyboard shortcut hints updated.

* **Chores**
  * Changed default action for one modifier to open in-pane instead of external editor.
  * Centralized and improved click-intent resolution across the changes sidebar.

* **Tests**
  * Added unit tests covering intent resolution and tier mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->