### PR TITLE
Revert "[codex] Add Codex hook trust bypass"

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -60,6 +60,7 @@ const {
 	AMP_PLUGIN_MARKER,
 	createAmpPlugin,
 	createAmpWrapper,
+	buildCodexWrapperExecLine,
 	buildCopilotWrapperExecLine,
 	buildWrapperScript,
 	createClaudeSettingsJson,
@@ -183,6 +184,54 @@ describe("agent-wrappers copilot", () => {
 		expect(updated).not.toContain("/tmp/old-hook.sh");
 	});
 
+	it("tails codex's process-scoped TUI session log to drive Start events", () => {
+		createCodexWrapper();
+
+		const wrapperPath = path.join(TEST_BIN_DIR, "codex");
+		const wrapper = readFileSync(wrapperPath, "utf-8");
+
+		expect(wrapper).toContain(
+			`"$REAL_BIN" "\${_superset_codex_args[@]}" --enable hooks -c 'notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]' "$@"`,
+		);
+		expect(wrapper).toContain('export SUPERSET_AGENT_ID="codex"');
+
+		expect(wrapper).toContain("# Superset agent-wrapper v3");
+
+		// Native hooks remain enabled, but the process-scoped TUI session log is
+		// the reliable Start signal for installed Codex TUI builds.
+		expect(wrapper).toContain("SUPERSET_CODEX_SESSION_WATCHER_PID");
+		expect(wrapper).toContain("CODEX_TUI_RECORD_SESSION");
+		expect(wrapper).toContain("CODEX_TUI_SESSION_LOG_PATH");
+		expect(wrapper).toContain("SUPERSET_TERMINAL_ID$SUPERSET_TAB_ID");
+		expect(wrapper).toContain("_superset_configure_project_trust");
+		expect(wrapper).toContain("SUPERSET_WORKSPACE_PATH/.codex");
+		expect(wrapper).toContain(
+			'projects={\\"$_superset_workspace_path_toml\\"={trust_level=\\"trusted\\"}}',
+		);
+		expect(wrapper).not.toContain("export CODEX_HOME=");
+		expect(wrapper).not.toContain("rollout-*.jsonl");
+		expect(wrapper).not.toContain("_superset_sessions_dir");
+		expect(wrapper).not.toContain("$" + "{CODEX_HOME:-$HOME/.codex}");
+		expect(wrapper).toContain("SUPERSET_HOOK_DEBUG_LOG");
+		expect(wrapper).toContain("tail -n +1 -F");
+		expect(wrapper).toContain("_superset_cleanup_session_watcher");
+		expect(wrapper).toContain("_superset_child_pids_for");
+		expect(wrapper).toContain('kill -TERM "$_superset_child_pid"');
+		expect(wrapper).toContain('kill -KILL "$_superset_watcher_pid"');
+		expect(wrapper).not.toContain("mkfifo");
+		expect(wrapper).not.toContain(
+			"SUPERSET_CODEX_SESSION_WATCHER_TAIL_PID_PATH",
+		);
+		expect(wrapper).toContain('"UserTurn"');
+		expect(wrapper).toContain("_approval_request");
+
+		const execLine = buildCodexWrapperExecLine(
+			path.join(TEST_HOOKS_DIR, "notify.sh"),
+		);
+		expect(execLine).not.toContain("{{NOTIFY_PATH}}");
+		expect(wrapper).toContain(execLine);
+	});
+
 	it("trusts the Superset workspace codex project config without replacing CODEX_HOME", () => {
 		const realBinDir = path.join(TEST_ROOT, "real-bin");
 		const realCodex = path.join(realBinDir, "codex");
@@ -226,7 +275,6 @@ exit 0
 				`projects={"${workspacePath}"={trust_level="trusted"}}`,
 				"--enable",
 				"hooks",
-				"--dangerously-bypass-hook-trust",
 				"-c",
 				`notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]`,
 			].join("\n")}\n`,
@@ -266,7 +314,6 @@ exit 0
 			`${[
 				"--enable",
 				"hooks",
-				"--dangerously-bypass-hook-trust",
 				"-c",
 				`notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]`,
 				"exec",

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -121,7 +121,7 @@ fi
 
 # `hooks` (formerly `codex_hooks`) is stable and default-enabled in codex
 # >=0.129; the legacy `notify=...` callback remains the completion source.
-"$REAL_BIN" "${_superset_codex_args[@]}" --enable hooks --dangerously-bypass-hook-trust -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
+"$REAL_BIN" "${_superset_codex_args[@]}" --enable hooks -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
 SUPERSET_CODEX_STATUS=$?
 _superset_debug "codex exited status=$SUPERSET_CODEX_STATUS"
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts
@@ -41,10 +41,7 @@ describe("createDefaultV2TerminalPresetRows", () => {
 					presetId: "codex",
 					label: "Codex",
 					command: "codex",
-					args: [
-						"--dangerously-bypass-approvals-and-sandbox",
-						"--dangerously-bypass-hook-trust",
-					],
+					args: ["--dangerously-bypass-approvals-and-sandbox"],
 					order: 1,
 				}),
 				createAgent({
@@ -87,7 +84,7 @@ describe("createDefaultV2TerminalPresetRows", () => {
 			"claude --dangerously-skip-permissions",
 		]);
 		expect(rows[1]?.commands).toEqual([
-			"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
+			"codex --dangerously-bypass-approvals-and-sandbox",
 		]);
 		expect(rows[2]?.commands).toEqual(["opencode"]);
 		expect(rows[3]?.commands).toEqual(["copilot --allow-tool\\=write"]);

--- a/apps/docs/content/docs/terminal-presets.mdx
+++ b/apps/docs/content/docs/terminal-presets.mdx
@@ -45,7 +45,7 @@ Pre-configured presets for popular AI agents. Defaults mirror the bundled Supers
 
 - **amp** - `amp` (built-in permission rules auto-deny destructive ops)
 - **claude** - `claude --dangerously-skip-permissions`
-- **codex** - `codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust` (most permissive)
+- **codex** - `codex --dangerously-bypass-approvals-and-sandbox` (most permissive)
 - **gemini** - `gemini --approval-mode=auto_edit`
 - **copilot** - `copilot --allow-tool=write`
 - **cursor-agent** - `cursor-agent` (prompts for every action)

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -76,7 +76,6 @@ describe("agentConfigsRouter", () => {
 			);
 			expect(codex?.args).toEqual([
 				"--dangerously-bypass-approvals-and-sandbox",
-				"--dangerously-bypass-hook-trust",
 			]);
 			expect(codex?.args).not.toContain("--sandbox");
 			expect(codex?.args).not.toContain("--ask-for-approval");

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -13,7 +13,7 @@ describe("buildAgentPromptCommand", () => {
 		});
 
 		expect(command).toContain(
-			"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
+			"codex --dangerously-bypass-approvals-and-sandbox -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
 		);
 		expect(command).toContain("- Only modified file: runtime.ts");
 	});

--- a/packages/shared/src/agent-launch-request.test.ts
+++ b/packages/shared/src/agent-launch-request.test.ts
@@ -45,8 +45,7 @@ describe("buildPromptAgentLaunchRequest", () => {
 			kind: "terminal",
 			agentType: "codex",
 			terminal: {
-				command:
-					"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
+				command: "codex --dangerously-bypass-approvals-and-sandbox",
 			},
 		});
 	});

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -79,10 +79,8 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		label: "Codex",
 		description:
 			"OpenAI's coding agent for reading, modifying, and running code across tasks.",
-		command:
-			"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
-		promptCommand:
-			"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust --",
+		command: "codex --dangerously-bypass-approvals-and-sandbox",
+		promptCommand: "codex --dangerously-bypass-approvals-and-sandbox --",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({

--- a/packages/shared/src/host-agent-presets.ts
+++ b/packages/shared/src/host-agent-presets.ts
@@ -59,10 +59,7 @@ export const HOST_AGENT_PRESETS = [
 		description:
 			"OpenAI's coding agent for reading, modifying, and running code across tasks.",
 		command: "codex",
-		args: [
-			"--dangerously-bypass-approvals-and-sandbox",
-			"--dangerously-bypass-hook-trust",
-		],
+		args: ["--dangerously-bypass-approvals-and-sandbox"],
 		promptTransport: "argv",
 		promptArgs: ["--"],
 		env: {},


### PR DESCRIPTION
Reverts superset-sh/superset#4881

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4886">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Codex hook trust bypass and removes the `--dangerously-bypass-hook-trust` flag across the app. The Codex wrapper now uses the process-scoped TUI session log to trigger reliable Start events while keeping native hooks enabled and workspace trust intact.

- **Bug Fixes**
  - Removed `--dangerously-bypass-hook-trust` from the wrapper script, default presets, built-in agent commands, launch/prompt commands, and docs.
  - Added a session watcher in the Codex wrapper to tail the TUI session log and detect Start events; includes proper PID cleanup.
  - Preserved workspace trust by writing trusted project config under `.codex` without overriding `CODEX_HOME`.
  - Added `buildCodexWrapperExecLine` and updated tests to reflect the new execution line and defaults.

<sup>Written for commit 499caf9fa4ebb5f3d70a64f59bbf83eb85485419. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4886?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `--dangerously-bypass-hook-trust` flag from Codex agent configurations across all presets, templates, and built-in definitions. The agent now launches with only the `--dangerously-bypass-approvals-and-sandbox` flag.

* **Tests**
  * Updated test suites to reflect the new Codex agent command-line arguments and wrapper behavior expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->