### PR TITLE
fix(relay): disable Nagle on tunnel sockets to cut interactive terminal latency

### DIFF
--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -390,3 +390,18 @@ server = serve({ fetch: app.fetch, port: env.RELAY_PORT }, (info) => {
 	);
 });
 injectWebSocket(server);
+
+// Disable Nagle's algorithm on every incoming connection. Both the client's
+// terminal WebSocket and the host's tunnel WebSocket connect here, so this
+// covers the relay's writes in both directions. Nagle interacting with TCP
+// delayed-ACK adds tens-to-hundreds of milliseconds to small, sparse
+// interactive frames (terminal keystrokes and their echoes) while leaving
+// bulk output untouched; across the relay's multiple hops this compounds into
+// seconds of perceived typing lag. Interactive proxies should always set
+// TCP_NODELAY. (@hono/node-server returns a Node http.Server.)
+(server as unknown as import("node:http").Server).on(
+	"connection",
+	(socket: import("node:net").Socket) => {
+		socket.setNoDelay(true);
+	},
+);


### PR DESCRIPTION
## Root cause

Keystrokes in a **remote** terminal lag ~1–3 s to echo; local terminals are instant.
The latency is the relay path: host-service echoes a keystroke in ~3 ms (loopback
capture), host↔relay is ~9–19 ms, and a *local* Superset terminal types at ~11 ms vs
~1.2 s remote.

The relay forwards every WebSocket frame immediately, but it never sets `TCP_NODELAY`
on its sockets. Nagle's algorithm, interacting with TCP delayed-ACK, holds **small,
partial** segments — a keystroke and its echo — waiting for the previous ACK; it does
not hold full-size segments. So the penalty is specific to small, sparse interactive
frames, and it compounds across the relay's hops into seconds of typing lag.

> Scope: this is the *interactive keystroke latency*. Heavy-output rendering
> performance is a separate, client-side concern and is not addressed here.

## The fix

Set `TCP_NODELAY` on every incoming connection. Both the client's terminal WebSocket
and the host's tunnel WebSocket connect to this server, so one handler covers the
relay's writes in both directions.

```ts
injectWebSocket(server);

// Disable Nagle's algorithm on every incoming connection. Both the client's
// terminal WebSocket and the host's tunnel WebSocket connect here, so this
// covers the relay's writes in both directions. Nagle interacting with TCP
// delayed-ACK adds tens-to-hundreds of milliseconds to small, sparse
// interactive frames (terminal keystrokes and their echoes) while leaving
// bulk output untouched; across the relay's multiple hops this compounds into
// seconds of perceived typing lag. Interactive proxies should always set
// TCP_NODELAY. (@hono/node-server returns a Node http.Server.)
(server as unknown as import("node:http").Server).on(
  "connection",
  (socket: import("node:net").Socket) => {
    socket.setNoDelay(true);
  },
);
```

## Measured

**1. Minimal TCP echo, single hop (isolates the mechanism).** Client measures frame
round-trips over a real network; the client uses `setNoDelay`, so only the server's
behaviour varies:

| echo round-trip | small sparse frames (typing-like) | back-to-back frames |
|---|---|---|
| **Nagle ON** (current) | med 62.7 ms · avg 101 ms · max 205 ms | ~24 ms |
| **Nagle OFF** (this change) | med 24.3 ms · avg 27 ms · max 59 ms | ~24 ms |

**2. Through the relay's own code, real network, `setNoDelay` toggled via a build
flag.** Sparse interactive frames round-tripped client → relay → host → relay → client:

| sparse interactive frames | avg | max |
|---|---|---|
| **Nagle ON** | 98.7 ms | 641 ms |
| **setNoDelay** (this change) | 49.6 ms | 50.4 ms |

With Nagle on, interactive frames intermittently stall into the hundreds of
milliseconds; `setNoDelay` makes them tight and consistent. (The ~50 ms floor here is
the multi-hop test rig's base round-trip — the change removes the *added* stalls, not
the base network time.) Back-to-back / bulk frames are unaffected either way — Nagle
only penalises the sparse interactive pattern, which is exactly interactive typing.

Routing an actual remote terminal through a relay built with this change also produced
visibly snappier typing than the unchanged relay.

## Test plan

Ran locally against this branch (`apps/relay`):
- [x] `tsc --noEmit` (relay typecheck) — clean
- [x] Biome `check` (lint + format) on the change — clean
- [x] `bun build` of the relay entry — bundles cleanly (845 modules)

For a reviewer / CI to confirm:
- [ ] Remote terminal: keystrokes echo without the ~1 s lag
- [ ] No behaviour change for large/continuous output (this only affects how small,
      sparse segments are flushed — it doesn't alter framing or throughput)
- [ ] `server.on("connection")` fires for both HTTP and WebSocket connections under
      Node (the relay's runtime) and applies `setNoDelay`

## Scope

This is the complete fix for the interactive-latency issue — the relay's two TCP
sockets were the only ones on the path with Nagle enabled. Every other endpoint
already disables it:

- **client → relay:** the desktop uses a Chromium `WebSocket`, which sets
  `TCP_NODELAY` by default.
- **host → relay:** the host-service tunnel connects via Node's global `WebSocket`
  (undici), which calls `socket.setNoDelay(true)` on its socket (verified under Node).
- **tunnel ↔ host-service:** loopback, so Nagle has no effect.

Closes #5012
