### PR TITLE
docs(cli): document opening a specific agent session via deep link

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -640,11 +640,17 @@ chosen by the session `kind` returned by `agents run`:
 | `terminal` | `claude`, `codex` | `?terminalId=<sessionId>` |
 
 ```bash
+# Run the agent with --json, then pull kind + sessionId out of the payload:
+session=$(superset agents run --workspace ws_… --agent claude --prompt "…" --json)
+kind=$(echo "$session" | jq -r '.kind')           # "chat" or "terminal"
+sessionId=$(echo "$session" | jq -r '.sessionId')
+
+# Open the session using the query param that matches its kind:
 # chat session (kind: "chat")
-open "superset://v2-workspace/<workspaceId>?chatSessionId=<sessionId>"
+open "superset://v2-workspace/<workspaceId>?chatSessionId=$sessionId"
 
 # terminal session (kind: "terminal")
-open "superset://v2-workspace/<workspaceId>?terminalId=<sessionId>"
+open "superset://v2-workspace/<workspaceId>?terminalId=$sessionId"
 ```
 
 Append `&focusRequestId=<unique>` to force a re-focus when opening the same link

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -625,6 +625,33 @@ superset workspaces open ws_… --print
 ```
 </Command>
 
+#### Opening a specific session
+
+`workspaces open` targets a workspace, not a session. A session started with
+[`agents run`](#superset-agents-run) syncs to the desktop app but has no pane in
+the workspace view until you navigate to it — and there is no session list, so a
+freshly created session is effectively invisible until opened. `workspaces open`
+can't focus a session, so build the deep link yourself and append a query param
+chosen by the session `kind` returned by `agents run`:
+
+| `kind` | Example agents | Query param |
+| --- | --- | --- |
+| `chat` | `superset` | `?chatSessionId=<sessionId>` |
+| `terminal` | `claude`, `codex` | `?terminalId=<sessionId>` |
+
+```bash
+# chat session (kind: "chat")
+open "superset://v2-workspace/<workspaceId>?chatSessionId=<sessionId>"
+
+# terminal session (kind: "terminal")
+open "superset://v2-workspace/<workspaceId>?terminalId=<sessionId>"
+```
+
+Append `&focusRequestId=<unique>` to force a re-focus when opening the same link
+more than once. The session must belong to the workspace in the URL. On
+Linux/Windows substitute your platform's URL opener (`xdg-open`, `start`) for
+`open`.
+
 ---
 
 ### agents

--- a/skills/superset/SKILL.md
+++ b/skills/superset/SKILL.md
@@ -46,7 +46,38 @@ superset agents list --local                     # Same, for this machine
 superset agents run --workspace <id> --agent claude --prompt "..."
 ```
 
-`--agent` accepts a preset id (e.g. `claude`, `codex`) or a HostAgentConfig instance UUID. Pass `--attachment-id <uuid>` once per attachment. Use `agents list` first if you don't already know which agents are installed on the target host.
+`--agent` accepts a preset id (e.g. `claude`, `codex`), a HostAgentConfig instance UUID, or `superset` for a built-in Superset chat session. Pass `--attachment-id <uuid>` once per attachment. Use `agents list` first if you don't already know which agents are installed on the target host.
+
+`agents run --json` returns `{ kind, sessionId, label }`. `kind` is `chat` (the `superset` agent) or `terminal` (e.g. `claude`, `codex`) — you need it to build a session deep link (see [Opening sessions in the desktop app](#opening-sessions-in-the-desktop-app)).
+
+## Opening sessions in the desktop app
+
+`superset workspaces open <id>` opens a **workspace** in the desktop app — it fires the deep link `superset://v2-workspace/<id>`; add `--print` to print the URL instead.
+
+```bash
+superset workspaces open <workspace-id>
+superset workspaces open <workspace-id> --print
+```
+
+A session you start with `agents run` syncs to the desktop app but has **no pane** in the workspace view until you navigate to it, and there is no session list — so a freshly created session is effectively invisible until opened. `workspaces open` targets only the workspace and cannot focus a session, so build the deep link yourself and append a query param chosen by the session `kind`:
+
+| `kind` (from `agents run --json`) | Agents | Deep-link param |
+| --- | --- | --- |
+| `chat` | `superset` | `?chatSessionId=<sessionId>` |
+| `terminal` | `claude`, `codex` | `?terminalId=<sessionId>` |
+
+```bash
+# chat session (agent: superset)
+open "superset://v2-workspace/<workspace-id>?chatSessionId=<sessionId>"
+
+# terminal session (agent: claude, codex, …)
+open "superset://v2-workspace/<workspace-id>?terminalId=<sessionId>"
+
+# from inside a workspace, open your own terminal via the env vars
+open "superset://v2-workspace/$SUPERSET_WORKSPACE_ID?terminalId=$SUPERSET_TERMINAL_ID"
+```
+
+Add `&focusRequestId=<unique>` to force a re-focus when opening the same link repeatedly. The session must belong to the workspace in the URL. On Linux/Windows use your platform's URL opener (`xdg-open`, `start`) instead of `open`.
 
 ## Tasks
 

--- a/skills/superset/SKILL.md
+++ b/skills/superset/SKILL.md
@@ -55,8 +55,8 @@ superset agents run --workspace <id> --agent claude --prompt "..."
 `superset workspaces open <id>` opens a **workspace** in the desktop app — it fires the deep link `superset://v2-workspace/<id>`; add `--print` to print the URL instead.
 
 ```bash
-superset workspaces open <workspace-id>
-superset workspaces open <workspace-id> --print
+superset workspaces open <workspaceId>
+superset workspaces open <workspaceId> --print
 ```
 
 A session you start with `agents run` syncs to the desktop app but has **no pane** in the workspace view until you navigate to it, and there is no session list — so a freshly created session is effectively invisible until opened. `workspaces open` targets only the workspace and cannot focus a session, so build the deep link yourself and append a query param chosen by the session `kind`:
@@ -68,10 +68,10 @@ A session you start with `agents run` syncs to the desktop app but has **no pane
 
 ```bash
 # chat session (agent: superset)
-open "superset://v2-workspace/<workspace-id>?chatSessionId=<sessionId>"
+open "superset://v2-workspace/<workspaceId>?chatSessionId=<sessionId>"
 
 # terminal session (agent: claude, codex, …)
-open "superset://v2-workspace/<workspace-id>?terminalId=<sessionId>"
+open "superset://v2-workspace/<workspaceId>?terminalId=<sessionId>"
 
 # from inside a workspace, open your own terminal via the env vars
 open "superset://v2-workspace/$SUPERSET_WORKSPACE_ID?terminalId=$SUPERSET_TERMINAL_ID"


### PR DESCRIPTION
## Summary
- Document the previously-undocumented `superset://v2-workspace/<id>` deep-link query params used to focus a **specific agent session** in the desktop app (#5029): `?chatSessionId=` (chat sessions), `?terminalId=` (terminal sessions), and optional `&focusRequestId=` to force a re-focus.
- `apps/docs/content/docs/cli/cli-reference.mdx`: new "Opening a specific session" subsection under `workspaces open`, with the `kind`→param mapping from `agents run --json`, bash examples, and a cross-platform opener note.
- `skills/superset/SKILL.md`: new "Opening sessions in the desktop app" section (same scheme/table/examples plus the `$SUPERSET_WORKSPACE_ID`/`$SUPERSET_TERMINAL_ID` shortcut and the "fresh session is invisible until opened" gotcha), an `--agent superset` mention, and a `kind` note in the Agents section.

## Why / Context
`superset workspaces open <id>` only ever targets a **workspace** — it fires `superset://v2-workspace/<id>` with no query string, and a session created via `agents run` has no pane and no session-list entry until you navigate to it, so a freshly created session is effectively invisible. The desktop route already parses `chatSessionId`/`terminalId`/`focusRequestId` and focuses/adds the matching pane, but the only way to use it was to hand-build the URL — and that was undocumented. This PR documents the workflow.

## Verification (docs vs. source)
Every command, URL, param, and the `kind`→param mapping was checked against the code:
- Bare URL + `--print`: `packages/cli/src/commands/workspaces/open/command.ts`
- `agents run --json` → `{ kind, sessionId, label }`; `kind` is `chat` for `superset`, `terminal` for `claude`/`codex`: `packages/cli/src/commands/agents/run/command.ts` + host-service `agents.ts` (`input.agent === "superset"` → `runChatAgent`)
- `validateSearch` parses all three params and the pane is focused/added with workspace-ownership enforced: desktop `v2-workspace/$workspaceId` route + `useConsumeAutomationRunLink` (`focusRequestId` is part of the consume key, so it forces re-focus)
- Cross-platform opener (`open` / `xdg-open` / `start`) matches the CLI's own `openUrl` platform branching.

## Testing
- Docs-only; reviewed rendered MDX (tables, fenced code, anchors). Both cross-reference anchors resolve.
- Biome ignores `.md`/`.mdx`, so no lint impact.

## Notes
- The `SKILL.md` edit lands in one tracked file but applies in three places: `plugins/superset/skills/superset` is a symlink to `skills/superset`, and the marketing `.well-known/agent-skills` route reads `skills/superset/SKILL.md` dynamically — so the bundled plugin and the served skill stay in sync with no duplicate blobs.
- Opened from a fork (`robertn702:adorable-chimpanzee`) as the author lacks direct push access.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5032">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document deep links for opening a specific agent session in the desktop app. CLI docs and `skills/superset/SKILL.md` now show how to build `superset://v2-workspace/<workspaceId>` URLs with `?chatSessionId=`/`?terminalId=` (optional `&focusRequestId=`), include the `kind`→param mapping with a bash `--json` round-trip example, and align placeholder casing and opener notes.

<sup>Written for commit cdb79447c4e9b90a92f90dd80d96d22135ed9b0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for opening specific agent sessions from the CLI, including how to deep-link to chat vs. terminal sessions
  * Documented response fields used to construct session links and provided example deep-link URLs and query parameters
  * Added note to append a focusRequestId when reopening the same link and platform-specific URL-opener tips for Linux/Windows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->