### PR TITLE
feat(web): workspace date filters + mobile terminal focus fix

### DIFF
--- a/apps/web/src/app/workspaces/page.tsx
+++ b/apps/web/src/app/workspaces/page.tsx
@@ -25,16 +25,16 @@ const CREATED_WITHIN_DAYS: Record<Exclude<CreatedWithin, "all">, number> = {
 
 function formatRelative(date: Date): string {
 	const diffMs = Date.now() - date.getTime();
-	const minutes = Math.round(diffMs / 60_000);
+	const minutes = Math.floor(diffMs / 60_000);
 	if (minutes < 1) return "just now";
 	if (minutes < 60) return `${minutes}m ago`;
-	const hours = Math.round(minutes / 60);
+	const hours = Math.floor(minutes / 60);
 	if (hours < 24) return `${hours}h ago`;
-	const days = Math.round(hours / 24);
+	const days = Math.floor(hours / 24);
 	if (days < 30) return `${days}d ago`;
-	const months = Math.round(days / 30);
+	const months = Math.floor(days / 30);
 	if (months < 12) return `${months}mo ago`;
-	const years = Math.round(months / 12);
+	const years = Math.floor(months / 12);
 	return `${years}y ago`;
 }
 

--- a/apps/web/src/app/workspaces/page.tsx
+++ b/apps/web/src/app/workspaces/page.tsx
@@ -11,6 +11,31 @@ interface WorkspaceRow {
 	projectId: string;
 	projectName: string;
 	hostId: string;
+	createdAt: Date;
+}
+
+type SortBy = "recent" | "oldest" | "name";
+type CreatedWithin = "all" | "7d" | "30d" | "90d";
+
+const CREATED_WITHIN_DAYS: Record<Exclude<CreatedWithin, "all">, number> = {
+	"7d": 7,
+	"30d": 30,
+	"90d": 90,
+};
+
+function formatRelative(date: Date): string {
+	const diffMs = Date.now() - date.getTime();
+	const minutes = Math.round(diffMs / 60_000);
+	if (minutes < 1) return "just now";
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.round(hours / 24);
+	if (days < 30) return `${days}d ago`;
+	const months = Math.round(days / 30);
+	if (months < 12) return `${months}mo ago`;
+	const years = Math.round(months / 12);
+	return `${years}y ago`;
 }
 
 interface ProjectRow {
@@ -44,6 +69,8 @@ export default function WorkspacesPage() {
 	const [search, setSearch] = useState("");
 	const [projectFilter, setProjectFilter] = useState("");
 	const [hostFilter, setHostFilter] = useState("");
+	const [sortBy, setSortBy] = useState<SortBy>("recent");
+	const [createdWithin, setCreatedWithin] = useState<CreatedWithin>("all");
 
 	const loadWorkspaces = useCallback(async (organization: string) => {
 		const rows = await trpcClient.v2Workspace.list.query({
@@ -57,6 +84,7 @@ export default function WorkspacesPage() {
 				projectId: row.projectId,
 				projectName: row.projectName,
 				hostId: row.hostId,
+				createdAt: new Date(row.createdAt),
 			})),
 		);
 	}, []);
@@ -100,25 +128,37 @@ export default function WorkspacesPage() {
 
 	const visibleWorkspaces = useMemo(() => {
 		const query = search.trim().toLowerCase();
-		return (workspaces ?? [])
-			.filter((workspace) => {
-				if (projectFilter && workspace.projectId !== projectFilter) {
-					return false;
-				}
-				if (hostFilter && workspace.hostId !== hostFilter) {
-					return false;
-				}
-				if (!query) return true;
-				return (
-					workspace.name.toLowerCase().includes(query) ||
-					workspace.branch.toLowerCase().includes(query) ||
-					workspace.projectName.toLowerCase().includes(query)
-				);
-			})
-			.sort((a, b) =>
-				a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+		const cutoff =
+			createdWithin === "all"
+				? null
+				: Date.now() - CREATED_WITHIN_DAYS[createdWithin] * 24 * 60 * 60 * 1000;
+		const filtered = (workspaces ?? []).filter((workspace) => {
+			if (projectFilter && workspace.projectId !== projectFilter) {
+				return false;
+			}
+			if (hostFilter && workspace.hostId !== hostFilter) {
+				return false;
+			}
+			if (cutoff !== null && workspace.createdAt.getTime() < cutoff) {
+				return false;
+			}
+			if (!query) return true;
+			return (
+				workspace.name.toLowerCase().includes(query) ||
+				workspace.branch.toLowerCase().includes(query) ||
+				workspace.projectName.toLowerCase().includes(query)
 			);
-	}, [workspaces, search, projectFilter, hostFilter]);
+		});
+		return filtered.sort((a, b) => {
+			if (sortBy === "recent") {
+				return b.createdAt.getTime() - a.createdAt.getTime();
+			}
+			if (sortBy === "oldest") {
+				return a.createdAt.getTime() - b.createdAt.getTime();
+			}
+			return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+		});
+	}, [workspaces, search, projectFilter, hostFilter, sortBy, createdWithin]);
 
 	const canCreate =
 		!!organizationId &&
@@ -251,6 +291,27 @@ export default function WorkspacesPage() {
 							</option>
 						))}
 					</select>
+					<select
+						value={createdWithin}
+						onChange={(event) =>
+							setCreatedWithin(event.target.value as CreatedWithin)
+						}
+						className="rounded-md border bg-transparent px-3 py-2 text-sm"
+					>
+						<option value="all">Any time</option>
+						<option value="7d">Last 7 days</option>
+						<option value="30d">Last 30 days</option>
+						<option value="90d">Last 90 days</option>
+					</select>
+					<select
+						value={sortBy}
+						onChange={(event) => setSortBy(event.target.value as SortBy)}
+						className="rounded-md border bg-transparent px-3 py-2 text-sm"
+					>
+						<option value="recent">Recently created</option>
+						<option value="oldest">Oldest first</option>
+						<option value="name">Name (A–Z)</option>
+					</select>
 				</div>
 				{workspaces === null ? (
 					<p className="text-muted-foreground mt-3 text-sm">Loading…</p>
@@ -270,7 +331,8 @@ export default function WorkspacesPage() {
 								>
 									<div className="text-sm font-medium">{workspace.name}</div>
 									<div className="text-muted-foreground mt-0.5 text-xs">
-										{workspace.projectName} · {workspace.branch}
+										{workspace.projectName} · {workspace.branch} · created{" "}
+										{formatRelative(workspace.createdAt)}
 									</div>
 								</Link>
 							</li>

--- a/apps/web/src/components/MobileTerminalInput/MobileTerminalInput.tsx
+++ b/apps/web/src/components/MobileTerminalInput/MobileTerminalInput.tsx
@@ -33,7 +33,35 @@ export function MobileTerminalInput({
 
 	const focusKeyboardInput = useCallback(() => {
 		if (!enabled) return;
+		const scrollingElement =
+			document.scrollingElement ?? document.documentElement;
+		const savedScrollTop = scrollingElement?.scrollTop ?? 0;
+		const savedScrollLeft = scrollingElement?.scrollLeft ?? 0;
+		const savedWindowY = window.scrollY;
+		const savedWindowX = window.scrollX;
 		textareaRef.current?.focus({ preventScroll: true });
+		// iOS Safari ignores preventScroll when focusing an input that sits
+		// under the soft keyboard — it scrolls the page to bring the caret
+		// into view, which on a viewport-height page yanks everything to
+		// the top. Restore the prior scroll across the next few frames in
+		// case the OS scroll fires after our focus call.
+		const restore = () => {
+			if (scrollingElement) {
+				if (scrollingElement.scrollTop !== savedScrollTop) {
+					scrollingElement.scrollTop = savedScrollTop;
+				}
+				if (scrollingElement.scrollLeft !== savedScrollLeft) {
+					scrollingElement.scrollLeft = savedScrollLeft;
+				}
+			}
+			if (window.scrollY !== savedWindowY || window.scrollX !== savedWindowX) {
+				window.scrollTo(savedWindowX, savedWindowY);
+			}
+		};
+		requestAnimationFrame(() => {
+			restore();
+			requestAnimationFrame(restore);
+		});
 	}, [enabled]);
 
 	useEffect(() => {
@@ -90,7 +118,7 @@ export function MobileTerminalInput({
 				autoCapitalize="none"
 				autoComplete="off"
 				autoCorrect="off"
-				className="fixed bottom-0 left-0 h-px w-px resize-none opacity-0"
+				className="pointer-events-none fixed top-0 left-0 h-px w-px resize-none opacity-0"
 				enterKeyHint="enter"
 				inputMode="text"
 				onBeforeInput={(event) => {

--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -147,6 +147,7 @@ export const v2WorkspaceRouter = {
 					projectId: v2Workspaces.projectId,
 					projectName: v2Projects.name,
 					hostId: v2Workspaces.hostId,
+					createdAt: v2Workspaces.createdAt,
 				})
 				.from(v2Workspaces)
 				.innerJoin(
@@ -179,6 +180,7 @@ export const v2WorkspaceRouter = {
 				projectId: row.projectId,
 				projectName: row.projectName ?? "",
 				hostId: row.hostId,
+				createdAt: row.createdAt,
 			}));
 		}),
 


### PR DESCRIPTION
## Summary
- Adds sort (Recently created / Oldest / Name) and a created-within filter (7/30/90 days) to the `/workspaces` page, with a relative "created Nd ago" label on each row. `v2Workspace.list` now returns `createdAt`.
- Fixes a mobile bug where focusing the web terminal scrolled the page to the top: the hidden capture input has been moved above the keyboard, and scroll position is defensively restored across the next two animation frames to defeat iOS Safari's keyboard-avoidance scroll.

## Test plan
- [ ] `/workspaces` — confirm new "Any time / 7d / 30d / 90d" and sort dropdowns render, filter and reorder rows, and the "created Nd ago" label appears
- [ ] `/workspaces` — verify project/host/search filters still work and compose with the new ones
- [ ] Mobile Safari on a workspace terminal — tap to focus and confirm the page no longer jumps to the top; keyboard still appears and typing still goes through
- [ ] Mobile Chrome — same flow, no regression
- [ ] Desktop — clicking the terminal still focuses xterm via the existing mouse path

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4655">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds created-date sorting and a “created Nd ago” label to the Workspaces list, fixes the mobile terminal focus jump, and corrects the relative time rounding near boundaries.

- New Features
  - Sort by Recently created, Oldest, or Name on `/workspaces`.
  - Filter by created within 7/30/90 days; composes with project/host/search.
  - `v2Workspace.list` now returns `createdAt` for client-side sort/filter.

- Bug Fixes
  - Mobile terminal focus no longer scrolls to the top on iOS.
  - Moved the hidden input above the keyboard and restored scroll across frames.
  - Relative time (“created Nd ago”) no longer rolls over early; uses Math.floor for each unit.

<sup>Written for commit 02753cf9acf93bef1b33dfb8f660af51203e5ea6. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4655?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspaces display relative "created ..." timestamps
  * Added "created within" date filter for workspaces
  * Added sorting options: most recent, oldest, or name

* **Bug Fixes**
  * Fixed iOS Safari issue where focusing the on-screen keyboard caused unwanted page scrolling by preserving and restoring scroll position

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->