### PR TITLE
fix(pty-daemon): raise daemon RLIMIT_NOFILE and surface real spawn errno

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -942,16 +942,28 @@ export class DaemonSupervisor {
 			// Prod: detached so PTYs survive host-service restarts via socket
 			// adoption. Dev: attached as defense-in-depth in case serve.ts's
 			// dev shutdown doesn't fire (e.g. host-service crash).
-			child = childProcess.spawn(
-				process.execPath,
-				[this.opts.scriptPath, `--socket=${socketPath}`],
-				{
-					detached: !isDev,
-					stdio,
-					env: childEnv,
-					windowsHide: true,
-				},
-			);
+			// Raise RLIMIT_NOFILE before exec: macOS's 256 soft default starves a
+			// daemon hosting many worktrees' PTYs and surfaces as node-pty
+			// "posix_spawnp failed" (EMFILE). The raised limit is inherited by
+			// handoff successors the daemon spawns from itself.
+			const isWindows = process.platform === "win32";
+			const command = isWindows ? process.execPath : "/bin/sh";
+			const commandArgs = isWindows
+				? [this.opts.scriptPath, `--socket=${socketPath}`]
+				: [
+						"-c",
+						'ulimit -n 1048576 2>/dev/null || ulimit -n "$(ulimit -Hn)" 2>/dev/null || true; exec "$@"',
+						"sh",
+						process.execPath,
+						this.opts.scriptPath,
+						`--socket=${socketPath}`,
+					];
+			child = childProcess.spawn(command, commandArgs, {
+				detached: !isDev,
+				stdio,
+				env: childEnv,
+				windowsHide: true,
+			});
 		} finally {
 			if (logFd >= 0) {
 				try {

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -142,6 +142,21 @@ function validateDims(cols: number, rows: number): void {
 	}
 }
 
+function reprobeErrno(meta: SessionMeta): string {
+	try {
+		const probe = childProcess.spawnSync(meta.shell, ["-c", ":"], {
+			cwd: meta.cwd,
+			timeout: 1000,
+			stdio: "ignore",
+		});
+		if (!probe.error) return "ok";
+		const e = probe.error as NodeJS.ErrnoException;
+		return e.code ?? e.message;
+	} catch (e) {
+		return `reprobe-failed:${(e as Error).message}`;
+	}
+}
+
 export function spawn({ meta }: SpawnOptions): Pty {
 	validateDims(meta.cols, meta.rows);
 	// Pre-flight: node-pty's "posix_spawnp failed" message swallows errno
@@ -178,9 +193,11 @@ export function spawn({ meta }: SpawnOptions): Pty {
 			encoding: null,
 		});
 	} catch (err) {
-		// Annotate with shell + cwd so the wire-error reply is actionable.
+		// node-pty's native "posix_spawnp failed." drops the errno, so re-probe
+		// the same shell+cwd with spawnSync to surface the real code (e.g.
+		// EMFILE/EAGAIN/ENOENT).
 		throw new Error(
-			`spawn failed (shell=${meta.shell} cwd=${meta.cwd ?? "(none)"}): ${(err as Error).message}`,
+			`spawn failed (shell=${meta.shell} cwd=${meta.cwd ?? "(none)"} errno=${reprobeErrno(meta)}): ${(err as Error).message}`,
 		);
 	}
 	const adapter = new NodePtyAdapter(term, meta);


### PR DESCRIPTION
## Problem

Users on dense shared hosts were getting this from the SDK:

```
open <uuid>: spawn failed (shell=/bin/zsh cwd=/Users/.../worktrees/.../public-method): posix_spawnp failed.
```

### Diagnosis

- The committed cwd pre-flight in `Pty.spawn` (`statSync`) had already passed, so the **cwd existed** — this is **not** a deleted/missing worktree.
- node-pty's native `pty.fork` throws a **bare** `Error("posix_spawnp failed.")` with `.code: undefined`, `.errno: undefined` — the errno is lost at the boundary.
- Empirically, a bad shell/cwd does **not** produce this message (node-pty spawns a helper; bad exec surfaces async via exit). `posix_spawnp failed.` is thrown specifically when spawning node-pty's **helper** fails — i.e. **resource exhaustion (EMFILE/EAGAIN)**.
- Prod DB confirms the scale: one org's daemon (`thrive-holdings`) was hosting **118 live worktrees on a single machine** (202 across 7 hosts), creation rate accelerating (1 → 21 → 42 → 56/week), no pruning. The daemon is one process per org per host and **never raised `RLIMIT_NOFILE`**, against macOS's **256** soft default. ~40–50 worktrees with a live agent shell exhausts 256 fds, after which every new PTY spawn fails with EMFILE for every user on that daemon.

## Changes

**`DaemonSupervisor.ts` — raise `RLIMIT_NOFILE`**
Spawn the daemon through `/bin/sh -c 'ulimit -n 1048576 …; exec "$@"'` (POSIX only; Windows path unchanged). `exec` preserves PID/argv/process-group (adoption-by-PID and `ps` matching unaffected), and handoff successors the daemon spawns from itself inherit the raised limit. `1048576` matches systemd's `LimitNOFILE` default; macOS clamps to the kernel ceiling.

**`Pty.ts` — surface the real errno**
On spawn failure, re-probe the same shell+cwd with `spawnSync` (which *does* report the errno) and include `errno=` in the wire error:

```
spawn failed (shell=/bin/zsh cwd=... errno=EMFILE): posix_spawnp failed.
```

Only runs on the (rare) failure path; resource errors like EMFILE are sticky enough to reproduce immediately.

## Testing

- typecheck (both packages) ✅ · `bun run lint` (4618 files) ✅ · pty-daemon unit tests 13/13 ✅
- **EMFILE path proven end-to-end**: a real `Server` over a unix socket under `node --experimental-strip-types` at `ulimit -n 256`, fds exhausted → daemon PTY spawn fails → error frame correctly carries `code: ESPAWN` + `errno=EMFILE`. (Smoke test was removed rather than kept, since it can only run under a low ulimit and would self-skip in CI.)
- The one failing host-service integration test (`terminal disposal cleans up background process groups`) is **pre-existing** — fails identically with this change stashed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the daemon’s file descriptor limit to prevent EMFILE-triggered PTY spawn failures on dense hosts, and surface the real errno when a PTY spawn fails. This reduces crashes and makes errors easier to diagnose.

- **Bug Fixes**
  - `host-service`: On POSIX, start the daemon via `/bin/sh -c 'ulimit -n 1048576 || ulimit -n "$(ulimit -Hn)" || true; exec "$@"'` so `RLIMIT_NOFILE` is raised before exec and inherited by children; Windows unchanged.
  - `pty-daemon`: On spawn failure, re-probe the same shell+cwd with `spawnSync` and include `errno=` in the error (e.g., EMFILE/EAGAIN/ENOENT); only runs on the failure path.

<sup>Written for commit f6536a15dff1725f3db351a7f0f9dd9483d9aea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for terminal creation failures with more detailed diagnostic information.
  * Enhanced daemon stability on macOS by optimizing system resource utilization during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->