### PR TITLE
fix(cli): launch browser without shell interpolation of the OAuth URL

### DIFF
--- a/packages/cli/src/lib/auth.test.ts
+++ b/packages/cli/src/lib/auth.test.ts
@@ -34,23 +34,29 @@ describe("isSafeBrowserUrl", () => {
 		// These are the chars that could break out of cmd.exe's `"..."`
 		// quoting if a URL ever contained them. Real URLs don't.
 		expect(isSafeBrowserUrl('https://x.com/"evil')).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/'evil")).toBe(false);
 		expect(isSafeBrowserUrl("https://x.com/`evil")).toBe(false);
 		expect(isSafeBrowserUrl("https://x.com/\\evil")).toBe(false);
 		expect(isSafeBrowserUrl("https://x.com/<evil")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/>evil")).toBe(false);
 		expect(isSafeBrowserUrl("https://x.com/^evil")).toBe(false);
 		expect(isSafeBrowserUrl("https://x.com/|evil")).toBe(false);
 	});
 
-	test("accepts percent-encoded URLs (cmd %-expansion is handled at launch)", () => {
+	test("accepts percent-encoded URLs", () => {
+		// rundll32 doesn't pass URLs through cmd, so %XX percent-encoding
+		// is safe to keep in the URL.
 		expect(
 			isSafeBrowserUrl("https://x.com/?redirect=http%3A%2F%2Fexample.com"),
 		).toBe(true);
 	});
 
-	test("rejects whitespace and control chars", () => {
+	test("rejects whitespace and control chars including DEL", () => {
 		expect(isSafeBrowserUrl("https://x.com/a b")).toBe(false);
 		expect(isSafeBrowserUrl("https://x.com/a\nb")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/a\rb")).toBe(false);
 		expect(isSafeBrowserUrl("https://x.com/a\x00b")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/a\x7fb")).toBe(false);
 	});
 });
 

--- a/packages/cli/src/lib/auth.test.ts
+++ b/packages/cli/src/lib/auth.test.ts
@@ -1,11 +1,57 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { CLIError } from "@superset/cli-framework";
-import { refreshAccessToken } from "./auth";
+import { isSafeBrowserUrl, refreshAccessToken } from "./auth";
 
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
+});
+
+describe("isSafeBrowserUrl", () => {
+	test("accepts a typical OAuth authorize URL with query params and ampersands", () => {
+		const url =
+			"https://api.superset.sh/api/auth/oauth2/authorize?client_id=cli&response_type=code&redirect_uri=http%3A%2F%2F127.0.0.1%3A51789%2Fcallback&scope=openid%20profile&state=abc";
+		expect(isSafeBrowserUrl(url)).toBe(true);
+	});
+
+	test("accepts http://localhost", () => {
+		expect(isSafeBrowserUrl("http://127.0.0.1:3000/x")).toBe(true);
+	});
+
+	test("rejects non-http(s) schemes", () => {
+		expect(isSafeBrowserUrl("javascript:alert(1)")).toBe(false);
+		expect(isSafeBrowserUrl("file:///etc/passwd")).toBe(false);
+		expect(isSafeBrowserUrl("ssh://user@host")).toBe(false);
+	});
+
+	test("rejects garbage that doesn't parse", () => {
+		expect(isSafeBrowserUrl("not a url")).toBe(false);
+		expect(isSafeBrowserUrl("")).toBe(false);
+	});
+
+	test("rejects shell metacharacters that could escape quoting", () => {
+		// These are the chars that could break out of cmd.exe's `"..."`
+		// quoting if a URL ever contained them. Real URLs don't.
+		expect(isSafeBrowserUrl('https://x.com/"evil')).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/`evil")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/\\evil")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/<evil")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/^evil")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/|evil")).toBe(false);
+	});
+
+	test("accepts percent-encoded URLs (cmd %-expansion is handled at launch)", () => {
+		expect(
+			isSafeBrowserUrl("https://x.com/?redirect=http%3A%2F%2Fexample.com"),
+		).toBe(true);
+	});
+
+	test("rejects whitespace and control chars", () => {
+		expect(isSafeBrowserUrl("https://x.com/a b")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/a\nb")).toBe(false);
+		expect(isSafeBrowserUrl("https://x.com/a\x00b")).toBe(false);
+	});
 });
 
 describe("refreshAccessToken", () => {

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -45,11 +45,9 @@ function generateState(): string {
  * forwards user-supplied text.
  *
  * Legitimate OAuth authorize URLs never contain whitespace, quotes,
- * backslashes, backticks, redirection operators, `^`, or `|`. `&` is
- * allowed because it appears in query strings and is safe under our launch
- * shapes (cmd quotes the URL; macOS/Linux use shell-free spawn). `%` is
- * allowed because URL percent-encoding uses it heavily; the Windows path
- * escapes `%` to `^%` so cmd cannot do variable expansion on it.
+ * backslashes, backticks, redirection operators, `^`, or `|`. `&` and `%`
+ * are allowed because they appear in query strings (cmd is bypassed on
+ * Windows so neither triggers expansion or command separation).
  */
 export function isSafeBrowserUrl(url: string): boolean {
 	let parsed: URL;
@@ -61,8 +59,8 @@ export function isSafeBrowserUrl(url: string): boolean {
 	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
 		return false;
 	}
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — we want to reject all control chars.
-	return !/[\s"'`\\<>^|\x00-\x1f]/.test(url);
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — we want to reject all control chars including DEL.
+	return !/[\s"'`\\<>^|\x00-\x1f\x7f]/.test(url);
 }
 
 async function openBrowser(url: string): Promise<void> {
@@ -79,20 +77,17 @@ async function openBrowser(url: string): Promise<void> {
 		console.error("[auth] failed to open browser:", err.message);
 	};
 
-	// We use spawn (not exec/execFile) with shell:false so the URL is never
-	// passed through a shell. On Windows we have to invoke cmd because
-	// `start` is a cmd built-in, but we keep our own quoting around the URL
-	// so an `&` in the OAuth query string doesn't end the start command.
+	// spawn with shell:false on every platform so the URL is never passed
+	// through a shell. On Windows we use rundll32 to call url.dll's
+	// FileProtocolHandler entry point, which is the documented shell-free
+	// way to open a URL. cmd is avoided entirely so there's no risk of
+	// `&` ending the command or `%FOO%` getting variable-expanded inside
+	// percent-encoded URLs.
 	let child: ReturnType<typeof spawn>;
 	if (process.platform === "darwin") {
 		child = spawn("open", [url], { detached: true, stdio: "ignore" });
 	} else if (process.platform === "win32") {
-		// Escape `%` to `^%` so cmd doesn't try to expand `%FOO%` patterns
-		// (URLs often contain `%XX` percent-encoding which would otherwise
-		// hit cmd's variable expansion).
-		const cmdSafeUrl = url.replace(/%/g, "^%");
-		child = spawn("cmd.exe", ["/d", "/s", "/c", `start "" "${cmdSafeUrl}"`], {
-			windowsVerbatimArguments: true,
+		child = spawn("rundll32.exe", ["url.dll,FileProtocolHandler", url], {
 			detached: true,
 			stdio: "ignore",
 		});

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -37,18 +37,70 @@ function generateState(): string {
 	return base64url(randomBytes(32));
 }
 
-async function openBrowser(url: string): Promise<void> {
-	const { exec } = await import("node:child_process");
-	switch (process.platform) {
-		case "darwin":
-			exec(`open "${url}"`);
-			break;
-		case "win32":
-			exec(`start "" "${url}"`);
-			break;
-		default:
-			exec(`xdg-open "${url}"`);
+/**
+ * Returns true if `url` is safe to hand to the OS browser launcher without
+ * any shell interpolation risk. We reject anything containing shell
+ * metacharacters even though the caller only passes URLs built from `URL`
+ * with controlled inputs. This is defense in depth in case a future caller
+ * forwards user-supplied text.
+ *
+ * Legitimate OAuth authorize URLs never contain whitespace, quotes,
+ * backslashes, backticks, redirection operators, `^`, or `|`. `&` is
+ * allowed because it appears in query strings and is safe under our launch
+ * shapes (cmd quotes the URL; macOS/Linux use shell-free spawn). `%` is
+ * allowed because URL percent-encoding uses it heavily; the Windows path
+ * escapes `%` to `^%` so cmd cannot do variable expansion on it.
+ */
+export function isSafeBrowserUrl(url: string): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return false;
 	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+		return false;
+	}
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — we want to reject all control chars.
+	return !/[\s"'`\\<>^|\x00-\x1f]/.test(url);
+}
+
+async function openBrowser(url: string): Promise<void> {
+	if (!isSafeBrowserUrl(url)) {
+		console.error(
+			"[auth] refusing to open browser: URL failed safety validation",
+		);
+		return;
+	}
+
+	const { spawn } = await import("node:child_process");
+	const onError = (err: Error) => {
+		// Non-fatal: paste fallback still works.
+		console.error("[auth] failed to open browser:", err.message);
+	};
+
+	// We use spawn (not exec/execFile) with shell:false so the URL is never
+	// passed through a shell. On Windows we have to invoke cmd because
+	// `start` is a cmd built-in, but we keep our own quoting around the URL
+	// so an `&` in the OAuth query string doesn't end the start command.
+	let child: ReturnType<typeof spawn>;
+	if (process.platform === "darwin") {
+		child = spawn("open", [url], { detached: true, stdio: "ignore" });
+	} else if (process.platform === "win32") {
+		// Escape `%` to `^%` so cmd doesn't try to expand `%FOO%` patterns
+		// (URLs often contain `%XX` percent-encoding which would otherwise
+		// hit cmd's variable expansion).
+		const cmdSafeUrl = url.replace(/%/g, "^%");
+		child = spawn("cmd.exe", ["/d", "/s", "/c", `start "" "${cmdSafeUrl}"`], {
+			windowsVerbatimArguments: true,
+			detached: true,
+			stdio: "ignore",
+		});
+	} else {
+		child = spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
+	}
+	child.on("error", onError);
+	child.unref();
 }
 
 export function getWebUrl(): string {


### PR DESCRIPTION
`openBrowser` in `packages/cli/src/lib/auth.ts` called `exec("open \"${url}\"")` and the Windows and Linux equivalents. The URL came from controlled inputs in practice, but shell-interpolating text into a command string is the textbook command injection class and shouldn't be in the codebase.

The fix swaps `exec` for `spawn` with `shell: false`. On macOS and Linux the URL is passed as a literal `argv` entry so no shell ever sees it. On Windows `start` is a `cmd.exe` built-in so the launch still has to go through `cmd`, but we keep our own quotes around the URL (with `windowsVerbatimArguments: true`) so an `&` in the OAuth query string can't end the `start` command. `%` is escaped to `^%` so `cmd` doesn't try to expand `%FOO%` patterns inside percent-encoded URLs.

Adds `isSafeBrowserUrl` as defense in depth. It requires the URL parses, requires http or https, and rejects whitespace, quotes, backticks, backslashes, redirection operators, `^`, and `|`. Real OAuth authorize URLs never contain any of those, and if a future caller forwards user-supplied text there is one extra check between it and the OS.

Tests cover accept and reject paths, including percent-encoded URLs (which need to pass) and cmd metacharacters (which should not).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4929">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents command injection when opening the OAuth URL from the CLI by removing shell interpolation and validating URLs. Uses shell-free process launching on all platforms without changing user behavior.

- **Bug Fixes**
  - Replaced `exec` with `spawn` (`shell: false`) on macOS/Linux to pass the URL as an argv entry.
  - On Windows, switched to `rundll32.exe url.dll,FileProtocolHandler <url>` to avoid `cmd.exe` entirely; `&` and `%` are preserved verbatim.
  - Strengthened `isSafeBrowserUrl`: requires `http`/`https`; rejects whitespace, quotes, backticks, backslashes, redirection operators, `^`, `|`, and all control chars (including DEL); added tests for these cases and percent-encoded URLs.

<sup>Written for commit fef8aea6d366f7050836d2c45d212ed15028d52c. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4929?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened URL validation for OAuth browser launches to block unsafe protocols and disallowed characters, reducing risk when opening external links.
  * Switched to a more robust, platform-aware browser-launch approach that avoids shell-based execution and logs non-fatal errors.

* **Tests**
  * Added comprehensive tests covering accepted and rejected URL patterns, edge cases, and unsafe inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->