### PR TITLE
[codex] fix v2 sidebar state reactivity

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@superset/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import { Search } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { LuFile, LuGitCompareArrows } from "react-icons/lu";
@@ -86,10 +88,17 @@ export function WorkspaceSidebar({
 	workspaceId,
 }: WorkspaceSidebarProps) {
 	const collections = useCollections();
-	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
+	const { data: [localState] = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ localState: collections.v2WorkspaceLocalState })
+				.where(({ localState }) => eq(localState.workspaceId, workspaceId)),
+		[collections, workspaceId],
+	);
 	const activeTab: SidebarTabId =
-		(localState?.sidebarState?.activeTab as SidebarTabId | undefined) ??
-		"changes";
+		localState && isSidebarTabId(localState.sidebarState.activeTab)
+			? localState.sidebarState.activeTab
+			: "changes";
 
 	function setActiveTab(tab: string) {
 		if (!isSidebarTabId(tab)) return;


### PR DESCRIPTION
## Summary

Fixes the v2 workspace sidebar state getting stale until a refresh or unrelated re-render.

The sidebar was reading `v2WorkspaceLocalState` with an imperative collection `get()` during render. That value does not subscribe React to local state changes, so updates like the active sidebar tab could be persisted without immediately showing in the UI.

This changes the sidebar to read the local workspace state through `useLiveQuery`, keeping the existing storage/update path while making the render reactive.

## Validation

- `bun run lint:fix`
- `bun run lint`
- `bun run --cwd apps/desktop typecheck`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4654">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 workspace sidebar getting stuck with stale state by making it reactive to local state changes. Sidebar now updates immediately when the active tab or other local state changes, without a refresh.

- **Bug Fixes**
  - Switched from `collections.v2WorkspaceLocalState.get(workspaceId)` to `useLiveQuery` from `@tanstack/react-db` with `eq` from `@tanstack/db` to subscribe to the workspace’s local state.
  - Validated `activeTab` with `isSidebarTabId`, defaulting to "changes" when invalid.

<sup>Written for commit 779108c2eb007a2fa0fb220ddc72d8b3dd0f9517. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4654?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated workspace sidebar data loading to use reactive queries, ensuring more responsive state management while maintaining existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->