### PR TITLE
release(sdk): cut alpha.11 + drop internal warnings from public create result

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -770,7 +770,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",
@@ -926,7 +926,7 @@
     },
     "packages/sdk": {
       "name": "@superset/sdk",
-      "version": "0.0.1-alpha.10",
+      "version": "0.0.1-alpha.11",
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "bun-types": "1.3.11",

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -574,7 +574,6 @@ export const workspacesRouter = router({
 			let worktreePath: string;
 			let alreadyExists = false;
 			let workspaceRow: CloudWorkspace;
-			const warnings: string[] = [];
 
 			if (input.pr !== undefined) {
 				const releaseCreateLock = await acquireWorkspaceCreateLock(
@@ -614,7 +613,6 @@ export const workspacesRouter = router({
 						) => {
 							if (materialized.warning) {
 								console.warn(`[workspaces.create] ${materialized.warning}`);
-								warnings.push(materialized.warning);
 							}
 						};
 						const normalizeExistingPrBranch = async () => {
@@ -1015,7 +1013,6 @@ export const workspacesRouter = router({
 				});
 				if (warning) {
 					console.warn(`[workspaces.create] setup warning: ${warning}`);
-					warnings.push(warning);
 				}
 				if (terminal) {
 					terminalsResult.push({
@@ -1036,7 +1033,6 @@ export const workspacesRouter = router({
 				terminals: terminalsResult,
 				agents: agentsResult,
 				alreadyExists,
-				warnings,
 				txid: extractCreateTxid(workspaceRow),
 			};
 		}),

--- a/packages/host-service/test/integration/workspace-create-pr.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-pr.integration.test.ts
@@ -193,7 +193,6 @@ describe("workspaces.create PR checkout integration", () => {
 		).toBe("HEAD:refs/heads/feature/pr-lockfile");
 		const dryRunOutput = await worktreeGit.raw(["push", "--dry-run"]);
 		expect(typeof dryRunOutput).toBe("string");
-		expect(result.warnings).toEqual([]);
 
 		const lockStatus = (
 			await worktreeGit.raw([
@@ -531,7 +530,6 @@ describe("workspaces.create PR checkout integration", () => {
 		expect(worktreePath).toBeTruthy();
 		if (!worktreePath) throw new Error("expected worktree path");
 		expect(result.workspace.branch).toBe("feature/same-repo");
-		expect(result.warnings).toEqual([]);
 		expect(
 			(
 				await scenario.repo.git.raw([
@@ -553,7 +551,7 @@ describe("workspaces.create PR checkout integration", () => {
 		).toBe(prHeadOid);
 	});
 
-	test("same-repo PR falls back to synthetic ref with a user-visible warning when the head branch is gone", async () => {
+	test("same-repo PR falls back to synthetic ref when the head branch is gone", async () => {
 		const prNumber = 8081;
 		let prHeadOid = "";
 
@@ -616,8 +614,6 @@ describe("workspaces.create PR checkout integration", () => {
 		)?.worktreePath;
 		expect(worktreePath).toBeTruthy();
 		if (!worktreePath) throw new Error("expected worktree path");
-		expect(result.warnings).toHaveLength(1);
-		expect(result.warnings[0]).toContain("was unavailable from origin");
 		expect(
 			(
 				await scenario.repo.git.raw([

--- a/packages/host-service/test/integration/workspace-create-pr.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-create-pr.integration.test.ts
@@ -614,6 +614,7 @@ describe("workspaces.create PR checkout integration", () => {
 		)?.worktreePath;
 		expect(worktreePath).toBeTruthy();
 		if (!worktreePath) throw new Error("expected worktree path");
+		expect(result.workspace.branch).toBe("feature/deleted-head");
 		expect(
 			(
 				await scenario.repo.git.raw([

--- a/packages/mcp-v2/src/tools/workspaces/create.ts
+++ b/packages/mcp-v2/src/tools/workspaces/create.ts
@@ -79,7 +79,6 @@ export function register(server: McpServer): void {
 					| { ok: false; error: string }
 				>;
 				alreadyExists: boolean;
-				warnings: string[];
 			}>(
 				{
 					relayUrl: ctx.relayUrl,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/sdk",
-	"version": "0.0.1-alpha.10",
+	"version": "0.0.1-alpha.11",
 	"description": "TypeScript SDK for the Superset API",
 	"private": true,
 	"type": "module",

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -203,7 +203,6 @@ export interface WorkspaceCreateResult {
 	terminals: Array<{ terminalId: string; label?: string }>;
 	agents: WorkspaceCreateAgentResult[];
 	alreadyExists: boolean;
-	warnings: string[];
 }
 
 export interface WorkspaceUpdateParams {


### PR DESCRIPTION
Cuts `@superset_sh/sdk` **0.0.1-alpha.11** and removes the internal `warnings[]` field from the public workspace-create surface.

## Why
`WorkspaceCreateResult.warnings` was added after alpha.10 (#4643) and **never published**. Nothing consumes it:
- Desktop only reads `warnings` from the **destroy/cleanup** flow, not create.
- CLI returns the raw result as `data`, so it leaked the field with no consumer.
- The create-time warnings are already `console.warn`'d server-side, so removing the field loses no signal.

CLI / SDK / MCP shouldn't carry this internal detail, so it's removed at the source.

## Changes
- **host-service** `workspaces.create`: drop the `warnings[]` array + return field (kept the `console.warn` logging)
- **sdk** `WorkspaceCreateResult`: remove `warnings`
- **mcp-v2** `workspaces/create`: remove `warnings` from the result type
- **release**: bump `packages/sdk/package.json` → `0.0.1-alpha.11` (+ `bun.lock`)

## Verify
- [x] typecheck: host-service, sdk, mcp-v2 all pass
- [x] sdk `bun run build` → dist clean, no `warnings` in emitted `.d.ts`
- [ ] publish: `cd packages/sdk/dist && npm publish --access public` (manual, after merge — needs npm auth)

Left untouched: destroy/cleanup `warnings` (separate feature, user-facing in desktop) and the internal `adopt`/`CheckoutResult` types (not part of the public surface).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Version Updates**
  * SDK package bumped to v0.0.1-alpha.11.

* **Changes**
  * Workspace creation no longer returns user-visible warnings; warnings are logged instead.
  * Create response now includes an explicit "already exists" indicator and focuses on workspace, terminals, and agents status.

* **Tests**
  * Integration tests updated to match the new create-response behavior and removed assertions about returned warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->