### PR TITLE
fix: scroll alt-screen TUIs with the mouse wheel in the embedded terminal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -13,6 +13,7 @@ import { loadAddons } from "./terminal-addons";
 import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
+import { installTerminalWheelEventHandler } from "./terminal-wheel-event-handler";
 
 const SERIALIZE_SCROLLBACK = 1000;
 const STORAGE_KEY_PREFIX = "terminal-buffer:";
@@ -213,6 +214,7 @@ export function createRuntime(
 	terminal.open(wrapper);
 
 	installTerminalKeyEventHandler(terminal);
+	installTerminalWheelEventHandler(terminal);
 
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)

--- a/apps/desktop/src/renderer/lib/terminal/terminal-wheel-event-handler.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-wheel-event-handler.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { createTerminalWheelEventHandler } from "./terminal-wheel-event-handler";
+
+function fakeTerminal(bufferType: "normal" | "alternate", cellHeight = 16) {
+	const inputs: string[] = [];
+	const terminal = {
+		buffer: { active: { type: bufferType } },
+		input: (data: string) => {
+			inputs.push(data);
+		},
+		_core: {
+			_renderService: { dimensions: { css: { cell: { height: cellHeight } } } },
+		},
+	} as unknown as XTerm;
+	return { terminal, inputs };
+}
+
+function wheel(overrides: Partial<WheelEvent>): WheelEvent {
+	return { deltaY: 0, deltaMode: 0, ...overrides } as WheelEvent;
+}
+
+describe("createTerminalWheelEventHandler", () => {
+	it("lets xterm handle the wheel on the normal buffer", () => {
+		const { terminal, inputs } = fakeTerminal("normal");
+		const handler = createTerminalWheelEventHandler(terminal);
+
+		expect(handler(wheel({ deltaY: -120 }))).toBe(true);
+		expect(inputs).toEqual([]);
+	});
+
+	it("sends PageUp and swallows the event when scrolling up on alt screen", () => {
+		const { terminal, inputs } = fakeTerminal("alternate");
+		const handler = createTerminalWheelEventHandler(terminal);
+
+		expect(handler(wheel({ deltaY: -16 }))).toBe(false);
+		expect(inputs).toEqual(["\x1b[5~"]);
+	});
+
+	it("sends PageDown when scrolling down on alt screen", () => {
+		const { terminal, inputs } = fakeTerminal("alternate");
+		const handler = createTerminalWheelEventHandler(terminal);
+
+		expect(handler(wheel({ deltaY: 16 }))).toBe(false);
+		expect(inputs).toEqual(["\x1b[6~"]);
+	});
+
+	it("scales pixel deltas by cell height", () => {
+		const { terminal, inputs } = fakeTerminal("alternate", 16);
+		const handler = createTerminalWheelEventHandler(terminal);
+
+		handler(wheel({ deltaY: 48 }));
+		expect(inputs).toEqual(["\x1b[6~", "\x1b[6~", "\x1b[6~"]);
+	});
+
+	it("treats line-mode deltas as line counts", () => {
+		const { terminal, inputs } = fakeTerminal("alternate");
+		const handler = createTerminalWheelEventHandler(terminal);
+
+		handler(wheel({ deltaY: -3, deltaMode: 1 }));
+		expect(inputs).toEqual(["\x1b[5~", "\x1b[5~", "\x1b[5~"]);
+	});
+
+	it("caps the number of sequences per event", () => {
+		const { terminal, inputs } = fakeTerminal("alternate");
+		const handler = createTerminalWheelEventHandler(terminal);
+
+		handler(wheel({ deltaY: 1000 }));
+		expect(inputs).toHaveLength(6);
+	});
+
+	it("swallows a zero-delta wheel event without emitting input", () => {
+		const { terminal, inputs } = fakeTerminal("alternate");
+		const handler = createTerminalWheelEventHandler(terminal);
+
+		expect(handler(wheel({ deltaY: 0 }))).toBe(false);
+		expect(inputs).toEqual([]);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-wheel-event-handler.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-wheel-event-handler.ts
@@ -1,0 +1,57 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+const PAGE_UP = "\x1b[5~";
+const PAGE_DOWN = "\x1b[6~";
+const MAX_TICKS_PER_EVENT = 6;
+const FALLBACK_CELL_HEIGHT = 16;
+
+interface RenderDimensionAccess {
+	_core?: {
+		_renderService?: {
+			dimensions?: { css?: { cell?: { height?: number } } };
+		};
+	};
+}
+
+function resolveCellHeight(terminal: XTerm): number {
+	const cell = (terminal as unknown as RenderDimensionAccess)._core
+		?._renderService?.dimensions?.css?.cell?.height;
+	return cell && cell > 0 ? cell : FALLBACK_CELL_HEIGHT;
+}
+
+function wheelTicks(event: WheelEvent, cellHeight: number): number {
+	const distance = Math.abs(event.deltaY);
+	if (distance === 0) return 0;
+	const raw =
+		event.deltaMode === 1
+			? Math.round(distance)
+			: Math.max(1, Math.round(distance / cellHeight));
+	return Math.min(raw, MAX_TICKS_PER_EVENT);
+}
+
+// The alternate screen buffer has no scrollback, so translate the wheel into
+// PageUp/PageDown for the TUI and let xterm keep native scrollback otherwise.
+export function createTerminalWheelEventHandler(terminal: XTerm) {
+	return (event: WheelEvent): boolean => {
+		if (terminal.buffer.active.type !== "alternate") return true;
+
+		const ticks = wheelTicks(event, resolveCellHeight(terminal));
+		if (ticks === 0) return false;
+
+		const sequence = event.deltaY < 0 ? PAGE_UP : PAGE_DOWN;
+		for (let i = 0; i < ticks; i++) {
+			terminal.input(sequence, true);
+		}
+		return false;
+	};
+}
+
+export function installTerminalWheelEventHandler(terminal: XTerm): () => void {
+	terminal.attachCustomWheelEventHandler(
+		createTerminalWheelEventHandler(terminal),
+	);
+
+	return () => {
+		terminal.attachCustomWheelEventHandler(() => true);
+	};
+}


### PR DESCRIPTION
## Description

On the alternate screen buffer (opencode, Codex, vim, etc.) the mouse wheel is translated into PageUp/PageDown and sent to the PTY, which every keyboard-driven TUI understands for scrolling. On the normal buffer nothing changes, so xterm keeps its native scrollback wheel scrolling.

Adds `installTerminalWheelEventHandler` (mirrors `installTerminalKeyEventHandler`) and wires it into `createRuntime`.

## Related Issues

closes #5038

## Type of Change

- [x] Bug fix

## Testing

`bun test` — 7/7 pass for the new handler.

## Screenshots

N/A

## Additional Notes

None


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps mouse wheel events to PageUp/PageDown on the terminal’s alternate screen so TUIs (vim, less, etc.) scroll with the wheel. Normal screen behavior is unchanged, preserving `@xterm/xterm` scrollback.

- **Bug Fixes**
  - Added `installTerminalWheelEventHandler` and wired it into `createRuntime`.
  - On alt screen, wheel sends PageUp/PageDown to the PTY; otherwise defers to `@xterm/xterm` scrollback. Handles pixel/line deltas and caps repeats.
  - Added unit tests for the handler.

<sup>Written for commit fe096db2ac73396cebf720fd76dcd7ea582e42f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse wheel scrolling support to the terminal, enabling seamless navigation using the mouse wheel across all terminal modes.

* **Tests**
  * Added comprehensive test coverage for wheel event handling to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->