### PR TITLE
feat(projects): restrict project deletion to organization owners

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/DeleteProjectSection/DeleteProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/DeleteProjectSection/DeleteProjectSection.tsx
@@ -11,8 +11,10 @@ import {
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
+import { authClient } from "renderer/lib/auth-client";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unavailable";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -29,6 +31,13 @@ export function DeleteProjectSection({
 	const navigate = useNavigate();
 	const hostService = useLocalHostService();
 	const { activeHostUrl } = hostService;
+	const { data: session } = authClient.useSession();
+	const { data: activeOrg } = authClient.useActiveOrganization();
+	const currentUserId = session?.user?.id;
+	const currentMember = activeOrg?.members?.find(
+		(m) => m.userId === currentUserId,
+	);
+	const isOwner = currentMember?.role === "owner";
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
 
@@ -58,40 +67,65 @@ export function DeleteProjectSection({
 			<div className="min-w-0 flex-1">
 				<div className="text-sm font-medium">Delete project</div>
 			</div>
-			<AlertDialog open={isOpen} onOpenChange={setIsOpen}>
-				<AlertDialogTrigger asChild>
-					<Button
-						type="button"
-						variant="destructive"
-						size="sm"
-						className="shrink-0"
-					>
-						Delete project
-					</Button>
-				</AlertDialogTrigger>
-				<AlertDialogContent>
-					<AlertDialogHeader>
-						<AlertDialogTitle>Delete "{projectName}"?</AlertDialogTitle>
-						<AlertDialogDescription>
-							This removes the project from the organization. Anyone with access
-							will lose it. This cannot be undone.
-						</AlertDialogDescription>
-					</AlertDialogHeader>
-					<AlertDialogFooter>
-						<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-						<AlertDialogAction
-							onClick={(e) => {
-								e.preventDefault();
-								handleDelete();
-							}}
-							disabled={isDeleting || !activeHostUrl}
-							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+			{!isOwner ? (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span>
+							<Button
+								type="button"
+								variant="destructive"
+								size="sm"
+								className="pointer-events-none shrink-0"
+								disabled
+							>
+								Delete project
+							</Button>
+						</span>
+					</TooltipTrigger>
+					<TooltipContent side="left">
+						Only organization owners can delete this project.
+					</TooltipContent>
+				</Tooltip>
+			) : (
+				<AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+					<AlertDialogTrigger asChild>
+						<Button
+							type="button"
+							variant="destructive"
+							size="sm"
+							className="shrink-0"
 						>
-							{isDeleting ? "Deleting…" : "Delete"}
-						</AlertDialogAction>
-					</AlertDialogFooter>
-				</AlertDialogContent>
-			</AlertDialog>
+							Delete project
+						</Button>
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Delete "{projectName}"?</AlertDialogTitle>
+							<AlertDialogDescription>
+								This deletes the project for{" "}
+								<span className="font-medium text-foreground">everyone</span> in
+								the organization and removes all of its workspaces from every
+								member's device. This cannot be undone.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel disabled={isDeleting}>
+								Cancel
+							</AlertDialogCancel>
+							<AlertDialogAction
+								onClick={(e) => {
+									e.preventDefault();
+									handleDelete();
+								}}
+								disabled={isDeleting || !activeHostUrl}
+								className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+							>
+								{isDeleting ? "Deleting…" : "Delete"}
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			)}
 		</div>
 	);
 }

--- a/packages/trpc/src/router/integration/utils.ts
+++ b/packages/trpc/src/router/integration/utils.ts
@@ -33,6 +33,19 @@ export async function verifyOrgAdmin(userId: string, organizationId: string) {
 	return { membership };
 }
 
+export async function verifyOrgOwner(userId: string, organizationId: string) {
+	const { membership } = await verifyOrgMembership(userId, organizationId);
+
+	if (membership.role !== "owner") {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Only owners can delete projects",
+		});
+	}
+
+	return { membership };
+}
+
 /**
  * Like `verifyOrgMembership` but also returns the org's currently-paying
  * subscription, joined into the same DB statement (no extra round-trip).

--- a/packages/trpc/src/router/project/project.ts
+++ b/packages/trpc/src/router/project/project.ts
@@ -9,7 +9,7 @@ import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../trpc";
-import { verifyOrgMembership } from "../integration/utils";
+import { verifyOrgMembership, verifyOrgOwner } from "../integration/utils";
 import {
 	requireOrgResourceAccess,
 	requireOrgScopedResource,
@@ -172,7 +172,7 @@ export const projectRouter = {
 			z.object({ id: z.string().uuid(), organizationId: z.string().uuid() }),
 		)
 		.mutation(async ({ ctx, input }) => {
-			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+			await verifyOrgOwner(ctx.session.user.id, input.organizationId);
 			const project = await getScopedProject(input.organizationId, input.id);
 			await dbWs.delete(projects).where(eq(projects.id, project.id));
 			return { success: true };

--- a/packages/trpc/src/router/v2-project/v2-project.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.ts
@@ -15,6 +15,7 @@ import { posthog } from "../../lib/analytics";
 import { fetchAndStoreGitHubAvatar } from "../../lib/github-avatar";
 import { generateImagePathname, uploadImage } from "../../lib/upload";
 import { jwtProcedure, protectedProcedure } from "../../trpc";
+import { verifyOrgOwner } from "../integration/utils";
 import { requireActiveOrgId } from "../utils/active-org";
 import {
 	requireOrgResourceAccess,
@@ -507,12 +508,7 @@ export const v2ProjectRouter = {
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
-			if (!ctx.organizationIds.includes(input.organizationId)) {
-				throw new TRPCError({
-					code: "FORBIDDEN",
-					message: "Not a member of this organization",
-				});
-			}
+			await verifyOrgOwner(ctx.userId, input.organizationId);
 			const project = await dbWs.query.v2Projects.findFirst({
 				columns: { id: true, organizationId: true, iconUrl: true },
 				where: eq(v2Projects.id, input.id),


### PR DESCRIPTION
## Why

Deleting a project is destructive at the org level — it removes the project for **every** member and tears down all of its workspaces on each member's device. Today any org member (including `member`-role users) can trigger this, so a single person can wipe out everyone's work. This gates deletion behind the `owner` role.

## What

**Backend (authoritative enforcement)**
- Add a `verifyOrgOwner(userId, organizationId)` helper in `integration/utils.ts`, mirroring the existing `verifyOrgAdmin` pattern.
- Enforce it on `v2Project.delete` (the cloud kill point that the desktop delete flow ultimately hits) — replaces the old "is a member of this org" check.
- Enforce it on the legacy `project.delete` too, for defense-in-depth.

**Frontend (UX)**
- In project settings, non-owners no longer see an actionable delete button. It renders **disabled** with a tooltip: *"Only organization owners can delete this project."* Owner status is read from Better Auth's `useActiveOrganization()` (same pattern as `BillingOverview` / `OrganizationSettings`).
- Clarify the confirm dialog copy to spell out the blast radius: *"This deletes the project for **everyone** in the organization and removes all of its workspaces from every member's device. This cannot be undone."*

## Notes

- The renderer guard is fail-safe (button stays disabled until owner is confirmed), but the backend `verifyOrgOwner` is the real enforcement — a forced request returns `FORBIDDEN: "Only owners can delete projects"`.
- Follow-up worth considering: deletion is still destructive even for owners (no soft-delete / undo). This PR only restricts *who* can trigger it.

## Test plan
- [x] `bun run lint` clean, `bun run typecheck` passes (all packages)
- [x] Manually verified as a downgraded `member` of the Superset org: delete button is disabled with the tooltip; owners see the dialog with updated copy.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5066">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts project deletion to organization owners to prevent org-wide data loss. Adds server-side enforcement and a clearer, safer UI.

- **New Features**
  - Server: added `verifyOrgOwner` and enforced it on `v2Project.delete` and legacy `project.delete` (non-owners get FORBIDDEN).
  - UI: non-owners see a disabled Delete button with a tooltip; owners see an updated confirmation explaining the org-wide impact.

<sup>Written for commit 17a6eae200a2a68c6acc5263b7f13c80618d1b05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project deletion is now restricted to organization owners. Non-organization owners see a disabled delete button with a tooltip explaining the permission requirement.
  * Updated delete confirmation messaging clarifies that project deletion removes workspaces from all organization members' devices and cannot be undone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->