### PR TITLE
fix(desktop): open DiffPane comment composer on pointer-up

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -88,7 +88,7 @@ export function DiffPane({
 
 	const {
 		composerAnnotationsByItemId,
-		onSelectedLinesChange,
+		onLineSelectionEnd,
 		onGutterUtilityClick,
 		clear: clearComposer,
 		submit: submitComposer,
@@ -127,8 +127,9 @@ export function DiffPane({
 			enableLineSelection: true,
 			enableGutterUtility: true,
 			onGutterUtilityClick,
+			onLineSelectionEnd,
 		}),
-		[options, onGutterUtilityClick],
+		[options, onGutterUtilityClick, onLineSelectionEnd],
 	);
 
 	const renderHeaderPrefix = useCallback(
@@ -250,7 +251,6 @@ export function DiffPane({
 			style={style}
 			items={items}
 			options={codeViewOptions}
-			onSelectedLinesChange={onSelectedLinesChange}
 			renderHeaderPrefix={renderHeaderPrefix}
 			renderHeaderMetadata={renderHeaderMetadata}
 			renderAnnotation={renderAnnotation}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCommentComposer/useDiffCommentComposer.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCommentComposer/useDiffCommentComposer.ts
@@ -1,5 +1,5 @@
 import type {
-	CodeViewLineSelection,
+	CodeViewOptions,
 	DiffLineAnnotation,
 	SelectedLineRange,
 } from "@pierre/diffs";
@@ -55,12 +55,16 @@ interface UseDiffCommentComposerArgs {
 	) => Promise<{ terminalId: string } | null>;
 }
 
+type OnLineSelectionEnd = NonNullable<
+	CodeViewOptions<DiffAnnotationMetadata>["onLineSelectionEnd"]
+>;
+
 interface UseDiffCommentComposerResult {
 	composerAnnotationsByItemId: ReadonlyMap<
 		string,
 		DiffLineAnnotation<DiffAnnotationMetadata>[]
 	> | null;
-	onSelectedLinesChange: (selection: CodeViewLineSelection | null) => void;
+	onLineSelectionEnd: OnLineSelectionEnd;
 	onGutterUtilityClick: () => void;
 	clear: () => void;
 	submit: (input: DiffCommentSubmitInput) => Promise<void>;
@@ -102,27 +106,31 @@ export function useDiffCommentComposer({
 		[clear],
 	);
 
-	const onSelectedLinesChange = useCallback(
-		(selection: CodeViewLineSelection | null) => {
-			if (!selection) {
+	// Open on pointer-up, not pointer-down. Pierre's top-level
+	// `onSelectedLinesChange` fires on every selection notify (start, drag,
+	// end) so using it would pop the composer the moment the user mouses
+	// down. `onLineSelectionEnd` is the strict pointer-up signal — and unlike
+	// `onLineSelected` it does *not* fire for imperative selection writes
+	// (e.g. our own clearSelectedLines or future jump-to-thread), so the
+	// composer never opens spuriously from code.
+	const onLineSelectionEnd = useCallback<OnLineSelectionEnd>(
+		(range, context) => {
+			if (context.type !== "diff") return;
+			if (!range) {
 				setComposer(null);
 				return;
 			}
-			setComposer({ itemId: selection.id, range: selection.range });
+			setComposer({ itemId: context.item.id, range });
 		},
 		[],
 	);
 
 	// Pierre gates the gutter "+" button's pointer flow behind a non-null
 	// onGutterUtilityClick (InteractionManager.startGutterSelectionFromPointerDown
-	// early-returns otherwise). We mirror the open from the CodeView's
-	// current selection — pierre updates that during the pointer session.
-	const onGutterUtilityClick = useCallback(() => {
-		const selection = codeViewRef.current?.getSelectedLines();
-		if (selection) {
-			setComposer({ itemId: selection.id, range: selection.range });
-		}
-	}, [codeViewRef]);
+	// early-returns otherwise). The gutter pointer-up path also fires
+	// notifySelectionEnd → onLineSelectionEnd, so the open is handled there;
+	// this stays as a required stub.
+	const onGutterUtilityClick = useCallback(() => {}, []);
 
 	const composerAnnotationsByItemId = useMemo(() => {
 		if (!composer) return null;
@@ -204,7 +212,7 @@ export function useDiffCommentComposer({
 
 	return {
 		composerAnnotationsByItemId,
-		onSelectedLinesChange,
+		onLineSelectionEnd,
 		onGutterUtilityClick,
 		clear,
 		submit,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCommentComposer/useDiffCommentComposer.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCommentComposer/useDiffCommentComposer.ts
@@ -106,13 +106,6 @@ export function useDiffCommentComposer({
 		[clear],
 	);
 
-	// Open on pointer-up, not pointer-down. Pierre's top-level
-	// `onSelectedLinesChange` fires on every selection notify (start, drag,
-	// end) so using it would pop the composer the moment the user mouses
-	// down. `onLineSelectionEnd` is the strict pointer-up signal — and unlike
-	// `onLineSelected` it does *not* fire for imperative selection writes
-	// (e.g. our own clearSelectedLines or future jump-to-thread), so the
-	// composer never opens spuriously from code.
 	const onLineSelectionEnd = useCallback<OnLineSelectionEnd>(
 		(range, context) => {
 			if (context.type !== "diff") return;


### PR DESCRIPTION
## Summary
- The inline agent-comment composer on the v2 DiffPane was popping open the moment the user moused down on a line and following the drag. Pierre's top-level `onSelectedLinesChange` fires for every selection notify (start, drag, end), which is why.
- Switch to the per-item `onLineSelectionEnd` callback, which only fires from pierre's `handleDocumentPointerUp`. The composer now appears once on mouse-up with the committed range.
- `onGutterUtilityClick` is reduced to a required non-null stub — pierre gates the "+" button's pointer flow on a non-null handler, but the gutter pointer-up path already fires `notifySelectionEnd` → `onLineSelectionEnd`, so the open is handled there.

`onLineSelectionEnd` chosen over `onLineSelected` because the latter also fires on imperative selection writes (`clearSelectedLines`, future jump-to-thread, etc.), which would re-open the composer spuriously.

## Test plan
- [ ] Drag-select a range in a diff file → composer appears only on mouse-up at the committed end line.
- [ ] Click a single line → composer appears on click release (single Start+End pointer cycle).
- [ ] Click the gutter "+" button → composer opens on release.
- [ ] Re-click the same selected line → selection clears, composer closes.
- [ ] Submit a comment → `clearSelectedLines` runs; composer does not re-open from the imperative clear.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the DiffPane inline comment composer so it opens on mouse-up, not mouse-down, preventing it from popping during drag. Uses the per-item selection end signal to open once with the committed range.

- **Bug Fixes**
  - Switched to `onLineSelectionEnd` from `@pierre/diffs` to open the composer on pointer-up.
  - Removed reliance on the top-level selection change event to avoid start/drag and imperative reopen triggers.
  - Kept `onGutterUtilityClick` as a no-op stub; the gutter path already triggers selection end on release.

<sup>Written for commit 134964713bb0fffe3f3774922035fee5100d9eff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4977?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal event handling for line selection in diff views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->