### PR TITLE
fix: route organization creation through auth hooks

### DIFF
--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -223,6 +223,13 @@ export const organizationRouter = {
 				},
 			});
 
+			if (!organization) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to create organization",
+				});
+			}
+
 			return organization;
 		}),
 

--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -1,3 +1,4 @@
+import { auth } from "@superset/auth/server";
 import { stripeClient } from "@superset/auth/stripe";
 import { db } from "@superset/db/client";
 import { members, organizations } from "@superset/db/schema";
@@ -6,7 +7,6 @@ import {
 	invitations,
 	verifications,
 } from "@superset/db/schema/auth";
-import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import { findOrgMembership } from "@superset/db/utils";
 import { canRemoveMember, type OrganizationRole } from "@superset/shared/auth";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
@@ -214,24 +214,14 @@ export const organizationRouter = {
 				}
 			}
 
-			const [organization] = await db
-				.insert(organizations)
-				.values({
+			const organization = await auth.api.createOrganization({
+				body: {
 					name: input.name,
 					slug: input.slug,
 					logo: input.logo,
-				})
-				.returning();
-
-			if (organization) {
-				await db.insert(members).values({
-					organizationId: organization.id,
 					userId: ctx.session.user.id,
-					role: "owner",
-				});
-
-				await seedDefaultStatuses(organization.id);
-			}
+				},
+			});
 
 			return organization;
 		}),


### PR DESCRIPTION
## Summary

- Route custom organization creation through Better Auth instead of manually inserting organization and member rows.
- Let Better Auth organization hooks remain the single source of truth for default team/status setup and Stripe customer creation.
- Fixes #5048.

## Root Cause

The desktop app creates additional organizations through the tRPC `organization.create` route. That route inserted directly into the database, bypassing Better Auth `afterCreateOrganization` hooks where billing setup runs. As a result, second organizations could miss billing lifecycle setup and the upgrade flow would fail to open checkout.

## Validation

- `bun run lint`
- `bun run typecheck`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5055">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route organization creation through Better Auth to trigger org hooks for billing and default setup, and add error handling for failed creates. Fixes failed upgrade checkout for second organizations created via the desktop app.

- **Bug Fixes**
  - Replace direct DB inserts with `auth.api.createOrganization` to run Stripe and default setup hooks.
  - Remove manual member/status seeding; hooks are the source of truth.
  - Throw `TRPCError` when `createOrganization` returns no org to prevent silent failures.

<sup>Written for commit 4feea3470b3dd8c8341dc6ac19ec5b72e7e82523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized organization creation into a shared authentication service for more consistent and maintainable behavior.
* **Bug Fixes**
  * Improved error handling: failed organization creation now surfaces a clear internal-server error instead of continuing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->