### PR TITLE
fix(terminal): forward Ctrl+<letter> to PTY under non-Latin IME

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-key-event-handler.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-key-event-handler.test.ts
@@ -113,4 +113,74 @@ describe("createTerminalKeyEventHandler", () => {
 		expect(handler(event)).toBe(true);
 		expect(xterm.input).not.toHaveBeenCalled();
 	});
+
+	describe("non-Latin IME Ctrl+<letter> fix", () => {
+		it("sends Ctrl+O to PTY when Korean IME maps KeyO to a non-ASCII glyph", () => {
+			const xterm = terminal();
+			// Korean 2-set: O key → "ㅐ" (U+1150, charCode 4432)
+			const event = keyboardEvent({
+				key: "ㅐ",
+				code: "KeyO",
+				ctrlKey: true,
+			});
+			const handler = createTerminalKeyEventHandler(xterm, {
+				platform: "MacIntel",
+			});
+
+			expect(handler(event)).toBe(false);
+			expect(event.preventDefault).toHaveBeenCalled();
+			// Ctrl+O = ASCII 15 = \x0f
+			expect(xterm.input).toHaveBeenCalledWith("\x0f", false);
+		});
+
+		it("sends Ctrl+K to PTY when Korean IME maps KeyK to a non-ASCII glyph", () => {
+			const xterm = terminal();
+			// Korean 2-set: K key → "ㅏ"
+			const event = keyboardEvent({
+				key: "ㅏ",
+				code: "KeyK",
+				ctrlKey: true,
+			});
+			const handler = createTerminalKeyEventHandler(xterm, {
+				platform: "MacIntel",
+			});
+
+			expect(handler(event)).toBe(false);
+			expect(event.preventDefault).toHaveBeenCalled();
+			// Ctrl+K = ASCII 11 = \x0b
+			expect(xterm.input).toHaveBeenCalledWith("\x0b", false);
+		});
+
+		it("does not intercept Ctrl+<letter> when Latin IME is active (event.key is ASCII)", () => {
+			const xterm = terminal();
+			const event = keyboardEvent({
+				key: "o",
+				code: "KeyO",
+				ctrlKey: true,
+			});
+			const handler = createTerminalKeyEventHandler(xterm, {
+				platform: "MacIntel",
+			});
+
+			// Let xterm handle it normally
+			expect(handler(event)).toBe(true);
+			expect(xterm.input).not.toHaveBeenCalled();
+		});
+
+		it("does not intercept Ctrl+Shift or Ctrl+Alt combos (only bare Ctrl)", () => {
+			const xterm = terminal();
+			const event = keyboardEvent({
+				key: "ㅐ",
+				code: "KeyO",
+				ctrlKey: true,
+				shiftKey: true,
+			});
+			const handler = createTerminalKeyEventHandler(xterm, {
+				platform: "MacIntel",
+			});
+
+			expect(handler(event)).toBe(true);
+			expect(xterm.input).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/terminal-key-event-handler.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-key-event-handler.ts
@@ -76,6 +76,29 @@ export function createTerminalKeyEventHandler(
 			return false;
 		}
 
+		// Non-Latin IME (e.g. Korean 2-set) maps physical letter keys to
+		// non-ASCII glyphs: pressing O while Korean is active yields
+		// event.key="ㅐ" instead of "o". xterm derives the Ctrl+<letter>
+		// control byte from event.key, so it silently drops Ctrl+O, Ctrl+K,
+		// and every other Ctrl+<letter> chord typed while such an IME is
+		// active. Compute the byte from the physical key position
+		// (event.code) instead — that value is always layout-agnostic.
+		if (
+			event.type === "keydown" &&
+			event.ctrlKey &&
+			!event.metaKey &&
+			!event.altKey &&
+			!event.shiftKey
+		) {
+			const codeMatch = event.code.match(/^Key([A-Z])$/);
+			if (codeMatch && event.key.charCodeAt(0) > 127) {
+				event.preventDefault();
+				const charCode = codeMatch[1].charCodeAt(0) - 64; // A→1 … Z→26
+				terminal.input(String.fromCharCode(charCode), false);
+				return false;
+			}
+		}
+
 		return true;
 	};
 }


### PR DESCRIPTION
## Problem

When a non-Latin IME (e.g. Korean 2-set, Japanese, Chinese) is active, physical letter keys are mapped to non-ASCII glyphs by the OS. Pressing **Ctrl+O** while Korean input is active yields:

- `event.code = "KeyO"` ✅ (always layout-agnostic)
- `event.key = "ㅐ"` ❌ (Korean glyph, charCode 4432)
- `event.ctrlKey = true`

xterm derives the Ctrl+<letter> control byte from `event.key`. Since `"ㅐ"` is not a Latin letter, xterm silently drops the chord — the byte is never written to the PTY.

This breaks **any TUI app shortcut** that uses a bare Ctrl+letter while a non-Latin IME is active. Confirmed with:

- **Claude Code** `Ctrl+O` (toggle transcript) and `Ctrl+K` (clear input line)

## Root cause

`createTerminalKeyEventHandler` returns `true` to let xterm handle Ctrl+letter chords, but xterm's own key encoder uses `event.key` to compute the control byte and fails silently when the value is non-ASCII.

## Fix

Intercept the chord **before** xterm runs: when `ctrlKey` is set, no other modifier is held, `event.code` is a letter key (`Key[A-Z]`), and `event.key` is non-ASCII (`charCodeAt(0) > 127`), compute the correct control byte from `event.code` and write it directly to the PTY via `terminal.input()`.

```
charCode = letter.charCodeAt(0) - 64   // 'A'→1, 'O'→15, 'K'→11, …
```

`event.code` is always physical-key-position based and unaffected by IME state, so the correct byte is sent regardless of active input source.

## Relation to prior work

- Closes the gap left by #3391, which applied `event.code`-based matching to the hotkey recorder and resolver but did not cover the xterm key-encoder path.
- The terminal-reserved set (`Ctrl+C/D/Z`) was already working because xterm handles those as signals internally; this fix covers the remaining Ctrl+letter chords forwarded as raw bytes.

## Testing

Added 4 unit tests in `terminal-key-event-handler.test.ts`:

| Test | Asserts |
|---|---|
| Korean IME + Ctrl+O → `\x0f` sent | ✅ |
| Korean IME + Ctrl+K → `\x0b` sent | ✅ |
| Latin IME + Ctrl+O → xterm handles normally | ✅ |
| Korean IME + Ctrl+Shift+O → not intercepted (modifier guard) | ✅ |

## Reproduction

1. Open Superset Desktop with a terminal pane
2. Switch input source to Korean (or any non-Latin IME)
3. Run `claude` (Claude Code CLI) in the terminal
4. Press `Ctrl+O` → transcript toggle does not fire (bug)
5. Apply this patch → `Ctrl+O` works correctly ✅

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4917">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ctrl+letter chords being dropped under non‑Latin IMEs by deriving the control byte from `event.code` and sending it to the PTY. Restores TUI shortcuts like Ctrl+O and Ctrl+K when Korean/Japanese/Chinese input is active.

- **Bug Fixes**
  - Intercepts bare Ctrl+letter when `event.code` is `Key[A-Z]` and `event.key` is non‑ASCII; computes `A→\x01 … Z→\x1a` and writes via `terminal.input()`.
  - Does not intercept when `event.key` is ASCII (Latin IME) or when Shift/Alt/Meta is pressed; lets `xterm` handle normally.
  - Adds tests for Korean IME Ctrl+O/K success, Latin IME passthrough, and modifier guard.

<sup>Written for commit 40238a1dbf3e73aca6d29dcbe6a60b5fc8f91249. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4917?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ctrl+<letter> keyboard shortcut handling when using non-Latin input methods in the terminal.

* **Tests**
  * Added test suite for keyboard event handling with non-Latin input method support, including edge cases with modifier key combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->