### PR TITLE
feat(desktop): track setup-script configuration in PostHog

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
@@ -18,7 +18,7 @@ import {
 	removeWorktree,
 	sanitizeGitError,
 } from "./git";
-import { copySupersetConfigToWorktree } from "./setup";
+import { copySupersetConfigToWorktree, loadSetupConfig } from "./setup";
 
 export interface WorkspaceInitParams {
 	workspaceId: string;
@@ -92,6 +92,16 @@ export async function initializeWorkspaceWorktree({
 			.from(projects)
 			.where(eq(projects.id, projectId))
 			.get();
+
+		// Coverage signal for the workspace_initialized event: does this project
+		// have any setup/teardown/run script configured?
+		const setupConfig = loadSetupConfig({ mainRepoPath, projectId });
+		const hasSetupScript = Boolean(
+			setupConfig &&
+				((setupConfig.setup?.length ?? 0) > 0 ||
+					(setupConfig.teardown?.length ?? 0) > 0 ||
+					(setupConfig.run?.length ?? 0) > 0),
+		);
 
 		const {
 			compareBaseBranch: configuredCompareBaseBranch,
@@ -180,6 +190,7 @@ export async function initializeWorkspaceWorktree({
 				branch,
 				base_branch: effectiveCompareBaseBranch,
 				use_existing_branch: true,
+				has_setup_script: hasSetupScript,
 			});
 
 			return;
@@ -525,6 +536,7 @@ export async function initializeWorkspaceWorktree({
 			project_id: projectId,
 			branch,
 			base_branch: effectiveCompareBaseBranch,
+			has_setup_script: hasSetupScript,
 		});
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);

--- a/apps/desktop/src/renderer/lib/project-scripts.ts
+++ b/apps/desktop/src/renderer/lib/project-scripts.ts
@@ -15,11 +15,32 @@ export async function invalidateProjectScriptQueries(
 	]);
 }
 
+const SCRIPT_KINDS = ["setup", "teardown", "run"] as const;
+
+/**
+ * Count configured commands consistently across surfaces. Some editors persist
+ * each command as its own array element (line-split), while others store the
+ * whole textarea as a single multi-line element — so we count non-empty lines
+ * across all elements rather than the raw array length.
+ */
+function countCommands(commands: string[] | undefined): number {
+	return (commands ?? [])
+		.flatMap((command) => command.split("\n"))
+		.filter((line) => line.trim().length > 0).length;
+}
+
 /**
  * Fire a PostHog event when a user saves a project setup/teardown/run script.
  * Called from every updateConfig save site (v1 settings, v2 settings, and the
  * save-and-create-workspace flow) so setup-script adoption is tracked across
  * all surfaces from one place.
+ *
+ * Only emits metrics for the script kinds the caller actually passed — a
+ * surface that doesn't edit `run` (e.g. save-and-create-workspace) omits the
+ * run_* properties instead of misreporting `has_run: false`.
+ *
+ * Never throws: analytics is non-critical and must not break the save path it
+ * is called from.
  */
 export function trackSetupScriptConfigured(input: {
 	projectId: string;
@@ -27,16 +48,21 @@ export function trackSetupScriptConfigured(input: {
 	teardown?: string[];
 	run?: string[];
 }): void {
-	const setup = input.setup ?? [];
-	const teardown = input.teardown ?? [];
-	const run = input.run ?? [];
-	track("setup_script_configured", {
-		project_id: input.projectId,
-		setup_command_count: setup.length,
-		teardown_command_count: teardown.length,
-		run_command_count: run.length,
-		has_setup: setup.length > 0,
-		has_teardown: teardown.length > 0,
-		has_run: run.length > 0,
-	});
+	try {
+		const properties: Record<string, unknown> = {
+			project_id: input.projectId,
+		};
+		for (const kind of SCRIPT_KINDS) {
+			if (input[kind] === undefined) continue;
+			const count = countCommands(input[kind]);
+			properties[`${kind}_command_count`] = count;
+			properties[`has_${kind}`] = count > 0;
+		}
+		track("setup_script_configured", properties);
+	} catch (error) {
+		console.error(
+			"[analytics] Failed to track setup_script_configured:",
+			error,
+		);
+	}
 }

--- a/apps/desktop/src/renderer/lib/project-scripts.ts
+++ b/apps/desktop/src/renderer/lib/project-scripts.ts
@@ -1,3 +1,4 @@
+import { track } from "renderer/lib/analytics";
 import type { electronTrpc } from "renderer/lib/electron-trpc";
 
 type ElectronTrpcUtils = ReturnType<typeof electronTrpc.useUtils>;
@@ -12,4 +13,30 @@ export async function invalidateProjectScriptQueries(
 		utils.workspaces.getWorkspaceRunDefinition.invalidate(),
 		utils.workspaces.getResolvedRunCommands.invalidate(),
 	]);
+}
+
+/**
+ * Fire a PostHog event when a user saves a project setup/teardown/run script.
+ * Called from every updateConfig save site (v1 settings, v2 settings, and the
+ * save-and-create-workspace flow) so setup-script adoption is tracked across
+ * all surfaces from one place.
+ */
+export function trackSetupScriptConfigured(input: {
+	projectId: string;
+	setup?: string[];
+	teardown?: string[];
+	run?: string[];
+}): void {
+	const setup = input.setup ?? [];
+	const teardown = input.teardown ?? [];
+	const run = input.run ?? [];
+	track("setup_script_configured", {
+		project_id: input.projectId,
+		setup_command_count: setup.length,
+		teardown_command_count: teardown.length,
+		run_command_count: run.length,
+		has_setup: setup.length > 0,
+		has_teardown: teardown.length > 0,
+		has_run: run.length > 0,
+	});
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
@@ -31,7 +31,10 @@ import {
 } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
-import { invalidateProjectScriptQueries } from "renderer/lib/project-scripts";
+import {
+	invalidateProjectScriptQueries,
+	trackSetupScriptConfigured,
+} from "renderer/lib/project-scripts";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { resolveEffectiveWorkspaceBaseBranch } from "renderer/lib/workspaceBaseBranch";
 import { useCreateWorkspace } from "renderer/react-query/workspaces";
@@ -267,6 +270,11 @@ function ProjectPage() {
 
 		try {
 			await updateConfigMutation.mutateAsync({
+				projectId,
+				setup: commands,
+				teardown: teardownCommands,
+			});
+			trackSetupScriptConfigured({
 				projectId,
 				setup: commands,
 				teardown: teardownCommands,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
@@ -274,6 +274,9 @@ function ProjectPage() {
 				setup: commands,
 				teardown: teardownCommands,
 			});
+			// This flow only edits setup/teardown — `run` is intentionally out of
+			// scope here, so it's omitted from the event rather than reported as
+			// absent.
 			trackSetupScriptConfigured({
 				projectId,
 				setup: commands,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ScriptsEditor/ScriptsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ScriptsEditor/ScriptsEditor.tsx
@@ -8,7 +8,10 @@ import {
 	HiDocumentArrowUp,
 } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { invalidateProjectScriptQueries } from "renderer/lib/project-scripts";
+import {
+	invalidateProjectScriptQueries,
+	trackSetupScriptConfigured,
+} from "renderer/lib/project-scripts";
 import { EXTERNAL_LINKS } from "shared/constants";
 
 interface ScriptsEditorProps {
@@ -259,6 +262,7 @@ export function ScriptsEditor({ projectId, className }: ScriptsEditorProps) {
 
 				await updateConfigMutation.mutateAsync(payload);
 				lastSavedPayloadRef.current = serializedPayload;
+				trackSetupScriptConfigured(payload);
 				await invalidateProjectScriptQueries(utils, projectId);
 			} while (saveQueuedRef.current);
 			setSaveStatus("saved");

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/V2ScriptsEditor/V2ScriptsEditor.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HiCheckCircle } from "react-icons/hi2";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { trackSetupScriptConfigured } from "renderer/lib/project-scripts";
 import { ScriptField } from "./components/ScriptField";
 
 interface V2ScriptsEditorProps {
@@ -195,6 +196,7 @@ export function V2ScriptsEditor({
 					if (!payloadsEqual(payloadToSave, lastSavedRef.current)) {
 						await updateMutation.mutateAsync({ projectId, ...payloadToSave });
 						lastSavedRef.current = payloadToSave;
+						trackSetupScriptConfigured({ projectId, ...payloadToSave });
 					}
 
 					payloadToSave = queuedPayloadRef.current;


### PR DESCRIPTION
## What

Adds PostHog analytics for **setup-script adoption**, which was previously not tracked anywhere (no event, no property, and no queryable DB field).

### A) `setup_script_configured` event — adoption
Fires whenever a user saves a setup/teardown/run script, via a shared `trackSetupScriptConfigured` helper called from **all three** save sites:
- v1 project settings (`ScriptsEditor`)
- v2 project settings (`V2ScriptsEditor`)
- the save-and-create-workspace flow (`project/$projectId/page.tsx`)

Properties: `project_id`, `setup_command_count`, `teardown_command_count`, `run_command_count`, `has_setup`, `has_teardown`, `has_run`.

### B) `has_setup_script` on `workspace_initialized` — coverage
Both emit sites now include `has_setup_script` (computed once via `loadSetupConfig`), so we can see what share of workspace runs use a setup script and which projects have one.

## Why
We had no way to answer "do users set up setup scripts for their projects?" from PostHog or Neon. This closes that gap on the desktop surfaces where setup scripts are authored.

## Scope / notes
- PostHog-only — **no schema change / migration**.
- The settings editors autosave on a debounce that diffs before saving, so the event fires once per actual change (not per keystroke).
- New events auto-appear in PostHog after the first capture.

## Testing
- `biome check` clean on all changed files
- `tsc --noEmit` passes for `@superset/desktop`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PostHog tracking for setup-script adoption in Desktop. Adds a new setup_script_configured event, includes has_setup_script on workspace_initialized for coverage, and makes tracking robust and consistent across editors.

- New Features
  - Added a shared trackSetupScriptConfigured helper, fired from v1 `ScriptsEditor`, v2 `V2ScriptsEditor`, and the create-workspace flow.
  - setup_script_configured properties: project_id, setup_command_count, teardown_command_count, run_command_count, has_setup, has_teardown, has_run.
  - Added has_setup_script to workspace_initialized, computed via loadSetupConfig and emitted from both initialization paths.

- Bug Fixes
  - trackSetupScriptConfigured is wrapped to never throw, so analytics can’t break saves.
  - Command counts are based on non-empty lines, ensuring consistent counts across v1 (textarea) and v2 (line-split) editors.
  - Only emits properties for script kinds provided by the caller; the create-workspace flow omits run_* instead of reporting has_run: false.

<sup>Written for commit 1529024d63db8674f57653efaf924fdb6ae72a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced telemetry to record when project setup/teardown/run scripts are configured from script editors and dashboard flows.
  * Workspace initialization events now include a flag indicating whether a setup script exists, improving analytics around setup usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->