### PR TITLE
fix(host-service): reap orphaned host-service before spawn (single-writer)

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -11,15 +11,18 @@ import { env as sharedEnv } from "shared/env.shared";
 import { getProcessEnvWithShellPath } from "../../lib/trpc/routers/workspaces/utils/shell-env";
 import { SUPERSET_HOME_DIR } from "./app-environment";
 import {
+	type HostServiceManifest,
 	isProcessAlive,
 	killProcess,
 	manifestDir,
 	readManifest,
 	removeManifest,
 } from "./host-service-manifest";
+import { reapPreviousHostService } from "./host-service-reap";
 import {
 	findFreePort,
 	HEALTH_POLL_TIMEOUT_MS,
+	healthCheckOnce,
 	MAX_HOST_LOG_BYTES,
 	openRotatingLogFd,
 	pollHealthCheck,
@@ -338,11 +341,53 @@ export class HostServiceCoordinator extends EventEmitter {
 
 	// ── Spawn ─────────────────────────────────────────────────────────
 
+	/**
+	 * Reap a host-service left running for this org by a previous process. See
+	 * `host-service-reap.ts` for why one can exist and the PID-reuse safety
+	 * rules. Identity is confirmed via the manifest's health endpoint (the
+	 * secret proves it's ours) with a best-effort argv check as a fallback for
+	 * a wedged child whose endpoint no longer answers.
+	 */
+	private async reapPreviousHostService(organizationId: string): Promise<void> {
+		await reapPreviousHostService(organizationId, {
+			readManifest,
+			removeManifest,
+			isProcessAlive,
+			killProcess,
+			isOwnLivePid: (pid) => {
+				const current = this.instances.get(organizationId);
+				return !!current && current.pid === pid && current.status !== "stopped";
+			},
+			confirmOurHostService: (manifest) => this.confirmOurHostService(manifest),
+			log: {
+				info: (message) => log.info(message),
+				warn: (message) => log.warn(message),
+			},
+		});
+	}
+
+	private async confirmOurHostService(
+		manifest: HostServiceManifest,
+	): Promise<boolean> {
+		// Strongest signal: the endpoint answers with the manifest secret.
+		if (await healthCheckOnce(manifest.endpoint, manifest.authToken, 1_500)) {
+			return true;
+		}
+		// Fallback for a wedged child whose endpoint no longer responds: match
+		// the pid's command line to our host-service script. POSIX only — on
+		// win32 we fall back to health-only and leave unrecognized pids alone.
+		return processLooksLikeHostService(manifest.pid, this.scriptPath);
+	}
+
 	private async spawn(
 		organizationId: string,
 		config: SpawnConfig,
 		preferredPorts: Iterable<number> = this.getPreferredPorts(organizationId),
 	): Promise<Connection> {
+		// Single-writer guarantee: reap any host-service left running for this
+		// org by a previous process before we bind a competitor to its host.db.
+		await this.reapPreviousHostService(organizationId);
+
 		const port = await findFreePort(preferredPorts);
 		this.rememberPort(organizationId, port);
 		const secret = randomBytes(32).toString("hex");
@@ -531,6 +576,27 @@ function pipeWithPrefix(
 		if (pending) target.write(`${tag} ${pending}\n`);
 		pending = "";
 	});
+}
+
+/**
+ * Best-effort identity check for a wedged host-service whose endpoint no longer
+ * answers: does the pid's command line reference our host-service script?
+ * POSIX only (uses `ps`); returns false on win32 and on any error, so an
+ * unrecognized pid is left alone rather than killed.
+ */
+function processLooksLikeHostService(pid: number, scriptPath: string): boolean {
+	if (process.platform === "win32") return false;
+	try {
+		const command = childProcess
+			.execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+				encoding: "utf8",
+				timeout: 1_500,
+			})
+			.trim();
+		return command.includes(path.basename(scriptPath));
+	} catch {
+		return false;
+	}
 }
 
 let coordinator: HostServiceCoordinator | null = null;

--- a/apps/desktop/src/main/lib/host-service-reap.test.ts
+++ b/apps/desktop/src/main/lib/host-service-reap.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { HostServiceManifest } from "./host-service-manifest";
+import { type ReapDeps, reapPreviousHostService } from "./host-service-reap";
+
+const ORG = "org-1";
+
+function manifest(pid: number): HostServiceManifest {
+	return {
+		pid,
+		endpoint: "http://127.0.0.1:48000",
+		authToken: "secret",
+		startedAt: 1,
+		organizationId: ORG,
+	};
+}
+
+function makeDeps(overrides: Partial<ReapDeps> = {}): ReapDeps {
+	return {
+		readManifest: mock(() => manifest(4242)),
+		removeManifest: mock(() => {}),
+		isProcessAlive: mock(() => true),
+		killProcess: mock(() => {}),
+		isOwnLivePid: mock(() => false),
+		confirmOurHostService: mock(async () => true),
+		// No real waiting in tests.
+		sleep: mock(async () => {}),
+		...overrides,
+	};
+}
+
+describe("reapPreviousHostService", () => {
+	test("no manifest → no-op", async () => {
+		const deps = makeDeps({ readManifest: mock(() => null) });
+		const result = await reapPreviousHostService(ORG, deps);
+		expect(result.reason).toBe("no-manifest");
+		expect(deps.killProcess).not.toHaveBeenCalled();
+		expect(deps.removeManifest).not.toHaveBeenCalled();
+	});
+
+	test("pid we already own → left running, manifest kept", async () => {
+		const deps = makeDeps({ isOwnLivePid: mock(() => true) });
+		const result = await reapPreviousHostService(ORG, deps);
+		expect(result.reason).toBe("own-live-instance");
+		expect(deps.killProcess).not.toHaveBeenCalled();
+		expect(deps.removeManifest).not.toHaveBeenCalled();
+	});
+
+	test("dead pid → manifest cleared, nothing killed", async () => {
+		const deps = makeDeps({ isProcessAlive: mock(() => false) });
+		const result = await reapPreviousHostService(ORG, deps);
+		expect(result.reason).toBe("dead-pid-cleared");
+		expect(deps.killProcess).not.toHaveBeenCalled();
+		expect(deps.removeManifest).toHaveBeenCalledTimes(1);
+	});
+
+	test("alive but unidentified (PID reuse) → NOT killed, manifest dropped", async () => {
+		const killProcess = mock(() => {});
+		const deps = makeDeps({
+			confirmOurHostService: mock(async () => false),
+			killProcess,
+		});
+		const result = await reapPreviousHostService(ORG, deps);
+		expect(result.reason).toBe("unidentified-left-alone");
+		expect(killProcess).not.toHaveBeenCalled();
+		expect(deps.removeManifest).toHaveBeenCalledTimes(1);
+	});
+
+	test("alive + ours + exits on SIGTERM → SIGTERM only, no SIGKILL", async () => {
+		const signals: NodeJS.Signals[] = [];
+		// Alive until SIGTERM is observed, then gone.
+		let sigtermed = false;
+		const deps = makeDeps({
+			killProcess: mock((_pid: number, sig: NodeJS.Signals) => {
+				signals.push(sig);
+				if (sig === "SIGTERM") sigtermed = true;
+			}),
+			isProcessAlive: mock(() => !sigtermed),
+		});
+		const result = await reapPreviousHostService(ORG, deps);
+		expect(result.reaped).toBe(true);
+		expect(result.reason).toBe("terminated-sigterm");
+		expect(signals).toEqual(["SIGTERM"]);
+		expect(deps.removeManifest).toHaveBeenCalledTimes(1);
+	});
+
+	test("alive + ours + ignores SIGTERM → escalates to SIGKILL", async () => {
+		const signals: NodeJS.Signals[] = [];
+		let sigkilled = false;
+		const deps = makeDeps({
+			killProcess: mock((_pid: number, sig: NodeJS.Signals) => {
+				signals.push(sig);
+				if (sig === "SIGKILL") sigkilled = true;
+			}),
+			// Survives SIGTERM (always alive until SIGKILL lands).
+			isProcessAlive: mock(() => !sigkilled),
+		});
+		const result = await reapPreviousHostService(ORG, deps);
+		expect(result.reaped).toBe(true);
+		expect(result.reason).toBe("terminated-sigkill");
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(deps.removeManifest).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/desktop/src/main/lib/host-service-reap.ts
+++ b/apps/desktop/src/main/lib/host-service-reap.ts
@@ -1,0 +1,140 @@
+import type { HostServiceManifest } from "./host-service-manifest";
+
+/**
+ * Reaping a previous host-service before spawning a new one for an org.
+ *
+ * The coordinator only tracks host-services it spawned in this Electron
+ * process (its in-memory `instances` map). After an Electron restart that map
+ * is empty, so a host-service left alive by a *previous* process is invisible:
+ *
+ *   - Electron died before `before-quit` ran (hard crash / SIGKILL / OOM), so
+ *     the child was never SIGTERMed and the parent watchdog hadn't fired yet;
+ *   - a CLI-spawned host-service (no `HOST_PARENT_PID`, so no watchdog at all);
+ *   - a wedged child from a failed spawn that ignored SIGTERM.
+ *
+ * Any of these keeps an open connection to the org's `host.db`. A second writer
+ * is what produces migration lock contention. So before spawning we reap based
+ * on the manifest — the only cross-process record that a host-service exists.
+ *
+ * PID-reuse safety: we only kill a pid we can positively identify as our
+ * host-service (`confirmOurHostService`). A live-but-unrecognized pid is left
+ * alone — we just drop the stale manifest. Killing blind would risk an
+ * unrelated process that happened to inherit the recycled pid.
+ */
+
+export const REAP_SIGTERM_GRACE_MS = 4_000;
+export const REAP_SIGKILL_GRACE_MS = 2_000;
+const PID_EXIT_POLL_INTERVAL_MS = 100;
+
+export type ReapReason =
+	| "no-manifest"
+	| "own-live-instance"
+	| "dead-pid-cleared"
+	| "unidentified-left-alone"
+	| "terminated-sigterm"
+	| "terminated-sigkill";
+
+export interface ReapResult {
+	reaped: boolean;
+	reason: ReapReason;
+	pid?: number;
+}
+
+export interface ReapDeps {
+	readManifest: (organizationId: string) => HostServiceManifest | null;
+	removeManifest: (organizationId: string) => void;
+	isProcessAlive: (pid: number) => boolean;
+	killProcess: (pid: number, signal: NodeJS.Signals) => void;
+	/** True when `pid` is a live host-service this process already tracks. */
+	isOwnLivePid: (pid: number) => boolean;
+	/** Positively confirm the live `pid` is our host-service (health + argv). */
+	confirmOurHostService: (manifest: HostServiceManifest) => Promise<boolean>;
+	log?: { info: (message: string) => void; warn: (message: string) => void };
+	/** Injectable for tests; defaults to setTimeout. */
+	sleep?: (ms: number) => Promise<void>;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForPidExit(
+	pid: number,
+	timeoutMs: number,
+	isProcessAlive: (pid: number) => boolean,
+	sleep: (ms: number) => Promise<void>,
+): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) return true;
+		await sleep(PID_EXIT_POLL_INTERVAL_MS);
+	}
+	return !isProcessAlive(pid);
+}
+
+export async function reapPreviousHostService(
+	organizationId: string,
+	deps: ReapDeps,
+): Promise<ReapResult> {
+	const sleep = deps.sleep ?? defaultSleep;
+	const manifest = deps.readManifest(organizationId);
+	if (!manifest) return { reaped: false, reason: "no-manifest" };
+
+	const { pid } = manifest;
+
+	// Never reap something we already own and track as live.
+	if (deps.isOwnLivePid(pid)) {
+		return { reaped: false, reason: "own-live-instance", pid };
+	}
+
+	if (!deps.isProcessAlive(pid)) {
+		deps.removeManifest(organizationId);
+		return { reaped: false, reason: "dead-pid-cleared", pid };
+	}
+
+	if (!(await deps.confirmOurHostService(manifest))) {
+		deps.log?.warn(
+			`[host-service:${organizationId}] manifest pid=${pid} is alive but not identifiable as our host-service; leaving it (possible PID reuse) and dropping the stale manifest`,
+		);
+		deps.removeManifest(organizationId);
+		return { reaped: false, reason: "unidentified-left-alone", pid };
+	}
+
+	deps.log?.info(
+		`[host-service:${organizationId}] reaping previous host-service pid=${pid} before spawn`,
+	);
+
+	let reason: ReapReason = "terminated-sigterm";
+	try {
+		deps.killProcess(pid, "SIGTERM");
+	} catch {
+		// Exited between the liveness check and the signal — nothing to do.
+		deps.removeManifest(organizationId);
+		return { reaped: true, reason: "terminated-sigterm", pid };
+	}
+
+	if (
+		!(await waitForPidExit(
+			pid,
+			REAP_SIGTERM_GRACE_MS,
+			deps.isProcessAlive,
+			sleep,
+		))
+	) {
+		try {
+			deps.killProcess(pid, "SIGKILL");
+			reason = "terminated-sigkill";
+		} catch {
+			// Raced to exit during the grace window.
+		}
+		await waitForPidExit(
+			pid,
+			REAP_SIGKILL_GRACE_MS,
+			deps.isProcessAlive,
+			sleep,
+		);
+	}
+
+	deps.removeManifest(organizationId);
+	return { reaped: true, reason, pid };
+}

--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -93,6 +93,31 @@ function canBindPort(port: number): Promise<boolean> {
 	});
 }
 
+/**
+ * Single health probe. Returns true only if the endpoint answers
+ * `health.check` 2xx with the given secret — which doubles as proof of
+ * identity (only the host-service that wrote a manifest knows its secret).
+ */
+export async function healthCheckOnce(
+	endpoint: string,
+	secret: string,
+	timeoutMs = 2_000,
+): Promise<boolean> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const res = await fetch(`${endpoint}/trpc/health.check`, {
+			signal: controller.signal,
+			headers: { Authorization: `Bearer ${secret}` },
+		});
+		return res.ok;
+	} catch {
+		return false;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
 export async function pollHealthCheck(
 	endpoint: string,
 	secret: string,
@@ -100,19 +125,7 @@ export async function pollHealthCheck(
 ): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 2_000);
-		try {
-			const res = await fetch(`${endpoint}/trpc/health.check`, {
-				signal: controller.signal,
-				headers: { Authorization: `Bearer ${secret}` },
-			});
-			if (res.ok) return true;
-		} catch {
-			// Not ready yet
-		} finally {
-			clearTimeout(timeout);
-		}
+		if (await healthCheckOnce(endpoint, secret)) return true;
 		await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
 	}
 	return false;


### PR DESCRIPTION
## Problem

The coordinator only tracks host-services it spawned in **this** Electron process (its in-memory `instances` map). After a restart that map is empty, so a host-service left alive by a *previous* process is invisible — and `spawn()` never consults the manifest before starting a new one. It just binds a competitor on a fresh port, giving **two processes connected to the same org `host.db`**. That concurrent-writer contention is the root trigger behind the migration lock-up (see #4996, which hardens the migration side).

How an orphan arises:
- Electron died before `before-quit` ran (hard crash / SIGKILL / OOM) — child never SIGTERMed, parent watchdog hadn't fired yet;
- a **CLI-spawned** host-service — no `HOST_PARENT_PID`, so no watchdog at all;
- a **wedged** child from a failed spawn that ignored SIGTERM.

(`reset()` already reaps via the manifest, but it's only reachable manually via tRPC — never on the normal start path.)

## Fix

Reap based on the manifest (the only cross-process record) **before spawning**, in `spawn()`:

- **Identity-validated kill (PID-reuse safe):** only terminate a pid we can positively confirm is our host-service — its endpoint answers `health.check` with the manifest secret, or (best-effort, POSIX) its command line matches our `host-service.js`. A live-but-unrecognized pid is **left alone** and the stale manifest dropped, so a recycled pid can't cause friendly-fire.
- **Escalation:** SIGTERM → await exit → SIGKILL → await.

Why safe to kill: host-service is stateless w.r.t. terminals — PTYs live in the detached pty-daemon, which a fresh host-service re-adopts. Reaping an orphan doesn't touch user sessions.

## Structure

- `host-service-reap.ts` — dependency-injected reap logic (electron-free, so it unit-tests under `bun test` without spawning real processes).
- `host-service-coordinator.ts` — wires real deps + the health/argv identity probe; calls reap at the top of `spawn()`.
- `host-service-utils.ts` — adds `healthCheckOnce` (single-shot identity probe; `pollHealthCheck` now reuses it).
- `host-service-reap.test.ts` — 6 cases: no-manifest, own-live-instance, dead-pid-cleared, **unidentified-left-alone (PID reuse)**, SIGTERM-exit, **SIGTERM→SIGKILL escalation**.

Desktop typecheck + lint clean; reap tests 6/6.

## Relationship to #4996

Independent and complementary. #4996 makes the DB migration survive contention (busy_timeout + fail-closed); this PR removes the *source* of the contention. Either can merge first.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/4997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents two host-service processes from writing to the same org DB by reaping any orphaned host-service before spawn. Uses manifest-driven identity checks to safely terminate previous instances and ensure a single writer, resolving migration contention.

- **Bug Fixes**
  - Reap any previous host-service for the org at the start of `spawn()` using the manifest.
  - Identity-validated kill: `health.check` with the manifest secret, with a POSIX argv fallback; unrecognized live PIDs are left alone and the stale manifest is removed.
  - Escalation flow: `SIGTERM` with grace, then `SIGKILL` if needed; clears the manifest after successful reaping or when the PID is dead.
  - Added `healthCheckOnce` and updated `pollHealthCheck` to reuse it.
  - Introduced dependency-injected `host-service-reap.ts` with unit tests covering no-manifest, own-live, dead-pid, PID-reuse, and SIGTERM→SIGKILL paths.

<sup>Written for commit 19143e535ac84d70fcaf0125b9353b8c95a255e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/4997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced host-service process lifecycle management with proactive cleanup of previous instances to prevent conflicts.
  
* **Tests**
  * Added comprehensive test coverage for host-service process cleanup logic, including edge cases for process termination and manifest handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/4997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->