### PR TITLE
fix: solve #4939 — right-click closing terminal/CLI tab

### DIFF
--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -98,18 +98,15 @@ function ContextMenuContent({
 	ref,
 	...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
-	// On Linux/Wayland the pointerup paired with `contextmenu` lands on the
-	// freshly-mounted item under the cursor. Radix's MenuItem treats
-	// pointerup-without-prior-pointerdown as "user dragged in" and synchronously
-	// calls `event.currentTarget?.click()` → onSelect, so the right-click that
-	// opens the menu also fires the item beneath it (usually destructive Close
-	// Pane). Intercept pointerup — not mouseup, which the browser dispatches
-	// after pointerup, by which time the synthesized click has already run.
-	// Reset per event so the guard re-arms for force-mounted content. Uses a
-	// callback ref so listeners attach when the portaled Content actually
-	// mounts (and detach when it unmounts) — a useEffect on the wrapper would
-	// run with a null ref, since Portal renders its child only when the menu
-	// is open. See superset-sh/superset#4939.
+	// Wayland delivers a stray pointerup with the opening `contextmenu`,
+	// landing on the just-mounted item under the cursor. Radix's MenuItem
+	// treats pointerup with no prior pointerdown as a drag-release and calls
+	// `event.currentTarget?.click()` → onSelect, so opening the menu fires
+	// whatever item sits under the cursor (usually destructive Close Pane).
+	// Intercept pointerup, not mouseup — mouseup arrives too late. Reset per
+	// event so the guard re-arms for force-mounted content. Callback ref
+	// (not useEffect): Portal renders its child only when open, so useEffect
+	// on the wrapper would see a null ref. See superset-sh/superset#4939.
 	const forwardedRef = React.useRef(ref);
 	forwardedRef.current = ref;
 	const cleanupRef = React.useRef<(() => void) | null>(null);

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -104,17 +104,15 @@ function ContextMenuContent({
 		() => innerRef.current as HTMLDivElement,
 	);
 
-	// Suppress the pointerup that opened the menu from triggering a menu item.
 	// On Linux/Wayland the pointerup paired with `contextmenu` lands on the
-	// freshly-mounted item under the cursor, and Radix's MenuItem treats
-	// pointerup-without-prior-pointerdown as "user dragged in" and synchronously
-	// calls `event.currentTarget?.click()` → onSelect. We intercept pointerup
-	// (not mouseup — the browser dispatches pointerup first, so by mouseup time
-	// the synthesized click has already run) in capture phase, gated on "did a
-	// real pointerdown happen on this content first?" so legitimate clicks
-	// (which always start with pointerdown on content) are never affected. The
-	// flag resets per pointerup so the guard works for every subsequent open,
-	// including force-mounted content. See superset-sh/superset#4939.
+	// freshly-mounted item under the cursor. Radix's MenuItem treats
+	// pointerup-without-prior-pointerdown as "user dragged in" and
+	// synchronously calls `event.currentTarget?.click()` → onSelect, so the
+	// right-click that opens the menu also fires the item beneath it (usually
+	// destructive Close Pane). Intercept pointerup — not mouseup, which the
+	// browser dispatches after pointerup, by which time the synthesized click
+	// has already run. Reset per event so the guard re-arms for force-mounted
+	// content. See superset-sh/superset#4939.
 	React.useLayoutEffect(() => {
 		const node = innerRef.current;
 		if (!node) return;

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
@@ -95,11 +95,50 @@ function ContextMenuSubContent({
 
 function ContextMenuContent({
 	className,
+	ref,
 	...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+	const innerRef = React.useRef<HTMLDivElement>(null);
+	React.useImperativeHandle(
+		ref as React.Ref<HTMLDivElement>,
+		() => innerRef.current as HTMLDivElement,
+	);
+
+	// Suppress the mouseup that opened the menu from triggering a menu item.
+	// On Linux/Wayland the mouseup paired with `contextmenu` lands on the
+	// freshly-mounted item under the cursor, and Radix's MenuItem treats
+	// pointerup-without-prior-pointerdown as "user dragged in" and fires a
+	// synthesized click → onSelect. We swallow that single leaked mouseup in
+	// capture phase, gated on "did a real mousedown happen on this content
+	// first?" so legitimate clicks (which always start with mousedown on
+	// content) are never affected. See superset-sh/superset#4939.
+	React.useEffect(() => {
+		const node = innerRef.current;
+		if (!node) return;
+		let sawMouseDown = false;
+		const onDown = () => {
+			sawMouseDown = true;
+		};
+		const onUp = (event: MouseEvent) => {
+			if (!sawMouseDown) {
+				event.stopPropagation();
+				event.preventDefault();
+			}
+			node.removeEventListener("mousedown", onDown, true);
+			node.removeEventListener("mouseup", onUp, true);
+		};
+		node.addEventListener("mousedown", onDown, true);
+		node.addEventListener("mouseup", onUp, true);
+		return () => {
+			node.removeEventListener("mousedown", onDown, true);
+			node.removeEventListener("mouseup", onUp, true);
+		};
+	}, []);
+
 	return (
 		<ContextMenuPrimitive.Portal>
 			<ContextMenuPrimitive.Content
+				ref={innerRef}
 				data-slot="context-menu-content"
 				className={cn(
 					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -98,23 +98,27 @@ function ContextMenuContent({
 	ref,
 	...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
-	const innerRef = React.useRef<HTMLDivElement>(null);
-	React.useImperativeHandle(
-		ref as React.Ref<HTMLDivElement>,
-		() => innerRef.current as HTMLDivElement,
-	);
-
 	// On Linux/Wayland the pointerup paired with `contextmenu` lands on the
 	// freshly-mounted item under the cursor. Radix's MenuItem treats
-	// pointerup-without-prior-pointerdown as "user dragged in" and
-	// synchronously calls `event.currentTarget?.click()` → onSelect, so the
-	// right-click that opens the menu also fires the item beneath it (usually
-	// destructive Close Pane). Intercept pointerup — not mouseup, which the
-	// browser dispatches after pointerup, by which time the synthesized click
-	// has already run. Reset per event so the guard re-arms for force-mounted
-	// content. See superset-sh/superset#4939.
-	React.useLayoutEffect(() => {
-		const node = innerRef.current;
+	// pointerup-without-prior-pointerdown as "user dragged in" and synchronously
+	// calls `event.currentTarget?.click()` → onSelect, so the right-click that
+	// opens the menu also fires the item beneath it (usually destructive Close
+	// Pane). Intercept pointerup — not mouseup, which the browser dispatches
+	// after pointerup, by which time the synthesized click has already run.
+	// Reset per event so the guard re-arms for force-mounted content. Uses a
+	// callback ref so listeners attach when the portaled Content actually
+	// mounts (and detach when it unmounts) — a useEffect on the wrapper would
+	// run with a null ref, since Portal renders its child only when the menu
+	// is open. See superset-sh/superset#4939.
+	const forwardedRef = React.useRef(ref);
+	forwardedRef.current = ref;
+	const cleanupRef = React.useRef<(() => void) | null>(null);
+	const setRef = React.useCallback((node: HTMLDivElement | null) => {
+		cleanupRef.current?.();
+		cleanupRef.current = null;
+		const forwarded = forwardedRef.current;
+		if (typeof forwarded === "function") forwarded(node);
+		else if (forwarded) forwarded.current = node;
 		if (!node) return;
 		let sawPointerDown = false;
 		const onDown = () => {
@@ -129,7 +133,7 @@ function ContextMenuContent({
 		};
 		node.addEventListener("pointerdown", onDown, true);
 		node.addEventListener("pointerup", onUp, true);
-		return () => {
+		cleanupRef.current = () => {
 			node.removeEventListener("pointerdown", onDown, true);
 			node.removeEventListener("pointerup", onUp, true);
 		};
@@ -138,7 +142,7 @@ function ContextMenuContent({
 	return (
 		<ContextMenuPrimitive.Portal>
 			<ContextMenuPrimitive.Content
-				ref={innerRef}
+				ref={setRef}
 				data-slot="context-menu-content"
 				className={cn(
 					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -104,34 +104,36 @@ function ContextMenuContent({
 		() => innerRef.current as HTMLDivElement,
 	);
 
-	// Suppress the mouseup that opened the menu from triggering a menu item.
-	// On Linux/Wayland the mouseup paired with `contextmenu` lands on the
+	// Suppress the pointerup that opened the menu from triggering a menu item.
+	// On Linux/Wayland the pointerup paired with `contextmenu` lands on the
 	// freshly-mounted item under the cursor, and Radix's MenuItem treats
-	// pointerup-without-prior-pointerdown as "user dragged in" and fires a
-	// synthesized click → onSelect. We swallow that single leaked mouseup in
-	// capture phase, gated on "did a real mousedown happen on this content
-	// first?" so legitimate clicks (which always start with mousedown on
-	// content) are never affected. See superset-sh/superset#4939.
-	React.useEffect(() => {
+	// pointerup-without-prior-pointerdown as "user dragged in" and synchronously
+	// calls `event.currentTarget?.click()` → onSelect. We intercept pointerup
+	// (not mouseup — the browser dispatches pointerup first, so by mouseup time
+	// the synthesized click has already run) in capture phase, gated on "did a
+	// real pointerdown happen on this content first?" so legitimate clicks
+	// (which always start with pointerdown on content) are never affected. The
+	// flag resets per pointerup so the guard works for every subsequent open,
+	// including force-mounted content. See superset-sh/superset#4939.
+	React.useLayoutEffect(() => {
 		const node = innerRef.current;
 		if (!node) return;
-		let sawMouseDown = false;
+		let sawPointerDown = false;
 		const onDown = () => {
-			sawMouseDown = true;
+			sawPointerDown = true;
 		};
-		const onUp = (event: MouseEvent) => {
-			if (!sawMouseDown) {
+		const onUp = (event: PointerEvent) => {
+			if (!sawPointerDown) {
 				event.stopPropagation();
 				event.preventDefault();
 			}
-			node.removeEventListener("mousedown", onDown, true);
-			node.removeEventListener("mouseup", onUp, true);
+			sawPointerDown = false;
 		};
-		node.addEventListener("mousedown", onDown, true);
-		node.addEventListener("mouseup", onUp, true);
+		node.addEventListener("pointerdown", onDown, true);
+		node.addEventListener("pointerup", onUp, true);
 		return () => {
-			node.removeEventListener("mousedown", onDown, true);
-			node.removeEventListener("mouseup", onUp, true);
+			node.removeEventListener("pointerdown", onDown, true);
+			node.removeEventListener("pointerup", onUp, true);
 		};
 	}, []);
 


### PR DESCRIPTION
## Root cause

On Linux/Wayland, the `mouseup` paired with the `contextmenu` event that opens the menu lands on the freshly-mounted item under the cursor. Radix's `MenuItem` has this heuristic in [menu.tsx](https://github.com/radix-ui/primitives/blob/main/packages/react/menu/src/menu.tsx):

```ts
const isPointerDownRef = React.useRef(false);
onPointerDown: () => { isPointerDownRef.current = true; }
onPointerUp: (event) => {
  if (!isPointerDownRef.current) event.currentTarget?.click();
}
```

The intent is "user dragged in and released → fire click." The Wayland leak satisfies that exact pattern: the item was just mounted, never saw a pointerdown, and the synthesized click runs `onSelect`. When the menu flips upward (right-click near viewport bottom — common for terminal/CLI panes) the bottom destructive item, **Close Pane**, lands under the cursor and the tab dies on the gesture that opened the menu.

No upstream Radix fix or tracked issue exists for this (searched).

## The fix

Add a guard at `ContextMenuContent` level so every consumer (terminal, chat, editor, browser, future menus) is covered:

- On mount, attach capture-phase `mousedown` + `mouseup` listeners on the content root.
- On the first `mouseup`: if no `mousedown` landed on the content first, call `stopPropagation()` + `preventDefault()`. That stops the event in capture before any MenuItem child sees it.
- Both listeners self-remove after the first `mouseup`. Steady-state cost is zero.

The discriminator — "was there a real mousedown on this content?" — is the *causal* signal, not a timer:
- A legitimate click always begins with mousedown on the content → never blocked.
- The Wayland leaked mouseup has no preceding mousedown on the content → always blocked.

## Why not the time-window approach in #4940

| | #4940 (300ms timer on Close Pane only) | this PR |
|---|---|---|
| Magic number | 300ms guess | none |
| Coverage | Close Pane only | every item in every `ContextMenu` |
| Sub-300ms intentional click | swallowed | works |
| Menu flips onto a non-Close item (Equalize, Move to Tab, etc.) | still fires | blocked |
| Discriminator | time-since-open | actual click vs. leaked event |

## Test plan

- [ ] Linux/Wayland: right-click terminal pane many times near viewport bottom; tab no longer closes
- [ ] Linux/Wayland: right-click chat, editor, browser panes; intentional Close Pane after menu opens still works
- [ ] macOS / Windows: no regression — context menus open and select normally
- [ ] Keyboard-opened menu (Shift+F10 or context key) still selects on Enter

Closes #4939

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4968">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents accidental tab closure when opening context menus on Linux/Wayland by intercepting the leaked `pointerup` that triggers a synthetic click in `@radix-ui/react-context-menu`. Closes #4939.

- **Bug Fixes**
  - Added capture-phase pointerdown/pointerup guard in ContextMenuContent via a callback ref that attaches when the portaled content mounts; intercepts pointerup before Radix’s item handler and cancels it if no prior pointerdown. Flag resets on each pointerup; listeners persist on force-mounted content.
  - Covers all context menus; no timers; real clicks and keyboard interactions remain unaffected.

<sup>Written for commit 9f471684b228394da359f3d4ccd98ba004343959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental item selection when opening context menus by improving pointer-event handling, making right-click menus more reliable.
  * Increased stability for context menus during rapid open/close interactions to reduce unintended activations and flicker.

* **Chores**
  * Internal compatibility and housekeeping updates to support more robust and predictable menu behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->