### PR TITLE
fix(billing): keep invoice access after downgrade

### DIFF
--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -3,7 +3,7 @@ import { db } from "@superset/db/client";
 import { members, subscriptions } from "@superset/db/schema";
 import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull } from "drizzle-orm";
 import type Stripe from "stripe";
 import { z } from "zod";
 import { env } from "../../env";
@@ -47,7 +47,11 @@ async function requireOwnerWithCustomer(ctx: {
 			),
 		}),
 		db.query.subscriptions.findFirst({
-			where: eq(subscriptions.referenceId, activeOrgId),
+			where: and(
+				eq(subscriptions.referenceId, activeOrgId),
+				isNotNull(subscriptions.stripeCustomerId),
+			),
+			orderBy: desc(subscriptions.createdAt),
 		}),
 	]);
 
@@ -94,8 +98,15 @@ export const billingRouter = {
 			});
 		}
 
+		// Intentionally unfiltered by status so invoices stay accessible after a
+		// downgrade. An org can have multiple subscription rows; take the most
+		// recent that has a Stripe customer.
 		const subscription = await db.query.subscriptions.findFirst({
-			where: eq(subscriptions.referenceId, activeOrgId),
+			where: and(
+				eq(subscriptions.referenceId, activeOrgId),
+				isNotNull(subscriptions.stripeCustomerId),
+			),
+			orderBy: desc(subscriptions.createdAt),
 		});
 
 		if (!subscription?.stripeCustomerId) {

--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -125,7 +125,7 @@ export const billingRouter = {
 		const twelveMonthsAgo = subtractMonthsClamped(new Date(), 12);
 
 		// A paid invoice belongs to exactly one customer, so merging across
-		// customers never produces duplicates — just sort by date for display.
+		// customers never produces duplicates.
 		const invoiceLists = await Promise.all(
 			customerIds.map((customer) =>
 				stripeClient.invoices.list({

--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -98,37 +98,55 @@ export const billingRouter = {
 			});
 		}
 
-		// Intentionally unfiltered by status so invoices stay accessible after a
-		// downgrade. An org can have multiple subscription rows; take the most
-		// recent that has a Stripe customer.
-		const subscription = await db.query.subscriptions.findFirst({
+		// The subscriptions table is the only org -> Stripe customer mapping, so
+		// gather every customer this org has ever billed under. Intentionally
+		// unfiltered by status so invoices stay accessible after a downgrade, and
+		// an org can accumulate more than one customer over its lifetime.
+		const subscriptionRows = await db.query.subscriptions.findMany({
 			where: and(
 				eq(subscriptions.referenceId, activeOrgId),
 				isNotNull(subscriptions.stripeCustomerId),
 			),
-			orderBy: desc(subscriptions.createdAt),
+			columns: { stripeCustomerId: true },
 		});
 
-		if (!subscription?.stripeCustomerId) {
+		const customerIds = [
+			...new Set(
+				subscriptionRows
+					.map((row) => row.stripeCustomerId)
+					.filter((id): id is string => id !== null),
+			),
+		];
+
+		if (customerIds.length === 0) {
 			return [];
 		}
 
 		const twelveMonthsAgo = subtractMonthsClamped(new Date(), 12);
 
-		const stripeInvoices = await stripeClient.invoices.list({
-			customer: subscription.stripeCustomerId,
-			limit: 100,
-			status: "paid",
-			created: { gte: Math.floor(twelveMonthsAgo.getTime() / 1000) },
-		});
+		// A paid invoice belongs to exactly one customer, so merging across
+		// customers never produces duplicates — just sort by date for display.
+		const invoiceLists = await Promise.all(
+			customerIds.map((customer) =>
+				stripeClient.invoices.list({
+					customer,
+					limit: 100,
+					status: "paid",
+					created: { gte: Math.floor(twelveMonthsAgo.getTime() / 1000) },
+				}),
+			),
+		);
 
-		return stripeInvoices.data.map((invoice) => ({
-			id: invoice.id,
-			date: invoice.created,
-			amount: invoice.amount_paid,
-			currency: invoice.currency,
-			hostedInvoiceUrl: invoice.hosted_invoice_url,
-		}));
+		return invoiceLists
+			.flatMap((list) => list.data)
+			.sort((a, b) => b.created - a.created)
+			.map((invoice) => ({
+				id: invoice.id,
+				date: invoice.created,
+				amount: invoice.amount_paid,
+				currency: invoice.currency,
+				hostedInvoiceUrl: invoice.hosted_invoice_url,
+			}));
 	}),
 
 	details: protectedProcedure.query(async ({ ctx }) => {


### PR DESCRIPTION
## Problem

After a user downgrades to free, their invoice history could silently disappear from settings — and even on an active plan, an org that had billed under more than one Stripe customer over its lifetime would only see a subset of its invoices.

The frontend was never the gate: `RecentInvoices` renders unconditionally, independent of plan. The gate was the `billing.invoices` tRPC query.

## Root cause

The `subscriptions` table has **no unique constraint on `referenceId`**, and better-auth inserts a **new row per checkout attempt** (a row gets its `stripeCustomerId` only once the customer is attached). So an org can hold several rows — some with a null `stripeCustomerId`, and occasionally with *different* customer ids.

The old query used:

```ts
db.query.subscriptions.findFirst({ where: eq(subscriptions.referenceId, activeOrgId) })
```

No `orderBy` (nondeterministic selection) and no requirement that the row had a `stripeCustomerId`. Two failure modes:
1. `findFirst` returns a customer-less row → hits `if (!stripeCustomerId) return []` → invoices silently hidden (the post-downgrade case).
2. The org has billed under multiple customers → only one customer's invoices are ever shown.

## Fix

The `subscriptions` table is the only org → Stripe customer mapping, so gather **every** customer the org has billed under and merge their invoices:

```ts
const subscriptionRows = await db.query.subscriptions.findMany({
  where: and(
    eq(subscriptions.referenceId, activeOrgId),
    isNotNull(subscriptions.stripeCustomerId),
  ),
  columns: { stripeCustomerId: true },
});
const customerIds = [...new Set(subscriptionRows.map(r => r.stripeCustomerId).filter(Boolean))];
// list paid invoices per customer, flatten, sort by date desc
```

- Intentionally **unfiltered by subscription status** so invoices stay accessible after a downgrade.
- A paid invoice belongs to exactly one customer, so the merge needs **no dedup** — just sort by date for display order.
- **Degrades to a single `invoices.list` call** for the common one-customer org (identical cost/behavior to before).
- Still scoped: customer ids come only from *this org's* rows, so no cross-tenant exposure.

`requireOwnerWithCustomer` (backing `details`/`portal`) keeps the single most-recent-customer resolution — a Stripe billing portal and payment-method/tax details are inherently per-customer and can't be unioned — but now also filters to `isNotNull(stripeCustomerId)` + `orderBy(desc(createdAt))` so it can't latch onto a customer-less row.

## Assumption

A Stripe customer maps to a single org (true here — better-auth creates/reuses one customer per `referenceId`). Also relies on `stripeCustomerId` never being cleared and rows never hard-deleted (confirmed in the schema/webhook handlers today).

## Testing

- `bun run lint` — clean
- `bun run typecheck --filter=@superset/trpc` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoices remain accessible after subscription downgrades.
  * Billing lookups now require a valid customer ID to avoid missing or incorrect records.

* **Improvements**
  * Invoice listing shows all historical paid invoices across past customer records and returns them sorted newest-first.
  * When multiple subscriptions exist, the most recent subscription is preferred for ownership resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->