### PR TITLE
fix(desktop): refit terminal after single-shot window grow (#5021)

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Reproduction tests for issue #5021:
+ * "Terminal stays narrow after the window grows back."
+ *
+ * Resize the Superset window to ~half the screen and the terminal reflows
+ * correctly to the narrower width. Grow it back to full / maximize and the
+ * terminal stays at the old narrow width — only the left half is used.
+ *
+ * Root cause: the v1 cache ResizeObserver ran a single SYNCHRONOUS
+ * `fitAddon.fit()` per event. `fit()` computes `cols = floor(parentWidth /
+ * cellWidth)` from the parent's computed width at call time. Shrinking is a
+ * continuous drag (many events; the last lands after layout settles), but a
+ * maximize / fullscreen is effectively one large grow event. The single
+ * synchronous fit reads intermediate/stale geometry (layout not flushed, WebGL
+ * cell metrics not refreshed) and latches a too-small `cols`. Because the
+ * observed container is already at its final width, no further event fires to
+ * correct it.
+ *
+ * Fix: fit immediately (snappy shrink) AND re-fit on the next animation frame
+ * so a single-shot grow re-reads the settled geometry.
+ */
+import { describe, expect, it } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Minimal model of the deferred-refit ResizeObserver handler in
+// v1-terminal-cache.ts `attachToContainer`. The "terminal" exposes a stale
+// geometry on the synchronous read and the settled geometry on the next frame,
+// mirroring how layout/cell metrics lag a single-shot grow event.
+// ---------------------------------------------------------------------------
+
+const CELL_WIDTH = 10;
+
+function makeHarness(opts: {
+	/** Width visible to the synchronous fit (intermediate, lags on grow). */
+	staleWidth: number;
+	/** Width visible once the next frame settles. */
+	settledWidth: number;
+}) {
+	const state = {
+		cols: opts.staleWidth / CELL_WIDTH,
+		resizeRafId: null as number | null,
+		// Switches from stale -> settled when the rAF callback runs.
+		settled: false,
+		onResizeCalls: 0,
+	};
+
+	const pendingRafs: Array<() => void> = [];
+	const requestAnimationFrame = (cb: () => void): number => {
+		pendingRafs.push(cb);
+		return pendingRafs.length;
+	};
+	const cancelAnimationFrame = (_id: number) => {};
+
+	const fitAndRefresh = (): boolean => {
+		const width = state.settled ? opts.settledWidth : opts.staleWidth;
+		const nextCols = width / CELL_WIDTH;
+		const changed = nextCols !== state.cols;
+		state.cols = nextCols;
+		return changed;
+	};
+
+	// Mirrors the production ResizeObserver callback.
+	const onResizeEvent = () => {
+		const changedNow = fitAndRefresh();
+		if (state.resizeRafId !== null) cancelAnimationFrame(state.resizeRafId);
+		state.resizeRafId = requestAnimationFrame(() => {
+			state.resizeRafId = null;
+			state.settled = true;
+			const changedLater = fitAndRefresh();
+			if (changedNow || changedLater) state.onResizeCalls++;
+		});
+	};
+
+	const flushFrame = () => {
+		const cbs = pendingRafs.splice(0);
+		for (const cb of cbs) cb();
+	};
+
+	return { state, onResizeEvent, flushFrame };
+}
+
+describe("v1-terminal-cache deferred resize refit (#5021)", () => {
+	it("re-fits to full width after a single-shot grow whose sync read is stale", () => {
+		// Window grows from half (600px) to full (1200px), but the synchronous
+		// fit only sees the half width — the settled full width is visible next
+		// frame.
+		const h = makeHarness({ staleWidth: 600, settledWidth: 1200 });
+
+		h.onResizeEvent();
+		// Synchronous fit alone would leave the terminal stuck at 60 cols.
+		expect(h.state.cols).toBe(60);
+
+		h.flushFrame();
+		// Deferred refit reads the settled width → full 120 cols.
+		expect(h.state.cols).toBe(120);
+		expect(h.state.onResizeCalls).toBe(1);
+		expect(h.state.resizeRafId).toBeNull();
+	});
+
+	it("notifies the backend even when only the deferred fit changes dims", () => {
+		// Sync read sees no change (still half), settled read grows.
+		const h = makeHarness({ staleWidth: 600, settledWidth: 1200 });
+		h.state.cols = 60; // already at the stale width
+
+		h.onResizeEvent();
+		expect(h.state.onResizeCalls).toBe(0); // not until the frame settles
+
+		h.flushFrame();
+		expect(h.state.cols).toBe(120);
+		expect(h.state.onResizeCalls).toBe(1);
+	});
+
+	it("does not notify when neither the sync nor deferred fit changes dims", () => {
+		const h = makeHarness({ staleWidth: 1200, settledWidth: 1200 });
+		h.state.cols = 120;
+
+		h.onResizeEvent();
+		h.flushFrame();
+
+		expect(h.state.cols).toBe(120);
+		expect(h.state.onResizeCalls).toBe(0);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.test.ts
@@ -44,12 +44,19 @@ function makeHarness(opts: {
 		onResizeCalls: 0,
 	};
 
-	const pendingRafs: Array<() => void> = [];
+	// Model rAF faithfully: ids are stable and cancel removes the pending
+	// callback, so back-to-back events reproduce production's "last rAF wins"
+	// behaviour rather than queueing every callback.
+	const pendingRafs = new Map<number, () => void>();
+	let nextRafId = 0;
 	const requestAnimationFrame = (cb: () => void): number => {
-		pendingRafs.push(cb);
-		return pendingRafs.length;
+		const id = ++nextRafId;
+		pendingRafs.set(id, cb);
+		return id;
 	};
-	const cancelAnimationFrame = (_id: number) => {};
+	const cancelAnimationFrame = (id: number) => {
+		pendingRafs.delete(id);
+	};
 
 	const fitAndRefresh = (): boolean => {
 		const width = state.settled ? opts.settledWidth : opts.staleWidth;
@@ -72,7 +79,8 @@ function makeHarness(opts: {
 	};
 
 	const flushFrame = () => {
-		const cbs = pendingRafs.splice(0);
+		const cbs = [...pendingRafs.values()];
+		pendingRafs.clear();
 		for (const cb of cbs) cb();
 	};
 
@@ -108,6 +116,21 @@ describe("v1-terminal-cache deferred resize refit (#5021)", () => {
 		h.flushFrame();
 		expect(h.state.cols).toBe(120);
 		expect(h.state.onResizeCalls).toBe(1);
+	});
+
+	it("collapses rapid back-to-back events into a single deferred refit", () => {
+		// Two events arrive before a frame is flushed. The second must cancel
+		// the first's pending rAF so only one deferred refit (and one backend
+		// notification) runs — guarding the last-rAF-wins invariant.
+		const h = makeHarness({ staleWidth: 600, settledWidth: 1200 });
+
+		h.onResizeEvent();
+		h.onResizeEvent();
+
+		h.flushFrame();
+		expect(h.state.cols).toBe(120);
+		expect(h.state.onResizeCalls).toBe(1);
+		expect(h.state.resizeRafId).toBeNull();
 	});
 
 	it("does not notify when neither the sync nor deferred fit changes dims", () => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.test.ts
@@ -42,6 +42,9 @@ function makeHarness(opts: {
 		// Switches from stale -> settled when the rAF callback runs.
 		settled: false,
 		onResizeCalls: 0,
+		// Mirrors `CachedTerminal.pendingResizeChange`: lives on the entry so the
+		// signal survives both rAF cancellation and a detach/reattach cycle.
+		pendingChange: false,
 	};
 
 	// Model rAF faithfully: ids are stable and cancel removes the pending
@@ -66,22 +69,39 @@ function makeHarness(opts: {
 		return changed;
 	};
 
-	// Mirrors the production ResizeObserver callback. `pendingChange` lives
-	// outside the handler so a dimension change survives rAF cancellation by a
-	// later event (otherwise the backend notification would be lost).
-	let pendingChange = false;
+	// Mirrors the production ResizeObserver callback. `state.pendingChange` lives
+	// on the entry so a dimension change survives rAF cancellation by a later
+	// event (otherwise the backend notification would be lost).
 	const onResizeEvent = () => {
-		if (fitAndRefresh()) pendingChange = true;
+		if (fitAndRefresh()) state.pendingChange = true;
 		if (state.resizeRafId !== null) cancelAnimationFrame(state.resizeRafId);
 		state.resizeRafId = requestAnimationFrame(() => {
 			state.resizeRafId = null;
 			state.settled = true;
-			if (fitAndRefresh()) pendingChange = true;
-			if (pendingChange) {
-				pendingChange = false;
+			if (fitAndRefresh()) state.pendingChange = true;
+			if (state.pendingChange) {
+				state.pendingChange = false;
 				state.onResizeCalls++;
 			}
 		});
+	};
+
+	// Mirrors detachFromContainer: cancels the pending rAF but deliberately
+	// preserves `pendingChange` so reattach can flush it.
+	const detach = () => {
+		if (state.resizeRafId !== null) {
+			cancelAnimationFrame(state.resizeRafId);
+			state.resizeRafId = null;
+		}
+	};
+
+	// Mirrors attachToContainer's reattach flush.
+	const reattach = () => {
+		if (fitAndRefresh()) state.pendingChange = true;
+		if (state.pendingChange) {
+			state.pendingChange = false;
+			state.onResizeCalls++;
+		}
 	};
 
 	const flushFrame = () => {
@@ -90,7 +110,7 @@ function makeHarness(opts: {
 		for (const cb of cbs) cb();
 	};
 
-	return { state, onResizeEvent, flushFrame };
+	return { state, onResizeEvent, detach, reattach, flushFrame };
 }
 
 describe("v1-terminal-cache deferred resize refit (#5021)", () => {
@@ -153,6 +173,27 @@ describe("v1-terminal-cache deferred resize refit (#5021)", () => {
 		h.flushFrame(); // deferred fit: 80 -> 80 (no change)
 		expect(h.state.cols).toBe(80);
 		expect(h.state.onResizeCalls).toBe(1);
+	});
+
+	it("flushes a pending resize on reattach when a detach cancelled its rAF", () => {
+		// Regression for #5022 (CodeRabbit Major): the synchronous fit changed
+		// dims (xterm adopted the new size) but a tab switch detached and
+		// cancelled the deferred rAF before onResize fired. On reattach — with
+		// the container unchanged so the reattach fit reports no change — the
+		// backend must STILL be reconciled from the preserved pending signal.
+		const h = makeHarness({ staleWidth: 800, settledWidth: 800 });
+		h.state.cols = 120; // backend/xterm currently at the wide width
+
+		h.onResizeEvent(); // sync fit: 120 -> 80 (changed), rAF scheduled
+		expect(h.state.cols).toBe(80);
+		expect(h.state.onResizeCalls).toBe(0); // not delivered yet
+
+		h.detach(); // cancels the rAF; pendingChange preserved
+		expect(h.state.onResizeCalls).toBe(0);
+
+		h.reattach(); // container unchanged -> fit no-op, but pending flushes
+		expect(h.state.onResizeCalls).toBe(1);
+		expect(h.state.pendingChange).toBe(false);
 	});
 
 	it("does not notify when neither the sync nor deferred fit changes dims", () => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.test.ts
@@ -66,15 +66,21 @@ function makeHarness(opts: {
 		return changed;
 	};
 
-	// Mirrors the production ResizeObserver callback.
+	// Mirrors the production ResizeObserver callback. `pendingChange` lives
+	// outside the handler so a dimension change survives rAF cancellation by a
+	// later event (otherwise the backend notification would be lost).
+	let pendingChange = false;
 	const onResizeEvent = () => {
-		const changedNow = fitAndRefresh();
+		if (fitAndRefresh()) pendingChange = true;
 		if (state.resizeRafId !== null) cancelAnimationFrame(state.resizeRafId);
 		state.resizeRafId = requestAnimationFrame(() => {
 			state.resizeRafId = null;
 			state.settled = true;
-			const changedLater = fitAndRefresh();
-			if (changedNow || changedLater) state.onResizeCalls++;
+			if (fitAndRefresh()) pendingChange = true;
+			if (pendingChange) {
+				pendingChange = false;
+				state.onResizeCalls++;
+			}
 		});
 	};
 
@@ -131,6 +137,22 @@ describe("v1-terminal-cache deferred resize refit (#5021)", () => {
 		expect(h.state.cols).toBe(120);
 		expect(h.state.onResizeCalls).toBe(1);
 		expect(h.state.resizeRafId).toBeNull();
+	});
+
+	it("does not drop a dimension change when a later event cancels its rAF", () => {
+		// Regression for #5022 (cubic P1): event 1's synchronous fit changes
+		// dims, event 2's fit sees no further change and cancels event 1's
+		// pending rAF, and the deferred fit also sees no change. The backend
+		// must STILL be notified — the change from event 1 must not be lost.
+		const h = makeHarness({ staleWidth: 800, settledWidth: 800 });
+		h.state.cols = 120; // backend/xterm currently at the wide width
+
+		h.onResizeEvent(); // sync fit: 120 -> 80 (changed)
+		h.onResizeEvent(); // sync fit: 80 -> 80 (no change), cancels prior rAF
+
+		h.flushFrame(); // deferred fit: 80 -> 80 (no change)
+		expect(h.state.cols).toBe(80);
+		expect(h.state.onResizeCalls).toBe(1);
 	});
 
 	it("does not notify when neither the sync nor deferred fit changes dims", () => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -175,6 +175,12 @@ export function attachToContainer(
 		cancelAnimationFrame(entry.resizeRafId);
 		entry.resizeRafId = null;
 	}
+	// Tracks whether any fit since the last delivered notification changed dims.
+	// Lives outside the callback so the signal survives rAF cancellation: when a
+	// later event cancels a pending deferred refit, the earlier event's
+	// dimension change must not be lost (otherwise the backend PTY never learns
+	// about it and ends up out of sync with xterm).
+	let pendingResizeChange = false;
 	const observer = new ResizeObserver(() => {
 		// Fit immediately so shrinking the window stays snappy, then re-fit on
 		// the next frame. A single-shot grow (window maximize / native
@@ -184,20 +190,19 @@ export function attachToContainer(
 		// its final size no further event arrives to correct it — leaving the
 		// terminal stuck at the old narrow width. The deferred refit re-reads
 		// the settled geometry. (superset-sh/superset#5021)
-		const changedNow = fitAndRefresh(entry);
+		if (fitAndRefresh(entry)) pendingResizeChange = true;
 		if (entry.resizeRafId !== null) {
 			cancelAnimationFrame(entry.resizeRafId);
 		}
 		// onResize (backend PTY resize) is intentionally deferred to the rAF
-		// rather than fired here: the deferred fit is authoritative, so we send
-		// one notification with the settled dims. `changedNow` is still carried
-		// in so a grow that only the synchronous fit caught (deferred read sees
-		// no further change) is not dropped. Cost is a ~1-frame PTY-resize delay
-		// on continuous drags, which is imperceptible.
+		// rather than fired synchronously: the deferred fit is authoritative, so
+		// we send a single notification with the settled dims. Cost is a
+		// ~1-frame PTY-resize delay on continuous drags, which is imperceptible.
 		entry.resizeRafId = requestAnimationFrame(() => {
 			entry.resizeRafId = null;
-			const changedLater = fitAndRefresh(entry);
-			if (changedNow || changedLater) {
+			if (fitAndRefresh(entry)) pendingResizeChange = true;
+			if (pendingResizeChange) {
+				pendingResizeChange = false;
 				onResize?.();
 			}
 		});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -57,6 +57,15 @@ export interface CachedTerminal {
 	resizeObserver: ResizeObserver | null;
 	/** Pending rAF id for the deferred resize refit. Cancelled on detach/dispose. */
 	resizeRafId: number | null;
+	/**
+	 * True when a synchronous fit has changed dims but the backend PTY has not
+	 * yet been notified (the deferred rAF hasn't delivered onResize). Lives on
+	 * the entry — not in the attach closure — so the signal survives both rAF
+	 * cancellation by a later event AND a detach/reattach cycle. Without this,
+	 * switching tabs mid-resize would drop the notification and leave the PTY
+	 * out of sync with xterm. Cleared once onResize is delivered.
+	 */
+	pendingResizeChange: boolean;
 	/** Live container, when attached. */
 	container: HTMLDivElement | null;
 }
@@ -133,6 +142,7 @@ export function getOrCreate(
 		subscriptionErrorHandler: null,
 		resizeObserver: null,
 		resizeRafId: null,
+		pendingResizeChange: false,
 		container: null,
 		lastCols: xterm.cols,
 		lastRows: xterm.rows,
@@ -157,7 +167,15 @@ export function attachToContainer(
 
 	// Refit and repaint on reattach because the wrapper may have been parked
 	// while its live container changed size.
-	fitAndRefresh(entry);
+	if (fitAndRefresh(entry)) entry.pendingResizeChange = true;
+	// Flush any resize whose backend notification was dropped: a synchronous fit
+	// can change xterm's size while its deferred onResize is still pending, and a
+	// detach (tab switch mid-resize) then cancels that rAF. Reconcile the PTY on
+	// reattach so it never stays out of sync with xterm. (#5022)
+	if (entry.pendingResizeChange) {
+		entry.pendingResizeChange = false;
+		onResize?.();
+	}
 	// xterm's initial cell-width measurement may have run before the configured
 	// font finished loading, baking wrong glyph metrics into the renderer
 	// (#4617). Refit once fonts are ready so the layout matches the rendered
@@ -175,12 +193,6 @@ export function attachToContainer(
 		cancelAnimationFrame(entry.resizeRafId);
 		entry.resizeRafId = null;
 	}
-	// Tracks whether any fit since the last delivered notification changed dims.
-	// Lives outside the callback so the signal survives rAF cancellation: when a
-	// later event cancels a pending deferred refit, the earlier event's
-	// dimension change must not be lost (otherwise the backend PTY never learns
-	// about it and ends up out of sync with xterm).
-	let pendingResizeChange = false;
 	const observer = new ResizeObserver(() => {
 		// Fit immediately so shrinking the window stays snappy, then re-fit on
 		// the next frame. A single-shot grow (window maximize / native
@@ -190,7 +202,13 @@ export function attachToContainer(
 		// its final size no further event arrives to correct it — leaving the
 		// terminal stuck at the old narrow width. The deferred refit re-reads
 		// the settled geometry. (superset-sh/superset#5021)
-		if (fitAndRefresh(entry)) pendingResizeChange = true;
+		//
+		// `entry.pendingResizeChange` (not a local) accumulates the "dims
+		// changed" signal so it survives the rAF cancellation below — when a
+		// later event cancels a pending deferred refit, the earlier event's
+		// change must not be lost — and a detach/reattach in between (flushed in
+		// attachToContainer above). (#5022)
+		if (fitAndRefresh(entry)) entry.pendingResizeChange = true;
 		if (entry.resizeRafId !== null) {
 			cancelAnimationFrame(entry.resizeRafId);
 		}
@@ -200,9 +218,9 @@ export function attachToContainer(
 		// ~1-frame PTY-resize delay on continuous drags, which is imperceptible.
 		entry.resizeRafId = requestAnimationFrame(() => {
 			entry.resizeRafId = null;
-			if (fitAndRefresh(entry)) pendingResizeChange = true;
-			if (pendingResizeChange) {
-				pendingResizeChange = false;
+			if (fitAndRefresh(entry)) entry.pendingResizeChange = true;
+			if (entry.pendingResizeChange) {
+				entry.pendingResizeChange = false;
 				onResize?.();
 			}
 		});
@@ -224,6 +242,9 @@ export function detachFromContainer(paneId: string): void {
 		cancelAnimationFrame(entry.resizeRafId);
 		entry.resizeRafId = null;
 	}
+	// Deliberately preserve `entry.pendingResizeChange`: if the cancelled rAF
+	// still owed an onResize, attachToContainer flushes it on reattach so the
+	// backend PTY is reconciled. (#5022)
 	entry.container = null;
 	// Park instead of .remove() so xterm survives the React unmount —
 	// see getTerminalParkingContainer.

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -188,6 +188,12 @@ export function attachToContainer(
 		if (entry.resizeRafId !== null) {
 			cancelAnimationFrame(entry.resizeRafId);
 		}
+		// onResize (backend PTY resize) is intentionally deferred to the rAF
+		// rather than fired here: the deferred fit is authoritative, so we send
+		// one notification with the settled dims. `changedNow` is still carried
+		// in so a grow that only the synchronous fit caught (deferred read sees
+		// no further change) is not dropped. Cost is a ~1-frame PTY-resize delay
+		// on continuous drags, which is imperceptible.
 		entry.resizeRafId = requestAnimationFrame(() => {
 			entry.resizeRafId = null;
 			const changedLater = fitAndRefresh(entry);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -55,6 +55,8 @@ export interface CachedTerminal {
 	subscriptionErrorHandler: ((error: unknown) => void) | null;
 	/** ResizeObserver for the attached container. Managed by attach/detach. */
 	resizeObserver: ResizeObserver | null;
+	/** Pending rAF id for the deferred resize refit. Cancelled on detach/dispose. */
+	resizeRafId: number | null;
 	/** Live container, when attached. */
 	container: HTMLDivElement | null;
 }
@@ -130,6 +132,7 @@ export function getOrCreate(
 		eventHandler: null,
 		subscriptionErrorHandler: null,
 		resizeObserver: null,
+		resizeRafId: null,
 		container: null,
 		lastCols: xterm.cols,
 		lastRows: xterm.rows,
@@ -168,10 +171,30 @@ export function attachToContainer(
 
 	// Manage ResizeObserver lifecycle in the cache, not in React.
 	entry.resizeObserver?.disconnect();
+	if (entry.resizeRafId !== null) {
+		cancelAnimationFrame(entry.resizeRafId);
+		entry.resizeRafId = null;
+	}
 	const observer = new ResizeObserver(() => {
-		if (fitAndRefresh(entry)) {
-			onResize?.();
+		// Fit immediately so shrinking the window stays snappy, then re-fit on
+		// the next frame. A single-shot grow (window maximize / native
+		// fullscreen) delivers one ResizeObserver event before layout and the
+		// WebGL renderer's cell metrics have settled; the synchronous fit then
+		// latches a too-small `cols`, and because the container is already at
+		// its final size no further event arrives to correct it — leaving the
+		// terminal stuck at the old narrow width. The deferred refit re-reads
+		// the settled geometry. (superset-sh/superset#5021)
+		const changedNow = fitAndRefresh(entry);
+		if (entry.resizeRafId !== null) {
+			cancelAnimationFrame(entry.resizeRafId);
 		}
+		entry.resizeRafId = requestAnimationFrame(() => {
+			entry.resizeRafId = null;
+			const changedLater = fitAndRefresh(entry);
+			if (changedNow || changedLater) {
+				onResize?.();
+			}
+		});
 	});
 	observer.observe(container);
 	entry.resizeObserver = observer;
@@ -186,6 +209,10 @@ export function detachFromContainer(paneId: string): void {
 	}
 	entry.resizeObserver?.disconnect();
 	entry.resizeObserver = null;
+	if (entry.resizeRafId !== null) {
+		cancelAnimationFrame(entry.resizeRafId);
+		entry.resizeRafId = null;
+	}
 	entry.container = null;
 	// Park instead of .remove() so xterm survives the React unmount —
 	// see getTerminalParkingContainer.
@@ -362,6 +389,10 @@ export function dispose(paneId: string): void {
 	}
 
 	entry.resizeObserver?.disconnect();
+	if (entry.resizeRafId !== null) {
+		cancelAnimationFrame(entry.resizeRafId);
+		entry.resizeRafId = null;
+	}
 	entry.subscription?.unsubscribe();
 	entry.cleanupCreation();
 	entry.wrapper.remove();


### PR DESCRIPTION
## Summary

Fixes #5021 — after resizing the Superset window to ~half the screen and then growing it back to full / fullscreen, the terminal text stays stuck at the old narrow width (only the left half is used) until a forced re-layout (tab switch, fullscreen toggle, font change).

## Root cause

The live terminal uses the v1 cache path. Its `ResizeObserver` ran a single **synchronous** `fitAddon.fit()` per event:

```ts
const observer = new ResizeObserver(() => {
  if (fitAndRefresh(entry)) onResize?.();
});
```

`FitAddon.fit()` computes `cols = floor(parentWidth / cellWidth)` from the parent's *computed* width at call time.

- **Shrinking** the window is a continuous drag → many ResizeObserver events; the last lands after layout settles, so `cols` ends up correct.
- **Maximize / fullscreen** is effectively a single large grow event. The one synchronous `fit()` reads intermediate/stale geometry (layout not yet flushed, WebGL renderer `css.cell` metrics not refreshed for the new frame) and latches a too-small `cols`. Because the observed container is already at its final full width, **no further ResizeObserver event fires** to correct it → stuck narrow.

The deferred-fit safety net (`scheduleFontSettleRefit`) existed only on the **attach** path, and PR #3469's rAF retry was for the v2 runtime — the v1 `ResizeObserver` path had no equivalent deferral. This is also why a tab switch / fullscreen toggle 'fixes' it (those re-run the deferred fit), matching the recovery behavior in #3281.

Related upstream FitAddon issues: xtermjs/xterm.js#5320, #4841, #3584, #3564.

## Fix

In the v1 cache `ResizeObserver`, fit immediately (keeps shrink snappy) **and** re-fit on the next animation frame so single-shot grows re-read the settled geometry. `onResize` (backend PTY resize) fires once after the deferred fit if either fit changed dims. The pending rAF is cancelled in `detachFromContainer` and `dispose`.

## Test plan

- [x] Added co-located regression test `v1-terminal-cache.test.ts` (minimal model of the deferred-refit handler): a single-shot grow whose synchronous read is stale ends up at full width after the frame settles; backend is notified when only the deferred fit changes dims; no notification when nothing changes. `bun test` → 3 pass.
- [x] `biome check` clean on changed files.
- [ ] Manual: shrink the window to half, then maximize / go fullscreen — terminal fills the full width without needing a tab switch.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5022">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5021. Ensures the desktop terminal refits after a single-shot window grow (maximize/fullscreen) so it uses the full width, while keeping shrink responsive. Also preserves and flushes pending PTY resize notifications across rAF cancellations and detach/reattach.

- **Bug Fixes**
  - `ResizeObserver` now fits immediately and again on the next animation frame; `onResize` fires once after the deferred fit if any pass changed size, and the change signal survives rAF cancellations and reattach.
  - Cancel any pending `requestAnimationFrame` on attach, detach, and dispose to prevent leaks and duplicate refits.
  - Expanded regression tests: model rAF ids/cancellation, add a back-to-back resize test for a single deferred refit/notification, a test to ensure a size change isn’t dropped when a later event cancels the rAF, and a detach/reattach test that flushes a pending resize after a cancelled rAF.

<sup>Written for commit 65320281fd6f574e5da02da307374f93d1c2378f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal resizing now reliably updates after rapid or deferred layout changes; canceled or stale pending refits no longer cause incorrect sizing or stale updates.
  * Size-change notifications are emitted only when visible terminal dimensions actually change.
  * Pending deferred resizes are canceled on detach/dispose, and preserved pending signals trigger a single notification on reattach.

* **Tests**
  * Added tests covering synchronous vs. deferred resize flows, rapid successive resizes, cancellation behavior, reattach flushes, and notification conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->