### PR TITLE
fix(desktop): upgrade @pierre/diffs to fix line-number ordering (SUPER-804)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -77,7 +77,7 @@
 		"@mastra/core": "1.33.1",
 		"@paper-design/shaders-react": "0.0.76",
 		"@parcel/watcher": "2.5.6",
-		"@pierre/diffs": "1.1.3",
+		"@pierre/diffs": "1.1.22",
 		"@pierre/trees": "1.0.0-beta.3",
 		"@radix-ui/react-dialog": "1.1.15",
 		"@radix-ui/react-label": "2.1.8",

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.10.3",
+      "version": "1.11.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -153,7 +153,7 @@
         "@mastra/core": "1.33.1",
         "@paper-design/shaders-react": "0.0.76",
         "@parcel/watcher": "2.5.6",
-        "@pierre/diffs": "1.1.3",
+        "@pierre/diffs": "1.1.22",
         "@pierre/trees": "1.0.0-beta.3",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-label": "2.1.8",
@@ -769,7 +769,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.11",
+      "version": "0.8.13",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",
@@ -2111,9 +2111,9 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.1.3", "", { "dependencies": { "@pierre/theme": "0.0.22", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-sV6G1FL0L4UtequXi+50Uge4QVsouo5vgJx7pCawQ4+ctFglh03zIsB81W8PNheh3coIlVzLzFgB9kI7X4eyjw=="],
+    "@pierre/diffs": ["@pierre/diffs@1.1.22", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-1Iv7kdl6OABFCd1n2HQbGUiRHouXPaHoIjcb7Lwg8zeJKY5ph+cESFcGEyIiwW0NCbKGtYS2bTnXmI+Eze5dwg=="],
 
-    "@pierre/theme": ["@pierre/theme@0.0.22", "", {}, "sha512-ePUIdQRNGjrveELTU7fY89Xa7YGHHEy5Po5jQy/18lm32eRn96+tnYJEtFooGdffrx55KBUtOXfvVy/7LDFFhA=="],
+    "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
 
     "@pierre/trees": ["@pierre/trees@1.0.0-beta.3", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ=="],
 


### PR DESCRIPTION
## Summary

- Upgrades `@pierre/diffs` from `1.1.3` → `1.1.22` to fix out-of-order line numbers in the diff viewer
- The package was downgraded from `1.1.7` → `1.1.3` in commit `4a2bcb116` (pane-redesign PR #3088) to satisfy `bunfig.toml`'s `minimumReleaseAge = 259200` (3-day) policy
- The line-number ordering bug exists in v1.1.3 and was fixed across subsequent releases

## Root Cause

`bunfig.toml` enforces a 3-day minimum release age for all packages. On April 1, `@pierre/diffs@1.1.7` was within the age window for CI, so it was downgraded to v1.1.3 to unblock the pane-redesign PR. v1.1.3 contains gutter rendering bugs documented in:
- pierrecomputer/pierre#405 (renderGutterUtility bug, fixed in v1.1.1 via PR #407)
- pierrecomputer/pierre#729 (Chrome-specific gutter quirk, fixed in v1.2.1)

## Why v1.1.22 instead of v1.2.2?

v1.2.0+ is currently blocked by the same `minimumReleaseAge` policy (v1.2.0 is only 1.9 days old). v1.1.22 is the newest version that passes the 3-day check (10.6 days old). Once v1.2.1+ ages past the 3-day window, a follow-up PR can upgrade to capture the Chrome-specific gutter fix from PR #729.

## Impact

- Only `apps/desktop` depends on `@pierre/diffs` (no other apps/packages affected)
- No breaking-change APIs used — verified that `fileGap`, `enableHoverUtility`, `renderHoverUtility`, `renderCustomMetadata` are not imported anywhere in `apps/desktop/src/`
- Typecheck passes (28/28 tasks)
- Lint passes (4558 files, no issues)

## Linear

Fixes SUPER-804

## Test plan

- [x] `bun install` succeeds
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Open desktop app, navigate to a workspace with changes, verify line numbers display in sequential order
- [x] Verify no regressions in diff viewer (syntax highlighting, colors, annotations, scroll decorations)

<!-- stage-review-badge-begin -->

should see this:
<img width="1840" height="1122" alt="image" src="https://github.com/user-attachments/assets/3d2be308-4380-4aa6-9afe-7ee68b6f7095" />


---

<a href="https://stagereview.app/superset-sh/superset/pull/4848">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the desktop diff viewer to fix out-of-order line numbers, restoring correct gutter numbering and resolving SUPER-804.

- **Dependencies**
  - Bump `@pierre/diffs` from `1.1.3` to `1.1.22` (newest allowed by `bunfig.toml` minimumReleaseAge); only `apps/desktop` uses it; no breaking APIs used.

<sup>Written for commit db31201896fddf7b4271d640db001200cf1eb9e1. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4848?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->