### PR TITLE
fix(host-service): unfreeze terminals wedged by flow control with no renderer attached

### DIFF
--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -296,6 +296,26 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		await disposeSessionAndWait(terminalId, db);
 	});
 
+	test("background output does not leave daemon flow control paused", async () => {
+		const terminalId = `e2e-bg-flow-${randomUUID().slice(0, 8)}`;
+		const result = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+		});
+		assert.ok(!("error" in result));
+		if ("error" in result) return;
+
+		const marker = `bg-flow-done-${randomUUID().slice(0, 6)}`;
+		result.pty.write(
+			`i=0; while [ "$i" -lt 3000 ]; do printf '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\\n'; i=$((i + 1)); done; echo ${marker}\n`,
+		);
+
+		await waitFor(() => sessionBufferText(result).includes(marker), 10_000);
+		await disposeSessionAndWait(terminalId, db);
+	});
+
 	test("adopts existing daemon session after host-service restart simulation", async () => {
 		const terminalId = `e2e-adopt-${randomUUID().slice(0, 8)}`;
 
@@ -666,4 +686,10 @@ async function waitForOutput(
 	} finally {
 		disposer.dispose();
 	}
+}
+
+function sessionBufferText(session: { buffer: Uint8Array[] }): string {
+	return Buffer.concat(session.buffer.map((b) => Buffer.from(b))).toString(
+		"utf8",
+	);
 }

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1325,6 +1325,12 @@ export async function createTerminalSessionInternal({
 
 				if (broadcastBytes(session, bytes) === 0) {
 					bufferOutput(session, bytes);
+					// Normally the renderer ACKs each byte it draws, which tells
+					// the daemon it's safe to keep sending. With no socket open,
+					// those ACKs never come, the daemon thinks we're overwhelmed,
+					// and it pauses the PTY forever. So ACK on its behalf: we've
+					// safely stored these bytes in our (size-capped) replay buffer.
+					session.pty.ackOutput(bytes.byteLength);
 				}
 			},
 			onExit({ code, signal }) {


### PR DESCRIPTION
## Summary

Fixes a permanent terminal freeze introduced by the output flow-control work in #4896.

That PR pauses the PTY when the pty-daemon's unacked-byte counter crosses the 100 KB high watermark, resuming only once renderer acks drain it below the 5 KB low watermark. The accounting has a gap:

- The **daemon counts every byte** it sends to host-service (`Server.ts` increments `flowControlUnacked` per output chunk).
- The **renderer is the only thing that acks**, and only for bytes that reach an *open* socket (after `xterm.write`'s callback fires).

When no renderer socket is open — a reconnect gap after a WS drop, a startup output burst before the renderer attaches, or a session running with no pane currently showing it — output still streams daemon → host-service, where `bufferOutput()` retains only the last **64 KB** (`MAX_BUFFER_BYTES`, older bytes evicted). Those bytes never reach a renderer, so they're never acked. The daemon's counter climbs past the high watermark and pauses the PTY. On re-attach the renderer can only ack the ≤64 KB that survived eviction, so the counter stays above the low watermark and **the PTY never resumes** — the terminal is frozen until the session is recreated.

Note: backgrounding a pane does *not* trigger this — `registry.detach()` keeps the socket open. It's specifically the windows where there is genuinely no open socket.

## Fix

When broadcast finds no open socket, host-service has still consumed the bytes into its bounded replay buffer, so it now credits the daemon's flow-control counter immediately instead of waiting for a renderer ack that will never come:

```ts
if (broadcastBytes(session, bytes) === 0) {
    bufferOutput(session, bytes);
    session.pty.ackOutput(bytes.byteLength); // host-service consumed them; daemon would otherwise stay paused
}
```

This is the only path that left a terminal **permanently** wedged. The open-socket case (transient back-pressure during a heavy burst you're actively watching) already self-heals via `maybeResume()` and is unchanged.

### Known, harmless side effect
Buffered bytes are acked again when replayed to a reconnecting renderer (which can't distinguish replay from live). The daemon clamps the counter at `Math.max(0, …)`, so the double-ack can't underflow — it only loosens back-pressure by up to ~64 KB for a single re-attach window. Bounded and transient; no OOM risk.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck --filter=@superset/host-service` — passes
- [x] New regression test in `terminal.adoption.node-test.ts`: ~195 KB produced with no socket attached must not leave the PTY flow-control paused (hangs without the fix, since the daemon pauses at 100 KB and never resumes)

Relates to #4896.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5006">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminals freezing when output is produced with no renderer socket attached. `host-service` now acks buffered bytes to the daemon so the PTY resumes instead of staying paused.

- **Bug Fixes**
  - When `broadcastBytes(...) === 0`, buffer the bytes and call `session.pty.ackOutput(bytes.byteLength)` to prevent unacked-byte buildup with no socket open.
  - Add regression test in `packages/host-service/src/terminal/terminal.adoption.node-test.ts` that writes ~195 KB with no renderer and verifies the daemon is not left paused.

<sup>Written for commit 8b01d2e95609d599159ba0ce11ffb489d5b1805b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal flow-control now properly credits daemon output even when no renderer is connected, preventing session stalls during very high-volume output and ensuring buffered output is replayed when renderers reconnect.

* **Tests**
  * Added end-to-end test coverage for terminal adoption with large continuous output to prevent regressions and validate reliable buffering and completion detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->