### PR TITLE
[codex] Focus active terminal panes

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -159,9 +159,14 @@ class TerminalRuntimeRegistryImpl {
 		}
 
 		const { runtime, transport } = entry;
-		attachToContainer(runtime, container, () => {
-			sendResize(transport, runtime.terminal.cols, runtime.terminal.rows);
-		});
+		attachToContainer(
+			runtime,
+			container,
+			() => {
+				sendResize(transport, runtime.terminal.cols, runtime.terminal.rows);
+			},
+			{ focus: false },
+		);
 	}
 
 	/**

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -250,9 +250,10 @@ export function attachToContainer(
 	runtime: TerminalRuntime,
 	container: HTMLDivElement,
 	onResize?: () => void,
+	options: { focus?: boolean } = {},
 ) {
 	// If we're already attached to this exact container, do nothing. Prevents
-	// redundant refresh/focus/fit from transient remounts during provider key
+	// redundant refresh/fit from transient remounts during provider key
 	// churn — VSCode setVisible() is idempotent for the same host element.
 	const sameContainer =
 		runtime.container === container &&
@@ -280,7 +281,9 @@ export function attachToContainer(
 	runtime.resizeObserver = observer;
 	runtime._disposeResizeObserver = scheduler.dispose;
 
-	runtime.terminal.focus();
+	if (options.focus !== false) {
+		runtime.terminal.focus();
+	}
 }
 
 export function detachFromContainer(runtime: TerminalRuntime) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -154,6 +154,14 @@ export function TerminalPane({
 		};
 	}, [terminalId, terminalInstanceId]);
 
+	useEffect(() => {
+		if (!ctx.isActive) return;
+
+		terminalRuntimeRegistry
+			.getTerminal(terminalId, terminalInstanceId)
+			?.focus();
+	}, [ctx.isActive, terminalId, terminalInstanceId]);
+
 	const lastInvalidatedOpenSessionRef = useRef<string | null>(null);
 	useEffect(() => {
 		const invalidateSessionsAfterSocketOpen = () => {


### PR DESCRIPTION
## Summary

- Focus the v2 terminal xterm instance whenever its pane becomes active.
- Disable registry-level terminal autofocus for v2 pane mounts so inactive terminals do not steal DOM focus while mounting.
- Keep shared `attachToContainer` autofocus as the default for non-pane callers, including onboarding.

## Root Cause

`setActivePane` updates the visual active-pane state, but it does not move DOM keyboard focus to xterm. Directional focus shortcuts and other pane activation paths can therefore leave typing attached to the previously focused terminal. Separately, the shared terminal attach path focused every mounted terminal, which could fight the active-pane invariant when multiple terminal panes mount.

## Validation

- `bun run lint`

Addresses #5052.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal pane now reliably receives keyboard focus when you activate its pane, improving input behavior when switching panes.
  * Terminal attachments no longer steal focus during background mounts, preventing unexpected focus changes when terminals are initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->