### PR TITLE
fix(desktop): anchor desktop_opened to a stable device id

### DIFF
--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -5,7 +5,7 @@ import { env } from "../env.renderer";
 // Cast to standard PostHog type for compatibility with posthog-js/react
 export const posthog = posthogFull as unknown as PostHog;
 
-export function initPostHog() {
+export function initPostHog(deviceId?: string) {
 	if (!env.NEXT_PUBLIC_POSTHOG_KEY) {
 		console.log("[posthog] No key configured, skipping");
 		return;
@@ -20,10 +20,14 @@ export function initPostHog() {
 		person_profiles: "identified_only",
 		persistence: "localStorage",
 		debug: false,
+		...(deviceId && {
+			bootstrap: { distinctID: deviceId, isIdentifiedID: false },
+		}),
 		loaded: (ph) => {
 			ph.register({
 				app_name: "desktop",
 				platform: window.navigator.platform,
+				...(deviceId && { device_id: deviceId }),
 			});
 		},
 	});

--- a/apps/desktop/src/renderer/providers/PostHogProvider/PostHogProvider.tsx
+++ b/apps/desktop/src/renderer/providers/PostHogProvider/PostHogProvider.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import { useEffect, useState } from "react";
 import { track } from "renderer/lib/analytics";
 import { initPostHog, posthog } from "renderer/lib/posthog";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 
 interface PostHogProviderProps {
 	children: React.ReactNode;
@@ -12,14 +13,32 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
 	const [isInitialized, setIsInitialized] = useState(false);
 
 	useEffect(() => {
-		try {
-			initPostHog();
-			track("desktop_opened");
-		} catch (error) {
-			console.error("[posthog] Failed to initialize:", error);
-		} finally {
-			setIsInitialized(true);
-		}
+		let cancelled = false;
+
+		(async () => {
+			let deviceId: string | undefined;
+			try {
+				deviceId = (await electronTrpcClient.device.getMachineId.query())
+					.machineId;
+			} catch (error) {
+				console.error("[posthog] Failed to resolve device id:", error);
+			}
+
+			if (cancelled) return;
+
+			try {
+				initPostHog(deviceId);
+				track("desktop_opened");
+			} catch (error) {
+				console.error("[posthog] Failed to initialize:", error);
+			} finally {
+				setIsInitialized(true);
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
 	}, []);
 
 	if (!isInitialized) {


### PR DESCRIPTION
## Problem

`desktop_opened` is the top of our activation funnel, but its identity isn't set properly, which inflated the funnel's first step. Two causes, both in the renderer:

- It's captured in `PostHogProvider` **on mount — before `identify()` runs** (identify waits for the auth session in `PostHogUserIdentifier`).
- With `person_profiles: "identified_only"` + the `2025-11-30` defaults, the pre-sign-in distinct id is **session-scoped and rotates**, so the same machine is recounted as a new anonymous person every launch.

PostHog data confirmed it (last 30d): anonymous opens fire `desktop_opened` **exactly 1.0× per id** (14,001 events across 13,989 "people"), while identified users fire it ~12× on one stable person. That rotation is what blew `first_time_for_user` up to ~21k "new users."

## Fix

Anchor anonymous opens to the stable device id that already exists — `getHostId()` (the HMAC'd machine id already used as the auth `deviceId` / host-registration id):

- Seed it as the posthog-js **`bootstrap.distinctID`** (`isIdentifiedID: false`). Same machine → one anonymous identity across launches; on sign-in it merges into the user via `$anon_distinct_id`, so `opened → signed in → workspace_created` connects for both v1 (local) and v2 (cloud).
- Register `device_id` on every renderer event for segmentation.
- Fetch the id via the **imperative `electronTrpcClient`** (`device.getMachineId`), because `PostHogProvider` sits *above* `ElectronTRPCProvider` (no hooks) and the preload runs **sandboxed** (`getHostId()` needs `child_process`/`fs`, which aren't available there).

`desktop_opened` still fires on launch, so logged-out opens are still captured.

## Notes / caveats

- **One-time discontinuity** at rollout: pre-existing anonymous persons won't retroactively merge, so person counts step-change once, then are clean.
- Sign-out calls `posthog.reset()` (fresh random anon id); re-seeding the device id post-reset is a possible follow-up.
- Does **not** change firing frequency (still once per renderer mount) — a separate change if we want exactly one open per real launch.
- For already-identified users this is an enrichment (`device_id`) + rescues the reinstall/cleared-storage case; it does not change their existing identity.

## Test plan

- [ ] `bun run lint` — passes (verified locally).
- [ ] `bun run typecheck` — the two changed files are type-clean; CI's frozen install is unaffected.
- [ ] Manual (`bun dev`): fresh/logged-out launch → `desktop_opened` fires with `device_id` set and a stable distinct id across relaunches; after sign-in, the pre-sign-in open merges into the user.

Context: this came out of building the [Onboarding Activation dashboard](https://us.posthog.com/project/264803/dashboard/1618640).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4858">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the `desktop_opened` event to a stable per-device id to stop anonymous session churn inflating activation metrics. Anonymous opens now persist across launches and merge into the identified user on sign-in.

- **Bug Fixes**
  - Initialize `posthog-js` with `bootstrap.distinctID = deviceId` (`isIdentifiedID: false`).
  - Register `device_id` on all renderer events.
  - Resolve `deviceId` via `electronTrpcClient.device.getMachineId` before initializing PostHog, then fire `desktop_opened`.
  - No change to event frequency; expect a one-time anonymous identity discontinuity at rollout.

<sup>Written for commit 7c9d0f09af79b8979941199b5d667509a5c593b7. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4858?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics initialization with device identifier tracking and improved error handling during setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->