### PR TITLE
fix(relay): read tunnel directory from regional replicas

### DIFF
--- a/apps/relay/src/directory.ts
+++ b/apps/relay/src/directory.ts
@@ -11,6 +11,7 @@ const TTL_GRACE_MS = 90_000;
 const redis = new Redis({
 	url: env.KV_REST_API_URL,
 	token: env.KV_REST_API_TOKEN,
+	readYourWrites: false,
 });
 
 export interface TunnelOwner {


### PR DESCRIPTION
## Problem

Users report poor latency in EU (and other non-primary regions). The relay is already multi-region on Fly (sjc/iad/fra/nrt/sin/gru, 1 machine each) and the Upstash KV directory has per-region read replicas — but the relay was not actually reading from them.

## Root cause

`apps/relay/src/directory.ts` constructed the Upstash client as `new Redis({ url, token })`. In `@upstash/redis@1.37.0`, **`readYourWrites` defaults to `true`** (`this.readYourWrites = config.readYourWrites ?? true`). With it on, the client stamps an `upstash-sync-token` on every request and each **read blocks until the nearest replica has replicated up to this client's latest write**.

Every relay writes continuously — `register` on connect, `heartbeat` on every pong (30s/tunnel), `sweepStale` every 30s — so the sync token is always advancing. Net effect: `directory.lookup` (the hot read in `maybeReplay`, used on every cross-region routing decision) never gets a fast local replica read; it pays cross-region replication lag, **defeating the per-region read replicas**.

## Fix

Set `readYourWrites: false`. The directory is eventually-consistent by design (90s `TTL_GRACE_MS` + `sweepStale` + the self-owner guard in `maybeReplay`), so read-your-writes consistency buys nothing here. Lookups now serve from the nearest regional replica. One-line change; writes (Lua `eval`) still go to the primary as before.

## Validation

- `bun run typecheck --filter=@superset/relay` ✅
- `biome check apps/relay/src/directory.ts` ✅
- Real-world `agent_session_launch` latency (PostHog, 30d) shows EU p50 ~330ms vs NA ~297ms — moderately elevated. This addresses one clear gap in the cross-region control path; it is not expected to be a silver bullet on its own (that metric is partly host-processing-dominated).

## Out of scope (flagged for follow-up)

- **All directory writes go to the single Upstash primary** (Lua `eval` is never replica-routed). Worth confirming the primary region is sensibly located vs. the traffic centroid.
- **Control-plane API is single-region** (`checkHostAccess` / JWKS / `setOnline` via `NEXT_PUBLIC_API_URL`) — cached, but cold-cache first interactions for EU pay a trans-region RTT.
- **1 machine per region (`--max-per-region 1`)** — no EU headroom; saturation/deploy spills EU traffic to `iad`.
- **Synthetic latency telemetry is disabled in prod** — `RELAY_SYNTHETIC_JWT` isn't set on `superset-relay`, so `relay_synthetic_check` / `latency_ms` is never emitted. Setting it would give per-region latency series to measure changes like this one.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5019">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read the tunnel directory from regional replicas by disabling read-your-writes on the `@upstash/redis` client. This avoids sync-token blocking and reduces cross‑region latency, especially in EU and other non-primary regions.

<sup>Written for commit 5a9cceab5e7a6a611c896cb226883550168d4f4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal system configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->