### PR TITLE
fix(desktop): repair terminal preset launches

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts
@@ -31,10 +31,10 @@ describe("normalizeExecutionMode", () => {
 		);
 	});
 
-	it("maps legacy modes to split-pane and missing modes to new-tab", () => {
+	it("keeps sequential, maps legacy parallel to split-pane, and missing modes to new-tab", () => {
 		expect(normalizeExecutionMode("split-pane")).toBe("split-pane");
 		expect(normalizeExecutionMode("parallel")).toBe("split-pane");
-		expect(normalizeExecutionMode("sequential")).toBe("split-pane");
+		expect(normalizeExecutionMode("sequential")).toBe("sequential");
 		expect(normalizeExecutionMode(undefined)).toBe("new-tab");
 		expect(normalizeExecutionMode("unknown")).toBe("new-tab");
 	});
@@ -45,6 +45,7 @@ describe("normalizeTerminalPresets", () => {
 		const normalized = normalizeTerminalPresets([
 			createPreset("new-tab"),
 			createPreset("new-tab-split-pane"),
+			createPreset("sequential"),
 			createPreset("parallel"),
 			createPreset(undefined),
 		]);
@@ -52,6 +53,7 @@ describe("normalizeTerminalPresets", () => {
 		expect(normalized.map((p) => p.executionMode)).toEqual([
 			"new-tab",
 			"new-tab-split-pane",
+			"sequential",
 			"split-pane",
 			"new-tab",
 		] satisfies TerminalPreset["executionMode"][]);
@@ -126,6 +128,7 @@ describe("shouldPersistNormalizedTerminalPresets", () => {
 				createPreset("split-pane"),
 				createPreset("new-tab"),
 				createPreset("new-tab-split-pane"),
+				createPreset("sequential"),
 			]),
 		).toBe(false);
 	});

--- a/apps/desktop/src/renderer/lib/terminal/launch-command.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.ts
@@ -30,7 +30,7 @@ interface LaunchCommandInPaneOptions {
 	waitForMountedSession?: boolean;
 }
 
-function normalizeTerminalCommand(command: string): string {
+export function normalizeTerminalCommand(command: string): string {
 	return command.endsWith("\n") ? command : `${command}\n`;
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -25,6 +25,7 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
 import { TerminalPaneIcon } from "../TerminalPaneIcon";
 import {
+	getTerminalDisplayTitle,
 	getTerminalSessionListRefetchInterval,
 	shouldQueryTerminalSessionList,
 	TERMINAL_SESSION_LIST_STALE_MS,
@@ -277,7 +278,10 @@ export function TerminalSessionDropdown({
 	const hostTitle =
 		runtimeTitle !== undefined ? runtimeTitle : currentSession?.title;
 	const titleOverride = context.pane.titleOverride;
-	const triggerTitle = hostTitle ?? titleOverride ?? "Terminal";
+	const triggerTitle = getTerminalDisplayTitle({
+		titleOverride,
+		runtimeTitle: hostTitle,
+	});
 
 	return (
 		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -355,7 +359,10 @@ export function TerminalSessionDropdown({
 											: "Detached";
 							const title = isCurrent
 								? triggerTitle
-								: (session.title ?? location?.titleOverride ?? "Terminal");
+								: getTerminalDisplayTitle({
+										titleOverride: location?.titleOverride,
+										sessionTitle: session.title,
+									});
 
 							return (
 								<DropdownMenuItem

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.utils.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	getTerminalDisplayTitle,
 	getTerminalSessionListRefetchInterval,
 	shouldQueryTerminalSessionList,
 	TERMINAL_SESSION_LIST_REFETCH_INTERVAL_MS,
@@ -23,5 +24,23 @@ describe("TerminalSessionDropdown query policy", () => {
 			expect(shouldQueryTerminalSessionList(false)).toBe(false);
 			expect(getTerminalSessionListRefetchInterval(false)).toBe(false);
 		}
+	});
+});
+
+describe("getTerminalDisplayTitle", () => {
+	it("prefers explicit pane title overrides over runtime titles", () => {
+		expect(
+			getTerminalDisplayTitle({
+				titleOverride: "echo sequence",
+				runtimeTitle: "Terminal",
+				sessionTitle: "zsh",
+			}),
+		).toBe("echo sequence");
+	});
+
+	it("falls back through runtime, session, and default titles", () => {
+		expect(getTerminalDisplayTitle({ runtimeTitle: "vim" })).toBe("vim");
+		expect(getTerminalDisplayTitle({ sessionTitle: "zsh" })).toBe("zsh");
+		expect(getTerminalDisplayTitle({})).toBe("Terminal");
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.utils.ts
@@ -10,3 +10,17 @@ export function getTerminalSessionListRefetchInterval(
 ): false | number {
 	return isOpen ? TERMINAL_SESSION_LIST_REFETCH_INTERVAL_MS : false;
 }
+
+export function getTerminalDisplayTitle({
+	titleOverride,
+	runtimeTitle,
+	sessionTitle,
+}: {
+	titleOverride?: string;
+	runtimeTitle?: string | null;
+	sessionTitle?: string | null;
+}): string {
+	// Explicit pane titles come from user/preset labels, so they should not be
+	// hidden by transient shell-reported titles such as "zsh" or "Terminal".
+	return titleOverride ?? runtimeTitle ?? sessionTitle ?? "Terminal";
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -1,15 +1,25 @@
-import type { CreatePaneInput, WorkspaceStore } from "@superset/panes";
+import type { CreatePaneInput, Pane, WorkspaceStore } from "@superset/panes";
 import { toast } from "@superset/ui/sonner";
+import { workspaceTrpc } from "@superset/workspace-client";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useCallback, useMemo } from "react";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
 import { resolvePresetLaunchCommands } from "renderer/lib/agent-launch-command";
+import {
+	buildTerminalCommand,
+	normalizeTerminalCommand,
+} from "renderer/lib/terminal/launch-command";
 import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { getPresetLaunchPlan } from "renderer/stores/tabs/preset-launch";
-import { filterMatchingPresetsForProject } from "shared/preset-project-targeting";
+import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
+import {
+	filterMatchingPresetsForProject,
+	isProjectTargetedPreset,
+} from "shared/preset-project-targeting";
+import { quote } from "shell-quote";
 import type { StoreApi } from "zustand/vanilla";
 import type { PaneViewerData, TerminalPaneData } from "../../types";
 import type { TerminalLauncher } from "../useV2TerminalLauncher";
@@ -26,7 +36,65 @@ function makeTerminalPane(
 }
 
 function resolveTarget(executionMode: V2TerminalPresetRow["executionMode"]) {
-	return executionMode === "split-pane" ? "active-tab" : "new-tab";
+	return executionMode === "split-pane" || executionMode === "sequential"
+		? "active-tab"
+		: "new-tab";
+}
+
+function normalizePresetCwd(cwd: string | undefined): string | undefined {
+	const trimmed = cwd?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function isTerminalPane(
+	pane: Pane<PaneViewerData> | null | undefined,
+): pane is Pane<TerminalPaneData> {
+	return pane?.kind === "terminal";
+}
+
+function getActiveTerminalPane(state: WorkspaceStore<PaneViewerData>) {
+	const active = state.getActivePane();
+	if (!active || !isTerminalPane(active.pane)) return null;
+	return {
+		tabId: active.tabId,
+		paneId: active.pane.id,
+		terminalId: active.pane.data.terminalId,
+	};
+}
+
+function buildFocusedTerminalCommand({
+	command,
+	cwd,
+	worktreePath,
+}: {
+	command: string;
+	cwd: string | undefined;
+	worktreePath: string | undefined;
+}) {
+	// Sequential presets write into an already-running shell, so the preset
+	// directory has to be applied as shell input instead of session metadata.
+	if (!cwd) return command;
+	const resolvedCwd = worktreePath
+		? toAbsoluteWorkspacePath(worktreePath, cwd)
+		: cwd;
+	return `cd ${quote([resolvedCwd])} && ${command}`;
+}
+
+function selectAutoApplyPresets(
+	presets: V2TerminalPresetRow[],
+	field: "applyOnWorkspaceCreated" | "applyOnNewTab",
+) {
+	const targetedPresets = presets.filter(isProjectTargetedPreset);
+	const globalPresets = presets.filter(
+		(preset) => !isProjectTargetedPreset(preset),
+	);
+
+	const targetedTagged = targetedPresets.filter((preset) => preset[field]);
+	if (targetedTagged.length > 0) {
+		return targetedTagged;
+	}
+
+	return globalPresets.filter((preset) => preset[field]);
 }
 
 interface UseV2PresetExecutionArgs {
@@ -39,8 +107,17 @@ export function useV2PresetExecution({
 	launcher,
 }: UseV2PresetExecutionArgs) {
 	const { workspace } = useWorkspace();
+	const workspaceId = workspace.id;
 	const projectId = workspace.projectId;
 	const collections = useCollections();
+	const workspaceQuery = workspaceTrpc.workspace.get.useQuery(
+		{ id: workspaceId },
+		{
+			refetchOnWindowFocus: false,
+			retry: false,
+		},
+	);
+	const writeInput = workspaceTrpc.terminal.writeInput.useMutation();
 
 	const { data: allPresets = [] } = useLiveQuery(
 		(query) =>
@@ -54,18 +131,23 @@ export function useV2PresetExecution({
 	// /settings/agents page, so user edits there propagate here. The hook is
 	// already invalidated by mutations in the agents settings page.
 	const { activeHostUrl } = useLocalHostService();
-	const { data: agents = [], refetch: refetchAgents } =
-		useV2AgentConfigs(activeHostUrl);
+	const { data: agents = [] } = useV2AgentConfigs(activeHostUrl);
 
 	const matchedPresets = useMemo(
 		() => filterMatchingPresetsForProject(allPresets, projectId),
 		[allPresets, projectId],
 	);
+	const newTabPresets = useMemo(
+		() => selectAutoApplyPresets(matchedPresets, "applyOnNewTab"),
+		[matchedPresets],
+	);
 
-	// Keep the resolver synchronous for render-time consumers like
-	// `useV2WorkspaceRun`. Direct preset execution does a one-shot refetch for
-	// linked agents before launch so a recently edited agent cannot run from a
-	// stale infinite-cache snapshot.
+	// `useV2AgentConfigs` is the cached source of truth for agent configs
+	// (`staleTime: Infinity`, invalidated on every Settings → Agents mutation),
+	// so resolving against the in-memory `agents` array is correct and
+	// synchronous. Re-fetching via the host-service client on every call would
+	// duplicate that query and pin this function async, which forced the
+	// previous consumer (`useV2WorkspaceRun`) into a re-render cycle.
 	const resolvePresetCommands = useCallback(
 		(preset: V2TerminalPresetRow): string[] =>
 			resolvePresetLaunchCommands(preset, agents),
@@ -73,11 +155,38 @@ export function useV2PresetExecution({
 	);
 
 	const executePreset = useCallback(
-		async (preset: V2TerminalPresetRow) => {
+		async (
+			preset: V2TerminalPresetRow,
+			options?: { target?: "new-tab" | "active-tab" },
+		) => {
 			const state = store.getState();
 			const activeTabId = state.activeTabId;
-			const target = resolveTarget(preset.executionMode);
+			const target = options?.target ?? resolveTarget(preset.executionMode);
 			const title = preset.name || undefined;
+			const commands = resolvePresetCommands(preset);
+			const activeTerminal =
+				target === "active-tab" && preset.executionMode === "sequential"
+					? getActiveTerminalPane(state)
+					: null;
+			// Sequential mode is one shell command sent to one terminal; every
+			// other grouped mode keeps one command per terminal session.
+			const launchCommands =
+				preset.executionMode === "sequential"
+					? [buildTerminalCommand(commands)].flatMap((command) =>
+							command === null ? [] : [command],
+						)
+					: commands;
+			const cwd = normalizePresetCwd(preset.cwd);
+			const createTerminal = (command?: string) =>
+				launcher.create({ command, cwd });
+
+			const plan = getPresetLaunchPlan({
+				mode: preset.executionMode,
+				target,
+				commandCount: launchCommands.length,
+				hasActiveTab: !!activeTabId,
+				hasActiveTerminal: !!activeTerminal,
+			});
 
 			// Sessions for every pane this plan creates are spun up in parallel
 			// before any of them land in the store, so background tabs (e.g.
@@ -86,31 +195,35 @@ export function useV2PresetExecution({
 			// host-service buffers PTY output until the user clicks the tab and
 			// the pane finally mounts and attaches the WS.
 			try {
-				const liveAgents =
-					preset.agentId && activeHostUrl
-						? ((await refetchAgents()).data ?? agents)
-						: agents;
-				const commands = resolvePresetLaunchCommands(preset, liveAgents);
-
-				const plan = getPresetLaunchPlan({
-					mode: preset.executionMode,
-					target,
-					commandCount: commands.length,
-					hasActiveTab: !!activeTabId,
-				});
-
 				switch (plan) {
+					case "active-terminal": {
+						const command = launchCommands[0];
+						if (!activeTerminal || !command) break;
+						await writeInput.mutateAsync({
+							terminalId: activeTerminal.terminalId,
+							workspaceId,
+							data: normalizeTerminalCommand(
+								buildFocusedTerminalCommand({
+									command,
+									cwd,
+									worktreePath: workspaceQuery.data?.worktreePath,
+								}),
+							),
+						});
+						break;
+					}
+
 					case "new-tab-single": {
-						const terminalId = await launcher.create({ command: commands[0] });
+						const terminalId = await createTerminal(launchCommands[0]);
 						state.addTab({ panes: [makeTerminalPane(terminalId, title)] });
 						break;
 					}
 
 					case "new-tab-multi-pane": {
 						const ids = await Promise.all(
-							commands.length > 0
-								? commands.map((command) => launcher.create({ command }))
-								: [launcher.create()],
+							launchCommands.length > 0
+								? launchCommands.map((command) => createTerminal(command))
+								: [createTerminal()],
 						);
 						state.addTab({
 							panes: ids.map((id) => makeTerminalPane(id, title)) as [
@@ -123,7 +236,7 @@ export function useV2PresetExecution({
 
 					case "new-tab-per-command": {
 						const ids = await Promise.all(
-							commands.map((command) => launcher.create({ command })),
+							launchCommands.map((command) => createTerminal(command)),
 						);
 						for (const terminalId of ids) {
 							state.addTab({ panes: [makeTerminalPane(terminalId, title)] });
@@ -132,7 +245,7 @@ export function useV2PresetExecution({
 					}
 
 					case "active-tab-single": {
-						const terminalId = await launcher.create({ command: commands[0] });
+						const terminalId = await createTerminal(launchCommands[0]);
 						const pane = makeTerminalPane(terminalId, title);
 						if (!activeTabId) {
 							state.addTab({ panes: [pane] });
@@ -144,9 +257,9 @@ export function useV2PresetExecution({
 
 					case "active-tab-multi-pane": {
 						const ids = await Promise.all(
-							commands.length > 0
-								? commands.map((command) => launcher.create({ command }))
-								: [launcher.create()],
+							launchCommands.length > 0
+								? launchCommands.map((command) => createTerminal(command))
+								: [createTerminal()],
 						);
 						const panes = ids.map((id) => makeTerminalPane(id, title));
 						if (!activeTabId) {
@@ -174,8 +287,20 @@ export function useV2PresetExecution({
 				});
 			}
 		},
-		[store, launcher, activeHostUrl, refetchAgents, agents],
+		[
+			store,
+			launcher,
+			resolvePresetCommands,
+			workspaceId,
+			workspaceQuery.data?.worktreePath,
+			writeInput,
+		],
 	);
 
-	return { matchedPresets, executePreset, resolvePresetCommands };
+	return {
+		matchedPresets,
+		newTabPresets,
+		executePreset,
+		resolvePresetCommands,
+	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -59,6 +59,7 @@ function getActiveTerminalPane(state: WorkspaceStore<PaneViewerData>) {
 		tabId: active.tabId,
 		paneId: active.pane.id,
 		terminalId: active.pane.data.terminalId,
+		titleOverride: active.pane.titleOverride,
 	};
 }
 
@@ -210,6 +211,17 @@ export function useV2PresetExecution({
 								}),
 							),
 						});
+						if (title && !activeTerminal.titleOverride?.trim()) {
+							// Reused terminals keep their existing pane, so apply the
+							// first preset label explicitly instead of relying on creation
+							// metadata. Once a pane has a label, later preset runs must not
+							// rename it.
+							state.setPaneTitleOverride({
+								tabId: activeTerminal.tabId,
+								paneId: activeTerminal.paneId,
+								titleOverride: title,
+							});
+						}
 						break;
 					}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -24,12 +24,14 @@ export function useWorkspaceHotkeys({
 	store,
 	matchedPresets,
 	executePreset,
+	addTerminalTab,
 	paneRegistry,
 	launcher,
 }: {
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
 	matchedPresets: V2TerminalPresetRow[];
 	executePreset: (preset: V2TerminalPresetRow) => void | Promise<void>;
+	addTerminalTab: () => Promise<void>;
 	paneRegistry: PaneRegistry<PaneViewerData>;
 	launcher: TerminalLauncher;
 }) {
@@ -54,15 +56,7 @@ export function useWorkspaceHotkeys({
 	// --- Tab creation ---
 
 	useHotkey("NEW_GROUP", async () => {
-		const terminalId = await launcher.create();
-		store.getState().addTab({
-			panes: [
-				{
-					kind: "terminal",
-					data: { terminalId } as TerminalPaneData,
-				},
-			],
-		});
+		await addTerminalTab();
 	});
 
 	useHotkey("NEW_CHAT", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceStore } from "@superset/panes";
 import { useCallback } from "react";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import type { StoreApi } from "zustand/vanilla";
 import type {
 	BrowserPaneData,
@@ -15,9 +16,16 @@ import type { TerminalLauncher } from "../useV2TerminalLauncher";
 export function useWorkspacePaneOpeners({
 	store,
 	launcher,
+	newTabPresets,
+	executePreset,
 }: {
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
 	launcher: TerminalLauncher;
+	newTabPresets: V2TerminalPresetRow[];
+	executePreset: (
+		preset: V2TerminalPresetRow,
+		options?: { target?: "new-tab" | "active-tab" },
+	) => void | Promise<void>;
 }): {
 	openDiffPane: (
 		filePath: string,
@@ -98,7 +106,7 @@ export function useWorkspacePaneOpeners({
 		[store],
 	);
 
-	const addTerminalTab = useCallback(async () => {
+	const addBlankTerminalTab = useCallback(async () => {
 		const terminalId = await launcher.create();
 		store.getState().addTab({
 			panes: [
@@ -109,6 +117,19 @@ export function useWorkspacePaneOpeners({
 			],
 		});
 	}, [store, launcher]);
+
+	const addTerminalTab = useCallback(async () => {
+		if (newTabPresets.length === 0) {
+			await addBlankTerminalTab();
+			return;
+		}
+
+		// New terminal tabs are the trigger point for applyOnNewTab presets.
+		// Each matching preset owns the tab/pane shape it creates.
+		for (const preset of newTabPresets) {
+			await executePreset(preset, { target: "new-tab" });
+		}
+	}, [addBlankTerminalTab, executePreset, newTabPresets]);
 
 	const addChatTab = useCallback(() => {
 		store.getState().addTab({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -125,11 +125,15 @@ function V2WorkspaceContent() {
 	const { store } = useV2WorkspacePaneLayout();
 	useClearActivePaneAttention({ store });
 	const launcher = useV2TerminalLauncher();
-	const { matchedPresets, executePreset, resolvePresetCommands } =
-		useV2PresetExecution({
-			store,
-			launcher,
-		});
+	const {
+		matchedPresets,
+		newTabPresets,
+		executePreset,
+		resolvePresetCommands,
+	} = useV2PresetExecution({
+		store,
+		launcher,
+	});
 	const workspaceRun = useV2WorkspaceRun({
 		store,
 		launcher,
@@ -179,7 +183,12 @@ function V2WorkspaceContent() {
 		addChatTab,
 		addBrowserTab,
 		openCommentPane,
-	} = useWorkspacePaneOpeners({ store, launcher });
+	} = useWorkspacePaneOpeners({
+		store,
+		launcher,
+		newTabPresets,
+		executePreset,
+	});
 
 	const quickOpenOpen = useQuickOpenStore(
 		(s) => s.open && s.target?.workspaceId === workspaceId,
@@ -244,6 +253,7 @@ function V2WorkspaceContent() {
 		store,
 		matchedPresets,
 		executePreset,
+		addTerminalTab,
 		paneRegistry,
 		launcher,
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -119,6 +119,7 @@ const v2ExecutionModeSchema = z.enum([
 	"split-pane",
 	"new-tab",
 	"new-tab-split-pane",
+	"sequential",
 ]);
 
 // projectIds uses plain z.string() (not uuid) because v1 accepts arbitrary

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
@@ -108,9 +108,13 @@ export function PresetRow({
 				? commands.length > 1
 					? "New tab + panes"
 					: "New tab"
-				: commands.length > 1
-					? "Single tab + panes"
-					: "Split pane";
+				: modeValue === "sequential"
+					? commands.length > 1
+						? "All in current tab"
+						: "Split pane"
+					: commands.length > 1
+						? "Single tab + panes"
+						: "Split pane";
 	const firstCommand =
 		commands.find((cmd) => cmd.trim().length > 0)?.trim() ?? "Empty command";
 	const commandSummary =

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
@@ -15,6 +15,7 @@ import {
 	getPresetProjectTargetLabel,
 	type PresetProjectOption,
 } from "../PresetsSection/preset-project-options";
+import { getPresetModeLabel } from "./PresetRow.utils";
 
 interface PresetWithAgent extends TerminalPreset {
 	agentId?: string;
@@ -99,22 +100,7 @@ export function PresetRow({
 	const isNewTab = !!preset.applyOnNewTab;
 	const isVisibleInBar = preset.pinnedToBar !== false;
 	const modeValue = normalizeExecutionMode(preset.executionMode);
-	const modeLabel =
-		modeValue === "new-tab"
-			? commands.length > 1
-				? "Tab per command"
-				: "New tab"
-			: modeValue === "new-tab-split-pane"
-				? commands.length > 1
-					? "New tab + panes"
-					: "New tab"
-				: modeValue === "sequential"
-					? commands.length > 1
-						? "All in current tab"
-						: "Split pane"
-					: commands.length > 1
-						? "Single tab + panes"
-						: "Split pane";
+	const modeLabel = getPresetModeLabel(modeValue, commands.length);
 	const firstCommand =
 		commands.find((cmd) => cmd.trim().length > 0)?.trim() ?? "Empty command";
 	const commandSummary =

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.utils.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { getPresetModeLabel } from "./PresetRow.utils";
+
+describe("getPresetModeLabel", () => {
+	it("does not describe sequential presets as split panes", () => {
+		expect(getPresetModeLabel("sequential", 1)).toBe("Current tab");
+		expect(getPresetModeLabel("sequential", 2)).toBe("All in current tab");
+	});
+
+	it("keeps split-pane labels for split-pane presets", () => {
+		expect(getPresetModeLabel("split-pane", 1)).toBe("Split pane");
+		expect(getPresetModeLabel("split-pane", 2)).toBe("Single tab + panes");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.utils.ts
@@ -1,0 +1,22 @@
+import type { ExecutionMode } from "@superset/local-db/schema/zod";
+
+export function getPresetModeLabel(
+	modeValue: ExecutionMode,
+	commandCount: number,
+): string {
+	const hasMultipleCommands = commandCount > 1;
+
+	if (modeValue === "new-tab") {
+		return hasMultipleCommands ? "Tab per command" : "New tab";
+	}
+
+	if (modeValue === "new-tab-split-pane") {
+		return hasMultipleCommands ? "New tab + panes" : "New tab";
+	}
+
+	if (modeValue === "sequential") {
+		return hasMultipleCommands ? "All in current tab" : "Current tab";
+	}
+
+	return hasMultipleCommands ? "Single tab + panes" : "Split pane";
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
@@ -383,7 +383,7 @@ export function PresetsSection({
 	const normalizedMode = normalizeExecutionMode(editingPreset?.executionMode);
 	const modeValue: ExecutionMode = hasMultipleCommands
 		? normalizedMode
-		: normalizedMode === "split-pane"
+		: normalizedMode === "split-pane" || normalizedMode === "sequential"
 			? "split-pane"
 			: "new-tab";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
@@ -318,6 +318,7 @@ export function PresetEditorDialog({
 
 	const launchModeOptions = hasMultipleCommands
 		? [
+				{ value: "sequential", label: "All in current tab" },
 				{ value: "split-pane", label: "All in current tab (split panes)" },
 				{ value: "new-tab", label: "Each in its own new tab" },
 				{
@@ -331,7 +332,7 @@ export function PresetEditorDialog({
 			];
 	const launchModeValue = hasMultipleCommands
 		? modeValue
-		: modeValue === "split-pane"
+		: modeValue === "split-pane" || modeValue === "sequential"
 			? "split-pane"
 			: "new-tab";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
@@ -509,7 +509,7 @@ export function V2PresetsSection({
 	const normalizedMode = normalizeExecutionMode(editingPreset?.executionMode);
 	const modeValue: ExecutionMode = hasMultipleCommands
 		? normalizedMode
-		: normalizedMode === "split-pane"
+		: normalizedMode === "split-pane" || normalizedMode === "sequential"
 			? "split-pane"
 			: "new-tab";
 

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { normalizeExecutionMode } from "@superset/local-db/schema/zod";
 import {
+	buildFocusedTerminalCommand,
 	getPresetLaunchPlan,
 	shouldApplyPresetPaneName,
 } from "./preset-launch";
@@ -64,6 +65,35 @@ describe("shouldApplyPresetPaneName", () => {
 				presetName: "  ",
 			}),
 		).toBe(false);
+	});
+});
+
+describe("buildFocusedTerminalCommand", () => {
+	it("prepends an explicit cd when a current terminal launch has a cwd", () => {
+		expect(
+			buildFocusedTerminalCommand({
+				commands: ["echo one", "echo two"],
+				cwd: "apps/my app",
+			}),
+		).toBe("cd 'apps/my app' && echo one && echo two");
+	});
+
+	it("leaves commands unchanged when cwd is blank", () => {
+		expect(
+			buildFocusedTerminalCommand({
+				commands: ["pwd"],
+				cwd: "  ",
+			}),
+		).toBe("pwd");
+	});
+
+	it("returns null when no runnable command exists", () => {
+		expect(
+			buildFocusedTerminalCommand({
+				commands: ["  "],
+				cwd: "apps/desktop",
+			}),
+		).toBeNull();
 	});
 });
 

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
@@ -13,10 +13,10 @@ describe("normalizeExecutionMode", () => {
 		);
 	});
 
-	it("maps legacy modes to split-pane and defaults unknown modes to new-tab", () => {
+	it("keeps sequential, maps legacy parallel to split-pane, and defaults unknown modes to new-tab", () => {
 		expect(normalizeExecutionMode("split-pane")).toBe("split-pane");
 		expect(normalizeExecutionMode("parallel")).toBe("split-pane");
-		expect(normalizeExecutionMode("sequential")).toBe("split-pane");
+		expect(normalizeExecutionMode("sequential")).toBe("sequential");
 		expect(normalizeExecutionMode(undefined)).toBe("new-tab");
 		expect(normalizeExecutionMode("unknown")).toBe("new-tab");
 	});
@@ -76,5 +76,28 @@ describe("getPresetLaunchPlan", () => {
 				hasActiveTab: true,
 			}),
 		).toBe("new-tab-multi-pane");
+	});
+
+	it("uses the active terminal for sequential commands", () => {
+		expect(
+			getPresetLaunchPlan({
+				mode: "sequential",
+				target: "active-tab",
+				commandCount: 2,
+				hasActiveTab: true,
+				hasActiveTerminal: true,
+			}),
+		).toBe("active-terminal");
+	});
+
+	it("uses one new-tab pane for sequential commands without an active terminal", () => {
+		expect(
+			getPresetLaunchPlan({
+				mode: "sequential",
+				target: "active-tab",
+				commandCount: 2,
+				hasActiveTab: true,
+			}),
+		).toBe("new-tab-single");
 	});
 });

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { normalizeExecutionMode } from "@superset/local-db/schema/zod";
-import { getPresetLaunchPlan } from "./preset-launch";
+import {
+	getPresetLaunchPlan,
+	shouldApplyPresetPaneName,
+} from "./preset-launch";
 
 describe("normalizeExecutionMode", () => {
 	it("returns new-tab for new-tab mode", () => {
@@ -19,6 +22,48 @@ describe("normalizeExecutionMode", () => {
 		expect(normalizeExecutionMode("sequential")).toBe("sequential");
 		expect(normalizeExecutionMode(undefined)).toBe("new-tab");
 		expect(normalizeExecutionMode("unknown")).toBe("new-tab");
+	});
+});
+
+describe("shouldApplyPresetPaneName", () => {
+	it("allows preset names for default terminal panes", () => {
+		expect(
+			shouldApplyPresetPaneName({
+				currentName: "Terminal",
+				presetName: "echo sequence",
+			}),
+		).toBe(true);
+		expect(
+			shouldApplyPresetPaneName({
+				currentName: "",
+				presetName: "desktop",
+			}),
+		).toBe(true);
+	});
+
+	it("preserves existing pane labels", () => {
+		expect(
+			shouldApplyPresetPaneName({
+				currentName: "echo sequence",
+				presetName: "desktop",
+			}),
+		).toBe(false);
+		expect(
+			shouldApplyPresetPaneName({
+				currentName: "Terminal",
+				presetName: "desktop",
+				userTitle: "my shell",
+			}),
+		).toBe(false);
+	});
+
+	it("ignores blank preset names", () => {
+		expect(
+			shouldApplyPresetPaneName({
+				currentName: "Terminal",
+				presetName: "  ",
+			}),
+		).toBe(false);
 	});
 });
 

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.ts
@@ -49,3 +49,23 @@ export function getPresetLaunchPlan({
 
 	return hasMultipleCommands ? "new-tab-multi-pane" : "new-tab-single";
 }
+
+export function shouldApplyPresetPaneName({
+	currentName,
+	presetName,
+	userTitle,
+}: {
+	currentName?: string | null;
+	presetName?: string | null;
+	userTitle?: string | null;
+}): boolean {
+	const trimmedName = presetName?.trim();
+	if (!trimmedName) return false;
+
+	if (userTitle?.trim()) return false;
+
+	const currentTitle = currentName?.trim() ?? "";
+	// Presets that reuse an existing terminal should only replace the default
+	// label. Once any real label is present, later preset runs leave it alone.
+	return currentTitle === "" || currentTitle === "Terminal";
+}

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.ts
@@ -4,6 +4,7 @@ export type PresetOpenTarget = "new-tab" | "active-tab";
 export type PresetMode = ExecutionMode;
 
 export type PresetLaunchPlan =
+	| "active-terminal"
 	| "new-tab-single"
 	| "new-tab-multi-pane"
 	| "new-tab-per-command"
@@ -15,15 +16,28 @@ export function getPresetLaunchPlan({
 	target,
 	commandCount,
 	hasActiveTab,
+	hasActiveTerminal,
 }: {
 	mode: PresetMode;
 	target: PresetOpenTarget;
 	commandCount: number;
 	hasActiveTab: boolean;
+	hasActiveTerminal?: boolean;
 }): PresetLaunchPlan {
 	const hasMultipleCommands = commandCount > 1;
 	const shouldUseActiveTab =
-		target === "active-tab" && mode === "split-pane" && hasActiveTab;
+		target === "active-tab" &&
+		(mode === "split-pane" || mode === "sequential") &&
+		hasActiveTab;
+
+	if (mode === "sequential") {
+		// Sequential grouped presets should never create split panes. Prefer the
+		// focused terminal, then fall back to one new terminal tab.
+		if (target === "active-tab" && hasActiveTerminal) {
+			return "active-terminal";
+		}
+		return "new-tab-single";
+	}
 
 	if (shouldUseActiveTab) {
 		return hasMultipleCommands ? "active-tab-multi-pane" : "active-tab-single";

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.ts
@@ -1,4 +1,6 @@
 import type { ExecutionMode } from "@superset/local-db/schema/zod";
+import { buildTerminalCommand } from "renderer/lib/terminal/launch-command";
+import { quote } from "shell-quote";
 
 export type PresetOpenTarget = "new-tab" | "active-tab";
 export type PresetMode = ExecutionMode;
@@ -48,6 +50,25 @@ export function getPresetLaunchPlan({
 	}
 
 	return hasMultipleCommands ? "new-tab-multi-pane" : "new-tab-single";
+}
+
+export function buildFocusedTerminalCommand({
+	commands,
+	cwd,
+}: {
+	commands: string[] | null | undefined;
+	cwd?: string | null;
+}): string | null {
+	const runnableCommands = commands?.filter((command) => command.trim());
+	const command = buildTerminalCommand(runnableCommands);
+	if (command === null) return null;
+
+	const trimmedCwd = cwd?.trim();
+	// Existing terminals cannot receive a session cwd, so preserve preset
+	// directory behavior by prepending an explicit cd before the commands.
+	if (!trimmedCwd) return command;
+
+	return `cd ${quote([trimmedCwd])} && ${command}`;
 }
 
 export function shouldApplyPresetPaneName({

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -11,8 +11,8 @@ import {
 	launchCommandInPane,
 	writeCommandsInPane,
 } from "renderer/lib/terminal/launch-command";
-import { quote } from "shell-quote";
 import {
+	buildFocusedTerminalCommand,
 	getPresetLaunchPlan,
 	type PresetMode,
 	type PresetOpenTarget,
@@ -40,16 +40,6 @@ interface PresetPaneLaunch {
 	workspaceId: string;
 	command: string;
 	cwd: string | undefined;
-}
-
-function buildFocusedTerminalCommand(preset: PreparedPreset): string | null {
-	const command = buildTerminalCommand(preset.commands);
-	if (command === null) return null;
-	const cwd = preset.initialCwd?.trim();
-	// Existing terminals cannot receive a session cwd, so preserve preset
-	// directory behavior by prepending an explicit cd before the commands.
-	if (!cwd) return command;
-	return `cd ${quote([cwd])} && ${command}`;
 }
 
 function preparePreset(preset: TerminalPreset): PreparedPreset {
@@ -231,11 +221,16 @@ export function useTabsWithPresets(projectId?: string | null) {
 		(workspaceId: string, preset: PreparedPreset) => {
 			const hasMultipleCommands = preset.commands.length > 1;
 
-			if (preset.mode === "sequential") {
-				const command = buildTerminalCommand(preset.commands);
+			const createPresetTab = () => {
 				const result = storeAddTab(workspaceId, {
 					initialCwd: preset.initialCwd,
 				});
+				applyTabName(result.tabId, preset.name);
+				return result;
+			};
+
+			const launchSinglePresetTab = (command: string | null) => {
+				const result = createPresetTab();
 				if (command !== null) {
 					launchPresetCommand({
 						paneId: result.paneId,
@@ -245,8 +240,11 @@ export function useTabsWithPresets(projectId?: string | null) {
 						cwd: preset.initialCwd,
 					});
 				}
-				applyTabName(result.tabId, preset.name);
 				return result;
+			};
+
+			if (preset.mode === "sequential") {
+				return launchSinglePresetTab(buildTerminalCommand(preset.commands));
 			}
 
 			if (preset.mode === "new-tab" && hasMultipleCommands) {
@@ -254,9 +252,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 				const launches: PresetPaneLaunch[] = [];
 
 				for (const command of preset.commands) {
-					const result = storeAddTab(workspaceId, {
-						initialCwd: preset.initialCwd,
-					});
+					const result = createPresetTab();
 					if (!firstResult) {
 						firstResult = result;
 					}
@@ -267,7 +263,6 @@ export function useTabsWithPresets(projectId?: string | null) {
 						command,
 						cwd: preset.initialCwd,
 					});
-					applyTabName(result.tabId, preset.name);
 				}
 
 				if (firstResult) {
@@ -275,11 +270,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 					return firstResult;
 				}
 
-				const fallback = storeAddTab(workspaceId, {
-					initialCwd: preset.initialCwd,
-				});
-				applyTabName(fallback.tabId, preset.name);
-				return fallback;
+				return createPresetTab();
 			}
 
 			if (hasMultipleCommands) {
@@ -307,21 +298,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 				return { tabId: multiPane.tabId, paneId: multiPane.paneIds[0] };
 			}
 
-			const command = buildTerminalCommand(preset.commands);
-			const result = storeAddTab(workspaceId, {
-				initialCwd: preset.initialCwd,
-			});
-			if (command !== null) {
-				launchPresetCommand({
-					paneId: result.paneId,
-					tabId: result.tabId,
-					workspaceId,
-					command,
-					cwd: preset.initialCwd,
-				});
-			}
-			applyTabName(result.tabId, preset.name);
-			return result;
+			return launchSinglePresetTab(buildTerminalCommand(preset.commands));
 		},
 		[
 			storeAddTab,
@@ -356,7 +333,10 @@ export function useTabsWithPresets(projectId?: string | null) {
 			});
 
 			if (plan === "active-terminal" && activeTabId && activeTerminalPaneId) {
-				const command = buildFocusedTerminalCommand(preset);
+				const command = buildFocusedTerminalCommand({
+					commands: preset.commands,
+					cwd: preset.initialCwd,
+				});
 				if (command !== null) {
 					void writeCommandsInPane({
 						paneId: activeTerminalPaneId,
@@ -463,21 +443,27 @@ export function useTabsWithPresets(projectId?: string | null) {
 			const pane = state.panes[paneId];
 			if (!pane || pane.type !== "terminal") return false;
 
-			void writeCommandsInPane({
-				paneId,
+			const command = buildFocusedTerminalCommand({
 				commands: preset.commands,
-				write: (input) => writeToTerminal.mutateAsync(input),
-			}).catch((error) => {
-				console.error(
-					"[useTabsWithPresets] Failed to send preset commands to current terminal:",
-					{
-						workspaceId,
-						tabId: activeTabId,
-						paneId,
-						error: error instanceof Error ? error.message : String(error),
-					},
-				);
+				cwd: preset.cwd,
 			});
+			if (command !== null) {
+				void writeCommandsInPane({
+					paneId,
+					commands: [command],
+					write: (input) => writeToTerminal.mutateAsync(input),
+				}).catch((error) => {
+					console.error(
+						"[useTabsWithPresets] Failed to send preset commands to current terminal:",
+						{
+							workspaceId,
+							tabId: activeTabId,
+							paneId,
+							error: error instanceof Error ? error.message : String(error),
+						},
+					);
+				});
+			}
 			const presetPaneName = preset.name?.trim();
 			if (presetPaneName && shouldLabelPaneForPreset(paneId, presetPaneName)) {
 				// This explicit "current terminal" action also reuses a pane, so

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -11,6 +11,7 @@ import {
 	launchCommandInPane,
 	writeCommandsInPane,
 } from "renderer/lib/terminal/launch-command";
+import { quote } from "shell-quote";
 import {
 	getPresetLaunchPlan,
 	type PresetMode,
@@ -38,6 +39,16 @@ interface PresetPaneLaunch {
 	workspaceId: string;
 	command: string;
 	cwd: string | undefined;
+}
+
+function buildFocusedTerminalCommand(preset: PreparedPreset): string | null {
+	const command = buildTerminalCommand(preset.commands);
+	if (command === null) return null;
+	const cwd = preset.initialCwd?.trim();
+	// Existing terminals cannot receive a session cwd, so preserve preset
+	// directory behavior by prepending an explicit cd before the commands.
+	if (!cwd) return command;
+	return `cd ${quote([cwd])} && ${command}`;
 }
 
 function preparePreset(preset: TerminalPreset): PreparedPreset {
@@ -201,6 +212,24 @@ export function useTabsWithPresets(projectId?: string | null) {
 		(workspaceId: string, preset: PreparedPreset) => {
 			const hasMultipleCommands = preset.commands.length > 1;
 
+			if (preset.mode === "sequential") {
+				const command = buildTerminalCommand(preset.commands);
+				const result = storeAddTab(workspaceId, {
+					initialCwd: preset.initialCwd,
+				});
+				if (command !== null) {
+					launchPresetCommand({
+						paneId: result.paneId,
+						tabId: result.tabId,
+						workspaceId,
+						command,
+						cwd: preset.initialCwd,
+					});
+				}
+				applyTabName(result.tabId, preset.name);
+				return result;
+			}
+
 			if (preset.mode === "new-tab" && hasMultipleCommands) {
 				let firstResult: { tabId: string; paneId: string } | null = null;
 				const launches: PresetPaneLaunch[] = [];
@@ -287,16 +316,47 @@ export function useTabsWithPresets(projectId?: string | null) {
 	const executePreset = useCallback(
 		(workspaceId: string, preset: PreparedPreset, target: PresetOpenTarget) => {
 			const activeTabId =
-				target === "active-tab" && preset.mode === "split-pane"
+				target === "active-tab" &&
+				(preset.mode === "split-pane" || preset.mode === "sequential")
 					? resolveActiveWorkspaceTabId(workspaceId)
 					: null;
+			const activeTerminalPaneId = (() => {
+				if (!activeTabId || preset.mode !== "sequential") return null;
+				const state = useTabsStore.getState();
+				const paneId = state.focusedPaneIds[activeTabId];
+				const pane = paneId ? state.panes[paneId] : undefined;
+				return pane?.type === "terminal" ? paneId : null;
+			})();
 
 			const plan = getPresetLaunchPlan({
 				mode: preset.mode,
 				target,
 				commandCount: preset.commands.length,
 				hasActiveTab: !!activeTabId,
+				hasActiveTerminal: !!activeTerminalPaneId,
 			});
+
+			if (plan === "active-terminal" && activeTabId && activeTerminalPaneId) {
+				const command = buildFocusedTerminalCommand(preset);
+				if (command !== null) {
+					void writeCommandsInPane({
+						paneId: activeTerminalPaneId,
+						commands: [command],
+						write: (input) => writeToTerminal.mutateAsync(input),
+					}).catch((error) => {
+						console.error(
+							"[useTabsWithPresets] Failed to send sequential preset to current terminal:",
+							{
+								workspaceId,
+								tabId: activeTabId,
+								paneId: activeTerminalPaneId,
+								error: error instanceof Error ? error.message : String(error),
+							},
+						);
+					});
+				}
+				return { tabId: activeTabId, paneId: activeTerminalPaneId };
+			}
 
 			if (plan === "active-tab-multi-pane" && activeTabId) {
 				const paneIds = storeAddPanesToTab(activeTabId, {
@@ -357,6 +417,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 			executePresetInNewTab,
 			launchPresetCommands,
 			launchPresetCommand,
+			writeToTerminal,
 		],
 	);
 

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -16,6 +16,7 @@ import {
 	getPresetLaunchPlan,
 	type PresetMode,
 	type PresetOpenTarget,
+	shouldApplyPresetPaneName,
 } from "./preset-launch";
 import { useTabsStore } from "./store";
 import type { AddTabOptions, SplitPaneOptions } from "./types";
@@ -60,6 +61,23 @@ function preparePreset(preset: TerminalPreset): PreparedPreset {
 	};
 }
 
+function shouldLabelPaneForPreset(
+	paneId: string,
+	presetName?: string,
+): boolean {
+	const trimmedName = presetName?.trim();
+	if (!trimmedName) return false;
+
+	const pane = useTabsStore.getState().panes[paneId];
+	if (!pane) return false;
+
+	return shouldApplyPresetPaneName({
+		currentName: pane.name,
+		presetName: trimmedName,
+		userTitle: pane.userTitle,
+	});
+}
+
 export function useTabsWithPresets(projectId?: string | null) {
 	const newTabPresetsInput = useMemo(
 		() => ({ projectId: projectId ?? null }),
@@ -77,6 +95,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 	const storeSplitPaneVertical = useTabsStore((s) => s.splitPaneVertical);
 	const storeSplitPaneHorizontal = useTabsStore((s) => s.splitPaneHorizontal);
 	const storeSplitPaneAuto = useTabsStore((s) => s.splitPaneAuto);
+	const setPaneName = useTabsStore((s) => s.setPaneName);
 	const renameTab = useTabsStore((s) => s.renameTab);
 	const createOrAttach = useCreateOrAttachWithTheme();
 	const writeToTerminal = electronTrpc.terminal.write.useMutation();
@@ -355,6 +374,16 @@ export function useTabsWithPresets(projectId?: string | null) {
 						);
 					});
 				}
+				const presetPaneName = preset.name?.trim();
+				if (
+					presetPaneName &&
+					shouldLabelPaneForPreset(activeTerminalPaneId, presetPaneName)
+				) {
+					// Reusing the focused terminal does not create a named tab/pane,
+					// so label the default pane once. Existing user/preset labels are
+					// preserved on later preset runs.
+					setPaneName(activeTerminalPaneId, presetPaneName);
+				}
 				return { tabId: activeTabId, paneId: activeTerminalPaneId };
 			}
 
@@ -418,6 +447,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 			launchPresetCommands,
 			launchPresetCommand,
 			writeToTerminal,
+			setPaneName,
 		],
 	);
 
@@ -448,10 +478,17 @@ export function useTabsWithPresets(projectId?: string | null) {
 					},
 				);
 			});
+			const presetPaneName = preset.name?.trim();
+			if (presetPaneName && shouldLabelPaneForPreset(paneId, presetPaneName)) {
+				// This explicit "current terminal" action also reuses a pane, so
+				// only apply the preset label while the pane still has its default
+				// title.
+				setPaneName(paneId, presetPaneName);
+			}
 
 			return true;
 		},
-		[resolveActiveWorkspaceTabId, writeToTerminal],
+		[resolveActiveWorkspaceTabId, writeToTerminal, setPaneName],
 	);
 
 	const openPreset = useCallback(

--- a/apps/desktop/test-setup.ts
+++ b/apps/desktop/test-setup.ts
@@ -219,7 +219,12 @@ const localDbMock = () => ({
 	agentCustomDefinitionSchema,
 	PROMPT_TRANSPORTS: ["argv", "stdin"],
 	EXTERNAL_APPS: [],
-	EXECUTION_MODES: ["sequential", "parallel"],
+	EXECUTION_MODES: [
+		"split-pane",
+		"new-tab",
+		"new-tab-split-pane",
+		"sequential",
+	],
 	BRANCH_PREFIX_MODES: ["none", "github", "author", "custom"],
 	TERMINAL_LINK_BEHAVIORS: ["external-editor", "file-viewer"],
 	FILE_OPEN_MODES: ["split-pane", "new-tab"],

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -79,6 +79,7 @@ export const EXECUTION_MODES = [
 	"split-pane",
 	"new-tab",
 	"new-tab-split-pane",
+	"sequential",
 ] as const;
 
 export type ExecutionMode = (typeof EXECUTION_MODES)[number];
@@ -87,12 +88,13 @@ export function normalizeExecutionMode(mode: unknown): ExecutionMode {
 	if (
 		mode === "split-pane" ||
 		mode === "new-tab" ||
-		mode === "new-tab-split-pane"
+		mode === "new-tab-split-pane" ||
+		mode === "sequential"
 	) {
 		return mode;
 	}
 
-	if (mode === "parallel" || mode === "sequential") {
+	if (mode === "parallel") {
 		return "split-pane";
 	}
 


### PR DESCRIPTION
## Description

Fixes regressions in desktop terminal presets that were discussed with Kiet before opening this PR.

Scope:
- Preserves the preset `Directory`/`cwd` when launching terminal commands.
- Keeps `sequential` as a valid execution mode instead of normalizing it away.
- Adds the grouped sequential launch option as `All in current tab`.
- Runs grouped sequential presets in one terminal without split panes.
- Runs `applyOnNewTab` presets when creating a new terminal tab, including the new-tab hotkey path.
- Keeps preset terminal labels visible for reused/default terminals without renaming an already labeled terminal.

## Related Issues

No GitHub issue. Discussed with Kiet in Slack; he confirmed this was a regression and said a PR would be welcome.

## Type of Change

Bug fix.

## Testing

- `bun test apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts apps/desktop/src/renderer/lib/terminal/launch-command.test.ts 'apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.utils.test.ts'`
- `bun run typecheck --filter=@superset/desktop --filter=@superset/api --filter=@superset/auth`
- `bun run lint`

## Demo

https://github.com/user-attachments/assets/703608de-9a1d-407c-a17f-249ba491327a

## Reviewer Notes

- This PR is scoped to terminal preset behavior only.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4926">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal preset launches in desktop: preserves preset cwd, restores sequential execution, auto-applies presets on new tabs, and keeps preset/user titles visible when reusing terminals.

- Bug Fixes
  - Respect preset Directory/cwd for all launches; sequential runs prepend cd when reusing a terminal.
  - Keep sequential as a valid mode and run grouped sequential presets in one terminal (no split panes); reuse the active terminal when available, else open one new tab.
  - Auto-run applyOnNewTab presets when creating a new terminal tab (UI and hotkey); project-targeted presets take priority over global.
  - Preserve preset labels on reused/default terminals and prefer explicit pane titles over runtime/session titles in the session dropdown.
  - Update UI to show “All in current tab” for sequential multi-command presets.

<sup>Written for commit 3b39797583b1be302af0597e1b50b8bfdc18929e. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4926?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Sequential" execution mode for terminal presets — run all preset commands in the current terminal tab.

* **Improvements**
  * UI now shows more consistent terminal titles and improved preset mode labels.
  * Preset execution respects working directory and can inject focused commands into existing terminals.
  * Hotkey and "add terminal" flows now respect preset-driven tab creation.

* **Tests**
  * Expanded test coverage for the new mode and title/command behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->