### PR TITLE
[codex] Fix terminal agent stdin transport

### DIFF
--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -774,6 +774,7 @@ function resolveShellReady(
 function queueInitialCommand(
 	session: TerminalSession,
 	initialCommand: string,
+	followUp?: { data: string; delayMs: number },
 ): void {
 	if (session.initialCommandQueued || session.exited) return;
 	session.initialCommandQueued = true;
@@ -781,9 +782,15 @@ function queueInitialCommand(
 		? initialCommand
 		: `${initialCommand}\n`;
 	session.shellReadyPromise.then(() => {
-		if (!session.exited) {
-			session.pty.write(cmd);
-		}
+		if (session.exited) return;
+		session.pty.write(cmd);
+
+		if (!followUp) return;
+		setTimeout(() => {
+			if (!session.exited) {
+				session.pty.write(followUp.data);
+			}
+		}, followUp.delayMs);
 	});
 }
 
@@ -990,6 +997,8 @@ interface CreateTerminalSessionOptions {
 	eventBus?: EventBus;
 	/** Command to run after the shell is ready. Queued behind shellReadyPromise. */
 	initialCommand?: string;
+	/** Optional PTY input written shortly after the initial command starts. */
+	initialCommandFollowUp?: { data: string; delayMs: number };
 	cwd?: string;
 	/** Hidden sessions are process-internal and should not appear in user pickers. */
 	listed?: boolean;
@@ -1045,6 +1054,7 @@ export async function createTerminalSessionInternal({
 	db,
 	eventBus,
 	initialCommand,
+	initialCommandFollowUp,
 	cwd: cwdOverride,
 	listed = true,
 	cols: requestedCols,
@@ -1062,7 +1072,9 @@ export async function createTerminalSessionInternal({
 		if (mismatchError) return { error: mismatchError };
 
 		if (listed) existing.listed = true;
-		if (initialCommand) queueInitialCommand(existing, initialCommand);
+		if (initialCommand) {
+			queueInitialCommand(existing, initialCommand, initialCommandFollowUp);
+		}
 		return existing;
 	}
 
@@ -1355,7 +1367,7 @@ export async function createTerminalSessionInternal({
 	);
 
 	if (initialCommand) {
-		queueInitialCommand(session, initialCommand);
+		queueInitialCommand(session, initialCommand, initialCommandFollowUp);
 	}
 
 	return session;

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import { HOST_AGENT_PRESETS } from "@superset/shared/host-agent-presets";
+import { buildAgentCommandString, buildAgentPromptFollowUp } from "./agents";
+
+function makeConfig(
+	overrides: Partial<Parameters<typeof buildAgentCommandString>[0]> = {},
+): Parameters<typeof buildAgentCommandString>[0] {
+	return {
+		id: "agent-1",
+		presetId: "custom",
+		label: "Agent",
+		command: "agent",
+		args: [],
+		promptTransport: "argv",
+		promptArgs: [],
+		env: {},
+		...overrides,
+	};
+}
+
+describe("buildAgentCommandString", () => {
+	it("passes argv prompts as a quoted positional argument", () => {
+		const command = buildAgentCommandString(
+			makeConfig({
+				command: "codex",
+				args: ["--dangerously-bypass-approvals-and-sandbox"],
+				promptArgs: ["--"],
+			}),
+			"fix Bob's test",
+		);
+
+		expect(command).toBe(
+			"'codex' '--dangerously-bypass-approvals-and-sandbox' '--' 'fix Bob'\\''s test'",
+		);
+	});
+
+	it("passes stdin prompts as delayed PTY follow-up input", () => {
+		const config = makeConfig({
+			command: "amp",
+			promptTransport: "stdin",
+			promptArgs: ["--prompt-mode"],
+		});
+		const command = buildAgentCommandString(config, "first line\nsecond line");
+		const followUp = buildAgentPromptFollowUp(
+			config,
+			"first line\nsecond line",
+		);
+
+		expect(command).toBe("'amp' '--prompt-mode'");
+		expect(followUp).toEqual({
+			data: "first line\nsecond line\n",
+			delayMs: 200,
+		});
+		expect(command).not.toContain("<<");
+		expect(command).not.toContain("SUPERSET_PROMPT");
+	});
+
+	it("builds every bundled terminal-agent preset without redirecting stdin", () => {
+		const launchInputsByPreset = Object.fromEntries(
+			HOST_AGENT_PRESETS.map((preset) => [
+				preset.presetId,
+				(() => {
+					const config = makeConfig({
+						presetId: preset.presetId,
+						label: preset.label,
+						command: preset.command,
+						args: [...preset.args],
+						promptTransport: preset.promptTransport,
+						promptArgs: [...preset.promptArgs],
+						env: { ...preset.env },
+					});
+					return {
+						command: buildAgentCommandString(config, "fix Bob's test"),
+						followUp: buildAgentPromptFollowUp(config, "fix Bob's test"),
+					};
+				})(),
+			]),
+		);
+
+		expect(launchInputsByPreset).toEqual({
+			amp: {
+				command: "'amp'",
+				followUp: { data: "fix Bob's test\n", delayMs: 200 },
+			},
+			claude: {
+				command:
+					"'claude' '--dangerously-skip-permissions' 'fix Bob'\\''s test'",
+				followUp: undefined,
+			},
+			codex: {
+				command:
+					"'codex' '--dangerously-bypass-approvals-and-sandbox' '--' 'fix Bob'\\''s test'",
+				followUp: undefined,
+			},
+			copilot: {
+				command: "'copilot' '--allow-tool=write' '-i' 'fix Bob'\\''s test'",
+				followUp: undefined,
+			},
+			"cursor-agent": {
+				command: "'cursor-agent' 'fix Bob'\\''s test'",
+				followUp: undefined,
+			},
+			gemini: {
+				command: "'gemini' '--approval-mode=auto_edit' 'fix Bob'\\''s test'",
+				followUp: undefined,
+			},
+			mastracode: {
+				command: "'mastracode' '--prompt' 'fix Bob'\\''s test'",
+				followUp: undefined,
+			},
+			opencode: {
+				command: "'opencode' '--prompt' 'fix Bob'\\''s test'",
+				followUp: undefined,
+			},
+			pi: { command: "'pi' 'fix Bob'\\''s test'", followUp: undefined },
+		});
+
+		for (const launchInput of Object.values(launchInputsByPreset)) {
+			expect(launchInput.command).not.toContain("<<");
+			expect(launchInput.command).not.toContain("SUPERSET_PROMPT");
+		}
+	});
+});

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -20,6 +20,8 @@ interface ResolvedHostAgentConfig {
 	env: Record<string, string>;
 }
 
+const STDIN_PROMPT_FOLLOW_UP_DELAY_MS = 200;
+
 function parseArgv(value: string): string[] {
 	try {
 		const parsed = JSON.parse(value);
@@ -103,13 +105,11 @@ function buildArgvCommand(argv: string[]): string {
 }
 
 /**
- * Build a shell command string that runs the resolved agent config with the
- * given prompt. argv transport appends the prompt as the final positional;
- * stdin transport pipes the prompt via a heredoc so the agent can read from
- * fd 0.
- *
- * Empty prompts drop `promptArgs` so codex/opencode/copilot don't get stray
- * prompt-mode flags during promptless launches.
+ * Build the initial terminal command for a prompted agent launch. argv
+ * transport appends the prompt as the final positional. stdin transport starts
+ * the agent only; the prompt is written as a delayed PTY follow-up so fd 0 stays
+ * attached to the terminal and shells like fish cannot read ahead and consume
+ * the prompt before the agent starts.
  */
 export function buildAgentCommandString(
 	config: ResolvedHostAgentConfig,
@@ -121,16 +121,18 @@ export function buildAgentCommandString(
 		return buildArgvCommand([...baseArgv, prompt]);
 	}
 
-	// stdin: pipe the prompt to the spawned process via heredoc. Delimiter is
-	// constructed to avoid collision with any line in the prompt content.
-	const baseDelimiter = "SUPERSET_PROMPT";
-	let delimiter = baseDelimiter;
-	let counter = 0;
-	while (prompt.split("\n").some((line) => line === delimiter)) {
-		counter += 1;
-		delimiter = `${baseDelimiter}_${counter}`;
-	}
-	return `${buildArgvCommand(baseArgv)} <<'${delimiter}'\n${prompt}\n${delimiter}`;
+	return buildArgvCommand(baseArgv);
+}
+
+export function buildAgentPromptFollowUp(
+	config: ResolvedHostAgentConfig,
+	prompt: string,
+): { data: string; delayMs: number } | undefined {
+	if (config.promptTransport !== "stdin") return undefined;
+	return {
+		data: prompt.endsWith("\n") ? prompt : `${prompt}\n`,
+		delayMs: STDIN_PROMPT_FOLLOW_UP_DELAY_MS,
+	};
 }
 
 function envOverlayPrefix(env: Record<string, string>): string {
@@ -250,6 +252,7 @@ async function runTerminalAgent(
 	const prompt = buildAttachmentBlock(input.prompt, resolvedAttachments);
 	const command = buildAgentCommandString(config, prompt);
 	const fullCommand = `${envOverlayPrefix(config.env)}${command}`;
+	const promptFollowUp = buildAgentPromptFollowUp(config, prompt);
 
 	const terminalId = crypto.randomUUID();
 	const result = await createTerminalSessionInternal({
@@ -258,6 +261,7 @@ async function runTerminalAgent(
 		db: ctx.db,
 		eventBus: ctx.eventBus,
 		initialCommand: fullCommand,
+		initialCommandFollowUp: promptFollowUp,
 	});
 
 	if ("error" in result) {

--- a/packages/shared/src/host-agent-presets.ts
+++ b/packages/shared/src/host-agent-presets.ts
@@ -24,8 +24,8 @@ export interface HostAgentPreset {
  *
  * `promptArgs` is only included when launching with a prompt — codex's
  * trailing `--`, opencode's `--prompt`, and copilot's `-i` therefore do
- * not appear in promptless launches. Stdin transport pipes the prompt to
- * the spawned process's stdin instead of pushing it to argv.
+ * not appear in promptless launches. Stdin transport sends the prompt through
+ * the terminal input stream instead of pushing it to argv.
  *
  * Superset is intentionally excluded — its model/provider config
  * lives in chat settings, not in terminal-agent configs.


### PR DESCRIPTION
## Summary

Fixes v2 terminal-agent prompt launching for stdin-based agents by preserving the PTY as stdin instead of routing prompts through a shell heredoc.

## Root Cause

The v2 host-service serialized stdin prompt transport into a heredoc. That made the launched agent read from a pipe/file on fd 0 instead of the terminal PTY, which breaks interactive CLIs. Fish also exposed a second issue: sending the command and prompt in the same PTY write can let the shell read ahead and consume the prompt before the agent owns the terminal.

## Changes

- Start stdin-transport agents with the command only.
- Send the prompt as delayed follow-up PTY input so fd 0 remains attached to the terminal.
- Add focused coverage for argv transport, stdin follow-up transport, and every bundled terminal-agent preset.
- Update preset docs to describe stdin as terminal input rather than a pipe.

## Validation

- `bun test packages/host-service/src/trpc/router/agents/agents.test.ts`
- `bun test packages/shared/src/agent-command.test.ts packages/shared/src/agent-launch-request.test.ts`
- `bun run lint`
- `bun run typecheck`
- Manual PTY smoke matrix with fake binaries across sh, bash, zsh, and fish profiles.
- Real-agent canary smoke tests confirmed prompt delivery for `claude`, `amp`, `codex`, `gemini`, `mastracode`, `opencode`, `pi`, `copilot`, and `cursor-agent` under fish login and zsh login.
- Real Amp stdin-transport canary tests passed under `sh_login`, `bash_clean`, `bash_login`, `zsh_clean`, `fish_clean`, and `fish_login`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4795">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stdin transport for terminal agents by keeping the terminal PTY on stdin and sending the prompt as delayed input. Restores interactive CLI behavior and removes heredoc-based prompt injection.

- **Bug Fixes**
  - Start stdin agents with the command only; send the prompt via PTY follow-up (200 ms) so fd 0 stays attached and shells like fish can’t read it early.
  - Add `initialCommandFollowUp` to terminal sessions and a builder for stdin prompt follow-ups.
  - Add tests for argv and stdin transports across all bundled presets; update preset docs to describe stdin as terminal input.

<sup>Written for commit d6b14f9ac8958d0038b599bd15111f56f6d5b897. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4795?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal session initialization with support for delayed follow-up operations to improve agent command execution
  * Improved stdin-based prompt transport for agent configurations

* **Documentation**
  * Clarified prompt transport mechanism documentation

* **Tests**
  * Added test suite for agent command composition and preset validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->