### PR TITLE
release(cli,sdk): cut cli v0.2.21 + sdk alpha.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -688,7 +688,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -925,7 +925,7 @@
     },
     "packages/sdk": {
       "name": "@superset/sdk",
-      "version": "0.0.1-alpha.11",
+      "version": "0.0.1-alpha.12",
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "bun-types": "1.3.11",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.20",
+	"version": "0.2.21",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/sdk",
-	"version": "0.0.1-alpha.11",
+	"version": "0.0.1-alpha.12",
 	"description": "TypeScript SDK for the Superset API",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
Version bump to release the command-surface changes merged in #5027.

| Package | From | To |
|---|---|---|
| `@superset/cli` | 0.2.20 | **0.2.21** |
| `@superset/sdk` (`@superset_sh/sdk`) | 0.0.1-alpha.11 | **0.0.1-alpha.12** |

## What's in this release (from #5027)

- `superset ws create --command <cmd>` — run a shell command in a freshly-created workspace.
- **Breaking:** `superset agents run` → `superset agents create` (and SDK `agents.run()` → `agents.create()`, MCP `agents_run` → `agents_create`). No alias — the old name is gone.
- New `superset terminals create` command, SDK `terminals.create()`, and MCP `terminals_create`.

## Versioning note

The CLI rename is technically breaking, but I followed the established 0.2.x patch-increment convention (every prior release — 0.2.15→…→0.2.20 — was a patch bump regardless of content). If you'd rather signal the break with a minor bump (0.3.0), say so and I'll adjust.

## Post-merge release steps (maintainer)

- **CLI**: push a `cli-v0.2.21` tag to trigger `release-cli.yml` (builds the 3-target matrix, cuts the GitHub release + rolling `cli-latest`, bumps Homebrew).
- **SDK**: there's no SDK release workflow — publish `@superset_sh/sdk` manually (`cd packages/sdk && bun run build && npm publish`).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5063">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@superset/cli` to 0.2.21 and `@superset/sdk` to 0.0.1-alpha.12. Ships workspace command execution and terminals support.

- **New Features**
  - `superset ws create --command <cmd>` to run a shell command in a fresh workspace.
  - `superset terminals create` in the CLI and `terminals.create()` in the SDK.

- **Migration**
  - Breaking rename: `superset agents run` → `superset agents create`; SDK `agents.run()` → `agents.create()`; MCP `agents_run` → `agents_create`. No alias; old name removed.

<sup>Written for commit 62cf69884e943609820a9060d08e285a6624f117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * CLI package version updated to 0.2.21
  * SDK package version updated to 0.0.1-alpha.12

<!-- end of auto-generated comment: release notes by coderabbit.ai -->