### PR TITLE
fix: solve #4690 — reuse existing Run tab instead of opening a new one

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspaceRun/useV2WorkspaceRun.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspaceRun/useV2WorkspaceRun.ts
@@ -182,10 +182,39 @@ export function useV2WorkspaceRun({
 				};
 			});
 
-			const tabId = crypto.randomUUID();
-			const paneId = crypto.randomUUID();
-			const pane = makeTerminalPane(terminalId, paneId);
-			store.getState().addTab({ id: tabId, panes: [pane] });
+			// Reuse the existing Workspace Run pane so repeated Run invocations
+			// don't accumulate a new tab every time. See issue #4690.
+			const state = store.getState();
+			let reused: { tabId: string; paneId: string } | null = null;
+			for (let i = state.tabs.length - 1; i >= 0; i--) {
+				const tab = state.tabs[i];
+				if (!tab) continue;
+				for (const [paneId, pane] of Object.entries(tab.panes)) {
+					if (
+						pane.kind === "terminal" &&
+						pane.titleOverride === "Workspace Run"
+					) {
+						reused = { tabId: tab.id, paneId };
+						break;
+					}
+				}
+				if (reused) break;
+			}
+
+			if (reused) {
+				const nextData: TerminalPaneData = { terminalId };
+				state.setPaneData({ paneId: reused.paneId, data: nextData });
+				state.setActivePane({
+					tabId: reused.tabId,
+					paneId: reused.paneId,
+				});
+				state.setActiveTab(reused.tabId);
+			} else {
+				const tabId = crypto.randomUUID();
+				const paneId = crypto.randomUUID();
+				const pane = makeTerminalPane(terminalId, paneId);
+				state.addTab({ id: tabId, panes: [pane] });
+			}
 		} catch (error) {
 			toast.error("Failed to run workspace command", {
 				description: error instanceof Error ? error.message : "Unknown error",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspaceRun/useV2WorkspaceRun.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspaceRun/useV2WorkspaceRun.ts
@@ -165,9 +165,9 @@ export function useV2WorkspaceRun({
 		isStartingRef.current = true;
 		setIsPending(true);
 		try {
-			// Snapshot prior workspace-run terminal IDs so we can identify the
-			// pane to reuse without depending on a UI string. A terminal pane is
-			// a "workspace run" pane iff its terminalId is in this set.
+			// A terminal pane is a "workspace run" pane iff its terminalId is in
+			// workspaceRunTerminals. Snapshot before launch so the new terminal
+			// we're about to create doesn't itself match.
 			const priorRunTerminalIds = new Set(Object.keys(workspaceRunTerminals));
 
 			const terminalId = await launcher.create({
@@ -187,8 +187,6 @@ export function useV2WorkspaceRun({
 				};
 			});
 
-			// Reuse the most recent workspace-run pane so repeated Run
-			// invocations don't accumulate a new tab every time. See #4690.
 			const state = store.getState();
 			let reused: { tabId: string; paneId: string } | null = null;
 			for (let i = state.tabs.length - 1; i >= 0; i--) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspaceRun/useV2WorkspaceRun.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspaceRun/useV2WorkspaceRun.ts
@@ -165,6 +165,11 @@ export function useV2WorkspaceRun({
 		isStartingRef.current = true;
 		setIsPending(true);
 		try {
+			// Snapshot prior workspace-run terminal IDs so we can identify the
+			// pane to reuse without depending on a UI string. A terminal pane is
+			// a "workspace run" pane iff its terminalId is in this set.
+			const priorRunTerminalIds = new Set(Object.keys(workspaceRunTerminals));
+
 			const terminalId = await launcher.create({
 				command,
 				cwd: definition.cwd,
@@ -182,18 +187,17 @@ export function useV2WorkspaceRun({
 				};
 			});
 
-			// Reuse the existing Workspace Run pane so repeated Run invocations
-			// don't accumulate a new tab every time. See issue #4690.
+			// Reuse the most recent workspace-run pane so repeated Run
+			// invocations don't accumulate a new tab every time. See #4690.
 			const state = store.getState();
 			let reused: { tabId: string; paneId: string } | null = null;
 			for (let i = state.tabs.length - 1; i >= 0; i--) {
 				const tab = state.tabs[i];
 				if (!tab) continue;
 				for (const [paneId, pane] of Object.entries(tab.panes)) {
-					if (
-						pane.kind === "terminal" &&
-						pane.titleOverride === "Workspace Run"
-					) {
+					if (pane.kind !== "terminal") continue;
+					const paneTerminalId = (pane.data as TerminalPaneData).terminalId;
+					if (paneTerminalId && priorRunTerminalIds.has(paneTerminalId)) {
 						reused = { tabId: tab.id, paneId };
 						break;
 					}
@@ -223,7 +227,14 @@ export function useV2WorkspaceRun({
 			isStartingRef.current = false;
 			setIsPending(false);
 		}
-	}, [definition, launcher, store, updateWorkspaceRunTerminals, workspaceId]);
+	}, [
+		definition,
+		launcher,
+		store,
+		updateWorkspaceRunTerminals,
+		workspaceId,
+		workspaceRunTerminals,
+	]);
 
 	const stopWorkspaceRun = useCallback(async () => {
 		if (!runningState) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
@@ -134,8 +134,41 @@ export function useWorkspaceRunCommand({
 			const fallbackCwd = worktreePath?.trim() ? worktreePath : undefined;
 			const initialCwd = runDefinition?.cwd ?? fallbackCwd;
 
-			// Always start in a fresh tab. Old run panes stay inspectable instead
-			// of having their terminal session swapped under the user.
+			// Reuse the existing (stopped) run pane so repeated Run invocations
+			// don't accumulate a new tab every time. See issue #4690.
+			if (runPane) {
+				const tabsState = useTabsStore.getState();
+				const tab = tabsState.tabs.find((t) => t.id === runPane.tabId);
+				if (tab) {
+					setActiveTab(workspaceId, tab.id);
+					setFocusedPane(tab.id, runPane.id);
+				}
+				setPaneName(runPane.id, "Workspace Run");
+				setPaneWorkspaceRun(
+					runPane.id,
+					createWorkspaceRun({
+						workspaceId,
+						state: "running",
+						command,
+					}),
+				);
+				try {
+					await launchWorkspaceRunInPane({
+						paneId: runPane.id,
+						tabId: runPane.tabId,
+						command,
+						cwd: initialCwd,
+					});
+				} catch (error) {
+					setPaneWorkspaceRunState(runPane.id, "stopped-by-exit");
+					toast.error("Failed to run workspace command", {
+						description:
+							error instanceof Error ? error.message : "Unknown error",
+					});
+				}
+				return;
+			}
+
 			const result = addTab(workspaceId, { initialCwd });
 			const { tabId, paneId } = result;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
@@ -136,16 +136,19 @@ export function useWorkspaceRunCommand({
 
 			// Reuse the existing (stopped) run pane so repeated Run invocations
 			// don't accumulate a new tab every time. See issue #4690.
-			if (runPane) {
-				const tabsState = useTabsStore.getState();
-				const tab = tabsState.tabs.find((t) => t.id === runPane.tabId);
-				if (tab) {
-					setActiveTab(workspaceId, tab.id);
-					setFocusedPane(tab.id, runPane.id);
-				}
-				setPaneName(runPane.id, "Workspace Run");
+			// Re-read from the store: runPane was captured before the await
+			// above and the pane/tab may have been closed in the meantime.
+			const tabsState = useTabsStore.getState();
+			const livePane = runPane ? tabsState.panes[runPane.id] : undefined;
+			const liveTab = livePane
+				? tabsState.tabs.find((t) => t.id === livePane.tabId)
+				: undefined;
+			if (livePane && liveTab) {
+				setActiveTab(workspaceId, liveTab.id);
+				setFocusedPane(liveTab.id, livePane.id);
+				setPaneName(livePane.id, "Workspace Run");
 				setPaneWorkspaceRun(
-					runPane.id,
+					livePane.id,
 					createWorkspaceRun({
 						workspaceId,
 						state: "running",
@@ -154,13 +157,13 @@ export function useWorkspaceRunCommand({
 				);
 				try {
 					await launchWorkspaceRunInPane({
-						paneId: runPane.id,
-						tabId: runPane.tabId,
+						paneId: livePane.id,
+						tabId: livePane.tabId,
 						command,
 						cwd: initialCwd,
 					});
 				} catch (error) {
-					setPaneWorkspaceRunState(runPane.id, "stopped-by-exit");
+					setPaneWorkspaceRunState(livePane.id, "stopped-by-exit");
 					toast.error("Failed to run workspace command", {
 						description:
 							error instanceof Error ? error.message : "Unknown error",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
@@ -134,8 +134,6 @@ export function useWorkspaceRunCommand({
 			const fallbackCwd = worktreePath?.trim() ? worktreePath : undefined;
 			const initialCwd = runDefinition?.cwd ?? fallbackCwd;
 
-			// Reuse the existing (stopped) run pane so repeated Run invocations
-			// don't accumulate a new tab every time. See issue #4690.
 			// Re-read from the store: runPane was captured before the await
 			// above and the pane/tab may have been closed in the meantime.
 			const tabsState = useTabsStore.getState();


### PR DESCRIPTION
## Summary
- Restores the pre-#4335 behavior in `useWorkspaceRunCommand` where triggering Run (button or `Cmd+G`) reuses the existing dedicated Run pane instead of opening a brand new tab.
- The `runPane` selector already prefers a running pane and falls back to any matching pane, so during a fresh start we pick the previous (stopped) run pane and re-launch the command in it.
- Fixes #4690.

## Test plan
- [ ] Open a workspace with a configured run script.
- [ ] Trigger Run (`Cmd+G` or button) — a Workspace Run tab opens and the command runs.
- [ ] Stop the run.
- [ ] Trigger Run again — confirm it re-launches in the **same** tab/pane (tab count does not grow).
- [ ] Repeat several times — tab count stays constant.
- [ ] While a run is already in progress, `Cmd+G` still acts as Stop (sends Ctrl+C) as before.
- [ ] `bun run lint` and `bun run typecheck` pass.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse the existing Workspace Run pane for Run (button or Cmd+G) in v1 and v2 so repeated runs don't open new tabs. Re-read the pane from the store after async setup with fallback if closed; in v2 match panes by terminalId (not title), restoring pre-#4335 and fixing #4690; also remove transient comments per `AGENTS.md`.

<sup>Written for commit 0dbb960338bd8c74ff5d97979294244f9249bf42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4960?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The workspace Run/Stop toggle now reuses existing terminal panes for previously stopped runs when available: it reactivates and updates the pane to running, launches the resolved command in the same working directory, and preserves the tab instead of creating a new one. If no reusable pane is found a new tab is created. On launch failure the pane is marked stopped and an error toast is shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->