### PR TITLE
[codex] Fix git status refresh storm

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDiffStats/useDiffStats.ts
@@ -24,6 +24,7 @@ export function useDiffStats(workspaceId: string): DiffStats | null {
 			if (!hostUrl) return null;
 			return getHostServiceClientByUrl(hostUrl).git.getStatus.query({
 				workspaceId,
+				priority: "background",
 			});
 		},
 		refetchOnWindowFocus: false,
@@ -34,7 +35,12 @@ export function useDiffStats(workspaceId: string): DiffStats | null {
 		void queryClient.invalidateQueries({ queryKey });
 	}, [queryClient, queryKey]);
 
-	useWorkspaceEvent("git:changed", workspaceId, invalidate);
+	useWorkspaceEvent(
+		"git:changed",
+		workspaceId,
+		invalidate,
+		Boolean(workspaceId) && Boolean(hostUrl),
+	);
 
 	return useMemo<DiffStats | null>(() => {
 		if (!status) return null;

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
@@ -1,4 +1,7 @@
-import { workspaceTrpc } from "@superset/workspace-client";
+import {
+	type GitChangedPayload,
+	workspaceTrpc,
+} from "@superset/workspace-client";
 import { useCallback } from "react";
 import { useWorkspaceEvent } from "../useWorkspaceEvent";
 
@@ -10,32 +13,48 @@ import { useWorkspaceEvent } from "../useWorkspaceEvent";
  * else) receive the query result as data and do not re-fetch.
  *
  * `git:changed` is already debounced server-side in `GitWatcher` and covers
- * both `.git/` metadata writes and worktree file edits — no client-side
- * debounce needed.
+ * both `.git/` metadata writes and worktree file edits.
  */
-export function useGitStatus(workspaceId: string) {
+export function useGitStatus(workspaceId: string, enabled = true) {
 	const utils = workspaceTrpc.useUtils();
 
 	const baseBranchQuery = workspaceTrpc.git.getBaseBranch.useQuery(
 		{ workspaceId },
-		{ staleTime: Number.POSITIVE_INFINITY, enabled: Boolean(workspaceId) },
+		{
+			staleTime: Number.POSITIVE_INFINITY,
+			enabled: enabled && Boolean(workspaceId),
+		},
 	);
 	const baseBranch = baseBranchQuery.data?.baseBranch ?? null;
 
 	const query = workspaceTrpc.git.getStatus.useQuery(
-		{ workspaceId, baseBranch: baseBranch ?? undefined },
-		{ refetchOnWindowFocus: true, enabled: Boolean(workspaceId) },
+		{
+			workspaceId,
+			baseBranch: baseBranch ?? undefined,
+			priority: "foreground",
+		},
+		{ refetchOnWindowFocus: true, enabled: enabled && Boolean(workspaceId) },
 	);
 
-	const invalidate = useCallback(() => {
-		void utils.git.getStatus.invalidate({ workspaceId });
-		// Current branch may have changed (external checkout), and
-		// branch.<name>.base is per-branch — drop the cache so the next read
-		// picks up the new branch's base.
-		void utils.git.getBaseBranch.invalidate({ workspaceId });
-	}, [utils, workspaceId]);
+	const invalidate = useCallback(
+		(payload?: GitChangedPayload) => {
+			void utils.git.getStatus.invalidate({ workspaceId });
+			if (payload?.paths && payload.paths.length > 0) {
+				for (const path of payload.paths) {
+					void utils.git.getDiff.invalidate({ workspaceId, path });
+				}
+			} else {
+				void utils.git.getDiff.invalidate({ workspaceId });
+				// Current branch may have changed (external checkout), and
+				// branch.<name>.base is per-branch — drop the cache so the next read
+				// picks up the new branch's base.
+				void utils.git.getBaseBranch.invalidate({ workspaceId });
+			}
+		},
+		[utils, workspaceId],
+	);
 
-	useWorkspaceEvent("git:changed", workspaceId, invalidate);
+	useWorkspaceEvent("git:changed", workspaceId, invalidate, enabled);
 
 	return query;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -5,7 +5,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { Search } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { LuFile, LuGitCompareArrows } from "react-icons/lu";
-import { useGitStatus } from "renderer/hooks/host-service/useGitStatus";
+import { useWorkspaceGitStatus } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useSettings } from "renderer/stores/settings";
 import type { CommentPaneData } from "../../types";
@@ -87,6 +87,7 @@ export function WorkspaceSidebar({
 	pendingReveal,
 	workspaceId,
 }: WorkspaceSidebarProps) {
+	const gitStatus = useWorkspaceGitStatus();
 	const collections = useCollections();
 	const { data: [localState] = [] } = useLiveQuery(
 		(query) =>
@@ -124,11 +125,8 @@ export function WorkspaceSidebar({
 		return () => ro.disconnect();
 	}, []);
 
-	const gitStatus = useGitStatus(workspaceId);
-
 	const changesTabDef = useChangesTab({
 		workspaceId,
-		gitStatus,
 		selectedFilePath,
 		onSelectFile: onSelectDiffFile,
 		onOpenFile: onSelectFile,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -5,10 +5,10 @@ import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { RefreshCw } from "lucide-react";
 import { useCallback, useState } from "react";
-import type { useGitStatus } from "renderer/hooks/host-service/useGitStatus";
 import { useChangeset } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
 import { useSidebarDiffRef } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useSidebarDiffRef";
+import { useWorkspaceGitStatus } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type {
 	ChangesFilter,
@@ -22,7 +22,6 @@ export type { ChangesFilter, ChangesViewMode };
 
 interface UseChangesTabParams {
 	workspaceId: string;
-	gitStatus: ReturnType<typeof useGitStatus>;
 	/** Absolute path of the file whose diff/preview is currently open. */
 	selectedFilePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
@@ -31,11 +30,11 @@ interface UseChangesTabParams {
 
 export function useChangesTab({
 	workspaceId,
-	gitStatus: status,
 	selectedFilePath,
 	onSelectFile,
 	onOpenFile,
 }: UseChangesTabParams): SidebarTabDefinition {
+	const status = useWorkspaceGitStatus();
 	const collections = useCollections();
 	const utils = workspaceTrpc.useUtils();
 	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
@@ -52,7 +51,10 @@ export function useChangesTab({
 	const baseBranch = baseBranchQuery.data?.baseBranch ?? null;
 
 	const ref = useSidebarDiffRef(workspaceId);
-	const { files, isLoading } = useChangeset({ workspaceId, ref });
+	const { files, isLoading } = useChangeset({
+		workspaceId,
+		ref,
+	});
 
 	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
 		id: workspaceId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
@@ -1,7 +1,7 @@
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useMemo } from "react";
-import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
 import type { FileStatus } from "../../components/StatusIndicator";
+import { useWorkspaceGitStatus } from "../../providers/WorkspaceGitStatusProvider";
 import type { ChangesetFile, DiffRef } from "./types";
 
 interface UseChangesetArgs {
@@ -20,18 +20,7 @@ export function useChangeset({
 	workspaceId,
 	ref,
 }: UseChangesetArgs): UseChangesetResult {
-	const utils = workspaceTrpc.useUtils();
-
-	const needsStatus = ref.kind === "against-base" || ref.kind === "uncommitted";
-	const statusQuery = workspaceTrpc.git.getStatus.useQuery(
-		{
-			workspaceId,
-			baseBranch:
-				ref.kind === "against-base" ? (ref.baseBranch ?? undefined) : undefined,
-		},
-		{ enabled: needsStatus, staleTime: Number.POSITIVE_INFINITY },
-	);
-
+	const gitStatus = useWorkspaceGitStatus();
 	const commitQuery = workspaceTrpc.git.getCommitFiles.useQuery(
 		ref.kind === "commit"
 			? {
@@ -44,22 +33,6 @@ export function useChangeset({
 			enabled: ref.kind === "commit",
 			staleTime: Number.POSITIVE_INFINITY,
 		},
-	);
-
-	useWorkspaceEvent(
-		"git:changed",
-		workspaceId,
-		(payload) => {
-			void utils.git.getStatus.invalidate({ workspaceId });
-			if (payload.paths && payload.paths.length > 0) {
-				for (const path of payload.paths) {
-					void utils.git.getDiff.invalidate({ workspaceId, path });
-				}
-			} else {
-				void utils.git.getDiff.invalidate({ workspaceId });
-			}
-		},
-		needsStatus,
 	);
 
 	const files = useMemo<ChangesetFile[]>(() => {
@@ -78,7 +51,7 @@ export function useChangeset({
 			}));
 		}
 
-		const status = statusQuery.data;
+		const status = gitStatus.data;
 		if (!status) return [];
 
 		if (ref.kind === "uncommitted") {
@@ -139,9 +112,9 @@ export function useChangeset({
 			});
 		}
 		return Array.from(seen.values());
-	}, [ref, statusQuery.data, commitQuery.data?.files]);
+	}, [ref, gitStatus.data, commitQuery.data?.files]);
 
-	const activeQuery = needsStatus ? statusQuery : commitQuery;
+	const activeQuery = ref.kind === "commit" ? commitQuery : gitStatus;
 
 	return {
 		files,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -34,6 +34,7 @@ import { useV2WorkspaceRun } from "./hooks/useV2WorkspaceRun";
 import { useWorkspaceFileNavigation } from "./hooks/useWorkspaceFileNavigation";
 import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
 import { useWorkspacePaneOpeners } from "./hooks/useWorkspacePaneOpeners";
+import { WorkspaceGitStatusProvider } from "./providers/WorkspaceGitStatusProvider";
 import { FileDocumentStoreProvider } from "./state/fileDocumentStore";
 import type { PaneViewerData } from "./types";
 import type { V2WorkspaceUrlOpenTarget } from "./utils/openUrlInV2Workspace";
@@ -120,6 +121,7 @@ function V2WorkspaceContent() {
 		setShowPresetsBar,
 	} = useV2UserPreferences();
 	const showPresetsBar = v2UserPreferences.showPresetsBar;
+	const sidebarOpen = v2UserPreferences.rightSidebarOpen;
 	const { store } = useV2WorkspacePaneLayout();
 	useClearActivePaneAttention({ store });
 	const launcher = useV2TerminalLauncher();
@@ -207,7 +209,6 @@ function V2WorkspaceContent() {
 	const defaultPaneActions = useDefaultPaneActions({ launcher });
 	const onBeforeCloseTab = useDirtyTabCloseGuard();
 
-	const sidebarOpen = v2UserPreferences.rightSidebarOpen;
 	// Fallback for rows persisted before the rightSidebarWidth field existed —
 	// the live collection skips zod defaults, so an older row reads undefined
 	// here and would render the ResizablePanel without a width (full-bleed).
@@ -264,90 +265,96 @@ function V2WorkspaceContent() {
 
 	return (
 		<FileDocumentStoreProvider>
-			<div className="flex min-h-0 min-w-0 flex-1">
-				<div
-					className="flex min-h-0 min-w-[320px] flex-1 flex-col overflow-hidden"
-					data-workspace-id={workspaceId}
-				>
-					<Workspace<PaneViewerData>
-						registry={paneRegistry}
-						paneActions={defaultPaneActions}
-						contextMenuActions={defaultContextMenuActions}
-						renderTabIcon={renderBrowserTabIcon}
-						renderTabAccessory={(tab) => (
-							<V2NotificationStatusIndicator
-								sources={getV2NotificationSourcesForTab(tab)}
-							/>
-						)}
-						renderBelowTabBar={() =>
-							showPresetsBar ? (
-								<V2PresetsBar
-									matchedPresets={matchedPresets}
-									executePreset={executePreset}
+			<WorkspaceGitStatusProvider
+				workspaceId={workspaceId}
+				store={store}
+				sidebarOpen={sidebarOpen}
+			>
+				<div className="flex min-h-0 min-w-0 flex-1">
+					<div
+						className="flex min-h-0 min-w-[320px] flex-1 flex-col overflow-hidden"
+						data-workspace-id={workspaceId}
+					>
+						<Workspace<PaneViewerData>
+							registry={paneRegistry}
+							paneActions={defaultPaneActions}
+							contextMenuActions={defaultContextMenuActions}
+							renderTabIcon={renderBrowserTabIcon}
+							renderTabAccessory={(tab) => (
+								<V2NotificationStatusIndicator
+									sources={getV2NotificationSourcesForTab(tab)}
+								/>
+							)}
+							renderBelowTabBar={() =>
+								showPresetsBar ? (
+									<V2PresetsBar
+										matchedPresets={matchedPresets}
+										executePreset={executePreset}
+										showPresetsBar={showPresetsBar}
+										onToggleShowPresetsBar={setShowPresetsBar}
+										trailing={workspaceRunButton}
+									/>
+								) : (
+									<div className="flex h-8 min-w-0 shrink-0 items-center border-b border-border bg-background px-2">
+										{workspaceRunButton}
+									</div>
+								)
+							}
+							renderAddTabMenu={() => (
+								<AddTabMenu
+									onAddTerminal={addTerminalTab}
+									onAddChat={addChatTab}
+									onAddBrowser={addBrowserTab}
 									showPresetsBar={showPresetsBar}
 									onToggleShowPresetsBar={setShowPresetsBar}
-									trailing={workspaceRunButton}
 								/>
-							) : (
-								<div className="flex h-8 min-w-0 shrink-0 items-center border-b border-border bg-background px-2">
-									{workspaceRunButton}
-								</div>
-							)
-						}
-						renderAddTabMenu={() => (
-							<AddTabMenu
-								onAddTerminal={addTerminalTab}
-								onAddChat={addChatTab}
-								onAddBrowser={addBrowserTab}
-								showPresetsBar={showPresetsBar}
-								onToggleShowPresetsBar={setShowPresetsBar}
-							/>
-						)}
-						renderTabBarTrailing={() => (
-							<BackgroundTerminalsButton
-								workspaceId={workspaceId}
-								store={store}
-							/>
-						)}
-						renderEmptyState={() => (
-							<WorkspaceEmptyState
-								onOpenBrowser={addBrowserTab}
-								onOpenChat={addChatTab}
-								onOpenQuickOpen={handleQuickOpen}
-								onOpenTerminal={addTerminalTab}
-							/>
-						)}
-						onBeforeCloseTab={onBeforeCloseTab}
-						onInteractionStateChange={onWorkspaceInteractionStateChange}
-						store={store}
-					/>
-				</div>
-			</div>
-			{sidebarOpen &&
-				sidebarSlotEl &&
-				createPortal(
-					<ResizablePanel
-						width={sidebarWidth}
-						onWidthChange={setRightSidebarWidth}
-						isResizing={isSidebarResizing}
-						onResizingChange={handleSidebarResizingChange}
-						minWidth={240}
-						maxWidth={640}
-						handleSide="left"
-						onDoubleClickHandle={() => setRightSidebarWidth(340)}
-					>
-						<WorkspaceSidebar
-							workspaceId={workspaceId}
-							onSelectFile={openFilePaneFromTreeClick}
-							onSelectDiffFile={openDiffPane}
-							onOpenComment={openCommentPane}
-							onSearch={handleQuickOpen}
-							selectedFilePath={selectedFilePath}
-							pendingReveal={pendingReveal}
+							)}
+							renderTabBarTrailing={() => (
+								<BackgroundTerminalsButton
+									workspaceId={workspaceId}
+									store={store}
+								/>
+							)}
+							renderEmptyState={() => (
+								<WorkspaceEmptyState
+									onOpenBrowser={addBrowserTab}
+									onOpenChat={addChatTab}
+									onOpenQuickOpen={handleQuickOpen}
+									onOpenTerminal={addTerminalTab}
+								/>
+							)}
+							onBeforeCloseTab={onBeforeCloseTab}
+							onInteractionStateChange={onWorkspaceInteractionStateChange}
+							store={store}
 						/>
-					</ResizablePanel>,
-					sidebarSlotEl,
-				)}
+					</div>
+				</div>
+				{sidebarOpen &&
+					sidebarSlotEl &&
+					createPortal(
+						<ResizablePanel
+							width={sidebarWidth}
+							onWidthChange={setRightSidebarWidth}
+							isResizing={isSidebarResizing}
+							onResizingChange={handleSidebarResizingChange}
+							minWidth={240}
+							maxWidth={640}
+							handleSide="left"
+							onDoubleClickHandle={() => setRightSidebarWidth(340)}
+						>
+							<WorkspaceSidebar
+								workspaceId={workspaceId}
+								onSelectFile={openFilePaneFromTreeClick}
+								onSelectDiffFile={openDiffPane}
+								onOpenComment={openCommentPane}
+								onSearch={handleQuickOpen}
+								selectedFilePath={selectedFilePath}
+								pendingReveal={pendingReveal}
+							/>
+						</ResizablePanel>,
+						sidebarSlotEl,
+					)}
+			</WorkspaceGitStatusProvider>
 			<CommandPalette
 				workspaceId={workspaceId}
 				open={quickOpenOpen}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider/WorkspaceGitStatusProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider/WorkspaceGitStatusProvider.tsx
@@ -1,0 +1,64 @@
+import type { WorkspaceStore } from "@superset/panes";
+import { createContext, useContext, useSyncExternalStore } from "react";
+import { useGitStatus } from "renderer/hooks/host-service/useGitStatus";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData } from "../../types";
+
+type WorkspaceGitStatus = ReturnType<typeof useGitStatus>;
+
+const WorkspaceGitStatusContext = createContext<WorkspaceGitStatus | null>(
+	null,
+);
+
+interface WorkspaceGitStatusProviderProps {
+	children: React.ReactNode;
+	sidebarOpen: boolean;
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+	workspaceId: string;
+}
+
+export function WorkspaceGitStatusProvider({
+	children,
+	sidebarOpen,
+	store,
+	workspaceId,
+}: WorkspaceGitStatusProviderProps) {
+	const hasDiffPane = useHasDiffPane(store);
+	const gitStatus = useGitStatus(workspaceId, sidebarOpen || hasDiffPane);
+
+	return (
+		<WorkspaceGitStatusContext.Provider value={gitStatus}>
+			{children}
+		</WorkspaceGitStatusContext.Provider>
+	);
+}
+
+export function useWorkspaceGitStatus(): WorkspaceGitStatus {
+	const value = useContext(WorkspaceGitStatusContext);
+	if (!value) {
+		throw new Error(
+			"useWorkspaceGitStatus must be used inside WorkspaceGitStatusProvider",
+		);
+	}
+	return value;
+}
+
+function hasDiffPane(store: StoreApi<WorkspaceStore<PaneViewerData>>): boolean {
+	const state = store.getState();
+	for (const tab of state.tabs) {
+		for (const pane of Object.values(tab.panes)) {
+			if (pane.kind === "diff") return true;
+		}
+	}
+	return false;
+}
+
+function useHasDiffPane(
+	store: StoreApi<WorkspaceStore<PaneViewerData>>,
+): boolean {
+	return useSyncExternalStore(
+		store.subscribe,
+		() => hasDiffPane(store),
+		() => false,
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider/index.ts
@@ -1,0 +1,4 @@
+export {
+	useWorkspaceGitStatus,
+	WorkspaceGitStatusProvider,
+} from "./WorkspaceGitStatusProvider";

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -52,6 +52,7 @@
 		"test:integration:daemon": "node --experimental-strip-types --test src/terminal/DaemonClient/DaemonClient.node-test.ts src/daemon/DaemonSupervisor.node-test.ts",
 		"test:e2e": "bun run scripts/test-e2e.ts",
 		"bench": "bun test test/integration/pull-requests-scaling.bench.ts",
+		"profile:git-status": "bun run scripts/git-status-large-repo-profile.ts",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {

--- a/packages/host-service/scripts/git-status-large-repo-profile.ts
+++ b/packages/host-service/scripts/git-status-large-repo-profile.ts
@@ -1,0 +1,947 @@
+import { spawn } from "node:child_process";
+import { chmodSync, existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import type { HostDb } from "../src/db";
+import { EventBus } from "../src/events/event-bus";
+import { GitWatcher } from "../src/events/git-watcher";
+import type { ServerMessage } from "../src/events/types";
+import { WorkspaceFilesystemManager } from "../src/runtime/filesystem";
+import { createUserSimpleGit } from "../src/runtime/git/simple-git";
+import { gitRouter } from "../src/trpc/router/git/git";
+import { getGitStatusSnapshot } from "../src/trpc/router/git/utils/git-status";
+import {
+	GitStatusRefreshLimiter,
+	gitStatusRefreshLimiter,
+} from "../src/trpc/router/git/utils/git-status-refresh-limiter";
+import type { HostServiceContext } from "../src/types";
+
+type Mode = "limited" | "unbounded";
+type Flow = "compute" | "event-bus";
+
+interface Options {
+	repoPath: string;
+	outDir: string;
+	files: number;
+	dirty: number;
+	events: number;
+	eventIntervalMs: number;
+	concurrency: number;
+	gitDelayMs: number;
+	mode: Mode | "both";
+	flow: Flow;
+	recreate: boolean;
+	cdpPort: number | null;
+}
+
+interface ScenarioResult {
+	flow: Flow;
+	mode: Mode;
+	requestedRefreshes: number;
+	worktreeMutations?: number;
+	gitChangedEvents?: number;
+	actualRefreshes: number;
+	durationMs: number;
+	maxActiveRefreshes: number;
+	gitInvocations: number;
+	maxActiveGitProcesses: number;
+	topGitCommands: Array<{ command: string; count: number }>;
+	statusSummary: {
+		againstBase: number;
+		staged: number;
+		unstaged: number;
+		ignoredPaths: number;
+	};
+}
+
+interface CdpCapture {
+	stop: () => Promise<{ profilePath: string; metricsPath: string } | null>;
+}
+
+const DEFAULT_REPO_PATH = ".cache/git-status-large-repo";
+const DEFAULT_OUT_DIR = ".cache/git-status-profiles";
+
+function parseArgs(argv: string[]): Options {
+	const options: Options = {
+		repoPath: resolve(DEFAULT_REPO_PATH),
+		outDir: resolve(DEFAULT_OUT_DIR),
+		files: 20_000,
+		dirty: 600,
+		events: 60,
+		eventIntervalMs: 50,
+		concurrency: 4,
+		gitDelayMs: 0,
+		mode: "both",
+		flow: "compute",
+		recreate: false,
+		cdpPort: null,
+	};
+
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		const next = () => {
+			const value = argv[++index];
+			if (!value) throw new Error(`Missing value for ${arg}`);
+			return value;
+		};
+
+		switch (arg) {
+			case "--repo":
+				options.repoPath = resolve(next());
+				break;
+			case "--out":
+				options.outDir = resolve(next());
+				break;
+			case "--files":
+				options.files = Number(next());
+				break;
+			case "--dirty":
+				options.dirty = Number(next());
+				break;
+			case "--events":
+				options.events = Number(next());
+				break;
+			case "--event-interval-ms":
+				options.eventIntervalMs = Number(next());
+				break;
+			case "--concurrency":
+				options.concurrency = Number(next());
+				break;
+			case "--git-delay-ms":
+				options.gitDelayMs = Number(next());
+				break;
+			case "--mode": {
+				const mode = next();
+				if (mode !== "limited" && mode !== "unbounded" && mode !== "both") {
+					throw new Error(`Invalid mode: ${mode}`);
+				}
+				options.mode = mode;
+				break;
+			}
+			case "--flow": {
+				const flow = next();
+				if (flow !== "compute" && flow !== "event-bus") {
+					throw new Error(`Invalid flow: ${flow}`);
+				}
+				options.flow = flow;
+				break;
+			}
+			case "--recreate":
+				options.recreate = true;
+				break;
+			case "--cdp-port":
+				options.cdpPort = Number(next());
+				break;
+			case "--help":
+				printHelp();
+				process.exit(0);
+				return options;
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+
+	for (const [name, value] of Object.entries({
+		files: options.files,
+		dirty: options.dirty,
+		events: options.events,
+		eventIntervalMs: options.eventIntervalMs,
+		concurrency: options.concurrency,
+		gitDelayMs: options.gitDelayMs,
+	})) {
+		if (!Number.isFinite(value) || value < 0) {
+			throw new Error(`${name} must be a non-negative number`);
+		}
+	}
+	if (options.files < 1) throw new Error("files must be at least 1");
+	if (options.events < 1) throw new Error("events must be at least 1");
+	if (options.concurrency < 1)
+		throw new Error("concurrency must be at least 1");
+
+	return options;
+}
+
+function printHelp(): void {
+	console.log(`Usage:
+  bun run packages/host-service/scripts/git-status-large-repo-profile.ts [options]
+
+Options:
+  --repo <path>                Synthetic repo path. Default: ${DEFAULT_REPO_PATH}
+  --out <path>                 Output directory. Default: ${DEFAULT_OUT_DIR}
+  --files <n>                  Tracked file count. Default: 20000
+  --dirty <n>                  Dirty file count. Default: 600
+  --events <n>                 Refresh invalidation count. Default: 60
+  --event-interval-ms <n>      Delay between invalidations. Default: 50
+  --concurrency <n>            Limiter concurrency. Default: 4
+  --git-delay-ms <n>           Artificial delay before each git subprocess.
+                               Useful for modeling EDR/exec overhead.
+  --mode <limited|unbounded|both>
+  --flow <compute|event-bus>   compute stresses getStatus directly; event-bus
+                               runs GitWatcher → EventBus → client refresh.
+  --recreate                   Delete and recreate the synthetic repo first
+  --cdp-port <port>            Capture renderer CPU profile from Electron CDP
+`);
+}
+
+async function main(): Promise<void> {
+	const options = parseArgs(process.argv.slice(2));
+	validateEventBusRepoPath(options);
+	await mkdir(options.outDir, { recursive: true });
+	await ensureLargeRepo(options);
+
+	const modes: Mode[] =
+		options.mode === "both" ? ["unbounded", "limited"] : [options.mode];
+	const results: ScenarioResult[] = [];
+
+	for (const mode of modes) {
+		await resetDirtyState(options.repoPath);
+		await makeDirtyState(options.repoPath, options);
+
+		const label = `${mode}-${Date.now()}`;
+		const cdp = await startCdpCapture(options, label);
+		const result = await runScenario(options, mode, label);
+		const cdpResult = cdp ? await cdp.stop() : null;
+
+		results.push(result);
+		console.log(JSON.stringify({ ...result, cdp: cdpResult }, null, 2));
+	}
+
+	const summaryPath = join(options.outDir, `summary-${Date.now()}.json`);
+	await writeFile(
+		summaryPath,
+		`${JSON.stringify({ options, results }, null, 2)}\n`,
+	);
+	console.log(`Wrote summary: ${summaryPath}`);
+}
+
+function validateEventBusRepoPath(options: Options): void {
+	if (options.flow !== "event-bus") return;
+	const ignoredSegment = options.repoPath
+		.split(/[\\/]+/)
+		.find((segment) =>
+			new Set([
+				".cache",
+				"node_modules",
+				"dist",
+				"build",
+				".next",
+				".turbo",
+				"coverage",
+				".parcel-cache",
+				".vite",
+				".svelte-kit",
+				".vercel",
+				"target",
+				"out",
+			]).has(segment),
+		);
+	if (!ignoredSegment) return;
+	throw new Error(
+		`--flow event-bus repo path must not live under ${ignoredSegment}; workspace-fs ignores that directory. Use a path like /tmp/superset-git-status-large-repo.`,
+	);
+}
+
+async function ensureLargeRepo(options: Options): Promise<void> {
+	if (options.recreate) {
+		await rm(options.repoPath, { recursive: true, force: true });
+	}
+	if (existsSync(join(options.repoPath, ".git"))) {
+		console.log(`Using existing synthetic repo: ${options.repoPath}`);
+		return;
+	}
+
+	console.log(
+		`Creating synthetic repo with ${options.files} tracked files: ${options.repoPath}`,
+	);
+	await mkdir(options.repoPath, { recursive: true });
+	await run("git", ["init", "-b", "main"], options.repoPath);
+	await run(
+		"git",
+		["config", "user.email", "stress@example.invalid"],
+		options.repoPath,
+	);
+	await run("git", ["config", "user.name", "Stress Harness"], options.repoPath);
+	await run("git", ["config", "gc.auto", "0"], options.repoPath);
+
+	const batchSize = 500;
+	for (let start = 0; start < options.files; start += batchSize) {
+		const end = Math.min(options.files, start + batchSize);
+		await Promise.all(
+			Array.from({ length: end - start }, (_, offset) => {
+				const id = start + offset;
+				const path = trackedFilePath(options.repoPath, id);
+				return writeTextFile(
+					path,
+					[
+						`export const value${id} = ${id};`,
+						`export function fn${id}() { return value${id}; }`,
+						"",
+					].join("\n"),
+				);
+			}),
+		);
+		if (end % 5_000 === 0 || end === options.files) {
+			console.log(`  wrote ${end}/${options.files} files`);
+		}
+	}
+
+	await run("git", ["add", "-A"], options.repoPath);
+	await run("git", ["commit", "-m", "seed large repo"], options.repoPath);
+}
+
+async function resetDirtyState(repoPath: string): Promise<void> {
+	await run("git", ["reset", "--hard", "HEAD"], repoPath);
+	await run("git", ["clean", "-fd"], repoPath);
+}
+
+async function makeDirtyState(
+	repoPath: string,
+	options: Options,
+): Promise<void> {
+	const modifyCount = Math.floor(options.dirty * 0.6);
+	const untrackedCount = Math.floor(options.dirty * 0.25);
+	const deleteCount = options.dirty - modifyCount - untrackedCount;
+
+	for (let index = 0; index < modifyCount; index++) {
+		const id = index % options.files;
+		await writeTextFile(
+			trackedFilePath(repoPath, id),
+			[
+				`export const value${id} = ${id};`,
+				`export function fn${id}() { return value${id} + ${index}; }`,
+				`export const dirty${index} = true;`,
+				"",
+			].join("\n"),
+		);
+	}
+
+	for (let index = 0; index < untrackedCount; index++) {
+		await writeTextFile(
+			join(repoPath, "generated", `untracked-${index}.txt`),
+			`untracked ${index}\n`,
+		);
+	}
+
+	for (let index = 0; index < deleteCount; index++) {
+		const id = options.files - index - 1;
+		await rm(trackedFilePath(repoPath, id), { force: true });
+	}
+}
+
+async function runScenario(
+	options: Options,
+	mode: Mode,
+	label: string,
+): Promise<ScenarioResult> {
+	if (options.flow === "event-bus") {
+		return runEventBusScenario(options, mode, label);
+	}
+
+	const gitLogPath = join(options.outDir, `${label}-git.log`);
+	const wrapperDir = join(options.outDir, `${label}-bin`);
+	const realGit = await commandOutput("git", ["--exec-path"]);
+	const realGitBinary = join(realGit.trim(), "git");
+	await installGitWrapper(wrapperDir, gitLogPath, realGitBinary);
+
+	let activeRefreshes = 0;
+	let maxActiveRefreshes = 0;
+	let actualRefreshes = 0;
+	let lastSummary: ScenarioResult["statusSummary"] | null = null;
+	const limiter = new GitStatusRefreshLimiter(options.concurrency);
+	const startedAt = performance.now();
+	const promises: Array<Promise<unknown>> = [];
+
+	const runRefresh = async () => {
+		actualRefreshes++;
+		activeRefreshes++;
+		maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
+		try {
+			const git = createUserSimpleGit(options.repoPath).env({
+				...process.env,
+				GIT_OPTIONAL_LOCKS: "0",
+				GIT_PROFILE_DELAY_SECONDS: (options.gitDelayMs / 1000).toFixed(3),
+				GIT_PROFILE_LOG: gitLogPath,
+				PATH: `${wrapperDir}:${process.env.PATH ?? ""}`,
+				REAL_GIT: realGitBinary,
+			});
+			const status = await getGitStatusSnapshot({
+				git,
+				worktreePath: options.repoPath,
+			});
+			lastSummary = {
+				againstBase: status.againstBase.length,
+				staged: status.staged.length,
+				unstaged: status.unstaged.length,
+				ignoredPaths: status.ignoredPaths.length,
+			};
+			return status;
+		} finally {
+			activeRefreshes--;
+		}
+	};
+
+	for (let event = 0; event < options.events; event++) {
+		await mutateChurnFile(options.repoPath, event);
+		const promise =
+			mode === "limited"
+				? limiter.run({
+						workspaceId: "large-repo",
+						requestKey: JSON.stringify({ baseBranch: null }),
+						run: runRefresh,
+					})
+				: runRefresh();
+		promises.push(promise);
+		if (options.eventIntervalMs > 0) {
+			await sleep(options.eventIntervalMs);
+		}
+	}
+
+	const settled = await Promise.allSettled(promises);
+	const failedRefreshes = settled.filter(
+		(result) => result.status === "rejected",
+	);
+	if (failedRefreshes.length > 0) {
+		throw new Error(
+			`${failedRefreshes.length} refreshes failed; first error: ${String(
+				failedRefreshes[0]?.reason,
+			)}`,
+		);
+	}
+	const gitStats = await parseGitLog(gitLogPath);
+
+	return {
+		flow: "compute",
+		mode,
+		requestedRefreshes: options.events,
+		actualRefreshes,
+		durationMs: Math.round(performance.now() - startedAt),
+		maxActiveRefreshes,
+		gitInvocations: gitStats.invocations,
+		maxActiveGitProcesses: gitStats.maxActive,
+		topGitCommands: gitStats.topCommands,
+		statusSummary: lastSummary ?? {
+			againstBase: 0,
+			staged: 0,
+			unstaged: 0,
+			ignoredPaths: 0,
+		},
+	};
+}
+
+async function runEventBusScenario(
+	options: Options,
+	mode: Mode,
+	label: string,
+): Promise<ScenarioResult> {
+	const workspaceId = "large-repo";
+	const gitLogPath = join(options.outDir, `${label}-git.log`);
+	const wrapperDir = join(options.outDir, `${label}-bin`);
+	const realGit = await commandOutput("git", ["--exec-path"]);
+	const realGitBinary = join(realGit.trim(), "git");
+	await installGitWrapper(wrapperDir, gitLogPath, realGitBinary);
+
+	const db = createSingleWorkspaceDb(workspaceId, options.repoPath);
+	const filesystem = new WorkspaceFilesystemManager({ db });
+	const gitWatcher = new GitWatcher(db, filesystem);
+	const eventBus = new EventBus({ db, filesystem, gitWatcher });
+	const refreshPromises: Array<Promise<unknown>> = [];
+	let gitChangedEvents = 0;
+	let actualRefreshes = 0;
+	let activeRefreshes = 0;
+	let maxActiveRefreshes = 0;
+	let lastSummary: ScenarioResult["statusSummary"] | null = null;
+
+	const createProfiledGit = (worktreePath: string) =>
+		createUserSimpleGit(worktreePath).env({
+			...process.env,
+			GIT_OPTIONAL_LOCKS: "0",
+			GIT_PROFILE_DELAY_SECONDS: (options.gitDelayMs / 1000).toFixed(3),
+			GIT_PROFILE_LOG: gitLogPath,
+			PATH: `${wrapperDir}:${process.env.PATH ?? ""}`,
+			REAL_GIT: realGitBinary,
+		});
+
+	const runRefresh = async () => {
+		actualRefreshes++;
+		activeRefreshes++;
+		maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
+		try {
+			const status = await getGitStatusSnapshot({
+				git: createProfiledGit(options.repoPath),
+				worktreePath: options.repoPath,
+			});
+			lastSummary = summarizeStatus(status);
+			return status;
+		} finally {
+			activeRefreshes--;
+		}
+	};
+
+	const runLimitedRefresh = async () => {
+		let counted = false;
+		const caller = gitRouter.createCaller(
+			createRouterContext({
+				db,
+				eventBus,
+				filesystem,
+				git: async (worktreePath) => {
+					if (!counted) {
+						counted = true;
+						actualRefreshes++;
+						activeRefreshes++;
+						maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
+					}
+					return createProfiledGit(worktreePath);
+				},
+			}),
+		);
+		try {
+			const status = await caller.getStatus({ workspaceId });
+			lastSummary = summarizeStatus(status);
+			return status;
+		} finally {
+			if (counted) activeRefreshes--;
+		}
+	};
+
+	const socket: {
+		readyState: number;
+		send: (data: string) => void;
+		close: () => void;
+	} = {
+		readyState: 1,
+		send: (data) => {
+			const message = JSON.parse(data) as ServerMessage;
+			if (
+				message.type !== "git:changed" ||
+				message.workspaceId !== workspaceId
+			) {
+				return;
+			}
+			gitChangedEvents++;
+			const promise = mode === "limited" ? runLimitedRefresh() : runRefresh();
+			if (promise) refreshPromises.push(promise);
+		},
+		close: () => {
+			socket.readyState = 3;
+		},
+	};
+
+	const startedAt = performance.now();
+	gitStatusRefreshLimiter.clear();
+	eventBus.start();
+	eventBus.handleOpen(socket);
+	await (gitWatcher as unknown as { rescan: () => Promise<void> }).rescan();
+
+	let closedEventSources = false;
+	const closeEventSources = async () => {
+		if (closedEventSources) return;
+		closedEventSources = true;
+		eventBus.handleClose(socket);
+		eventBus.close();
+		gitWatcher.close();
+		await filesystem.close();
+	};
+
+	try {
+		for (let event = 0; event < options.events; event++) {
+			await mutateChurnFile(options.repoPath, event);
+			if (options.eventIntervalMs > 0) {
+				await sleep(options.eventIntervalMs);
+			}
+		}
+
+		await sleep(Math.max(1_000, options.eventIntervalMs + 1_000));
+		await closeEventSources();
+		const settled = await Promise.allSettled(refreshPromises);
+		const failedRefreshes = settled.filter(
+			(result) => result.status === "rejected",
+		);
+		if (failedRefreshes.length > 0) {
+			throw new Error(
+				`${failedRefreshes.length} refreshes failed; first error: ${String(
+					failedRefreshes[0]?.reason,
+				)}`,
+			);
+		}
+
+		const gitStats = await parseGitLog(gitLogPath);
+		return {
+			flow: "event-bus",
+			mode,
+			requestedRefreshes: gitChangedEvents,
+			worktreeMutations: options.events,
+			gitChangedEvents,
+			actualRefreshes,
+			durationMs: Math.round(performance.now() - startedAt),
+			maxActiveRefreshes,
+			gitInvocations: gitStats.invocations,
+			maxActiveGitProcesses: gitStats.maxActive,
+			topGitCommands: gitStats.topCommands,
+			statusSummary: lastSummary ?? {
+				againstBase: 0,
+				staged: 0,
+				unstaged: 0,
+				ignoredPaths: 0,
+			},
+		};
+	} finally {
+		await closeEventSources();
+		gitStatusRefreshLimiter.clear();
+	}
+}
+
+async function startCdpCapture(
+	options: Options,
+	label: string,
+): Promise<CdpCapture | null> {
+	if (!options.cdpPort) return null;
+
+	try {
+		const targets = (await fetch(
+			`http://127.0.0.1:${options.cdpPort}/json/list`,
+		).then((response) => response.json())) as Array<{
+			type?: string;
+			title?: string;
+			url?: string;
+			webSocketDebuggerUrl?: string;
+		}>;
+		const target =
+			targets.find(
+				(item) => item.type === "page" && item.webSocketDebuggerUrl,
+			) ?? targets.find((item) => item.webSocketDebuggerUrl);
+		if (!target?.webSocketDebuggerUrl) {
+			console.warn(`No CDP target found on port ${options.cdpPort}`);
+			return null;
+		}
+
+		const client = await connectCdp(target.webSocketDebuggerUrl);
+		await client.send("Profiler.enable");
+		await client.send("Performance.enable");
+		const beforeMetrics = await client
+			.send("Performance.getMetrics")
+			.catch(() => null);
+		await client.send("Profiler.start");
+
+		return {
+			stop: async () => {
+				const stopped = await client.send("Profiler.stop").catch((error) => {
+					console.warn(`CDP Profiler.stop failed: ${String(error)}`);
+					return null;
+				});
+				const afterMetrics = await client
+					.send("Performance.getMetrics")
+					.catch(() => null);
+				client.close();
+				if (
+					!stopped ||
+					typeof stopped !== "object" ||
+					!("profile" in stopped)
+				) {
+					return null;
+				}
+
+				const profilePath = join(options.outDir, `${label}.cpuprofile`);
+				const metricsPath = join(options.outDir, `${label}-cdp-metrics.json`);
+				await writeFile(
+					profilePath,
+					`${JSON.stringify((stopped as { profile: unknown }).profile)}\n`,
+				);
+				await writeFile(
+					metricsPath,
+					`${JSON.stringify(
+						{
+							target: {
+								title: target.title,
+								url: target.url,
+							},
+							before: beforeMetrics,
+							after: afterMetrics,
+						},
+						null,
+						2,
+					)}\n`,
+				);
+				return { profilePath, metricsPath };
+			},
+		};
+	} catch (error) {
+		console.warn(`CDP capture disabled: ${String(error)}`);
+		return null;
+	}
+}
+
+function summarizeStatus(
+	status: Awaited<ReturnType<typeof getGitStatusSnapshot>>,
+): ScenarioResult["statusSummary"] {
+	return {
+		againstBase: status.againstBase.length,
+		staged: status.staged.length,
+		unstaged: status.unstaged.length,
+		ignoredPaths: status.ignoredPaths.length,
+	};
+}
+
+function createSingleWorkspaceDb(
+	workspaceId: string,
+	worktreePath: string,
+): HostDb {
+	const workspace = { id: workspaceId, worktreePath };
+	return {
+		select: () => ({
+			from: () => ({
+				all: () => [workspace],
+			}),
+		}),
+		query: {
+			workspaces: {
+				findFirst: () => ({
+					sync: () => workspace,
+				}),
+			},
+		},
+	} as unknown as HostDb;
+}
+
+function createRouterContext({
+	db,
+	eventBus,
+	filesystem,
+	git,
+}: {
+	db: HostDb;
+	eventBus: EventBus;
+	filesystem: WorkspaceFilesystemManager;
+	git: HostServiceContext["git"];
+}): HostServiceContext {
+	return {
+		api: {} as HostServiceContext["api"],
+		db,
+		eventBus,
+		execGh: (() => {
+			throw new Error("execGh is not used by git-status profiling");
+		}) as HostServiceContext["execGh"],
+		git,
+		github: (async () => {
+			throw new Error("github is not used by git-status profiling");
+		}) as HostServiceContext["github"],
+		isAuthenticated: true,
+		organizationId: "profile-org",
+		runtime: {
+			filesystem,
+		} as HostServiceContext["runtime"],
+	};
+}
+
+async function connectCdp(webSocketUrl: string): Promise<{
+	send: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+	close: () => void;
+}> {
+	const socket = new WebSocket(webSocketUrl);
+	let id = 0;
+	let closed = false;
+	const pending = new Map<
+		number,
+		{
+			resolve: (value: unknown) => void;
+			reject: (reason: unknown) => void;
+		}
+	>();
+
+	const rejectPending = (error: Error) => {
+		closed = true;
+		for (const request of pending.values()) {
+			request.reject(error);
+		}
+		pending.clear();
+	};
+
+	socket.addEventListener("message", (event) => {
+		const message = JSON.parse(String(event.data)) as {
+			id?: number;
+			result?: unknown;
+			error?: unknown;
+		};
+		if (!message.id) return;
+		const request = pending.get(message.id);
+		if (!request) return;
+		pending.delete(message.id);
+		if (message.error) request.reject(message.error);
+		else request.resolve(message.result);
+	});
+	socket.addEventListener("close", () => {
+		rejectPending(new Error("CDP socket closed"));
+	});
+	socket.addEventListener("error", (event) => {
+		rejectPending(new Error(`CDP socket error: ${event.type}`));
+	});
+
+	await new Promise<void>((resolveOpen, rejectOpen) => {
+		socket.addEventListener("open", () => resolveOpen(), { once: true });
+		socket.addEventListener(
+			"error",
+			(event) => rejectOpen(new Error(`CDP socket error: ${event.type}`)),
+			{ once: true },
+		);
+	});
+
+	return {
+		send: (method, params = {}) =>
+			new Promise((resolveSend, rejectSend) => {
+				if (closed || socket.readyState !== WebSocket.OPEN) {
+					rejectSend(new Error("CDP socket is not open"));
+					return;
+				}
+				const requestId = ++id;
+				pending.set(requestId, {
+					resolve: resolveSend,
+					reject: rejectSend,
+				});
+				try {
+					socket.send(JSON.stringify({ id: requestId, method, params }));
+				} catch (error) {
+					pending.delete(requestId);
+					rejectSend(error);
+				}
+			}),
+		close: () => {
+			rejectPending(new Error("CDP socket closed by profiler"));
+			socket.close();
+		},
+	};
+}
+
+async function installGitWrapper(
+	wrapperDir: string,
+	logPath: string,
+	realGit: string,
+): Promise<void> {
+	await mkdir(wrapperDir, { recursive: true });
+	await writeFile(
+		join(wrapperDir, "git"),
+		[
+			"#!/bin/sh",
+			'printf "start\\t%s\\t%s\\n" "$$" "$*" >> "$GIT_PROFILE_LOG"',
+			'if [ -n "$GIT_PROFILE_DELAY_SECONDS" ] && [ "$GIT_PROFILE_DELAY_SECONDS" != "0.000" ]; then sleep "$GIT_PROFILE_DELAY_SECONDS"; fi',
+			'"$REAL_GIT" "$@"',
+			"status=$?",
+			'printf "end\\t%s\\t%s\\n" "$$" "$status" >> "$GIT_PROFILE_LOG"',
+			'exit "$status"',
+			"",
+		].join("\n"),
+	);
+	chmodSync(join(wrapperDir, "git"), 0o755);
+	await writeFile(logPath, "");
+	process.env.REAL_GIT = realGit;
+}
+
+async function parseGitLog(logPath: string): Promise<{
+	invocations: number;
+	maxActive: number;
+	topCommands: Array<{ command: string; count: number }>;
+}> {
+	const raw = await readFile(logPath, "utf8").catch(() => "");
+	let active = 0;
+	let maxActive = 0;
+	let invocations = 0;
+	const commands = new Map<string, number>();
+
+	for (const line of raw.split("\n")) {
+		if (!line) continue;
+		const [type, , rest = ""] = line.split("\t");
+		if (type === "start") {
+			active++;
+			invocations++;
+			maxActive = Math.max(maxActive, active);
+			const command = summarizeGitCommand(rest);
+			commands.set(command, (commands.get(command) ?? 0) + 1);
+		} else if (type === "end") {
+			active = Math.max(0, active - 1);
+		}
+	}
+
+	return {
+		invocations,
+		maxActive,
+		topCommands: Array.from(commands.entries())
+			.map(([command, count]) => ({ command, count }))
+			.sort((a, b) => b.count - a.count)
+			.slice(0, 12),
+	};
+}
+
+function summarizeGitCommand(args: string): string {
+	const parts = args.split(" ").filter(Boolean);
+	const command = parts[0] ?? "(unknown)";
+	if (command === "diff") {
+		return ["diff", ...parts.filter((part) => part.startsWith("--"))].join(" ");
+	}
+	if (command === "config") return `config ${parts[1] ?? ""}`.trim();
+	if (command === "rev-parse") return `rev-parse ${parts[1] ?? ""}`.trim();
+	return command;
+}
+
+async function mutateChurnFile(repoPath: string, event: number): Promise<void> {
+	await writeTextFile(
+		join(repoPath, "churn", `event-${event % 20}.txt`),
+		`event ${event} at ${new Date().toISOString()}\n`,
+	);
+}
+
+function trackedFilePath(repoPath: string, id: number): string {
+	const bucket = String(Math.floor(id / 1_000)).padStart(4, "0");
+	const file = String(id).padStart(6, "0");
+	return join(repoPath, "src", bucket, `file-${file}.ts`);
+}
+
+async function writeTextFile(path: string, contents: string): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, contents);
+}
+
+async function commandOutput(command: string, args: string[]): Promise<string> {
+	const output: Buffer[] = [];
+	await run(command, args, process.cwd(), undefined, (chunk) => {
+		output.push(chunk);
+	});
+	return Buffer.concat(output).toString("utf8");
+}
+
+async function run(
+	command: string,
+	args: string[],
+	cwd: string,
+	env?: NodeJS.ProcessEnv,
+	onStdout?: (chunk: Buffer) => void,
+): Promise<void> {
+	await new Promise<void>((resolveRun, rejectRun) => {
+		const child = spawn(command, args, {
+			cwd,
+			env: env ? { ...process.env, ...env } : process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const stderr: Buffer[] = [];
+		child.stdout.on("data", (chunk: Buffer) => onStdout?.(chunk));
+		child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+		child.on("error", rejectRun);
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolveRun();
+				return;
+			}
+			rejectRun(
+				new Error(
+					`${command} ${args.join(" ")} exited ${code}: ${Buffer.concat(
+						stderr,
+					).toString("utf8")}`,
+				),
+			);
+		});
+	});
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+await main();

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -7,7 +7,6 @@ import { pullRequests, workspaces } from "../../../db/schema";
 import { protectedProcedure, queryProcedure, router } from "../../index";
 import { resolveGithubRepo } from "../workspace-creation/shared/project-helpers";
 import type {
-	ChangedFile,
 	CheckConclusionState,
 	CheckRun,
 	CheckStatusState,
@@ -20,15 +19,12 @@ import type {
 } from "./types";
 import { gitConfigWrite } from "./utils/config-write";
 import {
-	buildBranch,
-	countUntrackedFileLines,
-	detectUnstagedRenames,
 	getChangedFilesForDiff,
 	getDefaultBranchName,
-	mapGitStatus,
-	parseNumstat,
 	resolveBaseComparison,
 } from "./utils/git-helpers";
+import { getGitStatusSnapshot } from "./utils/git-status";
+import { gitStatusRefreshLimiter } from "./utils/git-status-refresh-limiter";
 import {
 	type GraphQLThreadsResult,
 	parseGraphQLThreads,
@@ -100,151 +96,27 @@ export const gitRouter = router({
 			z.object({
 				workspaceId: z.string(),
 				baseBranch: z.string().optional(),
+				priority: z.enum(["foreground", "background"]).optional(),
 			}),
 		)
 		.query(async ({ ctx, input }) => {
-			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
-			const git = await ctx.git(worktreePath);
-
-			const currentBranchName = (
-				await git.revparse(["--abbrev-ref", "HEAD"]).catch(() => "")
-			).trim();
-			const base = await resolveBaseComparison(git, input.baseBranch);
-			const defaultBranchName = base?.branchName ?? null;
-			const baseRef = base?.baseRef ?? "HEAD";
-
-			const [currentBranch, defaultBranch, status, ignoredRaw] =
-				await Promise.all([
-					buildBranch(git, currentBranchName, true, baseRef),
-					defaultBranchName
-						? buildBranch(git, defaultBranchName, false)
-						: buildBranch(git, currentBranchName, true),
-					git.status(),
-					git
-						.raw([
-							"ls-files",
-							"--others",
-							"--ignored",
-							"--exclude-standard",
-							"--directory",
-						])
-						.catch(() => ""),
-				]);
-
-			// Top-level gitignored paths. `--directory` collapses entirely-ignored
-			// folders to a single entry (e.g. `node_modules`) instead of
-			// enumerating every file inside, so this stays cheap in large repos.
-			const ignoredPaths = ignoredRaw
-				.split("\n")
-				.map((line) => line.trim().replace(/\/$/, ""))
-				.filter(Boolean);
-
-			const againstBase = await getChangedFilesForDiff(git, [
-				`${baseRef}...HEAD`,
-			]);
-
-			// Staged — use status.files index character for correct status.
-			// `-M -C` lets the numstat collapse renamed/copied entries so a
-			// `git add` of `mv old new` yields a single 0/0 rename row
-			// instead of an A + D pair.
-			const stagedNumstat = parseNumstat(
-				await git
-					.raw(["diff", "--numstat", "-z", "-M", "-C", "--cached"])
-					.catch(() => ""),
-			);
-			const staged: ChangedFile[] = [];
-			for (const file of status.files) {
-				const idx = file.index;
-				if (idx && idx !== " " && idx !== "?") {
-					const stats = stagedNumstat.get(file.path) ?? {
-						additions: 0,
-						deletions: 0,
-					};
-					staged.push({
-						path: file.path,
-						oldPath:
-							file.from && file.from !== file.path ? file.from : undefined,
-						status: mapGitStatus(idx),
-						additions: stats.additions,
-						deletions: stats.deletions,
+			const requestKey = JSON.stringify({
+				baseBranch: input.baseBranch ?? null,
+			});
+			return gitStatusRefreshLimiter.run({
+				workspaceId: input.workspaceId,
+				requestKey,
+				priority: input.priority,
+				run: async () => {
+					const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+					const git = await ctx.git(worktreePath);
+					return getGitStatusSnapshot({
+						git,
+						worktreePath,
+						baseBranch: input.baseBranch,
 					});
-				}
-			}
-
-			// Unstaged — use status.files working_dir character
-			const unstagedNumstat = parseNumstat(
-				await git.raw(["diff", "--numstat", "-z"]).catch(() => ""),
-			);
-			const unstaged: ChangedFile[] = [];
-			const untrackedFiles: ChangedFile[] = [];
-			for (const file of status.files) {
-				const wd = file.working_dir;
-				if (file.index === "?" && wd === "?") {
-					const entry: ChangedFile = {
-						path: file.path,
-						status: "untracked",
-						additions: 0,
-						deletions: 0,
-					};
-					untrackedFiles.push(entry);
-					unstaged.push(entry);
-				} else if (wd && wd !== " ") {
-					const stats = unstagedNumstat.get(file.path) ?? {
-						additions: 0,
-						deletions: 0,
-					};
-					unstaged.push({
-						path: file.path,
-						status: mapGitStatus(wd),
-						additions: stats.additions,
-						deletions: stats.deletions,
-					});
-				}
-			}
-			await countUntrackedFileLines(worktreePath, untrackedFiles);
-
-			const hasDeletions = unstaged.some((f) => f.status === "deleted");
-			const renames = await detectUnstagedRenames(
-				git,
-				worktreePath,
-				untrackedFiles.map((f) => f.path),
-				hasDeletions,
-			);
-
-			let mergedUnstaged = unstaged;
-			if (renames.length > 0) {
-				const consumedDeleted = new Set<string>();
-				const consumedUntracked = new Set<string>();
-				for (const r of renames) {
-					if (r.status === "renamed") consumedDeleted.add(r.oldPath);
-					consumedUntracked.add(r.newPath);
-				}
-				mergedUnstaged = unstaged.filter((f) => {
-					if (f.status === "deleted" && consumedDeleted.has(f.path))
-						return false;
-					if (f.status === "untracked" && consumedUntracked.has(f.path))
-						return false;
-					return true;
-				});
-				for (const r of renames) {
-					mergedUnstaged.push({
-						path: r.newPath,
-						oldPath: r.oldPath,
-						status: r.status,
-						additions: r.additions,
-						deletions: r.deletions,
-					});
-				}
-			}
-
-			return {
-				currentBranch,
-				defaultBranch,
-				againstBase,
-				staged,
-				unstaged: mergedUnstaged,
-				ignoredPaths,
-			};
+				},
+			});
 		}),
 
 	listCommits: queryProcedure

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -293,17 +293,17 @@ export async function countUntrackedFileLines(
 export interface DetectedRename {
 	oldPath: string;
 	newPath: string;
-	status: "renamed" | "copied";
+	status: "renamed";
 	additions: number;
 	deletions: number;
 }
 
 /**
- * Run git's real rename/copy detection across the working tree by
- * copying the index to a temp file, marking untracked files
- * intent-to-add against that copy, and diffing. Real index is never
- * mutated. Falls back to an empty result on any error — caller still
- * has the unrelated deleted+untracked entries to display.
+ * Run git's real rename detection across the working tree by copying the
+ * index to a temp file, marking untracked files intent-to-add against that
+ * copy, and diffing. Real index is never mutated. Falls back to an empty
+ * result on any error — caller still has the unrelated deleted+untracked
+ * entries to display.
  */
 export async function detectUnstagedRenames(
 	git: SimpleGit,
@@ -312,9 +312,7 @@ export async function detectUnstagedRenames(
 	hasDeletions: boolean,
 ): Promise<DetectedRename[]> {
 	if (untrackedPaths.length === 0) return [];
-	// Renames need a deletion; copy detection between two untracked
-	// files needs at least two of them.
-	if (!hasDeletions && untrackedPaths.length < 2) return [];
+	if (!hasDeletions) return [];
 
 	let indexPath: string;
 	try {
@@ -344,8 +342,8 @@ export async function detectUnstagedRenames(
 		await tempGit.raw(["add", "--intent-to-add", "--", ...untrackedPaths]);
 
 		const [nameStatusRaw, numstatRaw] = await Promise.all([
-			tempGit.raw(["diff", "--name-status", "-z", "-M", "-C"]),
-			tempGit.raw(["diff", "--numstat", "-z", "-M", "-C"]),
+			tempGit.raw(["diff", "--name-status", "-z", "-M"]),
+			tempGit.raw(["diff", "--numstat", "-z", "-M"]),
 		]);
 
 		const nameStatus = parseNameStatus(nameStatusRaw);
@@ -355,12 +353,12 @@ export async function detectUnstagedRenames(
 		for (const entry of nameStatus) {
 			if (!entry.oldPath) continue;
 			const code = entry.status[0];
-			if (code !== "R" && code !== "C") continue;
+			if (code !== "R") continue;
 			const stats = numstat.get(entry.path) ?? { additions: 0, deletions: 0 };
 			result.push({
 				oldPath: entry.oldPath,
 				newPath: entry.path,
-				status: code === "R" ? "renamed" : "copied",
+				status: "renamed",
 				additions: stats.additions,
 				deletions: stats.deletions,
 			});

--- a/packages/host-service/src/trpc/router/git/utils/git-status-refresh-limiter.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-status-refresh-limiter.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, test } from "bun:test";
+import { GitStatusRefreshLimiter } from "./git-status-refresh-limiter";
+
+function deferred<T = void>() {
+	let resolve: (value: T | PromiseLike<T>) => void = () => {};
+	let reject: (reason?: unknown) => void = () => {};
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe("GitStatusRefreshLimiter", () => {
+	test("keeps one trailing refresh for the same workspace and request key", async () => {
+		const limiter = new GitStatusRefreshLimiter(4);
+		const firstGate = deferred();
+		const secondGate = deferred();
+		let runs = 0;
+
+		const first = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				runs++;
+				await firstGate.promise;
+				return "first";
+			},
+		});
+		const second = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				runs++;
+				await secondGate.promise;
+				return "second";
+			},
+		});
+		const third = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				runs++;
+				return "third";
+			},
+		});
+
+		expect(second).not.toBe(first);
+		expect(third).toBe(second);
+		expect(runs).toBe(0);
+		await Promise.resolve();
+		expect(runs).toBe(1);
+
+		firstGate.resolve();
+		await expect(first).resolves.toBe("first");
+		await Promise.resolve();
+		expect(runs).toBe(2);
+
+		secondGate.resolve();
+		await expect(second).resolves.toBe("second");
+		await expect(third).resolves.toBe("second");
+		expect(runs).toBe(2);
+	});
+
+	test("serializes different request keys for the same workspace", async () => {
+		const limiter = new GitStatusRefreshLimiter(4);
+		const firstGate = deferred();
+		const secondGate = deferred();
+		const events: string[] = [];
+
+		const first = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("first:start");
+				await firstGate.promise;
+				events.push("first:end");
+				return "first";
+			},
+		});
+		const second = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:release",
+			run: async () => {
+				events.push("second:start");
+				await secondGate.promise;
+				events.push("second:end");
+				return "second";
+			},
+		});
+
+		await Promise.resolve();
+		expect(events).toEqual(["first:start"]);
+
+		firstGate.resolve();
+		await expect(first).resolves.toBe("first");
+		await Promise.resolve();
+		expect(events).toEqual(["first:start", "first:end", "second:start"]);
+
+		secondGate.resolve();
+		await expect(second).resolves.toBe("second");
+		expect(events).toEqual([
+			"first:start",
+			"first:end",
+			"second:start",
+			"second:end",
+		]);
+	});
+
+	test("caps active refreshes across workspaces", async () => {
+		const limiter = new GitStatusRefreshLimiter(1);
+		const firstGate = deferred();
+		const secondGate = deferred();
+		const events: string[] = [];
+
+		const first = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("first:start");
+				await firstGate.promise;
+				events.push("first:end");
+				return "first";
+			},
+		});
+		const second = limiter.run({
+			workspaceId: "workspace-2",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("second:start");
+				await secondGate.promise;
+				events.push("second:end");
+				return "second";
+			},
+		});
+
+		await Promise.resolve();
+		expect(events).toEqual(["first:start"]);
+
+		firstGate.resolve();
+		await expect(first).resolves.toBe("first");
+		await Promise.resolve();
+		expect(events).toEqual(["first:start", "first:end", "second:start"]);
+
+		secondGate.resolve();
+		await expect(second).resolves.toBe("second");
+	});
+
+	test("prioritizes foreground work over stale background work", async () => {
+		const limiter = new GitStatusRefreshLimiter(1);
+		const firstGate = deferred();
+		const secondGate = deferred();
+		const thirdGate = deferred();
+		const events: string[] = [];
+
+		const first = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("first:start");
+				await firstGate.promise;
+				events.push("first:end");
+				return "first";
+			},
+		});
+		const second = limiter.run({
+			workspaceId: "workspace-2",
+			requestKey: "base:main",
+			priority: "background",
+			run: async () => {
+				events.push("second:start");
+				await secondGate.promise;
+				events.push("second:end");
+				return "second";
+			},
+		});
+		const third = limiter.run({
+			workspaceId: "workspace-3",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("third:start");
+				await thirdGate.promise;
+				events.push("third:end");
+				return "third";
+			},
+		});
+
+		await Promise.resolve();
+		expect(events).toEqual(["first:start"]);
+
+		firstGate.resolve();
+		await expect(first).resolves.toBe("first");
+		await Promise.resolve();
+		expect(events).toEqual(["first:start", "first:end", "third:start"]);
+
+		thirdGate.resolve();
+		await expect(third).resolves.toBe("third");
+		await Promise.resolve();
+		expect(events).toEqual([
+			"first:start",
+			"first:end",
+			"third:start",
+			"third:end",
+			"second:start",
+		]);
+
+		secondGate.resolve();
+		await expect(second).resolves.toBe("second");
+	});
+
+	test("runs same-priority work in queue order so requests do not starve", async () => {
+		const limiter = new GitStatusRefreshLimiter(1);
+		const firstGate = deferred();
+		const secondGate = deferred();
+		const thirdGate = deferred();
+		const events: string[] = [];
+
+		const first = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("first:start");
+				await firstGate.promise;
+				events.push("first:end");
+				return "first";
+			},
+		});
+		const second = limiter.run({
+			workspaceId: "workspace-2",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("second:start");
+				await secondGate.promise;
+				events.push("second:end");
+				return "second";
+			},
+		});
+		const third = limiter.run({
+			workspaceId: "workspace-3",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("third:start");
+				await thirdGate.promise;
+				events.push("third:end");
+				return "third";
+			},
+		});
+
+		await Promise.resolve();
+		expect(events).toEqual(["first:start"]);
+
+		firstGate.resolve();
+		await expect(first).resolves.toBe("first");
+		await Promise.resolve();
+		expect(events).toEqual(["first:start", "first:end", "second:start"]);
+
+		secondGate.resolve();
+		await expect(second).resolves.toBe("second");
+		await Promise.resolve();
+		expect(events).toEqual([
+			"first:start",
+			"first:end",
+			"second:start",
+			"second:end",
+			"third:start",
+		]);
+
+		thirdGate.resolve();
+		await expect(third).resolves.toBe("third");
+	});
+
+	test("promotes a queued background refresh when a foreground request joins it", async () => {
+		const limiter = new GitStatusRefreshLimiter(1);
+		const firstGate = deferred();
+		const secondGate = deferred();
+		const thirdGate = deferred();
+		const events: string[] = [];
+
+		const first = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("first:start");
+				await firstGate.promise;
+				events.push("first:end");
+				return "first";
+			},
+		});
+		const second = limiter.run({
+			workspaceId: "workspace-2",
+			requestKey: "base:main",
+			priority: "background",
+			run: async () => {
+				events.push("second:start");
+				await secondGate.promise;
+				events.push("second:end");
+				return "second";
+			},
+		});
+		const third = limiter.run({
+			workspaceId: "workspace-3",
+			requestKey: "base:main",
+			priority: "background",
+			run: async () => {
+				events.push("third:start");
+				await thirdGate.promise;
+				events.push("third:end");
+				return "third";
+			},
+		});
+		const promotedSecond = limiter.run({
+			workspaceId: "workspace-2",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("promoted-second:start");
+				return "promoted-second";
+			},
+		});
+
+		expect(promotedSecond).toBe(second);
+
+		await Promise.resolve();
+		expect(events).toEqual(["first:start"]);
+
+		firstGate.resolve();
+		await expect(first).resolves.toBe("first");
+		await Promise.resolve();
+		expect(events).toEqual(["first:start", "first:end", "second:start"]);
+
+		secondGate.resolve();
+		await expect(second).resolves.toBe("second");
+		await expect(promotedSecond).resolves.toBe("second");
+		await Promise.resolve();
+		expect(events).toEqual([
+			"first:start",
+			"first:end",
+			"second:start",
+			"second:end",
+			"third:start",
+		]);
+
+		thirdGate.resolve();
+		await expect(third).resolves.toBe("third");
+	});
+
+	test("clear rejects queued work and lets active work finish without reviving stale queues", async () => {
+		const limiter = new GitStatusRefreshLimiter(1);
+		const firstGate = deferred();
+		const events: string[] = [];
+
+		const first = limiter.run({
+			workspaceId: "workspace-1",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("first:start");
+				await firstGate.promise;
+				events.push("first:end");
+				return "first";
+			},
+		});
+		const second = limiter.run({
+			workspaceId: "workspace-2",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("second:start");
+				return "second";
+			},
+		});
+
+		await Promise.resolve();
+		expect(events).toEqual(["first:start"]);
+
+		limiter.clear();
+		await expect(second).rejects.toThrow("queue was cleared");
+
+		firstGate.resolve();
+		await expect(first).resolves.toBe("first");
+		await Promise.resolve();
+		expect(events).toEqual(["first:start", "first:end"]);
+
+		const third = limiter.run({
+			workspaceId: "workspace-3",
+			requestKey: "base:main",
+			run: async () => {
+				events.push("third:start");
+				return "third";
+			},
+		});
+
+		await expect(third).resolves.toBe("third");
+		expect(events).toEqual(["first:start", "first:end", "third:start"]);
+	});
+});

--- a/packages/host-service/src/trpc/router/git/utils/git-status-refresh-limiter.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-status-refresh-limiter.ts
@@ -1,0 +1,204 @@
+import { cpus } from "node:os";
+
+const DEFAULT_CONCURRENCY = Math.max(1, Math.min(4, cpus().length - 1));
+
+export type GitStatusRefreshPriority = "foreground" | "background";
+
+interface ActiveTask {
+	requestKey: string;
+	promise: Promise<unknown>;
+}
+
+interface QueuedTask {
+	workspaceId: string;
+	requestKey: string;
+	run: () => Promise<unknown>;
+	promise: Promise<unknown>;
+	resolve: (value: unknown) => void;
+	reject: (reason: unknown) => void;
+	priority: GitStatusRefreshPriority;
+	sequence: number;
+	generation: number;
+}
+
+interface WorkspaceQueue {
+	active: ActiveTask | null;
+	queued: QueuedTask[];
+}
+
+export class GitStatusRefreshLimiter {
+	private readonly concurrency: number;
+	private readonly workspaces = new Map<string, WorkspaceQueue>();
+	private readonly readyQueue: QueuedTask[] = [];
+	private activeCount = 0;
+	private sequence = 0;
+	private generation = 0;
+
+	constructor(concurrency = DEFAULT_CONCURRENCY) {
+		this.concurrency = Math.max(1, concurrency);
+	}
+
+	run<T>({
+		workspaceId,
+		requestKey,
+		run,
+		priority = "foreground",
+	}: {
+		workspaceId: string;
+		requestKey: string;
+		run: () => Promise<T>;
+		priority?: GitStatusRefreshPriority;
+	}): Promise<T> {
+		const workspace = this.getWorkspaceQueue(workspaceId);
+
+		// Collapse repeated invalidations while a workspace refresh is active into
+		// one trailing refresh per request key. That keeps the final snapshot fresh
+		// without letting fs-event churn enqueue unbounded git subprocess work.
+		const queued = workspace.queued.find(
+			(task) => task.requestKey === requestKey,
+		);
+		if (queued) {
+			this.promoteQueuedTask(queued, priority);
+			return queued.promise as Promise<T>;
+		}
+
+		const task = this.createTask(workspaceId, requestKey, run, priority);
+		workspace.queued.push(task);
+		if (!workspace.active && workspace.queued[0] === task) {
+			this.readyQueue.push(task);
+			this.pump();
+		}
+		return task.promise as Promise<T>;
+	}
+
+	clear(): void {
+		this.generation++;
+		const queuedTasks = new Set<QueuedTask>();
+		for (const workspace of this.workspaces.values()) {
+			for (const task of workspace.queued) {
+				queuedTasks.add(task);
+			}
+		}
+		this.workspaces.clear();
+		this.readyQueue.length = 0;
+		this.activeCount = 0;
+		for (const task of queuedTasks) {
+			task.reject(new Error("Git status refresh queue was cleared"));
+		}
+	}
+
+	private getWorkspaceQueue(workspaceId: string): WorkspaceQueue {
+		let workspace = this.workspaces.get(workspaceId);
+		if (!workspace) {
+			workspace = { active: null, queued: [] };
+			this.workspaces.set(workspaceId, workspace);
+		}
+		return workspace;
+	}
+
+	private createTask<T>(
+		workspaceId: string,
+		requestKey: string,
+		run: () => Promise<T>,
+		priority: GitStatusRefreshPriority,
+	): QueuedTask {
+		let resolve: (value: unknown) => void = () => {};
+		let reject: (reason: unknown) => void = () => {};
+		const promise = new Promise<unknown>((res, rej) => {
+			resolve = res;
+			reject = rej;
+		});
+		return {
+			workspaceId,
+			requestKey,
+			run,
+			promise,
+			resolve,
+			reject,
+			priority,
+			sequence: ++this.sequence,
+			generation: this.generation,
+		};
+	}
+
+	private promoteQueuedTask(
+		task: QueuedTask,
+		priority: GitStatusRefreshPriority,
+	): void {
+		if (priority === "foreground" && task.priority === "background") {
+			task.priority = "foreground";
+		}
+		task.sequence = ++this.sequence;
+	}
+
+	private pump(): void {
+		while (this.activeCount < this.concurrency && this.readyQueue.length > 0) {
+			const task = this.takeNextReadyTask();
+			if (!task) return;
+			if (task.generation !== this.generation) continue;
+
+			const workspace = this.workspaces.get(task.workspaceId);
+			if (!workspace || workspace.active || workspace.queued[0] !== task) {
+				continue;
+			}
+
+			this.startTask(workspace, task);
+		}
+	}
+
+	private takeNextReadyTask(): QueuedTask | undefined {
+		let bestIndex = -1;
+		let bestTask: QueuedTask | undefined;
+
+		for (let index = 0; index < this.readyQueue.length; index++) {
+			const task = this.readyQueue[index];
+			if (!task) continue;
+			if (!bestTask || compareTaskPriority(task, bestTask) > 0) {
+				bestTask = task;
+				bestIndex = index;
+			}
+		}
+
+		if (bestIndex < 0) return undefined;
+		this.readyQueue.splice(bestIndex, 1);
+		return bestTask;
+	}
+
+	private startTask(workspace: WorkspaceQueue, task: QueuedTask): void {
+		workspace.queued.shift();
+		workspace.active = {
+			requestKey: task.requestKey,
+			promise: task.promise,
+		};
+		this.activeCount++;
+
+		void Promise.resolve()
+			.then(task.run)
+			.then(task.resolve, task.reject)
+			.finally(() => {
+				if (task.generation !== this.generation) return;
+				this.activeCount--;
+				if (workspace.active?.promise === task.promise) {
+					workspace.active = null;
+				}
+
+				if (workspace.queued.length > 0) {
+					const next = workspace.queued[0];
+					if (next) this.readyQueue.push(next);
+				} else if (!workspace.active) {
+					this.workspaces.delete(task.workspaceId);
+				}
+
+				this.pump();
+			});
+	}
+}
+
+export const gitStatusRefreshLimiter = new GitStatusRefreshLimiter();
+
+function compareTaskPriority(a: QueuedTask, b: QueuedTask): number {
+	if (a.priority !== b.priority) {
+		return a.priority === "foreground" ? 1 : -1;
+	}
+	return b.sequence - a.sequence;
+}

--- a/packages/host-service/src/trpc/router/git/utils/git-status.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-status.ts
@@ -1,0 +1,164 @@
+import type { SimpleGit } from "simple-git";
+import type { Branch, ChangedFile } from "../types";
+import {
+	buildBranch,
+	countUntrackedFileLines,
+	detectUnstagedRenames,
+	getChangedFilesForDiff,
+	mapGitStatus,
+	parseNumstat,
+	resolveBaseComparison,
+} from "./git-helpers";
+
+export interface GitStatusSnapshot {
+	currentBranch: Branch;
+	defaultBranch: Branch;
+	againstBase: ChangedFile[];
+	staged: ChangedFile[];
+	unstaged: ChangedFile[];
+	ignoredPaths: string[];
+}
+
+export async function getGitStatusSnapshot({
+	git,
+	worktreePath,
+	baseBranch,
+}: {
+	git: SimpleGit;
+	worktreePath: string;
+	baseBranch?: string;
+}): Promise<GitStatusSnapshot> {
+	const currentBranchName = (
+		await git.revparse(["--abbrev-ref", "HEAD"]).catch(() => "")
+	).trim();
+	const base = await resolveBaseComparison(git, baseBranch);
+	const defaultBranchName = base?.branchName ?? null;
+	const baseRef = base?.baseRef ?? "HEAD";
+
+	const [currentBranch, defaultBranch, status, ignoredRaw] = await Promise.all([
+		buildBranch(git, currentBranchName, true, baseRef),
+		defaultBranchName
+			? buildBranch(git, defaultBranchName, false)
+			: buildBranch(git, currentBranchName, true),
+		git.status(),
+		git
+			.raw([
+				"ls-files",
+				"--others",
+				"--ignored",
+				"--exclude-standard",
+				"--directory",
+			])
+			.catch(() => ""),
+	]);
+
+	// Top-level gitignored paths. `--directory` collapses entirely-ignored
+	// folders to a single entry (e.g. `node_modules`) instead of enumerating
+	// every file inside, so this stays cheap in large repos.
+	const ignoredPaths = ignoredRaw
+		.split("\n")
+		.map((line) => line.trim().replace(/\/$/, ""))
+		.filter(Boolean);
+
+	const againstBase = await getChangedFilesForDiff(git, [`${baseRef}...HEAD`]);
+
+	// Staged — use status.files index character for correct status. `-M` lets
+	// numstat collapse renamed entries without the tree-wide copy-source scan
+	// that `-C` performs.
+	const stagedNumstat = parseNumstat(
+		await git
+			.raw(["diff", "--numstat", "-z", "-M", "--cached"])
+			.catch(() => ""),
+	);
+	const staged: ChangedFile[] = [];
+	for (const file of status.files) {
+		const idx = file.index;
+		if (idx && idx !== " " && idx !== "?") {
+			const stats = stagedNumstat.get(file.path) ?? {
+				additions: 0,
+				deletions: 0,
+			};
+			staged.push({
+				path: file.path,
+				oldPath: file.from && file.from !== file.path ? file.from : undefined,
+				status: mapGitStatus(idx),
+				additions: stats.additions,
+				deletions: stats.deletions,
+			});
+		}
+	}
+
+	const unstagedNumstat = parseNumstat(
+		await git.raw(["diff", "--numstat", "-z"]).catch(() => ""),
+	);
+	const unstaged: ChangedFile[] = [];
+	const untrackedFiles: ChangedFile[] = [];
+	for (const file of status.files) {
+		const wd = file.working_dir;
+		if (file.index === "?" && wd === "?") {
+			const entry: ChangedFile = {
+				path: file.path,
+				status: "untracked",
+				additions: 0,
+				deletions: 0,
+			};
+			untrackedFiles.push(entry);
+			unstaged.push(entry);
+		} else if (wd && wd !== " ") {
+			const stats = unstagedNumstat.get(file.path) ?? {
+				additions: 0,
+				deletions: 0,
+			};
+			unstaged.push({
+				path: file.path,
+				status: mapGitStatus(wd),
+				additions: stats.additions,
+				deletions: stats.deletions,
+			});
+		}
+	}
+	await countUntrackedFileLines(worktreePath, untrackedFiles);
+
+	const hasDeletions = unstaged.some((file) => file.status === "deleted");
+	const renames = await detectUnstagedRenames(
+		git,
+		worktreePath,
+		untrackedFiles.map((file) => file.path),
+		hasDeletions,
+	);
+
+	let mergedUnstaged = unstaged;
+	if (renames.length > 0) {
+		const consumedDeleted = new Set<string>();
+		const consumedUntracked = new Set<string>();
+		for (const rename of renames) {
+			consumedDeleted.add(rename.oldPath);
+			consumedUntracked.add(rename.newPath);
+		}
+		mergedUnstaged = unstaged.filter((file) => {
+			if (file.status === "deleted" && consumedDeleted.has(file.path))
+				return false;
+			if (file.status === "untracked" && consumedUntracked.has(file.path))
+				return false;
+			return true;
+		});
+		for (const rename of renames) {
+			mergedUnstaged.push({
+				path: rename.newPath,
+				oldPath: rename.oldPath,
+				status: rename.status,
+				additions: rename.additions,
+				deletions: rename.deletions,
+			});
+		}
+	}
+
+	return {
+		currentBranch,
+		defaultBranch,
+		againstBase,
+		staged,
+		unstaged: mergedUnstaged,
+		ignoredPaths,
+	};
+}


### PR DESCRIPTION
## What changed

- Adds a host-service `git.getStatus` refresh limiter that serializes refreshes per workspace, keeps one trailing refresh per request key, and caps global concurrent status refreshes.
- Prioritizes foreground/current-workspace status refreshes over background dashboard badge refreshes, and promotes a queued background refresh if the user navigates to that workspace.
- Extracts the git status snapshot computation so the router and stress profiler exercise the same code path.
- Refactors the v2 workspace renderer to have one `useGitStatus` owner/provider per workspace instead of multiple consumers independently subscribing to `git:changed` and refetching status.
- Drops copy detection (`-C`) from status diff calls while keeping rename detection (`-M`).
- Adds a large-repo git-status profiler with compute and event-bus flows, optional CDP capture, subprocess counting, and an EDR-style per-git delay.

## Why

Under worktree churn, `GitWatcher` correctly debounces filesystem events, but every emitted `git:changed` could still trigger overlapping full git status refreshes. Each refresh fans out to many git subprocesses, so sustained churn could produce a process swarm and pin CPU. This bounds the expensive work in the host service and removes duplicate renderer ownership of the live status query.

The limiter bounds event storms per workspace, but rapid switching can still enqueue work across many distinct workspaces. To avoid stale background work delaying the workspace the user is actually looking at, foreground requests are scheduled ahead of background sidebar stats without cancelling visible requests.

## Validation

- `bun test packages/host-service/src/trpc/router/git/utils/git-status-refresh-limiter.test.ts packages/host-service/test/integration/git.integration.test.ts`
- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd apps/desktop typecheck`
- `bun run lint`
- `git diff --check`

Large event-flow profiler, 30k tracked files, 1k dirty files, 60 worktree mutations, 100ms artificial git delay:

- Reverted/unbounded shape: 31-34 refreshes, 496-544 git subprocesses, peak 9-10 active git processes.
- Current limiter: 14 refreshes, 224 git subprocesses, peak 4 active git processes.

I also tried a more aggressive server-side trailing debounce, but rejected it because queued tRPC callers can hit the existing 15s `getStatus` timeout under heavy churn. This PR keeps the safer fix that bounds process fanout without delaying the normal first refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Global, rate-limited git status refreshes with foreground/background prioritization to reduce resource use and contention
  * Smarter cache invalidation targeting changed file paths when possible, lowering unnecessary refreshes
  * Workspace-scoped Git status provider to stabilize status across workspace UI panes
  * More accurate rename detection and consistent status snapshots

* **New Features**
  * Git-status profiling utility to benchmark and trace performance on large repositories

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->