### PR TITLE
polish v2 project settings + follow-up review feedback from #4665

### DIFF
--- a/apps/desktop/src/renderer/components/RemotePathPicker/RemotePathPicker.tsx
+++ b/apps/desktop/src/renderer/components/RemotePathPicker/RemotePathPicker.tsx
@@ -1,0 +1,255 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { ScrollArea } from "@superset/ui/scroll-area";
+import { Skeleton } from "@superset/ui/skeleton";
+import { toast } from "@superset/ui/sonner";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import {
+	LuArrowUp,
+	LuFolder,
+	LuFolderOpen,
+	LuHouse,
+	LuRefreshCw,
+} from "react-icons/lu";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+
+interface RemotePathPickerProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	hostUrl: string | null;
+	hostName: string;
+	/** Initial directory shown when the picker opens. Defaults to `~`. */
+	initialPath?: string | null;
+	onPick: (absolutePath: string) => void;
+	title?: string;
+	description?: string;
+	confirmLabel?: string;
+}
+
+interface BrowseResult {
+	path: string;
+	parentPath: string | null;
+	homePath: string;
+	entries: { name: string; isDirectory: boolean; isSymlink: boolean }[];
+}
+
+export function RemotePathPicker({
+	open,
+	onOpenChange,
+	hostUrl,
+	hostName,
+	initialPath,
+	onPick,
+	title = "Choose a folder",
+	description,
+	confirmLabel = "Use this folder",
+}: RemotePathPickerProps) {
+	const [currentPath, setCurrentPath] = useState<string | null>(
+		initialPath ?? null,
+	);
+	const [pathDraft, setPathDraft] = useState<string>(initialPath ?? "");
+
+	useEffect(() => {
+		if (open) {
+			setCurrentPath(initialPath ?? null);
+			setPathDraft(initialPath ?? "");
+		}
+	}, [open, initialPath]);
+
+	const query = useQuery<BrowseResult>({
+		enabled: open && !!hostUrl,
+		queryKey: ["remote-path-picker", hostUrl, currentPath],
+		queryFn: async () => {
+			if (!hostUrl) throw new Error("Host unavailable");
+			const client = getHostServiceClientByUrl(hostUrl);
+			return await client.filesystem.browseHost.query({
+				path: currentPath ?? undefined,
+			});
+		},
+	});
+
+	useEffect(() => {
+		if (query.data) {
+			setCurrentPath(query.data.path);
+			setPathDraft(query.data.path);
+		}
+	}, [query.data]);
+
+	useEffect(() => {
+		if (query.error) {
+			toast.error(
+				query.error instanceof Error
+					? query.error.message
+					: "Could not list directory",
+			);
+		}
+	}, [query.error]);
+
+	const goTo = (path: string) => {
+		setCurrentPath(path);
+	};
+
+	const goUp = () => {
+		if (query.data?.parentPath) goTo(query.data.parentPath);
+	};
+
+	const goHome = () => {
+		if (query.data?.homePath) goTo(query.data.homePath);
+		else setCurrentPath(null);
+	};
+
+	const submitPathDraft = () => {
+		const trimmed = pathDraft.trim();
+		if (!trimmed) return;
+		setCurrentPath(trimmed);
+	};
+
+	const handlePick = () => {
+		const target = query.data?.path ?? currentPath;
+		if (!target) return;
+		onPick(target);
+		onOpenChange(false);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange} modal>
+			<DialogContent className="max-w-[560px]">
+				<DialogHeader>
+					<DialogTitle>{title}</DialogTitle>
+					<DialogDescription>
+						{description ?? `Browse folders on ${hostName}.`}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-3">
+					<div className="flex items-center gap-1.5">
+						<Button
+							type="button"
+							variant="outline"
+							size="icon"
+							onClick={goUp}
+							disabled={!query.data?.parentPath || query.isFetching}
+							aria-label="Up one folder"
+							className="shrink-0"
+						>
+							<LuArrowUp className="size-4" />
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							size="icon"
+							onClick={goHome}
+							disabled={query.isFetching}
+							aria-label="Home folder"
+							className="shrink-0"
+						>
+							<LuHouse className="size-4" />
+						</Button>
+						<Input
+							value={pathDraft}
+							onChange={(e) => setPathDraft(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									submitPathDraft();
+								}
+							}}
+							onBlur={submitPathDraft}
+							placeholder={`Path on ${hostName} (~ for home)`}
+							className="flex-1 font-mono text-sm"
+							spellCheck={false}
+						/>
+						<Button
+							type="button"
+							variant="outline"
+							size="icon"
+							onClick={() => query.refetch()}
+							disabled={query.isFetching}
+							aria-label="Refresh"
+							className="shrink-0"
+						>
+							<LuRefreshCw
+								className={`size-4 ${query.isFetching ? "animate-spin" : ""}`}
+							/>
+						</Button>
+					</div>
+
+					<ScrollArea className="h-64 rounded-md border">
+						{query.isLoading ? (
+							<div className="flex flex-col gap-1 p-2">
+								{[0, 1, 2, 3, 4].map((i) => (
+									<Skeleton key={i} className="h-7 w-full" />
+								))}
+							</div>
+						) : query.data ? (
+							query.data.entries.filter((e) => e.isDirectory).length === 0 ? (
+								<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+									{query.data.entries.length === 0
+										? "Empty folder"
+										: "No subfolders"}
+								</div>
+							) : (
+								<ul className="flex flex-col">
+									{query.data.entries
+										.filter((entry) => entry.isDirectory)
+										.map((entry) => {
+											const childPath = `${query.data.path.replace(/\/$/, "")}/${entry.name}`;
+											return (
+												<li key={entry.name}>
+													<button
+														type="button"
+														onDoubleClick={() => goTo(childPath)}
+														onClick={() => setPathDraft(childPath)}
+														className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+													>
+														<LuFolder className="size-4 shrink-0 text-muted-foreground" />
+														<span className="truncate">{entry.name}</span>
+														{entry.isSymlink && (
+															<span className="ml-auto text-xs text-muted-foreground">
+																link
+															</span>
+														)}
+													</button>
+												</li>
+											);
+										})}
+								</ul>
+							)
+						) : (
+							<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+								No data
+							</div>
+						)}
+					</ScrollArea>
+				</div>
+
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<Button
+						type="button"
+						onClick={handlePick}
+						disabled={!query.data || query.isFetching}
+					>
+						<LuFolderOpen className="size-4" />
+						{confirmLabel}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/components/RemotePathPicker/RemotePathPicker.tsx
+++ b/apps/desktop/src/renderer/components/RemotePathPicker/RemotePathPicker.tsx
@@ -1,3 +1,12 @@
+import {
+	Breadcrumb,
+	BreadcrumbEllipsis,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+} from "@superset/ui/breadcrumb";
 import { Button } from "@superset/ui/button";
 import {
 	Dialog,
@@ -7,17 +16,16 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@superset/ui/dialog";
-import { Input } from "@superset/ui/input";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { Skeleton } from "@superset/ui/skeleton";
 import { toast } from "@superset/ui/sonner";
+import { cn } from "@superset/ui/utils";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import {
-	LuArrowUp,
+	LuExternalLink,
 	LuFolder,
 	LuFolderOpen,
-	LuHouse,
 	LuRefreshCw,
 } from "react-icons/lu";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -27,7 +35,6 @@ interface RemotePathPickerProps {
 	onOpenChange: (open: boolean) => void;
 	hostUrl: string | null;
 	hostName: string;
-	/** Initial directory shown when the picker opens. Defaults to `~`. */
 	initialPath?: string | null;
 	onPick: (absolutePath: string) => void;
 	title?: string;
@@ -40,6 +47,41 @@ interface BrowseResult {
 	parentPath: string | null;
 	homePath: string;
 	entries: { name: string; isDirectory: boolean; isSymlink: boolean }[];
+}
+
+interface Segment {
+	label: string;
+	path: string;
+}
+
+const MAX_VISIBLE_SEGMENTS = 4;
+
+function pathToSegments(path: string, homePath: string | null): Segment[] {
+	const segments: Segment[] = [];
+	if (homePath && (path === homePath || path === `${homePath}/`)) {
+		return [{ label: "Home", path: homePath }];
+	}
+	if (homePath && path.startsWith(`${homePath}/`)) {
+		segments.push({ label: "Home", path: homePath });
+		const rest = path.slice(homePath.length + 1);
+		let cumulative = homePath;
+		for (const part of rest.split("/").filter(Boolean)) {
+			cumulative = `${cumulative}/${part}`;
+			segments.push({ label: part, path: cumulative });
+		}
+		return segments;
+	}
+	segments.push({ label: "/", path: "/" });
+	let cumulative = "";
+	for (const part of path.split("/").filter(Boolean)) {
+		cumulative = `${cumulative}/${part}`;
+		segments.push({ label: part, path: cumulative });
+	}
+	return segments;
+}
+
+function joinPath(base: string, child: string): string {
+	return `${base.replace(/\/$/, "")}/${child}`;
 }
 
 export function RemotePathPicker({
@@ -56,12 +98,10 @@ export function RemotePathPicker({
 	const [currentPath, setCurrentPath] = useState<string | null>(
 		initialPath ?? null,
 	);
-	const [pathDraft, setPathDraft] = useState<string>(initialPath ?? "");
 
 	useEffect(() => {
 		if (open) {
 			setCurrentPath(initialPath ?? null);
-			setPathDraft(initialPath ?? "");
 		}
 	}, [open, initialPath]);
 
@@ -78,10 +118,7 @@ export function RemotePathPicker({
 	});
 
 	useEffect(() => {
-		if (query.data) {
-			setCurrentPath(query.data.path);
-			setPathDraft(query.data.path);
-		}
+		if (query.data) setCurrentPath(query.data.path);
 	}, [query.data]);
 
 	useEffect(() => {
@@ -94,145 +131,142 @@ export function RemotePathPicker({
 		}
 	}, [query.error]);
 
-	const goTo = (path: string) => {
-		setCurrentPath(path);
-	};
+	const allSegments = query.data
+		? pathToSegments(query.data.path, query.data.homePath)
+		: [];
 
-	const goUp = () => {
-		if (query.data?.parentPath) goTo(query.data.parentPath);
-	};
+	const segments: (Segment | "ellipsis")[] =
+		allSegments.length > MAX_VISIBLE_SEGMENTS
+			? [
+					allSegments[0],
+					"ellipsis",
+					...allSegments.slice(-(MAX_VISIBLE_SEGMENTS - 1)),
+				]
+			: allSegments;
 
-	const goHome = () => {
-		if (query.data?.homePath) goTo(query.data.homePath);
-		else setCurrentPath(null);
-	};
-
-	const submitPathDraft = () => {
-		const trimmed = pathDraft.trim();
-		if (!trimmed) return;
-		setCurrentPath(trimmed);
-	};
+	const folders = query.data?.entries.filter((e) => e.isDirectory) ?? [];
 
 	const handlePick = () => {
-		const target = query.data?.path ?? currentPath;
-		if (!target) return;
-		onPick(target);
+		if (!query.data) return;
+		onPick(query.data.path);
 		onOpenChange(false);
 	};
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange} modal>
-			<DialogContent className="max-w-[560px]">
-				<DialogHeader>
+			<DialogContent className="max-w-[560px] gap-0 p-0">
+				<DialogHeader className="px-5 pt-5 pb-3">
 					<DialogTitle>{title}</DialogTitle>
 					<DialogDescription>
 						{description ?? `Browse folders on ${hostName}.`}
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex flex-col gap-3">
-					<div className="flex items-center gap-1.5">
-						<Button
-							type="button"
-							variant="outline"
-							size="icon"
-							onClick={goUp}
-							disabled={!query.data?.parentPath || query.isFetching}
-							aria-label="Up one folder"
-							className="shrink-0"
-						>
-							<LuArrowUp className="size-4" />
-						</Button>
-						<Button
-							type="button"
-							variant="outline"
-							size="icon"
-							onClick={goHome}
-							disabled={query.isFetching}
-							aria-label="Home folder"
-							className="shrink-0"
-						>
-							<LuHouse className="size-4" />
-						</Button>
-						<Input
-							value={pathDraft}
-							onChange={(e) => setPathDraft(e.target.value)}
-							onKeyDown={(e) => {
-								if (e.key === "Enter") {
-									e.preventDefault();
-									submitPathDraft();
-								}
-							}}
-							onBlur={submitPathDraft}
-							placeholder={`Path on ${hostName} (~ for home)`}
-							className="flex-1 font-mono text-sm"
-							spellCheck={false}
-						/>
-						<Button
-							type="button"
-							variant="outline"
-							size="icon"
-							onClick={() => query.refetch()}
-							disabled={query.isFetching}
-							aria-label="Refresh"
-							className="shrink-0"
-						>
-							<LuRefreshCw
-								className={`size-4 ${query.isFetching ? "animate-spin" : ""}`}
-							/>
-						</Button>
-					</div>
-
-					<ScrollArea className="h-64 rounded-md border">
-						{query.isLoading ? (
-							<div className="flex flex-col gap-1 p-2">
-								{[0, 1, 2, 3, 4].map((i) => (
-									<Skeleton key={i} className="h-7 w-full" />
-								))}
-							</div>
-						) : query.data ? (
-							query.data.entries.filter((e) => e.isDirectory).length === 0 ? (
-								<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
-									{query.data.entries.length === 0
-										? "Empty folder"
-										: "No subfolders"}
-								</div>
-							) : (
-								<ul className="flex flex-col">
-									{query.data.entries
-										.filter((entry) => entry.isDirectory)
-										.map((entry) => {
-											const childPath = `${query.data.path.replace(/\/$/, "")}/${entry.name}`;
+				<div className="flex items-center gap-2 border-y border-border px-5 py-2">
+					<div className="min-w-0 flex-1">
+						{query.data ? (
+							<Breadcrumb>
+								<BreadcrumbList className="flex-nowrap">
+									{segments.map((seg, i) => {
+										const isLast = i === segments.length - 1;
+										if (seg === "ellipsis") {
 											return (
-												<li key={entry.name}>
-													<button
-														type="button"
-														onDoubleClick={() => goTo(childPath)}
-														onClick={() => setPathDraft(childPath)}
-														className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
-													>
-														<LuFolder className="size-4 shrink-0 text-muted-foreground" />
-														<span className="truncate">{entry.name}</span>
-														{entry.isSymlink && (
-															<span className="ml-auto text-xs text-muted-foreground">
-																link
-															</span>
-														)}
-													</button>
-												</li>
+												<Fragment key="ellipsis">
+													<BreadcrumbItem>
+														<BreadcrumbEllipsis />
+													</BreadcrumbItem>
+													<BreadcrumbSeparator />
+												</Fragment>
 											);
-										})}
-								</ul>
-							)
+										}
+										return (
+											<Fragment key={seg.path}>
+												<BreadcrumbItem className="min-w-0">
+													{isLast ? (
+														<BreadcrumbPage className="truncate">
+															{seg.label}
+														</BreadcrumbPage>
+													) : (
+														<BreadcrumbLink asChild>
+															<button
+																type="button"
+																onClick={() => setCurrentPath(seg.path)}
+																className="truncate hover:text-foreground"
+															>
+																{seg.label}
+															</button>
+														</BreadcrumbLink>
+													)}
+												</BreadcrumbItem>
+												{!isLast && <BreadcrumbSeparator />}
+											</Fragment>
+										);
+									})}
+								</BreadcrumbList>
+							</Breadcrumb>
 						) : (
-							<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
-								No data
-							</div>
+							<Skeleton className="h-4 w-40" />
 						)}
-					</ScrollArea>
+					</div>
+					<button
+						type="button"
+						onClick={() => query.refetch()}
+						disabled={query.isFetching}
+						aria-label="Refresh"
+						className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+					>
+						<LuRefreshCw
+							className={cn("size-3.5", query.isFetching && "animate-spin")}
+						/>
+					</button>
 				</div>
 
-				<DialogFooter>
+				<ScrollArea className="h-72">
+					{query.isLoading ? (
+						<div className="flex flex-col gap-0.5 p-2">
+							{[0, 1, 2, 3, 4].map((i) => (
+								<div key={i} className="flex items-center gap-2 px-2 py-1.5">
+									<Skeleton className="size-4 shrink-0 rounded-sm" />
+									<Skeleton className="h-4 w-40" />
+								</div>
+							))}
+						</div>
+					) : folders.length === 0 ? (
+						<div className="flex h-72 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+							<LuFolder className="size-6 opacity-40" />
+							<span>
+								{query.data?.entries.length === 0
+									? "Empty folder"
+									: "No subfolders"}
+							</span>
+						</div>
+					) : (
+						<ul className="flex flex-col gap-0.5 p-2">
+							{folders.map((entry) => {
+								const childPath = query.data
+									? joinPath(query.data.path, entry.name)
+									: entry.name;
+								return (
+									<li key={entry.name}>
+										<button
+											type="button"
+											onClick={() => setCurrentPath(childPath)}
+											className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+										>
+											<LuFolder className="size-4 shrink-0 text-muted-foreground" />
+											<span className="truncate">{entry.name}</span>
+											{entry.isSymlink && (
+												<LuExternalLink className="ml-auto size-3 shrink-0 text-muted-foreground/60" />
+											)}
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</ScrollArea>
+
+				<DialogFooter className="border-t border-border px-5 py-3">
 					<Button
 						type="button"
 						variant="ghost"

--- a/apps/desktop/src/renderer/components/RemotePathPicker/index.ts
+++ b/apps/desktop/src/renderer/components/RemotePathPicker/index.ts
@@ -1,0 +1,1 @@
+export { RemotePathPicker } from "./RemotePathPicker";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/ClickablePath/ClickablePath.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/ClickablePath/ClickablePath.tsx
@@ -15,9 +15,14 @@ import { useThemeStore } from "renderer/stores/theme";
 interface ClickablePathProps {
 	path: string;
 	className?: string;
+	truncate?: boolean;
 }
 
-export function ClickablePath({ path, className }: ClickablePathProps) {
+export function ClickablePath({
+	path,
+	className,
+	truncate,
+}: ClickablePathProps) {
 	const activeTheme = useThemeStore((state) => state.activeTheme);
 	const [isOpen, setIsOpen] = useState(false);
 	const utils = electronTrpc.useUtils();
@@ -55,14 +60,16 @@ export function ClickablePath({ path, className }: ClickablePathProps) {
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
+					title={truncate ? path : undefined}
 					className={cn(
-						"group inline-flex items-center gap-1.5 text-sm font-mono break-all text-left",
+						"group inline-flex items-center gap-1.5 text-sm font-mono text-left max-w-full min-w-0",
+						truncate ? "" : "break-all",
 						"hover:underline decoration-current/40 underline-offset-2",
 						"transition-colors cursor-pointer",
 						className,
 					)}
 				>
-					<span>{path}</span>
+					<span className={truncate ? "truncate" : undefined}>{path}</span>
 					<LuExternalLink className="size-3.5 shrink-0 opacity-0 group-hover:opacity-60 transition-opacity" />
 				</button>
 			</DropdownMenuTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/ClickablePath/ClickablePath.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/ClickablePath/ClickablePath.tsx
@@ -69,7 +69,9 @@ export function ClickablePath({
 						className,
 					)}
 				>
-					<span className={truncate ? "truncate" : undefined}>{path}</span>
+					<span className={truncate ? "min-w-0 truncate" : undefined}>
+						{path}
+					</span>
 					<LuExternalLink className="size-3.5 shrink-0 opacity-0 group-hover:opacity-60 transition-opacity" />
 				</button>
 			</DropdownMenuTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
@@ -1,13 +1,22 @@
+import { Label } from "@superset/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { type ReactNode, useMemo } from "react";
+import { HiOutlineComputerDesktop, HiOutlineServer } from "react-icons/hi2";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import { SettingsSection } from "../../../../project/$projectId/components/ProjectSettings";
-import { ProjectSettingsHeader } from "../../../../project/$projectId/components/ProjectSettingsHeader";
 import { DeleteProjectSection } from "./components/DeleteProjectSection";
 import { IconUploadField } from "./components/IconUploadField";
 import { NameSection } from "./components/NameSection";
@@ -20,12 +29,46 @@ interface V2ProjectSettingsProps {
 	hostId: string | null;
 }
 
+interface ProjectSettingsHostOption {
+	id: string;
+	name: string;
+	isLocal: boolean;
+	isOnline: boolean;
+}
+
+function SettingsRow({
+	label,
+	hint,
+	htmlFor,
+	children,
+}: {
+	label: string;
+	hint?: ReactNode;
+	htmlFor?: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className="flex items-center justify-between gap-8 py-2.5">
+			<div className="min-w-0 flex-1">
+				<Label htmlFor={htmlFor} className="text-sm font-medium">
+					{label}
+				</Label>
+				{hint && <p className="mt-0.5 text-xs text-muted-foreground">{hint}</p>}
+			</div>
+			<div className="shrink-0">{children}</div>
+		</div>
+	);
+}
+
 export function V2ProjectSettings({
 	projectId,
 	hostId,
 }: V2ProjectSettingsProps) {
+	const navigate = useNavigate();
 	const collections = useCollections();
 	const { machineId } = useLocalHostService();
+	const { currentDeviceName, localHostId, otherHosts } =
+		useWorkspaceHostOptions();
 	const targetHostUrl = useHostUrl(hostId);
 	const targetHostId = hostId ?? machineId;
 
@@ -38,22 +81,45 @@ export function V2ProjectSettings({
 		[collections, projectId],
 	);
 
-	const { data: hostRows = [] } = useLiveQuery(
-		(q) =>
-			q
-				.from({ hosts: collections.v2Hosts })
-				.where(({ hosts }) => eq(hosts.machineId, targetHostId ?? ""))
-				.select(({ hosts }) => ({
-					machineId: hosts.machineId,
-					name: hosts.name,
-				})),
-		[collections, targetHostId],
+	const hostOptions = useMemo<ProjectSettingsHostOption[]>(() => {
+		const options: ProjectSettingsHostOption[] = [];
+		if (localHostId) {
+			options.push({
+				id: localHostId,
+				name: currentDeviceName ?? "This device",
+				isLocal: true,
+				isOnline: true,
+			});
+		}
+		for (const host of otherHosts) {
+			options.push({
+				id: host.id,
+				name: host.name,
+				isLocal: false,
+				isOnline: host.isOnline,
+			});
+		}
+		if (targetHostId && !options.some((option) => option.id === targetHostId)) {
+			options.push({
+				id: targetHostId,
+				name: targetHostId === machineId ? "This device" : targetHostId,
+				isLocal: targetHostId === machineId,
+				isOnline: targetHostId === machineId,
+			});
+		}
+		return options;
+	}, [currentDeviceName, localHostId, machineId, otherHosts, targetHostId]);
+
+	const selectedHost = useMemo(
+		() => hostOptions.find((option) => option.id === targetHostId) ?? null,
+		[hostOptions, targetHostId],
 	);
 	const targetHostName = useMemo(() => {
-		if (hostRows[0]?.name) return hostRows[0].name;
+		if (selectedHost?.name) return selectedHost.name;
 		if (!targetHostId || targetHostId === machineId) return "this device";
 		return targetHostId;
-	}, [hostRows, machineId, targetHostId]);
+	}, [machineId, selectedHost, targetHostId]);
+	const hasMultipleHosts = hostOptions.length > 1;
 	const isRemoteTarget = Boolean(
 		targetHostId && machineId && targetHostId !== machineId,
 	);
@@ -73,61 +139,122 @@ export function V2ProjectSettings({
 
 	return (
 		<div className="p-6 max-w-4xl w-full mx-auto select-text">
-			<ProjectSettingsHeader title={project.name} />
-
-			<div className="space-y-6">
-				<SettingsSection title="Name">
-					<NameSection projectId={projectId} currentName={project.name} />
-				</SettingsSection>
-
-				<SettingsSection title="Repository">
-					<RepositorySection
-						projectId={projectId}
-						currentRepoCloneUrl={project.repoCloneUrl}
-					/>
-				</SettingsSection>
-
-				<SettingsSection
-					title="Project location"
-					description={`Where this project lives on disk on ${targetHostName}.`}
-				>
-					<ProjectLocationSection
-						projectId={projectId}
-						currentPath={hostProject?.repoPath ?? null}
-						repoCloneUrl={project.repoCloneUrl}
-						hostUrl={targetHostUrl}
-						hostName={targetHostName}
-						isRemoteTarget={isRemoteTarget}
-						onChanged={() => refetchHostProject()}
-					/>
-				</SettingsSection>
-
-				<SettingsSection
-					title="Appearance"
-					description="A custom icon shown next to this project in the sidebar. PNG, JPEG, or WebP up to 4.5MB."
-				>
+			<header className="mb-8 flex items-center justify-between gap-4">
+				<div className="flex min-w-0 items-center gap-3">
 					<IconUploadField
 						projectId={projectId}
 						iconUrl={project.iconUrl ?? null}
 						hasGitHubRepo={project.repoCloneUrl != null}
 					/>
-				</SettingsSection>
-
-				{targetHostUrl && (
-					<SettingsSection
-						title="Scripts"
-						description="Runs in a terminal for setup, teardown, and the workspace Run button. Saved to .superset/config.json in the main repo."
+					<h2 className="truncate text-xl font-semibold">{project.name}</h2>
+				</div>
+				{hasMultipleHosts && targetHostId ? (
+					<Select
+						value={targetHostId}
+						onValueChange={(nextHostId) => {
+							void navigate({
+								to: "/settings/projects/$projectId",
+								params: { projectId },
+								search: { hostId: nextHostId },
+								replace: true,
+							});
+						}}
 					>
-						<V2ScriptsEditor hostUrl={targetHostUrl} projectId={projectId} />
-					</SettingsSection>
-				)}
+						<SelectTrigger
+							size="sm"
+							className="h-8 gap-1.5 px-2 text-foreground"
+						>
+							<SelectValue>
+								<span className="flex items-center gap-1.5">
+									<span className="truncate">
+										{selectedHost?.isLocal
+											? "This device"
+											: (selectedHost?.name ?? targetHostId)}
+									</span>
+									{selectedHost && !selectedHost.isLocal && (
+										<span
+											title={selectedHost.isOnline ? "Online" : "Offline"}
+											className={
+												selectedHost.isOnline
+													? "size-1.5 shrink-0 rounded-full bg-emerald-500"
+													: "size-1.5 shrink-0 rounded-full bg-muted-foreground/60"
+											}
+										/>
+									)}
+								</span>
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent align="end">
+							{hostOptions.map((option) => (
+								<SelectItem key={option.id} value={option.id}>
+									<span className="flex items-center gap-2">
+										{option.isLocal ? (
+											<HiOutlineComputerDesktop className="size-4 text-muted-foreground" />
+										) : (
+											<HiOutlineServer className="size-4 text-muted-foreground" />
+										)}
+										<span className="truncate">
+											{option.isLocal ? "This device" : option.name}
+										</span>
+										{!option.isLocal && !option.isOnline && (
+											<span className="text-xs text-muted-foreground">
+												offline
+											</span>
+										)}
+									</span>
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				) : null}
+			</header>
 
-				<div className="pt-2 border-t border-border">
+			<div className="space-y-10">
+				<section>
+					<SettingsRow label="Name" htmlFor="project-name">
+						<NameSection projectId={projectId} currentName={project.name} />
+					</SettingsRow>
+					<SettingsRow label="Repository" htmlFor="project-repo">
+						<RepositorySection
+							projectId={projectId}
+							currentRepoCloneUrl={project.repoCloneUrl}
+						/>
+					</SettingsRow>
+				</section>
+
+				<section>
+					<SettingsRow label="Location">
+						<ProjectLocationSection
+							projectId={projectId}
+							currentPath={hostProject?.repoPath ?? null}
+							repoCloneUrl={project.repoCloneUrl}
+							hostId={targetHostId ?? null}
+							hostUrl={targetHostUrl}
+							hostName={targetHostName}
+							isRemoteTarget={isRemoteTarget}
+							onChanged={() => refetchHostProject()}
+						/>
+					</SettingsRow>
+					{targetHostUrl && (
+						<div className="pt-4">
+							<div className="mb-3">
+								<h3 className="text-sm font-medium">Scripts</h3>
+								<p className="mt-0.5 text-xs text-muted-foreground">
+									Runs in a terminal for setup, teardown, and the workspace Run
+									button.
+								</p>
+							</div>
+							<V2ScriptsEditor hostUrl={targetHostUrl} projectId={projectId} />
+						</div>
+					)}
+				</section>
+
+				<section>
 					<DeleteProjectSection
 						projectId={projectId}
 						projectName={project.name}
 					/>
-				</div>
+				</section>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
@@ -1,4 +1,3 @@
-import { Label } from "@superset/ui/label";
 import {
 	Select,
 	SelectContent,
@@ -10,7 +9,7 @@ import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { type ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 import { HiOutlineComputerDesktop, HiOutlineServer } from "react-icons/hi2";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -22,6 +21,7 @@ import { IconUploadField } from "./components/IconUploadField";
 import { NameSection } from "./components/NameSection";
 import { ProjectLocationSection } from "./components/ProjectLocationSection";
 import { RepositorySection } from "./components/RepositorySection";
+import { SettingsRow } from "./components/SettingsRow";
 import { V2ScriptsEditor } from "./components/V2ScriptsEditor";
 
 interface V2ProjectSettingsProps {
@@ -34,30 +34,6 @@ interface ProjectSettingsHostOption {
 	name: string;
 	isLocal: boolean;
 	isOnline: boolean;
-}
-
-function SettingsRow({
-	label,
-	hint,
-	htmlFor,
-	children,
-}: {
-	label: string;
-	hint?: ReactNode;
-	htmlFor?: string;
-	children: ReactNode;
-}) {
-	return (
-		<div className="flex items-center justify-between gap-8 py-2.5">
-			<div className="min-w-0 flex-1">
-				<Label htmlFor={htmlFor} className="text-sm font-medium">
-					{label}
-				</Label>
-				{hint && <p className="mt-0.5 text-xs text-muted-foreground">{hint}</p>}
-			</div>
-			<div className="shrink-0">{children}</div>
-		</div>
-	);
 }
 
 export function V2ProjectSettings({

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/DeleteProjectSection/DeleteProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/DeleteProjectSection/DeleteProjectSection.tsx
@@ -54,13 +54,9 @@ export function DeleteProjectSection({
 	};
 
 	return (
-		<div className="flex items-center justify-between gap-8">
+		<div className="flex items-center justify-between gap-8 py-2.5">
 			<div className="min-w-0 flex-1">
 				<div className="text-sm font-medium">Delete project</div>
-				<p className="text-xs text-muted-foreground mt-0.5">
-					Removes the project from the organization. Workspaces and local clones
-					on any host are not affected.
-				</p>
 			</div>
 			<AlertDialog open={isOpen} onOpenChange={setIsOpen}>
 				<AlertDialogTrigger asChild>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/IconUploadField/IconUploadField.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/IconUploadField/IconUploadField.tsx
@@ -1,8 +1,14 @@
-import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
 import { useCallback, useRef, useState } from "react";
 import { FaGithub } from "react-icons/fa";
-import { LuImagePlus, LuTrash2 } from "react-icons/lu";
+import { LuImagePlus, LuTrash2, LuUpload } from "react-icons/lu";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 
 const ACCEPTED_MIME_TYPES = "image/png,image/jpeg,image/webp";
@@ -105,25 +111,64 @@ export function IconUploadField({
 		}
 	}, [projectId]);
 
+	const hasSecondaryActions = hasGitHubRepo || Boolean(iconUrl);
+
+	const Thumbnail = (
+		<button
+			type="button"
+			onClick={hasSecondaryActions ? undefined : handleClickUpload}
+			disabled={isPending}
+			aria-label={
+				hasSecondaryActions
+					? "Project icon options"
+					: iconUrl
+						? "Replace icon"
+						: "Upload icon"
+			}
+			className="size-9 rounded-md border overflow-hidden flex items-center justify-center text-muted-foreground transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed"
+		>
+			{iconUrl ? (
+				<img
+					src={iconUrl}
+					alt="Project icon"
+					className="size-full object-cover"
+				/>
+			) : (
+				<LuImagePlus className="size-4" />
+			)}
+		</button>
+	);
+
 	return (
-		<div className="flex items-center gap-3">
-			<button
-				type="button"
-				onClick={handleClickUpload}
-				disabled={isPending}
-				aria-label={iconUrl ? "Replace icon" : "Upload icon"}
-				className="size-10 rounded border overflow-hidden flex items-center justify-center text-muted-foreground transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed"
-			>
-				{iconUrl ? (
-					<img
-						src={iconUrl}
-						alt="Project icon"
-						className="size-full object-cover"
-					/>
-				) : (
-					<LuImagePlus className="size-4" />
-				)}
-			</button>
+		<>
+			{hasSecondaryActions ? (
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>{Thumbnail}</DropdownMenuTrigger>
+					<DropdownMenuContent align="start" className="w-48">
+						<DropdownMenuItem onSelect={handleClickUpload}>
+							<LuUpload className="size-4" />
+							Upload image…
+						</DropdownMenuItem>
+						{hasGitHubRepo && (
+							<DropdownMenuItem onSelect={handleUseGitHub}>
+								<FaGithub className="size-4" />
+								Use GitHub icon
+							</DropdownMenuItem>
+						)}
+						{iconUrl && (
+							<>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem variant="destructive" onSelect={handleRemove}>
+									<LuTrash2 className="size-4" />
+									Remove icon
+								</DropdownMenuItem>
+							</>
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			) : (
+				Thumbnail
+			)}
 			<input
 				ref={fileInputRef}
 				type="file"
@@ -131,32 +176,6 @@ export function IconUploadField({
 				className="hidden"
 				onChange={handleFileChange}
 			/>
-			{hasGitHubRepo && (
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					onClick={handleUseGitHub}
-					disabled={isPending}
-					className="gap-1.5"
-				>
-					<FaGithub className="size-4" />
-					Use GitHub icon
-				</Button>
-			)}
-			{iconUrl && (
-				<Button
-					type="button"
-					variant="ghost"
-					size="sm"
-					onClick={handleRemove}
-					disabled={isPending}
-					className="gap-1.5 text-muted-foreground hover:text-destructive"
-				>
-					<LuTrash2 className="size-4" />
-					Remove
-				</Button>
-			)}
-		</div>
+		</>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/NameSection/NameSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/NameSection/NameSection.tsx
@@ -27,6 +27,7 @@ export function NameSection({ projectId, currentName }: NameSectionProps) {
 
 	return (
 		<Input
+			id="project-name"
 			value={value}
 			onChange={(e) => setValue(e.target.value)}
 			onBlur={commit}
@@ -42,6 +43,7 @@ export function NameSection({ projectId, currentName }: NameSectionProps) {
 				}
 			}}
 			placeholder="Project name"
+			className="w-96"
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
@@ -10,6 +10,13 @@ import {
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
@@ -56,6 +63,9 @@ export function ProjectLocationSection({
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [remoteImportPath, setRemoteImportPath] = useState("");
 	const [remoteCloneParentDir, setRemoteCloneParentDir] = useState("");
+	const [remoteMode, setRemoteMode] = useState<"clone" | "import">(
+		repoCloneUrl ? "clone" : "import",
+	);
 
 	const runSetup = async (repoPath: string, allowRelocate: boolean) => {
 		if (!hostUrl) {
@@ -252,122 +262,117 @@ export function ProjectLocationSection({
 
 	return (
 		<>
-			<div className="flex items-center gap-2">
+			{currentPath ? (
 				<div className="relative w-96">
-					<div
-						className={`flex h-9 items-center overflow-x-auto whitespace-nowrap rounded-md border bg-transparent px-3 dark:bg-input/30 ${currentPath ? "pr-9" : ""}`}
-					>
-						{currentPath ? (
-							<ClickablePath
-								path={currentPath}
-								className="max-w-none shrink-0"
-							/>
-						) : (
-							<span className="shrink-0 text-sm text-muted-foreground">
-								Not set up on {hostName}
-							</span>
-						)}
+					<div className="flex h-9 items-center overflow-x-auto whitespace-nowrap rounded-md border bg-transparent px-3 pr-9 dark:bg-input/30">
+						<ClickablePath path={currentPath} className="max-w-none shrink-0" />
 					</div>
-					{currentPath && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									type="button"
-									variant="ghost"
-									size="icon"
-									className="absolute right-1 top-1 size-7 text-muted-foreground hover:text-foreground"
-									onClick={handleChange}
-									disabled={selectDirectory.isPending || isSubmitting}
-									aria-label="Change location"
-								>
-									<LuFolderOpen className="size-4" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Change location</TooltipContent>
-						</Tooltip>
-					)}
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								type="button"
+								variant="ghost"
+								size="icon"
+								className="absolute right-1 top-1 size-7 text-muted-foreground hover:text-foreground"
+								onClick={handleChange}
+								disabled={selectDirectory.isPending || isSubmitting}
+								aria-label="Change location"
+							>
+								<LuFolderOpen className="size-4" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Change location</TooltipContent>
+					</Tooltip>
 				</div>
-				{!currentPath && (
-					<div className="flex items-center gap-2 shrink-0">
-						{isRemoteTarget ? (
-							<div className="flex flex-col gap-2 min-w-80">
-								<div className="flex items-center gap-2">
-									<Input
-										value={remoteImportPath}
-										onChange={(event) =>
-											setRemoteImportPath(event.currentTarget.value)
-										}
-										placeholder={`Existing repo path on ${hostName}`}
-										className="h-8"
-									/>
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										onClick={handleImport}
-										disabled={!hostUrl || isSubmitting}
-									>
-										Import
-									</Button>
-								</div>
-								<div className="flex items-center gap-2">
-									<Input
-										value={remoteCloneParentDir}
-										onChange={(event) =>
-											setRemoteCloneParentDir(event.currentTarget.value)
-										}
-										placeholder={`Parent directory on ${hostName}`}
-										className="h-8"
-										disabled={!repoCloneUrl}
-									/>
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										onClick={handleClone}
-										disabled={!hostUrl || !repoCloneUrl || isSubmitting}
-										title={
-											repoCloneUrl
-												? undefined
-												: "Link a GitHub repository first to enable cloning"
-										}
-									>
-										Clone
-									</Button>
-								</div>
-							</div>
-						) : (
-							<>
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									onClick={handleClone}
-									disabled={
-										!repoCloneUrl || selectDirectory.isPending || isSubmitting
-									}
-									title={
-										repoCloneUrl
-											? undefined
-											: "Link a GitHub repository first to enable cloning"
-									}
-								>
-									Clone here…
-								</Button>
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									onClick={handleImport}
-									disabled={selectDirectory.isPending || isSubmitting}
-								>
-									Import existing…
-								</Button>
-							</>
-						)}
-					</div>
-				)}
-			</div>
+			) : isRemoteTarget ? (
+				<div className="flex items-center gap-2">
+					<Select
+						value={remoteMode}
+						onValueChange={(value) =>
+							setRemoteMode(value as "clone" | "import")
+						}
+					>
+						<SelectTrigger size="sm" className="w-28">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem
+								value="clone"
+								disabled={!repoCloneUrl}
+								title={
+									repoCloneUrl
+										? undefined
+										: "Link a GitHub repository first to enable cloning"
+								}
+							>
+								Clone
+							</SelectItem>
+							<SelectItem value="import">Import</SelectItem>
+						</SelectContent>
+					</Select>
+					{remoteMode === "clone" ? (
+						<Input
+							value={remoteCloneParentDir}
+							onChange={(event) =>
+								setRemoteCloneParentDir(event.currentTarget.value)
+							}
+							placeholder={`Parent directory on ${hostName}`}
+							className="w-72"
+							disabled={!repoCloneUrl}
+						/>
+					) : (
+						<Input
+							value={remoteImportPath}
+							onChange={(event) =>
+								setRemoteImportPath(event.currentTarget.value)
+							}
+							placeholder={`Existing repo path on ${hostName}`}
+							className="w-72"
+						/>
+					)}
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={remoteMode === "clone" ? handleClone : handleImport}
+						disabled={
+							!hostUrl ||
+							isSubmitting ||
+							(remoteMode === "clone" && !repoCloneUrl)
+						}
+					>
+						Set up
+					</Button>
+				</div>
+			) : (
+				<div className="flex items-center gap-2">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={handleClone}
+						disabled={
+							!repoCloneUrl || selectDirectory.isPending || isSubmitting
+						}
+						title={
+							repoCloneUrl
+								? undefined
+								: "Link a GitHub repository first to enable cloning"
+						}
+					>
+						Clone here…
+					</Button>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={handleImport}
+						disabled={selectDirectory.isPending || isSubmitting}
+					>
+						Import existing…
+					</Button>
+				</div>
+			)}
 
 			<AlertDialog
 				open={conflict !== null}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
@@ -14,6 +14,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { LuFolderOpen } from "react-icons/lu";
+import { RemotePathPicker } from "renderer/components/RemotePathPicker";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
@@ -55,6 +56,7 @@ export function ProjectLocationSection({
 	const [conflict, setConflict] = useState<BackfillConflict | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [setupOpen, setSetupOpen] = useState(false);
+	const [changeBrowseOpen, setChangeBrowseOpen] = useState(false);
 
 	const pickPath = async (title: string) => {
 		if (!hostUrl) {
@@ -74,9 +76,7 @@ export function ProjectLocationSection({
 		}
 	};
 
-	const handleChange = async () => {
-		const path = await pickPath("Select new project location");
-		if (!path) return;
+	const proposeRelocate = async (path: string) => {
 		if (path === currentPath) {
 			toast.info("Project is already at that location");
 			return;
@@ -100,6 +100,16 @@ export function ProjectLocationSection({
 			return;
 		}
 		setPendingPath(path);
+	};
+
+	const handleChange = async () => {
+		if (isRemoteTarget) {
+			setChangeBrowseOpen(true);
+			return;
+		}
+		const path = await pickPath("Select new project location");
+		if (!path) return;
+		await proposeRelocate(path);
 	};
 
 	const handleConfirmRelocate = async () => {
@@ -181,6 +191,20 @@ export function ProjectLocationSection({
 				isRemoteTarget={isRemoteTarget}
 				onChanged={onChanged}
 				onConflict={setConflict}
+			/>
+
+			<RemotePathPicker
+				open={changeBrowseOpen}
+				onOpenChange={setChangeBrowseOpen}
+				hostUrl={hostUrl}
+				hostName={hostName}
+				initialPath={currentPath ?? undefined}
+				title="Change project location"
+				description={`Pick the new project folder on ${hostName}.`}
+				confirmLabel="Use this folder"
+				onPick={(path) => {
+					void proposeRelocate(path);
+				}}
 			/>
 
 			<AlertDialog

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
@@ -381,7 +381,7 @@ export function ProjectLocationSection({
 				<AlertDialogContent>
 					<AlertDialogHeader>
 						<AlertDialogTitle>Repository already linked</AlertDialogTitle>
-						<AlertDialogDescription>
+						<AlertDialogDescription className="select-text cursor-text">
 							This repository is already linked to project "
 							{conflict?.name ?? ""}" in this organization. Open that project to
 							set it up on {hostName}.
@@ -419,7 +419,7 @@ export function ProjectLocationSection({
 					<AlertDialogHeader>
 						<AlertDialogTitle>Relocate project?</AlertDialogTitle>
 						<AlertDialogDescription asChild>
-							<div className="space-y-3 text-sm">
+							<div className="space-y-3 text-sm select-text cursor-text">
 								<div>
 									<div className="text-muted-foreground text-xs">From</div>
 									<div className="font-mono break-all">{currentPath}</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
@@ -9,14 +9,6 @@ import {
 	AlertDialogTitle,
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
-import { Input } from "@superset/ui/input";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@superset/ui/select";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
@@ -26,6 +18,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { ClickablePath } from "../../../../../../components/ClickablePath";
+import { SetupProjectModal } from "../SetupProjectModal";
 
 interface BackfillConflict {
 	id: string;
@@ -61,65 +54,7 @@ export function ProjectLocationSection({
 	const [pendingPath, setPendingPath] = useState<string | null>(null);
 	const [conflict, setConflict] = useState<BackfillConflict | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [remoteImportPath, setRemoteImportPath] = useState("");
-	const [remoteCloneParentDir, setRemoteCloneParentDir] = useState("");
-	const [remoteMode, setRemoteMode] = useState<"clone" | "import">(
-		repoCloneUrl ? "clone" : "import",
-	);
-
-	const runSetup = async (repoPath: string, allowRelocate: boolean) => {
-		if (!hostUrl) {
-			toast.error(`Host unavailable: ${hostName}`);
-			return false;
-		}
-		try {
-			const client = getHostServiceClientByUrl(hostUrl);
-			const result = await client.project.setup.mutate({
-				projectId,
-				mode: { kind: "import", repoPath, allowRelocate },
-			});
-			toast.success(
-				allowRelocate
-					? `Project relocated to ${result.repoPath}`
-					: `Project set up at ${result.repoPath}`,
-			);
-			if (result.mainWorkspaceId) {
-				ensureWorkspaceInSidebar(result.mainWorkspaceId, projectId);
-			} else {
-				ensureProjectInSidebar(projectId);
-			}
-			onChanged?.();
-			return true;
-		} catch (err) {
-			toast.error(err instanceof Error ? err.message : String(err));
-			return false;
-		}
-	};
-
-	const runClone = async (parentDir: string) => {
-		if (!hostUrl) {
-			toast.error(`Host unavailable: ${hostName}`);
-			return false;
-		}
-		try {
-			const client = getHostServiceClientByUrl(hostUrl);
-			const result = await client.project.setup.mutate({
-				projectId,
-				mode: { kind: "clone", parentDir },
-			});
-			toast.success(`Cloned to ${result.repoPath}`);
-			if (result.mainWorkspaceId) {
-				ensureWorkspaceInSidebar(result.mainWorkspaceId, projectId);
-			} else {
-				ensureProjectInSidebar(projectId);
-			}
-			onChanged?.();
-			return true;
-		} catch (err) {
-			toast.error(err instanceof Error ? err.message : String(err));
-			return false;
-		}
-	};
+	const [setupOpen, setSetupOpen] = useState(false);
 
 	const pickPath = async (title: string) => {
 		if (!hostUrl) {
@@ -136,91 +71,6 @@ export function ProjectLocationSection({
 		} catch (err) {
 			toast.error(err instanceof Error ? err.message : String(err));
 			return null;
-		}
-	};
-
-	const handleImport = async () => {
-		if (isRemoteTarget) {
-			const path = remoteImportPath.trim();
-			if (!path) {
-				toast.error(`Enter a path on ${hostName}`);
-				return;
-			}
-			if (!hostUrl) {
-				toast.error(`Host unavailable: ${hostName}`);
-				return;
-			}
-			setIsSubmitting(true);
-			let keepSubmitting = false;
-			try {
-				const client = getHostServiceClientByUrl(hostUrl);
-				const precheck = await client.project.findBackfillConflict.query({
-					projectId,
-					repoPath: path,
-				});
-				if (precheck.conflict) {
-					setConflict(precheck.conflict);
-					keepSubmitting = true;
-					return;
-				}
-				await runSetup(path, false);
-				setRemoteImportPath("");
-			} catch (err) {
-				toast.error(err instanceof Error ? err.message : String(err));
-			} finally {
-				if (!keepSubmitting) setIsSubmitting(false);
-			}
-			return;
-		}
-		const path = await pickPath("Select project location");
-		if (!path) return;
-		if (!hostUrl) {
-			toast.error(`Host unavailable: ${hostName}`);
-			return;
-		}
-		setIsSubmitting(true);
-		let keepSubmitting = false;
-		try {
-			const client = getHostServiceClientByUrl(hostUrl);
-			const precheck = await client.project.findBackfillConflict.query({
-				projectId,
-				repoPath: path,
-			});
-			if (precheck.conflict) {
-				setConflict(precheck.conflict);
-				keepSubmitting = true;
-				return;
-			}
-			await runSetup(path, false);
-		} catch (err) {
-			toast.error(err instanceof Error ? err.message : String(err));
-		} finally {
-			if (!keepSubmitting) setIsSubmitting(false);
-		}
-	};
-
-	const handleClone = async () => {
-		if (isRemoteTarget) {
-			const parentDir = remoteCloneParentDir.trim();
-			if (!parentDir) {
-				toast.error(`Enter a parent directory on ${hostName}`);
-				return;
-			}
-			setIsSubmitting(true);
-			try {
-				await runClone(parentDir);
-			} finally {
-				setIsSubmitting(false);
-			}
-			return;
-		}
-		const parentDir = await pickPath("Select parent directory to clone into");
-		if (!parentDir) return;
-		setIsSubmitting(true);
-		try {
-			await runClone(parentDir);
-		} finally {
-			setIsSubmitting(false);
 		}
 	};
 
@@ -254,10 +104,30 @@ export function ProjectLocationSection({
 
 	const handleConfirmRelocate = async () => {
 		if (!pendingPath) return;
+		if (!hostUrl) {
+			toast.error(`Host unavailable: ${hostName}`);
+			return;
+		}
 		setIsSubmitting(true);
-		const ok = await runSetup(pendingPath, true);
-		setIsSubmitting(false);
-		if (ok) setPendingPath(null);
+		try {
+			const client = getHostServiceClientByUrl(hostUrl);
+			const result = await client.project.setup.mutate({
+				projectId,
+				mode: { kind: "import", repoPath: pendingPath, allowRelocate: true },
+			});
+			toast.success(`Project relocated to ${result.repoPath}`);
+			if (result.mainWorkspaceId) {
+				ensureWorkspaceInSidebar(result.mainWorkspaceId, projectId);
+			} else {
+				ensureProjectInSidebar(projectId);
+			}
+			onChanged?.();
+			setPendingPath(null);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : String(err));
+		} finally {
+			setIsSubmitting(false);
+		}
 	};
 
 	return (
@@ -284,95 +154,34 @@ export function ProjectLocationSection({
 						<TooltipContent>Change location</TooltipContent>
 					</Tooltip>
 				</div>
-			) : isRemoteTarget ? (
-				<div className="flex items-center gap-2">
-					<Select
-						value={remoteMode}
-						onValueChange={(value) =>
-							setRemoteMode(value as "clone" | "import")
-						}
-					>
-						<SelectTrigger size="sm" className="w-28">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem
-								value="clone"
-								disabled={!repoCloneUrl}
-								title={
-									repoCloneUrl
-										? undefined
-										: "Link a GitHub repository first to enable cloning"
-								}
-							>
-								Clone
-							</SelectItem>
-							<SelectItem value="import">Import</SelectItem>
-						</SelectContent>
-					</Select>
-					{remoteMode === "clone" ? (
-						<Input
-							value={remoteCloneParentDir}
-							onChange={(event) =>
-								setRemoteCloneParentDir(event.currentTarget.value)
-							}
-							placeholder={`Parent directory on ${hostName}`}
-							className="w-72"
-							disabled={!repoCloneUrl}
-						/>
-					) : (
-						<Input
-							value={remoteImportPath}
-							onChange={(event) =>
-								setRemoteImportPath(event.currentTarget.value)
-							}
-							placeholder={`Existing repo path on ${hostName}`}
-							className="w-72"
-						/>
-					)}
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						onClick={remoteMode === "clone" ? handleClone : handleImport}
-						disabled={
-							!hostUrl ||
-							isSubmitting ||
-							(remoteMode === "clone" && !repoCloneUrl)
-						}
-					>
-						Set up
-					</Button>
-				</div>
 			) : (
-				<div className="flex items-center gap-2">
+				<div className="flex items-center gap-3">
+					<span className="text-sm text-muted-foreground">
+						Not set up on {hostName}
+					</span>
 					<Button
 						type="button"
 						variant="outline"
 						size="sm"
-						onClick={handleClone}
-						disabled={
-							!repoCloneUrl || selectDirectory.isPending || isSubmitting
-						}
-						title={
-							repoCloneUrl
-								? undefined
-								: "Link a GitHub repository first to enable cloning"
-						}
+						onClick={() => setSetupOpen(true)}
+						disabled={!hostUrl}
 					>
-						Clone here…
-					</Button>
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						onClick={handleImport}
-						disabled={selectDirectory.isPending || isSubmitting}
-					>
-						Import existing…
+						Set up project…
 					</Button>
 				</div>
 			)}
+
+			<SetupProjectModal
+				open={setupOpen}
+				onOpenChange={setSetupOpen}
+				projectId={projectId}
+				hostUrl={hostUrl}
+				hostName={hostName}
+				repoCloneUrl={repoCloneUrl}
+				isRemoteTarget={isRemoteTarget}
+				onChanged={onChanged}
+				onConflict={setConflict}
+			/>
 
 			<AlertDialog
 				open={conflict !== null}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
@@ -11,8 +11,10 @@ import {
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
 import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
+import { LuFolderOpen } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
@@ -27,6 +29,7 @@ interface ProjectLocationSectionProps {
 	projectId: string;
 	currentPath: string | null;
 	repoCloneUrl: string | null;
+	hostId: string | null;
 	hostUrl: string | null;
 	hostName: string;
 	isRemoteTarget: boolean;
@@ -37,6 +40,7 @@ export function ProjectLocationSection({
 	projectId,
 	currentPath,
 	repoCloneUrl,
+	hostId,
 	hostUrl,
 	hostName,
 	isRemoteTarget,
@@ -248,27 +252,42 @@ export function ProjectLocationSection({
 
 	return (
 		<>
-			<div className="flex items-center gap-4">
-				<div className="flex-1 min-w-0">
-					{currentPath ? (
-						<ClickablePath path={currentPath} />
-					) : (
-						<span className="text-sm text-muted-foreground">
-							Not set up on {hostName}.
-						</span>
+			<div className="flex items-center gap-2">
+				<div className="relative w-96">
+					<div
+						className={`flex h-9 items-center overflow-x-auto whitespace-nowrap rounded-md border bg-transparent px-3 dark:bg-input/30 ${currentPath ? "pr-9" : ""}`}
+					>
+						{currentPath ? (
+							<ClickablePath
+								path={currentPath}
+								className="max-w-none shrink-0"
+							/>
+						) : (
+							<span className="shrink-0 text-sm text-muted-foreground">
+								Not set up on {hostName}
+							</span>
+						)}
+					</div>
+					{currentPath && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon"
+									className="absolute right-1 top-1 size-7 text-muted-foreground hover:text-foreground"
+									onClick={handleChange}
+									disabled={selectDirectory.isPending || isSubmitting}
+									aria-label="Change location"
+								>
+									<LuFolderOpen className="size-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>Change location</TooltipContent>
+						</Tooltip>
 					)}
 				</div>
-				{currentPath ? (
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						onClick={handleChange}
-						disabled={selectDirectory.isPending || isSubmitting}
-					>
-						Change…
-					</Button>
-				) : (
+				{!currentPath && (
 					<div className="flex items-center gap-2 shrink-0">
 						{isRemoteTarget ? (
 							<div className="flex flex-col gap-2 min-w-80">
@@ -380,6 +399,7 @@ export function ProjectLocationSection({
 								navigate({
 									to: "/settings/projects/$projectId",
 									params: { projectId: target.id },
+									search: { hostId: hostId ?? undefined },
 								});
 							}}
 						>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/RepositorySection/RepositorySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/RepositorySection/RepositorySection.tsx
@@ -1,6 +1,7 @@
 import { parseGitHubRemote } from "@superset/shared/github-remote";
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useEffect, useRef, useState } from "react";
 import { FaGithub } from "react-icons/fa";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -38,8 +39,9 @@ export function RepositorySection({
 		: null;
 
 	return (
-		<div className="flex items-center gap-2">
+		<div className="relative w-96">
 			<Input
+				id="project-repo"
 				value={value}
 				onChange={(e) => setValue(e.target.value)}
 				onFocus={() => {
@@ -61,19 +63,24 @@ export function RepositorySection({
 					}
 				}}
 				placeholder="https://github.com/owner/repo"
-				className="font-mono text-sm flex-1 min-w-0"
+				className="w-full font-mono text-sm pr-9"
 			/>
 			{parsed && (
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					className="shrink-0 gap-1.5"
-					onClick={() => openUrl.mutate(parsed.url)}
-				>
-					<FaGithub className="size-4" />
-					Open
-				</Button>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className="absolute right-1 top-1 size-7 text-muted-foreground hover:text-foreground"
+							onClick={() => openUrl.mutate(parsed.url)}
+							aria-label="Open in GitHub"
+						>
+							<FaGithub className="size-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Open in GitHub</TooltipContent>
+				</Tooltip>
 			)}
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SettingsRow/SettingsRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SettingsRow/SettingsRow.tsx
@@ -1,0 +1,28 @@
+import { Label } from "@superset/ui/label";
+import type { ReactNode } from "react";
+
+interface SettingsRowProps {
+	label: string;
+	hint?: ReactNode;
+	htmlFor?: string;
+	children: ReactNode;
+}
+
+export function SettingsRow({
+	label,
+	hint,
+	htmlFor,
+	children,
+}: SettingsRowProps) {
+	return (
+		<div className="flex items-center justify-between gap-8 py-2.5">
+			<div className="min-w-0 flex-1">
+				<Label htmlFor={htmlFor} className="text-sm font-medium">
+					{label}
+				</Label>
+				{hint && <p className="mt-0.5 text-xs text-muted-foreground">{hint}</p>}
+			</div>
+			<div className="shrink-0">{children}</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SettingsRow/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SettingsRow/index.ts
@@ -1,0 +1,1 @@
+export { SettingsRow } from "./SettingsRow";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SetupProjectModal/SetupProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SetupProjectModal/SetupProjectModal.tsx
@@ -1,0 +1,330 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@superset/ui/tabs";
+import { useEffect, useState } from "react";
+import { LuFolderOpen, LuLoaderCircle } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+
+type SetupMode = "clone" | "import";
+
+interface SetupProjectModalProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	projectId: string;
+	hostUrl: string | null;
+	hostName: string;
+	repoCloneUrl: string | null;
+	isRemoteTarget: boolean;
+	onChanged?: () => void;
+	onConflict: (conflict: { id: string; name: string }) => void;
+}
+
+export function SetupProjectModal({
+	open,
+	onOpenChange,
+	projectId,
+	hostUrl,
+	hostName,
+	repoCloneUrl,
+	isRemoteTarget,
+	onChanged,
+	onConflict,
+}: SetupProjectModalProps) {
+	const selectDirectory = electronTrpc.window.selectDirectory.useMutation();
+	const { ensureProjectInSidebar, ensureWorkspaceInSidebar } =
+		useDashboardSidebarState();
+
+	const [mode, setMode] = useState<SetupMode>(
+		repoCloneUrl ? "clone" : "import",
+	);
+	const [parentDir, setParentDir] = useState("");
+	const [importPath, setImportPath] = useState("");
+	const [working, setWorking] = useState(false);
+
+	useEffect(() => {
+		if (!open) return;
+		setMode(repoCloneUrl ? "clone" : "import");
+	}, [open, repoCloneUrl]);
+
+	const reset = () => {
+		setParentDir("");
+		setImportPath("");
+		setWorking(false);
+	};
+
+	const handleOpenChange = (next: boolean) => {
+		if (!next && working) return;
+		if (!next) reset();
+		onOpenChange(next);
+	};
+
+	const browseFor = async (
+		title: string,
+		target: "parentDir" | "importPath",
+	) => {
+		try {
+			const result = await selectDirectory.mutateAsync({ title });
+			if (result.canceled || !result.path) return;
+			if (target === "parentDir") setParentDir(result.path);
+			else setImportPath(result.path);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : String(err));
+		}
+	};
+
+	const runClone = async () => {
+		if (!hostUrl) {
+			toast.error(`Host unavailable: ${hostName}`);
+			return;
+		}
+		const trimmed = parentDir.trim();
+		if (!trimmed) {
+			toast.error(
+				isRemoteTarget
+					? `Enter a parent directory on ${hostName}`
+					: "Pick a parent directory",
+			);
+			return;
+		}
+		setWorking(true);
+		try {
+			const client = getHostServiceClientByUrl(hostUrl);
+			const result = await client.project.setup.mutate({
+				projectId,
+				mode: { kind: "clone", parentDir: trimmed },
+			});
+			toast.success(`Cloned to ${result.repoPath}`);
+			if (result.mainWorkspaceId) {
+				ensureWorkspaceInSidebar(result.mainWorkspaceId, projectId);
+			} else {
+				ensureProjectInSidebar(projectId);
+			}
+			onChanged?.();
+			reset();
+			onOpenChange(false);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : String(err));
+		} finally {
+			setWorking(false);
+		}
+	};
+
+	const runImport = async () => {
+		if (!hostUrl) {
+			toast.error(`Host unavailable: ${hostName}`);
+			return;
+		}
+		const trimmed = importPath.trim();
+		if (!trimmed) {
+			toast.error(
+				isRemoteTarget
+					? `Enter a path on ${hostName}`
+					: "Pick a project location",
+			);
+			return;
+		}
+		setWorking(true);
+		try {
+			const client = getHostServiceClientByUrl(hostUrl);
+			const precheck = await client.project.findBackfillConflict.query({
+				projectId,
+				repoPath: trimmed,
+			});
+			if (precheck.conflict) {
+				onConflict(precheck.conflict);
+				onOpenChange(false);
+				return;
+			}
+			const result = await client.project.setup.mutate({
+				projectId,
+				mode: { kind: "import", repoPath: trimmed, allowRelocate: false },
+			});
+			toast.success(`Project set up at ${result.repoPath}`);
+			if (result.mainWorkspaceId) {
+				ensureWorkspaceInSidebar(result.mainWorkspaceId, projectId);
+			} else {
+				ensureProjectInSidebar(projectId);
+			}
+			onChanged?.();
+			reset();
+			onOpenChange(false);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : String(err));
+		} finally {
+			setWorking(false);
+		}
+	};
+
+	const submit = mode === "clone" ? runClone : runImport;
+	const submitLabel = mode === "clone" ? "Clone" : "Import";
+	const cloneDisabled = !repoCloneUrl;
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange} modal>
+			<DialogContent className="max-w-[480px]">
+				<DialogHeader>
+					<DialogTitle>Set up project on {hostName}</DialogTitle>
+					<DialogDescription>
+						Clone the repository, or import an existing folder on the host.
+					</DialogDescription>
+				</DialogHeader>
+
+				<Tabs
+					value={mode}
+					onValueChange={(value) => setMode(value as SetupMode)}
+				>
+					<TabsList className="w-full">
+						<TabsTrigger
+							value="clone"
+							disabled={cloneDisabled}
+							className="flex-1"
+						>
+							Clone
+						</TabsTrigger>
+						<TabsTrigger value="import" className="flex-1">
+							Import existing
+						</TabsTrigger>
+					</TabsList>
+
+					<TabsContent value="clone" className="mt-4 space-y-3">
+						{cloneDisabled ? (
+							<p className="text-sm text-muted-foreground">
+								Link a GitHub repository on the project first to enable cloning.
+							</p>
+						) : (
+							<>
+								{repoCloneUrl && (
+									<div className="flex flex-col gap-1">
+										<Label className="text-xs">Repository</Label>
+										<p className="font-mono text-xs text-muted-foreground select-text cursor-text break-all">
+											{repoCloneUrl}
+										</p>
+									</div>
+								)}
+								<div className="flex flex-col gap-1.5">
+									<Label htmlFor="setup-parent-dir" className="text-xs">
+										Parent directory{isRemoteTarget ? ` on ${hostName}` : ""}
+									</Label>
+									<div className="flex gap-1.5">
+										<Input
+											id="setup-parent-dir"
+											value={parentDir}
+											onChange={(e) => setParentDir(e.target.value)}
+											placeholder={
+												isRemoteTarget
+													? "/home/user/projects"
+													: "Pick a folder…"
+											}
+											disabled={working}
+											className="flex-1 font-mono text-sm"
+											onKeyDown={(e) => {
+												if (e.key === "Enter" && !working) void runClone();
+											}}
+										/>
+										{!isRemoteTarget && (
+											<Button
+												type="button"
+												variant="outline"
+												size="icon"
+												onClick={() =>
+													browseFor(
+														"Select parent directory to clone into",
+														"parentDir",
+													)
+												}
+												disabled={working || selectDirectory.isPending}
+												className="shrink-0"
+												aria-label="Browse for directory"
+											>
+												<LuFolderOpen className="size-4" />
+											</Button>
+										)}
+									</div>
+								</div>
+							</>
+						)}
+					</TabsContent>
+
+					<TabsContent value="import" className="mt-4 space-y-3">
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="setup-import-path" className="text-xs">
+								Existing repo path{isRemoteTarget ? ` on ${hostName}` : ""}
+							</Label>
+							<div className="flex gap-1.5">
+								<Input
+									id="setup-import-path"
+									value={importPath}
+									onChange={(e) => setImportPath(e.target.value)}
+									placeholder={
+										isRemoteTarget
+											? "/home/user/projects/my-repo"
+											: "Pick a folder…"
+									}
+									disabled={working}
+									className="flex-1 font-mono text-sm"
+									onKeyDown={(e) => {
+										if (e.key === "Enter" && !working) void runImport();
+									}}
+								/>
+								{!isRemoteTarget && (
+									<Button
+										type="button"
+										variant="outline"
+										size="icon"
+										onClick={() =>
+											browseFor("Select project location", "importPath")
+										}
+										disabled={working || selectDirectory.isPending}
+										className="shrink-0"
+										aria-label="Browse for directory"
+									>
+										<LuFolderOpen className="size-4" />
+									</Button>
+								)}
+							</div>
+						</div>
+					</TabsContent>
+				</Tabs>
+
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={() => handleOpenChange(false)}
+						disabled={working}
+					>
+						Cancel
+					</Button>
+					<Button
+						type="button"
+						onClick={() => void submit()}
+						disabled={
+							working || !hostUrl || (mode === "clone" && cloneDisabled)
+						}
+					>
+						{working ? (
+							<>
+								<LuLoaderCircle className="size-4 animate-spin" />
+								{submitLabel}…
+							</>
+						) : (
+							submitLabel
+						)}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SetupProjectModal/SetupProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SetupProjectModal/SetupProjectModal.tsx
@@ -13,6 +13,7 @@ import { toast } from "@superset/ui/sonner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@superset/ui/tabs";
 import { useEffect, useState } from "react";
 import { LuFolderOpen, LuLoaderCircle } from "react-icons/lu";
+import { RemotePathPicker } from "renderer/components/RemotePathPicker";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
@@ -52,6 +53,9 @@ export function SetupProjectModal({
 	const [parentDir, setParentDir] = useState("");
 	const [importPath, setImportPath] = useState("");
 	const [working, setWorking] = useState(false);
+	const [browseTarget, setBrowseTarget] = useState<
+		"parentDir" | "importPath" | null
+	>(null);
 
 	useEffect(() => {
 		if (!open) return;
@@ -172,159 +176,194 @@ export function SetupProjectModal({
 	const cloneDisabled = !repoCloneUrl;
 
 	return (
-		<Dialog open={open} onOpenChange={handleOpenChange} modal>
-			<DialogContent className="max-w-[480px]">
-				<DialogHeader>
-					<DialogTitle>Set up project on {hostName}</DialogTitle>
-					<DialogDescription>
-						Clone the repository, or import an existing folder on the host.
-					</DialogDescription>
-				</DialogHeader>
+		<>
+			<Dialog open={open} onOpenChange={handleOpenChange} modal>
+				<DialogContent className="max-w-[480px]">
+					<DialogHeader>
+						<DialogTitle>Set up project on {hostName}</DialogTitle>
+						<DialogDescription>
+							Clone the repository, or import an existing folder on the host.
+						</DialogDescription>
+					</DialogHeader>
 
-				<Tabs
-					value={mode}
-					onValueChange={(value) => setMode(value as SetupMode)}
-				>
-					<TabsList className="w-full">
-						<TabsTrigger
-							value="clone"
-							disabled={cloneDisabled}
-							className="flex-1"
-						>
-							Clone
-						</TabsTrigger>
-						<TabsTrigger value="import" className="flex-1">
-							Import existing
-						</TabsTrigger>
-					</TabsList>
+					<Tabs
+						value={mode}
+						onValueChange={(value) => setMode(value as SetupMode)}
+					>
+						<TabsList className="w-full">
+							<TabsTrigger
+								value="clone"
+								disabled={cloneDisabled}
+								className="flex-1"
+							>
+								Clone
+							</TabsTrigger>
+							<TabsTrigger value="import" className="flex-1">
+								Import existing
+							</TabsTrigger>
+						</TabsList>
 
-					<TabsContent value="clone" className="mt-4 space-y-3">
-						{cloneDisabled ? (
-							<p className="text-sm text-muted-foreground">
-								Link a GitHub repository on the project first to enable cloning.
-							</p>
-						) : (
-							<>
-								{repoCloneUrl && (
-									<div className="flex flex-col gap-1">
-										<Label className="text-xs">Repository</Label>
-										<p className="font-mono text-xs text-muted-foreground select-text cursor-text break-all">
-											{repoCloneUrl}
-										</p>
-									</div>
-								)}
-								<div className="flex flex-col gap-1.5">
-									<Label htmlFor="setup-parent-dir" className="text-xs">
-										Parent directory{isRemoteTarget ? ` on ${hostName}` : ""}
-									</Label>
-									<div className="flex gap-1.5">
-										<Input
-											id="setup-parent-dir"
-											value={parentDir}
-											onChange={(e) => setParentDir(e.target.value)}
-											placeholder={
-												isRemoteTarget
-													? "/home/user/projects"
-													: "Pick a folder…"
-											}
-											disabled={working}
-											className="flex-1 font-mono text-sm"
-											onKeyDown={(e) => {
-												if (e.key === "Enter" && !working) void runClone();
-											}}
-										/>
-										{!isRemoteTarget && (
+						<TabsContent value="clone" className="mt-4 space-y-3">
+							{cloneDisabled ? (
+								<p className="text-sm text-muted-foreground">
+									Link a GitHub repository on the project first to enable
+									cloning.
+								</p>
+							) : (
+								<>
+									{repoCloneUrl && (
+										<div className="flex flex-col gap-1">
+											<Label className="text-xs">Repository</Label>
+											<p className="font-mono text-xs text-muted-foreground select-text cursor-text break-all">
+												{repoCloneUrl}
+											</p>
+										</div>
+									)}
+									<div className="flex flex-col gap-1.5">
+										<Label htmlFor="setup-parent-dir" className="text-xs">
+											Parent directory{isRemoteTarget ? ` on ${hostName}` : ""}
+										</Label>
+										<div className="flex gap-1.5">
+											<Input
+												id="setup-parent-dir"
+												value={parentDir}
+												onChange={(e) => setParentDir(e.target.value)}
+												placeholder={
+													isRemoteTarget
+														? "/home/user/projects"
+														: "Pick a folder…"
+												}
+												disabled={working}
+												className="flex-1 font-mono text-sm"
+												onKeyDown={(e) => {
+													if (e.key === "Enter" && !working) void runClone();
+												}}
+											/>
 											<Button
 												type="button"
 												variant="outline"
 												size="icon"
-												onClick={() =>
-													browseFor(
-														"Select parent directory to clone into",
-														"parentDir",
-													)
-												}
+												onClick={() => {
+													if (isRemoteTarget) {
+														setBrowseTarget("parentDir");
+													} else {
+														void browseFor(
+															"Select parent directory to clone into",
+															"parentDir",
+														);
+													}
+												}}
 												disabled={working || selectDirectory.isPending}
 												className="shrink-0"
 												aria-label="Browse for directory"
 											>
 												<LuFolderOpen className="size-4" />
 											</Button>
-										)}
+										</div>
 									</div>
-								</div>
-							</>
-						)}
-					</TabsContent>
+								</>
+							)}
+						</TabsContent>
 
-					<TabsContent value="import" className="mt-4 space-y-3">
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="setup-import-path" className="text-xs">
-								Existing repo path{isRemoteTarget ? ` on ${hostName}` : ""}
-							</Label>
-							<div className="flex gap-1.5">
-								<Input
-									id="setup-import-path"
-									value={importPath}
-									onChange={(e) => setImportPath(e.target.value)}
-									placeholder={
-										isRemoteTarget
-											? "/home/user/projects/my-repo"
-											: "Pick a folder…"
-									}
-									disabled={working}
-									className="flex-1 font-mono text-sm"
-									onKeyDown={(e) => {
-										if (e.key === "Enter" && !working) void runImport();
-									}}
-								/>
-								{!isRemoteTarget && (
+						<TabsContent value="import" className="mt-4 space-y-3">
+							<div className="flex flex-col gap-1.5">
+								<Label htmlFor="setup-import-path" className="text-xs">
+									Existing repo path{isRemoteTarget ? ` on ${hostName}` : ""}
+								</Label>
+								<div className="flex gap-1.5">
+									<Input
+										id="setup-import-path"
+										value={importPath}
+										onChange={(e) => setImportPath(e.target.value)}
+										placeholder={
+											isRemoteTarget
+												? "/home/user/projects/my-repo"
+												: "Pick a folder…"
+										}
+										disabled={working}
+										className="flex-1 font-mono text-sm"
+										onKeyDown={(e) => {
+											if (e.key === "Enter" && !working) void runImport();
+										}}
+									/>
 									<Button
 										type="button"
 										variant="outline"
 										size="icon"
-										onClick={() =>
-											browseFor("Select project location", "importPath")
-										}
+										onClick={() => {
+											if (isRemoteTarget) {
+												setBrowseTarget("importPath");
+											} else {
+												void browseFor("Select project location", "importPath");
+											}
+										}}
 										disabled={working || selectDirectory.isPending}
 										className="shrink-0"
 										aria-label="Browse for directory"
 									>
 										<LuFolderOpen className="size-4" />
 									</Button>
-								)}
+								</div>
 							</div>
-						</div>
-					</TabsContent>
-				</Tabs>
+						</TabsContent>
+					</Tabs>
 
-				<DialogFooter>
-					<Button
-						type="button"
-						variant="ghost"
-						onClick={() => handleOpenChange(false)}
-						disabled={working}
-					>
-						Cancel
-					</Button>
-					<Button
-						type="button"
-						onClick={() => void submit()}
-						disabled={
-							working || !hostUrl || (mode === "clone" && cloneDisabled)
-						}
-					>
-						{working ? (
-							<>
-								<LuLoaderCircle className="size-4 animate-spin" />
-								{submitLabel}…
-							</>
-						) : (
-							submitLabel
-						)}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="ghost"
+							onClick={() => handleOpenChange(false)}
+							disabled={working}
+						>
+							Cancel
+						</Button>
+						<Button
+							type="button"
+							onClick={() => void submit()}
+							disabled={
+								working || !hostUrl || (mode === "clone" && cloneDisabled)
+							}
+						>
+							{working ? (
+								<>
+									<LuLoaderCircle className="size-4 animate-spin" />
+									{submitLabel}…
+								</>
+							) : (
+								submitLabel
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<RemotePathPicker
+				open={browseTarget !== null}
+				onOpenChange={(next) => {
+					if (!next) setBrowseTarget(null);
+				}}
+				hostUrl={hostUrl}
+				hostName={hostName}
+				initialPath={
+					browseTarget === "parentDir"
+						? parentDir || undefined
+						: browseTarget === "importPath"
+							? importPath || undefined
+							: undefined
+				}
+				title={
+					browseTarget === "parentDir"
+						? "Choose a parent directory"
+						: "Choose an existing repo folder"
+				}
+				confirmLabel={
+					browseTarget === "parentDir" ? "Use this folder" : "Use this repo"
+				}
+				onPick={(path) => {
+					if (browseTarget === "parentDir") setParentDir(path);
+					else if (browseTarget === "importPath") setImportPath(path);
+				}}
+			/>
+		</>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SetupProjectModal/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/SetupProjectModal/index.ts
@@ -1,0 +1,1 @@
+export { SetupProjectModal } from "./SetupProjectModal";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
@@ -1,16 +1,11 @@
-import { Button } from "@superset/ui/button";
+import { Skeleton } from "@superset/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@superset/ui/tabs";
 import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-	HiArrowTopRightOnSquare,
-	HiCheckCircle,
-	HiDocumentArrowUp,
-} from "react-icons/hi2";
+import { HiCheckCircle, HiDocumentArrowUp } from "react-icons/hi2";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
-import { EXTERNAL_LINKS } from "shared/constants";
 
 interface V2ScriptsEditorProps {
 	hostUrl: string;
@@ -283,50 +278,53 @@ export function V2ScriptsEditor({
 
 	if (isLoading) {
 		return (
-			<div className={cn("space-y-3", className)}>
-				<div className="h-24 bg-muted/30 rounded-lg animate-pulse" />
+			<div className={cn("space-y-3", className)} aria-busy="true">
+				<div className="flex h-9 items-center gap-5 border-b border-border px-2">
+					<Skeleton className="h-3 w-10" />
+					<Skeleton className="h-3 w-14" />
+					<Skeleton className="h-3 w-8" />
+				</div>
+				<Skeleton className="h-24 w-full rounded-md" />
 			</div>
 		);
 	}
 
 	return (
 		<div className={cn("space-y-3", className)}>
-			<div className="flex items-center justify-between gap-2">
-				<div className="flex items-center gap-2 text-xs text-muted-foreground">
-					{saveStatus === "saving" && (
-						<span className="flex items-center gap-1">
-							<span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
-							Saving…
-						</span>
-					)}
-					{saveStatus === "saved" && (
-						<span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-							<HiCheckCircle className="h-3.5 w-3.5" />
-							Saved
-						</span>
-					)}
-				</div>
-				<Button variant="ghost" size="sm" className="h-7" asChild>
-					<a
-						href={EXTERNAL_LINKS.SETUP_TEARDOWN_SCRIPTS}
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Docs
-						<HiArrowTopRightOnSquare className="h-3.5 w-3.5" />
-					</a>
-				</Button>
-			</div>
-
 			<Tabs defaultValue="setup">
-				<TabsList>
-					<TabsTrigger value="setup">Setup</TabsTrigger>
-					<TabsTrigger value="teardown">Teardown</TabsTrigger>
-					<TabsTrigger value="run">Run</TabsTrigger>
-				</TabsList>
+				<div className="flex items-center justify-between gap-2 border-b border-border">
+					<TabsList className="h-auto gap-0 rounded-none bg-transparent p-0">
+						<TabsTrigger
+							value="setup"
+							className="relative h-8 rounded-none border-0 bg-transparent px-3 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none after:absolute after:inset-x-0 after:-bottom-px after:h-px after:bg-transparent data-[state=active]:after:bg-foreground"
+						>
+							Setup
+						</TabsTrigger>
+						<TabsTrigger
+							value="teardown"
+							className="relative h-8 rounded-none border-0 bg-transparent px-3 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none after:absolute after:inset-x-0 after:-bottom-px after:h-px after:bg-transparent data-[state=active]:after:bg-foreground"
+						>
+							Teardown
+						</TabsTrigger>
+						<TabsTrigger
+							value="run"
+							className="relative h-8 rounded-none border-0 bg-transparent px-3 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none after:absolute after:inset-x-0 after:-bottom-px after:h-px after:bg-transparent data-[state=active]:after:bg-foreground"
+						>
+							Run
+						</TabsTrigger>
+					</TabsList>
+					<div className="flex h-5 items-center pb-1.5 text-xs text-muted-foreground">
+						{saveStatus === "saving" && <span>Saving…</span>}
+						{saveStatus === "saved" && (
+							<span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+								<HiCheckCircle className="h-3.5 w-3.5" />
+								Saved
+							</span>
+						)}
+					</div>
+				</div>
 				<TabsContent value="setup">
 					<ScriptField
-						description="Runs when a new workspace is created. Multiple lines run as one chain — failures short-circuit."
 						placeholder="bun install&#10;bun run db:migrate"
 						value={setupValue}
 						onChange={(value) => handleChange("setup", value)}
@@ -338,7 +336,6 @@ export function V2ScriptsEditor({
 				</TabsContent>
 				<TabsContent value="teardown">
 					<ScriptField
-						description="Runs when a workspace is deleted."
 						placeholder="docker compose down"
 						value={teardownValue}
 						onChange={(value) => handleChange("teardown", value)}
@@ -350,7 +347,6 @@ export function V2ScriptsEditor({
 				</TabsContent>
 				<TabsContent value="run">
 					<ScriptField
-						description="Runs from the workspace Run button."
 						placeholder="bun dev"
 						value={runValue}
 						onChange={(value) => handleChange("run", value)}
@@ -366,7 +362,6 @@ export function V2ScriptsEditor({
 }
 
 interface ScriptFieldProps {
-	description: string;
 	placeholder: string;
 	value: string;
 	onChange: (value: string) => void;
@@ -375,7 +370,6 @@ interface ScriptFieldProps {
 }
 
 function ScriptField({
-	description,
 	placeholder,
 	value,
 	onChange,
@@ -401,9 +395,7 @@ function ScriptField({
 	);
 
 	return (
-		<div className="space-y-2">
-			<p className="text-xs text-muted-foreground">{description}</p>
-
+		<>
 			{/* biome-ignore lint/a11y/useSemanticElements: drop zone wrapper */}
 			<div
 				role="region"
@@ -440,6 +432,15 @@ function ScriptField({
 					rows={4}
 					className="font-mono text-sm border-0 shadow-none focus-visible:ring-0 focus-visible:border-0 resize-y"
 				/>
+				<button
+					type="button"
+					onClick={() => fileInputRef.current?.click()}
+					title="Import from file"
+					className="absolute bottom-2 right-2 flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+				>
+					<HiDocumentArrowUp className="h-3.5 w-3.5" />
+					Import
+				</button>
 				{isDragOver && (
 					<div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-md bg-primary/10">
 						<div className="flex items-center gap-2 text-primary text-sm font-medium">
@@ -449,16 +450,6 @@ function ScriptField({
 					</div>
 				)}
 			</div>
-
-			<Button
-				variant="ghost"
-				size="sm"
-				className="h-7 gap-1.5 text-muted-foreground"
-				onClick={() => fileInputRef.current?.click()}
-			>
-				<HiDocumentArrowUp className="h-3.5 w-3.5" />
-				Import file
-			</Button>
 			<input
 				ref={fileInputRef}
 				type="file"
@@ -470,6 +461,6 @@ function ScriptField({
 					e.target.value = "";
 				}}
 			/>
-		</div>
+		</>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
@@ -1,11 +1,11 @@
 import { Skeleton } from "@superset/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@superset/ui/tabs";
-import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { HiCheckCircle, HiDocumentArrowUp } from "react-icons/hi2";
+import { HiCheckCircle } from "react-icons/hi2";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { ScriptField } from "./components/ScriptField";
 
 interface V2ScriptsEditorProps {
 	hostUrl: string;
@@ -358,109 +358,5 @@ export function V2ScriptsEditor({
 				</TabsContent>
 			</Tabs>
 		</div>
-	);
-}
-
-interface ScriptFieldProps {
-	placeholder: string;
-	value: string;
-	onChange: (value: string) => void;
-	onFocus: () => void;
-	onBlur: () => void;
-}
-
-function ScriptField({
-	placeholder,
-	value,
-	onChange,
-	onFocus,
-	onBlur,
-}: ScriptFieldProps) {
-	const [isDragOver, setIsDragOver] = useState(false);
-	const fileInputRef = useRef<HTMLInputElement>(null);
-
-	const importFirstFile = useCallback(
-		async (files: File[]) => {
-			const scriptFile = files.find((file) =>
-				file.name.match(/\.(sh|bash|zsh|command)$/i),
-			);
-			if (!scriptFile) return;
-			try {
-				onChange(await scriptFile.text());
-			} catch (error) {
-				console.error("[v2-scripts/import] failed to read file", error);
-			}
-		},
-		[onChange],
-	);
-
-	return (
-		<>
-			{/* biome-ignore lint/a11y/useSemanticElements: drop zone wrapper */}
-			<div
-				role="region"
-				aria-label="Script editor with file drop support"
-				className={cn(
-					"relative rounded-md border transition-colors",
-					isDragOver
-						? "ring-2 ring-primary/40 border-primary/60"
-						: "border-input",
-				)}
-				onDragOver={(e) => {
-					e.preventDefault();
-					e.stopPropagation();
-					setIsDragOver(true);
-				}}
-				onDragLeave={(e) => {
-					e.preventDefault();
-					e.stopPropagation();
-					setIsDragOver(false);
-				}}
-				onDrop={async (e) => {
-					e.preventDefault();
-					e.stopPropagation();
-					setIsDragOver(false);
-					await importFirstFile(Array.from(e.dataTransfer.files));
-				}}
-			>
-				<Textarea
-					value={value}
-					onChange={(e) => onChange(e.target.value)}
-					onFocus={onFocus}
-					onBlur={onBlur}
-					placeholder={placeholder}
-					rows={4}
-					className="font-mono text-sm border-0 shadow-none focus-visible:ring-0 focus-visible:border-0 resize-y"
-				/>
-				<button
-					type="button"
-					onClick={() => fileInputRef.current?.click()}
-					title="Import from file"
-					className="absolute bottom-2 right-2 flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-				>
-					<HiDocumentArrowUp className="h-3.5 w-3.5" />
-					Import
-				</button>
-				{isDragOver && (
-					<div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-md bg-primary/10">
-						<div className="flex items-center gap-2 text-primary text-sm font-medium">
-							<HiDocumentArrowUp className="h-5 w-5" />
-							Drop to import
-						</div>
-					</div>
-				)}
-			</div>
-			<input
-				ref={fileInputRef}
-				type="file"
-				accept=".sh,.bash,.zsh,.command"
-				className="hidden"
-				onChange={async (e) => {
-					const files = e.target.files ? Array.from(e.target.files) : [];
-					await importFirstFile(files);
-					e.target.value = "";
-				}}
-			/>
-		</>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/components/ScriptField/ScriptField.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/components/ScriptField/ScriptField.tsx
@@ -1,0 +1,108 @@
+import { Textarea } from "@superset/ui/textarea";
+import { cn } from "@superset/ui/utils";
+import { useCallback, useRef, useState } from "react";
+import { HiDocumentArrowUp } from "react-icons/hi2";
+
+interface ScriptFieldProps {
+	placeholder: string;
+	value: string;
+	onChange: (value: string) => void;
+	onFocus: () => void;
+	onBlur: () => void;
+}
+
+export function ScriptField({
+	placeholder,
+	value,
+	onChange,
+	onFocus,
+	onBlur,
+}: ScriptFieldProps) {
+	const [isDragOver, setIsDragOver] = useState(false);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const importFirstFile = useCallback(
+		async (files: File[]) => {
+			const scriptFile = files.find((file) =>
+				file.name.match(/\.(sh|bash|zsh|command)$/i),
+			);
+			if (!scriptFile) return;
+			try {
+				onChange(await scriptFile.text());
+			} catch (error) {
+				console.error("[v2-scripts/import] failed to read file", error);
+			}
+		},
+		[onChange],
+	);
+
+	return (
+		<>
+			{/* biome-ignore lint/a11y/useSemanticElements: drop zone wrapper */}
+			<div
+				role="region"
+				aria-label="Script editor with file drop support"
+				className={cn(
+					"relative rounded-md border transition-colors",
+					isDragOver
+						? "ring-2 ring-primary/40 border-primary/60"
+						: "border-input",
+				)}
+				onDragOver={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					setIsDragOver(true);
+				}}
+				onDragLeave={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					setIsDragOver(false);
+				}}
+				onDrop={async (e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					setIsDragOver(false);
+					await importFirstFile(Array.from(e.dataTransfer.files));
+				}}
+			>
+				<Textarea
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+					onFocus={onFocus}
+					onBlur={onBlur}
+					placeholder={placeholder}
+					rows={4}
+					className="font-mono text-sm border-0 shadow-none focus-visible:ring-0 focus-visible:border-0 resize-y pb-8 pr-20"
+				/>
+				<button
+					type="button"
+					onClick={() => fileInputRef.current?.click()}
+					title="Import from file"
+					className="absolute bottom-2 right-2 flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+				>
+					<HiDocumentArrowUp className="h-3.5 w-3.5" />
+					Import
+				</button>
+				{isDragOver && (
+					<div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-md bg-primary/10">
+						<div className="flex items-center gap-2 text-primary text-sm font-medium">
+							<HiDocumentArrowUp className="h-5 w-5" />
+							Drop to import
+						</div>
+					</div>
+				)}
+			</div>
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept=".sh,.bash,.zsh,.command"
+				className="hidden"
+				onChange={async (e) => {
+					const files = e.target.files ? Array.from(e.target.files) : [];
+					await importFirstFile(files);
+					e.target.value = "";
+				}}
+			/>
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/components/ScriptField/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/components/ScriptField/index.ts
@@ -1,0 +1,1 @@
+export { ScriptField } from "./ScriptField";

--- a/packages/cli/src/commands/projects/list/command.ts
+++ b/packages/cli/src/commands/projects/list/command.ts
@@ -25,17 +25,28 @@ export default command({
 			host: options.host ?? undefined,
 			local: options.local ?? undefined,
 		});
-		const target = resolveHostTarget({
-			requestedHostId: hostId,
-			organizationId,
-			userJwt: ctx.bearer,
-		});
-		const hostProjects = await target.client.project.list.query();
-		const hostProjectById = new Map(
-			hostProjects.map((project) => [project.id, project]),
-		);
+		const hostExplicit = options.host !== undefined || options.local === true;
+
+		let hostProjectById: Map<string, { id: string; repoPath: string }> | null =
+			null;
+		try {
+			const target = resolveHostTarget({
+				requestedHostId: hostId,
+				organizationId,
+				userJwt: ctx.bearer,
+			});
+			const hostProjects = await target.client.project.list.query();
+			hostProjectById = new Map(
+				hostProjects.map((project) => [project.id, project]),
+			);
+		} catch (err) {
+			if (hostExplicit) throw err;
+		}
 
 		return projects.map((project) => {
+			if (!hostProjectById) {
+				return { ...project, setUp: "?", path: "-" };
+			}
 			const hostProject = hostProjectById.get(project.id);
 			return {
 				...project,

--- a/packages/cli/src/commands/projects/setup/command.ts
+++ b/packages/cli/src/commands/projects/setup/command.ts
@@ -24,17 +24,17 @@ export default command({
 		),
 	},
 	run: async ({ ctx, args, options }) => {
+		if (options.project !== undefined && args.id !== undefined) {
+			throw new CLIError(
+				"Project ID specified twice",
+				"Use either --project <projectId> or the positional project ID, not both.",
+			);
+		}
 		const projectId = (options.project ?? args.id) as string | undefined;
 		if (!projectId) {
 			throw new CLIError(
 				"Project ID required",
 				"Pass --project <projectId>, or provide the project ID as the first argument.",
-			);
-		}
-		if (options.project && args.id && options.project !== args.id) {
-			throw new CLIError(
-				"Project ID specified twice",
-				"Use either --project <projectId> or the positional project ID, not both.",
 			);
 		}
 		const organizationId = ctx.config.organizationId;

--- a/packages/host-service/src/trpc/router/filesystem/filesystem.ts
+++ b/packages/host-service/src/trpc/router/filesystem/filesystem.ts
@@ -1,9 +1,28 @@
-import { stat } from "node:fs/promises";
-import { isAbsolute, join, normalize, resolve } from "node:path";
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, normalize, resolve } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import type { HostServiceContext } from "../../../types";
 import { protectedProcedure, queryProcedure, router } from "../../index";
+
+function expandTildeAbsolute(input: string): string {
+	const trimmed = input.trim();
+	if (trimmed.startsWith("~")) {
+		const home = homedir();
+		const rest = trimmed.slice(1);
+		if (rest === "" || rest.startsWith("/") || rest.startsWith("\\")) {
+			return normalize(join(home, rest));
+		}
+	}
+	if (!isAbsolute(trimmed)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Path must be absolute or start with ~",
+		});
+	}
+	return normalize(trimmed);
+}
 
 function getFilesystemService(ctx: HostServiceContext, workspaceId: string) {
 	try {
@@ -51,6 +70,87 @@ const writeFileContentSchema = z.union([
 ]);
 
 export const filesystemRouter = router({
+	/**
+	 * Browse any directory on the host filesystem. Unlike `listDirectory`,
+	 * this is not scoped to a workspace — used by the project setup flow to
+	 * pick a parent/repo path on a host that doesn't yet have a workspace.
+	 *
+	 * Path handling: absolute paths or ~-prefixed paths only. Returns the
+	 * normalized absolute path along with subdirectory entries, sorted with
+	 * dotfiles last.
+	 */
+	browseHost: protectedProcedure
+		.input(
+			z.object({
+				path: z.string().optional(),
+				includeHidden: z.boolean().optional(),
+			}),
+		)
+		.query(async ({ input }) => {
+			const targetPath = input.path
+				? expandTildeAbsolute(input.path)
+				: homedir();
+
+			let stats: Awaited<ReturnType<typeof stat>>;
+			try {
+				stats = await stat(targetPath);
+			} catch {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `Path not found: ${targetPath}`,
+				});
+			}
+			if (!stats.isDirectory()) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Not a directory: ${targetPath}`,
+				});
+			}
+
+			let rawEntries: Array<{
+				name: string;
+				isDirectory: boolean;
+				isSymlink: boolean;
+			}>;
+			try {
+				const dirents = await readdir(targetPath, {
+					withFileTypes: true,
+					encoding: "utf8",
+				});
+				rawEntries = dirents.map((d) => ({
+					name: d.name,
+					isDirectory: d.isDirectory(),
+					isSymlink: d.isSymbolicLink(),
+				}));
+			} catch (err) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message:
+						err instanceof Error
+							? err.message
+							: `Cannot read directory: ${targetPath}`,
+				});
+			}
+
+			const entries = rawEntries
+				.filter((e) => input.includeHidden || !e.name.startsWith("."))
+				.sort((a, b) => {
+					const aHidden = a.name.startsWith(".");
+					const bHidden = b.name.startsWith(".");
+					if (aHidden !== bHidden) return aHidden ? 1 : -1;
+					if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+					return a.name.localeCompare(b.name);
+				});
+
+			const parent = dirname(targetPath);
+			return {
+				path: targetPath,
+				parentPath: parent === targetPath ? null : parent,
+				homePath: homedir(),
+				entries,
+			};
+		}),
+
 	listDirectory: queryProcedure
 		.input(
 			z.object({


### PR DESCRIPTION
## Summary

Stacked on top of #4665 (merged as `ca7ad95e5`). Two commits:

- **`feat(desktop): polish v2 project settings to Linear-style layout`** — restructures the v2 project settings page to match the canonical `SettingsRow` pattern used in `OrganizationSettings`: flat list of `flex items-center justify-between gap-8 py-2.5` rows, uniform `w-96` controls, no inner borders or card chrome. Project icon moves into the page header (click thumbnail → dropdown menu for Upload / Use GitHub icon / Remove). Host scope chip rendered in the header. Repository and Location each render a single `w-96` field with a ghost icon button absolutely positioned inside (GitHub icon for Open in GitHub, folder icon for Change location). Location path uses `overflow-x-auto whitespace-nowrap` so long paths scroll horizontally inside the field. Scripts editor uses underline-style tabs (no pill chrome, hover transition), a skeleton-shaped loading state, and an inline "Import" button tucked into the textarea corner. All input text normalized to `text-sm`.

- **`fix: address review feedback on PR #4665`** — three items flagged by `greptile-apps`, `cubic-dev-ai`, and `coderabbitai` on the original PR:
  - `cli/projects list`: gracefully degrade when the host service can't be reached and the user did not pass `--host`/`--local`. Falls back to `setUp="?"` / `path="-"` instead of throwing, restoring the previously API-only listing behavior. Still throws when `--host` or `--local` was passed explicitly. (P1 from greptile-apps + cubic-dev-ai.)
  - `cli/projects setup`: reject "Project ID specified twice" whenever both `--project` and the positional argument are present, even when the values match. (coderabbitai.)
  - `ProjectLocationSection.tsx`: add `select-text cursor-text` to both `AlertDialogDescription` blocks so users can copy the conflict project name and the From/To paths into bug reports. Aligns with the renderer-wide "error text must be selectable" rule from `apps/desktop/AGENTS.md`. (coderabbitai.)

## Test plan

- [ ] Open v2 project settings on a project with a GitHub remote — verify Repository field shows a GitHub icon button at the right; tooltip "Open in GitHub" appears; click opens the repo in browser.
- [ ] On a set-up project: Location row shows the path inside an input-shaped field; long paths scroll horizontally; pencil/folder icon button at the right opens the directory picker.
- [ ] On a project not set up on this host: Location shows "Not set up on {host}" with `Clone here…` / `Import existing…` buttons (and the remote-host variant with the two input rows).
- [ ] Click the project icon thumbnail in the header — dropdown shows Upload / Use GitHub icon / Remove icon (last only when an icon is set).
- [ ] Scripts editor: confirm tabs are underline-style with hover transition; loading state shows a skeleton tab strip + textarea (refresh to see); Import button sits in the bottom-right of the textarea.
- [ ] Multi-host: host chip in the page header switches setup context; URL search param `?hostId=…` updates.
- [ ] `superset projects list` with no host service running and **no** `--host`/`--local` flag — lists projects with `setUp="?"`/`path="-"` instead of erroring.
- [ ] `superset projects list --local` with no host service running — errors with the resolveHostTarget message (expected).
- [ ] `superset projects setup <id> --project <id>` — errors with "Project ID specified twice" even though the values are identical.
- [ ] Trigger the "Repository already linked" conflict and the "Relocate project?" confirm — confirm both dialog descriptions are selectable (drag to highlight, Cmd+C copies).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4675">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the v2 Project Settings with a flatter layout, a header icon menu, a multi-host selector, a first-time setup modal, and a breadcrumb-based remote folder picker. Also addressed review feedback with fixes to remote “Change location,” scripts editor UI, and CLI edge cases.

- **New Features**
  - Flat `SettingsRow` layout with uniform w-96 controls.
  - Header: project icon dropdown (Upload / Use GitHub icon / Remove) and multi-host selector with online/offline state; syncs `?hostId`.
  - Repository and Location: single-field UI with inline icon buttons + tooltips (Open in GitHub, Change location); long paths scroll; `ClickablePath` supports truncation.
  - First-time setup: “Set up project…” modal with Clone/Import tabs, repo readout on Clone, and browse buttons for local and remote.
  - Remote browsing: `RemotePathPicker` with breadcrumb navigation (Home-aware, ellipsis for long paths, symlink indicator, refresh, skeleton rows), backed by `host-service` `filesystem.browseHost` (absolute or `~` paths; hidden files filtered).
  - Scripts editor: underline tabs, skeleton loading, and an inline “Import” button inside the textarea.

- **Bug Fixes**
  - Change location on remote hosts now uses `RemotePathPicker` (no more local picker on remote targets).
  - Scripts editor: “Import” button no longer overlaps text.
  - `ClickablePath` truncation works reliably in flex layouts.
  - `projects list`: when the host service is unreachable and no `--host`/`--local` is passed, degrade to `setUp="?"` and `path="-"`; still errors when a host is explicitly requested.
  - `projects setup`: now errors when both a positional ID and `--project` are provided, even if they match.
  - Location dialogs: error text and paths are selectable for copy/paste.

<sup>Written for commit 78f75f85b797a6f222c9e9730ff11a510089841a. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4675?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-host project switcher in settings
  * New project setup modal (clone/import) for host-based setup
  * Remote path picker dialog for browsing remote host folders
  * Project icon management now uses a dropdown

* **Improvements**
  * Optional path truncation for cleaner path display
  * Restructured settings layout with tighter row grouping
  * Script editor shows loading states and simplified save/status UI
  * CLI project commands tolerate host resolution failures

* **UI**
  * Compact input sizing, streamlined delete header text, and improved repo/GitHub button spacing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->