### PR TITLE
fix(desktop): decode terminal clipboard as UTF-8 (#4839, #4956)

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/clipboard-base64.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/clipboard-base64.test.ts
@@ -51,7 +51,9 @@ describe("Utf8Base64", () => {
 		}
 	});
 
-	it("propagates on malformed base64 so the addon can bail", () => {
+	it("throws so the addon can bail on malformed base64 or non-UTF-8 bytes", () => {
 		expect(() => codec.decodeText("@@@not base64@@@")).toThrow();
+		// "/w==" is valid base64 for a lone 0xFF, which is not valid UTF-8.
+		expect(() => codec.decodeText("/w==")).toThrow();
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/clipboard-base64.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/clipboard-base64.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { Utf8Base64 } from "./clipboard-base64";
+
+const codec = new Utf8Base64();
+
+// The exact bytes a shell emits for these characters, base64-encoded. These are
+// what an OSC 52 copy payload actually contains; decodeText must turn them back
+// into the original characters rather than Latin-1 byte-chars.
+const cases: Array<{ name: string; text: string; base64: string }> = [
+	{ name: "ascii", text: "hello", base64: "aGVsbG8=" },
+	// の = U+306E = E3 81 AE
+	{ name: "single hiragana の", text: "の", base64: "44Gu" },
+	// あいうえお = E3 81 82 / E3 81 84 / E3 81 86 / E3 81 88 / E3 81 8A
+	{
+		name: "hiragana run あいうえお",
+		text: "あいうえお",
+		base64: "44GC44GE44GG44GI44GK",
+	},
+	// accented Latin: Sautéed (é = U+00E9 = C3 A9)
+	{ name: "accented latin", text: "Sautéed", base64: "U2F1dMOpZWQ=" },
+	// box-drawing horizontal line U+2500 = E2 94 80
+	{ name: "box drawing ─", text: "─", base64: "4pSA" },
+	// emoji outside the BMP (surrogate pair): 😀 = F0 9F 98 80
+	{ name: "emoji 😀", text: "😀", base64: "8J+YgA==" },
+];
+
+describe("Utf8Base64", () => {
+	it("decodes UTF-8 OSC 52 payloads back to the original text", () => {
+		for (const { name, text, base64 } of cases) {
+			expect(codec.decodeText(base64), name).toBe(text);
+		}
+	});
+
+	it("encodes text to the real UTF-8 byte base64", () => {
+		for (const { name, text, base64 } of cases) {
+			expect(codec.encodeText(text), name).toBe(base64);
+		}
+	});
+
+	it("round-trips arbitrary multibyte text", () => {
+		const samples = [
+			"の",
+			"あいうえお",
+			"Sautéed",
+			"─━│",
+			"😀🎉",
+			"mixed ABC 日本語 123",
+		];
+		for (const sample of samples) {
+			expect(codec.decodeText(codec.encodeText(sample))).toBe(sample);
+		}
+	});
+
+	it("does not reproduce the double-UTF-8 mojibake of the default btoa/atob codec", () => {
+		// Regression guard: the buggy default returned a Latin-1 byte-string for
+		// `の`, which the clipboard then re-encoded as `c3 a3 ...` mojibake.
+		const decoded = codec.decodeText("44GC44GE44GG44GI44GK");
+		expect(decoded).toBe("あいうえお");
+		expect(decoded).not.toContain("ã");
+	});
+
+	it("propagates on malformed base64 so the addon can bail", () => {
+		expect(() => codec.decodeText("@@@not base64@@@")).toThrow();
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/clipboard-base64.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/clipboard-base64.test.ts
@@ -51,14 +51,6 @@ describe("Utf8Base64", () => {
 		}
 	});
 
-	it("does not reproduce the double-UTF-8 mojibake of the default btoa/atob codec", () => {
-		// Regression guard: the buggy default returned a Latin-1 byte-string for
-		// `の`, which the clipboard then re-encoded as `c3 a3 ...` mojibake.
-		const decoded = codec.decodeText("44GC44GE44GG44GI44GK");
-		expect(decoded).toBe("あいうえお");
-		expect(decoded).not.toContain("ã");
-	});
-
 	it("propagates on malformed base64 so the addon can bail", () => {
 		expect(() => codec.decodeText("@@@not base64@@@")).toThrow();
 	});

--- a/apps/desktop/src/renderer/lib/terminal/clipboard-base64.ts
+++ b/apps/desktop/src/renderer/lib/terminal/clipboard-base64.ts
@@ -22,12 +22,14 @@ export class Utf8Base64 implements IBase64 {
 	}
 
 	decodeText(data: string): string {
-		// `atob` throws on malformed base64; the addon relies on that to bail.
 		const binary = atob(data);
 		const bytes = new Uint8Array(binary.length);
 		for (let i = 0; i < binary.length; i++) {
 			bytes[i] = binary.charCodeAt(i);
 		}
-		return new TextDecoder("utf-8").decode(bytes);
+		// Throw on malformed base64 (atob) or non-UTF-8 bytes (fatal decode)
+		// rather than writing replacement characters to the clipboard; the addon
+		// catches and clears instead, matching alacritty/kitty's strict decode.
+		return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
 	}
 }

--- a/apps/desktop/src/renderer/lib/terminal/clipboard-base64.ts
+++ b/apps/desktop/src/renderer/lib/terminal/clipboard-base64.ts
@@ -3,21 +3,13 @@ import type { IBase64 } from "@xterm/addon-clipboard";
 /**
  * UTF-8-aware base64 codec for xterm's ClipboardAddon (OSC 52 copy/paste).
  *
- * The addon's bundled `Base64` provider uses `btoa`/`atob`, which only speak
- * Latin-1 "binary strings" — one char per byte. For any multi-byte UTF-8
- * character (Japanese/CJK, accented Latin, box-drawing/em-dash) that breaks
- * both directions:
- *
- * - decode: `atob` returns a string whose chars ARE the raw UTF-8 bytes
- *   (e.g. あ → "ã"). Handing that to `navigator.clipboard`
- *   re-encodes each char as UTF-8, so `0xe3` (ã) becomes `c3 a3`, etc. —
- *   classic double-UTF-8 mojibake (`あいうえお` pastes as `ããããã`).
- * - encode: `btoa` throws on any code point > 0xFF, so reporting the
- *   selection back via OSC 52 silently fails for non-Latin text.
- *
- * Routing through TextEncoder/TextDecoder makes the base64 payload the real
- * UTF-8 byte stream, matching the OSC 52 spec and what macOS Terminal.app and
- * other emulators produce. See GitHub #4839 / #4956.
+ * The addon's bundled codec uses `btoa`/`atob`, which treat the payload as
+ * Latin-1 (one char per byte). Multi-byte characters (CJK, accented Latin,
+ * box-drawing) then get double-UTF-8-encoded on copy and pasted back as
+ * mojibake, and non-Latin selections throw on read. Routing through
+ * TextEncoder/TextDecoder treats the payload as the real UTF-8 byte stream,
+ * matching the OSC 52 spec and native terminals (alacritty, kitty).
+ * See GitHub #4839 / #4956.
  */
 export class Utf8Base64 implements IBase64 {
 	encodeText(data: string): string {
@@ -30,8 +22,7 @@ export class Utf8Base64 implements IBase64 {
 	}
 
 	decodeText(data: string): string {
-		// `atob` throws on malformed base64; the addon relies on that to bail,
-		// so let it propagate rather than swallowing it here.
+		// `atob` throws on malformed base64; the addon relies on that to bail.
 		const binary = atob(data);
 		const bytes = new Uint8Array(binary.length);
 		for (let i = 0; i < binary.length; i++) {

--- a/apps/desktop/src/renderer/lib/terminal/clipboard-base64.ts
+++ b/apps/desktop/src/renderer/lib/terminal/clipboard-base64.ts
@@ -1,0 +1,42 @@
+import type { IBase64 } from "@xterm/addon-clipboard";
+
+/**
+ * UTF-8-aware base64 codec for xterm's ClipboardAddon (OSC 52 copy/paste).
+ *
+ * The addon's bundled `Base64` provider uses `btoa`/`atob`, which only speak
+ * Latin-1 "binary strings" — one char per byte. For any multi-byte UTF-8
+ * character (Japanese/CJK, accented Latin, box-drawing/em-dash) that breaks
+ * both directions:
+ *
+ * - decode: `atob` returns a string whose chars ARE the raw UTF-8 bytes
+ *   (e.g. あ → "ã"). Handing that to `navigator.clipboard`
+ *   re-encodes each char as UTF-8, so `0xe3` (ã) becomes `c3 a3`, etc. —
+ *   classic double-UTF-8 mojibake (`あいうえお` pastes as `ããããã`).
+ * - encode: `btoa` throws on any code point > 0xFF, so reporting the
+ *   selection back via OSC 52 silently fails for non-Latin text.
+ *
+ * Routing through TextEncoder/TextDecoder makes the base64 payload the real
+ * UTF-8 byte stream, matching the OSC 52 spec and what macOS Terminal.app and
+ * other emulators produce. See GitHub #4839 / #4956.
+ */
+export class Utf8Base64 implements IBase64 {
+	encodeText(data: string): string {
+		const bytes = new TextEncoder().encode(data);
+		let binary = "";
+		for (const byte of bytes) {
+			binary += String.fromCharCode(byte);
+		}
+		return btoa(binary);
+	}
+
+	decodeText(data: string): string {
+		// `atob` throws on malformed base64; the addon relies on that to bail,
+		// so let it propagate rather than swallowing it here.
+		const binary = atob(data);
+		const bytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i++) {
+			bytes[i] = binary.charCodeAt(i);
+		}
+		return new TextDecoder("utf-8").decode(bytes);
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -6,6 +6,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { Utf8Base64 } from "./clipboard-base64";
 
 export interface LoadAddonsResult {
 	searchAddon: SearchAddon;
@@ -25,7 +26,9 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 	let disposed = false;
 	let webglAddon: WebglAddon | null = null;
 
-	terminal.loadAddon(new ClipboardAddon());
+	// Custom UTF-8 base64 codec: the addon's default btoa/atob mangles
+	// multi-byte characters into double-UTF-8 mojibake on OSC 52 copy (#4839).
+	terminal.loadAddon(new ClipboardAddon(new Utf8Base64()));
 
 	const unicode11 = new Unicode11Addon();
 	terminal.loadAddon(unicode11);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -26,8 +26,7 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 	let disposed = false;
 	let webglAddon: WebglAddon | null = null;
 
-	// Custom UTF-8 base64 codec: the addon's default btoa/atob mangles
-	// multi-byte characters into double-UTF-8 mojibake on OSC 52 copy (#4839).
+	// Utf8Base64 replaces the addon's UTF-8-unsafe default codec (#4839).
 	terminal.loadAddon(new ClipboardAddon(new Utf8Base64()));
 
 	const unicode11 = new Unicode11Addon();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -9,6 +9,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { applyTerminalFontFamilyCssVariable } from "renderer/lib/terminal/appearance";
+import { Utf8Base64 } from "renderer/lib/terminal/clipboard-base64";
 import type { DetectedLink } from "renderer/lib/terminal/links";
 import { TerminalLinkManager } from "renderer/lib/terminal/terminal-link-manager";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
@@ -100,7 +101,9 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const fitAddon = new FitAddon();
 	const searchAddon = new SearchAddon();
 
-	const clipboardAddon = new ClipboardAddon();
+	// Custom UTF-8 base64 codec: the addon's default btoa/atob mangles
+	// multi-byte characters into double-UTF-8 mojibake on OSC 52 copy (#4839).
+	const clipboardAddon = new ClipboardAddon(new Utf8Base64());
 	const unicode11Addon = new Unicode11Addon();
 	const imageAddon = new ImageAddon();
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -101,8 +101,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const fitAddon = new FitAddon();
 	const searchAddon = new SearchAddon();
 
-	// Custom UTF-8 base64 codec: the addon's default btoa/atob mangles
-	// multi-byte characters into double-UTF-8 mojibake on OSC 52 copy (#4839).
+	// Utf8Base64 replaces the addon's UTF-8-unsafe default codec (#4839).
 	const clipboardAddon = new ClipboardAddon(new Utf8Base64());
 	const unicode11Addon = new Unicode11Addon();
 	const imageAddon = new ImageAddon();


### PR DESCRIPTION
## Problem

Copying multi-byte text out of the desktop terminal produces mojibake. Typing/display is correct, but `Cmd+C` / `/copy` (anything using OSC 52) writes double-UTF-8-encoded bytes to the system clipboard:

- `あいうえお` pastes as `ããããã`
- `Sautéed` pastes as `SautÃ©ed`
- box-drawing/divider lines paste as runs of `Ã¢...`

Fixes #4839, #4956.

## Root cause

The full PTY → daemon → host-service → xterm pipeline is already byte-clean (verified by `no-encoding-hops.test.ts`), which is why **display** is correct. The corruption is isolated to the **clipboard write**.

xterm's `@xterm/addon-clipboard` ships a default base64 codec built on `btoa`/`atob`, which only speak Latin-1 (one char per byte). On OSC 52 copy, `atob` returns a string whose chars are the raw UTF-8 bytes; handing that to `navigator.clipboard` re-encodes each char as UTF-8 — classic double-UTF-8 mojibake. Even the latest upstream xterm.js (6.0.0) still ships this codec and exposes the `IBase64` constructor param specifically so consumers can override it.

## Fix

Add a UTF-8-aware `IBase64` (`Utf8Base64`) that routes through `TextEncoder`/`TextDecoder`, and pass it to both `ClipboardAddon` instances. This matches how native terminals decode OSC 52:

- **alacritty**: `Base64.decode(...)` → `String::from_utf8(bytes)`
- **kitty**: `base64.standard_b64decode(x).decode('utf-8')`

…and mirrors the existing `bytesToBase64`/`base64ToBytes` idiom already used in `RemoteTerminal.tsx`.

## Test plan

- New `clipboard-base64.test.ts`: round-trips Japanese, accented Latin, box-drawing, emoji, ASCII; asserts the exact UTF-8 byte payloads; includes a regression guard for the `ããããã` mojibake.
- Verified the test fails against the old `btoa`/`atob` codec (reproduces `ããããã`) and passes with the fix.
- `bun run lint`, `typecheck`, and all 229 terminal-lib tests pass.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mojibake when copying from the desktop terminal by decoding OSC 52 clipboard data as UTF-8 and rejecting non-UTF-8 payloads. Japanese, accented Latin, box-drawing, and emoji now copy/paste correctly.

- **Bug Fixes**
  - Introduced `Utf8Base64` implementing `IBase64` via `TextEncoder`/`TextDecoder({ fatal: true })`; passed to `@xterm/addon-clipboard`’s `ClipboardAddon` at both call sites.
  - Replaced `btoa`/`atob` codec to stop double-UTF-8; non-UTF-8 OSC 52 payloads now fail fast instead of pasting U+FFFD.
  - Added `clipboard-base64.test.ts` covering UTF-8 cases, round-trips, and malformed input; dropped a redundant regression test.
  - Fixes #4839, #4956.

<sup>Written for commit 5e6b39034db78507f7702cda894c64cef6053def. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4983?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a UTF-8-safe Base64 clipboard codec and configured the app to use it so copy/paste reliably preserves Unicode and multibyte characters.

* **Tests**
  * Added tests verifying encode/decode correctness, round-trip integrity, and proper errors for malformed or non-UTF-8 payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->