### PR TITLE
[codex] Fix desktop terminal font inheritance

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -187,6 +187,11 @@
 		height: 100%;
 		width: 100%;
 	}
+
+	.xterm {
+		font-family: var(--superset-terminal-font-family, ui-monospace, monospace);
+	}
+
 	.xterm .xterm-rows a {
 		color: inherit;
 		cursor: pointer;

--- a/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
@@ -13,6 +13,16 @@ export interface TerminalAppearance {
 	fontSize: number;
 }
 
+export const TERMINAL_FONT_FAMILY_CSS_VARIABLE =
+	"--superset-terminal-font-family";
+
+export function applyTerminalFontFamilyCssVariable(
+	element: HTMLElement,
+	fontFamily: string,
+): void {
+	element.style.setProperty(TERMINAL_FONT_FAMILY_CSS_VARIABLE, fontFamily);
+}
+
 const GENERIC_FONT_FAMILIES = new Set([
 	"serif",
 	"sans-serif",

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -4,7 +4,10 @@ import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
-import type { TerminalAppearance } from "./appearance";
+import {
+	applyTerminalFontFamilyCssVariable,
+	type TerminalAppearance,
+} from "./appearance";
 import { loadAddons } from "./terminal-addons";
 import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
@@ -205,6 +208,7 @@ export function createRuntime(
 	const wrapper = document.createElement("div");
 	wrapper.style.width = "100%";
 	wrapper.style.height = "100%";
+	applyTerminalFontFamilyCssVariable(wrapper, appearance.fontFamily);
 	terminal.open(wrapper);
 
 	installTerminalKeyEventHandler(terminal);
@@ -297,6 +301,7 @@ export function updateRuntimeAppearance(
 		terminal.options.fontSize !== appearance.fontSize;
 
 	if (fontChanged) {
+		applyTerminalFontFamilyCssVariable(runtime.wrapper, appearance.fontFamily);
 		terminal.options.fontFamily = appearance.fontFamily;
 		terminal.options.fontSize = appearance.fontSize;
 		if (hostIsVisible(runtime.container)) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -8,6 +8,7 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { applyTerminalFontFamilyCssVariable } from "renderer/lib/terminal/appearance";
 import type { DetectedLink } from "renderer/lib/terminal/links";
 import { TerminalLinkManager } from "renderer/lib/terminal/terminal-link-manager";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
@@ -17,7 +18,7 @@ import {
 	DEFAULT_THEME_ID,
 	getTerminalColors,
 } from "shared/themes";
-import { TERMINAL_OPTIONS } from "./config";
+import { DEFAULT_TERMINAL_FONT_FAMILY, TERMINAL_OPTIONS } from "./config";
 import { suppressQueryResponses } from "./suppressQueryResponses";
 
 /**
@@ -110,6 +111,10 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const wrapper = document.createElement("div");
 	wrapper.style.width = "100%";
 	wrapper.style.height = "100%";
+	applyTerminalFontFamilyCssVariable(
+		wrapper,
+		terminalOptions.fontFamily ?? DEFAULT_TERMINAL_FONT_FAMILY,
+	);
 	xterm.open(wrapper);
 
 	xterm.loadAddon(fitAddon);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -2,6 +2,7 @@ import type { Unsubscribable } from "@trpc/server/observable";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { applyTerminalFontFamilyCssVariable } from "renderer/lib/terminal/appearance";
 import { getTerminalParkingContainer } from "renderer/lib/terminal/terminal-parking";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { DEBUG_TERMINAL } from "./config";
@@ -198,6 +199,7 @@ export function updateAppearance(
 		xterm.options.fontSize !== fontSize;
 	if (!fontChanged) return null;
 
+	applyTerminalFontFamilyCssVariable(entry.wrapper, fontFamily);
 	xterm.options.fontFamily = fontFamily;
 	xterm.options.fontSize = fontSize;
 


### PR DESCRIPTION
## What changed

Fixes the desktop terminal's `.xterm` root so it uses the configured terminal font stack instead of inheriting the app's default Tailwind sans-serif stack.

- Adds a terminal font-family CSS variable and applies it to `.xterm`.
- Sets the CSS variable on v2 terminal wrappers before `terminal.open(...)`.
- Sets the CSS variable on v1 terminal wrappers and updates it when font settings change.

## Why

Reports in #4639 and the earlier #3570 thread showed CJK glyph corruption in the terminal. Local validation confirmed the live terminal root was computing to:

```text
ui-sans-serif, system-ui, sans-serif, ...
```

while xterm was configured with the terminal monospace stack. After this change, the same DevTools check returns the configured terminal font stack with no inline style override, so xterm measurement and DOM font inheritance agree.

## Validation

- `bun test src/renderer/lib/terminal/appearance/appearance.test.ts`
- `bun run lint -- apps/desktop/src/renderer/globals.css apps/desktop/src/renderer/lib/terminal/appearance/index.ts apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts`
- `bun run --cwd apps/desktop typecheck`
- Manual DevTools check: `getComputedStyle(document.querySelector(".xterm")).fontFamily` now resolves to the configured terminal font stack.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4646">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop terminal font inheritance so `.xterm` always uses the configured monospace stack instead of the app’s sans-serif default. Resolves CJK glyph corruption and keeps xterm measurement aligned with DOM rendering.

- **Bug Fixes**
  - Added `--superset-terminal-font-family` and applied it to `.xterm` in `globals.css`.
  - Set the CSS variable on v2 and v1 terminal wrappers before `terminal.open(...)` and on font updates.
  - Falls back to `ui-monospace, monospace` and uses `DEFAULT_TERMINAL_FONT_FAMILY` when unset.

<sup>Written for commit f38eb52b3bd0c88932b286807d5da2e775a4d4d4. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4646?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced terminal font family handling to ensure consistent styling across terminal instances through improved font management implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->