### PR TITLE
feat(mobile): add dev sign-in button (mirrors #4778)

### DIFF
--- a/apps/mobile/screens/(auth)/sign-in/SignInScreen.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/SignInScreen.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Image, Linking, View } from "react-native";
+
 import { Text } from "@/components/ui/text";
 import { signIn } from "@/lib/auth/client";
 
+import { DevSignInButton } from "./components/DevSignInButton";
 import type { SocialProvider } from "./components/SocialButton";
 import { SocialButton } from "./components/SocialButton";
 
@@ -54,6 +56,7 @@ export function SignInScreen() {
 					onPress={() => handleSignIn("google")}
 					className="w-4/5"
 				/>
+				{__DEV__ && <DevSignInButton />}
 			</View>
 
 			{error && (

--- a/apps/mobile/screens/(auth)/sign-in/components/DevSignInButton/DevSignInButton.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/components/DevSignInButton/DevSignInButton.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { signIn, signUp } from "@/lib/auth/client";
+
+const DEV_EMAIL = "admin@local.test";
+const DEV_PASSWORD = "supersetdev";
+const DEV_NAME = "Local Admin";
+
+export function DevSignInButton() {
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleSignIn = async () => {
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			let res = await signIn.email({
+				email: DEV_EMAIL,
+				password: DEV_PASSWORD,
+			});
+
+			if (res.error) {
+				// Account doesn't exist, create it
+				const signUpRes = await signUp.email({
+					email: DEV_EMAIL,
+					password: DEV_PASSWORD,
+					name: DEV_NAME,
+				});
+
+				if (signUpRes.error) {
+					throw new Error(signUpRes.error.message);
+				}
+
+				// Retry sign-in after account creation
+				res = await signIn.email({
+					email: DEV_EMAIL,
+					password: DEV_PASSWORD,
+				});
+			}
+
+			if (res.error) {
+				throw new Error(res.error.message);
+			}
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : "Something went wrong";
+			console.error("[dev-sign-in] Error:", err);
+			setError(message);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return (
+		<View className="w-full items-center gap-2">
+			<Button
+				onPress={handleSignIn}
+				disabled={isLoading}
+				variant="outline"
+				size="lg"
+				className="w-4/5"
+			>
+				<Text>
+					{isLoading ? "Signing in..." : "Sign in as Local Admin (dev)"}
+				</Text>
+			</Button>
+			{error && (
+				<Text className="text-center text-sm text-destructive">{error}</Text>
+			)}
+		</View>
+	);
+}

--- a/apps/mobile/screens/(auth)/sign-in/components/DevSignInButton/index.ts
+++ b/apps/mobile/screens/(auth)/sign-in/components/DevSignInButton/index.ts
@@ -1,0 +1,1 @@
+export { DevSignInButton } from "./DevSignInButton";


### PR DESCRIPTION
## Summary

Adds a dev-only "Sign in as Local Admin (dev)" button to the mobile sign-in screen, mirroring the web/desktop change in #4778 (`feat/web-dev-email-signin`) for the React Native app.

- New `DevSignInButton` component under `apps/mobile/screens/(auth)/sign-in/components/`
- Gated on Metro's `__DEV__` flag (the RN-native equivalent of web's `NODE_ENV !== "production"`)
- Calls `signIn.email()` from the existing Better Auth Expo client; on credential error, falls back to `signUp.email()` then retries — same flow as web
- Dev credentials inlined (`admin@local.test` / `supersetdev` / `Local Admin`) — intentional duplication since RN can't import the web/`packages/ui` DOM components. Unifying via `packages/shared` is captured as a follow-up to land once #4778 merges.
- No backend, `packages/shared`, `packages/auth`, or `apps/mobile/package.json` changes

## Test plan

- [x] AC-1 Button labeled "Sign in as Local Admin (dev)" renders below social providers in dev builds
- [ ] **AC-2 Tapping signs in as `admin@local.test` against a running local API (runtime-verify required)**
- [x] AC-3 Auto-`signUp.email()` fallback + retry when the dev account doesn't exist
- [x] AC-4 Loading/disabled state during sign-in (no double-tap)
- [x] AC-5 Inline error display below the button on failure
- [x] AC-6 Absent in production builds (`__DEV__` Metro-guaranteed false)
- [x] AC-7 `bun run typecheck` and `bun run lint` exit 0 in `apps/mobile`

## Notes for reviewers

- No explicit `router.replace()` after sign-in — the existing `Stack.Protected guard={!!session}` watcher in `apps/mobile/screens/RootLayout/RootLayout.tsx:26-29` handles navigation reactively when the session updates.
- `__DEV__` chosen over `env.NODE_ENV !== "production"` because `apps/mobile/lib/env.ts` defaults `NODE_ENV` to `"development"` in its zod schema, which would leak the button into prod builds that don't explicitly set it.
- The `.spec/improvements/feat-mobile-dev-email-signin/` directory contains the scoping artifacts (BRIEF, evidence vs web PR, binding SCOPE, follow-ups) produced by `/kb-improvement-plan`. Happy to drop these from the PR if the project prefers product-code-only PRs — let me know.

## Related

- Mirrors #4778 (web/desktop dev sign-in)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4821">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev‑only email sign‑in button to the mobile sign‑in screen so developers can log in as a local admin without OAuth. Mirrors the web/desktop dev flow; production builds are unaffected.

- **New Features**
  - Mobile: new `DevSignInButton` in `apps/mobile/screens/(auth)/sign-in/components/DevSignInButton`, rendered under social providers when `__DEV__` is true.
  - Uses `signIn.email()` with `signUp.email()` fallback and retry; inlined dev creds; shows loading and inline errors; navigation relies on the existing session guard.
  - Wired into `SignInScreen.tsx` and hidden in production; no backend or package changes.

<sup>Written for commit 9b714217c9c0ff8e54964ef5e7d2582230ca267d. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4821?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development-only quick sign-in option for internal testing that automatically creates accounts when needed, includes loading indicators, and displays error messages when sign-in fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->