### PR TITLE
fix(cli): stop --json pipe truncation + add pagination to 'tasks list'

### DIFF
--- a/packages/cli-framework/src/index.ts
+++ b/packages/cli-framework/src/index.ts
@@ -17,7 +17,8 @@ export type {
 	TypeOf,
 } from "./option";
 export { boolean, number, positional, string } from "./option";
-export { formatOutput, table } from "./output";
+export type { OutputFlags, PaginatedResult, Pagination } from "./output";
+export { formatOutput, paginated, table } from "./output";
 export { camelToKebab, isAgentMode, parseArgv } from "./parser";
 export type { CommandsPluginOptions } from "./plugin";
 export { createCommandsPlugin } from "./plugin";

--- a/packages/cli-framework/src/output.ts
+++ b/packages/cli-framework/src/output.ts
@@ -7,8 +7,8 @@ export type OutputFlags = {
 export type Pagination = {
 	/** Number of items in this response. */
 	returned: number;
-	/** Max items the caller asked for. */
-	limit: number;
+	/** Max items the caller asked for, or `null` if no cap was applied (e.g. `--all`). */
+	limit: number | null;
 	/** Items skipped before this page. */
 	offset: number;
 	/** Whether more items exist beyond this page. */
@@ -96,12 +96,18 @@ function paginationFooter(pagination: Pagination): string {
 function isPaginatedResult(
 	result: unknown,
 ): result is PaginatedResult<unknown> {
+	if (typeof result !== "object" || result === null) return false;
+	if (!("data" in result) || !("pagination" in result)) return false;
+	const data = (result as { data: unknown }).data;
+	const pagination = (result as { pagination: unknown }).pagination;
+	if (!Array.isArray(data)) return false;
+	if (typeof pagination !== "object" || pagination === null) return false;
+	const p = pagination as Record<string, unknown>;
 	return (
-		typeof result === "object" &&
-		result !== null &&
-		"data" in result &&
-		"pagination" in result &&
-		Array.isArray((result as { data: unknown }).data)
+		typeof p.returned === "number" &&
+		(typeof p.limit === "number" || p.limit === null) &&
+		typeof p.offset === "number" &&
+		typeof p.hasMore === "boolean"
 	);
 }
 

--- a/packages/cli-framework/src/output.ts
+++ b/packages/cli-framework/src/output.ts
@@ -3,11 +3,46 @@ export type OutputFlags = {
 	quiet: boolean;
 };
 
+/** Pagination metadata describing a single page of a larger result set. */
+export type Pagination = {
+	/** Number of items in this response. */
+	returned: number;
+	/** Max items the caller asked for. */
+	limit: number;
+	/** Items skipped before this page. */
+	offset: number;
+	/** Whether more items exist beyond this page. */
+	hasMore: boolean;
+};
+
+/** A page of list results paired with pagination metadata. */
+export type PaginatedResult<T> = {
+	data: T[];
+	pagination: Pagination;
+};
+
+/**
+ * Wrap a page of results with pagination metadata. Commands that return this
+ * get a "more results available" footer in human output and a structured
+ * `{ data, pagination }` object under `--json`, so both people and agents can
+ * tell when results were capped by `--limit`.
+ */
+export function paginated<T>(
+	data: T[],
+	pagination: Pagination,
+): PaginatedResult<T> {
+	return { data, pagination };
+}
+
 export function formatOutput(
 	result: unknown,
 	display: ((data: unknown) => string) | undefined,
 	flags: OutputFlags,
 ): string {
+	if (isPaginatedResult(result)) {
+		return formatPaginated(result, display, flags);
+	}
+
 	const data = isResultWithData(result) ? result.data : result;
 	const message = isResultWithMessage(result) ? result.message : undefined;
 
@@ -29,6 +64,45 @@ export function formatOutput(
 
 	// Fallback: JSON
 	return JSON.stringify(data, null, 2);
+}
+
+function formatPaginated(
+	result: PaginatedResult<unknown>,
+	display: ((data: unknown) => string) | undefined,
+	flags: OutputFlags,
+): string {
+	const { data, pagination } = result;
+
+	// JSON keeps the metadata so agents can read `hasMore` programmatically.
+	if (flags.json) {
+		return JSON.stringify({ data, pagination }, null, 2);
+	}
+
+	if (flags.quiet) {
+		return extractIds(data);
+	}
+
+	const body = display ? display(data) : JSON.stringify(data, null, 2);
+	const footer = paginationFooter(pagination);
+	return footer ? `${body}\n\n${footer}` : body;
+}
+
+function paginationFooter(pagination: Pagination): string {
+	if (!pagination.hasMore) return "";
+	const next = pagination.offset + pagination.returned;
+	return `Showing ${pagination.returned} result(s); more available — pass --offset ${next} or a higher --limit for the rest.`;
+}
+
+function isPaginatedResult(
+	result: unknown,
+): result is PaginatedResult<unknown> {
+	return (
+		typeof result === "object" &&
+		result !== null &&
+		"data" in result &&
+		"pagination" in result &&
+		Array.isArray((result as { data: unknown }).data)
+	);
 }
 
 function isResultWithData(result: unknown): result is { data: unknown } {

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -54,10 +54,19 @@ export async function run(opts: RunOptions): Promise<void> {
  * (a file redirect masks it because the write lands fast). Awaiting the
  * `write` callback guarantees the bytes reached the OS before the command
  * completes and the process is allowed to exit.
+ *
+ * Broken-pipe errors (consumer exited early, e.g. `… | head`) resolve
+ * cleanly — `console.log` swallowed them silently, and surfacing them as
+ * `Error: write EPIPE` is worse UX than the truncation we set out to fix.
  */
 async function writeStdout(text: string): Promise<void> {
 	await new Promise<void>((resolve, reject) => {
-		process.stdout.write(`${text}\n`, (err) => (err ? reject(err) : resolve()));
+		process.stdout.write(`${text}\n`, (err) => {
+			if (!err) return resolve();
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === "EPIPE" || code === "ECONNRESET") return resolve();
+			reject(err);
+		});
 	});
 }
 

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -45,6 +45,22 @@ export async function run(opts: RunOptions): Promise<void> {
 	}
 }
 
+/**
+ * Write final command output to stdout, waiting for the write to drain
+ * before resolving.
+ *
+ * `console.log` of a large payload races the process exit: the binary can
+ * exit before an async write to a *pipe* finishes, truncating the output
+ * (a file redirect masks it because the write lands fast). Awaiting the
+ * `write` callback guarantees the bytes reached the OS before the command
+ * completes and the process is allowed to exit.
+ */
+async function writeStdout(text: string): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		process.stdout.write(`${text}\n`, (err) => (err ? reject(err) : resolve()));
+	});
+}
+
 function formatZodIssues(message: string): string | null {
 	const trimmed = message.trim();
 	if (!trimmed.startsWith("[")) return null;
@@ -355,6 +371,6 @@ async function execute(
 			json: isJson,
 			quiet: isQuiet,
 		});
-		if (output) console.log(output);
+		if (output) await writeStdout(output);
 	}
 }

--- a/packages/cli/CLI_SPEC_TARGET.md
+++ b/packages/cli/CLI_SPEC_TARGET.md
@@ -500,22 +500,34 @@ Output:
 | `--assignee-me`, `-m` | Tasks assigned to current user. |
 | `--creator-me` | Tasks created by current user. |
 | `--search <query>`, `-s` | Substring search on title. |
-| `--limit <n>` | Default 50, max 200. |
+| `--limit <n>` | Total results to return; default 50. Auto-paginated under the hood (API caps each request at 500). |
 | `--offset <n>` | Default 0. |
+| `--all` | Fetch every result (ignores `--limit`). |
 
 All filters are sent to the API and respected. No silent-ignore.
 
 tRPC: `task.list` *(new — replaces `task.all` for the CLI; takes the filter
 input shape above)*.
 
-Output (array, raw):
+Output (`--json`): paginated envelope so consumers can detect when results
+were capped without a separate count query.
 
 ```ts
-Array<Task>
+{
+  data: Array<Task>;
+  pagination: {
+    returned: number;
+    limit: number | null;   // `null` when `--all` was set
+    offset: number;
+    hasMore: boolean;
+  };
+}
 ```
 
-Quiet: task IDs.
-Human: table with `SLUG, TITLE, STATUS, PRIORITY, ASSIGNEE`.
+Quiet: task IDs (one per line).
+Human: table with `SLUG, TITLE, PRIORITY, ASSIGNEE`, followed by a
+"Showing N result(s); more available — pass --offset … or a higher
+--limit for the rest." footer only when `hasMore` is true.
 
 ### `superset tasks get <idOrSlug>`
 

--- a/packages/cli/src/commands/tasks/list/command.ts
+++ b/packages/cli/src/commands/tasks/list/command.ts
@@ -1,5 +1,14 @@
-import { boolean, number, string, table } from "@superset/cli-framework";
+import {
+	boolean,
+	number,
+	paginated,
+	string,
+	table,
+} from "@superset/cli-framework";
 import { command } from "../../../lib/command";
+
+// `task.list` caps each request at 500 rows, so page through in 500s.
+const API_PAGE_SIZE = 500;
 
 export default command({
 	description: "List tasks in the organization",
@@ -12,8 +21,9 @@ export default command({
 		assigneeMe: boolean().alias("m").desc("Filter to my tasks"),
 		creatorMe: boolean().desc("Filter to tasks I created"),
 		search: string().alias("s").desc("Search by title"),
-		limit: number().default(50).desc("Max results"),
+		limit: number().default(50).desc("Max results to return (auto-paginated)"),
 		offset: number().default(0).desc("Skip results"),
+		all: boolean().desc("Fetch every result (ignores --limit)"),
 	},
 	display: (data) =>
 		table(
@@ -22,19 +32,43 @@ export default command({
 			["SLUG", "TITLE", "PRIORITY", "ASSIGNEE"],
 		),
 	run: async ({ ctx, options }) => {
-		const result = await ctx.api.task.list.query({
+		const filters = {
 			statusId: options.status ?? undefined,
 			priority: options.priority,
 			assigneeId: options.assignee ?? undefined,
 			assigneeMe: options.assigneeMe ?? undefined,
 			creatorMe: options.creatorMe ?? undefined,
 			search: options.search ?? undefined,
-			limit: options.limit,
-			offset: options.offset,
-		});
-		return result.map((row) => ({
+		};
+
+		// Fetch one row beyond what was asked for: if it comes back, more
+		// results exist — this avoids a separate count query.
+		const want = options.all ? Number.POSITIVE_INFINITY : options.limit;
+		const rows: Awaited<ReturnType<typeof ctx.api.task.list.query>> = [];
+		let offset = options.offset;
+		while (rows.length <= want) {
+			const pageSize = Math.min(API_PAGE_SIZE, want + 1 - rows.length);
+			const page = await ctx.api.task.list.query({
+				...filters,
+				limit: pageSize,
+				offset,
+			});
+			rows.push(...page);
+			if (page.length < pageSize) break;
+			offset += page.length;
+		}
+
+		const hasMore = rows.length > want;
+		const data = (hasMore ? rows.slice(0, want) : rows).map((row) => ({
 			...row.task,
 			assignee: row.assignee?.name ?? "—",
 		}));
+
+		return paginated(data, {
+			returned: data.length,
+			limit: options.all ? data.length : options.limit,
+			offset: options.offset,
+			hasMore,
+		});
 	},
 });

--- a/packages/cli/src/commands/tasks/list/command.ts
+++ b/packages/cli/src/commands/tasks/list/command.ts
@@ -21,8 +21,12 @@ export default command({
 		assigneeMe: boolean().alias("m").desc("Filter to my tasks"),
 		creatorMe: boolean().desc("Filter to tasks I created"),
 		search: string().alias("s").desc("Search by title"),
-		limit: number().default(50).desc("Max results to return (auto-paginated)"),
-		offset: number().default(0).desc("Skip results"),
+		limit: number()
+			.int()
+			.min(1)
+			.default(50)
+			.desc("Max results to return (auto-paginated)"),
+		offset: number().int().min(0).default(0).desc("Skip results"),
 		all: boolean().desc("Fetch every result (ignores --limit)"),
 	},
 	display: (data) =>
@@ -66,7 +70,9 @@ export default command({
 
 		return paginated(data, {
 			returned: data.length,
-			limit: options.all ? data.length : options.limit,
+			// `--all` ignores --limit, so `null` signals "no cap applied"
+			// rather than echoing back a misleading number.
+			limit: options.all ? null : options.limit,
 			offset: options.offset,
 			hasMore,
 		});


### PR DESCRIPTION
**Links**
- Issue: https://github.com/superset-sh/superset/issues/4827

## Summary
- **Fix:** `superset` CLI `--json` output was truncated (invalid JSON) when piped to another process. The binary exited before the async stdout write to the pipe finished.
- **Feature:** `tasks list` now auto-paginates and reports when results were capped, so humans and agents both know more exist.

## Why / Context
Investigating a flaky `superset tasks list --json | jq` (`Unfinished JSON term at EOF`) surfaced two problems:

1. **Truncation** — piping `--json` produced non-deterministic, truncated output (measured cut-offs at 64 KB / 96 KB / 704 KB across runs); the same command redirected to a file was always complete. Classic exit-before-stdout-drain race. This defeats the purpose of `--json` (scripting/automation). See #4827.
2. **No pagination signal** — `tasks list` returns a bare page (default 50) of an org that can hold 900+ tasks, with no indication more exist and no easy way to fetch them all.

## How It Works

**Truncation fix** (`cli-framework/src/runner.ts`)
Command output went out via fire-and-forget `console.log`. Replaced with `writeStdout`, which awaits the `process.stdout.write` callback — the command can't resolve (and the process can't exit) until the bytes reach the OS. It's in the shared output path, so every command's `--json` is covered.

**Pagination** (`cli-framework/src/output.ts`, `tasks/list/command.ts`)
- New framework `paginated(data, pagination)` wrapper + `Pagination` type. When a command returns one:
  - `--json` → `{ data, pagination }` so agents read `hasMore` programmatically
  - human/table → a `Showing N result(s); more available — pass --offset … or a higher --limit` footer, shown only when results were capped
- `tasks list` auto-paginates in 500-row chunks (the API's per-call cap). `--limit` now means *total results wanted*; new `--all` fetches everything. `hasMore` is derived by fetching one row past the limit — no separate count query.

## Manual QA Checklist

Verified against the live API with a binary built from this branch (`bun run build:darwin-arm64`):

### Truncation fix
- [x] `tasks list --limit 480 --json` piped through `cat` 5× — all 1,003,611 bytes, identical to the file-redirect baseline
- [x] `tasks list --limit 480 --json | jq '.data | length'` parses cleanly (`480`)

### Pagination
- [x] `--limit 5 --json` → `{"returned":5,"limit":5,"offset":0,"hasMore":true}`
- [x] `--all --json` → auto-paged all 957 tasks, `hasMore:false`
- [x] table mode, capped (`--limit 3`) → table + "more available" footer
- [x] table mode, not capped (8-task assignee) → table, no footer

## Testing
- `bun run typecheck` (cli + cli-framework) — pass
- `bun run lint` — pass (exit 0)
- Manual QA above (no automated test suite exists for these CLI commands)

## Design Decisions
- **`--json` shape change**: `tasks list --json` now returns `{ data, pagination }` instead of a bare array. A bare array can't carry `hasMore`; the object shape matches `aws`/`gcloud` conventions. Only `tasks list` is affected — `formatPaginated` triggers solely on a `paginated()` result.
- **`hasMore` via +1 fetch** instead of a count query — one cheap extra row, no API change, no second round-trip.

## Known Limitations
- **Breaking for `tasks list --json` consumers**: scripts using `jq '.[]'` must switch to `jq '.data[]'`. Acceptable — the CLI is pre-1.0 and this is the only command with the new shape.
- The framework pagination capability is generic but only `tasks list` is wired up; other list commands (`workspaces list`, `projects list`, …) can adopt `paginated()` in follow-ups.

## Follow-ups
- Wire `paginated()` into the other `*/list` commands.
- #4827 also notes secondary CLI papercuts (undocumented `--limit` 500 cap, duplicate status rows) — left for separate PRs.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4832">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes truncated `--json` output when piping by waiting for stdout to drain and handling broken pipes quietly. Adds auto‑pagination to `tasks list` with clear “more results” signaling, a `{ data, pagination }` JSON shape, and a new `--all` flag.

- **Migration**
  - Update scripts: `tasks list --json | jq '.data[]'` (was `.[]`); if reading `pagination.limit`, handle `null` with `--all`.
  - Use `--all` to fetch everything. `--limit` sets total results requested (auto‑paged; ints ≥1; `--offset` ≥0).

<sup>Written for commit 4a4bfa25eb7480982ae02ec13cd1c2155bc971d9. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4832?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task list command now pages results and adds a --all flag to fetch everything.

* **Improvements**
  * JSON output now returns a paginated envelope with data + pagination metadata (returned, limit, offset, hasMore).
  * Human output shows a “more available” footer when appropriate; quiet mode emits one task ID per line.
  * Default limit is 50 with automatic internal paging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->