### PR TITLE
fix(relay): return tRPC error envelopes for failed tRPC requests

### DIFF
--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
@@ -10,6 +10,7 @@ import * as directory from "./directory";
 import { env } from "./env";
 import { captureSentryException, initSentry } from "./sentry";
 import { startSyntheticCheck } from "./synthetic";
+import { isTrpcPath, trpcErrorResponse } from "./trpc-error";
 import { TunnelManager } from "./tunnel";
 
 // Bearer tokens we never want in stdout. The remote-control viewer must
@@ -141,12 +142,26 @@ async function maybeReplay(hostId: string): Promise<{
 	};
 }
 
+function pathAfterHost(c: Context<AppContext>): string {
+	const hostId = c.req.param("hostId") ?? "";
+	const path = new URL(c.req.url).pathname;
+	return path.slice(`/hosts/${hostId}`.length);
+}
+
 const authMiddleware: MiddlewareHandler<AppContext> = async (c, next) => {
+	const wantsTrpc = isTrpcPath(pathAfterHost(c));
+
 	const token = extractToken(c);
-	if (!token) return c.json({ error: "Unauthorized" }, 401);
+	if (!token)
+		return wantsTrpc
+			? trpcErrorResponse(c, "UNAUTHORIZED", "Unauthorized")
+			: c.json({ error: "Unauthorized" }, 401);
 
 	const auth = await verifyJWT(token, env.NEXT_PUBLIC_API_URL);
-	if (!auth) return c.json({ error: "Unauthorized" }, 401);
+	if (!auth)
+		return wantsTrpc
+			? trpcErrorResponse(c, "UNAUTHORIZED", "Unauthorized")
+			: c.json({ error: "Unauthorized" }, 401);
 
 	const hostId = c.req.param("hostId");
 	if (!hostId) return c.json({ error: "Missing hostId" }, 400);
@@ -157,11 +172,16 @@ const authMiddleware: MiddlewareHandler<AppContext> = async (c, next) => {
 	if (!tunnelManager.hasTunnel(hostId)) {
 		const replay = await maybeReplay(hostId);
 		if (replay) return c.body(null, 200, replay.header);
-		return c.json({ error: "Host not connected" }, 503);
+		return wantsTrpc
+			? trpcErrorResponse(c, "SERVICE_UNAVAILABLE", "Host is not online")
+			: c.json({ error: "Host not connected" }, 503);
 	}
 
 	const hasAccess = await checkHostAccess(auth, token, hostId);
-	if (!hasAccess) return c.json({ error: "Forbidden" }, 403);
+	if (!hasAccess)
+		return wantsTrpc
+			? trpcErrorResponse(c, "FORBIDDEN", "Forbidden")
+			: c.json({ error: "Forbidden" }, 403);
 
 	c.set("auth", auth);
 	c.set("token", token);
@@ -306,10 +326,8 @@ app.all("/hosts/:hostId/trpc/*", async (c) => {
 		});
 	} catch (error) {
 		captureSentryException(error, { hostId, path });
-		return c.json(
-			{ error: error instanceof Error ? error.message : "Proxy error" },
-			502,
-		);
+		const message = error instanceof Error ? error.message : "Proxy error";
+		return trpcErrorResponse(c, "BAD_GATEWAY", message);
 	}
 });
 

--- a/apps/relay/src/trpc-error.ts
+++ b/apps/relay/src/trpc-error.ts
@@ -1,0 +1,41 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import superjson from "superjson";
+
+type TrpcErrorCode =
+	| "UNAUTHORIZED"
+	| "FORBIDDEN"
+	| "SERVICE_UNAVAILABLE"
+	| "BAD_GATEWAY";
+
+const RPC_CODE: Record<TrpcErrorCode, number> = {
+	UNAUTHORIZED: -32001,
+	FORBIDDEN: -32003,
+	SERVICE_UNAVAILABLE: -32603,
+	BAD_GATEWAY: -32603,
+};
+
+const HTTP_STATUS: Record<TrpcErrorCode, ContentfulStatusCode> = {
+	UNAUTHORIZED: 401,
+	FORBIDDEN: 403,
+	SERVICE_UNAVAILABLE: 503,
+	BAD_GATEWAY: 502,
+};
+
+export function isTrpcPath(pathAfterHost: string): boolean {
+	return pathAfterHost.startsWith("/trpc");
+}
+
+export function trpcErrorResponse(
+	c: Context,
+	code: TrpcErrorCode,
+	message: string,
+) {
+	const httpStatus = HTTP_STATUS[code];
+	const error = superjson.serialize({
+		message,
+		code: RPC_CODE[code],
+		data: { code, httpStatus },
+	});
+	return c.json({ error }, httpStatus);
+}


### PR DESCRIPTION
## Problem

Avi hit an error toast deleting a cloud workspace:

> Failed to delete …: **Unable to transform response from server**

That string isn't ours — it's `@trpc/client`'s `TransformResultError`, thrown when the HTTP body isn't a tRPC envelope it can deserialize.

## Root cause

Deleting a **cloud** workspace routes `workspaceCleanup.destroy` through the relay tunnel (`/hosts/:hostId/trpc/*`). When the relay can't complete the request, it replied with bare `{ error: string }` JSON:

- `authMiddleware`: `{ error: "Host not connected" }` (503) when the host's sandbox is offline — the most likely trigger here.
- proxy `catch`: `{ error: "Request timed out" | "Host overloaded" | … }` (502) — the destroy saga (teardown → worktree → cloud delete) can also exceed the relay's 30s request timeout.

The host-service tRPC clients run **superjson**, and `transformResult` throws `"Unable to transform response from server"` on any body it can't deserialize. That opaque string then flows straight into the toast via `normalizeError` → `{ kind: "unknown", message }`. Local workspaces hit `127.0.0.1:<port>/trpc` directly, so they never see this — it's cloud-only.

## Fix

Make the relay speak tRPC on tRPC paths. New `apps/relay/src/trpc-error.ts` builds a **superjson-encoded tRPC error envelope** (using the relay's existing `superjson` dep, so it's correct-by-construction and matches what the host-service itself emits). Wired into `index.ts`:

- `authMiddleware` → tRPC envelopes for 401 / **503 "Host is not online"** / 403 on tRPC requests; non-tRPC paths (ports, remote-control) keep the old `{ error }` shape.
- `/hosts/:hostId/trpc/*` proxy `catch` → **502 BAD_GATEWAY** envelope carrying the real underlying message.

### Result

> Failed to delete …: **Host is not online**

instead of the opaque transform error. No client changes required.

## Scope / notes

- Only the non-batch `httpLink` path is handled — the sole relay-targeting tRPC client (`host-service-client.ts`) is non-batch; batch clients talk to the cloud API directly.
- Follow-ups worth tracking separately: (1) renderer could map `data.code === "SERVICE_UNAVAILABLE"` to the delete dialog's `host-unavailable` state; (2) deeper gap — deleting a cloud workspace still requires its host online, and a >30s destroy times out the relay even when the cloud delete eventually succeeds.

## Test plan

- [x] `bun run lint` clean
- [x] `@superset/relay` typecheck passes
- [ ] Manual: delete a cloud workspace whose host sandbox is stopped → toast shows "Host is not online", not the transform error.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5034">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `superjson`-encoded tRPC error envelopes from the relay on `/hosts/:hostId/trpc/*` so users see clear errors (e.g., “Host is not online”) instead of `@trpc/client`’s “Unable to transform response from server.” No client changes needed.

- **Bug Fixes**
  - Added `trpc-error.ts` to build envelopes and detect tRPC paths; wired into auth middleware and the `/hosts/:hostId/trpc/*` proxy.
  - Auth now returns envelopes for 401, 403, and 503 (host offline); proxy failures return 502 BAD_GATEWAY with the real message. Non‑tRPC paths still use `{ error }`.

<sup>Written for commit 7a1319d37ecb1fa45beb15941b324f04d3ec93ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tRPC request routing in the relay service with proper error response formatting.

* **Bug Fixes**
  * Improved error handling for failed requests through the relay proxy to return properly formatted error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->