### PR TITLE
ci: add canary artifact build mode

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: number
         default: 30
+      checkout_ref:
+        description: "Git ref or SHA to check out for the build. Defaults to the workflow ref."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-macos:
@@ -42,6 +47,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Setup Bun
         id: setup-bun
@@ -187,6 +194,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Setup Bun
         id: setup-bun

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -11,9 +11,14 @@ on:
         required: false
         type: boolean
         default: false
+      publish_release:
+        description: "Publish the desktop-canary GitHub release after building"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check-changes:
@@ -79,8 +84,8 @@ jobs:
       artifact_retention_days: 7
     secrets: inherit
 
-  release:
-    name: Update Canary Release
+  collect-artifacts:
+    name: Collect Canary Artifacts
     needs: [check-changes, build]
     if: needs.check-changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
@@ -126,6 +131,49 @@ jobs:
         run: |
           echo "Release artifacts:"
           ls -la release-artifacts/
+
+      - name: Upload collected artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: canary-release-artifacts-${{ needs.check-changes.outputs.short_sha }}
+          path: release-artifacts/*
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Write artifact summary
+        run: |
+          {
+            echo "## Desktop Canary Build"
+            echo ""
+            echo "- Commit: ${{ github.sha }}"
+            echo "- Short SHA: ${{ needs.check-changes.outputs.short_sha }}"
+            echo "- Built: ${{ needs.check-changes.outputs.build_time }}"
+            echo "- Artifact bundle: canary-release-artifacts-${{ needs.check-changes.outputs.short_sha }}"
+            echo ""
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_release }}" = "false" ]; then
+              echo "Artifact-only mode: no GitHub release was created, deleted, edited, or published."
+            else
+              echo "Release publish mode: the next job will update the desktop-canary GitHub release."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release:
+    name: Update Canary Release
+    needs: [check-changes, collect-artifacts]
+    if: needs.check-changes.outputs.should_build == 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_release)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download collected artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: canary-release-artifacts-${{ needs.check-changes.outputs.short_sha }}
+          path: release-artifacts
 
       - name: Delete existing canary release
         env:

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: boolean
         default: true
+      build_ref:
+        description: "Git ref or SHA to build. Defaults to the workflow ref."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -26,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
+      full_sha: ${{ steps.check.outputs.full_sha }}
       short_sha: ${{ steps.check.outputs.short_sha }}
       build_time: ${{ steps.check.outputs.build_time }}
       version_timestamp: ${{ steps.check.outputs.version_timestamp }}
@@ -35,12 +41,16 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.build_ref || github.ref }}
 
       - name: Check for changes since last canary
         id: check
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+          FULL_SHA=$(git rev-parse HEAD)
+          echo "full_sha=$FULL_SHA" >> $GITHUB_OUTPUT
 
           # Capture build timestamp (works for both scheduled and manual runs)
           BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -82,6 +92,7 @@ jobs:
       electron_builder_config: electron-builder.canary.ts
       artifact_prefix: desktop-canary
       artifact_retention_days: 7
+      checkout_ref: ${{ needs.check-changes.outputs.full_sha }}
     secrets: inherit
 
   collect-artifacts:
@@ -145,7 +156,7 @@ jobs:
           {
             echo "## Desktop Canary Build"
             echo ""
-            echo "- Commit: ${{ github.sha }}"
+            echo "- Commit: ${{ needs.check-changes.outputs.full_sha }}"
             echo "- Short SHA: ${{ needs.check-changes.outputs.short_sha }}"
             echo "- Built: ${{ needs.check-changes.outputs.build_time }}"
             echo "- Artifact bundle: canary-release-artifacts-${{ needs.check-changes.outputs.short_sha }}"
@@ -194,7 +205,7 @@ jobs:
 
             This is an automated canary build from `main` branch.
 
-            - Commit: ${{ github.sha }}
+            - Commit: ${{ needs.check-changes.outputs.full_sha }}
             - Short SHA: ${{ needs.check-changes.outputs.short_sha }}
             - Built: ${{ needs.check-changes.outputs.build_time }}
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"clean:workspaces": "turbo clean",
 		"release:desktop": "./apps/desktop/create-release.sh",
 		"release:canary": "./scripts/release-canary.sh",
+		"build:canary-artifacts": "./scripts/build-canary-artifacts.sh",
 		"db:push": "bun run --cwd packages/db push",
 		"db:migrate": "bun run --cwd packages/db migrate",
 		"db:generate:desktop": "bun run --cwd packages/local-db generate"

--- a/scripts/build-canary-artifacts.sh
+++ b/scripts/build-canary-artifacts.sh
@@ -5,22 +5,24 @@ COMMIT="${1:-}"
 WORKFLOW="release-desktop-canary.yml"
 BUILD_REF_ARGS=()
 WORKFLOW_BRANCH="$(git symbolic-ref --quiet --short HEAD || true)"
-WORKFLOW_REF="${WORKFLOW_BRANCH:-$(git rev-parse HEAD)}"
 WORKFLOW_SHA="$(git rev-parse HEAD)"
+WORKFLOW_REF="$WORKFLOW_BRANCH"
+
+if [ -z "$WORKFLOW_REF" ]; then
+  WORKFLOW_REF="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name')"
+  BUILD_REF_ARGS=(-f build_ref="$WORKFLOW_SHA")
+fi
+
 DISPATCHED_AFTER="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 RUN_LIST_ARGS=(
   --workflow="$WORKFLOW"
   --event workflow_dispatch
-  --commit "$WORKFLOW_SHA"
+  --branch "$WORKFLOW_REF"
   --created ">=$DISPATCHED_AFTER"
   --limit=1
   --json url
   -q '.[0].url'
 )
-
-if [ -n "$WORKFLOW_BRANCH" ]; then
-  RUN_LIST_ARGS+=(--branch "$WORKFLOW_BRANCH")
-fi
 
 if [ -n "$COMMIT" ]; then
   FULL_SHA=$(git rev-parse "$COMMIT")

--- a/scripts/build-canary-artifacts.sh
+++ b/scripts/build-canary-artifacts.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMIT="${1:-}"
+WORKFLOW="release-desktop-canary.yml"
+TEMP_BRANCH=""
+REF_ARGS=()
+
+if [ -n "$COMMIT" ]; then
+  FULL_SHA=$(git rev-parse "$COMMIT")
+  TEMP_BRANCH="canary-artifact-build-${FULL_SHA:0:9}"
+  git push origin "$FULL_SHA:refs/heads/$TEMP_BRANCH"
+  REF_ARGS=(--ref "$TEMP_BRANCH")
+fi
+
+gh workflow run "$WORKFLOW" -f force_build=true -f publish_release=false "${REF_ARGS[@]}"
+sleep 2
+gh run list --workflow="$WORKFLOW" --limit=1 --json url -q '.[0].url'

--- a/scripts/build-canary-artifacts.sh
+++ b/scripts/build-canary-artifacts.sh
@@ -3,16 +3,44 @@ set -euo pipefail
 
 COMMIT="${1:-}"
 WORKFLOW="release-desktop-canary.yml"
-TEMP_BRANCH=""
-REF_ARGS=()
+BUILD_REF_ARGS=()
+WORKFLOW_BRANCH="$(git symbolic-ref --quiet --short HEAD || true)"
+WORKFLOW_REF="${WORKFLOW_BRANCH:-$(git rev-parse HEAD)}"
+WORKFLOW_SHA="$(git rev-parse HEAD)"
+DISPATCHED_AFTER="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+RUN_LIST_ARGS=(
+  --workflow="$WORKFLOW"
+  --event workflow_dispatch
+  --commit "$WORKFLOW_SHA"
+  --created ">=$DISPATCHED_AFTER"
+  --limit=1
+  --json url
+  -q '.[0].url'
+)
+
+if [ -n "$WORKFLOW_BRANCH" ]; then
+  RUN_LIST_ARGS+=(--branch "$WORKFLOW_BRANCH")
+fi
 
 if [ -n "$COMMIT" ]; then
   FULL_SHA=$(git rev-parse "$COMMIT")
-  TEMP_BRANCH="canary-artifact-build-${FULL_SHA:0:9}"
-  git push origin "$FULL_SHA:refs/heads/$TEMP_BRANCH"
-  REF_ARGS=(--ref "$TEMP_BRANCH")
+  BUILD_REF_ARGS=(-f build_ref="$FULL_SHA")
 fi
 
-gh workflow run "$WORKFLOW" -f force_build=true -f publish_release=false "${REF_ARGS[@]}"
-sleep 2
-gh run list --workflow="$WORKFLOW" --limit=1 --json url -q '.[0].url'
+gh workflow run "$WORKFLOW" \
+  --ref "$WORKFLOW_REF" \
+  -f force_build=true \
+  -f publish_release=false \
+  "${BUILD_REF_ARGS[@]}"
+
+for _ in {1..15}; do
+  RUN_URL="$(gh run list "${RUN_LIST_ARGS[@]}")"
+  if [ -n "$RUN_URL" ] && [ "$RUN_URL" != "null" ]; then
+    printf '%s\n' "$RUN_URL"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Timed out waiting for workflow_dispatch run to appear for $WORKFLOW_REF" >&2
+exit 1

--- a/scripts/build-canary-artifacts.sh
+++ b/scripts/build-canary-artifacts.sh
@@ -13,10 +13,12 @@ if [ -z "$WORKFLOW_REF" ]; then
   BUILD_REF_ARGS=(-f build_ref="$WORKFLOW_SHA")
 fi
 
+DISPATCH_USER="$(gh api user --jq '.login')"
 DISPATCHED_AFTER="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 RUN_LIST_ARGS=(
   --workflow="$WORKFLOW"
   --event workflow_dispatch
+  --user "$DISPATCH_USER"
   --branch "$WORKFLOW_REF"
   --created ">=$DISPATCHED_AFTER"
   --limit=1


### PR DESCRIPTION
## Summary
- add an artifact-only mode to the existing desktop canary workflow via `publish_release=false`
- collect the same canary release artifacts into a downloadable Actions artifact bundle
- add `bun run build:canary-artifacts` as the non-publishing script entry point

## Validation
- `bun run lint`
- `bash -n scripts/build-canary-artifacts.sh`
- Artifact-only canary workflow run: https://github.com/superset-sh/superset/actions/runs/26114447074
  - all platform builds passed
  - `Collect Canary Artifacts` passed
  - `Update Canary Release` was skipped
  - `desktop-canary` release remained unchanged


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4724">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an artifact-only mode to the desktop canary workflow so you can build and download canary artifacts without publishing a GitHub release. Also supports ref-targeted builds, bundles artifacts into one download, and hardens the dispatcher to avoid run collisions.

- **New Features**
  - Added `publish_release=false` to run canary builds in artifact-only mode.
  - Introduced a `collect-artifacts` job to bundle all platform outputs into a single Actions artifact; the release job now consumes this bundle.
  - Tightened permissions: default `contents: read`; grant `contents: write` only in the release job.
  - Deterministic ref builds via `build_ref`; plumbed `checkout_ref` into `build-desktop` to check out the exact SHA.
  - Added `bun run build:canary-artifacts` (`scripts/build-canary-artifacts.sh`) to trigger an artifact-only build for a specific commit; the script now picks the correct branch/commit, filters run lookup by actor, prints the workflow run URL, and writes a build summary.

<sup>Written for commit d104804f44cd1471860ff6b89732e2d6b17b6f58. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4724?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual inputs to control canary runs (publish vs artifact-only) and to override the build ref/SHA.
  * CLI script and npm helper to trigger and monitor canary artifact builds.

* **Chores**
  * Split release flow to collect/upload downloadable artifact bundles and conditionally publish.
  * Reusable build workflow accepts an optional ref override.
  * Reduced default workflow permissions; write access confined to the release job.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->