### PR TITLE
fix(desktop): don't block onboarding on GitHub CLI auth

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/system.ts
+++ b/apps/desktop/src/lib/trpc/routers/system.ts
@@ -30,7 +30,11 @@ async function detectGhCli(): Promise<GhDetectResult> {
 
 	let authenticated = false;
 	try {
-		await execWithShellEnv("gh", ["auth", "status"], { timeout: 5000 });
+		await execWithShellEnv(
+			"gh",
+			["auth", "status", "--active", "--hostname", "github.com"],
+			{ timeout: 5000 },
+		);
 		authenticated = true;
 	} catch {
 		// `gh auth status` exits non-zero when not logged in.

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
@@ -35,7 +35,6 @@ const STEPS = [
 function OnboardingFlowLayout() {
 	const { data: session, isPending } = authClient.useSession();
 	const { data: platform } = electronTrpc.window.getPlatform.useQuery();
-	const { data: ghStatus } = electronTrpc.system.detectGhCli.useQuery();
 	const isMac = platform === undefined || platform === "darwin";
 	const chatClient = useMemo(() => createChatServiceIpcClient(), []);
 	const location = useLocation();
@@ -51,11 +50,6 @@ function OnboardingFlowLayout() {
 	const isFirstStep = currentStepIdx === 0;
 	const currentStep = isOnMainStep ? STEPS[currentStepIdx] : null;
 
-	// Step 1 requires GitHub CLI installed + authenticated before continuing.
-	// Shares the query cache with the dashboard page, so rechecks update both.
-	const ghReady =
-		ghStatus?.installed === true && ghStatus.authenticated === true;
-
 	const handleBack = () => {
 		if (currentStepIdx <= 0) return;
 		const target = STEPS[currentStepIdx - 1];
@@ -68,7 +62,6 @@ function OnboardingFlowLayout() {
 	const handleContinue = isFirstStep
 		? () => navigate({ to: "/onboarding/project" })
 		: null;
-	const continueDisabled = isFirstStep && !ghReady;
 
 	return (
 		<ChatServiceProvider client={chatClient} queryClient={electronQueryClient}>
@@ -100,7 +93,6 @@ function OnboardingFlowLayout() {
 						totalSteps={STEPS.length}
 						onBack={isFirstStep ? null : handleBack}
 						onContinue={handleContinue}
-						continueDisabled={continueDisabled}
 						continueLabel="Continue"
 					/>
 				)}


### PR DESCRIPTION
## Why

Onboarding hard-blocked the **Required** GitHub CLI step for users who are actually authenticated. The device-login modal even reports `Logged in as <user>` / `already logged in to this account`, yet Continue stayed disabled.

Two contributing factors:

1. **Detection false-negative.** `detectGhCli` ran a blanket `gh auth status`, which (per gh's docs) exits non-zero if *any* account on *any* host has an issue. Power users with a stale secondary/enterprise account have a working active github.com login but a broken other account, so the check failed.

2. **Hard gate.** The onboarding step disabled Continue until gh auth was detected, so any detection miss left users stuck with no way forward.

## Changes

1. **Fix detection** (`system.ts`): check `gh auth status --active --hostname github.com` so only a broken *active github.com* account counts as unauthenticated. `--active` exists only in gh >= 2.40 (the release that also introduced the multi-account "any host fails" behavior), so older gh falls back to `gh auth status --hostname github.com`, which every version accepts and which still validates the token.

2. **Stop gating on it** (`onboarding/layout.tsx`): the GitHub CLI step no longer disables Continue. Users can proceed and sign in later; the row still shows accurate Connected/Required status via the corrected detection.

(Replaces an earlier `disable-onboarding` PostHog kill-switch approach — no flag needed.)

## Testing

- `bun run lint` ✅
- `bun run typecheck` ✅ (28/28)
- gh auth behavior confirmed against gh 2.92.0: `--active --hostname github.com` and the `--hostname`-only fallback both exit 0 for a valid login; unknown flags exit 1 (why old gh needs the fallback).

Note: the detection path only runs in the packaged Electron app, so end-to-end verification means running the desktop app.