### PR TITLE
chore(setup): write NEXT_PUBLIC_RELAY_URL into generated .env

### DIFF
--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -531,6 +531,7 @@ step_write_env() {
     write_env_var "NEXT_PUBLIC_ADMIN_URL" "http://localhost:$ADMIN_PORT"
     write_env_var "NEXT_PUBLIC_DOCS_URL" "http://localhost:$DOCS_PORT"
     write_env_var "NEXT_PUBLIC_DESKTOP_URL" "http://localhost:$DESKTOP_VITE_PORT"
+    write_env_var "NEXT_PUBLIC_RELAY_URL" "http://localhost:$RELAY_PORT"
     write_env_var "EXPO_PUBLIC_WEB_URL" "http://localhost:$WEB_PORT"
     write_env_var "EXPO_PUBLIC_API_URL" "http://localhost:$API_PORT"
     write_env_var "RELAY_URL" "http://localhost:$RELAY_PORT"


### PR DESCRIPTION
## Summary
- The dev setup script (`.superset/lib/setup/steps.sh`) writes the cross-app URL block into `.env` but only emitted `RELAY_URL`. Adds `NEXT_PUBLIC_RELAY_URL`, pointed at the same local relay port.

## Why
The web app now reads `NEXT_PUBLIC_RELAY_URL` (browser-side relay origin for the host-service tRPC + terminal WebSocket). Without this line, a freshly set-up `.env` is missing the var and the web app's env validation fails on `bun dev`.

## Testing
- `bash -n .superset/lib/setup/steps.sh` — syntax OK

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `NEXT_PUBLIC_RELAY_URL` to the generated `.env` in `.superset/lib/setup/steps.sh`, pointing to the local relay port. This fixes the web app’s env validation on `bun dev` by providing the browser-side relay origin.

<sup>Written for commit 67f31b49c28c5cb4b1d18b70f04f41d151a15ac2. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4651?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup configuration to include relay URL environment variable for workspace initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->