### PR TITLE
fix(host-service): make v2 worktree removal idempotent

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -25,6 +26,18 @@ import { isMainWorkspace } from "./is-main-workspace";
  * after restart is safe.
  */
 const destroysInFlight = new Set<string>();
+
+/**
+ * `git worktree remove` fails with this when the path is no longer a
+ * registered worktree (its `.git/worktrees/<id>` metadata is gone) even
+ * though the directory may still exist on disk. This happens when a
+ * concurrent `git worktree prune` (run by `workspaces.create` on every
+ * invocation, including idempotent window opens/refreshes) or a prior
+ * partially-completed delete deregistered the worktree first. Retrying
+ * `git worktree remove` can never succeed in this state, so we treat it as
+ * already-deregistered and clean up the leftover directory ourselves.
+ */
+const NOT_A_WORKING_TREE = /is not a working tree/i;
 
 /** @internal — exposed for tests to introspect / clear the guard. */
 export const __testDestroysInFlight = destroysInFlight;
@@ -315,7 +328,23 @@ async function runDestroy(
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				if (!existsSync(local.worktreePath)) {
+					// Directory already gone — nothing left to remove.
 					worktreeRemoved = true;
+				} else if (NOT_A_WORKING_TREE.test(message)) {
+					// Deregistered but lingering: prune stale metadata, then remove
+					// the leftover directory directly so the delete is idempotent.
+					await git.raw(["worktree", "prune"]).catch(() => undefined);
+					try {
+						await rm(local.worktreePath, { recursive: true, force: true });
+						worktreeRemoved = true;
+					} catch (rmErr) {
+						const rmMessage =
+							rmErr instanceof Error ? rmErr.message : String(rmErr);
+						throw new TRPCError({
+							code: "INTERNAL_SERVER_ERROR",
+							message: `Failed to remove leftover worktree directory at ${local.worktreePath}: ${rmMessage}`,
+						});
+					}
 				} else {
 					throw new TRPCError({
 						code: "INTERNAL_SERVER_ERROR",

--- a/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-cleanup.integration.test.ts
@@ -4,6 +4,7 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	renameSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -359,6 +360,50 @@ describe("workspaceCleanup.destroy integration", () => {
 		expect(worktreeList).not.toContain(scenario.worktreePath);
 		const branches = await scenario.repo.git.branchLocal();
 		expect(branches.all).not.toContain(scenario.branch);
+	});
+
+	test("deregistered worktree whose directory lingers is removed without error", async () => {
+		// Reproduce the >50% deletion failure: something deregistered the
+		// worktree from git's metadata (a concurrent `git worktree prune` from
+		// workspaces.create, or a prior partial delete) while the directory
+		// stayed on disk. `git worktree remove` then fails permanently with
+		// "is not a working tree". Simulate by pruning the metadata while the
+		// directory is briefly moved aside, then restoring the directory.
+		const stash = `${scenario.worktreePath}.stash`;
+		renameSync(scenario.worktreePath, stash);
+		await scenario.repo.git.raw(["worktree", "prune"]);
+		renameSync(stash, scenario.worktreePath);
+
+		// Precondition: git no longer registers the path, but it exists on disk.
+		const before = await scenario.repo.git.raw([
+			"worktree",
+			"list",
+			"--porcelain",
+		]);
+		expect(before).not.toContain(scenario.worktreePath);
+		expect(existsSync(scenario.worktreePath)).toBe(true);
+
+		const result = await scenario.host.trpc.workspaceCleanup.destroy.mutate({
+			workspaceId: scenario.featureWorkspaceId,
+			deleteBranch: true,
+		});
+		expect(result.success).toBe(true);
+		expect(result.worktreeRemoved).toBe(true);
+		expect(result.branchDeleted).toBe(true);
+		expect(result.warnings).toEqual([]);
+		expect(existsSync(scenario.worktreePath)).toBe(false);
+		expect(
+			scenario.host.apiCalls.some(
+				(c) => c.path === "v2Workspace.delete.mutate",
+			),
+		).toBe(true);
+
+		const remaining = scenario.host.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.id, scenario.featureWorkspaceId))
+			.all();
+		expect(remaining).toHaveLength(0);
 	});
 
 	test("cloud delete failure after local removal keeps row so delete can retry", async () => {

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
 	rmSync,
@@ -32,6 +33,7 @@ interface ContextSpec {
 	revListCount?: string | (() => Promise<string>);
 	gitFactoryThrows?: boolean;
 	worktreeRemove?: () => Promise<unknown>;
+	worktreePrune?: () => Promise<unknown>;
 	branchDelete?: () => Promise<unknown>;
 	dbDeleteThrows?: boolean;
 	noApi?: boolean;
@@ -57,6 +59,7 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 			: (spec.revListCount ?? "0\n"),
 	);
 	const worktreeRemove = mock(spec.worktreeRemove ?? (async () => undefined));
+	const worktreePrune = mock(spec.worktreePrune ?? (async () => undefined));
 	const branchDelete = mock(spec.branchDelete ?? (async () => undefined));
 
 	const git = mock(async () => {
@@ -65,6 +68,8 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 			status,
 			raw: mock(async (args: string[]) => {
 				if (args[0] === "rev-list") return await revList();
+				if (args[0] === "worktree" && args[1] === "prune")
+					return await worktreePrune();
 				if (args[0] === "worktree") return await worktreeRemove();
 				if (args[0] === "branch") return await branchDelete();
 				throw new Error(`unexpected git raw: ${args.join(" ")}`);
@@ -389,6 +394,54 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 				}),
 			).rejects.toThrow(/Failed to remove worktree/i);
 			expect(cloudCallCount).toBe(0);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("deregistered worktree ('is not a working tree') is cleaned up idempotently and delete proceeds", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "workspace-delete-"));
+		writeFileSync(join(tmp, ".keep"), "");
+		let cloudCallCount = 0;
+		let pruneCount = 0;
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: tmp,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: "/repo" },
+				cloudType: "worktree",
+				cloudDelete: async () => {
+					cloudCallCount += 1;
+				},
+				// Directory still on disk, but git no longer registers it — a
+				// concurrent prune/partial-delete deregistered it. Retrying
+				// `git worktree remove` can never succeed.
+				worktreeRemove: async () => {
+					throw new Error(`fatal: '${tmp}' is not a working tree`);
+				},
+				worktreePrune: async () => {
+					pruneCount += 1;
+				},
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			const result = await caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.worktreeRemoved).toBe(true);
+			expect(result.cloudDeleted).toBe(true);
+			expect(cloudCallCount).toBe(1);
+			expect(pruneCount).toBe(1);
+			// Leftover directory removed from disk.
+			expect(existsSync(tmp)).toBe(false);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Problem

v2 workspace deletion fails **>50% of the time** with:

```
Failed to delete <name>: Failed to remove worktree at <path>: fatal: '<path>' is not a working tree
```

Reported by Mike McQuaid — *"feels like perhaps a race condition based on when I close windows."*

## Root cause

`git worktree remove` emits `fatal: '<path>' is not a working tree` when the path is **no longer a registered worktree** (its `.git/worktrees/<id>` metadata is gone) — *even though the directory still exists on disk*. I confirmed this against real git:

| State | `git worktree remove --force --force` |
|---|---|
| directory deleted, metadata intact | **succeeds** (exit 0) |
| directory exists, **metadata deregistered** | `fatal: '…' is not a working tree` (exit 128) |

The destroy saga in `workspace-cleanup.ts` only treated `!existsSync(path)` as the success-equivalent fallback. In the deregistered-but-lingering case `existsSync` is `true`, so it re-threw — and since git can *never* re-remove an unregistered worktree, **every retry failed permanently**, producing the >50% rate.

How the worktree gets deregistered while its directory lingers: `workspaces.create` runs an unconditional `git worktree prune` on **every** call — including the idempotent "open"/refresh that fires on window events. When that prune races a partially-completed prior delete (directory left behind, or momentarily moved), it strips the metadata, and the workspace becomes permanently undeletable via the git path. This matches the "based on when I close windows" symptom.

## Fix

Make worktree removal **idempotent**. When `git worktree remove` reports the path is not a working tree and the directory still exists, treat it as already-deregistered: `git worktree prune` any stale metadata, remove the leftover directory directly, and continue the deletion saga (cloud delete → branch delete → sqlite cleanup). The end state — worktree gone from git, directory gone from disk, cloud/sqlite rows gone — is exactly what deletion wants, so this converges to the correct result regardless of which path deregistered the worktree first.

Genuine failures (directory persists for any other reason — permissions, locked, broken repo) still throw as before.

## Tests

- **Unit** (`workspace-cleanup.test.ts`): `git worktree remove` throws "is not a working tree" with the directory present → asserts prune runs, the leftover directory is removed, and the delete proceeds to cloud delete + success.
- **Integration, real git** (`workspace-cleanup.integration.test.ts`): prunes the worktree metadata while the directory is briefly moved aside, restores the directory to reproduce the exact deregistered-but-lingering state, asserts git no longer lists the path but it exists on disk, then asserts `destroy` removes everything cleanly with no warnings. This test fails against the old code.

All host-service tests pass; typecheck and biome clean.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5075">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make v2 workspace deletion idempotent to stop frequent failures when a Git worktree is deregistered but its directory still exists. This removes the >50% "is not a working tree" error caused by a race with `git worktree prune`.

- **Bug Fixes**
  - On `git worktree remove` failure with "is not a working tree" and the directory still present, treat it as already deregistered.
  - Run `git worktree prune`, remove the leftover directory directly, then continue deletion (cloud, branch, DB).
  - Genuine failures still throw; added unit and real-git integration tests to cover this path.

<sup>Written for commit da27d3bccdbb67aab1b9b85bc32223fbe17ff129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace cleanup robustness to handle deregistered worktrees that linger on disk, allowing cleanup to complete successfully instead of failing.

* **Tests**
  * Added integration and unit tests to verify graceful cleanup of orphaned worktree directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->