### PR TITLE
fix(desktop): always show completion badge on agent Stop

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/useAgentHookListener.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useAgentHookListener.ts
@@ -12,7 +12,10 @@ import { resolveNotificationTarget } from "./utils/resolve-notification-target";
  *
  * STATUS MAPPING:
  * - Start → "working" (amber pulsing indicator)
- * - Stop → "review" (green static) if pane's tab not active, "idle" if tab is active
+ * - Stop → "review" (green static) so the user gets a completion badge even on
+ *   the active/focused pane. It clears automatically on next tab switch / pane
+ *   refocus / next Start (see acknowledgedStatus in shared/tabs-types).
+ *   Exception: if pane was "permission", Stop → "idle" (user already engaged).
  * - PermissionRequest → "permission" (red pulsing indicator)
  * - Terminal Exit → "idle" (handled in Terminal.tsx when mounted; also forwarded via notifications for unmounted panes)
  *
@@ -31,21 +34,6 @@ import { resolveNotificationTarget } from "./utils/resolve-notification-target";
  * Note: Terminal exit detection (in Terminal.tsx) provides a reliable fallback
  * for clearing stuck indicators when agent hooks fail to fire.
  */
-
-/**
- * Returns the current workspace ID from the live URL hash.
- * The app uses hash routing: file:///.../index.html#/workspace/<id>
- * We must read window.location.hash (not pathname) at event time since the
- * _authenticated layout does not re-render on workspace navigation.
- */
-function getCurrentWorkspaceId(): string | null {
-	try {
-		const match = window.location.hash.match(/\/workspace\/([^/?#]+)/);
-		return match ? match[1] : null;
-	} catch {
-		return null;
-	}
-}
 
 export function useAgentHookListener() {
 	const navigate = useNavigate();
@@ -79,30 +67,17 @@ export function useAgentHookListener() {
 				) {
 					state.setPaneStatus(paneId, "permission");
 				} else if (eventType === "Stop") {
-					const activeTabId = state.activeTabIds[workspaceId];
 					const pane = state.panes[paneId];
-					const tabId = pane?.tabId;
-					// Tab must be active for this workspace
-					const isTabActive = tabId != null && tabId === activeTabId;
-					// User is on this workspace if the URL hash matches OR if they have this
-					// pane focused (more reliable than URL parsing which can lag behind navigation)
-					const isPaneFocused =
-						tabId != null && state.focusedPaneIds[tabId] === paneId;
-					const isInActiveTab =
-						isTabActive &&
-						(getCurrentWorkspaceId() === workspaceId || isPaneFocused);
 
-					// If stopping from a pending question state, always go idle (user already engaged)
-					const nextStatus =
-						pane?.status === "permission"
-							? "idle"
-							: isInActiveTab
-								? "idle"
-								: "review";
+					// Always surface a "review" badge on Stop so the user sees a
+					// completion indicator everywhere (sidebar / tab strip / pane).
+					// It auto-clears on tab switch, focused-pane change, or next
+					// Start event via acknowledgedStatus() in the tabs store.
+					// Exception: if pane was in "permission" the user already
+					// engaged with the prompt, so resolve to idle instead.
+					const nextStatus = pane?.status === "permission" ? "idle" : "review";
 
 					debugLog("agent-hooks", "Stop event:", {
-						isInActiveTab,
-						activeTabId,
 						paneTabId: pane?.tabId,
 						paneId,
 						paneStatus: pane?.status,


### PR DESCRIPTION
## Description

When Claude Code (or any v1 agent) finished a response, the green completion badge **only** appeared on tabs/panes the user was *not* viewing. On the active/focused pane, the Stop hook resolved to `idle`, so the user got no visual confirmation that the agent had stopped — they had to watch the terminal output to know it was their turn again.

This PR makes the completion badge appear everywhere — sidebar workspace icon, tab strip, pane header — regardless of whether the pane is focused.

## Root cause

`useAgentHookListener.ts` gated the `review` status on `!isInActiveTab`. The original intent was \"don't clutter the pane the user is already looking at,\" but in practice it hides the only completion signal exactly where it's most useful.

## Fix

Drop the `isInActiveTab` gate. Stop now always resolves to `review` (green static dot), with one carve-out: if the pane was in `permission`, the user already engaged with the request, so resolve to `idle` instead of re-arming an indicator.

The badge auto-clears on the next:
- tab switch (`setActiveTab` runs `acknowledgedStatus()` on the tab's panes)
- focused-pane change (`setFocusedPane` same)
- `Start` event (working overwrites review)

…so the existing dismissal flow stays intact. No new state, no timers.

## Related Issues

<!-- Add issue numbers if there are tracking issues -->

## Type of Change

- [x] Bug fix

## Testing

- `bun test src/renderer/stores/tabs/`: 159/159 pass.
- `bun run typecheck`: clean.
- `biome check` on changed file: clean.

⚠ No unit test added for the listener itself — there is no existing test file for `useAgentHookListener.ts` in the repo, so adding one would require new harness scaffolding. Happy to add one in a follow-up if reviewers want it.

Behaviour verified in dev: triggered Stop hook with active tab/focused pane → green dot now appears on the pane header and tab strip (previously: no dot).

## Additional Notes

This is a **deliberate behaviour change** from the previously documented \"hide badge on active pane\" rule (see the jsdoc that was updated). Calling it out explicitly in case a reviewer recognises the original logic as intentional UX — but in user testing the suppressed-badge behaviour was confusing, so we're flipping it.

The unused `getCurrentWorkspaceId()` helper was removed since the gate it served is gone.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4992">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the green completion badge on agent Stop, including on the active tab/pane, so users get a clear “done” signal. The badge still auto-clears on tab switch, focus change, or next Start; panes in `permission` go to `idle`.

- **Bug Fixes**
  - Removed the active-tab gate in `useAgentHookListener.ts`; Stop now sets status to `review` everywhere (sidebar, tab strip, pane header).
  - Exception: if the pane was in `permission`, Stop resolves to `idle`.
  - Dismissal uses existing `acknowledgedStatus()` flows (tab switch, focused-pane change, next Start).
  - Deleted unused `getCurrentWorkspaceId()` helper.

<sup>Written for commit 081978eaff23c858da085d7593fc0760b7ad5c93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

