### PR TITLE
feat(desktop): add Cmd+F search to v2 changes pane

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -380,6 +380,16 @@ export const HOTKEYS_REGISTRY = {
 		category: "Terminal",
 		description: "Search text in the active chat",
 	},
+	FIND_IN_DIFF: {
+		key: {
+			mac: L("meta+f"),
+			windows: L("ctrl+shift+f"),
+			linux: L("ctrl+shift+f"),
+		},
+		label: "Find in Changes",
+		category: "Terminal",
+		description: "Search text in the active changes pane",
+	},
 	NEW_GROUP: {
 		key: {
 			mac: L("meta+t"),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/hooks/useChatMessageSearch/useChatMessageSearch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/hooks/useChatMessageSearch/useChatMessageSearch.ts
@@ -1,63 +1,22 @@
 import type { RefObject } from "react";
-import { useEffect } from "react";
-import { useHotkey } from "renderer/hotkeys";
-import { useTextSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
+import {
+	type FindHotkeySearchController,
+	useFindHotkeySearch,
+} from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
 
 interface UseChatMessageSearchOptions {
 	containerRef: RefObject<HTMLDivElement | null>;
 	isFocused: boolean;
 }
 
-interface UseChatMessageSearchReturn {
-	isSearchOpen: boolean;
-	query: string;
-	caseSensitive: boolean;
-	matchCount: number;
-	activeMatchIndex: number;
-	setQuery: (query: string) => void;
-	setCaseSensitive: (caseSensitive: boolean) => void;
-	findNext: () => void;
-	findPrevious: () => void;
-	closeSearch: () => void;
-}
-
 export function useChatMessageSearch({
 	containerRef,
 	isFocused,
-}: UseChatMessageSearchOptions): UseChatMessageSearchReturn {
-	const textSearch = useTextSearch({
+}: UseChatMessageSearchOptions): FindHotkeySearchController {
+	return useFindHotkeySearch({
 		containerRef,
+		hotkeyId: "FIND_IN_CHAT",
 		highlightPrefix: "chat-search",
+		isActive: isFocused,
 	});
-
-	useEffect(() => {
-		if (!isFocused && textSearch.isSearchOpen) {
-			textSearch.closeSearch();
-		}
-	}, [isFocused, textSearch.closeSearch, textSearch.isSearchOpen]);
-
-	useHotkey(
-		"FIND_IN_CHAT",
-		() => {
-			if (textSearch.isSearchOpen) {
-				textSearch.closeSearch();
-				return;
-			}
-			textSearch.setIsSearchOpen(true);
-		},
-		{ enabled: isFocused, preventDefault: true },
-	);
-
-	return {
-		isSearchOpen: textSearch.isSearchOpen,
-		query: textSearch.query,
-		caseSensitive: textSearch.caseSensitive,
-		matchCount: textSearch.matchCount,
-		activeMatchIndex: textSearch.activeMatchIndex,
-		setQuery: textSearch.setQuery,
-		setCaseSensitive: textSearch.setCaseSensitive,
-		findNext: textSearch.findNext,
-		findPrevious: textSearch.findPrevious,
-		closeSearch: textSearch.closeSearch,
-	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -6,6 +6,7 @@ import type {
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import type { RendererContext } from "@superset/panes";
 import { useCallback, useMemo, useRef } from "react";
+import { MarkdownSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/MarkdownSearch";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import { type ChangesetFile, useChangeset } from "../../../useChangeset";
 import { useOpenInExternalEditor } from "../../../useOpenInExternalEditor";
@@ -23,6 +24,7 @@ import { useDiffCodeViewItems } from "./hooks/useDiffCodeViewItems";
 import { useDiffCodeViewScroll } from "./hooks/useDiffCodeViewScroll";
 import { useDiffCodeViewTheme } from "./hooks/useDiffCodeViewTheme";
 import { useDiffCommentComposer } from "./hooks/useDiffCommentComposer";
+import { useDiffPaneSearch } from "./hooks/useDiffPaneSearch";
 
 interface CreateNewAgentSessionInput {
 	configId: string;
@@ -47,6 +49,12 @@ export function DiffPane({
 }: DiffPaneProps) {
 	const data = context.pane.data as DiffPaneData;
 	const codeViewRef = useRef<CodeViewHandle<DiffAnnotationMetadata>>(null);
+	const searchContainerRef = useRef<HTMLDivElement>(null);
+
+	const search = useDiffPaneSearch({
+		containerRef: searchContainerRef,
+		isActive: context.isActive,
+	});
 
 	const ref = useSidebarDiffRef(workspaceId);
 	const { files, isLoading } = useChangeset({ workspaceId, ref });
@@ -245,15 +253,29 @@ export function DiffPane({
 	}
 
 	return (
-		<CodeView<DiffAnnotationMetadata>
-			ref={codeViewRef}
-			className="h-full w-full overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
-			style={style}
-			items={items}
-			options={codeViewOptions}
-			renderHeaderPrefix={renderHeaderPrefix}
-			renderHeaderMetadata={renderHeaderMetadata}
-			renderAnnotation={renderAnnotation}
-		/>
+		<div ref={searchContainerRef} className="relative h-full w-full">
+			<MarkdownSearch
+				isOpen={search.isSearchOpen}
+				query={search.query}
+				caseSensitive={search.caseSensitive}
+				matchCount={search.matchCount}
+				activeMatchIndex={search.activeMatchIndex}
+				onQueryChange={search.setQuery}
+				onCaseSensitiveChange={search.setCaseSensitive}
+				onFindNext={search.findNext}
+				onFindPrevious={search.findPrevious}
+				onClose={search.closeSearch}
+			/>
+			<CodeView<DiffAnnotationMetadata>
+				ref={codeViewRef}
+				className="h-full w-full overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
+				style={style}
+				items={items}
+				options={codeViewOptions}
+				renderHeaderPrefix={renderHeaderPrefix}
+				renderHeaderMetadata={renderHeaderMetadata}
+				renderAnnotation={renderAnnotation}
+			/>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/index.ts
@@ -1,0 +1,1 @@
+export { useDiffPaneSearch } from "./useDiffPaneSearch";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/useDiffPaneSearch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/useDiffPaneSearch.ts
@@ -1,8 +1,9 @@
 import type { RefObject } from "react";
-import { useCallback, useEffect } from "react";
-import { useHotkey } from "renderer/hotkeys";
 import { getDiffSearchRoots } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/utils/diffRendererRoots";
-import { useTextSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
+import {
+	type FindHotkeySearchController,
+	useFindHotkeySearch,
+} from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
 
 interface UseDiffPaneSearchOptions {
 	containerRef: RefObject<HTMLDivElement | null>;
@@ -10,68 +11,21 @@ interface UseDiffPaneSearchOptions {
 	isActive: boolean;
 }
 
-interface UseDiffPaneSearchReturn {
-	isSearchOpen: boolean;
-	query: string;
-	caseSensitive: boolean;
-	matchCount: number;
-	activeMatchIndex: number;
-	setQuery: (query: string) => void;
-	setCaseSensitive: (caseSensitive: boolean) => void;
-	findNext: () => void;
-	findPrevious: () => void;
-	closeSearch: () => void;
-}
-
 /**
  * Cmd+F text search for the v2 changes (diff) pane. Searches the rendered diff
- * content across each file's `@pierre/diffs` shadow root via the shared
- * DOM-highlight `useTextSearch` hook. Because the underlying CodeView is
- * virtualized, matches are scoped to currently rendered/expanded lines.
+ * content across each file's `@pierre/diffs` shadow root. Because the underlying
+ * CodeView is virtualized, matches are scoped to currently rendered/expanded
+ * lines.
  */
 export function useDiffPaneSearch({
 	containerRef,
 	isActive,
-}: UseDiffPaneSearchOptions): UseDiffPaneSearchReturn {
-	const getSearchRoots = useCallback(
-		(container: HTMLDivElement) => getDiffSearchRoots(container),
-		[],
-	);
-
-	const textSearch = useTextSearch({
+}: UseDiffPaneSearchOptions): FindHotkeySearchController {
+	return useFindHotkeySearch({
 		containerRef,
-		getSearchRoots,
+		hotkeyId: "FIND_IN_DIFF",
 		highlightPrefix: "diff-pane-search",
+		isActive,
+		getSearchRoots: getDiffSearchRoots,
 	});
-
-	useEffect(() => {
-		if (!isActive && textSearch.isSearchOpen) {
-			textSearch.closeSearch();
-		}
-	}, [isActive, textSearch.closeSearch, textSearch.isSearchOpen]);
-
-	useHotkey(
-		"FIND_IN_DIFF",
-		() => {
-			if (textSearch.isSearchOpen) {
-				textSearch.closeSearch();
-				return;
-			}
-			textSearch.setIsSearchOpen(true);
-		},
-		{ enabled: isActive, preventDefault: true },
-	);
-
-	return {
-		isSearchOpen: textSearch.isSearchOpen,
-		query: textSearch.query,
-		caseSensitive: textSearch.caseSensitive,
-		matchCount: textSearch.matchCount,
-		activeMatchIndex: textSearch.activeMatchIndex,
-		setQuery: textSearch.setQuery,
-		setCaseSensitive: textSearch.setCaseSensitive,
-		findNext: textSearch.findNext,
-		findPrevious: textSearch.findPrevious,
-		closeSearch: textSearch.closeSearch,
-	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/useDiffPaneSearch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/useDiffPaneSearch.ts
@@ -1,0 +1,77 @@
+import type { RefObject } from "react";
+import { useCallback, useEffect } from "react";
+import { useHotkey } from "renderer/hotkeys";
+import { getDiffSearchRoots } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/utils/diffRendererRoots";
+import { useTextSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
+
+interface UseDiffPaneSearchOptions {
+	containerRef: RefObject<HTMLDivElement | null>;
+	/** Whether the diff pane is the active pane (drives hotkey + auto-close). */
+	isActive: boolean;
+}
+
+interface UseDiffPaneSearchReturn {
+	isSearchOpen: boolean;
+	query: string;
+	caseSensitive: boolean;
+	matchCount: number;
+	activeMatchIndex: number;
+	setQuery: (query: string) => void;
+	setCaseSensitive: (caseSensitive: boolean) => void;
+	findNext: () => void;
+	findPrevious: () => void;
+	closeSearch: () => void;
+}
+
+/**
+ * Cmd+F text search for the v2 changes (diff) pane. Searches the rendered diff
+ * content across each file's `@pierre/diffs` shadow root via the shared
+ * DOM-highlight `useTextSearch` hook. Because the underlying CodeView is
+ * virtualized, matches are scoped to currently rendered/expanded lines.
+ */
+export function useDiffPaneSearch({
+	containerRef,
+	isActive,
+}: UseDiffPaneSearchOptions): UseDiffPaneSearchReturn {
+	const getSearchRoots = useCallback(
+		(container: HTMLDivElement) => getDiffSearchRoots(container),
+		[],
+	);
+
+	const textSearch = useTextSearch({
+		containerRef,
+		getSearchRoots,
+		highlightPrefix: "diff-pane-search",
+	});
+
+	useEffect(() => {
+		if (!isActive && textSearch.isSearchOpen) {
+			textSearch.closeSearch();
+		}
+	}, [isActive, textSearch.closeSearch, textSearch.isSearchOpen]);
+
+	useHotkey(
+		"FIND_IN_DIFF",
+		() => {
+			if (textSearch.isSearchOpen) {
+				textSearch.closeSearch();
+				return;
+			}
+			textSearch.setIsSearchOpen(true);
+		},
+		{ enabled: isActive, preventDefault: true },
+	);
+
+	return {
+		isSearchOpen: textSearch.isSearchOpen,
+		query: textSearch.query,
+		caseSensitive: textSearch.caseSensitive,
+		matchCount: textSearch.matchCount,
+		activeMatchIndex: textSearch.activeMatchIndex,
+		setQuery: textSearch.setQuery,
+		setCaseSensitive: textSearch.setCaseSensitive,
+		findNext: textSearch.findNext,
+		findPrevious: textSearch.findPrevious,
+		closeSearch: textSearch.closeSearch,
+	};
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/hooks/useChatMessageSearch/useChatMessageSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/hooks/useChatMessageSearch/useChatMessageSearch.ts
@@ -1,63 +1,22 @@
 import type { RefObject } from "react";
-import { useEffect } from "react";
-import { useHotkey } from "renderer/hotkeys";
-import { useTextSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
+import {
+	type FindHotkeySearchController,
+	useFindHotkeySearch,
+} from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
 
 interface UseChatMessageSearchOptions {
 	containerRef: RefObject<HTMLDivElement | null>;
 	isFocused: boolean;
 }
 
-interface UseChatMessageSearchReturn {
-	isSearchOpen: boolean;
-	query: string;
-	caseSensitive: boolean;
-	matchCount: number;
-	activeMatchIndex: number;
-	setQuery: (query: string) => void;
-	setCaseSensitive: (caseSensitive: boolean) => void;
-	findNext: () => void;
-	findPrevious: () => void;
-	closeSearch: () => void;
-}
-
 export function useChatMessageSearch({
 	containerRef,
 	isFocused,
-}: UseChatMessageSearchOptions): UseChatMessageSearchReturn {
-	const textSearch = useTextSearch({
+}: UseChatMessageSearchOptions): FindHotkeySearchController {
+	return useFindHotkeySearch({
 		containerRef,
+		hotkeyId: "FIND_IN_CHAT",
 		highlightPrefix: "chat-search",
+		isActive: isFocused,
 	});
-
-	useEffect(() => {
-		if (!isFocused && textSearch.isSearchOpen) {
-			textSearch.closeSearch();
-		}
-	}, [isFocused, textSearch.closeSearch, textSearch.isSearchOpen]);
-
-	useHotkey(
-		"FIND_IN_CHAT",
-		() => {
-			if (textSearch.isSearchOpen) {
-				textSearch.closeSearch();
-				return;
-			}
-			textSearch.setIsSearchOpen(true);
-		},
-		{ enabled: isFocused, preventDefault: true },
-	);
-
-	return {
-		isSearchOpen: textSearch.isSearchOpen,
-		query: textSearch.query,
-		caseSensitive: textSearch.caseSensitive,
-		matchCount: textSearch.matchCount,
-		activeMatchIndex: textSearch.activeMatchIndex,
-		setQuery: textSearch.setQuery,
-		setCaseSensitive: textSearch.setCaseSensitive,
-		findNext: textSearch.findNext,
-		findPrevious: textSearch.findPrevious,
-		closeSearch: textSearch.closeSearch,
-	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useDiffSearch/useDiffSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useDiffSearch/useDiffSearch.ts
@@ -1,7 +1,8 @@
 import type { RefObject } from "react";
-import { useCallback, useEffect } from "react";
-import { useHotkey } from "renderer/hotkeys";
-import { useTextSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
+import {
+	type FindHotkeySearchController,
+	useFindHotkeySearch,
+} from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
 import { getDiffSearchRoots } from "../../utils/diffRendererRoots";
 
 interface UseDiffSearchOptions {
@@ -11,73 +12,18 @@ interface UseDiffSearchOptions {
 	filePath: string;
 }
 
-interface UseDiffSearchReturn {
-	isSearchOpen: boolean;
-	query: string;
-	caseSensitive: boolean;
-	matchCount: number;
-	activeMatchIndex: number;
-	setQuery: (query: string) => void;
-	setCaseSensitive: (caseSensitive: boolean) => void;
-	findNext: () => void;
-	findPrevious: () => void;
-	closeSearch: () => void;
-}
-
 export function useDiffSearch({
 	containerRef,
 	isFocused,
 	isDiffMode,
 	filePath,
-}: UseDiffSearchOptions): UseDiffSearchReturn {
-	const getSearchRoots = useCallback(
-		(container: HTMLDivElement) => getDiffSearchRoots(container),
-		[],
-	);
-
-	const textSearch = useTextSearch({
+}: UseDiffSearchOptions): FindHotkeySearchController {
+	return useFindHotkeySearch({
 		containerRef,
-		getSearchRoots,
+		hotkeyId: "FIND_IN_FILE_VIEWER",
 		highlightPrefix: "diff-search",
+		isActive: isFocused && isDiffMode,
+		getSearchRoots: getDiffSearchRoots,
+		resetKey: filePath,
 	});
-
-	useEffect(() => {
-		if (!isFocused || !isDiffMode) {
-			if (textSearch.isSearchOpen) {
-				textSearch.closeSearch();
-			}
-		}
-	}, [isFocused, isDiffMode, textSearch.closeSearch, textSearch.isSearchOpen]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset on file change only
-	useEffect(() => {
-		if (textSearch.isSearchOpen) {
-			textSearch.closeSearch();
-		}
-	}, [filePath]);
-
-	useHotkey(
-		"FIND_IN_FILE_VIEWER",
-		() => {
-			if (textSearch.isSearchOpen) {
-				textSearch.closeSearch();
-				return;
-			}
-			textSearch.setIsSearchOpen(true);
-		},
-		{ enabled: isFocused && isDiffMode, preventDefault: true },
-	);
-
-	return {
-		isSearchOpen: textSearch.isSearchOpen,
-		query: textSearch.query,
-		caseSensitive: textSearch.caseSensitive,
-		matchCount: textSearch.matchCount,
-		activeMatchIndex: textSearch.activeMatchIndex,
-		setQuery: textSearch.setQuery,
-		setCaseSensitive: textSearch.setCaseSensitive,
-		findNext: textSearch.findNext,
-		findPrevious: textSearch.findPrevious,
-		closeSearch: textSearch.closeSearch,
-	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useMarkdownSearch/useMarkdownSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useMarkdownSearch/useMarkdownSearch.ts
@@ -1,7 +1,8 @@
 import type { RefObject } from "react";
-import { useEffect } from "react";
-import { useHotkey } from "renderer/hotkeys";
-import { useTextSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
+import {
+	type FindHotkeySearchController,
+	useFindHotkeySearch,
+} from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
 
 interface UseMarkdownSearchOptions {
 	containerRef: RefObject<HTMLDivElement | null>;
@@ -10,74 +11,17 @@ interface UseMarkdownSearchOptions {
 	filePath: string;
 }
 
-interface UseMarkdownSearchReturn {
-	isSearchOpen: boolean;
-	query: string;
-	caseSensitive: boolean;
-	matchCount: number;
-	activeMatchIndex: number;
-	setQuery: (query: string) => void;
-	setCaseSensitive: (caseSensitive: boolean) => void;
-	findNext: () => void;
-	findPrevious: () => void;
-	closeSearch: () => void;
-}
-
 export function useMarkdownSearch({
 	containerRef,
 	isFocused,
 	isRenderedMode,
 	filePath,
-}: UseMarkdownSearchOptions): UseMarkdownSearchReturn {
-	const textSearch = useTextSearch({
+}: UseMarkdownSearchOptions): FindHotkeySearchController {
+	return useFindHotkeySearch({
 		containerRef,
+		hotkeyId: "FIND_IN_FILE_VIEWER",
 		highlightPrefix: "markdown-search",
+		isActive: isFocused && isRenderedMode,
+		resetKey: filePath,
 	});
-
-	// Close search when pane loses focus or exits rendered mode
-	useEffect(() => {
-		if (!isFocused || !isRenderedMode) {
-			if (textSearch.isSearchOpen) {
-				textSearch.closeSearch();
-			}
-		}
-	}, [
-		isFocused,
-		isRenderedMode,
-		textSearch.closeSearch,
-		textSearch.isSearchOpen,
-	]);
-
-	// Reset search when file changes so stale Range objects don't linger
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset on file change only
-	useEffect(() => {
-		if (textSearch.isSearchOpen) {
-			textSearch.closeSearch();
-		}
-	}, [filePath]);
-
-	useHotkey(
-		"FIND_IN_FILE_VIEWER",
-		() => {
-			if (textSearch.isSearchOpen) {
-				textSearch.closeSearch();
-				return;
-			}
-			textSearch.setIsSearchOpen(true);
-		},
-		{ enabled: isFocused && isRenderedMode, preventDefault: true },
-	);
-
-	return {
-		isSearchOpen: textSearch.isSearchOpen,
-		query: textSearch.query,
-		caseSensitive: textSearch.caseSensitive,
-		matchCount: textSearch.matchCount,
-		activeMatchIndex: textSearch.activeMatchIndex,
-		setQuery: textSearch.setQuery,
-		setCaseSensitive: textSearch.setCaseSensitive,
-		findNext: textSearch.findNext,
-		findPrevious: textSearch.findPrevious,
-		closeSearch: textSearch.closeSearch,
-	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/index.ts
@@ -1,4 +1,9 @@
 export {
+	type FindHotkeySearchController,
+	type UseFindHotkeySearchOptions,
+	useFindHotkeySearch,
+} from "./useFindHotkeySearch";
+export {
 	type SplitOrientation,
 	useSplitOrientation,
 } from "./useSplitOrientation";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useFindHotkeySearch/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useFindHotkeySearch/index.ts
@@ -1,0 +1,5 @@
+export {
+	type FindHotkeySearchController,
+	type UseFindHotkeySearchOptions,
+	useFindHotkeySearch,
+} from "./useFindHotkeySearch";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useFindHotkeySearch/useFindHotkeySearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useFindHotkeySearch/useFindHotkeySearch.ts
@@ -1,0 +1,83 @@
+import type { RefObject } from "react";
+import { useEffect } from "react";
+import { type HotkeyId, useHotkey } from "renderer/hotkeys";
+import { type UseTextSearchReturn, useTextSearch } from "../useTextSearch";
+
+export interface UseFindHotkeySearchOptions {
+	containerRef: RefObject<HTMLDivElement | null>;
+	/** Hotkey that toggles the search bar (e.g. "FIND_IN_DIFF"). */
+	hotkeyId: HotkeyId;
+	/** Distinguishes this instance's CSS highlight registrations. */
+	highlightPrefix: string;
+	/**
+	 * Whether the owning pane is active/focused. Gates the toggle hotkey and
+	 * auto-closes the search bar when it becomes false.
+	 */
+	isActive: boolean;
+	/** Optional restriction of the DOM subtrees that are searched. */
+	getSearchRoots?: (container: HTMLDivElement) => Array<Node & ParentNode>;
+	/**
+	 * When this value changes, any open search is closed (e.g. the active file
+	 * path) so stale match Ranges don't linger across content swaps.
+	 */
+	resetKey?: unknown;
+}
+
+/** The search controller surface exposed to a pane's search UI. */
+export type FindHotkeySearchController = Omit<
+	UseTextSearchReturn,
+	"setIsSearchOpen"
+>;
+
+/**
+ * Shared orchestration for a pane's Cmd+F text search: wires the DOM-highlight
+ * {@link useTextSearch} engine to a toggle hotkey, closes the bar when the pane
+ * goes inactive (or `resetKey` changes), and exposes the controller surface its
+ * search UI needs. Consumers supply only what differs between panes — the
+ * hotkey, the highlight namespace, the active predicate, and optional search
+ * roots — instead of re-implementing the flow.
+ */
+export function useFindHotkeySearch({
+	containerRef,
+	hotkeyId,
+	highlightPrefix,
+	isActive,
+	getSearchRoots,
+	resetKey,
+}: UseFindHotkeySearchOptions): FindHotkeySearchController {
+	const textSearch = useTextSearch({
+		containerRef,
+		highlightPrefix,
+		getSearchRoots,
+	});
+
+	const { isSearchOpen, setIsSearchOpen, closeSearch } = textSearch;
+
+	useEffect(() => {
+		if (!isActive && isSearchOpen) {
+			closeSearch();
+		}
+	}, [isActive, isSearchOpen, closeSearch]);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on resetKey change only
+	useEffect(() => {
+		if (isSearchOpen) {
+			closeSearch();
+		}
+	}, [resetKey]);
+
+	useHotkey(
+		hotkeyId,
+		() => {
+			if (isSearchOpen) {
+				closeSearch();
+				return;
+			}
+			setIsSearchOpen(true);
+		},
+		{ enabled: isActive, preventDefault: true },
+	);
+
+	const { setIsSearchOpen: _setIsSearchOpen, ...controller } = textSearch;
+	return controller;
+}


### PR DESCRIPTION
## Summary

Adds Cmd+F (Ctrl+Shift+F on Windows/Linux) text search to the v2 changes (diff) pane, matching the existing find-in-terminal / find-in-chat / find-in-file-viewer experience.

- New `FIND_IN_DIFF` hotkey in the renderer hotkey registry (`⌘F` mac, `Ctrl+Shift+F` win/linux), gated to the active diff pane.
- New `useDiffPaneSearch` hook that wraps the shared `useTextSearch` engine, searching across each file's `@pierre/diffs` shadow root via `getDiffSearchRoots` and auto-closing when the pane loses focus.
- `DiffPane` now wraps `CodeView` in a relative container and renders the existing `MarkdownSearch` overlay (input, `X of Y` match count, case toggle, prev/next, Esc to close; Enter / Shift+Enter to navigate).

### Known limitation

`CodeView` is virtualized, so off-screen lines aren't in the DOM. Matches are scoped to currently rendered/expanded content and the count updates as you scroll — the same trade-off the shipped v1 diff/chat search makes. Collapsed files are naturally excluded. A stable total count + jump-to-off-screen would require a data-driven search with `scrollTo` navigation (possible follow-up).

## Test Plan

- [ ] Open the Changes pane in a v2 workspace, press `⌘F`, type a query, and confirm matches highlight with a `X of Y` count.
- [ ] Enter / Shift+Enter cycle through matches; case toggle works; Esc closes.
- [ ] Search closes automatically when focus leaves the diff pane.
- [x] `bun run lint` and `bun run typecheck` pass.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4982">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cmd+F (Ctrl+Shift+F on Windows/Linux) search to the v2 Changes pane. Uses the shared find UI with match highlighting, X of Y, case toggle, Enter/Shift+Enter navigation, and Esc to close.

- **New Features**
  - Added `FIND_IN_DIFF` hotkey scoped to the active changes pane.
  - `DiffPane` mounts `MarkdownSearch` and uses `useDiffPaneSearch` (via `useFindHotkeySearch`) to search inside `@pierre/diffs` shadow roots; auto-closes on focus loss.
  - Limitation: `CodeView` is virtualized, so only visible/expanded lines are searchable; counts update as you scroll.

- **Refactors**
  - Extracted `useFindHotkeySearch` to standardize Cmd+F behavior (toggle, auto-close, file-change reset).
  - Migrated chat and file viewer search hooks to `useFindHotkeySearch`.

<sup>Written for commit a89c19dcb6491e583c68034fe7e369feb224a1b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4982?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-pane Markdown search added to the diff view with Cmd/Ctrl+F support, case-sensitive matching, and next/previous navigation.
  * A new platform-aware "Find in diff" hotkey is available.

* **Refactor**
  * Search behavior unified into a shared find-hotkey system and applied to file viewer, markdown, and chat panes for consistent UX.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->