### PR TITLE
fix: restore controlling TTY for PTY child processes and strip OSC response sequences from stdin

### DIFF
--- a/packages/pty-daemon/src/Pty/Pty.test.ts
+++ b/packages/pty-daemon/src/Pty/Pty.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { spawn } from "./Pty.ts";
+import { OscInputFilter, spawn } from "./Pty.ts";
 
 // node-pty's runtime requires Node (Bun's tty.ReadStream handling is
 // incompatible with the master fd setup). The daemon ships running under
@@ -30,5 +30,37 @@ describe("Pty wrapper (validation only — spawn behavior tested under node)", (
 				meta: { shell: "/bin/sh", argv: [], cols: 80.5, rows: 24 },
 			}),
 		).toThrow(/invalid cols/);
+	});
+
+	test("strips OSC sequences from input bytes", () => {
+		const filter = new OscInputFilter();
+		const filtered = filter.write(
+			Buffer.from(
+				"ab\x1b]10;?\x07cd\x1b]11;?\x07ef\x1b]52;c;Zm9v\x07gh",
+				"utf8",
+			),
+		);
+		expect(filtered.toString("utf8")).toBe("abcdefgh");
+	});
+
+	test("strips OSC sequences split across input chunks", () => {
+		const filter = new OscInputFilter();
+		expect(filter.write(Buffer.from("a\x1b]10;?", "utf8")).toString()).toBe(
+			"a",
+		);
+		expect(filter.write(Buffer.from("\x07b", "utf8")).toString()).toBe("b");
+	});
+
+	test("preserves non-OSC escape sequences", () => {
+		const filter = new OscInputFilter();
+		const filtered = filter.write(Buffer.from("a\x1b[A", "utf8"));
+		expect(filtered).toEqual(Buffer.from("a\x1b[A", "utf8"));
+	});
+
+	test("preserves standalone escape at input chunk boundary", () => {
+		const filter = new OscInputFilter();
+		expect(filter.write(Buffer.from("\x1b", "utf8"))).toEqual(
+			Buffer.from("\x1b", "utf8"),
+		);
 	});
 });

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -11,6 +11,11 @@ import {
 import type { SessionMeta } from "../protocol/index.ts";
 
 const KILL_ESCALATION_TIMEOUT_MS = 1000;
+const ESC = 0x1b;
+const BEL = 0x07;
+const RIGHT_BRACKET = 0x5d;
+const BACKSLASH = 0x5c;
+const C1_OSC = 0x9d;
 
 export type PtyOnData = (data: Buffer) => void;
 export type PtyOnExit = (info: {
@@ -52,6 +57,7 @@ class NodePtyAdapter implements Pty {
 	readonly pid: number;
 	meta: SessionMeta;
 	private term: nodePty.IPty;
+	private readonly inputFilter = new OscInputFilter();
 	private exited = false;
 	private killEscalationTimer: NodeJS.Timeout | null = null;
 	private exitInfo: { code: number | null; signal: number | null } | null =
@@ -87,8 +93,10 @@ class NodePtyAdapter implements Pty {
 	}
 
 	write(data: Buffer): void {
+		const filtered = this.inputFilter.write(data);
+		if (filtered.byteLength === 0) return;
 		// node-pty's write accepts strings or buffers; pass buffer to keep bytes intact.
-		this.term.write(data as unknown as string);
+		this.term.write(filtered as unknown as string);
 	}
 
 	pause(): void {
@@ -194,9 +202,7 @@ export function spawn({ meta }: SpawnOptions): Pty {
 		});
 	} catch (err) {
 		// Annotate with shell + cwd so the wire-error reply is actionable.
-		throw new Error(
-			`spawn failed (shell=${meta.shell} cwd=${meta.cwd ?? "(none)"}): ${(err as Error).message}`,
-		);
+		throw new Error(formatSpawnError(meta, err));
 	}
 	const adapter = new NodePtyAdapter(term, meta);
 	// Validate the private-fd dependency at spawn time, not handoff time.
@@ -227,6 +233,7 @@ class AdoptedPty implements Pty {
 	meta: SessionMeta;
 	private readonly fd: number;
 	private readonly reader: tty.ReadStream;
+	private readonly inputFilter = new OscInputFilter();
 	private exitFired = false;
 	private livenessTimer: NodeJS.Timeout | null = null;
 	private killEscalationTimer: NodeJS.Timeout | null = null;
@@ -280,13 +287,15 @@ class AdoptedPty implements Pty {
 		if (this.exitFired) {
 			throw new Error(`session exited: ${this.pid}`);
 		}
+		const filtered = this.inputFilter.write(data);
+		if (filtered.byteLength === 0) return;
 		let offset = 0;
-		while (offset < data.byteLength) {
+		while (offset < filtered.byteLength) {
 			const written = fs.writeSync(
 				this.fd,
-				data,
+				filtered,
 				offset,
-				data.byteLength - offset,
+				filtered.byteLength - offset,
 			);
 			if (written <= 0) {
 				throw new Error(`pty write wrote ${written} bytes`);
@@ -386,4 +395,84 @@ export function adoptFromFd({ fd, pid, meta }: AdoptOptions): Pty {
 	}
 	validateDims(meta.cols, meta.rows);
 	return new AdoptedPty(fd, pid, meta);
+}
+
+type OscInputFilterState = "normal" | "esc" | "osc" | "osc-esc";
+
+/**
+ * Drops OSC replies that belong to the terminal emulator control plane, not to
+ * the shell stdin stream. These can be injected by renderer-side terminal
+ * queries and confuse raw-mode prompt readers like gh, ssh, and credential
+ * helpers if forwarded into the PTY.
+ */
+export class OscInputFilter {
+	private state: OscInputFilterState = "normal";
+
+	write(data: Buffer): Buffer {
+		const out: number[] = [];
+		for (const byte of data) {
+			this.pushByte(byte, out);
+		}
+		if (this.state === "esc") {
+			out.push(ESC);
+			this.state = "normal";
+		}
+		return Buffer.from(out);
+	}
+
+	private pushByte(byte: number, out: number[]): void {
+		switch (this.state) {
+			case "normal":
+				if (byte === ESC) {
+					this.state = "esc";
+					return;
+				}
+				if (byte === C1_OSC) {
+					this.state = "osc";
+					return;
+				}
+				out.push(byte);
+				return;
+			case "esc":
+				if (byte === RIGHT_BRACKET) {
+					this.state = "osc";
+					return;
+				}
+				out.push(ESC);
+				this.state = "normal";
+				this.pushByte(byte, out);
+				return;
+			case "osc":
+				if (byte === BEL) {
+					this.state = "normal";
+					return;
+				}
+				if (byte === ESC) {
+					this.state = "osc-esc";
+				}
+				return;
+			case "osc-esc":
+				if (byte === BACKSLASH || byte === BEL) {
+					this.state = "normal";
+					return;
+				}
+				this.state = byte === ESC ? "osc-esc" : "osc";
+				return;
+		}
+	}
+}
+
+function formatSpawnError(meta: SessionMeta, err: unknown): string {
+	const e = err as NodeJS.ErrnoException;
+	const message = e.message ?? String(err);
+	const context = `shell=${meta.shell} cwd=${meta.cwd ?? "(none)"}`;
+	if (
+		e.code === "ENXIO" ||
+		e.code === "EAGAIN" ||
+		e.code === "ENOSPC" ||
+		/openpty|forkpty|pty/i.test(message)
+	) {
+		return `spawn failed to allocate PTY (${context}): ${message}`;
+	}
+	return `spawn failed (${context}): ${message}`;
 }

--- a/packages/pty-daemon/test/integration.test.ts
+++ b/packages/pty-daemon/test/integration.test.ts
@@ -88,6 +88,93 @@ test("input is forwarded and echoed via output", async () => {
 	await c.close();
 });
 
+test("spawned PTY child can open /dev/tty", async () => {
+	const c = await connectAndHello(sockPath);
+	c.send({
+		type: "open",
+		id: "tty-control",
+		meta: {
+			shell: process.execPath,
+			argv: [
+				"-e",
+				[
+					'const fs = require("node:fs");',
+					'const fd = fs.openSync("/dev/tty", "r+");',
+					"fs.closeSync(fd);",
+					'console.log("tty-open-ok");',
+				].join(" "),
+			],
+			cols: 80,
+			rows: 24,
+		},
+	});
+	await c.waitFor((m) => m.type === "open-ok" && m.id === "tty-control", 3000);
+	c.send({ type: "subscribe", id: "tty-control", replay: true });
+	await c.waitFor(
+		(m) =>
+			m.type === "output" &&
+			m.id === "tty-control" &&
+			payloadAsString(m).includes("tty-open-ok"),
+		3000,
+	);
+	const exit = await c.waitFor(
+		(m) => m.type === "exit" && m.id === "tty-control",
+		3000,
+	);
+	if (exit.type === "exit") assert.equal(exit.code, 0);
+	await c.close();
+});
+
+test("OSC responses in input are stripped before reaching PTY stdin", async () => {
+	const c = await connectAndHello(sockPath);
+	c.send({
+		type: "open",
+		id: "osc-strip",
+		meta: {
+			shell: process.execPath,
+			argv: [
+				"-e",
+				[
+					"const chunks = [];",
+					"process.stdin.setRawMode(true);",
+					"process.stdin.resume();",
+					"function done() {",
+					"  const bytes = Buffer.concat(chunks);",
+					'  console.log("RAW:" + bytes.toString("hex"));',
+					"  process.exit(0);",
+					"}",
+					'process.stdin.on("data", (chunk) => {',
+					"  chunks.push(chunk);",
+					'  if (Buffer.concat(chunks).includes(Buffer.from("b"))) done();',
+					"});",
+					"setTimeout(done, 1000).unref();",
+				].join(" "),
+			],
+			cols: 80,
+			rows: 24,
+		},
+	});
+	await c.waitFor((m) => m.type === "open-ok" && m.id === "osc-strip", 3000);
+	c.send({ type: "subscribe", id: "osc-strip", replay: true });
+	c.send(
+		{ type: "input", id: "osc-strip" },
+		Buffer.from("a\x1b]10;?\x07\x1b]11;?\x07\x1b]52;c;Zm9v\x07b", "utf8"),
+	);
+	await c.waitFor(
+		(m) =>
+			m.type === "output" &&
+			m.id === "osc-strip" &&
+			payloadAsString(m).includes("RAW:6162"),
+		3000,
+	);
+	const exit = await c.waitFor(
+		(m) => m.type === "exit" && m.id === "osc-strip",
+		3000,
+	);
+	if (exit.type === "exit") assert.equal(exit.code, 0);
+	await c.close();
+});
+
 test("Pty.getMasterFd returns a usable kernel fd", () => {
 	// Phase 2 fd-handoff depends on this — surface a clear failure if the
 	// node-pty private-property contract changes under us.


### PR DESCRIPTION
## Summary

fix: restore controlling TTY for PTY child processes and strip OSC response sequences from stdin

Closes #4775

---
AI was used for assistance.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4948">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the controlling TTY for PTY child processes so programs can open `/dev/tty`, and strips OSC response sequences from stdin before writing to the PTY. This prevents terminal query replies from reaching tools like ssh/gh and adds clearer spawn error messages.

- **Bug Fixes**
  - Restored controlling TTY for spawned/adopted PTYs; verified with a new integration test that opens `/dev/tty`.
  - Added `OscInputFilter` to drop OSC replies (C1 OSC, `ESC ] ... BEL`/`ESC \`), handles split chunks, and preserves non-OSC escapes; applied in both `NodePtyAdapter.write` and `AdoptedPty.write`.
  - Improved PTY spawn error formatting for common allocation failures in `node-pty` and OS PTY paths.

<sup>Written for commit 221ad7df661e9d4960a84a332b6bf639d52a1c04. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4948?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of terminal control sequences by filtering escape sequences from input before reaching the PTY.
  * Enhanced error reporting for PTY spawning failures with better formatting and guidance for common allocation errors.

* **Tests**
  * Added comprehensive tests validating input filtering and PTY terminal operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->