### PR TITLE
feat(slack): make Slack agent proactive about spawning workspaces

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -399,16 +399,18 @@ async function handleGetChannelHistory({
 	return JSON.stringify({ messages });
 }
 
-const SYSTEM_PROMPT = `You are a helpful assistant in Slack for Superset, a task management application.
+const SYSTEM_PROMPT = `You are a helpful assistant in Slack for Superset, a platform for managing tasks and running coding agents in workspaces.
 
 You can:
 - Create, update, search, and manage tasks using superset_* tools
+- Spawn workspaces and launch coding agents to do the work using superset_* tools
 - Read recent channel messages using slack_get_channel_history
 - Search the web for current information using web_search
 - Help users understand conversations and create actionable items from discussions
 
 Guidelines:
 - Be concise and clear (this is Slack, not email)
+- Default to taking action when intent is clear — for requests that involve code changes, prefer spawning a workspace and agent over just filing a task, and only ask for clarification when the request is genuinely ambiguous
 - When creating tasks, extract key details from the conversation
 - Use Slack formatting: *bold*, _italic_, \`code\`, > quotes
 - If an action fails, explain what went wrong and suggest alternatives


### PR DESCRIPTION
## Summary
- Reframe the Slack agent's `SYSTEM_PROMPT` opener — it described the bot as a task-management assistant, but it can also spawn workspaces and run coding agents.
- Add that capability to the "You can" list and add one guideline so the bot defaults to action: for code-change requests, prefer spawning a workspace + agent over just filing a task.

## Why / Context
For "can someone fix X" style messages the bot tended to file a task or ask questions rather than kick off the work, partly because the prompt only framed it around task tracking. This nudges it toward action while keeping it a general Slack assistant.

## Testing
- `bunx biome check` on the changed file — clean
- No automated tests added (prompt-text-only change)

## Notes
- Only the static `SYSTEM_PROMPT` string changed; the dynamic context interpolation (org, channel, members, statuses, hosts) is untouched.
- The prompt is shared across the v1 and v2 MCP feature-flag paths (`FEATURE_FLAGS.SLACK_MCP_V2`). Workspace/agent spawning is a v2 capability; on v1 the bot adapts to the tools it's given.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Slack assistant prompt updated to focus on Superset-related tasks and tool usage.
  * Guidance restructured to emphasize using Superset tools, workspace spawning, and launching coding agents.
  * Assistant more proactive: when intent is clear (especially for code changes), it favors spawning a workspace/agent to take action.
  * Retains task creation, formatting, error handling, sourcing, and context-gathering behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->