### PR TITLE
fix(panes): remove redundant close tooltip on tabs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.11.3",
+      "version": "1.12.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -769,7 +769,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.15",
+      "version": "0.8.17",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -172,6 +172,7 @@ export function TabItem<TData>({
 									</span>
 								)}
 								<Button
+									aria-label="Close tab"
 									className={cn(
 										"pointer-events-none size-5 cursor-pointer text-current opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
 										isActive ? "hover:bg-foreground/10" : "hover:bg-muted",

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -171,31 +171,24 @@ export function TabItem<TData>({
 										{accessory}
 									</span>
 								)}
-								<Tooltip delayDuration={500}>
-									<TooltipTrigger asChild>
-										<Button
-											className={cn(
-												"pointer-events-none size-5 cursor-pointer text-current opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-												isActive ? "hover:bg-foreground/10" : "hover:bg-muted",
-											)}
-											onClick={(event) => {
-												event.stopPropagation();
-												onClose();
-											}}
-											onMouseDown={(event) => {
-												event.stopPropagation();
-											}}
-											size="icon"
-											type="button"
-											variant="ghost"
-										>
-											<XIcon className="size-3.5" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top" showArrow={false}>
-										Close
-									</TooltipContent>
-								</Tooltip>
+								<Button
+									className={cn(
+										"pointer-events-none size-5 cursor-pointer text-current opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+										isActive ? "hover:bg-foreground/10" : "hover:bg-muted",
+									)}
+									onClick={(event) => {
+										event.stopPropagation();
+										onClose();
+									}}
+									onMouseDown={(event) => {
+										event.stopPropagation();
+									}}
+									size="icon"
+									type="button"
+									variant="ghost"
+								>
+									<XIcon className="size-3.5" />
+								</Button>
 							</div>
 						</>
 					)}


### PR DESCRIPTION
## Summary
Removes the "Close" tooltip on the tab close button. An X icon for closing a tab is self-explanatory, and the same action is already available via the right-click context menu and middle-click.

## Changes
- `packages/panes/.../TabItem/TabItem.tsx`: drop the `Tooltip`/`TooltipTrigger`/`TooltipContent` wrapper around the close `Button`, keeping the button itself unchanged. Tooltip imports remain in use by the tab-title tooltip.

## Testing
- `bun run lint` — passes
- `bun run typecheck` — passes

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5037">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “Close” tooltip from tab close buttons to reduce visual noise, and added an aria-label (“Close tab”) for screen readers. Close button behavior is unchanged; the tab title tooltip, right‑click menu, and middle‑click still work.

<sup>Written for commit 1d80693591f0ece04def5fa7dc66a4c295f565dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed tooltip overlay from tab close buttons for a cleaner interface.
  * Close button remains visible, clickable, and continues to behave responsively (still prevents unintended interactions and triggers the expected close action).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->