### PR TITLE
fix(host-service): tolerate locked+missing worktrees in destroy

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -267,7 +268,9 @@ async function runDestroy(ctx: HostServiceContext, input: DestroyInput) {
 		warnings.push(`Failed to dispose terminal sessions: ${message}`);
 	}
 
-	// 3b. Worktree (always --force: we're past the commit point)
+	// 3b. Worktree (always --force --force: we're past the commit point,
+	//     and double-force unlocks the rare locked-worktree case the user
+	//     can hit by manually `rm -rf`-ing a worktree that ended up locked.)
 	// 3c. Optional branch delete
 	let worktreeRemoved = false;
 	let branchDeleted = false;
@@ -287,11 +290,26 @@ async function runDestroy(ctx: HostServiceContext, input: DestroyInput) {
 
 		if (git) {
 			try {
-				await git.raw(["worktree", "remove", "--force", local.worktreePath]);
+				await git.raw([
+					"worktree",
+					"remove",
+					"--force",
+					"--force",
+					local.worktreePath,
+				]);
 				worktreeRemoved = true;
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
-				if (
+				// If the worktree dir is already gone, the user's goal is met
+				// regardless of what git complains about — locale-translated
+				// messages, future git phrasing, or "locked working tree" with
+				// the dir already rm'd. The substring matcher below stays as
+				// belt-and-braces for the rare race where the dir disappears
+				// between this check and the git invocation, but `existsSync`
+				// is the authoritative signal.
+				if (!existsSync(local.worktreePath)) {
+					worktreeRemoved = true;
+				} else if (
 					message.includes("is not a working tree") ||
 					message.includes("No such file or directory") ||
 					message.includes("does not exist") ||

--- a/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
@@ -192,6 +192,34 @@ describe("workspaceCleanup.destroy integration", () => {
 		expect(worktreeList).toContain(otherWorktreePath);
 	});
 
+	test("missing worktree that was locked is still removed without warnings", async () => {
+		// A locked worktree whose dir was manually deleted is the scenario
+		// that breaks the substring-based error matcher: git says
+		// "fatal: cannot remove a locked working tree" and single `--force`
+		// is not enough. `--force --force` plus the existsSync fallback
+		// closes the loop so the user always gets a clean delete.
+		await scenario.repo.git.raw(["worktree", "lock", scenario.worktreePath]);
+		rmSync(scenario.worktreePath, { recursive: true, force: true });
+
+		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
+			workspaceId: scenario.featureWorkspaceId,
+			deleteBranch: true,
+		});
+		expect(result.success).toBe(true);
+		expect(result.worktreeRemoved).toBe(true);
+		expect(result.branchDeleted).toBe(true);
+		expect(result.warnings).toEqual([]);
+
+		const worktreeList = await scenario.repo.git.raw([
+			"worktree",
+			"list",
+			"--porcelain",
+		]);
+		expect(worktreeList).not.toContain(scenario.worktreePath);
+		const branches = await scenario.repo.git.branchLocal();
+		expect(branches.all).not.toContain(scenario.branch);
+	});
+
 	test("returns success when no local workspace row exists, still calls cloud delete", async () => {
 		await scenario.dispose();
 		const fresh = await createBasicScenario({


### PR DESCRIPTION
## Summary

- Customers can end up with a workspace whose worktree directory is gone from disk. If git also has the worktree locked (rare but possible — a long-running operation or tool that locks during work, then crashes), `git worktree remove --force` fails with `fatal: cannot remove a locked working tree; use 'remove -f -f' to override or unlock first`. The existing substring matcher in [`workspace-cleanup.ts:294-300`](packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts) doesn't catch this phrasing, so the step pushes a confusing "Failed to remove worktree" warning even though the directory the user wanted gone is already gone.
- Escalate the command to `--force --force` (we're past the cloud-delete commit point — the workspace is already gone from the user's perspective, so the conservative single `--force` no longer earns its keep) and add an `existsSync` fallback: any git failure whose post-condition is "the worktree dir is gone" is success, regardless of what git printed. The substring matcher stays as belt-and-braces for the rare race where the dir disappears mid-remove.
- Add an integration test for the locked-and-missing case. Verified it fails on the unfixed code (`worktreeRemoved: false`, warnings non-empty) and passes after the fix.

Closes [SUPER-779](https://linear.app/superset-sh/issue/SUPER-779).

## Test plan

- [x] `bun test packages/host-service/test/integration/workspace-cleanup.integration.test.ts` — 10 pass (9 existing + 1 new).
- [x] `bun run lint` clean.
- [x] `bunx tsc --noEmit` clean.
- [ ] Manual: in desktop v2, create a workspace, `rm -rf` its worktree dir, click delete from the sidebar — workspace disappears with no warning toasts.
- [ ] Manual locked variant: same but also `git worktree lock <path>` first.

## Out of scope

The renderer-side paths (`useDestroyWorkspace.normalizeError`, dialog inspect-failure handling) were verified to already swallow git failures correctly — no changes needed there.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `host-service` workspace destroy tolerate locked + missing git worktrees so deletes complete without false warnings. Addresses SUPER-779 by escalating remove and treating a missing worktree dir as success.

- **Bug Fixes**
  - Use `git worktree remove --force --force` to handle locked worktrees after manual `rm -rf`.
  - If `existsSync(worktreePath)` is false after a git error, mark the worktree as removed; keep the substring matcher as a fallback.
  - Added an integration test for the locked+missing case to ensure clean deletes with no warnings.

<sup>Written for commit 2043ca08b97493eab4b17482402d392ab3990737. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4693?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace cleanup reliability for edge cases involving locked worktrees.
  * Enhanced error handling to properly detect when worktree directories have been manually removed, ensuring cleanup operations complete successfully.
  * Added integration test coverage for locked worktree scenarios with manually deleted directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->