### PR TITLE
[codex] Add v2 workspace delete hotkey support

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
@@ -9,7 +9,8 @@ import {
 import { Button } from "@superset/ui/button";
 import { Checkbox } from "@superset/ui/checkbox";
 import { Label } from "@superset/ui/label";
-import { useId } from "react";
+import { useEffect, useId } from "react";
+import { shouldConfirmDeleteDialogKey } from "../../utils/shouldConfirmDeleteDialogKey";
 
 interface DestroyConfirmPaneProps {
 	open: boolean;
@@ -40,6 +41,20 @@ export function DestroyConfirmPane({
 }: DestroyConfirmPaneProps) {
 	const checkboxId = useId();
 	const hasWarnings = hasChanges || hasUnpushedCommits;
+
+	useEffect(() => {
+		if (!open || !canConfirm) return;
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (!shouldConfirmDeleteDialogKey(event)) return;
+			event.preventDefault();
+			onConfirm();
+		};
+
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [canConfirm, onConfirm, open]);
+
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
 			<AlertDialogContent className="max-w-[340px] gap-0 p-0">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
@@ -46,6 +46,7 @@ export function DestroyConfirmPane({
 		if (!open || !canConfirm) return;
 
 		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.target instanceof HTMLButtonElement) return;
 			if (!shouldConfirmDeleteDialogKey(event)) return;
 			event.preventDefault();
 			onConfirm();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
@@ -46,7 +46,6 @@ export function DestroyConfirmPane({
 		if (!open || !canConfirm) return;
 
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.target instanceof HTMLButtonElement) return;
 			if (!shouldConfirmDeleteDialogKey(event)) return;
 			event.preventDefault();
 			onConfirm();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/TeardownFailedPane/TeardownFailedPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/TeardownFailedPane/TeardownFailedPane.tsx
@@ -8,7 +8,9 @@ import {
 	AlertDialogTitle,
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
+import { useEffect } from "react";
 import stripAnsi from "strip-ansi";
+import { shouldConfirmDeleteDialogKey } from "../../utils/shouldConfirmDeleteDialogKey";
 import { formatTeardownReason } from "./formatTeardownReason";
 
 interface TeardownFailedPaneProps {
@@ -29,6 +31,19 @@ export function TeardownFailedPane({
 	const reason = formatTeardownReason(cause);
 	// Strip ANSI so raw PTY bytes render readably in the <pre>.
 	const cleanTail = stripAnsi(cause.outputTail ?? "");
+
+	useEffect(() => {
+		if (!open) return;
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (!shouldConfirmDeleteDialogKey(event)) return;
+			event.preventDefault();
+			onForceDelete();
+		};
+
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [onForceDelete, open]);
 
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/TeardownFailedPane/TeardownFailedPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/TeardownFailedPane/TeardownFailedPane.tsx
@@ -36,6 +36,7 @@ export function TeardownFailedPane({
 		if (!open) return;
 
 		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.target instanceof HTMLButtonElement) return;
 			if (!shouldConfirmDeleteDialogKey(event)) return;
 			event.preventDefault();
 			onForceDelete();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/TeardownFailedPane/TeardownFailedPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/TeardownFailedPane/TeardownFailedPane.tsx
@@ -36,7 +36,6 @@ export function TeardownFailedPane({
 		if (!open) return;
 
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.target instanceof HTMLButtonElement) return;
 			if (!shouldConfirmDeleteDialogKey(event)) return;
 			event.preventDefault();
 			onForceDelete();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { shouldConfirmDeleteDialogKey } from "./shouldConfirmDeleteDialogKey";
+
+const plainEnter = {
+	key: "Enter",
+	shiftKey: false,
+	metaKey: false,
+	ctrlKey: false,
+	altKey: false,
+};
+
+describe("shouldConfirmDeleteDialogKey", () => {
+	test("accepts unmodified Enter", () => {
+		expect(shouldConfirmDeleteDialogKey(plainEnter)).toBe(true);
+	});
+
+	test("rejects modified Enter", () => {
+		expect(shouldConfirmDeleteDialogKey({ ...plainEnter, metaKey: true })).toBe(
+			false,
+		);
+		expect(
+			shouldConfirmDeleteDialogKey({ ...plainEnter, shiftKey: true }),
+		).toBe(false);
+	});
+
+	test("rejects composition and non-Enter keys", () => {
+		expect(
+			shouldConfirmDeleteDialogKey({ ...plainEnter, isComposing: true }),
+		).toBe(false);
+		expect(shouldConfirmDeleteDialogKey({ ...plainEnter, keyCode: 229 })).toBe(
+			false,
+		);
+		expect(shouldConfirmDeleteDialogKey({ ...plainEnter, key: " " })).toBe(
+			false,
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.test.ts
@@ -21,6 +21,12 @@ describe("shouldConfirmDeleteDialogKey", () => {
 		expect(
 			shouldConfirmDeleteDialogKey({ ...plainEnter, shiftKey: true }),
 		).toBe(false);
+		expect(shouldConfirmDeleteDialogKey({ ...plainEnter, ctrlKey: true })).toBe(
+			false,
+		);
+		expect(shouldConfirmDeleteDialogKey({ ...plainEnter, altKey: true })).toBe(
+			false,
+		);
 	});
 
 	test("rejects composition and non-Enter keys", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.ts
@@ -1,0 +1,22 @@
+interface ConfirmDeleteDialogKeyEvent {
+	key: string;
+	shiftKey: boolean;
+	metaKey: boolean;
+	ctrlKey: boolean;
+	altKey: boolean;
+	isComposing?: boolean;
+	keyCode?: number;
+}
+
+export function shouldConfirmDeleteDialogKey(
+	event: ConfirmDeleteDialogKeyEvent,
+): boolean {
+	if (event.isComposing || event.keyCode === 229) return false;
+	return (
+		event.key === "Enter" &&
+		!event.shiftKey &&
+		!event.metaKey &&
+		!event.ctrlKey &&
+		!event.altKey
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -164,6 +164,7 @@ export function DashboardSidebarWorkspaceItem({
 							isLocalWorkspace={hostType === "local-device"}
 							isPinned={isMainWorkspace && hostType === "local-device"}
 							onCreateSection={handleCreateSection}
+							showDeleteHotkey={isActive}
 							onMoveToSection={(targetSectionId) =>
 								moveWorkspaceToSection(id, projectId, targetSectionId)
 							}
@@ -254,6 +255,7 @@ export function DashboardSidebarWorkspaceItem({
 						isLocalWorkspace={hostType === "local-device"}
 						isPinned={isMainWorkspace && hostType === "local-device"}
 						onOpenInFinder={handleOpenInFinder}
+						showDeleteHotkey={isActive}
 						onCopyPath={handleCopyPath}
 						onCopyBranchName={handleCopyBranchName}
 						onRemoveFromSidebar={handleRemoveFromSidebar}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -3,6 +3,7 @@ import {
 	ContextMenuContent,
 	ContextMenuItem,
 	ContextMenuSeparator,
+	ContextMenuShortcut,
 	ContextMenuSub,
 	ContextMenuSubContent,
 	ContextMenuSubTrigger,
@@ -23,6 +24,7 @@ import {
 	LuTrash2,
 	LuX,
 } from "react-icons/lu";
+import { useHotkeyDisplay } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useDashboardSidebarHover } from "../../../../providers/DashboardSidebarHoverProvider";
 
@@ -32,6 +34,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 	isLocalWorkspace: boolean;
 	isPinned?: boolean;
 	isUnread: boolean;
+	showDeleteHotkey?: boolean;
 	onCreateSection: () => void;
 	onMoveToSection: (sectionId: string | null) => void;
 	onOpenInFinder: () => void;
@@ -50,6 +53,7 @@ export function DashboardSidebarWorkspaceContextMenu({
 	isLocalWorkspace,
 	isPinned = false,
 	isUnread,
+	showDeleteHotkey = false,
 	onCreateSection,
 	onMoveToSection,
 	onOpenInFinder,
@@ -63,6 +67,9 @@ export function DashboardSidebarWorkspaceContextMenu({
 }: DashboardSidebarWorkspaceContextMenuProps) {
 	const collections = useCollections();
 	const { setContextMenuOpen } = useDashboardSidebarHover();
+	const deleteHotkeyText = useHotkeyDisplay("CLOSE_WORKSPACE").text;
+	const showDeleteShortcut =
+		showDeleteHotkey && deleteHotkeyText !== "Unassigned";
 	const { data: sections = [] } = useLiveQuery(
 		(q) =>
 			q
@@ -174,6 +181,9 @@ export function DashboardSidebarWorkspaceContextMenu({
 					>
 						<LuTrash2 className="size-4 mr-2 text-destructive" />
 						Delete
+						{showDeleteShortcut && (
+							<ContextMenuShortcut>{deleteHotkeyText}</ContextMenuShortcut>
+						)}
 					</ContextMenuItem>
 				) : null}
 			</ContextMenuContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -1,3 +1,5 @@
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import {
 	createFileRoute,
 	Outlet,
@@ -10,7 +12,10 @@ import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { DashboardSidebar } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar";
+import { DashboardSidebarDeleteDialog } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useDevSeedV2Sidebar } from "renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
 import { DeleteWorkspaceDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
@@ -30,10 +35,26 @@ export const Route = createFileRoute("/_authenticated/_dashboard")({
 	component: DashboardLayout,
 });
 
+type DeleteTarget =
+	| {
+			version: "v1";
+			workspaceId: string;
+			workspaceName: string;
+			workspaceType: "worktree" | "branch";
+	  }
+	| {
+			version: "v2";
+			workspaceId: string;
+			workspaceName: string;
+			open: boolean;
+	  };
+
 function DashboardLayout() {
 	const navigate = useNavigate();
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const collections = useCollections();
+	const { removeWorkspaceFromSidebar } = useDashboardSidebarState();
 	useDevSeedV2Sidebar();
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
@@ -47,6 +68,8 @@ function DashboardLayout() {
 		to: "/v2-workspace/$workspaceId",
 		fuzzy: true,
 	});
+	const currentV2WorkspaceId =
+		v2WorkspaceMatch !== false ? v2WorkspaceMatch.workspaceId : null;
 	const onV1WorkspaceRoute = currentWorkspaceMatch !== false;
 	const onV2WorkspaceRoute = v2WorkspaceMatch !== false;
 	const versionMismatch =
@@ -57,6 +80,18 @@ function DashboardLayout() {
 		{ id: currentWorkspaceId ?? "" },
 		{ enabled: !!currentWorkspaceId },
 	);
+
+	const { data: currentV2Workspaces = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ workspaces: collections.v2Workspaces })
+				.where(({ workspaces }) =>
+					eq(workspaces.id, currentV2WorkspaceId ?? ""),
+				),
+		[collections, currentV2WorkspaceId],
+	);
+	const currentV2Workspace =
+		currentV2WorkspaceId != null ? (currentV2Workspaces[0] ?? null) : null;
 
 	const {
 		isOpen: isWorkspaceSidebarOpen,
@@ -83,11 +118,7 @@ function DashboardLayout() {
 		openNewWorkspaceModal(currentWorkspace?.projectId),
 	);
 
-	const [deleteTarget, setDeleteTarget] = useState<{
-		workspaceId: string;
-		workspaceName: string;
-		workspaceType: "worktree" | "branch";
-	} | null>(null);
+	const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 
 	useHotkey(
 		"CLOSE_WORKSPACE",
@@ -97,10 +128,31 @@ function DashboardLayout() {
 					workspaceId: currentWorkspaceId,
 					workspaceName: currentWorkspace.name,
 					workspaceType: currentWorkspace.type,
+					version: "v1",
+				});
+				return;
+			}
+
+			if (
+				currentV2WorkspaceId &&
+				currentV2Workspace &&
+				currentV2Workspace.type !== "main"
+			) {
+				setDeleteTarget({
+					workspaceId: currentV2WorkspaceId,
+					workspaceName: currentV2Workspace.name || currentV2Workspace.branch,
+					version: "v2",
+					open: true,
 				});
 			}
 		},
-		{ enabled: !!currentWorkspaceId },
+		{
+			enabled:
+				(!!currentWorkspaceId && !!currentWorkspace) ||
+				(!!currentV2WorkspaceId &&
+					!!currentV2Workspace &&
+					currentV2Workspace.type !== "main"),
+		},
 	);
 
 	const sidebarPanel = isWorkspaceSidebarOpen && (
@@ -152,7 +204,7 @@ function DashboardLayout() {
 			</div>
 			<div id="workspace-right-sidebar-slot" className="flex h-full shrink-0" />
 			<AddRepositoryModals />
-			{deleteTarget && (
+			{deleteTarget?.version === "v1" && (
 				<DeleteWorkspaceDialog
 					workspaceId={deleteTarget.workspaceId}
 					workspaceName={deleteTarget.workspaceName}
@@ -160,6 +212,22 @@ function DashboardLayout() {
 					open={true}
 					onOpenChange={(open) => {
 						if (!open) setDeleteTarget(null);
+					}}
+				/>
+			)}
+			{deleteTarget?.version === "v2" && (
+				<DashboardSidebarDeleteDialog
+					workspaceId={deleteTarget.workspaceId}
+					workspaceName={deleteTarget.workspaceName}
+					open={deleteTarget.open}
+					onOpenChange={(open) => {
+						setDeleteTarget((target) =>
+							target?.version === "v2" ? { ...target, open } : target,
+						);
+					}}
+					onDeleted={() => {
+						removeWorkspaceFromSidebar(deleteTarget.workspaceId);
+						setDeleteTarget(null);
 					}}
 				/>
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -221,9 +221,14 @@ function DashboardLayout() {
 					workspaceName={deleteTarget.workspaceName}
 					open={deleteTarget.open}
 					onOpenChange={(open) => {
-						setDeleteTarget((target) =>
-							target?.version === "v2" ? { ...target, open } : target,
-						);
+						setDeleteTarget((target) => {
+							if (target?.version === "v2") {
+								return open ? { ...target, open: true } : null;
+							}
+							if (open && target === null)
+								return { ...deleteTarget, open: true };
+							return target;
+						});
 					}}
 					onDeleted={() => {
 						removeWorkspaceFromSidebar(deleteTarget.workspaceId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -221,14 +221,9 @@ function DashboardLayout() {
 					workspaceName={deleteTarget.workspaceName}
 					open={deleteTarget.open}
 					onOpenChange={(open) => {
-						setDeleteTarget((target) => {
-							if (target?.version === "v2") {
-								return open ? { ...target, open: true } : null;
-							}
-							if (open && target === null)
-								return { ...deleteTarget, open: true };
-							return target;
-						});
+						setDeleteTarget((target) =>
+							target?.version === "v2" ? { ...target, open } : target,
+						);
 					}}
 					onDeleted={() => {
 						removeWorkspaceFromSidebar(deleteTarget.workspaceId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -3,6 +3,7 @@ import {
 	ContextMenuContent,
 	ContextMenuItem,
 	ContextMenuSeparator,
+	ContextMenuShortcut,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
 import {
@@ -14,6 +15,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { type RefObject, useMemo, useState } from "react";
 import { LuCopy, LuGitBranch, LuX } from "react-icons/lu";
+import { useHotkeyDisplay } from "renderer/hotkeys";
 import { createContextMenuDeleteDialogCoordinator } from "renderer/react-query/workspaces/useWorkspaceDeleteHandler";
 import type { ActivePaneStatus } from "shared/tabs-types";
 import { STROKE_WIDTH } from "../constants";
@@ -69,6 +71,8 @@ export function CollapsedWorkspaceItem({
 	const [renameBranchTarget, setRenameBranchTarget] = useState<string | null>(
 		null,
 	);
+	const deleteHotkeyText = useHotkeyDisplay("CLOSE_WORKSPACE").text;
+	const showDeleteShortcut = isActive && deleteHotkeyText !== "Unassigned";
 
 	const collapsedButton = (
 		<button
@@ -163,6 +167,9 @@ export function CollapsedWorkspaceItem({
 						>
 							<LuX className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 							Close Workspace
+							{showDeleteShortcut && (
+								<ContextMenuShortcut>{deleteHotkeyText}</ContextMenuShortcut>
+							)}
 						</ContextMenuItem>
 					</ContextMenuContent>
 				</ContextMenu>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -3,6 +3,7 @@ import {
 	ContextMenuContent,
 	ContextMenuItem,
 	ContextMenuSeparator,
+	ContextMenuShortcut,
 	ContextMenuSub,
 	ContextMenuSubContent,
 	ContextMenuSubTrigger,
@@ -28,6 +29,7 @@ import {
 	LuPencil,
 	LuX,
 } from "react-icons/lu";
+import { useHotkeyDisplay } from "renderer/hotkeys";
 import {
 	useCreateSectionFromWorkspaces,
 	useMoveWorkspacesToSection,
@@ -45,6 +47,7 @@ interface WorkspaceContextMenuProps {
 	name: string;
 	isBranchWorkspace: boolean;
 	isUnread: boolean;
+	showDeleteHotkey?: boolean;
 	workspaceStatus: string | null | undefined;
 	sections: { id: string; name: string }[];
 	onRename: () => void;
@@ -64,6 +67,7 @@ export function WorkspaceContextMenu({
 	name,
 	isBranchWorkspace,
 	isUnread,
+	showDeleteHotkey = false,
 	workspaceStatus,
 	sections,
 	onRename,
@@ -85,6 +89,9 @@ export function WorkspaceContextMenu({
 	const moveToSection = useMoveWorkspaceToSection();
 	const bulkMoveToSection = useMoveWorkspacesToSection();
 	const createSectionFromWorkspaces = useCreateSectionFromWorkspaces();
+	const deleteHotkeyText = useHotkeyDisplay("CLOSE_WORKSPACE").text;
+	const showDeleteShortcut =
+		showDeleteHotkey && deleteHotkeyText !== "Unassigned";
 	const deleteDialogCoordinator = useMemo(
 		() => createContextMenuDeleteDialogCoordinator(onDelete),
 		[onDelete],
@@ -206,6 +213,9 @@ export function WorkspaceContextMenu({
 			>
 				<LuX className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 				{isBranchWorkspace ? "Close Workspace" : "Close Worktree"}
+				{showDeleteShortcut && (
+					<ContextMenuShortcut>{deleteHotkeyText}</ContextMenuShortcut>
+				)}
 			</ContextMenuItem>
 		</>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -468,6 +468,7 @@ export function WorkspaceListItem({
 				name={name}
 				isBranchWorkspace={isBranchWorkspace}
 				isUnread={isUnread}
+				showDeleteHotkey={isActive}
 				workspaceStatus={workspaceStatus}
 				sections={sections}
 				onRename={rename.startRename}


### PR DESCRIPTION
## Summary

Adds v2 support for the existing current-workspace delete hotkey. The dashboard-level `CLOSE_WORKSPACE` binding now resolves the active v2 workspace and opens the v2 workspace destroy dialog for non-main workspaces, while preserving the existing v1 dialog path.

The v2 delete confirmation flow now accepts plain Enter to confirm in both the normal delete confirmation pane and the teardown-failed "Delete anyway" pane. A shared predicate keeps modifier/composition handling consistent and covered by a focused test.

## Impact

Users can delete the current v2 workspace with the same keyboard shortcut already shown in the sidebar, then confirm from the keyboard without reaching for the mouse.

## Root Cause

The hotkey was registered globally as `CLOSE_WORKSPACE`, but the dashboard layout only had v1 workspace data available when deciding what dialog to open. The v2 destroy dialog also only confirmed through click handlers.

## Validation

- `bun test apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.test.ts`
- `bun run lint`
- `bun run --cwd apps/desktop typecheck`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4673">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds v2 support for the delete-current-workspace hotkey and keeps Enter-to-confirm in the v2 delete dialog. Pressing the `CLOSE_WORKSPACE` shortcut on a non‑main v2 workspace opens the v2 delete dialog; the v1 flow is unchanged.

- New Features
  - `CLOSE_WORKSPACE` opens the v2 delete dialog when on a v2 (non‑main) workspace; v1 flow unchanged.
  - Plain Enter confirms in both the confirmation and teardown‑failed panes; modifiers and IME composition are ignored via `shouldConfirmDeleteDialogKey` (with tests).
  - Deleted v2 workspaces are removed from the sidebar after completion.
  - Context menus show the `CLOSE_WORKSPACE` shortcut on the active workspace in both the dashboard and workspace sidebars when assigned.

- Refactors
  - Simplified v2 delete dialog open state management in the dashboard layout.

<sup>Written for commit 5786e9b4f7371fbabf3cc7e41a94b10513a8fe10. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4673?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Enter key now confirms workspace deletion and can trigger force-delete in failure dialogs
  - Dashboard supports deletion for v2 workspaces in addition to v1
  - Context menus and workspace items optionally display the configured "Close Workspace" hotkey when active and assigned

* **Tests**
  - Added tests validating keyboard handling for delete confirmation dialogs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->