### PR TITLE
[codex] Fix Codex workspace MCP loading

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,6 @@
 [mcp_servers.superset]
 type = "sse"
-url = "https://api.superset.sh/api/agent/mcp"
+url = "https://api.superset.sh/api/v2/agent/mcp"
 
 [mcp_servers.expo-mcp]
 type = "sse"

--- a/.mastracode/mcp.json
+++ b/.mastracode/mcp.json
@@ -2,7 +2,7 @@
 	"mcpServers": {
 		"superset": {
 			"command": "npx",
-			"args": ["-y", "mcp-remote", "https://api.superset.sh/api/agent/mcp"]
+			"args": ["-y", "mcp-remote", "https://api.superset.sh/api/v2/agent/mcp"]
 		},
 		"maestro": {
 			"command": "maestro",

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { SUPERSET_MANAGED_BINARIES } from "./desktop-agent-capabilities";
 import { BIN_DIR } from "./paths";
 
-export const WRAPPER_MARKER = "# Superset agent-wrapper v2";
+export const WRAPPER_MARKER = "# Superset agent-wrapper v3";
 export { SUPERSET_MANAGED_BINARIES };
 
 // Dev setup (.superset/lib/setup/steps.sh) points SUPERSET_HOME_DIR at

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -191,7 +191,7 @@ describe("agent-wrappers copilot", () => {
 		const wrapper = readFileSync(wrapperPath, "utf-8");
 
 		expect(wrapper).toContain(
-			`"$REAL_BIN" --enable hooks -c 'notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]' "$@"`,
+			`"$REAL_BIN" "\${_superset_codex_args[@]}" --enable hooks -c 'notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]' "$@"`,
 		);
 		expect(wrapper).toContain('export SUPERSET_AGENT_ID="codex"');
 
@@ -203,6 +203,12 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).toContain("CODEX_TUI_RECORD_SESSION");
 		expect(wrapper).toContain("CODEX_TUI_SESSION_LOG_PATH");
 		expect(wrapper).toContain("SUPERSET_TERMINAL_ID$SUPERSET_TAB_ID");
+		expect(wrapper).toContain("_superset_configure_project_trust");
+		expect(wrapper).toContain("SUPERSET_WORKSPACE_PATH/.codex");
+		expect(wrapper).toContain(
+			'projects={\\"$_superset_workspace_path_toml\\"={trust_level=\\"trusted\\"}}',
+		);
+		expect(wrapper).not.toContain("export CODEX_HOME=");
 		expect(wrapper).not.toContain("rollout-*.jsonl");
 		expect(wrapper).not.toContain("_superset_sessions_dir");
 		expect(wrapper).not.toContain("$" + "{CODEX_HOME:-$HOME/.codex}");
@@ -224,6 +230,55 @@ describe("agent-wrappers copilot", () => {
 		);
 		expect(execLine).not.toContain("{{NOTIFY_PATH}}");
 		expect(wrapper).toContain(execLine);
+	});
+
+	it("trusts the Superset workspace codex project config without replacing CODEX_HOME", () => {
+		const realBinDir = path.join(TEST_ROOT, "real-bin");
+		const realCodex = path.join(realBinDir, "codex");
+		const wrapperPath = path.join(TEST_BIN_DIR, "codex");
+		const workspacePath = path.join(TEST_ROOT, "workspace");
+		const workspaceCodexHome = path.join(workspacePath, ".codex");
+		const explicitCodexHome = path.join(TEST_ROOT, "custom-codex-home");
+		const codexHomeFile = path.join(TEST_ROOT, "codex-home.txt");
+		const argsFile = path.join(TEST_ROOT, "codex-trust-args.txt");
+
+		mkdirSync(realBinDir, { recursive: true });
+		mkdirSync(workspaceCodexHome, { recursive: true });
+		writeFileSync(path.join(workspaceCodexHome, "config.toml"), "\n");
+		writeFileSync(
+			realCodex,
+			`#!/bin/bash
+printf '%s\n' "\${CODEX_HOME:-}" > "${codexHomeFile}"
+printf '%s\n' "$@" > "${argsFile}"
+exit 0
+`,
+			{ mode: 0o755 },
+		);
+		chmodSync(realCodex, 0o755);
+
+		createCodexWrapper();
+
+		execFileSync(wrapperPath, [], {
+			env: {
+				...process.env,
+				CODEX_HOME: explicitCodexHome,
+				PATH: `${TEST_BIN_DIR}:${realBinDir}:${process.env.PATH || ""}`,
+				SUPERSET_WORKSPACE_PATH: workspacePath,
+			},
+			encoding: "utf-8",
+		});
+
+		expect(readFileSync(codexHomeFile, "utf-8")).toBe(`${explicitCodexHome}\n`);
+		expect(readFileSync(argsFile, "utf-8")).toBe(
+			`${[
+				"-c",
+				`projects={"${workspacePath}"={trust_level="trusted"}}`,
+				"--enable",
+				"hooks",
+				"-c",
+				`notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]`,
+			].join("\n")}\n`,
+		);
 	});
 
 	it("forwards hooks enablement through the codex wrapper for manual launches", () => {
@@ -249,6 +304,7 @@ exit 0
 			env: {
 				...process.env,
 				PATH: `${TEST_BIN_DIR}:${realBinDir}:${process.env.PATH || ""}`,
+				SUPERSET_WORKSPACE_PATH: "",
 				SUPERSET_TERMINAL_ID: "terminal-1",
 			},
 			encoding: "utf-8",

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -195,7 +195,7 @@ describe("agent-wrappers copilot", () => {
 		);
 		expect(wrapper).toContain('export SUPERSET_AGENT_ID="codex"');
 
-		expect(wrapper).toContain("# Superset agent-wrapper v2");
+		expect(wrapper).toContain("# Superset agent-wrapper v3");
 
 		// Native hooks remain enabled, but the process-scoped TUI session log is
 		// the reliable Start signal for installed Codex TUI builds.

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -22,7 +22,7 @@ _superset_debug() {
 }
 
 _superset_toml_escape() {
-  _superset_value="$1"
+  local _superset_value="$1"
   _superset_value="${_superset_value//\\/\\\\}"
   _superset_value="${_superset_value//\"/\\\"}"
   printf '%s' "$_superset_value"
@@ -31,9 +31,10 @@ _superset_toml_escape() {
 _superset_configure_project_trust() {
   [ -n "${SUPERSET_WORKSPACE_PATH:-}" ] || return 0
 
-  _superset_workspace_codex_home="$SUPERSET_WORKSPACE_PATH/.codex"
+  local _superset_workspace_codex_home="$SUPERSET_WORKSPACE_PATH/.codex"
   [ -f "$_superset_workspace_codex_home/config.toml" ] || return 0
 
+  local _superset_workspace_path_toml
   _superset_workspace_path_toml="$(_superset_toml_escape "$SUPERSET_WORKSPACE_PATH")"
   _superset_codex_args+=("-c" "projects={\"$_superset_workspace_path_toml\"={trust_level=\"trusted\"}}")
   _superset_debug "using trusted workspace Codex project config path=$SUPERSET_WORKSPACE_PATH"

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -14,11 +14,32 @@ _superset_debug_log="${SUPERSET_HOOK_DEBUG_LOG:-/tmp/superset-codex-hooks.log}"
 _superset_has_superset_context="0"
 [ -n "$SUPERSET_TERMINAL_ID$SUPERSET_TAB_ID$SUPERSET_PANE_ID" ] && _superset_has_superset_context="1"
 SUPERSET_CODEX_SESSION_WATCHER_PID=""
+_superset_codex_args=()
 
 _superset_debug() {
   [ "$_superset_debug_enabled" = "1" ] || return 0
   printf '%s [codex-wrapper] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" "$*" >> "$_superset_debug_log" 2>/dev/null || true
 }
+
+_superset_toml_escape() {
+  _superset_value="$1"
+  _superset_value="${_superset_value//\\/\\\\}"
+  _superset_value="${_superset_value//\"/\\\"}"
+  printf '%s' "$_superset_value"
+}
+
+_superset_configure_project_trust() {
+  [ -n "${SUPERSET_WORKSPACE_PATH:-}" ] || return 0
+
+  _superset_workspace_codex_home="$SUPERSET_WORKSPACE_PATH/.codex"
+  [ -f "$_superset_workspace_codex_home/config.toml" ] || return 0
+
+  _superset_workspace_path_toml="$(_superset_toml_escape "$SUPERSET_WORKSPACE_PATH")"
+  _superset_codex_args+=("-c" "projects={\"$_superset_workspace_path_toml\"={trust_level=\"trusted\"}}")
+  _superset_debug "using trusted workspace Codex project config path=$SUPERSET_WORKSPACE_PATH"
+}
+
+_superset_configure_project_trust
 
 _superset_child_pids_for() {
   if command -v pgrep >/dev/null 2>&1; then
@@ -99,7 +120,7 @@ fi
 
 # `hooks` (formerly `codex_hooks`) is stable and default-enabled in codex
 # >=0.129; the legacy `notify=...` callback remains the completion source.
-"$REAL_BIN" --enable hooks -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
+"$REAL_BIN" "${_superset_codex_args[@]}" --enable hooks -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
 SUPERSET_CODEX_STATUS=$?
 _superset_debug "codex exited status=$SUPERSET_CODEX_STATUS"
 

--- a/opencode.json
+++ b/opencode.json
@@ -6,7 +6,7 @@
 	"mcp": {
 		"superset": {
 			"type": "remote",
-			"url": "https://api.superset.sh/api/agent/mcp",
+			"url": "https://api.superset.sh/api/v2/agent/mcp",
 			"oauth": {}
 		},
 		"expo-mcp": {


### PR DESCRIPTION
## Summary

Fixes Codex MCP loading in Superset terminals by letting Codex use its native workspace project config path instead of replacing `CODEX_HOME`.

The Codex wrapper now adds a per-invocation project trust override when `SUPERSET_WORKSPACE_PATH/.codex/config.toml` exists. This allows Codex to load the workspace `.codex/config.toml` layer while preserving the user's existing `CODEX_HOME`, auth, hooks, plugins, skills, history, and sessions.

Also updates the Superset MCP endpoint in Codex, Mastra, and OpenCode configs from `/api/agent/mcp` to `/api/v2/agent/mcp`.

## Root Cause

Codex has project-local config layers for `.codex/config.toml`, but those layers are disabled until the project is trusted. Superset terminals launched Codex without establishing that trust, so the workspace MCP config was skipped even though the file existed.

## Validation

- `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`
- `bun run lint`
- `bun run typecheck`
- `git diff --check`
- Manual clean-HOME check: `codex -c 'projects={"<workspace>"={trust_level="trusted"}}' mcp get superset` resolves the v2 Superset MCP server


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4742">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex MCP loading in Superset terminals by trusting the workspace `.codex/config.toml` without changing the user's `CODEX_HOME`. Updates Superset MCP configs to the v2 endpoint and scopes wrapper helper variables; bumps the agent wrapper marker to v3.

- **Bug Fixes**
  - Trust the workspace Codex project when `SUPERSET_WORKSPACE_PATH/.codex/config.toml` exists by adding `-c 'projects={"<workspace>"={trust_level="trusted"}}'` via the wrapper.
  - Preserve the user's `CODEX_HOME`, auth, plugins, history, and sessions; stop overriding `CODEX_HOME`.
  - Wrapper builds `_superset_codex_args` with TOML escaping, scopes helper vars/functions to `_superset_*`, and injects args before hooks; adds tests for trust and `CODEX_HOME` preservation.

- **Dependencies**
  - Switch Superset MCP URL to `https://api.superset.sh/api/v2/agent/mcp` in `.codex/config.toml`, `.mastracode/mcp.json`, and `opencode.json`.

<sup>Written for commit d25c1ffb228a9504a63debd1bde8dc8d6af4012a. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4742?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent wrapper supports per-workspace trust for Codex projects, preserves existing Codex home, and adds safer workspace path handling and additional Codex launch arguments.

* **Chores**
  * Superset MCP server configuration updated to the v2 API endpoint.
  * Agent wrapper version bumped to v3 with improved argument handling.

* **Tests**
  * Wrapper tests updated and expanded to cover new wrapper behavior and workspace trust handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->