### PR TITLE
[codex] fix dangerouslySetInnerHTML XSS findings

### DIFF
--- a/apps/marketing/src/app/team/[id]/page.tsx
+++ b/apps/marketing/src/app/team/[id]/page.tsx
@@ -12,8 +12,10 @@ import {
 } from "react-icons/ri";
 import { GridCross } from "@/app/blog/components/GridCross";
 import { mdxComponents } from "@/app/blog/components/mdx-components";
-import { BreadcrumbJsonLd } from "@/components/JsonLd";
+import { BreadcrumbJsonLd, JsonLdScript } from "@/components/JsonLd";
 import { getAllPeople, getPersonById } from "@/lib/people";
+import { TeamBio } from "../components/TeamBio";
+import { getTeamBioText } from "../utils/teamBio";
 
 interface PageProps {
 	params: Promise<{ id: string }>;
@@ -56,13 +58,7 @@ function PersonJsonLd({
 		...(sameAs.length > 0 && { sameAs }),
 	};
 
-	return (
-		<script
-			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
-		/>
-	);
+	return <JsonLdScript schema={schema} />;
 }
 
 export default async function TeamMemberPage({ params }: PageProps) {
@@ -143,10 +139,9 @@ export default async function TeamMemberPage({ params }: PageProps) {
 							</h1>
 
 							{person.bio && (
-								<p
+								<TeamBio
+									bio={person.bio}
 									className="text-base md:text-lg text-muted-foreground max-w-2xl mx-auto mb-6 [&_a]:text-muted-foreground [&_a]:underline [&_a]:underline-offset-2 [&_a]:hover:text-foreground"
-									// biome-ignore lint/security/noDangerouslySetInnerHtml: controlled content from team data
-									dangerouslySetInnerHTML={{ __html: person.bio }}
 								/>
 							)}
 
@@ -303,16 +298,19 @@ export async function generateMetadata({
 	}
 
 	const url = `${COMPANY.MARKETING_URL}/team/${id}`;
+	const description = person.bio
+		? getTeamBioText(person.bio)
+		: `${person.name}, ${person.role} at Superset`;
 
 	return {
 		title: `${person.name} — ${person.role}`,
-		description: person.bio ?? `${person.name}, ${person.role} at Superset`,
+		description,
 		alternates: {
 			canonical: url,
 		},
 		openGraph: {
 			title: `${person.name} — ${person.role} at Superset`,
-			description: person.bio ?? `${person.name}, ${person.role} at Superset`,
+			description,
 			type: "profile",
 			url,
 			siteName: COMPANY.NAME,
@@ -323,7 +321,7 @@ export async function generateMetadata({
 		twitter: {
 			card: "summary",
 			title: `${person.name} — ${person.role} at Superset`,
-			description: person.bio ?? `${person.name}, ${person.role} at Superset`,
+			description,
 			...(person.avatar && {
 				images: [`${COMPANY.MARKETING_URL}${person.avatar}`],
 			}),

--- a/apps/marketing/src/app/team/components/TeamBio/TeamBio.tsx
+++ b/apps/marketing/src/app/team/components/TeamBio/TeamBio.tsx
@@ -1,0 +1,31 @@
+import { parseTeamBio } from "../../utils/teamBio";
+
+interface TeamBioProps {
+	bio: string;
+	className?: string;
+}
+
+export function TeamBio({ bio, className }: TeamBioProps) {
+	return (
+		<p className={className}>
+			{parseTeamBio(bio).map((segment, index) => {
+				const key = `${segment.type}-${index}-${segment.text}`;
+
+				if (segment.type === "link") {
+					return (
+						<a
+							href={segment.href}
+							key={key}
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							{segment.text}
+						</a>
+					);
+				}
+
+				return <span key={key}>{segment.text}</span>;
+			})}
+		</p>
+	);
+}

--- a/apps/marketing/src/app/team/components/TeamBio/index.ts
+++ b/apps/marketing/src/app/team/components/TeamBio/index.ts
@@ -1,0 +1,1 @@
+export { TeamBio } from "./TeamBio";

--- a/apps/marketing/src/app/team/page.tsx
+++ b/apps/marketing/src/app/team/page.tsx
@@ -8,6 +8,7 @@ import {
 	RiTwitterXFill,
 } from "react-icons/ri";
 import { getAllPeople } from "@/lib/people";
+import { TeamBio } from "./components/TeamBio";
 
 export const metadata: Metadata = {
 	title: "About",
@@ -112,10 +113,9 @@ export default function TeamPage() {
 											{person.role}
 										</p>
 										{person.bio && (
-											<p
+											<TeamBio
+												bio={person.bio}
 												className="text-sm text-muted-foreground leading-relaxed mt-3 [&_a]:text-muted-foreground [&_a]:underline [&_a]:underline-offset-2 [&_a]:hover:text-foreground"
-												// biome-ignore lint/security/noDangerouslySetInnerHtml: controlled content from team data
-												dangerouslySetInnerHTML={{ __html: person.bio }}
 											/>
 										)}
 

--- a/apps/marketing/src/app/team/utils/teamBio/index.ts
+++ b/apps/marketing/src/app/team/utils/teamBio/index.ts
@@ -1,0 +1,2 @@
+export type { TeamBioSegment } from "./teamBio";
+export { getTeamBioText, parseTeamBio } from "./teamBio";

--- a/apps/marketing/src/app/team/utils/teamBio/teamBio.ts
+++ b/apps/marketing/src/app/team/utils/teamBio/teamBio.ts
@@ -1,0 +1,56 @@
+export type TeamBioSegment =
+	| {
+			type: "text";
+			text: string;
+	  }
+	| {
+			type: "link";
+			text: string;
+			href: string;
+	  };
+
+const safeAnchorPattern =
+	/<a\s+[^>]*href=["'](https?:\/\/[^"']+)["'][^>]*>([^<]+)<\/a>/gi;
+const htmlTagPattern = /<[^>]*>/g;
+
+function toText(value: string): string {
+	return value.replace(htmlTagPattern, "");
+}
+
+export function parseTeamBio(bio: string): TeamBioSegment[] {
+	const segments: TeamBioSegment[] = [];
+	let lastIndex = 0;
+
+	for (const match of bio.matchAll(safeAnchorPattern)) {
+		const fullMatch = match[0];
+		const href = match[1] ?? "";
+		const linkText = match[2] ?? "";
+		const index = match.index ?? 0;
+
+		if (index > lastIndex) {
+			segments.push({
+				type: "text",
+				text: toText(bio.slice(lastIndex, index)),
+			});
+		}
+
+		segments.push({ type: "link", text: toText(linkText), href });
+
+		lastIndex = index + fullMatch.length;
+	}
+
+	if (lastIndex < bio.length) {
+		segments.push({
+			type: "text",
+			text: toText(bio.slice(lastIndex)),
+		});
+	}
+
+	return segments;
+}
+
+export function getTeamBioText(bio: string): string {
+	return parseTeamBio(bio)
+		.map((segment) => segment.text)
+		.join("");
+}

--- a/apps/marketing/src/components/JsonLd/JsonLd.tsx
+++ b/apps/marketing/src/components/JsonLd/JsonLd.tsx
@@ -1,5 +1,34 @@
 import { COMPANY } from "@superset/shared/constants";
 
+function serializeJsonLd(schema: unknown): string {
+	const json = JSON.stringify(schema);
+
+	if (typeof json !== "string") {
+		return "null";
+	}
+
+	return json.replace(/[<>&\u2028\u2029]/g, (character) => {
+		switch (character) {
+			case "<":
+				return "\\u003c";
+			case ">":
+				return "\\u003e";
+			case "&":
+				return "\\u0026";
+			case "\u2028":
+				return "\\u2028";
+			case "\u2029":
+				return "\\u2029";
+			default:
+				return character;
+		}
+	});
+}
+
+export function JsonLdScript({ schema }: { schema: unknown }) {
+	return <script type="application/ld+json">{serializeJsonLd(schema)}</script>;
+}
+
 export function OrganizationJsonLd() {
 	const schema = {
 		"@context": "https://schema.org",
@@ -11,13 +40,7 @@ export function OrganizationJsonLd() {
 		sameAs: [COMPANY.GITHUB_URL, COMPANY.X_URL],
 	};
 
-	return (
-		<script
-			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
-		/>
-	);
+	return <JsonLdScript schema={schema} />;
 }
 
 export function SoftwareApplicationJsonLd() {
@@ -36,13 +59,7 @@ export function SoftwareApplicationJsonLd() {
 		url: COMPANY.MARKETING_URL,
 	};
 
-	return (
-		<script
-			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
-		/>
-	);
+	return <JsonLdScript schema={schema} />;
 }
 
 interface ArticleAuthor {
@@ -102,13 +119,7 @@ export function ArticleJsonLd({
 		}),
 	};
 
-	return (
-		<script
-			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
-		/>
-	);
+	return <JsonLdScript schema={schema} />;
 }
 
 interface ComparisonJsonLdProps {
@@ -161,13 +172,7 @@ export function ComparisonJsonLd({
 		}),
 	};
 
-	return (
-		<script
-			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
-		/>
-	);
+	return <JsonLdScript schema={schema} />;
 }
 
 export function WebsiteJsonLd() {
@@ -178,13 +183,7 @@ export function WebsiteJsonLd() {
 		url: COMPANY.MARKETING_URL,
 	};
 
-	return (
-		<script
-			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
-		/>
-	);
+	return <JsonLdScript schema={schema} />;
 }
 
 interface FAQPageJsonLdProps {
@@ -205,13 +204,7 @@ export function FAQPageJsonLd({ items }: FAQPageJsonLdProps) {
 		})),
 	};
 
-	return (
-		<script
-			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
-		/>
-	);
+	return <JsonLdScript schema={schema} />;
 }
 
 interface BreadcrumbJsonLdProps {
@@ -230,11 +223,5 @@ export function BreadcrumbJsonLd({ items }: BreadcrumbJsonLdProps) {
 		})),
 	};
 
-	return (
-		<script
-			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
-		/>
-	);
+	return <JsonLdScript schema={schema} />;
 }

--- a/apps/marketing/src/components/JsonLd/index.ts
+++ b/apps/marketing/src/components/JsonLd/index.ts
@@ -3,6 +3,7 @@ export {
 	BreadcrumbJsonLd,
 	ComparisonJsonLd,
 	FAQPageJsonLd,
+	JsonLdScript,
 	OrganizationJsonLd,
 	SoftwareApplicationJsonLd,
 	WebsiteJsonLd,

--- a/bun.lock
+++ b/bun.lock
@@ -1014,6 +1014,7 @@
         "cmdk": "1.1.1",
         "date-fns": "4.1.0",
         "embla-carousel-react": "8.6.0",
+        "hast-util-to-jsx-runtime": "2.3.6",
         "input-otp": "1.4.2",
         "lucide-react": "0.563.0",
         "motion": "12.38.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,6 +61,7 @@
 		"cmdk": "1.1.1",
 		"date-fns": "4.1.0",
 		"embla-carousel-react": "8.6.0",
+		"hast-util-to-jsx-runtime": "2.3.6",
 		"input-otp": "1.4.2",
 		"lucide-react": "0.563.0",
 		"motion": "12.38.0",

--- a/packages/ui/src/components/ai-elements/code-block.tsx
+++ b/packages/ui/src/components/ai-elements/code-block.tsx
@@ -1,15 +1,18 @@
 "use client";
 
+import { toJsxRuntime } from "hast-util-to-jsx-runtime";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import {
 	type ComponentProps,
 	createContext,
+	Fragment,
 	type HTMLAttributes,
 	useContext,
 	useEffect,
 	useState,
 } from "react";
-import { type BundledLanguage, codeToHtml, type ShikiTransformer } from "shiki";
+import { jsx, jsxs } from "react/jsx-runtime";
+import { type BundledLanguage, codeToHast, type ShikiTransformer } from "shiki";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 
@@ -30,6 +33,8 @@ type CodeBlockContextType = {
 const CodeBlockContext = createContext<CodeBlockContextType>({
 	code: "",
 });
+
+type HighlightedCode = Awaited<ReturnType<typeof codeToHast>>;
 
 function createLineNumberTransformer(startLine = 1): ShikiTransformer {
 	return {
@@ -55,24 +60,45 @@ function createLineNumberTransformer(startLine = 1): ShikiTransformer {
 	};
 }
 
+function plainTextToHast(code: string) {
+	return {
+		type: "root",
+		children: [
+			{
+				type: "element",
+				tagName: "pre",
+				properties: {},
+				children: [
+					{
+						type: "element",
+						tagName: "code",
+						properties: {},
+						children: [{ type: "text", value: code }],
+					},
+				],
+			},
+		],
+	} satisfies HighlightedCode;
+}
+
 export async function highlightCode(
 	code: string,
 	language: BundledLanguage,
 	showLineNumbers = false,
 	startLine = 1,
-): Promise<[string, string]> {
+): Promise<[HighlightedCode, HighlightedCode]> {
 	const transformers: ShikiTransformer[] = showLineNumbers
 		? [createLineNumberTransformer(startLine)]
 		: [];
 
 	try {
 		return await Promise.all([
-			codeToHtml(code, {
+			codeToHast(code, {
 				lang: language,
 				theme: "one-light",
 				transformers,
 			}),
-			codeToHtml(code, {
+			codeToHast(code, {
 				lang: language,
 				theme: "one-dark-pro",
 				transformers,
@@ -80,12 +106,8 @@ export async function highlightCode(
 		]);
 	} catch {
 		if (language === ("text" as BundledLanguage)) {
-			const escaped = code
-				.replace(/&/g, "&amp;")
-				.replace(/</g, "&lt;")
-				.replace(/>/g, "&gt;");
-			const html = `<pre><code>${escaped}</code></pre>`;
-			return [html, html];
+			const plainText = plainTextToHast(code);
+			return [plainText, plainText];
 		}
 		// Unknown/unsupported language — fall back to plain text
 		return highlightCode(
@@ -95,6 +117,15 @@ export async function highlightCode(
 			startLine,
 		);
 	}
+}
+
+function renderHighlightedCode(root: HighlightedCode) {
+	return toJsxRuntime(root, {
+		Fragment,
+		development: false,
+		jsx,
+		jsxs,
+	});
 }
 
 export const CodeBlock = ({
@@ -107,16 +138,18 @@ export const CodeBlock = ({
 	children,
 	...props
 }: CodeBlockProps) => {
-	const [html, setHtml] = useState<string>("");
-	const [darkHtml, setDarkHtml] = useState<string>("");
+	const [highlightedCode, setHighlightedCode] =
+		useState<HighlightedCode | null>(null);
+	const [darkHighlightedCode, setDarkHighlightedCode] =
+		useState<HighlightedCode | null>(null);
 
 	useEffect(() => {
 		let cancelled = false;
 		highlightCode(code, language, showLineNumbers, startLine).then(
 			([light, dark]) => {
 				if (!cancelled) {
-					setHtml(light);
-					setDarkHtml(dark);
+					setHighlightedCode(light);
+					setDarkHighlightedCode(dark);
 				}
 			},
 		);
@@ -141,18 +174,20 @@ export const CodeBlock = ({
 							!colorize &&
 								"[&_span[style]]:!text-foreground [&_.line>.shiki-line-number]:!opacity-50",
 						)}
-						// biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
-						dangerouslySetInnerHTML={{ __html: html }}
-					/>
+					>
+						{highlightedCode ? renderHighlightedCode(highlightedCode) : null}
+					</div>
 					<div
 						className={cn(
 							"hidden overflow-auto dark:block [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm",
 							!colorize &&
 								"[&_span[style]]:!text-foreground [&_.line>.shiki-line-number]:!opacity-50",
 						)}
-						// biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
-						dangerouslySetInnerHTML={{ __html: darkHtml }}
-					/>
+					>
+						{darkHighlightedCode
+							? renderHighlightedCode(darkHighlightedCode)
+							: null}
+					</div>
 					{children && (
 						<div className="absolute top-2 right-2 flex items-center gap-2">
 							{children}

--- a/packages/ui/src/components/ui/chart.tsx
+++ b/packages/ui/src/components/ui/chart.tsx
@@ -7,6 +7,8 @@ import { cn } from "../../lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
+const chartIdPattern = /[^a-zA-Z0-9_-]/g;
+const cssVariableNamePattern = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
 
 export type ChartConfig = {
 	[k in string]: {
@@ -47,7 +49,10 @@ function ChartContainer({
 	>["children"];
 }) {
 	const uniqueId = React.useId();
-	const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+	const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`.replace(
+		chartIdPattern,
+		"-",
+	);
 
 	return (
 		<ChartContext.Provider value={{ config }}>
@@ -78,30 +83,53 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 		return null;
 	}
 
-	return (
-		<style
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: required for dynamic CSS variable injection
-			dangerouslySetInnerHTML={{
-				__html: Object.entries(THEMES)
-					.map(
-						([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
-${colorConfig
-	.map(([key, itemConfig]) => {
-		const color =
-			itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-			itemConfig.color;
-		return color ? `  --color-${key}: ${color};` : null;
-	})
-	.join("\n")}
-}
-`,
-					)
-					.join("\n"),
-			}}
-		/>
-	);
+	const css = Object.entries(THEMES)
+		.map(([theme, prefix]) => {
+			const variables = colorConfig
+				.map(([key, itemConfig]) => {
+					const color =
+						itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+						itemConfig.color;
+
+					if (
+						!color ||
+						!cssVariableNamePattern.test(key) ||
+						!isSafeCssColor(color)
+					) {
+						return null;
+					}
+
+					return `  --color-${key}: ${color};`;
+				})
+				.filter((line): line is string => line !== null);
+
+			if (variables.length === 0) {
+				return null;
+			}
+
+			return `${prefix} [data-chart="${id}"] {\n${variables.join("\n")}\n}`;
+		})
+		.filter((rule): rule is string => rule !== null)
+		.join("\n");
+
+	return css ? <style>{css}</style> : null;
 };
+
+function isSafeCssColor(color: string): boolean {
+	const value = color.trim();
+
+	if (
+		!value ||
+		/[;{}<>]/.test(value) ||
+		/(?:@import|expression|url)\s*\(/i.test(value)
+	) {
+		return false;
+	}
+
+	return /^(#[\da-f]{3,8}|[a-z]+|(?:rgb|hsl|oklch|oklab|color-mix)\([\w\s.,%#+\-/*]+\)|var\(--[a-zA-Z0-9_-]+(?:,\s*[\w\s.,%#+\-/*]+)?\))$/i.test(
+		value,
+	);
+}
 
 const ChartTooltip = RechartsPrimitive.Tooltip;
 


### PR DESCRIPTION
## Summary

Removes the raw React HTML injection sinks flagged by Oneleet/OpenGrep for `javascript.react.dangerouslysetinnerhtml`.

## What changed

- Replaced marketing JSON-LD `dangerouslySetInnerHTML` usage with a shared `JsonLdScript` helper that serializes JSON and escapes script-breaking characters.
- Replaced team bio raw HTML rendering with a small `TeamBio` renderer that preserves only safe `http`/`https` anchor links and lets React escape text.
- Switched UI code blocks from Shiki HTML strings to Shiki HAST rendered through `hast-util-to-jsx-runtime`.
- Replaced chart style raw HTML injection with style text children and validation for chart IDs, CSS variable names, and color values.

## Why

The previous code relied on trusted inputs and inline Biome suppressions, but each `dangerouslySetInnerHTML` call still appeared as an unresolved medium-severity XSS finding. This removes the sinks instead of suppressing them.

## Validation

- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck` in `packages/ui`
- `bun run typecheck` in `apps/marketing`
- `rg "dangerouslySetInnerHTML|noDangerouslySetInnerHtml" -S .` returns no matches

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes all `dangerouslySetInnerHTML` usage across marketing and UI and replaces it with safe renderers, closing XSS findings without changing the UI. This eliminates the reported sinks and hardens content rendering.

- **Bug Fixes**
  - JSON-LD: Added `JsonLdScript` that serializes JSON and escapes script-breaking characters.
  - Team bios: New `TeamBio` renderer that keeps only http/https links; metadata uses text-only `getTeamBioText`.
  - Code blocks: Switched from Shiki HTML strings to HAST via `hast-util-to-jsx-runtime` to avoid HTML injection.
  - Charts: Replaced raw style HTML with `<style>` children and validation for chart IDs, CSS variable names, and color values.

- **Dependencies**
  - Added `hast-util-to-jsx-runtime@2.3.6`.

<sup>Written for commit a2a99b9388de313b0a0fe960d8c3fe9adfd7d7fd. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4741?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by removing unsafe HTML injection practices across team bios, code blocks, and chart rendering.
  
* **New Features**
  * Added safe team member bio rendering with automatic link detection and proper formatting.
  
* **Refactor**
  * Code highlighting now renders as proper React components instead of injected HTML.
  * Chart styling generation improved with safer CSS variable validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->