### PR TITLE
[codex] Broaden assignee-me task filter

### DIFF
--- a/packages/trpc/src/router/task/task.test.ts
+++ b/packages/trpc/src/router/task/task.test.ts
@@ -19,19 +19,60 @@ let dbSelectResults: unknown[][] = [];
 let selectResults: unknown[][] = [];
 let updateResults: unknown[][] = [];
 
+type SelectQuery = {
+	catch: Promise<unknown[]>["catch"];
+	finally: Promise<unknown[]>["finally"];
+	from: (...args: unknown[]) => SelectQuery;
+	innerJoin: (...args: unknown[]) => SelectQuery;
+	leftJoin: (...args: unknown[]) => SelectQuery;
+	limit: (...args: unknown[]) => SelectQuery;
+	offset: (...args: unknown[]) => SelectQuery;
+	orderBy: (...args: unknown[]) => SelectQuery;
+	then: Promise<unknown[]>["then"];
+	where: (...args: unknown[]) => SelectQuery;
+};
+
 function createDb() {
-	const selectLimitMock = mock(async () => dbSelectResults.shift() ?? []);
-	const selectOrderByMock = mock(async () => dbSelectResults.shift() ?? []);
-	const selectWhereMock = mock(() => ({
-		limit: selectLimitMock,
-		orderBy: selectOrderByMock,
-	}));
-	const selectFromMock = mock(() => ({
-		where: selectWhereMock,
-	}));
-	const selectMock = mock(() => ({
-		from: selectFromMock,
-	}));
+	let currentQuery: SelectQuery;
+	const selectLimitMock = mock((..._args: unknown[]) => currentQuery);
+	const selectOffsetMock = mock((..._args: unknown[]) => currentQuery);
+	const selectOrderByMock = mock((..._args: unknown[]) => currentQuery);
+	const selectWhereMock = mock((..._args: unknown[]) => currentQuery);
+	const selectInnerJoinMock = mock((..._args: unknown[]) => currentQuery);
+	const selectLeftJoinMock = mock((..._args: unknown[]) => currentQuery);
+	const selectFromMock = mock((..._args: unknown[]) => currentQuery);
+	const createSelectQuery = (): SelectQuery => {
+		let rowsPromise: Promise<unknown[]> | null = null;
+		const resolveRows = () => {
+			rowsPromise ??= Promise.resolve(dbSelectResults.shift() ?? []);
+			return rowsPromise;
+		};
+
+		return {
+			catch: ((onRejected) => resolveRows().catch(onRejected)) as Promise<
+				unknown[]
+			>["catch"],
+			finally: ((onFinally) => resolveRows().finally(onFinally)) as Promise<
+				unknown[]
+			>["finally"],
+			from: selectFromMock,
+			innerJoin: selectInnerJoinMock,
+			leftJoin: selectLeftJoinMock,
+			limit: selectLimitMock,
+			offset: selectOffsetMock,
+			orderBy: selectOrderByMock,
+			// biome-ignore lint/suspicious/noThenProperty: Mock Drizzle queries are awaited directly in the router.
+			then: ((onFulfilled, onRejected) =>
+				resolveRows().then(onFulfilled, onRejected)) as Promise<
+				unknown[]
+			>["then"],
+			where: selectWhereMock,
+		};
+	};
+	const selectMock = mock(() => {
+		currentQuery = createSelectQuery();
+		return currentQuery;
+	});
 
 	return {
 		db: {
@@ -39,6 +80,7 @@ function createDb() {
 		},
 		mocks: {
 			selectMock,
+			selectWhereMock,
 		},
 	};
 }
@@ -109,6 +151,11 @@ mock.module("@superset/db/client", () => ({
 }));
 
 mock.module("@superset/db/schema", () => ({
+	accounts: {
+		accountId: "accounts.accountId",
+		providerId: "accounts.providerId",
+		userId: "accounts.userId",
+	},
 	members: {
 		organizationId: "members.organizationId",
 		userId: "members.userId",
@@ -139,6 +186,7 @@ mock.module("@superset/db/schema", () => ({
 		organizationId: "task_statuses.organizationId",
 	},
 	tasks: {
+		assigneeExternalId: "tasks.assigneeExternalId",
 		assigneeId: "tasks.assigneeId",
 		createdAt: "tasks.createdAt",
 		creatorId: "tasks.creatorId",
@@ -147,7 +195,10 @@ mock.module("@superset/db/schema", () => ({
 		externalProvider: "tasks.externalProvider",
 		id: "tasks.id",
 		organizationId: "tasks.organizationId",
+		priority: "tasks.priority",
 		slug: "tasks.slug",
+		statusId: "tasks.statusId",
+		title: "tasks.title",
 	},
 	users: {
 		id: "users.id",
@@ -174,7 +225,13 @@ mock.module("drizzle-orm", () => ({
 	desc: (value: unknown) => ({ type: "desc", value }),
 	eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
 	ilike: (left: unknown, right: unknown) => ({ type: "ilike", left, right }),
+	inArray: (left: unknown, values: unknown[]) => ({
+		type: "inArray",
+		left,
+		values,
+	}),
 	isNull: (value: unknown) => ({ type: "isNull", value }),
+	or: (...conditions: unknown[]) => ({ type: "or", conditions }),
 	sql: Object.assign(
 		(strings: TemplateStringsArray, ...values: unknown[]) => ({
 			type: "sql",
@@ -213,6 +270,8 @@ const ASSIGNEE_ID = "22222222-2222-4222-8222-222222222222";
 const ORGANIZATION_ID = "33333333-3333-4333-8333-333333333333";
 const STATUS_ID = "44444444-4444-4444-8444-444444444444";
 const TASK_ID = "55555555-5555-4555-8555-555555555555";
+const LINEAR_ACCOUNT_ID = "99a67c67-11f1-4e3d-961a-8cc4987a1964";
+const OTHER_LINEAR_ACCOUNT_ID = "88888888-8888-4888-8888-888888888888";
 
 function createContext() {
 	return {
@@ -228,6 +287,51 @@ function createContext() {
 		auth: {} as never,
 		headers: new Headers(),
 	};
+}
+
+function conditionMatchesTaskAssignee(
+	condition: unknown,
+	task: { assigneeExternalId: string | null; assigneeId: string | null },
+): boolean {
+	if (!condition || typeof condition !== "object") {
+		return true;
+	}
+
+	const candidate = condition as {
+		conditions?: unknown[];
+		left?: unknown;
+		right?: unknown;
+		type?: string;
+		values?: unknown[];
+	};
+
+	if (candidate.type === "and") {
+		return (candidate.conditions ?? []).every((child) =>
+			conditionMatchesTaskAssignee(child, task),
+		);
+	}
+
+	if (candidate.type === "or") {
+		return (candidate.conditions ?? []).some((child) =>
+			conditionMatchesTaskAssignee(child, task),
+		);
+	}
+
+	if (candidate.type === "eq" && candidate.left === "tasks.assigneeId") {
+		return task.assigneeId === candidate.right;
+	}
+
+	if (
+		candidate.type === "inArray" &&
+		candidate.left === "tasks.assigneeExternalId"
+	) {
+		return (
+			task.assigneeExternalId !== null &&
+			(candidate.values ?? []).includes(task.assigneeExternalId)
+		);
+	}
+
+	return true;
 }
 
 describe("task router authorization", () => {
@@ -337,6 +441,98 @@ describe("task router authorization", () => {
 			slug: "demo-task",
 			title: "Scoped task",
 		});
+	});
+
+	it("returns Linear-synced tasks assigned to my linked external account", async () => {
+		const linearTaskRow = {
+			assignee: null,
+			creator: {
+				id: ACTOR_USER_ID,
+				image: null,
+				name: "Actor",
+			},
+			statusName: "In Progress",
+			task: {
+				assigneeExternalId: LINEAR_ACCOUNT_ID,
+				assigneeId: null,
+				id: TASK_ID,
+				organizationId: ORGANIZATION_ID,
+				slug: "SUPER-820",
+				title: "Linear assigned task",
+			},
+		};
+		dbSelectResults.push([{ accountId: LINEAR_ACCOUNT_ID }]);
+		dbSelectResults.push([linearTaskRow]);
+		const caller = createCaller(createContext());
+
+		const result = await caller.task.list({
+			assigneeMe: true,
+			statusId: STATUS_ID,
+		});
+
+		expect(result).toEqual([linearTaskRow]);
+		const accountWhere = dbState.mocks.selectWhereMock.mock.calls.at(-2)?.[0];
+		expect(accountWhere).toEqual(
+			expect.objectContaining({
+				conditions: expect.arrayContaining([
+					{
+						left: "accounts.providerId",
+						type: "inArray",
+						values: ["linear"],
+					},
+				]),
+				type: "and",
+			}),
+		);
+		const taskWhere = dbState.mocks.selectWhereMock.mock.calls.at(-1)?.[0];
+		expect(taskWhere).toEqual(
+			expect.objectContaining({
+				conditions: expect.arrayContaining([
+					{
+						conditions: [
+							{
+								left: "tasks.assigneeId",
+								right: ACTOR_USER_ID,
+								type: "eq",
+							},
+							{
+								left: "tasks.assigneeExternalId",
+								type: "inArray",
+								values: [LINEAR_ACCOUNT_ID],
+							},
+						],
+						type: "or",
+					},
+				]),
+				type: "and",
+			}),
+		);
+		expect(
+			conditionMatchesTaskAssignee(taskWhere, {
+				assigneeExternalId: LINEAR_ACCOUNT_ID,
+				assigneeId: null,
+			}),
+		).toBe(true);
+	});
+
+	it("excludes Linear-synced tasks assigned to a different external account", async () => {
+		dbSelectResults.push([{ accountId: LINEAR_ACCOUNT_ID }]);
+		dbSelectResults.push([]);
+		const caller = createCaller(createContext());
+
+		const result = await caller.task.list({
+			assigneeMe: true,
+			statusId: STATUS_ID,
+		});
+
+		expect(result).toEqual([]);
+		const taskWhere = dbState.mocks.selectWhereMock.mock.calls.at(-1)?.[0];
+		expect(
+			conditionMatchesTaskAssignee(taskWhere, {
+				assigneeExternalId: OTHER_LINEAR_ACCOUNT_ID,
+				assigneeId: null,
+			}),
+		).toBe(false);
 	});
 
 	it("rejects cross-tenant task updates before modifying the row", async () => {

--- a/packages/trpc/src/router/task/task.ts
+++ b/packages/trpc/src/router/task/task.ts
@@ -1,5 +1,11 @@
 import { db, dbWs } from "@superset/db/client";
-import { members, taskStatuses, tasks, users } from "@superset/db/schema";
+import {
+	accounts,
+	members,
+	taskStatuses,
+	tasks,
+	users,
+} from "@superset/db/schema";
 import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import { getCurrentTxid } from "@superset/db/utils";
 import {
@@ -7,7 +13,8 @@ import {
 	generateUniqueTaskSlug,
 } from "@superset/shared/task-slug";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, desc, eq, ilike, isNull } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { and, desc, eq, ilike, inArray, isNull, or } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 import { syncTask } from "../../lib/integrations/sync";
@@ -27,6 +34,7 @@ import { taskStatusesRouter } from "./statuses";
 
 const TASK_SLUG_CONSTRAINT = "tasks_org_slug_unique";
 const TASK_SLUG_RETRY_LIMIT = 5;
+const TASK_SYNC_EXTERNAL_ACCOUNT_PROVIDER_IDS = ["linear"] as const;
 
 function escapeLikePattern(value: string): string {
 	return value.replace(/[\\%_]/g, (match) => `\\${match}`);
@@ -41,6 +49,38 @@ function isConstraintError(error: unknown, constraint: string): boolean {
 
 	const maybeError = error as { code?: string; constraint?: string };
 	return maybeError.code === "23505" && maybeError.constraint === constraint;
+}
+
+async function getTaskSyncExternalAccountIds(userId: string) {
+	const linkedAccounts = await db
+		.select({ accountId: accounts.accountId })
+		.from(accounts)
+		.where(
+			and(
+				eq(accounts.userId, userId),
+				inArray(accounts.providerId, [
+					...TASK_SYNC_EXTERNAL_ACCOUNT_PROVIDER_IDS,
+				]),
+			),
+		);
+
+	return linkedAccounts.map((account) => account.accountId);
+}
+
+function getAssigneeMeFilter(
+	userId: string,
+	externalAccountIds: string[],
+): SQL<unknown> {
+	if (externalAccountIds.length === 0) {
+		return eq(tasks.assigneeId, userId);
+	}
+
+	return (
+		or(
+			eq(tasks.assigneeId, userId),
+			inArray(tasks.assigneeExternalId, externalAccountIds),
+		) ?? eq(tasks.assigneeId, userId)
+	);
 }
 
 async function getTaskAccess(
@@ -304,19 +344,24 @@ export const taskRouter = {
 		.input(taskListInputSchema)
 		.query(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
+			const taskSyncExternalAccountIds = input?.assigneeMe
+				? await getTaskSyncExternalAccountIds(ctx.session.user.id)
+				: [];
 
 			const assignee = alias(users, "assignee");
 			const creator = alias(users, "creator");
 			const status = alias(taskStatuses, "status");
 
-			const filters = [
+			const filters: SQL<unknown>[] = [
 				eq(tasks.organizationId, organizationId),
 				isNull(tasks.deletedAt),
 			];
 			if (input?.priority) filters.push(eq(tasks.priority, input.priority));
 			if (input?.statusId) filters.push(eq(tasks.statusId, input.statusId));
 			if (input?.assigneeMe) {
-				filters.push(eq(tasks.assigneeId, ctx.session.user.id));
+				filters.push(
+					getAssigneeMeFilter(ctx.session.user.id, taskSyncExternalAccountIds),
+				);
 			} else if (input?.assigneeId) {
 				filters.push(eq(tasks.assigneeId, input.assigneeId));
 			}


### PR DESCRIPTION
## Summary

Fixes #4888.

`task.list` now broadens `assigneeMe` from only `tasks.assigneeId = caller` to also include Linear-synced external assignees linked to the caller through `auth.accounts`.

- Adds a small task-sync provider allowlist containing `linear`.
- Keeps `assigneeId` / `--assignee <id>` strict to Superset user UUIDs.
- Leaves `creatorMe` unchanged because `tasks.creatorExternalId` does not exist.
- Adds tRPC coverage for a Linear-synced task matching the caller external account and for a different external account being excluded.

## Validation

- `bun test packages/trpc/src/router/task/task.test.ts`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run --cwd packages/cli build:darwin-arm64`
- Started local API for this worktree and ran `SUPERSET_API_URL=http://localhost:5881 ./dist/superset-darwin-arm64 tasks statuses list --json`

Live CLI caveat: running `SUPERSET_API_URL=http://localhost:5881 ./dist/superset-darwin-arm64 tasks list --assignee-me --status bc172d27-01a9-4256-b017-186f06072a6b --json` returned `[]` because this database currently has only a Google `accounts` row for the authenticated user and no `provider_id = "linear"` row / Linear UUID account mapping. A read-only direct predicate check with the issue Linear UUID returns the expected Linear external-assignee rows, including `SUPER-820`, `SUPER-822`, `SUPER-832`, and `SUPER-835`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadened the `assigneeMe` filter in `task.list` to include tasks synced from Linear that are assigned to the caller’s linked external account, not just direct Superset assignments. This makes `assigneeMe` return both internal and Linear-assigned tasks.

- **Bug Fixes**
  - When `assigneeMe` is set, match `tasks.assigneeId = me` OR `tasks.assigneeExternalId IN [my linked Linear account IDs]`.
  - Added a small task-sync provider allowlist for external accounts (`linear`); `assigneeId`/`--assignee <id>` remains strict to Superset user UUIDs; `creatorMe` unchanged.
  - Added tRPC tests to include a matching Linear-synced task and exclude tasks assigned to other external accounts.

<sup>Written for commit 24b35cb2a5006d58cb03101e79bc0276a6ead135. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4891?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

