### PR TITLE
release(cli): cut v0.2.20

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -688,7 +688,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -769,7 +769,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.19",
+	"version": "0.2.20",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Cuts `@superset/cli` **v0.2.20**. First CLI release since `cli-v0.2.19` (2026-05-16).

## CLI-affecting changes since 0.2.19
- host auth refresh (SUPER-752, #4738)
- worktree delete cleanup ordering (#4801)
- PR-checkout materialization fix (#4643)
- project setup on selected host (#4665)
- SDK/CLI tRPC audit-gap docs (#4771)

## Release steps
- [x] bump `packages/cli/package.json` 0.2.19 → 0.2.20 (+ `bun.lock`)
- [ ] merge this PR
- [ ] push tag `cli-v0.2.20` at the merge commit → triggers `release-cli.yml` (3-target build + GitHub release + rolling `cli-latest` + homebrew bump per #4826)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4830">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.20 with host auth refresh, selected-host project setup, and fixes to PR checkout and worktree cleanup. Improves sign-in stability (SUPER-752) and reliability across common workflows.

- **New Features**
  - Refresh host auth to prevent expired sessions (SUPER-752).
  - Allow project setup on a selected host.

- **Bug Fixes**
  - Fix PR checkout materialization.
  - Correct worktree delete cleanup order.

<sup>Written for commit 9ad28c09d56f0129ef498b12b0388352b09cf5f8. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4830?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped `@superset/cli` package version to 0.2.20.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->