### PR TITLE
feat(marketing): add Google Ads gtag tracking

### DIFF
--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { COMPANY } from "@superset/shared/constants";
 import { GeistPixelGrid, GeistPixelSquare } from "geist/font/pixel";
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Inter, Micro_5, Pixelify_Sans } from "next/font/google";
+import Script from "next/script";
 
 import { CookieConsent } from "@/components/CookieConsent";
 import {
@@ -129,6 +130,19 @@ export default function RootLayout({
 				<OrganizationJsonLd />
 				<SoftwareApplicationJsonLd />
 				<WebsiteJsonLd />
+				{/* Google tag (gtag.js) — Google Ads */}
+				<Script
+					src="https://www.googletagmanager.com/gtag/js?id=AW-18209336001"
+					strategy="afterInteractive"
+				/>
+				<Script id="google-ads-gtag" strategy="afterInteractive">
+					{`
+						window.dataLayer = window.dataLayer || [];
+						function gtag(){dataLayer.push(arguments);}
+						gtag('js', new Date());
+						gtag('config', 'AW-18209336001');
+					`}
+				</Script>
 			</head>
 			<body className="overscroll-none font-sans">
 				<Providers>


### PR DESCRIPTION
## Summary
Adds the Google Ads gtag.js tag (`AW-18209336001`) to the marketing site so we can track Google Ads.

We didn't already have any Google Ads / `gtag` tracking — the marketing app only had PostHog analytics.

## Changes
- `apps/marketing/src/app/layout.tsx`: load gtag.js via `next/script` (`strategy="afterInteractive"`) in `<head>` and initialize `gtag('config', 'AW-18209336001')`.

## Notes
- The tag fires for all visitors and is **not** gated behind the existing `CookieConsent` banner (per request — consent gating not required for this).
- This is the base tag only; conversion events (`gtag('event', 'conversion', ...)`) are not wired up yet.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5074">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Ads `gtag.js` (`AW-18209336001`) to the marketing site to enable Ads tracking. Loaded after page interaction for minimal impact.

- **New Features**
  - Load `gtag.js` via `next/script` in `<head>` and initialize `gtag('config', 'AW-18209336001')`.
  - Fires for all visitors (not gated by `CookieConsent`); conversion events not added yet.

<sup>Written for commit 076a531216045573964d5c21be0cb11c714b3af7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Google Ads conversion tracking into the application to enable analytics and performance monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/superset-sh/superset/pull/5074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->