### PR TITLE
[codex] fix changes tree context menu

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PathActionsMenuItems/PathActionsMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PathActionsMenuItems/PathActionsMenuItems.tsx
@@ -2,6 +2,10 @@ import {
 	ContextMenuItem,
 	ContextMenuSeparator,
 } from "@superset/ui/context-menu";
+import {
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+} from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
 import { Clipboard, Copy, FolderOpen } from "lucide-react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
@@ -10,11 +14,13 @@ import { electronTrpcClient } from "renderer/lib/trpc-client";
 interface PathActionsMenuItemsProps {
 	absolutePath: string;
 	relativePath?: string;
+	menuType?: "context" | "dropdown";
 }
 
 export function PathActionsMenuItems({
 	absolutePath,
 	relativePath,
+	menuType = "context",
 }: PathActionsMenuItemsProps) {
 	const { copyToClipboard } = useCopyToClipboard();
 
@@ -35,6 +41,32 @@ export function PathActionsMenuItems({
 			);
 		}
 	};
+
+	if (menuType === "dropdown") {
+		return (
+			<>
+				<DropdownMenuItem onSelect={handleRevealInFinder}>
+					<FolderOpen />
+					Reveal in Finder
+				</DropdownMenuItem>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem
+					onSelect={() => handleCopy(absolutePath, "Path copied")}
+				>
+					<Clipboard />
+					Copy Path
+				</DropdownMenuItem>
+				{relativePath && (
+					<DropdownMenuItem
+						onSelect={() => handleCopy(relativePath, "Relative path copied")}
+					>
+						<Copy />
+						Copy Relative Path
+					</DropdownMenuItem>
+				)}
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
@@ -110,6 +110,7 @@ export function FileRowContextMenuItems({
 					<PathActionsMenuItems
 						absolutePath={absolutePath}
 						relativePath={file.path}
+						menuType="dropdown"
 					/>
 				</>
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FolderContextMenuItems/FolderContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FolderContextMenuItems/FolderContextMenuItems.tsx
@@ -42,6 +42,7 @@ export function FolderContextMenuItems({
 					<PathActionsMenuItems
 						absolutePath={absolutePath}
 						relativePath={relativePath}
+						menuType="dropdown"
 					/>
 				</>
 			)}


### PR DESCRIPTION
## What changed

- Updated shared path action menu items to render either context-menu or dropdown-menu primitives depending on the caller.
- Switched the V2 Changes tree file and folder menus to request dropdown menu primitives.

## Why

The Changes tree row menu is implemented with a controlled Radix dropdown menu, but its shared path actions rendered Radix context-menu items. Opening a tree context menu that included those path actions mounted `ContextMenuItem` under `DropdownMenuContent`, which triggers Radix provider error: `MenuItem must be used within Menu`.

## Impact

Right-click and hover actions in the Changes tree can now show path actions like Reveal in Finder and Copy Path without crashing. Existing flat-file context menus keep their context-menu behavior by default.

## Validation

- `bunx biome check --write --unsafe <touched files>`
- `bunx tsc --noEmit -p apps/desktop/tsconfig.json`
- `bun run lint`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4736">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Changes tree context menu crash by rendering the correct menu primitives. V2 Changes tree path actions now use dropdown items, removing the Radix “MenuItem must be used within Menu” error.

- **Bug Fixes**
  - Added a `menuType` prop to PathActionsMenuItems to switch between `@superset/ui/context-menu` and `@superset/ui/dropdown-menu`.
  - Updated V2 Changes tree file and folder menus to request dropdown items.
  - Preserves context-menu behavior for other views.

<sup>Written for commit d9d10228b0e3316dc2d697946cb505ba7d26af56. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4736?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Path action menus in the workspace sidebar now support dual rendering modes. File and folder operation menus can now be displayed as either context menus or dropdown menus based on the specific interface context. This affects menu presentation throughout the workspace interface, including file and folder management operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->