### PR TITLE
feat(desktop): setup-script card opens new-workspace modal with a guided prompt

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -142,6 +142,15 @@ interface MarkdownEditorProps {
 	onModEnter?: () => void;
 	/** If provided, enables @-mention file search for the editor. */
 	searchFiles?: FileMentionSearchFn;
+	/** Toggle optional affordances. Each defaults to enabled. */
+	features?: {
+		slashCommand?: boolean;
+		emoji?: boolean;
+		fileMention?: boolean;
+		bubbleMenu?: boolean;
+	};
+	/** Tailwind min-height for the editable area. Defaults to "min-h-[100px]". */
+	minHeightClassName?: string;
 }
 
 function getMarkdown(editor: Editor | null): string {
@@ -175,7 +184,13 @@ export function MarkdownEditor({
 	editorClassName,
 	onModEnter,
 	searchFiles,
+	features,
+	minHeightClassName = "min-h-[100px]",
 }: MarkdownEditorProps) {
+	const showSlashCommand = features?.slashCommand ?? true;
+	const showEmoji = features?.emoji ?? true;
+	const showFileMention = features?.fileMention ?? true;
+	const showBubbleMenu = features?.bubbleMenu ?? true;
 	// useEditor captures extensions on first render, so searchFiles gets frozen
 	// at its initial (likely stale, since projectId resolves in an effect) value.
 	// Thread through a ref so the extension reads the live callback each fire.
@@ -293,19 +308,23 @@ export function MarkdownEditor({
 				transformPastedText: true,
 				transformCopiedText: true,
 			}),
-			SlashCommand,
-			EmojiSuggestion,
-			FileMentionNode,
-			FileMentionSuggestion.configure({
-				searchFiles: (query) =>
-					searchFilesRef.current?.(query) ?? Promise.resolve([]),
-			}),
+			...(showSlashCommand ? [SlashCommand] : []),
+			...(showEmoji ? [EmojiSuggestion] : []),
+			...(showFileMention
+				? [
+						FileMentionNode,
+						FileMentionSuggestion.configure({
+							searchFiles: (query) =>
+								searchFilesRef.current?.(query) ?? Promise.resolve([]),
+						}),
+					]
+				: []),
 			KeyboardHandler,
 		],
 		content,
 		editorProps: {
 			attributes: {
-				class: cn("focus:outline-none min-h-[100px]", editorClassName),
+				class: cn("focus:outline-none", minHeightClassName, editorClassName),
 			},
 			handleKeyDown: (_, event) => {
 				if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
@@ -367,7 +386,7 @@ export function MarkdownEditor({
 
 	return (
 		<div className={cn("w-full", className)}>
-			{editor && (
+			{showBubbleMenu && editor && (
 				<BubbleMenu
 					editor={editor}
 					options={{

--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -136,7 +136,8 @@ interface MarkdownEditorProps {
 	onSave?: (markdown: string) => void;
 	onChange?: (markdown: string) => void;
 	placeholder?: string;
-	autoFocus?: boolean;
+	/** true focuses at the end; "start"/"end" pick the caret position. */
+	autoFocus?: boolean | "start" | "end";
 	className?: string;
 	editorClassName?: string;
 	onModEnter?: () => void;
@@ -149,8 +150,6 @@ interface MarkdownEditorProps {
 		fileMention?: boolean;
 		bubbleMenu?: boolean;
 	};
-	/** Tailwind min-height for the editable area. Defaults to "min-h-[100px]". */
-	minHeightClassName?: string;
 }
 
 function getMarkdown(editor: Editor | null): string {
@@ -185,7 +184,6 @@ export function MarkdownEditor({
 	onModEnter,
 	searchFiles,
 	features,
-	minHeightClassName = "min-h-[100px]",
 }: MarkdownEditorProps) {
 	const showSlashCommand = features?.slashCommand ?? true;
 	const showEmoji = features?.emoji ?? true;
@@ -201,12 +199,12 @@ export function MarkdownEditor({
 	const urlPolicy = useInlineUrlPolicy();
 
 	const editor = useEditor({
-		autofocus: autoFocus ? "end" : false,
+		autofocus: autoFocus === true ? "end" : autoFocus || false,
 		extensions: [
 			Document,
 			Text,
 			Paragraph.configure({
-				HTMLAttributes: { class: "mt-0 mb-3 leading-relaxed" },
+				HTMLAttributes: { class: "my-0 leading-relaxed" },
 			}),
 			StyledHeading.configure({ levels: [1, 2, 3, 4, 5, 6] }),
 			Bold.configure({
@@ -324,7 +322,7 @@ export function MarkdownEditor({
 		content,
 		editorProps: {
 			attributes: {
-				class: cn("focus:outline-none", minHeightClassName, editorClassName),
+				class: cn("focus:outline-none min-h-[100px]", editorClassName),
 			},
 			handleKeyDown: (_, event) => {
 				if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/V2SetupScriptCard/V2SetupScriptCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/V2SetupScriptCard/V2SetupScriptCard.tsx
@@ -1,9 +1,11 @@
 import { SidebarCard } from "@superset/ui/sidebar-card";
 import { useQuery } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useNewWorkspaceDraftStore } from "renderer/stores/new-workspace-draft";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 import { useV2SetupCardDismissalsStore } from "renderer/stores/v2-setup-card-dismissals";
+import setupScriptPrompt from "./setup-script-prompt.md?raw";
 
 interface V2SetupScriptCardProps {
 	hostUrl: string;
@@ -18,7 +20,7 @@ export function V2SetupScriptCard({
 	projectName,
 	isCollapsed,
 }: V2SetupScriptCardProps) {
-	const navigate = useNavigate();
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const isDismissed = useV2SetupCardDismissalsStore((s) =>
 		s.isDismissed(projectId),
 	);
@@ -35,6 +37,16 @@ export function V2SetupScriptCard({
 
 	if (isCollapsed || isDismissed || !shouldShow) return null;
 
+	// Configure → open the new-workspace modal seeded with a prompt that walks
+	// the agent through writing setup/teardown scripts for this project, rather
+	// than sending the user to the settings page to hand-write config.json.
+	const handleConfigure = () => {
+		const draftStore = useNewWorkspaceDraftStore.getState();
+		draftStore.resetDraft();
+		draftStore.updateDraft({ prompt: setupScriptPrompt });
+		openNewWorkspaceModal(projectId);
+	};
+
 	return (
 		<AnimatePresence>
 			<motion.div
@@ -50,12 +62,7 @@ export function V2SetupScriptCard({
 					title="Setup scripts"
 					description={`Automate workspace setup for ${projectName}`}
 					actionLabel="Configure"
-					onAction={() =>
-						navigate({
-							to: "/settings/projects/$projectId",
-							params: { projectId },
-						})
-					}
+					onAction={handleConfigure}
 					onDismiss={() => dismiss(projectId)}
 				/>
 			</motion.div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/V2SetupScriptCard/setup-script-prompt.md
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/V2SetupScriptCard/setup-script-prompt.md
@@ -1,0 +1,54 @@
+Set up [Superset workspace setup & teardown scripts](https://docs.superset.sh/setup-teardown-scripts) for this project.
+
+## Goal
+
+Create `.superset/config.json` in the repository root with `setup` and `teardown` commands tailored to this project — plus a `run` command if it has a dev server. First inspect the codebase to figure out the right commands: detect the package manager, how dependencies are installed, how the dev server starts, and any services (databases, Docker, etc.) that need to start and stop. Then write commands that match what you find.
+
+## What each field does
+
+- **setup** — runs in a terminal every time a new workspace is created. Use it to install dependencies and prepare the workspace (install packages, copy env files, start required services).
+- **teardown** — runs when a workspace is deleted. Undo whatever setup started (e.g. stop and remove containers).
+- **run** (optional) — an on-demand dev-server command launched by the Run button, in its own pane. Prefer this over putting long-running servers in `setup`: run commands are restartable and don't block workspace creation.
+
+Setup and teardown commands run sequentially in the workspace directory.
+
+## Format
+
+```json
+{
+  "setup": ["bun install", "cp \"$SUPERSET_ROOT_PATH/.env\" .env"],
+  "teardown": ["docker-compose down"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+## Environment variables available to scripts
+
+- `SUPERSET_ROOT_PATH` — path to the root repository
+- `SUPERSET_WORKSPACE_NAME` — current workspace name
+- `SUPERSET_WORKSPACE_PATH` — path to the workspace worktree
+
+## Examples
+
+**Node.js**
+
+```json
+{ "setup": ["bun install", "cp \"$SUPERSET_ROOT_PATH/.env\" .env"] }
+```
+
+**Docker**
+
+```json
+{
+  "setup": ["docker-compose up -d", "bun run db:migrate"],
+  "teardown": ["docker-compose down -v"]
+}
+```
+
+## Tips
+
+- Keep setup fast — it runs on every workspace creation.
+- For anything non-trivial, put the logic in a shell script and call it: `"setup": ["./.superset/setup.sh"]` (create the script too).
+- Commit `.superset/` so your team shares the same setup.
+
+When you're done, briefly summarize what you configured and why.

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -59,7 +59,7 @@ export function DashboardNewWorkspaceModal() {
 					<DialogContent
 						showCloseButton={false}
 						onFocusOutside={(e) => e.preventDefault()}
-						className="bg-popover text-popover-foreground sm:max-w-[560px] max-h-[min(70vh,600px)] !top-[calc(50%-min(35vh,300px))] !-translate-y-0 flex flex-col overflow-hidden p-0"
+						className="bg-popover text-popover-foreground sm:max-w-[680px] flex flex-col overflow-hidden p-0"
 					>
 						<DashboardNewWorkspaceModalContent
 							isOpen={isOpen}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -4,7 +4,6 @@ import {
 	PromptInputButton,
 	PromptInputFooter,
 	PromptInputSubmit,
-	PromptInputTextarea,
 	PromptInputTools,
 	useProviderAttachments,
 } from "@superset/ui/ai-elements/prompt-input";
@@ -23,6 +22,7 @@ import { SiLinear } from "react-icons/si";
 import { AgentSelect } from "renderer/components/AgentSelect";
 import { LinkedIssuePill } from "renderer/components/Chat/ChatInterface/components/ChatInputFooter/components/LinkedIssuePill";
 import { IssueLinkCommand } from "renderer/components/Chat/ChatInterface/components/IssueLinkCommand";
+import { MarkdownEditor } from "renderer/components/MarkdownEditor";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
@@ -74,7 +74,8 @@ export function PromptGroup({
 }: PromptGroupProps) {
 	const modKey = PLATFORM === "mac" ? "⌘" : "Ctrl";
 	const isNewWorkspaceModalOpen = useNewWorkspaceModalOpen();
-	const { closeModal, draft, updateDraft } = useDashboardNewWorkspaceDraft();
+	const { closeModal, draft, updateDraft, resetKey } =
+		useDashboardNewWorkspaceDraft();
 	const navigate = useNavigate();
 	const attachments = useProviderAttachments();
 	const hostService = useLocalHostService();
@@ -426,18 +427,18 @@ export function PromptGroup({
 						))}
 					</div>
 				)}
-				<PromptInputTextarea
+				{/* Markdown prompt editor. Submit stays on draft.prompt (now markdown):
+				    the editor swallows Cmd/Ctrl+Enter (no newline) and the window-level
+				    listener does the single submit, so onModEnter is intentionally unset
+				    to avoid a double-fire. resetKey remounts a clean editor on reset. */}
+				<MarkdownEditor
+					key={resetKey}
+					content={prompt}
+					onChange={(markdown) => updateDraft({ prompt: markdown })}
 					autoFocus
 					placeholder="What do you want to do?"
-					className="min-h-10"
-					value={prompt}
-					onChange={(e) => updateDraft({ prompt: e.target.value })}
-					onKeyDown={(e) => {
-						// Disable the library's plain-Enter → submit. Submit only
-						// happens via the button or the window-level Cmd/Ctrl+Enter
-						// listener. Plain Enter inserts a newline (default).
-						if (e.key === "Enter" && !e.metaKey && !e.ctrlKey) return;
-					}}
+					className="px-3 pt-3"
+					editorClassName="max-h-[200px] overflow-y-auto text-sm"
 				/>
 				<PromptInputFooter>
 					<PromptInputTools className="gap-1.5">

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -439,6 +439,13 @@ export function PromptGroup({
 					placeholder="What do you want to do?"
 					className="px-3 pt-3"
 					editorClassName="max-h-[200px] overflow-y-auto text-sm"
+					minHeightClassName="min-h-[44px]"
+					features={{
+						slashCommand: false,
+						emoji: false,
+						fileMention: false,
+						bubbleMenu: false,
+					}}
 				/>
 				<PromptInputFooter>
 					<PromptInputTools className="gap-1.5">

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -435,11 +435,10 @@ export function PromptGroup({
 					key={resetKey}
 					content={prompt}
 					onChange={(markdown) => updateDraft({ prompt: markdown })}
-					autoFocus
+					autoFocus="start"
 					placeholder="What do you want to do?"
-					className="px-3 pt-3"
-					editorClassName="max-h-[200px] overflow-y-auto text-sm"
-					minHeightClassName="min-h-[44px]"
+					className="flex flex-col h-[200px] px-3 pt-3"
+					editorClassName="overflow-y-auto text-sm"
 					features={{
 						slashCommand: false,
 						emoji: false,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -437,7 +437,7 @@ export function PromptGroup({
 					onChange={(markdown) => updateDraft({ prompt: markdown })}
 					autoFocus="start"
 					placeholder="What do you want to do?"
-					className="flex flex-col h-[200px] px-3 pt-3"
+					className="flex flex-col min-h-[100px] max-h-[200px] px-3 pt-3"
 					editorClassName="overflow-y-auto text-sm"
 					features={{
 						slashCommand: false,


### PR DESCRIPTION
## What

The v2 **Setup scripts** sidebar card's **Configure** action used to navigate to `/settings/projects/$projectId` so the user could hand-write `.superset/config.json`. Instead, it now opens the **new-workspace modal** pre-seeded with a prompt that walks a coding agent through writing setup/teardown (and run) scripts tailored to the project.

## How

- New `setup-script-prompt.md` (imported `?raw`) co-located with the card — a self-contained instruction covering the `config.json` format, the `setup`/`teardown`/`run` fields, available env vars, and examples, told as an agent task ('inspect the project, then write commands that match').
- `V2SetupScriptCard.onAction` now resets the new-workspace draft, seeds `draft.prompt` with that markdown, and opens the modal pre-selected to the project. The prompt textarea is controlled by `draft.prompt`, and the modal's open/preselection effects don't touch `prompt`, so the seed survives.

v1 untouched (v2-only, per current direction).

## Test plan

- [ ] Click **Configure** on the Setup scripts card → new-workspace modal opens, pre-selected to the project, prompt textarea filled with the setup-script instructions.
- [ ] Submitting launches a workspace whose agent has the guidance to write `.superset/config.json`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4819">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The v2 Setup scripts card now opens the new-workspace modal with a pre-filled prompt to generate `.superset/config.json` (`setup`, `teardown`, optional `run`) for the project. This replaces the settings redirect and removes manual config steps.

- **New Features**
  - Added `setup-script-prompt.md` with format, fields, env vars, and examples.
  - `V2SetupScriptCard` now resets the draft, seeds `draft.prompt`, and opens the modal pre-selected to the project via `useOpenNewWorkspaceModal`.
  - The new-workspace prompt uses `MarkdownEditor` with chat affordances off (via new feature toggles), auto-focuses at the start, grows from 100px up to 200px then scrolls, and keeps single submit via the window Mod+Enter.
  - Editor and modal polish: tighter paragraph spacing and caret-position `autoFocus`; modal widened to 680px.

<sup>Written for commit 79b35b7ed63572e8976d209fcccd77aedbdd3a23. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4819?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure action now opens a workspace setup modal pre-filled with the setup-script prompt.
  * Prompt input replaced with a Markdown editor that resets reliably and relies on global submit (Cmd/Ctrl+Enter).
  * Markdown editor adds toggles to enable/disable slash-commands, emoji suggestions, file-mentions, and bubble menu.

* **Documentation**
  * Added workspace automation guide: lifecycle scripts, env vars, examples, and tips.

* **Style**
  * New-workspace modal content area widened for improved layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->