### PR TITLE
feat(desktop): offer window reload when workspace creation stalls

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -109,7 +109,7 @@ export function WorkspaceCreatingState({
 
 				{stuck && (
 					<div className="flex w-full flex-col gap-2 border-t border-border/60 pt-4 animate-in fade-in slide-in-from-bottom-1 duration-500">
-						<p className="text-[12px] leading-relaxed text-muted-foreground">
+						<p className="select-text cursor-text text-[12px] leading-relaxed text-muted-foreground">
 							This is taking longer than usual. The workspace may already be
 							ready — reloading can pick it up.
 						</p>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -108,7 +108,7 @@ export function WorkspaceCreatingState({
 				</div>
 
 				{stuck && (
-					<div className="flex w-full flex-col gap-2 border-t border-border/60 pt-4">
+					<div className="flex w-full flex-col gap-2 border-t border-border/60 pt-4 animate-in fade-in slide-in-from-bottom-1 duration-500">
 						<p className="text-[12px] leading-relaxed text-muted-foreground">
 							This is taking longer than usual. The workspace may already be
 							ready — reloading can pick it up.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -28,9 +28,9 @@ const TOTAL_SECONDS = STEPS[STEPS.length - 1].doneAt;
 // Cap synthetic progress so the bar never claims completion before the real
 // workspaces.create mutation resolves.
 const PROGRESS_CAP = 0.94;
-// ~2× the typical budget — past this we offer a window reload as an escape
-// hatch in case the renderer state has drifted from the real workspace row.
-const STUCK_AFTER_SECONDS = 45;
+// Past the typical budget — offer a window reload as an escape hatch in
+// case the renderer state has drifted from the real workspace row.
+const STUCK_AFTER_SECONDS = 30;
 
 interface WorkspaceCreatingStateProps {
 	name?: string;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreatingState/WorkspaceCreatingState.tsx
@@ -1,5 +1,6 @@
+import { Button } from "@superset/ui/button";
 import { cn } from "@superset/ui/utils";
-import { Check, GitBranch, Loader2 } from "lucide-react";
+import { Check, GitBranch, Loader2, RotateCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import "./WorkspaceCreatingState.css";
 
@@ -27,6 +28,9 @@ const TOTAL_SECONDS = STEPS[STEPS.length - 1].doneAt;
 // Cap synthetic progress so the bar never claims completion before the real
 // workspaces.create mutation resolves.
 const PROGRESS_CAP = 0.94;
+// ~2× the typical budget — past this we offer a window reload as an escape
+// hatch in case the renderer state has drifted from the real workspace row.
+const STUCK_AFTER_SECONDS = 45;
 
 interface WorkspaceCreatingStateProps {
 	name?: string;
@@ -42,6 +46,7 @@ export function WorkspaceCreatingState({
 	const elapsed = useElapsedSeconds(startedAt);
 	const activeIndex = getActiveIndex(elapsed);
 	const progress = Math.min(elapsed / TOTAL_SECONDS, PROGRESS_CAP);
+	const stuck = elapsed >= STUCK_AFTER_SECONDS;
 
 	return (
 		<div className="flex h-full w-full items-center justify-center p-6">
@@ -101,6 +106,28 @@ export function WorkspaceCreatingState({
 						<span>~{TOTAL_SECONDS}s typical</span>
 					</div>
 				</div>
+
+				{stuck && (
+					<div className="flex w-full flex-col gap-2 border-t border-border/60 pt-4">
+						<p className="text-[12px] leading-relaxed text-muted-foreground">
+							This is taking longer than usual. The workspace may already be
+							ready — reloading can pick it up.
+						</p>
+						<Button
+							size="sm"
+							variant="outline"
+							className="h-7 w-fit gap-1.5 px-2 text-[12px] font-medium"
+							onClick={() => window.location.reload()}
+						>
+							<RotateCw
+								className="size-3.5"
+								strokeWidth={2}
+								aria-hidden="true"
+							/>
+							Reload window
+						</Button>
+					</div>
+				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- When the v2 workspace creating screen stays mounted past 45s (~2× the typical 23s budget), surface a subtle "Reload window" button.
- Reload calls `window.location.reload()` — the same escape-hatch pattern as `BootErrorBoundary` and `routes/error.tsx`. Useful when Electric/renderer state has drifted from the real workspace row.
- Hidden during normal creation; only fades in once we're well past the synthetic progress budget.

## Test plan
- [ ] Start a v2 workspace creation, confirm normal flow shows no reload button.
- [ ] Force the creating state to persist (e.g. stop Electric sync) and confirm the reload button appears after ~45s.
- [ ] Click "Reload window" — verify renderer reloads and picks up the workspace if it has since synced.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a subtle "Reload window" button on the v2 workspace creation screen after 30s. It fades in with a short, selectable note and reloads the window to recover from stalled or out‑of‑sync state; hidden during normal creation.

<sup>Written for commit 9883b7ed4dc9494cefb95c0105169122f985125f. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4699?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace creation now monitors setup progress and displays a “taking longer than usual” notice when the process appears stalled.
  * The notice includes an outlined "Reload window" action to refresh the app and attempt recovery without losing context, making it easier to resolve hung workspace setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->