### PR TITLE
chore(env): default client-validated URLs in .env.example so web boots locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,21 @@
 # Required for fresh-clone local development without third-party credentials.
 SUPERSET_PROFILE=local
 
+# Default Node mode for worktrees. Dev servers (Next.js, electron-vite,
+# host-service) read this to enable hot reload, source maps, dev-only
+# routes (the email/password auth form), and unminified output.
+NODE_ENV=development
+
+# Opt-in: bypass t3-env schema validation at boot. Most app/package env.ts
+# schemas mark integration keys (Stripe, Resend, KV, PostHog, Slack billing,
+# Anthropic, etc.) as required strings — they fail validation on the empty
+# placeholders below even though those features are never exercised in the
+# local flow. Uncomment to unblock `bun dev` until lenient-profile env.ts
+# changes (PR #4616's `shouldSkipEnvValidation()` helper) are restored.
+# Stripped automatically in production by every env.ts schema gating on
+# this flag.
+# SKIP_ENV_VALIDATION=1
+
 # Keep desktop dev state separate from production / canary installs.
 # `bun setup:local` rewrites this to local-dev-<worktree>.
 SUPERSET_WORKSPACE_NAME=local-dev

--- a/.env.example
+++ b/.env.example
@@ -106,7 +106,14 @@ BLOB_READ_WRITE_TOKEN=
 # -----------------------------------------------------------------------------
 # PostHog Analytics (Local Dev)
 # -----------------------------------------------------------------------------
-NEXT_PUBLIC_POSTHOG_KEY=
+# Marker string the renderer treats as "telemetry off" — non-empty so any
+# z.string().min(1) gate passes, but recognized by PostHog wrappers as a
+# disabled key so no network calls fire.
+NEXT_PUBLIC_POSTHOG_KEY=phc_local_dev_disabled
+# Browser-validated URL (apps/web client schema requires z.string().url()).
+# Leave at the upstream PostHog ingest URL — no events fire locally without
+# a real NEXT_PUBLIC_POSTHOG_KEY anyway.
+NEXT_PUBLIC_POSTHOG_HOST=https://us.posthog.com
 POSTHOG_API_KEY=
 POSTHOG_PROJECT_ID=
 
@@ -162,4 +169,7 @@ SUPERSET_MCP_API_KEY=
 # to host-service instances on user devices). Local dev: http://localhost:4734
 RELAY_URL=
 # Browser-exposed relay URL — the web app's host-service tRPC + terminal WS.
-NEXT_PUBLIC_RELAY_URL=
+# Browser-validated URL (apps/web client schema requires z.string().url()).
+# Placeholder — the relay isn't running locally; this just satisfies the
+# browser-side env schema so React can hydrate without throwing.
+NEXT_PUBLIC_RELAY_URL=http://localhost:4734


### PR DESCRIPTION
## Context

Running this stack locally on top of PR #4616 (`local-setup-no-env`) — fresh `bun setup:local` → `bun dev` → open `http://localhost:4640/sign-in` to try the dev email/password form. **Every button on the sign-in page was inert.** No OAuth, no dev sign-in, no console errors from the click handlers. Nothing happened.

Console showed the real failure:

\`\`\`
Uncaught (in promise) Error: Invalid environment variables
  at createEnv (index.ts:375:12)
  at module evaluation (env.ts:5:29)

❌ Invalid environment variables: [
  { path: ['NEXT_PUBLIC_RELAY_URL'],   message: 'Invalid input: expected string, received undefined' },
  { path: ['NEXT_PUBLIC_POSTHOG_HOST'], message: 'Invalid input: expected string, received undefined' },
]
\`\`\`

\`apps/web/src/env.ts\` validates both as \`z.string().url()\` **in the client schema**, so the check runs on every browser hydration. With \`.env\` shipping them blank, React throws before any \`onClick\` handler attaches. The page renders, but it's dead.

\`SKIP_ENV_VALIDATION\` can't fix this on the client. t3-env strips any non-\`NEXT_PUBLIC_*\` var from the browser bundle, so the flag is server-only.

## Changes

All in \`.env.example\`. Nothing else touched.

### \`NODE_ENV=development\` (uncommented, new)

Default Node mode for any worktree generated by \`bun setup:local\`. Dev servers (Next.js, electron-vite, host-service) gate hot reload, source maps, unminified output, and the local email/password auth form on \`NODE_ENV !== "production"\`. Without it set explicitly, parts of the desktop renderer and web sign-in flow misbehave even though \`SUPERSET_PROFILE=local\` is correct.

### \`# SKIP_ENV_VALIDATION=1\` (commented out, new)

Documented opt-in escape hatch. Most app/package env.ts schemas (apps/web, marketing, admin, docs, relay, packages/auth, db, trpc) mark integration keys (Stripe price IDs, KV, Resend, Slack billing, Anthropic, etc.) as required strings. The empty placeholders in this file fail validation at boot. Every schema already gates on \`skipValidation: !!process.env.SKIP_ENV_VALIDATION\`, so uncommenting unblocks \`bun dev\` immediately on the server. Left commented by default so the file is safe to source verbatim in stricter contexts (CI, internal) without accidentally disabling validation.

(Long-term fix is restoring PR #4616's original \`shouldSkipEnvValidation()\` helper across the env.ts files that the trim commit \`5d9b5aad3\` reverted — but that's a separate, larger change. This PR just unblocks contributors today.)

### \`NEXT_PUBLIC_POSTHOG_KEY=phc_local_dev_disabled\` (placeholder, was empty)

Non-empty so any \`z.string().min(1)\` gate passes, but the \`phc_local_dev_disabled\` marker is recognized by PostHog client wrappers as a disabled-telemetry key — no network calls fire.

### \`NEXT_PUBLIC_POSTHOG_HOST=https://us.posthog.com\` (new)

Default value the client schema requires. Real PostHog ingest URL — no events fire locally without a real \`NEXT_PUBLIC_POSTHOG_KEY\` anyway.

### \`NEXT_PUBLIC_RELAY_URL=http://localhost:4734\` (was empty)

Default value the client schema requires. Matches the documented "Local dev:" comment that was already in the file. The relay isn't actually running in local profile — this is a placeholder URL purely to satisfy the browser-side \`z.string().url()\` so React can hydrate.

## Verification

\`\`\`bash
bun setup:local --skip-caddy-trust
bun dev
\`\`\`

Open \`http://localhost:4640/sign-in\`. Buttons respond to clicks. Devtools console is clean of env-validation throws. Server-side bun dev output also clean once \`SKIP_ENV_VALIDATION=1\` is uncommented.

## Why \`.env.example\` and not \`scripts/setup-local.ts\`

Considered hardcoding the defaults in the setup script's \`writeEnvValues()\` call. Rejected: \`setup:local\` already copies \`.env.example → .env\` unchanged when \`.env\` doesn't exist, and rewrites worktree-specific keys (DB name, workspace name) on top. Adding client-URL defaults to \`.env.example\` is the smaller, single-source-of-truth path — no TS edits, no drift surface, identical effect.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4779">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets safe defaults in `.env.example` so the web app hydrates in local dev and the sign-in page buttons work. Prevents client-side env validation errors from blocking clicks.

- **Bug Fixes**
  - Default `NODE_ENV=development` for local worktrees.
  - Add commented `SKIP_ENV_VALIDATION=1` as a server-only escape hatch.
  - Set `NEXT_PUBLIC_POSTHOG_HOST=https://us.posthog.com` and `NEXT_PUBLIC_POSTHOG_KEY=phc_local_dev_disabled` to satisfy the client schema without sending data.
  - Set `NEXT_PUBLIC_RELAY_URL=http://localhost:4734` as a placeholder to satisfy the browser schema.

<sup>Written for commit 1ab968e669f61d3b94ccf890bf80ab83fe1471de. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4779?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

