### PR TITLE
fix(desktop): route Email Founders through shell.openExternal

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHelpMenu/DashboardSidebarHelpMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHelpMenu/DashboardSidebarHelpMenu.tsx
@@ -22,6 +22,7 @@ import {
 import { IoBugOutline } from "react-icons/io5";
 import { LuKeyboard, LuMegaphone } from "react-icons/lu";
 import { useHotkeyDisplay } from "renderer/hotkeys";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { SubmitPromptDialog } from "./components/SubmitPromptDialog";
 
 interface DashboardSidebarHelpMenuProps {
@@ -34,9 +35,10 @@ export function DashboardSidebarHelpMenu({
 	const navigate = useNavigate();
 	const shortcutsHotkey = useHotkeyDisplay("SHOW_HOTKEYS").text;
 	const [submitPromptOpen, setSubmitPromptOpen] = useState(false);
+	const openUrlMutation = electronTrpc.external.openUrl.useMutation();
 
 	const openExternal = (url: string) => {
-		window.open(url, "_blank");
+		openUrlMutation.mutate(url);
 	};
 
 	const triggerButton = (


### PR DESCRIPTION
## Summary
- The **Help → Contact Us → Email Founders** item in the dashboard sidebar did nothing — `window.open(\"mailto:…\", \"_blank\")` doesn't trigger the OS mail handler in Electron's renderer.
- Route every entry in the help menu through `electronTrpc.external.openUrl` so `shell.openExternal` is called from the main process. `mailto:` is already in the safe-scheme allowlist.

## Test plan
- [ ] Click Help → Contact Us → Email Founders → default mail client opens a new draft to founders@superset.sh
- [ ] Other items in the menu (Documentation, Report Issue, GitHub, Discord, X) still open in the default browser

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Help → Contact Us → Email Founders item in the desktop app by opening external links via `electronTrpc.external.openUrl` so the main process calls `shell.openExternal`. This ensures `mailto:` opens the default mail client and other Help links open in the default browser.

<sup>Written for commit 470cbe73433e9b2d4f57b587027dd9d057201a80. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4782?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the reliability and consistency of opening external links from the Help Menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->