### PR TITLE
fix(desktop): rename "Issues & PRs" sidebar label to "Tasks & PRs"

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -161,7 +161,7 @@ export function DashboardSidebarHeader({
 							<HiOutlineClipboardDocumentList className="size-4" />
 						</button>
 					</TooltipTrigger>
-					<TooltipContent side="right">Issues & PRs</TooltipContent>
+					<TooltipContent side="right">Tasks & PRs</TooltipContent>
 				</Tooltip>
 
 				<Tooltip delayDuration={300}>
@@ -266,7 +266,7 @@ export function DashboardSidebarHeader({
 				)}
 			>
 				<HiOutlineClipboardDocumentList className="size-4 shrink-0" />
-				<span className="flex-1 text-left">Issues & PRs</span>
+				<span className="flex-1 text-left">Tasks & PRs</span>
 			</button>
 
 			<div className="flex items-center gap-0">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -96,7 +96,7 @@ export function WorkspaceSidebarHeader({
 							/>
 						</button>
 					</TooltipTrigger>
-					<TooltipContent side="right">Issues & PRs</TooltipContent>
+					<TooltipContent side="right">Tasks & PRs</TooltipContent>
 				</Tooltip>
 
 				<NewWorkspaceButton isCollapsed />
@@ -139,7 +139,7 @@ export function WorkspaceSidebarHeader({
 					/>
 				</div>
 				<span className="text-sm font-medium flex-1 text-left">
-					Issues & PRs
+					Tasks & PRs
 				</span>
 			</button>
 


### PR DESCRIPTION
## Summary
Renames the user-facing sidebar label from **Issues & PRs** to **Tasks & PRs** to match the current product terminology (the view is the tasks view, with `tasks` / `prs` / `issues` tabs).

## Changes
- `WorkspaceSidebarHeader.tsx` — collapsed tooltip + expanded button label
- `DashboardSidebarHeader.tsx` — collapsed tooltip + expanded button label

Copy-only change; no behavior or routing affected.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4816">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the sidebar label from “Issues & PRs” to “Tasks & PRs” to match the tasks view.
Updated the tooltip and expanded label in both the Dashboard and Workspace sidebars; no behavior or routing changes.

<sup>Written for commit afff202aad053ba4c16e8f45bd4ce636b0f74640. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4816?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar navigation labels from "Issues & PRs" to "Tasks & PRs" for improved terminology consistency across the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->