### PR TITLE
[codex] Allow deleting workspaces with missing worktrees

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
@@ -4,6 +4,7 @@ import type {
 } from "@superset/host-service";
 import { TRPCClientError } from "@trpc/client";
 import { useCallback } from "react";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import {
 	useWorkspaceHostTarget,
@@ -78,6 +79,20 @@ export function useDestroyWorkspace(workspaceId: string): UseDestroyWorkspace {
 		async (
 			input: DestroyWorkspaceInput = {},
 		): Promise<DestroyWorkspaceSuccess> => {
+			if (hostStatus === "not-found") {
+				try {
+					await apiTrpcClient.v2Workspace.delete.mutate({ id: workspaceId });
+					return {
+						success: true,
+						worktreeRemoved: false,
+						branchDeleted: false,
+						cloudDeleted: true,
+						warnings: [],
+					};
+				} catch (err) {
+					throw normalizeError(err);
+				}
+			}
 			const client = getReadyClient(hostUrl, hostStatus);
 			try {
 				return await client.workspaceCleanup.destroy.mutate({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/getWorkspaceMissingOnHostPreview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/getWorkspaceMissingOnHostPreview.ts
@@ -1,0 +1,10 @@
+import type { DestroyWorkspacePreview } from "renderer/hooks/host-service/useDestroyWorkspace";
+
+export function getWorkspaceMissingOnHostPreview(): DestroyWorkspacePreview {
+	return {
+		canDelete: true,
+		reason: null,
+		hasChanges: false,
+		hasUnpushedCommits: false,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { getWorkspaceMissingOnHostPreview } from "./getWorkspaceMissingOnHostPreview";
+
+describe("getWorkspaceMissingOnHostPreview", () => {
+	test("keeps delete confirmation enabled for missing host workspace state", () => {
+		expect(getWorkspaceMissingOnHostPreview()).toEqual({
+			canDelete: true,
+			reason: null,
+			hasChanges: false,
+			hasUnpushedCommits: false,
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -11,6 +11,7 @@ import {
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences/useV2UserPreferences";
 import { useNavigateAwayFromWorkspace } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace";
 import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
+import { getWorkspaceMissingOnHostPreview } from "./getWorkspaceMissingOnHostPreview";
 
 interface UseDestroyDialogStateOptions {
 	workspaceId: string;
@@ -66,12 +67,7 @@ export function useDestroyDialogState({
 		if (hostTarget.status === "not-found") {
 			setInspectState({
 				status: "ready",
-				preview: {
-					canDelete: false,
-					reason: "Workspace is no longer available on this host.",
-					hasChanges: false,
-					hasUnpushedCommits: false,
-				},
+				preview: getWorkspaceMissingOnHostPreview(),
 			});
 			return;
 		}

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -286,17 +287,29 @@ async function runDestroy(ctx: HostServiceContext, input: DestroyInput) {
 		}
 
 		if (git) {
+			if (!existsSync(local.worktreePath)) {
+				console.info(
+					"[workspaceCleanup.destroy] worktree path already missing; continuing cleanup",
+					{
+						workspaceId: input.workspaceId,
+						worktreePath: local.worktreePath,
+					},
+				);
+			}
 			try {
 				await git.raw(["worktree", "remove", "--force", local.worktreePath]);
 				worktreeRemoved = true;
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
-				if (
-					message.includes("is not a working tree") ||
-					message.includes("No such file or directory") ||
-					message.includes("does not exist") ||
-					message.includes("ENOENT")
-				) {
+				if (isMissingWorktreeRemovalError(message)) {
+					console.info(
+						"[workspaceCleanup.destroy] worktree already removed; continuing cleanup",
+						{
+							workspaceId: input.workspaceId,
+							worktreePath: local.worktreePath,
+							message,
+						},
+					);
 					worktreeRemoved = true;
 				} else {
 					warnings.push(
@@ -345,4 +358,13 @@ async function runDestroy(ctx: HostServiceContext, input: DestroyInput) {
 		branchDeleted,
 		warnings,
 	};
+}
+
+function isMissingWorktreeRemovalError(message: string) {
+	return (
+		message.includes("is not a working tree") ||
+		message.includes("No such file or directory") ||
+		message.includes("does not exist") ||
+		message.includes("ENOENT")
+	);
 }

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -30,6 +30,9 @@ interface ContextSpec {
 	cloudDelete?: () => Promise<unknown>;
 	gitStatus?: { isClean: () => boolean };
 	revListCount?: string | (() => Promise<string>);
+	worktreeRemove?: () => Promise<unknown>;
+	branchDelete?: () => Promise<unknown>;
+	gitRawCalls?: string[][];
 	gitFactoryThrows?: boolean;
 	dbDeleteThrows?: boolean;
 }
@@ -53,14 +56,15 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 			? await spec.revListCount()
 			: (spec.revListCount ?? "0\n"),
 	);
-	const worktreeRemove = mock(async () => undefined);
-	const branchDelete = mock(async () => undefined);
+	const worktreeRemove = mock(spec.worktreeRemove ?? (async () => undefined));
+	const branchDelete = mock(spec.branchDelete ?? (async () => undefined));
 
 	const git = mock(async () => {
 		if (spec.gitFactoryThrows) throw new Error("git factory boom");
 		return {
 			status,
 			raw: mock(async (args: string[]) => {
+				spec.gitRawCalls?.push(args);
 				if (args[0] === "rev-list") return await revList();
 				if (args[0] === "worktree") return await worktreeRemove();
 				if (args[0] === "branch") return await branchDelete();
@@ -411,5 +415,41 @@ describe("workspaceCleanup.destroy phase-3 best-effort cleanup", () => {
 				w.includes("Failed to remove local workspace row"),
 			),
 		).toBe(true);
+	});
+
+	test("missing worktree removal error is success-equivalent and branch delete still runs", async () => {
+		const gitRawCalls: string[][] = [];
+		const ctx = makeCtx({
+			workspace: {
+				id: "ws-1",
+				projectId: "p-1",
+				worktreePath: "/branch/already-gone",
+				branch: "feature/already-gone",
+			},
+			project: { id: "p-1", repoPath: "/repo" },
+			cloudType: "worktree",
+			gitRawCalls,
+			worktreeRemove: async () => {
+				throw new Error("fatal: '/branch/already-gone' is not a working tree");
+			},
+		});
+		const caller = workspaceCleanupRouter.createCaller(ctx);
+
+		const result = await caller.destroy({
+			workspaceId: "ws-1",
+			deleteBranch: true,
+			force: true,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.cloudDeleted).toBe(true);
+		expect(result.worktreeRemoved).toBe(true);
+		expect(result.branchDeleted).toBe(true);
+		expect(result.warnings).toEqual([]);
+		expect(gitRawCalls).toContainEqual([
+			"branch",
+			"-D",
+			"feature/already-gone",
+		]);
 	});
 });


### PR DESCRIPTION
## Summary
- Treat missing worktree paths/removal errors as already removed during host-side workspace cleanup, while still proceeding to cloud delete, branch delete, and local row cleanup.
- Let the dashboard delete dialog confirm when workspace host routing is missing, and fall back to direct cloud workspace deletion for that case.
- Add focused tests for missing worktree cleanup and the enabled delete-dialog preview state.

## Root Cause
The delete dialog converted a missing host/workspace routing state into a blocking preview, disabling the Delete button. Host cleanup also handled missing worktree errors implicitly but did not explicitly log the already-missing path condition.

## Validation
- `bun test packages/host-service/test/workspace-cleanup.test.ts packages/host-service/test/integration/workspace-cleanup.integration.test.ts`
- `bun test apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.test.ts`
- `bun run lint`
- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd apps/desktop typecheck`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4686">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow deleting workspaces when the local worktree or host routing is missing. The delete flow no longer blocks and proceeds with cloud deletion and branch cleanup.

- **Bug Fixes**
  - Desktop: If the host is not found, keep Delete enabled and call `v2Workspace.delete` directly.
  - Host service: Treat missing worktree paths and removal errors as already removed; continue with branch delete and emit informative logs.
  - Tests: Added focused tests for missing worktree cleanup and the enabled delete-dialog preview state.

<sup>Written for commit 2b7da132accadf30ba15cf96986806554acca2b5. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4686?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

