### PR TITLE
docs: modernize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <img width="full" alt="Superset" src="apps/marketing/public/images/readme-hero.png" />
 
-### The Code Editor for AI Agents
+### Run dozens of coding agents in parallel.
+
+A native macOS app that gives every agent its own git worktree, terminal, and review surface — with notifications when they need you.
 
 [![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
@@ -12,46 +14,60 @@
 
 <br />
 
-Orchestrate swarms of Claude Code, Codex, and more in parallel.<br />
-Works with any CLI agent. Built for local worktree-based development.
-
-<br />
-
 [**Download for macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Documentation](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
 
 <br />
 
+<!-- TODO: replace with real product screenshot of the main UI with multiple workspaces -->
+<img width="900" alt="Superset main UI" src="apps/marketing/public/images/readme-hero.png" />
+
+<a href="https://www.youtube.com/"><!-- TODO: replace with actual demo video URL -->▶ Watch the 90-second demo</a>
 
 </div>
 
-## Code 10x Faster With No Switching Cost
+## About
 
-Superset orchestrates CLI-based coding agents across isolated git worktrees, with built-in terminal, review, and open-in-editor workflows.
+Superset is a native macOS app for running many CLI-based coding agents in parallel. Each agent gets its own git worktree, terminal, and review surface, so agents can work on different branches at the same time without trampling each other or your main checkout. Notifications surface in one place — you stay in flow until something actually needs your attention.
 
-- **Run multiple agents simultaneously** without context switching overhead
-- **Isolate each task** in its own git worktree so agents don't interfere with each other
-- **Monitor all your agents** from one place and get notified when they need attention
-- **Review and edit changes quickly** with the built-in diff viewer and editor
-- **Open any workspace where you need it** with one-click handoff to your editor or terminal
+Superset is built for developers who already run agents like Claude Code, Codex, and Cursor Agent from the terminal and want a faster way to orchestrate many of them at once. It works with any CLI agent.
 
-Wait less, ship more.
+## What Superset Does
 
-## Features
+| # | Pillar |
+| :-: | --- |
+| 1 | [Parallel agents in isolated git worktrees](#parallel-agents-in-isolated-git-worktrees) |
+| 2 | [Notifications when agents need you](#notifications-when-agents-need-you) |
+| 3 | [Built-in diff review and inline editing](#built-in-diff-review-and-inline-editing) |
+| 4 | [Reproducible workspace setup](#reproducible-workspace-setup) |
+| 5 | [Universal CLI-agent compatibility](#universal-cli-agent-compatibility) |
 
-| Feature | Description |
-|:--------|:------------|
-| **Parallel Execution** | Run 10+ coding agents simultaneously on your machine |
-| **Worktree Isolation** | Each task gets its own branch and working directory |
-| **Agent Monitoring** | Track agent status and get notified when changes are ready |
-| **Built-in Diff Viewer** | Inspect and edit agent changes without leaving the app |
-| **Workspace Presets** | Automate env setup, dependency installation, and more |
-| **Universal Compatibility** | Works with any CLI agent that runs in a terminal |
-| **Quick Context Switching** | Jump between tasks as they need your attention |
-| **IDE Integration** | Open any workspace in your favorite editor with one click |
+#### Parallel agents in isolated git worktrees
+
+Superset runs each task in its own git worktree off the same repository. Workspaces share the underlying object store but have independent working directories and branches, so agents can edit files, install dependencies, and run tests without touching each other or your main checkout.
+
+You can spin up ten workspaces from a single project and have ten agents working on ten different branches simultaneously. When a workspace is done, its branch goes through the same review and merge flow you already use.
+
+#### Notifications when agents need you
+
+Long-running agents alternate between heads-down work and questions for the user. Superset watches every workspace and pings you the moment an agent stops to ask something or finishes a task. The notification list lives in the sidebar so you can scan the state of every workspace at a glance, jump to whichever one needs you, and ignore the ones still working.
+
+This is the difference between checking on agents every few minutes and letting them tell you when they need you.
+
+#### Built-in diff review and inline editing
+
+Every workspace ships with a diff view that shows uncommitted changes, staged changes, and the agent's most recent turn. You can edit files in place, stage hunks, and commit without leaving the app or switching to an external editor.
+
+When you want a full IDE, one click hands the workspace off to VS Code, Cursor, Zed, or your terminal — the worktree path is the same path your editor opens.
+
+#### Reproducible workspace setup
+
+A `.superset/config.json` at your repo root defines what should happen when a workspace is created or destroyed — copy `.env`, install dependencies, run migrations, tear down branches, and anything else you'd normally do by hand. New workspaces come up identical to your main checkout in seconds. See the [setup/teardown docs](https://docs.superset.sh/setup-teardown-scripts).
+
+#### Universal CLI-agent compatibility
+
+Superset works with any agent that runs in a terminal. Claude Code, Codex, Cursor Agent, Gemini, Copilot CLI, OpenCode, Amp, and Pi all work without per-agent configuration. If it talks to stdin/stdout, Superset can run it.
 
 ## Supported Agents
-
-Superset works with any CLI-based coding agent, including:
 
 | Agent | Status |
 |:------|:-------|
@@ -65,7 +81,7 @@ Superset works with any CLI-based coding agent, including:
 | [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
 | Any CLI agent | Will work |
 
-If it runs in a terminal, it runs on Superset
+If it runs in a terminal, it runs on Superset.
 
 ## Requirements
 
@@ -79,14 +95,10 @@ If it runs in a terminal, it runs on Superset
 
 ## Getting Started
 
-### Quick Start (Pre-built)
-
 **[Download Superset for macOS](https://github.com/superset-sh/superset/releases/latest)**
 
-### Build from Source
-
 <details>
-<summary>Click to expand build instructions</summary>
+<summary>Or build from source</summary>
 
 **1. Clone the repository**
 
@@ -136,81 +148,13 @@ open apps/desktop/release
 
 </details>
 
-## Keyboard Shortcuts
-
-All shortcuts are customizable via **Settings > Keyboard Shortcuts** (`⌘/`). See [full documentation](https://docs.superset.sh/keyboard-shortcuts).
-
-### Workspace Navigation
-
-| Shortcut | Action |
-|:---------|:-------|
-| `⌘1-9` | Switch to workspace 1-9 |
-| `⌘⌥↑/↓` | Previous/next workspace |
-| `⌘N` | New workspace |
-| `⌘⇧N` | Quick create workspace |
-| `⌘⇧O` | Open project |
-
-### Terminal
-
-| Shortcut | Action |
-|:---------|:-------|
-| `⌘T` | New tab |
-| `⌘W` | Close pane/terminal |
-| `⌘D` | Split right |
-| `⌘⇧D` | Split down |
-| `⌘K` | Clear terminal |
-| `⌘F` | Find in terminal |
-| `⌘⌥←/→` | Previous/next tab |
-| `Ctrl+1-9` | Open preset 1-9 |
-
-### Layout
-
-| Shortcut | Action |
-|:---------|:-------|
-| `⌘B` | Toggle workspaces sidebar |
-| `⌘L` | Toggle changes panel |
-| `⌘O` | Open in external app |
-| `⌘⇧C` | Copy path |
-
 ## Configuration
 
-Configure workspace setup and teardown in `.superset/config.json`. See [full documentation](https://docs.superset.sh/setup-teardown-scripts).
+Configure workspace setup, teardown, and presets in `.superset/config.json`. See the [configuration docs](https://docs.superset.sh/setup-teardown-scripts).
 
-```json
-{
-  "setup": ["./.superset/setup.sh"],
-  "teardown": ["./.superset/teardown.sh"]
-}
-```
+## Keyboard Shortcuts
 
-| Option | Type | Description |
-|:-------|:-----|:------------|
-| `setup` | `string[]` | Commands to run when creating a workspace |
-| `teardown` | `string[]` | Commands to run when deleting a workspace |
-
-### Example setup script
-
-```bash
-#!/bin/bash
-# .superset/setup.sh
-
-# Copy environment variables
-cp ../.env .env
-
-# Install dependencies
-bun install
-
-# Run any other setup tasks
-echo "Workspace ready!"
-```
-
-Scripts have access to environment variables:
-- `SUPERSET_WORKSPACE_NAME` — Name of the workspace
-- `SUPERSET_ROOT_PATH` — Path to the main repository
-
-## Mastra Dependencies
-
-This repo uses the published upstream `mastracode` and `@mastra/*` packages directly. Avoid adding custom tarball overrides unless there is a repo-specific blocker.
+All shortcuts are customizable via **Settings > Keyboard Shortcuts** (`⌘/`). See the [full shortcut reference](https://docs.superset.sh/keyboard-shortcuts).
 
 ## Tech Stack
 
@@ -227,32 +171,15 @@ This repo uses the published upstream `mastracode` and `@mastra/*` packages dire
   <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
 </p>
 
-## Private by Default
-
-- **Source Available** — Full source is available on GitHub under Elastic License 2.0 (ELv2).
-- **Explicit Connections** — You choose which agents, providers, and integrations to connect.
-
 ## Contributing
 
-We welcome contributions! If you have a suggestion that would make Superset better:
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-You can also [open issues](https://github.com/superset-sh/superset/issues) for bugs or feature requests.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed instructions and code of conduct.
+We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and the PR workflow. For bugs or feature requests, [open an issue](https://github.com/superset-sh/superset/issues).
 
 <a href="https://github.com/superset-sh/superset/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
 </a>
 
 ## Community
-
-Join the Superset community to get help, share feedback, and connect with other users:
 
 - **[Discord](https://discord.gg/cZeD9WYcV7)** — Chat with the team and community
 - **[Twitter](https://x.com/superset_sh)** — Follow for updates and announcements
@@ -267,4 +194,4 @@ Join the Superset community to get help, share feedback, and connect with other 
 
 ## License
 
-Distributed under the Elastic License 2.0 (ELv2). See [LICENSE.md](LICENSE.md) for more information.
+Distributed under the Elastic License 2.0 (ELv2) — source is available on GitHub; you choose which agents, providers, and integrations to connect. See [LICENSE.md](LICENSE.md) for full terms.

--- a/README.md
+++ b/README.md
@@ -20,52 +20,48 @@ A macOS app that gives every agent its own git worktree, terminal, and review su
 
 ## What it is
 
-Superset is a macOS app for running many CLI coding agents in parallel. Each agent gets its own git worktree, terminal, and diff view, so agents work on different branches at the same time without trampling each other or your main checkout. When an agent stops to ask a question or finishes a task, Superset tells you — so you direct the work instead of babysitting it.
+Superset is a macOS app for running many CLI coding agents in parallel. Each agent gets its own git worktree, terminal, and diff view, so agents work on different branches at once without trampling each other or your main checkout. When an agent stops to ask a question or finishes a task, Superset notifies you — so you direct the work instead of babysitting it.
 
-It's built for developers who already run agents like Claude Code, Codex, and Cursor Agent from the terminal and want to drive several at once. It works with any agent that runs in a terminal.
+It's built for developers who already run agents like Claude Code, Codex, and Cursor Agent from the terminal, and works with any agent that runs in a terminal.
 
 ## Why Superset
 
-Most tools in this space are built around one or two specific agents — usually Claude Code and Codex. Superset is deliberately agent-agnostic: if it talks to stdin/stdout, Superset can run it, and you can mix agents across workspaces. Everything runs as a local process on your machine — your code and git history never leave it (see [What runs locally](#what-runs-locally)). You bring your own agent subscriptions and API keys; Superset doesn't proxy or resell them.
+Most tools in this space are built around one or two specific agents. Superset is agent-agnostic — if it talks to stdin/stdout, Superset can run it, and you can mix agents across workspaces. Everything runs locally; your code and git history never leave your machine. You bring your own subscriptions and API keys — Superset doesn't proxy or resell them.
 
 ## Features
 
 #### Parallel agents in isolated git worktrees
 
-Superset runs each task in its own git worktree off the same repository. Workspaces share the underlying object store but have independent working directories and branches, so agents can edit files, install dependencies, and run tests without touching each other or your main checkout.
-
-Spin up ten workspaces from a single project and have ten agents working on ten branches at once. When a workspace is done, its branch goes through the same review and merge flow you already use.
+Each task runs in its own git worktree off the same repository — shared object store, independent working directory and branch. Agents edit files, install dependencies, and run tests without touching each other or your main checkout. Spin up ten workspaces, run ten agents on ten branches, then merge each through your normal review flow.
 
 #### Works with any CLI agent
 
-Superset works with any agent that runs in a terminal. Claude Code, Codex, Cursor Agent, Gemini, Copilot CLI, OpenCode, Amp, and Pi all work without per-agent configuration. No lock-in to a single vendor — pick a different agent per workspace if you want.
+Claude Code, Codex, Cursor Agent, Gemini, Copilot CLI, OpenCode, Amp, and Pi all work with no per-agent configuration. No vendor lock-in — pick a different agent per workspace if you want.
 
 #### Notifications when agents need you
 
-Long-running agents alternate between heads-down work and questions for you. Superset watches every workspace and pings you the moment an agent stops to ask something or finishes a task. The notification list lives in the sidebar, so you can scan the state of every workspace at a glance and jump straight to whichever one needs you.
+Superset watches every workspace and pings you the moment an agent asks a question or finishes a task. The sidebar shows the state of every workspace at a glance, so you jump straight to whichever one needs you.
 
 #### Built-in diff review and inline editing
 
-Every workspace ships with a diff view that shows uncommitted changes, staged changes, and the agent's most recent turn. You can edit files in place, stage hunks, and commit without leaving the app.
-
-When you want a full IDE, one click hands the workspace off to VS Code, Cursor, Zed, or your terminal — the worktree path is the same path your editor opens.
+Every workspace has a diff view for uncommitted, staged, and last-turn changes. Edit files in place, stage hunks, and commit without leaving the app — or hand the worktree to VS Code, Cursor, Zed, or your terminal in one click.
 
 #### Reproducible workspace setup
 
-A `.superset/config.json` at your repo root defines what happens when a workspace is created or destroyed — copy `.env`, install dependencies, run migrations, tear down branches, and anything else you'd normally do by hand. New workspaces come up identical to your main checkout in seconds. See the [setup/teardown docs](https://docs.superset.sh/setup-teardown-scripts).
+A `.superset/config.json` at your repo root defines what happens when a workspace is created or destroyed — copy `.env`, install dependencies, run migrations, tear down branches. New workspaces come up identical to your main checkout in seconds. See the [setup/teardown docs](https://docs.superset.sh/setup-teardown-scripts).
 
 ## Supported Agents
 
 | Agent | Status |
 |:------|:-------|
-| [Amp Code](https://ampcode.com/) | Fully supported |
-| [Claude Code](https://github.com/anthropics/claude-code) | Fully supported |
-| [OpenAI Codex CLI](https://github.com/openai/codex) | Fully supported |
-| [Cursor Agent](https://docs.cursor.com/agent) | Fully supported |
-| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
-| [GitHub Copilot](https://github.com/features/copilot) | Fully supported |
-| [OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
-| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Fully supported |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Fully supported |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Fully supported |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
 | Any other CLI agent | Works without configuration |
 
 If it runs in a terminal, it runs on Superset.
@@ -74,9 +70,9 @@ If it runs in a terminal, it runs on Superset.
 
 Superset runs on your machine. Your code, git worktrees, and agent processes never leave it.
 
-- **Local** — every git worktree, file edit, diff, and agent process (Claude Code, Codex, and the rest) runs as a local process on your Mac. Your source code is never uploaded.
-- **Account** — Superset requires a free account (GitHub or Google sign-in). The hosted backend stores your account and workspace metadata — names, branches, and status — so the app can sync state across sessions.
-- **Bring your own agents** — Superset doesn't proxy your agents. They use whatever subscriptions or API keys you've already configured.
+- **Local** — every git worktree, file edit, diff, and agent process runs as a local process on your Mac. Your source code is never uploaded.
+- **Account** — Superset requires a free account (GitHub or Google sign-in). The hosted backend stores only your account and workspace metadata — names, branches, status — to sync state across sessions.
+- **Your agents** — Superset doesn't proxy your agents; they use whatever subscriptions or API keys you've already configured.
 
 ## Getting Started
 
@@ -146,9 +142,7 @@ open apps/desktop/release
 
 ## Configuration
 
-Configure workspace setup, teardown, and presets in `.superset/config.json`. See the [configuration docs](https://docs.superset.sh/setup-teardown-scripts).
-
-Keyboard shortcuts are customizable via **Settings > Keyboard Shortcuts** (`⌘/`). See the [full shortcut reference](https://docs.superset.sh/keyboard-shortcuts).
+Configure workspace setup, teardown, and presets in `.superset/config.json`. See the [configuration docs](https://docs.superset.sh/setup-teardown-scripts). Keyboard shortcuts are customizable via **Settings > Keyboard Shortcuts** (`⌘/`) — see the [shortcut reference](https://docs.superset.sh/keyboard-shortcuts).
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -20,35 +20,37 @@ A macOS app that gives every agent its own git worktree, terminal, and review su
 
 ## What it is
 
-Superset is a macOS app for running many CLI coding agents in parallel. Each agent gets its own git worktree, terminal, and diff view, so agents work on different branches at once without trampling each other or your main checkout. When an agent stops to ask a question or finishes a task, Superset notifies you — so you direct the work instead of babysitting it.
+Superset is a macOS app for running many CLI coding agents in parallel. Each agent gets its own git worktree, terminal, and diff view — so they work on different branches at once without trampling each other or your main checkout.
 
-It's built for developers who already run agents like Claude Code, Codex, and Cursor Agent from the terminal, and works with any agent that runs in a terminal.
+**How it works:**
+
+1. **Create a workspace** — Superset cuts a git worktree on a fresh branch and runs your setup script.
+2. **Run any agent in it** — Claude Code, Codex, Cursor Agent, or any CLI agent, each in its own terminal.
+3. **Review and merge** — Superset pings you when an agent needs input; review the diff in-app and merge through your normal flow.
 
 ## Why Superset
 
-Most tools in this space are built around one or two specific agents. Superset is agent-agnostic — if it talks to stdin/stdout, Superset can run it, and you can mix agents across workspaces. Everything runs locally; your code and git history never leave your machine. You bring your own subscriptions and API keys — Superset doesn't proxy or resell them.
+- **Agent-agnostic** — if it talks to stdin/stdout, Superset runs it. Mix Claude Code, Codex, Cursor, and others across workspaces — no vendor lock-in.
+- **Local-first** — worktrees, file edits, and agent processes run on your machine. Your code and git history never leave it.
+- **Bring your own keys** — Superset doesn't proxy or resell agents. They use the subscriptions and API keys you already have.
 
 ## Features
 
-#### Parallel agents in isolated git worktrees
+#### 🌳 &nbsp;Parallel agents in isolated git worktrees
 
-Each task runs in its own git worktree off the same repository — shared object store, independent working directory and branch. Agents edit files, install dependencies, and run tests without touching each other or your main checkout. Spin up ten workspaces, run ten agents on ten branches, then merge each through your normal review flow.
+Each task runs in its own git worktree off the same repository — shared object store, independent branch and working directory. Agents install dependencies and run tests without touching each other or your main checkout.
 
-#### Works with any CLI agent
+#### 🔔 &nbsp;Notifications when an agent needs you
 
-Claude Code, Codex, Cursor Agent, Gemini, Copilot CLI, OpenCode, Amp, and Pi all work with no per-agent configuration. No vendor lock-in — pick a different agent per workspace if you want.
+Superset watches every workspace and pings you the moment an agent asks a question or finishes. The sidebar shows every workspace's state at a glance, so you jump straight to the one that needs you.
 
-#### Notifications when agents need you
+#### 🔍 &nbsp;Built-in diff review and inline editing
 
-Superset watches every workspace and pings you the moment an agent asks a question or finishes a task. The sidebar shows the state of every workspace at a glance, so you jump straight to whichever one needs you.
+Every workspace has a diff view for uncommitted, staged, and last-turn changes. Edit and commit in-app — or hand the worktree to VS Code, Cursor, Zed, or your terminal in one click.
 
-#### Built-in diff review and inline editing
+#### ⚙️ &nbsp;Reproducible workspace setup
 
-Every workspace has a diff view for uncommitted, staged, and last-turn changes. Edit files in place, stage hunks, and commit without leaving the app — or hand the worktree to VS Code, Cursor, Zed, or your terminal in one click.
-
-#### Reproducible workspace setup
-
-A `.superset/config.json` at your repo root defines what happens when a workspace is created or destroyed — copy `.env`, install dependencies, run migrations, tear down branches. New workspaces come up identical to your main checkout in seconds. See the [setup/teardown docs](https://docs.superset.sh/setup-teardown-scripts).
+A `.superset/config.json` defines what runs on create and destroy — copy `.env`, install dependencies, run migrations, tear down branches. New workspaces come up identical to your main checkout in seconds.
 
 ## Supported Agents
 
@@ -60,6 +62,7 @@ A `.superset/config.json` at your repo root defines what happens when a workspac
 | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Fully supported |
 | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastracode](https://code.mastra.ai/) | Fully supported |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
 | Any other CLI agent | Works without configuration |

--- a/README.md
+++ b/README.md
@@ -34,44 +34,6 @@ Superset is a macOS app for running many CLI coding agents in parallel. Each age
 - **Local-first** — worktrees, file edits, and agent processes run on your machine. Your code and git history never leave it.
 - **Bring your own keys** — Superset doesn't proxy or resell agents. They use the subscriptions and API keys you already have.
 
-## Features
-
-### Parallel agents in isolated git worktrees
-
-Each task runs in its own git worktree off the same repository — shared object store, independent branch and working directory. Agents install dependencies and run tests without touching each other or your main checkout.
-
-### Notifications when an agent needs you
-
-Superset watches every workspace and pings you the moment an agent asks a question or finishes. The sidebar shows every workspace's state at a glance, so you jump straight to the one that needs you.
-
-### Built-in diff review and inline editing
-
-Every workspace has a diff view for uncommitted, staged, and last-turn changes. Edit and commit in-app — or hand the worktree to VS Code, Cursor, Zed, or your terminal in one click.
-
-### Reproducible workspace setup
-
-A `.superset/config.json` defines what runs on create and destroy — copy `.env`, install dependencies, run migrations, tear down branches. New workspaces come up identical to your main checkout in seconds.
-
-## Supported Agents
-
-These agents run out of the box — no per-agent configuration:
-
-|  |  |  |
-|:--|:--|:--|
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) |
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastracode](https://code.mastra.ai/) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) |
-
-**Plus any other CLI agent** — if it runs in a terminal, it runs on Superset.
-
-## What runs locally
-
-Superset runs on your machine. Your code, git worktrees, and agent processes never leave it.
-
-- **Local** — every git worktree, file edit, diff, and agent process runs as a local process on your Mac. Your source code is never uploaded.
-- **Account** — Superset requires a free account (GitHub or Google sign-in). The hosted backend stores only your account and workspace metadata — names, branches, status — to sync state across sessions.
-- **Your agents** — Superset doesn't proxy your agents; they use whatever subscriptions or API keys you've already configured.
-
 ## Getting Started
 
 > [!NOTE]
@@ -140,6 +102,44 @@ open apps/desktop/release
 ```
 
 </details>
+
+## Features
+
+### Parallel agents in isolated git worktrees
+
+Each task runs in its own git worktree off the same repository — shared object store, independent branch and working directory. Agents install dependencies and run tests without touching each other or your main checkout.
+
+### Notifications when an agent needs you
+
+Superset watches every workspace and pings you the moment an agent asks a question or finishes. The sidebar shows every workspace's state at a glance, so you jump straight to the one that needs you.
+
+### Built-in diff review and inline editing
+
+Every workspace has a diff view for uncommitted, staged, and last-turn changes. Edit and commit in-app — or hand the worktree to VS Code, Cursor, Zed, or your terminal in one click.
+
+### Reproducible workspace setup
+
+A `.superset/config.json` defines what runs on create and destroy — copy `.env`, install dependencies, run migrations, tear down branches. New workspaces come up identical to your main checkout in seconds.
+
+## Supported Agents
+
+These agents run out of the box — no per-agent configuration:
+
+|  |  |  |
+|:--|:--|:--|
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastracode](https://code.mastra.ai/) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) |
+
+**Plus any other CLI agent** — if it runs in a terminal, it runs on Superset.
+
+## What runs locally
+
+Superset runs on your machine. Your code, git worktrees, and agent processes never leave it.
+
+- **Local** — every git worktree, file edit, diff, and agent process runs as a local process on your Mac. Your source code is never uploaded.
+- **Account** — Superset requires a free account (GitHub or Google sign-in). The hosted backend stores only your account and workspace metadata — names, branches, status — to sync state across sessions.
+- **Your agents** — Superset doesn't proxy your agents; they use whatever subscriptions or API keys you've already configured.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -36,38 +36,33 @@ Superset is a macOS app for running many CLI coding agents in parallel. Each age
 
 ## Features
 
-#### 🌳 &nbsp;Parallel agents in isolated git worktrees
+### Parallel agents in isolated git worktrees
 
 Each task runs in its own git worktree off the same repository — shared object store, independent branch and working directory. Agents install dependencies and run tests without touching each other or your main checkout.
 
-#### 🔔 &nbsp;Notifications when an agent needs you
+### Notifications when an agent needs you
 
 Superset watches every workspace and pings you the moment an agent asks a question or finishes. The sidebar shows every workspace's state at a glance, so you jump straight to the one that needs you.
 
-#### 🔍 &nbsp;Built-in diff review and inline editing
+### Built-in diff review and inline editing
 
 Every workspace has a diff view for uncommitted, staged, and last-turn changes. Edit and commit in-app — or hand the worktree to VS Code, Cursor, Zed, or your terminal in one click.
 
-#### ⚙️ &nbsp;Reproducible workspace setup
+### Reproducible workspace setup
 
 A `.superset/config.json` defines what runs on create and destroy — copy `.env`, install dependencies, run migrations, tear down branches. New workspaces come up identical to your main checkout in seconds.
 
 ## Supported Agents
 
-| Agent | Status |
-|:------|:-------|
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Fully supported |
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Fully supported |
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Fully supported |
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastracode](https://code.mastra.ai/) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
-| Any other CLI agent | Works without configuration |
+These agents run out of the box — no per-agent configuration:
 
-If it runs in a terminal, it runs on Superset.
+|  |  |  |
+|:--|:--|:--|
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastracode](https://code.mastra.ai/) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) |
+
+**Plus any other CLI agent** — if it runs in a terminal, it runs on Superset.
 
 ## What runs locally
 
@@ -78,6 +73,9 @@ Superset runs on your machine. Your code, git worktrees, and agent processes nev
 - **Your agents** — Superset doesn't proxy your agents; they use whatever subscriptions or API keys you've already configured.
 
 ## Getting Started
+
+> [!NOTE]
+> Superset is macOS-only and requires a free account (GitHub or Google sign-in). Windows and Linux aren't supported yet.
 
 **[Download Superset for macOS](https://github.com/superset-sh/superset/releases/latest)**, then sign in with GitHub or Google.
 

--- a/README.md
+++ b/README.md
@@ -1,71 +1,58 @@
 <div align="center">
 
-<img width="full" alt="Superset" src="apps/marketing/public/images/readme-hero.png" />
+<img width="100%" alt="Superset" src="apps/marketing/public/images/readme-hero.png" />
 
-### Run dozens of coding agents in parallel.
+### Run 100+ coding agents in parallel.
 
-A native macOS app that gives every agent its own git worktree, terminal, and review surface — with notifications when they need you.
+A macOS app that gives every agent its own git worktree, terminal, and review surface — and notifies you when one needs your input.
 
 [![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
-[![License](https://img.shields.io/github/license/superset-sh/superset?style=flat)](LICENSE.md)
+[![License](https://img.shields.io/badge/license-ELv2-blue)](LICENSE.md)
 [![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
 [![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
 
 <br />
 
-[**Download for macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Documentation](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
-
-<br />
-
-<!-- TODO: replace with real product screenshot of the main UI with multiple workspaces -->
-<img width="900" alt="Superset main UI" src="apps/marketing/public/images/readme-hero.png" />
-
-<a href="https://www.youtube.com/"><!-- TODO: replace with actual demo video URL -->▶ Watch the 90-second demo</a>
+[**Download for macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [▶ Watch the demo](https://www.youtube.com/watch?v=mk02bSQmEKY) &nbsp;&bull;&nbsp; [Website](https://superset.sh) &nbsp;&bull;&nbsp; [Docs](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
 
 </div>
 
-## About
+## What it is
 
-Superset is a native macOS app for running many CLI-based coding agents in parallel. Each agent gets its own git worktree, terminal, and review surface, so agents can work on different branches at the same time without trampling each other or your main checkout. Notifications surface in one place — you stay in flow until something actually needs your attention.
+Superset is a macOS app for running many CLI coding agents in parallel. Each agent gets its own git worktree, terminal, and diff view, so agents work on different branches at the same time without trampling each other or your main checkout. When an agent stops to ask a question or finishes a task, Superset tells you — so you direct the work instead of babysitting it.
 
-Superset is built for developers who already run agents like Claude Code, Codex, and Cursor Agent from the terminal and want a faster way to orchestrate many of them at once. It works with any CLI agent.
+It's built for developers who already run agents like Claude Code, Codex, and Cursor Agent from the terminal and want to drive several at once. It works with any agent that runs in a terminal.
 
-## What Superset Does
+## Why Superset
 
-| # | Pillar |
-| :-: | --- |
-| 1 | [Parallel agents in isolated git worktrees](#parallel-agents-in-isolated-git-worktrees) |
-| 2 | [Notifications when agents need you](#notifications-when-agents-need-you) |
-| 3 | [Built-in diff review and inline editing](#built-in-diff-review-and-inline-editing) |
-| 4 | [Reproducible workspace setup](#reproducible-workspace-setup) |
-| 5 | [Universal CLI-agent compatibility](#universal-cli-agent-compatibility) |
+Most tools in this space are built around one or two specific agents — usually Claude Code and Codex. Superset is deliberately agent-agnostic: if it talks to stdin/stdout, Superset can run it, and you can mix agents across workspaces. Everything runs as a local process on your machine — your code and git history never leave it (see [What runs locally](#what-runs-locally)). You bring your own agent subscriptions and API keys; Superset doesn't proxy or resell them.
+
+## Features
 
 #### Parallel agents in isolated git worktrees
 
 Superset runs each task in its own git worktree off the same repository. Workspaces share the underlying object store but have independent working directories and branches, so agents can edit files, install dependencies, and run tests without touching each other or your main checkout.
 
-You can spin up ten workspaces from a single project and have ten agents working on ten different branches simultaneously. When a workspace is done, its branch goes through the same review and merge flow you already use.
+Spin up ten workspaces from a single project and have ten agents working on ten branches at once. When a workspace is done, its branch goes through the same review and merge flow you already use.
+
+#### Works with any CLI agent
+
+Superset works with any agent that runs in a terminal. Claude Code, Codex, Cursor Agent, Gemini, Copilot CLI, OpenCode, Amp, and Pi all work without per-agent configuration. No lock-in to a single vendor — pick a different agent per workspace if you want.
 
 #### Notifications when agents need you
 
-Long-running agents alternate between heads-down work and questions for the user. Superset watches every workspace and pings you the moment an agent stops to ask something or finishes a task. The notification list lives in the sidebar so you can scan the state of every workspace at a glance, jump to whichever one needs you, and ignore the ones still working.
-
-This is the difference between checking on agents every few minutes and letting them tell you when they need you.
+Long-running agents alternate between heads-down work and questions for you. Superset watches every workspace and pings you the moment an agent stops to ask something or finishes a task. The notification list lives in the sidebar, so you can scan the state of every workspace at a glance and jump straight to whichever one needs you.
 
 #### Built-in diff review and inline editing
 
-Every workspace ships with a diff view that shows uncommitted changes, staged changes, and the agent's most recent turn. You can edit files in place, stage hunks, and commit without leaving the app or switching to an external editor.
+Every workspace ships with a diff view that shows uncommitted changes, staged changes, and the agent's most recent turn. You can edit files in place, stage hunks, and commit without leaving the app.
 
 When you want a full IDE, one click hands the workspace off to VS Code, Cursor, Zed, or your terminal — the worktree path is the same path your editor opens.
 
 #### Reproducible workspace setup
 
-A `.superset/config.json` at your repo root defines what should happen when a workspace is created or destroyed — copy `.env`, install dependencies, run migrations, tear down branches, and anything else you'd normally do by hand. New workspaces come up identical to your main checkout in seconds. See the [setup/teardown docs](https://docs.superset.sh/setup-teardown-scripts).
-
-#### Universal CLI-agent compatibility
-
-Superset works with any agent that runs in a terminal. Claude Code, Codex, Cursor Agent, Gemini, Copilot CLI, OpenCode, Amp, and Pi all work without per-agent configuration. If it talks to stdin/stdout, Superset can run it.
+A `.superset/config.json` at your repo root defines what happens when a workspace is created or destroyed — copy `.env`, install dependencies, run migrations, tear down branches, and anything else you'd normally do by hand. New workspaces come up identical to your main checkout in seconds. See the [setup/teardown docs](https://docs.superset.sh/setup-teardown-scripts).
 
 ## Supported Agents
 
@@ -79,26 +66,35 @@ Superset works with any agent that runs in a terminal. Claude Code, Codex, Curso
 | [GitHub Copilot](https://github.com/features/copilot) | Fully supported |
 | [OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
 | [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
-| Any CLI agent | Will work |
+| Any other CLI agent | Works without configuration |
 
 If it runs in a terminal, it runs on Superset.
 
-## Requirements
+## What runs locally
 
-| Requirement | Details |
-|:------------|:--------|
-| **OS** | macOS (Windows/Linux untested) |
-| **Runtime** | [Bun](https://bun.sh/) v1.0+ |
-| **Version Control** | Git 2.20+ |
-| **GitHub CLI** | [gh](https://cli.github.com/) |
-| **Caddy** | [caddy](https://caddyserver.com/docs/install) (for dev server) |
+Superset runs on your machine. Your code, git worktrees, and agent processes never leave it.
+
+- **Local** — every git worktree, file edit, diff, and agent process (Claude Code, Codex, and the rest) runs as a local process on your Mac. Your source code is never uploaded.
+- **Account** — Superset requires a free account (GitHub or Google sign-in). The hosted backend stores your account and workspace metadata — names, branches, and status — so the app can sync state across sessions.
+- **Bring your own agents** — Superset doesn't proxy your agents. They use whatever subscriptions or API keys you've already configured.
 
 ## Getting Started
 
-**[Download Superset for macOS](https://github.com/superset-sh/superset/releases/latest)**
+**[Download Superset for macOS](https://github.com/superset-sh/superset/releases/latest)**, then sign in with GitHub or Google.
+
+### Requirements
+
+| Requirement | Details |
+|:------------|:--------|
+| **OS** | macOS (Windows and Linux are not supported) |
+| **Git** | 2.20+ — Superset manages real git worktrees |
+| **Account** | A free Superset account (GitHub or Google sign-in) |
+| **GitHub CLI** | [gh](https://cli.github.com/) — optional, for PR workflows |
 
 <details>
-<summary>Or build from source</summary>
+<summary>Build from source</summary>
+
+Building from source additionally requires [Bun](https://bun.sh/) v1.0+ and [Caddy](https://caddyserver.com/docs/install).
 
 **1. Clone the repository**
 
@@ -152,9 +148,7 @@ open apps/desktop/release
 
 Configure workspace setup, teardown, and presets in `.superset/config.json`. See the [configuration docs](https://docs.superset.sh/setup-teardown-scripts).
 
-## Keyboard Shortcuts
-
-All shortcuts are customizable via **Settings > Keyboard Shortcuts** (`⌘/`). See the [full shortcut reference](https://docs.superset.sh/keyboard-shortcuts).
+Keyboard shortcuts are customizable via **Settings > Keyboard Shortcuts** (`⌘/`). See the [full shortcut reference](https://docs.superset.sh/keyboard-shortcuts).
 
 ## Tech Stack
 
@@ -170,6 +164,8 @@ All shortcuts are customizable via **Settings > Keyboard Shortcuts** (`⌘/`). S
   <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
   <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
 </p>
+
+Superset is a desktop app built on Electron.
 
 ## Contributing
 
@@ -194,4 +190,4 @@ We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for development
 
 ## License
 
-Distributed under the Elastic License 2.0 (ELv2) — source is available on GitHub; you choose which agents, providers, and integrations to connect. See [LICENSE.md](LICENSE.md) for full terms.
+Superset is **source-available** under the Elastic License 2.0 (ELv2). You can read, modify, build, and self-host it for free. ELv2 is not an OSI-approved open-source license — the one real restriction is that you can't offer Superset as a hosted service to third parties. See [LICENSE.md](LICENSE.md) for full terms.


### PR DESCRIPTION
## Summary

Cleans up the README, tightens the copy, and reorganizes it to match the layout of widely-used repos.

## Changes

**Content fixes**
- Fix the demo link to point at the [Introducing Superset](https://www.youtube.com/watch?v=mk02bSQmEKY) video; remove leftover TODO placeholders and a duplicated hero image
- Drop the "native macOS app" wording since the app is built on Electron
- Make the license section explicit: source-available under ELv2 (not OSI open-source)
- Split Requirements into what you need to run the app vs. to build from source
- Add Mastracode to the supported agents (it was missing); list now matches `builtin-terminal-agents.ts`

**New sections**
- "What runs locally" — clarifies that code, worktrees, and agent processes stay on the machine; the backend only holds account and workspace metadata
- "Why Superset" — short agent-agnostic / local-first / bring-your-own-keys summary

**Structure & style**
- Replace the numbered pillar table with plain feature headers
- Add agent icons to the supported-agents grid (theme-aware for monochrome logos)
- Add a numbered "How it works" and tighten each section to scan faster
- Move Getting Started up near the top, ahead of the feature detail
- Align the headline with superset.sh ("100+ coding agents")

## Notes

- The hero image is still the single marketing banner — a real in-app screenshot or demo GIF would be a worthwhile follow-up.