### PR TITLE
[codex] add contact page

### DIFF
--- a/apps/marketing/src/app/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/components/Footer/Footer.tsx
@@ -33,6 +33,7 @@ interface FooterLink {
 
 const COMPANY_LINKS: FooterLink[] = [
 	{ href: "/team", label: "About" },
+	{ href: "/contact", label: "Contact" },
 	{ href: COMPANY.CAREERS_URL, label: "Careers", external: true },
 	{ href: COMPANY.STATUS_URL, label: "Status", external: true },
 ];

--- a/apps/marketing/src/app/contact/actions.ts
+++ b/apps/marketing/src/app/contact/actions.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { ContactInquiryEmail } from "@superset/email/emails/contact-inquiry";
+import { Resend } from "resend";
+import { env } from "@/env";
+
+const resend = new Resend(env.RESEND_API_KEY);
+
+interface ContactFormData {
+	name: string;
+	email: string;
+	topic: string;
+	message: string;
+	honeypot?: string;
+}
+
+function validateEmail(email: string): boolean {
+	const parts = email.split("@");
+	return (
+		parts.length === 2 &&
+		parts[0] !== undefined &&
+		parts[0].length > 0 &&
+		parts[1] !== undefined &&
+		parts[1].length > 0 &&
+		parts[1].includes(".")
+	);
+}
+
+function sanitizeSingleLine(input: string): string {
+	return input.replace(/[\r\n\0]/g, "").trim();
+}
+
+function sanitizeMessage(input: string): string {
+	return input.replace(/\0/g, "").trim();
+}
+
+export async function submitContactInquiry(data: ContactFormData) {
+	const { name, email, topic, message, honeypot } = data;
+
+	if (honeypot && honeypot.length > 0) {
+		return { success: false, error: "Something went wrong. Please try again." };
+	}
+
+	if (!name || !email || !message) {
+		return { success: false, error: "Missing required fields." };
+	}
+
+	const sanitizedName = sanitizeSingleLine(name);
+	const sanitizedEmail = sanitizeSingleLine(email);
+	const sanitizedTopic = topic ? sanitizeSingleLine(topic) : "General question";
+	const sanitizedMessage = sanitizeMessage(message);
+
+	if (!sanitizedName || !sanitizedEmail || !sanitizedMessage) {
+		return { success: false, error: "Invalid input detected." };
+	}
+
+	if (!validateEmail(sanitizedEmail)) {
+		return { success: false, error: "Invalid email address." };
+	}
+
+	try {
+		const { error } = await resend.emails.send({
+			from: "Superset <noreply@superset.sh>",
+			to: "founders@superset.sh",
+			replyTo: sanitizedEmail,
+			subject: `Contact message from ${sanitizedName}: ${sanitizedTopic}`,
+			react: ContactInquiryEmail({
+				name: sanitizedName,
+				email: sanitizedEmail,
+				topic: sanitizedTopic,
+				message: sanitizedMessage,
+			}),
+		});
+
+		if (error) {
+			console.error("Failed to send contact inquiry email:", error);
+			return {
+				success: false,
+				error: "Something went wrong. Please try again.",
+			};
+		}
+
+		return { success: true };
+	} catch (error) {
+		console.error("Failed to send contact inquiry email:", error);
+		return { success: false, error: "Something went wrong. Please try again." };
+	}
+}

--- a/apps/marketing/src/app/contact/components/ContactForm/ContactForm.tsx
+++ b/apps/marketing/src/app/contact/components/ContactForm/ContactForm.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { ArrowRight, CheckCircle2, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { submitContactInquiry } from "../../actions";
+
+export function ContactForm() {
+	const [formState, setFormState] = useState({
+		name: "",
+		email: "",
+		topic: "",
+		message: "",
+		honeypot: "",
+	});
+	const [status, setStatus] = useState<
+		"idle" | "submitting" | "success" | "error"
+	>("idle");
+	const [errorMessage, setErrorMessage] = useState("");
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setStatus("submitting");
+		setErrorMessage("");
+
+		try {
+			const result = await submitContactInquiry(formState);
+
+			if (result.success) {
+				setStatus("success");
+			} else {
+				setStatus("error");
+				setErrorMessage(result.error ?? "Something went wrong.");
+			}
+		} catch (_error) {
+			setStatus("error");
+			setErrorMessage("Something went wrong. Please try again.");
+		}
+	};
+
+	if (status === "success") {
+		return (
+			<div className="flex flex-col items-center justify-center py-16 text-center">
+				<CheckCircle2 className="size-6 text-muted-foreground mb-4" />
+				<p className="text-lg font-medium text-foreground">
+					Thanks for reaching out
+				</p>
+				<p className="mt-2 text-sm text-muted-foreground">
+					We&apos;ll get back to you shortly.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<form onSubmit={handleSubmit} className="relative space-y-5">
+			<div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+				<div>
+					<label
+						htmlFor="contact-name"
+						className="block text-sm text-muted-foreground mb-1.5"
+					>
+						Full name
+					</label>
+					<input
+						id="contact-name"
+						type="text"
+						required
+						value={formState.name}
+						onChange={(e) =>
+							setFormState((s) => ({ ...s, name: e.target.value }))
+						}
+						className="w-full px-3.5 py-2.5 text-sm bg-background border border-border text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:border-foreground/25 transition-colors"
+					/>
+				</div>
+
+				<div>
+					<label
+						htmlFor="contact-email"
+						className="block text-sm text-muted-foreground mb-1.5"
+					>
+						Email
+					</label>
+					<input
+						id="contact-email"
+						type="email"
+						required
+						value={formState.email}
+						onChange={(e) =>
+							setFormState((s) => ({ ...s, email: e.target.value }))
+						}
+						className="w-full px-3.5 py-2.5 text-sm bg-background border border-border text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:border-foreground/25 transition-colors"
+					/>
+				</div>
+			</div>
+
+			<div>
+				<label
+					htmlFor="contact-topic"
+					className="block text-sm text-muted-foreground mb-1.5"
+				>
+					Topic
+				</label>
+				<input
+					id="contact-topic"
+					type="text"
+					value={formState.topic}
+					onChange={(e) =>
+						setFormState((s) => ({ ...s, topic: e.target.value }))
+					}
+					className="w-full px-3.5 py-2.5 text-sm bg-background border border-border text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:border-foreground/25 transition-colors"
+				/>
+			</div>
+
+			<div>
+				<label
+					htmlFor="contact-message"
+					className="block text-sm text-muted-foreground mb-1.5"
+				>
+					How can we help?
+				</label>
+				<textarea
+					id="contact-message"
+					rows={5}
+					required
+					value={formState.message}
+					onChange={(e) =>
+						setFormState((s) => ({ ...s, message: e.target.value }))
+					}
+					className="w-full px-3.5 py-2.5 text-sm bg-background border border-border text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:border-foreground/25 transition-colors resize-none"
+				/>
+			</div>
+
+			<input
+				type="text"
+				name="website"
+				value={formState.honeypot}
+				onChange={(e) =>
+					setFormState((s) => ({ ...s, honeypot: e.target.value }))
+				}
+				tabIndex={-1}
+				autoComplete="off"
+				className="absolute left-0 top-0 opacity-0 pointer-events-none h-0 w-0"
+				aria-hidden="true"
+			/>
+
+			{status === "error" && (
+				<p className="text-sm text-red-400">{errorMessage}</p>
+			)}
+
+			<button
+				type="submit"
+				disabled={status === "submitting"}
+				className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium bg-foreground text-background hover:bg-foreground/90 transition-colors disabled:opacity-50"
+			>
+				{status === "submitting" ? (
+					<>
+						Sending
+						<Loader2 className="size-3.5 animate-spin" />
+					</>
+				) : (
+					<>
+						Send message
+						<ArrowRight className="size-3.5" />
+					</>
+				)}
+			</button>
+		</form>
+	);
+}

--- a/apps/marketing/src/app/contact/components/ContactForm/index.ts
+++ b/apps/marketing/src/app/contact/components/ContactForm/index.ts
@@ -1,0 +1,1 @@
+export { ContactForm } from "./ContactForm";

--- a/apps/marketing/src/app/contact/page.tsx
+++ b/apps/marketing/src/app/contact/page.tsx
@@ -1,0 +1,52 @@
+import { COMPANY } from "@superset/shared/constants";
+import type { Metadata } from "next";
+import { GridCross } from "@/app/blog/components/GridCross";
+import { ContactForm } from "./components/ContactForm";
+
+export const metadata: Metadata = {
+	title: "Contact",
+	description: `Get in touch with the ${COMPANY.NAME} team.`,
+	alternates: {
+		canonical: `${COMPANY.MARKETING_URL}/contact`,
+	},
+};
+
+export default function ContactPage() {
+	return (
+		<main className="relative min-h-screen">
+			<div
+				className="absolute inset-0 pointer-events-none"
+				style={{
+					backgroundImage: `
+						linear-gradient(to right, transparent 0%, transparent calc(50% - 384px), rgba(255,255,255,0.06) calc(50% - 384px), rgba(255,255,255,0.06) calc(50% - 383px), transparent calc(50% - 383px), transparent calc(50% + 383px), rgba(255,255,255,0.06) calc(50% + 383px), rgba(255,255,255,0.06) calc(50% + 384px), transparent calc(50% + 384px))
+					`,
+				}}
+			/>
+
+			<header className="relative border-b border-border">
+				<div className="max-w-3xl mx-auto px-6 pt-16 pb-10 md:pt-20 md:pb-12 relative">
+					<GridCross className="top-0 left-0" />
+					<GridCross className="top-0 right-0" />
+
+					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+						Contact
+					</span>
+					<h1 className="text-3xl md:text-4xl font-medium tracking-tight text-foreground mt-4">
+						Talk to Superset
+					</h1>
+					<p className="text-muted-foreground mt-3 max-w-lg">
+						Questions, feedback, support, or anything else. Send a note and
+						we&apos;ll route it to the right person.
+					</p>
+
+					<GridCross className="bottom-0 left-0" />
+					<GridCross className="bottom-0 right-0" />
+				</div>
+			</header>
+
+			<div className="relative max-w-3xl mx-auto px-6 py-12 md:py-16">
+				<ContactForm />
+			</div>
+		</main>
+	);
+}

--- a/packages/email/src/components/layout/StandardLayout/components/Footer/Footer.tsx
+++ b/packages/email/src/components/layout/StandardLayout/components/Footer/Footer.tsx
@@ -89,7 +89,7 @@ export function Footer({ showSocial = true }: FooterProps) {
 				</Link>
 				{" • "}
 				<Link
-					href="https://superset.sh/contact"
+					href={`${env.NEXT_PUBLIC_MARKETING_URL}/contact`}
 					className="text-muted no-underline"
 				>
 					Contact

--- a/packages/email/src/emails/contact-inquiry.tsx
+++ b/packages/email/src/emails/contact-inquiry.tsx
@@ -1,0 +1,112 @@
+import {
+	Body,
+	Container,
+	Head,
+	Heading,
+	Hr,
+	Html,
+	Preview,
+	Text,
+} from "@react-email/components";
+
+interface ContactInquiryEmailProps {
+	name: string;
+	email: string;
+	topic?: string;
+	message: string;
+}
+
+export function ContactInquiryEmail({
+	name = "Jane Doe",
+	email = "jane@example.com",
+	topic = "General question",
+	message = "Hello from the marketing site.",
+}: ContactInquiryEmailProps) {
+	return (
+		<Html>
+			<Head />
+			<Preview>
+				Contact message from {name} ({email})
+			</Preview>
+			<Body style={body}>
+				<Container style={container}>
+					<Heading style={heading}>New Contact Message</Heading>
+
+					<Text style={paragraph}>
+						A new contact message was submitted from the marketing site.
+					</Text>
+
+					<Hr style={hr} />
+
+					<Text style={label}>Name</Text>
+					<Text style={value}>{name}</Text>
+
+					<Text style={label}>Email</Text>
+					<Text style={value}>{email}</Text>
+
+					<Text style={label}>Topic</Text>
+					<Text style={value}>{topic}</Text>
+
+					<Text style={label}>Message</Text>
+					<Text style={messageValue}>{message}</Text>
+				</Container>
+			</Body>
+		</Html>
+	);
+}
+
+export default ContactInquiryEmail;
+
+const body = {
+	backgroundColor: "#ffffff",
+	fontFamily:
+		'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+};
+
+const container = {
+	margin: "0 auto",
+	padding: "40px 24px",
+	maxWidth: "560px",
+};
+
+const heading = {
+	color: "#000000",
+	fontSize: "28px",
+	fontWeight: "600" as const,
+	lineHeight: "1.3",
+	margin: "0 0 24px 0",
+};
+
+const paragraph = {
+	color: "#515759",
+	fontSize: "16px",
+	lineHeight: "22px",
+	margin: "0 0 16px 0",
+};
+
+const hr = {
+	borderColor: "#EBEBEB",
+	margin: "24px 0",
+};
+
+const label = {
+	color: "#77767e",
+	fontSize: "12px",
+	fontWeight: "600" as const,
+	textTransform: "uppercase" as const,
+	letterSpacing: "0.05em",
+	lineHeight: "16px",
+	margin: "16px 0 4px 0",
+};
+
+const value = {
+	color: "#242424",
+	fontSize: "16px",
+	lineHeight: "22px",
+	margin: "0 0 0 0",
+};
+
+const messageValue = {
+	...value,
+	whiteSpace: "pre-wrap" as const,
+};


### PR DESCRIPTION
## Summary

Adds a standalone marketing `/contact` page with a lighter-weight contact form separate from the enterprise inquiry flow.

The new form collects name, email, topic, and message, then sends a generic contact inquiry email to `founders@superset.sh` through Resend. It keeps the same basic bot, validation, sanitization, success, and error patterns used by the enterprise form.

Also adds Contact to the marketing footer and updates shared email footer contact links to use the configured marketing URL.

## Impact

Users now have a general contact path that is less enterprise-focused, while `/enterprise` remains unchanged for sales-oriented inquiries.

## Validation

- `bun run --cwd apps/marketing typecheck`
- `bun run --cwd packages/email typecheck`
- `bun run lint`
- `bunx dotenv -e ../../.env -- bun run build` from `apps/marketing`
- Live local checks confirmed `/contact` renders the new contact form and `/enterprise` still renders the enterprise form.
- Server action validation checked invalid email and honeypot rejection paths without sending a real email.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4788">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a standalone marketing /contact page with a simple contact form that emails inquiries via `resend`. Provides a general contact path while leaving /enterprise for sales.

- **New Features**
  - New `/contact` page with a lightweight form (name, email, topic, message).
  - Server action validates, sanitizes, includes a honeypot, and sends to founders@superset.sh using `@superset/email`’s contact inquiry template.
  - Added “Contact” to the marketing footer and updated email footer links to the configured marketing URL.

<sup>Written for commit 472789fed589e84aa372ebce5e8a45f4451ddffa. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4788?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched a new contact page with an interactive form for user inquiries
  * Contact form includes input validation and displays real-time feedback on submission attempts
  * Added "Contact" link to footer navigation for improved accessibility
  * Form provides success or error messages confirming submission status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->