### PR TITLE
chore(relay): prod deploy script — 6 regions, scale before deploy

### DIFF
--- a/apps/relay/scripts/deploy.sh
+++ b/apps/relay/scripts/deploy.sh
@@ -2,18 +2,11 @@
 set -euo pipefail
 
 APP=superset-relay
-REGIONS=(sjc)
+REGIONS=(sjc iad fra nrt sin gru)
 COUNT=${#REGIONS[@]}
 REGION_LIST=$(IFS=, ; echo "${REGIONS[*]}")
 
 cd "$(git rev-parse --show-toplevel)"
-
-echo "==> fly deploy"
-fly deploy \
-  --config apps/relay/fly.toml \
-  --dockerfile apps/relay/Dockerfile \
-  --app "$APP" \
-  .
 
 echo "==> fly scale count: $COUNT machines, 1 per region across $REGION_LIST"
 fly scale count "app=$COUNT" \
@@ -21,6 +14,14 @@ fly scale count "app=$COUNT" \
   --max-per-region 1 \
   --app "$APP" \
   --yes
+
+echo "==> fly deploy (rolling)"
+fly deploy \
+  --config apps/relay/fly.toml \
+  --dockerfile apps/relay/Dockerfile \
+  --app "$APP" \
+  --strategy rolling \
+  .
 
 echo "==> Status"
 fly status --app "$APP"


### PR DESCRIPTION
Prepares `apps/relay/scripts/deploy.sh` for the prod multi-region cutover.

- `REGIONS` → full prod target: `sjc iad fra nrt sin gru`
- Reorders **scale before deploy** — provisioning the new-region machines first means a rolling deploy always has healthy machines in other regions to catch host reconnects. Deploy-then-scale would replace the lone existing sjc machine before the others exist → single-machine outage window on the first cutover.
- Deploy pinned to `--strategy rolling`.

The relay image itself (graceful drain + multi-region routing) is already on `main` via #4594.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `apps/relay/scripts/deploy.sh` for the prod multi‑region cutover. Scale to six regions (sjc, iad, fra, nrt, sin, gru) before deploying, then deploy with `--strategy rolling` to avoid downtime during the first cutover.

<sup>Written for commit 3acae224bd34827dd19aa4934fc9b1a98cf30771. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4678?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment configuration to automatically scale the application across multiple geographic regions, improving global coverage and availability
  * Deployment process now uses a rolling update strategy to minimize service disruption and maintain uptime during releases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->