### PR TITLE
docs: document setup.local.sh contributor flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@ When contributing to this repository, please first discuss the change you wish t
 
 Please note we have a [code of conduct](./CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
+## Local Development Setup
+
+Prereqs: `bun`, `docker`, `jq`, `caddy` (`brew install jq caddy && caddy trust`).
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+This copies `.env.local.example` → `.env`, brings up a per-workspace Postgres + neon-proxy + Electric stack on isolated ports, runs migrations, and seeds a `Local Admin` account. Sign in with the **"Sign in as dev"** button on the sign-in page, or use `admin@local.test` / `supersetdev`. Tear the stack down with `./.superset/teardown.local.sh`.
+
+You do not need a Neon account, Stripe keys, or any other third-party credentials for local development — `.env.local.example` ships fake placeholders that pass env validation.
+
 ## Pull Request Process
 
 1. To create a Pull Request (PR), [create a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) of the project. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,14 @@ Please note we have a [code of conduct](./CODE_OF_CONDUCT.md), please follow it 
 
 ## Local Development Setup
 
-Prereqs: `bun`, `docker`, `jq`, `caddy` (`brew install jq caddy && caddy trust`).
+See [**DEVELOPMENT.md**](./DEVELOPMENT.md) for the full guide. TL;DR:
 
 ```bash
 ./.superset/setup.local.sh
 bun run dev
 ```
 
-This copies `.env.local.example` → `.env`, brings up a per-workspace Postgres + neon-proxy + Electric stack on isolated ports, runs migrations, and seeds a `Local Admin` account. Sign in with the **"Sign in as dev"** button on the sign-in page, or use `admin@local.test` / `supersetdev`. Tear the stack down with `./.superset/teardown.local.sh`.
-
-You do not need a Neon account, Stripe keys, or any other third-party credentials for local development — `.env.local.example` ships fake placeholders that pass env validation.
+No Neon or third-party credentials required for local development.
 
 ## Pull Request Process
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,91 @@
+# Developing Superset
+
+This guide is for contributors building Superset from source. If you just want to use Superset, [download the macOS app](https://github.com/superset-sh/superset/releases/latest) instead.
+
+## Prerequisites
+
+| Tool | Install |
+|:-----|:--------|
+| [Bun](https://bun.sh/) (v1.0+) | `curl -fsSL https://bun.sh/install \| bash` |
+| [Docker](https://docs.docker.com/get-docker/) | Docker Desktop or OrbStack |
+| `jq` | `brew install jq` |
+| [Caddy](https://caddyserver.com/docs/install) | `brew install caddy && caddy trust` |
+| Git 2.20+ and [`gh`](https://cli.github.com/) | `brew install gh` |
+
+macOS is the primary supported platform. Windows / Linux are untested.
+
+## Run it (one command)
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+cd superset
+./.superset/setup.local.sh
+bun run dev
+```
+
+That's it. **You do not need a Neon account, Stripe keys, or any other third-party credentials** — `.env.local.example` ships fake placeholders that pass env validation, and `setup.local.sh` runs everything against a local Docker stack.
+
+### What `setup.local.sh` does
+
+1. Copies `.env.local.example` → `.env`
+2. Allocates a per-workspace port range so multiple worktrees don't collide
+3. Brings up Postgres + neon-proxy + Electric via `docker compose` (project-scoped to this worktree)
+4. Runs `bun install` and `bun run db:migrate`
+5. Seeds a `Local Admin` dev account via `bun run db:seed-dev`
+6. Writes a gitignored `.superset/config.local.json` overlay so subsequent worktrees automatically use this setup
+
+Re-run the script any time to refresh the workspace. To tear the local DB stack down:
+
+```bash
+./.superset/teardown.local.sh
+```
+
+### Signing in
+
+After `bun run dev`, open the web app and click the **"Sign in as dev"** button on the sign-in page (also available in the desktop sign-in screen). Or use the credentials directly:
+
+- Email: `admin@local.test`
+- Password: `supersetdev`
+
+The dev sign-in button and email/password auth are gated on `NODE_ENV=development` — they don't ship in production.
+
+## Manual setup (advanced)
+
+If you need to point at real Neon / third-party services instead of the local Docker stack:
+
+```bash
+cp .env.example .env             # fill in real Neon, Stripe, etc. credentials
+cp Caddyfile.example Caddyfile   # HTTPS reverse proxy for Electric streams
+bun install
+bun run dev
+```
+
+## Building the desktop app
+
+```bash
+bun run build
+open apps/desktop/release
+```
+
+## Common commands
+
+```bash
+bun dev                # Start all dev servers
+bun test               # Run tests
+bun run lint:fix       # Fix lint + format
+bun run typecheck      # Type-check all packages
+bun run build          # Build all packages
+```
+
+See [`AGENTS.md`](./AGENTS.md) for repo structure, monorepo conventions, and database/migration workflow.
+
+## Troubleshooting
+
+- **`caddy trust` prompts for sudo** — expected, once per machine. Without it Chromium rejects `https://localhost:*` with `ERR_CERT_AUTHORITY_INVALID`.
+- **Port collision** — `setup.local.sh` allocates a fresh port window per worktree. If you ran the script before this change landed, re-run it to migrate.
+- **DB connection errors after pulling main** — re-run `./.superset/setup.local.sh`; it's idempotent and will apply any new migrations.
+- **Stuck Docker stack** — `./.superset/teardown.local.sh` then re-run setup.
+
+## Contributing
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the PR process and code-of-conduct expectations.

--- a/README.md
+++ b/README.md
@@ -79,46 +79,24 @@ If it runs in a terminal, it runs on Superset
 
 ## Getting Started
 
-### Quick Start (Pre-built)
+### Install the app
 
 **[Download Superset for macOS](https://github.com/superset-sh/superset/releases/latest)**
 
-### Build from Source
+### Run from source
 
-<details>
-<summary>Click to expand build instructions</summary>
-
-**Recommended: one-command local setup (no Neon or third-party accounts required)**
+One command. No Neon account, no third-party credentials.
 
 ```bash
 git clone https://github.com/superset-sh/superset.git
 cd superset
-
-# Prereqs: bun, docker, jq, caddy (`brew install jq caddy && caddy trust`)
 ./.superset/setup.local.sh
-
 bun run dev
 ```
 
-`setup.local.sh` copies `.env.local.example` → `.env`, installs deps, brings up a per-workspace Postgres + Electric stack via `docker compose`, runs migrations, and seeds a `Local Admin` dev account. Sign in with the **"Sign in as dev"** button on the sign-in page (web + desktop), or use `admin@local.test` / `supersetdev`. Re-run the script to refresh; `./.superset/teardown.local.sh` tears the stack down.
+Then open the web app and click **"Sign in as dev"** (or use `admin@local.test` / `supersetdev`).
 
-**Manual setup** (if you need to point at real Neon / third-party services):
-
-```bash
-cp .env.example .env             # fill in real credentials
-cp Caddyfile.example Caddyfile   # `caddy trust` once for HTTPS on localhost
-bun install
-bun run dev
-```
-
-**Build the desktop app**
-
-```bash
-bun run build
-open apps/desktop/release
-```
-
-</details>
+Prereqs: `bun`, `docker`, `jq`, `caddy` (`brew install jq caddy && caddy trust`). See [**DEVELOPMENT.md**](./DEVELOPMENT.md) for the full guide — what the setup script does, manual setup against real services, troubleshooting, and how to build the desktop app.
 
 ## Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -55,15 +55,17 @@ Superset works with any CLI-based coding agent, including:
 
 | Agent | Status |
 |:------|:-------|
-| [Amp Code](https://ampcode.com/) | Fully supported |
-| [Claude Code](https://github.com/anthropics/claude-code) | Fully supported |
-| [OpenAI Codex CLI](https://github.com/openai/codex) | Fully supported |
-| [Cursor Agent](https://docs.cursor.com/agent) | Fully supported |
-| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
-| [GitHub Copilot](https://github.com/features/copilot) | Fully supported |
-| [OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
-| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
-| Any CLI agent | Will work |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Fully supported |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Fully supported |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Fully supported |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
+| Any other CLI agent | Works without configuration |
 
 If it runs in a terminal, it runs on Superset
 

--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ If it runs in a terminal, it runs on Superset
 | **GitHub CLI** | [gh](https://cli.github.com/) |
 | **Caddy** | [caddy](https://caddyserver.com/docs/install) (for dev server) |
 
-## Getting Started
-
-### Install the app
+## Install
 
 **[Download Superset for macOS](https://github.com/superset-sh/superset/releases/latest)**
 
-### Run from source
+Builds for Windows and Linux are not yet available.
 
-One command. No Neon account, no third-party credentials.
+## Development
+
+Want to hack on Superset or contribute a PR? Spin up a local dev environment in one command:
 
 ```bash
 git clone https://github.com/superset-sh/superset.git
@@ -94,9 +94,11 @@ cd superset
 bun run dev
 ```
 
-Then open the web app and click **"Sign in as dev"** (or use `admin@local.test` / `supersetdev`).
+No Neon account or third-party credentials needed — `setup.local.sh` brings up a local Postgres + Electric stack via Docker and seeds a dev account. Sign in with the **"Sign in as dev"** button (or `admin@local.test` / `supersetdev`).
 
-Prereqs: `bun`, `docker`, `jq`, `caddy` (`brew install jq caddy && caddy trust`). See [**DEVELOPMENT.md**](./DEVELOPMENT.md) for the full guide — what the setup script does, manual setup against real services, troubleshooting, and how to build the desktop app.
+Prereqs: `bun`, `docker`, `jq`, `caddy` (`brew install jq caddy && caddy trust`).
+
+See [**DEVELOPMENT.md**](./DEVELOPMENT.md) for the full guide — what the setup script does, manual setup against real services, common commands, troubleshooting, and how to build the desktop app. Contribution process lives in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
 
 ## Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -88,46 +88,30 @@ If it runs in a terminal, it runs on Superset
 <details>
 <summary>Click to expand build instructions</summary>
 
-**1. Clone the repository**
+**Recommended: one-command local setup (no Neon or third-party accounts required)**
 
 ```bash
 git clone https://github.com/superset-sh/superset.git
 cd superset
+
+# Prereqs: bun, docker, jq, caddy (`brew install jq caddy && caddy trust`)
+./.superset/setup.local.sh
+
+bun run dev
 ```
 
-**2. Set up environment variables** (choose one):
+`setup.local.sh` copies `.env.local.example` → `.env`, installs deps, brings up a per-workspace Postgres + Electric stack via `docker compose`, runs migrations, and seeds a `Local Admin` dev account. Sign in with the **"Sign in as dev"** button on the sign-in page (web + desktop), or use `admin@local.test` / `supersetdev`. Re-run the script to refresh; `./.superset/teardown.local.sh` tears the stack down.
 
-Option A: Full setup
-```bash
-cp .env.example .env
-# Edit .env and fill in the values
-```
-
-Option B: Skip env validation (for quick local testing)
-```bash
-cp .env.example .env
-echo 'SKIP_ENV_VALIDATION=1' >> .env
-```
-
-**3. Set up Caddy** (reverse proxy for Electric SQL streams):
+**Manual setup** (if you need to point at real Neon / third-party services):
 
 ```bash
-# Install caddy: brew install caddy (macOS) or see https://caddyserver.com/docs/install
-cp Caddyfile.example Caddyfile
-
-# Without this, Chromium rejects https://localhost:* with ERR_CERT_AUTHORITY_INVALID.
-# Prompts for sudo once.
-caddy trust
-```
-
-**4. Install dependencies and run**
-
-```bash
+cp .env.example .env             # fill in real credentials
+cp Caddyfile.example Caddyfile   # `caddy trust` once for HTTPS on localhost
 bun install
 bun run dev
 ```
 
-**5. Build the desktop app**
+**Build the desktop app**
 
 ```bash
 bun run build


### PR DESCRIPTION
## Summary

- README's Build from Source still pointed contributors at the prod `.env` template and manual Caddy setup, never mentioning the one-command flow added in #4837. Lead with `./.superset/setup.local.sh` and document the seeded dev account + sign-in button. Manual setup is preserved as the fallback for anyone who needs to point at real Neon / third-party services.
- CONTRIBUTING.md had no local-dev section at all — added one that mirrors the README.

## Test plan
- [ ] Render README on GitHub and confirm the new section reads cleanly
- [ ] Fresh clone → `./.superset/setup.local.sh` → `bun run dev` → sign in via the dev button (sanity check the documented flow still matches reality)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4969">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make local dev easy to find and use: README now has separate Install and Development sections and leads with the one-command flow via `./.superset/setup.local.sh` (no Neon/third-party creds). Restored agent icons in the Supported Agents table and added Droid and Mastra Code.

Added `DEVELOPMENT.md` and linked it from `CONTRIBUTING.md`. Documented the seeded dev account, the “Sign in as dev” button, and `./.superset/teardown.local.sh`. Manual setup remains as the fallback for real services.

<sup>Written for commit 2a390a17a2d1b3b05ca48a3fb0359a35ef39c2d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4969?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined local development onboarding with a one-command local setup and a quick dev-start command.
  * README shortened to a concise install + development flow and clarified supported agents wording.
  * Full developer guide added: prerequisites, local development sign-in (no third‑party credentials needed), optional production credential path, desktop build steps, common commands, and troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->