### PR TITLE
revert: drop host-offline workspace gate from #4672

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -14,11 +14,6 @@ export type RemoteHostStatus =
 	| { status: "skip" }
 	| { status: "loading" }
 	| {
-			status: "offline";
-			hostId: string;
-			hostName: string;
-	  }
-	| {
 			status: "incompatible";
 			hostName: string;
 			hostVersion: string;
@@ -52,7 +47,6 @@ export function useRemoteHostStatus(
 				)
 				.select(({ hosts }) => ({
 					name: hosts.name,
-					isOnline: hosts.isOnline,
 				})),
 		[collections, organizationId, filterMachineId],
 	);
@@ -66,8 +60,7 @@ export function useRemoteHostStatus(
 	const infoQuery = useQuery({
 		queryKey: ["remoteHostInfo", organizationId, hostId],
 		queryFn: () => getHostServiceClientByUrl(hostUrl).host.info.query(),
-		enabled:
-			workspace != null && !isLocal && isReady && hostRow?.isOnline !== false,
+		enabled: workspace != null && !isLocal,
 		staleTime: HOST_INFO_STALE_MS,
 		retry: false,
 	});
@@ -75,13 +68,6 @@ export function useRemoteHostStatus(
 	if (!workspace) return { status: "loading" };
 	if (isLocal) return { status: "skip" };
 	if (!isReady) return { status: "loading" };
-	if (hostRow?.isOnline === false) {
-		return {
-			status: "offline",
-			hostId,
-			hostName: hostRow.name,
-		};
-	}
 
 	if (infoQuery.isSuccess) {
 		const hostVersion = infoQuery.data.version;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -8,7 +8,6 @@ import { useWorkspaceCreatesStore } from "renderer/stores/workspace-creates";
 import { WorkspaceCreateErrorState } from "./components/WorkspaceCreateErrorState";
 import { WorkspaceCreatingState } from "./components/WorkspaceCreatingState";
 import { WorkspaceHostIncompatibleState } from "./components/WorkspaceHostIncompatibleState";
-import { WorkspaceHostOfflineState } from "./components/WorkspaceHostOfflineState";
 import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { useRemoteHostStatus } from "./hooks/useRemoteHostStatus";
 import { WorkspaceProvider } from "./providers/WorkspaceProvider";
@@ -90,14 +89,6 @@ function V2WorkspaceLayout() {
 				hostName={hostStatus.hostName}
 				hostVersion={hostStatus.hostVersion}
 				minVersion={hostStatus.minVersion}
-			/>
-		);
-	}
-	if (hostStatus.status === "offline") {
-		return (
-			<WorkspaceHostOfflineState
-				hostId={hostStatus.hostId}
-				hostName={hostStatus.hostName}
 			/>
 		);
 	}


### PR DESCRIPTION
## Summary
- Reverts the layout wiring and `useRemoteHostStatus` offline branch added in #4672, so v2 workspaces no longer render a full-screen gate when the paired host is marked offline.
- Keeps `WorkspaceHostOfflineState` on disk (unused) so we can reuse it once we have a less aggressive treatment.

## Why
- The hard block was too aggressive — workspaces should render optimistically and let individual operations degrade rather than blocking the whole page on `hosts.isOnline`.

## Test plan
- [ ] Open a v2 workspace whose paired host is offline → workspace UI renders normally (no full-screen offline state)
- [ ] Open a v2 workspace on a reachable host → unchanged
- [ ] `bun run typecheck` clean

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4727">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the offline host gate for v2 workspaces so the UI renders normally even when the paired host is offline. Drops the `offline` branch and `hosts.isOnline` check in `useRemoteHostStatus`; keeps `WorkspaceHostOfflineState` in the codebase for future use.

<sup>Written for commit a25834f726c30ca03deef60d57dddcc2ef8606ea. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4727?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the remote host offline status state and its associated UI component. Remote hosts now transition through alternative status flows instead of displaying a dedicated offline indicator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->