### PR TITLE
[codex] gate offline host workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/WorkspaceHostOfflineState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/WorkspaceHostOfflineState.tsx
@@ -1,0 +1,109 @@
+import { Button } from "@superset/ui/button";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Monitor, Settings, WifiOff } from "lucide-react";
+
+interface WorkspaceHostOfflineStateProps {
+	hostId: string;
+	hostName: string;
+}
+
+export function WorkspaceHostOfflineState({
+	hostId,
+	hostName,
+}: WorkspaceHostOfflineStateProps) {
+	return (
+		<div className="flex h-full w-full items-center justify-center p-6">
+			<div className="flex w-full max-w-sm flex-col items-start gap-6">
+				<div className="relative">
+					<div className="grid size-10 place-items-center rounded-lg border border-border/60 bg-muted/30">
+						<Monitor
+							className="size-[18px] text-muted-foreground"
+							strokeWidth={1.5}
+							aria-hidden="true"
+						/>
+					</div>
+					<span
+						aria-hidden="true"
+						className="absolute -bottom-0.5 -right-0.5 grid size-3.5 place-items-center rounded-full bg-muted-foreground/80 text-background ring-2 ring-background"
+					>
+						<WifiOff className="size-2.5" strokeWidth={3} />
+					</span>
+				</div>
+
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Host offline
+					</h1>
+					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
+						This workspace lives on a paired device that is not reachable right
+						now. Terminals and file actions are unavailable until that device
+						reconnects.
+					</p>
+				</div>
+
+				<div className="flex w-full flex-col gap-0 overflow-hidden rounded-md border border-border/60 bg-muted/30">
+					<div className="flex items-center gap-2.5 px-3 py-2">
+						<span
+							aria-hidden="true"
+							className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+						/>
+						<span
+							className="select-text cursor-text min-w-0 truncate text-[13px] font-medium text-foreground"
+							title={hostName}
+						>
+							{hostName}
+						</span>
+					</div>
+					<div className="border-t border-border/60 px-3 py-2">
+						<div className="grid gap-1.5 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center sm:gap-3">
+							<span className="shrink-0 text-[11px] uppercase tracking-wider text-muted-foreground/70">
+								Host ID
+							</span>
+							<div className="min-w-0 overflow-x-auto sm:text-right">
+								<code
+									className="inline-block min-w-max select-text cursor-text whitespace-nowrap font-mono text-[12px] tabular-nums text-muted-foreground"
+									title={hostId}
+								>
+									{hostId}
+								</code>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						asChild
+						size="sm"
+						variant="ghost"
+						className="-ml-2 h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
+					>
+						<Link to="/settings/hosts/$hostId" params={{ hostId }}>
+							<Settings
+								className="size-3.5"
+								strokeWidth={2}
+								aria-hidden="true"
+							/>
+							Host settings
+						</Link>
+					</Button>
+					<Button
+						asChild
+						size="sm"
+						variant="ghost"
+						className="h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
+					>
+						<Link to="/v2-workspaces">
+							Browse workspaces
+							<ArrowRight
+								className="size-3.5"
+								strokeWidth={2}
+								aria-hidden="true"
+							/>
+						</Link>
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceHostOfflineState } from "./WorkspaceHostOfflineState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -14,6 +14,11 @@ export type RemoteHostStatus =
 	| { status: "skip" }
 	| { status: "loading" }
 	| {
+			status: "offline";
+			hostId: string;
+			hostName: string;
+	  }
+	| {
 			status: "incompatible";
 			hostName: string;
 			hostVersion: string;
@@ -47,6 +52,7 @@ export function useRemoteHostStatus(
 				)
 				.select(({ hosts }) => ({
 					name: hosts.name,
+					isOnline: hosts.isOnline,
 				})),
 		[collections, organizationId, filterMachineId],
 	);
@@ -60,7 +66,8 @@ export function useRemoteHostStatus(
 	const infoQuery = useQuery({
 		queryKey: ["remoteHostInfo", organizationId, hostId],
 		queryFn: () => getHostServiceClientByUrl(hostUrl).host.info.query(),
-		enabled: workspace != null && !isLocal,
+		enabled:
+			workspace != null && !isLocal && isReady && hostRow?.isOnline !== false,
 		staleTime: HOST_INFO_STALE_MS,
 		retry: false,
 	});
@@ -68,6 +75,13 @@ export function useRemoteHostStatus(
 	if (!workspace) return { status: "loading" };
 	if (isLocal) return { status: "skip" };
 	if (!isReady) return { status: "loading" };
+	if (hostRow?.isOnline === false) {
+		return {
+			status: "offline",
+			hostId,
+			hostName: hostRow.name,
+		};
+	}
 
 	if (infoQuery.isSuccess) {
 		const hostVersion = infoQuery.data.version;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -8,6 +8,7 @@ import { useWorkspaceCreatesStore } from "renderer/stores/workspace-creates";
 import { WorkspaceCreateErrorState } from "./components/WorkspaceCreateErrorState";
 import { WorkspaceCreatingState } from "./components/WorkspaceCreatingState";
 import { WorkspaceHostIncompatibleState } from "./components/WorkspaceHostIncompatibleState";
+import { WorkspaceHostOfflineState } from "./components/WorkspaceHostOfflineState";
 import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { useRemoteHostStatus } from "./hooks/useRemoteHostStatus";
 import { WorkspaceProvider } from "./providers/WorkspaceProvider";
@@ -89,6 +90,14 @@ function V2WorkspaceLayout() {
 				hostName={hostStatus.hostName}
 				hostVersion={hostStatus.hostVersion}
 				minVersion={hostStatus.minVersion}
+			/>
+		);
+	}
+	if (hostStatus.status === "offline") {
+		return (
+			<WorkspaceHostOfflineState
+				hostId={hostStatus.hostId}
+				hostName={hostStatus.hostName}
 			/>
 		);
 	}


### PR DESCRIPTION
## Summary

- Gate remote V2 workspace routes when the owning host is marked offline.
- Add a dedicated offline-host state instead of mounting workspace children against an unreachable host service.
- Include a responsive Host ID row plus links to host settings and the V2 workspaces list.

## Why

Remote workspaces already depend on host availability. When a host is offline, the workspace detail route should behave like the existing missing-worktree gate: explain why terminals and file actions are unavailable and avoid downstream host-service queries.

## Validation

- `bunx biome check --write --unsafe apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/WorkspaceHostOfflineState.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/index.ts`
- `bun run --cwd apps/desktop typecheck`
- `bun run lint -- apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/WorkspaceHostOfflineState.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostOfflineState/index.ts`
- `git diff --check`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4672">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates V2 workspace routes when the host is offline and shows a clear offline state. This avoids unreachable host calls and explains why terminals and file actions are unavailable.

- **New Features**
  - Detect offline hosts via `isOnline` and return an `offline` status; skip remote `host.info` queries when offline.
  - Render a dedicated offline state with host name, Host ID, and links to host settings and the V2 workspaces list.
  - Prevent terminals and file actions from mounting when the host is offline, matching the missing-worktree gate.

<sup>Written for commit 2ef0f217f709c46634306c8c17f7adf5f1527c3a. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4672?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added offline host state display for workspaces. When a host is unavailable, users now see a dedicated interface showing the host information with options to navigate to host settings or browse other workspaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->