### PR TITLE
Add Kimi CLI integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,14 @@ DATABASE_URL_UNPOOLED=
 # Cross-App URLs
 # -----------------------------------------------------------------------------
 NEXT_PUBLIC_API_URL=
+NEXT_PUBLIC_ELECTRIC_URL=
 NEXT_PUBLIC_WEB_URL=
 NEXT_PUBLIC_ADMIN_URL=
 NEXT_PUBLIC_MARKETING_URL=
 NEXT_PUBLIC_DOCS_URL=
+AUTH_URL=
+ELECTRIC_SHAPE_URL=
+ELECTRIC_SECRET=
 
 # -----------------------------------------------------------------------------
 # Better Auth
@@ -75,6 +79,14 @@ SLACK_BILLING_WEBHOOK_URL=
 # Anthropic (server-side AI features)
 # -----------------------------------------------------------------------------
 ANTHROPIC_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Kimi / Moonshot (OpenAI-compatible model backend)
+# The runtime maps this to OPENAI_API_KEY + OPENAI_BASE_URL for Kimi models.
+# -----------------------------------------------------------------------------
+MOONSHOT_API_KEY=
+KIMI_BASE_URL=https://api.moonshot.ai/v1
+KIMI_SMALL_MODEL_ID=kimi-k2.6
 
 # -----------------------------------------------------------------------------
 # Blob Storage

--- a/.env.kimi.example
+++ b/.env.kimi.example
@@ -1,0 +1,14 @@
+# Kimi / Moonshot OpenAI-compatible chat overlay for Superset.
+# Copy .env.local.example to .env first, then add these values.
+#
+# Kimi Code CLI agent usage does not require this file. Run `kimi login`
+# instead, then use the Kimi terminal agent preset in Superset.
+
+# Official Kimi docs use MOONSHOT_API_KEY for Authorization: Bearer.
+MOONSHOT_API_KEY=
+
+# Superset also accepts KIMI_API_KEY as an alias.
+# KIMI_API_KEY=
+
+KIMI_BASE_URL=https://api.moonshot.ai/v1
+KIMI_SMALL_MODEL_ID=kimi-k2.6

--- a/.env.local.example
+++ b/.env.local.example
@@ -32,10 +32,16 @@ DATABASE_URL_UNPOOLED=postgres://postgres:postgres@localhost:5432/main
 # Cross-App URLs (Local Dev)
 # -----------------------------------------------------------------------------
 NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_ELECTRIC_URL=http://localhost:8787
 NEXT_PUBLIC_WEB_URL=http://localhost:3000
 NEXT_PUBLIC_ADMIN_URL=http://localhost:3003
 NEXT_PUBLIC_MARKETING_URL=http://localhost:3002
 NEXT_PUBLIC_DOCS_URL=http://localhost:3004
+
+# Electric proxy (local dev)
+AUTH_URL=http://localhost:3001
+ELECTRIC_SHAPE_URL=http://localhost:3100/v1/shape
+ELECTRIC_SECRET=local_electric_dev_secret
 
 # -----------------------------------------------------------------------------
 # Better Auth
@@ -83,6 +89,15 @@ SLACK_BILLING_WEBHOOK_URL=https://hooks.slack.com/services/FAKE/FAKE/fake
 # Anthropic (server-side AI features — fake for local dev)
 # -----------------------------------------------------------------------------
 ANTHROPIC_API_KEY=sk-ant-fake-local-dev
+
+# -----------------------------------------------------------------------------
+# Kimi / Moonshot (OpenAI-compatible model backend)
+# Fill MOONSHOT_API_KEY or KIMI_API_KEY to use the Kimi models in chat.
+# Leave blank when you do not want local chat routed through Kimi.
+# -----------------------------------------------------------------------------
+MOONSHOT_API_KEY=
+KIMI_BASE_URL=https://api.moonshot.ai/v1
+KIMI_SMALL_MODEL_ID=kimi-k2.6
 
 # -----------------------------------------------------------------------------
 # Blob Storage (fake for local dev)

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn.lock
 # Env variables
 .env
 .env.*
+!.env.kimi.example
 !.bun-version
 
 mise.toml

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ModelPicker/utils/providerToLogo/providerToLogo.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ModelPicker/utils/providerToLogo/providerToLogo.ts
@@ -15,6 +15,7 @@ export function providerToLogo(provider: string): string {
 		lower.includes("codex")
 	)
 		return OPENAI_LOGO_PROVIDER;
+	if (lower.includes("kimi") || lower.includes("moonshot")) return "kimi";
 	if (lower.includes("google") || lower.includes("gemini")) return "google";
 	if (lower.includes("mistral")) return "mistral";
 	if (lower.includes("deepseek")) return "deepseek";

--- a/apps/desktop/src/renderer/lib/dev-chat.ts
+++ b/apps/desktop/src/renderer/lib/dev-chat.ts
@@ -24,6 +24,16 @@ export const DEV_CHAT_MODELS: ModelOption[] = [
 		provider: "Anthropic",
 	},
 	{
+		id: "openai/kimi-k2.6",
+		name: "Kimi K2.6",
+		provider: "Kimi",
+	},
+	{
+		id: "openai/kimi-k2.5",
+		name: "Kimi K2.5",
+		provider: "Kimi",
+	},
+	{
 		id: "openai/gpt-5.5",
 		name: "GPT-5.5",
 		provider: "OpenAI",

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { authClient, setAuthToken, setJwt } from "renderer/lib/auth-client";
 import { SupersetLogo } from "renderer/routes/sign-in/components/SupersetLogo/SupersetLogo";
 import { electronTrpc } from "../../lib/electron-trpc";
@@ -6,6 +6,16 @@ import { electronTrpc } from "../../lib/electron-trpc";
 export function AuthProvider({ children }: { children: ReactNode }) {
 	const [isHydrated, setIsHydrated] = useState(false);
 	const { refetch: refetchSession } = authClient.useSession();
+
+	const refreshJwt = useCallback(async () => {
+		try {
+			const res = await authClient.token();
+			setJwt(res.data?.token ?? null);
+		} catch (err) {
+			setJwt(null);
+			console.warn("[AuthProvider] JWT refresh failed", err);
+		}
+	}, []);
 
 	const { data: storedToken, isSuccess } =
 		electronTrpc.auth.getStoredToken.useQuery(undefined, {
@@ -32,10 +42,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 						);
 					}
 					try {
-						const res = await authClient.token();
-						if (res.data?.token) {
-							setJwt(res.data.token);
-						}
+						await refreshJwt();
 					} catch (err) {
 						console.warn(
 							"[AuthProvider] JWT fetch failed during hydration",
@@ -53,7 +60,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 		return () => {
 			cancelled = true;
 		};
-	}, [storedToken, isSuccess, isHydrated, refetchSession]);
+	}, [storedToken, isSuccess, isHydrated, refetchSession, refreshJwt]);
 
 	electronTrpc.auth.onTokenChanged.useSubscription(undefined, {
 		onData: async (data) => {
@@ -69,6 +76,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 						err,
 					);
 				}
+				await refreshJwt();
 				setIsHydrated(true);
 			} else if (data === null) {
 				setAuthToken(null);
@@ -88,22 +96,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	useEffect(() => {
 		if (!isHydrated) return;
 
-		const refreshJwt = () =>
-			authClient
-				.token()
-				.then((res) => {
-					if (res.data?.token) {
-						setJwt(res.data.token);
-					}
-				})
-				.catch((err: unknown) => {
-					console.warn("[AuthProvider] JWT refresh failed", err);
-				});
-
 		refreshJwt();
 		const interval = setInterval(refreshJwt, 50 * 60 * 1000);
 		return () => clearInterval(interval);
-	}, [isHydrated]);
+	}, [isHydrated, refreshJwt]);
 
 	if (!isHydrated) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ModelPicker/utils/providerToLogo/providerToLogo.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ModelPicker/utils/providerToLogo/providerToLogo.ts
@@ -15,6 +15,7 @@ export function providerToLogo(provider: string): string {
 		lower.includes("codex")
 	)
 		return OPENAI_LOGO_PROVIDER;
+	if (lower.includes("kimi") || lower.includes("moonshot")) return "kimi";
 	if (lower.includes("google") || lower.includes("gemini")) return "google";
 	if (lower.includes("mistral")) return "mistral";
 	if (lower.includes("deepseek")) return "deepseek";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts
@@ -49,7 +49,7 @@ describe("createDefaultV2TerminalPresetRows", () => {
 					presetId: "opencode",
 					label: "OpenCode",
 					command: "opencode",
-					order: 2,
+					order: 3,
 				}),
 				createAgent({
 					id: "copilot-config",
@@ -57,9 +57,17 @@ describe("createDefaultV2TerminalPresetRows", () => {
 					label: "Copilot",
 					command: "copilot",
 					args: ["--allow-tool=write"],
-					order: 3,
+					order: 4,
 				}),
-				createAgent({ presetId: "amp", order: 4 }),
+				createAgent({
+					id: "kimi-config",
+					presetId: "kimi",
+					label: "Kimi",
+					command: "kimi",
+					args: ["--yolo"],
+					order: 2,
+				}),
+				createAgent({ presetId: "amp", order: 5 }),
 			],
 			existingPresets: [],
 			createId: () =>
@@ -70,24 +78,27 @@ describe("createDefaultV2TerminalPresetRows", () => {
 		expect(rows.map((row) => row.agentId)).toEqual([
 			"claude-config",
 			"codex-config",
+			"kimi-config",
 			"opencode-config",
 			"copilot-config",
 		]);
 		expect(rows.map((row) => row.name)).toEqual([
 			"Claude",
 			"Codex",
+			"Kimi",
 			"OpenCode",
 			"Copilot",
 		]);
-		expect(rows.map((row) => row.tabOrder)).toEqual([0, 1, 2, 3]);
+		expect(rows.map((row) => row.tabOrder)).toEqual([0, 1, 2, 3, 4]);
 		expect(rows[0]?.commands).toEqual([
 			"claude --dangerously-skip-permissions",
 		]);
 		expect(rows[1]?.commands).toEqual([
 			"codex --dangerously-bypass-approvals-and-sandbox",
 		]);
-		expect(rows[2]?.commands).toEqual(["opencode"]);
-		expect(rows[3]?.commands).toEqual(["copilot --allow-tool=write"]);
+		expect(rows[2]?.commands).toEqual(["kimi --yolo"]);
+		expect(rows[3]?.commands).toEqual(["opencode"]);
+		expect(rows[4]?.commands).toEqual(["copilot --allow-tool=write"]);
 	});
 
 	it("includes structured agent env in seeded preset command snapshots", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.ts
@@ -6,6 +6,7 @@ import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/provide
 export const DEFAULT_V2_TERMINAL_PRESET_IDS = [
 	"claude",
 	"codex",
+	"kimi",
 	"opencode",
 	"copilot",
 ] as const;

--- a/apps/electric-proxy/.dev.vars.example
+++ b/apps/electric-proxy/.dev.vars.example
@@ -1,5 +1,5 @@
-AUTH_URL=http://localhost:3141
-ELECTRIC_SHAPE_URL=http://localhost:3069/v1/shape
+AUTH_URL=http://localhost:3001
+ELECTRIC_SHAPE_URL=http://localhost:3100/v1/shape
 ELECTRIC_SECRET=local_electric_dev_secret
 ELECTRIC_SOURCE_ID=
 ELECTRIC_SOURCE_SECRET=

--- a/docs/kimi-integration.md
+++ b/docs/kimi-integration.md
@@ -1,0 +1,47 @@
+# Kimi Integration
+
+Superset has two Kimi paths:
+
+- Kimi Code CLI as a terminal agent. This uses the local `kimi` login, including Kimi Code plans from `https://www.kimi.com/code/console`.
+- Kimi through Moonshot's OpenAI-compatible API for the built-in chat model picker.
+
+The CLI path is the short-path integration. Superset seeds a `Kimi` terminal agent preset that launches `kimi --yolo` interactively, and launches prompted tasks with `kimi --yolo --prompt`.
+
+The ACP path is intentionally separate. Kimi CLI supports `kimi acp`, but Superset does not yet act as an ACP client. A full ACP branch should spawn `kimi acp`, initialize the protocol, and map Superset workspace context, prompts, and tool permissions into ACP messages.
+
+## Local Setup
+
+### Kimi Code CLI
+
+```bash
+kimi login
+kimi info
+```
+
+Then open Superset, create or open a workspace, and choose the `Kimi` terminal agent. No Superset `.env` value is needed for this path because credentials live in the local Kimi CLI config.
+
+### OpenAI-Compatible Chat
+
+```bash
+cp .env.local.example .env
+# Edit .env and set MOONSHOT_API_KEY or KIMI_API_KEY.
+docker compose up -d
+bun install
+bun run db:migrate
+bun run db:seed-dev
+bun run dev
+```
+
+Then open Superset, create or open a workspace, and choose `Kimi K2.6` from the model picker.
+
+## Production Env
+
+For OpenAI-compatible chat, set these on the process that runs the host service:
+
+```bash
+MOONSHOT_API_KEY=sk-...
+KIMI_BASE_URL=https://api.moonshot.ai/v1
+KIMI_SMALL_MODEL_ID=kimi-k2.6
+```
+
+`KIMI_API_KEY` is accepted as an alias for `MOONSHOT_API_KEY`. If `OPENAI_API_KEY` or `OPENAI_AUTH_TOKEN` is also set, direct OpenAI credentials take precedence so existing OpenAI deployments keep working.

--- a/packages/chat/src/server/shared/small-model/get-small-model.test.ts
+++ b/packages/chat/src/server/shared/small-model/get-small-model.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { isAnthropicApiKey, isOpenAIApiKey } from "./get-small-model";
+import {
+	isAnthropicApiKey,
+	isKimiApiKey,
+	isOpenAIApiKey,
+} from "./get-small-model";
 
 describe("isAnthropicApiKey", () => {
 	it("accepts a real-shaped key", () => {
@@ -54,5 +58,19 @@ describe("isOpenAIApiKey", () => {
 
 	it("rejects values without the sk- prefix", () => {
 		expect(isOpenAIApiKey("api-key-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).toBe(false);
+	});
+});
+
+describe("isKimiApiKey", () => {
+	it("accepts real-shaped Moonshot API keys", () => {
+		expect(isKimiApiKey("sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).toBe(
+			true,
+		);
+	});
+
+	it("rejects local placeholders", () => {
+		expect(isKimiApiKey("dummy")).toBe(false);
+		expect(isKimiApiKey("sk-kimi-fake-local-dev")).toBe(false);
+		expect(isKimiApiKey("")).toBe(false);
 	});
 });

--- a/packages/chat/src/server/shared/small-model/get-small-model.ts
+++ b/packages/chat/src/server/shared/small-model/get-small-model.ts
@@ -9,8 +9,16 @@ import {
 
 const ANTHROPIC_SMALL_MODEL_ID = "claude-haiku-4-5-20251001";
 const OPENAI_SMALL_MODEL_ID = "gpt-4o-mini";
+const KIMI_SMALL_MODEL_ID = "kimi-k2.6";
+const DEFAULT_KIMI_BASE_URL = "https://api.moonshot.ai/v1";
 
 const MIN_API_KEY_LENGTH = 30;
+const DEV_PLACEHOLDER_KEYS = new Set([
+	"dummy",
+	"placeholder",
+	"sk-kimi-fake-local-dev",
+	"sk-moonshot-fake-local-dev",
+]);
 
 // OAuth tokens issued through the Claude Code flow are accepted by the
 // Anthropic API only when these companion headers are sent alongside the
@@ -52,8 +60,29 @@ export function isOpenAIApiKey(key: string): boolean {
 	return key.startsWith("sk-") && key.length >= MIN_API_KEY_LENGTH;
 }
 
+export function isKimiApiKey(key: string): boolean {
+	const trimmed = key.trim();
+	if (trimmed.length < MIN_API_KEY_LENGTH) return false;
+	const normalized = trimmed.toLowerCase();
+	return !DEV_PLACEHOLDER_KEYS.has(normalized) && !normalized.includes("fake");
+}
+
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
+}
+
+function trimEnvValue(value: string | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function normalizeBaseUrl(value: string | null): string {
+	if (!value) return DEFAULT_KIMI_BASE_URL;
+	try {
+		return new URL(value).toString().replace(/\/$/, "");
+	} catch {
+		return value;
+	}
 }
 
 type AnthropicResolved =
@@ -139,6 +168,37 @@ async function resolveOpenAIApiKey(): Promise<string | null> {
 	return null;
 }
 
+function resolveKimiConfig(): {
+	apiKey: string;
+	baseURL: string;
+	modelId: string;
+} | null {
+	if (
+		trimEnvValue(process.env.OPENAI_API_KEY) ||
+		trimEnvValue(process.env.OPENAI_AUTH_TOKEN)
+	) {
+		return null;
+	}
+
+	const apiKey =
+		trimEnvValue(process.env.KIMI_API_KEY) ??
+		trimEnvValue(process.env.MOONSHOT_API_KEY);
+	if (!apiKey || !isKimiApiKey(apiKey)) return null;
+
+	return {
+		apiKey,
+		baseURL: normalizeBaseUrl(
+			trimEnvValue(process.env.KIMI_BASE_URL) ??
+				trimEnvValue(process.env.KIMI_API_BASE_URL) ??
+				trimEnvValue(process.env.MOONSHOT_BASE_URL),
+		),
+		modelId:
+			trimEnvValue(process.env.KIMI_SMALL_MODEL_ID) ??
+			trimEnvValue(process.env.MOONSHOT_SMALL_MODEL_ID) ??
+			KIMI_SMALL_MODEL_ID,
+	};
+}
+
 /**
  * Returns an AI-SDK `LanguageModel` for small-model tasks (branch naming,
  * title generation). Returns `null` if no usable credentials are available.
@@ -147,8 +207,10 @@ async function resolveOpenAIApiKey(): Promise<string | null> {
  *   1. ANTHROPIC_API_KEY env var (validated)
  *   2. mastracode auth storage — Anthropic api key
  *   3. mastracode auth storage — Anthropic OAuth (refreshed on the fly)
- *   4. OPENAI_API_KEY env var (validated)
- *   5. mastracode auth storage — OpenAI api key (`openai-codex` / `openai`)
+ *   4. KIMI_API_KEY / MOONSHOT_API_KEY env var (OpenAI-compatible, when no
+ *      direct OpenAI env credential is set)
+ *   5. OPENAI_API_KEY env var (validated)
+ *   6. mastracode auth storage — OpenAI api key (`openai-codex` / `openai`)
  *
  * API keys are validated by prefix + minimum length so dev placeholders
  * (e.g. `ANTHROPIC_API_KEY=dummy` from a sample .env) fall through to the
@@ -166,9 +228,23 @@ export async function getSmallModel(): Promise<MastraModelConfig | null> {
 		})(ANTHROPIC_SMALL_MODEL_ID);
 	}
 
+	const kimi = resolveKimiConfig();
+	if (kimi) {
+		return createOpenAI({
+			apiKey: kimi.apiKey,
+			baseURL: kimi.baseURL,
+		}).chat(kimi.modelId);
+	}
+
 	const openaiKey = await resolveOpenAIApiKey();
 	if (openaiKey) {
-		return createOpenAI({ apiKey: openaiKey }).chat(OPENAI_SMALL_MODEL_ID);
+		const openAIBaseURL = trimEnvValue(process.env.OPENAI_BASE_URL);
+		return createOpenAI({
+			apiKey: openaiKey,
+			...(openAIBaseURL
+				? { baseURL: normalizeBaseUrl(openAIBaseURL) }
+				: {}),
+		}).chat(OPENAI_SMALL_MODEL_ID);
 	}
 
 	console.warn(

--- a/packages/chat/src/server/trpc/service.ts
+++ b/packages/chat/src/server/trpc/service.ts
@@ -36,10 +36,46 @@ import {
 } from "./zod";
 
 const ENABLE_MASTRA_MCP_SERVERS = false;
+const DEFAULT_KIMI_BASE_URL = "https://api.moonshot.ai/v1";
 
 type RuntimeQuestionPayload = Parameters<
 	RuntimeSession["harness"]["respondToQuestion"]
 >[0];
+
+function trimEnvValue(value: string | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function normalizeBaseUrl(value: string | null): string {
+	if (!value) return DEFAULT_KIMI_BASE_URL;
+	try {
+		return new URL(value).toString().replace(/\/$/, "");
+	} catch {
+		return value;
+	}
+}
+
+function applyKimiOpenAICompatibleEnv(): void {
+	if (
+		trimEnvValue(process.env.OPENAI_API_KEY) ||
+		trimEnvValue(process.env.OPENAI_AUTH_TOKEN)
+	) {
+		return;
+	}
+
+	const kimiApiKey =
+		trimEnvValue(process.env.KIMI_API_KEY) ??
+		trimEnvValue(process.env.MOONSHOT_API_KEY);
+	if (!kimiApiKey) return;
+
+	process.env.OPENAI_API_KEY = kimiApiKey;
+	process.env.OPENAI_BASE_URL = normalizeBaseUrl(
+		trimEnvValue(process.env.KIMI_BASE_URL) ??
+			trimEnvValue(process.env.KIMI_API_BASE_URL) ??
+			trimEnvValue(process.env.MOONSHOT_BASE_URL),
+	);
+}
 
 function respondToQuestionWithOptimisticState(
 	runtime: RuntimeSession,
@@ -144,6 +180,7 @@ export class ChatRuntimeService {
 					this.opts.apiUrl,
 				);
 
+				applyKimiOpenAICompatibleEnv();
 				const runtime = await createMastraCode({
 					cwd: runtimeCwd,
 					extraTools,

--- a/packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.ts
+++ b/packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.ts
@@ -10,6 +10,11 @@ const CLOUD_PROVIDER_ENV_KEYS = [
 	"OPENAI_API_KEY",
 	"OPENAI_AUTH_TOKEN",
 	"OPENAI_BASE_URL",
+	"KIMI_API_KEY",
+	"KIMI_BASE_URL",
+	"KIMI_API_BASE_URL",
+	"MOONSHOT_API_KEY",
+	"MOONSHOT_BASE_URL",
 	"CLAUDE_CODE_USE_BEDROCK",
 	"AWS_REGION",
 	"AWS_DEFAULT_REGION",
@@ -19,6 +24,8 @@ const CLOUD_PROVIDER_ENV_KEYS = [
 	"AWS_SESSION_TOKEN",
 ] as const;
 
+const DEFAULT_KIMI_BASE_URL = "https://api.moonshot.ai/v1";
+
 interface CloudModelProviderOptions {
 	envResolver?: () => Promise<Record<string, string | undefined>>;
 }
@@ -26,6 +33,15 @@ interface CloudModelProviderOptions {
 function trimEnvValue(value: string | undefined): string | null {
 	const trimmed = value?.trim();
 	return trimmed ? trimmed : null;
+}
+
+function normalizeBaseUrl(value: string | null): string {
+	if (!value) return DEFAULT_KIMI_BASE_URL;
+	try {
+		return new URL(value).toString().replace(/\/$/, "");
+	} catch {
+		return value;
+	}
 }
 
 export class CloudModelProvider implements ModelProviderRuntimeResolver {
@@ -52,6 +68,20 @@ export class CloudModelProvider implements ModelProviderRuntimeResolver {
 			const value = trimEnvValue(sourceEnv[key]);
 			if (!value) continue;
 			nextEnv[key] = value;
+		}
+
+		if (!nextEnv.OPENAI_API_KEY && !nextEnv.OPENAI_AUTH_TOKEN) {
+			const kimiApiKey =
+				trimEnvValue(sourceEnv.KIMI_API_KEY) ??
+				trimEnvValue(sourceEnv.MOONSHOT_API_KEY);
+			if (kimiApiKey) {
+				nextEnv.OPENAI_API_KEY = kimiApiKey;
+				nextEnv.OPENAI_BASE_URL = normalizeBaseUrl(
+					trimEnvValue(sourceEnv.KIMI_BASE_URL) ??
+						trimEnvValue(sourceEnv.KIMI_API_BASE_URL) ??
+						trimEnvValue(sourceEnv.MOONSHOT_BASE_URL),
+				);
+			}
 		}
 
 		const anthropicEnv = buildAnthropicRuntimeEnv({

--- a/packages/host-service/src/providers/model-providers/LocalModelProvider/LocalModelProvider.ts
+++ b/packages/host-service/src/providers/model-providers/LocalModelProvider/LocalModelProvider.ts
@@ -16,10 +16,65 @@ const CLEANUP_KEYS = [
 	"ANTHROPIC_AUTH_TOKEN",
 	"OPENAI_API_KEY",
 	"OPENAI_AUTH_TOKEN",
+	"OPENAI_BASE_URL",
+	"KIMI_API_KEY",
+	"KIMI_BASE_URL",
+	"KIMI_API_BASE_URL",
+	"MOONSHOT_API_KEY",
+	"MOONSHOT_BASE_URL",
 ] as const;
+
+const DEFAULT_KIMI_BASE_URL = "https://api.moonshot.ai/v1";
 
 interface LocalModelProviderOptions {
 	anthropicEnvConfigPath?: string;
+}
+
+function trimEnvValue(value: string | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function normalizeBaseUrl(value: string | null): string {
+	if (!value) return DEFAULT_KIMI_BASE_URL;
+	try {
+		return new URL(value).toString().replace(/\/$/, "");
+	} catch {
+		return value;
+	}
+}
+
+function buildOpenAICompatibleRuntimeEnv(
+	sourceEnv: Record<string, string | undefined>,
+): Record<string, string> {
+	const directOpenAIEnv = {
+		OPENAI_API_KEY: trimEnvValue(sourceEnv.OPENAI_API_KEY),
+		OPENAI_AUTH_TOKEN: trimEnvValue(sourceEnv.OPENAI_AUTH_TOKEN),
+		OPENAI_BASE_URL: trimEnvValue(sourceEnv.OPENAI_BASE_URL),
+	};
+	const hasDirectOpenAIAuth = Boolean(
+		directOpenAIEnv.OPENAI_API_KEY || directOpenAIEnv.OPENAI_AUTH_TOKEN,
+	);
+
+	const runtimeEnv: Record<string, string> = {};
+	for (const [key, value] of Object.entries(directOpenAIEnv)) {
+		if (value) runtimeEnv[key] = value;
+	}
+
+	if (hasDirectOpenAIAuth) return runtimeEnv;
+
+	const kimiApiKey =
+		trimEnvValue(sourceEnv.KIMI_API_KEY) ??
+		trimEnvValue(sourceEnv.MOONSHOT_API_KEY);
+	if (!kimiApiKey) return runtimeEnv;
+
+	runtimeEnv.OPENAI_API_KEY = kimiApiKey;
+	runtimeEnv.OPENAI_BASE_URL = normalizeBaseUrl(
+		trimEnvValue(sourceEnv.KIMI_BASE_URL) ??
+			trimEnvValue(sourceEnv.KIMI_API_BASE_URL) ??
+			trimEnvValue(sourceEnv.MOONSHOT_BASE_URL),
+	);
+	return runtimeEnv;
 }
 
 export class LocalModelProvider implements ModelProviderRuntimeResolver {
@@ -40,16 +95,27 @@ export class LocalModelProvider implements ModelProviderRuntimeResolver {
 		const anthropicEnvConfig = getAnthropicEnvConfig({
 			configPath: this.anthropicEnvConfigPath,
 		});
-		const runtimeEnv = buildAnthropicRuntimeEnv(
+		const openAICompatibleRuntimeEnv = buildOpenAICompatibleRuntimeEnv(
+			process.env as Record<string, string | undefined>,
+		);
+		const anthropicRuntimeEnv = buildAnthropicRuntimeEnv(
 			stripAnthropicCredentialEnvVariables(anthropicEnvConfig.variables),
 		);
+		const runtimeEnv = {
+			...openAICompatibleRuntimeEnv,
+			...anthropicRuntimeEnv,
+		};
 
 		return {
 			env: runtimeEnv,
 			cleanupKeys: [...CLEANUP_KEYS],
 			hasUsableRuntimeEnv:
 				hasUsableCredential(anthropicCredential) ||
-				hasUsableCredential(openaiCredential),
+				hasUsableCredential(openaiCredential) ||
+				Boolean(
+					openAICompatibleRuntimeEnv.OPENAI_API_KEY ||
+						openAICompatibleRuntimeEnv.OPENAI_AUTH_TOKEN,
+				),
 		};
 	}
 

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -39,7 +39,14 @@ async function listFirst(
 	return first;
 }
 
-const DEFAULT_PRESET_IDS = ["claude", "amp", "codex", "gemini", "copilot"];
+const DEFAULT_PRESET_IDS = [
+	"claude",
+	"amp",
+	"codex",
+	"gemini",
+	"kimi",
+	"copilot",
+];
 
 describe("agentConfigsRouter", () => {
 	describe("list()", () => {
@@ -49,7 +56,7 @@ describe("agentConfigsRouter", () => {
 			const result = await caller.list();
 
 			expect(result.map((row) => row.presetId)).toEqual(DEFAULT_PRESET_IDS);
-			expect(result.map((row) => row.order)).toEqual([0, 1, 2, 3, 4]);
+			expect(result.map((row) => row.order)).toEqual([0, 1, 2, 3, 4, 5]);
 		});
 
 		it("does not seed Superset", async () => {
@@ -81,6 +88,20 @@ describe("agentConfigsRouter", () => {
 			expect(codex?.args).not.toContain("--ask-for-approval");
 		});
 
+		it("seeds Kimi with the Kimi Code prompt flag", async () => {
+			const caller = createCaller();
+			const result = await caller.list();
+			const kimi = result.find((row) => row.presetId === "kimi");
+
+			expect(kimi).toMatchObject({
+				label: "Kimi",
+				command: "kimi",
+				args: ["--yolo"],
+				promptTransport: "argv",
+				promptArgs: ["--prompt"],
+			});
+		});
+
 		it("returns existing rows on subsequent calls without re-seeding", async () => {
 			const caller = createCaller();
 			const first = await caller.list();
@@ -99,7 +120,7 @@ describe("agentConfigsRouter", () => {
 			expect(reordered.map((row) => row.presetId)).toEqual(
 				[...DEFAULT_PRESET_IDS].reverse(),
 			);
-			expect(reordered.map((row) => row.order)).toEqual([0, 1, 2, 3, 4]);
+			expect(reordered.map((row) => row.order)).toEqual([0, 1, 2, 3, 4, 5]);
 		});
 	});
 
@@ -113,10 +134,10 @@ describe("agentConfigsRouter", () => {
 			expect(created.presetId).toBe("pi");
 			expect(created.command).toBe("pi");
 			expect(created.promptTransport).toBe("argv");
-			expect(created.order).toBe(5);
+			expect(created.order).toBe(6);
 			const all = await caller.list();
-			expect(all).toHaveLength(6);
-			expect(new Set(all.map((row) => row.id)).size).toBe(6);
+			expect(all).toHaveLength(7);
+			expect(new Set(all.map((row) => row.id)).size).toBe(7);
 		});
 
 		it("allows duplicate presetId tags with distinct ids", async () => {
@@ -300,7 +321,7 @@ describe("agentConfigsRouter", () => {
 			const result = await caller.reorder({ ids: reversed });
 
 			expect(result.map((row) => row.id)).toEqual(reversed);
-			expect(result.map((row) => row.order)).toEqual([0, 1, 2, 3, 4]);
+			expect(result.map((row) => row.order)).toEqual([0, 1, 2, 3, 4, 5]);
 		});
 
 		it("rejects when ids do not match existing configs", async () => {

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -50,6 +50,18 @@ describe("buildAgentPromptCommand", () => {
 		expect(command).toBe("amp < '.superset/task-demo.md'");
 	});
 
+	it("adds Kimi's prompt flag after yolo mode", () => {
+		const command = buildAgentPromptCommand({
+			prompt: "hello",
+			randomId: "kimi-1234",
+			agent: "kimi",
+		});
+
+		expect(command).toStartWith(
+			"kimi --yolo --prompt \"$(cat <<'SUPERSET_PROMPT_kimi1234'",
+		);
+	});
+
 	it("uses pi interactive mode for prompt launches", () => {
 		const command = buildAgentPromptCommand({
 			prompt: "hello",

--- a/packages/shared/src/agent-settings.test.ts
+++ b/packages/shared/src/agent-settings.test.ts
@@ -80,6 +80,19 @@ describe("resolveAgentConfigs", () => {
 		});
 	});
 
+	test("includes Kimi as a built-in terminal config", () => {
+		const kimi = resolveAgentConfigs({}).find((preset) => preset.id === "kimi");
+
+		expect(kimi).toMatchObject({
+			id: "kimi",
+			kind: "terminal",
+			label: "Kimi",
+			command: "kimi --yolo",
+			promptCommand: "kimi --yolo --prompt",
+			enabled: true,
+		});
+	});
+
 	test("includes custom terminal configs from stored definitions", () => {
 		const custom = resolveAgentConfigs({
 			customDefinitions: [

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -93,6 +93,15 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
+		id: "kimi",
+		label: "Kimi",
+		description:
+			"Kimi Code CLI agent backed by the local Kimi login and Kimi Code managed provider.",
+		command: "kimi --yolo",
+		promptCommand: "kimi --yolo --prompt",
+		includeInDefaultTerminalPresets: true,
+	}),
+	createBuiltinTerminalAgent({
 		id: "mastracode",
 		label: "Mastracode",
 		description:

--- a/packages/shared/src/host-agent-presets.ts
+++ b/packages/shared/src/host-agent-presets.ts
@@ -76,6 +76,17 @@ export const HOST_AGENT_PRESETS = [
 		env: {},
 	},
 	{
+		presetId: "kimi",
+		label: "Kimi",
+		description:
+			"Kimi Code CLI agent backed by the local Kimi login and Kimi Code managed provider.",
+		command: "kimi",
+		args: ["--yolo"],
+		promptTransport: "argv",
+		promptArgs: ["--prompt"],
+		env: {},
+	},
+	{
 		presetId: "mastracode",
 		label: "Mastracode",
 		description:
@@ -136,6 +147,7 @@ const DEFAULT_PRESET_IDS = new Set([
 	"amp",
 	"codex",
 	"gemini",
+	"kimi",
 	"copilot",
 ]);
 

--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -30,6 +30,16 @@ const AVAILABLE_MODELS = [
 		provider: "Anthropic",
 	},
 	{
+		id: "openai/kimi-k2.6",
+		name: "Kimi K2.6",
+		provider: "Kimi",
+	},
+	{
+		id: "openai/kimi-k2.5",
+		name: "Kimi K2.5",
+		provider: "Kimi",
+	},
+	{
 		id: "openai/gpt-5.5",
 		name: "GPT-5.5",
 		provider: "OpenAI",


### PR DESCRIPTION
## Summary
- add Kimi/Moonshot OpenAI-compatible chat configuration and model picker entries
- seed Kimi as a built-in terminal agent using the local Kimi CLI short path
- document Kimi Code console/API key setup and defer ACP client support to a later branch
- refresh desktop auth JWT during token hydration to keep local dev Electric auth in sync

## Verification
- bun test packages/shared/src/agent-command.test.ts packages/shared/src/agent-settings.test.ts packages/host-service/src/trpc/router/settings/agent-configs.test.ts apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts packages/chat/src/server/shared/small-model/get-small-model.test.ts packages/chat/src/server/trpc/service.test.ts packages/chat/src/server/trpc/service.runtime-creation.test.ts
- git diff --check
- launched the desktop app, verified the Kimi agent preset and terminal import UI, and sent a successful Kimi CLI prompt via the workspace terminal

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4953">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kimi integration: a built-in Kimi Code CLI terminal agent and OpenAI-compatible Kimi/Moonshot chat support with model picker entries. Also refreshes the desktop auth JWT on hydration and updates local Electric dev env examples.

- New Features
  - Seeded Kimi terminal agent preset (`kimi --yolo`; prompts via `--prompt`).
  - Added Kimi/Moonshot models to the chat model picker and logo mapping.
  - Auto-map `KIMI_API_KEY`/`MOONSHOT_API_KEY` to `OPENAI_*` when no OpenAI creds are set (runtime, cloud/local providers, small-model selection). Defaults to `kimi-k2.6` with `https://api.moonshot.ai/v1`.
  - Improved desktop auth: refresh JWT on hydration and token changes. Added `.env.kimi.example` and `docs/kimi-integration.md`. Updated local Electric dev URLs in examples.

- Migration
  - CLI: run `kimi login` to use the Kimi terminal agent (no env needed).
  - API: set `MOONSHOT_API_KEY` (or `KIMI_API_KEY`); optional `KIMI_BASE_URL` and `KIMI_SMALL_MODEL_ID`. Existing `OPENAI_*` envs still take precedence.
  - Local dev (if needed): update `.env.local` with `NEXT_PUBLIC_ELECTRIC_URL`, `AUTH_URL`, `ELECTRIC_SHAPE_URL`, and `ELECTRIC_SECRET`.

<sup>Written for commit 529beea81a443d6f59e82e05b4a194f5880909a6. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/4953?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

