### PR TITLE
fix(trpc): verify setOnline actually updates a host row

### DIFF
--- a/packages/trpc/src/router/host/host.ts
+++ b/packages/trpc/src/router/host/host.ts
@@ -241,7 +241,7 @@ export const hostRouter = {
 				});
 			}
 
-			await db
+			const [updated] = await db
 				.update(v2Hosts)
 				.set({ isOnline: input.isOnline })
 				.where(
@@ -249,7 +249,16 @@ export const hostRouter = {
 						eq(v2Hosts.organizationId, parsed.organizationId),
 						eq(v2Hosts.machineId, parsed.machineId),
 					),
-				);
+				)
+				.returning();
+
+			if (!updated) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Host not found",
+				});
+			}
+
 			return { success: true };
 		}),
 } satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary
- Add `.returning()` to the `setOnline` UPDATE query and check the result
- Throw `NOT_FOUND` when no row is updated, instead of silently returning `{ success: true }`

## The bug
In `packages/trpc/src/router/host/host.ts`, the `setOnline` mutation:

1. Validates the host routing key
2. Checks organization membership
3. Queries `v2UsersHosts` to verify user access
4. Runs `UPDATE v2Hosts SET isOnline = ... WHERE ...`
5. Returns `{ success: true }` unconditionally

The problem is step 5: the UPDATE may affect **zero rows** if the host was deleted between the access check (step 3) and the update (step 4), or if the routing key parses correctly but doesn't match any host row. The client receives `{ success: true }` despite nothing being updated.

The `ensure` and `ensureClient` mutations in the same file already use `.returning()` with null checks — this PR brings `setOnline` in line with that pattern.

## Test plan
- [ ] Call `setOnline` with a valid hostId — should succeed (existing behavior)
- [ ] Call `setOnline` with a hostId that matches the routing key format but doesn't exist — should return `NOT_FOUND` instead of `{ success: true }`
- [ ] Verify no regression in host online/offline toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throw NOT_FOUND when `setOnline` doesn’t update a host, using `.returning()` to confirm an updated row. Prevents false-success responses if the host was deleted or the routing key matches no row.

- **Bug Fixes**
  - Add `.returning()` to the `setOnline` UPDATE and check the result.
  - Throw `TRPCError` with code `NOT_FOUND` when zero rows are updated.
  - Aligns with `ensure` and `ensureClient` patterns to avoid race-condition false positives.

<sup>Written for commit ef12f5e732c878bd9909b6195175ff0c4fb34ef6. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4905?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host status validation to ensure the host exists before updating its online status. The API now properly returns an error when attempting to update a non-existent host instead of reporting false success.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->