### PR TITLE
Recover pty daemon adoption from live socket

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -11,7 +11,6 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as childProcess from "node:child_process";
-import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as net from "node:net";
 import * as os from "node:os";
@@ -24,6 +23,7 @@ import {
 import {
 	DaemonSupervisor,
 	probeDaemonVersion,
+	ptyDaemonSocketPath,
 	shouldKillStaleDaemonForDev,
 } from "./DaemonSupervisor.ts";
 import { readPtyDaemonManifest, writePtyDaemonManifest } from "./manifest.ts";
@@ -233,7 +233,7 @@ describe("DaemonSupervisor.tryAdopt", () => {
 		const originalHome = process.env.SUPERSET_HOME_DIR;
 		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pty-daemon-unit-"));
 		process.env.SUPERSET_HOME_DIR = tmpHome;
-		const socketPath = expectedSocketPathForOrg(orgId);
+		const socketPath = ptyDaemonSocketPath(orgId);
 		try {
 			try {
 				fs.unlinkSync(socketPath);
@@ -1076,14 +1076,6 @@ function invokeTryAdopt(
 			tryAdopt: (id: string) => Promise<unknown | null>;
 		}
 	).tryAdopt(organizationId);
-}
-
-function expectedSocketPathForOrg(organizationId: string): string {
-	const shortId = createHash("sha256")
-		.update(organizationId)
-		.digest("hex")
-		.slice(0, 12);
-	return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
 }
 
 async function waitForProcessExit(

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -11,6 +11,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as childProcess from "node:child_process";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as net from "node:net";
 import * as os from "node:os";
@@ -25,12 +26,19 @@ import {
 	probeDaemonVersion,
 	shouldKillStaleDaemonForDev,
 } from "./DaemonSupervisor.ts";
-import { writePtyDaemonManifest } from "./manifest.ts";
+import { readPtyDaemonManifest, writePtyDaemonManifest } from "./manifest.ts";
 
 // Capture supervisor-emitted log events. We replace console.log for the
 // duration of the test, then filter for our supervisor's component prefix.
 const loggedEvents: { event: string; props: Record<string, unknown> }[] = [];
 const realConsoleLog = console.log;
+
+interface AdoptedForTest {
+	pid: number;
+	socketPath: string;
+	runningVersion: string;
+	updatePending: boolean;
+}
 
 beforeEach(() => {
 	loggedEvents.length = 0;
@@ -61,7 +69,9 @@ afterEach(() => {
 });
 
 interface FakeDaemonOptions {
+	socketPath?: string;
 	respondWithVersion?: string;
+	daemonPid?: number;
 	respondRaw?: Buffer;
 	hangUpAfterHello?: boolean;
 	respondWithWrongMessageFirst?: boolean;
@@ -72,10 +82,12 @@ async function startFakeDaemon(opts: FakeDaemonOptions): Promise<{
 	socketPath: string;
 	close: () => Promise<void>;
 }> {
-	const socketPath = path.join(
-		os.tmpdir(),
-		`fake-pty-daemon-${process.pid}-${Math.random().toString(36).slice(2, 8)}.sock`,
-	);
+	const socketPath =
+		opts.socketPath ??
+		path.join(
+			os.tmpdir(),
+			`fake-pty-daemon-${process.pid}-${Math.random().toString(36).slice(2, 8)}.sock`,
+		);
 	const server = net.createServer((sock) => {
 		const decoder = new FrameDecoder();
 		sock.on("data", (chunk: Buffer) => {
@@ -108,6 +120,7 @@ async function startFakeDaemon(opts: FakeDaemonOptions): Promise<{
 							type: "hello-ack",
 							protocol: 1,
 							daemonVersion: opts.respondWithVersion,
+							daemonPid: opts.daemonPid,
 						}),
 					);
 					return;
@@ -215,6 +228,67 @@ describe("shouldKillStaleDaemonForDev", () => {
 });
 
 describe("DaemonSupervisor.tryAdopt", () => {
+	test("recovers adoption from a live expected socket when the manifest is missing", async () => {
+		const orgId = "org-socket-fallback";
+		const originalHome = process.env.SUPERSET_HOME_DIR;
+		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pty-daemon-unit-"));
+		process.env.SUPERSET_HOME_DIR = tmpHome;
+		const socketPath = expectedSocketPathForOrg(orgId);
+		try {
+			try {
+				fs.unlinkSync(socketPath);
+			} catch {
+				// best-effort cleanup from a failed prior run
+			}
+			const fake = await startFakeDaemon({
+				socketPath,
+				respondWithVersion: "0.1.0",
+				daemonPid: process.pid,
+			});
+			try {
+				const sup = new DaemonSupervisor({
+					scriptPath: "/nonexistent",
+					autoUpdate: false,
+				});
+				const adopted = (await invokeTryAdopt(
+					sup,
+					orgId,
+				)) as AdoptedForTest | null;
+				expect(adopted).not.toBeNull();
+				expect(adopted?.pid).toBe(process.pid);
+				expect(adopted?.socketPath).toBe(socketPath);
+				expect(adopted?.runningVersion).toBe("0.1.0");
+				expect(readPtyDaemonManifest(orgId)).toMatchObject({
+					pid: process.pid,
+					socketPath,
+					organizationId: orgId,
+				});
+				expect(
+					loggedEvents.some(
+						(e) =>
+							e.event === "pty_daemon_socket_adopt_manifest_recovered" &&
+							e.props.sourceReason === "manifest_missing" &&
+							e.props.pid === process.pid,
+					),
+				).toBe(true);
+			} finally {
+				await fake.close();
+			}
+		} finally {
+			if (originalHome !== undefined) {
+				process.env.SUPERSET_HOME_DIR = originalHome;
+			} else {
+				delete process.env.SUPERSET_HOME_DIR;
+			}
+			fs.rmSync(tmpHome, { recursive: true, force: true });
+			try {
+				fs.unlinkSync(socketPath);
+			} catch {
+				// best-effort
+			}
+		}
+	});
+
 	test("rejects and replaces a reachable daemon that cannot answer the version probe", async () => {
 		const orgId = "org-unprobeable";
 		const fake = await startFakeDaemon({ silent: true });
@@ -1002,6 +1076,14 @@ function invokeTryAdopt(
 			tryAdopt: (id: string) => Promise<unknown | null>;
 		}
 	).tryAdopt(organizationId);
+}
+
+function expectedSocketPathForOrg(organizationId: string): string {
+	const shortId = createHash("sha256")
+		.update(organizationId)
+		.digest("hex")
+		.slice(0, 12);
+	return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
 }
 
 async function waitForProcessExit(

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -50,6 +50,11 @@ interface DaemonInstance {
 	updatePending: boolean;
 }
 
+interface DaemonProbeResult {
+	daemonVersion: string;
+	daemonPid?: number;
+}
+
 const SOCKET_READY_TIMEOUT_MS = 5_000;
 const VERSION_PROBE_TIMEOUT_MS = 1_500;
 const HANDOFF_PREDECESSOR_EXIT_TIMEOUT_MS = 3_000;
@@ -845,24 +850,38 @@ export class DaemonSupervisor {
 		organizationId: string,
 	): Promise<DaemonInstance | null> {
 		const manifest = readPtyDaemonManifest(organizationId);
-		if (!manifest) return null;
+		const expectedSocketPath = ptyDaemonSocketPath(organizationId);
+		if (!manifest) {
+			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+				reason: "manifest_missing",
+			});
+		}
 		if (!isProcessAlive(manifest.pid)) {
 			removePtyDaemonManifest(organizationId);
-			return null;
+			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+				reason: "manifest_pid_dead",
+				previousManifest: manifest,
+			});
 		}
 		const reachable = await isSocketConnectable(manifest.socketPath, 1000);
 		if (!reachable) {
 			// PID alive but socket gone — daemon is wedged. Kill and respawn.
 			await terminateProcessTreeAndGroups(manifest.pid, "SIGTERM");
 			removePtyDaemonManifest(organizationId);
+			if (manifest.socketPath !== expectedSocketPath) {
+				return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+					reason: "manifest_socket_unreachable",
+					previousManifest: manifest,
+				});
+			}
 			return null;
 		}
 
-		const probed = await probeDaemonVersionWithRetry(
+		const probe = await probeDaemonHelloWithRetry(
 			manifest.socketPath,
 			ADOPTION_PROBE_TOTAL_TIMEOUT_MS,
 		);
-		if (!probed) {
+		if (!probe) {
 			logEvent("pty_daemon_adopt_rejected", {
 				organizationId,
 				pid: manifest.pid,
@@ -871,11 +890,17 @@ export class DaemonSupervisor {
 			});
 			await terminateProcessTreeAndGroups(manifest.pid, "SIGTERM");
 			removePtyDaemonManifest(organizationId);
+			if (manifest.socketPath !== expectedSocketPath) {
+				return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+					reason: "manifest_version_probe_failed",
+					previousManifest: manifest,
+				});
+			}
 			return null;
 		}
-		const runningVersion = probed;
+		const runningVersion = probe.daemonVersion;
 		const updatePending = !semver.satisfies(
-			probed,
+			runningVersion,
 			`>=${EXPECTED_DAEMON_VERSION}`,
 		);
 
@@ -886,6 +911,73 @@ export class DaemonSupervisor {
 			runningVersion,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
 			updatePending,
+		};
+	}
+
+	private async tryAdoptFromSocket(
+		organizationId: string,
+		socketPath: string,
+		context: {
+			reason: string;
+			previousManifest?: PtyDaemonManifest;
+		},
+	): Promise<DaemonInstance | null> {
+		const reachable = await isSocketConnectable(socketPath, 1000);
+		if (!reachable) return null;
+
+		const probe = await probeDaemonHelloWithRetry(
+			socketPath,
+			ADOPTION_PROBE_TOTAL_TIMEOUT_MS,
+		);
+		if (!probe) {
+			logEvent("pty_daemon_socket_adopt_rejected", {
+				organizationId,
+				socketPath,
+				reason: "version_probe_failed",
+				sourceReason: context.reason,
+			});
+			return null;
+		}
+
+		const resolvedPid = probe.daemonPid;
+		if (!isPositiveInteger(resolvedPid) || !isProcessAlive(resolvedPid)) {
+			logEvent("pty_daemon_socket_adopt_rejected", {
+				organizationId,
+				socketPath,
+				reason: "pid_unavailable",
+				sourceReason: context.reason,
+				probedPid: resolvedPid,
+			});
+			return null;
+		}
+
+		const startedAt = context.previousManifest?.startedAt ?? Date.now();
+		writePtyDaemonManifest({
+			pid: resolvedPid,
+			socketPath,
+			protocolVersions: [CURRENT_PROTOCOL_VERSION],
+			startedAt,
+			organizationId,
+		});
+
+		logEvent("pty_daemon_socket_adopt_manifest_recovered", {
+			organizationId,
+			pid: resolvedPid,
+			socketPath,
+			sourceReason: context.reason,
+			runningVersion: probe.daemonVersion,
+		});
+
+		return {
+			pid: resolvedPid,
+			socketPath,
+			startedAt,
+			runningVersion: probe.daemonVersion,
+			expectedVersion: EXPECTED_DAEMON_VERSION,
+			updatePending: !semver.satisfies(
+				probe.daemonVersion,
+				`>=${EXPECTED_DAEMON_VERSION}`,
+			),
 		};
 	}
 
@@ -1051,7 +1143,7 @@ export class DaemonSupervisor {
 		const manifest: PtyDaemonManifest = {
 			pid: childPid,
 			socketPath,
-			protocolVersions: [1],
+			protocolVersions: [CURRENT_PROTOCOL_VERSION],
 			startedAt,
 			organizationId,
 		};
@@ -1209,19 +1301,29 @@ export async function listDaemonSessions(
  * `probeDaemonVersion` resolves to null on the first connect-error;
  * we have to actively retry.
  */
-async function probeDaemonVersionWithRetry(
+async function probeDaemonHelloWithRetry(
 	socketPath: string,
 	totalTimeoutMs: number,
-): Promise<string | null> {
+): Promise<DaemonProbeResult | null> {
 	const deadline = Date.now() + totalTimeoutMs;
 	while (Date.now() < deadline) {
 		const remaining = deadline - Date.now();
 		const perAttempt = Math.min(remaining, VERSION_PROBE_TIMEOUT_MS);
-		const v = await probeDaemonVersion(socketPath, perAttempt);
-		if (v !== null) return v;
+		const probe = await probeDaemonHello(socketPath, perAttempt);
+		if (probe !== null) return probe;
 		await new Promise((r) => setTimeout(r, 50));
 	}
 	return null;
+}
+
+async function probeDaemonVersionWithRetry(
+	socketPath: string,
+	totalTimeoutMs: number,
+): Promise<string | null> {
+	return (
+		(await probeDaemonHelloWithRetry(socketPath, totalTimeoutMs))
+			?.daemonVersion ?? null
+	);
 }
 
 function terminatePidOnly(pid: number, signal: NodeJS.Signals): void {
@@ -1282,12 +1384,19 @@ export async function probeDaemonVersion(
 	socketPath: string,
 	timeoutMs: number,
 ): Promise<string | null> {
-	return new Promise<string | null>((resolve) => {
+	return (await probeDaemonHello(socketPath, timeoutMs))?.daemonVersion ?? null;
+}
+
+function probeDaemonHello(
+	socketPath: string,
+	timeoutMs: number,
+): Promise<DaemonProbeResult | null> {
+	return new Promise<DaemonProbeResult | null>((resolve) => {
 		const sock = net.createConnection({ path: socketPath });
 		const decoder = new FrameDecoder();
 		let settled = false;
 
-		const cleanup = (value: string | null) => {
+		const cleanup = (value: DaemonProbeResult | null) => {
 			if (settled) return;
 			settled = true;
 			clearTimeout(timer);
@@ -1330,7 +1439,15 @@ export async function probeDaemonVersion(
 				for (const decoded of decoder.drain()) {
 					const msg = decoded.message as ServerMessage;
 					if (msg.type === "hello-ack") {
-						cleanup(msg.daemonVersion ?? null);
+						const daemonVersion = msg.daemonVersion;
+						if (!daemonVersion) {
+							cleanup(null);
+							return;
+						}
+						cleanup({
+							daemonVersion,
+							daemonPid: msg.daemonPid,
+						});
 						return;
 					}
 					cleanup(null);

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -91,7 +91,7 @@ export function shouldKillStaleDaemonForDev(
  * file mode (0600, set by the daemon's Server.listen) is the auth boundary;
  * the directory permissions don't matter.
  */
-function ptyDaemonSocketPath(organizationId: string): string {
+export function ptyDaemonSocketPath(organizationId: string): string {
 	const shortId = createHash("sha256")
 		.update(organizationId)
 		.digest("hex")
@@ -860,7 +860,6 @@ export class DaemonSupervisor {
 			removePtyDaemonManifest(organizationId);
 			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
 				reason: "manifest_pid_dead",
-				previousManifest: manifest,
 			});
 		}
 		const reachable = await isSocketConnectable(manifest.socketPath, 1000);

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -372,6 +372,7 @@ export class Server {
 				type: "hello-ack",
 				protocol: negotiated,
 				daemonVersion: this.opts.daemonVersion,
+				daemonPid: process.pid,
 			});
 			return;
 		}

--- a/packages/pty-daemon/src/protocol/messages.ts
+++ b/packages/pty-daemon/src/protocol/messages.ts
@@ -35,6 +35,12 @@ export interface HelloAckMessage {
 	type: "hello-ack";
 	protocol: number;
 	daemonVersion: string;
+	/**
+	 * Process id of the daemon process that accepted the connection. Supervisors
+	 * use this to recover adoption state from a live socket when the manifest is
+	 * missing or stale.
+	 */
+	daemonPid?: number;
 }
 
 // ---------- Client -> Daemon ----------


### PR DESCRIPTION
## Summary
- Recover v2 daemon adoption from the deterministic org socket when the pty-daemon manifest is missing or stale.
- Include the daemon process id in `hello-ack` so the host service can rebuild adoption state without host-side PID discovery.
- Keep the fix scoped to the daemon handshake and supervisor adoption path so host restarts behave closer to v1 socket-first recovery.

## Testing
- `bun test packages/host-service/src/daemon/DaemonSupervisor.test.ts packages/pty-daemon/src/protocol/wire-shape.test.ts`
- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd packages/pty-daemon typecheck`
- `bun run --cwd packages/host-service test:integration:daemon`
- `bun run lint`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover v2 pty-daemon adoption from the deterministic org socket when the manifest is missing or stale, rebuilding state using the daemon-reported PID. Also avoids stale adoption metadata so host restarts are reliable and closer to v1’s socket-first recovery.

- **Bug Fixes**
  - Extended fallback in `DaemonSupervisor.tryAdopt` to also handle version-probe failures; adopts from the expected org socket and rewrites the manifest with the resolved PID and preserved `startedAt`.
  - Replaced version-only probe with a hello handshake that returns both `daemonVersion` and `daemonPid` (with retry).
  - Updated `hello-ack` and server reply in `packages/pty-daemon`; manifest writes now use `CURRENT_PROTOCOL_VERSION`.
  - Adds clear adoption logs and a test for manifest-missing socket recovery.

<sup>Written for commit ea910661a83672c0bd0c69f97a81927d15e53aaf. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4781?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon recovery when local configuration or socket state is missing or stale, automatically restoring expected runtime state for more reliable startup.

* **Improvements**
  * Daemon handshake now reports process identity and version more reliably, improving detection of running daemons and update-pending status.

* **Tests**
  * Added tests verifying recovery flow, manifest recreation, and telemetry when a daemon manifest is missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->