### PR TITLE
[codex] Track workspace transaction state

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -35,7 +35,7 @@ export function DashboardSidebarWorkspaceItem({
 		hostIsOnline,
 		name,
 		branch,
-		isSynced,
+		pendingTransaction,
 		pullRequest,
 	} = workspace;
 	const isMainWorkspace = workspace.type === "main";
@@ -76,7 +76,7 @@ export function DashboardSidebarWorkspaceItem({
 	const handleAfterBranchRename = (newBranchName: string) => {
 		v2WorkspaceActions.updateWorkspace(id, { branch: newBranchName });
 	};
-	const isPending = !isSynced;
+	const isPending = pendingTransaction?.type === "insert";
 	// Keep the delete dialog outside the hidden wrapper below — the destroy
 	// flow reopens it into an error pane on conflict/teardown-failed.
 	const isDeleting = useDeletingWorkspaces().isDeleting(id);
@@ -136,7 +136,7 @@ export function DashboardSidebarWorkspaceItem({
 					isActive={isActive}
 					workspaceStatus={workspaceStatus}
 					onClick={handleClick}
-					isSynced={isSynced}
+					isCreatePending={isPending}
 					pullRequestState={pullRequest?.state ?? null}
 					aria-label={isPending ? `Creating workspace: ${name}` : undefined}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -15,7 +15,7 @@ interface DashboardSidebarCollapsedWorkspaceButtonProps
 	hostIsOnline: boolean | null;
 	isActive: boolean;
 	workspaceStatus?: ActivePaneStatus | null;
-	isSynced: boolean;
+	isCreatePending: boolean;
 	pullRequestState?: DashboardSidebarWorkspacePullRequest["state"] | null;
 }
 
@@ -30,7 +30,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 			hostIsOnline,
 			isActive,
 			workspaceStatus = null,
-			isSynced,
+			isCreatePending,
 			pullRequestState = null,
 			className,
 			...props
@@ -56,7 +56,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 					isActive={isActive}
 					variant="collapsed"
 					workspaceStatus={workspaceStatus}
-					isSynced={isSynced}
+					isCreatePending={isCreatePending}
 					pullRequestState={pullRequestState}
 				/>
 			</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -81,9 +81,9 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			name,
 			branch,
 			pullRequest,
-			isSynced,
+			pendingTransaction,
 		} = workspace;
-		const isPending = !isSynced;
+		const isPending = pendingTransaction?.type === "insert";
 		const showsStandaloneActiveStripe = accentColor == null;
 		const localRef = useRef<HTMLDivElement>(null);
 		const openUrl = electronTrpc.external.openUrl.useMutation();
@@ -170,7 +170,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 									isActive={isActive}
 									variant="expanded"
 									workspaceStatus={workspaceStatus}
-									isSynced={isSynced}
+									isCreatePending={isPending}
 									pullRequestState={pullRequest.state}
 								/>
 							</button>
@@ -183,7 +183,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 									isActive={isActive}
 									variant="expanded"
 									workspaceStatus={workspaceStatus}
-									isSynced={isSynced}
+									isCreatePending={isPending}
 									pullRequestState={null}
 								/>
 							</div>
@@ -265,7 +265,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 								/>
 							)
 						)}
-						{isSynced && (
+						{!isPending && (
 							<div className="hidden items-center justify-end gap-1.5 group-hover:flex">
 								{shortcutLabel && (
 									<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -24,7 +24,7 @@ interface DashboardSidebarWorkspaceIconProps {
 	isActive: boolean;
 	variant: "collapsed" | "expanded";
 	workspaceStatus?: ActivePaneStatus | null;
-	isSynced: boolean;
+	isCreatePending: boolean;
 	pullRequestState?: DashboardSidebarWorkspacePullRequest["state"] | null;
 }
 
@@ -54,7 +54,7 @@ export function DashboardSidebarWorkspaceIcon({
 	isActive,
 	variant,
 	workspaceStatus = null,
-	isSynced,
+	isCreatePending,
 	pullRequestState = null,
 }: DashboardSidebarWorkspaceIconProps) {
 	const overlayPosition = OVERLAY_POSITION[variant];
@@ -102,7 +102,7 @@ export function DashboardSidebarWorkspaceIcon({
 
 	return (
 		<>
-			{!isSynced || workspaceStatus === "working" ? (
+			{isCreatePending || workspaceStatus === "working" ? (
 				<AsciiSpinner className="text-base" />
 			) : (
 				renderPrimaryIcon()

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -292,7 +292,8 @@ export function useDashboardSidebarData() {
 			...rawSidebarWorkspaces,
 			...rawLocalMainWorkspaces,
 		]) {
-			if (workspace.isSynced && workspaceTransactionsById[workspace.id]) {
+			const transaction = workspaceTransactionsById[workspace.id];
+			if (workspace.isSynced && transaction?.type === "insert") {
 				clearWorkspaceTransaction(workspace.id);
 			}
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -1,13 +1,14 @@
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { getVisibleSidebarWorkspaces } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useWorkspaceTransactionsStore } from "renderer/stores/workspace-creates";
 import type {
 	DashboardSidebarProject,
 	DashboardSidebarProjectChild,
@@ -128,6 +129,12 @@ export function useDashboardSidebarData() {
 	const relayUrl = useRelayUrl();
 	const { toggleProjectCollapsed } = useDashboardSidebarState();
 	const queryClient = useQueryClient();
+	const workspaceTransactionsById = useWorkspaceTransactionsStore(
+		(state) => state.byWorkspaceId,
+	);
+	const clearWorkspaceTransaction = useWorkspaceTransactionsStore(
+		(state) => state.clear,
+	);
 
 	const { data: hosts = [] } = useLiveQuery(
 		(q) =>
@@ -234,8 +241,9 @@ export function useDashboardSidebarData() {
 			rawSidebarWorkspaces.map((workspace) => ({
 				...workspace,
 				hostIsOnline: hostsByMachineId.get(workspace.hostId)?.isOnline ?? false,
+				pendingTransaction: workspaceTransactionsById[workspace.id] ?? null,
 			})),
-		[hostsByMachineId, rawSidebarWorkspaces],
+		[hostsByMachineId, rawSidebarWorkspaces, workspaceTransactionsById],
 	);
 
 	const sidebarWorkspaces = useMemo(
@@ -274,9 +282,26 @@ export function useDashboardSidebarData() {
 			rawLocalMainWorkspaces.map((workspace) => ({
 				...workspace,
 				hostIsOnline: hostsByMachineId.get(workspace.hostId)?.isOnline ?? false,
+				pendingTransaction: workspaceTransactionsById[workspace.id] ?? null,
 			})),
-		[hostsByMachineId, rawLocalMainWorkspaces],
+		[hostsByMachineId, rawLocalMainWorkspaces, workspaceTransactionsById],
 	);
+
+	useEffect(() => {
+		for (const workspace of [
+			...rawSidebarWorkspaces,
+			...rawLocalMainWorkspaces,
+		]) {
+			if (workspace.isSynced && workspaceTransactionsById[workspace.id]) {
+				clearWorkspaceTransaction(workspace.id);
+			}
+		}
+	}, [
+		clearWorkspaceTransaction,
+		rawLocalMainWorkspaces,
+		rawSidebarWorkspaces,
+		workspaceTransactionsById,
+	]);
 
 	const visibleSidebarWorkspaces = useMemo(() => {
 		const sidebarProjectIds = new Set(
@@ -435,6 +460,7 @@ export function useDashboardSidebarData() {
 				updatedAt: workspace.updatedAt,
 				taskId: workspace.taskId,
 				isSynced: workspace.isSynced,
+				pendingTransaction: workspace.pendingTransaction,
 			};
 
 			if (workspace.sectionId) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -59,7 +59,11 @@ export function useDashboardSidebarShortcuts(
 		() =>
 			groups
 				.flatMap((project) => getProjectChildrenWorkspaces(project.children))
-				.filter((workspace) => workspace.isSynced && !isDeleting(workspace.id)),
+				.filter(
+					(workspace) =>
+						workspace.pendingTransaction?.type !== "insert" &&
+						!isDeleting(workspace.id),
+				),
 		[groups, isDeleting],
 	);
 	const workspaceShortcutLabels =

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -1,3 +1,5 @@
+import type { WorkspaceTransactionSnapshot } from "renderer/stores/workspace-creates";
+
 export type DashboardSidebarWorkspaceHostType =
 	| "local-device"
 	| "remote-device"
@@ -42,6 +44,7 @@ export interface DashboardSidebarWorkspace {
 	updatedAt: Date;
 	taskId: string | null;
 	isSynced: boolean;
+	pendingTransaction: WorkspaceTransactionSnapshot | null;
 }
 
 export interface DashboardSidebarSection {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -53,10 +53,10 @@ function V2WorkspaceLayout() {
 	const failedEntry = failedEntries?.[0] ?? null;
 
 	useEffect(() => {
-		if (workspace?.$synced === true) {
+		if (workspace?.$synced === true && pendingTransaction?.type === "insert") {
 			clearWorkspaceTransaction(workspace.id);
 		}
-	}, [clearWorkspaceTransaction, workspace]);
+	}, [clearWorkspaceTransaction, pendingTransaction, workspace]);
 
 	const lastEnsuredWorkspaceIdRef = useRef<string | null>(null);
 	useEffect(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useWorkspaceTransactionsStore } from "renderer/stores/workspace-creates";
 import { WorkspaceCreateErrorState } from "./components/WorkspaceCreateErrorState";
 import { WorkspaceCreatingState } from "./components/WorkspaceCreatingState";
 import { WorkspaceHostIncompatibleState } from "./components/WorkspaceHostIncompatibleState";
@@ -26,6 +27,13 @@ function V2WorkspaceLayout() {
 		workspaceMatch !== false ? workspaceMatch.workspaceId : null;
 	const collections = useCollections();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
+	const pendingTransaction = useWorkspaceTransactionsStore((state) =>
+		workspaceId ? (state.byWorkspaceId[workspaceId] ?? null) : null,
+	);
+	const clearWorkspaceTransaction = useWorkspaceTransactionsStore(
+		(state) => state.clear,
+	);
+	const isCreatePending = pendingTransaction?.type === "insert";
 
 	const { data: workspaces, isReady } = useLiveQuery(
 		(q) =>
@@ -43,21 +51,26 @@ function V2WorkspaceLayout() {
 	);
 	const workspace = workspaces?.[0] ?? null;
 	const failedEntry = failedEntries?.[0] ?? null;
-	const isSynced = workspace?.$synced === true;
+
+	useEffect(() => {
+		if (workspace?.$synced === true) {
+			clearWorkspaceTransaction(workspace.id);
+		}
+	}, [clearWorkspaceTransaction, workspace]);
 
 	const lastEnsuredWorkspaceIdRef = useRef<string | null>(null);
 	useEffect(() => {
 		if (
 			!workspace ||
-			!isSynced ||
+			isCreatePending ||
 			lastEnsuredWorkspaceIdRef.current === workspace.id
 		)
 			return;
 		lastEnsuredWorkspaceIdRef.current = workspace.id;
 		ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
-	}, [ensureWorkspaceInSidebar, workspace, isSynced]);
+	}, [ensureWorkspaceInSidebar, workspace, isCreatePending]);
 
-	const hostStatus = useRemoteHostStatus(isSynced ? workspace : null);
+	const hostStatus = useRemoteHostStatus(isCreatePending ? null : workspace);
 
 	if (!workspaceId || !isReady || !workspaces) {
 		return <div className="flex h-full w-full" />;
@@ -70,7 +83,7 @@ function V2WorkspaceLayout() {
 		return <WorkspaceNotFoundState workspaceId={workspaceId} />;
 	}
 
-	if (!isSynced) {
+	if (isCreatePending) {
 		return (
 			<WorkspaceCreatingState
 				name={workspace.name}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -51,6 +51,9 @@ function V2WorkspaceLayout() {
 	);
 	const workspace = workspaces?.[0] ?? null;
 	const failedEntry = failedEntries?.[0] ?? null;
+	const canUseWorkspace =
+		workspace !== null &&
+		(workspace.$synced === true || pendingTransaction?.type === "update");
 
 	useEffect(() => {
 		if (workspace?.$synced === true && pendingTransaction?.type === "insert") {
@@ -62,15 +65,15 @@ function V2WorkspaceLayout() {
 	useEffect(() => {
 		if (
 			!workspace ||
-			isCreatePending ||
+			!canUseWorkspace ||
 			lastEnsuredWorkspaceIdRef.current === workspace.id
 		)
 			return;
 		lastEnsuredWorkspaceIdRef.current = workspace.id;
 		ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
-	}, [ensureWorkspaceInSidebar, workspace, isCreatePending]);
+	}, [ensureWorkspaceInSidebar, workspace, canUseWorkspace]);
 
-	const hostStatus = useRemoteHostStatus(isCreatePending ? null : workspace);
+	const hostStatus = useRemoteHostStatus(canUseWorkspace ? workspace : null);
 
 	if (!workspaceId || !isReady || !workspaces) {
 		return <div className="flex h-full w-full" />;
@@ -91,6 +94,10 @@ function V2WorkspaceLayout() {
 				startedAt={new Date(workspace.createdAt).getTime()}
 			/>
 		);
+	}
+
+	if (!canUseWorkspace) {
+		return <div className="flex h-full w-full" />;
 	}
 
 	if (hostStatus.status === "incompatible") {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
@@ -4,14 +4,14 @@ import { useCallback, useMemo } from "react";
 import { isDesktopChatDevMode } from "renderer/lib/dev-chat";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
+	type TrackableWorkspaceTransactionState,
 	useWorkspaceTransactionsStore,
-	type WorkspaceTransactionState,
 	type WorkspaceTransactionType,
 } from "renderer/stores/workspace-creates";
 
 export type PersistableTransaction = {
 	id: string;
-	state: WorkspaceTransactionState;
+	state: TrackableWorkspaceTransactionState;
 	createdAt: Date;
 	mutations: Array<{ type: WorkspaceTransactionType }>;
 	isPersisted: {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticCollectionActions/useOptimisticCollectionActions.ts
@@ -3,8 +3,17 @@ import { toast } from "@superset/ui/sonner";
 import { useCallback, useMemo } from "react";
 import { isDesktopChatDevMode } from "renderer/lib/dev-chat";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import {
+	useWorkspaceTransactionsStore,
+	type WorkspaceTransactionState,
+	type WorkspaceTransactionType,
+} from "renderer/stores/workspace-creates";
 
 export type PersistableTransaction = {
+	id: string;
+	state: WorkspaceTransactionState;
+	createdAt: Date;
+	mutations: Array<{ type: WorkspaceTransactionType }>;
 	isPersisted: {
 		promise: Promise<unknown>;
 	};
@@ -73,6 +82,9 @@ function useOptimisticMutationRunner() {
 export function useOptimisticCollectionActions() {
 	const collections = useCollections();
 	const runMutation = useOptimisticMutationRunner();
+	const trackWorkspaceTransaction = useWorkspaceTransactionsStore(
+		(state) => state.track,
+	);
 
 	return useMemo(() => {
 		const runTaskMutation = (
@@ -178,29 +190,43 @@ export function useOptimisticCollectionActions() {
 					),
 			},
 			v2Workspaces: {
-				updateWorkspace: (workspaceId: string, patch: V2WorkspacePatch) =>
-					runWorkspaceMutation("Failed to update workspace", () =>
-						collections.v2Workspaces.update(workspaceId, (draft) => {
-							if (patch.name !== undefined) {
-								draft.name = patch.name;
-							}
-							if (patch.branch !== undefined) {
-								draft.branch = patch.branch;
-							}
-							if (patch.hostId !== undefined) {
-								draft.hostId = patch.hostId;
-							}
-							if (patch.taskId !== undefined) {
-								draft.taskId = patch.taskId;
-							}
-						}),
-					),
-				renameWorkspace: (workspaceId: string, name: string) =>
-					runWorkspaceMutation("Failed to rename workspace", () =>
-						collections.v2Workspaces.update(workspaceId, (draft) => {
-							draft.name = name;
-						}),
-					),
+				updateWorkspace: (workspaceId: string, patch: V2WorkspacePatch) => {
+					const transaction = runWorkspaceMutation(
+						"Failed to update workspace",
+						() =>
+							collections.v2Workspaces.update(workspaceId, (draft) => {
+								if (patch.name !== undefined) {
+									draft.name = patch.name;
+								}
+								if (patch.branch !== undefined) {
+									draft.branch = patch.branch;
+								}
+								if (patch.hostId !== undefined) {
+									draft.hostId = patch.hostId;
+								}
+								if (patch.taskId !== undefined) {
+									draft.taskId = patch.taskId;
+								}
+							}),
+					);
+					if (transaction) {
+						trackWorkspaceTransaction(workspaceId, transaction);
+					}
+					return transaction;
+				},
+				renameWorkspace: (workspaceId: string, name: string) => {
+					const transaction = runWorkspaceMutation(
+						"Failed to rename workspace",
+						() =>
+							collections.v2Workspaces.update(workspaceId, (draft) => {
+								draft.name = name;
+							}),
+					);
+					if (transaction) {
+						trackWorkspaceTransaction(workspaceId, transaction);
+					}
+					return transaction;
+				},
 			},
 			chatSessions: {
 				deleteSession: (sessionId: string) => {
@@ -249,5 +275,5 @@ export function useOptimisticCollectionActions() {
 					),
 			},
 		};
-	}, [collections, runMutation]);
+	}, [collections, runMutation, trackWorkspaceTransaction]);
 }

--- a/apps/desktop/src/renderer/stores/workspace-creates/index.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/index.ts
@@ -7,6 +7,7 @@ export {
 	type WorkspacesCreateInput,
 } from "./useWorkspaceCreates";
 export {
+	type TrackableWorkspaceTransactionState,
 	useWorkspaceTransactionsStore,
 	type WorkspaceTransactionSnapshot,
 	type WorkspaceTransactionState,

--- a/apps/desktop/src/renderer/stores/workspace-creates/index.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/index.ts
@@ -6,3 +6,9 @@ export {
 	useWorkspaceCreates,
 	type WorkspacesCreateInput,
 } from "./useWorkspaceCreates";
+export {
+	useWorkspaceTransactionsStore,
+	type WorkspaceTransactionSnapshot,
+	type WorkspaceTransactionState,
+	type WorkspaceTransactionType,
+} from "./workspaceTransactions";

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -8,6 +8,7 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import type { WorkspaceCreateMutationMetadata } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
 import type { WorkspacesCreateInput } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useWorkspaceTransactionsStore } from "./workspaceTransactions";
 import { writeWorkspacePaneLayout } from "./writeWorkspacePaneLayout";
 
 export type { WorkspacesCreateInput };
@@ -38,6 +39,9 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 	const userId = session?.user?.id ?? null;
 	const collections = useCollections();
 	const relayUrl = useRelayUrl();
+	const trackWorkspaceTransaction = useWorkspaceTransactionsStore(
+		(state) => state.track,
+	);
 
 	const submit = useCallback(
 		(args: SubmitArgs): SubmitHandle => {
@@ -115,6 +119,7 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 			const transaction = collections.v2Workspaces.insert(optimisticRow, {
 				metadata,
 			});
+			trackWorkspaceTransaction(workspaceId, transaction);
 			writeWorkspacePaneLayout(
 				collections,
 				{ id: workspaceId, projectId: args.snapshot.projectId },
@@ -157,6 +162,7 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 			collections,
 			relayUrl,
 			hostService,
+			trackWorkspaceTransaction,
 		],
 	);
 

--- a/apps/desktop/src/renderer/stores/workspace-creates/workspaceTransactions.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/workspaceTransactions.ts
@@ -1,9 +1,9 @@
 import { create } from "zustand";
 
 export type WorkspaceTransactionType = "insert" | "update" | "delete";
-export type WorkspaceTransactionState =
-	| "pending"
-	| "persisting"
+export type WorkspaceTransactionState = "pending" | "persisting";
+export type TrackableWorkspaceTransactionState =
+	| WorkspaceTransactionState
 	| "completed"
 	| "failed";
 
@@ -18,7 +18,7 @@ export interface WorkspaceTransactionSnapshot {
 
 interface TrackableWorkspaceTransaction {
 	id: string;
-	state: WorkspaceTransactionState;
+	state: TrackableWorkspaceTransactionState;
 	createdAt: Date;
 	mutations: Array<{ type: WorkspaceTransactionType }>;
 	isPersisted: {
@@ -41,6 +41,9 @@ export const useWorkspaceTransactionsStore = create<WorkspaceTransactionsState>(
 		track: (workspaceId, transaction) => {
 			const mutation = transaction.mutations[0];
 			if (!mutation) return;
+			if (transaction.state === "completed" || transaction.state === "failed") {
+				return;
+			}
 
 			const writeSnapshot = (state: WorkspaceTransactionState) => {
 				set((current) => ({
@@ -59,18 +62,15 @@ export const useWorkspaceTransactionsStore = create<WorkspaceTransactionsState>(
 			};
 
 			writeSnapshot(transaction.state);
-			queueMicrotask(() => writeSnapshot(transaction.state));
 
 			void transaction.isPersisted.promise.then(
 				() => {
 					if (get().byWorkspaceId[workspaceId]?.id === transaction.id) {
-						writeSnapshot("completed");
 						get().clear(workspaceId);
 					}
 				},
 				() => {
 					if (get().byWorkspaceId[workspaceId]?.id === transaction.id) {
-						writeSnapshot("failed");
 						get().clear(workspaceId);
 					}
 				},

--- a/apps/desktop/src/renderer/stores/workspace-creates/workspaceTransactions.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/workspaceTransactions.ts
@@ -1,0 +1,86 @@
+import { create } from "zustand";
+
+export type WorkspaceTransactionType = "insert" | "update" | "delete";
+export type WorkspaceTransactionState =
+	| "pending"
+	| "persisting"
+	| "completed"
+	| "failed";
+
+export interface WorkspaceTransactionSnapshot {
+	id: string;
+	workspaceId: string;
+	type: WorkspaceTransactionType;
+	state: WorkspaceTransactionState;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+interface TrackableWorkspaceTransaction {
+	id: string;
+	state: WorkspaceTransactionState;
+	createdAt: Date;
+	mutations: Array<{ type: WorkspaceTransactionType }>;
+	isPersisted: {
+		promise: Promise<unknown>;
+	};
+}
+
+interface WorkspaceTransactionsState {
+	byWorkspaceId: Record<string, WorkspaceTransactionSnapshot>;
+	track: (
+		workspaceId: string,
+		transaction: TrackableWorkspaceTransaction,
+	) => void;
+	clear: (workspaceId: string) => void;
+}
+
+export const useWorkspaceTransactionsStore = create<WorkspaceTransactionsState>(
+	(set, get) => ({
+		byWorkspaceId: {},
+		track: (workspaceId, transaction) => {
+			const mutation = transaction.mutations[0];
+			if (!mutation) return;
+
+			const writeSnapshot = (state: WorkspaceTransactionState) => {
+				set((current) => ({
+					byWorkspaceId: {
+						...current.byWorkspaceId,
+						[workspaceId]: {
+							id: transaction.id,
+							workspaceId,
+							type: mutation.type,
+							state,
+							createdAt: transaction.createdAt,
+							updatedAt: new Date(),
+						},
+					},
+				}));
+			};
+
+			writeSnapshot(transaction.state);
+			queueMicrotask(() => writeSnapshot(transaction.state));
+
+			void transaction.isPersisted.promise.then(
+				() => {
+					if (get().byWorkspaceId[workspaceId]?.id === transaction.id) {
+						writeSnapshot("completed");
+						get().clear(workspaceId);
+					}
+				},
+				() => {
+					if (get().byWorkspaceId[workspaceId]?.id === transaction.id) {
+						writeSnapshot("failed");
+						get().clear(workspaceId);
+					}
+				},
+			);
+		},
+		clear: (workspaceId) =>
+			set((state) => {
+				if (!state.byWorkspaceId[workspaceId]) return state;
+				const { [workspaceId]: _removed, ...rest } = state.byWorkspaceId;
+				return { byWorkspaceId: rest };
+			}),
+	}),
+);


### PR DESCRIPTION
## Summary

- Track workspace TanStack DB transaction projections by workspace id, including mutation type and state.
- Augment dashboard sidebar workspace rows with `pendingTransaction` instead of deriving create loading from ``.
- Show workspace creation loading only for pending insert transactions, so rename/task-link updates no longer show the create state.
- Clear transaction projections when persistence settles or when Electric confirms the row as synced.

## Root Cause

`` is a row-level optimistic-state flag. It becomes false for any pending optimistic mutation, including updates, so using it as “workspace is being created” made normal workspace edits look like creates.

## Validation

- `bun run lint`
- `bun run --cwd apps/desktop typecheck`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4740">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track per-workspace transaction state to show “creating” only for inserts and keep update transactions until they finish. Insert transactions auto-clear on persistence or when `$synced === true`; updates are preserved until persistence settles and no longer block workspace usage.

- **New Features**
  - Added `useWorkspaceTransactionsStore` to snapshot per-workspace transactions (id, type, state, timestamps) and clear them on settle.
  - Exposed `pendingTransaction` on sidebar workspace data; insert transactions clear on `$synced === true`, updates are not cleared by sync.
  - Insert, update, and rename mutations register with the store; layout and sidebar use this to gate host status, “ensure in sidebar,” and creation state.

- **Bug Fixes**
  - Replaced `!isSynced` checks with `isCreatePending` (only when type is `insert`), so edits no longer show the create spinner.
  - Workspace view, host status, and shortcuts are blocked only during creates; spinner shows for creates or when `workspaceStatus === "working"`.

<sup>Written for commit c0b29d189a1012756bf23a0b8c7a51af9974478d. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4740?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sidebar now tracks workspace operations via transaction-based pending state instead of sync flags.
* **New Features**
  * Workspaces being created show a distinct "creating" state (spinner/icon) and are excluded from hover/shortcut lists.
* **Bug Fixes**
  * Pending create state is automatically cleared once a workspace finishes syncing, improving sidebar consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->