### PR TITLE
Prevent tab button from stealing focus

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.11.3",
+      "version": "1.12.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -769,7 +769,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.15",
+      "version": "0.8.17",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -123,7 +123,10 @@ export function TabItem<TData>({
 						isDragging && "opacity-30",
 					)}
 					onMouseDown={(event) => {
-						if (event.button === 0) onSelect();
+						if (event.button === 0) {
+							event.preventDefault();
+							onSelect();
+						}
 					}}
 				>
 					{isEditing ? (
@@ -217,3 +220,4 @@ export function TabItem<TData>({
 		</ContextMenu>
 	);
 }
+

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -220,4 +220,3 @@ export function TabItem<TData>({
 		</ContextMenu>
 	);
 }
-


### PR DESCRIPTION
## Summary

Addresses part of #4967 by preventing the tab button from receiving focus when a user clicks a tab.

Currently, clicking a horizontal tab causes browser focus to move to the tab button element. As a result, the next keyboard input is captured by the tab rather than the active terminal/chat pane.

This change adds `event.preventDefault()` to the tab's `onMouseDown` handler before selecting the tab, preventing the button from stealing focus.

## Changes

* Added `event.preventDefault()` in `TabItem.tsx`
* Preserved existing tab selection behavior
* Prevented browser focus from moving to the tab button on left-click

## Notes

This is a focused fix for the focus-stealing behavior described in #4967.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5025">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents tab buttons from taking focus on left-click so keyboard input stays in the active terminal/chat pane. Addresses #4967 by keeping focus in the active pane while still selecting the tab.

- **Bug Fixes**
  - Call event.preventDefault() in TabItem’s onMouseDown (primary click) before onSelect.
  - Keeps tab selection; focus remains on the active pane.

- **Refactors**
  - Removed trailing blank line in TabItem (lint).

<sup>Written for commit 9aad81a0eb7593709a5051952aa68b615b71971d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tab selection now only responds to the primary (left) mouse button and suppresses default browser behavior before selecting. This reduces accidental selections from other mouse buttons and prevents unintended browser actions (like native drag/focus) when clicking tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->