### PR TITLE
[codex] Harden v2 workspace terminal pane ownership

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx
@@ -33,7 +33,8 @@ import {
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
 import { useStore } from "zustand";
 import type { StoreApi } from "zustand/vanilla";
-import type { PaneViewerData, TerminalPaneData } from "../../types";
+import type { PaneViewerData } from "../../types";
+import { focusOrAddTerminalPane } from "../../utils/focusTerminalPane";
 import {
 	BACKGROUND_TERMINAL_ATTACHMENT_DEBOUNCE_MS,
 	getAttachedTerminalIdsKey,
@@ -201,17 +202,10 @@ export const BackgroundTerminalsButton = memo(
 
 		const handleAdopt = (terminalId: string) => {
 			clearTerminalBackgroundMarker(workspaceId, terminalId);
-			store.getState().addTab({
-				panes: [
-					{
-						kind: "terminal",
-						data: { terminalId } as TerminalPaneData,
-					},
-				],
-			});
+			const result = focusOrAddTerminalPane(store, terminalId);
 			void utils.terminal.listSessions.invalidate({ workspaceId });
 			void utils.terminal.countBackgroundSessions.invalidate({ workspaceId });
-			logStressEvent("background-terminals.adopt", { workspaceId });
+			logStressEvent("background-terminals.adopt", { result, workspaceId });
 			setIsOpen(false);
 		};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { getAutomationRunLinkConsumeKey } from "./useConsumeAutomationRunLink";
+import {
+	chatSessionBelongsToWorkspace,
+	getAutomationRunLinkConsumeKey,
+	terminalSessionBelongsToWorkspace,
+} from "./useConsumeAutomationRunLink";
 
 describe("getAutomationRunLinkConsumeKey", () => {
 	it("dedupes plain automation links by source id", () => {
@@ -34,5 +38,56 @@ describe("getAutomationRunLinkConsumeKey", () => {
 				focusRequestId: "request-2",
 			}),
 		).toBe("terminal:terminal-1:focus:request-2");
+	});
+});
+
+describe("automation run link ownership checks", () => {
+	it("accepts terminal sessions only from the current workspace", () => {
+		const sessions = [
+			{ terminalId: "terminal-a", workspaceId: "workspace-a" },
+			{ terminalId: "terminal-b", workspaceId: "workspace-b" },
+		];
+
+		expect(
+			terminalSessionBelongsToWorkspace({
+				sessions,
+				terminalId: "terminal-a",
+				workspaceId: "workspace-a",
+			}),
+		).toBe(true);
+		expect(
+			terminalSessionBelongsToWorkspace({
+				sessions,
+				terminalId: "terminal-a",
+				workspaceId: "workspace-b",
+			}),
+		).toBe(false);
+	});
+
+	it("accepts chat sessions only from the current v2 workspace", () => {
+		expect(
+			chatSessionBelongsToWorkspace({
+				chatSession: { v2WorkspaceId: "workspace-a" },
+				workspaceId: "workspace-a",
+			}),
+		).toBe(true);
+		expect(
+			chatSessionBelongsToWorkspace({
+				chatSession: { v2WorkspaceId: "workspace-a" },
+				workspaceId: "workspace-b",
+			}),
+		).toBe(false);
+		expect(
+			chatSessionBelongsToWorkspace({
+				chatSession: null,
+				workspaceId: "workspace-a",
+			}),
+		).toBe(false);
+		expect(
+			chatSessionBelongsToWorkspace({
+				chatSession: { v2WorkspaceId: null },
+				workspaceId: "workspace-a",
+			}),
+		).toBe(false);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.ts
@@ -1,14 +1,16 @@
 import type { WorkspaceStore } from "@superset/panes";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useRef } from "react";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { StoreApi } from "zustand/vanilla";
-import type {
-	ChatPaneData,
-	PaneViewerData,
-	TerminalPaneData,
-} from "../../types";
+import type { ChatPaneData, PaneViewerData } from "../../types";
+import { focusOrAddTerminalPane } from "../../utils/focusTerminalPane";
 
 interface UseConsumeAutomationRunLinkArgs {
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+	workspaceId: string;
 	terminalId: string | undefined;
 	chatSessionId: string | undefined;
 	focusRequestId: string | undefined;
@@ -22,14 +24,32 @@ interface UseConsumeAutomationRunLinkArgs {
  */
 export function useConsumeAutomationRunLink({
 	store,
+	workspaceId,
 	terminalId,
 	chatSessionId,
 	focusRequestId,
 }: UseConsumeAutomationRunLinkArgs): void {
 	const consumedRef = useRef<Set<string>>(new Set());
+	const collections = useCollections();
+	const terminalSessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
+		{ workspaceId },
+		{
+			enabled: terminalId != null,
+			refetchOnWindowFocus: false,
+		},
+	);
+	const { data: chatSessionRows, isReady: chatSessionsReady } = useLiveQuery(
+		(q) =>
+			q
+				.from({ chatSessions: collections.chatSessions })
+				.where(({ chatSessions }) => eq(chatSessions.id, chatSessionId ?? "")),
+		[collections, chatSessionId],
+	);
+	const chatSession = chatSessionRows?.[0] ?? null;
 
 	useEffect(() => {
 		if (!terminalId) return;
+		if (!terminalSessionsQuery.isSuccess) return;
 		const key = getAutomationRunLinkConsumeKey({
 			type: "terminal",
 			id: terminalId,
@@ -37,11 +57,33 @@ export function useConsumeAutomationRunLink({
 		});
 		if (consumedRef.current.has(key)) return;
 		consumedRef.current.add(key);
+		if (
+			!terminalSessionBelongsToWorkspace({
+				sessions: terminalSessionsQuery.data.sessions,
+				terminalId,
+				workspaceId,
+			})
+		) {
+			console.warn(
+				"[automation-run-link] Ignoring terminal link for another workspace",
+				{ terminalId, workspaceId },
+			);
+			return;
+		}
 		focusOrAddTerminalPane(store, terminalId);
-	}, [store, terminalId, focusRequestId]);
+	}, [
+		store,
+		terminalId,
+		focusRequestId,
+		terminalSessionsQuery.isSuccess,
+		terminalSessionsQuery.data,
+		workspaceId,
+	]);
 
 	useEffect(() => {
 		if (!chatSessionId) return;
+		if (!chatSessionsReady) return;
+		if (!chatSession) return;
 		const key = getAutomationRunLinkConsumeKey({
 			type: "chat",
 			id: chatSessionId,
@@ -49,8 +91,22 @@ export function useConsumeAutomationRunLink({
 		});
 		if (consumedRef.current.has(key)) return;
 		consumedRef.current.add(key);
+		if (!chatSessionBelongsToWorkspace({ chatSession, workspaceId })) {
+			console.warn(
+				"[automation-run-link] Ignoring chat link for another workspace",
+				{ chatSessionId, workspaceId },
+			);
+			return;
+		}
 		focusOrAddChatPane(store, chatSessionId);
-	}, [store, chatSessionId, focusRequestId]);
+	}, [
+		store,
+		chatSessionId,
+		focusRequestId,
+		chatSession,
+		chatSessionsReady,
+		workspaceId,
+	]);
 }
 
 export function getAutomationRunLinkConsumeKey({
@@ -67,30 +123,29 @@ export function getAutomationRunLinkConsumeKey({
 		: `${type}:${id}`;
 }
 
-function focusOrAddTerminalPane(
-	store: StoreApi<WorkspaceStore<PaneViewerData>>,
-	terminalId: string,
-): void {
-	const state = store.getState();
-	for (const tab of state.tabs) {
-		for (const pane of Object.values(tab.panes)) {
-			if (pane.kind !== "terminal") continue;
-			const data = pane.data as TerminalPaneData;
-			if (data.terminalId === terminalId) {
-				state.setActiveTab(tab.id);
-				state.setActivePane({ tabId: tab.id, paneId: pane.id });
-				return;
-			}
-		}
-	}
-	state.addTab({
-		panes: [
-			{
-				kind: "terminal",
-				data: { terminalId } as PaneViewerData,
-			},
-		],
-	});
+export function terminalSessionBelongsToWorkspace({
+	sessions,
+	terminalId,
+	workspaceId,
+}: {
+	sessions: Array<{ terminalId: string; workspaceId: string }>;
+	terminalId: string;
+	workspaceId: string;
+}): boolean {
+	return sessions.some(
+		(session) =>
+			session.terminalId === terminalId && session.workspaceId === workspaceId,
+	);
+}
+
+export function chatSessionBelongsToWorkspace({
+	chatSession,
+	workspaceId,
+}: {
+	chatSession: { v2WorkspaceId: string | null } | null;
+	workspaceId: string;
+}): boolean {
+	return chatSession?.v2WorkspaceId === workspaceId;
 }
 
 function focusOrAddChatPane(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -1,7 +1,7 @@
 import { createWorkspaceStore, type WorkspaceState } from "@superset/panes";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { PaneViewerData } from "../../types";
@@ -20,12 +20,24 @@ export function useV2WorkspacePaneLayout() {
 	const { workspace } = useWorkspace();
 	const workspaceId = workspace.id;
 	const collections = useCollections();
-	const [store] = useState(() =>
-		createWorkspaceStore<PaneViewerData>({
-			initialState: EMPTY_STATE,
+	// Keep the volatile pane store scoped to the route workspace. During fast
+	// workspace switches, live queries can briefly return stale rows; sharing
+	// the same store across that boundary lets panes from one worktree render
+	// and persist under another.
+	const workspaceRuntime = useMemo(
+		() => ({
+			workspaceId,
+			store: createWorkspaceStore<PaneViewerData>({
+				initialState: EMPTY_STATE,
+			}),
 		}),
+		[workspaceId],
 	);
-	const lastSyncedSnapshotRef = useRef(getSnapshot(EMPTY_STATE));
+	const { store } = workspaceRuntime;
+	const syncStateRef = useRef({
+		workspaceId,
+		lastSyncedSnapshot: getSnapshot(EMPTY_STATE),
+	});
 
 	const { data: localWorkspaceRows = [] } = useLiveQuery(
 		(query) =>
@@ -36,33 +48,44 @@ export function useV2WorkspacePaneLayout() {
 				),
 		[collections, workspaceId],
 	);
-	const localWorkspaceState = localWorkspaceRows[0] ?? null;
+	const localWorkspaceState =
+		localWorkspaceRows.find((row) => row.workspaceId === workspaceId) ?? null;
 	const persistedPaneLayout = useMemo(
 		() =>
-			(localWorkspaceState?.paneLayout as
-				| WorkspaceState<PaneViewerData>
-				| undefined) ?? EMPTY_STATE,
-		[localWorkspaceState],
+			localWorkspaceState?.workspaceId === workspaceId
+				? ((localWorkspaceState.paneLayout as
+						| WorkspaceState<PaneViewerData>
+						| undefined) ?? EMPTY_STATE)
+				: EMPTY_STATE,
+		[localWorkspaceState, workspaceId],
 	);
 
 	useEffect(() => {
+		syncStateRef.current = {
+			workspaceId,
+			lastSyncedSnapshot: getSnapshot(EMPTY_STATE),
+		};
+	}, [workspaceId]);
+
+	useEffect(() => {
 		const nextSnapshot = getSnapshot(persistedPaneLayout);
-		if (nextSnapshot === lastSyncedSnapshotRef.current) {
+		if (nextSnapshot === syncStateRef.current.lastSyncedSnapshot) {
 			return;
 		}
 
-		lastSyncedSnapshotRef.current = nextSnapshot;
+		syncStateRef.current.lastSyncedSnapshot = nextSnapshot;
 		store.getState().replaceState(persistedPaneLayout);
 	}, [persistedPaneLayout, store]);
 
 	useEffect(() => {
 		const unsubscribe = store.subscribe((nextStore) => {
-			const nextSnapshot = getSnapshot({
+			const nextWorkspaceState: WorkspaceState<PaneViewerData> = {
 				version: nextStore.version,
 				tabs: nextStore.tabs,
 				activeTabId: nextStore.activeTabId,
-			});
-			if (nextSnapshot === lastSyncedSnapshotRef.current) {
+			};
+			const nextSnapshot = getSnapshot(nextWorkspaceState);
+			if (nextSnapshot === syncStateRef.current.lastSyncedSnapshot) {
 				return;
 			}
 
@@ -71,13 +94,9 @@ export function useV2WorkspacePaneLayout() {
 			}
 
 			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.paneLayout = {
-					version: nextStore.version,
-					tabs: nextStore.tabs,
-					activeTabId: nextStore.activeTabId,
-				};
+				draft.paneLayout = nextWorkspaceState;
 			});
-			lastSyncedSnapshotRef.current = nextSnapshot;
+			syncStateRef.current.lastSyncedSnapshot = nextSnapshot;
 		});
 
 		return () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -138,6 +138,7 @@ function V2WorkspaceContent() {
 	});
 	useConsumeAutomationRunLink({
 		store,
+		workspaceId,
 		terminalId,
 		chatSessionId,
 		focusRequestId,
@@ -276,6 +277,7 @@ function V2WorkspaceContent() {
 						data-workspace-id={workspaceId}
 					>
 						<Workspace<PaneViewerData>
+							key={workspaceId}
 							registry={paneRegistry}
 							paneActions={defaultPaneActions}
 							contextMenuActions={defaultContextMenuActions}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/focusTerminalPane.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/focusTerminalPane.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createWorkspaceStore,
+	type LayoutNode,
+	type WorkspaceState,
+} from "@superset/panes";
+import type { PaneViewerData } from "../../types";
+import {
+	findTerminalPaneLocation,
+	focusOrAddTerminalPane,
+	focusTerminalPane,
+} from "./focusTerminalPane";
+
+function terminalPane(id: string, terminalId: string) {
+	return {
+		id,
+		kind: "terminal",
+		data: { terminalId } as PaneViewerData,
+	};
+}
+
+function paneLayout(paneId: string): LayoutNode {
+	return { type: "pane", paneId };
+}
+
+function workspaceState(): WorkspaceState<PaneViewerData> {
+	return {
+		version: 1,
+		activeTabId: "tab-1",
+		tabs: [
+			{
+				id: "tab-1",
+				createdAt: 1,
+				activePaneId: "pane-1",
+				layout: paneLayout("pane-1"),
+				panes: {
+					"pane-1": terminalPane("pane-1", "terminal-1"),
+				},
+			},
+			{
+				id: "tab-2",
+				createdAt: 2,
+				activePaneId: "pane-2",
+				layout: paneLayout("pane-2"),
+				panes: {
+					"pane-2": terminalPane("pane-2", "terminal-2"),
+				},
+			},
+		],
+	};
+}
+
+describe("findTerminalPaneLocation", () => {
+	it("finds the first pane displaying a terminal", () => {
+		expect(findTerminalPaneLocation(workspaceState(), "terminal-2")).toEqual({
+			tabId: "tab-2",
+			paneId: "pane-2",
+		});
+	});
+
+	it("returns null when no pane displays the terminal", () => {
+		expect(findTerminalPaneLocation(workspaceState(), "missing")).toBeNull();
+	});
+});
+
+describe("focusTerminalPane", () => {
+	it("navigates to an existing terminal pane", () => {
+		const store = createWorkspaceStore<PaneViewerData>({
+			initialState: workspaceState(),
+		});
+
+		expect(focusTerminalPane(store, "terminal-2")).toBe(true);
+		expect(store.getState().activeTabId).toBe("tab-2");
+		expect(store.getState().getTab("tab-2")?.activePaneId).toBe("pane-2");
+		expect(store.getState().tabs).toHaveLength(2);
+	});
+
+	it("does not mutate when no pane displays the terminal", () => {
+		const store = createWorkspaceStore<PaneViewerData>({
+			initialState: workspaceState(),
+		});
+
+		expect(focusTerminalPane(store, "missing")).toBe(false);
+		expect(store.getState().activeTabId).toBe("tab-1");
+		expect(store.getState().getTab("tab-1")?.activePaneId).toBe("pane-1");
+		expect(store.getState().tabs).toHaveLength(2);
+	});
+});
+
+describe("focusOrAddTerminalPane", () => {
+	it("focuses an existing terminal pane instead of adding a duplicate", () => {
+		const store = createWorkspaceStore<PaneViewerData>({
+			initialState: workspaceState(),
+		});
+
+		expect(focusOrAddTerminalPane(store, "terminal-2")).toBe("focused");
+		expect(store.getState().activeTabId).toBe("tab-2");
+		expect(store.getState().tabs).toHaveLength(2);
+	});
+
+	it("adds a terminal pane when no existing pane displays it", () => {
+		const store = createWorkspaceStore<PaneViewerData>({
+			initialState: workspaceState(),
+		});
+
+		expect(focusOrAddTerminalPane(store, "terminal-3")).toBe("added");
+
+		const state = store.getState();
+		expect(state.tabs).toHaveLength(3);
+		const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+		expect(activeTab).toBeDefined();
+		expect(
+			Object.values(activeTab?.panes ?? {}).some(
+				(pane) =>
+					pane.kind === "terminal" &&
+					(pane.data as { terminalId?: string }).terminalId === "terminal-3",
+			),
+		).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/focusTerminalPane.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/focusTerminalPane.ts
@@ -1,0 +1,56 @@
+import type { WorkspaceState, WorkspaceStore } from "@superset/panes";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData, TerminalPaneData } from "../../types";
+
+interface TerminalPaneLocation {
+	tabId: string;
+	paneId: string;
+}
+
+export type FocusOrAddTerminalPaneResult = "focused" | "added";
+
+export function findTerminalPaneLocation(
+	state: WorkspaceState<PaneViewerData>,
+	terminalId: string,
+): TerminalPaneLocation | null {
+	for (const tab of state.tabs) {
+		for (const pane of Object.values(tab.panes)) {
+			if (pane.kind !== "terminal") continue;
+			const data = pane.data as Partial<TerminalPaneData>;
+			if (data.terminalId !== terminalId) continue;
+			return { tabId: tab.id, paneId: pane.id };
+		}
+	}
+
+	return null;
+}
+
+export function focusTerminalPane(
+	store: StoreApi<WorkspaceStore<PaneViewerData>>,
+	terminalId: string,
+): boolean {
+	const state = store.getState();
+	const location = findTerminalPaneLocation(state, terminalId);
+	if (!location) return false;
+
+	state.setActiveTab(location.tabId);
+	state.setActivePane(location);
+	return true;
+}
+
+export function focusOrAddTerminalPane(
+	store: StoreApi<WorkspaceStore<PaneViewerData>>,
+	terminalId: string,
+): FocusOrAddTerminalPaneResult {
+	if (focusTerminalPane(store, terminalId)) return "focused";
+
+	store.getState().addTab({
+		panes: [
+			{
+				kind: "terminal",
+				data: { terminalId } as PaneViewerData,
+			},
+		],
+	});
+	return "added";
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/index.ts
@@ -1,0 +1,6 @@
+export type { FocusOrAddTerminalPaneResult } from "./focusTerminalPane";
+export {
+	findTerminalPaneLocation,
+	focusOrAddTerminalPane,
+	focusTerminalPane,
+} from "./focusTerminalPane";


### PR DESCRIPTION
## What changed

- Scope the v2 workspace pane store/runtime by `workspaceId` and force the pane surface to remount when changing workspaces.
- Validate automation-run terminal deep links against `terminal.listSessions({ workspaceId })` before adding or focusing a terminal pane.
- Validate chat deep links against the current `v2WorkspaceId` before adding or focusing a chat pane.
- Reuse a shared terminal focus helper so automation links and background-terminal adoption navigate to an existing terminal pane instead of adding a second pane for the same terminal.
- Add focused tests for the terminal/chat ownership guards and focus-or-add terminal behavior.

## Why

CDP reproduced a concrete cross-workspace terminal leak: a terminal created in Workspace A could be injected into Workspace B by navigating to Workspace B with `?terminalId=<workspace-a-terminal>`. Workspace B persisted a terminal pane for the A-owned terminal while host DB still showed `origin_workspace_id = Workspace A`.

The deep-link guard prevents cross-workspace adoption. The focus helper keeps repeated terminal links or stale background-terminal adoption from opening a second pane for a terminal that is already displayed in the current workspace.

## Validation

- Reproduced the failure with CDP before the guard: Workspace B persisted Workspace A's terminal id.
- Re-ran the CDP failure after the guard: Workspace B stayed empty (`terminalIds: []`, `xterms: 0`) and logged the ignored-cross-workspace warning.
- Re-ran a positive CDP case: same-workspace terminal link still opens.
- `bun test 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/focusTerminalPane.test.ts' 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.test.ts'`
- `bunx biome check 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts' 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.ts' 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumeAutomationRunLink/useConsumeAutomationRunLink.test.ts' 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/BackgroundTerminalsButton/BackgroundTerminalsButton.tsx' 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/focusTerminalPane.ts' 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/focusTerminalPane.test.ts' 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/focusTerminalPane/index.ts'`
- `bun run --cwd apps/desktop typecheck`
- `bun run lint:fix`
- `bun run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add utilities to find, focus, or add terminal panes; workspace UI now uses them and remounts workspace on workspaceId change.

* **Bug Fixes**
  * Enforce workspace ownership when consuming automation run links to ignore cross-workspace links.
  * Reduce redundant persistence by improving workspace layout sync checks.

* **Tests**
  * Add tests for terminal-pane focus/add behavior and automation link workspace-validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->