### PR TITLE
[codex] Remove terminal atlas clearing

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/font-settle.ts
+++ b/apps/desktop/src/renderer/lib/terminal/font-settle.ts
@@ -4,9 +4,8 @@
  * xterm measures cell width at `terminal.open()` time using whatever font the
  * browser has resolved so far. If a custom `@font-face` (or a user-selected
  * system font that the browser hasn't surfaced yet) finishes loading after
- * that measurement, the cached glyph metrics — and, with the WebGL renderer,
- * the texture atlas — diverge from the actual rendered font, producing
- * "mangled" text that only repairs on the next resize. See issue #4617 and
+ * that measurement, the cached glyph metrics diverge from the actual rendered
+ * font, producing "mangled" text that only repairs on the next resize. See issue #4617 and
  * `plans/20260425-v2-terminal-rendering-divergences.md` (#1).
  *
  * Callers `await` this before re-fitting / refreshing the terminal.
@@ -52,8 +51,8 @@ export async function waitForFontReady({
 }
 
 /**
- * Wait for the terminal's configured font to load, then clear the texture
- * atlas and run a refit. Shared between v1 and v2 — both need identical
+ * Wait for the terminal's configured font to load, then run a refit.
+ * Shared between v1 and v2 — both need identical
  * "measured-too-early" recovery after `terminal.open()` and after
  * font-setting changes. `refit` should return true iff terminal dimensions
  * changed (so the caller can propagate to the PTY). `isAlive` is checked
@@ -72,10 +71,6 @@ export function scheduleFontSettleRefit(
 
 	void waitForFontReady({ fontFamily, fontSize }).then(() => {
 		if (!isAlive()) return;
-		// xterm no-ops this when WebGL isn't the active renderer.
-		try {
-			terminal.clearTextureAtlas();
-		} catch {}
 		const changed = refit();
 		if (changed) onDimensionsChanged?.();
 	});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -316,7 +316,7 @@ export function updateRuntimeAppearance(
 			measureAndResize(runtime);
 		}
 		// The freshly-selected font may still be loading — schedule a follow-up
-		// refit once it resolves so dimensions/atlas track the rendered glyphs.
+		// refit once it resolves so dimensions track the rendered glyphs.
 		scheduleFontSettleRefit(
 			runtime.terminal,
 			() => hostIsVisible(runtime.container),

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts
@@ -9,9 +9,8 @@
  *
  * When a user returns from an external browser to the Electron app, the
  * `window.focus` event fires and schedules reattach recovery. This recovery:
- *   1. Clears the stale WebGL texture atlas (`clearTextureAtlas`)
- *   2. Re-fits the terminal to its container (`fitAddon.fit()`)
- *   3. Forces a full repaint (`xterm.refresh()`)
+ *   1. Re-fits the terminal to its container (`fitAddon.fit()`)
+ *   2. Forces a full repaint (`xterm.refresh()`)
  *
  * If the user switches focus multiple times in rapid succession (within 120ms),
  * subsequent recovery calls hit the throttle and return early — without ever

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -66,10 +66,7 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 	return container.clientWidth > 0 && container.clientHeight > 0;
 }
 
-function fitAndRefresh(
-	entry: CachedTerminal,
-	options: { clearAtlas?: boolean } = {},
-): boolean {
+function fitAndRefresh(entry: CachedTerminal): boolean {
 	if (!hostIsVisible(entry.container)) return false;
 
 	const { xterm } = entry;
@@ -93,13 +90,6 @@ function fitAndRefresh(
 	}
 
 	const dimensionsChanged = xterm.cols !== prevCols || xterm.rows !== prevRows;
-	if (options.clearAtlas || dimensionsChanged) {
-		// xterm no-ops this when WebGL isn't the active renderer.
-		try {
-			xterm.clearTextureAtlas();
-		} catch {}
-	}
-
 	xterm.refresh(0, Math.max(0, xterm.rows - 1));
 
 	return dimensionsChanged;
@@ -162,13 +152,11 @@ export function attachToContainer(
 	entry.container = container;
 	container.appendChild(entry.wrapper);
 
-	// On reattach, force an atlas clear: while the wrapper was parked, the
-	// macOS GPU compositor can drop or corrupt atlas pages without firing
-	// `onContextLoss`, leaving stale glyphs that paint as RTL-looking
-	// gibberish (issue #4010).
-	fitAndRefresh(entry, { clearAtlas: true });
+	// Refit and repaint on reattach because the wrapper may have been parked
+	// while its live container changed size.
+	fitAndRefresh(entry);
 	// xterm's initial cell-width measurement may have run before the configured
-	// font finished loading, baking wrong glyph metrics into the renderer atlas
+	// font finished loading, baking wrong glyph metrics into the renderer
 	// (#4617). Refit once fonts are ready so the layout matches the rendered
 	// font without requiring a manual resize.
 	scheduleFontSettleRefit(
@@ -233,7 +221,7 @@ export function updateAppearance(
 	const changed = fitAndRefresh(entry);
 
 	// The new font may still be loading — schedule a second refit once it
-	// resolves so the atlas/dimensions match the actually-rendered glyphs.
+	// resolves so dimensions match the actually-rendered glyphs.
 	scheduleFontSettleRefit(
 		xterm,
 		() => cache.get(paneId) === entry && hostIsVisible(entry.container),


### PR DESCRIPTION
## Summary

- Remove explicit `clearTextureAtlas()` calls from terminal font-settle and v1 reattach/resize recovery paths.
- Keep the existing WebGL renderer, ImageAddon, CSP, and Chromium WebGL context-cap behavior unchanged.
- Update comments/test prose so recovery is described as refit + repaint, not atlas flushing.

## Why

The glyph-corruption investigation pointed at our proactive WebGL atlas flushing as a likely source of extra renderer churn. This PR narrows the mitigation to that behavior only, avoiding broader changes to terminal image support or WebGL fallback semantics.

## Impact

Terminal recovery still refits and refreshes after font readiness and attach/resize events, but no longer directly clears xterm's WebGL texture atlas.

## Validation

- `bun run --cwd apps/desktop typecheck`
- `bun run lint`
- `bun run --cwd apps/desktop test src/renderer/lib/terminal/font-settle.test.ts`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop clearing the `xterm` WebGL texture atlas during font-settle and reattach/resize recovery. This reduces renderer churn and helps prevent glyph corruption while keeping rendering behavior the same.

- **Bug Fixes**
  - Removed `clearTextureAtlas()` from font-settle and v1 reattach/resize paths; recovery is now refit + repaint.
  - Updated comments/tests to reflect refit + repaint behavior.
  - No changes to WebGL renderer, `ImageAddon`, CSP, or Chromium context handling.

<sup>Written for commit 16a4151d02dab99e8b556b016d0ec650265459d5. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4796?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified terminal font settling and display refresh operations
  * Streamlined font recovery workflow by removing optional parameters
  * Updated terminal reattachment and recovery procedures
  * Refined font metrics tracking in display rendering

* **Documentation**
  * Updated comments describing font loading and rendering behavior
  * Revised explanations for terminal recovery procedures across components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->