### PR TITLE
fix(desktop): preselect last-used agent in automation create dialog

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
@@ -18,6 +18,7 @@ import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { DevicePicker } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker";
 import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions";
+import { AGENT_STORAGE_KEY as V2_WORKSPACE_AGENT_STORAGE_KEY } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types";
 import { hideAll as hideAllTippy } from "tippy.js";
 import { useProjectFileSearch } from "../../hooks/useProjectFileSearch";
 import { useRecentProjects } from "../../hooks/useRecentProjects";
@@ -55,7 +56,11 @@ export function CreateAutomationDialog({
 	const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
 		null,
 	);
-	const [agent, setAgent] = useState<string | null>(null);
+	const [agent, setAgent] = useState<string | null>(() => {
+		if (typeof window === "undefined") return null;
+		const stored = window.localStorage.getItem(V2_WORKSPACE_AGENT_STORAGE_KEY);
+		return stored && stored !== "none" ? stored : null;
+	});
 	const [rrule, setRrule] = useState(DEFAULT_RRULE);
 	const [v2WorkspaceId, setV2WorkspaceId] = useState<string | null>(null);
 
@@ -75,7 +80,15 @@ export function CreateAutomationDialog({
 
 	useEffect(() => {
 		if (agent && hostAgents.some((option) => option.id === agent)) return;
-		const fallback = hostAgents[0]?.id ?? null;
+		const stored =
+			typeof window !== "undefined"
+				? window.localStorage.getItem(V2_WORKSPACE_AGENT_STORAGE_KEY)
+				: null;
+		const storedMatch =
+			stored && stored !== "none"
+				? hostAgents.find((option) => option.id === stored)?.id
+				: undefined;
+		const fallback = storedMatch ?? hostAgents[0]?.id ?? null;
 		if (fallback !== agent) setAgent(fallback);
 	}, [agent, hostAgents]);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
@@ -43,6 +43,17 @@ const DEFAULT_TIMEZONE =
 
 const DEFAULT_RRULE = "FREQ=DAILY;BYHOUR=9;BYMINUTE=0";
 
+const AUTOMATION_AGENT_STORAGE_KEY = "lastSelectedV2AutomationAgent";
+
+function readStoredAgent(): string | null {
+	if (typeof window === "undefined") return null;
+	const automation = window.localStorage.getItem(AUTOMATION_AGENT_STORAGE_KEY);
+	if (automation && automation !== "none") return automation;
+	const workspace = window.localStorage.getItem(V2_WORKSPACE_AGENT_STORAGE_KEY);
+	if (workspace && workspace !== "none") return workspace;
+	return null;
+}
+
 export function CreateAutomationDialog({
 	open,
 	onOpenChange,
@@ -56,11 +67,7 @@ export function CreateAutomationDialog({
 	const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
 		null,
 	);
-	const [agent, setAgent] = useState<string | null>(() => {
-		if (typeof window === "undefined") return null;
-		const stored = window.localStorage.getItem(V2_WORKSPACE_AGENT_STORAGE_KEY);
-		return stored && stored !== "none" ? stored : null;
-	});
+	const [agent, setAgent] = useState<string | null>(() => readStoredAgent());
 	const [rrule, setRrule] = useState(DEFAULT_RRULE);
 	const [v2WorkspaceId, setV2WorkspaceId] = useState<string | null>(null);
 
@@ -80,17 +87,20 @@ export function CreateAutomationDialog({
 
 	useEffect(() => {
 		if (agent && hostAgents.some((option) => option.id === agent)) return;
-		const stored =
-			typeof window !== "undefined"
-				? window.localStorage.getItem(V2_WORKSPACE_AGENT_STORAGE_KEY)
-				: null;
-		const storedMatch =
-			stored && stored !== "none"
-				? hostAgents.find((option) => option.id === stored)?.id
-				: undefined;
+		const stored = readStoredAgent();
+		const storedMatch = stored
+			? hostAgents.find((option) => option.id === stored)?.id
+			: undefined;
 		const fallback = storedMatch ?? hostAgents[0]?.id ?? null;
 		if (fallback !== agent) setAgent(fallback);
 	}, [agent, hostAgents]);
+
+	const handleAgentChange = useCallback((next: string) => {
+		setAgent(next);
+		if (typeof window !== "undefined") {
+			window.localStorage.setItem(AUTOMATION_AGENT_STORAGE_KEY, next);
+		}
+	}, []);
 
 	// Default to first project once the Electric-synced list lands.
 	useEffect(() => {
@@ -304,7 +314,7 @@ export function CreateAutomationDialog({
 										className="w-[100px]"
 										hostId={targetHostId}
 										value={agent ?? ""}
-										onChange={setAgent}
+										onChange={handleAgentChange}
 									/>
 								</div>
 


### PR DESCRIPTION
## Summary
- The "New automation" dialog opened with no agent selected until the host's first agent loaded, ignoring whatever the user last picked in the v2 NewWorkspaceModal.
- Seed `CreateAutomationDialog`'s agent state from the same `lastSelectedV2WorkspaceCreateAgent` localStorage key the v2 workspace modal writes, and prefer that stored value (when it exists on the current host) over `hostAgents[0]` in the corrective effect.

## Test plan
- [ ] Pick a non-default agent in the v2 NewWorkspaceModal, close it, open "New automation" — the same agent is preselected.
- [ ] On a host where the stored agent isn't available, the picker falls back to the first host agent instead of staying empty.
- [ ] After closing/reopening the automation dialog, the preselection persists.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4697">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preselects the last-used agent in the “New automation” dialog and remembers it independently, matching the v2 New Workspace modal and avoiding an empty picker. Reads `lastSelectedV2AutomationAgent` first, falls back to `lastSelectedV2WorkspaceCreateAgent`, then to the first host agent.

- **Bug Fixes**
  - Seed agent from `lastSelectedV2AutomationAgent`; if missing, use `lastSelectedV2WorkspaceCreateAgent` when it exists on the current host, otherwise `hostAgents[0]`.
  - Persist selection to `lastSelectedV2AutomationAgent` so the automation dialog remembers separately; selection persists across reopen.

<sup>Written for commit a367f69f19a91c056d5f6b7ae2cd4c148bb9fbf5. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4697?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The automation creation dialog now saves your selected agent preference and automatically restores it when reopened. It re-evaluates the saved selection whenever available agents load or change, falling back to a sensible default if needed. Selecting a different agent updates both the dialog and the persisted preference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->