### PR TITLE
fix(desktop): stop spinner sticking on v1 agent SessionStart

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -22,7 +22,22 @@ describe("getNotifyScriptContent", () => {
 			"event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID",
 		);
 		expect(script).toContain('V1_EVENT_TYPE="$EVENT_TYPE"');
-		expect(script).toContain('V1_EVENT_TYPE="Stop"');
+	});
+
+	it("does not rewrite session-lifetime events to per-turn Start/Stop", () => {
+		// SessionStart/SessionEnd must reach mapEventType verbatim so the server
+		// can drop them. Rewriting them here would re-create the stuck-spinner
+		// bug at the bash layer where the server fix can't reach.
+		const script = readFileSync(
+			path.join(import.meta.dir, "templates", "notify-hook.template.sh"),
+			"utf-8",
+		);
+		expect(script).not.toContain(
+			"Attached|attached|SessionStart|sessionStart|session_start",
+		);
+		expect(script).not.toContain(
+			"Detached|detached|SessionEnd|sessionEnd|session_end",
+		);
 	});
 
 	it("gives the v2 host-service hook enough time to deliver", () => {

--- a/apps/desktop/src/main/lib/agent-setup/templates/copilot-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/copilot-hook.template.sh
@@ -23,10 +23,6 @@ esac
 printf '{}\n'
 
 V1_EVENT_TYPE="$EVENT_TYPE"
-case "$V1_EVENT_TYPE" in
-  SessionStart) V1_EVENT_TYPE="Start" ;;
-  SessionEnd)   V1_EVENT_TYPE="Stop" ;;
-esac
 
 json_escape() {
   printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'

--- a/apps/desktop/src/main/lib/agent-setup/templates/cursor-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/cursor-hook.template.sh
@@ -21,10 +21,6 @@ if [ "$NEEDS_RESPONSE" = "true" ]; then
 fi
 
 V1_EVENT_TYPE="$EVENT_TYPE"
-case "$V1_EVENT_TYPE" in
-  SessionStart) V1_EVENT_TYPE="Start" ;;
-  SessionEnd)   V1_EVENT_TYPE="Stop" ;;
-esac
 
 json_escape() {
   printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'

--- a/apps/desktop/src/main/lib/agent-setup/templates/gemini-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/gemini-hook.template.sh
@@ -22,10 +22,6 @@ esac
 printf '{}\n'
 
 V1_EVENT_TYPE="$EVENT_TYPE"
-case "$V1_EVENT_TYPE" in
-  SessionStart) V1_EVENT_TYPE="Start" ;;
-  SessionEnd)   V1_EVENT_TYPE="Stop" ;;
-esac
 
 json_escape() {
   printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -59,15 +59,14 @@ debug_log() {
 
 debug_log "event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID tabId=$SUPERSET_TAB_ID"
 
+# Forward EVENT_TYPE as-is to the v1 fallback. Session-lifetime events
+# (SessionStart/SessionEnd and aliases) must NOT be rewritten to Start/Stop
+# here — the server's mapEventType drops them on purpose, because flipping
+# the pane to "working" on SessionStart leaves the spinner stuck until the
+# first real per-turn Stop. Keeping the raw event lets mapEventType apply
+# its canonical mapping (Attached/Detached are intentionally not mapped to
+# anything in v1 because v1 has no Attached/Detached pane state).
 V1_EVENT_TYPE="$EVENT_TYPE"
-case "$V1_EVENT_TYPE" in
-  Attached|attached|SessionStart|sessionStart|session_start)
-    V1_EVENT_TYPE="Start"
-    ;;
-  Detached|detached|SessionEnd|sessionEnd|session_end)
-    V1_EVENT_TYPE="Stop"
-    ;;
-esac
 
 json_escape() {
   printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'

--- a/apps/desktop/src/main/lib/notifications/map-event-type.ts
+++ b/apps/desktop/src/main/lib/notifications/map-event-type.ts
@@ -1,3 +1,11 @@
+// Session-lifetime events (SessionStart/SessionEnd and aliases) are
+// intentionally NOT mapped here. They fire when an agent attaches to / detaches
+// from a terminal — the agent is idle waiting for input, not generating —
+// so flipping the pane to "working" on SessionStart leaves the spinner stuck
+// until the first real per-turn Stop. v1 has no Attached/Detached state to
+// map to, so let these return null and rely on per-turn events
+// (UserPromptSubmit/Start → Stop/AfterAgent/task_complete) for the working
+// indicator, and on terminal-exit for stuck-state cleanup.
 export function mapEventType(
 	eventType: string | undefined,
 ): "Start" | "Stop" | "PermissionRequest" | null {
@@ -6,14 +14,11 @@ export function mapEventType(
 	}
 	if (
 		eventType === "Start" ||
-		eventType === "SessionStart" ||
 		eventType === "UserPromptSubmit" ||
 		eventType === "PostToolUse" ||
 		eventType === "PostToolUseFailure" ||
 		eventType === "BeforeAgent" ||
 		eventType === "AfterTool" ||
-		eventType === "sessionStart" ||
-		eventType === "session_start" ||
 		eventType === "userPromptSubmitted" ||
 		eventType === "user_prompt_submit" ||
 		eventType === "postToolUse" ||
@@ -39,8 +44,6 @@ export function mapEventType(
 		eventType === "stop" ||
 		eventType === "agent-turn-complete" ||
 		eventType === "AfterAgent" ||
-		eventType === "sessionEnd" ||
-		eventType === "session_end" ||
 		eventType === "task_complete"
 	) {
 		return "Stop";

--- a/apps/desktop/src/main/lib/notifications/server.test.ts
+++ b/apps/desktop/src/main/lib/notifications/server.test.ts
@@ -16,8 +16,18 @@ describe("notifications/server", () => {
 			expect(mapEventType("Start")).toBe("Start");
 		});
 
-		it("should map 'SessionStart' to 'Start'", () => {
-			expect(mapEventType("SessionStart")).toBe("Start");
+		it("returns null for session-lifetime events (SessionStart/SessionEnd and aliases)", () => {
+			// SessionStart fires when the agent attaches and is idle waiting for
+			// the first prompt — must NOT flip the pane to "working", or the
+			// spinner is stuck until the first real Stop event. Same shape for
+			// SessionEnd: it's the session-lifetime counterpart to SessionStart,
+			// not a per-turn Stop signal, so it must not clear working either.
+			expect(mapEventType("SessionStart")).toBeNull();
+			expect(mapEventType("sessionStart")).toBeNull();
+			expect(mapEventType("session_start")).toBeNull();
+			expect(mapEventType("SessionEnd")).toBeNull();
+			expect(mapEventType("sessionEnd")).toBeNull();
+			expect(mapEventType("session_end")).toBeNull();
 		});
 
 		it("should map 'UserPromptSubmit' to 'Start'", () => {
@@ -25,7 +35,6 @@ describe("notifications/server", () => {
 		});
 
 		it("should map Codex snake_case start events to 'Start'", () => {
-			expect(mapEventType("session_start")).toBe("Start");
 			expect(mapEventType("user_prompt_submit")).toBe("Start");
 			expect(mapEventType("post_tool_use")).toBe("Start");
 			expect(mapEventType("task_started")).toBe("Start");


### PR DESCRIPTION
## Description

Launching Claude Code (or any v1-pane agent that emits `SessionStart`/`SessionEnd` hooks) flipped the pane to **working** and the amber spinner stayed on until terminal exit. The bash notify hook script rewrote `SessionStart → Start` at the v1-fallback layer before the URL ever reached the server, and `mapEventType` then mapped `Start` to the per-turn working state. `SessionStart` fires when the agent attaches and is idle waiting for the first prompt — not a per-turn cadence signal — so the working indicator latched on with no `Stop` ever arriving to clear it.

## Root cause

Two layers conspired:

1. **bash hook template** (`notify-hook.template.sh` + per-agent variants) rewrote `SessionStart → Start` and `SessionEnd → Stop` before posting to the v1 hook endpoint. The server never saw the original event.
2. **server-side `mapEventType`** then mapped `Start` to the per-turn working state. Even if (1) were fixed in isolation, the server would still produce the same bug.

## Fix

Two-layer fix so the symptom can't recur if either layer regresses:

1. **`notify-hook.template.sh` + `cursor-hook.template.sh` + `copilot-hook.template.sh` + `gemini-hook.template.sh`**: drop the `SessionStart → Start` / `SessionEnd → Stop` case rewrite. Forward `EVENT_TYPE` verbatim and let the server decide.
2. **`notifications/map-event-type.ts`**: drop `SessionStart`/`sessionStart`/`session_start` from the `Start` bucket and `SessionEnd`/`sessionEnd`/`session_end` from the `Stop` bucket. `mapEventType` now returns `null` for session-lifetime events on v1, matching the v2 host-service mapper's `SessionStart → Attached` / `SessionEnd → Detached` intent (v1 has no `Attached`/`Detached` pane state to map to).

## Related Issues

<!-- Add issue numbers if there are tracking issues -->

## Type of Change

- [x] Bug fix

## Testing

- `server.test.ts`: assert `SessionStart`/`SessionEnd` (and all-case aliases) return `null` from `mapEventType`.
- `notify-hook.test.ts`: assert the rendered template no longer contains the session→start/stop case block.
- 19/19 server tests + 8/8 notify-hook tests pass; full `bun test` for `notifications/` and `agent-setup/` green.
- End-to-end verified via Chrome DevTools Protocol screenshot in dev: relaunching `claude` in a v1 worktree workspace no longer shows the amber spinner on tab title, pane title, or sidebar workspace icon. Terminal-exit handler still clears any genuinely stuck state, so dropping `SessionEnd → Stop` is safe.

## Additional Notes

- The v2 host-service mapper already handles `SessionStart`/`SessionEnd` correctly as `Attached`/`Detached`; this PR only touches the v1 path.
- Template files ship inside the desktop binary and are also rendered into existing agent installs on disk; users will pick up the fixed script next time the renderer overwrites the hook.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4991">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop spinner getting stuck after launching a v1 agent by treating `SessionStart`/`SessionEnd` as session events, not per-turn signals. We now pass these events through unchanged and ignore them in the v1 mapper, so “working” only reflects real turn activity.

- **Bug Fixes**
  - `notify-hook.template.sh` and agent hook templates: removed `SessionStart → Start` / `SessionEnd → Stop` rewrites; forward `EVENT_TYPE` as-is.
  - `notifications/map-event-type.ts`: no longer maps `SessionStart`/`SessionEnd` (and aliases) to `Start`/`Stop`; returns `null` for these session-lifetime events.

<sup>Written for commit a97cdc7dc6b456961745bd3bb8efb87509d5f7e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

