### PR TITLE
[codex] fix missing preset icons

### DIFF
--- a/apps/desktop/src/renderer/lib/preset-icon-key.test.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon-key.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import type { HostAgentConfig } from "@superset/host-service/settings";
+import { resolveV2PresetIconKey } from "./preset-icon-key";
+
+function createAgent(
+	overrides: Partial<HostAgentConfig> &
+		Pick<HostAgentConfig, "id" | "presetId">,
+): HostAgentConfig {
+	const { id, presetId, ...rest } = overrides;
+	return {
+		id,
+		presetId,
+		label: presetId,
+		command: presetId,
+		args: [],
+		promptTransport: "argv",
+		promptArgs: [],
+		env: {},
+		order: 0,
+		...rest,
+	};
+}
+
+describe("resolveV2PresetIconKey", () => {
+	it("resolves linked host-agent config ids", () => {
+		expect(
+			resolveV2PresetIconKey({ agentId: "claude-config" }, [
+				createAgent({ id: "claude-config", presetId: "claude" }),
+			]),
+		).toBe("claude");
+	});
+
+	it("keeps supporting legacy rows whose agentId is already a preset id", () => {
+		expect(resolveV2PresetIconKey({ agentId: "codex" }, [])).toBe("codex");
+	});
+
+	it("infers the icon from stored commands when the agent link is stale", () => {
+		expect(
+			resolveV2PresetIconKey(
+				{
+					agentId: "deleted-config-id",
+					commands: ["opencode"],
+				},
+				[createAgent({ id: "opencode-config", presetId: "opencode" })],
+			),
+		).toBe("opencode");
+	});
+
+	it("infers the icon from command paths for unlinked presets", () => {
+		expect(
+			resolveV2PresetIconKey(
+				{
+					commands: ["/opt/homebrew/bin/cursor-agent"],
+				},
+				[],
+			),
+		).toBe("cursor-agent");
+	});
+
+	it("does not infer from editable preset names", () => {
+		expect(
+			resolveV2PresetIconKey(
+				{
+					commands: ["echo claude"],
+				},
+				[createAgent({ id: "claude-config", presetId: "claude" })],
+			),
+		).toBeUndefined();
+	});
+
+	it("does not infer an icon when commands point at multiple agents", () => {
+		expect(
+			resolveV2PresetIconKey(
+				{
+					commands: ["claude", "codex"],
+				},
+				[
+					createAgent({ id: "claude-config", presetId: "claude" }),
+					createAgent({ id: "codex-config", presetId: "codex" }),
+				],
+			),
+		).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/renderer/lib/preset-icon-key.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon-key.ts
@@ -1,0 +1,94 @@
+import type { HostAgentConfig } from "@superset/host-service/settings";
+import { HOST_AGENT_PRESETS } from "@superset/shared/host-agent-presets";
+import { parseCommandString } from "./argv";
+
+export interface PresetIconSource {
+	agentId?: string;
+	commands?: readonly string[];
+}
+
+const BUILTIN_PRESET_IDS: ReadonlySet<string> = new Set(
+	HOST_AGENT_PRESETS.map((preset) => preset.presetId),
+);
+
+function getExecutableName(command: string): string | undefined {
+	let parsed: ReturnType<typeof parseCommandString>;
+	try {
+		parsed = parseCommandString(command.trim());
+	} catch {
+		return undefined;
+	}
+	const executable = parsed.command.trim();
+	if (!executable) return undefined;
+	const normalizedPath = executable.replaceAll("\\", "/");
+	const segments = normalizedPath.split("/");
+	return segments.at(-1)?.toLowerCase();
+}
+
+function singlePresetId(ids: Iterable<string | undefined>): string | undefined {
+	const uniqueIds = new Set<string>();
+	for (const id of ids) {
+		const trimmed = id?.trim();
+		if (trimmed) uniqueIds.add(trimmed);
+	}
+	return uniqueIds.size === 1 ? uniqueIds.values().next().value : undefined;
+}
+
+function getLinkedPresetId(
+	preset: PresetIconSource,
+	agents: HostAgentConfig[] | undefined,
+): string | undefined {
+	const agentId = preset.agentId?.trim();
+	if (!agentId) return undefined;
+
+	const linkedAgentPresetId =
+		agents?.find((agent) => agent.id === agentId)?.presetId ??
+		agents?.find((agent) => agent.presetId === agentId)?.presetId;
+	if (linkedAgentPresetId) return linkedAgentPresetId;
+
+	const normalizedAgentId = agentId.toLowerCase();
+	return BUILTIN_PRESET_IDS.has(normalizedAgentId)
+		? normalizedAgentId
+		: undefined;
+}
+
+function getPresetIdFromExecutable(
+	executable: string,
+	agents: HostAgentConfig[] | undefined,
+): string | undefined {
+	const agentPresetId = singlePresetId(
+		(agents ?? [])
+			.filter((agent) => getExecutableName(agent.command) === executable)
+			.map((agent) => agent.presetId),
+	);
+	if (agentPresetId) return agentPresetId;
+
+	return singlePresetId(
+		HOST_AGENT_PRESETS.filter(
+			(preset) => getExecutableName(preset.command) === executable,
+		).map((preset) => preset.presetId),
+	);
+}
+
+function getCommandPresetId(
+	preset: PresetIconSource,
+	agents: HostAgentConfig[] | undefined,
+): string | undefined {
+	const presetIds = new Set<string>();
+	for (const command of preset.commands ?? []) {
+		const executable = getExecutableName(command);
+		if (!executable) continue;
+		const presetId = getPresetIdFromExecutable(executable, agents);
+		if (presetId) presetIds.add(presetId);
+	}
+	return presetIds.size === 1 ? presetIds.values().next().value : undefined;
+}
+
+export function resolveV2PresetIconKey(
+	preset: PresetIconSource,
+	agents: HostAgentConfig[] | undefined,
+): string | undefined {
+	return (
+		getLinkedPresetId(preset, agents) ?? getCommandPresetId(preset, agents)
+	);
+}

--- a/apps/desktop/src/renderer/lib/preset-icon.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon.ts
@@ -1,9 +1,9 @@
 import type { HostAgentConfig } from "@superset/host-service/settings";
 import { getPresetIcon } from "renderer/assets/app-icons/preset-icons";
-
-interface PresetWithAgent {
-	agentId?: string;
-}
+import {
+	type PresetIconSource,
+	resolveV2PresetIconKey,
+} from "./preset-icon-key";
 
 /**
  * Resolves the preset-icon key for a v2 terminal preset.
@@ -14,21 +14,18 @@ interface PresetWithAgent {
  * `agentId → agent → agent.presetId → icon`. Falls back to `agentId` itself
  * for legacy v2 rows whose `agentId` still holds a presetId.
  *
+ * If the link is missing or stale, falls back to the stored command's
+ * executable for display only. Launch still uses the linked agent when present
+ * and the preset's stored commands otherwise.
+ *
  * Never resolve by `preset.name` — it's user-editable display text and would
  * silently break for any label with spaces, casing differences, or edits.
  */
 export function resolveV2PresetIcon(
-	preset: PresetWithAgent,
+	preset: PresetIconSource,
 	agents: HostAgentConfig[] | undefined,
 	isDark: boolean,
 ): string | undefined {
-	if (!preset.agentId) return undefined;
-	const linkedAgentPresetId =
-		agents?.find((agent) => agent.id === preset.agentId)?.presetId ??
-		agents?.find((agent) => agent.presetId === preset.agentId)?.presetId;
-	return (
-		(linkedAgentPresetId
-			? getPresetIcon(linkedAgentPresetId, isDark)
-			: undefined) ?? getPresetIcon(preset.agentId, isDark)
-	);
+	const iconKey = resolveV2PresetIconKey(preset, agents);
+	return iconKey ? getPresetIcon(iconKey, isDark) : undefined;
 }


### PR DESCRIPTION
## Summary

Fixes missing agent logos for v2 terminal presets when the preferred host-agent link cannot resolve.

## Root Cause

V2 preset rows store a host-agent config id in `agentId`, while the icon key lives on the linked agent's `presetId`. Older, imported, custom, or stale rows can have no usable link, so the resolver returned no icon and the UI fell back to the generic terminal glyph even when the stored command was clearly a known agent like `opencode` or `cursor-agent`.

## Changes

- Adds a shared `resolveV2PresetIconKey` helper that prefers the current linked agent, keeps legacy preset-id rows working, then falls back to the stored command executable for display only.
- Keeps launch behavior unchanged: linked presets still launch through the host-agent config, and unlinked presets still use their stored commands.
- Avoids inferring from editable preset names and leaves ambiguous multi-agent presets generic.
- Adds tests for linked, legacy, stale-link, unlinked command-path, name-only, and ambiguous-command cases.

## Validation

- `bun test apps/desktop/src/renderer/lib/preset-icon-key.test.ts`
- `bun test apps/desktop/src/renderer/lib/argv.test.ts`
- `bun run lint:fix`
- `bun run lint`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4748">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing preset icons in the v2 terminal list by resolving the icon from the linked host-agent or, if the link is stale, from the stored command executable. Launch behavior is unchanged.

- **Bug Fixes**
  - Added `resolveV2PresetIconKey` to prefer the linked agent’s `presetId`, support legacy rows where `agentId` is a preset id, and fall back to the executable name when the link can’t resolve.
  - Updated `resolveV2PresetIcon` to use the new helper and return the correct icon via `getPresetIcon`.
  - Avoid inferring from editable names; leave ambiguous multi-agent commands generic.
  - Added tests for linked, legacy, stale-link, unlinked command-path, name-only, and ambiguous-command cases using `@superset/host-service/settings` and `@superset/shared/host-agent-presets`.

<sup>Written for commit 087cc3475dfd223f146a2ff11e96f1ac6ba91922. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4748?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests covering preset icon key resolution across linked agents, legacy entries, command-based inference, and ambiguous or editable cases.

* **Refactor**
  * Centralized and improved preset icon resolution: reliably derives icon keys from agent links or command paths, with clearer fallbacks and undefined for ambiguous inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->