### PR TITLE
feat(cli,sdk,mcp-v2): expose worktreePath for adopting external worktrees

### DIFF
--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -15,6 +15,9 @@ export default command({
 		baseBranch: string().desc(
 			"Branch to fork from when `branch` does not exist (defaults to project default)",
 		),
+		worktreePath: string().desc(
+			"Absolute path to an existing git worktree to adopt instead of creating one. When set, the server reads the current branch from git at this path; `--branch` becomes caller context only. Cannot be combined with `--pr`",
+		),
 		agent: string().desc(
 			"Agent to spawn after creation. Preset id (`claude`, `codex`, …), HostAgentConfig instance UUID, or `superset`",
 		),
@@ -33,10 +36,19 @@ export default command({
 			throw new CLIError("No active organization", "Run: superset auth login");
 		}
 
-		if (Boolean(options.branch) === Boolean(options.pr)) {
+		const hasPr = options.pr !== undefined;
+		const hasBranch = Boolean(options.branch);
+
+		if (options.worktreePath && hasPr) {
+			throw new CLIError(
+				"Cannot combine --worktree-path with --pr",
+				"Adoption reads the branch from git; pass --branch as context only",
+			);
+		}
+		if (!options.worktreePath && hasBranch === hasPr) {
 			throw new CLIError(
 				"Specify exactly one of --branch or --pr",
-				"Use --branch <name> or --pr <number>",
+				"Use --branch <name>, --pr <number>, or --worktree-path <path>",
 			);
 		}
 
@@ -91,6 +103,7 @@ export default command({
 			branch: options.branch,
 			pr: options.pr,
 			baseBranch: options.baseBranch,
+			worktreePath: options.worktreePath,
 			agents,
 		});
 

--- a/packages/mcp-v2/src/tools/workspaces/create.ts
+++ b/packages/mcp-v2/src/tools/workspaces/create.ts
@@ -23,7 +23,7 @@ export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_create",
 		description:
-			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. Provide exactly one of `branch` or `pr`. Optionally pass `agents` to spawn one or more agents in the workspace as soon as it is ready (each entry runs the equivalent of `agents_run` against the new workspace). Use projects_list and hosts_list first to get the projectId and hostId.",
+			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. Provide exactly one of `branch` or `pr`, or pass `worktreePath` to adopt an existing git worktree already on disk (created by some other tool, e.g. an external `git worktree add`). Optionally pass `agents` to spawn one or more agents in the workspace as soon as it is ready (each entry runs the equivalent of `agents_run` against the new workspace). Use projects_list and hosts_list first to get the projectId and hostId.",
 		inputSchema: {
 			projectId: z.string().uuid().describe("Project UUID."),
 			name: z.string().min(1).describe("Workspace name (display)."),
@@ -48,6 +48,13 @@ export function register(server: McpServer): void {
 				.describe(
 					"Branch to fork from when `branch` does not exist (defaults to project default). Ignored when `pr` is set.",
 				),
+			worktreePath: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"Absolute path to an existing git worktree to adopt instead of creating one. When set, the server reads the current branch from git at this path; `branch` becomes caller context only. Cannot be combined with `pr`.",
+				),
 			hostId: z
 				.string()
 				.min(1)
@@ -65,6 +72,19 @@ export function register(server: McpServer): void {
 				),
 		},
 		handler: async (input, ctx) => {
+			const hasPr = input.pr !== undefined;
+			const hasBranch = Boolean(input.branch);
+			const hasWorktreePath = Boolean(input.worktreePath);
+
+			if (hasWorktreePath && hasPr) {
+				throw new Error("Cannot combine `worktreePath` with `pr`.");
+			}
+			if (!hasWorktreePath && hasBranch === hasPr) {
+				throw new Error(
+					"Specify exactly one of `branch` or `pr`, or pass `worktreePath`.",
+				);
+			}
+
 			return hostServiceCall<{
 				workspace: {
 					id: string;
@@ -95,6 +115,7 @@ export function register(server: McpServer): void {
 					branch: input.branch,
 					pr: input.pr,
 					baseBranch: input.baseBranch,
+					worktreePath: input.worktreePath,
 					taskId: input.taskId,
 					agents: input.agents,
 				},

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -36,7 +36,9 @@ export class Workspaces extends APIResource {
 	 * runs `agents.run` once per entry against the freshly-created workspace).
 	 *
 	 * The host service must be running and reachable via the relay tunnel.
-	 * Provide exactly one of `branch` or `pr`.
+	 * Provide exactly one of `branch` or `pr`, or pass `worktreePath` to
+	 * adopt an existing git worktree already on disk (created by some other
+	 * tool, e.g. an external `git worktree add`).
 	 */
 	create(
 		params: WorkspaceCreateParams,
@@ -51,6 +53,7 @@ export class Workspaces extends APIResource {
 				branch: params.branch,
 				pr: params.pr,
 				baseBranch: params.baseBranch,
+				worktreePath: params.worktreePath,
 				taskId: params.taskId,
 				agents: params.agents,
 			},
@@ -165,6 +168,12 @@ export interface WorkspaceCreateParams {
 	pr?: number;
 	/** Branch to fork from when `branch` does not exist. Ignored with `pr`. */
 	baseBranch?: string;
+	/**
+	 * Absolute path to an existing git worktree to adopt instead of creating
+	 * one. When set, the server reads the current branch from git at this
+	 * path; `branch` is caller context only. Cannot be combined with `pr`.
+	 */
+	worktreePath?: string;
 	/** Optional Superset task id to link to the new workspace. */
 	taskId?: string;
 	/** Spawn one or more agents in the workspace immediately after creation. */


### PR DESCRIPTION
## Description

The host-service `workspaces.create` mutation already supports an optional `worktreePath` parameter that lets a caller adopt a git worktree which was materialized **outside** Superset (e.g. by an external `git worktree add`). The parameter exists in `packages/host-service/src/trpc/router/workspaces/workspaces.ts` (lines 75-85) with this docstring:

```ts
// Adopt the worktree git already has at this path instead of
// inferring the path from `branch`. When present, `branch` is
// caller context only; the server reads the current branch from git.
worktreePath: z.string().min(1).optional(),
```

…but it is **not surfaced** through any of the public client packages (CLI, SDK, MCP). The only available adoption path today is the auto-adoption keyed on branch-name lookup at `workspaces.ts:867-895`, which calls `git worktree list` against the registered project repo. That misses worktrees created externally, so calling `workspaces.create` for such a branch ends up creating a duplicate worktree under `~/.superset/worktrees/<projectId>/<branch>` instead of registering the externally-created one in place.

This patch exposes the parameter through the three public surfaces so callers don't have to talk to the local tRPC endpoint directly:

- **CLI** (`packages/cli`): new `--worktree-path` flag. Adds a `--worktree-path`/`--pr` mutex (mirroring the host-service refine) and relaxes the `--branch`/`--pr` requirement when adopting (the server reads the branch from git anyway).
- **SDK** (`packages/sdk`): new `worktreePath?: string` field on `WorkspaceCreateParams`, with JSDoc.
- **MCP v2** (`packages/mcp-v2`): new `worktreePath` field in the `workspaces_create` zod `inputSchema`, with description. Tool-level description updated to mention adoption.

No host-service changes, as the server already handles this fully.

## Related Issues

None — small enhancement on top of existing host-service capability.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Code cleanup
- [ ] Other (please describe):

Strictly additive — no existing signatures or behavior change. Default behavior with no `worktreePath` is unchanged.

## Testing

- `bunx @biomejs/biome@2.4.2 check` clean on all three modified files.
- `bunx turbo run typecheck --filter=@superset/sdk --filter=@superset/cli --filter=@superset/mcp-v2` — all green.
- No existing tests cover `workspaces.create` in CLI/SDK/MCP packages; nothing pre-existing to regress.
- Manually verified the host-service path end-to-end by calling the local tRPC endpoint directly with `worktreePath` set against an externally-created git worktree:
  - `alreadyExists: true` in the response
  - Workspace row registered at the supplied `worktree_path` (verified via `sqlite3 ~/.superset/host/<orgId>/host.db`)
  - No duplicate created under `~/.superset/worktrees/<projectId>/`

## Screenshots

n/a — pure CLI/SDK/MCP surface change.

## Additional Notes

The v1 MCP tool (`packages/mcp/src/tools/devices/create-workspace`) was intentionally left out of this PR. It routes through `apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/create-worktree.ts` and ultimately the desktop's own `workspaces.create` procedure (`apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts`), which uses a different schema shape (`branchName`/`compareBaseBranch` instead of `branch`/`baseBranch`). I'm happy to wire it up in this PR or a follow-up — let me know your preference.

"Allow edits from maintainers" is enabled on this PR.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4765">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `worktreePath` in the CLI, SDK, and MCP v2 so users can adopt an existing git worktree on disk instead of creating a new one. This prevents duplicate worktrees and supports multi-repo umbrella setups.

- **New Features**
  - `@superset/cli`: add `--worktree-path`; mutex with `--pr`. Validation now requires exactly one of `--branch` or `--pr`, or `--worktree-path`. When adopting, `--branch` is context only.
  - `@superset/sdk`: add `worktreePath?: string` to `WorkspaceCreateParams` and forward it to the API.
  - `@superset/mcp-v2`: add `worktreePath` to `workspaces_create` input schema and tool description. Validate `worktreePath` vs `pr` and exclusive selection.

- **Migration**
  - No changes required. Behavior is unchanged when `worktreePath` is not provided.

<sup>Written for commit 1d774eb74c2b0f6c9128bdb88c43e826aca3692a. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4765?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace creation can adopt existing local git worktrees via a new worktree-path option in the CLI and corresponding SDK/tools parameter.

* **Behavior Changes**
  * Validation updated: worktree-path cannot be combined with PR, and callers must specify exactly one of branch, PR, or worktree-path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->