### PR TITLE
[codex] Align v2 changeset ordering

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
@@ -83,14 +83,6 @@ export function useChangeset({
 
 		if (ref.kind === "uncommitted") {
 			return [
-				...status.staged.map<ChangesetFile>((file) => ({
-					path: file.path,
-					oldPath: file.oldPath,
-					status: file.status as FileStatus,
-					additions: file.additions,
-					deletions: file.deletions,
-					source: { kind: "staged" },
-				})),
 				...status.unstaged.map<ChangesetFile>((file) => ({
 					path: file.path,
 					oldPath: file.oldPath,
@@ -99,25 +91,33 @@ export function useChangeset({
 					deletions: file.deletions,
 					source: { kind: "unstaged" },
 				})),
+				...status.staged.map<ChangesetFile>((file) => ({
+					path: file.path,
+					oldPath: file.oldPath,
+					status: file.status as FileStatus,
+					additions: file.additions,
+					deletions: file.deletions,
+					source: { kind: "staged" },
+				})),
 			];
 		}
 
-		// against-base: merge committed + dirty, last-wins by path, each file
-		// tagged with its actual source so downstream getDiff fetches the right
-		// bucket (dirty files show their working-tree diff; purely committed
-		// files show the base-branch diff).
+		// against-base: merge committed + dirty by path in the same order the
+		// sidebar renders sections. Dirty files win over committed files so
+		// downstream getDiff fetches the right bucket.
 		const seen = new Map<string, ChangesetFile>();
-		for (const file of status.againstBase) {
+		for (const file of status.unstaged) {
 			seen.set(file.path, {
 				path: file.path,
 				oldPath: file.oldPath,
 				status: file.status as FileStatus,
 				additions: file.additions,
 				deletions: file.deletions,
-				source: { kind: "against-base", baseBranch: ref.baseBranch },
+				source: { kind: "unstaged" },
 			});
 		}
 		for (const file of status.staged) {
+			if (seen.has(file.path)) continue;
 			seen.set(file.path, {
 				path: file.path,
 				oldPath: file.oldPath,
@@ -127,14 +127,15 @@ export function useChangeset({
 				source: { kind: "staged" },
 			});
 		}
-		for (const file of status.unstaged) {
+		for (const file of status.againstBase) {
+			if (seen.has(file.path)) continue;
 			seen.set(file.path, {
 				path: file.path,
 				oldPath: file.oldPath,
 				status: file.status as FileStatus,
 				additions: file.additions,
 				deletions: file.deletions,
-				source: { kind: "unstaged" },
+				source: { kind: "against-base", baseBranch: ref.baseBranch },
 			});
 		}
 		return Array.from(seen.values());


### PR DESCRIPTION
## Summary

Align the shared v2 changeset ordering with the changes sidebar so the diff pane and sidebar render files in the same section order.

## Root Cause

The sidebar grouped files as unstaged, staged, then against-base, but `useChangeset` emitted uncommitted files as staged before unstaged and built against-base results from committed files first. That made the diff pane order diverge from the sidebar even though both surfaces consumed the same hook.

## Impact

The diff pane now follows the same ordering users see in the changes sidebar. Dirty files still win over committed/base entries for the same path, so diff fetching continues to target the working-tree or staged bucket when appropriate.

## Validation

- `bunx @biomejs/biome@2.4.2 check apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts`
- `bun run --cwd apps/desktop typecheck`
- `bun run lint:fix`
- `bun run lint`
- `git diff --check`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns v2 changeset ordering with the changes sidebar so the diff pane and sidebar show files in the same section order. Prevents mismatches and ensures dirty files take precedence when selecting the diff source.

- **Bug Fixes**
  - Uncommitted: show Unstaged first, then Staged in `useChangeset`.
  - Against-base: merge by path in order Unstaged → Staged → Against-base; dirty files win over committed/base to target the correct diff source.

<sup>Written for commit f8609ca5cd9f5f50d15cc67aa0732d10770580ad. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4650?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file display order to show unstaged changes before staged changes in the workspace.
  * Refined file comparison logic when viewing changes against the base branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->