### PR TITLE
feat(api): respect relay-url-override flag in Slack agent + MCP

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/mcp-clients.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/mcp-clients.ts
@@ -3,8 +3,8 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { McpContext } from "@superset/mcp/auth";
 import { createInMemoryMcpClient as createV1Client } from "@superset/mcp/in-memory";
 import { createInMemoryMcpClient as createV2Client } from "@superset/mcp-v2/in-memory";
-import { env } from "@/env";
 import { posthog } from "@/lib/analytics";
+import { getRelayUrl } from "@/lib/relay-url";
 
 interface McpTool {
 	name: string;
@@ -51,7 +51,7 @@ export async function createSupersetMcpV2Client({
 		organizationId,
 		userId,
 		clientLabel: SLACK_CLIENT_LABEL,
-		relayUrl: env.RELAY_URL,
+		relayUrl: await getRelayUrl(userId),
 		onToolCall: (event) => {
 			posthog.capture({
 				distinctId: event.userId,

--- a/apps/api/src/app/api/v2/agent/[transport]/route.ts
+++ b/apps/api/src/app/api/v2/agent/[transport]/route.ts
@@ -8,6 +8,7 @@ import {
 import { env } from "@/env";
 import { posthog } from "@/lib/analytics";
 import { getOAuthProtectedResourceMetadataUrl } from "@/lib/oauth-metadata";
+import { getRelayUrl } from "@/lib/relay-url";
 
 function unauthorizedResponse(req: Request, message: string): Response {
 	return new Response(
@@ -35,6 +36,8 @@ async function handle(req: Request): Promise<Response> {
 		}
 		throw error;
 	}
+
+	ctx.relayUrl = await getRelayUrl(ctx.userId);
 
 	const server = createMcpServer({
 		onToolCall: (event) => {

--- a/apps/api/src/lib/relay-url.ts
+++ b/apps/api/src/lib/relay-url.ts
@@ -1,0 +1,29 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { env } from "@/env";
+import { posthog } from "@/lib/analytics";
+
+interface RelayUrlPayload {
+	url?: string;
+}
+
+/**
+ * Resolves the relay base URL for a user. Reads the `relay-url-override`
+ * PostHog flag payload; falls back to `env.RELAY_URL` when the flag is off,
+ * the payload is malformed, or PostHog is unreachable. Mirrors the desktop
+ * and CLI relay-url helpers so the Slack agent and external MCP callers reach
+ * the same relay the user's host tunneled into (e.g. the staging relay).
+ */
+export async function getRelayUrl(userId: string): Promise<string> {
+	const fallback = env.RELAY_URL;
+	try {
+		const payload = (await posthog.getFeatureFlagPayload(
+			FEATURE_FLAGS.RELAY_URL_OVERRIDE,
+			userId,
+		)) as RelayUrlPayload | undefined | null;
+		const override = payload?.url;
+		if (typeof override === "string" && override.length > 0) return override;
+	} catch (error) {
+		console.warn("[relay-url] PostHog payload fetch failed:", error);
+	}
+	return fallback;
+}


### PR DESCRIPTION
## Problem

The Slack agent's MCP v2 client (`createSupersetMcpV2Client`) and the external MCP HTTP/SSE endpoint (`/api/v2/agent/[transport]`) both hardcoded `env.RELAY_URL`. So they always route to the **production** relay — even when a user's host has tunneled into the **staging** relay via the `relay-url-override` PostHog flag.

Result: whenever the team rolls the staging-relay flag out for testing, the Slack app breaks for the whole company, because the agent's MCP calls land on production relay where the host's tunnel isn't registered.

The desktop main process, the desktop renderer, the web app, and the CLI all already resolve the relay URL through this flag. Only the API app's MCP paths didn't.

## Change

- New `apps/api/src/lib/relay-url.ts` — `getRelayUrl(userId)` reads the `relay-url-override` PostHog flag payload for the user and falls back to `env.RELAY_URL` when the flag is off / payload malformed / PostHog unreachable. Mirrors `apps/desktop/src/main/lib/relay-url` and `packages/cli/src/lib/host/relay-url`.
- `createSupersetMcpV2Client` (Slack agent) now passes `await getRelayUrl(userId)` instead of `env.RELAY_URL`.
- The external MCP route now overrides `ctx.relayUrl` with `getRelayUrl(ctx.userId)` after resolving the auth context (the userId isn't known until then).

MCP v1 is in-memory and never touches the relay, so it's untouched.

## Testing

- `bun run lint` — clean
- `bun run typecheck` (`@superset/api`) — passes

To exercise: set the `relay-url-override` flag payload to `{ "url": "https://superset-relay-staging.fly.dev" }` for a user, then `@mention` the Slack app — the agent's host-touching tools should route to staging.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4656">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the `relay-url-override` PostHog flag so Slack MCP v2 and external MCP requests use the correct relay per user, not always `env.RELAY_URL`. This prevents Slack from breaking during staging relay tests by matching the relay the host registered with.

- **Bug Fixes**
  - Added `getRelayUrl(userId)` in `apps/api/src/lib/relay-url.ts` to read the flag and fall back to `env.RELAY_URL`.
  - Slack agent `createSupersetMcpV2Client` now uses `await getRelayUrl(userId)`.
  - External route `/api/v2/agent/[transport]` sets `ctx.relayUrl = await getRelayUrl(ctx.userId)` after auth.

<sup>Written for commit 2a9d59c86e46793d22980f9475947099d34845e9. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4656?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for user-specific relay URL configuration via feature flags, with automatic fallback to default settings.

* **Refactor**
  * Updated Slack and API agent integrations to dynamically resolve relay URLs per user instead of using static configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->