### PR TITLE
fix(workspace-fs): add symlink validation to movePath and copyPath

### DIFF
--- a/packages/workspace-fs/src/fs.ts
+++ b/packages/workspace-fs/src/fs.ts
@@ -713,6 +713,8 @@ export async function movePath({
 		rootPath,
 		absolutePath: sourceAbsolutePath,
 	});
+	await assertRealpathWithinRoot(rootPath, sourcePath);
+
 	const destinationPath = ensureWithinRoot({
 		rootPath,
 		absolutePath: destinationAbsolutePath,
@@ -746,6 +748,8 @@ export async function copyPath({
 		rootPath,
 		absolutePath: sourceAbsolutePath,
 	});
+	await assertRealpathWithinRoot(rootPath, sourcePath);
+
 	const destinationPath = ensureWithinRoot({
 		rootPath,
 		absolutePath: destinationAbsolutePath,


### PR DESCRIPTION
## Summary
- Add `assertRealpathWithinRoot` check for source paths in both `movePath` and `copyPath`
- This prevents symlink escape where a symlink inside the workspace points to a target outside the workspace root

## The bug
Both `movePath` and `copyPath` in `packages/workspace-fs/src/fs.ts` only call `ensureWithinRoot`, which validates the lexical path but does NOT resolve symlinks. In contrast, `writeFile` calls `assertRealpathWithinRoot` after `ensureWithinRoot` to ensure the real path (after resolving symlinks) stays within the workspace root.

This means a user could create a symlink inside the workspace pointing to a sensitive file outside the workspace (e.g. `/etc/passwd`), and then:
- `copyPath` would copy the external file contents into the workspace via `fs.cp`
- `movePath` would move the symlink entry, which while not directly leaking external file contents, still operates on a path whose target escapes the workspace boundary

## Test plan
- [ ] Create a symlink inside a workspace that points outside the workspace root
- [ ] Call `copyPath` with the symlink as source — should throw `SYMLINK_ESCAPE`
- [ ] Call `movePath` with the symlink as source — should throw `SYMLINK_ESCAPE`
- [ ] Verify normal copy/move operations (non-symlink paths) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4904">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add realpath checks to movePath and copyPath in `workspace-fs` to block symlink escapes outside the workspace root. If the source resolves outside the root, these functions now throw SYMLINK_ESCAPE, aligning with writeFile and preventing copies/moves of external files.

<sup>Written for commit 88b8fa39dcd1b13e82cf7825e8fb971a840fdd94. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4904?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path validation for move and copy operations to ensure source paths remain within the workspace boundary, preventing potential unauthorized access to files outside the designated workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->