### PR TITLE
Only resize on double clicking separators

### DIFF
--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -77,10 +77,6 @@ function SplitView<TData>({
 					});
 				}
 			}}
-			onDoubleClick={(e) => {
-				e.stopPropagation();
-				groupRef.current?.setLayout([50, 50]);
-			}}
 		>
 			<ResizablePanel
 				className={PANE_MIN_SIZE_CLASS_NAME}
@@ -102,6 +98,10 @@ function SplitView<TData>({
 				onDragging={(isDragging) =>
 					onSplitResizeDragging?.(resizeSourceId, isDragging)
 				}
+				onDoubleClick={(e) => {
+					e.stopPropagation();
+					groupRef.current?.setLayout([50, 50]);
+				}}
 			/>
 			<ResizablePanel
 				className={PANE_MIN_SIZE_CLASS_NAME}


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4838">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the 50/50 pane reset to double-clicks on the separator handle so accidental resets from double-clicking content are avoided.

Moved the double-click handler to the `ResizablePanel` handle; double-clicks elsewhere in the split view are ignored.

<sup>Written for commit 06ec22c2ab8e8fdaed693da7032493087d8e4434. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4838?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed double-click behavior on the workspace tab resizable separator to properly reset the layout to an even split.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->