### PR TITLE
fix(api): enforce ownership on chat session endpoints

### DIFF
--- a/apps/api/src/app/api/chat/[sessionId]/route.ts
+++ b/apps/api/src/app/api/chat/[sessionId]/route.ts
@@ -125,10 +125,14 @@ export async function PUT(
 	}
 
 	// onConflictDoNothing is silent when another caller raced us with the
-	// same sessionId. Re-check ownership so the loser of a race gets a 404
-	// instead of a 200 pointing at a row they don't own.
+	// same sessionId. Re-check both ownership and organizationId so the
+	// loser of a race gets a 404 instead of a 200 pointing at a row
+	// stored under a different org than the one the caller asked for.
 	const postInsert = await getOwnedChatSession(sessionId, session.user.id);
-	if (postInsert.kind !== "ok") {
+	if (
+		postInsert.kind !== "ok" ||
+		postInsert.row.organizationId !== body.organizationId
+	) {
 		return Response.json({ error: "Not found" }, { status: 404 });
 	}
 

--- a/apps/api/src/app/api/chat/[sessionId]/route.ts
+++ b/apps/api/src/app/api/chat/[sessionId]/route.ts
@@ -1,7 +1,13 @@
 import { db } from "@superset/db/client";
 import { chatSessions } from "@superset/db/schema";
 import { and, eq, isNull } from "drizzle-orm";
-import { getDurableStream, requireAuth } from "../lib";
+import {
+	accessErrorResponse,
+	getDurableStream,
+	getOwnedChatSession,
+	isOrganizationMember,
+	requireAuth,
+} from "../lib";
 
 function errorMessage(error: unknown): string {
 	if (error instanceof Error) return error.message;
@@ -42,6 +48,27 @@ export async function PUT(
 			{ error: "organizationId is required" },
 			{ status: 400 },
 		);
+	}
+
+	// If the session already exists, the caller must own it. Otherwise the
+	// caller must be a member of the org they're creating the session under,
+	// so chat sessions can't be planted in arbitrary orgs.
+	const existing = await getOwnedChatSession(sessionId, session.user.id);
+	if (existing.kind === "forbidden") {
+		return accessErrorResponse(existing);
+	}
+	if (existing.kind === "not-found") {
+		const isMember = await isOrganizationMember(
+			session.user.id,
+			body.organizationId,
+		);
+		if (!isMember) {
+			return Response.json({ error: "Not found" }, { status: 404 });
+		}
+	} else if (existing.row.organizationId !== body.organizationId) {
+		// Owner is the caller, but they're trying to move the session to a
+		// different org. Reject silently.
+		return Response.json({ error: "Not found" }, { status: 404 });
 	}
 
 	const stream = getDurableStream(sessionId);
@@ -97,6 +124,14 @@ export async function PUT(
 		await db.insert(chatSessions).values(baseValues).onConflictDoNothing();
 	}
 
+	// onConflictDoNothing is silent when another caller raced us with the
+	// same sessionId. Re-check ownership so the loser of a race gets a 404
+	// instead of a 200 pointing at a row they don't own.
+	const postInsert = await getOwnedChatSession(sessionId, session.user.id);
+	if (postInsert.kind !== "ok") {
+		return Response.json({ error: "Not found" }, { status: 404 });
+	}
+
 	if (body.workspaceId) {
 		try {
 			await db
@@ -138,11 +173,21 @@ export async function PATCH(
 	const { sessionId } = await params;
 	const body = (await request.json()) as { title?: string };
 
+	const access = await getOwnedChatSession(sessionId, session.user.id);
+	if (access.kind !== "ok") {
+		return accessErrorResponse(access);
+	}
+
 	if (body.title !== undefined) {
 		await db
 			.update(chatSessions)
 			.set({ title: body.title })
-			.where(eq(chatSessions.id, sessionId));
+			.where(
+				and(
+					eq(chatSessions.id, sessionId),
+					eq(chatSessions.createdBy, session.user.id),
+				),
+			);
 	}
 
 	return Response.json({ success: true }, { status: 200 });

--- a/apps/api/src/app/api/chat/[sessionId]/stream/route.ts
+++ b/apps/api/src/app/api/chat/[sessionId]/stream/route.ts
@@ -158,14 +158,22 @@ export async function DELETE(
 		},
 	});
 
-	await db
-		.delete(chatSessions)
-		.where(
-			and(
-				eq(chatSessions.id, sessionId),
-				eq(chatSessions.createdBy, session.user.id),
-			),
-		);
+	// Only delete the DB row when upstream confirms the stream is gone.
+	// fetch() does not throw on non-2xx, so we have to check explicitly,
+	// otherwise an upstream 5xx leaves an orphaned stream with no DB row
+	// pointing at it. 404 from upstream is treated as success because
+	// the stream is already absent.
+	const upstreamGone = response.ok || response.status === 404;
+	if (upstreamGone) {
+		await db
+			.delete(chatSessions)
+			.where(
+				and(
+					eq(chatSessions.id, sessionId),
+					eq(chatSessions.createdBy, session.user.id),
+				),
+			);
+	}
 
 	const headers = new Headers();
 	for (const [key, value] of response.headers.entries()) {

--- a/apps/api/src/app/api/chat/[sessionId]/stream/route.ts
+++ b/apps/api/src/app/api/chat/[sessionId]/stream/route.ts
@@ -1,8 +1,10 @@
 import { db } from "@superset/db/client";
 import { chatSessions } from "@superset/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { env } from "@/env";
 import {
+	accessErrorResponse,
+	getOwnedChatSession,
 	PRODUCER_RESPONSE_HEADERS,
 	PROTOCOL_QUERY_PARAMS,
 	PROTOCOL_RESPONSE_HEADERS,
@@ -23,6 +25,10 @@ export async function GET(
 	if (!session) return new Response("Unauthorized", { status: 401 });
 
 	const { sessionId } = await params;
+	const access = await getOwnedChatSession(sessionId, session.user.id);
+	if (access.kind !== "ok") {
+		return accessErrorResponse(access);
+	}
 	const url = new URL(request.url);
 
 	const upstream = new URL(streamUrl(sessionId));
@@ -83,6 +89,10 @@ export async function POST(
 	if (!session) return new Response("Unauthorized", { status: 401 });
 
 	const { sessionId } = await params;
+	const access = await getOwnedChatSession(sessionId, session.user.id);
+	if (access.kind !== "ok") {
+		return accessErrorResponse(access);
+	}
 	const upstream = streamUrl(sessionId);
 
 	const headers: Record<string, string> = {
@@ -136,6 +146,10 @@ export async function DELETE(
 	if (!session) return new Response("Unauthorized", { status: 401 });
 
 	const { sessionId } = await params;
+	const access = await getOwnedChatSession(sessionId, session.user.id);
+	if (access.kind !== "ok") {
+		return accessErrorResponse(access);
+	}
 
 	const response = await fetch(streamUrl(sessionId), {
 		method: "DELETE",
@@ -144,7 +158,14 @@ export async function DELETE(
 		},
 	});
 
-	await db.delete(chatSessions).where(eq(chatSessions.id, sessionId));
+	await db
+		.delete(chatSessions)
+		.where(
+			and(
+				eq(chatSessions.id, sessionId),
+				eq(chatSessions.createdBy, session.user.id),
+			),
+		);
 
 	const headers = new Headers();
 	for (const [key, value] of response.headers.entries()) {
@@ -171,6 +192,10 @@ export async function HEAD(
 	if (!session) return new Response("Unauthorized", { status: 401 });
 
 	const { sessionId } = await params;
+	const access = await getOwnedChatSession(sessionId, session.user.id);
+	if (access.kind !== "ok") {
+		return accessErrorResponse(access);
+	}
 
 	const response = await fetch(streamUrl(sessionId), {
 		method: "HEAD",

--- a/apps/api/src/app/api/chat/lib.ts
+++ b/apps/api/src/app/api/chat/lib.ts
@@ -1,5 +1,12 @@
 import { DurableStream } from "@durable-streams/client";
 import { auth } from "@superset/auth/server";
+import { db } from "@superset/db/client";
+import {
+	chatSessions,
+	members,
+	type SelectChatSession,
+} from "@superset/db/schema";
+import { and, eq } from "drizzle-orm";
 import { env } from "@/env";
 
 export const PROTOCOL_QUERY_PARAMS = ["offset", "live", "cursor"];
@@ -34,6 +41,53 @@ export async function requireAuth(request: Request) {
 	});
 	if (!sessionData?.user) return null;
 	return sessionData;
+}
+
+export type ChatSessionAccess =
+	| { kind: "ok"; row: SelectChatSession }
+	| { kind: "not-found" }
+	| { kind: "forbidden" };
+
+/**
+ * Confirms the requesting user owns the chat session. Chat sessions are
+ * per-user (`createdBy` is notNull and is the only identity we trust to
+ * read/write the stream). We never gate solely on org membership, since
+ * session IDs are exposed in URLs and can be guessed.
+ */
+export async function getOwnedChatSession(
+	sessionId: string,
+	userId: string,
+): Promise<ChatSessionAccess> {
+	const row = await db.query.chatSessions.findFirst({
+		where: eq(chatSessions.id, sessionId),
+	});
+	if (!row) return { kind: "not-found" };
+	if (row.createdBy !== userId) return { kind: "forbidden" };
+	return { kind: "ok", row };
+}
+
+/**
+ * Returns a 404 for both not-found and forbidden so unauthorized callers
+ * can't probe which session IDs exist.
+ */
+export function accessErrorResponse(
+	_access: Exclude<ChatSessionAccess, { kind: "ok" }>,
+): Response {
+	return Response.json({ error: "Not found" }, { status: 404 });
+}
+
+export async function isOrganizationMember(
+	userId: string,
+	organizationId: string,
+): Promise<boolean> {
+	const row = await db.query.members.findFirst({
+		where: and(
+			eq(members.userId, userId),
+			eq(members.organizationId, organizationId),
+		),
+		columns: { id: true },
+	});
+	return Boolean(row);
 }
 
 export function streamUrl(sessionId: string) {


### PR DESCRIPTION
Any authenticated user could read, write, rename, or delete another user's chat by guessing the session ID. The PATCH route and the GET/POST/DELETE/HEAD routes under `/api/chat/[sessionId]/stream` only checked that the request was authenticated, not that the caller owned the session.

PUT also accepted an arbitrary `organizationId` and inserted a row with the caller as `createdBy`, so a user could plant a chat session in an org they weren't a member of.

The fix adds two helpers in `apps/api/src/app/api/chat/lib.ts`:

- `getOwnedChatSession(sessionId, userId)` looks up the row and returns `not-found` / `forbidden` / `ok`.
- `isOrganizationMember(userId, orgId)` checks the `members` table.

Every read and mutation path now gates on `getOwnedChatSession`. Both `not-found` and `forbidden` map to 404 through `accessErrorResponse` so callers can't probe which session IDs exist. PUT requires org membership when creating, rejects org-mismatch when the session already exists, and re-checks ownership after the insert so a caller that loses a race on the same `sessionId` gets a 404 instead of a misleading 200.

Session IDs show up in URLs and headers, so this is exploitable by any authenticated user who sees one float by.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down chat session endpoints so only the creator can read, write, rename, or delete their own sessions. Tighten PUT race checks and DELETE behavior; validate org membership and avoid DB/stream drift.

- **Bug Fixes**
  - Added `getOwnedChatSession`, `isOrganizationMember`, and `accessErrorResponse` in `apps/api/src/app/api/chat/lib.ts`.
  - Gate all GET/POST/DELETE/HEAD/PATCH on ownership; return 404 for both missing and unauthorized.
  - PUT: require org membership on create; reject org mismatch; after insert, re-check ownership and `organizationId` so race losers get 404.
  - DELETE: remove the DB row only when upstream returns 2xx or 404; guard updates/deletes with `createdBy`.

<sup>Written for commit 6a1c79f01b9041f7d7165c2d7f521106b1d5440e. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4927?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger ownership checks: only the session creator can view, modify, stream, or delete a chat session.
  * Creation now requires confirmed organization membership for the requested organization.
  * Update and delete operations strictly verify creator identity to prevent cross-session or cross-organization changes.
  * Access failures return consistent not-found/access responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->