### PR TITLE
fix: solve #2419 — respect Claude command overrides for prompt launches

### DIFF
--- a/packages/shared/src/agent-launch-request.test.ts
+++ b/packages/shared/src/agent-launch-request.test.ts
@@ -188,6 +188,44 @@ describe("buildTaskAgentLaunchRequest", () => {
 		});
 	});
 
+	test("respects a Claude command override for task prompt files", () => {
+		const configsById = indexResolvedAgentConfigs(
+			resolveAgentConfigs({
+				overrideEnvelope: {
+					version: 1,
+					presets: [
+						{
+							id: "claude",
+							command: "claude",
+						},
+					],
+				},
+			}),
+		);
+		const request = buildTaskAgentLaunchRequest({
+			workspaceId: "workspace-1",
+			source: "open-in-workspace",
+			selectedAgent: "claude",
+			task: TASK,
+			autoRun: false,
+			configsById,
+		});
+
+		expect(request).toMatchObject({
+			kind: "terminal",
+			terminal: {
+				command: "claude \"$(cat '.superset/task-demo-task.md')\"",
+			},
+		});
+		expect(request?.kind).toBe("terminal");
+		if (request?.kind !== "terminal") {
+			throw new Error("Expected terminal launch request");
+		}
+		expect(request.terminal.command).not.toContain(
+			"--dangerously-skip-permissions",
+		);
+	});
+
 	test("builds Amp task launches in interactive stdin mode", () => {
 		const configsById = indexResolvedAgentConfigs(resolveAgentConfigs({}));
 		const request = buildTaskAgentLaunchRequest({

--- a/packages/shared/src/agent-settings.test.ts
+++ b/packages/shared/src/agent-settings.test.ts
@@ -80,6 +80,72 @@ describe("resolveAgentConfigs", () => {
 		});
 	});
 
+	test("uses overridden command for prompt launches unless prompt command is overridden", () => {
+		const presets = resolveAgentConfigs({
+			overrideEnvelope: {
+				version: 1,
+				presets: [
+					{
+						id: "claude",
+						command: "claude",
+					},
+					{
+						id: "codex",
+						command: "codex",
+					},
+					{
+						id: "copilot",
+						command: "copilot",
+					},
+				],
+			},
+		});
+		const claude = presets.find((preset) => preset.id === "claude");
+		const codex = presets.find((preset) => preset.id === "codex");
+		const copilot = presets.find((preset) => preset.id === "copilot");
+
+		expect(claude).toMatchObject({
+			id: "claude",
+			kind: "terminal",
+			command: "claude",
+			promptCommand: "claude",
+		});
+		expect(codex).toMatchObject({
+			id: "codex",
+			kind: "terminal",
+			command: "codex",
+			promptCommand: "codex --",
+		});
+		expect(copilot).toMatchObject({
+			id: "copilot",
+			kind: "terminal",
+			command: "copilot",
+			promptCommand: "copilot -i",
+		});
+	});
+
+	test("preserves an explicit prompt command override", () => {
+		const claude = resolveAgentConfigs({
+			overrideEnvelope: {
+				version: 1,
+				presets: [
+					{
+						id: "claude",
+						command: "claude",
+						promptCommand: "claude --permission-mode acceptEdits",
+					},
+				],
+			},
+		}).find((preset) => preset.id === "claude");
+
+		expect(claude).toMatchObject({
+			id: "claude",
+			kind: "terminal",
+			command: "claude",
+			promptCommand: "claude --permission-mode acceptEdits",
+		});
+	});
+
 	test("includes custom terminal configs from stored definitions", () => {
 		const custom = resolveAgentConfigs({
 			customDefinitions: [

--- a/packages/shared/src/agent-settings.ts
+++ b/packages/shared/src/agent-settings.ts
@@ -301,6 +301,30 @@ function resolvePromptCommandSuffix(
 	return override.promptCommandSuffix ?? undefined;
 }
 
+function resolvePromptCommand(
+	definition: TerminalAgentDefinition,
+	override: AgentPresetOverride | undefined,
+): string {
+	if (!override) return definition.promptCommand;
+	if (Object.hasOwn(override, "promptCommand")) {
+		return override.promptCommand ?? definition.promptCommand;
+	}
+	if (Object.hasOwn(override, "command")) {
+		if (!override.command) {
+			return definition.promptCommand;
+		}
+
+		const promptCommandSuffix =
+			definition.promptCommand === definition.command ||
+			definition.promptCommand.startsWith(`${definition.command} `)
+				? definition.promptCommand.slice(definition.command.length)
+				: "";
+
+		return `${override.command}${promptCommandSuffix}`;
+	}
+	return definition.promptCommand;
+}
+
 function resolveModel(
 	model: string | undefined,
 	override: AgentPresetOverride | undefined,
@@ -324,7 +348,7 @@ function resolveAgentConfig(
 			description: resolveDescription(definition.description, override),
 			enabled: override?.enabled ?? definition.enabled,
 			command: override?.command ?? definition.command,
-			promptCommand: override?.promptCommand ?? definition.promptCommand,
+			promptCommand: resolvePromptCommand(definition, override),
 			promptCommandSuffix: resolvePromptCommandSuffix(
 				definition.promptCommandSuffix,
 				override,


### PR DESCRIPTION
## Description

  - Respect a user's Claude command override when resolving task and prompt launch commands
  - Preserve explicit `promptCommand` overrides when users configure a separate prompt command
  - Add regression coverage for resolved Claude configs and task prompt file launches without `--dangerously-skip-permissions`



## Related Issues

Fixes [#2419](https://github.com/superset-sh/superset/issues/2419)

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4976">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal agent prompt launches to use overridden `command` values (including Claude) and preserve explicit `promptCommand` overrides. Also removes `--dangerously-skip-permissions` from Claude task prompt file runs.

- **Bug Fixes**
  - When `promptCommand` isn’t provided, it now derives from the overridden `command` and preserves any suffix (e.g., `--`, `-i`).
  - Keeps an explicit `promptCommand` override unchanged.
  - Builds Claude task prompt file launches with `claude "$(cat '...')"` and omits `--dangerously-skip-permissions`.

<sup>Written for commit 69993ade4c3062417d647a221a9e1a97e6cce797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4976?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests verifying terminal launch requests honor overridden command and prompt-command behaviors and correctly include task prompt content.

* **Chores**
  * Improved agent configuration resolution so terminal prompt-command is derived from overrides (preserving suffixes when appropriate) with sensible fallbacks when not explicitly provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Co-authored-by: @ndaden 