### PR TITLE
fix(desktop): bound applied_tx growth in tanstack-db.sqlite (SUPER-967)

### DIFF
--- a/apps/desktop/src/main/lib/persistence/persistence.ts
+++ b/apps/desktop/src/main/lib/persistence/persistence.ts
@@ -14,7 +14,11 @@ let database: Database.Database | null = null;
 export function initTanstackDbPersistence(): void {
 	ensureSupersetHomeDirExists();
 	database = new Database(join(SUPERSET_HOME_DIR, "tanstack-db.sqlite"));
-	const persistence = createNodeSQLitePersistence({ database });
+	const persistence = createNodeSQLitePersistence({
+		database,
+		appliedTxPruneMaxRows: 1_000,
+		appliedTxPruneMaxAgeSeconds: 24 * 60 * 60,
+	});
 	dispose = exposeElectronSQLitePersistence({ ipcMain, persistence });
 }
 


### PR DESCRIPTION
## Problem

Superset v2's local sync DB (`~/.superset/tanstack-db.sqlite`) bloats to hundreds of MB and never prunes, triggering endpoint security agents (Code42/XProtect) to continuously re-hash the file and cook users' laptops.

On one real machine: **501k `applied_tx` rows / 428 MB / 34 days**, of which **97.6% are pure no-op writes**.

## Root cause (two independent bugs)

1. **No-op write storm.** The Electric collection re-stamps an `electric:resume` metadata record with `updatedAt: Date.now()` on *every* `up-to-date` heartbeat (`electric-db-collection/.../electric.js:696-703`, called at `:900-902`). The always-changing timestamp defeats the persistence layer's no-op guard, so every collection appends a transaction row every few minutes even when nothing changed — for all ~115 collections.
2. **Pruning never configured.** `db-sqlite-persistence-core` has working prune logic (`pruneAppliedTxRows`) that runs after every write, but it's gated on `appliedTxPruneMaxRows` / `appliedTxPruneMaxAgeSeconds`. The desktop app called `createNodeSQLitePersistence({ database })` with neither, so prune was a no-op and the log grew forever.

## This PR — Fix A (cap growth)

Configures the existing per-collection prune in `persistence.ts`: **1,000-row cap + 24h age backstop**. The prune runs inside each write transaction, so every collection self-trims on its next sync. One-line-ish change activating already-tested upstream code; only affects the local, rebuildable cache DB.

## Verification

Mechanism verified on a **copy** of a real bloated DB:

| Stage | Size | `applied_tx` rows |
|---|---|---|
| Before | 448 MB | 503,540 |
| After prune (24h + 1k-cap) | 448 MB | **14,011** |
| After VACUUM | 28.5 MB | 14,011 |

`integrity_check: ok`, all collections still registered, no data loss. (The 24h window did ~all the work; the row-cap is the safety ceiling.)

Typecheck + Biome clean. **Reviewer check that can't be done from a worktree:** run a packaged/canary desktop build and confirm the row count caps in practice and the small cap doesn't cause excessive full-reloads.

## Follow-ups (not in this PR)

- **One-time `VACUUM` for already-bloated users.** Pruning bounds growth but `auto_vacuum=0`, so it does **not** shrink an existing 448 MB file (verified above) — existing users need a gated startup VACUUM to actually get relief.
- **Fix B — kill the no-op write storm at the source.** Not fixed upstream (verified at `electric@0.3.5` / `persistence-core@0.1.11`), so a version bump won't help; needs an upstream PR or local patch. Deferrable: once the file is small, re-hash cost is low.

Closes SUPER-967 (partial — Fix A).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database transaction management by configuring automatic pruning limits to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->