### PR TITLE
fix(chat): drop broken /login slash command from builtins

### DIFF
--- a/packages/chat/src/server/desktop/slash-commands/builtins.ts
+++ b/packages/chat/src/server/desktop/slash-commands/builtins.ts
@@ -33,16 +33,6 @@ const BUILTIN_COMMANDS: SlashCommandRegistryEntry[] = [
 		template: "Switch active model in this chat. Requested model: $ARGUMENTS",
 	},
 	{
-		name: "login",
-		aliases: [],
-		description: "Open the model picker to authenticate a provider.",
-		argumentHint: "",
-		kind: "builtin",
-		source: "builtin",
-		action: { type: "set_model" },
-		template: "Open the model picker to authenticate a model provider.",
-	},
-	{
 		name: "mcp",
 		aliases: [],
 		description: "Show configured MCP servers and their current state.",

--- a/packages/chat/src/server/desktop/slash-commands/resolver.test.ts
+++ b/packages/chat/src/server/desktop/slash-commands/resolver.test.ts
@@ -118,11 +118,6 @@ Clean up this branch.`,
 			"Switch active model in this chat. Requested model: gpt-4.1",
 		);
 
-		const login = resolveSlashCommand(cwd, "/login");
-		expect(login.handled).toBe(true);
-		expect(login.action?.type).toBe("set_model");
-		expect(login.action?.argument).toBeUndefined();
-
 		const mcp = resolveSlashCommand(cwd, "/mcp");
 		expect(mcp.handled).toBe(true);
 		expect(mcp.action?.type).toBe("show_mcp_overview");


### PR DESCRIPTION
## Summary
- Remove the broken `/login` slash command from `BUILTIN_COMMANDS` — it silently aliased `/model` (same `set_model` action type), opening the model picker instead of authenticating
- Remove the test case asserting this broken behavior

## Why / Context
SUPER-754 defines the canonical builtin slash command set. The `/login` command was listed with description "authenticate a provider" but its action was `{ type: "set_model" }` — functionally identical to `/model` with no arguments. This is confusing and misleading.

Deep research across 10+ AI coding platforms (Claude Code CLI/Desktop, Codex CLI, Cursor, Windsurf, Aider, Cline, Continue.dev, Zed, GitHub Copilot, ChatGPT Desktop) confirms **no tool implements login as a chat-area slash command**. Authentication is always a pre-condition gate before the user reaches any chat surface.

Since our desktop app requires auth before the chat surface is accessible, `/login` inside chat solves a problem that doesn't exist.

Research findings: holocron `js79rk7qcenmata2nsfrkcrwz9877rrd`
Linear ticket: [SUPER-754](https://linear.app/superset-sh/issue/SUPER-754/define-the-set-of-chat-builtin-slash-commands-we-need-and-implement)

## Testing
<img width="1840" height="1121" alt="image" src="https://github.com/user-attachments/assets/e9dae53f-d986-49a8-9bd7-a89857b0980b" />

- `bun test packages/chat/src/server/desktop/slash-commands/resolver.test.ts` — 14 pass (was 15; removed `/login` test)
- No doc references to `/login` found in codebase (grep confirmed)

## Follow-ups
- SUPER-754 remaining work: audit each remaining builtin for correct action wiring and accurate descriptions
- Consider whether prompt-template builtins (`/review`, `/plan`, `/test`, `/refactor`) should stay builtin or move to `.agents/commands`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4856">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the broken `/login` chat command that silently aliased `/model`, aligning built-ins with SUPER-754. This avoids a misleading command that opened the model picker instead of authenticating.

- **Bug Fixes**
  - Removed `/login` from `BUILTIN_COMMANDS`.
  - Deleted the `/login` resolver test.

<sup>Written for commit 1e36572db069811bdfcf923ea5e2bf0a27332ac1. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4856?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * The `/login` slash command has been removed from available chat commands. Users can authenticate providers and select models through alternative methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->