### PR TITLE
fix: allow v2 project setup on selected remote host

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -103,8 +103,11 @@ export function PromptGroup({
 		void navigate({
 			to: "/settings/projects/$projectId",
 			params: { projectId: targetProjectId },
+			search: {
+				hostId: draft.hostId ?? machineId ?? undefined,
+			},
 		});
-	}, [closeModal, navigate, selectedProject?.id]);
+	}, [closeModal, draft.hostId, machineId, navigate, selectedProject?.id]);
 	const {
 		baseBranch,
 		hostId,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/projects/$projectId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/projects/$projectId/page.tsx
@@ -17,10 +17,14 @@ export const Route = createFileRoute(
 )({
 	component: ProjectDetailPage,
 	notFoundComponent: NotFound,
+	validateSearch: (search: Record<string, unknown>): { hostId?: string } => ({
+		hostId: typeof search.hostId === "string" ? search.hostId : undefined,
+	}),
 });
 
 function ProjectDetailPage() {
 	const { projectId } = Route.useParams();
+	const { hostId } = Route.useSearch();
 	const collections = useCollections();
 	const { data: session } = authClient.useSession();
 	const searchQuery = useSettingsSearchQuery();
@@ -49,7 +53,7 @@ function ProjectDetailPage() {
 	}, [searchQuery]);
 
 	if (v2Match.length > 0) {
-		return <V2ProjectSettings projectId={projectId} />;
+		return <V2ProjectSettings projectId={projectId} hostId={hostId ?? null} />;
 	}
 	return <ProjectSettings projectId={projectId} visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
@@ -1,6 +1,8 @@
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -15,11 +17,17 @@ import { V2ScriptsEditor } from "./components/V2ScriptsEditor";
 
 interface V2ProjectSettingsProps {
 	projectId: string;
+	hostId: string | null;
 }
 
-export function V2ProjectSettings({ projectId }: V2ProjectSettingsProps) {
+export function V2ProjectSettings({
+	projectId,
+	hostId,
+}: V2ProjectSettingsProps) {
 	const collections = useCollections();
-	const { activeHostUrl } = useLocalHostService();
+	const { machineId } = useLocalHostService();
+	const targetHostUrl = useHostUrl(hostId);
+	const targetHostId = hostId ?? machineId;
 
 	const { data: v2Project } = useLiveQuery(
 		(q) =>
@@ -30,12 +38,32 @@ export function V2ProjectSettings({ projectId }: V2ProjectSettingsProps) {
 		[collections, projectId],
 	);
 
+	const { data: hostRows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ hosts: collections.v2Hosts })
+				.where(({ hosts }) => eq(hosts.machineId, targetHostId ?? ""))
+				.select(({ hosts }) => ({
+					machineId: hosts.machineId,
+					name: hosts.name,
+				})),
+		[collections, targetHostId],
+	);
+	const targetHostName = useMemo(() => {
+		if (hostRows[0]?.name) return hostRows[0].name;
+		if (!targetHostId || targetHostId === machineId) return "this device";
+		return targetHostId;
+	}, [hostRows, machineId, targetHostId]);
+	const isRemoteTarget = Boolean(
+		targetHostId && machineId && targetHostId !== machineId,
+	);
+
 	const { data: hostProject, refetch: refetchHostProject } = useQuery({
-		queryKey: ["host-project", "get", activeHostUrl, projectId],
-		enabled: !!activeHostUrl,
+		queryKey: ["host-project", "get", targetHostUrl, projectId],
+		enabled: !!targetHostUrl,
 		queryFn: async () => {
-			if (!activeHostUrl) return null;
-			const client = getHostServiceClientByUrl(activeHostUrl);
+			if (!targetHostUrl) return null;
+			const client = getHostServiceClientByUrl(targetHostUrl);
 			return client.project.get.query({ projectId });
 		},
 	});
@@ -61,12 +89,15 @@ export function V2ProjectSettings({ projectId }: V2ProjectSettingsProps) {
 
 				<SettingsSection
 					title="Project location"
-					description="Where this project lives on disk on this device."
+					description={`Where this project lives on disk on ${targetHostName}.`}
 				>
 					<ProjectLocationSection
 						projectId={projectId}
 						currentPath={hostProject?.repoPath ?? null}
 						repoCloneUrl={project.repoCloneUrl}
+						hostUrl={targetHostUrl}
+						hostName={targetHostName}
+						isRemoteTarget={isRemoteTarget}
 						onChanged={() => refetchHostProject()}
 					/>
 				</SettingsSection>
@@ -82,12 +113,12 @@ export function V2ProjectSettings({ projectId }: V2ProjectSettingsProps) {
 					/>
 				</SettingsSection>
 
-				{activeHostUrl && (
+				{targetHostUrl && (
 					<SettingsSection
 						title="Scripts"
 						description="Runs in a terminal for setup, teardown, and the workspace Run button. Saved to .superset/config.json in the main repo."
 					>
-						<V2ScriptsEditor hostUrl={activeHostUrl} projectId={projectId} />
+						<V2ScriptsEditor hostUrl={targetHostUrl} projectId={projectId} />
 					</SettingsSection>
 				)}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
@@ -9,14 +9,13 @@ import {
 	AlertDialogTitle,
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
 import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
-import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unavailable";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
-import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { ClickablePath } from "../../../../../../components/ClickablePath";
 
 interface BackfillConflict {
@@ -28,6 +27,9 @@ interface ProjectLocationSectionProps {
 	projectId: string;
 	currentPath: string | null;
 	repoCloneUrl: string | null;
+	hostUrl: string | null;
+	hostName: string;
+	isRemoteTarget: boolean;
 	onChanged?: () => void;
 }
 
@@ -35,10 +37,11 @@ export function ProjectLocationSection({
 	projectId,
 	currentPath,
 	repoCloneUrl,
+	hostUrl,
+	hostName,
+	isRemoteTarget,
 	onChanged,
 }: ProjectLocationSectionProps) {
-	const hostService = useLocalHostService();
-	const { activeHostUrl } = hostService;
 	const selectDirectory = electronTrpc.window.selectDirectory.useMutation();
 	const navigate = useNavigate();
 	const { ensureProjectInSidebar, ensureWorkspaceInSidebar } =
@@ -47,16 +50,16 @@ export function ProjectLocationSection({
 	const [pendingPath, setPendingPath] = useState<string | null>(null);
 	const [conflict, setConflict] = useState<BackfillConflict | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [remoteImportPath, setRemoteImportPath] = useState("");
+	const [remoteCloneParentDir, setRemoteCloneParentDir] = useState("");
 
 	const runSetup = async (repoPath: string, allowRelocate: boolean) => {
-		if (!activeHostUrl) {
-			showHostServiceUnavailableToast(hostService, {
-				action: allowRelocate ? "relocate the project" : "set up the project",
-			});
+		if (!hostUrl) {
+			toast.error(`Host unavailable: ${hostName}`);
 			return false;
 		}
 		try {
-			const client = getHostServiceClientByUrl(activeHostUrl);
+			const client = getHostServiceClientByUrl(hostUrl);
 			const result = await client.project.setup.mutate({
 				projectId,
 				mode: { kind: "import", repoPath, allowRelocate },
@@ -80,14 +83,12 @@ export function ProjectLocationSection({
 	};
 
 	const runClone = async (parentDir: string) => {
-		if (!activeHostUrl) {
-			showHostServiceUnavailableToast(hostService, {
-				action: "clone the project",
-			});
+		if (!hostUrl) {
+			toast.error(`Host unavailable: ${hostName}`);
 			return false;
 		}
 		try {
-			const client = getHostServiceClientByUrl(activeHostUrl);
+			const client = getHostServiceClientByUrl(hostUrl);
 			const result = await client.project.setup.mutate({
 				projectId,
 				mode: { kind: "clone", parentDir },
@@ -107,10 +108,8 @@ export function ProjectLocationSection({
 	};
 
 	const pickPath = async (title: string) => {
-		if (!activeHostUrl) {
-			showHostServiceUnavailableToast(hostService, {
-				action: "choose a project path",
-			});
+		if (!hostUrl) {
+			toast.error(`Host unavailable: ${hostName}`);
 			return null;
 		}
 		try {
@@ -127,18 +126,48 @@ export function ProjectLocationSection({
 	};
 
 	const handleImport = async () => {
+		if (isRemoteTarget) {
+			const path = remoteImportPath.trim();
+			if (!path) {
+				toast.error(`Enter a path on ${hostName}`);
+				return;
+			}
+			if (!hostUrl) {
+				toast.error(`Host unavailable: ${hostName}`);
+				return;
+			}
+			setIsSubmitting(true);
+			let keepSubmitting = false;
+			try {
+				const client = getHostServiceClientByUrl(hostUrl);
+				const precheck = await client.project.findBackfillConflict.query({
+					projectId,
+					repoPath: path,
+				});
+				if (precheck.conflict) {
+					setConflict(precheck.conflict);
+					keepSubmitting = true;
+					return;
+				}
+				await runSetup(path, false);
+				setRemoteImportPath("");
+			} catch (err) {
+				toast.error(err instanceof Error ? err.message : String(err));
+			} finally {
+				if (!keepSubmitting) setIsSubmitting(false);
+			}
+			return;
+		}
 		const path = await pickPath("Select project location");
 		if (!path) return;
-		if (!activeHostUrl) {
-			showHostServiceUnavailableToast(hostService, {
-				action: "check the project location",
-			});
+		if (!hostUrl) {
+			toast.error(`Host unavailable: ${hostName}`);
 			return;
 		}
 		setIsSubmitting(true);
 		let keepSubmitting = false;
 		try {
-			const client = getHostServiceClientByUrl(activeHostUrl);
+			const client = getHostServiceClientByUrl(hostUrl);
 			const precheck = await client.project.findBackfillConflict.query({
 				projectId,
 				repoPath: path,
@@ -157,6 +186,20 @@ export function ProjectLocationSection({
 	};
 
 	const handleClone = async () => {
+		if (isRemoteTarget) {
+			const parentDir = remoteCloneParentDir.trim();
+			if (!parentDir) {
+				toast.error(`Enter a parent directory on ${hostName}`);
+				return;
+			}
+			setIsSubmitting(true);
+			try {
+				await runClone(parentDir);
+			} finally {
+				setIsSubmitting(false);
+			}
+			return;
+		}
 		const parentDir = await pickPath("Select parent directory to clone into");
 		if (!parentDir) return;
 		setIsSubmitting(true);
@@ -174,14 +217,12 @@ export function ProjectLocationSection({
 			toast.info("Project is already at that location");
 			return;
 		}
-		if (!activeHostUrl) {
-			showHostServiceUnavailableToast(hostService, {
-				action: "check the project location",
-			});
+		if (!hostUrl) {
+			toast.error(`Host unavailable: ${hostName}`);
 			return;
 		}
 		try {
-			const client = getHostServiceClientByUrl(activeHostUrl);
+			const client = getHostServiceClientByUrl(hostUrl);
 			const precheck = await client.project.findBackfillConflict.query({
 				projectId,
 				repoPath: path,
@@ -213,7 +254,7 @@ export function ProjectLocationSection({
 						<ClickablePath path={currentPath} />
 					) : (
 						<span className="text-sm text-muted-foreground">
-							Not set up on this device.
+							Not set up on {hostName}.
 						</span>
 					)}
 				</div>
@@ -229,31 +270,82 @@ export function ProjectLocationSection({
 					</Button>
 				) : (
 					<div className="flex items-center gap-2 shrink-0">
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={handleClone}
-							disabled={
-								!repoCloneUrl || selectDirectory.isPending || isSubmitting
-							}
-							title={
-								repoCloneUrl
-									? undefined
-									: "Link a GitHub repository first to enable cloning"
-							}
-						>
-							Clone here…
-						</Button>
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={handleImport}
-							disabled={selectDirectory.isPending || isSubmitting}
-						>
-							Import existing…
-						</Button>
+						{isRemoteTarget ? (
+							<div className="flex flex-col gap-2 min-w-80">
+								<div className="flex items-center gap-2">
+									<Input
+										value={remoteImportPath}
+										onChange={(event) =>
+											setRemoteImportPath(event.currentTarget.value)
+										}
+										placeholder={`Existing repo path on ${hostName}`}
+										className="h-8"
+									/>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={handleImport}
+										disabled={!hostUrl || isSubmitting}
+									>
+										Import
+									</Button>
+								</div>
+								<div className="flex items-center gap-2">
+									<Input
+										value={remoteCloneParentDir}
+										onChange={(event) =>
+											setRemoteCloneParentDir(event.currentTarget.value)
+										}
+										placeholder={`Parent directory on ${hostName}`}
+										className="h-8"
+										disabled={!repoCloneUrl}
+									/>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={handleClone}
+										disabled={!hostUrl || !repoCloneUrl || isSubmitting}
+										title={
+											repoCloneUrl
+												? undefined
+												: "Link a GitHub repository first to enable cloning"
+										}
+									>
+										Clone
+									</Button>
+								</div>
+							</div>
+						) : (
+							<>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={handleClone}
+									disabled={
+										!repoCloneUrl || selectDirectory.isPending || isSubmitting
+									}
+									title={
+										repoCloneUrl
+											? undefined
+											: "Link a GitHub repository first to enable cloning"
+									}
+								>
+									Clone here…
+								</Button>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={handleImport}
+									disabled={selectDirectory.isPending || isSubmitting}
+								>
+									Import existing…
+								</Button>
+							</>
+						)}
 					</div>
 				)}
 			</div>
@@ -273,7 +365,7 @@ export function ProjectLocationSection({
 						<AlertDialogDescription>
 							This repository is already linked to project "
 							{conflict?.name ?? ""}" in this organization. Open that project to
-							set it up on this device.
+							set it up on {hostName}.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/packages/cli/src/commands/projects/list/command.ts
+++ b/packages/cli/src/commands/projects/list/command.ts
@@ -1,20 +1,47 @@
-import { CLIError, table } from "@superset/cli-framework";
+import { boolean, CLIError, string, table } from "@superset/cli-framework";
 import { command } from "../../../lib/command";
+import { resolveHostFilter, resolveHostTarget } from "../../../lib/host-target";
 
 export default command({
 	description: "List projects in the active organization",
 	display: (data) =>
 		table(
 			data as Record<string, unknown>[],
-			["name", "slug", "repoCloneUrl", "id"],
-			["NAME", "SLUG", "REPO", "ID"],
+			["name", "slug", "repoCloneUrl", "setUp", "path", "id"],
+			["NAME", "SLUG", "REPO", "SET UP", "PATH", "ID"],
 		),
-	run: async ({ ctx }) => {
+	options: {
+		host: string().desc("Show setup status for a specific host machineId"),
+		local: boolean().desc("Show setup status for this machine"),
+	},
+	run: async ({ ctx, options }) => {
 		const organizationId = ctx.config.organizationId;
 		if (!organizationId) {
 			throw new CLIError("No active organization", "Run: superset auth login");
 		}
 
-		return ctx.api.v2Project.list.query({ organizationId });
+		const projects = await ctx.api.v2Project.list.query({ organizationId });
+		const hostId = resolveHostFilter({
+			host: options.host ?? undefined,
+			local: options.local ?? undefined,
+		});
+		const target = resolveHostTarget({
+			requestedHostId: hostId,
+			organizationId,
+			userJwt: ctx.bearer,
+		});
+		const hostProjects = await target.client.project.list.query();
+		const hostProjectById = new Map(
+			hostProjects.map((project) => [project.id, project]),
+		);
+
+		return projects.map((project) => {
+			const hostProject = hostProjectById.get(project.id);
+			return {
+				...project,
+				setUp: hostProject ? "yes" : "no",
+				path: hostProject?.repoPath ?? "-",
+			};
+		});
 	},
 });

--- a/packages/cli/src/commands/projects/setup/command.ts
+++ b/packages/cli/src/commands/projects/setup/command.ts
@@ -1,14 +1,18 @@
 import { boolean, CLIError, positional, string } from "@superset/cli-framework";
 import { command } from "../../../lib/command";
-import { requireHostTarget, resolveHostTarget } from "../../../lib/host-target";
+import { resolveHostFilter, resolveHostTarget } from "../../../lib/host-target";
 
 export default command({
 	description:
 		"Adopt an existing project on a host (clone its repo or import a folder)",
-	args: [positional("id").required().desc("Project UUID to adopt")],
+	args: [positional("id").desc("Project UUID to adopt")],
 	options: {
 		host: string().desc("Target host machineId"),
 		local: boolean().desc("Target this machine"),
+		project: string().desc("Project UUID to adopt"),
+		path: string().desc(
+			"Existing local repo path on the target host (alias for --import)",
+		),
 		parentDir: string().desc(
 			"Parent directory to clone the project's repo into (clone mode)",
 		),
@@ -20,26 +24,45 @@ export default command({
 		),
 	},
 	run: async ({ ctx, args, options }) => {
-		const projectId = args.id as string;
+		const projectId = (options.project ?? args.id) as string | undefined;
+		if (!projectId) {
+			throw new CLIError(
+				"Project ID required",
+				"Pass --project <projectId>, or provide the project ID as the first argument.",
+			);
+		}
+		if (options.project && args.id && options.project !== args.id) {
+			throw new CLIError(
+				"Project ID specified twice",
+				"Use either --project <projectId> or the positional project ID, not both.",
+			);
+		}
 		const organizationId = ctx.config.organizationId;
 		if (!organizationId) {
 			throw new CLIError("No active organization", "Run: superset auth login");
 		}
 
-		if (Boolean(options.parentDir) === Boolean(options.import)) {
+		if (options.path && options.import) {
 			throw new CLIError(
-				"Specify exactly one of --parent-dir or --import",
-				"Use --parent-dir <path> to clone, or --import <path> to register an existing folder",
+				"Pass either --path or --import, not both",
+				"--path is an alias for --import.",
 			);
 		}
-		if (options.allowRelocate && !options.import) {
+		const importPath = options.path ?? options.import;
+		if (Boolean(options.parentDir) === Boolean(importPath)) {
 			throw new CLIError(
-				"--allow-relocate only applies to --import",
-				"Drop --allow-relocate, or switch to --import <path>",
+				"Specify exactly one of --parent-dir or --path",
+				"Use --parent-dir <path> to clone, or --path <path> to register an existing folder.",
+			);
+		}
+		if (options.allowRelocate && !importPath) {
+			throw new CLIError(
+				"--allow-relocate only applies to --path",
+				"Drop --allow-relocate, or switch to --path <path>.",
 			);
 		}
 
-		const hostId = requireHostTarget({
+		const hostId = resolveHostFilter({
 			host: options.host ?? undefined,
 			local: options.local ?? undefined,
 		});
@@ -57,7 +80,7 @@ export default command({
 				}
 			: {
 					kind: "import" as const,
-					repoPath: options.import as string,
+					repoPath: importPath as string,
 					allowRelocate: options.allowRelocate ?? false,
 				};
 


### PR DESCRIPTION
Fixes the remote/headless host setup gap where the New Workspace modal detects that a project is not registered on the selected host, but project setup opens local-only settings.

This change:
- threads selected host context from the New Workspace setup CTA into v2 project settings
- resolves the selected host URL/name in project settings and uses that host client for project setup, conflict checks, and scripts
- adds remote path entry for headless hosts instead of using the local directory picker for remote setup
- supports `superset projects setup --project <projectId> --path <path>` while keeping existing positional/`--import` usage
- enhances `superset projects list` with per-host setup status and path

Verification:
- `bunx biome check packages/cli/src/commands/projects/list/command.ts packages/cli/src/commands/projects/setup/command.ts apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx apps/desktop/src/renderer/routes/_authenticated/settings/projects/\$projectId/page.tsx apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/\$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/\$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd apps/desktop typecheck`
- `git diff --check`

Note: initial `bun install` failed rebuilding native `node-pty` because `node-gyp` is not installed in this environment; reran `bun install --ignore-scripts` to install JS tooling for typecheck.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4665">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 project setup so a selected remote/headless host is honored end-to-end. The New Workspace flow now opens project settings for that host and runs setup, conflict checks, and scripts on that host.

- **Bug Fixes**
  - Thread `hostId` from New Workspace to v2 project settings and resolve target host URL/name.
  - Use the target host client for project fetch, setup, conflict checks, and scripts.
  - For remote/headless hosts, replace the local directory picker with inputs for remote import path and clone parent directory.
  - Clarify UI copy (e.g., “this device” vs the remote host name).

- **New Features**
  - `superset projects setup` supports `--project <id>` and `--path <path>` (alias for `--import`), with stricter argument validation; existing positional ID and `--parentDir` still work.
  - `superset projects list` adds per-host setup status and path columns and supports `--host <machineId>` or `--local` filters.

<sup>Written for commit 3bb34e3400cbb8e5ef69a438442fcaacd8815f74. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4665?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote host support for project settings and configuration management
  * CLI projects list now displays per-host setup status and repository paths
  * CLI projects setup command now supports --project flag and --path option for flexible project registration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->