### PR TITLE
fix(api): enforce chat session ownership on /api/chat routes (IDOR)

### DIFF
--- a/apps/api/src/app/api/chat/[sessionId]/route.ts
+++ b/apps/api/src/app/api/chat/[sessionId]/route.ts
@@ -1,7 +1,7 @@
 import { db } from "@superset/db/client";
 import { chatSessions } from "@superset/db/schema";
 import { and, eq, isNull } from "drizzle-orm";
-import { getDurableStream, requireAuth } from "../lib";
+import { findChatSessionOwner, getDurableStream, requireAuth } from "../lib";
 
 function errorMessage(error: unknown): string {
 	if (error instanceof Error) return error.message;
@@ -42,6 +42,11 @@ export async function PUT(
 			{ error: "organizationId is required" },
 			{ status: 400 },
 		);
+	}
+
+	const existingOwner = await findChatSessionOwner(sessionId);
+	if (existingOwner && existingOwner.createdBy !== session.user.id) {
+		return new Response("Not found", { status: 404 });
 	}
 
 	const stream = getDurableStream(sessionId);
@@ -139,10 +144,20 @@ export async function PATCH(
 	const body = (await request.json()) as { title?: string };
 
 	if (body.title !== undefined) {
-		await db
+		const [updated] = await db
 			.update(chatSessions)
 			.set({ title: body.title })
-			.where(eq(chatSessions.id, sessionId));
+			.where(
+				and(
+					eq(chatSessions.id, sessionId),
+					eq(chatSessions.createdBy, session.user.id),
+				),
+			)
+			.returning({ id: chatSessions.id });
+
+		if (!updated) {
+			return new Response("Not found", { status: 404 });
+		}
 	}
 
 	return Response.json({ success: true }, { status: 200 });

--- a/apps/api/src/app/api/chat/[sessionId]/stream/route.ts
+++ b/apps/api/src/app/api/chat/[sessionId]/stream/route.ts
@@ -1,8 +1,9 @@
 import { db } from "@superset/db/client";
 import { chatSessions } from "@superset/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { env } from "@/env";
 import {
+	loadOwnedChatSession,
 	PRODUCER_RESPONSE_HEADERS,
 	PROTOCOL_QUERY_PARAMS,
 	PROTOCOL_RESPONSE_HEADERS,
@@ -23,6 +24,10 @@ export async function GET(
 	if (!session) return new Response("Unauthorized", { status: 401 });
 
 	const { sessionId } = await params;
+
+	const owned = await loadOwnedChatSession(sessionId, session.user.id);
+	if (!owned) return new Response("Not found", { status: 404 });
+
 	const url = new URL(request.url);
 
 	const upstream = new URL(streamUrl(sessionId));
@@ -83,6 +88,10 @@ export async function POST(
 	if (!session) return new Response("Unauthorized", { status: 401 });
 
 	const { sessionId } = await params;
+
+	const owned = await loadOwnedChatSession(sessionId, session.user.id);
+	if (!owned) return new Response("Not found", { status: 404 });
+
 	const upstream = streamUrl(sessionId);
 
 	const headers: Record<string, string> = {
@@ -137,6 +146,9 @@ export async function DELETE(
 
 	const { sessionId } = await params;
 
+	const owned = await loadOwnedChatSession(sessionId, session.user.id);
+	if (!owned) return new Response("Not found", { status: 404 });
+
 	const response = await fetch(streamUrl(sessionId), {
 		method: "DELETE",
 		headers: {
@@ -144,7 +156,14 @@ export async function DELETE(
 		},
 	});
 
-	await db.delete(chatSessions).where(eq(chatSessions.id, sessionId));
+	await db
+		.delete(chatSessions)
+		.where(
+			and(
+				eq(chatSessions.id, sessionId),
+				eq(chatSessions.createdBy, session.user.id),
+			),
+		);
 
 	const headers = new Headers();
 	for (const [key, value] of response.headers.entries()) {
@@ -171,6 +190,9 @@ export async function HEAD(
 	if (!session) return new Response("Unauthorized", { status: 401 });
 
 	const { sessionId } = await params;
+
+	const owned = await loadOwnedChatSession(sessionId, session.user.id);
+	if (!owned) return new Response("Not found", { status: 404 });
 
 	const response = await fetch(streamUrl(sessionId), {
 		method: "HEAD",

--- a/apps/api/src/app/api/chat/lib.ts
+++ b/apps/api/src/app/api/chat/lib.ts
@@ -1,5 +1,8 @@
 import { DurableStream } from "@durable-streams/client";
 import { auth } from "@superset/auth/server";
+import { db } from "@superset/db/client";
+import { chatSessions } from "@superset/db/schema";
+import { and, eq } from "drizzle-orm";
 import { env } from "@/env";
 
 export const PROTOCOL_QUERY_PARAMS = ["offset", "live", "cursor"];
@@ -34,6 +37,26 @@ export async function requireAuth(request: Request) {
 	});
 	if (!sessionData?.user) return null;
 	return sessionData;
+}
+
+export async function loadOwnedChatSession(sessionId: string, userId: string) {
+	const [row] = await db
+		.select({ id: chatSessions.id, createdBy: chatSessions.createdBy })
+		.from(chatSessions)
+		.where(
+			and(eq(chatSessions.id, sessionId), eq(chatSessions.createdBy, userId)),
+		)
+		.limit(1);
+	return row ?? null;
+}
+
+export async function findChatSessionOwner(sessionId: string) {
+	const [row] = await db
+		.select({ createdBy: chatSessions.createdBy })
+		.from(chatSessions)
+		.where(eq(chatSessions.id, sessionId))
+		.limit(1);
+	return row ?? null;
 }
 
 export function streamUrl(sessionId: string) {


### PR DESCRIPTION
## Problem

The `/api/chat/[sessionId]` and `/api/chat/[sessionId]/stream` route handlers only verified that the caller was authenticated (`requireAuth`), never that they owned the session for that `sessionId`. Any logged-in user could act on another organization's chat session by id:

| Method | Endpoint | Impact |
| --- | --- | --- |
| GET | `/api/chat/[sessionId]/stream` | Read another org's transcript (confidentiality) |
| POST | `/api/chat/[sessionId]/stream` | Inject arbitrary events into the victim's live stream (integrity) |
| PATCH | `/api/chat/[sessionId]` | Rename another org's session (integrity) |
| DELETE | `/api/chat/[sessionId]/stream` | Delete another org's session + stream (availability) |

Classic IDOR — cross-tenant loss of confidentiality, integrity, and availability from a single ordinary account, with no notification to the victim.

## Fix

Added two ownership helpers in `apps/api/src/app/api/chat/lib.ts`:
- `loadOwnedChatSession(sessionId, userId)` — returns the row only when `createdBy` matches the caller
- `findChatSessionOwner(sessionId)` — looks up the owner for the idempotent create path

Every handler now enforces ownership:
- **GET / POST / DELETE / HEAD** — `404` before proxying to durable-streams if the caller doesn't own the session; DELETE's DB delete is scoped by `createdBy`.
- **PATCH** — update scoped by `createdBy` with `.returning()`; `404` if nothing matched.
- **PUT** (idempotent create) — `404` if a row already exists under a different user; the caller's own create/retry is unchanged.

Scoping is by `createdBy` to match the canonical secure tRPC `chatRouter` (`packages/trpc/src/router/chat/chat.ts`), which already scopes every op the same way. `404` (not `403`) is returned so session ids aren't enumerable.

## Compatibility

- **API-only change** — three files under `apps/api/src/app/api/chat/`, no client/schema changes.
- The shipped desktop client (`useChatPaneController`) creates and operates only on its own self-generated session UUIDs, so the normal flow is unaffected and **no desktop release is required**.

These HTTP routes are v1 legacy; v2 already uses the secure tRPC `chatRouter`. This patches the IDOR in place — the whole `apps/api/.../chat` HTTP tree can be removed later once v1 ChatPane is migrated.

## Verification

- `bun run lint` — clean
- `bun run typecheck` — 28/28 packages pass

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5017">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces ownership checks on `/api/chat/[sessionId]` and `/api/chat/[sessionId]/stream` to fix an IDOR allowing cross-tenant read/write/delete. Non-owned sessions now return 404, matching the secure `chatRouter` behavior.

- **Bug Fixes**
  - Scope all handlers by `createdBy`: GET/POST/DELETE/HEAD verify ownership before proxying; PATCH updates only owned rows and returns 404 if none; PUT returns 404 if the session exists under another user.
  - Add `loadOwnedChatSession` and `findChatSessionOwner` helpers to enforce ownership.
  - Delete and updates are owner-scoped; durable streams are accessed only after ownership is confirmed.

<sup>Written for commit fb0612e09bb5a703cbecae34ef8dff97857043e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened access controls for chat sessions to prevent unauthorized users from accessing or modifying sessions created by others.

* **Bug Fixes**
  * Fixed session update and deletion operations to enforce ownership validation.
  * API now returns proper 404 responses when users attempt to access sessions they do not own.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->