### PR TITLE
feat(web): identify main workspaces in /workspaces list

### DIFF
--- a/apps/web/src/app/workspaces/page.tsx
+++ b/apps/web/src/app/workspaces/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Laptop } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { trpcClient } from "../../trpc/client";
@@ -11,6 +12,7 @@ interface WorkspaceRow {
 	projectId: string;
 	projectName: string;
 	hostId: string;
+	type: "main" | "worktree";
 	createdAt: Date;
 }
 
@@ -84,6 +86,7 @@ export default function WorkspacesPage() {
 				projectId: row.projectId,
 				projectName: row.projectName,
 				hostId: row.hostId,
+				type: row.type,
 				createdAt: new Date(row.createdAt),
 			})),
 		);
@@ -329,7 +332,15 @@ export default function WorkspacesPage() {
 									href={`/workspaces/${workspace.id}`}
 									className="hover:bg-muted/50 block rounded-lg border px-4 py-3"
 								>
-									<div className="text-sm font-medium">{workspace.name}</div>
+									<div className="flex items-center gap-1.5 text-sm font-medium">
+										{workspace.type === "main" && (
+											<Laptop
+												aria-label="Main workspace"
+												className="text-muted-foreground size-3.5 shrink-0"
+											/>
+										)}
+										<span>{workspace.name}</span>
+									</div>
 									<div className="text-muted-foreground mt-0.5 text-xs">
 										{workspace.projectName} · {workspace.branch} · created{" "}
 										{formatRelative(workspace.createdAt)}

--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -147,6 +147,7 @@ export const v2WorkspaceRouter = {
 					projectId: v2Workspaces.projectId,
 					projectName: v2Projects.name,
 					hostId: v2Workspaces.hostId,
+					type: v2Workspaces.type,
 					createdAt: v2Workspaces.createdAt,
 				})
 				.from(v2Workspaces)
@@ -180,6 +181,7 @@ export const v2WorkspaceRouter = {
 				projectId: row.projectId,
 				projectName: row.projectName ?? "",
 				hostId: row.hostId,
+				type: row.type,
 				createdAt: row.createdAt,
 			}));
 		}),


### PR DESCRIPTION
## What changed

On the `/workspaces` page, main workspaces were visually indistinguishable from regular (worktree) workspaces — every card looked the same.

This adds a **laptop icon** next to the workspace name on the card for `type === "main"` workspaces, so they're identifiable at a glance.

## Why

Main workspaces have different semantics (they can't be deleted, are idempotent per project/host) and are treated specially elsewhere in the product. The desktop app already surfaces a laptop icon for main workspaces in its workspace list (`V2WorkspaceRow`); this brings the web `/workspaces` list to parity.

## Changes

- **`packages/trpc/src/router/v2-workspace/v2-workspace.ts`** — `v2Workspace.list` now selects and returns the workspace `type` (`"main" | "worktree"`). Additive, no breaking change for existing consumers.
- **`apps/web/src/app/workspaces/page.tsx`** — `WorkspaceRow` carries `type`; the card renders a `lucide-react` `Laptop` icon (with `aria-label="Main workspace"`) before the name for main workspaces. Styling stays consistent with the existing design system — muted foreground color, `size-3.5`, same lucide icon set used throughout the web app.

## Testing

- `bun run lint` — clean
- `bun run typecheck` — all 28 packages pass

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make main workspaces easy to spot on /workspaces by showing a laptop icon next to their name. Expose `type` in `v2Workspace.list` and pass it through the page; this is additive and non-breaking.

<sup>Written for commit 4f86179320e457851483c12495fb2a73eef35857. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4659?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Workspace type information is now displayed in the workspaces list. The main workspace is visually marked with a distinctive icon, making it easier to identify your primary workspace at a glance when managing multiple workspaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->