### PR TITLE
fix(desktop): stop v2 file tree from mangling names into mid-ellipsis stubs

### DIFF
--- a/apps/desktop/src/renderer/lib/pierreTree/index.ts
+++ b/apps/desktop/src/renderer/lib/pierreTree/index.ts
@@ -5,4 +5,5 @@ export {
 	type PierreGitStatus,
 	type PierreGitStatusEntry,
 } from "./pierreGitStatus";
+export { PIERRE_TREE_UNSAFE_CSS } from "./pierreTreeUnsafeCss";
 export { stripTrailingSlash } from "./treePaths";

--- a/apps/desktop/src/renderer/lib/pierreTree/pierreTreeUnsafeCss.ts
+++ b/apps/desktop/src/renderer/lib/pierreTree/pierreTreeUnsafeCss.ts
@@ -1,0 +1,21 @@
+/**
+ * CSS injected into the `@pierre/trees` shadow root via the model's `unsafeCSS`
+ * option (lands in `@layer unsafe`, which outranks Pierre's own `@layer base`).
+ *
+ * Works around a Pierre row-layout bug: the filename lives in
+ * `[data-item-section='content']` (`flex: 0 1 auto`) beside an empty, *growing*
+ * `[data-item-section='decoration']` lane (`flex: 1 1 0`) that Pierre renders
+ * whenever git status is set. When `content`'s `flex-basis: auto` resolves to
+ * min-content — which it does in some Chromium builds — the decoration lane
+ * hoards the whole row and every name collapses to a middle-ellipsis stub
+ * (`.aude`, `node_……dules`) despite empty space to the right.
+ *
+ * Making `content` the grower (and the decoration lane size to its own content)
+ * lets the name claim the available width, so it only truncates on real
+ * overflow. Decoration content (the changes-tab `+N/−N`) still right-aligns
+ * because the filled content cell pushes it to the row's trailing edge.
+ */
+export const PIERRE_TREE_UNSAFE_CSS = `
+[data-item-section='content'] { flex: 1 1 auto; min-width: 0; }
+[data-item-section='decoration'] { flex: 0 1 auto; }
+`;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -28,7 +28,10 @@ import {
 	useSidebarFilePolicy,
 } from "renderer/lib/clickPolicy";
 import { useFallthroughIcons } from "renderer/lib/fileIcons";
-import { createPierreTreeStyle } from "renderer/lib/pierreTree";
+import {
+	createPierreTreeStyle,
+	PIERRE_TREE_UNSAFE_CSS,
+} from "renderer/lib/pierreTree";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
 import { PierreRowContextMenu } from "../PierreRowContextMenu";
 import { FileMenuItems } from "./components/FileMenuItems";
@@ -110,6 +113,7 @@ export function FilesTab({
 		paths: [],
 		initialExpansion: "closed",
 		search: false,
+		unsafeCSS: PIERRE_TREE_UNSAFE_CSS,
 		renaming: {
 			onRename: (event) => handlersRef.current.onRename(event),
 			onError: (message) => toast.error(message),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
@@ -23,6 +23,7 @@ import { useFallthroughIcons } from "renderer/lib/fileIcons";
 import {
 	createPierreTreeStyle,
 	FILE_STATUS_TO_PIERRE,
+	PIERRE_TREE_UNSAFE_CSS,
 	type PierreGitStatusEntry,
 	stripTrailingSlash,
 } from "renderer/lib/pierreTree";
@@ -122,6 +123,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 		paths,
 		initialExpansion: "open",
 		search: false,
+		unsafeCSS: PIERRE_TREE_UNSAFE_CSS,
 		gitStatus: initialGitStatusEntriesRef.current,
 		icons: { set: "complete", colored: true },
 		itemHeight: ITEM_HEIGHT,


### PR DESCRIPTION
## Problem

In the v2 diff viewer's **Files / Explorer** tab (and the Changes-tab tree), every file and folder name was squeezed into a middle-ellipsis stub — `.aude` for `.claude`, `node_……dules`, `package-loc……on`, even `apps` → `..)ps` — despite the sidebar being plenty wide, with empty space to the right of each truncated name. `Cmd+R` / full restart didn't help, confirming a layout (not state) bug.

## Root cause

Both trees use the `@pierre/trees` web component. Inside a row, the filename lives in `[data-item-section='content']` (`flex: 0 1 auto`) next to an empty but **growing** `[data-item-section='decoration']` lane (`flex: 1 1 0`) that Pierre renders whenever git status is set (which the v2 trees always do).

When `content`'s `flex-basis: auto` resolves to **min-content** — which it does in some Chromium builds (this is the Pierre internal fragility we'd hit) — the growing decoration lane hoards the entire row width and the name collapses to ~1 character, while the slack sits unused to the right. In Chromium builds where `auto` resolves to max-content the layout looks fine, which is why it reproduces on some machines and not others.

## Fix

Inject `unsafeCSS` into the Pierre shadow root (it lands in `@layer unsafe`, which outranks Pierre's own `@layer base`) from a shared constant used by both v2 trees:

```css
[data-item-section='content']    { flex: 1 1 auto; min-width: 0; }
[data-item-section='decoration'] { flex: 0 1 auto; }
```

The content cell becomes the grower (so it claims the available width regardless of how `flex-basis` resolves), and the decoration lane sizes to its own content. Names now use the full horizontal space and only truncate on genuine overflow. The Changes-tab `+N/−N` decoration still right-aligns, because the filled content cell pushes it to the row's trailing edge.

## Verification

Rendered the real `@pierre/trees` component in Electron with the exact FilesTab configuration (gitStatus set → decoration lane present, `display:contents` wrapper, closed expansion):

- **Reproduce:** forcing `content` to a min-content basis collapses **13/13** rows to 0–8px wide — only icons and right-aligned git badges visible (matches the bug screenshot).
- **Fix applied:** all rows recover to full width, **0/13** truncated.
- **Regression check:** applying the fix to the already-healthy case is a no-op — names render fully, git badges stay right-aligned.

`bun run lint` and desktop `typecheck` both pass.

## Files

- `apps/desktop/src/renderer/lib/pierreTree/pierreTreeUnsafeCss.ts` (new) — shared `PIERRE_TREE_UNSAFE_CSS` constant + rationale
- `pierreTree/index.ts` — export it
- `FilesTab.tsx`, `ChangesTreeView.tsx` — pass `unsafeCSS` to `useFileTree`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4923">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 desktop file/changes trees where names were mangled into mid-ellipsis despite wide sidebars. We inject scoped CSS into `@pierre/trees` so the name cell grows and the decoration lane does not, letting names use the full width.

- **Bug Fixes**
  - Added shared `PIERRE_TREE_UNSAFE_CSS` and exported it from `pierreTree`.
  - Passed `unsafeCSS` to both trees in `FilesTab` and `ChangesTreeView`.
  - CSS changes:
    - `[data-item-section='content'] { flex: 1 1 auto; min-width: 0; }`
    - `[data-item-section='decoration'] { flex: 0 1 auto; }`
  - Verified in Electron: collapse reproduced pre-fix; 0/13 rows truncated post-fix; no regressions.

<sup>Written for commit 000df716f314534ea18f403a275e373640c01b10. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4923?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where filenames in the file tree would incorrectly display as truncated text (ellipsis) even when sufficient space was available in the sidebar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->