### PR TITLE
fix(cli): wait for host process to exit before reporting startup failure

### DIFF
--- a/packages/cli/src/lib/host/spawn.test.ts
+++ b/packages/cli/src/lib/host/spawn.test.ts
@@ -31,8 +31,13 @@ const spawnMock = mock(
 		spawnCalls.push({ command, args, options });
 		return {
 			pid: 12345,
+			exitCode: null,
+			signalCode: null,
 			kill: mock(() => undefined),
 			unref: mock(() => undefined),
+			on: mock(() => undefined),
+			once: mock(() => undefined),
+			removeListener: mock(() => undefined),
 		};
 	},
 );

--- a/packages/cli/src/lib/host/spawn.test.ts
+++ b/packages/cli/src/lib/host/spawn.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,25 +21,56 @@ type SpawnOptions = {
 	stdio?: unknown;
 };
 
+type FakeChild = EventEmitter & {
+	pid: number | undefined;
+	exitCode: number | null;
+	signalCode: NodeJS.Signals | null;
+	kill: (signal?: NodeJS.Signals | number) => boolean;
+	unref: () => void;
+};
+
+type ChildOverrides = {
+	pidless?: boolean;
+	killResult?: boolean;
+	emitOnSpawn?: {
+		event: "exit" | "error";
+		args: ReadonlyArray<unknown>;
+	};
+};
+
 const spawnCalls: Array<{
 	command: string;
 	args: string[];
 	options: SpawnOptions;
 }> = [];
 
+let nextChildOverrides: ChildOverrides = {};
+
+function createFakeChild(overrides: ChildOverrides): FakeChild {
+	const child = new EventEmitter() as FakeChild;
+	child.pid = overrides.pidless ? undefined : 12345;
+	child.exitCode = null;
+	child.signalCode = null;
+	child.kill = mock(() =>
+		overrides.killResult === undefined ? true : overrides.killResult,
+	);
+	child.unref = mock(() => undefined);
+	return child;
+}
+
 const spawnMock = mock(
 	(command: string, args: string[], options: SpawnOptions) => {
 		spawnCalls.push({ command, args, options });
-		return {
-			pid: 12345,
-			exitCode: null,
-			signalCode: null,
-			kill: mock(() => undefined),
-			unref: mock(() => undefined),
-			on: mock(() => undefined),
-			once: mock(() => undefined),
-			removeListener: mock(() => undefined),
-		};
+		const overrides = nextChildOverrides;
+		const child = createFakeChild(overrides);
+		// Fire the requested event after the listener is wired up, but
+		// before pollHealth makes its first fetch, so the test exercises
+		// the early-exit / error path deterministically.
+		if (overrides.emitOnSpawn) {
+			const { event, args: emitArgs } = overrides.emitOnSpawn;
+			queueMicrotask(() => child.emit(event, ...emitArgs));
+		}
+		return child;
 	},
 );
 
@@ -62,6 +94,7 @@ function createApi(): ApiClient {
 afterEach(() => {
 	spawnCalls.length = 0;
 	spawnMock.mockClear();
+	nextChildOverrides = {};
 	globalThis.fetch = originalFetch;
 });
 
@@ -99,5 +132,117 @@ describe("spawnHostService", () => {
 			SUPERSET_CONFIG_PATH,
 		);
 		expect(spawnCalls[0]?.options.env?.AUTH_TOKEN).toBe("session-token");
+	});
+
+	test("throws with code/signal when child exits during startup", async () => {
+		// Fetch never returns OK, so health polling never resolves true.
+		globalThis.fetch = mock(
+			async () => new Response("not ready", { status: 503 }),
+		) as unknown as typeof fetch;
+
+		// Spawn emits 'exit' once listeners are wired so pollHealth bails
+		// via the early-exit predicate instead of running the full timeout.
+		nextChildOverrides = {
+			emitOnSpawn: { event: "exit", args: [137, "SIGKILL"] },
+		};
+
+		let thrown: unknown;
+		try {
+			await spawnHostService({
+				organizationId: "00000000-0000-0000-0000-000000000002",
+				sessionToken: "session-token",
+				api: createApi(),
+				port: 54880,
+				daemon: true,
+			});
+		} catch (err) {
+			thrown = err;
+		}
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).message).toContain("exited during startup");
+		expect((thrown as Error).message).toContain("code=137");
+		expect((thrown as Error).message).toContain("SIGKILL");
+	});
+
+	test("attaches an 'error' listener before the pid check", async () => {
+		// When spawn fails (e.g. ENOENT), Node returns a child with no pid
+		// and emits 'error' asynchronously. The listener has to be wired
+		// up before the !pid throw, otherwise the trailing emit hits an
+		// EventEmitter with no listener and Node terminates the process.
+		// We verify the wiring by checking the listener count on the
+		// returned child rather than trying to deterministically time the
+		// emit.
+		globalThis.fetch = mock(
+			async () => new Response("ok", { status: 200 }),
+		) as unknown as typeof fetch;
+
+		nextChildOverrides = { pidless: true };
+
+		let thrown: unknown;
+		let listenerCount = 0;
+		// Wrap the spawn mock so we can observe the listener count on the
+		// returned child right after spawn returns. The error listener is
+		// attached synchronously between spawn() and the pid check.
+		const originalImpl = spawnMock.getMockImplementation();
+		if (!originalImpl) throw new Error("expected mock impl");
+		spawnMock.mockImplementation((command, args, options) => {
+			const child = originalImpl(command, args, options) as FakeChild;
+			queueMicrotask(() => {
+				listenerCount = child.listenerCount("error");
+			});
+			return child;
+		});
+
+		try {
+			await spawnHostService({
+				organizationId: "00000000-0000-0000-0000-000000000003",
+				sessionToken: "session-token",
+				api: createApi(),
+				port: 54881,
+				daemon: true,
+			});
+		} catch (err) {
+			thrown = err;
+		}
+
+		if (originalImpl) spawnMock.mockImplementation(originalImpl);
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).message).toContain("Failed to spawn");
+		expect(listenerCount).toBeGreaterThan(0);
+	});
+
+	test("terminateChild does not hang when kill() returns false", async () => {
+		// Force kill() to return false so terminateChild's "process already
+		// gone" fast-path runs. With the TDZ bug this path used to throw
+		// ReferenceError because the timer handles weren't initialized
+		// yet when finish() ran. We also emit 'exit' so pollHealth bails
+		// fast via the early-exit predicate instead of running the full
+		// 10s health-check timeout.
+		nextChildOverrides = {
+			killResult: false,
+			emitOnSpawn: { event: "exit", args: [1, null] },
+		};
+		globalThis.fetch = mock(
+			async () => new Response("not ready", { status: 503 }),
+		) as unknown as typeof fetch;
+
+		let thrown: unknown;
+		try {
+			await spawnHostService({
+				organizationId: "00000000-0000-0000-0000-000000000004",
+				sessionToken: "session-token",
+				api: createApi(),
+				port: 54882,
+				daemon: true,
+			});
+		} catch (err) {
+			thrown = err;
+		}
+
+		// The fix replaces a ReferenceError (TDZ on the timer handles)
+		// with a clean exit-during-startup error.
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).message).toContain("exited during startup");
 	});
 });

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { createServer } from "node:net";
@@ -14,6 +14,11 @@ import { getRelayUrl } from "./relay-url";
 
 const HEALTH_POLL_INTERVAL_MS = 200;
 const HEALTH_POLL_TIMEOUT_MS = 10_000;
+// Failed startup means the host process never became healthy, so an
+// aggressive 1s SIGTERM->SIGKILL window is intentional: we want the port
+// released for the caller's retry, not a graceful drain.
+const KILL_GRACE_PERIOD_MS = 1_000;
+const KILL_HARD_DEADLINE_MS = 4_000;
 
 export interface SpawnHostOptions {
 	organizationId: string;
@@ -33,22 +38,87 @@ export interface SpawnHostResult {
 async function findFreePort(): Promise<number> {
 	return new Promise((resolve, reject) => {
 		const server = createServer();
-		server.listen(0, "127.0.0.1", () => {
+		const onError = (err: Error) => {
+			server.removeListener("listening", onListening);
+			reject(err);
+		};
+		const onListening = () => {
+			server.removeListener("error", onError);
 			const addr = server.address();
-			if (addr && typeof addr === "object") {
-				const { port } = addr;
-				server.close(() => resolve(port));
-			} else {
-				server.close(() => reject(new Error("Could not get port")));
+			if (!addr || typeof addr !== "object") {
+				server.close();
+				reject(new Error("Could not get port"));
+				return;
 			}
-		});
-		server.on("error", reject);
+			const { port } = addr;
+			server.close((closeErr) => {
+				if (closeErr) reject(closeErr);
+				else resolve(port);
+			});
+		};
+		server.once("error", onError);
+		server.once("listening", onListening);
+		server.listen(0, "127.0.0.1");
 	});
 }
 
-async function pollHealth(port: number, secret: string): Promise<boolean> {
+/**
+ * Send SIGTERM, then escalate to SIGKILL if the child is still alive after a
+ * short grace period. Resolves once the child has actually exited (or after
+ * the kill window elapses), so callers don't return while a zombie is still
+ * holding the port. `ChildProcess.kill()` returns false when the OS reports
+ * the process is already gone (ESRCH); we treat that as "already exited" so
+ * we don't wait on an exit event that won't fire.
+ */
+async function terminateChild(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	await new Promise<void>((resolve) => {
+		let settled = false;
+		const finish = () => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(escalation);
+			clearTimeout(hardDeadline);
+			child.removeListener("exit", onExit);
+			resolve();
+		};
+		const onExit = () => finish();
+		child.once("exit", onExit);
+		let sentSignal: boolean;
+		try {
+			sentSignal = child.kill("SIGTERM");
+		} catch {
+			finish();
+			return;
+		}
+		if (!sentSignal) {
+			// kill() returned false: the OS says the process is already gone.
+			// No exit event will fire, so resolve now.
+			finish();
+			return;
+		}
+		const escalation = setTimeout(() => {
+			try {
+				child.kill("SIGKILL");
+			} catch {
+				// Process already gone; the hardDeadline will resolve us.
+			}
+		}, KILL_GRACE_PERIOD_MS);
+		escalation.unref();
+		// Absolute backstop so we don't hang the CLI if the OS misses the exit event.
+		const hardDeadline = setTimeout(finish, KILL_HARD_DEADLINE_MS);
+		hardDeadline.unref();
+	});
+}
+
+async function pollHealth(
+	port: number,
+	secret: string,
+	hasExited: () => boolean = () => false,
+): Promise<boolean> {
 	const deadline = Date.now() + HEALTH_POLL_TIMEOUT_MS;
 	while (Date.now() < deadline) {
+		if (hasExited()) return false;
 		try {
 			const controller = new AbortController();
 			const timeout = setTimeout(() => controller.abort(), 2_000);
@@ -128,13 +198,55 @@ export async function spawnHostService(
 		throw new Error("Failed to spawn host-service");
 	}
 
-	const healthy = await pollHealth(port, secret);
+	// Surface spawn errors instead of letting them bubble as unhandled
+	// 'error' events on the ChildProcess (which crash the CLI process).
+	// Only relevant during startup; we detach the handler once healthy so
+	// later 'error' events (e.g. EPIPE on stdio) don't get silently captured.
+	let spawnError: Error | null = null;
+	const onSpawnError = (err: Error) => {
+		spawnError = err;
+	};
+	child.on("error", onSpawnError);
+
+	// Track early exit so health-check can stop polling instead of waiting
+	// for the full timeout when the child already died. Same detach pattern
+	// as above: once startup succeeds, we no longer care about this exit.
+	type ExitInfo = { code: number | null; signal: NodeJS.Signals | null };
+	const exitRef: { current: ExitInfo | null } = { current: null };
+	const onStartupExit = (
+		code: number | null,
+		signal: NodeJS.Signals | null,
+	) => {
+		exitRef.current = { code, signal };
+	};
+	child.once("exit", onStartupExit);
+
+	const healthy = await pollHealth(
+		port,
+		secret,
+		() => exitRef.current !== null,
+	);
 	if (!healthy) {
-		child.kill("SIGTERM");
+		// Always wait for actual termination so the port is released before
+		// we throw. Otherwise the caller's retry sees EADDRINUSE.
+		await terminateChild(child);
+		if (spawnError) throw spawnError;
+		const exit = exitRef.current;
+		if (exit) {
+			throw new Error(
+				`Host service exited during startup (code=${exit.code}, signal=${exit.signal})`,
+			);
+		}
 		throw new Error(
 			`Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,
 		);
 	}
+
+	// Healthy: detach the startup-only listeners so any later
+	// 'error'/'exit' events surface through normal Node behavior instead
+	// of being silently captured by closure refs we no longer read.
+	child.removeListener("error", onSpawnError);
+	child.removeListener("exit", onStartupExit);
 
 	const manifest: HostServiceManifest = {
 		pid: child.pid,

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -74,11 +74,17 @@ async function terminateChild(child: ChildProcess): Promise<void> {
 	if (child.exitCode !== null || child.signalCode !== null) return;
 	await new Promise<void>((resolve) => {
 		let settled = false;
+		// Declare the timer handles up front so `finish()` can always
+		// reach them. If `finish()` runs before the timers are set
+		// (kill() throws or returns false) these stay undefined, and
+		// the clearTimeout guards below are no-ops.
+		let escalation: ReturnType<typeof setTimeout> | undefined;
+		let hardDeadline: ReturnType<typeof setTimeout> | undefined;
 		const finish = () => {
 			if (settled) return;
 			settled = true;
-			clearTimeout(escalation);
-			clearTimeout(hardDeadline);
+			if (escalation) clearTimeout(escalation);
+			if (hardDeadline) clearTimeout(hardDeadline);
 			child.removeListener("exit", onExit);
 			resolve();
 		};
@@ -97,7 +103,7 @@ async function terminateChild(child: ChildProcess): Promise<void> {
 			finish();
 			return;
 		}
-		const escalation = setTimeout(() => {
+		escalation = setTimeout(() => {
 			try {
 				child.kill("SIGKILL");
 			} catch {
@@ -106,7 +112,7 @@ async function terminateChild(child: ChildProcess): Promise<void> {
 		}, KILL_GRACE_PERIOD_MS);
 		escalation.unref();
 		// Absolute backstop so we don't hang the CLI if the OS misses the exit event.
-		const hardDeadline = setTimeout(finish, KILL_HARD_DEADLINE_MS);
+		hardDeadline = setTimeout(finish, KILL_HARD_DEADLINE_MS);
 		hardDeadline.unref();
 	});
 }
@@ -194,19 +200,20 @@ export async function spawnHostService(
 		},
 	});
 
-	if (!child.pid) {
-		throw new Error("Failed to spawn host-service");
-	}
-
-	// Surface spawn errors instead of letting them bubble as unhandled
-	// 'error' events on the ChildProcess (which crash the CLI process).
-	// Only relevant during startup; we detach the handler once healthy so
-	// later 'error' events (e.g. EPIPE on stdio) don't get silently captured.
+	// Attach the 'error' listener immediately after spawn, before the pid
+	// check. Spawn failures (e.g. ENOENT) emit 'error' asynchronously and
+	// would crash the CLI as an unhandled event if no listener is attached
+	// by the time the event loop processes them. `once` auto-detaches so a
+	// later error after startup doesn't fire into a stale closure.
 	let spawnError: Error | null = null;
 	const onSpawnError = (err: Error) => {
 		spawnError = err;
 	};
-	child.on("error", onSpawnError);
+	child.once("error", onSpawnError);
+
+	if (!child.pid) {
+		throw new Error("Failed to spawn host-service");
+	}
 
 	// Track early exit so health-check can stop polling instead of waiting
 	// for the full timeout when the child already died. Same detach pattern
@@ -245,6 +252,7 @@ export async function spawnHostService(
 	// Healthy: detach the startup-only listeners so any later
 	// 'error'/'exit' events surface through normal Node behavior instead
 	// of being silently captured by closure refs we no longer read.
+	// removeListener is a no-op for `once` listeners that already fired.
 	child.removeListener("error", onSpawnError);
 	child.removeListener("exit", onStartupExit);
 


### PR DESCRIPTION
`spawnHostService` had three issues that made host startup flaky and could leave zombie processes holding the port:

1. `findFreePort` closed its temporary listener before returning the port. Another process could grab that port between `close()` and the host's `bind()`, and the host would then fail to start on a port the CLI just told it to use.

2. On health-check failure the code sent `SIGTERM` and threw immediately. The host could still be alive holding the port, so the next retry would also fail with `EADDRINUSE`. `ChildProcess.kill()` also returns `false` when the OS reports the process is already gone, which the previous code would have silently waited on forever.

3. No `error` or `exit` listeners were attached. Spawn errors bubbled as unhandled and could crash the CLI process, and the health-check polled the full 10 second timeout even when the child had already died on the first tick.

The fix:

- Rewrites `findFreePort` with explicit `listening` / `error` dispatch.
- Adds `terminateChild` that sends `SIGTERM`, escalates to `SIGKILL` after a 1 second grace period, and resolves only once the child has actually exited (or a 4 second hard backstop fires). Handles `kill()` returning `false` so we don't wait on an exit event that won't come.
- Attaches `error` and `exit` listeners during startup and detaches them once healthy, so later events don't get silently captured by stale closures.
- Adds an early-exit predicate to `pollHealth` so it stops as soon as the child dies instead of polling the full timeout.
- Throws a structured error with the exit code and signal on startup failure.

A small TOCTOU window remains between `findFreePort` releasing the socket and the host binding it. Eliminating it would require passing the listening fd into the host process, which is a larger change.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky CLI host startup by safely choosing a free port, detecting early spawn failures, and waiting for the child to exit before retry. Prevents zombie processes holding the port and avoids unhandled CLI crashes.

- **Bug Fixes**
  - Rewrote findFreePort with explicit listening/error flow and close callback before returning the port.
  - Added terminateChild: send SIGTERM, escalate to SIGKILL after 1s, resolve only once the process exits (4s hard backstop); fixed a TDZ so kill() returning false no longer crashes.
  - Attached an 'error' listener immediately after spawn (before the pid check) and an 'exit' listener during startup; detach once healthy.
  - pollHealth now stops early if the child exits, instead of waiting the full timeout.
  - On startup failure, wait for termination and throw a structured error including exit code and signal.

<sup>Written for commit fe5dfc818a12034b247d381af03fedaa16888e67. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4928?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host service startup reliability: better error handling, robust termination (escalation to force-kill) and health-check behavior to avoid hangs and port-in-use races.
* **Tests**
  * Added tests covering startup failures, error-listener ordering, and termination behavior to prevent hangs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->