### PR TITLE
[codex] Render cached workspaces before sync

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useWorkspaceHostUrl/useWorkspaceHostUrl.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useWorkspaceHostUrl/useWorkspaceHostUrl.ts
@@ -34,7 +34,6 @@ export function useWorkspaceHostTarget(
 				.select(({ workspaces }) => ({
 					organizationId: workspaces.organizationId,
 					hostId: workspaces.hostId,
-					isSynced: workspaces.$synced,
 				})),
 		[collections, workspaceId],
 	);
@@ -44,7 +43,6 @@ export function useWorkspaceHostTarget(
 	return useMemo(() => {
 		if (!workspaceId || (!isReady && !match)) return { status: "loading" };
 		if (!match) return { status: "not-found" };
-		if (!match.isSynced) return { status: "loading" };
 		if (machineId && match.hostId === machineId) {
 			if (activeHostUrl) {
 				return {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -460,7 +460,6 @@ export function useDashboardSidebarData() {
 				createdAt: workspace.createdAt,
 				updatedAt: workspace.updatedAt,
 				taskId: workspace.taskId,
-				isSynced: workspace.isSynced,
 				pendingTransaction: workspace.pendingTransaction,
 			};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -43,7 +43,6 @@ export interface DashboardSidebarWorkspace {
 	createdAt: Date;
 	updatedAt: Date;
 	taskId: string | null;
-	isSynced: boolean;
 	pendingTransaction: WorkspaceTransactionSnapshot | null;
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -35,7 +35,7 @@ export function useRemoteHostStatus(
 		workspace != null && machineId != null && workspace.hostId === machineId;
 	const filterMachineId = !workspace || isLocal ? "" : hostId;
 
-	const { data: hostRows = [], isReady } = useLiveQuery(
+	const { data: hostRows = [] } = useLiveQuery(
 		(q) =>
 			q
 				.from({ hosts: collections.v2Hosts })
@@ -67,7 +67,6 @@ export function useRemoteHostStatus(
 
 	if (!workspace) return { status: "loading" };
 	if (isLocal) return { status: "skip" };
-	if (!isReady && !hostRow) return { status: "loading" };
 
 	if (infoQuery.isSuccess) {
 		const hostVersion = infoQuery.data.version;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -51,9 +51,6 @@ function V2WorkspaceLayout() {
 	);
 	const workspace = workspaces?.[0] ?? null;
 	const failedEntry = failedEntries?.[0] ?? null;
-	const canUseWorkspace =
-		workspace !== null &&
-		(workspace.$synced === true || pendingTransaction?.type === "update");
 
 	useEffect(() => {
 		if (workspace?.$synced === true && pendingTransaction?.type === "insert") {
@@ -63,17 +60,13 @@ function V2WorkspaceLayout() {
 
 	const lastEnsuredWorkspaceIdRef = useRef<string | null>(null);
 	useEffect(() => {
-		if (
-			!workspace ||
-			!canUseWorkspace ||
-			lastEnsuredWorkspaceIdRef.current === workspace.id
-		)
+		if (!workspace || lastEnsuredWorkspaceIdRef.current === workspace.id)
 			return;
 		lastEnsuredWorkspaceIdRef.current = workspace.id;
 		ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
-	}, [ensureWorkspaceInSidebar, workspace, canUseWorkspace]);
+	}, [ensureWorkspaceInSidebar, workspace]);
 
-	const hostStatus = useRemoteHostStatus(canUseWorkspace ? workspace : null);
+	const hostStatus = useRemoteHostStatus(workspace);
 
 	if (!workspaceId || !workspaces || (!workspace && !isReady)) {
 		return <div className="flex h-full w-full" />;
@@ -94,10 +87,6 @@ function V2WorkspaceLayout() {
 				startedAt={new Date(workspace.createdAt).getTime()}
 			/>
 		);
-	}
-
-	if (!canUseWorkspace) {
-		return <div className="flex h-full w-full" />;
 	}
 
 	if (hostStatus.status === "incompatible") {


### PR DESCRIPTION
## Summary

- Stop gating workspace host targeting and v2 workspace layout rendering on Electric `$synced` once a cached workspace row exists.
- Let remote host status render from cached workspace data even when the host collection has not reached `isReady`.
- Remove the unused sidebar `isSynced` field from the rendered workspace model so components cannot accidentally block on it.

## Root Cause

TanStack DB live queries can return persisted rows before the Electric collection reports readiness or `$synced === true`. The v2 workspace route and host-target hook were still treating those sync states as UI readiness, so an Electric outage or delayed shape could blank an otherwise cached workspace.

## Impact

Cached workspace rows now remain usable while Electric catches up. `isReady` is only used to distinguish loading from not-found when no row exists, and `$synced` remains only as internal bookkeeping for clearing pending insert state.

## Validation

- `bun run lint:fix`
- `bun run lint`
- `bun run --cwd apps/desktop typecheck`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4820">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render cached workspace rows before Electric sync so the v2 workspace layout and remote host status don’t blank while shapes catch up. Improves resiliency during Electric outages or delays.

- **Bug Fixes**
  - Stop gating workspace layout and host targeting on `$synced`/`isReady` when a cached workspace row exists.
  - Render remote host status from cached data; drop readiness check in `useRemoteHostStatus`.
  - Remove `isSynced` from the sidebar workspace model and related gating in `V2WorkspaceLayout`.

<sup>Written for commit fa650ea572862636068e38f690faf7ffa6a34794. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4820?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workspace responsiveness through optimized state detection
  * Dashboard workspace status (loading, incompatible states) now displays more consistently without unnecessary delays
  * Workspace functionality determined faster based on query readiness
  * Sidebar updates respond more dynamically to workspace availability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->