### PR TITLE
[codex] add web terminal presets

### DIFF
--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -534,6 +534,7 @@ step_write_env() {
     write_env_var "EXPO_PUBLIC_WEB_URL" "http://localhost:$WEB_PORT"
     write_env_var "EXPO_PUBLIC_API_URL" "http://localhost:$API_PORT"
     write_env_var "RELAY_URL" "http://localhost:$RELAY_PORT"
+    write_env_var "NEXT_PUBLIC_RELAY_URL" "http://localhost:$RELAY_PORT"
     write_env_var "SUPERSET_WEB_URL" "http://localhost:$WEB_PORT"
     echo ""
     echo "# Streams URLs (overrides from root .env)"

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminalPresetsBar/WebTerminalPresetsBar.tsx
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminalPresetsBar/WebTerminalPresetsBar.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { getPresetById } from "@superset/shared/host-agent-presets";
+import { getPresetIcon } from "@superset/ui/icons/preset-icons";
+import { Loader2, Settings, Terminal } from "lucide-react";
+import Image from "next/image";
+import type { HostAgentConfig } from "../../../../../trpc/host-client";
+
+interface WebTerminalPresetsBarProps {
+	presets: HostAgentConfig[] | null;
+	runningPresetId: string | null;
+	disabled?: boolean;
+	onRunPreset: (preset: HostAgentConfig) => void;
+}
+
+export function WebTerminalPresetsBar({
+	presets,
+	runningPresetId,
+	disabled = false,
+	onRunPreset,
+}: WebTerminalPresetsBarProps) {
+	if (presets === null) {
+		return (
+			<div
+				className="flex h-9 shrink-0 items-center gap-2 overflow-hidden border-b px-3 text-xs text-[#a8a5a3]"
+				style={{ borderColor: "#2a2827", backgroundColor: "#171413" }}
+			>
+				<Loader2 className="size-3.5 animate-spin" />
+				<span>Loading presets...</span>
+			</div>
+		);
+	}
+
+	if (presets.length === 0) return null;
+
+	return (
+		<div
+			className="flex h-8 shrink-0 items-center gap-1 overflow-x-auto overflow-y-hidden border-b px-2"
+			style={{
+				borderColor: "#2a2827",
+				backgroundColor: "#0d0908",
+				scrollbarWidth: "none",
+			}}
+		>
+			<button
+				type="button"
+				title="Manage presets"
+				aria-label="Manage presets"
+				className="flex size-6 shrink-0 items-center justify-center rounded-md text-[#8f8983] transition-colors hover:bg-[#211d1b] hover:text-[#f3f0ed]"
+			>
+				<Settings className="size-4" />
+			</button>
+			<div className="mx-1 h-4 w-px shrink-0 bg-[#2a2827]" />
+			{presets.map((preset) => {
+				const details = getPresetById(preset.presetId);
+				const icon = getPresetIcon(preset.presetId, true);
+				const isRunning = runningPresetId === preset.id;
+				const label = preset.label || details?.label || preset.command;
+				const title = details?.description
+					? `${label}: ${details.description}`
+					: `Run ${label}`;
+
+				return (
+					<button
+						key={preset.id}
+						type="button"
+						title={title}
+						aria-label={`Run ${label}`}
+						onClick={() => onRunPreset(preset)}
+						disabled={disabled || isRunning}
+						className="flex h-6 max-w-36 shrink-0 items-center gap-2 rounded-md border border-transparent px-1.5 text-sm text-[#8f8172] transition-colors hover:border-[#3a3633] hover:bg-[#211d1b] hover:text-[#d9d2cb] disabled:cursor-not-allowed disabled:opacity-55"
+					>
+						{isRunning ? (
+							<Loader2 className="size-4 shrink-0 animate-spin" />
+						) : icon ? (
+							<Image
+								src={icon}
+								alt=""
+								width={16}
+								height={16}
+								className="size-4 shrink-0 object-contain"
+							/>
+						) : (
+							<Terminal className="size-4 shrink-0" />
+						)}
+						<span className="min-w-0 truncate">{label}</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminalPresetsBar/index.ts
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminalPresetsBar/index.ts
@@ -1,0 +1,1 @@
+export { WebTerminalPresetsBar } from "./WebTerminalPresetsBar";

--- a/apps/web/src/app/workspaces/[workspaceId]/page.tsx
+++ b/apps/web/src/app/workspaces/[workspaceId]/page.tsx
@@ -5,15 +5,23 @@ import Link from "next/link";
 import { use, useCallback, useEffect, useState } from "react";
 import { trpcClient } from "../../../trpc/client";
 import {
+	buildHostAgentLaunchCommand,
 	createHostTerminal,
+	type HostAgentConfig,
+	listHostAgentConfigs,
 	listHostTerminals,
 } from "../../../trpc/host-client";
 import { WebTerminal } from "./components/WebTerminal";
+import { WebTerminalPresetsBar } from "./components/WebTerminalPresetsBar";
 
 interface HostTerminal {
 	terminalId: string;
 	title: string | null;
 	exited: boolean;
+}
+
+function getErrorMessage(caught: unknown): string {
+	return caught instanceof Error ? caught.message : String(caught);
 }
 
 export default function WorkspaceTerminalPage({
@@ -24,11 +32,13 @@ export default function WorkspaceTerminalPage({
 	const { workspaceId } = use(params);
 	const [routingKey, setRoutingKey] = useState<string | null>(null);
 	const [terminals, setTerminals] = useState<HostTerminal[] | null>(null);
+	const [presets, setPresets] = useState<HostAgentConfig[] | null>(null);
 	const [selectedTerminalId, setSelectedTerminalId] = useState<string | null>(
 		null,
 	);
 	const [loadError, setLoadError] = useState<string | null>(null);
 	const [creating, setCreating] = useState(false);
+	const [runningPresetId, setRunningPresetId] = useState<string | null>(null);
 	const [viewportHeight, setViewportHeight] = useState<number | null>(null);
 
 	const loadTerminals = useCallback(
@@ -44,7 +54,7 @@ export default function WorkspaceTerminalPage({
 					})),
 				);
 			} catch (caught) {
-				setLoadError(caught instanceof Error ? caught.message : String(caught));
+				setLoadError(getErrorMessage(caught));
 				setTerminals([]);
 			}
 		},
@@ -58,6 +68,7 @@ export default function WorkspaceTerminalPage({
 				if (!organization) {
 					setLoadError("No active organization.");
 					setTerminals([]);
+					setPresets([]);
 					return;
 				}
 				const workspace = await trpcClient.v2Workspace.getFromHost.query({
@@ -67,35 +78,53 @@ export default function WorkspaceTerminalPage({
 				if (!workspace) {
 					setLoadError("Workspace not found.");
 					setTerminals([]);
+					setPresets([]);
 					return;
 				}
 				const key = buildHostRoutingKey(organization.id, workspace.hostId);
 				setRoutingKey(key);
-				await loadTerminals(key);
+				const [presetResult] = await Promise.allSettled([
+					listHostAgentConfigs(key),
+					loadTerminals(key),
+				]);
+				if (presetResult.status === "fulfilled") {
+					setPresets(presetResult.value);
+				} else {
+					setPresets([]);
+					setLoadError(getErrorMessage(presetResult.reason));
+				}
 			} catch (caught) {
-				setLoadError(caught instanceof Error ? caught.message : String(caught));
+				setLoadError(getErrorMessage(caught));
 				setTerminals([]);
+				setPresets([]);
 			}
 		})();
 	}, [workspaceId, loadTerminals]);
 
-	useEffect(() => {
-		if (selectedTerminalId || !terminals) return;
-		const first =
-			terminals.find((terminal) => !terminal.exited) ?? terminals[0];
-		if (first) setSelectedTerminalId(first.terminalId);
-	}, [terminals, selectedTerminalId]);
+	const activeTerminalId =
+		selectedTerminalId &&
+		terminals?.some((terminal) => terminal.terminalId === selectedTerminalId)
+			? selectedTerminalId
+			: (terminals?.find((terminal) => !terminal.exited)?.terminalId ??
+				terminals?.[0]?.terminalId ??
+				null);
 
 	useEffect(() => {
 		const visualViewport = window.visualViewport;
 		if (!visualViewport) return;
 		const update = () => setViewportHeight(visualViewport.height);
+		const scrollListenerOptions = { passive: true };
+		const visualViewportTarget = visualViewport as EventTarget;
 		update();
 		visualViewport.addEventListener("resize", update);
-		visualViewport.addEventListener("scroll", update);
+		visualViewportTarget.addEventListener(
+			"scroll",
+			update,
+			scrollListenerOptions,
+		);
 		return () => {
 			visualViewport.removeEventListener("resize", update);
-			visualViewport.removeEventListener("scroll", update);
+			visualViewportTarget.removeEventListener("scroll", update);
 		};
 	}, []);
 
@@ -107,11 +136,28 @@ export default function WorkspaceTerminalPage({
 			await loadTerminals(routingKey);
 			setSelectedTerminalId(created.terminalId);
 		} catch (caught) {
-			setLoadError(caught instanceof Error ? caught.message : String(caught));
-		} finally {
-			setCreating(false);
+			setLoadError(getErrorMessage(caught));
 		}
+		setCreating(false);
 	}, [routingKey, workspaceId, loadTerminals]);
+
+	const runPreset = useCallback(
+		async (preset: HostAgentConfig) => {
+			if (!routingKey) return;
+			setRunningPresetId(preset.id);
+			try {
+				const created = await createHostTerminal(routingKey, workspaceId, {
+					initialCommand: buildHostAgentLaunchCommand(preset),
+				});
+				await loadTerminals(routingKey);
+				setSelectedTerminalId(created.terminalId);
+			} catch (caught) {
+				setLoadError(getErrorMessage(caught));
+			}
+			setRunningPresetId(null);
+		},
+		[routingKey, workspaceId, loadTerminals],
+	);
 
 	return (
 		<div
@@ -129,7 +175,7 @@ export default function WorkspaceTerminalPage({
 					← Workspaces
 				</Link>
 				<select
-					value={selectedTerminalId ?? ""}
+					value={activeTerminalId ?? ""}
 					onChange={(event) =>
 						setSelectedTerminalId(event.target.value || null)
 					}
@@ -169,12 +215,18 @@ export default function WorkspaceTerminalPage({
 					{loadError}
 				</div>
 			)}
+			<WebTerminalPresetsBar
+				presets={presets}
+				runningPresetId={runningPresetId}
+				disabled={!routingKey}
+				onRunPreset={(preset) => void runPreset(preset)}
+			/>
 			<div className="relative flex-1 overflow-hidden">
-				{selectedTerminalId && routingKey ? (
+				{activeTerminalId && routingKey ? (
 					<WebTerminal
-						key={selectedTerminalId}
+						key={activeTerminalId}
 						workspaceId={workspaceId}
-						terminalId={selectedTerminalId}
+						terminalId={activeTerminalId}
 						routingKey={routingKey}
 					/>
 				) : (

--- a/apps/web/src/trpc/host-client.ts
+++ b/apps/web/src/trpc/host-client.ts
@@ -15,6 +15,22 @@ export interface HostTerminalSession {
 	title: string | null;
 }
 
+export interface HostAgentConfig {
+	id: string;
+	presetId: string;
+	label: string;
+	command: string;
+	args: string[];
+	promptTransport: "argv" | "stdin";
+	promptArgs: string[];
+	env: Record<string, string>;
+	order: number;
+}
+
+interface CreateHostTerminalOptions {
+	initialCommand?: string;
+}
+
 async function hostCall<TOutput>(
 	routingKey: string,
 	procedure: string,
@@ -22,10 +38,10 @@ async function hostCall<TOutput>(
 	method: "GET" | "POST",
 ): Promise<TOutput> {
 	const token = await getAuthToken();
-	const encoded = SuperJSON.serialize(input);
 	const base = `${getRelayUrl()}/hosts/${routingKey}/trpc/${procedure}`;
+	const encoded = input === undefined ? undefined : SuperJSON.serialize(input);
 	const url =
-		method === "GET"
+		method === "GET" && encoded !== undefined
 			? `${base}?input=${encodeURIComponent(JSON.stringify(encoded))}`
 			: base;
 
@@ -35,7 +51,10 @@ async function hostCall<TOutput>(
 			authorization: `Bearer ${token}`,
 			...(method === "POST" ? { "content-type": "application/json" } : {}),
 		},
-		body: method === "POST" ? JSON.stringify(encoded) : undefined,
+		body:
+			method === "POST" && encoded !== undefined
+				? JSON.stringify(encoded)
+				: undefined,
 	});
 	if (!response.ok) {
 		throw new Error(`host ${procedure} failed (${response.status})`);
@@ -57,11 +76,54 @@ export function listHostTerminals(routingKey: string, workspaceId: string) {
 	);
 }
 
-export function createHostTerminal(routingKey: string, workspaceId: string) {
+export function createHostTerminal(
+	routingKey: string,
+	workspaceId: string,
+	options: CreateHostTerminalOptions = {},
+) {
+	const input =
+		options.initialCommand === undefined
+			? { workspaceId }
+			: { workspaceId, initialCommand: options.initialCommand };
 	return hostCall<{ terminalId: string; status: string }>(
 		routingKey,
 		"terminal.createSession",
-		{ workspaceId },
+		input,
 		"POST",
 	);
+}
+
+export function listHostAgentConfigs(routingKey: string) {
+	return hostCall<HostAgentConfig[]>(
+		routingKey,
+		"settings.agentConfigs.list",
+		undefined,
+		"GET",
+	);
+}
+
+function quoteSingleShell(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function buildArgvCommand(argv: string[]): string {
+	return argv.map(quoteSingleShell).join(" ");
+}
+
+function envOverlayPrefix(env: Record<string, string>): string {
+	const assignments = Object.entries(env).map(
+		([key, value]) => `${key}=${quoteSingleShell(value)}`,
+	);
+	return assignments.length > 0 ? `${assignments.join(" ")} ` : "";
+}
+
+export function buildHostAgentLaunchCommand(config: {
+	command: string;
+	args: string[];
+	env: Record<string, string>;
+}) {
+	return `${envOverlayPrefix(config.env)}${buildArgvCommand([
+		config.command,
+		...config.args,
+	])}`;
 }

--- a/apps/web/src/types/svg.d.ts
+++ b/apps/web/src/types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+	const content: string;
+	export default content;
+}


### PR DESCRIPTION
## Summary
- Add a web terminal preset bar backed by host agent configs, including the shared preset SVG icons used by desktop.
- Let web terminal creation pass an initial command so preset clicks launch the selected terminal agent.
- Write NEXT_PUBLIC_RELAY_URL from the workspace setup script alongside RELAY_URL so browser host-service calls use the allocated relay port.

## Validation
- bun --filter @superset/web typecheck
- bun run lint
- npx -y react-doctor@latest . --verbose --diff (98/100; remaining warnings are existing metadata/useReducer/state-shape suggestions on the page)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4653">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a web terminal presets bar powered by host agent configs, letting users launch a preconfigured terminal in one click. Also enables browser host-service calls via `NEXT_PUBLIC_RELAY_URL` so the relay port is used correctly.

- **New Features**
  - Presets bar with shared SVG icons, loading state, and disabled/running states.
  - Terminal creation accepts an initial command; clicking a preset builds the agent launch command and opens a terminal.
  - Host client: `settings.agentConfigs.list` to fetch presets and a helper to build the launch command; supports GET requests without input.
  - Adds `svg.d.ts` to allow importing preset SVGs.

- **Migration**
  - Re-run the workspace setup to write `NEXT_PUBLIC_RELAY_URL` to the environment and restart the web app.

<sup>Written for commit f9d0e16cf1106c80484cb47f2ddaef098a55d26f. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4653?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a terminal presets bar above the terminal area, allowing users to quickly launch predefined terminal configurations.
  * Terminal presets can now be executed with a single click, automatically creating new terminal sessions.
  * Improved terminal selection logic to better manage active terminal sessions.

* **Bug Fixes**
  * Enhanced error handling and messaging during terminal operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->