### PR TITLE
[codex] fix marketing email form hardening

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -20,6 +20,8 @@
 		"@superset/shared": "workspace:*",
 		"@superset/ui": "workspace:*",
 		"@t3-oss/env-nextjs": "0.13.11",
+		"@upstash/ratelimit": "2.0.8",
+		"@upstash/redis": "1.37.0",
 		"framer-motion": "12.38.0",
 		"geist": "1.7.0",
 		"gray-matter": "4.0.3",

--- a/apps/marketing/src/app/contact/actions.ts
+++ b/apps/marketing/src/app/contact/actions.ts
@@ -2,40 +2,32 @@
 
 import { ContactInquiryEmail } from "@superset/email/emails/contact-inquiry";
 import { Resend } from "resend";
+import { z } from "zod";
 import { env } from "@/env";
+import { checkEmailFormRateLimit } from "@/lib/email-rate-limit";
+import {
+	sanitizeMessage,
+	sanitizeSingleLine,
+	validateEmail,
+} from "@/lib/form-utils";
 
 const resend = new Resend(env.RESEND_API_KEY);
 
-interface ContactFormData {
-	name: string;
-	email: string;
-	topic: string;
-	message: string;
-	honeypot?: string;
-}
+const contactFormDataSchema = z.object({
+	name: z.string(),
+	email: z.string(),
+	topic: z.string().optional().default(""),
+	message: z.string(),
+	honeypot: z.string().optional(),
+});
 
-function validateEmail(email: string): boolean {
-	const parts = email.split("@");
-	return (
-		parts.length === 2 &&
-		parts[0] !== undefined &&
-		parts[0].length > 0 &&
-		parts[1] !== undefined &&
-		parts[1].length > 0 &&
-		parts[1].includes(".")
-	);
-}
+export async function submitContactInquiry(data: unknown) {
+	const parsedData = contactFormDataSchema.safeParse(data);
+	if (!parsedData.success) {
+		return { success: false, error: "Invalid input detected." };
+	}
 
-function sanitizeSingleLine(input: string): string {
-	return input.replace(/[\r\n\0]/g, "").trim();
-}
-
-function sanitizeMessage(input: string): string {
-	return input.replace(/\0/g, "").trim();
-}
-
-export async function submitContactInquiry(data: ContactFormData) {
-	const { name, email, topic, message, honeypot } = data;
+	const { name, email, topic, message, honeypot } = parsedData.data;
 
 	if (honeypot && honeypot.length > 0) {
 		return { success: false, error: "Something went wrong. Please try again." };
@@ -47,7 +39,7 @@ export async function submitContactInquiry(data: ContactFormData) {
 
 	const sanitizedName = sanitizeSingleLine(name);
 	const sanitizedEmail = sanitizeSingleLine(email);
-	const sanitizedTopic = topic ? sanitizeSingleLine(topic) : "General question";
+	const sanitizedTopic = sanitizeSingleLine(topic) || "General question";
 	const sanitizedMessage = sanitizeMessage(message);
 
 	if (!sanitizedName || !sanitizedEmail || !sanitizedMessage) {
@@ -59,6 +51,13 @@ export async function submitContactInquiry(data: ContactFormData) {
 	}
 
 	try {
+		if (!(await checkEmailFormRateLimit(sanitizedEmail))) {
+			return {
+				success: false,
+				error: "Too many messages. Please try again later.",
+			};
+		}
+
 		const { error } = await resend.emails.send({
 			from: "Superset <noreply@superset.sh>",
 			to: "founders@superset.sh",

--- a/apps/marketing/src/app/enterprise/actions.ts
+++ b/apps/marketing/src/app/enterprise/actions.ts
@@ -2,40 +2,31 @@
 
 import { EnterpriseInquiryEmail } from "@superset/email/emails/enterprise-inquiry";
 import { Resend } from "resend";
+import { z } from "zod";
 import { env } from "@/env";
+import { checkEmailFormRateLimit } from "@/lib/email-rate-limit";
+import { sanitizeSingleLine, validateEmail } from "@/lib/form-utils";
 
 const resend = new Resend(env.RESEND_API_KEY);
 
-interface EnterpriseFormData {
-	name: string;
-	role: string;
-	company: string;
-	email: string;
-	phone: string;
-	message: string;
-	honeypot?: string;
-}
+const enterpriseFormDataSchema = z.object({
+	name: z.string(),
+	role: z.string(),
+	company: z.string(),
+	email: z.string(),
+	phone: z.string().optional().default(""),
+	message: z.string().optional().default(""),
+	honeypot: z.string().optional(),
+});
 
-function validateEmail(email: string): boolean {
-	// Basic email validation - check for @ with text before and after
-	const parts = email.split("@");
-	return (
-		parts.length === 2 &&
-		parts[0] !== undefined &&
-		parts[0].length > 0 &&
-		parts[1] !== undefined &&
-		parts[1].length > 0 &&
-		parts[1].includes(".")
-	);
-}
+export async function submitEnterpriseInquiry(data: unknown) {
+	const parsedData = enterpriseFormDataSchema.safeParse(data);
+	if (!parsedData.success) {
+		return { success: false, error: "Invalid input detected." };
+	}
 
-function sanitizeInput(input: string): string {
-	// Remove control characters (CR, LF, null bytes) to prevent header injection
-	return input.replace(/[\r\n\0]/g, "").trim();
-}
-
-export async function submitEnterpriseInquiry(data: EnterpriseFormData) {
-	const { name, role, company, email, phone, message, honeypot } = data;
+	const { name, role, company, email, phone, message, honeypot } =
+		parsedData.data;
 
 	// Honeypot check - if filled, silently reject (don't leak that we detected a bot)
 	if (honeypot && honeypot.length > 0) {
@@ -48,12 +39,12 @@ export async function submitEnterpriseInquiry(data: EnterpriseFormData) {
 	}
 
 	// Sanitize inputs FIRST to prevent header injection
-	const sanitizedName = sanitizeInput(name);
-	const sanitizedRole = sanitizeInput(role);
-	const sanitizedCompany = sanitizeInput(company);
-	const sanitizedEmail = sanitizeInput(email);
-	const sanitizedPhone = phone ? sanitizeInput(phone) : "";
-	const sanitizedMessage = message ? sanitizeInput(message) : "";
+	const sanitizedName = sanitizeSingleLine(name);
+	const sanitizedRole = sanitizeSingleLine(role);
+	const sanitizedCompany = sanitizeSingleLine(company);
+	const sanitizedEmail = sanitizeSingleLine(email);
+	const sanitizedPhone = phone ? sanitizeSingleLine(phone) : "";
+	const sanitizedMessage = message ? sanitizeSingleLine(message) : "";
 
 	// Ensure sanitized values are not empty (trimming might have removed everything)
 	if (
@@ -71,6 +62,13 @@ export async function submitEnterpriseInquiry(data: EnterpriseFormData) {
 	}
 
 	try {
+		if (!(await checkEmailFormRateLimit(sanitizedEmail))) {
+			return {
+				success: false,
+				error: "Too many messages. Please try again later.",
+			};
+		}
+
 		const { error } = await resend.emails.send({
 			from: "Superset <noreply@superset.sh>",
 			to: "founders@superset.sh",

--- a/apps/marketing/src/lib/email-rate-limit.ts
+++ b/apps/marketing/src/lib/email-rate-limit.ts
@@ -1,0 +1,44 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { headers } from "next/headers";
+import { env } from "@/env";
+
+type HeaderReader = {
+	get(name: string): string | null;
+};
+
+const emailFormRateLimit = new Ratelimit({
+	redis: new Redis({
+		url: env.KV_REST_API_URL,
+		token: env.KV_REST_API_TOKEN,
+	}),
+	limiter: Ratelimit.slidingWindow(5, "1 h"),
+	prefix: "ratelimit:marketing:email-form",
+});
+
+function firstHeaderValue(value: string | null): string | null {
+	return value?.split(",")[0]?.trim() || null;
+}
+
+function getClientIdentifier(requestHeaders: HeaderReader): string {
+	return (
+		firstHeaderValue(requestHeaders.get("cf-connecting-ip")) ??
+		firstHeaderValue(requestHeaders.get("x-real-ip")) ??
+		firstHeaderValue(requestHeaders.get("x-vercel-forwarded-for")) ??
+		firstHeaderValue(requestHeaders.get("x-forwarded-for")) ??
+		"unknown"
+	);
+}
+
+export async function checkEmailFormRateLimit(email: string): Promise<boolean> {
+	const requestHeaders = await headers();
+	const clientIdentifier = getClientIdentifier(requestHeaders);
+	const normalizedEmail = email.toLowerCase();
+
+	const [clientLimit, emailLimit] = await Promise.all([
+		emailFormRateLimit.limit(`client:${clientIdentifier}`),
+		emailFormRateLimit.limit(`email:${normalizedEmail}`),
+	]);
+
+	return clientLimit.success && emailLimit.success;
+}

--- a/apps/marketing/src/lib/form-utils.ts
+++ b/apps/marketing/src/lib/form-utils.ts
@@ -1,0 +1,19 @@
+export function validateEmail(email: string): boolean {
+	const parts = email.split("@");
+	return (
+		parts.length === 2 &&
+		parts[0] !== undefined &&
+		parts[0].length > 0 &&
+		parts[1] !== undefined &&
+		parts[1].length > 0 &&
+		parts[1].includes(".")
+	);
+}
+
+export function sanitizeSingleLine(input: string): string {
+	return input.replace(/[\r\n\0]/g, "").trim();
+}
+
+export function sanitizeMessage(input: string): string {
+	return input.replace(/\0/g, "").trim();
+}

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.9.9",
+      "version": "1.10.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -416,6 +416,8 @@
         "@superset/shared": "workspace:*",
         "@superset/ui": "workspace:*",
         "@t3-oss/env-nextjs": "0.13.11",
+        "@upstash/ratelimit": "2.0.8",
+        "@upstash/redis": "1.37.0",
         "framer-motion": "12.38.0",
         "geist": "1.7.0",
         "gray-matter": "4.0.3",
@@ -768,7 +770,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",

--- a/packages/email/src/components/layout/StandardLayout/components/Footer/Footer.tsx
+++ b/packages/email/src/components/layout/StandardLayout/components/Footer/Footer.tsx
@@ -75,14 +75,14 @@ export function Footer({ showSocial = true }: FooterProps) {
 			{/* Legal Links */}
 			<Text className="text-muted text-xs leading-none m-0 mb-4">
 				<Link
-					href="https://superset.sh/privacy"
+					href={`${env.NEXT_PUBLIC_MARKETING_URL}/privacy`}
 					className="text-muted no-underline"
 				>
 					Privacy
 				</Link>
 				{" • "}
 				<Link
-					href="https://superset.sh/terms"
+					href={`${env.NEXT_PUBLIC_MARKETING_URL}/terms`}
 					className="text-muted no-underline"
 				>
 					Terms


### PR DESCRIPTION
## Summary

Follow-up to #4788 with the review fixes that were useful after the original contact page PR merged.

- Validate marketing contact and enterprise server action payloads at runtime before sanitizing fields
- Apply the contact topic fallback after sanitization so whitespace-only topics become `General question`
- Extract shared email validation and sanitization helpers to avoid drift between the two forms
- Add shared Upstash-backed rate limiting for the public marketing email send paths
- Use `NEXT_PUBLIC_MARKETING_URL` for email footer Privacy and Terms links, matching Contact and asset URLs

## Impact

Public marketing forms are less fragile at the server boundary and have basic abuse protection before sending mail to `founders@superset.sh`. The footer links now respect the configured marketing URL across environments.

## Validation

- `bun run lint:fix`
- `bun run --cwd apps/marketing typecheck`
- `bun run --cwd packages/email typecheck`
- `bun run lint`
- `bunx dotenv -e ../../.env -- bun run build` from `apps/marketing`

Build passes with existing Sentry deprecation warnings and existing `CTAButtons` dynamic-server logs.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the marketing contact and enterprise forms with runtime validation, consistent sanitization, and shared rate limiting to block abuse and bad inputs. Updated email footer links to respect `NEXT_PUBLIC_MARKETING_URL`.

- **Bug Fixes**
  - Validate server action payloads with `zod`, then sanitize; extracted shared email and sanitization helpers.
  - Apply topic fallback after sanitization so whitespace-only becomes "General question".
  - Add shared rate limiting for email submissions (5/hour per client and per email).
  - Use `NEXT_PUBLIC_MARKETING_URL` for Privacy/Terms links in email footers.

- **Dependencies**
  - Added `@upstash/ratelimit` and `@upstash/redis`.

<sup>Written for commit 87d4a6e8828b4a143b8be11328ea9cad1f352f0b. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4794?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented rate-limiting for contact and enterprise inquiry forms.

* **Improvements**
  * Enhanced form validation and sanitization for contact and enterprise submissions.

* **Chores**
  * Updated footer legal links to use configuration-based URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->