### PR TITLE
chore(marketing): update trusted-by logo

### DIFF
--- a/apps/marketing/src/app/components/TrustedBySection/TrustedBySection.tsx
+++ b/apps/marketing/src/app/components/TrustedBySection/TrustedBySection.tsx
@@ -16,9 +16,9 @@ const CLIENT_LOGOS = [
 		height: 20,
 	},
 	{
-		name: "netflix",
-		label: "Netflix",
-		logo: "/logos/netflix-wordmark.svg",
+		name: "runway",
+		label: "Runway",
+		logo: "/logos/runway-wordmark.svg",
 		height: 20,
 	},
 	{

--- a/apps/marketing/src/app/components/TrustedBySection/TrustedBySection.tsx
+++ b/apps/marketing/src/app/components/TrustedBySection/TrustedBySection.tsx
@@ -19,7 +19,7 @@ const CLIENT_LOGOS = [
 		name: "runway",
 		label: "Runway",
 		logo: "/logos/runway-wordmark.svg",
-		height: 20,
+		height: 18,
 	},
 	{
 		name: "wordware",


### PR DESCRIPTION
## Summary
- Refresh a logo in the marketing site's "Trusted by builders from" wall.

## Test plan
- [ ] Marketing site renders the updated logo wall without layout shift

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4728">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the "Trusted by builders from" logo wall by replacing the Netflix wordmark with Runway and slightly reducing its height to keep the layout stable.

<sup>Written for commit 57012822f506a4653cf8452c6d141d4770d7be17. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4728?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The trusted clients section now includes the Runway logo, visible across mobile responsive layouts and the desktop two-row display—ensuring consistent branding and improved partner visibility in the marketing site.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->