### PR TITLE
feat(presets): add Factory Droid as a terminal agent preset

### DIFF
--- a/packages/shared/src/agent-identity.ts
+++ b/packages/shared/src/agent-identity.ts
@@ -6,14 +6,13 @@ import type { AgentDefinitionId, BuiltinAgentId } from "./agent-catalog";
  * Reported by the in-shell `notify-hook.sh` script, broadcast over the
  * host-service event bus, and stored in renderer state keyed by terminalId.
  *
- * `agentId` is the wrapper-level id. Most values match `BuiltinAgentId` and
- * `PRESET_ICONS`; `droid` is managed by desktop setup but is not currently a
- * built-in terminal preset. `definitionId` is the user-customized id when the
- * launch path stamps it; it's reserved for a future PR — wrappers can't
- * distinguish user definitions on their own.
+ * `agentId` is the wrapper-level id. All built-in terminal agents derive from
+ * `BuiltinAgentId`. `definitionId` is the user-customized id when the launch
+ * path stamps it; it's reserved for a future PR — wrappers can't distinguish
+ * user definitions on their own.
  */
 export interface AgentIdentity {
-	agentId: BuiltinAgentId | "droid";
+	agentId: BuiltinAgentId;
 	sessionId?: string;
 	definitionId?: AgentDefinitionId;
 }

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -131,6 +131,14 @@ export const BUILTIN_TERMINAL_AGENTS = [
 			"Cursor's coding agent for editing, running, and debugging code in parallel.",
 		command: "cursor-agent",
 	}),
+	createBuiltinTerminalAgent({
+		id: "droid",
+		label: "Droid",
+		description:
+			"Factory's agent-native coding CLI for autonomous software development.",
+		command: "droid --auto medium",
+		promptCommand: "droid --auto medium",
+	}),
 ] as const;
 
 export type BuiltinTerminalAgentType =


### PR DESCRIPTION
## Summary

- Add `droid` to `HOST_AGENT_PRESETS` and `BUILTIN_TERMINAL_AGENTS` with `--auto medium` autonomy level
- Simplify `agent-identity.ts` type union — `BuiltinAgentId | "droid"` → `BuiltinAgentId` (auto-derived from the array)
- Add branded SVG icons (light + dark variants) for the preset picker

Closes SUPER-869

## Test plan

- [x] TypeScript compiles without errors (`bunx tsc --noEmit` on packages/shared and packages/ui)
- [x] Biome lint passes on all changed files
- [ ] Verify droid appears in the desktop terminal preset picker UI
- [ ] Verify the icon renders correctly in light and dark themes

Should look like this:
<img width="1840" height="1121" alt="image" src="https://github.com/user-attachments/assets/8b42e0ce-beef-4d4b-b3e5-34cbb0254159" />

<img width="1840" height="1121" alt="image" src="https://github.com/user-attachments/assets/7aad2326-0874-4bda-a877-4d5a8d0b63de" />


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4853">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Factory Droid as a built-in terminal agent preset with `--auto medium` so it appears in the preset picker. Also simplifies identity typing so `agentId` derives from `BuiltinAgentId`. Implements SUPER-869.

- **New Features**
  - Added `droid` to `BUILTIN_TERMINAL_AGENTS` with `command`/`promptCommand` set to `droid --auto medium`.

- **Refactors**
  - Updated `AgentIdentity` to use `BuiltinAgentId` for `agentId` (removed the `"droid"` union case).

<sup>Written for commit 8642c100a7c6a25077fff58e50f71397089e91ab. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4853?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Factory Droid is now available as a first-class terminal agent preset option in the preset picker, enabling users to select and configure Droid directly from the available presets.

* **Documentation**
  * Added implementation and scope documentation for the Factory Droid feature integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->