### PR TITLE
fix(desktop): add overlay terminal scrollbar

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -62,6 +62,8 @@ function createTerminal(
 		cursorStyle: "block",
 		cursorInactiveStyle: "outline",
 		vtExtensions: { kittyKeyboard: true },
+		// Built-in xterm scrollbars reserve width from fitted terminal columns.
+		// TerminalOverlayScrollbar provides the hover affordance without a gutter.
 		scrollbar: { showScrollbar: false },
 	});
 	terminal.loadAddon(fitAddon);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -422,8 +422,8 @@ export function TerminalPane({
 					style={{ backgroundColor: appearance.background }}
 				/>
 				<TerminalOverlayScrollbar
-					backgroundColor={appearance.background}
 					controlsId={scrollAreaId}
+					foregroundColor={appearance.theme.foreground}
 					terminal={terminal}
 				/>
 				<ScrollToBottomButton terminal={terminal} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -5,6 +5,7 @@ import "@xterm/xterm/css/xterm.css";
 import {
 	useCallback,
 	useEffect,
+	useId,
 	useMemo,
 	useRef,
 	useState,
@@ -32,6 +33,7 @@ import type {
 import { openUrlInV2Workspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openUrlInV2Workspace";
 import { useWorkspaceWsUrl } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
 import { ScrollToBottomButton } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton";
+import { TerminalOverlayScrollbar } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalOverlayScrollbar";
 import { TerminalSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalSearch";
 import { useTheme } from "renderer/stores/theme";
 import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
@@ -67,6 +69,7 @@ export function TerminalPane({
 	const { terminalId } = paneData;
 	const terminalInstanceId = ctx.pane.id;
 	const containerRef = useRef<HTMLDivElement | null>(null);
+	const scrollAreaId = useId();
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
 
 	const appearance = useTerminalAppearance();
@@ -406,16 +409,22 @@ export function TerminalPane({
 			onDragLeave={handleDragLeave}
 			onDrop={handleDrop}
 		>
-			<div className="relative min-h-0 flex-1 overflow-hidden">
+			<div className="group/terminal-scroll relative min-h-0 flex-1 overflow-hidden">
 				<TerminalSearch
 					searchAddon={searchAddon}
 					isOpen={isSearchOpen}
 					onClose={() => setIsSearchOpen(false)}
 				/>
 				<div
+					id={scrollAreaId}
 					ref={containerRef}
 					className="h-full w-full"
 					style={{ backgroundColor: appearance.background }}
+				/>
+				<TerminalOverlayScrollbar
+					backgroundColor={appearance.background}
+					controlsId={scrollAreaId}
+					terminal={terminal}
 				/>
 				<ScrollToBottomButton terminal={terminal} />
 			</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -10,7 +10,7 @@ import { useTabsStore } from "renderer/stores/tabs/store";
 import { useTerminalTheme } from "renderer/stores/theme";
 import { SessionKilledOverlay } from "./components";
 import { DEFAULT_TERMINAL_FONT_SIZE } from "./config";
-import { getDefaultTerminalBg } from "./helpers";
+import { getDefaultTerminalTheme } from "./helpers";
 import {
 	useFileLinkClick,
 	useTerminalColdRestore,
@@ -425,7 +425,8 @@ export const Terminal = memo(function Terminal({
 		}
 	}, [paneId, fontSettings]);
 
-	const terminalBg = terminalTheme?.background ?? getDefaultTerminalBg();
+	const resolvedTerminalTheme = terminalTheme ?? getDefaultTerminalTheme();
+	const terminalBg = resolvedTerminalTheme.background ?? "#151110";
 
 	const handleDragOver = (event: React.DragEvent) => {
 		event.preventDefault();
@@ -465,8 +466,8 @@ export const Terminal = memo(function Terminal({
 				onClose={() => setIsSearchOpen(false)}
 			/>
 			<TerminalOverlayScrollbar
-				backgroundColor={terminalBg}
 				controlsId={scrollAreaId}
+				foregroundColor={resolvedTerminalTheme.foreground}
 				terminal={xtermInstance}
 			/>
 			<ScrollToBottomButton terminal={xtermInstance} />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -2,7 +2,7 @@ import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useId, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { sanitizeTerminalFontFamily } from "renderer/lib/terminal/appearance";
 import { buildTerminalCommand } from "renderer/lib/terminal/launch-command";
@@ -24,6 +24,7 @@ import {
 	useTerminalStream,
 } from "./hooks";
 import { ScrollToBottomButton } from "./ScrollToBottomButton";
+import { TerminalOverlayScrollbar } from "./TerminalOverlayScrollbar";
 import { TerminalSearch } from "./TerminalSearch";
 import type {
 	TerminalExitReason,
@@ -88,6 +89,7 @@ export const Terminal = memo(function Terminal({
 	const xtermRef = useRef<XTerm | null>(null);
 	const fitAddonRef = useRef<FitAddon | null>(null);
 	const searchAddonRef = useRef<SearchAddon | null>(null);
+	const scrollAreaId = useId();
 	const isExitedRef = useRef(false);
 	const [exitStatus, setExitStatus] = useState<"killed" | "exited" | null>(
 		null,
@@ -452,7 +454,7 @@ export const Terminal = memo(function Terminal({
 	return (
 		<div
 			role="application"
-			className="relative h-full w-full overflow-hidden"
+			className="group/terminal-scroll relative h-full w-full overflow-hidden"
 			style={{ backgroundColor: terminalBg }}
 			onDragOver={handleDragOver}
 			onDrop={handleDrop}
@@ -462,6 +464,11 @@ export const Terminal = memo(function Terminal({
 				isOpen={isSearchOpen}
 				onClose={() => setIsSearchOpen(false)}
 			/>
+			<TerminalOverlayScrollbar
+				backgroundColor={terminalBg}
+				controlsId={scrollAreaId}
+				terminal={xtermInstance}
+			/>
 			<ScrollToBottomButton terminal={xtermInstance} />
 			{exitStatus === "killed" &&
 				!connectionError &&
@@ -470,7 +477,7 @@ export const Terminal = memo(function Terminal({
 					<SessionKilledOverlay onRestart={restartTerminal} />
 				)}
 			<div className="h-full w-full p-2">
-				<div ref={terminalRef} className="h-full w-full" />
+				<div id={scrollAreaId} ref={terminalRef} className="h-full w-full" />
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalOverlayScrollbar/TerminalOverlayScrollbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalOverlayScrollbar/TerminalOverlayScrollbar.tsx
@@ -4,8 +4,8 @@ import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 interface TerminalOverlayScrollbarProps {
-	backgroundColor?: string;
 	controlsId: string;
+	foregroundColor?: string;
 	terminal: XTerm | null | undefined;
 }
 
@@ -32,62 +32,17 @@ interface ScrollbarStyle extends CSSProperties {
 	"--terminal-scrollbar-thumb-hover": string;
 }
 
-function parseColor(
-	color: string | undefined,
-): [number, number, number] | null {
-	if (!color) return null;
-
-	const hex = color.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
-	if (hex) {
-		const value = hex[1];
-		const normalized =
-			value.length === 3
-				? value
-						.split("")
-						.map((char) => char + char)
-						.join("")
-				: value;
-		return [
-			Number.parseInt(normalized.slice(0, 2), 16),
-			Number.parseInt(normalized.slice(2, 4), 16),
-			Number.parseInt(normalized.slice(4, 6), 16),
-		];
-	}
-
-	const rgb = color.match(
-		/^rgba?\(\s*(\d{1,3})[\s,]+(\d{1,3})[\s,]+(\d{1,3})/i,
-	);
-	if (!rgb) return null;
-
-	return [
-		Number.parseInt(rgb[1], 10),
-		Number.parseInt(rgb[2], 10),
-		Number.parseInt(rgb[3], 10),
-	];
-}
-
-function isLightBackground(color: string | undefined): boolean {
-	const rgb = parseColor(color);
-	if (!rgb) return false;
-	const [red, green, blue] = rgb;
-	return (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255 > 0.6;
-}
+const DEFAULT_SCROLLBAR_FOREGROUND = "var(--foreground)";
 
 function getScrollbarStyle(
-	backgroundColor: string | undefined,
+	foregroundColor: string | undefined,
 ): ScrollbarStyle {
-	if (isLightBackground(backgroundColor)) {
-		return {
-			"--terminal-scrollbar-rail": "rgba(39, 39, 42, 0.04)",
-			"--terminal-scrollbar-thumb": "rgba(113, 113, 122, 0.46)",
-			"--terminal-scrollbar-thumb-hover": "rgba(82, 82, 91, 0.58)",
-		};
-	}
+	const color = foregroundColor?.trim() || DEFAULT_SCROLLBAR_FOREGROUND;
 
 	return {
-		"--terminal-scrollbar-rail": "rgba(255, 255, 255, 0.04)",
-		"--terminal-scrollbar-thumb": "rgba(255, 255, 255, 0.18)",
-		"--terminal-scrollbar-thumb-hover": "rgba(255, 255, 255, 0.3)",
+		"--terminal-scrollbar-rail": `color-mix(in srgb, ${color} 4%, transparent)`,
+		"--terminal-scrollbar-thumb": `color-mix(in srgb, ${color} 18%, transparent)`,
+		"--terminal-scrollbar-thumb-hover": `color-mix(in srgb, ${color} 30%, transparent)`,
 	};
 }
 
@@ -117,12 +72,13 @@ function readScrollMetrics(terminal: XTerm | null | undefined): ScrollMetrics {
 }
 
 export function TerminalOverlayScrollbar({
-	backgroundColor,
 	controlsId,
+	foregroundColor,
 	terminal,
 }: TerminalOverlayScrollbarProps) {
 	const railRef = useRef<HTMLDivElement | null>(null);
 	const dragOffsetRef = useRef(0);
+	const isDraggingRef = useRef(false);
 	const [isDragging, setIsDragging] = useState(false);
 	const [metrics, setMetrics] = useState<ScrollMetrics>(() =>
 		readScrollMetrics(terminal),
@@ -174,7 +130,12 @@ export function TerminalOverlayScrollbar({
 
 	if (!terminal || !metrics.isScrollable) return null;
 
-	const scrollbarStyle = getScrollbarStyle(backgroundColor);
+	const scrollbarStyle = getScrollbarStyle(foregroundColor);
+	const scrollPositionRatio =
+		metrics.maxScroll > 0
+			? Math.min(1, Math.max(0, metrics.viewportY / metrics.maxScroll))
+			: 0;
+	const scrollPositionPercent = Math.round(scrollPositionRatio * 100);
 
 	return (
 		<div
@@ -202,6 +163,7 @@ export function TerminalOverlayScrollbar({
 				aria-valuemin={0}
 				aria-valuemax={metrics.maxScroll}
 				aria-valuenow={metrics.viewportY}
+				aria-valuetext={`${scrollPositionPercent}%`}
 				tabIndex={0}
 				className={cn(
 					"pointer-events-auto absolute right-0 w-1 rounded-full bg-[var(--terminal-scrollbar-thumb)] outline-none transition-[background-color,width] hover:w-2 hover:bg-[var(--terminal-scrollbar-thumb-hover)] focus-visible:w-2 active:bg-[var(--terminal-scrollbar-thumb-hover)] group-hover/terminal-overlay-scrollbar:w-2",
@@ -239,22 +201,25 @@ export function TerminalOverlayScrollbar({
 					event.currentTarget.setPointerCapture(event.pointerId);
 					const thumbRect = event.currentTarget.getBoundingClientRect();
 					dragOffsetRef.current = event.clientY - thumbRect.top;
+					isDraggingRef.current = true;
 					setIsDragging(true);
 				}}
 				onPointerMove={(event) => {
-					if (!isDragging) return;
+					if (!isDraggingRef.current) return;
 					event.preventDefault();
 					scrollToPointer(event.clientY, dragOffsetRef.current);
 				}}
 				onPointerUp={(event) => {
-					if (!isDragging) return;
+					if (!isDraggingRef.current) return;
 					event.preventDefault();
+					isDraggingRef.current = false;
 					if (event.currentTarget.hasPointerCapture(event.pointerId)) {
 						event.currentTarget.releasePointerCapture(event.pointerId);
 					}
 					setIsDragging(false);
 				}}
 				onPointerCancel={(event) => {
+					isDraggingRef.current = false;
 					if (event.currentTarget.hasPointerCapture(event.pointerId)) {
 						event.currentTarget.releasePointerCapture(event.pointerId);
 					}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalOverlayScrollbar/TerminalOverlayScrollbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalOverlayScrollbar/TerminalOverlayScrollbar.tsx
@@ -1,0 +1,266 @@
+import { cn } from "@superset/ui/utils";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface TerminalOverlayScrollbarProps {
+	backgroundColor?: string;
+	controlsId: string;
+	terminal: XTerm | null | undefined;
+}
+
+interface ScrollMetrics {
+	isScrollable: boolean;
+	maxScroll: number;
+	thumbHeightPercent: number;
+	thumbTopPercent: number;
+	viewportY: number;
+}
+
+const MIN_THUMB_HEIGHT_PERCENT = 8;
+const DEFAULT_SCROLL_METRICS: ScrollMetrics = {
+	isScrollable: false,
+	maxScroll: 0,
+	thumbHeightPercent: 100,
+	thumbTopPercent: 0,
+	viewportY: 0,
+};
+
+interface ScrollbarStyle extends CSSProperties {
+	"--terminal-scrollbar-rail": string;
+	"--terminal-scrollbar-thumb": string;
+	"--terminal-scrollbar-thumb-hover": string;
+}
+
+function parseColor(
+	color: string | undefined,
+): [number, number, number] | null {
+	if (!color) return null;
+
+	const hex = color.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+	if (hex) {
+		const value = hex[1];
+		const normalized =
+			value.length === 3
+				? value
+						.split("")
+						.map((char) => char + char)
+						.join("")
+				: value;
+		return [
+			Number.parseInt(normalized.slice(0, 2), 16),
+			Number.parseInt(normalized.slice(2, 4), 16),
+			Number.parseInt(normalized.slice(4, 6), 16),
+		];
+	}
+
+	const rgb = color.match(
+		/^rgba?\(\s*(\d{1,3})[\s,]+(\d{1,3})[\s,]+(\d{1,3})/i,
+	);
+	if (!rgb) return null;
+
+	return [
+		Number.parseInt(rgb[1], 10),
+		Number.parseInt(rgb[2], 10),
+		Number.parseInt(rgb[3], 10),
+	];
+}
+
+function isLightBackground(color: string | undefined): boolean {
+	const rgb = parseColor(color);
+	if (!rgb) return false;
+	const [red, green, blue] = rgb;
+	return (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255 > 0.6;
+}
+
+function getScrollbarStyle(
+	backgroundColor: string | undefined,
+): ScrollbarStyle {
+	if (isLightBackground(backgroundColor)) {
+		return {
+			"--terminal-scrollbar-rail": "rgba(39, 39, 42, 0.04)",
+			"--terminal-scrollbar-thumb": "rgba(113, 113, 122, 0.46)",
+			"--terminal-scrollbar-thumb-hover": "rgba(82, 82, 91, 0.58)",
+		};
+	}
+
+	return {
+		"--terminal-scrollbar-rail": "rgba(255, 255, 255, 0.04)",
+		"--terminal-scrollbar-thumb": "rgba(255, 255, 255, 0.18)",
+		"--terminal-scrollbar-thumb-hover": "rgba(255, 255, 255, 0.3)",
+	};
+}
+
+function readScrollMetrics(terminal: XTerm | null | undefined): ScrollMetrics {
+	if (!terminal) return DEFAULT_SCROLL_METRICS;
+
+	const buffer = terminal.buffer.active;
+	const maxScroll = buffer.baseY;
+	if (maxScroll <= 0) return DEFAULT_SCROLL_METRICS;
+
+	const totalRows = Math.max(buffer.length, terminal.rows);
+	const thumbHeightPercent = Math.max(
+		MIN_THUMB_HEIGHT_PERCENT,
+		Math.min(100, (terminal.rows / totalRows) * 100),
+	);
+	const maxThumbTopPercent = 100 - thumbHeightPercent;
+	const thumbTopPercent =
+		maxScroll > 0 ? (buffer.viewportY / maxScroll) * maxThumbTopPercent : 0;
+
+	return {
+		isScrollable: true,
+		maxScroll,
+		thumbHeightPercent,
+		thumbTopPercent,
+		viewportY: buffer.viewportY,
+	};
+}
+
+export function TerminalOverlayScrollbar({
+	backgroundColor,
+	controlsId,
+	terminal,
+}: TerminalOverlayScrollbarProps) {
+	const railRef = useRef<HTMLDivElement | null>(null);
+	const dragOffsetRef = useRef(0);
+	const [isDragging, setIsDragging] = useState(false);
+	const [metrics, setMetrics] = useState<ScrollMetrics>(() =>
+		readScrollMetrics(terminal),
+	);
+
+	const updateMetrics = useCallback(() => {
+		setMetrics(readScrollMetrics(terminal));
+	}, [terminal]);
+
+	const scrollToPointer = useCallback(
+		(clientY: number, dragOffset = 0) => {
+			if (!terminal || !railRef.current || metrics.maxScroll <= 0) return;
+			const railRect = railRef.current.getBoundingClientRect();
+			const thumbHeight = railRect.height * (metrics.thumbHeightPercent / 100);
+			const maxThumbTop = Math.max(0, railRect.height - thumbHeight);
+			if (maxThumbTop <= 0) return;
+
+			const thumbTop = Math.min(
+				Math.max(0, clientY - railRect.top - dragOffset),
+				maxThumbTop,
+			);
+			const scrollRatio = thumbTop / maxThumbTop;
+			terminal.scrollToLine(Math.round(scrollRatio * metrics.maxScroll));
+			setMetrics(readScrollMetrics(terminal));
+		},
+		[metrics.maxScroll, metrics.thumbHeightPercent, terminal],
+	);
+
+	useEffect(() => {
+		if (!terminal) {
+			setMetrics(DEFAULT_SCROLL_METRICS);
+			return;
+		}
+
+		updateMetrics();
+		const disposables = [
+			terminal.onScroll(updateMetrics),
+			terminal.onResize(updateMetrics),
+			terminal.onWriteParsed(updateMetrics),
+			terminal.buffer.onBufferChange(updateMetrics),
+		];
+
+		return () => {
+			for (const disposable of disposables) {
+				disposable.dispose();
+			}
+		};
+	}, [terminal, updateMetrics]);
+
+	if (!terminal || !metrics.isScrollable) return null;
+
+	const scrollbarStyle = getScrollbarStyle(backgroundColor);
+
+	return (
+		<div
+			ref={railRef}
+			className={cn(
+				"group/terminal-overlay-scrollbar pointer-events-none absolute top-2 right-0 bottom-2 z-20 w-2 rounded-full opacity-0 transition-opacity duration-150 hover:bg-[var(--terminal-scrollbar-rail)]",
+				"group-hover/terminal-scroll:pointer-events-auto group-hover/terminal-scroll:opacity-100 group-focus-within/terminal-scroll:pointer-events-auto group-focus-within/terminal-scroll:opacity-100",
+				isDragging && "pointer-events-auto opacity-100",
+			)}
+			style={scrollbarStyle}
+			onPointerDown={(event) => {
+				if (event.target !== event.currentTarget) return;
+				event.preventDefault();
+				const railRect = event.currentTarget.getBoundingClientRect();
+				const thumbHeight =
+					railRect.height * (metrics.thumbHeightPercent / 100);
+				scrollToPointer(event.clientY, thumbHeight / 2);
+			}}
+		>
+			<div
+				role="scrollbar"
+				aria-controls={controlsId}
+				aria-label="Terminal scrollback"
+				aria-orientation="vertical"
+				aria-valuemin={0}
+				aria-valuemax={metrics.maxScroll}
+				aria-valuenow={metrics.viewportY}
+				tabIndex={0}
+				className={cn(
+					"pointer-events-auto absolute right-0 w-1 rounded-full bg-[var(--terminal-scrollbar-thumb)] outline-none transition-[background-color,width] hover:w-2 hover:bg-[var(--terminal-scrollbar-thumb-hover)] focus-visible:w-2 active:bg-[var(--terminal-scrollbar-thumb-hover)] group-hover/terminal-overlay-scrollbar:w-2",
+					isDragging && "w-2",
+				)}
+				style={{
+					height: `${metrics.thumbHeightPercent}%`,
+					top: `${metrics.thumbTopPercent}%`,
+				}}
+				onKeyDown={(event) => {
+					if (!terminal) return;
+					if (event.key === "ArrowUp") {
+						event.preventDefault();
+						terminal.scrollLines(-1);
+					} else if (event.key === "ArrowDown") {
+						event.preventDefault();
+						terminal.scrollLines(1);
+					} else if (event.key === "PageUp") {
+						event.preventDefault();
+						terminal.scrollPages(-1);
+					} else if (event.key === "PageDown") {
+						event.preventDefault();
+						terminal.scrollPages(1);
+					} else if (event.key === "Home") {
+						event.preventDefault();
+						terminal.scrollToTop();
+					} else if (event.key === "End") {
+						event.preventDefault();
+						terminal.scrollToBottom();
+					}
+				}}
+				onPointerDown={(event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					event.currentTarget.setPointerCapture(event.pointerId);
+					const thumbRect = event.currentTarget.getBoundingClientRect();
+					dragOffsetRef.current = event.clientY - thumbRect.top;
+					setIsDragging(true);
+				}}
+				onPointerMove={(event) => {
+					if (!isDragging) return;
+					event.preventDefault();
+					scrollToPointer(event.clientY, dragOffsetRef.current);
+				}}
+				onPointerUp={(event) => {
+					if (!isDragging) return;
+					event.preventDefault();
+					if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+						event.currentTarget.releasePointerCapture(event.pointerId);
+					}
+					setIsDragging(false);
+				}}
+				onPointerCancel={(event) => {
+					if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+						event.currentTarget.releasePointerCapture(event.pointerId);
+					}
+					setIsDragging(false);
+				}}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalOverlayScrollbar/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalOverlayScrollbar/index.ts
@@ -1,0 +1,1 @@
+export { TerminalOverlayScrollbar } from "./TerminalOverlayScrollbar";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -35,8 +35,8 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
 	cursorInactiveStyle: "outline",
 	vtExtensions: { kittyKeyboard: true },
 	screenReaderMode: false,
-	// xterm's fit addon permanently reserves scrollbar width from usable columns.
-	// Hide the built-in scrollbar so terminal content can use the full pane width.
+	// Built-in xterm scrollbars reserve width from fitted terminal columns.
+	// TerminalOverlayScrollbar provides the hover affordance without a gutter.
 	scrollbar: {
 		showScrollbar: false,
 	},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -49,14 +49,6 @@ export function getDefaultTerminalTheme(): ITheme {
 		: { background: "#151110", foreground: "#eae8e6" };
 }
 
-/**
- * Get the default terminal background based on stored theme.
- * This reads from localStorage before store hydration to prevent flash.
- */
-export function getDefaultTerminalBg(): string {
-	return getDefaultTerminalTheme().background ?? "#151110";
-}
-
 // Once WebGL fails, skip it for all subsequent terminals (VS Code pattern).
 let suggestedRendererType: "webgl" | "dom" | undefined;
 


### PR DESCRIPTION
## Description

  Adds a custom overlay scrollbar for desktop terminal panes while keeping
  xterm's built-in scrollbar disabled so it does not reserve terminal width. The
  overlay appears on hover/focus, supports dragging and keyboard scrolling, and
  adjusts thumb contrast from the actual terminal background so light and dark
  terminal themes remain visible.

  ## Related Issues

  Fixes #4908

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Other (please describe):

  ## Testing

  - `bunx biome check apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
  apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/
  $workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
  apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/
  TabsContent/Terminal/Terminal.tsx apps/desktop/src/renderer/screens/main/
  components/WorkspaceView/ContentView/TabsContent/Terminal/
  TerminalOverlayScrollbar/TerminalOverlayScrollbar.tsx apps/desktop/src/
  renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/
  Terminal/TerminalOverlayScrollbar/index.ts apps/desktop/src/renderer/screens/
  main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts`
  - `bun run typecheck` from `apps/desktop`

  ## Screenshots (if applicable)

<img width="1724" height="1004" alt="2026-05-28_20-04-12" src="https://github.com/user-attachments/assets/4771f905-ca30-461a-8bf9-46d05a98a65c" />
<img width="1724" height="1004" alt="2026-05-28_20-04-29" src="https://github.com/user-attachments/assets/12d3eef9-2e37-4e54-89c7-f90aa9fa5f9b" />
<img width="1724" height="1004" alt="2026-05-28_20-04-33" src="https://github.com/user-attachments/assets/7b2f9013-2d61-4bb5-8c27-89b6c73e69df" />
<img width="1724" height="1004" alt="2026-05-28_20-10-12" src="https://github.com/user-attachments/assets/bb125c41-beb0-48ad-9165-c3f0e614fd3c" />


  ## Additional Notes

  The branch is pushed to `nullbio/superset:pat/terminal-overlay-scrollbar`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4973">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an overlay scrollbar to desktop terminal panes that appears on hover/focus and preserves terminal width by keeping `@xterm/xterm`’s scrollbar disabled. Aligns scrollbar colors with the terminal theme foreground for clear contrast in light and dark themes.

- **Bug Fixes**
  - Added `TerminalOverlayScrollbar` with hover/focus visibility.
  - Keeps `@xterm/xterm` scrollbar off; no reserved gutter, full columns.
  - Supports drag plus Arrow/PageUp/PageDown/Home/End keys.
  - Derives rail/thumb colors from theme foreground for consistent contrast.
  - Integrated in `Terminal` and `TerminalPane` with `aria-controls` linked to the scroll area.

<sup>Written for commit 5a90a8b43f4f38e0daf33f093c949cc48652925b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overlay scrollbar for terminal panes with draggable thumb and pointer capture
  * Full keyboard navigation (Arrow keys, Page Up/Down, Home, End)
  * ARIA scrollbar semantics for improved accessibility

* **UX / Styling**
  * Automatic color adaptation to terminal theme foregrounds
  * Hover-only affordance that avoids reserving extra gutter space

* **Refactor**
  * Simplified terminal background/theme fallback logic and stable scroll area IDs for improved integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->