### PR TITLE
[codex] fix stuck workspace deletion

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
@@ -5,6 +5,7 @@ import type {
 import { TRPCClientError } from "@trpc/client";
 import { useCallback } from "react";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import {
 	useWorkspaceHostTarget,
 	type WorkspaceHostTarget,
@@ -66,13 +67,23 @@ export interface UseDestroyWorkspace {
  */
 export function useDestroyWorkspace(workspaceId: string): UseDestroyWorkspace {
 	const hostTarget = useWorkspaceHostTarget(workspaceId);
+	const { activeHostUrl } = useLocalHostService();
 
 	// Reduce the (object-identity-unstable) hostTarget down to two scalars so
 	// memoized callbacks below don't churn on every collection notification.
 	// useLiveQuery returns a new array each tick, which would otherwise rebuild
 	// `inspect`/`destroy` and re-fire effects that depend on them.
-	const hostUrl = hostTarget.status === "ready" ? hostTarget.url : null;
-	const hostStatus = hostTarget.status;
+	const shouldTryLocalCleanup =
+		hostTarget.status === "not-found" && activeHostUrl !== null;
+	const hostUrl =
+		hostTarget.status === "ready"
+			? hostTarget.url
+			: shouldTryLocalCleanup
+				? activeHostUrl
+				: null;
+	const hostStatus: WorkspaceHostTarget["status"] = shouldTryLocalCleanup
+		? "ready"
+		: hostTarget.status;
 
 	const destroy = useCallback(
 		async (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -66,19 +66,6 @@ export function useDestroyDialogState({
 			setInspectState({ status: "loading" });
 			return;
 		}
-		if (hostTarget.status === "not-found") {
-			setInspectState({
-				status: "ready",
-				preview: {
-					canDelete: false,
-					reason: "Workspace is no longer available on this host.",
-					hasChanges: false,
-					hasUnpushedCommits: false,
-				},
-			});
-			return;
-		}
-
 		let cancelled = false;
 		setInspectState({ status: "loading" });
 		inspect()


### PR DESCRIPTION
## Summary
- Remove the renderer-side `not-found` block that disabled workspace deletion before cleanup could run.
- When the synced workspace row is missing but the local host service is available, still call local `workspaceCleanup` so the backend can finish its idempotent cleanup path.

## Issue
Deleting a workspace could get stuck behind the message "Workspace is no longer available on this host." The host cleanup endpoint already tolerates missing state: no local workspace row, missing worktree, and already-deleted cloud rows are valid delete outcomes.

The renderer was blocking too early. The delete dialog treated `useWorkspaceHostTarget(...).status === "not-found"` as a terminal UI error and manufactured a blocking preview with `canDelete: false`. That disabled the Delete button, so `workspaceCleanup.destroy` never ran.

This can happen after a partial delete, slow Electric sync, or inconsistent local/sidebar/cloud state: the workspace row may already be absent from the live collection while local host cleanup still needs to complete.

## Fix
- Stop converting `not-found` into a blocking dialog state.
- Let inspect failures remain non-fatal, as the dialog already does for other preview failures.
- If the workspace target is `not-found` but the local host service is running, route `inspect`/`destroy` to the local host service and let the backend decide based on actual cleanup state.

## Impact
Users can retry/delete a workspace even when sync has already removed or hidden the workspace row, instead of getting stuck before the idempotent cleanup endpoint runs.

## Validation
- `bun run lint`
- `bun run typecheck --filter=@superset/desktop`
- `bun test packages/host-service/test/integration/workspace-cleanup.integration.test.ts`
