### PR TITLE
fix(desktop): bundle DuckDB native binding into x64 macOS build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -142,6 +142,19 @@ jobs:
           }
           "$CLI_BIN" --version
 
+      - name: Verify native bindings packaged
+        working-directory: apps/desktop
+        run: |
+          APP_DIR=$(find release -maxdepth 2 -name "*.app" -type d | head -1)
+          UNPACKED="$APP_DIR/Contents/Resources/app.asar.unpacked/node_modules"
+          BINDING="$UNPACKED/@duckdb/node-bindings-darwin-${{ matrix.arch }}/duckdb.node"
+          test -f "$BINDING" || {
+            echo "::error::DuckDB native binding missing from packaged app — Intel/arm launch will crash. Expected: $BINDING"
+            ls -la "$UNPACKED/@duckdb" 2>/dev/null || echo "  (no @duckdb directory in app.asar.unpacked)"
+            exit 1
+          }
+          echo "OK: bundled $BINDING ($(du -h "$BINDING" | cut -f1))"
+
       - name: Upload DMG artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/apps/desktop/runtime-dependencies.ts
+++ b/apps/desktop/runtime-dependencies.ts
@@ -79,6 +79,19 @@ const externalizedRuntimeModules: ExternalizedRuntimeModule[] = [
 		],
 		asarUnpackGlobs: ["**/node_modules/@libsql/**/*"],
 	},
+	{
+		specifier: "@mastra/duckdb",
+		materialize: [
+			"@mastra/duckdb",
+			"@duckdb/node-api",
+			"@duckdb/node-bindings",
+		],
+		packagedCopies: [
+			copyWholeModule("@mastra/duckdb"),
+			copyWholeModule("@duckdb"),
+		],
+		asarUnpackGlobs: ["**/node_modules/@duckdb/**/*"],
+	},
 ];
 
 const packagedSupportModules = [

--- a/apps/desktop/scripts/copy-native-modules.ts
+++ b/apps/desktop/scripts/copy-native-modules.ts
@@ -470,6 +470,50 @@ function copyParcelWatcherPlatformPackages(nodeModulesDir: string): void {
 	}
 }
 
+function copyDuckdbPlatformPackages(nodeModulesDir: string): void {
+	const nodeBindingsPath = join(nodeModulesDir, "@duckdb", "node-bindings");
+	const nodeBindingsPkgJsonPath = join(nodeBindingsPath, "package.json");
+	if (!existsSync(nodeBindingsPkgJsonPath)) return;
+
+	type DuckdbBindingsPackageJson = {
+		optionalDependencies?: Record<string, string>;
+	};
+	const nodeBindingsPkg = JSON.parse(
+		readFileSync(nodeBindingsPkgJsonPath, "utf8"),
+	) as DuckdbBindingsPackageJson;
+	const optionalDeps = nodeBindingsPkg.optionalDependencies ?? {};
+
+	console.log("\nPreparing duckdb platform package...");
+
+	// The native binding is a `cpu`/`os`-gated optional dependency, so Bun only
+	// installs the host's. For the target arch, fetch it from npm when missing.
+	const targetSuffix = `${TARGET_PLATFORM}-${TARGET_ARCH}`;
+	const targetEntry = Object.entries(optionalDeps).find(([name]) =>
+		name.endsWith(targetSuffix),
+	);
+	if (!targetEntry) {
+		console.error(
+			`  [ERROR] No @duckdb/node-bindings optional dependency matched ${targetSuffix}`,
+		);
+		process.exit(1);
+	}
+
+	const [targetName, targetVersion] = targetEntry;
+	const destPath = join(nodeModulesDir, targetName);
+	if (existsSync(destPath)) {
+		copyModuleIfSymlink(nodeModulesDir, targetName, true);
+		return;
+	}
+
+	copyExactModuleVersion(
+		nodeModulesDir,
+		targetName,
+		targetVersion,
+		destPath,
+		true,
+	);
+}
+
 function prepareNativeModules() {
 	console.log("Preparing external runtime modules for electron-builder...");
 	console.log(
@@ -488,6 +532,7 @@ function prepareNativeModules() {
 	copyAstGrepPlatformPackages(nodeModulesDir);
 	copyParcelWatcherPlatformPackages(nodeModulesDir);
 	copyLibsqlDependencies(nodeModulesDir);
+	copyDuckdbPlatformPackages(nodeModulesDir);
 
 	console.log("\nDone!");
 }

--- a/apps/desktop/scripts/validate-native-runtime.ts
+++ b/apps/desktop/scripts/validate-native-runtime.ts
@@ -504,6 +504,27 @@ function validateParcelWatcherPrepared(): void {
 	);
 }
 
+function validateDuckdbPrepared(): void {
+	const nodeModulesDir = join(projectRoot, "node_modules");
+	const targetArch = process.env.TARGET_ARCH || process.arch;
+	const targetPlatform = process.env.TARGET_PLATFORM || process.platform;
+	const bindingPackage = `@duckdb/node-bindings-${targetPlatform}-${targetArch}`;
+
+	if (!existsSync(join(nodeModulesDir, bindingPackage, "duckdb.node"))) {
+		fail(
+			[
+				"Missing platform-specific @duckdb/node-bindings package.",
+				`Expected: ${bindingPackage}/duckdb.node`,
+				"Run `bun run copy:native-modules` and ensure optional dependencies are materialized.",
+			].join("\n"),
+		);
+	}
+
+	console.log(
+		`[validate:native-runtime] OK: platform duckdb binding present (${bindingPackage})`,
+	);
+}
+
 function main(): void {
 	validateWorkspacePackagesBundled();
 	validateOnlyExpectedExternalRequires();
@@ -511,6 +532,7 @@ function main(): void {
 	validateParcelWatcherNotBundled();
 	validateNativeModulesPrepared();
 	validateParcelWatcherPrepared();
+	validateDuckdbPrepared();
 	console.log("[validate:native-runtime] All checks passed");
 }
 


### PR DESCRIPTION
## Problem

The Intel (x64) macOS build crashes immediately on launch:

```
Error: Cannot find module '@duckdb/node-bindings-darwin-x64/duckdb.node'
```

Any Intel Mac user is fully blocked — the app cannot start. Reproduced across 1.9.5 and 1.9.6; a clean reinstall does not help.

## Root cause

`mastracode` is externalized from the desktop main bundle, so at runtime Node resolves `@mastra/duckdb` → `@duckdb/node-api` → `@duckdb/node-bindings` → the platform binding from `node_modules`. The desktop native-module pipeline (`runtime-dependencies.ts` + `copy-native-modules.ts`) never accounted for DuckDB at all.

`@duckdb/node-bindings-darwin-x64` is a `cpu: "x64"` / `os: "darwin"`-gated optional dependency. Both macOS build legs run on an arm64 runner, so Bun only ever installs the arm64 binding — the x64 leg packages **no** x64 binding. arm64 was unaffected only because the runner arch happened to match.

`packages/cli/scripts/build-dist.ts` and `packages/host-service/build.ts` already externalize the full `@duckdb/node-bindings-*` set, confirming the desktop config was the outlier.

## Fix

- **`runtime-dependencies.ts`** — externalize `@mastra/duckdb` and materialize + copy `@mastra/duckdb` / `@duckdb/node-api` / `@duckdb/node-bindings`, with `asarUnpack` for the native `@duckdb` files (`duckdb.node` + `libduckdb.dylib`).
- **`copy-native-modules.ts`** — add `copyDuckdbPlatformPackages`, modeled on `copyAstGrepPlatformPackages` / `copyLibsqlDependencies`: resolve the `@duckdb/node-bindings` `optionalDependencies`, and fetch the `TARGET_ARCH` platform package from npm at the pinned `1.5.2-r.1` version when it is missing from the Bun store (cross-arch build scenario).
- **`validate-native-runtime.ts`** — add `validateDuckdbPrepared`, a build-time guard that the target-arch binding is present before packaging, matching the existing libsql / ast-grep / parcel-watcher guards.

## Linux audit

Per the ticket gotcha — the Linux job runs on `ubuntu-latest` (x64 host) with `TARGET_ARCH=x64`. Host arch matches target, so Bun installs `@duckdb/node-bindings-linux-x64` and `copyDuckdbPlatformPackages` finds it in the Bun store. No gap, no workflow change needed.

## Verification

- `bun run scripts/copy-native-modules.ts` (host arm64) materializes the three DuckDB modules and copies the arm64 binding from the Bun store.
- `TARGET_ARCH=x64 bun run scripts/copy-native-modules.ts` fetches `@duckdb/node-bindings-darwin-x64@1.5.2-r.1` (`duckdb.node` + `libduckdb.dylib`) from npm — the previously-missing piece.
- `bun run lint` and `bun run typecheck` pass.
- Remaining: build the x64 DMG in CI and launch it on an Intel Mac (or `arch -x86_64`).

Fixes #4666

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4694">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Intel (x64) macOS desktop crash by bundling the DuckDB native binding into the x64 build and validating it at build time and in CI. Ensures cross-arch builds fetch the correct `@duckdb/node-bindings-*` package so the app launches on x64. Fixes #4666.

- **Bug Fixes**
  - Externalized `@mastra/duckdb` and materialized/copied `@mastra/duckdb`, `@duckdb/node-api`, and `@duckdb/node-bindings`; unpack native `@duckdb` files from ASAR.
  - Added copy step to resolve platform-gated `@duckdb/node-bindings-<platform>-<arch>`; fetches the target-arch package from npm when Bun doesn’t install it.
  - Added validations: build-time guard for the target binding and a CI check that fails if `@duckdb/node-bindings-darwin-<arch>/duckdb.node` is missing from the packaged app.

<sup>Written for commit c545de670ed53db70bf0b20eb19411ee25e70b10. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4694?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added DuckDB runtime dependency configuration for the desktop application.
  * Implemented handling to materialize/copy platform-specific DuckDB native modules into the app package.
  * Added build-time validation and CI verification to ensure the correct DuckDB native bindings are present for each target platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->