### PR TITLE
rename sidebar 'Tasks' to 'Issues & PRs'

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -163,7 +163,7 @@ export function DashboardSidebarHeader({
 							<HiOutlineClipboardDocumentList className="size-4" />
 						</button>
 					</TooltipTrigger>
-					<TooltipContent side="right">Tasks</TooltipContent>
+					<TooltipContent side="right">Issues & PRs</TooltipContent>
 				</Tooltip>
 
 				<Tooltip delayDuration={300}>
@@ -268,7 +268,7 @@ export function DashboardSidebarHeader({
 				)}
 			>
 				<HiOutlineClipboardDocumentList className="size-4 shrink-0" />
-				<span className="flex-1 text-left">Tasks</span>
+				<span className="flex-1 text-left">Issues & PRs</span>
 			</button>
 
 			<div className="flex items-center gap-0">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -96,7 +96,7 @@ export function WorkspaceSidebarHeader({
 							/>
 						</button>
 					</TooltipTrigger>
-					<TooltipContent side="right">Tasks</TooltipContent>
+					<TooltipContent side="right">Issues & PRs</TooltipContent>
 				</Tooltip>
 
 				<NewWorkspaceButton isCollapsed />
@@ -138,7 +138,9 @@ export function WorkspaceSidebarHeader({
 						strokeWidth={STROKE_WIDTH}
 					/>
 				</div>
-				<span className="text-sm font-medium flex-1 text-left">Tasks</span>
+				<span className="text-sm font-medium flex-1 text-left">
+					Issues & PRs
+				</span>
 			</button>
 
 			<NewWorkspaceButton />


### PR DESCRIPTION
## Summary
- Renames the sidebar entry label "Tasks" → "Issues & PRs" in both `DashboardSidebarHeader` and `WorkspaceSidebarHeader` (collapsed tooltip + expanded label).
- Internal identifiers (route `/tasks`, `useTasksFilterStore`, `isTasksOpen`) are unchanged — label-only change.

## Test plan
- [ ] Open desktop app; confirm sidebar shows "Issues & PRs" in expanded and collapsed (tooltip) states.
- [ ] Clicking the entry still routes to `/tasks`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4698">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the sidebar entry from "Tasks" to "Issues & PRs" in both the Dashboard and Workspace sidebars, covering the collapsed tooltip and expanded label. Routes and internal identifiers are unchanged; clicking still navigates to /tasks.

<sup>Written for commit 8b12646c02e13915abaea9289ca9f8325c8584e8. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4698?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar navigation labels from "Tasks" to "Issues & PRs" in both collapsed (tooltip) and expanded (button label) states across dashboard and workspace sidebars.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->