### PR TITLE
Improve workspace pane interaction performance

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -90,7 +90,6 @@ export function TerminalSessionDropdown({
 }: TerminalSessionDropdownProps) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [isCreatingTerminal, setIsCreatingTerminal] = useState(false);
-	const collections = useCollections();
 	const { terminalId } = context.pane.data as TerminalPaneData;
 	const terminalInstanceId = context.pane.id;
 	const utils = workspaceTrpc.useUtils();
@@ -106,15 +105,7 @@ export function TerminalSessionDropdown({
 			staleTime: TERMINAL_SESSION_LIST_STALE_MS,
 		},
 	);
-	useRenderStressInstrumentation("TerminalSessionDropdown", {
-		warnAt: 30,
-		getDetails: () => ({
-			workspaceId,
-			terminalId,
-			isOpen,
-			hasSessionData: Boolean(sessionsQuery.data),
-		}),
-	});
+	const collections = useCollections();
 	const { data: localWorkspaceRows = [] } = useLiveQuery(
 		(query) =>
 			query
@@ -126,6 +117,15 @@ export function TerminalSessionDropdown({
 	);
 	const workspaceRunTerminals =
 		localWorkspaceRows[0]?.workspaceRunTerminals ?? {};
+	useRenderStressInstrumentation("TerminalSessionDropdown", {
+		warnAt: 30,
+		getDetails: () => ({
+			workspaceId,
+			terminalId,
+			isOpen,
+			hasSessionData: Boolean(sessionsQuery.data),
+		}),
+	});
 	const workspaceRunState = workspaceRunTerminals[terminalId]?.state ?? null;
 
 	const sessions = useMemo<VisibleTerminalSession[]>(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -11,6 +11,7 @@ const EMPTY_STATE: WorkspaceState<PaneViewerData> = {
 	tabs: [],
 	activeTabId: null,
 };
+const PANE_LAYOUT_PERSIST_DEBOUNCE_MS = 1_000;
 
 function getSnapshot(state: WorkspaceState<PaneViewerData>): string {
 	return JSON.stringify(state);
@@ -38,6 +39,11 @@ export function useV2WorkspacePaneLayout() {
 		workspaceId,
 		lastSyncedSnapshot: getSnapshot(EMPTY_STATE),
 	});
+	const pendingPersistRef = useRef<{
+		snapshot: string;
+		state: WorkspaceState<PaneViewerData>;
+	} | null>(null);
+	const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const { data: localWorkspaceRows = [] } = useLiveQuery(
 		(query) =>
@@ -65,6 +71,11 @@ export function useV2WorkspacePaneLayout() {
 			workspaceId,
 			lastSyncedSnapshot: getSnapshot(EMPTY_STATE),
 		};
+		pendingPersistRef.current = null;
+		if (persistTimerRef.current) {
+			clearTimeout(persistTimerRef.current);
+			persistTimerRef.current = null;
+		}
 	}, [workspaceId]);
 
 	useEffect(() => {
@@ -78,6 +89,22 @@ export function useV2WorkspacePaneLayout() {
 	}, [persistedPaneLayout, store]);
 
 	useEffect(() => {
+		const flushPendingPersist = () => {
+			const pending = pendingPersistRef.current;
+			pendingPersistRef.current = null;
+			persistTimerRef.current = null;
+			if (!pending) return;
+
+			if (!collections.v2WorkspaceLocalState.get(workspaceId)) {
+				return;
+			}
+
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				draft.paneLayout = pending.state;
+			});
+			syncStateRef.current.lastSyncedSnapshot = pending.snapshot;
+		};
+
 		const unsubscribe = store.subscribe((nextStore) => {
 			const nextWorkspaceState: WorkspaceState<PaneViewerData> = {
 				version: nextStore.version,
@@ -93,13 +120,24 @@ export function useV2WorkspacePaneLayout() {
 				return;
 			}
 
-			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.paneLayout = nextWorkspaceState;
-			});
-			syncStateRef.current.lastSyncedSnapshot = nextSnapshot;
+			pendingPersistRef.current = {
+				snapshot: nextSnapshot,
+				state: nextWorkspaceState,
+			};
+			if (persistTimerRef.current) {
+				clearTimeout(persistTimerRef.current);
+			}
+			persistTimerRef.current = setTimeout(
+				flushPendingPersist,
+				PANE_LAYOUT_PERSIST_DEBOUNCE_MS,
+			);
 		});
 
 		return () => {
+			if (persistTimerRef.current) {
+				clearTimeout(persistTimerRef.current);
+				flushPendingPersist();
+			}
 			unsubscribe();
 		};
 	}, [collections, store, workspaceId]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,7 +1,7 @@
 import { Workspace } from "@superset/panes";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useQuickOpenStore } from "renderer/commandPalette/ui/QuickOpen/quickOpenStore";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
@@ -263,16 +263,91 @@ function V2WorkspaceContent() {
 		void workspaceRun.toggleWorkspaceRun();
 	});
 
-	const workspaceRunButton = (
-		<V2WorkspaceRunButton
-			projectId={workspace.projectId}
-			definition={workspaceRun.definition}
-			isRunning={workspaceRun.isRunning}
-			isPending={workspaceRun.isPending}
-			canForceStop={workspaceRun.canForceStop}
-			onToggle={workspaceRun.toggleWorkspaceRun}
-			onForceStop={workspaceRun.forceStopWorkspaceRun}
-		/>
+	const workspaceRunButton = useMemo(
+		() => (
+			<V2WorkspaceRunButton
+				projectId={workspace.projectId}
+				definition={workspaceRun.definition}
+				isRunning={workspaceRun.isRunning}
+				isPending={workspaceRun.isPending}
+				canForceStop={workspaceRun.canForceStop}
+				onToggle={workspaceRun.toggleWorkspaceRun}
+				onForceStop={workspaceRun.forceStopWorkspaceRun}
+			/>
+		),
+		[
+			workspace.projectId,
+			workspaceRun.canForceStop,
+			workspaceRun.definition,
+			workspaceRun.forceStopWorkspaceRun,
+			workspaceRun.isPending,
+			workspaceRun.isRunning,
+			workspaceRun.toggleWorkspaceRun,
+		],
+	);
+	const renderTabAccessory = useCallback(
+		(tab: Parameters<typeof getV2NotificationSourcesForTab>[0]) => (
+			<V2NotificationStatusIndicator
+				sources={getV2NotificationSourcesForTab(tab)}
+			/>
+		),
+		[],
+	);
+	const renderBelowTabBar = useCallback(
+		() =>
+			showPresetsBar ? (
+				<V2PresetsBar
+					matchedPresets={matchedPresets}
+					executePreset={executePreset}
+					showPresetsBar={showPresetsBar}
+					onToggleShowPresetsBar={setShowPresetsBar}
+					trailing={workspaceRunButton}
+				/>
+			) : (
+				<div className="flex h-8 min-w-0 shrink-0 items-center border-b border-border bg-background px-2">
+					{workspaceRunButton}
+				</div>
+			),
+		[
+			executePreset,
+			matchedPresets,
+			setShowPresetsBar,
+			showPresetsBar,
+			workspaceRunButton,
+		],
+	);
+	const renderAddTabMenu = useCallback(
+		() => (
+			<AddTabMenu
+				onAddTerminal={addTerminalTab}
+				onAddChat={addChatTab}
+				onAddBrowser={addBrowserTab}
+				showPresetsBar={showPresetsBar}
+				onToggleShowPresetsBar={setShowPresetsBar}
+			/>
+		),
+		[
+			addBrowserTab,
+			addChatTab,
+			addTerminalTab,
+			setShowPresetsBar,
+			showPresetsBar,
+		],
+	);
+	const renderTabBarTrailing = useCallback(
+		() => <BackgroundTerminalsButton workspaceId={workspaceId} store={store} />,
+		[store, workspaceId],
+	);
+	const renderEmptyState = useCallback(
+		() => (
+			<WorkspaceEmptyState
+				onOpenBrowser={addBrowserTab}
+				onOpenChat={addChatTab}
+				onOpenQuickOpen={handleQuickOpen}
+				onOpenTerminal={addTerminalTab}
+			/>
+		),
+		[addBrowserTab, addChatTab, addTerminalTab, handleQuickOpen],
 	);
 
 	return (
@@ -293,49 +368,11 @@ function V2WorkspaceContent() {
 							paneActions={defaultPaneActions}
 							contextMenuActions={defaultContextMenuActions}
 							renderTabIcon={renderBrowserTabIcon}
-							renderTabAccessory={(tab) => (
-								<V2NotificationStatusIndicator
-									sources={getV2NotificationSourcesForTab(tab)}
-								/>
-							)}
-							renderBelowTabBar={() =>
-								showPresetsBar ? (
-									<V2PresetsBar
-										matchedPresets={matchedPresets}
-										executePreset={executePreset}
-										showPresetsBar={showPresetsBar}
-										onToggleShowPresetsBar={setShowPresetsBar}
-										trailing={workspaceRunButton}
-									/>
-								) : (
-									<div className="flex h-8 min-w-0 shrink-0 items-center border-b border-border bg-background px-2">
-										{workspaceRunButton}
-									</div>
-								)
-							}
-							renderAddTabMenu={() => (
-								<AddTabMenu
-									onAddTerminal={addTerminalTab}
-									onAddChat={addChatTab}
-									onAddBrowser={addBrowserTab}
-									showPresetsBar={showPresetsBar}
-									onToggleShowPresetsBar={setShowPresetsBar}
-								/>
-							)}
-							renderTabBarTrailing={() => (
-								<BackgroundTerminalsButton
-									workspaceId={workspaceId}
-									store={store}
-								/>
-							)}
-							renderEmptyState={() => (
-								<WorkspaceEmptyState
-									onOpenBrowser={addBrowserTab}
-									onOpenChat={addChatTab}
-									onOpenQuickOpen={handleQuickOpen}
-									onOpenTerminal={addTerminalTab}
-								/>
-							)}
+							renderTabAccessory={renderTabAccessory}
+							renderBelowTabBar={renderBelowTabBar}
+							renderAddTabMenu={renderAddTabMenu}
+							renderTabBarTrailing={renderTabBarTrailing}
+							renderEmptyState={renderEmptyState}
 							onBeforeCloseTab={onBeforeCloseTab}
 							onInteractionStateChange={onWorkspaceInteractionStateChange}
 							store={store}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/WorkspaceProvider.tsx
@@ -1,6 +1,6 @@
 import type { SelectV2Workspace } from "@superset/db/schema";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import {
 	getHostServiceHeaders,
@@ -32,13 +32,18 @@ export function WorkspaceProvider({
 					workspace.organizationId,
 					workspace.hostId,
 				)}`;
+	const resolvedHostUrl = hostUrl ?? "";
+	const contextValue = useMemo(
+		() => ({ workspace, hostUrl: resolvedHostUrl }),
+		[workspace, resolvedHostUrl],
+	);
 
 	if (!hostUrl) {
 		return <div className="flex h-full w-full" />;
 	}
 
 	return (
-		<WorkspaceContext.Provider value={{ workspace, hostUrl }}>
+		<WorkspaceContext.Provider value={contextValue}>
 			<WorkspaceTrpcProvider
 				cacheKey={workspace.id}
 				key={`${workspace.id}:${hostUrl}`}

--- a/docs/react-scan-workspace-performance-findings.md
+++ b/docs/react-scan-workspace-performance-findings.md
@@ -1,0 +1,181 @@
+# React Scan Workspace Performance Findings
+
+Date: 2026-06-02
+Repo: `main` at `5881fdcced92917e08531a741c608e73bfaebdec`
+Trace files:
+
+- `/tmp/superset-react-scan-broader.jsonl`
+- `/tmp/superset-react-scan-root-main.jsonl`
+- `/tmp/superset-react-scan-open-oboe-claude.jsonl`
+- `/tmp/superset-react-scan-final2.jsonl`
+
+## Summary
+
+The observed CPU spikes are interaction-triggered render fanout, not an idle render loop. Idle with the workspace open was nearly quiet, but tab switching, pane creation, and opening the right sidebar produced many React commits and long tasks.
+
+The biggest cost is not the terminal renderer itself. Pane layout changes write broad workspace-local state, which wakes unrelated workspace UI. The render cascade then flows through the route/provider stack, tab bar, pane headers, right sidebar, and Radix tooltip/dropdown/context-menu wrappers.
+
+## Profile Results
+
+| Scenario | Commits | React commit duration | Long tasks |
+| --- | ---: | ---: | ---: |
+| Idle, right sidebar open | 1 | 1.4 ms | 0 |
+| Idle, right sidebar closed | 1 | 4.6 ms | 0 |
+| Switch tabs, right sidebar open | 76 | 290.8 ms | 7 |
+| Switch tabs, right sidebar closed | 51 | 265.7 ms | 5 |
+| Create 4 terminal tabs, right sidebar closed | 41 | 118.4 ms | 4 |
+| Open right sidebar | 22 | 226.6 ms | 1 |
+| Create 2 terminal tabs, right sidebar open | 37 | 136.2 ms | 5 |
+
+## Open Workspace With Claude Active
+
+I also profiled the currently opened workspace, `test / open-oboe`, with the right sidebar open and Claude visible. This run used the active desktop route:
+
+`http://localhost:7665/#/v2-workspace/d3010a09-de89-4c81-8ff1-0a6663ce6ba9`
+
+| Scenario | Commits | React commit duration | Long tasks | Long task duration |
+| --- | ---: | ---: | ---: | ---: |
+| Activate Claude from Chat | 23 | 145.8 ms | 4 | 354 ms |
+| Switch Claude/terminal tabs | 88 | 263.6 ms | 11 | 836 ms |
+| Create panes from Claude-open workspace | 125 | 318.2 ms | 11 | 1009 ms |
+| Idle with Claude active after multi-terminal setup | 3 | 9.9 ms | 0 | 0 ms |
+
+Notes:
+
+- `Cmd+T` created a new Chat pane in this workspace, so the pane-creation scenario includes one accidental Chat pane followed by two Terminal panes created through the add-pane menu.
+- The idle result again argues against a continuous idle render loop. The CPU spikes are tied to interaction bursts.
+- The hot local components matched the earlier root-main profiles:
+  - `TooltipTrigger` rendered 3,028 times during the Claude/terminal switch burst and 4,461 times during pane creation.
+  - `TabBar` rendered 434 times during the switch burst and 566 times during pane creation.
+  - `DropdownMenu` rendered 864 times during the switch burst and 1,312 times during pane creation.
+  - `WorkspaceClientProvider`, `TRPCProvider`, and `QueryClientProvider` each rendered 176 times during the switch burst and 250 times during pane creation.
+
+This reinforces the diagnosis that pane interactions fan out through shared workspace state, then through the workspace provider stack and every tab/header overlay primitive. Claude being open is not a separate root cause; it adds another pane type into the same expensive tab and provider cascade.
+
+## Fixes Applied
+
+The first patch set targeted the measured render fanout without changing pane behavior:
+
+- Debounced `paneLayout` persistence in `useV2WorkspacePaneLayout` so rapid pane/tab mutations write one local-state update after the burst instead of on every store mutation.
+- Stabilized workspace render props in `V2WorkspaceContent`, including tab accessory, add menu, below-tab-bar, trailing controls, empty state, and workspace-run button.
+- Stabilized tab callbacks in `Workspace` and `TabBar`, then memoized `TabItem`.
+- Removed always-mounted tab label and close-button `Tooltip` wrappers in favor of native `title` and `aria-label`.
+- Lazy-mounted tab and pane context-menu content only while the menu is open.
+- Reused the cached `WorkspaceClientProvider` client object as the context value.
+- Memoized the `WorkspaceProvider` value.
+
+I also tested hoisting `workspaceRunTerminals` from each terminal dropdown into the pane registry. React Scan showed that this made the registry depend on a broad, frequently changing map and increased workspace-wide rerenders, so I reverted that part. The better follow-up is to split workspace-run terminal state out of the broad `v2WorkspaceLocalState` row, not to pass the full map through the whole pane registry.
+
+## Validation After Fixes
+
+Final validation used the same open workspace route with Claude open and the right sidebar open. It is a conservative comparison because the final run had more existing terminal tabs than the baseline after repeated create-pane tests.
+
+| Scenario | Baseline commits | Final commits | Baseline React duration | Final React duration | Baseline long tasks | Final long tasks | Baseline long-task duration | Final long-task duration |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Idle with Claude active | 3 | 7 | 9.9 ms | 27.4 ms | 0 | 0 | 0 ms | 0 ms |
+| Switch Claude/terminal tabs | 88 | 36 | 263.6 ms | 211.6 ms | 11 | 1 | 836 ms | 70 ms |
+| Create 2 terminal tabs | 125 | 76 | 318.2 ms | 232.6 ms | 11 | 4 | 1009 ms | 299 ms |
+
+Key deltas:
+
+- Tab switching: commits down 59%, React commit duration down 20%, long-task count down 91%, long-task duration down 92%.
+- Creating two terminal panes: commits down 39%, React commit duration down 27%, long-task count down 64%, long-task duration down 70%.
+- Idle is still quiet in terms of long tasks, but the final idle commit count was higher than baseline because the workspace had accumulated more panes during profiling and sidebar/git status work was active.
+
+Hot components after fixes:
+
+- `TooltipTrigger` remains the biggest local render counter during pane creation, but dropped from 4,461 renders to 1,824 renders.
+- `TabBar`/tab-item context-menu work dropped substantially after lazy-mounting menu content. `ContextMenu` no longer shows up as a top local component in the final switch burst.
+- The route/provider stack still rerenders once per workspace interaction commit, so the next larger improvement needs narrower state subscriptions rather than more tab-level memoization.
+
+## Main Findings
+
+1. Workspace-local state is too broad.
+
+   `v2WorkspaceLocalState` currently stores `paneLayout`, `sidebarState`, `viewedFiles`, `recentlyViewedFiles`, and `workspaceRunTerminals` in one localStorage collection row. A pane layout change therefore invalidates subscribers that only care about sidebar state or workspace-run terminal state.
+
+   Relevant files:
+
+   - `apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts`
+   - `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts`
+
+2. Terminal panes still read workspace-run state from the broad local-state row.
+
+   Every `TerminalSessionDropdown` performs a `useLiveQuery` against the full `v2WorkspaceLocalState` row to read `workspaceRunTerminals[terminalId]`. With several terminal tabs open, each pane layout update can wake each terminal header. Hoisting the full map into the pane registry made the wider workspace subtree depend on the same state, so the right fix is splitting or narrowing the stored state.
+
+   Relevant file:
+
+   - `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx`
+
+3. The right sidebar adds significant render cost, but it is not the whole issue.
+
+   Closing the sidebar reduced commits during tab switching from 76 to 51, but still left 5 long tasks. The sidebar subscribes to the same workspace-local row and the Changes tab rerenders during terminal-only interactions.
+
+   Relevant file:
+
+   - `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx`
+
+4. Tab rendering scales with tab count.
+
+   `TabBar` maps all tabs on each active-tab change. Each `TabItem` mounts context menu and tooltip primitives, and callback/accessory props are recreated from `V2WorkspaceContent`. This showed up as thousands of `TooltipTrigger`, `DropdownMenu`, and `ContextMenu` renders.
+
+   Relevant files:
+
+   - `packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx`
+   - `packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx`
+   - `packages/ui/src/components/ui/tooltip.tsx`
+   - `packages/ui/src/components/ui/dropdown-menu.tsx`
+
+5. Provider context values participate in the cascade.
+
+   `WorkspaceClientProvider` recreates its context value on parent renders. React Scan repeatedly showed `WorkspaceClientProvider`, `TRPCProvider`, and `QueryClientProvider` in the hot path during tab switching and pane creation.
+
+   Relevant file:
+
+   - `packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx`
+
+## Proposed Fix Plan
+
+1. Split or narrow workspace-local state subscriptions.
+
+   Prefer separate local collections for:
+
+   - pane layout
+   - sidebar state
+   - workspace-run terminal state
+   - viewed/recent files
+
+   If a schema split is too large for the first pass, add selector hooks that expose stable, narrow values and avoid passing full local-state rows into unrelated UI.
+
+2. Split workspace-run terminal state out of the pane-layout row.
+
+   Do not pass the full `workspaceRunTerminals` map through `usePaneRegistry`. Prefer a separate local collection, or a selector that subscribes only to one `terminalId` so terminal status updates do not invalidate unrelated tab/header UI.
+
+3. Continue reducing always-mounted overlay primitives.
+
+   Tab context-menu content is now lazy-mounted, but tooltip wrappers across the sidebar, preset bar, and pane headers remain hot. Convert low-value static tooltips on frequently rerendered chrome to native `title` or a shared/lazy tooltip trigger.
+
+4. Batch pane layout persistence.
+
+   `useV2WorkspacePaneLayout` currently snapshots the full pane store with `JSON.stringify` and writes each store update to local storage. Debounce or microtask-batch persistence so rapid tab/pane mutations produce one local state write, and compare a cheaper revision/snapshot where possible.
+
+5. Stabilize remaining workspace render props.
+
+   The main `V2WorkspaceContent` render props are now memoized. Continue this work in sidebar/pane header components that still recreate dropdown/tooltip props during workspace-level commits.
+
+6. Memoize pane header components and avoid always-mounted overlays.
+
+   `TabItem` is now memoized and tab/pane context-menu content is lazy-mounted. Extend the same approach to pane header extras and right-sidebar toolbar components after narrowing state subscriptions.
+
+7. Re-profile against budgets.
+
+   Suggested budgets for the same scenarios:
+
+   - idle: 0-1 commits per 10 seconds, no long tasks
+   - tab switch burst: under 25 commits, no long tasks
+   - create 4 terminal tabs: under 25 commits, no long tasks
+   - `TooltipTrigger` render count reduced by at least 70 percent
+
+## Notes
+
+React Scan attributed render and CPU work, not heap retention. A real memory-leak investigation should add Chromium/Electron heap snapshots after repeated open/switch/close cycles, but reducing the render fanout should come first because it is the directly measured CPU spike.

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@superset/ui/utils";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useStore } from "zustand";
 import type { Pane } from "../../../types";
 import type { WorkspaceProps } from "../../types";
@@ -46,22 +46,58 @@ export function Workspace<TData>({
 		previousPanesRef.current = current;
 	}, [tabs, registry]);
 
-	const closeTab = async (tabId: string) => {
-		const tab = store.getState().getTab(tabId);
-		if (!tab) return;
-		if (onBeforeCloseTab) {
-			const allowed = await onBeforeCloseTab(tab);
-			if (!allowed) return;
+	const closeTab = useCallback(
+		async (tabId: string) => {
+			const tab = store.getState().getTab(tabId);
+			if (!tab) return;
+			if (onBeforeCloseTab) {
+				const allowed = await onBeforeCloseTab(tab);
+				if (!allowed) return;
+			}
+			// Re-check after the await: the tab may have been removed concurrently.
+			if (!store.getState().getTab(tabId)) return;
+			store.getState().removeTab(tabId);
+			try {
+				onAfterCloseTab?.(tab);
+			} catch (err) {
+				console.error("onAfterCloseTab threw", err);
+			}
+		},
+		[onAfterCloseTab, onBeforeCloseTab, store],
+	);
+
+	const selectTab = useCallback(
+		(tabId: string) => store.getState().setActiveTab(tabId),
+		[store],
+	);
+	const closeOtherTabs = useCallback(
+		async (tabId: string) => {
+			for (const tab of store.getState().tabs) {
+				if (tab.id !== tabId) await closeTab(tab.id);
+			}
+		},
+		[closeTab, store],
+	);
+	const closeAllTabs = useCallback(async () => {
+		for (const tab of store.getState().tabs) {
+			await closeTab(tab.id);
 		}
-		// Re-check after the await: the tab may have been removed concurrently.
-		if (!store.getState().getTab(tabId)) return;
-		store.getState().removeTab(tabId);
-		try {
-			onAfterCloseTab?.(tab);
-		} catch (err) {
-			console.error("onAfterCloseTab threw", err);
-		}
-	};
+	}, [closeTab, store]);
+	const renameTab = useCallback(
+		(tabId: string, title: string | undefined) =>
+			store.getState().setTabTitleOverride({ tabId, titleOverride: title }),
+		[store],
+	);
+	const reorderTab = useCallback(
+		(tabId: string, toIndex: number) =>
+			store.getState().reorderTab({ tabId, toIndex }),
+		[store],
+	);
+	const movePaneToNewTab = useCallback(
+		(paneId: string, toIndex: number) =>
+			store.getState().movePaneToNewTab({ paneId, toIndex }),
+		[store],
+	);
 
 	return (
 		<div
@@ -72,29 +108,16 @@ export function Workspace<TData>({
 		>
 			<TabBar
 				tabs={tabs}
+				store={store}
 				registry={registry}
 				activeTabId={activeTabId}
-				onSelectTab={(tabId) => store.getState().setActiveTab(tabId)}
+				onSelectTab={selectTab}
 				onCloseTab={closeTab}
-				onCloseOtherTabs={async (tabId) => {
-					for (const tab of tabs) {
-						if (tab.id !== tabId) await closeTab(tab.id);
-					}
-				}}
-				onCloseAllTabs={async () => {
-					for (const tab of tabs) {
-						await closeTab(tab.id);
-					}
-				}}
-				onRenameTab={(tabId, title) =>
-					store.getState().setTabTitleOverride({ tabId, titleOverride: title })
-				}
-				onReorderTab={(tabId, toIndex) =>
-					store.getState().reorderTab({ tabId, toIndex })
-				}
-				onMovePaneToNewTab={(paneId, toIndex) =>
-					store.getState().movePaneToNewTab({ paneId, toIndex })
-				}
+				onCloseOtherTabs={closeOtherTabs}
+				onCloseAllTabs={closeAllTabs}
+				onRenameTab={renameTab}
+				onReorderTab={reorderTab}
+				onMovePaneToNewTab={movePaneToNewTab}
 				renderTabIcon={renderTabIcon}
 				renderAddTabMenu={renderAddTabMenu}
 				renderTabBarTrailing={renderTabBarTrailing}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneContextMenu/PaneContextMenu.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneContextMenu/PaneContextMenu.tsx
@@ -9,7 +9,7 @@ import {
 	ContextMenuSubTrigger,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import type {
 	ContextMenuActionConfig,
 	RendererContext,
@@ -83,16 +83,20 @@ export function PaneContextMenu<TData>({
 	actions,
 	context,
 }: PaneContextMenuProps<TData>) {
+	const [isOpen, setIsOpen] = useState(false);
+
 	if (actions.length === 0) {
 		return <>{children}</>;
 	}
 
 	return (
-		<ContextMenu>
+		<ContextMenu onOpenChange={setIsOpen}>
 			<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-			<ContextMenuContent>
-				<ContextMenuItems actions={actions} context={context} />
-			</ContextMenuContent>
+			{isOpen && (
+				<ContextMenuContent>
+					<ContextMenuItems actions={actions} context={context} />
+				</ContextMenuContent>
+			)}
 		</ContextMenu>
 	);
 }

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -14,6 +14,8 @@ import {
 	useState,
 } from "react";
 import { useDrop } from "react-dnd";
+import type { StoreApi } from "zustand/vanilla";
+import type { WorkspaceStore } from "../../../../../core/store";
 import type { Tab } from "../../../../../types";
 import type { PaneRegistry } from "../../../../types";
 import { PANE_DRAG_TYPE } from "../Tab/components/Pane/components/PaneHeader";
@@ -22,6 +24,7 @@ import { computeInsertIndex, TAB_WIDTH } from "./utils";
 
 interface TabBarProps<TData> {
 	tabs: Tab<TData>[];
+	store: StoreApi<WorkspaceStore<TData>>;
 	registry: PaneRegistry<TData>;
 	activeTabId: string | null;
 	onSelectTab: (tabId: string) => void;
@@ -72,6 +75,7 @@ function AddTabButton<_TData>({
 
 export function TabBar<TData>({
 	tabs,
+	store,
 	registry,
 	activeTabId,
 	onSelectTab,
@@ -204,16 +208,17 @@ export function TabBar<TData>({
 							<TabItem
 								tab={tab}
 								tabs={tabs}
+								store={store}
 								registry={registry}
 								index={i}
 								isActive={tab.id === activeTabId}
-								onSelect={() => onSelectTab(tab.id)}
-								onClose={() => onCloseTab(tab.id)}
-								onCloseOthers={() => onCloseOtherTabs(tab.id)}
+								onSelectTab={onSelectTab}
+								onCloseTab={onCloseTab}
+								onCloseOtherTabs={onCloseOtherTabs}
 								onCloseAll={onCloseAllTabs}
-								onRename={(title) => onRenameTab(tab.id, title)}
-								icon={renderTabIcon?.(tab)}
-								accessory={renderTabAccessory?.(tab)}
+								onRenameTab={onRenameTab}
+								renderIcon={renderTabIcon}
+								renderAccessory={renderTabAccessory}
 							/>
 						</div>
 					))}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -7,13 +7,22 @@ import {
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
 import { OverflowFadeText } from "@superset/ui/overflow-fade-text";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { PencilIcon, XIcon } from "lucide-react";
-import { type ReactNode, useCallback, useRef, useState } from "react";
+import {
+	memo,
+	type ReactNode,
+	useCallback,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useDrag, useDrop } from "react-dnd";
+import type { StoreApi } from "zustand/vanilla";
+import type { WorkspaceStore } from "../../../../../../../core/store";
 import type { Tab } from "../../../../../../../types";
-import type { PaneRegistry } from "../../../../../../types";
+import type { PaneRegistry, RendererContext } from "../../../../../../types";
+import { pickTabTitlePane } from "../../../../utils/resolveTabTitle";
 import { useTabTitle } from "../../../../utils/useTabTitle";
 import { PANE_DRAG_TYPE } from "../../../Tab/components/Pane/components/PaneHeader";
 import { TabRenameInput } from "./components/TabRenameInput";
@@ -23,35 +32,81 @@ export const TAB_DRAG_TYPE = "tab";
 interface TabItemProps<TData> {
 	tab: Tab<TData>;
 	tabs: Tab<TData>[];
+	store: StoreApi<WorkspaceStore<TData>>;
 	registry: PaneRegistry<TData>;
 	index: number;
 	isActive: boolean;
-	onSelect: () => void;
-	onClose: () => void;
-	onCloseOthers: () => void;
+	onSelectTab: (tabId: string) => void;
+	onCloseTab: (tabId: string) => void;
+	onCloseOtherTabs: (tabId: string) => void;
 	onCloseAll: () => void;
-	onRename: (title: string | undefined) => void;
-	icon?: ReactNode;
-	accessory?: ReactNode;
+	onRenameTab: (tabId: string, title: string | undefined) => void;
+	renderIcon?: (tab: Tab<TData>) => ReactNode;
+	renderAccessory?: (tab: Tab<TData>) => ReactNode;
 }
 
-export function TabItem<TData>({
+function TabItemInner<TData>({
 	tab,
 	tabs,
+	store,
 	registry,
 	index,
 	isActive,
-	onSelect,
-	onClose,
-	onCloseOthers,
+	onSelectTab,
+	onCloseTab,
+	onCloseOtherTabs,
 	onCloseAll,
-	onRename,
-	icon,
-	accessory,
+	onRenameTab,
+	renderIcon,
+	renderAccessory,
 }: TabItemProps<TData>) {
 	const [isEditing, setIsEditing] = useState(false);
+	const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
 	const [editValue, setEditValue] = useState("");
 	const title = useTabTitle(tab, tabs, registry);
+	const fallbackIcon = useMemo(() => {
+		const pane = pickTabTitlePane(tab);
+		if (!pane) return null;
+		const definition = registry[pane.kind];
+		if (!definition?.getIcon) return null;
+		const context: RendererContext<TData> = {
+			pane: { ...pane, parentDirection: null },
+			tab: { ...tab, position: index },
+			isActive,
+			store,
+			actions: {
+				close: () => {
+					store.getState().closePane({ tabId: tab.id, paneId: pane.id });
+				},
+				focus: () =>
+					store.getState().setActivePane({ tabId: tab.id, paneId: pane.id }),
+				setTitle: (nextTitle) =>
+					store.getState().setPaneTitleOverride({
+						tabId: tab.id,
+						paneId: pane.id,
+						titleOverride: nextTitle,
+					}),
+				pin: () =>
+					store.getState().setPanePinned({
+						paneId: pane.id,
+						pinned: true,
+					}),
+				updateData: (data) =>
+					store.getState().setPaneData({ paneId: pane.id, data }),
+				split: (position, newPane) =>
+					store.getState().splitPane({
+						tabId: tab.id,
+						paneId: pane.id,
+						position: position === "down" ? "bottom" : "right",
+						newPane,
+					}),
+			},
+			components: { PaneHeaderActions: () => null },
+		};
+		return definition.getIcon(context);
+	}, [index, isActive, registry, store, tab]);
+	const icon = renderIcon?.(tab) ?? fallbackIcon;
+	const accessory = renderAccessory?.(tab);
 
 	const startEditing = () => {
 		setEditValue(title);
@@ -65,12 +120,21 @@ export function TabItem<TData>({
 	const saveEdit = () => {
 		const nextTitle = editValue.trim();
 		if (nextTitle.length === 0) {
-			onRename(undefined);
+			onRenameTab(tab.id, undefined);
 		} else if (nextTitle !== title) {
-			onRename(nextTitle);
+			onRenameTab(tab.id, nextTitle);
 		}
 		stopEditing();
 	};
+	const selectTab = useCallback(() => {
+		onSelectTab(tab.id);
+	}, [onSelectTab, tab.id]);
+	const closeTab = useCallback(() => {
+		onCloseTab(tab.id);
+	}, [onCloseTab, tab.id]);
+	const closeOtherTabs = useCallback(() => {
+		onCloseOtherTabs(tab.id);
+	}, [onCloseOtherTabs, tab.id]);
 
 	const nodeRef = useRef<HTMLDivElement>(null);
 
@@ -90,13 +154,13 @@ export function TabItem<TData>({
 		() => ({
 			accept: PANE_DRAG_TYPE,
 			hover: () => {
-				if (!isActive) onSelect();
+				if (!isActive) selectTab();
 			},
 			collect: (monitor) => ({
 				isOver: monitor.isOver(),
 			}),
 		}),
-		[isActive, onSelect],
+		[isActive, selectTab],
 	);
 
 	const setRef = useCallback(
@@ -109,7 +173,7 @@ export function TabItem<TData>({
 	);
 
 	return (
-		<ContextMenu>
+		<ContextMenu onOpenChange={setIsContextMenuOpen}>
 			<ContextMenuTrigger asChild>
 				{/* biome-ignore lint/a11y/noStaticElementInteractions: mousedown selects tab immediately before drag threshold */}
 				<div
@@ -123,7 +187,7 @@ export function TabItem<TData>({
 						isDragging && "opacity-30",
 					)}
 					onMouseDown={(event) => {
-						if (event.button === 0) onSelect();
+						if (event.button === 0) selectTab();
 					}}
 				>
 					{isEditing ? (
@@ -139,81 +203,71 @@ export function TabItem<TData>({
 						</div>
 					) : (
 						<>
-							<Tooltip
-								delayDuration={500}
-								open={isDragging ? false : undefined}
+							<button
+								className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-colors"
+								onAuxClick={(event) => {
+									if (event.button === 1) {
+										event.preventDefault();
+										closeTab();
+									}
+								}}
+								onDoubleClick={startEditing}
+								title={isDragging ? undefined : title}
+								type="button"
 							>
-								<TooltipTrigger asChild>
-									<button
-										className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-colors"
-										onAuxClick={(event) => {
-											if (event.button === 1) {
-												event.preventDefault();
-												onClose();
-											}
-										}}
-										onDoubleClick={startEditing}
-										type="button"
-									>
-										{icon && <span className="shrink-0">{icon}</span>}
-										<OverflowFadeText className="flex-1">
-											{title}
-										</OverflowFadeText>
-									</button>
-								</TooltipTrigger>
-								<TooltipContent side="bottom" showArrow={false}>
-									{title}
-								</TooltipContent>
-							</Tooltip>
+								{icon && <span className="shrink-0">{icon}</span>}
+								<OverflowFadeText className="flex-1">{title}</OverflowFadeText>
+							</button>
 							<div className="relative flex h-full w-7 shrink-0 items-center justify-center">
 								{accessory && (
 									<span className="pointer-events-none absolute inset-0 flex items-center justify-center leading-none opacity-100 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
 										{accessory}
 									</span>
 								)}
-								<Tooltip delayDuration={500}>
-									<TooltipTrigger asChild>
-										<Button
-											className={cn(
-												"pointer-events-none size-5 cursor-pointer text-current opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-												isActive ? "hover:bg-foreground/10" : "hover:bg-muted",
-											)}
-											onClick={(event) => {
-												event.stopPropagation();
-												onClose();
-											}}
-											onMouseDown={(event) => {
-												event.stopPropagation();
-											}}
-											size="icon"
-											type="button"
-											variant="ghost"
-										>
-											<XIcon className="size-3.5" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top" showArrow={false}>
-										Close
-									</TooltipContent>
-								</Tooltip>
+								<Button
+									aria-label="Close"
+									className={cn(
+										"pointer-events-none size-5 cursor-pointer text-current opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+										isActive ? "hover:bg-foreground/10" : "hover:bg-muted",
+									)}
+									onClick={(event) => {
+										event.stopPropagation();
+										closeTab();
+									}}
+									onMouseDown={(event) => {
+										event.stopPropagation();
+									}}
+									size="icon"
+									title="Close"
+									type="button"
+									variant="ghost"
+								>
+									<XIcon className="size-3.5" />
+								</Button>
 							</div>
 						</>
 					)}
 				</div>
 			</ContextMenuTrigger>
-			<ContextMenuContent>
-				<ContextMenuItem onSelect={startEditing}>
-					<PencilIcon className="mr-2 size-4" />
-					Rename
-				</ContextMenuItem>
-				<ContextMenuSeparator />
-				<ContextMenuItem onSelect={onClose}>
-					<XIcon className="mr-2 size-4" />
-					Close
-				</ContextMenuItem>
-				<ContextMenuItem onSelect={onCloseOthers}>Close Others</ContextMenuItem>
-				<ContextMenuItem onSelect={onCloseAll}>Close All</ContextMenuItem>
-			</ContextMenuContent>
+			{isContextMenuOpen && (
+				<ContextMenuContent>
+					<ContextMenuItem onSelect={startEditing}>
+						<PencilIcon className="mr-2 size-4" />
+						Rename
+					</ContextMenuItem>
+					<ContextMenuSeparator />
+					<ContextMenuItem onSelect={closeTab}>
+						<XIcon className="mr-2 size-4" />
+						Close
+					</ContextMenuItem>
+					<ContextMenuItem onSelect={closeOtherTabs}>
+						Close Others
+					</ContextMenuItem>
+					<ContextMenuItem onSelect={onCloseAll}>Close All</ContextMenuItem>
+				</ContextMenuContent>
+			)}
 		</ContextMenu>
 	);
 }
+
+export const TabItem = memo(TabItemInner) as typeof TabItemInner;

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -102,15 +102,9 @@ export function WorkspaceClientProvider({
 	children,
 }: WorkspaceClientProviderProps) {
 	const clients = getWorkspaceClients(cacheKey, hostUrl, headers, wsToken);
-	const contextValue: WorkspaceClientContextValue = {
-		hostUrl: clients.hostUrl,
-		queryClient: clients.queryClient,
-		trpcClient: clients.trpcClient,
-		getWsToken: clients.getWsToken,
-	};
 
 	return (
-		<WorkspaceClientContext.Provider value={contextValue}>
+		<WorkspaceClientContext.Provider value={clients}>
 			<workspaceTrpc.Provider
 				client={clients.trpcClient}
 				queryClient={clients.queryClient}


### PR DESCRIPTION
## Summary
- debounce workspace pane layout persistence and stabilize workspace/tab render callbacks
- memoize tab items, lazy-mount context menu content, and preserve registry tab icons for file/diff panes
- memoize workspace/workspace-client provider values and document React Scan findings

## Validation
- `./node_modules/.bin/biome check --write <touched files>`
- `PATH="/Users/avipeltz/.bun/bin:$PATH" ./node_modules/.bin/turbo run typecheck --filter=@superset/panes --filter=@superset/desktop`
- `PATH="/Users/avipeltz/.bun/bin:$PATH" ./node_modules/.bin/turbo run typecheck --filter=@superset/panes --filter=@superset/workspace-client --filter=@superset/desktop`
- `git diff --check`
- React Scan final trace: `/tmp/superset-react-scan-final2.jsonl`

## React Scan Results
- Switch Claude/terminal tabs: 88 commits / 263.6ms / 11 long tasks -> 36 commits / 211.6ms / 1 long task
- Create 2 terminal tabs: 125 commits / 318.2ms / 11 long tasks -> 76 commits / 232.6ms / 4 long tasks

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5042">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves workspace pane interaction performance by debouncing layout persistence, stabilizing render props and callbacks, and memoizing tab items and providers. This cuts render fanout during tab switching and pane creation.

- **Refactors**
  - Debounced `paneLayout` persistence in `useV2WorkspacePaneLayout` (1s).
  - Memoized workspace render props in `V2WorkspaceContent` and stabilized tab callbacks in `Workspace`/`TabBar`; memoized `TabItem`.
  - Lazy-mounted tab/pane context-menu content and replaced always-on tooltips with `title`/ARIA.
  - Memoized `WorkspaceProvider` value and passed cached clients directly in `WorkspaceClientProvider`; preserved registry tab icons for file/diff panes.

- **Performance**
  - Tab switch: commits 88 → 36, React time 263.6ms → 211.6ms, long tasks 11 → 1.
  - Create 2 terminals: commits 125 → 76, React time 318.2ms → 232.6ms, long tasks 11 → 4.

<sup>Written for commit f8cc83abbe15c3d741d646be7a4a2940ee86d191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace rendering performance and responsiveness.
  * Optimized context menu rendering behavior.
  * Removed tooltip overlays from tab controls.

* **Documentation**
  * Added workspace performance profiling analysis documenting baseline measurements and optimization recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->