### PR TITLE
fix(task): include assigneeExternalId in assigneeMe filter for Linear…

### DIFF
--- a/packages/trpc/src/router/task/task.test.ts
+++ b/packages/trpc/src/router/task/task.test.ts
@@ -20,15 +20,40 @@ let selectResults: unknown[][] = [];
 let updateResults: unknown[][] = [];
 
 function createDb() {
+	const selectOffsetMock = mock(async () => dbSelectResults.shift() ?? []);
+	const selectLimitWithOffsetMock = mock(() => ({ offset: selectOffsetMock }));
+
 	const selectLimitMock = mock(async () => dbSelectResults.shift() ?? []);
-	const selectOrderByMock = mock(async () => dbSelectResults.shift() ?? []);
+
+	const selectOrderByMock = mock(() => ({
+		limit: selectLimitWithOffsetMock,
+		// intentional mock thenable. Lets `await .orderBy()` resolve for byOrganization while task.list chains .limit().offset().
+		then(resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) {
+			return Promise.resolve(dbSelectResults.shift() ?? []).then(
+				resolve,
+				reject,
+			);
+		},
+	}));
+
 	const selectWhereMock = mock(() => ({
 		limit: selectLimitMock,
 		orderBy: selectOrderByMock,
+		// intentional mock thenable. Lets `await .where()` resolve directly for the accounts query.
+		then(resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) {
+			return Promise.resolve(dbSelectResults.shift() ?? []).then(
+				resolve,
+				reject,
+			);
+		},
 	}));
-	const selectFromMock = mock(() => ({
+
+	const joinable: Record<string, unknown> = {
 		where: selectWhereMock,
-	}));
+	};
+	joinable.leftJoin = mock(() => joinable);
+
+	const selectFromMock = mock(() => joinable);
 	const selectMock = mock(() => ({
 		from: selectFromMock,
 	}));
@@ -109,6 +134,13 @@ mock.module("@superset/db/client", () => ({
 }));
 
 mock.module("@superset/db/schema", () => ({
+	// auth.accounts — stores OAuth connections (e.g. user linked their Linear
+	// account). accountId is the external provider's user ID ("lin_usr_abc").
+	accounts: {
+		accountId: "accounts.accountId",
+		providerId: "accounts.providerId",
+		userId: "accounts.userId",
+	},
 	members: {
 		organizationId: "members.organizationId",
 		userId: "members.userId",
@@ -139,6 +171,7 @@ mock.module("@superset/db/schema", () => ({
 		organizationId: "task_statuses.organizationId",
 	},
 	tasks: {
+		assigneeExternalId: "tasks.assigneeExternalId",
 		assigneeId: "tasks.assigneeId",
 		createdAt: "tasks.createdAt",
 		creatorId: "tasks.creatorId",
@@ -174,7 +207,13 @@ mock.module("drizzle-orm", () => ({
 	desc: (value: unknown) => ({ type: "desc", value }),
 	eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
 	ilike: (left: unknown, right: unknown) => ({ type: "ilike", left, right }),
+	inArray: (col: unknown, values: unknown) => ({
+		type: "inArray",
+		col,
+		values,
+	}),
 	isNull: (value: unknown) => ({ type: "isNull", value }),
+	or: (...conditions: unknown[]) => ({ type: "or", conditions }),
 	sql: Object.assign(
 		(strings: TemplateStringsArray, ...values: unknown[]) => ({
 			type: "sql",
@@ -444,5 +483,81 @@ describe("task router authorization", () => {
 			title: "Renamed task",
 		});
 		expect(syncTaskMock).toHaveBeenCalledWith(TASK_ID);
+	});
+});
+
+
+/**
+ * task.list assigneeMe filter
+ */
+describe("task.list assigneeMe filter", () => {
+	const LINEAR_EXTERNAL_ID = "lin_usr_abc123";
+
+	it("returns tasks matched by native assigneeId when user has no linked external accounts", async () => {
+		// No linked external accounts — plain UUID check.
+		dbSelectResults.push([]); // accounts lookup → empty (no linked Linear)
+		dbSelectResults.push([
+			{
+				task: {
+					id: TASK_ID,
+					assigneeId: ACTOR_USER_ID,
+					assigneeExternalId: null,
+				},
+				assignee: { id: ACTOR_USER_ID, name: "Actor" },
+				creator: null,
+				statusName: "In Progress",
+			},
+		]);
+
+		const caller = createCaller(createContext());
+		const result = await caller.task.list({ assigneeMe: true });
+
+		expect(result).toHaveLength(1);
+		expect(result[0].task.id).toBe(TASK_ID);
+	});
+
+	it("returns tasks matched by assigneeExternalId when Linear sync had an email mismatch", async () => {
+		// Your Superset email is "you@company.com".
+		// Your Linear email is "you@gmail.com".
+		//
+		// When Linear synced, it couldn't find "you@gmail.com" in Superset's
+		// user table, so it stored:
+		//   tasks.assigneeId = NULL
+		//   tasks.assigneeExternalId = "lin_usr_abc123"  ← your Linear user ID
+		//
+		// The OLD filter: eq(tasks.assigneeId, userId) → 0 results (bug!)
+		// The NEW filter: or(eq(assigneeId, ...), inArray(assigneeExternalId, [...]))
+		//                 → finds the task via assigneeExternalId
+		dbSelectResults.push([{ accountId: LINEAR_EXTERNAL_ID }]); // user linked Linear → we know their Linear ID
+		dbSelectResults.push([
+			{
+				task: {
+					id: TASK_ID,
+					assigneeId: null,
+					assigneeExternalId: LINEAR_EXTERNAL_ID,
+				},
+				assignee: null, // no Superset user row — email mismatch
+				creator: null,
+				statusName: "In Progress",
+			},
+		]);
+
+		const caller = createCaller(createContext());
+		const result = await caller.task.list({ assigneeMe: true });
+
+		// Before the fix this returned []. After the fix it returns the task.
+		expect(result).toHaveLength(1);
+		expect(result[0].task.assigneeExternalId).toBe(LINEAR_EXTERNAL_ID);
+	});
+
+	it("returns an empty list when no tasks match either assigneeId or assigneeExternalId", async () => {
+		// No linked external accounts — plain UUID check.
+		dbSelectResults.push([{ accountId: LINEAR_EXTERNAL_ID }]);
+		dbSelectResults.push([]); // tasks query finds nothing for this user
+
+		const caller = createCaller(createContext());
+		const result = await caller.task.list({ assigneeMe: true });
+
+		expect(result).toHaveLength(0);
 	});
 });

--- a/packages/trpc/src/router/task/task.ts
+++ b/packages/trpc/src/router/task/task.ts
@@ -1,5 +1,11 @@
 import { db, dbWs } from "@superset/db/client";
-import { members, taskStatuses, tasks, users } from "@superset/db/schema";
+import {
+	accounts,
+	members,
+	taskStatuses,
+	tasks,
+	users,
+} from "@superset/db/schema";
 import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import { getCurrentTxid } from "@superset/db/utils";
 import {
@@ -7,7 +13,7 @@ import {
 	generateUniqueTaskSlug,
 } from "@superset/shared/task-slug";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, desc, eq, ilike, isNull } from "drizzle-orm";
+import { and, desc, eq, ilike, inArray, isNull, or } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 import { syncTask } from "../../lib/integrations/sync";
@@ -27,6 +33,7 @@ import { taskStatusesRouter } from "./statuses";
 
 const TASK_SLUG_CONSTRAINT = "tasks_org_slug_unique";
 const TASK_SLUG_RETRY_LIMIT = 5;
+const TASK_SYNC_PROVIDERS = ["linear"] as const;
 
 function escapeLikePattern(value: string): string {
 	return value.replace(/[\\%_]/g, (match) => `\\${match}`);
@@ -316,7 +323,34 @@ export const taskRouter = {
 			if (input?.priority) filters.push(eq(tasks.priority, input.priority));
 			if (input?.statusId) filters.push(eq(tasks.statusId, input.statusId));
 			if (input?.assigneeMe) {
-				filters.push(eq(tasks.assigneeId, ctx.session.user.id));
+				const userId = ctx.session.user.id;
+
+				// Check if the user has linked any of the task sync providers.
+				const linkedAccounts = await db
+					.select({ accountId: accounts.accountId })
+					.from(accounts)
+					.where(
+						and(
+							eq(accounts.userId, userId),
+							inArray(accounts.providerId, [...TASK_SYNC_PROVIDERS]),
+						),
+					);
+
+				const externalIds = linkedAccounts.map((a) => a.accountId);
+
+				if (externalIds.length > 0) {
+					
+					// Match tasks assigned either natively OR via an external provider.
+					filters.push(
+						or(
+							eq(tasks.assigneeId, userId),
+							inArray(tasks.assigneeExternalId, externalIds),
+						)!,
+					);
+				} else {
+					// No linked external accounts — plain UUID check.
+					filters.push(eq(tasks.assigneeId, userId));
+				}
 			} else if (input?.assigneeId) {
 				filters.push(eq(tasks.assigneeId, input.assigneeId));
 			}


### PR DESCRIPTION
## Summary
Fixes #4888

When `assigneeMe` filter is applied, tasks synced from Linear where the
assignee's email didn't match a Superset user were invisible. These tasks have
`assigneeId = NULL` and `assigneeExternalId = "lin_usr_xxx"` instead.

**Fix:** Look up the user's linked OAuth account IDs from `auth.accounts`
(providerId = "linear"), then filter by `assigneeId OR assigneeExternalId IN
[externalIds]` so both native and externally-synced tasks appear.

## Changes
- `packages/trpc/src/router/task/task.ts` — broadened `assigneeMe` filter to
  include `assigneeExternalId` for known sync providers (Linear)
- `packages/trpc/src/router/task/task.test.ts` — added 3 unit tests covering
  native assignment, external ID match, and empty result case

## Test plan
- [ ] `bun test packages/trpc/src/router/task/task.test.ts` → 11 tests pass
- [ ] `bun run lint` → 0 errors
- [ ] `bun run typecheck` → 0 errors

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4916">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the assigneeMe filter so Linear-synced tasks show up for the current user by matching `assigneeExternalId` from linked `linear` accounts. This resolves issue #4891 where tasks were hidden when emails didn’t match.

- **Bug Fixes**
  - Look up user’s linked `linear` account IDs from `auth.accounts` and include them in the filter.
  - Apply `assigneeId = userId OR assigneeExternalId IN [externalIds]` when `assigneeMe` is set.
  - Added unit tests for native assignment, external ID match, and empty results.

<sup>Written for commit a801289b48488cf9b9a4b080b143ddd6b24775ca. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4916?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the "assigned to me" task filter to recognize assignments from linked external accounts (such as Linear) in addition to native assignments, providing more accurate task filtering for integrated workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->