### PR TITLE
[codex] Add Stripe cancellation details to Slack alerts

### DIFF
--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/route.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/route.ts
@@ -9,8 +9,6 @@ import { z } from "zod";
 import { env } from "@/env";
 
 import {
-	cancellationFeedbackValues,
-	cancellationReasonValues,
 	type EnrichedSubscription,
 	formatPaymentFailed,
 	formatPaymentSucceeded,
@@ -39,13 +37,19 @@ const basePayload = z.object({
 	stripeSubscriptionId: z.string(),
 });
 
+const optionalNullableString = z.preprocess(
+	(value) => (typeof value === "string" || value == null ? value : null),
+	z.string().nullable().optional(),
+);
+
 const cancellationDetailsSchema = z
 	.object({
-		comment: z.string().nullable().optional(),
-		feedback: z.enum(cancellationFeedbackValues).nullable().optional(),
-		reason: z.enum(cancellationReasonValues).nullable().optional(),
+		comment: optionalNullableString,
+		feedback: optionalNullableString,
+		reason: optionalNullableString,
 	})
-	.nullable();
+	.nullable()
+	.catch(null);
 
 const payloadSchema = z.discriminatedUnion("eventType", [
 	basePayload.extend({ eventType: z.literal("subscription_started") }),
@@ -148,7 +152,15 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Invalid signature" }, { status: 401 });
 	}
 
-	const parsed = payloadSchema.safeParse(JSON.parse(body));
+	let rawPayload: unknown;
+	try {
+		rawPayload = JSON.parse(body);
+	} catch (error) {
+		console.error("[stripe/notify-slack] Invalid JSON payload:", error);
+		return Response.json({ error: "Invalid JSON payload" }, { status: 400 });
+	}
+
+	const parsed = payloadSchema.safeParse(rawPayload);
 	if (!parsed.success) {
 		console.error("[stripe/notify-slack] Invalid payload:", parsed.error);
 		return Response.json({ error: "Invalid payload" }, { status: 400 });

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/route.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/route.ts
@@ -9,6 +9,8 @@ import { z } from "zod";
 import { env } from "@/env";
 
 import {
+	cancellationFeedbackValues,
+	cancellationReasonValues,
 	type EnrichedSubscription,
 	formatPaymentFailed,
 	formatPaymentSucceeded,
@@ -37,9 +39,20 @@ const basePayload = z.object({
 	stripeSubscriptionId: z.string(),
 });
 
+const cancellationDetailsSchema = z
+	.object({
+		comment: z.string().nullable().optional(),
+		feedback: z.enum(cancellationFeedbackValues).nullable().optional(),
+		reason: z.enum(cancellationReasonValues).nullable().optional(),
+	})
+	.nullable();
+
 const payloadSchema = z.discriminatedUnion("eventType", [
 	basePayload.extend({ eventType: z.literal("subscription_started") }),
-	basePayload.extend({ eventType: z.literal("subscription_cancelled") }),
+	basePayload.extend({
+		eventType: z.literal("subscription_cancelled"),
+		cancellationDetails: cancellationDetailsSchema.optional(),
+	}),
 	basePayload.extend({
 		eventType: z.literal("seat_added"),
 		memberName: z.string(),
@@ -111,6 +124,7 @@ async function enrichFromSubscription(
 		interval,
 		discount: getDiscountInfo(stripeSub),
 		accessEndsAt: dbSub?.periodEnd ?? null,
+		cancellationDetails: stripeSub.cancellation_details,
 	};
 }
 
@@ -157,7 +171,11 @@ export async function POST(request: Request) {
 			blocks = formatSubscriptionStarted(enriched);
 			break;
 		case "subscription_cancelled":
-			blocks = formatSubscriptionCancelled(enriched);
+			blocks = formatSubscriptionCancelled({
+				...enriched,
+				cancellationDetails:
+					payload.cancellationDetails ?? enriched.cancellationDetails,
+			});
 			break;
 		case "seat_added":
 			blocks = formatSeatAdded(

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type EnrichedSubscription,
+	formatSubscriptionCancelled,
+} from "./slack-blocks";
+
+function createEnrichedSubscription(
+	overrides: Partial<EnrichedSubscription> = {},
+): EnrichedSubscription {
+	return {
+		organizationName: "Acme",
+		planName: "Pro",
+		stripeCustomerId: "cus_123",
+		stripeSubscriptionId: "sub_123",
+		seatCount: 3,
+		pricePerSeatCents: 2000,
+		currency: "usd",
+		interval: "monthly",
+		discount: null,
+		accessEndsAt: new Date("2026-05-31T00:00:00.000Z"),
+		cancellationDetails: null,
+		...overrides,
+	};
+}
+
+describe("formatSubscriptionCancelled", () => {
+	test("includes Stripe cancellation details in Slack blocks", () => {
+		const blocks = formatSubscriptionCancelled(
+			createEnrichedSubscription({
+				cancellationDetails: {
+					comment: "Missing an admin approval workflow.",
+					feedback: "missing_features",
+					reason: "cancellation_requested",
+				},
+			}),
+		);
+
+		const serializedBlocks = JSON.stringify(blocks);
+
+		expect(serializedBlocks).toContain(
+			"*Cancellation reason:*\\nMissing features",
+		);
+		expect(serializedBlocks).toContain(
+			"*Stripe reason:*\\nCancellation requested",
+		);
+		expect(serializedBlocks).toContain(
+			"*Comment:*\\nMissing an admin approval workflow.",
+		);
+	});
+});

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts
@@ -67,6 +67,25 @@ describe("formatSubscriptionCancelled", () => {
 		expect(serializedBlocks).toContain("*Stripe reason:*\\nAccount closed");
 	});
 
+	test("escapes unknown cancellation feedback and reason values", () => {
+		const blocks = formatSubscriptionCancelled(
+			createEnrichedSubscription({
+				cancellationDetails: {
+					comment: null,
+					feedback: "<@U123>",
+					reason: "<!subteam^S123>",
+				},
+			}),
+		);
+
+		const serializedBlocks = JSON.stringify(blocks);
+
+		expect(serializedBlocks).not.toContain("<@U123>");
+		expect(serializedBlocks).not.toContain("<!subteam^S123>");
+		expect(serializedBlocks).toContain(`&lt;@${"\u200B"}U123&gt;`);
+		expect(serializedBlocks).toContain("&lt;!subteam^S123&gt;");
+	});
+
 	test("escapes and truncates cancellation comments for Slack", () => {
 		const longComment = `<!channel> & <https://example.com|link> ${"a".repeat(510)}`;
 		const blocks = formatSubscriptionCancelled(

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts
@@ -47,4 +47,43 @@ describe("formatSubscriptionCancelled", () => {
 			"*Comment:*\\nMissing an admin approval workflow.",
 		);
 	});
+
+	test("renders unknown Stripe cancellation values without throwing", () => {
+		const blocks = formatSubscriptionCancelled(
+			createEnrichedSubscription({
+				cancellationDetails: {
+					comment: null,
+					feedback: "pricing_changed",
+					reason: "account_closed",
+				},
+			}),
+		);
+
+		const serializedBlocks = JSON.stringify(blocks);
+
+		expect(serializedBlocks).toContain(
+			"*Cancellation reason:*\\nPricing changed",
+		);
+		expect(serializedBlocks).toContain("*Stripe reason:*\\nAccount closed");
+	});
+
+	test("escapes and truncates cancellation comments for Slack", () => {
+		const longComment = `<!channel> & <https://example.com|link> ${"a".repeat(510)}`;
+		const blocks = formatSubscriptionCancelled(
+			createEnrichedSubscription({
+				cancellationDetails: {
+					comment: longComment,
+					feedback: "other",
+					reason: "cancellation_requested",
+				},
+			}),
+		);
+
+		const serializedBlocks = JSON.stringify(blocks);
+
+		expect(serializedBlocks).toContain("&lt;!channel&gt;");
+		expect(serializedBlocks).toContain("&amp;");
+		expect(serializedBlocks).toContain("&lt;https://example.com|link&gt;");
+		expect(serializedBlocks).toContain("...");
+	});
 });

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.ts
@@ -34,8 +34,8 @@ export const cancellationReasonValues = [
 
 export interface CancellationDetails {
 	comment?: string | null;
-	feedback?: (typeof cancellationFeedbackValues)[number] | null;
-	reason?: (typeof cancellationReasonValues)[number] | null;
+	feedback?: string | null;
+	reason?: string | null;
 }
 
 export function getDiscountInfo(
@@ -147,24 +147,61 @@ const cancellationFeedbackLabels = {
 	too_complex: "Too complex",
 	too_expensive: "Too expensive",
 	unused: "Unused",
-} satisfies Record<NonNullable<CancellationDetails["feedback"]>, string>;
+} satisfies Record<(typeof cancellationFeedbackValues)[number], string>;
 
 const cancellationReasonLabels = {
 	cancellation_requested: "Cancellation requested",
 	payment_disputed: "Payment disputed",
 	payment_failed: "Payment failed",
-} satisfies Record<NonNullable<CancellationDetails["reason"]>, string>;
+} satisfies Record<(typeof cancellationReasonValues)[number], string>;
+
+const maxCancellationCommentLength = 500;
+
+function escapeSlackMrkdwn(text: string): string {
+	return text
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;");
+}
+
+function humanizeStripeValue(
+	value: string | null | undefined,
+	labels: Record<string, string>,
+): string {
+	if (!value) return "N/A";
+
+	const fallback = value.split("_").filter(Boolean).join(" ");
+
+	return (
+		labels[value] ?? `${fallback.charAt(0).toUpperCase()}${fallback.slice(1)}`
+	);
+}
+
+function formatCancellationComment(comment: string | null | undefined): string {
+	const trimmed = comment?.trim();
+	if (!trimmed) return "N/A";
+
+	const normalized = trimmed.replace(/\s+/g, " ");
+	const truncated =
+		normalized.length > maxCancellationCommentLength
+			? `${normalized.slice(0, maxCancellationCommentLength - 3)}...`
+			: normalized;
+
+	return escapeSlackMrkdwn(truncated);
+}
 
 function cancellationDetailsBlock(
 	cancellationDetails: CancellationDetails | null,
 ): unknown {
-	const feedback = cancellationDetails?.feedback
-		? cancellationFeedbackLabels[cancellationDetails.feedback]
-		: "N/A";
-	const reason = cancellationDetails?.reason
-		? cancellationReasonLabels[cancellationDetails.reason]
-		: "N/A";
-	const comment = cancellationDetails?.comment?.trim() || "N/A";
+	const feedback = humanizeStripeValue(
+		cancellationDetails?.feedback,
+		cancellationFeedbackLabels,
+	);
+	const reason = humanizeStripeValue(
+		cancellationDetails?.reason,
+		cancellationReasonLabels,
+	);
+	const comment = formatCancellationComment(cancellationDetails?.comment);
 
 	return {
 		type: "section",
@@ -174,6 +211,20 @@ function cancellationDetailsBlock(
 			{ type: "mrkdwn", text: `*Comment:*\n${comment}` },
 		],
 	};
+}
+
+function safeCancellationDetailsBlock(
+	cancellationDetails: CancellationDetails | null,
+): unknown {
+	try {
+		return cancellationDetailsBlock(cancellationDetails);
+	} catch (error) {
+		console.error(
+			"[stripe/notify-slack] Failed to format cancellation details:",
+			error,
+		);
+		return cancellationDetailsBlock(null);
+	}
 }
 
 /**
@@ -240,7 +291,7 @@ export function formatSubscriptionCancelled(
 			type: "section",
 			text: { type: "mrkdwn", text: `*Access ends:*\n${endsAtStr}` },
 		},
-		cancellationDetailsBlock(enriched.cancellationDetails),
+		safeCancellationDetailsBlock(enriched.cancellationDetails),
 		stripeDashboardButtons(
 			enriched.stripeCustomerId,
 			enriched.stripeSubscriptionId,

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.ts
@@ -161,7 +161,8 @@ function escapeSlackMrkdwn(text: string): string {
 	return text
 		.replaceAll("&", "&amp;")
 		.replaceAll("<", "&lt;")
-		.replaceAll(">", "&gt;");
+		.replaceAll(">", "&gt;")
+		.replaceAll("@", "@\u200B");
 }
 
 function humanizeStripeValue(
@@ -171,10 +172,10 @@ function humanizeStripeValue(
 	if (!value) return "N/A";
 
 	const fallback = value.split("_").filter(Boolean).join(" ");
+	const humanized =
+		labels[value] ?? `${fallback.charAt(0).toUpperCase()}${fallback.slice(1)}`;
 
-	return (
-		labels[value] ?? `${fallback.charAt(0).toUpperCase()}${fallback.slice(1)}`
-	);
+	return escapeSlackMrkdwn(humanized);
 }
 
 function formatCancellationComment(comment: string | null | undefined): string {

--- a/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.ts
@@ -15,6 +15,29 @@ export interface DiscountInfo {
 	amountOff: number | null;
 }
 
+export const cancellationFeedbackValues = [
+	"customer_service",
+	"low_quality",
+	"missing_features",
+	"other",
+	"switched_service",
+	"too_complex",
+	"too_expensive",
+	"unused",
+] as const;
+
+export const cancellationReasonValues = [
+	"cancellation_requested",
+	"payment_disputed",
+	"payment_failed",
+] as const;
+
+export interface CancellationDetails {
+	comment?: string | null;
+	feedback?: (typeof cancellationFeedbackValues)[number] | null;
+	reason?: (typeof cancellationReasonValues)[number] | null;
+}
+
 export function getDiscountInfo(
 	stripeSub: Stripe.Subscription,
 ): DiscountInfo | null {
@@ -85,6 +108,7 @@ export interface EnrichedSubscription {
 	interval: "monthly" | "yearly";
 	discount: DiscountInfo | null;
 	accessEndsAt: Date | null;
+	cancellationDetails: CancellationDetails | null;
 }
 
 // --- Shared field builders ---
@@ -112,6 +136,44 @@ function totalField(enriched: EnrichedSubscription): string {
 		return `*Total:*\n${formatPrice(total)}/${suffix} (was ${formatPrice(subtotal)}/${suffix})`;
 	}
 	return `*Total:*\n${formatPrice(total)}/${suffix}`;
+}
+
+const cancellationFeedbackLabels = {
+	customer_service: "Customer service",
+	low_quality: "Low quality",
+	missing_features: "Missing features",
+	other: "Other",
+	switched_service: "Switched service",
+	too_complex: "Too complex",
+	too_expensive: "Too expensive",
+	unused: "Unused",
+} satisfies Record<NonNullable<CancellationDetails["feedback"]>, string>;
+
+const cancellationReasonLabels = {
+	cancellation_requested: "Cancellation requested",
+	payment_disputed: "Payment disputed",
+	payment_failed: "Payment failed",
+} satisfies Record<NonNullable<CancellationDetails["reason"]>, string>;
+
+function cancellationDetailsBlock(
+	cancellationDetails: CancellationDetails | null,
+): unknown {
+	const feedback = cancellationDetails?.feedback
+		? cancellationFeedbackLabels[cancellationDetails.feedback]
+		: "N/A";
+	const reason = cancellationDetails?.reason
+		? cancellationReasonLabels[cancellationDetails.reason]
+		: "N/A";
+	const comment = cancellationDetails?.comment?.trim() || "N/A";
+
+	return {
+		type: "section",
+		fields: [
+			{ type: "mrkdwn", text: `*Cancellation reason:*\n${feedback}` },
+			{ type: "mrkdwn", text: `*Stripe reason:*\n${reason}` },
+			{ type: "mrkdwn", text: `*Comment:*\n${comment}` },
+		],
+	};
 }
 
 /**
@@ -178,6 +240,7 @@ export function formatSubscriptionCancelled(
 			type: "section",
 			text: { type: "mrkdwn", text: `*Access ends:*\n${endsAtStr}` },
 		},
+		cancellationDetailsBlock(enriched.cancellationDetails),
 		stripeDashboardButtons(
 			enriched.stripeCustomerId,
 			enriched.stripeSubscriptionId,

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -51,13 +51,21 @@ const desktopDevOrigins =
 function serializeCancellationDetails(
 	cancellationDetails?: Stripe.Subscription.CancellationDetails | null,
 ) {
-	if (!cancellationDetails) return undefined;
+	try {
+		if (!cancellationDetails) return undefined;
 
-	return {
-		comment: cancellationDetails.comment,
-		feedback: cancellationDetails.feedback,
-		reason: cancellationDetails.reason,
-	};
+		return {
+			comment: cancellationDetails.comment,
+			feedback: cancellationDetails.feedback,
+			reason: cancellationDetails.reason,
+		};
+	} catch (error) {
+		console.error(
+			"[stripe/subscription-cancel] Failed to serialize cancellation details:",
+			error,
+		);
+		return undefined;
+	}
 }
 
 export const auth = betterAuth({

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -48,6 +48,18 @@ const desktopDevOrigins =
 			]
 		: [];
 
+function serializeCancellationDetails(
+	cancellationDetails?: Stripe.Subscription.CancellationDetails | null,
+) {
+	if (!cancellationDetails) return undefined;
+
+	return {
+		comment: cancellationDetails.comment,
+		feedback: cancellationDetails.feedback,
+		reason: cancellationDetails.reason,
+	};
+}
+
 export const auth = betterAuth({
 	baseURL: env.NEXT_PUBLIC_API_URL,
 	secret: env.BETTER_AUTH_SECRET,
@@ -920,7 +932,11 @@ export const auth = betterAuth({
 					}
 				},
 
-				onSubscriptionCancel: async ({ subscription, stripeSubscription }) => {
+				onSubscriptionCancel: async ({
+					subscription,
+					stripeSubscription,
+					cancellationDetails,
+				}) => {
 					const org = await db.query.organizations.findFirst({
 						where: eq(authSchema.organizations.id, subscription.referenceId),
 					});
@@ -957,6 +973,10 @@ export const auth = betterAuth({
 							body: {
 								eventType: "subscription_cancelled",
 								stripeSubscriptionId: stripeSubscription.id,
+								cancellationDetails: serializeCancellationDetails(
+									cancellationDetails ??
+										stripeSubscription.cancellation_details,
+								),
 							},
 							retries: 3,
 						});


### PR DESCRIPTION
## Summary
- Include Stripe cancellation details in subscription cancellation Slack notifications.
- Pass Better Auth Stripe cancellation details through the QStash notify-slack job payload, with a fallback to the retrieved Stripe subscription.
- Render cancellation reason, Stripe reason, and customer comment in the Slack block payload.
- Add a focused formatter test for cancellation detail rendering.

## Context
Stripe only populates customer-submitted cancellation feedback/comment when cancellation reason collection is enabled in the Stripe Billing Portal configuration. Without that Stripe setting, the Slack fields render as `N/A`.

## Validation
- `bun run lint:fix`
- `bun run lint`
- `bun test apps/api/src/app/api/integrations/stripe/jobs/notify-slack/slack-blocks.test.ts`
- `bun run --cwd apps/api typecheck`
- `bun run --cwd packages/auth typecheck`
- `git diff --check`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4671">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Stripe cancellation details to Slack alerts for subscription cancellations. Hardens payload parsing and Slack formatting with safe fallbacks, label/comment escaping (prevents mentions), and tests.

- New Features
  - Send cancellation details from `packages/auth` to `apps/api` `notify-slack` via `QStash`; the API falls back to the Stripe subscription fields.
  - Validate JSON and payload shape; return 400 on bad JSON; accept nullable strings in `cancellationDetails`.
  - Slack blocks humanize unknown values, escape markdown, and neutralize @ in labels and comments; comments are truncated to 500 chars; missing values show as N/A.
  - Add tests for formatting, unknown values, label/comment escaping, and truncation.

<sup>Written for commit 5b679e5731640204bc3cbeaa1d6ac655815e8c3e. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4671?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription cancellation notifications now include optional cancellation details (reason, feedback, comment) in Slack, with safe formatting, escaping, and truncation for long comments.
* **Bug Fixes**
  * Improved request handling with explicit JSON validation returning clear 400 errors for invalid JSON and preferring provided cancellation details when present.
* **Tests**
  * Added tests validating formatting, escaping/truncation, and rendering of cancellation information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->