### PR TITLE
fix(web): recover terminal websockets after mobile background/resume

### DIFF
--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
@@ -1,0 +1,237 @@
+import { getAuthToken } from "../../../../../trpc/auth-token";
+import { getRelayUrl } from "../../../../../trpc/relay-url";
+
+export type TerminalConnectionState = "connecting" | "reconnecting" | "error";
+
+type TerminalServerMessage =
+	| { type: "attached"; terminalId: string }
+	| { type: "title"; title: string | null }
+	| { type: "error"; message: string }
+	| { type: "exit"; exitCode: number; signal: number };
+
+export type TerminalControlMessage = TerminalServerMessage;
+
+type TerminalClientMessage =
+	| { type: "input"; data: string }
+	| { type: "resize"; cols: number; rows: number };
+
+interface TerminalConnectionTarget {
+	workspaceId: string;
+	terminalId: string;
+	routingKey: string;
+}
+
+interface TerminalConnectionHandlers {
+	onBinary: (bytes: Uint8Array) => void;
+	onControl: (message: TerminalControlMessage) => void;
+	onStateChange: (state: TerminalConnectionState) => void;
+}
+
+const BASE_RECONNECT_DELAY_MS = 500;
+const MAX_RECONNECT_DELAY_MS = 10_000;
+const MAX_RECONNECT_ATTEMPTS = 12;
+
+// Owns the terminal WebSocket lifecycle: exponential-backoff reconnect on an
+// unexpected close, plus page-visibility recovery. Mobile browsers freeze
+// backgrounded tabs and drop the socket; the visibility, pageshow, resume and
+// online listeners reconnect the moment the page comes back. The server keys
+// sessions by terminalId and adopts/respawns the PTY on reattach, so reopening
+// the same URL resumes the session.
+export class TerminalConnection {
+	private readonly target: TerminalConnectionTarget;
+	private readonly handlers: TerminalConnectionHandlers;
+	private socket: WebSocket | null = null;
+	private state: TerminalConnectionState = "connecting";
+	private generation = 0;
+	private reconnectAttempt = 0;
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private hasReceivedBytes = false;
+	private everAttached = false;
+	private terminated = false;
+	private disposed = false;
+
+	constructor(
+		target: TerminalConnectionTarget,
+		handlers: TerminalConnectionHandlers,
+	) {
+		this.target = target;
+		this.handlers = handlers;
+	}
+
+	start() {
+		if (typeof document !== "undefined") {
+			document.addEventListener("visibilitychange", this.handleResume);
+			document.addEventListener("resume", this.handleResume);
+		}
+		if (typeof window !== "undefined") {
+			window.addEventListener("pageshow", this.handleResume);
+			window.addEventListener("online", this.handleResume);
+		}
+		void this.connect();
+	}
+
+	dispose() {
+		this.disposed = true;
+		this.cancelReconnect();
+		if (typeof document !== "undefined") {
+			document.removeEventListener("visibilitychange", this.handleResume);
+			document.removeEventListener("resume", this.handleResume);
+		}
+		if (typeof window !== "undefined") {
+			window.removeEventListener("pageshow", this.handleResume);
+			window.removeEventListener("online", this.handleResume);
+		}
+		this.teardownSocket();
+	}
+
+	send(message: TerminalClientMessage) {
+		const socket = this.socket;
+		if (!socket || socket.readyState !== WebSocket.OPEN) return;
+		socket.send(JSON.stringify(message));
+	}
+
+	private connect = async () => {
+		if (this.disposed || this.terminated) return;
+		this.cancelReconnect();
+		this.teardownSocket();
+		const generation = ++this.generation;
+		this.emitState(this.everAttached ? "reconnecting" : "connecting");
+
+		let url: string;
+		try {
+			url = await this.buildUrl();
+		} catch {
+			if (generation !== this.generation || this.disposed) return;
+			this.scheduleReconnect();
+			return;
+		}
+		if (generation !== this.generation || this.disposed || this.terminated) {
+			return;
+		}
+
+		let socket: WebSocket;
+		try {
+			socket = new WebSocket(url);
+		} catch {
+			this.scheduleReconnect();
+			return;
+		}
+		socket.binaryType = "arraybuffer";
+		this.socket = socket;
+		this.attachListeners(socket);
+	};
+
+	private async buildUrl(): Promise<string> {
+		const token = await getAuthToken();
+		const base = getRelayUrl().replace(/^http/, "ws").replace(/\/$/, "");
+		const url = new URL(
+			`${base}/hosts/${this.target.routingKey}/terminal/${encodeURIComponent(
+				this.target.terminalId,
+			)}`,
+		);
+		url.searchParams.set("workspaceId", this.target.workspaceId);
+		url.searchParams.set("themeType", "dark");
+		url.searchParams.set("token", token);
+		// Once xterm holds scrollback, skip the daemon ring-buffer re-dump on
+		// reattach; the in-memory buffer still replays output missed offline.
+		if (this.hasReceivedBytes) url.searchParams.set("replay", "0");
+		return url.toString();
+	}
+
+	private attachListeners(socket: WebSocket) {
+		socket.onmessage = (event) => {
+			if (this.socket !== socket) return;
+			if (event.data instanceof ArrayBuffer) {
+				this.hasReceivedBytes = true;
+				this.handlers.onBinary(new Uint8Array(event.data));
+				return;
+			}
+			let message: TerminalServerMessage;
+			try {
+				message = JSON.parse(String(event.data)) as TerminalServerMessage;
+			} catch {
+				return;
+			}
+			if (message.type === "attached") {
+				this.reconnectAttempt = 0;
+				this.everAttached = true;
+			} else if (message.type === "exit" || message.type === "error") {
+				this.terminated = true;
+				this.cancelReconnect();
+			}
+			this.handlers.onControl(message);
+		};
+
+		socket.onclose = () => {
+			if (this.socket !== socket) return;
+			this.socket = null;
+			if (this.terminated || this.disposed) return;
+			this.scheduleReconnect();
+		};
+	}
+
+	private teardownSocket() {
+		const socket = this.socket;
+		this.socket = null;
+		if (!socket) return;
+		socket.onmessage = null;
+		socket.onclose = null;
+		try {
+			socket.close();
+		} catch {
+			// best-effort
+		}
+	}
+
+	private scheduleReconnect() {
+		if (this.reconnectTimer !== null) return;
+		if (this.terminated || this.disposed) return;
+		if (this.reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
+			this.emitState("error");
+			return;
+		}
+		this.emitState("reconnecting");
+		// Frozen tabs don't run timers; the visibility listener reconnects on
+		// resume instead of burning the attempt budget on a timer that won't fire.
+		if (typeof document !== "undefined" && document.hidden) return;
+
+		const delay = Math.min(
+			BASE_RECONNECT_DELAY_MS * 2 ** this.reconnectAttempt,
+			MAX_RECONNECT_DELAY_MS,
+		);
+		this.reconnectAttempt += 1;
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = null;
+			void this.connect();
+		}, delay);
+	}
+
+	private cancelReconnect() {
+		if (this.reconnectTimer !== null) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+	}
+
+	private handleResume = () => {
+		if (this.disposed || this.terminated) return;
+		if (typeof document !== "undefined" && document.hidden) return;
+		this.reconnectAttempt = 0;
+		const socket = this.socket;
+		if (
+			socket &&
+			(socket.readyState === WebSocket.OPEN ||
+				socket.readyState === WebSocket.CONNECTING)
+		) {
+			return;
+		}
+		this.cancelReconnect();
+		void this.connect();
+	};
+
+	private emitState(state: TerminalConnectionState) {
+		if (this.state === state) return;
+		this.state = state;
+		this.handlers.onStateChange(state);
+	}
+}

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx
@@ -6,8 +6,7 @@ import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MobileTerminalInput } from "../../../../../components/MobileTerminalInput";
-import { getAuthToken } from "../../../../../trpc/auth-token";
-import { getRelayUrl } from "../../../../../trpc/relay-url";
+import { TerminalConnection } from "./TerminalConnection";
 
 const TERMINAL_THEME: ITheme = {
 	background: "#151110",
@@ -42,16 +41,12 @@ interface WebTerminalProps {
 	routingKey: string;
 }
 
-type ConnectionState = "connecting" | "open" | "error" | "exited";
-
-// Wire protocol mirrors the desktop's terminal transport
-// (apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts): binary
-// frames are raw PTY bytes, control messages are JSON.
-type TerminalServerMessage =
-	| { type: "attached"; terminalId: string }
-	| { type: "title"; title: string | null }
-	| { type: "error"; message: string }
-	| { type: "exit"; exitCode: number; signal: number };
+type ConnectionState =
+	| "connecting"
+	| "open"
+	| "reconnecting"
+	| "error"
+	| "exited";
 
 export function WebTerminal({
 	workspaceId,
@@ -59,48 +54,59 @@ export function WebTerminal({
 	routingKey,
 }: WebTerminalProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
-	const socketRef = useRef<WebSocket | null>(null);
+	const connectionRef = useRef<TerminalConnection | null>(null);
 	const [state, setState] = useState<ConnectionState>("connecting");
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
 	const sendSequence = useCallback((sequence: string) => {
-		const socket = socketRef.current;
-		if (!socket || socket.readyState !== WebSocket.OPEN) return;
-		socket.send(JSON.stringify({ type: "input", data: sequence }));
+		connectionRef.current?.send({ type: "input", data: sequence });
 	}, []);
 
 	useEffect(() => {
-		let cancelled = false;
-		let terminal: Terminal | null = null;
-		let fitAddon: FitAddon | null = null;
-		let socket: WebSocket | null = null;
-		let resizeObserver: ResizeObserver | null = null;
+		const container = containerRef.current;
+		if (!container) return;
+
 		let resizeTimer: ReturnType<typeof setTimeout> | null = null;
 		const visualViewport = window.visualViewport;
 
-		const sendResize = () => {
-			const activeSocket = socketRef.current;
-			if (
-				!terminal ||
-				!activeSocket ||
-				activeSocket.readyState !== WebSocket.OPEN
-			) {
-				return;
+		const terminal = new Terminal({
+			cursorBlink: true,
+			cursorStyle: "block",
+			fontFamily: TERMINAL_FONT_FAMILY,
+			fontSize: 14,
+			scrollback: 5000,
+			theme: TERMINAL_THEME,
+			allowProposedApi: true,
+		});
+		const fitAddon = new FitAddon();
+		terminal.loadAddon(fitAddon);
+		terminal.open(container);
+		if (window.matchMedia("(pointer: coarse)").matches) {
+			const xtermInput = terminal.textarea;
+			if (xtermInput) {
+				xtermInput.readOnly = true;
+				xtermInput.inputMode = "none";
+				xtermInput.tabIndex = -1;
 			}
-			activeSocket.send(
-				JSON.stringify({
-					type: "resize",
-					cols: terminal.cols,
-					rows: terminal.rows,
-				}),
-			);
+		}
+		try {
+			fitAddon.fit();
+		} catch {
+			// container may not be sized yet
+		}
+
+		const sendResize = () => {
+			connectionRef.current?.send({
+				type: "resize",
+				cols: terminal.cols,
+				rows: terminal.rows,
+			});
 		};
 
 		// Refit on every layout change; the visualViewport listeners are what
 		// keep the prompt above the soft keyboard on mobile, since the keyboard
 		// resizes the visual viewport rather than the layout viewport.
 		const refit = () => {
-			if (!fitAddon) return;
 			try {
 				fitAddon.fit();
 			} catch {
@@ -110,63 +116,19 @@ export function WebTerminal({
 			resizeTimer = setTimeout(sendResize, 150);
 		};
 
-		(async () => {
-			try {
-				const token = await getAuthToken();
-				if (cancelled) return;
-				const container = containerRef.current;
-				if (!container) return;
-
-				terminal = new Terminal({
-					cursorBlink: true,
-					cursorStyle: "block",
-					fontFamily: TERMINAL_FONT_FAMILY,
-					fontSize: 14,
-					scrollback: 5000,
-					theme: TERMINAL_THEME,
-					allowProposedApi: true,
-				});
-				fitAddon = new FitAddon();
-				terminal.loadAddon(fitAddon);
-				terminal.open(container);
-				if (window.matchMedia("(pointer: coarse)").matches) {
-					const xtermInput = terminal.textarea;
-					if (xtermInput) {
-						xtermInput.readOnly = true;
-						xtermInput.inputMode = "none";
-						xtermInput.tabIndex = -1;
-					}
-				}
-				try {
-					fitAddon.fit();
-				} catch {
-					// container may not be sized yet
-				}
-
-				const wsBase = getRelayUrl().replace(/^http/, "ws").replace(/\/$/, "");
-				const url = `${wsBase}/hosts/${routingKey}/terminal/${encodeURIComponent(terminalId)}?workspaceId=${encodeURIComponent(workspaceId)}&themeType=dark&token=${encodeURIComponent(token)}`;
-				socket = new WebSocket(url);
-				socket.binaryType = "arraybuffer";
-				socketRef.current = socket;
-
-				socket.onmessage = (event) => {
-					if (event.data instanceof ArrayBuffer) {
-						terminal?.write(new Uint8Array(event.data));
-						return;
-					}
-					let message: TerminalServerMessage;
-					try {
-						message = JSON.parse(String(event.data)) as TerminalServerMessage;
-					} catch {
-						return;
-					}
+		const connection = new TerminalConnection(
+			{ workspaceId, terminalId, routingKey },
+			{
+				onBinary: (bytes) => terminal.write(bytes),
+				onControl: (message) => {
 					switch (message.type) {
 						case "attached":
+							setErrorMessage(null);
 							setState("open");
 							sendResize();
 							return;
 						case "exit":
-							terminal?.write(
+							terminal.write(
 								`\r\n\x1b[33m[process exited code=${message.exitCode}]\x1b[0m\r\n`,
 							);
 							setState("exited");
@@ -178,53 +140,30 @@ export function WebTerminal({
 						default:
 							return;
 					}
-				};
+				},
+				onStateChange: (next) => setState(next),
+			},
+		);
+		connectionRef.current = connection;
+		connection.start();
 
-				socket.onclose = () => {
-					setState((previous) =>
-						previous === "open" || previous === "connecting"
-							? "error"
-							: previous,
-					);
-				};
+		terminal.onData((data) => {
+			connectionRef.current?.send({ type: "input", data });
+		});
 
-				socket.onerror = () => {
-					setErrorMessage("WebSocket connection failed.");
-				};
-
-				terminal.onData((data) => {
-					const activeSocket = socketRef.current;
-					if (activeSocket?.readyState === WebSocket.OPEN) {
-						activeSocket.send(JSON.stringify({ type: "input", data }));
-					}
-				});
-
-				resizeObserver = new ResizeObserver(refit);
-				resizeObserver.observe(container);
-				visualViewport?.addEventListener("resize", refit);
-				visualViewport?.addEventListener("scroll", refit);
-			} catch (caught) {
-				if (cancelled) return;
-				setErrorMessage(
-					caught instanceof Error ? caught.message : String(caught),
-				);
-				setState("error");
-			}
-		})();
+		const resizeObserver = new ResizeObserver(refit);
+		resizeObserver.observe(container);
+		visualViewport?.addEventListener("resize", refit);
+		visualViewport?.addEventListener("scroll", refit);
 
 		return () => {
-			cancelled = true;
 			if (resizeTimer !== null) clearTimeout(resizeTimer);
-			resizeObserver?.disconnect();
+			resizeObserver.disconnect();
 			visualViewport?.removeEventListener("resize", refit);
 			visualViewport?.removeEventListener("scroll", refit);
-			try {
-				socket?.close();
-			} catch {
-				// best-effort
-			}
-			terminal?.dispose();
-			socketRef.current = null;
+			connection.dispose();
+			connectionRef.current = null;
+			terminal.dispose();
 		};
 	}, [workspaceId, terminalId, routingKey]);
 
@@ -239,9 +178,11 @@ export function WebTerminal({
 					>
 						{state === "connecting"
 							? "Connecting…"
-							: state === "exited"
-								? "Process exited."
-								: (errorMessage ?? "Disconnected.")}
+							: state === "reconnecting"
+								? "Reconnecting…"
+								: state === "exited"
+									? "Process exited."
+									: (errorMessage ?? "Disconnected.")}
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
## Problem

On mobile Chrome, after minimizing the browser and reopening it, workspace terminal websocket connections are dropped and never recover — the terminal sits dead with a "Disconnected." banner.

## Root cause

`WebTerminal.tsx` opened a **single one-shot `WebSocket`**. Its entire failure handling was:

```ts
socket.onclose = () => {
  setState((previous) =>
    previous === "open" || previous === "connecting" ? "error" : previous,
  );
};
```

No reconnect, no backoff, and **no handling of page-lifecycle events**. Mobile Chrome aggressively freezes backgrounded tabs and closes their websockets while frozen. When the tab resumes, the queued `close` event fires (or the socket is already dead) — and the component just flips to `"error"` permanently. There was no path back to a live connection.

The desktop app doesn't hit this because Electron windows aren't frozen the way mobile browser tabs are; its terminal transport already reconnects on close. The web client never got an equivalent.

## Fix (web-only — no server changes)

Extracted the socket lifecycle out of the component into `TerminalConnection`:

- **Exponential-backoff reconnect** on any unexpected close (500ms → 10s, 12 attempts), mirroring the desktop terminal transport. A clean PTY `exit` or a fatal server `error` marks the connection terminated and suppresses reconnect.
- **Page-lifecycle recovery** — listeners on `visibilitychange`, `pageshow` (bfcache restore), `resume` (Page Lifecycle API), and `online`. When the page comes back, the attempt counter resets and it reconnects immediately if the socket isn't open, instead of waiting out a backoff timer that was frozen with the tab.
- **No reconnect timers scheduled while `document.hidden`** — a frozen tab can't run them; the visibility listener drives recovery on resume.
- **Session resumption** — the host-service already keys terminal sessions by `terminalId` and adopts (or respawns) the PTY on reattach, so reopening the same URL resumes the session. After the first PTY bytes land, reconnects pass `?replay=0` (an existing server query param) to skip re-dumping scrollback xterm already holds; the in-memory buffer still replays output produced while disconnected.
- New `"reconnecting"` UI state so the user sees "Reconnecting…" instead of a dead "Disconnected." banner.

### Note on heartbeat

A heartbeat/ping was considered but **not added** — a real heartbeat needs the server to answer with `pong`, and this change is intentionally web-only. The desktop terminal transport (which works reliably) also has no heartbeat; reconnect-on-close + visibility triggers cover the reported failure. If idle-connection NAT drops show up later, a `ping`/`pong` pair on the host-service is the follow-up.

## Testing

Manual, on mobile Chrome (and desktop via DevTools):

1. Open a workspace terminal, confirm it attaches and echoes input.
2. **Background test** — minimize the browser / switch apps for 30s+, reopen. The terminal reconnects automatically (brief "Reconnecting…"), session resumes, and any output produced while away is replayed.
3. **Network test** — toggle airplane mode briefly; on reconnect (`online` event) the terminal recovers.
4. DevTools: with the terminal open, run `Application → close the WS` or kill the relay — the client retries with growing backoff and recovers when the endpoint returns.
5. Switch terminals / unmount — `dispose()` removes all listeners and closes the socket; no leaks or stray reconnects.

`bun run lint` and `bun run typecheck` pass.

## Out of scope

`RemoteTerminal.tsx` (the public remote-control viewer) has the same one-shot pattern and no visibility handling. It's a separate, ephemeral, unauthenticated endpoint without the adopt/respawn resumption — left for a follow-up.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dead terminal websockets on mobile after backgrounding by adding reconnect and page-lifecycle recovery. Terminals now auto-reconnect and resume sessions with a clear "Reconnecting…" state.

- **Bug Fixes**
  - Added `TerminalConnection` with exponential-backoff reconnect on unexpected close.
  - Recover on `visibilitychange`, `pageshow`, `resume`, and `online`; no reconnect timers while the page is hidden.
  - Resume the same PTY session via `terminalId`; after first bytes, reconnects pass `?replay=0` to avoid duplicate scrollback.
  - New "reconnecting" UI state; "Disconnected." no longer sticks after background/resume.
  - Clean teardown on unmount: closes the socket and removes listeners.
  - Web-only change; no server updates required.

<sup>Written for commit b7cf83cfc5feddb905e16895d7f9328c47352b8f. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4685?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal now displays "Reconnecting…" status when connection is temporarily lost.
  * Enhanced connection recovery when switching between tabs or regaining connectivity.
  * Improved terminal session stability with automatic reconnection capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->