### PR TITLE
fix(desktop): show cloned repo in sidebar after onboarding

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
@@ -10,6 +10,7 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useFinalizeProjectSetup } from "renderer/react-query/projects";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
@@ -32,6 +33,7 @@ function OnboardingProjectPage() {
 	const folderImport = useFolderFirstImport({
 		onError: (message) => toast.error(message),
 	});
+	const finalizeSetup = useFinalizeProjectSetup();
 
 	// Adding a project finishes onboarding: mark onboarded, then hand off to the
 	// dashboard's new-workspace modal pre-selected to the project just added.
@@ -75,6 +77,7 @@ function OnboardingProjectPage() {
 				name: repoNameFromUrl(trimmed),
 				mode: { kind: "clone", parentDir: cloneTargetDir, url: trimmed },
 			});
+			finalizeSetup(activeHostUrl, created);
 			await finish(created.projectId);
 		} catch (err) {
 			toast.error(


### PR DESCRIPTION
## Description

In the new v2 onboarding flow, cloning a repo from a GitHub URL completed successfully but the project never appeared in the dashboard sidebar. Linking a local folder worked fine.

## Root cause

The sidebar (`useDashboardSidebarData`) renders projects via an **inner join** of two collections:

- `v2SidebarProjects` — localStorage-backed, the user's visible projects
- `v2Projects` — Electric-synced from the cloud

A project shows up only if it has a row in **both**.

The **folder-import** path writes the local `v2SidebarProjects` row through `finalizeSetup()` (inside `useFolderFirstImport`). The **clone** path in `onboarding/project/page.tsx` called `hostService.project.create.mutate({ mode: { kind: "clone" } })` and went straight to `finish()`, **never calling `finalizeSetup`**. So the cloned project got its synced `v2Projects` row but no local `v2SidebarProjects` row, and the inner join produced nothing.

## Fix

Call `finalizeSetup(activeHostUrl, created)` in the clone handler before `finish()`, mirroring the folder-import path. The clone `project.create` returns the same `ProjectSetupResult` (`projectId` / `repoPath` / `mainWorkspaceId`), so `finalizeSetup` inserts the sidebar project/workspace row and invalidates the host project list. The project then appears reactively as soon as Electric delivers the `v2Projects` row.

## Testing

- `@superset/desktop` typecheck: clean
- `bun run lint`: clean

Manual:
1. Start the new onboarding flow
2. Paste a GitHub URL and clone
3. Land on the dashboard → expect the cloned project in the sidebar (same as the local-folder path)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4846">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the onboarding clone flow so newly cloned repositories appear in the dashboard sidebar. Calls `finalizeSetup` (`useFinalizeProjectSetup`) after `project.create` to insert the local `v2SidebarProjects` row required for the sidebar’s inner join with `v2Projects`.

<sup>Written for commit c55929b1d1b939ae2e6469c402cf41a6bf509ae5. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4846?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved project setup finalization workflow during onboarding by delegating finalization responsibility to a dedicated hook.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->