### PR TITLE
feat(desktop): restart daemon from terminal-unreachable toast

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -1,3 +1,4 @@
+import { toast } from "@superset/ui/sonner";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
@@ -250,6 +251,25 @@ export const Terminal = memo(function Terminal({
 	// Auto-retry connection with exponential backoff
 	const retryCountRef = useRef(0);
 	const MAX_RETRIES = 5;
+	const daemonFailureToastShownRef = useRef(false);
+
+	const restartDaemonMutation = electronTrpc.terminal.restartDaemon.useMutation(
+		{
+			onSuccess: () => {
+				toast.success("Daemon restarted", {
+					description:
+						"All sessions killed and daemon restarted. The app will use a fresh daemon.",
+				});
+			},
+			onError: (error) => {
+				toast.error("Failed to restart daemon", {
+					description: error.message,
+				});
+			},
+		},
+	);
+	const restartDaemonMutationRef = useRef(restartDaemonMutation);
+	restartDaemonMutationRef.current = restartDaemonMutation;
 
 	// Stream handling
 	const { handleTerminalExit, handleStreamError, handleStreamData } =
@@ -272,9 +292,28 @@ export const Terminal = memo(function Terminal({
 
 	// Auto-retry when connection error is set
 	useEffect(() => {
-		if (!connectionError) return;
+		if (!connectionError) {
+			daemonFailureToastShownRef.current = false;
+			return;
+		}
 		if (isExitedRef.current) return;
-		if (retryCountRef.current >= MAX_RETRIES) return;
+		if (retryCountRef.current >= MAX_RETRIES) {
+			if (!daemonFailureToastShownRef.current) {
+				daemonFailureToastShownRef.current = true;
+				toast.error("Terminal daemon unreachable", {
+					description:
+						"Couldn't reconnect after several attempts. Restart the daemon to recover.",
+					duration: Number.POSITIVE_INFINITY,
+					action: {
+						label: "Restart daemon",
+						onClick: () => {
+							restartDaemonMutationRef.current.mutate();
+						},
+					},
+				});
+			}
+			return;
+		}
 
 		if (retryCountRef.current === 0) {
 			xtermRef.current?.writeln(


### PR DESCRIPTION
## Summary
- Adds a persistent "Terminal daemon unreachable" toast that fires once after auto-reconnect exhausts its 5 retries.
- Toast includes a **Restart daemon** action that calls the same `electronTrpc.terminal.restartDaemon` mutation used by Settings → Terminal → Manage sessions.
- Toast state resets when the connection recovers, so it won't double-fire on subsequent failures.

## Test plan
- [ ] Kill host-service / pty-daemon while a terminal pane is open; confirm reconnect attempts fire, then the toast appears after retries exhaust.
- [ ] Click **Restart daemon** in the toast; verify success toast appears and a fresh daemon starts on the next terminal action.
- [ ] Toast does not re-fire on transient disconnects that recover within 5 retries.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4962">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent "Terminal daemon unreachable" toast after 5 failed auto-reconnect attempts, with a Restart daemon action that calls `electronTrpc.terminal.restartDaemon`. The toast shows only once per failure, resets on recovery, and displays success/error feedback.

<sup>Written for commit 51fdacf80b3991fd331080dbb7da0ea162caec90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4962?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Terminal now displays clearer notifications when the daemon becomes unreachable, with a quick restart action button available directly in the error message.
  * Improved terminal connection error state handling and feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->