### PR TITLE
fix: avoid heredoc prompt launches

### DIFF
--- a/apps/desktop/docs/V2_LAUNCH_CONTEXT_GAPS.md
+++ b/apps/desktop/docs/V2_LAUNCH_CONTEXT_GAPS.md
@@ -35,9 +35,10 @@ empty strings. The pipeline otherwise works end-to-end.
    head branch. Prompt says so.
 3. **No body truncation** (or very high cap, e.g. 200 KB/source). Modern
    context windows are large. Don't cap aggressively.
-4. **No sanitization.** Prompt goes into a heredoc with a random
-   delimiter (no shell injection). Agent reads raw text, no HTML parser
-   downstream. V1's entity escaping was unnecessary.
+4. **No sanitization.** Prompt text is shell-quoted as a single argv value or
+   piped through `printf` for stdin transports (no prompt shell injection).
+   Agent reads raw text, no HTML parser downstream. V1's entity escaping was
+   unnecessary.
 5. **Attachments framing.** The `{{attachments}}` block includes a short
    header cueing the agent to read the files. Just paths; agent handles
    the rest.

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { buildAgentCommandString } from "./agents";
+
+type AgentConfig = Parameters<typeof buildAgentCommandString>[0];
+
+function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
+	return {
+		id: "agent-1",
+		presetId: "amp",
+		label: "Amp",
+		command: "amp",
+		args: [],
+		promptTransport: "stdin",
+		promptArgs: [],
+		env: {},
+		...overrides,
+	};
+}
+
+describe("buildAgentCommandString", () => {
+	it("pipes stdin prompts without heredoc syntax", () => {
+		const command = buildAgentCommandString(
+			config(),
+			"hello from fish\nit's safe",
+		);
+
+		expect(command).toBe(
+			"printf '%s\\n' 'hello from fish\nit'\\''s safe' | 'amp'",
+		);
+		expect(command).not.toContain("<<");
+	});
+
+	it("quotes argv prompts as a single shell argument", () => {
+		const command = buildAgentCommandString(
+			config({
+				command: "codex",
+				args: ["--dangerously-bypass-approvals-and-sandbox"],
+				promptArgs: ["--"],
+				promptTransport: "argv",
+			}),
+			"- prompt with spaces",
+		);
+
+		expect(command).toBe(
+			"'codex' '--dangerously-bypass-approvals-and-sandbox' '--' '- prompt with spaces'",
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -105,8 +105,8 @@ function buildArgvCommand(argv: string[]): string {
 /**
  * Build a shell command string that runs the resolved agent config with the
  * given prompt. argv transport appends the prompt as the final positional;
- * stdin transport pipes the prompt via a heredoc so the agent can read from
- * fd 0.
+ * stdin transport pipes the prompt through printf so the command is parsable
+ * by non-POSIX interactive shells such as fish.
  *
  * Empty prompts drop `promptArgs` so codex/opencode/copilot don't get stray
  * prompt-mode flags during promptless launches.
@@ -121,16 +121,7 @@ export function buildAgentCommandString(
 		return buildArgvCommand([...baseArgv, prompt]);
 	}
 
-	// stdin: pipe the prompt to the spawned process via heredoc. Delimiter is
-	// constructed to avoid collision with any line in the prompt content.
-	const baseDelimiter = "SUPERSET_PROMPT";
-	let delimiter = baseDelimiter;
-	let counter = 0;
-	while (prompt.split("\n").some((line) => line === delimiter)) {
-		counter += 1;
-		delimiter = `${baseDelimiter}_${counter}`;
-	}
-	return `${buildArgvCommand(baseArgv)} <<'${delimiter}'\n${prompt}\n${delimiter}`;
+	return `printf '%s\\n' ${quoteSingleShell(prompt)} | ${buildArgvCommand(baseArgv)}`;
 }
 
 function envOverlayPrefix(env: Record<string, string>): string {

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -12,10 +12,9 @@ describe("buildAgentPromptCommand", () => {
 			agent: "codex",
 		});
 
-		expect(command).toContain(
-			"codex --dangerously-bypass-approvals-and-sandbox -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
+		expect(command).toBe(
+			"codex --dangerously-bypass-approvals-and-sandbox -- '- Only modified file: runtime.ts'",
 		);
-		expect(command).toContain("- Only modified file: runtime.ts");
 	});
 
 	it("does not change non-codex commands", () => {
@@ -25,9 +24,7 @@ describe("buildAgentPromptCommand", () => {
 			agent: "claude",
 		});
 
-		expect(command).toStartWith(
-			"claude --permission-mode acceptEdits \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
-		);
+		expect(command).toBe("claude --permission-mode acceptEdits 'hello'");
 	});
 
 	it("uses Amp interactive stdin mode for prompt launches", () => {
@@ -37,8 +34,22 @@ describe("buildAgentPromptCommand", () => {
 			agent: "amp",
 		});
 
-		expect(command).toStartWith("amp <<'SUPERSET_PROMPT_amp1234'");
+		expect(command).toBe("printf '%s\\n' 'hello' | amp");
 		expect(command).not.toContain("amp -x");
+	});
+
+	it("escapes single quotes without heredoc syntax", () => {
+		const command = buildAgentPromptCommand({
+			prompt: "it's fish-safe",
+			randomId: "quote-1234",
+			agent: "claude",
+		});
+
+		expect(command).toBe(
+			"claude --permission-mode acceptEdits 'it'\\''s fish-safe'",
+		);
+		expect(command).not.toContain("<<");
+		expect(command).not.toContain("$(cat");
 	});
 
 	it("uses Amp interactive stdin mode for file launches", () => {
@@ -57,7 +68,7 @@ describe("buildAgentPromptCommand", () => {
 			agent: "pi",
 		});
 
-		expect(command).toStartWith("pi \"$(cat <<'SUPERSET_PROMPT_pi1234'");
+		expect(command).toBe("pi 'hello'");
 		expect(command).not.toContain("pi -p");
 	});
 });

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -61,6 +61,30 @@ describe("buildAgentPromptCommand", () => {
 		expect(command).toBe("amp < '.superset/task-demo.md'");
 	});
 
+	it("uses shell-agnostic argv file launches without command substitution", () => {
+		const command = buildAgentFileCommand({
+			filePath: ".superset/task-demo's.md",
+			agent: "claude",
+		});
+
+		expect(command).toBe(
+			"xargs -0 -I __SUP_PROMPT__ claude --permission-mode acceptEdits __SUP_PROMPT__ < '.superset/task-demo'\\''s.md'",
+		);
+		expect(command).not.toContain("$(cat");
+		expect(command).not.toContain("<<");
+	});
+
+	it("keeps codex file prompt separator before the file payload", () => {
+		const command = buildAgentFileCommand({
+			filePath: ".superset/task-demo.md",
+			agent: "codex",
+		});
+
+		expect(command).toBe(
+			"xargs -0 -I __SUP_PROMPT__ codex --dangerously-bypass-approvals-and-sandbox -- __SUP_PROMPT__ < '.superset/task-demo.md'",
+		);
+	});
+
 	it("uses pi interactive mode for prompt launches", () => {
 		const command = buildAgentPromptCommand({
 			prompt: "hello",

--- a/packages/shared/src/agent-launch-request.test.ts
+++ b/packages/shared/src/agent-launch-request.test.ts
@@ -103,7 +103,7 @@ describe("buildPromptAgentLaunchRequest", () => {
 		if (request?.kind !== "terminal") {
 			throw new Error("Expected terminal launch request");
 		}
-		expect(request.terminal.command).toStartWith("amp <<'SUPERSET_PROMPT_");
+		expect(request.terminal.command).toBe("printf '%s\\n' 'wasssup' | amp");
 		expect(request.terminal.command).not.toContain("amp -x");
 	});
 });

--- a/packages/shared/src/agent-prompt-launch.ts
+++ b/packages/shared/src/agent-prompt-launch.ts
@@ -7,16 +7,12 @@ export const PROMPT_TRANSPORTS = ["argv", "stdin"] as const;
 
 export type PromptTransport = (typeof PROMPT_TRANSPORTS)[number];
 
-function resolveDelimiter(prompt: string, randomId: string): string {
-	let delimiter = `SUPERSET_PROMPT_${randomId.replaceAll("-", "")}`;
-	while (prompt.includes(delimiter)) {
-		delimiter = `${delimiter}_X`;
-	}
-	return delimiter;
-}
-
 function quoteSingleShell(value: string): string {
 	return value.replaceAll("'", "'\\''");
+}
+
+function quoteShellArg(value: string): string {
+	return `'${quoteSingleShell(value)}'`;
 }
 
 function joinCommand(command: string, suffix?: string): string {
@@ -28,7 +24,6 @@ export function buildPromptCommandString({
 	suffix,
 	transport,
 	prompt,
-	randomId,
 }: {
 	command: string;
 	suffix?: string;
@@ -36,14 +31,14 @@ export function buildPromptCommandString({
 	prompt: string;
 	randomId: string;
 }): string {
-	const delimiter = resolveDelimiter(prompt, randomId);
 	const fullCommand = joinCommand(command, suffix);
+	const promptArg = quoteShellArg(prompt);
 
 	if (transport === "stdin") {
-		return `${fullCommand} <<'${delimiter}'\n${prompt}\n${delimiter}`;
+		return `printf '%s\\n' ${promptArg} | ${fullCommand}`;
 	}
 
-	return `${command} "$(cat <<'${delimiter}'\n${prompt}\n${delimiter}\n)"${suffix ? ` ${suffix}` : ""}`;
+	return `${command} ${promptArg}${suffix ? ` ${suffix}` : ""}`;
 }
 
 export function buildPromptFileCommandString({
@@ -57,12 +52,12 @@ export function buildPromptFileCommandString({
 	transport: PromptTransport;
 	filePath: string;
 }): string {
-	const escapedPath = quoteSingleShell(filePath);
+	const escapedPath = quoteShellArg(filePath);
 	const fullCommand = joinCommand(command, suffix);
 
 	if (transport === "stdin") {
-		return `${fullCommand} < '${escapedPath}'`;
+		return `${fullCommand} < ${escapedPath}`;
 	}
 
-	return `${command} "$(cat '${escapedPath}')"${suffix ? ` ${suffix}` : ""}`;
+	return `${command} "$(cat ${escapedPath})"${suffix ? ` ${suffix}` : ""}`;
 }

--- a/packages/shared/src/agent-prompt-launch.ts
+++ b/packages/shared/src/agent-prompt-launch.ts
@@ -7,6 +7,8 @@ export const PROMPT_TRANSPORTS = ["argv", "stdin"] as const;
 
 export type PromptTransport = (typeof PROMPT_TRANSPORTS)[number];
 
+const XARGS_PROMPT_PLACEHOLDER = "__SUP_PROMPT__";
+
 function quoteSingleShell(value: string): string {
 	return value.replaceAll("'", "'\\''");
 }
@@ -59,5 +61,7 @@ export function buildPromptFileCommandString({
 		return `${fullCommand} < ${escapedPath}`;
 	}
 
-	return `${command} "$(cat ${escapedPath})"${suffix ? ` ${suffix}` : ""}`;
+	return `xargs -0 -I ${XARGS_PROMPT_PLACEHOLDER} ${command} ${XARGS_PROMPT_PLACEHOLDER}${
+		suffix ? ` ${suffix}` : ""
+	} < ${escapedPath}`;
 }


### PR DESCRIPTION
## Description

Fixes fish-shell agent launches by removing bash-only heredoc prompt transport from the generated agent commands.

- pass argv prompts as a single shell-quoted argument instead of `"$(cat <<...)"`
- pipe stdin prompts with `printf '%s\n' '<prompt>' | <agent>` instead of attaching a heredoc
- add shared and host-service regression coverage for quoted prompts and heredoc-free stdin launches
- update the V2 launch-context note that still described heredoc transport

## Related Issues

Closes #4705

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- [x] `bun install --frozen --ignore-scripts`
- [x] `bun test packages/shared/src/agent-command.test.ts packages/shared/src/agent-launch-request.test.ts`
- [x] `bun test packages/host-service/src/trpc/router/agents/agents.test.ts`
- [x] `bash -lc <generated argv/stdin prompt commands>` and `zsh -fc <generated argv/stdin prompt commands>` smoke tests with multiline + single-quote prompt text
- [x] `bun run lint:fix`
- [x] `bun run lint`
- [x] `bun run --cwd packages/shared typecheck`
- [x] `bun run --cwd packages/host-service typecheck`
- [x] `bun run typecheck`
- [x] `bun run --cwd packages/shared test`
- [x] `bun run --cwd packages/host-service test`
- [x] `git diff --check`

## Screenshots (if applicable)

N/A

## Additional Notes

`fish` is not installed in my local environment, so I could not execute the generated commands under fish directly. The generated commands no longer contain heredoc syntax or `$(cat ...)` for direct prompt launches, which is the syntax fish rejected in the reported failure.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4706">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent prompt launches in fish by removing heredocs and command substitution. Prompts are now shell-agnostic: argv prompts are a single quoted arg, stdin prompts use `printf`, and file prompts use `xargs`.

- **Bug Fixes**
  - stdin prompts: `printf '%s\n' '<prompt>' | <agent>` instead of heredocs.
  - argv prompts: pass prompt as one shell-quoted arg; escape single quotes.
  - file prompts (argv): `xargs -0 -I __SUP_PROMPT__ <command> __SUP_PROMPT__ < '<path>'` instead of `$(cat ...)`; stdin remains `< '<path>'`.
  - Updated command builders and tests in `packages/shared` and `packages/host-service`.
  - Updated `apps/desktop/docs/V2_LAUNCH_CONTEXT_GAPS.md` to reflect non-heredoc, non-substitution transport.

<sup>Written for commit 8c2ccda5b023a24367c28c3288ccd732d64137c6. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4706?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt handling and shell-escaping so agent commands receive prompts safely and deterministically (no heredoc usage).

* **Tests**
  * Expanded and tightened tests to assert exact command strings and escaping across agent types and transports.

* **Documentation**
  * Updated user-facing docs to reflect the new prompt transmission and parsing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->