### PR TITLE
feat(desktop): group assistant turns in chat with a collapsible step view

### DIFF
--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/AssistantTurnGroup.test.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/AssistantTurnGroup.test.tsx
@@ -18,7 +18,7 @@ describe("AssistantTurnGroup", () => {
 		expect(html).toContain("3 tools · 1 message");
 	});
 
-	it("shows the Claude lead and a status-colored dot", () => {
+	it("shows the assistant lead plus a status dot and screen-reader label", () => {
 		const complete = renderToStaticMarkup(
 			<AssistantTurnGroup
 				summary="1 tool call"
@@ -26,8 +26,9 @@ describe("AssistantTurnGroup", () => {
 				steps={<div />}
 			/>,
 		);
-		expect(complete).toContain("Claude");
+		expect(complete).toContain("Assistant");
 		expect(complete).toContain("bg-emerald-500");
+		expect(complete).toContain("Done"); // sr-only status text
 		expect(
 			renderToStaticMarkup(
 				<AssistantTurnGroup
@@ -42,6 +43,21 @@ describe("AssistantTurnGroup", () => {
 				<AssistantTurnGroup summary="" status="in_progress" steps={<div />} />,
 			),
 		).toContain("bg-sky-500");
+	});
+
+	it("signals a pending action with an amber dot + sr-only label", () => {
+		const html = renderToStaticMarkup(
+			<AssistantTurnGroup
+				summary="1 tool call"
+				status="complete"
+				pendingAction
+				steps={<div />}
+			/>,
+		);
+		expect(html).toContain("bg-amber-500");
+		expect(html).toContain("Awaiting approval");
+		// The misleading "complete/green" state must not win while pending.
+		expect(html).not.toContain("bg-emerald-500");
 	});
 
 	it("renders step content when opened by default", () => {

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/AssistantTurnGroup.test.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/AssistantTurnGroup.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AssistantTurnGroup } from "./AssistantTurnGroup";
+
+describe("AssistantTurnGroup", () => {
+	it("keeps the final answer visible even when collapsed", () => {
+		const html = renderToStaticMarkup(
+			<AssistantTurnGroup
+				summary="3 tools · 1 message"
+				status="complete"
+				defaultOpen={false}
+				steps={<div>STEP_CONTENT</div>}
+				lastOutput={<div>FINAL_ANSWER</div>}
+			/>,
+		);
+		// The answer lives outside the collapsible, so it is always present.
+		expect(html).toContain("FINAL_ANSWER");
+		expect(html).toContain("3 tools · 1 message");
+	});
+
+	it("shows the Claude lead and a status-colored dot", () => {
+		const complete = renderToStaticMarkup(
+			<AssistantTurnGroup
+				summary="1 tool call"
+				status="complete"
+				steps={<div />}
+			/>,
+		);
+		expect(complete).toContain("Claude");
+		expect(complete).toContain("bg-emerald-500");
+		expect(
+			renderToStaticMarkup(
+				<AssistantTurnGroup
+					summary="1 tool call"
+					status="error"
+					steps={<div />}
+				/>,
+			),
+		).toContain("bg-red-500");
+		expect(
+			renderToStaticMarkup(
+				<AssistantTurnGroup summary="" status="in_progress" steps={<div />} />,
+			),
+		).toContain("bg-sky-500");
+	});
+
+	it("renders step content when opened by default", () => {
+		const html = renderToStaticMarkup(
+			<AssistantTurnGroup
+				summary="2 tools"
+				status="in_progress"
+				defaultOpen
+				steps={<div>OPEN_STEP_CONTENT</div>}
+			/>,
+		);
+		expect(html).toContain("OPEN_STEP_CONTENT");
+	});
+});

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/AssistantTurnGroup.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/AssistantTurnGroup.tsx
@@ -5,16 +5,22 @@ import {
 } from "@superset/ui/collapsible";
 import { cn } from "@superset/ui/utils";
 import { BotIcon, ChevronRightIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import type { TurnStatus } from "../../utils/group-assistant-turn";
 
 interface AssistantTurnGroupProps {
 	/** One-line summary, e.g. "3 tool calls · 1 subagent · 1 message". */
 	summary: string;
 	status: TurnStatus;
+	/**
+	 * A required user action (e.g. plan approval) is pending. Overrides the
+	 * status dot with an amber "awaiting" state so a collapsed turn still signals
+	 * that something needs attention.
+	 */
+	pendingAction?: boolean;
 	/** When the turn started — shown as a compact clock in the header. */
 	timestamp?: string | number | Date | null;
-	/** Expanded on first render (live turns, errors, or when nothing else shows). */
+	/** Whether the turn should be open: live/errored turns expand, finished ones collapse. */
 	defaultOpen?: boolean;
 	/** The intermediate step nodes (thinking, tools, images) — collapsible. */
 	steps: ReactNode;
@@ -38,6 +44,12 @@ const STATUS_DOT_CLASS: Record<TurnStatus, string> = {
 	complete: "bg-emerald-500",
 };
 
+const STATUS_LABEL: Record<TurnStatus, string> = {
+	in_progress: "Running",
+	error: "Failed",
+	complete: "Done",
+};
+
 /**
  * Groups an assistant turn's intermediate actions into a single collapsible
  * card — the vendored agent-inspector's signature presentation — while the
@@ -47,15 +59,37 @@ const STATUS_DOT_CLASS: Record<TurnStatus, string> = {
 export function AssistantTurnGroup({
 	summary,
 	status,
+	pendingAction = false,
 	timestamp,
 	defaultOpen = false,
 	steps,
 	lastOutput,
 }: AssistantTurnGroupProps) {
+	const dotClass = pendingAction ? "bg-amber-500" : STATUS_DOT_CLASS[status];
+	const statusLabel = pendingAction
+		? "Awaiting approval"
+		: STATUS_LABEL[status];
+	// Controlled open state so a turn that started open while streaming collapses
+	// once it finishes (`defaultOpen` flips to false) — unless the user has
+	// manually toggled it, in which case their choice wins.
+	const [open, setOpen] = useState(defaultOpen);
+	const userToggled = useRef(false);
+	useEffect(() => {
+		if (!userToggled.current) setOpen(defaultOpen);
+	}, [defaultOpen]);
+	const handleOpenChange = (next: boolean) => {
+		userToggled.current = true;
+		setOpen(next);
+	};
+
 	const clock = formatClock(timestamp);
 	return (
 		<div className="flex flex-col gap-1.5">
-			<Collapsible defaultOpen={defaultOpen} className="not-prose group/turn">
+			<Collapsible
+				open={open}
+				onOpenChange={handleOpenChange}
+				className="not-prose group/turn"
+			>
 				<CollapsibleTrigger
 					className={cn(
 						"flex w-full min-w-0 items-center gap-2 rounded-md px-1 py-1 text-left text-xs",
@@ -65,7 +99,9 @@ export function AssistantTurnGroup({
 				>
 					<ChevronRightIcon className="size-3 shrink-0 transition-transform group-data-[state=open]/turn:rotate-90" />
 					<BotIcon className="size-3.5 shrink-0" />
-					<span className="shrink-0 font-medium text-foreground">Claude</span>
+					<span className="shrink-0 font-medium text-foreground">
+						Assistant
+					</span>
 					{summary ? (
 						<>
 							<span className="shrink-0 opacity-50">·</span>
@@ -79,10 +115,12 @@ export function AssistantTurnGroup({
 							{clock}
 						</span>
 					) : null}
+					<span className="sr-only">{statusLabel}</span>
 					<span
 						className={cn(
 							"size-1.5 shrink-0 rounded-full",
-							STATUS_DOT_CLASS[status],
+							dotClass,
+							pendingAction && "animate-pulse",
 						)}
 						aria-hidden
 					/>

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/AssistantTurnGroup.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/AssistantTurnGroup.tsx
@@ -1,0 +1,97 @@
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@superset/ui/collapsible";
+import { cn } from "@superset/ui/utils";
+import { BotIcon, ChevronRightIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import type { TurnStatus } from "../../utils/group-assistant-turn";
+
+interface AssistantTurnGroupProps {
+	/** One-line summary, e.g. "3 tool calls · 1 subagent · 1 message". */
+	summary: string;
+	status: TurnStatus;
+	/** When the turn started — shown as a compact clock in the header. */
+	timestamp?: string | number | Date | null;
+	/** Expanded on first render (live turns, errors, or when nothing else shows). */
+	defaultOpen?: boolean;
+	/** The intermediate step nodes (thinking, tools, images) — collapsible. */
+	steps: ReactNode;
+	/** The final answer — always visible, even when steps are collapsed. */
+	lastOutput?: ReactNode;
+}
+
+function formatClock(value: string | number | Date | null | undefined): string {
+	if (value == null) return "";
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) return "";
+	return date.toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+const STATUS_DOT_CLASS: Record<TurnStatus, string> = {
+	in_progress: "bg-sky-500 animate-pulse",
+	error: "bg-red-500",
+	complete: "bg-emerald-500",
+};
+
+/**
+ * Groups an assistant turn's intermediate actions into a single collapsible
+ * card — the vendored agent-inspector's signature presentation — while the
+ * final answer stays visible below the header. Reuses the existing
+ * `ToolCallBlock`/`ReasoningBlock` nodes verbatim as `steps`.
+ */
+export function AssistantTurnGroup({
+	summary,
+	status,
+	timestamp,
+	defaultOpen = false,
+	steps,
+	lastOutput,
+}: AssistantTurnGroupProps) {
+	const clock = formatClock(timestamp);
+	return (
+		<div className="flex flex-col gap-1.5">
+			<Collapsible defaultOpen={defaultOpen} className="not-prose group/turn">
+				<CollapsibleTrigger
+					className={cn(
+						"flex w-full min-w-0 items-center gap-2 rounded-md px-1 py-1 text-left text-xs",
+						"text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground",
+						"outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+					)}
+				>
+					<ChevronRightIcon className="size-3 shrink-0 transition-transform group-data-[state=open]/turn:rotate-90" />
+					<BotIcon className="size-3.5 shrink-0" />
+					<span className="shrink-0 font-medium text-foreground">Claude</span>
+					{summary ? (
+						<>
+							<span className="shrink-0 opacity-50">·</span>
+							<span className="min-w-0 flex-1 truncate">{summary}</span>
+						</>
+					) : (
+						<span className="min-w-0 flex-1" />
+					)}
+					{clock ? (
+						<span className="shrink-0 text-[10px] tabular-nums opacity-60">
+							{clock}
+						</span>
+					) : null}
+					<span
+						className={cn(
+							"size-1.5 shrink-0 rounded-full",
+							STATUS_DOT_CLASS[status],
+						)}
+						aria-hidden
+					/>
+				</CollapsibleTrigger>
+				<CollapsibleContent className="mt-1 ml-1.5 flex flex-col gap-2 border-l border-border/40 pl-3 outline-none">
+					{steps}
+				</CollapsibleContent>
+			</Collapsible>
+			{lastOutput ? <div className="min-w-0">{lastOutput}</div> : null}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/index.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/AssistantTurnGroup/index.ts
@@ -1,0 +1,1 @@
+export { AssistantTurnGroup } from "./AssistantTurnGroup";

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/SubagentToolCall/SubagentToolCall.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/SubagentToolCall/SubagentToolCall.tsx
@@ -29,8 +29,10 @@ function formatDuration(ms: number): string {
 	if (ms < 1000) return `${Math.round(ms)}ms`;
 	const seconds = ms / 1000;
 	if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
-	const minutes = Math.floor(seconds / 60);
-	const remainder = Math.round(seconds % 60);
+	// Round to whole seconds first, then split, so the remainder can't carry to 60.
+	const roundedSeconds = Math.round(seconds);
+	const minutes = Math.floor(roundedSeconds / 60);
+	const remainder = roundedSeconds % 60;
 	return `${minutes}m ${remainder}s`;
 }
 
@@ -87,57 +89,62 @@ export function SubagentToolCall({
 		) : undefined;
 
 	return (
-		<ToolCallRow
-			icon={BotIcon}
-			isError={isError}
-			isPending={isPending}
-			title={titleNode}
-			headerExtra={headerExtra}
-		>
-			{hasDetails ? (
-				<div className="space-y-2 pl-2 text-xs">
-					<MessageResponse
-						animated={false}
-						className={`font-medium ${TOOL_CALL_MD_CLASSNAME}`}
-						isAnimating={false}
-						mermaid={{ config: { theme: "default" } }}
-					>
-						{task}
-					</MessageResponse>
-					{parsed.tools.length > 0 ? (
-						<div className="space-y-1">
-							<div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-								<TerminalIcon className="size-3 shrink-0" />
-								<span className="font-medium">Execution Trace</span>
-								<span className="opacity-50">·</span>
-								<span>{toolCallLabel}</span>
-							</div>
-							{parsed.tools.map((tool, index) => (
-								<SubagentInnerToolCall
-									key={`${tool.name}-${index}`}
-									name={tool.name}
-									isError={tool.isError}
-									args={tool.args}
-									result={tool.result}
-									workspaceId={workspaceId}
-									workspaceCwd={workspaceCwd}
-									onOpenFileInPane={onOpenFileInPane}
-								/>
-							))}
-						</div>
-					) : null}
-					{parsed.text ? (
+		// Distinct card so the spawned agent reads as its own contained unit
+		// (matching the agent-inspector subagent card), set apart from the
+		// parent turn's inline steps.
+		<div className="rounded-md border border-border/60 bg-muted/20 px-2 py-0.5">
+			<ToolCallRow
+				icon={BotIcon}
+				isError={isError}
+				isPending={isPending}
+				title={titleNode}
+				headerExtra={headerExtra}
+			>
+				{hasDetails ? (
+					<div className="space-y-2 pl-2 text-xs">
 						<MessageResponse
 							animated={false}
-							className={`${TOOL_CALL_MD_CLASSNAME} [&_[data-streamdown=table-header-cell]]:px-2.5 [&_[data-streamdown=table-header-cell]]:py-1.5 [&_[data-streamdown=table-header-cell]]:text-xs [&_[data-streamdown=table-cell]]:px-2.5 [&_[data-streamdown=table-cell]]:py-1.5 [&_[data-streamdown=table-cell]]:text-xs`}
+							className={`font-medium ${TOOL_CALL_MD_CLASSNAME}`}
 							isAnimating={false}
 							mermaid={{ config: { theme: "default" } }}
 						>
-							{parsed.text}
+							{task}
 						</MessageResponse>
-					) : null}
-				</div>
-			) : undefined}
-		</ToolCallRow>
+						{parsed.tools.length > 0 ? (
+							<div className="space-y-1">
+								<div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+									<TerminalIcon className="size-3 shrink-0" />
+									<span className="font-medium">Execution Trace</span>
+									<span className="opacity-50">·</span>
+									<span>{toolCallLabel}</span>
+								</div>
+								{parsed.tools.map((tool, index) => (
+									<SubagentInnerToolCall
+										key={`${tool.name}-${index}`}
+										name={tool.name}
+										isError={tool.isError}
+										args={tool.args}
+										result={tool.result}
+										workspaceId={workspaceId}
+										workspaceCwd={workspaceCwd}
+										onOpenFileInPane={onOpenFileInPane}
+									/>
+								))}
+							</div>
+						) : null}
+						{parsed.text ? (
+							<MessageResponse
+								animated={false}
+								className={`${TOOL_CALL_MD_CLASSNAME} [&_[data-streamdown=table-header-cell]]:px-2.5 [&_[data-streamdown=table-header-cell]]:py-1.5 [&_[data-streamdown=table-header-cell]]:text-xs [&_[data-streamdown=table-cell]]:px-2.5 [&_[data-streamdown=table-cell]]:py-1.5 [&_[data-streamdown=table-cell]]:text-xs`}
+								isAnimating={false}
+								mermaid={{ config: { theme: "default" } }}
+							>
+								{parsed.text}
+							</MessageResponse>
+						) : null}
+					</div>
+				) : undefined}
+			</ToolCallRow>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/SubagentToolCall/SubagentToolCall.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/SubagentToolCall/SubagentToolCall.tsx
@@ -3,7 +3,7 @@ import {
 	TOOL_CALL_MD_CLASSNAME,
 } from "@superset/ui/ai-elements/message";
 import { ToolCallRow } from "@superset/ui/ai-elements/tool-call-row";
-import { BotIcon } from "lucide-react";
+import { BotIcon, TerminalIcon } from "lucide-react";
 import { useMemo } from "react";
 import { SubagentInnerToolCall } from "renderer/components/Chat/components/SubagentInnerToolCall";
 import type { ToolPart } from "../../../../utils/tool-helpers";
@@ -22,6 +22,16 @@ function asString(value: unknown): string | null {
 	if (typeof value !== "string") return null;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : null;
+}
+
+function formatDuration(ms: number): string {
+	if (!Number.isFinite(ms) || ms < 0) return "";
+	if (ms < 1000) return `${Math.round(ms)}ms`;
+	const seconds = ms / 1000;
+	if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+	const minutes = Math.floor(seconds / 60);
+	const remainder = Math.round(seconds % 60);
+	return `${minutes}m ${remainder}s`;
 }
 
 export function SubagentToolCall({
@@ -45,13 +55,36 @@ export function SubagentToolCall({
 	const hasDetails =
 		task.length > 0 || parsed.text.length > 0 || parsed.tools.length > 0;
 
-	// Title: "Agent" (foreground) — agentType goes in description (muted)
+	// Title: a "TASK" badge + "Agent {type}", matching the inspector card.
 	const titleNode = (
-		<span className="shrink-0 font-medium text-xs">
-			<span className="text-foreground">Agent</span>{" "}
+		<span className="flex shrink-0 items-center gap-1.5 font-medium text-xs">
+			<span className="rounded border border-sky-500/40 px-1 py-px font-semibold text-[9px] text-sky-400 uppercase tracking-wide">
+				Task
+			</span>
+			<span className="text-foreground">Agent</span>
 			<span className="text-muted-foreground">{agentType}</span>
 		</span>
 	);
+
+	const toolCallLabel = `${parsed.tools.length} tool call${
+		parsed.tools.length === 1 ? "" : "s"
+	}`;
+
+	// Surface the subagent's model + run duration (parsed from <subagent-meta>),
+	// matching the agent-inspector subagent card.
+	const durationLabel =
+		typeof parsed.durationMs === "number"
+			? formatDuration(parsed.durationMs)
+			: "";
+	const metaBits = [parsed.modelId, durationLabel].filter(
+		(bit): bit is string => Boolean(bit),
+	);
+	const headerExtra =
+		metaBits.length > 0 ? (
+			<span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
+				{metaBits.join(" · ")}
+			</span>
+		) : undefined;
 
 	return (
 		<ToolCallRow
@@ -59,6 +92,7 @@ export function SubagentToolCall({
 			isError={isError}
 			isPending={isPending}
 			title={titleNode}
+			headerExtra={headerExtra}
 		>
 			{hasDetails ? (
 				<div className="space-y-2 pl-2 text-xs">
@@ -72,6 +106,12 @@ export function SubagentToolCall({
 					</MessageResponse>
 					{parsed.tools.length > 0 ? (
 						<div className="space-y-1">
+							<div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+								<TerminalIcon className="size-3 shrink-0" />
+								<span className="font-medium">Execution Trace</span>
+								<span className="opacity-50">·</span>
+								<span>{toolCallLabel}</span>
+							</div>
 							{parsed.tools.map((tool, index) => (
 								<SubagentInnerToolCall
 									key={`${tool.name}-${index}`}

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/TurnTextItem/TurnTextItem.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/TurnTextItem/TurnTextItem.tsx
@@ -27,7 +27,7 @@ export function TurnTextItem({ kind, text, isStreaming }: TurnTextItemProps) {
 			description={toPreview(text)}
 		>
 			{isThinking ? (
-				<div className="whitespace-pre-wrap py-1 pl-3 text-muted-foreground text-xs">
+				<div className="cursor-text select-text whitespace-pre-wrap py-1 pl-3 text-muted-foreground text-xs">
 					{text}
 				</div>
 			) : (

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/TurnTextItem/TurnTextItem.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/TurnTextItem/TurnTextItem.tsx
@@ -1,0 +1,44 @@
+import { ToolCallRow } from "@superset/ui/ai-elements/tool-call-row";
+import { BrainIcon, MessageSquareIcon } from "lucide-react";
+import { StreamingMessageText } from "renderer/components/Chat/ChatInterface/components/MessagePartsRenderer/components/StreamingMessageText";
+
+interface TurnTextItemProps {
+	kind: "output" | "thinking";
+	text: string;
+	isStreaming?: boolean;
+}
+
+function toPreview(text: string, max = 90): string {
+	const collapsed = text.replace(/\s+/g, " ").trim();
+	return collapsed.length > max ? `${collapsed.slice(0, max)}…` : collapsed;
+}
+
+/**
+ * Renders an intermediate assistant text output or a thinking block as an
+ * agent-inspector-style collapsible item row (icon + label + preview + token
+ * badge), reusing the shared `ToolCallRow` so it matches tool rows exactly.
+ */
+export function TurnTextItem({ kind, text, isStreaming }: TurnTextItemProps) {
+	const isThinking = kind === "thinking";
+	return (
+		<ToolCallRow
+			icon={isThinking ? BrainIcon : MessageSquareIcon}
+			title={isThinking ? "Thinking" : "Output"}
+			description={toPreview(text)}
+		>
+			{isThinking ? (
+				<div className="whitespace-pre-wrap py-1 pl-3 text-muted-foreground text-xs">
+					{text}
+				</div>
+			) : (
+				<div className="py-1 pl-3">
+					<StreamingMessageText
+						text={text}
+						isAnimating={Boolean(isStreaming)}
+						mermaid={{ config: { theme: "default" } }}
+					/>
+				</div>
+			)}
+		</ToolCallRow>
+	);
+}

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/TurnTextItem/index.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/TurnTextItem/index.ts
@@ -1,0 +1,1 @@
+export { TurnTextItem } from "./TurnTextItem";

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/group-assistant-turn.test.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/group-assistant-turn.test.ts
@@ -81,10 +81,25 @@ describe("summarizeAssistantTurn", () => {
 		expect(summary.status).toBe("in_progress");
 	});
 
-	it("marks pure-text turns as having no steps", () => {
+	it("marks a single-text turn as having no steps", () => {
 		const summary = summarizeAssistantTurn([{ type: "text" }] as never);
 		expect(summary.hasSteps).toBe(false);
 		expect(summary.lastTextIndex).toBe(0);
+	});
+
+	it("groups a turn with intermediate text (output) before the final answer", () => {
+		const summary = summarizeAssistantTurn([
+			{ type: "text" }, // intermediate narration
+			{ type: "text" }, // final answer
+		] as never);
+		expect(summary.outputCount).toBe(1);
+		expect(summary.hasSteps).toBe(true);
+	});
+
+	it("does not group an image-only turn", () => {
+		const summary = summarizeAssistantTurn([{ type: "image" }] as never);
+		expect(summary.imageCount).toBe(1);
+		expect(summary.hasSteps).toBe(false);
 	});
 });
 

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/group-assistant-turn.test.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/group-assistant-turn.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type AssistantTurnSummary,
+	formatTurnSummary,
+	summarizeAssistantTurn,
+} from "./group-assistant-turn";
+
+describe("summarizeAssistantTurn", () => {
+	it("counts tools, thinking, and intermediate outputs", () => {
+		const summary = summarizeAssistantTurn([
+			{ type: "thinking" },
+			{ type: "text" }, // intermediate narration
+			{ type: "tool_call", id: "a" },
+			{ type: "tool_result", id: "a" },
+			{ type: "tool_call", id: "b" },
+			{ type: "tool_result", id: "b" },
+			{ type: "text" }, // final answer
+		] as never);
+
+		expect(summary.thinkingCount).toBe(1);
+		expect(summary.toolCount).toBe(2);
+		expect(summary.outputCount).toBe(1);
+		expect(summary.lastTextIndex).toBe(6);
+		expect(summary.hasSteps).toBe(true);
+		expect(summary.status).toBe("complete");
+	});
+
+	it("does not double-count a tool_call and its tool_result", () => {
+		const summary = summarizeAssistantTurn([
+			{ type: "tool_call", id: "x" },
+			{ type: "tool_result", id: "x" },
+		] as never);
+		expect(summary.toolCount).toBe(1);
+	});
+
+	it("counts an orphaned tool_result as one tool", () => {
+		const summary = summarizeAssistantTurn([
+			{ type: "tool_result", id: "orphan" },
+		] as never);
+		expect(summary.toolCount).toBe(1);
+	});
+
+	it("counts subagent tool calls separately from regular tools", () => {
+		const summary = summarizeAssistantTurn([
+			{ type: "tool_call", id: "a", name: "read_file" },
+			{ type: "tool_result", id: "a" },
+			{ type: "tool_call", id: "b", name: "subagent" },
+			{ type: "tool_result", id: "b" },
+		] as never);
+		expect(summary.toolCount).toBe(1);
+		expect(summary.subagentCount).toBe(1);
+	});
+
+	it("reports error status when any tool_result errored", () => {
+		const summary = summarizeAssistantTurn([
+			{ type: "tool_call", id: "a" },
+			{ type: "tool_result", id: "a", isError: true },
+		] as never);
+		expect(summary.status).toBe("error");
+	});
+
+	it("reports error status when the message itself errored", () => {
+		const summary = summarizeAssistantTurn(
+			[
+				{ type: "tool_call", id: "a" },
+				{ type: "tool_result", id: "a" },
+			] as never,
+			{ errored: true },
+		);
+		expect(summary.status).toBe("error");
+	});
+
+	it("reports in_progress while streaming regardless of errors", () => {
+		const summary = summarizeAssistantTurn(
+			[
+				{ type: "tool_call", id: "a" },
+				{ type: "tool_result", id: "a", isError: true },
+			] as never,
+			{ isStreaming: true },
+		);
+		expect(summary.status).toBe("in_progress");
+	});
+
+	it("marks pure-text turns as having no steps", () => {
+		const summary = summarizeAssistantTurn([{ type: "text" }] as never);
+		expect(summary.hasSteps).toBe(false);
+		expect(summary.lastTextIndex).toBe(0);
+	});
+});
+
+describe("formatTurnSummary", () => {
+	const base: AssistantTurnSummary = {
+		thinkingCount: 0,
+		toolCount: 0,
+		subagentCount: 0,
+		outputCount: 0,
+		imageCount: 0,
+		status: "complete",
+		lastTextIndex: -1,
+		hasSteps: false,
+	};
+
+	it("pluralizes correctly", () => {
+		expect(formatTurnSummary({ ...base, toolCount: 1 })).toBe("1 tool call");
+		expect(formatTurnSummary({ ...base, toolCount: 3 })).toBe("3 tool calls");
+	});
+
+	it("joins segments with a middot in a stable order", () => {
+		expect(
+			formatTurnSummary({
+				...base,
+				thinkingCount: 2,
+				toolCount: 3,
+				subagentCount: 1,
+				outputCount: 1,
+			}),
+		).toBe("2 reasonings · 3 tool calls · 1 subagent · 1 message");
+	});
+
+	it("returns empty string when nothing notable", () => {
+		expect(formatTurnSummary(base)).toBe("");
+	});
+});

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/group-assistant-turn.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/group-assistant-turn.ts
@@ -1,0 +1,148 @@
+/**
+ * Turn-level grouping for assistant messages — the "agent inspector" flavor.
+ *
+ * The Superset chat renders an assistant message as a flat stream of content
+ * parts. The vendored `agent-inspector` instead bundles a turn into a single
+ * group with a one-line summary ("3 tools · 1 message"), an overall status,
+ * and an always-visible final answer. This helper computes that summary from
+ * the raw parts so the renderer can present the same grouping.
+ */
+
+export type TurnStatus = "in_progress" | "error" | "complete";
+
+interface AssistantTurnPartLike {
+	type: string;
+	name?: string;
+	isError?: boolean;
+}
+
+export interface AssistantTurnSummary {
+	thinkingCount: number;
+	/** Regular tool calls (excludes subagents). */
+	toolCount: number;
+	/** Tool calls whose name is `subagent`. */
+	subagentCount: number;
+	/** Text parts that are NOT the final answer (intermediate narration). */
+	outputCount: number;
+	imageCount: number;
+	status: TurnStatus;
+	/** Index of the last text part — surfaced as the always-visible answer. */
+	lastTextIndex: number;
+	/** Whether the turn has any tool/thinking work worth grouping. */
+	hasSteps: boolean;
+}
+
+const SUBAGENT_TOOL_NAME = "subagent";
+const TOKEN_THINKING = "reasoning";
+const TOKEN_TOOL = "tool call";
+const TOKEN_SUBAGENT = "subagent";
+const TOKEN_MESSAGE = "message";
+
+/**
+ * Summarize the parts of a single assistant message into turn-level metadata.
+ * `tool_result` parts are not counted separately — they are folded into their
+ * matching `tool_call` the same way the renderer links them.
+ */
+export function summarizeAssistantTurn(
+	parts: readonly AssistantTurnPartLike[],
+	options: { isStreaming?: boolean; errored?: boolean } = {},
+): AssistantTurnSummary {
+	let thinkingCount = 0;
+	let toolCount = 0;
+	let subagentCount = 0;
+	let outputCount = 0;
+	let imageCount = 0;
+	let lastTextIndex = -1;
+	let hasError = false;
+	const toolCallIds = new Set<string>();
+
+	for (let index = 0; index < parts.length; index++) {
+		const part = parts[index];
+		switch (part.type) {
+			case "text":
+				lastTextIndex = index;
+				break;
+			case "thinking":
+				thinkingCount++;
+				break;
+			case "tool_call": {
+				const id = (part as { id?: string }).id;
+				if (id && toolCallIds.has(id)) break;
+				if (id) toolCallIds.add(id);
+				if (part.name === SUBAGENT_TOOL_NAME) subagentCount++;
+				else toolCount++;
+				break;
+			}
+			case "tool_result": {
+				// Orphaned results (no preceding call) still represent a tool.
+				const id = (part as { id?: string }).id;
+				if (id && !toolCallIds.has(id)) {
+					toolCallIds.add(id);
+					if (part.name === SUBAGENT_TOOL_NAME) subagentCount++;
+					else toolCount++;
+				}
+				if (part.isError) hasError = true;
+				break;
+			}
+			case "image":
+				imageCount++;
+				break;
+			default:
+				if (part.type === "file") imageCount++;
+				break;
+		}
+	}
+
+	// Every non-final text part is intermediate narration ("output").
+	if (lastTextIndex >= 0) {
+		for (let index = 0; index < lastTextIndex; index++) {
+			if (parts[index].type === "text") outputCount++;
+		}
+	}
+
+	const status: TurnStatus = options.isStreaming
+		? "in_progress"
+		: hasError || options.errored
+			? "error"
+			: "complete";
+
+	return {
+		thinkingCount,
+		toolCount,
+		subagentCount,
+		outputCount,
+		imageCount,
+		status,
+		lastTextIndex,
+		hasSteps: toolCount > 0 || subagentCount > 0 || thinkingCount > 0,
+	};
+}
+
+function pluralize(count: number, token: string): string {
+	return `${count} ${token}${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Human-readable one-line summary, e.g. "2 reasonings · 3 tools · 1 message".
+ * Returns an empty string when there is nothing notable to summarize.
+ */
+export function formatTurnSummary(summary: AssistantTurnSummary): string {
+	const parts: string[] = [];
+	if (summary.thinkingCount > 0) {
+		parts.push(pluralize(summary.thinkingCount, TOKEN_THINKING));
+	}
+	if (summary.toolCount > 0) {
+		parts.push(pluralize(summary.toolCount, TOKEN_TOOL));
+	}
+	if (summary.subagentCount > 0) {
+		parts.push(pluralize(summary.subagentCount, TOKEN_SUBAGENT));
+	}
+	// Intermediate messages + a trailing answer collapsed into the body.
+	if (summary.outputCount > 0) {
+		parts.push(pluralize(summary.outputCount, TOKEN_MESSAGE));
+	}
+	if (summary.imageCount > 0) {
+		parts.push(pluralize(summary.imageCount, "image"));
+	}
+	return parts.join(" · ");
+}

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/group-assistant-turn.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/group-assistant-turn.ts
@@ -114,7 +114,11 @@ export function summarizeAssistantTurn(
 		imageCount,
 		status,
 		lastTextIndex,
-		hasSteps: toolCount > 0 || subagentCount > 0 || thinkingCount > 0,
+		hasSteps:
+			toolCount > 0 ||
+			subagentCount > 0 ||
+			thinkingCount > 0 ||
+			outputCount > 0,
 	};
 }
 
@@ -140,9 +144,6 @@ export function formatTurnSummary(summary: AssistantTurnSummary): string {
 	// Intermediate messages + a trailing answer collapsed into the body.
 	if (summary.outputCount > 0) {
 		parts.push(pluralize(summary.outputCount, TOKEN_MESSAGE));
-	}
-	if (summary.imageCount > 0) {
-		parts.push(pluralize(summary.imageCount, "image"));
 	}
 	return parts.join(" · ");
 }

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/index.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/utils/group-assistant-turn/index.ts
@@ -1,0 +1,6 @@
+export {
+	type AssistantTurnSummary,
+	formatTurnSummary,
+	summarizeAssistantTurn,
+	type TurnStatus,
+} from "./group-assistant-turn";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -1,7 +1,7 @@
 import { Message, MessageContent } from "@superset/ui/ai-elements/message";
 import { ShimmerLabel } from "@superset/ui/ai-elements/shimmer-label";
 import { FileSearchIcon } from "lucide-react";
-import { type ReactNode, useCallback } from "react";
+import { type ReactNode, useCallback, useMemo } from "react";
 import { AssistantTurnGroup } from "renderer/components/Chat/ChatInterface/components/AssistantTurnGroup";
 import { StreamingMessageText } from "renderer/components/Chat/ChatInterface/components/MessagePartsRenderer/components/StreamingMessageText";
 import { ToolCallBlock } from "renderer/components/Chat/ChatInterface/components/ToolCallBlock";
@@ -129,12 +129,15 @@ export function AssistantMessage({
 	const errored =
 		messageMeta.stopReason === "error" ||
 		Boolean(messageMeta.errorMessage?.trim());
-	const turnSummary = summarizeAssistantTurn(message.content, {
-		isStreaming,
-		errored,
-	});
+	const turnSummary = useMemo(
+		() => summarizeAssistantTurn(message.content, { isStreaming, errored }),
+		[message.content, isStreaming, errored],
+	);
 	const stepNodes: ReactNode[] = [];
 	const lastOutputNodes: ReactNode[] = [];
+	// Required actions (e.g. plan approval) render OUTSIDE the collapsible group so
+	// collapsing a turn can never hide an action the user must take.
+	const pendingActionNodes: ReactNode[] = [];
 	const renderedToolCallIds = new Set<string>();
 	let didRenderPendingPlanApproval = false;
 	const handleAttachmentClick = useCallback(
@@ -310,7 +313,7 @@ export function AssistantMessage({
 					isStreaming={isStreaming}
 				/>,
 			);
-			stepNodes.push(...getInlineToolStateNodes(part.id));
+			pendingActionNodes.push(...getInlineToolStateNodes(part.id));
 
 			if (resultIndex === partIndex + 1) {
 				partIndex++;
@@ -333,7 +336,7 @@ export function AssistantMessage({
 					workspaceCwd={workspaceCwd}
 				/>,
 			);
-			stepNodes.push(...getInlineToolStateNodes(part.id));
+			pendingActionNodes.push(...getInlineToolStateNodes(part.id));
 			continue;
 		}
 
@@ -362,10 +365,16 @@ export function AssistantMessage({
 				workspaceCwd={workspaceCwd}
 			/>,
 		);
-		stepNodes.push(...getInlineToolStateNodes(previewPart.toolCallId));
+		pendingActionNodes.push(...getInlineToolStateNodes(previewPart.toolCallId));
 	}
 
-	const hasAnyNode = stepNodes.length > 0 || lastOutputNodes.length > 0;
+	const hasPendingAction = pendingActionNodes.length > 0;
+	const hasAnyNode =
+		stepNodes.length > 0 || lastOutputNodes.length > 0 || hasPendingAction;
+
+	if (!hasAnyNode && !isStreaming && !footer) {
+		return null;
+	}
 
 	let body: ReactNode;
 	if (!hasAnyNode && isStreaming) {
@@ -380,12 +389,13 @@ export function AssistantMessage({
 		const defaultOpen =
 			isStreaming ||
 			turnSummary.status === "error" ||
-			Boolean(pendingPlanApproval) ||
+			hasPendingAction ||
 			lastOutputNodes.length === 0;
 		body = (
 			<AssistantTurnGroup
 				summary={formatTurnSummary(turnSummary)}
 				status={turnSummary.status}
+				pendingAction={hasPendingAction}
 				timestamp={messageMeta.createdAt}
 				defaultOpen={defaultOpen}
 				steps={stepNodes}
@@ -405,7 +415,10 @@ export function AssistantMessage({
 	return (
 		<Message from="assistant">
 			<MessageContent>
+				{/* Pending actions sit outside `body` so they stay visible even when
+				    the turn group is collapsed. */}
 				{body}
+				{pendingActionNodes}
 				{footer}
 			</MessageContent>
 		</Message>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -2,9 +2,14 @@ import { Message, MessageContent } from "@superset/ui/ai-elements/message";
 import { ShimmerLabel } from "@superset/ui/ai-elements/shimmer-label";
 import { FileSearchIcon } from "lucide-react";
 import { type ReactNode, useCallback } from "react";
+import { AssistantTurnGroup } from "renderer/components/Chat/ChatInterface/components/AssistantTurnGroup";
 import { StreamingMessageText } from "renderer/components/Chat/ChatInterface/components/MessagePartsRenderer/components/StreamingMessageText";
-import { ReasoningBlock } from "renderer/components/Chat/ChatInterface/components/ReasoningBlock";
 import { ToolCallBlock } from "renderer/components/Chat/ChatInterface/components/ToolCallBlock";
+import { TurnTextItem } from "renderer/components/Chat/ChatInterface/components/TurnTextItem";
+import {
+	formatTurnSummary,
+	summarizeAssistantTurn,
+} from "renderer/components/Chat/ChatInterface/utils/group-assistant-turn";
 import type { ToolPart } from "renderer/components/Chat/ChatInterface/utils/tool-helpers";
 import { normalizeToolName } from "renderer/components/Chat/ChatInterface/utils/tool-helpers";
 import type { UseChatDisplayReturn } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay";
@@ -114,7 +119,22 @@ export function AssistantMessage({
 	onPlanRespond,
 }: AssistantMessageProps) {
 	const addFileViewerPane = useTabsStore((store) => store.addFileViewerPane);
-	const nodes: ReactNode[] = [];
+	// Turn-level grouping ("agent inspector" flavor): intermediate actions
+	// collapse into a single group while the final answer stays visible.
+	const messageMeta = message as {
+		stopReason?: string;
+		errorMessage?: string;
+		createdAt?: string | number | Date;
+	};
+	const errored =
+		messageMeta.stopReason === "error" ||
+		Boolean(messageMeta.errorMessage?.trim());
+	const turnSummary = summarizeAssistantTurn(message.content, {
+		isStreaming,
+		errored,
+	});
+	const stepNodes: ReactNode[] = [];
+	const lastOutputNodes: ReactNode[] = [];
 	const renderedToolCallIds = new Set<string>();
 	let didRenderPendingPlanApproval = false;
 	const handleAttachmentClick = useCallback(
@@ -155,26 +175,37 @@ export function AssistantMessage({
 		const part = message.content[partIndex];
 
 		if (part.type === "text") {
-			nodes.push(
-				<StreamingMessageText
-					key={`${message.id}-${partIndex}`}
-					text={part.text}
-					isAnimating={isStreaming}
-					mermaid={{
-						config: {
-							theme: "default",
-						},
-					}}
-				/>,
-			);
+			// The final text part is the turn's answer — surfaced outside the
+			// collapsible group so it stays visible even when steps collapse.
+			if (partIndex === turnSummary.lastTextIndex) {
+				lastOutputNodes.push(
+					<StreamingMessageText
+						key={`${message.id}-${partIndex}`}
+						text={part.text}
+						isAnimating={isStreaming}
+						mermaid={{ config: { theme: "default" } }}
+					/>,
+				);
+			} else {
+				// Intermediate narration → collapsible "Output" item row.
+				stepNodes.push(
+					<TurnTextItem
+						key={`${message.id}-${partIndex}`}
+						kind="output"
+						text={part.text}
+						isStreaming={isStreaming}
+					/>,
+				);
+			}
 			continue;
 		}
 
 		if (part.type === "thinking") {
-			nodes.push(
-				<ReasoningBlock
+			stepNodes.push(
+				<TurnTextItem
 					key={`${message.id}-${partIndex}`}
-					reasoning={part.thinking}
+					kind="thinking"
+					text={part.thinking}
 				/>,
 			);
 			continue;
@@ -198,7 +229,7 @@ export function AssistantMessage({
 
 			if (part.type === "image" && "mimeType" in part && !rawPart.mediaType) {
 				const legacySrc = `data:${part.mimeType};base64,${part.data}`;
-				nodes.push(
+				stepNodes.push(
 					<ImageHoverPreview
 						key={`${message.id}-${partIndex}`}
 						src={legacySrc}
@@ -212,7 +243,7 @@ export function AssistantMessage({
 			}
 
 			if (mediaType.startsWith("image/")) {
-				nodes.push(
+				stepNodes.push(
 					<ImageHoverPreview
 						key={`${message.id}-${partIndex}`}
 						src={data}
@@ -240,7 +271,7 @@ export function AssistantMessage({
 					</ImageHoverPreview>,
 				);
 			} else {
-				nodes.push(
+				stepNodes.push(
 					<AttachmentChip
 						key={`${message.id}-${partIndex}`}
 						data={data}
@@ -264,7 +295,7 @@ export function AssistantMessage({
 				startAt: partIndex + 1,
 			});
 
-			nodes.push(
+			stepNodes.push(
 				<ToolCallBlock
 					key={`${message.id}-tool-${part.id}`}
 					part={toToolPartFromCall({
@@ -279,7 +310,7 @@ export function AssistantMessage({
 					isStreaming={isStreaming}
 				/>,
 			);
-			nodes.push(...getInlineToolStateNodes(part.id));
+			stepNodes.push(...getInlineToolStateNodes(part.id));
 
 			if (resultIndex === partIndex + 1) {
 				partIndex++;
@@ -292,7 +323,7 @@ export function AssistantMessage({
 				continue;
 			}
 			renderedToolCallIds.add(part.id);
-			nodes.push(
+			stepNodes.push(
 				<ToolCallBlock
 					key={`${message.id}-tool-result-${part.id}`}
 					part={toToolPartFromResult(part)}
@@ -302,12 +333,12 @@ export function AssistantMessage({
 					workspaceCwd={workspaceCwd}
 				/>,
 			);
-			nodes.push(...getInlineToolStateNodes(part.id));
+			stepNodes.push(...getInlineToolStateNodes(part.id));
 			continue;
 		}
 
 		if (part.type.startsWith("om_")) {
-			nodes.push(
+			stepNodes.push(
 				<div
 					key={`${message.id}-${partIndex}`}
 					className="flex items-center gap-2 text-xs text-muted-foreground"
@@ -321,7 +352,7 @@ export function AssistantMessage({
 
 	for (const previewPart of previewToolParts) {
 		if (renderedToolCallIds.has(previewPart.toolCallId)) continue;
-		nodes.push(
+		stepNodes.push(
 			<ToolCallBlock
 				key={`${message.id}-tool-preview-${previewPart.toolCallId}`}
 				part={previewPart}
@@ -331,19 +362,50 @@ export function AssistantMessage({
 				workspaceCwd={workspaceCwd}
 			/>,
 		);
-		nodes.push(...getInlineToolStateNodes(previewPart.toolCallId));
+		stepNodes.push(...getInlineToolStateNodes(previewPart.toolCallId));
+	}
+
+	const hasAnyNode = stepNodes.length > 0 || lastOutputNodes.length > 0;
+
+	let body: ReactNode;
+	if (!hasAnyNode && isStreaming) {
+		body = (
+			<ShimmerLabel className="text-sm text-muted-foreground">
+				Thinking...
+			</ShimmerLabel>
+		);
+	} else if (turnSummary.hasSteps) {
+		// Keep the live turn (or one needing attention) open; collapse a finished
+		// turn down to its summary + answer.
+		const defaultOpen =
+			isStreaming ||
+			turnSummary.status === "error" ||
+			Boolean(pendingPlanApproval) ||
+			lastOutputNodes.length === 0;
+		body = (
+			<AssistantTurnGroup
+				summary={formatTurnSummary(turnSummary)}
+				status={turnSummary.status}
+				timestamp={messageMeta.createdAt}
+				defaultOpen={defaultOpen}
+				steps={stepNodes}
+				lastOutput={lastOutputNodes.length > 0 ? lastOutputNodes : null}
+			/>
+		);
+	} else {
+		// No tool/thinking work — render the plain answer (simple Q&A stays clean).
+		body = (
+			<>
+				{stepNodes}
+				{lastOutputNodes}
+			</>
+		);
 	}
 
 	return (
 		<Message from="assistant">
 			<MessageContent>
-				{nodes.length === 0 && isStreaming ? (
-					<ShimmerLabel className="text-sm text-muted-foreground">
-						Thinking...
-					</ShimmerLabel>
-				) : (
-					nodes
-				)}
+				{body}
 				{footer}
 			</MessageContent>
 		</Message>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -3,9 +3,14 @@ import { Message, MessageContent } from "@superset/ui/ai-elements/message";
 import { ShimmerLabel } from "@superset/ui/ai-elements/shimmer-label";
 import { FileSearchIcon } from "lucide-react";
 import { type ReactNode, useCallback } from "react";
+import { AssistantTurnGroup } from "renderer/components/Chat/ChatInterface/components/AssistantTurnGroup";
 import { StreamingMessageText } from "renderer/components/Chat/ChatInterface/components/MessagePartsRenderer/components/StreamingMessageText";
-import { ReasoningBlock } from "renderer/components/Chat/ChatInterface/components/ReasoningBlock";
 import { ToolCallBlock } from "renderer/components/Chat/ChatInterface/components/ToolCallBlock";
+import { TurnTextItem } from "renderer/components/Chat/ChatInterface/components/TurnTextItem";
+import {
+	formatTurnSummary,
+	summarizeAssistantTurn,
+} from "renderer/components/Chat/ChatInterface/utils/group-assistant-turn";
 import type { ToolPart } from "renderer/components/Chat/ChatInterface/utils/tool-helpers";
 import { normalizeToolName } from "renderer/components/Chat/ChatInterface/utils/tool-helpers";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -115,7 +120,22 @@ export function AssistantMessage({
 	onPlanRespond,
 }: AssistantMessageProps) {
 	const addFileViewerPane = useTabsStore((store) => store.addFileViewerPane);
-	const nodes: ReactNode[] = [];
+	// Turn-level grouping ("agent inspector" flavor): intermediate actions
+	// collapse into a single group while the final answer stays visible.
+	const messageMeta = message as {
+		stopReason?: string;
+		errorMessage?: string;
+		createdAt?: string | number | Date;
+	};
+	const errored =
+		messageMeta.stopReason === "error" ||
+		Boolean(messageMeta.errorMessage?.trim());
+	const turnSummary = summarizeAssistantTurn(message.content, {
+		isStreaming,
+		errored,
+	});
+	const stepNodes: ReactNode[] = [];
+	const lastOutputNodes: ReactNode[] = [];
 	const renderedToolCallIds = new Set<string>();
 	let didRenderPendingPlanApproval = false;
 	const handleAttachmentClick = useCallback(
@@ -156,26 +176,37 @@ export function AssistantMessage({
 		const part = message.content[partIndex];
 
 		if (part.type === "text") {
-			nodes.push(
-				<StreamingMessageText
-					key={`${message.id}-${partIndex}`}
-					text={part.text}
-					isAnimating={isStreaming}
-					mermaid={{
-						config: {
-							theme: "default",
-						},
-					}}
-				/>,
-			);
+			// The final text part is the turn's answer — surfaced outside the
+			// collapsible group so it stays visible even when steps collapse.
+			if (partIndex === turnSummary.lastTextIndex) {
+				lastOutputNodes.push(
+					<StreamingMessageText
+						key={`${message.id}-${partIndex}`}
+						text={part.text}
+						isAnimating={isStreaming}
+						mermaid={{ config: { theme: "default" } }}
+					/>,
+				);
+			} else {
+				// Intermediate narration → collapsible "Output" item row.
+				stepNodes.push(
+					<TurnTextItem
+						key={`${message.id}-${partIndex}`}
+						kind="output"
+						text={part.text}
+						isStreaming={isStreaming}
+					/>,
+				);
+			}
 			continue;
 		}
 
 		if (part.type === "thinking") {
-			nodes.push(
-				<ReasoningBlock
+			stepNodes.push(
+				<TurnTextItem
 					key={`${message.id}-${partIndex}`}
-					reasoning={part.thinking}
+					kind="thinking"
+					text={part.thinking}
 				/>,
 			);
 			continue;
@@ -198,7 +229,7 @@ export function AssistantMessage({
 			}
 
 			if (part.type === "image" && "mimeType" in part && !rawPart.mediaType) {
-				nodes.push(
+				stepNodes.push(
 					<div key={`${message.id}-${partIndex}`} className="max-w-[85%]">
 						<ImagePart data={part.data} mimeType={part.mimeType} />
 					</div>,
@@ -207,7 +238,7 @@ export function AssistantMessage({
 			}
 
 			if (mediaType.startsWith("image/")) {
-				nodes.push(
+				stepNodes.push(
 					<button
 						type="button"
 						key={`${message.id}-${partIndex}`}
@@ -227,7 +258,7 @@ export function AssistantMessage({
 					</button>,
 				);
 			} else {
-				nodes.push(
+				stepNodes.push(
 					<AttachmentChip
 						key={`${message.id}-${partIndex}`}
 						data={data}
@@ -251,7 +282,7 @@ export function AssistantMessage({
 				startAt: partIndex + 1,
 			});
 
-			nodes.push(
+			stepNodes.push(
 				<ToolCallBlock
 					key={`${message.id}-tool-${part.id}`}
 					part={toToolPartFromCall({
@@ -267,7 +298,7 @@ export function AssistantMessage({
 					isInterrupted={isInterrupted}
 				/>,
 			);
-			nodes.push(...getInlineToolStateNodes(part.id));
+			stepNodes.push(...getInlineToolStateNodes(part.id));
 
 			if (resultIndex === partIndex + 1) {
 				partIndex++;
@@ -280,7 +311,7 @@ export function AssistantMessage({
 				continue;
 			}
 			renderedToolCallIds.add(part.id);
-			nodes.push(
+			stepNodes.push(
 				<ToolCallBlock
 					key={`${message.id}-tool-result-${part.id}`}
 					part={toToolPartFromResult(part)}
@@ -292,12 +323,12 @@ export function AssistantMessage({
 					isInterrupted={isInterrupted}
 				/>,
 			);
-			nodes.push(...getInlineToolStateNodes(part.id));
+			stepNodes.push(...getInlineToolStateNodes(part.id));
 			continue;
 		}
 
 		if (part.type.startsWith("om_")) {
-			nodes.push(
+			stepNodes.push(
 				<div
 					key={`${message.id}-${partIndex}`}
 					className="flex items-center gap-2 text-xs text-muted-foreground"
@@ -311,7 +342,7 @@ export function AssistantMessage({
 
 	for (const previewPart of previewToolParts) {
 		if (renderedToolCallIds.has(previewPart.toolCallId)) continue;
-		nodes.push(
+		stepNodes.push(
 			<ToolCallBlock
 				key={`${message.id}-tool-preview-${previewPart.toolCallId}`}
 				part={previewPart}
@@ -322,23 +353,54 @@ export function AssistantMessage({
 				isStreaming={isStreaming}
 			/>,
 		);
-		nodes.push(...getInlineToolStateNodes(previewPart.toolCallId));
+		stepNodes.push(...getInlineToolStateNodes(previewPart.toolCallId));
 	}
 
-	if (nodes.length === 0 && !isStreaming && !footer) {
+	const hasAnyNode = stepNodes.length > 0 || lastOutputNodes.length > 0;
+
+	if (!hasAnyNode && !isStreaming && !footer) {
 		return null;
+	}
+
+	let body: ReactNode;
+	if (!hasAnyNode && isStreaming) {
+		body = (
+			<ShimmerLabel className="text-sm text-muted-foreground">
+				Thinking...
+			</ShimmerLabel>
+		);
+	} else if (turnSummary.hasSteps) {
+		// Keep the live turn (or one needing attention) open; collapse a finished
+		// turn down to its summary + answer.
+		const defaultOpen =
+			isStreaming ||
+			turnSummary.status === "error" ||
+			Boolean(pendingPlanApproval) ||
+			lastOutputNodes.length === 0;
+		body = (
+			<AssistantTurnGroup
+				summary={formatTurnSummary(turnSummary)}
+				status={turnSummary.status}
+				timestamp={messageMeta.createdAt}
+				defaultOpen={defaultOpen}
+				steps={stepNodes}
+				lastOutput={lastOutputNodes.length > 0 ? lastOutputNodes : null}
+			/>
+		);
+	} else {
+		// No tool/thinking work — render the plain answer (simple Q&A stays clean).
+		body = (
+			<>
+				{stepNodes}
+				{lastOutputNodes}
+			</>
+		);
 	}
 
 	return (
 		<Message from="assistant">
 			<MessageContent>
-				{nodes.length === 0 && isStreaming ? (
-					<ShimmerLabel className="text-sm text-muted-foreground">
-						Thinking...
-					</ShimmerLabel>
-				) : (
-					nodes
-				)}
+				{body}
 				{footer}
 			</MessageContent>
 		</Message>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -2,7 +2,7 @@ import type { UseChatDisplayReturn } from "@superset/chat/client";
 import { Message, MessageContent } from "@superset/ui/ai-elements/message";
 import { ShimmerLabel } from "@superset/ui/ai-elements/shimmer-label";
 import { FileSearchIcon } from "lucide-react";
-import { type ReactNode, useCallback } from "react";
+import { type ReactNode, useCallback, useMemo } from "react";
 import { AssistantTurnGroup } from "renderer/components/Chat/ChatInterface/components/AssistantTurnGroup";
 import { StreamingMessageText } from "renderer/components/Chat/ChatInterface/components/MessagePartsRenderer/components/StreamingMessageText";
 import { ToolCallBlock } from "renderer/components/Chat/ChatInterface/components/ToolCallBlock";
@@ -130,12 +130,15 @@ export function AssistantMessage({
 	const errored =
 		messageMeta.stopReason === "error" ||
 		Boolean(messageMeta.errorMessage?.trim());
-	const turnSummary = summarizeAssistantTurn(message.content, {
-		isStreaming,
-		errored,
-	});
+	const turnSummary = useMemo(
+		() => summarizeAssistantTurn(message.content, { isStreaming, errored }),
+		[message.content, isStreaming, errored],
+	);
 	const stepNodes: ReactNode[] = [];
 	const lastOutputNodes: ReactNode[] = [];
+	// Required actions (e.g. plan approval) render OUTSIDE the collapsible group so
+	// collapsing a turn can never hide an action the user must take.
+	const pendingActionNodes: ReactNode[] = [];
 	const renderedToolCallIds = new Set<string>();
 	let didRenderPendingPlanApproval = false;
 	const handleAttachmentClick = useCallback(
@@ -298,7 +301,7 @@ export function AssistantMessage({
 					isInterrupted={isInterrupted}
 				/>,
 			);
-			stepNodes.push(...getInlineToolStateNodes(part.id));
+			pendingActionNodes.push(...getInlineToolStateNodes(part.id));
 
 			if (resultIndex === partIndex + 1) {
 				partIndex++;
@@ -323,7 +326,7 @@ export function AssistantMessage({
 					isInterrupted={isInterrupted}
 				/>,
 			);
-			stepNodes.push(...getInlineToolStateNodes(part.id));
+			pendingActionNodes.push(...getInlineToolStateNodes(part.id));
 			continue;
 		}
 
@@ -353,10 +356,12 @@ export function AssistantMessage({
 				isStreaming={isStreaming}
 			/>,
 		);
-		stepNodes.push(...getInlineToolStateNodes(previewPart.toolCallId));
+		pendingActionNodes.push(...getInlineToolStateNodes(previewPart.toolCallId));
 	}
 
-	const hasAnyNode = stepNodes.length > 0 || lastOutputNodes.length > 0;
+	const hasPendingAction = pendingActionNodes.length > 0;
+	const hasAnyNode =
+		stepNodes.length > 0 || lastOutputNodes.length > 0 || hasPendingAction;
 
 	if (!hasAnyNode && !isStreaming && !footer) {
 		return null;
@@ -375,12 +380,13 @@ export function AssistantMessage({
 		const defaultOpen =
 			isStreaming ||
 			turnSummary.status === "error" ||
-			Boolean(pendingPlanApproval) ||
+			hasPendingAction ||
 			lastOutputNodes.length === 0;
 		body = (
 			<AssistantTurnGroup
 				summary={formatTurnSummary(turnSummary)}
 				status={turnSummary.status}
+				pendingAction={hasPendingAction}
 				timestamp={messageMeta.createdAt}
 				defaultOpen={defaultOpen}
 				steps={stepNodes}
@@ -400,7 +406,10 @@ export function AssistantMessage({
 	return (
 		<Message from="assistant">
 			<MessageContent>
+				{/* Pending actions sit outside `body` so they stay visible even when
+				    the turn group is collapsed. */}
 				{body}
+				{pendingActionNodes}
 				{footer}
 			</MessageContent>
 		</Message>


### PR DESCRIPTION
## Description

Renders an assistant turn as a single collapsible group instead of a flat
stream of parts. The header summarises the turn ("3 tool calls · 1 subagent ·
1 message") with a status dot and timestamp, and the final answer stays visible
even when the intermediate steps are collapsed.

- **`AssistantTurnGroup`** — a collapsible turn card (header + steps + always-visible
  final answer). A finished turn collapses to its summary + answer; live, errored,
  or approval-pending turns stay open. Open state is controlled so a turn that
  streamed in open auto-collapses when it finishes (manual toggles are respected).
- **`summarizeAssistantTurn` / `formatTurnSummary`** (unit-tested) count
  reasoning/tool/subagent/message parts and derive turn status from tool errors
  and the message `stopReason`/`errorMessage`.
- Intermediate text and thinking render as collapsible item rows (**`TurnTextItem`**),
  reusing `ToolCallRow` for visual consistency.
- **Subagent card** — a contained card with a `TASK` badge, the sub-agent model +
  run duration (parsed from `<subagent-meta>`), and an "Execution Trace · N tool
  calls" of its inner tools.
- **Required actions stay visible** — a pending plan approval renders *outside* the
  collapsible group (with an amber "awaiting approval" header indicator), so
  collapsing a turn can never hide an action the user must take.
- Status is exposed as screen-reader text alongside the dot; the assistant is
  labelled generically (works for any provider).

Applied to both the v2-workspace and legacy chat panes. Pure render-layer change —
reuses the existing per-tool `ToolCallBlock` viewers, no backend or data changes.

## Related Issues

Closes #5188

## Type of Change

- [x] New feature

## Testing

- `bun test` across the chat area (64 tests, incl. new unit + render tests) — pass
- `bun run typecheck` (desktop + ui) — pass
- `bun run lint` — pass
- Manually verified in the desktop app: turn grouping/collapse, final-answer
  visibility while collapsed, subagent Execution Trace, error/streaming status
  states, and the pending-approval-stays-visible behaviour.

## Screenshots

**1. Completed turn — collapses to a one-line summary + the final answer**
<img width="873" height="231" alt="Captura de Tela 2026-06-02 às 18 10 42" src="https://github.com/user-attachments/assets/ec89f141-a94b-403d-915d-bf7844c9fde1" />

**2. Expanded — intermediate steps render as item rows (reasoning · output · tools)**
<img width="873" height="387" alt="Captura de Tela 2026-06-02 às 18 11 38" src="https://github.com/user-attachments/assets/a0e3c01a-1ae1-42f0-899a-681033c6eb80" />

**3. Subagent card — `TASK` badge, model · duration, and the Execution Trace**
<img width="876" height="387" alt="Captura de Tela 2026-06-02 às 18 12 05" src="https://github.com/user-attachments/assets/2d93cee1-b07f-4b61-81d8-07d1cb9ea1b4" />

**4. Pending plan approval — rendered outside the group with an amber status**
<img width="874" height="609" alt="Captura de Tela 2026-06-02 às 18 12 37" src="https://github.com/user-attachments/assets/b46dcaee-629d-4417-a61c-fdcdb062d8bf" />


**5. …and it stays visible when the turn is collapsed (required action is never hidden)**
<img width="878" height="530" alt="Captura de Tela 2026-06-02 às 18 12 53" src="https://github.com/user-attachments/assets/fd0e0486-76e6-4f3d-b15e-adf77da8818f" />

## Additional Notes

Token/cost metrics are intentionally omitted — they are not available client-side
without exposing per-message usage from the harness, so nothing here relies on
estimated values.

