### PR TITLE
[codex] fix auth.users UUID array cast

### DIFF
--- a/apps/electric-proxy/src/where.ts
+++ b/apps/electric-proxy/src/where.ts
@@ -101,7 +101,7 @@ export function buildWhereClause(
 		}
 
 		case "auth.users": {
-			const fragment = `$1 = ANY("organization_ids")`;
+			const fragment = `"organization_ids" @> ARRAY[$1::uuid]`;
 			return { fragment, params: [organizationId] };
 		}
 


### PR DESCRIPTION
## Summary
- Update the `auth.users` Electric proxy WHERE fragment to use `"organization_ids" @> ARRAY[$1::uuid]`.
- This keeps the UUID cast inline on the parameter instead of casting the whole array, matching balegas's feedback that the GIN index can be used.
- Searched for other `ARRAY[$N]::uuid[]` patterns and did not find any additional instances to update.

## Context
This follows up on https://github.com/superset-sh/superset/pull/4489, which reverted the earlier GIN-friendly predicate because Electric rejected `ARRAY[$1]::uuid[]`. The inline parameter cast keeps the containment predicate while avoiding the unsupported whole-array cast form.

## Validation
- `bun run lint:fix`
- `bun run lint`
- `bun run --cwd apps/electric-proxy typecheck`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4687">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `auth.users` WHERE clause in the Electric proxy to use `"organization_ids" @> ARRAY[$1::uuid]` so the GIN index is used and the query is compatible with Electric.

- **Bug Fixes**
  - Replaced `$1 = ANY("organization_ids")` with a containment check using an inline UUID cast.

<sup>Written for commit 67b239b373125ac5ec7493f500f9210609c6039d. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4687?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of organization filtering in authorization checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->