### PR TITLE
[codex] Add workspace navigation to command palette

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/core/frames.ts
+++ b/apps/desktop/src/renderer/commandPalette/core/frames.ts
@@ -1,3 +1,4 @@
+import { track } from "renderer/lib/analytics";
 import { create } from "zustand";
 import type { Command } from "./types";
 
@@ -17,7 +18,14 @@ interface FrameStackState {
 export const useFrameStackStore = create<FrameStackState>((set) => ({
 	open: false,
 	frames: [],
-	setOpen: (open) => set(open ? { open: true } : { open: false, frames: [] }),
+	setOpen: (open) =>
+		set((state) => {
+			if (open) {
+				if (!state.open) track("command_palette_opened");
+				return { open: true };
+			}
+			return { open: false, frames: [] };
+		}),
 	pushFrame: (command) =>
 		set((state) => ({ frames: [...state.frames, { command }] })),
 	popFrame: () => set((state) => ({ frames: state.frames.slice(0, -1) })),

--- a/apps/desktop/src/renderer/commandPalette/core/types.ts
+++ b/apps/desktop/src/renderer/commandPalette/core/types.ts
@@ -1,5 +1,5 @@
 import type { ExternalApp } from "@superset/local-db";
-import type { LucideIcon } from "lucide-react";
+import type { ElementType } from "react";
 import type { HotkeyId } from "renderer/hotkeys/registry";
 import type { HostServiceAvailabilityStatus } from "renderer/lib/host-service-unavailable";
 
@@ -32,7 +32,7 @@ export interface Command {
 	id: string;
 	title: string;
 	section: SectionId;
-	icon?: LucideIcon;
+	icon?: ElementType<{ className?: string }>;
 	iconUrl?: string;
 	keywords?: string[];
 	hotkeyId?: HotkeyId;

--- a/apps/desktop/src/renderer/commandPalette/modules/navigation/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/navigation/commands.tsx
@@ -1,6 +1,8 @@
 import { BookOpenIcon, HistoryIcon, SettingsIcon } from "lucide-react";
+import { LuLayers } from "react-icons/lu";
 import type { Command, CommandProvider } from "../../core/types";
 import { RecentlyViewedFrame } from "../../ui/RecentlyViewed/RecentlyViewedFrame";
+import { WorkspaceListFrame } from "../../ui/WorkspaceList";
 import { settingsTabCommands } from "../settings/commands";
 
 export const navigationProvider: CommandProvider = {
@@ -23,6 +25,14 @@ export const navigationProvider: CommandProvider = {
 				icon: HistoryIcon,
 				keywords: ["history", "recent", "back"],
 				renderFrame: () => <RecentlyViewedFrame />,
+			},
+			{
+				id: "nav.workspaces",
+				title: "Workspaces",
+				section: "navigation",
+				icon: LuLayers,
+				keywords: ["workspace", "project", "repo", "repository", "switch"],
+				renderFrame: () => <WorkspaceListFrame />,
 			},
 			{
 				id: "nav.docs",

--- a/apps/desktop/src/renderer/commandPalette/ui/WorkspaceList/WorkspaceListFrame.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/WorkspaceList/WorkspaceListFrame.tsx
@@ -1,0 +1,209 @@
+import {
+	CommandEmpty,
+	CommandGroup,
+	CommandItem,
+	CommandList,
+} from "@superset/ui/command";
+import { cn } from "@superset/ui/utils";
+import { useLocation, useNavigate } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { CgLaptop } from "react-icons/cg";
+import { LuGitBranch, LuLaptop, LuMonitor } from "react-icons/lu";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	navigateToV2Workspace,
+	navigateToWorkspace,
+} from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useAccessibleV2Workspaces } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { useFrameStackStore } from "../../core/frames";
+import { useCommandPaletteQuery } from "../CommandPalette/CommandPalette";
+
+interface V1WorkspaceItem {
+	id: string;
+	name: string;
+	branch: string;
+	projectName: string;
+	projectColor: string;
+}
+
+interface V1ProjectGroup {
+	projectId: string;
+	projectName: string;
+	workspaces: V1WorkspaceItem[];
+}
+
+const ROW_CLASS =
+	"gap-2.5 !py-2.5 text-sm [&_svg]:!size-4 [&_svg]:stroke-[1.5]";
+
+function matchesQuery(
+	workspace: Pick<V1WorkspaceItem, "name" | "branch" | "projectName">,
+	query: string,
+): boolean {
+	if (!query) return true;
+	const normalized = query.toLowerCase();
+	return (
+		workspace.name.toLowerCase().includes(normalized) ||
+		workspace.branch.toLowerCase().includes(normalized) ||
+		workspace.projectName.toLowerCase().includes(normalized)
+	);
+}
+
+export function WorkspaceListFrame() {
+	const rawQuery = useCommandPaletteQuery();
+	const query = rawQuery.trim();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
+
+	return isV2CloudEnabled ? (
+		<V2WorkspaceList query={query} />
+	) : (
+		<V1WorkspaceList query={query} />
+	);
+}
+
+function V1WorkspaceList({ query }: { query: string }) {
+	const { data: groups = [] } =
+		electronTrpc.workspaces.getAllGrouped.useQuery();
+	const currentPath = useLocation({ select: (loc) => loc.pathname });
+	const navigate = useNavigate();
+	const setOpen = useFrameStackStore((s) => s.setOpen);
+
+	const projectGroups = useMemo<V1ProjectGroup[]>(() => {
+		return groups.flatMap((group) => {
+			const workspaces = group.workspaces
+				.map((workspace) => ({
+					id: workspace.id,
+					name: workspace.name,
+					branch: workspace.branch ?? workspace.name,
+					projectName: group.project.name,
+					projectColor: group.project.color,
+				}))
+				.filter((workspace) => matchesQuery(workspace, query));
+
+			if (workspaces.length === 0) return [];
+			return [
+				{
+					projectId: group.project.id,
+					projectName: group.project.name,
+					workspaces,
+				},
+			];
+		});
+	}, [groups, query]);
+
+	const handleSelect = (workspaceId: string) => {
+		void navigateToWorkspace(workspaceId, navigate);
+		setOpen(false);
+	};
+
+	return (
+		<CommandList>
+			<CommandEmpty>No workspaces found.</CommandEmpty>
+			{projectGroups.map((group) => (
+				<CommandGroup key={group.projectId} heading={group.projectName}>
+					{group.workspaces.map((workspace) => (
+						<CommandItem
+							key={workspace.id}
+							value={`workspace ${workspace.id} ${workspace.projectName} ${workspace.name} ${workspace.branch}`}
+							onSelect={() => handleSelect(workspace.id)}
+							className={cn(
+								ROW_CLASS,
+								currentPath === `/workspace/${workspace.id}` && "bg-accent/50",
+							)}
+						>
+							<span className="flex w-4 shrink-0 items-center justify-center">
+								<span
+									className="size-2 rounded-full"
+									style={{ background: workspace.projectColor }}
+								/>
+							</span>
+							<span className="min-w-0 flex-1 truncate font-normal">
+								{workspace.name}
+							</span>
+							<span className="flex min-w-0 max-w-48 items-center gap-1 text-muted-foreground text-xs">
+								<LuGitBranch className="!size-3 shrink-0" />
+								<span className="truncate">{workspace.branch}</span>
+							</span>
+						</CommandItem>
+					))}
+				</CommandGroup>
+			))}
+		</CommandList>
+	);
+}
+
+function V2WorkspaceList({ query }: { query: string }) {
+	const { all: workspaces } = useAccessibleV2Workspaces({
+		searchQuery: query,
+	});
+	const currentPath = useLocation({ select: (loc) => loc.pathname });
+	const navigate = useNavigate();
+	const setOpen = useFrameStackStore((s) => s.setOpen);
+
+	const projectGroups = useMemo(() => {
+		const grouped = new Map<
+			string,
+			{ projectName: string; workspaces: typeof workspaces }
+		>();
+
+		for (const workspace of workspaces) {
+			const group = grouped.get(workspace.projectId);
+			if (group) {
+				group.workspaces.push(workspace);
+			} else {
+				grouped.set(workspace.projectId, {
+					projectName: workspace.projectName,
+					workspaces: [workspace],
+				});
+			}
+		}
+
+		return Array.from(grouped.entries()).map(([projectId, group]) => ({
+			projectId,
+			...group,
+		}));
+	}, [workspaces]);
+
+	const handleSelect = (workspaceId: string) => {
+		void navigateToV2Workspace(workspaceId, navigate);
+		setOpen(false);
+	};
+
+	return (
+		<CommandList>
+			<CommandEmpty>No workspaces found.</CommandEmpty>
+			{projectGroups.map((group) => (
+				<CommandGroup key={group.projectId} heading={group.projectName}>
+					{group.workspaces.map((workspace) => {
+						const HostIcon =
+							workspace.hostType === "local-device" ? LuLaptop : LuMonitor;
+						const displayName = workspace.name || workspace.branch;
+						return (
+							<CommandItem
+								key={workspace.id}
+								value={`workspace v2 ${workspace.id} ${workspace.projectName} ${displayName} ${workspace.branch} ${workspace.hostName}`}
+								onSelect={() => handleSelect(workspace.id)}
+								className={cn(
+									ROW_CLASS,
+									currentPath === `/v2-workspace/${workspace.id}` &&
+										"bg-accent/50",
+								)}
+							>
+								<span className="flex min-w-0 flex-1 items-center gap-1.5">
+									<span className="min-w-0 truncate font-normal">
+										{displayName}
+									</span>
+									<CgLaptop className="!size-3.5 shrink-0 text-muted-foreground" />
+								</span>
+								<span className="flex min-w-0 max-w-44 items-center gap-1 text-muted-foreground text-xs">
+									<HostIcon className="!size-3 shrink-0" />
+									<span className="truncate">{workspace.hostName}</span>
+								</span>
+							</CommandItem>
+						);
+					})}
+				</CommandGroup>
+			))}
+		</CommandList>
+	);
+}

--- a/apps/desktop/src/renderer/commandPalette/ui/WorkspaceList/index.ts
+++ b/apps/desktop/src/renderer/commandPalette/ui/WorkspaceList/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceListFrame } from "./WorkspaceListFrame";


### PR DESCRIPTION
## Summary

Adds a Workspaces entry to the desktop command palette navigation section. Selecting it opens a searchable workspace list that supports both legacy workspaces and v2/cloud workspaces.

## Details

- Adds a command-palette workspace list frame grouped by project.
- Uses the existing workspace navigation helpers to open selected workspaces.
- Matches existing workspace icon language by using the sidebar Workspaces icon for the navigation command and the v2 workspace list laptop glyph next to workspace titles.
- Widens command icon typing so command palette entries can use the app's existing `react-icons` components, not only Lucide icons.

## Validation

- `bun run lint`
- `bun --filter @superset/desktop typecheck`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4730">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Workspaces item to the desktop command palette with a searchable, project‑grouped list for quick switching across legacy and v2/cloud workspaces. Also logs an analytics event when the palette opens.

- New Features
  - Adds Workspaces under Navigation with `LuLayers`.
  - Search by workspace, branch, or project; v1 shows branch, v2 shows host with laptop/monitor icons.
  - Selection navigates using existing helpers and closes the palette.

- Refactors
  - Command icon type widened from `LucideIcon` to `ElementType` to support `react-icons`.
  - Introduces `WorkspaceListFrame` for rendering the list.

<sup>Written for commit dc8420244b89cd99f65f6ac906773132d0e77aa3. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4730?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Workspaces command to the command palette enabling quick navigation and switching between your workspaces with project grouping and search functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->