### PR TITLE
fix(desktop): preserve chat drafts per-pane in v2 workspace

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
@@ -8,12 +8,14 @@ export function ChatPane({
 	workspaceId,
 	initialLaunchConfig,
 	onConsumeLaunchConfig,
+	onSaveDraft,
 }: {
 	onSessionIdChange: (sessionId: string | null) => void;
 	sessionId: string | null;
 	workspaceId: string;
 	initialLaunchConfig?: ChatLaunchConfig | null;
 	onConsumeLaunchConfig?: () => void;
+	onSaveDraft?: (draft: string | undefined) => void;
 }) {
 	const { organizationId, workspacePath, handleNewChat, getOrCreateSession } =
 		useWorkspaceChatController({
@@ -27,6 +29,7 @@ export function ChatPane({
 			getOrCreateSession={getOrCreateSession}
 			initialLaunchConfig={initialLaunchConfig ?? null}
 			onConsumeLaunchConfig={onConsumeLaunchConfig}
+			onSaveDraft={onSaveDraft}
 			isFocused
 			onResetSession={handleNewChat}
 			sessionId={sessionId}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
@@ -29,6 +29,7 @@ import {
 import { ChatInputFooter } from "./components/ChatInputFooter";
 import { ChatMessageList } from "./components/ChatMessageList";
 import type { UserMessageRestartRequest } from "./components/ChatMessageList/ChatMessageList.types";
+import { DraftSaver } from "./components/DraftSaver";
 import { McpControls } from "./components/McpControls";
 import { useMcpUi } from "./hooks/useMcpUi";
 import { useOptimisticUpload } from "./hooks/useOptimisticUpload";
@@ -191,6 +192,7 @@ export function ChatPaneInterface({
 	sessionId,
 	initialLaunchConfig,
 	onConsumeLaunchConfig,
+	onSaveDraft,
 	workspaceId,
 	organizationId,
 	cwd,
@@ -237,6 +239,8 @@ export function ChatPaneInterface({
 		useState<PendingUserTurn | null>(null);
 	const currentMcpScopeRef = useRef<string | null>(null);
 	const consumedLaunchConfigRef = useRef<string | null>(null);
+	const isSendingRef = useRef(false);
+	const previousSessionIdRef = useRef(sessionId);
 	const autoLaunchInFlightRef = useRef<string | null>(null);
 	const autoLaunchAttemptsRef = useRef<Record<string, number>>({});
 	const autoLaunchSessionLockRef = useRef<Record<string, string | null>>({});
@@ -453,6 +457,16 @@ export function ChatPaneInterface({
 		}
 	}, [cwd, refreshMcpOverview, resetMcpUi, sessionId]);
 
+	const clearDraftInStore = useCallback(() => {
+		onSaveDraft?.(undefined);
+	}, [onSaveDraft]);
+
+	useEffect(() => {
+		if (sessionId === previousSessionIdRef.current) return;
+		previousSessionIdRef.current = sessionId;
+		clearDraftInStore();
+	}, [clearDraftInStore, sessionId]);
+
 	useEffect(() => {
 		if (
 			shouldClearPendingUserTurn({
@@ -566,6 +580,7 @@ export function ChatPaneInterface({
 			};
 
 			let targetSessionId = effectiveSessionId;
+			isSendingRef.current = true;
 			try {
 				if (!targetSessionId) {
 					targetSessionId = await getOrCreateSession();
@@ -598,12 +613,15 @@ export function ChatPaneInterface({
 					onUserMessageSubmitted?.(content);
 				}
 			} catch (error) {
+				isSendingRef.current = false;
 				const sendErrorMessage = toSendFailureMessage(error);
 				setSubmitStatus(undefined);
 				setRuntimeErrorMessage(sendErrorMessage);
 				if (error instanceof Error) throw error;
 				throw new Error(sendErrorMessage);
 			}
+
+			clearDraftInStore();
 
 			captureChatEvent("chat_message_sent", {
 				session_id: targetSessionId,
@@ -618,6 +636,7 @@ export function ChatPaneInterface({
 		[
 			activeModel?.id,
 			captureChatEvent,
+			clearDraftInStore,
 			clearRuntimeError,
 			commands,
 			getOrCreateSession,
@@ -920,6 +939,13 @@ export function ChatPaneInterface({
 
 	return (
 		<PromptInputProvider initialInput={initialLaunchConfig?.draftInput}>
+			{onSaveDraft && (
+				<DraftSaver
+					sessionId={sessionId}
+					isSendingRef={isSendingRef}
+					onSaveDraft={onSaveDraft}
+				/>
+			)}
 			<div className="flex h-full w-full flex-col bg-background">
 				<ChatMessageList
 					messages={visibleMessages}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/DraftSaver/DraftSaver.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/DraftSaver/DraftSaver.tsx
@@ -1,0 +1,52 @@
+import { usePromptInputController } from "@superset/ui/ai-elements/prompt-input";
+import type React from "react";
+import { useEffect, useRef } from "react";
+
+interface DraftSaverProps {
+	sessionId: string | null;
+	isSendingRef: React.RefObject<boolean>;
+	onSaveDraft: (draft: string | undefined) => void;
+}
+
+/**
+ * Saves the current chat textarea draft to the owning pane's persisted data on
+ * unmount, so switching tabs/panes away and back preserves what the user typed.
+ * Must be rendered inside <PromptInputProvider> to access the text input context.
+ *
+ * Uses refs for all mutable values so the unmount cleanup always reads the latest
+ * state (and latest `onSaveDraft` closure) without re-registering the effect on
+ * every render.
+ */
+export function DraftSaver({
+	sessionId,
+	isSendingRef,
+	onSaveDraft,
+}: DraftSaverProps) {
+	const { textInput, attachments } = usePromptInputController();
+	const textRef = useRef(textInput.value);
+	const onSaveDraftRef = useRef(onSaveDraft);
+	const previousSessionIdRef = useRef(sessionId);
+
+	// Synchronous ref updates so the unmount cleanup always reads the latest values
+	textRef.current = textInput.value;
+	onSaveDraftRef.current = onSaveDraft;
+	if (isSendingRef.current && textInput.value.length === 0) {
+		isSendingRef.current = false;
+	}
+
+	useEffect(() => {
+		if (sessionId === previousSessionIdRef.current) return;
+		previousSessionIdRef.current = sessionId;
+		textInput.clear();
+		attachments.clear();
+	}, [attachments.clear, sessionId, textInput.clear]);
+
+	useEffect(() => {
+		return () => {
+			if (isSendingRef.current) return;
+			onSaveDraftRef.current(textRef.current || undefined);
+		};
+	}, [isSendingRef]);
+
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/DraftSaver/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/DraftSaver/index.ts
@@ -1,0 +1,1 @@
+export { DraftSaver } from "./DraftSaver";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/types.ts
@@ -9,6 +9,11 @@ export interface ChatPaneInterfaceProps {
 	 * launchConfig and not re-trigger on re-render.
 	 */
 	onConsumeLaunchConfig?: () => void;
+	/**
+	 * Persists the current textarea draft to the owning pane so it survives
+	 * tab/pane switches. Called with `undefined` to clear the saved draft.
+	 */
+	onSaveDraft?: (draft: string | undefined) => void;
 	workspaceId: string;
 	organizationId: string | null;
 	cwd: string;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -491,7 +491,12 @@ export function usePaneRegistry({
 				renderPane: (ctx: RendererContext<PaneViewerData>) => {
 					const data = ctx.pane.data as ChatPaneData;
 					return (
+						// Key by pane id so switching between two chat tabs remounts the
+						// chat subtree instead of reusing one instance (the active Tab is
+						// rendered unkeyed, so same-kind panes at the same layout slot would
+						// otherwise share editor state and bleed drafts across panes).
 						<ChatPane
+							key={ctx.pane.id}
 							workspaceId={workspaceId}
 							sessionId={data.sessionId}
 							onSessionIdChange={(id) =>
@@ -500,6 +505,12 @@ export function usePaneRegistry({
 							initialLaunchConfig={data.launchConfig ?? null}
 							onConsumeLaunchConfig={() =>
 								ctx.actions.updateData({ ...data, launchConfig: null })
+							}
+							onSaveDraft={(draftInput) =>
+								ctx.actions.updateData({
+									...data,
+									launchConfig: { ...(data.launchConfig ?? {}), draftInput },
+								})
 							}
 						/>
 					);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -19,6 +19,8 @@ export interface ChatPaneData {
 	 */
 	launchConfig?: {
 		initialPrompt?: string;
+		/** Unsent textarea draft, persisted so it survives tab/pane switches. */
+		draftInput?: string;
 		initialFiles?: Array<{
 			data: string;
 			mediaType: string;


### PR DESCRIPTION
## Problem

Two related bugs in the v2 workspace chat:

1. **Drafts lost on tab switch** — typing in the chat composer and switching tabs discarded the text.
2. **Drafts bleed across panes** — two chat panes shared the same draft; typing in one replaced the other.

## Root cause

The v2 `WorkspaceChatInterface` **read** a persisted draft on mount (`initialInput={initialLaunchConfig?.draftInput}`) but had no save-on-unmount logic — the v1 `DraftSaver` (PR #2631) was never ported.

The deeper cause is in `packages/panes`: `Workspace.tsx` renders only the active tab as `<Tab tab={activeTab}>` **with no `key`**. When two tabs each hold a chat pane at the same layout slot, React reconciles them into the **same** `ChatPaneInterface` → `PromptInputProvider` instance instead of remounting. Since `useState(initialInput)` only runs on first mount, the editor text never resets:

- Both panes session-less → text bleeds across panes (bug #2).
- Different sessions → the session-change clear effect wipes the editor (bug #1).

Because the instance is reused, unmount/remount-based persistence never engaged.

## Fix

- **Port v1's `DraftSaver` pattern into v2**: save the textarea draft to the pane's `launchConfig.draftInput` on unmount (guarded by `isSendingRef` so an in-flight send isn't re-persisted), and clear it on send and on session change. Threaded a new `onSaveDraft` callback through `usePaneRegistry` → `ChatPane` → `ChatPaneInterface`, wired to the pane registry's `updateData`.
- **Key the chat pane by `ctx.pane.id`** in `usePaneRegistry` so switching between chat tabs cleanly remounts the chat subtree instead of reusing one instance. Scoped to chat on purpose — keying `<Tab>` itself would remount terminals/browsers, which intentionally persist.
- Added `draftInput` to v2's `ChatPaneData.launchConfig` type (its inline type lacked it).

## Testing

- `bun run typecheck` → pass
- `bun run lint` → pass
- Manual: not yet run in the Electron app.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5040">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves chat drafts per pane in the v2 workspace so drafts aren’t lost on tab switch or shared across chat panes. Users can switch tabs without losing what they typed.

- **Bug Fixes**
  - Ported v1 DraftSaver to v2: save textarea draft on unmount to `launchConfig.draftInput`, clear on send and on session change (guarded by `isSendingRef`).
  - Keyed chat panes by `pane.id` in the registry to remount the chat subtree when switching tabs, preventing state bleed across panes; scoped to chat only.
  - Added `draftInput` to `ChatPaneData.launchConfig` and threaded `onSaveDraft` through the registry → `ChatPane` → `ChatPaneInterface` to persist drafts.

<sup>Written for commit 2fda2dfdbcb937ee25d678e217059394f769da38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat message drafts now automatically persist when switching between tabs and conversations, ensuring your unsent messages are saved and restored when you return to a chat session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->