### PR TITLE
fix(web): physical terminal input on mobile, no tap-to-type

### DIFF
--- a/apps/web/src/app/(public)/agents/remote-control/[sessionId]/components/RemoteTerminal/RemoteTerminal.tsx
+++ b/apps/web/src/app/(public)/agents/remote-control/[sessionId]/components/RemoteTerminal/RemoteTerminal.tsx
@@ -185,6 +185,14 @@ export function RemoteTerminal({ sessionId, token }: RemoteTerminalProps) {
 		}
 		termRef.current = term;
 		fitRef.current = fit;
+		if (window.matchMedia("(pointer: coarse)").matches) {
+			const xtermInput = term.textarea;
+			if (xtermInput) {
+				xtermInput.readOnly = true;
+				xtermInput.inputMode = "none";
+				xtermInput.tabIndex = -1;
+			}
+		}
 
 		const url = `${meta.wsUrl}?${REMOTE_CONTROL_TOKEN_PARAM}=${encodeURIComponent(token)}`;
 		const ws = new WebSocket(url);
@@ -490,13 +498,7 @@ export function RemoteTerminal({ sessionId, token }: RemoteTerminalProps) {
 			>
 				<div ref={containerRef} className="absolute inset-0" />
 			</div>
-			{isFull && (
-				<MobileTerminalInput
-					focusTargetRef={containerRef}
-					onFocusTerminal={() => termRef.current?.focus()}
-					onSend={sendInputText}
-				/>
-			)}
+			{isFull && <MobileTerminalInput onSend={sendInputText} />}
 		</div>
 	);
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7,3 +7,8 @@
 	--font-family-mono: var(--font-ibm-plex-mono), ui-monospace, monospace;
 	--font-family-sans: var(--font-inter), ui-sans-serif, sans-serif;
 }
+
+.xterm-viewport {
+	touch-action: pan-y;
+	overscroll-behavior: contain;
+}

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx
@@ -59,7 +59,6 @@ export function WebTerminal({
 	routingKey,
 }: WebTerminalProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
-	const terminalRef = useRef<Terminal | null>(null);
 	const socketRef = useRef<WebSocket | null>(null);
 	const [state, setState] = useState<ConnectionState>("connecting");
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -130,7 +129,14 @@ export function WebTerminal({
 				fitAddon = new FitAddon();
 				terminal.loadAddon(fitAddon);
 				terminal.open(container);
-				terminalRef.current = terminal;
+				if (window.matchMedia("(pointer: coarse)").matches) {
+					const xtermInput = terminal.textarea;
+					if (xtermInput) {
+						xtermInput.readOnly = true;
+						xtermInput.inputMode = "none";
+						xtermInput.tabIndex = -1;
+					}
+				}
 				try {
 					fitAddon.fit();
 				} catch {
@@ -218,7 +224,6 @@ export function WebTerminal({
 				// best-effort
 			}
 			terminal?.dispose();
-			terminalRef.current = null;
 			socketRef.current = null;
 		};
 	}, [workspaceId, terminalId, routingKey]);
@@ -240,12 +245,7 @@ export function WebTerminal({
 					</div>
 				)}
 			</div>
-			<MobileTerminalInput
-				focusTargetRef={containerRef}
-				onFocusTerminal={() => terminalRef.current?.focus()}
-				onSend={sendSequence}
-				toolbarVisibility="always"
-			/>
+			<MobileTerminalInput onSend={sendSequence} visibility="always" />
 		</div>
 	);
 }

--- a/apps/web/src/app/workspaces/[workspaceId]/page.tsx
+++ b/apps/web/src/app/workspaces/[workspaceId]/page.tsx
@@ -39,7 +39,10 @@ export default function WorkspaceTerminalPage({
 	const [loadError, setLoadError] = useState<string | null>(null);
 	const [creating, setCreating] = useState(false);
 	const [runningPresetId, setRunningPresetId] = useState<string | null>(null);
-	const [viewportHeight, setViewportHeight] = useState<number | null>(null);
+	const [viewport, setViewport] = useState<{
+		height: number;
+		offsetTop: number;
+	} | null>(null);
 
 	const loadTerminals = useCallback(
 		async (key: string) => {
@@ -112,7 +115,11 @@ export default function WorkspaceTerminalPage({
 	useEffect(() => {
 		const visualViewport = window.visualViewport;
 		if (!visualViewport) return;
-		const update = () => setViewportHeight(visualViewport.height);
+		const update = () =>
+			setViewport({
+				height: visualViewport.height,
+				offsetTop: visualViewport.offsetTop,
+			});
 		const scrollListenerOptions = { passive: true };
 		const visualViewportTarget = visualViewport as EventTarget;
 		update();
@@ -161,8 +168,11 @@ export default function WorkspaceTerminalPage({
 
 	return (
 		<div
-			className="flex flex-col overflow-hidden bg-[#151110] text-[#eae8e6]"
-			style={{ height: viewportHeight ? `${viewportHeight}px` : "100dvh" }}
+			className="fixed inset-x-0 flex flex-col overflow-hidden bg-[#151110] text-[#eae8e6]"
+			style={{
+				top: viewport ? `${viewport.offsetTop}px` : 0,
+				height: viewport ? `${viewport.height}px` : "100dvh",
+			}}
 		>
 			<header
 				className="flex flex-wrap items-center gap-2 border-b px-3 py-2 text-sm"

--- a/apps/web/src/components/MobileTerminalInput/MobileTerminalInput.tsx
+++ b/apps/web/src/components/MobileTerminalInput/MobileTerminalInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type RefObject, useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const KEY_BUTTONS: Array<{ label: string; sequence: string }> = [
 	{ label: "Tab", sequence: "\t" },
@@ -14,78 +14,28 @@ const KEY_BUTTONS: Array<{ label: string; sequence: string }> = [
 ];
 
 interface MobileTerminalInputProps {
-	focusTargetRef: RefObject<HTMLElement | null>;
 	onSend: (sequence: string) => void;
-	onFocusTerminal?: () => void;
-	enabled?: boolean;
-	toolbarVisibility?: "always" | "mobile";
+	visibility?: "always" | "mobile";
 }
 
 export function MobileTerminalInput({
-	focusTargetRef,
 	onSend,
-	onFocusTerminal,
-	enabled = true,
-	toolbarVisibility = "mobile",
+	visibility = "mobile",
 }: MobileTerminalInputProps) {
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const isComposingRef = useRef(false);
-
-	const focusKeyboardInput = useCallback(() => {
-		if (!enabled) return;
-		const scrollingElement =
-			document.scrollingElement ?? document.documentElement;
-		const savedScrollTop = scrollingElement?.scrollTop ?? 0;
-		const savedScrollLeft = scrollingElement?.scrollLeft ?? 0;
-		const savedWindowY = window.scrollY;
-		const savedWindowX = window.scrollX;
-		textareaRef.current?.focus({ preventScroll: true });
-		// iOS Safari ignores preventScroll when focusing an input that sits
-		// under the soft keyboard — it scrolls the page to bring the caret
-		// into view, which on a viewport-height page yanks everything to
-		// the top. Restore the prior scroll across the next few frames in
-		// case the OS scroll fires after our focus call.
-		const restore = () => {
-			if (scrollingElement) {
-				if (scrollingElement.scrollTop !== savedScrollTop) {
-					scrollingElement.scrollTop = savedScrollTop;
-				}
-				if (scrollingElement.scrollLeft !== savedScrollLeft) {
-					scrollingElement.scrollLeft = savedScrollLeft;
-				}
-			}
-			if (window.scrollY !== savedWindowY || window.scrollX !== savedWindowX) {
-				window.scrollTo(savedWindowX, savedWindowY);
-			}
-		};
-		requestAnimationFrame(() => {
-			restore();
-			requestAnimationFrame(restore);
-		});
-	}, [enabled]);
+	const [focused, setFocused] = useState(false);
+	const [coarsePointer, setCoarsePointer] = useState(false);
 
 	useEffect(() => {
-		const target = focusTargetRef.current;
-		if (!target) return;
-
-		const onPointerDown = (event: PointerEvent) => {
-			if (event.pointerType === "mouse") {
-				onFocusTerminal?.();
-				return;
-			}
-			focusKeyboardInput();
+		const query = window.matchMedia("(pointer: coarse)");
+		setCoarsePointer(query.matches);
+		const onChange = (event: MediaQueryListEvent) => {
+			setCoarsePointer(event.matches);
 		};
-		const onTouchStart = () => {
-			focusKeyboardInput();
-		};
-
-		target.addEventListener("pointerdown", onPointerDown, { passive: true });
-		target.addEventListener("touchstart", onTouchStart, { passive: true });
-		return () => {
-			target.removeEventListener("pointerdown", onPointerDown);
-			target.removeEventListener("touchstart", onTouchStart);
-		};
-	}, [focusKeyboardInput, focusTargetRef, onFocusTerminal]);
+		query.addEventListener("change", onChange);
+		return () => query.removeEventListener("change", onChange);
+	}, []);
 
 	const flushTextareaValue = useCallback(
 		(textarea: HTMLTextAreaElement) => {
@@ -99,28 +49,42 @@ export function MobileTerminalInput({
 
 	const sendButtonSequence = useCallback(
 		(sequence: string) => {
-			focusKeyboardInput();
+			textareaRef.current?.focus({ preventScroll: true });
 			onSend(sequence);
 		},
-		[focusKeyboardInput, onSend],
+		[onSend],
 	);
 
-	const toolbarClassName =
-		toolbarVisibility === "mobile"
-			? "border-t px-2 py-1 sm:hidden"
-			: "border-t p-1";
+	if (visibility === "mobile" && !coarsePointer) return null;
 
 	return (
-		<>
+		<div
+			className="flex flex-col gap-2 border-t px-2 py-2"
+			style={{
+				borderColor: "#2a2827",
+				backgroundColor: "#1a1716",
+				paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))",
+			}}
+		>
 			<textarea
 				ref={textareaRef}
 				aria-label="Terminal input"
 				autoCapitalize="none"
 				autoComplete="off"
 				autoCorrect="off"
-				className="pointer-events-none fixed top-0 left-0 h-px w-px resize-none opacity-0"
+				className="w-full resize-none overflow-hidden rounded border px-3 py-2 text-sm outline-none"
 				enterKeyHint="enter"
 				inputMode="text"
+				placeholder={focused ? undefined : "Type here to send to the terminal"}
+				rows={1}
+				spellCheck={false}
+				style={{
+					borderColor: focused ? "#e07850" : "#2a2827",
+					backgroundColor: "#151110",
+					color: "#eae8e6",
+				}}
+				onBlur={() => setFocused(false)}
+				onFocus={() => setFocused(true)}
 				onBeforeInput={(event) => {
 					const nativeEvent = event.nativeEvent as InputEvent;
 					switch (nativeEvent.inputType) {
@@ -205,26 +169,21 @@ export function MobileTerminalInput({
 					event.currentTarget.value = "";
 					onSend(text);
 				}}
-				spellCheck={false}
 			/>
-			<div
-				className={toolbarClassName}
-				style={{ borderColor: "#2a2827", backgroundColor: "#1a1716" }}
-			>
-				<div className="flex flex-wrap gap-1">
-					{KEY_BUTTONS.map((button) => (
-						<button
-							key={button.label}
-							type="button"
-							onClick={() => sendButtonSequence(button.sequence)}
-							className="rounded border px-2 py-1 text-xs"
-							style={{ borderColor: "#2a2827", color: "#eae8e6" }}
-						>
-							{button.label}
-						</button>
-					))}
-				</div>
+			<div className="flex flex-wrap gap-1">
+				{KEY_BUTTONS.map((button) => (
+					<button
+						key={button.label}
+						type="button"
+						onPointerDown={(event) => event.preventDefault()}
+						onClick={() => sendButtonSequence(button.sequence)}
+						className="rounded border px-2 py-1 text-xs"
+						style={{ borderColor: "#2a2827", color: "#eae8e6" }}
+					>
+						{button.label}
+					</button>
+				))}
 			</div>
-		</>
+		</div>
 	);
 }


### PR DESCRIPTION
## Problem

On the `/workspaces` web terminal, input was a hidden 1px `opacity-0` textarea that got focused whenever the terminal body was tapped. On mobile this meant:

- You couldn't scroll the terminal without the soft keyboard popping up.
- Focusing that `position: fixed` offscreen element made iOS snap the page to the top.
- The "input" wasn't a real, visible thing you could deliberately tap.

## Changes

**`MobileTerminalInput`** — now a visible input bar (a real `textarea` + the key toolbar) in normal layout flow, instead of an offscreen 1px field. Placeholder affordance, focus ring, and `env(safe-area-inset-bottom)` padding for the home indicator. Keystrokes still pass straight through to the PTY, so interactive programs keep working.

**No more tap-to-type** — the terminal container no longer captures `pointerdown`/`touchstart` to focus an input. On coarse-pointer devices, xterm's own helper textarea is set `readonly` + `inputmode="none"`, so tapping the terminal scrolls/selects instead of opening the keyboard. Desktop (fine pointer) keeps native xterm input — click the terminal and type as before.

**No snap to top** — the workspace page now pins itself to the visual viewport (`position: fixed` + tracked `offsetTop`/`height`) so opening the keyboard resizes the app in place rather than scrolling the document.

**Smoother mobile scroll** — `.xterm-viewport` gets `touch-action: pan-y` and `overscroll-behavior: contain`.

The shared `MobileTerminalInput` is also used by the remote-control viewer; it's updated to match. Its visibility is now driven by `(pointer: coarse)` rather than the `sm` breakpoint, so coarse-pointer tablets get the input bar too.

## Files

- `components/MobileTerminalInput/MobileTerminalInput.tsx` — visible input bar, pointer-based visibility, drop container focus listeners
- `workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx` — readonly xterm textarea on touch, drop `onFocusTerminal`
- `workspaces/[workspaceId]/page.tsx` — pin to visual viewport
- `(public)/agents/remote-control/[sessionId]/components/RemoteTerminal/RemoteTerminal.tsx` — same readonly-on-touch + prop update
- `app/globals.css` — `.xterm-viewport` touch scrolling

## Testing

- `bun run typecheck` (apps/web) — passes
- `bunx biome check` on changed files — clean
- Manual mobile verification recommended: scrolling without keyboard, tapping the input bar to type, keyboard open/close not snapping the page.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4657">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile terminal input on touch devices by replacing the hidden field with a visible input bar and disabling tap-to-type so you can scroll without opening the keyboard. Also stops iOS from snapping to the top when the keyboard opens and smooths touch scrolling.

- **Bug Fixes**
  - Visible input bar (real textarea + key toolbar); input goes straight to the PTY.
  - No tap-to-type: on coarse-pointer devices, `xterm`’s textarea is `readonly` with `inputmode="none"` (and `tabIndex=-1`), so taps scroll/select; desktop typing is unchanged.
  - Workspace page pins to the visual viewport (fixed with tracked `offsetTop`/`height`) to prevent snap-to-top when the keyboard appears.
  - Smoother touch scroll via `.xterm-viewport { touch-action: pan-y; overscroll-behavior: contain; }`.
  - Remote-control viewer gets the same behavior; the input bar shows on `(pointer: coarse)` devices.

<sup>Written for commit a3a8c83e5d1d8b30cb54c4c259dc6b3238478a19. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4657?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mobile devices: direct keyboard/text input is disabled on coarse-pointer devices; terminal input is provided via an optimized, button-first mobile input.
  * Simplified mobile input behavior and focus handling for more consistent typing and button sends.
  * Improved touch scrolling/overscroll behavior and visual-viewport–aware terminal sizing for better mobile layout and positioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->