### PR TITLE
fix(api): reject OAuth tokens from untrusted clients on tRPC bearer path

### DIFF
--- a/apps/api/src/trpc/context.ts
+++ b/apps/api/src/trpc/context.ts
@@ -8,6 +8,8 @@ import { env } from "@/env";
 
 const apiUrl = env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
 
+const TRUSTED_API_CLIENTS = new Set(["superset-cli"]);
+
 function looksLikeJwt(token: string): boolean {
 	const parts = token.split(".");
 	return parts.length === 3 && parts.every(Boolean);
@@ -31,6 +33,12 @@ async function sessionFromOAuthBearer(
 			},
 		})) as Record<string, unknown>;
 	} catch {
+		return null;
+	}
+
+	const authorizedClientId =
+		typeof payload.azp === "string" ? payload.azp : null;
+	if (authorizedClientId && !TRUSTED_API_CLIENTS.has(authorizedClientId)) {
 		return null;
 	}
 


### PR DESCRIPTION
## Summary

Closes an account-takeover vector reported by external researchers (Jemin Khunt, Hitarth Shah).

The tRPC bearer path (\`apps/api/src/trpc/context.ts\`) granted a **full user session** to any JWT whose \`aud\` matched the API URL, **without checking which OAuth client minted the token** (\`azp\`). Combined with unauthenticated dynamic client registration, an attacker could:

1. Register an OAuth client via \`POST /api/auth/oauth2/register\` (no auth) with an attacker-hosted \`redirect_uri\`.
2. Phish a victim through the legitimate consent screen on \`api.superset.sh\`.
3. Exchange the code (with \`resource=https://api.superset.sh\`) for a signed JWT carrying \`aud: https://api.superset.sh\` + \`organizationIds\`.
4. Call any tRPC procedure — \`user.updateProfile\`, \`user.myOrganizations\` (Stripe customer id), etc. — with full read/write access.

## Fix

Gate the bearer path to trusted first-party clients. Tokens whose \`azp\` is present but not in the trusted set (i.e. dynamically-registered / attacker clients) are rejected.

\`\`\`ts
const TRUSTED_API_CLIENTS = new Set(["superset-cli"]);
// ...
const authorizedClientId = typeof payload.azp === "string" ? payload.azp : null;
if (authorizedClientId && !TRUSTED_API_CLIENTS.has(authorizedClientId)) {
  return null;
}
\`\`\`

## Why this approach (and not disabling DCR)

The report's headline fix — \`allowUnauthenticatedClientRegistration: false\` — would **break MCP**. Better Auth's own docs confirm unauthenticated DCR is "especially useful for an MCP to dynamically register themselves as a public client"; turning it off means external MCP clients (Claude, Cursor, Codex, etc.) can no longer self-register, which is a shipped, documented feature (\`apps/docs/content/docs/mcp.mdx\`).

The real defect is **audience confusion**: tRPC trusted tokens by audience instead of by issuing client. The \`azp\` gate fixes that directly and surgically.

## Not in scope here

- The report's "\`superset-cli\` accepts any redirect_uri" finding is a mischaracterization: the matcher only ignores the **port for loopback** addresses (RFC 8252), and loopback delivers the code to the victim's own machine — not a remote vector. The prod \`superset-cli\` row is already loopback + \`app.superset.sh\` only. No change needed.
- Consent-screen hardening (showing untrusted clients clearly) is a reasonable follow-up but out of scope for this fix.

## Non-breaking — verified

| Consumer | Path | Affected? |
|---|---|---|
| CLI / host-service | OAuth JWT, \`azp=superset-cli\` (allowlisted) | No |
| SDK direct API calls | API key (\`x-api-key\` / \`Bearer sk_live_\`, not a JWT → \`getSession\`) | No |
| SDK host calls | JWT to **relay.superset.sh**, never api tRPC | No |
| Web app | Session cookies | No |
| MCP clients | Own verifier in \`auth-flow.ts\` (accepts any client) | No |

\`bun run lint\` and \`bun run typecheck\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5018">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
tRPC bearer auth in `apps/api/src/trpc/context.ts` now checks `azp` and only accepts tokens from trusted OAuth clients (currently `superset-cli`), closing an account-takeover vector that relied on audience-only JWTs.

- **Bug Fixes**
  - Reject JWTs with `azp` set to an untrusted client; only trusted IDs are allowed.
  - No change to API keys, JWTs without `azp`, web app cookies, or MCP flows.

<sup>Written for commit 9ea4b3592fa542db4ded5a0be3b415e37bf6c3c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened OAuth and JWT bearer session authentication with enhanced validation of API client authorization status
  * Sessions from API clients not included in the trusted authorization list are now rejected during the authentication process
  * All existing OAuth and JWT authentication flows continue to function normally for authorized API clients and users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->