### PR TITLE
docs(sdk,cli): close audit gaps against tRPC API

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -589,6 +589,8 @@ superset workspaces delete ws_a ws_b ws_c
 	]}
 	options={[
 		{ flag: "--name <name>", description: "New workspace name." },
+		{ flag: "--task-id <id>", description: "Link the workspace to a task by id." },
+		{ flag: "--clear-task", description: "Unlink the workspace from its current task. Mutually exclusive with --task-id." },
 	]}
 	output="Workspace"
 >
@@ -596,6 +598,8 @@ Update a workspace.
 
 ```bash
 superset workspaces update ws_… --name "better-name"
+superset workspaces update ws_… --task-id tsk_…
+superset workspaces update ws_… --clear-task
 ```
 </Command>
 

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -984,9 +984,8 @@ superset automations resume aut_…
 		{ name: "id", required: true, description: "Automation ID." },
 	]}
 	output={`{
-  runId: string;
   automationId: string;
-  dispatchedAt: string;
+  runId: string;
 }`}
 >
 Dispatch an automation immediately. Does not wait for completion.

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -100,6 +100,17 @@ Soft-delete a task.
 await client.tasks.delete(id);
 ```
 
+### `tasks.statuses.list()`
+
+List the task statuses (workflow states) configured for the active organization, in display order. Useful for resolving status ids before [`tasks.create`](#taskscreatebody) or [`tasks.update`](#tasksupdatebody).
+
+```ts
+const statuses = await client.tasks.statuses.list();
+const todo = statuses.find((s) => s.type === 'unstarted');
+```
+
+Returns `Array<TaskStatus>` — each entry is `{ id, name, color, type, position }`.
+
 ---
 
 ## workspaces
@@ -145,6 +156,16 @@ Returns a `WorkspaceCreateResult`:
 - `workspace` — the created workspace row (`id`, `name`, `branch`, `hostId`, `projectId`, `type`, `taskId`, …).
 - `terminals` — terminals opened on the host (`{ terminalId, label? }`).
 - `agents` — one entry per agent in the request (empty if `agents` was omitted). Each entry is either `{ ok: true, kind: 'terminal' | 'chat', sessionId, label }` or `{ ok: false, error }`.
+
+### `workspaces.update(id, params)`
+
+Update fields on an existing workspace. Currently only `name` is exposed — moving a workspace to a different branch or host requires host-side orchestration and is not safe to drive from the cloud API directly.
+
+```ts
+await client.workspaces.update('<workspaceId>', { name: 'wire-up-auth-v2' });
+```
+
+Returns the updated workspace row (`id`, `name`, `branch`, `hostId`, `projectId`, `type`, `taskId`, …).
 
 ### `workspaces.delete(id, opts?)`
 

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -159,7 +159,7 @@ Returns a `WorkspaceCreateResult`:
 
 ### `workspaces.update(id, params)`
 
-Update fields on an existing workspace. Currently only `name` is exposed — moving a workspace to a different branch or host requires host-side orchestration and is not safe to drive from the cloud API directly.
+Update fields on an existing workspace. Moving a workspace to a different branch or host requires host-side orchestration and is not safe to drive from the cloud API directly.
 
 ```ts
 await client.workspaces.update('<workspaceId>', { name: 'wire-up-auth-v2' });

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -122,7 +122,7 @@ Create a worktree on a specific host. Optionally spawn one or more agents inside
 Each entry in `agents` takes a preset id (e.g. `"claude"`) or a `HostAgentConfig` instance UUID — the host service resolves it against its configured rows and copies their stored `command`, `args`, and `env`. Use [`agents.list({ hostId })`](#agentslist-hostid-) to enumerate what's installed.
 
 ```ts
-const ws = await client.workspaces.create({
+const result = await client.workspaces.create({
   hostId: '<machineId>',     // see hosts.list()
   projectId: '<uuid>',       // see projects.list()
   name: 'wire-up-auth',
@@ -133,10 +133,18 @@ const ws = await client.workspaces.create({
   ],
 });
 
-console.log(ws.id, ws.agentRuns.map((r) => r.runId));
+console.log(result.workspace.id);
+for (const agent of result.agents) {
+  if (agent.ok) console.log(agent.kind, agent.sessionId, agent.label);
+  else console.error(agent.error);
+}
 ```
 
-Returns a `CreatedWorkspace` — a `HostWorkspace` plus an `agentRuns` array (one entry per agent in the request, empty if `agents` was omitted).
+Returns a `WorkspaceCreateResult`:
+
+- `workspace` — the created workspace row (`id`, `name`, `branch`, `hostId`, `projectId`, `type`, `taskId`, …).
+- `terminals` — terminals opened on the host (`{ terminalId, label? }`).
+- `agents` — one entry per agent in the request (empty if `agents` was omitted). Each entry is either `{ ok: true, kind: 'terminal' | 'chat', sessionId, label }` or `{ ok: false, error }`.
 
 ### `workspaces.delete(id, opts?)`
 

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -244,10 +244,12 @@ const { sessionId } = await client.agents.run({
 
 Recurring agent runs scheduled by RRULE. Requires a Pro subscription on the org for `create` / `update` / `delete`.
 
-### `automations.list()`
+### `automations.list(params?)`
 
 ```ts
 const automations = await client.automations.list();
+// or filter by case-insensitive substring on name:
+const triage = await client.automations.list({ name: 'triage' });
 ```
 
 Each row is an `AutomationSummary` — the `prompt` body is omitted (it can be

--- a/packages/cli/src/commands/workspaces/update/command.ts
+++ b/packages/cli/src/commands/workspaces/update/command.ts
@@ -1,4 +1,4 @@
-import { CLIError, positional, string } from "@superset/cli-framework";
+import { boolean, CLIError, positional, string } from "@superset/cli-framework";
 import { command } from "../../../lib/command";
 
 export default command({
@@ -6,6 +6,8 @@ export default command({
 	args: [positional("id").required().desc("Workspace UUID")],
 	options: {
 		name: string().desc("Workspace name"),
+		taskId: string().desc("Link the workspace to a task by id"),
+		clearTask: boolean().desc("Unlink the workspace from its current task"),
 	},
 	run: async ({ ctx, args, options }) => {
 		const id = args.id as string;
@@ -14,13 +16,30 @@ export default command({
 			throw new CLIError("No active organization", "Run: superset auth login");
 		}
 
-		if (options.name === undefined) {
-			throw new CLIError("No fields to update", "Pass --name <new-name>");
+		if (options.taskId && options.clearTask) {
+			throw new CLIError(
+				"Cannot combine --task-id and --clear-task",
+				"Pass one or the other",
+			);
+		}
+
+		const taskId = options.clearTask
+			? null
+			: options.taskId !== undefined
+				? options.taskId
+				: undefined;
+
+		if (options.name === undefined && taskId === undefined) {
+			throw new CLIError(
+				"No fields to update",
+				"Pass --name, --task-id, or --clear-task",
+			);
 		}
 
 		const updated = await ctx.api.v2Workspace.update.mutate({
 			id,
-			name: options.name,
+			...(options.name !== undefined ? { name: options.name } : {}),
+			...(taskId !== undefined ? { taskId } : {}),
 		});
 
 		return {

--- a/packages/cli/src/commands/workspaces/update/command.ts
+++ b/packages/cli/src/commands/workspaces/update/command.ts
@@ -16,7 +16,7 @@ export default command({
 			throw new CLIError("No active organization", "Run: superset auth login");
 		}
 
-		if (options.taskId && options.clearTask) {
+		if (options.taskId !== undefined && options.clearTask) {
 			throw new CLIError(
 				"Cannot combine --task-id and --clear-task",
 				"Pass one or the other",

--- a/packages/sdk/api.md
+++ b/packages/sdk/api.md
@@ -3,7 +3,11 @@
 Types:
 
 - <code><a href="./src/resources/tasks.ts">Task</a></code>
+- <code><a href="./src/resources/tasks.ts">TaskListItem</a></code>
+- <code><a href="./src/resources/tasks.ts">TaskListParams</a></code>
 - <code><a href="./src/resources/tasks.ts">TaskListResponse</a></code>
+- <code><a href="./src/resources/tasks.ts">TaskCreateParams</a></code>
+- <code><a href="./src/resources/tasks.ts">TaskUpdateParams</a></code>
 
 Methods:
 
@@ -12,3 +16,118 @@ Methods:
 - <code title="get /api/trpc/task.list">client.tasks.<a href="./src/resources/tasks.ts">list</a>({ ...params }) -> TaskListResponse</code>
 - <code title="post /api/trpc/task.update">client.tasks.<a href="./src/resources/tasks.ts">update</a>({ ...params }) -> Task</code>
 - <code title="post /api/trpc/task.delete">client.tasks.<a href="./src/resources/tasks.ts">delete</a>(id) -> void</code>
+
+## Statuses
+
+Types:
+
+- <code><a href="./src/resources/tasks.ts">TaskStatus</a></code>
+- <code><a href="./src/resources/tasks.ts">TaskStatusListResponse</a></code>
+
+Methods:
+
+- <code title="get /api/trpc/task.statuses.list">client.tasks.statuses.<a href="./src/resources/tasks.ts">list</a>() -> TaskStatusListResponse</code>
+
+# Workspaces
+
+Types:
+
+- <code><a href="./src/resources/workspaces.ts">Workspace</a></code>
+- <code><a href="./src/resources/workspaces.ts">HostWorkspace</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceListParams</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceListResponse</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceCreateParams</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceCreateResult</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceAgentLaunch</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceCreateAgentResult</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceUpdateParams</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceUpdateResult</a></code>
+- <code><a href="./src/resources/workspaces.ts">WorkspaceDeleteResult</a></code>
+
+Methods:
+
+- <code title="get /api/trpc/v2Workspace.list">client.workspaces.<a href="./src/resources/workspaces.ts">list</a>({ ...params }) -> WorkspaceListResponse</code>
+- <code title="host post /api/trpc/workspaces.create">client.workspaces.<a href="./src/resources/workspaces.ts">create</a>({ ...params }) -> WorkspaceCreateResult</code>
+- <code title="post /api/trpc/v2Workspace.update">client.workspaces.<a href="./src/resources/workspaces.ts">update</a>(id, { ...params }) -> WorkspaceUpdateResult</code>
+- <code title="host post /api/trpc/workspace.delete">client.workspaces.<a href="./src/resources/workspaces.ts">delete</a>(id, { hostId? }) -> WorkspaceDeleteResult</code>
+
+# Projects
+
+Types:
+
+- <code><a href="./src/resources/projects.ts">Project</a></code>
+- <code><a href="./src/resources/projects.ts">ProjectListResponse</a></code>
+
+Methods:
+
+- <code title="get /api/trpc/v2Project.list">client.projects.<a href="./src/resources/projects.ts">list</a>() -> ProjectListResponse</code>
+
+# Hosts
+
+Types:
+
+- <code><a href="./src/resources/hosts.ts">Host</a></code>
+- <code><a href="./src/resources/hosts.ts">HostListResponse</a></code>
+
+Methods:
+
+- <code title="get /api/trpc/host.list">client.hosts.<a href="./src/resources/hosts.ts">list</a>() -> HostListResponse</code>
+
+# Agents
+
+Types:
+
+- <code><a href="./src/resources/agents.ts">HostAgentConfig</a></code>
+- <code><a href="./src/resources/agents.ts">PromptTransport</a></code>
+- <code><a href="./src/resources/agents.ts">AgentListParams</a></code>
+- <code><a href="./src/resources/agents.ts">AgentListResponse</a></code>
+- <code><a href="./src/resources/agents.ts">AgentRunParams</a></code>
+- <code><a href="./src/resources/agents.ts">AgentRunResult</a></code>
+
+Methods:
+
+- <code title="host get /api/trpc/settings.agentConfigs.list">client.agents.<a href="./src/resources/agents.ts">list</a>({ hostId }) -> AgentListResponse</code>
+- <code title="host post /api/trpc/agents.run">client.agents.<a href="./src/resources/agents.ts">run</a>({ workspaceId, agent, prompt, attachmentIds? }, { hostId? }) -> AgentRunResult</code>
+
+# Automations
+
+Types:
+
+- <code><a href="./src/resources/automations.ts">Automation</a></code>
+- <code><a href="./src/resources/automations.ts">AutomationSummary</a></code>
+- <code><a href="./src/resources/automations.ts">AutomationListResponse</a></code>
+- <code><a href="./src/resources/automations.ts">AutomationCreateParams</a></code>
+- <code><a href="./src/resources/automations.ts">AutomationUpdateParams</a></code>
+- <code><a href="./src/resources/automations.ts">AutomationRun</a></code>
+- <code><a href="./src/resources/automations.ts">AutomationRunDispatched</a></code>
+- <code><a href="./src/resources/automations.ts">AutomationLogsParams</a></code>
+- <code><a href="./src/resources/automations.ts">AutomationLogsResponse</a></code>
+
+Methods:
+
+- <code title="get /api/trpc/automation.list">client.automations.<a href="./src/resources/automations.ts">list</a>({ name? }) -> AutomationListResponse</code>
+- <code title="get /api/trpc/automation.get">client.automations.<a href="./src/resources/automations.ts">retrieve</a>(id) -> AutomationSummary</code>
+- <code title="post /api/trpc/automation.create">client.automations.<a href="./src/resources/automations.ts">create</a>({ ...params }) -> Automation</code>
+- <code title="post /api/trpc/automation.update">client.automations.<a href="./src/resources/automations.ts">update</a>({ ...params }) -> Automation</code>
+- <code title="post /api/trpc/automation.delete">client.automations.<a href="./src/resources/automations.ts">delete</a>(id) -> void</code>
+- <code title="post /api/trpc/automation.runNow">client.automations.<a href="./src/resources/automations.ts">run</a>(id) -> AutomationRunDispatched</code>
+- <code title="post /api/trpc/automation.setEnabled">client.automations.<a href="./src/resources/automations.ts">pause</a>(id) -> Automation</code>
+- <code title="post /api/trpc/automation.setEnabled">client.automations.<a href="./src/resources/automations.ts">resume</a>(id) -> Automation</code>
+- <code title="get /api/trpc/automation.listRuns">client.automations.<a href="./src/resources/automations.ts">logs</a>(automationId, { limit? }) -> AutomationLogsResponse</code>
+- <code title="get /api/trpc/automation.getPrompt">client.automations.<a href="./src/resources/automations.ts">getPrompt</a>(id) -> &#123; prompt: string &#125;</code>
+- <code title="post /api/trpc/automation.setPrompt">client.automations.<a href="./src/resources/automations.ts">setPrompt</a>(id, prompt) -> Automation</code>
+
+# Organization
+
+Types:
+
+- <code><a href="./src/resources/organization.ts">OrganizationRole</a></code>
+- <code><a href="./src/resources/organization.ts">Member</a></code>
+- <code><a href="./src/resources/organization.ts">MemberListParams</a></code>
+- <code><a href="./src/resources/organization.ts">MemberListResponse</a></code>
+
+## Members
+
+Methods:
+
+- <code title="get /api/trpc/organization.members.list">client.organization.members.<a href="./src/resources/organization.ts">list</a>({ search?, limit? }) -> MemberListResponse</code>

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -60,8 +60,9 @@ export class Workspaces extends APIResource {
 
 	/**
 	 * Update fields on a workspace. At least one field is required. Currently
-	 * only `name` is exposed — branch and host moves require host-side
-	 * orchestration and aren't safe to set directly.
+	 * exposes `name` and `taskId`; branch and host moves require host-side
+	 * orchestration and aren't safe to set directly. Pass `taskId: null` to
+	 * unlink the workspace from its current task.
 	 *
 	 * Mirrors `superset workspaces update`.
 	 */
@@ -208,6 +209,8 @@ export interface WorkspaceCreateResult {
 export interface WorkspaceUpdateParams {
 	/** New workspace name. */
 	name?: string;
+	/** Link the workspace to a task by id, or pass `null` to unlink. */
+	taskId?: string | null;
 }
 
 export interface WorkspaceUpdateResult {


### PR DESCRIPTION
## Summary
- Audited the `@superset/sdk`, `superset` CLI, and the `apps/docs/content/docs/{sdk,cli}` docs against the canonical tRPC routers in `packages/trpc/src/router/`.
- Fixed stale/wrong docs (examples that would throw at runtime, fabricated fields), filled in undocumented existing surface, and closed one SDK↔CLI mirror gap by wiring `taskId` through `workspaces update`.
- Deliberately did not add net-new surface (`validateRrule`, `automation.versions.*`, `v2Project.update/delete`, `apiKey.create`, `user.me`, `organization.list`, `v2Workspace.setTask`) — discussed and held off as either UI-form helpers, sensitive ops, or not-a-fit for the service-account-oriented SDK.

## Commits

1. `docs: fix stale SDK/CLI reference shapes` — `workspaces.create` example used `ws.id` / `ws.agentRuns.map(r => r.runId)` (neither exists); `automations run` doc listed a fabricated `dispatchedAt` field. Both now match the actual return shapes from `packages/sdk/src/resources/workspaces.ts:188` and `packages/trpc/src/router/automation/automation.ts:475`.
2. `docs(sdk): rewrite api.md to cover all exposed resources` — the hand-maintained \`packages/sdk/api.md\` only listed the 5 task methods. Rewrote to mirror what \`packages/sdk/src/resources/index.ts\` actually exports across workspaces, projects, hosts, agents, automations, organization (incl. \`tasks.statuses\` and \`organization.members\`). Host-routed calls tagged \`host …\` in the title attribute.
3. `docs(sdk): document existing tasks.statuses.list and workspaces.update` — both methods are exposed by the SDK but were missing from the reference page.
4. `feat(sdk,cli): expose taskId on workspaces update` — \`v2Workspace.update\` already accepted \`taskId\`; surfaced it in \`WorkspaceUpdateParams\` (SDK) and added \`--task-id\` / \`--clear-task\` to the CLI. Reused \`v2Workspace.update\` rather than introducing a separate \`setTask\` method.
5. `docs(sdk): show name filter in automations.list example` — \`AutomationListParams.name\` was already exposed but the doc example didn't show it.

## Held off (recorded for follow-up)

| Surface | Reason |
|---|---|
| \`automation.validateRrule\` | RRule preview is a UI-form helper, not a shell/SDK ergonomic |
| \`automation.versions.*\` | Same — prompt history inspection/restore is a UI op |
| \`v2Project.update\` / \`delete\` | Symmetric with tasks/workspaces CRUD; deferred for a dedicated PR |
| \`apiKey.create\` | Chicken-and-egg (need an API key to call it) + sensitive op |
| \`user.me\`, \`organization.list\` | Don't fit service-account SDK use |
| \`v2Workspace.setTask\` (dedicated method) | Covered by \`workspaces.update\` |

## Known minor nits left

- SDK types \`AutomationCreateParams.dtstart\` / \`AutomationUpdateParams.dtstart\` as \`string\`; tRPC uses \`z.coerce.date()\` so \`Date\` works too. Functional today, mildly misleading.
- \`task.update\` zod input still accepts a deprecated \`branch\` field flagged "accepted-but-ignored, drop in CLI-vNext cleanup".

## Test plan
- [x] \`bun run --filter=@superset/sdk --filter=@superset/cli typecheck\` clean
- [x] \`bun run lint\` clean
- [ ] Spot-check the rendered SDK reference and CLI reference pages on a preview build

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4771">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closed docs gaps and aligned `@superset/sdk`, the `superset` CLI, and SDK/CLI docs with the tRPC API. Added task-linking to workspace updates and tightened CLI validation to match runtime behavior.

- **New Features**
  - SDK: `workspaces.update` now accepts `taskId?: string | null` to link/unlink a task.
  - CLI: `superset workspaces update` adds `--task-id <id>` and `--clear-task` (mutually exclusive), using `v2Workspace.update`.

- **Bug Fixes**
  - Corrected return shapes in docs: `workspaces.create` now shows `WorkspaceCreateResult`; removed fabricated `dispatchedAt` from `automations run` output.
  - Expanded docs to match runtime: added `tasks.statuses.list`, `workspaces.update` (incl. `taskId`), and the `name` filter on `automations.list`; rewrote `packages/sdk/api.md`; updated CLI ref to show new workspace update flags.
  - CLI: enforce `--task-id` and `--clear-task` as mutually exclusive (catches empty-string `--task-id ""`).

<sup>Written for commit c96f141cd3b7423b96270caf3a18dd004d8f0bc6. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4771?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: Workspace update supports linking/unlinking to tasks via new options.
  * SDK: Added task status listing method; automations list supports optional name filter.

* **Documentation**
  * Updated CLI and SDK docs and examples to reflect new options, list/filter signatures, and workspace creation/result shape.

* **Breaking Changes**
  * automations run output no longer includes dispatchedAt; workspace create/update result shapes updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->