### PR TITLE
[codex] Fix v1 import modal layout

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
@@ -1,8 +1,14 @@
+import { Button } from "@superset/ui/button";
+import { Spinner } from "@superset/ui/spinner";
+import type { QueryClient } from "@tanstack/react-query";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { LuFolder } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import {
+	getHostServiceClientByUrl,
+	type HostServiceClient,
+} from "renderer/lib/host-service-client";
 import { getBaseName } from "renderer/lib/pathBasename";
 import { useFinalizeProjectSetup } from "renderer/react-query/projects";
 import { ImportPageShell } from "../components/ImportPageShell";
@@ -16,15 +22,32 @@ interface ImportProjectsPageProps {
 const FIND_BY_PATH_KEY_PREFIX = ["v1-import", "findByPath"] as const;
 const HOST_PROJECT_LIST_KEY_PREFIX = ["v1-import", "hostProjectList"] as const;
 
+type V1Project = {
+	id: string;
+	name: string;
+	mainRepoPath: string;
+	githubOwner: string | null;
+};
+
+type ProjectFindByPathResult = Awaited<
+	ReturnType<HostServiceClient["project"]["findByPath"]["query"]>
+>;
+
 export function ImportProjectsPage({
 	organizationId,
 	activeHostUrl,
 }: ImportProjectsPageProps) {
 	const queryClient = useQueryClient();
+	const finalizeSetup = useFinalizeProjectSetup();
 	const projectsQuery = electronTrpc.migration.readV1Projects.useQuery();
 	const [isRefreshing, setIsRefreshing] = useState(false);
+	const [importAllProgress, setImportAllProgress] = useState<{
+		current: number;
+		total: number;
+	} | null>(null);
 
 	const isLoading = projectsQuery.isPending;
+	const isImportingAll = importAllProgress !== null;
 
 	const projects = projectsQuery.data ?? [];
 
@@ -40,6 +63,75 @@ export function ImportProjectsPage({
 		}
 	};
 
+	const importAll = async () => {
+		if (isImportingAll) return;
+		const queue = projects;
+		setImportAllProgress({ current: 0, total: queue.length });
+		try {
+			for (let i = 0; i < queue.length; i++) {
+				const project = queue[i];
+				if (!project) continue;
+				setImportAllProgress({ current: i, total: queue.length });
+				try {
+					const findByPathResult = await fetchProjectFindByPath(
+						queryClient,
+						project,
+						activeHostUrl,
+					);
+					if (isProjectAlreadyImported(findByPathResult)) {
+						continue;
+					}
+					if (findByPathResult.candidates.length > 1) {
+						continue;
+					}
+					if (
+						findByPathResult.candidates.length === 0 &&
+						findByPathResult.cloudErrors.length > 0
+					) {
+						continue;
+					}
+					const result = await importProject({
+						project,
+						activeHostUrl,
+						findByPathResult,
+						finalizeSetup,
+					});
+					if (result.kind === "imported") {
+						await invalidateProjectImportQueries(queryClient, project);
+					}
+				} catch (err) {
+					console.error("[v1-import] project import all failed", {
+						v1ProjectId: project.id,
+						mainRepoPath: project.mainRepoPath,
+						organizationId,
+						err,
+					});
+				}
+			}
+		} finally {
+			setImportAllProgress(null);
+		}
+	};
+
+	const headerAction =
+		projects.length > 0 ? (
+			<Button
+				type="button"
+				size="sm"
+				variant="default"
+				onClick={() => {
+					void importAll();
+				}}
+				disabled={isImportingAll || isLoading}
+				className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px] font-medium tabular-nums"
+			>
+				{importAllProgress && <Spinner className="size-3" />}
+				{importAllProgress
+					? `Importing ${importAllProgress.current + 1}/${importAllProgress.total}`
+					: "Import all"}
+			</Button>
+		) : null;
+
 	return (
 		<ImportPageShell
 			title="Bring over your projects"
@@ -49,6 +141,7 @@ export function ImportProjectsPage({
 			emptyMessage="No v1 projects found on this device."
 			onRefresh={refresh}
 			isRefreshing={isRefreshing}
+			headerAction={headerAction}
 		>
 			{projects.map((project) => (
 				<ProjectRow
@@ -63,12 +156,7 @@ export function ImportProjectsPage({
 }
 
 interface ProjectRowProps {
-	project: {
-		id: string;
-		name: string;
-		mainRepoPath: string;
-		githubOwner: string | null;
-	};
+	project: V1Project;
 	organizationId: string;
 	activeHostUrl: string;
 }
@@ -96,6 +184,137 @@ function expectedRemoteUrlFor(project: {
 	return `https://github.com/${project.githubOwner}/${repoName}`;
 }
 
+function projectFindByPathQueryKey(project: V1Project, activeHostUrl: string) {
+	return [
+		...FIND_BY_PATH_KEY_PREFIX,
+		project.mainRepoPath,
+		expectedRemoteUrlFor(project) ?? "",
+		activeHostUrl,
+	] as const;
+}
+
+function projectFindByPathQueryFn(project: V1Project, activeHostUrl: string) {
+	return async () => {
+		const client = getHostServiceClientByUrl(activeHostUrl);
+		return client.project.findByPath.query({
+			repoPath: project.mainRepoPath,
+			walkAllRemotes: true,
+			expectedRemoteUrl: expectedRemoteUrlFor(project),
+		});
+	};
+}
+
+function fetchProjectFindByPath(
+	queryClient: QueryClient,
+	project: V1Project,
+	activeHostUrl: string,
+) {
+	return queryClient.fetchQuery({
+		queryKey: projectFindByPathQueryKey(project, activeHostUrl),
+		queryFn: projectFindByPathQueryFn(project, activeHostUrl),
+		retry: false,
+	});
+}
+
+function isProjectAlreadyImported(
+	findByPathResult: ProjectFindByPathResult | undefined,
+) {
+	return !!findByPathResult?.candidates.find((c) => c.source === "local-path");
+}
+
+type FinalizeProjectSetup = ReturnType<typeof useFinalizeProjectSetup>;
+
+async function importProject({
+	project,
+	activeHostUrl,
+	findByPathResult,
+	finalizeSetup,
+	linkToProjectId,
+	allowRelocate = false,
+}: {
+	project: V1Project;
+	activeHostUrl: string;
+	findByPathResult: ProjectFindByPathResult | undefined;
+	finalizeSetup: FinalizeProjectSetup;
+	linkToProjectId?: string;
+	allowRelocate?: boolean;
+}): Promise<
+	| { kind: "imported"; v2ProjectId: string }
+	| { kind: "needs-relocate"; v2ProjectId: string; message: string }
+> {
+	const client = getHostServiceClientByUrl(activeHostUrl);
+	const candidates = findByPathResult?.candidates ?? [];
+
+	let v2ProjectId: string;
+	let mainWorkspaceId: string | null = null;
+	let repoPath = project.mainRepoPath;
+
+	const targetCandidate = linkToProjectId
+		? candidates.find((c) => c.id === linkToProjectId)
+		: candidates[0];
+
+	if (linkToProjectId && !targetCandidate) {
+		throw new Error(
+			"Selected v2 project is no longer in the candidate list. Refresh and pick again.",
+		);
+	}
+
+	if (targetCandidate) {
+		try {
+			const result = await client.project.setup.mutate({
+				projectId: targetCandidate.id,
+				mode: {
+					kind: "import",
+					repoPath: project.mainRepoPath,
+					allowRelocate,
+				},
+			});
+			v2ProjectId = targetCandidate.id;
+			mainWorkspaceId = result.mainWorkspaceId;
+			repoPath = result.repoPath;
+		} catch (err) {
+			if (isAlreadySetUpElsewhereError(err) && !allowRelocate) {
+				return {
+					kind: "needs-relocate",
+					v2ProjectId: targetCandidate.id,
+					message: err instanceof Error ? err.message : String(err),
+				};
+			}
+			throw err;
+		}
+	} else {
+		const result = await client.project.create.mutate({
+			name: project.name,
+			mode: { kind: "importLocal", repoPath: project.mainRepoPath },
+		});
+		v2ProjectId = result.projectId;
+		mainWorkspaceId = result.mainWorkspaceId;
+		repoPath = result.repoPath;
+	}
+
+	finalizeSetup(activeHostUrl, {
+		projectId: v2ProjectId,
+		repoPath,
+		mainWorkspaceId,
+	});
+
+	return { kind: "imported", v2ProjectId };
+}
+
+function invalidateProjectImportQueries(
+	queryClient: QueryClient,
+	project: V1Project,
+) {
+	return Promise.all([
+		queryClient.invalidateQueries({
+			queryKey: [...FIND_BY_PATH_KEY_PREFIX, project.mainRepoPath],
+		}),
+		queryClient.invalidateQueries({
+			queryKey: HOST_PROJECT_LIST_KEY_PREFIX,
+		}),
+	]);
+}
+
 function ProjectRow({
 	project,
 	organizationId,
@@ -111,30 +330,14 @@ function ProjectRow({
 	} | null>(null);
 	const [linkedV2Id, setLinkedV2Id] = useState<string | null>(null);
 
-	const expectedRemoteUrl = expectedRemoteUrlFor(project);
-
 	const findByPathQuery = useQuery({
-		queryKey: [
-			...FIND_BY_PATH_KEY_PREFIX,
-			project.mainRepoPath,
-			expectedRemoteUrl ?? "",
-			activeHostUrl,
-		],
-		queryFn: async () => {
-			const client = getHostServiceClientByUrl(activeHostUrl);
-			return client.project.findByPath.query({
-				repoPath: project.mainRepoPath,
-				walkAllRemotes: true,
-				expectedRemoteUrl,
-			});
-		},
+		queryKey: projectFindByPathQueryKey(project, activeHostUrl),
+		queryFn: projectFindByPathQueryFn(project, activeHostUrl),
 		retry: false,
 	});
 
-	const importedCandidate = findByPathQuery.data?.candidates.find(
-		(c) => c.source === "local-path",
-	);
-	const isImported = !!importedCandidate || !!linkedV2Id;
+	const isImported =
+		isProjectAlreadyImported(findByPathQuery.data) || !!linkedV2Id;
 
 	const runImport = async (
 		linkToProjectId?: string,
@@ -144,72 +347,26 @@ function ProjectRow({
 		setErrorMessage(null);
 		setPendingRelocate(null);
 		try {
-			const client = getHostServiceClientByUrl(activeHostUrl);
-			const candidates = findByPathQuery.data?.candidates ?? [];
-
-			let v2ProjectId: string;
-			let mainWorkspaceId: string | null = null;
-			let repoPath = project.mainRepoPath;
-
-			const targetCandidate = linkToProjectId
-				? candidates.find((c) => c.id === linkToProjectId)
-				: candidates[0];
-
-			if (linkToProjectId && !targetCandidate) {
-				throw new Error(
-					"Selected v2 project is no longer in the candidate list. Refresh and pick again.",
-				);
-			}
-
-			if (targetCandidate) {
-				try {
-					const result = await client.project.setup.mutate({
-						projectId: targetCandidate.id,
-						mode: {
-							kind: "import",
-							repoPath: project.mainRepoPath,
-							allowRelocate: options.allowRelocate ?? false,
-						},
-					});
-					v2ProjectId = targetCandidate.id;
-					mainWorkspaceId = result.mainWorkspaceId;
-					repoPath = result.repoPath;
-				} catch (err) {
-					if (isAlreadySetUpElsewhereError(err) && !options.allowRelocate) {
-						setPendingRelocate({
-							v2ProjectId: targetCandidate.id,
-							message: err instanceof Error ? err.message : String(err),
-						});
-						setRunning(false);
-						return;
-					}
-					throw err;
-				}
-			} else {
-				const result = await client.project.create.mutate({
-					name: project.name,
-					mode: { kind: "importLocal", repoPath: project.mainRepoPath },
-				});
-				v2ProjectId = result.projectId;
-				mainWorkspaceId = result.mainWorkspaceId;
-				repoPath = result.repoPath;
-			}
-
-			finalizeSetup(activeHostUrl, {
-				projectId: v2ProjectId,
-				repoPath,
-				mainWorkspaceId,
+			const result = await importProject({
+				project,
+				activeHostUrl,
+				findByPathResult: findByPathQuery.data,
+				finalizeSetup,
+				linkToProjectId,
+				allowRelocate: options.allowRelocate ?? false,
 			});
 
-			setLinkedV2Id(v2ProjectId);
-			await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: [...FIND_BY_PATH_KEY_PREFIX, project.mainRepoPath],
-				}),
-				queryClient.invalidateQueries({
-					queryKey: HOST_PROJECT_LIST_KEY_PREFIX,
-				}),
-			]);
+			if (result.kind === "needs-relocate") {
+				setPendingRelocate({
+					v2ProjectId: result.v2ProjectId,
+					message: result.message,
+				});
+				setRunning(false);
+				return;
+			}
+
+			setLinkedV2Id(result.v2ProjectId);
+			await invalidateProjectImportQueries(queryClient, project);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			setErrorMessage(message);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
@@ -46,6 +46,7 @@ export function V1ImportModal() {
 		>
 			<DialogContent
 				className="flex flex-col w-[min(744px,calc(100vw-2rem))] !max-w-[744px] h-[min(540px,calc(100vh-2rem))] max-h-[calc(100vh-2rem)] p-0 gap-0 overflow-hidden !rounded-none [&>[data-slot=dialog-close]]:top-5 [&>[data-slot=dialog-close]]:right-5 [&>[data-slot=dialog-close]]:z-10 [&>[data-slot=dialog-close]]:opacity-100 [&>[data-slot=dialog-close]]:text-muted-foreground hover:[&>[data-slot=dialog-close]]:text-foreground"
+				showCloseButton={false}
 				onEscapeKeyDown={(event) => event.preventDefault()}
 				onPointerDownOutside={(event) => event.preventDefault()}
 				onInteractOutside={(event) => event.preventDefault()}
@@ -92,35 +93,43 @@ export function V1ImportModal() {
 				</div>
 
 				<div className="box-border flex shrink-0 items-center justify-between gap-3 border-t border-border/60 bg-background px-5 py-3">
-					{previousPage ? (
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => setPage(previousPage)}
-							className="h-8 shrink-0 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground"
-						>
-							Back
-						</Button>
-					) : (
-						<div />
-					)}
-					{nextPage ? (
-						<Button
-							size="sm"
-							onClick={() => setPage(nextPage)}
-							className="h-8 shrink-0 px-3 text-[13px] font-medium"
-						>
-							{page === "welcome" ? "Get started" : "Next"}
-						</Button>
-					) : (
-						<Button
-							size="sm"
-							onClick={close}
-							className="h-8 shrink-0 px-3 text-[13px] font-medium"
-						>
-							Done
-						</Button>
-					)}
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={close}
+						className="h-8 shrink-0 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground"
+					>
+						Cancel
+					</Button>
+					<div className="flex shrink-0 items-center gap-2">
+						{previousPage && (
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => setPage(previousPage)}
+								className="h-8 shrink-0 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground"
+							>
+								Back
+							</Button>
+						)}
+						{nextPage ? (
+							<Button
+								size="sm"
+								onClick={() => setPage(nextPage)}
+								className="h-8 shrink-0 px-3 text-[13px] font-medium"
+							>
+								{page === "welcome" ? "Get started" : "Next"}
+							</Button>
+						) : (
+							<Button
+								size="sm"
+								onClick={close}
+								className="h-8 shrink-0 px-3 text-[13px] font-medium"
+							>
+								Done
+							</Button>
+						)}
+					</div>
 				</div>
 			</DialogContent>
 		</Dialog>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/V1ImportModal.tsx
@@ -15,6 +15,7 @@ import {
 } from "renderer/stores/v1-import-modal";
 import { MOCK_ORG_ID } from "shared/constants";
 import { IntroPage } from "./components/IntroPage";
+import { StepProgress } from "./components/StepProgress";
 import { WelcomePage } from "./components/WelcomePage";
 import { ImportPresetsPage } from "./ImportPresetsPage";
 import { ImportProjectsPage } from "./ImportProjectsPage";
@@ -92,7 +93,11 @@ export function V1ImportModal() {
 					)}
 				</div>
 
-				<div className="box-border flex shrink-0 items-center justify-between gap-3 border-t border-border/60 bg-background px-5 py-3">
+				<div className="relative box-border flex shrink-0 items-center justify-between gap-3 border-t border-border/60 bg-background px-5 py-3">
+					<StepProgress
+						currentIndex={currentIndex}
+						totalSteps={V1_IMPORT_PAGE_ORDER.length}
+					/>
 					<Button
 						variant="ghost"
 						size="sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportPageShell/ImportPageShell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportPageShell/ImportPageShell.tsx
@@ -28,7 +28,7 @@ export function ImportPageShell({
 }: ImportPageShellProps) {
 	return (
 		<div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-			<div className="flex items-center gap-3 border-b border-border/60 px-6 py-3.5 pr-16">
+			<div className="flex items-center gap-3 border-b border-border/60 px-6 py-3.5">
 				<div className="min-w-0 flex-1">
 					<div className="truncate text-[14px] font-medium tracking-tight text-foreground">
 						{title}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/ImportRow/ImportRow.tsx
@@ -52,22 +52,22 @@ export function ImportRow({
 	action,
 }: ImportRowProps) {
 	return (
-		<div className="group flex w-full min-w-0 max-w-full items-center gap-3 overflow-hidden rounded-md px-2.5 py-1.5 transition-colors hover:bg-accent/40">
+		<div className="group grid w-full min-w-0 max-w-full shrink-0 grid-cols-[1rem_minmax(0,1fr)] items-center gap-x-3 gap-y-2 overflow-hidden rounded-md px-2.5 py-2 transition-colors hover:bg-accent/40 sm:grid-cols-[1rem_minmax(0,1fr)_auto]">
 			{icon && (
-				<div className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+				<div className="row-start-1 flex size-4 shrink-0 items-center justify-center self-start pt-0.5 text-muted-foreground sm:self-center sm:pt-0">
 					{icon}
 				</div>
 			)}
-			<div className="flex min-w-0 flex-1 flex-col">
+			<div className="col-start-2 flex min-w-0 flex-col">
 				<span
-					className="truncate text-[13px] font-medium leading-tight text-foreground"
+					className="truncate text-[13px] font-medium leading-4 text-foreground"
 					title={primary}
 				>
 					{primary}
 				</span>
 				{secondary && (
 					<span
-						className="mt-0.5 truncate font-mono text-[11px] leading-tight text-muted-foreground"
+						className="mt-0.5 truncate font-mono text-[11px] leading-4 text-muted-foreground"
 						title={secondary}
 					>
 						{secondary}
@@ -75,7 +75,7 @@ export function ImportRow({
 				)}
 				{action.kind === "error" && (
 					<span
-						className="mt-0.5 select-text cursor-text truncate text-[11px] leading-tight text-destructive"
+						className="mt-0.5 select-text cursor-text truncate text-[11px] leading-4 text-destructive"
 						title={action.message}
 					>
 						{action.message}
@@ -83,19 +83,21 @@ export function ImportRow({
 				)}
 				{action.kind === "blocked" && (
 					<span
-						className="mt-0.5 truncate text-[11px] leading-tight text-muted-foreground"
+						className="mt-0.5 truncate text-[11px] leading-4 text-muted-foreground"
 						title={action.reason}
 					>
 						{action.reason}
 					</span>
 				)}
 				{action.kind === "confirm" && (
-					<span className="mt-0.5 select-text cursor-text text-[11px] leading-tight text-muted-foreground [overflow-wrap:anywhere]">
+					<span className="mt-0.5 select-text cursor-text text-[11px] leading-4 text-muted-foreground [overflow-wrap:anywhere]">
 						{action.message}
 					</span>
 				)}
 			</div>
-			<RowActionView action={action} />
+			<div className="col-start-2 flex shrink-0 items-center justify-self-end sm:col-start-3 sm:row-start-1">
+				<RowActionView action={action} />
+			</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/StepProgress/StepProgress.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/StepProgress/StepProgress.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { getStepProgress, StepProgress } from "./StepProgress";
+
+describe("StepProgress", () => {
+	it("converts a zero-based page index into user-facing progress", () => {
+		expect(getStepProgress({ currentIndex: 2, totalSteps: 5 })).toEqual({
+			currentStep: 3,
+			totalSteps: 5,
+			percent: 60,
+			label: "Step 3 of 5",
+		});
+	});
+
+	it("renders an accessible step progress bar", () => {
+		const markup = renderToStaticMarkup(
+			<StepProgress currentIndex={2} totalSteps={5} />,
+		);
+
+		expect(markup).toContain("Step 3 of 5");
+		expect(markup).toContain('role="progressbar"');
+		expect(markup).toContain('aria-label="Step 3 of 5"');
+		expect(markup).toContain('aria-valuenow="3"');
+		expect(markup).toContain('aria-valuemax="5"');
+		expect(markup).toContain("-top-px");
+		expect(markup).toContain("h-px");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/StepProgress/StepProgress.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/StepProgress/StepProgress.tsx
@@ -1,0 +1,43 @@
+interface StepProgressProps {
+	currentIndex: number;
+	totalSteps: number;
+}
+
+export function getStepProgress({
+	currentIndex,
+	totalSteps,
+}: StepProgressProps) {
+	const safeTotalSteps = Math.max(totalSteps, 1);
+	const safeCurrentIndex = Math.min(
+		Math.max(currentIndex, 0),
+		safeTotalSteps - 1,
+	);
+	const currentStep = safeCurrentIndex + 1;
+
+	return {
+		currentStep,
+		totalSteps: safeTotalSteps,
+		percent: (currentStep / safeTotalSteps) * 100,
+		label: `Step ${currentStep} of ${safeTotalSteps}`,
+	};
+}
+
+export function StepProgress(props: StepProgressProps) {
+	const progress = getStepProgress(props);
+
+	return (
+		<div
+			role="progressbar"
+			aria-label={progress.label}
+			aria-valuemin={1}
+			aria-valuemax={progress.totalSteps}
+			aria-valuenow={progress.currentStep}
+			className="pointer-events-none absolute -top-px left-0 h-px w-full overflow-hidden"
+		>
+			<div
+				className="h-full bg-foreground transition-[width] duration-200"
+				style={{ width: `${progress.percent}%` }}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/StepProgress/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/components/StepProgress/index.ts
@@ -1,0 +1,1 @@
+export { getStepProgress, StepProgress } from "./StepProgress";


### PR DESCRIPTION
## Summary

- Fix the v1 import modal row layout so rows keep their height, align actions predictably, and allow the list to scroll.
- Move modal close affordance into the footer, remove the old header padding reserved for the top-right close icon, and keep Back next to the primary Next/Done action.
- Add project Import all support with conservative skips for already-linked, ambiguous, and cloud-error rows.
- Add a footer-border step progress indicator with focused test coverage.

## Why

The importer list was visually compressed and did not scroll correctly because rows could shrink inside the flex scroll container. The close button placement also left unused header padding after moving the action into the footer.

## Validation

- `bun test ./src/renderer/routes/_authenticated/components/V1ImportModal/components/StepProgress/StepProgress.test.tsx`
- `bun run --cwd apps/desktop typecheck`
- `bun run lint`

## Notes

- `bun.lock` has an unrelated local modification and was intentionally excluded from this PR.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4822">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v1 import modal layout and adds “Import all” with a step progress indicator for a smoother import experience. Rows keep a stable height, actions align predictably, and the list scrolls correctly.

- **New Features**
  - Added “Import all” for projects with conservative skips (already linked, ambiguous matches, cloud errors) and inline progress (spinner + x/y).
  - Added an accessible footer step progress bar with focused tests.
  - Moved controls to the footer: Cancel, Back beside Next/Done.

- **Bug Fixes**
  - Prevented row shrinkage and action jitter; `ImportRow` uses a grid layout to keep heights consistent.
  - Removed unused header padding from the old top-right close icon; content area now uses the full width.
  - Fixed scrolling inside the modal so long lists are usable.

<sup>Written for commit b81bf3f1e0109d31deed0e509a9a4b1666bc0cd2. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4822?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Import all" action to import multiple V1 projects in a single workflow with progress tracking
  * Added progress indicator showing current step during imports
  * Already-imported projects are automatically skipped

* **Improvements**
  * Added Cancel button for better control during the import workflow
  * Refined navigation flow and modal layout for improved usability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->