### PR TITLE
[codex] Fix full disk access detection

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/permissions.ts
+++ b/apps/desktop/src/lib/trpc/routers/permissions.ts
@@ -1,86 +1,37 @@
-import fs from "node:fs";
-import { homedir } from "node:os";
-import path from "node:path";
-import { shell, systemPreferences } from "electron";
 import { publicProcedure, router } from "..";
-
-function checkFullDiskAccess(): boolean {
-	try {
-		// Safari bookmarks are TCC-protected — readable only with Full Disk Access
-		const tccProtectedPath = path.join(
-			homedir(),
-			"Library/Safari/Bookmarks.plist",
-		);
-		fs.accessSync(tccProtectedPath, fs.constants.R_OK);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-function checkAccessibility(): boolean {
-	return systemPreferences.isTrustedAccessibilityClient(false);
-}
-
-function checkMicrophone(): boolean {
-	try {
-		return systemPreferences.getMediaAccessStatus("microphone") === "granted";
-	} catch {
-		return false;
-	}
-}
+import {
+	getPermissionStatus,
+	requestAccessibility,
+	requestAppleEvents,
+	requestFullDiskAccess,
+	requestLocalNetwork,
+	requestMicrophone,
+} from "./permissions/native-permissions";
 
 export const createPermissionsRouter = () => {
 	return router({
 		getStatus: publicProcedure.query(() => {
-			return {
-				fullDiskAccess: checkFullDiskAccess(),
-				accessibility: checkAccessibility(),
-				microphone: checkMicrophone(),
-			};
+			return getPermissionStatus();
 		}),
 
 		requestFullDiskAccess: publicProcedure.mutation(async () => {
-			await shell.openExternal(
-				"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-			);
+			await requestFullDiskAccess();
 		}),
 
 		requestAccessibility: publicProcedure.mutation(async () => {
-			await shell.openExternal(
-				"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
-			);
+			await requestAccessibility();
 		}),
 
 		requestMicrophone: publicProcedure.mutation(async () => {
-			try {
-				if (process.platform === "darwin") {
-					const granted =
-						await systemPreferences.askForMediaAccess("microphone");
-					if (granted) {
-						return { granted: true };
-					}
-				}
-			} catch {
-				// Fall through to opening System Settings.
-			}
-
-			await shell.openExternal(
-				"x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
-			);
-			return { granted: false };
+			return requestMicrophone();
 		}),
 
 		requestAppleEvents: publicProcedure.mutation(async () => {
-			await shell.openExternal(
-				"x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Automation",
-			);
+			await requestAppleEvents();
 		}),
 
 		requestLocalNetwork: publicProcedure.mutation(async () => {
-			await shell.openExternal(
-				"x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_LocalNetwork",
-			);
+			await requestLocalNetwork();
 		}),
 	});
 };

--- a/apps/desktop/src/lib/trpc/routers/permissions/full-disk-access.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/permissions/full-disk-access.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { checkFullDiskAccess } from "./full-disk-access";
+
+const homeDirectory = "/Users/tester";
+const tccDatabasePath = path.join(
+	homeDirectory,
+	"Library",
+	"Application Support",
+	"com.apple.TCC",
+	"TCC.db",
+);
+const safariHistoryPath = path.join(
+	homeDirectory,
+	"Library",
+	"Safari",
+	"History.db",
+);
+const safariBookmarksPath = path.join(
+	homeDirectory,
+	"Library",
+	"Safari",
+	"Bookmarks.plist",
+);
+const messagesDatabasePath = path.join(
+	homeDirectory,
+	"Library",
+	"Messages",
+	"chat.db",
+);
+
+function createFileSystemError(code: NodeJS.ErrnoException["code"]) {
+	const error = new Error(code);
+	(error as NodeJS.ErrnoException).code = code;
+	return error;
+}
+
+describe("checkFullDiskAccess", () => {
+	it("returns true when the TCC database can be opened", () => {
+		const openedPaths: string[] = [];
+
+		const hasFullDiskAccess = checkFullDiskAccess({
+			homeDirectory,
+			readProbe: (filePath) => {
+				openedPaths.push(filePath);
+			},
+		});
+
+		expect(hasFullDiskAccess).toBe(true);
+		expect(openedPaths).toEqual([tccDatabasePath]);
+	});
+
+	it("continues past missing optional probe files", () => {
+		const openedPaths: string[] = [];
+
+		const hasFullDiskAccess = checkFullDiskAccess({
+			homeDirectory,
+			readProbe: (filePath) => {
+				openedPaths.push(filePath);
+
+				if (filePath !== messagesDatabasePath) {
+					throw createFileSystemError("ENOENT");
+				}
+			},
+		});
+
+		expect(hasFullDiskAccess).toBe(true);
+		expect(openedPaths).toEqual([
+			tccDatabasePath,
+			safariHistoryPath,
+			safariBookmarksPath,
+			messagesDatabasePath,
+		]);
+	});
+
+	it("continues past missing optional probe directories", () => {
+		const openedPaths: string[] = [];
+
+		const hasFullDiskAccess = checkFullDiskAccess({
+			homeDirectory,
+			readProbe: (filePath) => {
+				openedPaths.push(filePath);
+
+				if (filePath !== messagesDatabasePath) {
+					throw createFileSystemError("ENOTDIR");
+				}
+			},
+		});
+
+		expect(hasFullDiskAccess).toBe(true);
+		expect(openedPaths).toEqual([
+			tccDatabasePath,
+			safariHistoryPath,
+			safariBookmarksPath,
+			messagesDatabasePath,
+		]);
+	});
+
+	it("opens real probe files when using the default read probe", () => {
+		const temporaryHomeDirectory = fs.mkdtempSync(
+			path.join(tmpdir(), "superset-full-disk-access-"),
+		);
+
+		try {
+			const realMessagesDatabasePath = path.join(
+				temporaryHomeDirectory,
+				"Library",
+				"Messages",
+				"chat.db",
+			);
+
+			fs.mkdirSync(path.dirname(realMessagesDatabasePath), { recursive: true });
+			fs.writeFileSync(realMessagesDatabasePath, "probe");
+
+			expect(
+				checkFullDiskAccess({ homeDirectory: temporaryHomeDirectory }),
+			).toBe(true);
+		} finally {
+			fs.rmSync(temporaryHomeDirectory, { force: true, recursive: true });
+		}
+	});
+
+	it("returns false when an existing protected file cannot be opened", () => {
+		const openedPaths: string[] = [];
+
+		const hasFullDiskAccess = checkFullDiskAccess({
+			homeDirectory,
+			readProbe: (filePath) => {
+				openedPaths.push(filePath);
+				throw createFileSystemError("EPERM");
+			},
+		});
+
+		expect(hasFullDiskAccess).toBe(false);
+		expect(openedPaths).toEqual([tccDatabasePath]);
+	});
+
+	it("returns false when an existing protected file is not readable", () => {
+		const openedPaths: string[] = [];
+
+		const hasFullDiskAccess = checkFullDiskAccess({
+			homeDirectory,
+			readProbe: (filePath) => {
+				openedPaths.push(filePath);
+				throw createFileSystemError("EACCES");
+			},
+		});
+
+		expect(hasFullDiskAccess).toBe(false);
+		expect(openedPaths).toEqual([tccDatabasePath]);
+	});
+
+	it("returns false when no probe file exists", () => {
+		const openedPaths: string[] = [];
+
+		const hasFullDiskAccess = checkFullDiskAccess({
+			homeDirectory,
+			readProbe: (filePath) => {
+				openedPaths.push(filePath);
+				throw createFileSystemError("ENOENT");
+			},
+		});
+
+		expect(hasFullDiskAccess).toBe(false);
+		expect(openedPaths).toEqual([
+			tccDatabasePath,
+			safariHistoryPath,
+			safariBookmarksPath,
+			messagesDatabasePath,
+		]);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/permissions/full-disk-access.ts
+++ b/apps/desktop/src/lib/trpc/routers/permissions/full-disk-access.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const FULL_DISK_ACCESS_PROBE_PATHS = [
+	["Library", "Application Support", "com.apple.TCC", "TCC.db"],
+	["Library", "Safari", "History.db"],
+	["Library", "Safari", "Bookmarks.plist"],
+	["Library", "Messages", "chat.db"],
+] as const;
+
+type ReadProbe = (filePath: string) => void;
+
+function openForRead(filePath: string): void {
+	const fileDescriptor = fs.openSync(filePath, "r");
+	fs.closeSync(fileDescriptor);
+}
+
+function isSkippableProbeError(error: unknown): boolean {
+	if (!(error instanceof Error) || !("code" in error)) {
+		return false;
+	}
+
+	const code = (error as NodeJS.ErrnoException).code;
+	return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function getFullDiskAccessProbePaths(homeDirectory: string): string[] {
+	return FULL_DISK_ACCESS_PROBE_PATHS.map((segments) =>
+		path.join(homeDirectory, ...segments),
+	);
+}
+
+export function checkFullDiskAccess({
+	homeDirectory = homedir(),
+	readProbe = openForRead,
+}: {
+	homeDirectory?: string;
+	readProbe?: ReadProbe;
+} = {}): boolean {
+	for (const probePath of getFullDiskAccessProbePaths(homeDirectory)) {
+		try {
+			readProbe(probePath);
+			return true;
+		} catch (error) {
+			// Some protected app data files are optional. Missing path probes fall
+			// through; permission errors mean macOS denied access to protected data.
+			if (isSkippableProbeError(error)) {
+				continue;
+			}
+
+			return false;
+		}
+	}
+
+	return false;
+}

--- a/apps/desktop/src/lib/trpc/routers/permissions/native-permissions.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/permissions/native-permissions.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("electron", () => ({
+	shell: {
+		openExternal: mock(async () => {}),
+	},
+	systemPreferences: {
+		askForMediaAccess: mock(async () => false),
+		getMediaAccessStatus: mock(() => "not-determined"),
+		isTrustedAccessibilityClient: mock(() => false),
+	},
+}));
+
+const {
+	checkAccessibility,
+	checkMicrophone,
+	PERMISSION_SETTINGS_URLS,
+	requestAccessibility,
+	requestAppleEvents,
+	requestFullDiskAccess,
+	requestLocalNetwork,
+	requestMicrophone,
+} = await import("./native-permissions");
+
+function createShellRecorder() {
+	const openedUrls: string[] = [];
+
+	return {
+		openedUrls,
+		shellApi: {
+			openExternal: async (url: string) => {
+				openedUrls.push(url);
+			},
+		},
+	};
+}
+
+describe("native permissions", () => {
+	it("checks Accessibility with the native trusted-client API", () => {
+		expect(
+			checkAccessibility({
+				systemPreferencesApi: {
+					isTrustedAccessibilityClient: (prompt) => prompt === false,
+				},
+			}),
+		).toBe(true);
+	});
+
+	it("checks Microphone granted status", () => {
+		expect(
+			checkMicrophone({
+				systemPreferencesApi: {
+					getMediaAccessStatus: () => "granted",
+				},
+			}),
+		).toBe(true);
+
+		expect(
+			checkMicrophone({
+				systemPreferencesApi: {
+					getMediaAccessStatus: () => "denied",
+				},
+			}),
+		).toBe(false);
+	});
+
+	it("treats Microphone status errors as not granted", () => {
+		expect(
+			checkMicrophone({
+				systemPreferencesApi: {
+					getMediaAccessStatus: () => {
+						throw new Error("unavailable");
+					},
+				},
+			}),
+		).toBe(false);
+	});
+
+	it("opens Full Disk Access settings", async () => {
+		const { openedUrls, shellApi } = createShellRecorder();
+
+		await requestFullDiskAccess({ shellApi });
+
+		expect(openedUrls).toEqual([PERMISSION_SETTINGS_URLS.fullDiskAccess]);
+	});
+
+	it("opens Accessibility settings", async () => {
+		const { openedUrls, shellApi } = createShellRecorder();
+
+		await requestAccessibility({ shellApi });
+
+		expect(openedUrls).toEqual([PERMISSION_SETTINGS_URLS.accessibility]);
+	});
+
+	it("returns granted when the native Microphone prompt grants access", async () => {
+		const { openedUrls, shellApi } = createShellRecorder();
+
+		const result = await requestMicrophone({
+			shellApi,
+			systemPreferencesApi: {
+				askForMediaAccess: async () => true,
+			},
+		});
+
+		if (process.platform === "darwin") {
+			expect(result).toEqual({ granted: true });
+			expect(openedUrls).toEqual([]);
+		} else {
+			expect(result).toEqual({ granted: false });
+			expect(openedUrls).toEqual([PERMISSION_SETTINGS_URLS.microphone]);
+		}
+	});
+
+	it("opens Microphone settings when the native prompt does not grant access", async () => {
+		const { openedUrls, shellApi } = createShellRecorder();
+
+		const result = await requestMicrophone({
+			shellApi,
+			systemPreferencesApi: {
+				askForMediaAccess: async () => false,
+			},
+		});
+
+		expect(result).toEqual({ granted: false });
+		expect(openedUrls).toEqual([PERMISSION_SETTINGS_URLS.microphone]);
+	});
+
+	it("opens Microphone settings when the native prompt fails", async () => {
+		const { openedUrls, shellApi } = createShellRecorder();
+
+		const result = await requestMicrophone({
+			shellApi,
+			systemPreferencesApi: {
+				askForMediaAccess: async () => {
+					throw new Error("unavailable");
+				},
+			},
+		});
+
+		expect(result).toEqual({ granted: false });
+		expect(openedUrls).toEqual([PERMISSION_SETTINGS_URLS.microphone]);
+	});
+
+	it("opens Automation settings", async () => {
+		const { openedUrls, shellApi } = createShellRecorder();
+
+		await requestAppleEvents({ shellApi });
+
+		expect(openedUrls).toEqual([PERMISSION_SETTINGS_URLS.appleEvents]);
+	});
+
+	it("opens Local Network settings", async () => {
+		const { openedUrls, shellApi } = createShellRecorder();
+
+		await requestLocalNetwork({ shellApi });
+
+		expect(openedUrls).toEqual([PERMISSION_SETTINGS_URLS.localNetwork]);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/permissions/native-permissions.ts
+++ b/apps/desktop/src/lib/trpc/routers/permissions/native-permissions.ts
@@ -1,0 +1,123 @@
+import type {
+	shell as electronShell,
+	systemPreferences as electronSystemPreferences,
+} from "electron";
+import { checkFullDiskAccess } from "./full-disk-access";
+
+export const PERMISSION_SETTINGS_URLS = {
+	fullDiskAccess:
+		"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
+	accessibility:
+		"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+	microphone:
+		"x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+	appleEvents:
+		"x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Automation",
+	localNetwork:
+		"x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_LocalNetwork",
+} as const;
+
+type ShellApi = Pick<typeof electronShell, "openExternal">;
+type SystemPreferencesApi = Pick<
+	typeof electronSystemPreferences,
+	"askForMediaAccess" | "getMediaAccessStatus" | "isTrustedAccessibilityClient"
+>;
+
+function getElectronShell(): ShellApi {
+	return (require("electron") as Partial<typeof import("electron")>)
+		.shell as ShellApi;
+}
+
+function getElectronSystemPreferences(): SystemPreferencesApi | undefined {
+	return (require("electron") as Partial<typeof import("electron")>)
+		.systemPreferences;
+}
+
+export function checkAccessibility({
+	systemPreferencesApi = getElectronSystemPreferences(),
+}: {
+	systemPreferencesApi?: Pick<
+		SystemPreferencesApi,
+		"isTrustedAccessibilityClient"
+	>;
+} = {}): boolean {
+	return systemPreferencesApi?.isTrustedAccessibilityClient(false) ?? false;
+}
+
+export function checkMicrophone({
+	systemPreferencesApi = getElectronSystemPreferences(),
+}: {
+	systemPreferencesApi?: Pick<SystemPreferencesApi, "getMediaAccessStatus">;
+} = {}): boolean {
+	try {
+		return (
+			systemPreferencesApi?.getMediaAccessStatus("microphone") === "granted"
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function getPermissionStatus() {
+	return {
+		fullDiskAccess: checkFullDiskAccess(),
+		accessibility: checkAccessibility(),
+		microphone: checkMicrophone(),
+	};
+}
+
+export async function requestFullDiskAccess({
+	shellApi = getElectronShell(),
+}: {
+	shellApi?: ShellApi;
+} = {}): Promise<void> {
+	await shellApi.openExternal(PERMISSION_SETTINGS_URLS.fullDiskAccess);
+}
+
+export async function requestAccessibility({
+	shellApi = getElectronShell(),
+}: {
+	shellApi?: ShellApi;
+} = {}): Promise<void> {
+	await shellApi.openExternal(PERMISSION_SETTINGS_URLS.accessibility);
+}
+
+export async function requestMicrophone({
+	shellApi = getElectronShell(),
+	systemPreferencesApi,
+}: {
+	shellApi?: ShellApi;
+	systemPreferencesApi?: Pick<SystemPreferencesApi, "askForMediaAccess">;
+} = {}): Promise<{ granted: boolean }> {
+	try {
+		if (process.platform === "darwin") {
+			const preferencesApi =
+				systemPreferencesApi ?? getElectronSystemPreferences();
+			const granted = await preferencesApi?.askForMediaAccess("microphone");
+			if (granted) {
+				return { granted: true };
+			}
+		}
+	} catch {
+		// Fall through to opening System Settings.
+	}
+
+	await shellApi.openExternal(PERMISSION_SETTINGS_URLS.microphone);
+	return { granted: false };
+}
+
+export async function requestAppleEvents({
+	shellApi = getElectronShell(),
+}: {
+	shellApi?: ShellApi;
+} = {}): Promise<void> {
+	await shellApi.openExternal(PERMISSION_SETTINGS_URLS.appleEvents);
+}
+
+export async function requestLocalNetwork({
+	shellApi = getElectronShell(),
+}: {
+	shellApi?: ShellApi;
+} = {}): Promise<void> {
+	await shellApi.openExternal(PERMISSION_SETTINGS_URLS.localNetwork);
+}


### PR DESCRIPTION
## Summary

Fixes the macOS Full Disk Access detector used by the desktop permissions router.

The previous implementation probed only `~/Library/Safari/Bookmarks.plist`. That file is TCC-protected, but it is also optional: users with no Safari bookmarks may not have it at all. In that case Superset reported Full Disk Access as missing even after the user granted it in System Settings.

This PR moves FDA detection into a small helper that probes multiple protected user-data files. Missing probe files are skipped, while actual open failures such as `EPERM` or `EACCES` still report FDA as unavailable. It also extracts the other native permission checks/request entry points into a tested helper so the settings deep links and Microphone grant fallback behavior are covered.

## Impact

Users who have granted Full Disk Access should no longer get stuck in onboarding or permissions settings just because Safari has no bookmarks file.

## Validation

- `bun test src/lib/trpc/routers/permissions/full-disk-access.test.ts src/lib/trpc/routers/permissions/native-permissions.test.ts` (15 tests covering FDA probe behavior, real `fs.openSync` fallback, Accessibility status, Microphone granted/denied/error branches, and all permission settings request URLs)
- Real Bun runtime call against this machine's macOS protected files returned `{"fullDiskAccess":true}`
- Real Electron runtime call returned `{"name":"Electron","fullDiskAccess":true,"accessibility":true,"microphone":"granted"}`
- Fresh temporary Electron app bundle with a new bundle id launched through LaunchServices returned `{"fullDiskAccess":false,"accessibility":false,"microphone":"not-determined"}`, confirming denied/not-yet-granted TCC paths
- Automation and Local Network currently have request deep links only; there is no app status reader for those permissions to verify after granting
- `bun run --cwd apps/desktop typecheck`
- `bun run lint:fix`
- `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS checks and user flows for Full Disk Access, Accessibility, Microphone, Apple Events, and Local Network permissions.

* **Refactor**
  * Unified permission status checks and request actions into shared native helpers for consistent behavior.

* **Tests**
  * Added thorough tests for Full Disk Access probing and for native permission request flows, including error and edge-case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->