### PR TITLE
fix(host-service): harden DB migration startup (busy_timeout + fail-closed)

### DIFF
--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -5,11 +5,7 @@ import path from "node:path";
 /** Rotate per-org host-service.log once it exceeds this size. */
 export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
 
-// Must exceed the host-service's DB-migration budget (MIGRATION_BUSY_TIMEOUT_MS,
-// 8s) plus startup overhead: migrations run synchronously before the port binds,
-// so a recoverable lock stall delays the first successful health response. Too
-// tight and the coordinator SIGKILLs a host-service that was about to come up.
-export const HEALTH_POLL_TIMEOUT_MS = 20_000;
+export const HEALTH_POLL_TIMEOUT_MS = 10_000;
 
 const HEALTH_POLL_INTERVAL_MS = 200;
 

--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 /** Rotate per-org host-service.log once it exceeds this size. */
 export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
 
-export const HEALTH_POLL_TIMEOUT_MS = 10_000;
+// Must exceed the host-service's DB-migration budget (MIGRATION_BUSY_TIMEOUT_MS,
+// 8s) plus startup overhead: migrations run synchronously before the port binds,
+// so a recoverable lock stall delays the first successful health response. Too
+// tight and the coordinator SIGKILLs a host-service that was about to come up.
+export const HEALTH_POLL_TIMEOUT_MS = 20_000;
 
 const HEALTH_POLL_INTERVAL_MS = 200;
 

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -50,6 +50,7 @@
 		"test": "bun test --pass-with-no-tests",
 		"test:integration": "bun test --pass-with-no-tests test/integration",
 		"test:integration:daemon": "node --experimental-strip-types --test src/terminal/DaemonClient/DaemonClient.node-test.ts src/daemon/DaemonSupervisor.node-test.ts",
+		"test:integration:db": "bun run scripts/run-db-integration-test.ts",
 		"test:e2e": "bun run scripts/test-e2e.ts",
 		"bench": "bun test test/integration/pull-requests-scaling.bench.ts",
 		"profile:git-status": "bun run scripts/git-status-large-repo-profile.ts",

--- a/packages/host-service/scripts/run-db-integration-test.ts
+++ b/packages/host-service/scripts/run-db-integration-test.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+// Runs the host-service DB integration tests under Electron-as-node.
+//
+// These tests load better-sqlite3 in-process, and in this workspace that native
+// addon is built for the Electron ABI (the host-service's real runtime) — plain
+// `node` is the wrong ABI and `bun` doesn't support better-sqlite3 at all. So we
+// resolve the Electron binary from the desktop package and run `node --test`
+// through it with ELECTRON_RUN_AS_NODE=1.
+
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+
+// The `electron` package's main export is the path to its binary (cross-platform).
+const requireFromDesktop = createRequire(
+	path.join(repoRoot, "apps/desktop/package.json"),
+);
+const electronBinary = requireFromDesktop("electron") as string;
+
+const testFiles = ["src/db/db.contention.node-test.ts"];
+
+const result = spawnSync(
+	electronBinary,
+	["--experimental-strip-types", "--test", ...testFiles],
+	{
+		cwd: path.resolve(__dirname, ".."),
+		stdio: "inherit",
+		env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+	},
+);
+
+process.exit(result.status ?? 1);

--- a/packages/host-service/src/db/db.contention.node-test.ts
+++ b/packages/host-service/src/db/db.contention.node-test.ts
@@ -105,15 +105,6 @@ function tableExists(targetDbPath: string, tableName: string): boolean {
 }
 
 describe("host-service DB migration under write-lock contention", () => {
-	test("baseline: no contention → 0005 applies, host_settings exists", () => {
-		createDb(dbPath, MIGRATIONS_FOLDER);
-		assert.equal(
-			tableExists(dbPath, "host_settings"),
-			true,
-			"host_settings should exist after a clean migration",
-		);
-	});
-
 	test("fail-closed: sustained contention past the busy timeout → createDb THROWS, DB left cleanly unmigrated", async () => {
 		// Hold the lock for 20s — longer than the 8s busy timeout, so migrate
 		// can't acquire it.

--- a/packages/host-service/src/db/db.contention.node-test.ts
+++ b/packages/host-service/src/db/db.contention.node-test.ts
@@ -1,0 +1,177 @@
+// Integration test for the 1.12.0 host-service migration crash and its fix.
+//
+// Real `createDb` + real drizzle migration files (incl. 0005) + a real second
+// process holding the write lock. Runs under Node (`node --test`) but MUST be
+// invoked with the Electron-ABI node — better-sqlite3 here is built for the
+// host-service runtime (Electron), which is also the only runtime that can
+// load it. Same-process lock holding would deadlock (better-sqlite3 is
+// synchronous and single-threaded), so we spawn a sibling process for genuine
+// cross-process contention.
+//
+//   ELECTRON_RUN_AS_NODE=1 <electron> --experimental-strip-types --test \
+//     src/db/db.contention.node-test.ts
+//
+// Pre-fix behavior (reproduced): contention → migrate stalls on the busy
+// timeout → SQLITE_BUSY → db.ts swallowed it → service came up on a
+// half-migrated DB (runtime "no such table host_settings").
+//
+// Post-fix behavior (asserted here):
+//   - sustained contention past the busy timeout → createDb THROWS (fail
+//     closed), and the DB is left cleanly unmigrated (atomic rollback), never
+//     half-applied;
+//   - contention that clears within the busy timeout → createDb WAITS then
+//     succeeds (host_settings present).
+
+import { strict as assert } from "node:assert";
+import * as childProcess from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { createDb } from "./db.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// packages/host-service/src/db → packages/host-service/drizzle
+const MIGRATIONS_FOLDER = path.resolve(__dirname, "../../drizzle");
+
+// Mirror of MIGRATION_BUSY_TIMEOUT_MS in db.ts. Kept local so the test pins the
+// behavior even if the source constant moves.
+const BUSY_TIMEOUT_MS = 8_000;
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hs-db-contention-"));
+	dbPath = path.join(tmpDir, "host.db");
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Spawn a sibling Node process that holds an IMMEDIATE (write) transaction on
+ * the db for `holdMs`, then rolls back and exits (persisting nothing).
+ * Resolves once the child confirms the lock is held.
+ */
+function holdWriteLock(
+	targetDbPath: string,
+	holdMs: number,
+): Promise<childProcess.ChildProcess> {
+	const script = `
+		const Database = require('better-sqlite3');
+		const db = new Database(${JSON.stringify(targetDbPath)}, { timeout: 0 });
+		db.pragma('journal_mode = WAL');
+		db.exec('BEGIN IMMEDIATE');          // acquire the write lock now
+		process.stdout.write('LOCKED\\n');
+		setTimeout(() => { try { db.exec('ROLLBACK'); } catch {} process.exit(0); }, ${holdMs});
+	`;
+	const child = childProcess.spawn(process.execPath, ["-e", script], {
+		cwd: path.resolve(__dirname, "../.."),
+		stdio: ["ignore", "pipe", "inherit"],
+	});
+	return new Promise((resolve, reject) => {
+		let out = "";
+		const timer = setTimeout(
+			() => reject(new Error("lock holder never confirmed LOCKED")),
+			10_000,
+		);
+		child.stdout.on("data", (chunk: Buffer) => {
+			out += chunk.toString();
+			if (out.includes("LOCKED")) {
+				clearTimeout(timer);
+				resolve(child);
+			}
+		});
+		child.on("exit", (code) => {
+			clearTimeout(timer);
+			reject(new Error(`lock holder exited early (code=${code})`));
+		});
+	});
+}
+
+function tableExists(targetDbPath: string, tableName: string): boolean {
+	const probe = new Database(targetDbPath, { readonly: true });
+	try {
+		const row = probe
+			.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+			.get(tableName);
+		return !!row;
+	} finally {
+		probe.close();
+	}
+}
+
+describe("host-service DB migration under write-lock contention", () => {
+	test("baseline: no contention → 0005 applies, host_settings exists", () => {
+		createDb(dbPath, MIGRATIONS_FOLDER);
+		assert.equal(
+			tableExists(dbPath, "host_settings"),
+			true,
+			"host_settings should exist after a clean migration",
+		);
+	});
+
+	test("fail-closed: sustained contention past the busy timeout → createDb THROWS, DB left cleanly unmigrated", async () => {
+		// Hold the lock for 20s — longer than the 8s busy timeout, so migrate
+		// can't acquire it.
+		const holder = await holdWriteLock(dbPath, 20_000);
+
+		const start = Date.now();
+		let threw = false;
+		try {
+			createDb(dbPath, MIGRATIONS_FOLDER);
+		} catch {
+			threw = true;
+		}
+		const elapsedMs = Date.now() - start;
+		holder.kill("SIGKILL");
+
+		// 1. Fail closed — no silently-served half-migrated DB.
+		assert.equal(
+			threw,
+			true,
+			"createDb must throw on sustained contention, not swallow and return",
+		);
+
+		// 2. It waited on the busy timeout (didn't fail instantly), bounded so it
+		//    stays inside the coordinator's health window.
+		assert.ok(
+			elapsedMs >= BUSY_TIMEOUT_MS - 1_500,
+			`expected to wait ~busy_timeout before failing, waited ${elapsedMs}ms`,
+		);
+		assert.ok(
+			elapsedMs <= BUSY_TIMEOUT_MS + 6_000,
+			`expected a bounded wait, waited ${elapsedMs}ms`,
+		);
+
+		// 3. The DB is cleanly unmigrated (atomic rollback), never half-applied.
+		assert.equal(
+			tableExists(dbPath, "host_settings"),
+			false,
+			"failed migration must leave host_settings absent (clean rollback)",
+		);
+	});
+
+	test("recovery: contention that clears within the busy timeout → createDb waits then succeeds", async () => {
+		// Hold for 2.5s, well under the 8s budget; migrate should wait it out.
+		await holdWriteLock(dbPath, 2_500);
+
+		const start = Date.now();
+		createDb(dbPath, MIGRATIONS_FOLDER);
+		const elapsedMs = Date.now() - start;
+
+		assert.ok(
+			elapsedMs >= 1_500,
+			`expected createDb to wait for the lock (~2.5s), took ${elapsedMs}ms`,
+		);
+		assert.equal(
+			tableExists(dbPath, "host_settings"),
+			true,
+			"host_settings should exist once the lock clears within the timeout",
+		);
+	});
+});

--- a/packages/host-service/src/db/db.contention.node-test.ts
+++ b/packages/host-service/src/db/db.contention.node-test.ts
@@ -11,16 +11,13 @@
 //   ELECTRON_RUN_AS_NODE=1 <electron> --experimental-strip-types --test \
 //     src/db/db.contention.node-test.ts
 //
-// Pre-fix behavior (reproduced): contention → migrate stalls on the busy
-// timeout → SQLITE_BUSY → db.ts swallowed it → service came up on a
-// half-migrated DB (runtime "no such table host_settings").
+// Pre-fix behavior (reproduced): contention → SQLITE_BUSY → db.ts swallowed it
+// → service came up on a half-migrated DB (runtime "no such table
+// host_settings").
 //
 // Post-fix behavior (asserted here):
-//   - sustained contention past the busy timeout → createDb THROWS (fail
-//     closed), and the DB is left cleanly unmigrated (atomic rollback), never
-//     half-applied;
-//   - contention that clears within the busy timeout → createDb WAITS then
-//     succeeds (host_settings present).
+//   - contention → createDb THROWS (fail closed), and the DB is left cleanly
+//     unmigrated (atomic rollback), never half-applied.
 
 import { strict as assert } from "node:assert";
 import * as childProcess from "node:child_process";
@@ -30,10 +27,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
-import {
-	MIGRATION_BUSY_TIMEOUT_MS as BUSY_TIMEOUT_MS,
-	createDb,
-} from "./db.ts";
+import { createDb } from "./db.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // packages/host-service/src/db → packages/host-service/drizzle
@@ -105,19 +99,15 @@ function tableExists(targetDbPath: string, tableName: string): boolean {
 }
 
 describe("host-service DB migration under write-lock contention", () => {
-	test("fail-closed: sustained contention past the busy timeout → createDb THROWS, DB left cleanly unmigrated", async () => {
-		// Hold the lock for 20s — longer than the 8s busy timeout, so migrate
-		// can't acquire it.
-		const holder = await holdWriteLock(dbPath, 20_000);
+	test("fail-closed: contention → createDb THROWS, DB left cleanly unmigrated", async () => {
+		const holder = await holdWriteLock(dbPath, 10_000);
 
-		const start = Date.now();
 		let threw = false;
 		try {
 			createDb(dbPath, MIGRATIONS_FOLDER);
 		} catch {
 			threw = true;
 		}
-		const elapsedMs = Date.now() - start;
 		holder.kill("SIGKILL");
 
 		// 1. Fail closed — no silently-served half-migrated DB.
@@ -127,41 +117,11 @@ describe("host-service DB migration under write-lock contention", () => {
 			"createDb must throw on sustained contention, not swallow and return",
 		);
 
-		// 2. It waited on the busy timeout (didn't fail instantly), bounded so it
-		//    stays inside the coordinator's health window.
-		assert.ok(
-			elapsedMs >= BUSY_TIMEOUT_MS - 1_500,
-			`expected to wait ~busy_timeout before failing, waited ${elapsedMs}ms`,
-		);
-		assert.ok(
-			elapsedMs <= BUSY_TIMEOUT_MS + 6_000,
-			`expected a bounded wait, waited ${elapsedMs}ms`,
-		);
-
-		// 3. The DB is cleanly unmigrated (atomic rollback), never half-applied.
+		// 2. The DB is cleanly unmigrated (atomic rollback), never half-applied.
 		assert.equal(
 			tableExists(dbPath, "host_settings"),
 			false,
 			"failed migration must leave host_settings absent (clean rollback)",
-		);
-	});
-
-	test("recovery: contention that clears within the busy timeout → createDb waits then succeeds", async () => {
-		// Hold for 2.5s, well under the 8s budget; migrate should wait it out.
-		await holdWriteLock(dbPath, 2_500);
-
-		const start = Date.now();
-		createDb(dbPath, MIGRATIONS_FOLDER);
-		const elapsedMs = Date.now() - start;
-
-		assert.ok(
-			elapsedMs >= 1_500,
-			`expected createDb to wait for the lock (~2.5s), took ${elapsedMs}ms`,
-		);
-		assert.equal(
-			tableExists(dbPath, "host_settings"),
-			true,
-			"host_settings should exist once the lock clears within the timeout",
 		);
 	});
 });

--- a/packages/host-service/src/db/db.contention.node-test.ts
+++ b/packages/host-service/src/db/db.contention.node-test.ts
@@ -30,15 +30,14 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
-import { createDb } from "./db.ts";
+import {
+	MIGRATION_BUSY_TIMEOUT_MS as BUSY_TIMEOUT_MS,
+	createDb,
+} from "./db.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // packages/host-service/src/db → packages/host-service/drizzle
 const MIGRATIONS_FOLDER = path.resolve(__dirname, "../../drizzle");
-
-// Mirror of MIGRATION_BUSY_TIMEOUT_MS in db.ts. Kept local so the test pins the
-// behavior even if the source constant moves.
-const BUSY_TIMEOUT_MS = 8_000;
 
 let tmpDir: string;
 let dbPath: string;

--- a/packages/host-service/src/db/db.ts
+++ b/packages/host-service/src/db/db.ts
@@ -8,14 +8,15 @@ import * as schema from "./schema.ts";
 export type HostDb = ReturnType<typeof createDb>;
 
 /**
- * How long a write statement waits for a lock before giving up. Migrations run
- * before the port binds, so contention here (a prior host-service draining, a
- * WAL checkpoint, a racing process) used to surface as an immediate SQLITE_BUSY.
- * We wait instead. Kept comfortably below the coordinator's health-check window
+ * How long a write statement waits for a lock before giving up. Applies for the
+ * connection's whole lifetime, not only migrations: migrations run before the
+ * port binds, so contention there (a prior host-service draining, a WAL
+ * checkpoint, a racing process) used to surface as an immediate SQLITE_BUSY — we
+ * wait instead. Kept comfortably below the coordinator's health-check window
  * (`HEALTH_POLL_TIMEOUT_MS`) so a recoverable stall finishes before the
  * supervisor declares the process dead.
  */
-const MIGRATION_BUSY_TIMEOUT_MS = 8_000;
+export const MIGRATION_BUSY_TIMEOUT_MS = 8_000;
 
 export function createDb(dbPath: string, migrationsFolder: string) {
 	mkdirSync(dirname(dbPath), { recursive: true });
@@ -31,22 +32,13 @@ export function createDb(dbPath: string, migrationsFolder: string) {
 		`[host-service:db] Initialized at ${dbPath}, migrations from ${migrationsFolder}`,
 	);
 
-	// Fail closed. drizzle runs all pending migrations in a single
-	// BEGIN/COMMIT and ROLLBACKs on any error, so a failure leaves the DB at
-	// its prior version (never half-applied). Throwing here propagates to
-	// `serve.ts` `main().catch(... process.exit(1))` so the coordinator's
-	// health check fails and it can recover (kill the stale process, respawn)
-	// instead of silently serving a DB that's missing tables.
-	try {
-		migrate(db, { migrationsFolder });
-	} catch (error) {
-		console.error("[host-service:db] Migration failed:", error);
-		sqlite.close();
-		throw new Error(
-			`[host-service:db] Migration failed for ${dbPath}; refusing to start on an unmigrated database`,
-			{ cause: error },
-		);
-	}
+	// No catch — fail closed. drizzle runs all pending migrations in a single
+	// BEGIN/COMMIT and ROLLBACKs on any error, so a failure leaves the DB at its
+	// prior version (never half-applied). Letting it throw propagates to
+	// `serve.ts` `main().catch(... process.exit(1))`, so the coordinator's health
+	// check fails and it recovers (kill the stale process, respawn) instead of
+	// silently serving a DB that's missing tables.
+	migrate(db, { migrationsFolder });
 
 	return db;
 }

--- a/packages/host-service/src/db/db.ts
+++ b/packages/host-service/src/db/db.ts
@@ -7,12 +7,23 @@ import * as schema from "./schema.ts";
 
 export type HostDb = ReturnType<typeof createDb>;
 
+/**
+ * How long a write statement waits for a lock before giving up. Migrations run
+ * before the port binds, so contention here (a prior host-service draining, a
+ * WAL checkpoint, a racing process) used to surface as an immediate SQLITE_BUSY.
+ * We wait instead. Kept comfortably below the coordinator's health-check window
+ * (`HEALTH_POLL_TIMEOUT_MS`) so a recoverable stall finishes before the
+ * supervisor declares the process dead.
+ */
+const MIGRATION_BUSY_TIMEOUT_MS = 8_000;
+
 export function createDb(dbPath: string, migrationsFolder: string) {
 	mkdirSync(dirname(dbPath), { recursive: true });
 
 	const sqlite = new Database(dbPath);
 	sqlite.pragma("journal_mode = WAL");
 	sqlite.pragma("foreign_keys = ON");
+	sqlite.pragma(`busy_timeout = ${MIGRATION_BUSY_TIMEOUT_MS}`);
 
 	const db = drizzle(sqlite, { schema });
 
@@ -20,10 +31,21 @@ export function createDb(dbPath: string, migrationsFolder: string) {
 		`[host-service:db] Initialized at ${dbPath}, migrations from ${migrationsFolder}`,
 	);
 
+	// Fail closed. drizzle runs all pending migrations in a single
+	// BEGIN/COMMIT and ROLLBACKs on any error, so a failure leaves the DB at
+	// its prior version (never half-applied). Throwing here propagates to
+	// `serve.ts` `main().catch(... process.exit(1))` so the coordinator's
+	// health check fails and it can recover (kill the stale process, respawn)
+	// instead of silently serving a DB that's missing tables.
 	try {
 		migrate(db, { migrationsFolder });
 	} catch (error) {
 		console.error("[host-service:db] Migration failed:", error);
+		sqlite.close();
+		throw new Error(
+			`[host-service:db] Migration failed for ${dbPath}; refusing to start on an unmigrated database`,
+			{ cause: error },
+		);
 	}
 
 	return db;

--- a/packages/host-service/src/db/db.ts
+++ b/packages/host-service/src/db/db.ts
@@ -7,24 +7,12 @@ import * as schema from "./schema.ts";
 
 export type HostDb = ReturnType<typeof createDb>;
 
-/**
- * How long a write statement waits for a lock before giving up. Applies for the
- * connection's whole lifetime, not only migrations: migrations run before the
- * port binds, so contention there (a prior host-service draining, a WAL
- * checkpoint, a racing process) used to surface as an immediate SQLITE_BUSY — we
- * wait instead. Kept comfortably below the coordinator's health-check window
- * (`HEALTH_POLL_TIMEOUT_MS`) so a recoverable stall finishes before the
- * supervisor declares the process dead.
- */
-export const MIGRATION_BUSY_TIMEOUT_MS = 8_000;
-
 export function createDb(dbPath: string, migrationsFolder: string) {
 	mkdirSync(dirname(dbPath), { recursive: true });
 
 	const sqlite = new Database(dbPath);
 	sqlite.pragma("journal_mode = WAL");
 	sqlite.pragma("foreign_keys = ON");
-	sqlite.pragma(`busy_timeout = ${MIGRATION_BUSY_TIMEOUT_MS}`);
 
 	const db = drizzle(sqlite, { schema });
 

--- a/plans/host-service-migration-startup-hardening.md
+++ b/plans/host-service-migration-startup-hardening.md
@@ -18,20 +18,15 @@ In progress on `host-service-lifecycle-bu`.
     drizzle wraps all pending migrations in one `BEGIN/COMMIT` with
     `ROLLBACK`+rethrow, so a failure leaves the DB at its prior version (never
     half-applied).
-  - The only genuine *addition* is one line: `busy_timeout = 8000`. It has no
-    bad code to replace, and it's what earns the deletion — once we fail closed,
-    a transient lock (a draining prior host-service) would otherwise crash, so
-    busy_timeout makes fail-closed wait-then-succeed instead of trigger-happy.
-    `MIGRATION_BUSY_TIMEOUT_MS` is now exported and imported by the test (deleted
-    the hand-mirrored copy so the budget can't drift).
-  - `apps/desktop/.../host-service-utils.ts`: `HEALTH_POLL_TIMEOUT_MS`
-    `10_000 → 20_000` so a recoverable ~8s stall isn't SIGKILLed before bind.
-  - Test now asserts the fixed behavior (fail-closed on sustained contention;
-    recovery when the lock clears within the timeout) + baseline. 3/3 green;
-    host-service unit suite 691/0; typecheck + lint clean.
+  - No `busy_timeout`, no wider health window, no retry loop. Those are
+    compensations for a two-writer startup race; the structural fix belongs in
+    #4997.
+  - Test now asserts the fixed behavior: write-lock contention makes `createDb`
+    throw instead of returning a broken DB, and the failed migration leaves the
+    DB cleanly unmigrated.
   - **Dropped vs. the original plan:** A's "bounded retry ~3× with backoff" — an
-    outer retry on `SQLITE_BUSY` is redundant when `busy_timeout` already makes
-    better-sqlite3 wait on the lock internally. Less code, same behavior.
+    outer retry adds recovery policy to the DB layer instead of removing the
+    source of the competing writer.
 - **Not yet done (structural layer):** C (coordinator auto-recovery on spawn
   failure — incl. failing fast on child-exit instead of polling the full 20s),
   D (decouple migrating/ready from port bind), E (single-writer per org). These
@@ -46,24 +41,20 @@ anywhere, not fixed by app rollback, fixed by a full quit + relaunch.
 
 ### Code-confirmed fragilities (verified, with locations)
 
-1. **No `busy_timeout`.** `createDb` sets only `journal_mode=WAL` and
-   `foreign_keys=ON` (`packages/host-service/src/db/db.ts:13-15`). better-sqlite3
-   throws `SQLITE_BUSY` on lock contention instead of waiting. `busy_timeout`
-   appears nowhere in the repo.
-2. **Migration failure is swallowed.** `migrate()` is wrapped in a catch that
+1. **Migration failure is swallowed.** `migrate()` is wrapped in a catch that
    logs and returns the db anyway (`db.ts:23-27`), so the service can come up on
    a half-migrated DB (later `no such table host_settings`).
-3. **`migrate()` blocks before the port binds.** `createApp` calls `createDb`
+2. **`migrate()` blocks before the port binds.** `createApp` calls `createDb`
    synchronously (`app.ts:80`); the port isn't bound until `serve()`
    (`serve.ts:48` → `:93`). A slow migration is indistinguishable from a dead
    process to the only observer that exists during it.
-4. **The readiness window kills slow startups with no recovery.** Coordinator
+3. **The readiness window kills slow startups with no recovery.** Coordinator
    polls `/trpc/health.check` for `HEALTH_POLL_TIMEOUT_MS = 10_000`
    (`host-service-utils.ts:8`), then SIGTERMs the child and throws
    (`host-service-coordinator.ts:423-430`). Nothing auto-escalates to `reset()`
    — it's only reachable via the tRPC router (manual). So a killed startup just
    respawns into the same condition: a loop.
-5. **The swallow defeats existing design intent.** `serve.ts:94-96` + `:113-115`
+4. **The swallow defeats existing design intent.** `serve.ts:94-96` + `:113-115`
    show startup throws are meant to reach `main().catch(... process.exit(1))`.
    Failing-closed already wires through; the catch in `db.ts` is what blocks it.
 
@@ -96,10 +87,8 @@ This tells us which layers actually bit, and lets us assert the fix resolves it.
 ## Fix
 
 Layered, and **removal-first**: prefer deleting the bad code over adding
-guards. Primary layer stops the bleeding with a deletion + one pragma;
-structural layer removes the failure mode by construction — and once it lands,
-the primary-layer compensations (busy_timeout, widened health window) can
-themselves be *removed*.
+guards. Primary layer stops the bleeding by deleting the swallow. Structural
+layer removes the failure mode by construction.
 
 ### Primary (resilience + correctness) — `db.ts` — DONE
 
@@ -108,24 +97,15 @@ themselves be *removed*.
   anyway. Deleting it is the whole fix: `migrate()` throws to `createApp →
   main().catch → exit(1)`, so the coordinator's health poll fails instead of
   serving a broken DB. Confirmed drizzle's per-migration transaction first, so a
-  rolled-back 0005 leaves a clean 0004 DB. No retry loop (busy_timeout subsumes
-  it), no re-throw wrapper, no manual `close()`.
-- Add exactly one line — `busy_timeout = 8000` — so a transient lock is waited
-  out rather than turned into a crash by the now-strict fail-closed path.
+  rolled-back 0005 leaves a clean 0004 DB. No retry loop, no `busy_timeout`, no
+  re-throw wrapper, no manual `close()`.
 
 **C. Auto-escalate a failed spawn to `reset()`** (`host-service-coordinator.ts`)
 — *not landed; this is #4997.*
-- On `pollHealthCheck` failure in `spawn()`, run `reset()` once (SIGKILL the
-  manifest pid + remove manifest + respawn) before giving up, **and fail fast on
-  child-exit** instead of polling the full 20s. Clears a stale lock-holder
-  automatically instead of looping. Guard against infinite escalation (one reset
-  attempt, then surface the error).
-
-**Numeric interaction:** busy_timeout (8s) sits under the health window (20s),
-so a recoverable stall finishes before the supervisor kills the child. These two
-numbers only matter because migration runs before bind under contention — D + E
-below remove that, after which the 20s window can drop back toward 10s and
-busy_timeout stops being load-bearing.
+- Reap a stale manifest pid before spawning a replacement, and fail fast on
+  child exit instead of waiting the full health window. Clears a stale
+  lock-holder automatically instead of looping. Guard against infinite
+  escalation.
 
 ### Structural (removes factors 3 & 4, and the contention source) — request lifecycle
 
@@ -142,16 +122,11 @@ busy_timeout stops being load-bearing.
 - In `spawn()`, before start: if `readManifest(org)?.pid` is alive and not an
   instance we own, SIGKILL + await exit before spawning, so two processes never
   race the same `host.db`.
-- Backstop: `BEGIN EXCLUSIVE` around `migrate()` so a slipped-through second
-  process waits (under `busy_timeout`) and no-ops on an already-migrated DB.
 
 ## Verification
 
-- Unit: `createDb` retries on `SQLITE_BUSY` and throws after exhausting retries
-  (mutate to prove the test catches both).
 - Integration: hold an exclusive lock on a temp `host.db`, start host-service,
-  assert it waits then succeeds (with A) / exits non-zero (B, if held past
-  retries) rather than serving a broken DB.
+  assert it exits non-zero rather than serving a broken DB.
 - Coordinator: simulate a stale live manifest pid; assert `spawn()` escalates to
   `reset()` and recovers (C), and that single-writer (E) kills the stale pid.
 - Regression: with D, assert routes 503 during migration and the coordinator
@@ -161,12 +136,11 @@ busy_timeout stops being load-bearing.
 
 1. Step 0 (log triage) — confirm bucket, in parallel with build.
 2. Confirm drizzle per-migration transaction behavior. *(done)*
-3. **A/B done** (delete the swallow + busy_timeout + health-budget bump) — small,
-   high-confidence; converts "permanent brick" → "self-heals on next launch."
-   **C** ships next as #4997 (reap orphan before spawn + fail-fast on child-exit).
+3. **A/B done** (delete the swallow) — small, high-confidence; converts
+   "silently serve broken DB" → fail closed. **C** ships next as #4997 (reap
+   orphan before spawn + fail-fast on child-exit).
 4. Land **D + E** as the durable follow-up that makes update-time contention
-   impossible — and lets us *remove* busy_timeout and shrink the health window
-   back, since neither is needed once nothing races the migration.
+   impossible.
 
 ## Risks / open questions
 

--- a/plans/host-service-migration-startup-hardening.md
+++ b/plans/host-service-migration-startup-hardening.md
@@ -1,0 +1,158 @@
+# Host-service migration / startup hardening
+
+## Status
+
+In progress on `host-service-lifecycle-bu`.
+
+- **Reproduced** the mechanism via integration test
+  (`packages/host-service/src/db/db.contention.node-test.ts`, run with
+  `bun run test:integration:db` under Electron-as-node): real `createDb` + real
+  0005 + a sibling process holding the write lock → ~5s stall → `SQLITE_BUSY` →
+  swallowed → `host_settings` missing.
+- **Landed (primary layer A + B + health window):**
+  - `db.ts`: explicit `busy_timeout = 8000` + **fail closed** (throw instead of
+    swallow). Confirmed safe — drizzle wraps all pending migrations in one
+    `BEGIN/COMMIT` with `ROLLBACK`+rethrow, so a failure leaves the DB at its
+    prior version (never half-applied).
+  - `apps/desktop/.../host-service-utils.ts`: `HEALTH_POLL_TIMEOUT_MS`
+    `10_000 → 20_000` so a recoverable ~8s stall isn't SIGKILLed before bind.
+  - Test now asserts the fixed behavior (fail-closed on sustained contention;
+    recovery when the lock clears within the timeout) + baseline. 3/3 green;
+    host-service unit suite 691/0; typecheck + lint clean.
+- **Not yet done (structural layer):** C (coordinator auto-recovery on spawn
+  failure — incl. failing fast on child-exit instead of polling the full 20s),
+  D (decouple migrating/ready from port bind), E (single-writer per org). These
+  address the contention *source*, which remains unproven (see below).
+
+## Problem
+
+After the desktop 1.12.0 update (the first release to add a host-service DB
+migration, `0005_host_settings_and_project_overrides`), some users' host-service
+fails to come up cleanly. Reported symptom: terminals dead / "can't type"
+anywhere, not fixed by app rollback, fixed by a full quit + relaunch.
+
+### Code-confirmed fragilities (verified, with locations)
+
+1. **No `busy_timeout`.** `createDb` sets only `journal_mode=WAL` and
+   `foreign_keys=ON` (`packages/host-service/src/db/db.ts:13-15`). better-sqlite3
+   throws `SQLITE_BUSY` on lock contention instead of waiting. `busy_timeout`
+   appears nowhere in the repo.
+2. **Migration failure is swallowed.** `migrate()` is wrapped in a catch that
+   logs and returns the db anyway (`db.ts:23-27`), so the service can come up on
+   a half-migrated DB (later `no such table host_settings`).
+3. **`migrate()` blocks before the port binds.** `createApp` calls `createDb`
+   synchronously (`app.ts:80`); the port isn't bound until `serve()`
+   (`serve.ts:48` → `:93`). A slow migration is indistinguishable from a dead
+   process to the only observer that exists during it.
+4. **The readiness window kills slow startups with no recovery.** Coordinator
+   polls `/trpc/health.check` for `HEALTH_POLL_TIMEOUT_MS = 10_000`
+   (`host-service-utils.ts:8`), then SIGTERMs the child and throws
+   (`host-service-coordinator.ts:423-430`). Nothing auto-escalates to `reset()`
+   — it's only reachable via the tRPC router (manual). So a killed startup just
+   respawns into the same condition: a loop.
+5. **The swallow defeats existing design intent.** `serve.ts:94-96` + `:113-115`
+   show startup throws are meant to reach `main().catch(... process.exit(1))`.
+   Failing-closed already wires through; the catch in `db.ts` is what blocks it.
+
+### NOT yet verified (confirm before claiming this fixes the specific incident)
+
+- That `SQLITE_BUSY` actually fires and that **concurrent writers** exist on one
+  org's `host.db`. This is the prior-session empirical diagnosis, not re-proven
+  here, and the contention *source* is unproven in code.
+- That drizzle wraps each migration file in a transaction (the basis for "a
+  failed 0005 rolls back cleanly to 0004, so fail-closed is safe"). Verify in
+  the installed drizzle-orm before relying on it.
+- Symptom mapping: "can't type everywhere" = the restart-loop bucket (service
+  never binds), which *requires* the stall/kill to be real. A half-migrated DB
+  alone would break settings/project-overrides, not typing.
+
+### Step 0 — confirm the trigger first
+
+Before/with the fix, pull a broken user's log and bucket it:
+
+```
+grep -nE "host-service\] (starting|listening)|Migration failed" ~/.superset/host/*/host-service.log
+```
+
+- Bucket A: `Migration failed` then `listening` → half-migrated (factors 1+2).
+- Bucket B: many `starting`, no `listening`, no `Migration failed` → restart
+  loop / killed mid-migration (factors 3+4). This is the "can't type" bucket.
+
+This tells us which layers actually bit, and lets us assert the fix resolves it.
+
+## Fix
+
+Layered. Primary layer stops the bleeding and is high-confidence; structural
+layer removes the failure mode by construction.
+
+### Primary (resilience + correctness) — `db.ts` + coordinator
+
+**A. `busy_timeout` + bounded retry around `migrate()`** (`db.ts`)
+- Add `sqlite.pragma("busy_timeout = 15000")`.
+- Retry `migrate()` up to ~3× with backoff, retrying only on
+  `SQLITE_BUSY`/`SQLITE_LOCKED`.
+
+**B. Stop swallowing — fail closed** (`db.ts`)
+- If `migrate()` still fails after retries, **throw**. Confirm drizzle's
+  per-migration transaction first (above) so a rolled-back 0005 leaves a clean
+  0004 DB. The throw propagates `createApp → main().catch → exit(1)`, so the
+  coordinator's health poll fails instead of serving a broken DB.
+
+**C. Auto-escalate a failed spawn to `reset()`** (`host-service-coordinator.ts`)
+- On `pollHealthCheck` failure in `spawn()`, run `reset()` once (SIGKILL the
+  manifest pid + remove manifest + respawn) before giving up. Clears a stale
+  lock-holder automatically instead of looping. Guard against infinite
+  escalation (one reset attempt, then surface the error).
+
+**Numeric interaction (must get right):** with migrate-before-bind, a 15s
+`busy_timeout` exceeds the 10s health window — B/C would just convert a
+half-migration into a clean kill at 10s. So **either** raise the health budget
+above `busy_timeout` + expected migration time, **or** land the structural fix
+(D) which removes the window's relevance. Don't ship A/B/C without one of these.
+
+### Structural (removes factors 3 & 4) — request lifecycle
+
+**D. Decouple "alive / migrating" from "ready."**
+- Bind the port first; run migration in the background; track
+  `dbState: "migrating" | "ready" | "failed"`.
+- `health.check` reports the state. DB-touching routes return `503 starting`
+  while `migrating` (fits optimistic-render direction — renderer shows
+  "starting", terminals connect once ready).
+- Coordinator polls until `ready` or child-exit (fail fast), generous budget;
+  treats `migrating` as alive. Removes the kill-mid-migration mode entirely.
+
+**E. Single-writer guarantee per org (root of the contention).**
+- In `spawn()`, before start: if `readManifest(org)?.pid` is alive and not an
+  instance we own, SIGKILL + await exit before spawning, so two processes never
+  race the same `host.db`.
+- Backstop: `BEGIN EXCLUSIVE` around `migrate()` so a slipped-through second
+  process waits (under `busy_timeout`) and no-ops on an already-migrated DB.
+
+## Verification
+
+- Unit: `createDb` retries on `SQLITE_BUSY` and throws after exhausting retries
+  (mutate to prove the test catches both).
+- Integration: hold an exclusive lock on a temp `host.db`, start host-service,
+  assert it waits then succeeds (with A) / exits non-zero (B, if held past
+  retries) rather than serving a broken DB.
+- Coordinator: simulate a stale live manifest pid; assert `spawn()` escalates to
+  `reset()` and recovers (C), and that single-writer (E) kills the stale pid.
+- Regression: with D, assert routes 503 during migration and the coordinator
+  does not SIGKILL within the old 10s window.
+
+## Sequencing
+
+1. Step 0 (log triage) — confirm bucket, in parallel with build.
+2. Confirm drizzle per-migration transaction behavior.
+3. Land **A + B + C** with the health-budget bump — small, high-confidence;
+   converts "permanent brick" → "self-heals on next launch."
+4. Land **D + E** as the durable follow-up that makes update-time contention
+   impossible.
+
+## Risks / open questions
+
+- If the real trigger is NOT contention, A/B/C still harden startup but won't
+  explain Roshvan's incident — hence Step 0.
+- `reset()` escalation (C) must be bounded to avoid a SIGKILL/respawn loop.
+- D changes the readiness contract; audit callers that assume DB-ready on first
+  successful health check.

--- a/plans/host-service-migration-startup-hardening.md
+++ b/plans/host-service-migration-startup-hardening.md
@@ -9,16 +9,29 @@ In progress on `host-service-lifecycle-bu`.
   `bun run test:integration:db` under Electron-as-node): real `createDb` + real
   0005 + a sibling process holding the write lock → ~5s stall → `SQLITE_BUSY` →
   swallowed → `host_settings` missing.
-- **Landed (primary layer A + B + health window):**
-  - `db.ts`: explicit `busy_timeout = 8000` + **fail closed** (throw instead of
-    swallow). Confirmed safe — drizzle wraps all pending migrations in one
-    `BEGIN/COMMIT` with `ROLLBACK`+rethrow, so a failure leaves the DB at its
-    prior version (never half-applied).
+- **Landed (primary layer — removal-first):**
+  - `db.ts`: the fix is mostly a **deletion**. The bug was the `try/catch` that
+    swallowed a failed `migrate()` and returned a broken `db`; deleting it *is*
+    fail-closed — `migrate()` throws naturally to `serve.ts`
+    `main().catch(... process.exit(1))`. No re-throw wrapper, no `sqlite.close()`
+    (the OS reclaims the fd on `exit(1)`), no retry loop. Confirmed safe —
+    drizzle wraps all pending migrations in one `BEGIN/COMMIT` with
+    `ROLLBACK`+rethrow, so a failure leaves the DB at its prior version (never
+    half-applied).
+  - The only genuine *addition* is one line: `busy_timeout = 8000`. It has no
+    bad code to replace, and it's what earns the deletion — once we fail closed,
+    a transient lock (a draining prior host-service) would otherwise crash, so
+    busy_timeout makes fail-closed wait-then-succeed instead of trigger-happy.
+    `MIGRATION_BUSY_TIMEOUT_MS` is now exported and imported by the test (deleted
+    the hand-mirrored copy so the budget can't drift).
   - `apps/desktop/.../host-service-utils.ts`: `HEALTH_POLL_TIMEOUT_MS`
     `10_000 → 20_000` so a recoverable ~8s stall isn't SIGKILLed before bind.
   - Test now asserts the fixed behavior (fail-closed on sustained contention;
     recovery when the lock clears within the timeout) + baseline. 3/3 green;
     host-service unit suite 691/0; typecheck + lint clean.
+  - **Dropped vs. the original plan:** A's "bounded retry ~3× with backoff" — an
+    outer retry on `SQLITE_BUSY` is redundant when `busy_timeout` already makes
+    better-sqlite3 wait on the lock internally. Less code, same behavior.
 - **Not yet done (structural layer):** C (coordinator auto-recovery on spawn
   failure — incl. failing fast on child-exit instead of polling the full 20s),
   D (decouple migrating/ready from port bind), E (single-writer per org). These
@@ -82,35 +95,39 @@ This tells us which layers actually bit, and lets us assert the fix resolves it.
 
 ## Fix
 
-Layered. Primary layer stops the bleeding and is high-confidence; structural
-layer removes the failure mode by construction.
+Layered, and **removal-first**: prefer deleting the bad code over adding
+guards. Primary layer stops the bleeding with a deletion + one pragma;
+structural layer removes the failure mode by construction — and once it lands,
+the primary-layer compensations (busy_timeout, widened health window) can
+themselves be *removed*.
 
-### Primary (resilience + correctness) — `db.ts` + coordinator
+### Primary (resilience + correctness) — `db.ts` — DONE
 
-**A. `busy_timeout` + bounded retry around `migrate()`** (`db.ts`)
-- Add `sqlite.pragma("busy_timeout = 15000")`.
-- Retry `migrate()` up to ~3× with backoff, retrying only on
-  `SQLITE_BUSY`/`SQLITE_LOCKED`.
-
-**B. Stop swallowing — fail closed** (`db.ts`)
-- If `migrate()` still fails after retries, **throw**. Confirm drizzle's
-  per-migration transaction first (above) so a rolled-back 0005 leaves a clean
-  0004 DB. The throw propagates `createApp → main().catch → exit(1)`, so the
-  coordinator's health poll fails instead of serving a broken DB.
+**A/B. Delete the swallow → fail closed** (`db.ts`)
+- The defect is the `try/catch` around `migrate()` that logs and returns the db
+  anyway. Deleting it is the whole fix: `migrate()` throws to `createApp →
+  main().catch → exit(1)`, so the coordinator's health poll fails instead of
+  serving a broken DB. Confirmed drizzle's per-migration transaction first, so a
+  rolled-back 0005 leaves a clean 0004 DB. No retry loop (busy_timeout subsumes
+  it), no re-throw wrapper, no manual `close()`.
+- Add exactly one line — `busy_timeout = 8000` — so a transient lock is waited
+  out rather than turned into a crash by the now-strict fail-closed path.
 
 **C. Auto-escalate a failed spawn to `reset()`** (`host-service-coordinator.ts`)
+— *not landed; this is #4997.*
 - On `pollHealthCheck` failure in `spawn()`, run `reset()` once (SIGKILL the
-  manifest pid + remove manifest + respawn) before giving up. Clears a stale
-  lock-holder automatically instead of looping. Guard against infinite
-  escalation (one reset attempt, then surface the error).
+  manifest pid + remove manifest + respawn) before giving up, **and fail fast on
+  child-exit** instead of polling the full 20s. Clears a stale lock-holder
+  automatically instead of looping. Guard against infinite escalation (one reset
+  attempt, then surface the error).
 
-**Numeric interaction (must get right):** with migrate-before-bind, a 15s
-`busy_timeout` exceeds the 10s health window — B/C would just convert a
-half-migration into a clean kill at 10s. So **either** raise the health budget
-above `busy_timeout` + expected migration time, **or** land the structural fix
-(D) which removes the window's relevance. Don't ship A/B/C without one of these.
+**Numeric interaction:** busy_timeout (8s) sits under the health window (20s),
+so a recoverable stall finishes before the supervisor kills the child. These two
+numbers only matter because migration runs before bind under contention — D + E
+below remove that, after which the 20s window can drop back toward 10s and
+busy_timeout stops being load-bearing.
 
-### Structural (removes factors 3 & 4) — request lifecycle
+### Structural (removes factors 3 & 4, and the contention source) — request lifecycle
 
 **D. Decouple "alive / migrating" from "ready."**
 - Bind the port first; run migration in the background; track
@@ -143,11 +160,13 @@ above `busy_timeout` + expected migration time, **or** land the structural fix
 ## Sequencing
 
 1. Step 0 (log triage) — confirm bucket, in parallel with build.
-2. Confirm drizzle per-migration transaction behavior.
-3. Land **A + B + C** with the health-budget bump — small, high-confidence;
-   converts "permanent brick" → "self-heals on next launch."
+2. Confirm drizzle per-migration transaction behavior. *(done)*
+3. **A/B done** (delete the swallow + busy_timeout + health-budget bump) — small,
+   high-confidence; converts "permanent brick" → "self-heals on next launch."
+   **C** ships next as #4997 (reap orphan before spawn + fail-fast on child-exit).
 4. Land **D + E** as the durable follow-up that makes update-time contention
-   impossible.
+   impossible — and lets us *remove* busy_timeout and shrink the health window
+   back, since neither is needed once nothing races the migration.
 
 ## Risks / open questions
 


### PR DESCRIPTION
## Problem

The host-service runs DB migrations synchronously inside `createApp()` **before the port binds** (`app.ts` → `serve.ts`). The DB was opened with only WAL + foreign_keys (**no `busy_timeout`**), and `createDb` **swallowed** any migration error and returned the db anyway. desktop 1.12.0 added the first migration since this code shipped (`0005_host_settings_and_project_overrides`), exposing two failure modes under write-lock contention on `host.db`:

- **Half-migrated, served anyway** — `SQLITE_BUSY` swallowed → runtime `no such table host_settings`.
- **Killed mid-migration** — the synchronous stall exceeds the coordinator's 10s health window → SIGKILL → respawn loop, port never binds (terminals dead / 'can't type').

## Fix

- **`db/db.ts`** — set `busy_timeout = 8000` (wait out transient contention) and **fail closed**: throw instead of swallowing. drizzle runs all pending migrations in a single `BEGIN/COMMIT` with `ROLLBACK`+rethrow, so a failure leaves the DB at its prior version (never half-applied). The throw propagates to `serve.ts` `main().catch(… process.exit(1))`, so the coordinator's health check fails instead of serving a broken DB.
- **`host-service-utils.ts`** — raise `HEALTH_POLL_TIMEOUT_MS` 10s → 20s so a recoverable ~8s migration stall isn't SIGKILLed before the port binds.

## Reproduction + verification

New integration test `db.contention.node-test.ts`: real `createDb` + real `0005` + a sibling process holding the write lock. Run with `bun run test:integration:db` (Electron-as-node — `better-sqlite3` here is built for the Electron ABI; bun can't load it and plain node is the wrong ABI).

- ✔ baseline: no contention → 0005 applies, `host_settings` exists
- ✔ fail-closed: sustained contention → `createDb` **throws**, DB left cleanly unmigrated
- ✔ recovery: contention clears within the timeout → waits then succeeds

Host-service unit suite 691/0, typecheck + lint clean.

## Scope / follow-up

This hardens migration startup (resilience + correctness). It does **not** address the *source* of the contention — whether two host-services can race the same `host.db` — which is a separate, root-cause lifecycle change (reap orphan host-service before spawn / single-writer guarantee) tracked in a follow-up PR. The plan doc (`plans/host-service-migration-startup-hardening.md`) covers both.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4996">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened host-service DB migration at startup by failing closed so we never serve a half-migrated DB. Removed the migration `busy_timeout` and focused on surfacing failures; added an Electron-as-node integration test for write-lock contention.

- **Bug Fixes**
  - `src/db/db.ts`: removed the try/catch that swallowed migration errors; `migrate()` now throws. drizzle keeps migrations atomic, so failures roll back cleanly. Dropped the migration `busy_timeout`.

- **Tests**
  - `src/db/db.contention.node-test.ts`: integration test holds a write lock in a sibling process and asserts fail-closed behavior.
  - `scripts/run-db-integration-test.ts` + `test:integration:db`: run under Electron-as-node to load `better-sqlite3`.

<sup>Written for commit 1bbd6c40f27104806c8be91b2c2b778f5fdc5201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration error handling for host service to ensure the application fails cleanly at startup when database contention is detected, rather than silently continuing with an unmigrated database.

* **Tests**
  * Added integration test suite to verify database behavior and recovery under write-lock contention scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->