### PR TITLE
[codex] fix v2 setup script autosave

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
@@ -24,6 +24,14 @@ interface ParsedConfig {
 	run: string;
 }
 
+type ScriptFieldName = keyof ParsedConfig;
+
+interface ScriptPayload {
+	setup: string[];
+	teardown: string[];
+	run: string[];
+}
+
 function parseConfigContent(content: string | null): ParsedConfig {
 	if (!content) return { setup: "", teardown: "", run: "" };
 	try {
@@ -60,6 +68,30 @@ function arraysEqual(a: string[], b: string[]): boolean {
 	return a.length === b.length && a.every((v, i) => v === b[i]);
 }
 
+function buildPayload(values: ParsedConfig): ScriptPayload {
+	return {
+		setup: toCommandsArray(values.setup),
+		teardown: toCommandsArray(values.teardown),
+		run: toCommandsArray(values.run),
+	};
+}
+
+function payloadsEqual(a: ScriptPayload, b: ScriptPayload): boolean {
+	return (
+		arraysEqual(a.setup, b.setup) &&
+		arraysEqual(a.teardown, b.teardown) &&
+		arraysEqual(a.run, b.run)
+	);
+}
+
+function trimScriptValue(value: string): string {
+	return value
+		.split("\n")
+		.map((line) => line.trim())
+		.join("\n")
+		.replace(/^\n+|\n+$/g, "");
+}
+
 type SaveStatus = "idle" | "saving" | "saved";
 
 export function V2ScriptsEditor({
@@ -88,34 +120,43 @@ export function V2ScriptsEditor({
 	const [teardownValue, setTeardownValue] = useState("");
 	const [runValue, setRunValue] = useState("");
 	const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
-	const focusedRef = useRef<"setup" | "teardown" | "run" | null>(null);
-	const lastSavedRef = useRef<{
-		setup: string[];
-		teardown: string[];
-		run: string[];
-	}>({
+	const focusedRef = useRef<ScriptFieldName | null>(null);
+	const latestValuesRef = useRef<ParsedConfig>({
+		setup: "",
+		teardown: "",
+		run: "",
+	});
+	const lastSavedRef = useRef<ScriptPayload>({
 		setup: [],
 		teardown: [],
 		run: [],
 	});
-	const savedTimerRef = useRef<NodeJS.Timeout | null>(null);
+	const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const saveInFlightRef = useRef(false);
+	const queuedPayloadRef = useRef<ScriptPayload | null>(null);
 
 	useEffect(() => {
 		// Don't clobber an in-progress edit when the server-side query refetches.
-		if (focusedRef.current) return;
+		if (
+			focusedRef.current ||
+			debounceTimerRef.current ||
+			saveInFlightRef.current ||
+			queuedPayloadRef.current
+		) {
+			return;
+		}
 		const parsed = parseConfigContent(configData?.content ?? null);
 		setSetupValue(parsed.setup);
 		setTeardownValue(parsed.teardown);
 		setRunValue(parsed.run);
-		lastSavedRef.current = {
-			setup: toCommandsArray(parsed.setup),
-			teardown: toCommandsArray(parsed.teardown),
-			run: toCommandsArray(parsed.run),
-		};
+		latestValuesRef.current = parsed;
+		lastSavedRef.current = buildPayload(parsed);
 	}, [configData?.content]);
 
 	useEffect(() => {
 		return () => {
+			if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 			if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
 		};
 	}, []);
@@ -133,12 +174,13 @@ export function V2ScriptsEditor({
 	});
 
 	const flushSave = useCallback(
-		async (next: { setup: string[]; teardown: string[]; run: string[] }) => {
-			if (
-				arraysEqual(next.setup, lastSavedRef.current.setup) &&
-				arraysEqual(next.teardown, lastSavedRef.current.teardown) &&
-				arraysEqual(next.run, lastSavedRef.current.run)
-			) {
+		async (next: ScriptPayload = buildPayload(latestValuesRef.current)) => {
+			if (payloadsEqual(next, lastSavedRef.current)) {
+				return;
+			}
+
+			if (saveInFlightRef.current) {
+				queuedPayloadRef.current = next;
 				return;
 			}
 
@@ -148,9 +190,21 @@ export function V2ScriptsEditor({
 			}
 
 			setSaveStatus("saving");
+			saveInFlightRef.current = true;
 			try {
-				await updateMutation.mutateAsync({ projectId, ...next });
-				lastSavedRef.current = next;
+				let payloadToSave: ScriptPayload | null = next;
+
+				while (payloadToSave) {
+					queuedPayloadRef.current = null;
+
+					if (!payloadsEqual(payloadToSave, lastSavedRef.current)) {
+						await updateMutation.mutateAsync({ projectId, ...payloadToSave });
+						lastSavedRef.current = payloadToSave;
+					}
+
+					payloadToSave = queuedPayloadRef.current;
+				}
+
 				setSaveStatus("saved");
 				savedTimerRef.current = setTimeout(() => {
 					setSaveStatus("idle");
@@ -159,42 +213,65 @@ export function V2ScriptsEditor({
 			} catch (error) {
 				console.error("[v2-scripts/save] failed", error);
 				setSaveStatus("idle");
+			} finally {
+				saveInFlightRef.current = false;
 			}
 		},
 		[projectId, updateMutation],
 	);
 
+	const scheduleSave = useCallback(
+		(nextValues: ParsedConfig) => {
+			latestValuesRef.current = nextValues;
+
+			if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+
+			debounceTimerRef.current = setTimeout(() => {
+				debounceTimerRef.current = null;
+				void flushSave(buildPayload(latestValuesRef.current));
+			}, 500);
+		},
+		[flushSave],
+	);
+
+	const handleChange = useCallback(
+		(field: ScriptFieldName, value: string) => {
+			const nextValues = { ...latestValuesRef.current, [field]: value };
+			latestValuesRef.current = nextValues;
+
+			if (field === "setup") setSetupValue(value);
+			if (field === "teardown") setTeardownValue(value);
+			if (field === "run") setRunValue(value);
+
+			scheduleSave(nextValues);
+		},
+		[scheduleSave],
+	);
+
 	const handleBlur = useCallback(
-		async (field: "setup" | "teardown" | "run") => {
+		async (_field: ScriptFieldName) => {
 			focusedRef.current = null;
 
-			const trimmedSetup = setupValue
-				.split("\n")
-				.map((line) => line.trim())
-				.join("\n")
-				.replace(/^\n+|\n+$/g, "");
-			const trimmedTeardown = teardownValue
-				.split("\n")
-				.map((line) => line.trim())
-				.join("\n")
-				.replace(/^\n+|\n+$/g, "");
-			const trimmedRun = runValue
-				.split("\n")
-				.map((line) => line.trim())
-				.join("\n")
-				.replace(/^\n+|\n+$/g, "");
+			if (debounceTimerRef.current) {
+				clearTimeout(debounceTimerRef.current);
+				debounceTimerRef.current = null;
+			}
 
-			if (trimmedSetup !== setupValue) setSetupValue(trimmedSetup);
-			if (trimmedTeardown !== teardownValue) setTeardownValue(trimmedTeardown);
-			if (trimmedRun !== runValue) setRunValue(trimmedRun);
+			const trimmedValues = {
+				setup: trimScriptValue(latestValuesRef.current.setup),
+				teardown: trimScriptValue(latestValuesRef.current.teardown),
+				run: trimScriptValue(latestValuesRef.current.run),
+			};
+			latestValuesRef.current = trimmedValues;
 
-			await flushSave({
-				setup: toCommandsArray(field === "setup" ? trimmedSetup : setupValue),
-				teardown: toCommandsArray(
-					field === "teardown" ? trimmedTeardown : teardownValue,
-				),
-				run: toCommandsArray(field === "run" ? trimmedRun : runValue),
-			});
+			if (trimmedValues.setup !== setupValue)
+				setSetupValue(trimmedValues.setup);
+			if (trimmedValues.teardown !== teardownValue) {
+				setTeardownValue(trimmedValues.teardown);
+			}
+			if (trimmedValues.run !== runValue) setRunValue(trimmedValues.run);
+
+			await flushSave(buildPayload(trimmedValues));
 		},
 		[flushSave, runValue, setupValue, teardownValue],
 	);
@@ -248,7 +325,7 @@ export function V2ScriptsEditor({
 						description="Runs when a new workspace is created. Multiple lines run as one chain — failures short-circuit."
 						placeholder="bun install&#10;bun run db:migrate"
 						value={setupValue}
-						onChange={setSetupValue}
+						onChange={(value) => handleChange("setup", value)}
 						onFocus={() => {
 							focusedRef.current = "setup";
 						}}
@@ -261,7 +338,7 @@ export function V2ScriptsEditor({
 						description="Runs when a workspace is deleted."
 						placeholder="docker compose down"
 						value={teardownValue}
-						onChange={setTeardownValue}
+						onChange={(value) => handleChange("teardown", value)}
 						onFocus={() => {
 							focusedRef.current = "teardown";
 						}}
@@ -274,7 +351,7 @@ export function V2ScriptsEditor({
 						description="Runs from the workspace Run button."
 						placeholder="bun dev"
 						value={runValue}
-						onChange={setRunValue}
+						onChange={(value) => handleChange("run", value)}
 						onFocus={() => {
 							focusedRef.current = "run";
 						}}
@@ -287,7 +364,7 @@ export function V2ScriptsEditor({
 }
 
 interface ScriptFieldProps {
-	field: "setup" | "teardown" | "run";
+	field: ScriptFieldName;
 	description: string;
 	placeholder: string;
 	value: string;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
@@ -212,7 +212,16 @@ export function V2ScriptsEditor({
 				}, 2000);
 			} catch (error) {
 				console.error("[v2-scripts/save] failed", error);
+				queuedPayloadRef.current =
+					queuedPayloadRef.current ?? buildPayload(latestValuesRef.current);
 				setSaveStatus("idle");
+				if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+				debounceTimerRef.current = setTimeout(() => {
+					debounceTimerRef.current = null;
+					const payloadToRetry = queuedPayloadRef.current;
+					queuedPayloadRef.current = null;
+					if (payloadToRetry) void flushSave(payloadToRetry);
+				}, 1000);
 			} finally {
 				saveInFlightRef.current = false;
 			}
@@ -248,33 +257,29 @@ export function V2ScriptsEditor({
 		[scheduleSave],
 	);
 
-	const handleBlur = useCallback(
-		async (_field: ScriptFieldName) => {
-			focusedRef.current = null;
+	const handleBlur = useCallback(async () => {
+		focusedRef.current = null;
 
-			if (debounceTimerRef.current) {
-				clearTimeout(debounceTimerRef.current);
-				debounceTimerRef.current = null;
-			}
+		if (debounceTimerRef.current) {
+			clearTimeout(debounceTimerRef.current);
+			debounceTimerRef.current = null;
+		}
 
-			const trimmedValues = {
-				setup: trimScriptValue(latestValuesRef.current.setup),
-				teardown: trimScriptValue(latestValuesRef.current.teardown),
-				run: trimScriptValue(latestValuesRef.current.run),
-			};
-			latestValuesRef.current = trimmedValues;
+		const trimmedValues = {
+			setup: trimScriptValue(latestValuesRef.current.setup),
+			teardown: trimScriptValue(latestValuesRef.current.teardown),
+			run: trimScriptValue(latestValuesRef.current.run),
+		};
+		latestValuesRef.current = trimmedValues;
 
-			if (trimmedValues.setup !== setupValue)
-				setSetupValue(trimmedValues.setup);
-			if (trimmedValues.teardown !== teardownValue) {
-				setTeardownValue(trimmedValues.teardown);
-			}
-			if (trimmedValues.run !== runValue) setRunValue(trimmedValues.run);
+		if (trimmedValues.setup !== setupValue) setSetupValue(trimmedValues.setup);
+		if (trimmedValues.teardown !== teardownValue) {
+			setTeardownValue(trimmedValues.teardown);
+		}
+		if (trimmedValues.run !== runValue) setRunValue(trimmedValues.run);
 
-			await flushSave(buildPayload(trimmedValues));
-		},
-		[flushSave, runValue, setupValue, teardownValue],
-	);
+		await flushSave(buildPayload(trimmedValues));
+	}, [flushSave, runValue, setupValue, teardownValue]);
 
 	if (isLoading) {
 		return (
@@ -321,7 +326,6 @@ export function V2ScriptsEditor({
 				</TabsList>
 				<TabsContent value="setup">
 					<ScriptField
-						field="setup"
 						description="Runs when a new workspace is created. Multiple lines run as one chain — failures short-circuit."
 						placeholder="bun install&#10;bun run db:migrate"
 						value={setupValue}
@@ -329,12 +333,11 @@ export function V2ScriptsEditor({
 						onFocus={() => {
 							focusedRef.current = "setup";
 						}}
-						onBlur={() => handleBlur("setup")}
+						onBlur={() => handleBlur()}
 					/>
 				</TabsContent>
 				<TabsContent value="teardown">
 					<ScriptField
-						field="teardown"
 						description="Runs when a workspace is deleted."
 						placeholder="docker compose down"
 						value={teardownValue}
@@ -342,12 +345,11 @@ export function V2ScriptsEditor({
 						onFocus={() => {
 							focusedRef.current = "teardown";
 						}}
-						onBlur={() => handleBlur("teardown")}
+						onBlur={() => handleBlur()}
 					/>
 				</TabsContent>
 				<TabsContent value="run">
 					<ScriptField
-						field="run"
 						description="Runs from the workspace Run button."
 						placeholder="bun dev"
 						value={runValue}
@@ -355,7 +357,7 @@ export function V2ScriptsEditor({
 						onFocus={() => {
 							focusedRef.current = "run";
 						}}
-						onBlur={() => handleBlur("run")}
+						onBlur={() => handleBlur()}
 					/>
 				</TabsContent>
 			</Tabs>
@@ -364,7 +366,6 @@ export function V2ScriptsEditor({
 }
 
 interface ScriptFieldProps {
-	field: ScriptFieldName;
 	description: string;
 	placeholder: string;
 	value: string;

--- a/packages/host-service/test/integration/setup-scripts.integration.test.ts
+++ b/packages/host-service/test/integration/setup-scripts.integration.test.ts
@@ -125,7 +125,7 @@ describe("setup scripts integration", () => {
 
 		await waitFor(
 			() => writes.includes("echo setup-a && echo setup-b\n"),
-			1000,
+			5000,
 			() => `expected setup command write, got ${JSON.stringify(writes)}`,
 		);
 
@@ -134,9 +134,16 @@ describe("setup scripts integration", () => {
 			.from(workspaces)
 			.where(eq(workspaces.id, created.workspace.id))
 			.get();
+		expect(workspaceRow).toBeDefined();
+		if (!workspaceRow) throw new Error("Expected workspace row to exist");
+
 		const setupTerminal = spawned.at(-1);
-		expect(setupTerminal?.meta.cwd).toBe(workspaceRow?.worktreePath);
-		expect(setupTerminal?.meta.env?.SUPERSET_ROOT_PATH).toBe(
+		expect(setupTerminal).toBeDefined();
+		if (!setupTerminal)
+			throw new Error("Expected setup terminal to be spawned");
+
+		expect(setupTerminal.meta.cwd).toBe(workspaceRow.worktreePath);
+		expect(setupTerminal.meta.env?.SUPERSET_ROOT_PATH).toBe(
 			scenario.repo.repoPath,
 		);
 	});

--- a/packages/host-service/test/integration/setup-scripts.integration.test.ts
+++ b/packages/host-service/test/integration/setup-scripts.integration.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Server } from "@superset/pty-daemon";
+import { eq } from "drizzle-orm";
+import { workspaces } from "../../src/db/schema";
+import { getProjectConfigPath } from "../../src/runtime/setup/config";
+import { disposeDaemonClient } from "../../src/terminal/daemon-client-singleton";
+import {
+	initTerminalBaseEnv,
+	resetTerminalBaseEnvForTests,
+} from "../../src/terminal/env";
+import { __resetSessionsForTesting } from "../../src/terminal/terminal";
+import { __setAccountShellForTesting } from "../../src/terminal/user-shell";
+import { cloudFlows } from "../helpers/cloud-fakes";
+import { createProjectScenario } from "../helpers/scenarios";
+
+describe("setup scripts integration", () => {
+	let dispose: (() => Promise<void>) | undefined;
+
+	afterEach(async () => {
+		__resetSessionsForTesting();
+		await disposeDaemonClient();
+		resetTerminalBaseEnvForTests();
+		__setAccountShellForTesting(undefined);
+		delete process.env.SUPERSET_PTY_DAEMON_SOCKET;
+		delete process.env.SUPERSET_HOME_DIR;
+
+		if (dispose) {
+			await dispose();
+			dispose = undefined;
+		}
+	});
+
+	test("v2 settings config is the same config used by workspace setup terminals", async () => {
+		const scenario = await createProjectScenario({
+			hostOptions: { apiOverrides: cloudFlows.workspaceCreateOk() },
+		});
+		const daemonRoot = mkdtempSync(join(tmpdir(), "setup-scripts-daemon-"));
+		const socketPath = join(daemonRoot, "pty-daemon.sock");
+		const writes: string[] = [];
+		const spawned: Array<{
+			meta: {
+				cwd?: string;
+				env?: Record<string, string>;
+			};
+		}> = [];
+
+		const server = new Server({
+			socketPath,
+			daemonVersion: "0.0.0-setup-scripts-test",
+			spawnPty: ({ meta }) => {
+				spawned.push({ meta });
+				return createFakePty(5200 + spawned.length, writes);
+			},
+		});
+
+		dispose = async () => {
+			await server.close();
+			rmSync(daemonRoot, { recursive: true, force: true });
+			await scenario.dispose();
+		};
+
+		await server.listen();
+		process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
+		process.env.SUPERSET_HOME_DIR = daemonRoot;
+		__setAccountShellForTesting("/bin/sh");
+		initTerminalBaseEnv({
+			PATH: process.env.PATH ?? "/usr/bin:/bin",
+			HOME: daemonRoot,
+			SHELL: "/bin/sh",
+		});
+
+		const emptyConfig = await scenario.host.trpc.config.getConfigContent.query({
+			projectId: scenario.projectId,
+		});
+		expect(emptyConfig).toEqual({ content: null, exists: false });
+
+		await scenario.host.trpc.config.updateConfig.mutate({
+			projectId: scenario.projectId,
+			setup: ["echo setup-a", "echo setup-b"],
+			teardown: ["echo teardown"],
+			run: ["bun dev"],
+		});
+
+		const configPath = getProjectConfigPath(scenario.repo.repoPath);
+		const diskConfig = JSON.parse(readFileSync(configPath, "utf-8"));
+		expect(diskConfig).toEqual({
+			setup: ["echo setup-a", "echo setup-b"],
+			teardown: ["echo teardown"],
+			run: ["bun dev"],
+		});
+
+		const readBack = await scenario.host.trpc.config.getConfigContent.query({
+			projectId: scenario.projectId,
+		});
+		expect(readBack.exists).toBe(true);
+		expect(JSON.parse(readBack.content ?? "{}")).toEqual(diskConfig);
+
+		await expect(
+			scenario.host.trpc.config.shouldShowSetupCard.query({
+				projectId: scenario.projectId,
+			}),
+		).resolves.toBe(false);
+
+		await expect(
+			scenario.host.trpc.config.getWorkspaceRunDefinition.query({
+				projectId: scenario.projectId,
+			}),
+		).resolves.toEqual({
+			source: "project-config",
+			projectId: scenario.projectId,
+			commands: ["bun dev"],
+		});
+
+		const created = await scenario.host.trpc.workspaces.create.mutate({
+			projectId: scenario.projectId,
+			name: "scripted setup",
+			branch: "scripted-setup",
+		});
+
+		expect(created.terminals).toHaveLength(1);
+		expect(created.terminals[0]?.label).toBe("Workspace Setup");
+
+		await waitFor(
+			() => writes.includes("echo setup-a && echo setup-b\n"),
+			1000,
+			() => `expected setup command write, got ${JSON.stringify(writes)}`,
+		);
+
+		const workspaceRow = scenario.host.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.id, created.workspace.id))
+			.get();
+		const setupTerminal = spawned.at(-1);
+		expect(setupTerminal?.meta.cwd).toBe(workspaceRow?.worktreePath);
+		expect(setupTerminal?.meta.env?.SUPERSET_ROOT_PATH).toBe(
+			scenario.repo.repoPath,
+		);
+	});
+});
+
+function createFakePty(pid: number, writes: string[]) {
+	const exitCallbacks: Array<
+		(info: { code: number | null; signal: number | null }) => void
+	> = [];
+
+	return {
+		pid,
+		write(data: string | Uint8Array) {
+			writes.push(
+				typeof data === "string" ? data : Buffer.from(data).toString("utf-8"),
+			);
+		},
+		resize() {},
+		kill() {
+			for (const callback of exitCallbacks.splice(0)) {
+				callback({ code: null, signal: null });
+			}
+		},
+		onData() {},
+		onExit(
+			callback: (info: { code: number | null; signal: number | null }) => void,
+		) {
+			exitCallbacks.push(callback);
+		},
+		getMasterFd() {
+			return 0;
+		},
+	};
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs: number,
+	message?: () => string,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error(message?.() ?? `condition timed out after ${timeoutMs}ms`);
+}


### PR DESCRIPTION
## Summary

Fixes v2 setup/teardown/run script editing so changes persist without relying on textarea blur.

- Adds debounced autosave for v2 setup, teardown, and run script fields.
- Routes file imports through the same autosave path as typed edits.
- Prevents config refetches from clobbering focused or pending edits.
- Adds an integration test proving v2 config writes are read back by the same workspace setup/run flow.

## Root Cause

The v1 scripts editor autosaved while editing, but the v2 editor only called `updateConfig` on blur. File import also only updated local component state, so users could type or import scripts in v2 without any save button or reliable autosave path.

## Validation

- `bun test packages/host-service/test/integration/setup-scripts.integration.test.ts`
- `bunx biome check --write apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx packages/host-service/test/integration/setup-scripts.integration.test.ts`
- `bunx biome check apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx packages/host-service/test/integration/setup-scripts.integration.test.ts`
- `bun run --cwd apps/desktop typecheck`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4661">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 setup/teardown/run script editor so changes autosave while typing and when importing files. Blocks background refetches from clobbering edits and makes saves resilient under rapid changes.

- Bug Fixes
  - Added debounced autosave with coalesced queued writes; dedupes unchanged payloads, retries on failure, and trims lines on blur.
  - Routed file imports through the same autosave path as typed edits.
  - Ignored config refetches while focused, debouncing, saving, or when a save is queued.
  - Added an integration test in `packages/host-service` proving v2 config powers workspace setup and run.

<sup>Written for commit f3c735e935a54ed2c2472d4109730421a5bdaabc. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4661?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script editor to avoid losing local edits during background refreshes or overlapping saves, debounce rapid edits, trim scripts on blur, and reliably serialize/retry save attempts.
* **Tests**
  * Added integration tests for setup/run/teardown scripts to verify persistence, terminal spawn behavior, and correct environment/command execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->