### PR TITLE
feat(desktop): drag-and-drop file upload into v2 Files tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -32,6 +32,7 @@ import { createPierreTreeStyle } from "renderer/lib/pierreTree";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
 import { PierreRowContextMenu } from "../PierreRowContextMenu";
 import { FileMenuItems } from "./components/FileMenuItems";
+import { FilesTabDropOverlay } from "./components/FilesTabDropOverlay";
 import { FilesTabHeaderButton } from "./components/FilesTabHeaderButton";
 import { FolderMenuItems } from "./components/FolderMenuItems";
 import {
@@ -41,6 +42,7 @@ import {
 } from "./constants";
 import { useFilesTabActions } from "./hooks/useFilesTabActions";
 import { useFilesTabBridge } from "./hooks/useFilesTabBridge";
+import { useFilesTabDrop } from "./hooks/useFilesTabDrop";
 import { buildPierreGitStatus } from "./utils/buildPierreGitStatus";
 import { stripTrailingSlash, toAbs, toRel } from "./utils/treePath";
 
@@ -140,6 +142,7 @@ export function FilesTab({
 			selectedFilePath,
 			onSelectFile,
 		});
+	const drop = useFilesTabDrop({ model, bridge, rootPath, workspaceId });
 
 	// Push live git status updates into Pierre.
 	useEffect(() => {
@@ -265,9 +268,13 @@ export function FilesTab({
 	}
 
 	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: Drop zone for external file upload
 		<div
-			className="flex h-full min-h-0 flex-col overflow-hidden"
+			className="relative flex h-full min-h-0 flex-col overflow-hidden"
 			onClickCapture={handleClickCapture}
+			onDragOver={drop.onDragOver}
+			onDragLeave={drop.onDragLeave}
+			onDrop={drop.onDrop}
 		>
 			<ShadowClickHint hint={filePolicy.hint} findRow={findFileRow}>
 				<PierreFileTree
@@ -305,6 +312,8 @@ export function FilesTab({
 					renderContextMenu={renderContextMenu}
 				/>
 			</ShadowClickHint>
+
+			{drop.dropTarget && <FilesTabDropOverlay label={drop.dropTarget.label} />}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -313,7 +313,7 @@ export function FilesTab({
 				/>
 			</ShadowClickHint>
 
-			{drop.dropTarget && <FilesTabDropOverlay label={drop.dropTarget.label} />}
+			{drop.dropTarget && <FilesTabDropOverlay target={drop.dropTarget} />}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabDropOverlay/FilesTabDropOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabDropOverlay/FilesTabDropOverlay.tsx
@@ -1,0 +1,24 @@
+import { FileUp } from "lucide-react";
+
+interface FilesTabDropOverlayProps {
+	/** Destination folder name shown to the user (e.g. "src" or "workspace root"). */
+	label: string;
+}
+
+/**
+ * Drop affordance shown while OS files are dragged over the Files tab. Renders
+ * as a non-interactive overlay so it never swallows the underlying drag events;
+ * `label` tracks the folder currently under the cursor.
+ */
+export function FilesTabDropOverlay({ label }: FilesTabDropOverlayProps) {
+	return (
+		<div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center p-1.5">
+			<div className="flex h-full w-full items-center justify-center rounded-md border-2 border-dashed border-primary/60 bg-primary/5 backdrop-blur-[1px]">
+				<div className="flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1.5 text-primary">
+					<FileUp className="size-4" />
+					<span className="text-xs font-medium">Copy into {label}</span>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabDropOverlay/FilesTabDropOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabDropOverlay/FilesTabDropOverlay.tsx
@@ -1,22 +1,39 @@
 import { FileUp } from "lucide-react";
+import type { FilesTabDropTarget } from "../../hooks/useFilesTabDrop";
 
 interface FilesTabDropOverlayProps {
-	/** Destination folder name shown to the user (e.g. "src" or "workspace root"). */
-	label: string;
+	/** The resolved drop destination — folder under the cursor, or root. */
+	target: FilesTabDropTarget;
 }
 
 /**
- * Drop affordance shown while OS files are dragged over the Files tab. Renders
- * as a non-interactive overlay so it never swallows the underlying drag events;
- * `label` tracks the folder currently under the cursor.
+ * Drop affordance shown while OS files are dragged over the Files tab. Highlights
+ * the exact destination folder row under the cursor (or frames the whole tree
+ * when dropping into the root), and names the target in a pinned chip. Rendered
+ * as a non-interactive overlay so it never swallows the underlying drag events.
  */
-export function FilesTabDropOverlay({ label }: FilesTabDropOverlayProps) {
+export function FilesTabDropOverlay({ target }: FilesTabDropOverlayProps) {
+	const { rect, label } = target;
 	return (
-		<div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center p-1.5">
-			<div className="flex h-full w-full items-center justify-center rounded-md border-2 border-dashed border-primary/60 bg-primary/5 backdrop-blur-[1px]">
-				<div className="flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1.5 text-primary">
-					<FileUp className="size-4" />
-					<span className="text-xs font-medium">Copy into {label}</span>
+		<div className="pointer-events-none absolute inset-0 z-20 overflow-hidden">
+			{rect ? (
+				<div
+					className="absolute rounded-sm bg-primary/15 ring-2 ring-inset ring-primary"
+					style={{
+						top: rect.top,
+						left: rect.left,
+						width: rect.width,
+						height: rect.height,
+					}}
+				/>
+			) : (
+				<div className="absolute inset-0 m-1 rounded-md border-2 border-dashed border-primary/60 bg-primary/5" />
+			)}
+
+			<div className="absolute inset-x-0 bottom-2 flex justify-center">
+				<div className="flex max-w-[90%] items-center gap-1.5 rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground shadow">
+					<FileUp className="size-3.5 shrink-0" />
+					<span className="truncate">Drop into {label}</span>
 				</div>
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabDropOverlay/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabDropOverlay/index.ts
@@ -1,0 +1,1 @@
+export { FilesTabDropOverlay } from "./FilesTabDropOverlay";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/index.ts
@@ -1,0 +1,5 @@
+export {
+	type FilesTabDrop,
+	type FilesTabDropTarget,
+	useFilesTabDrop,
+} from "./useFilesTabDrop";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -20,7 +20,7 @@ interface UseFilesTabDropOptions {
 }
 
 export interface FilesTabDropTarget {
-	/** Relative directory the dropped files copy into. "" = worktree root. */
+	/** Relative directory the dropped files write into. "" = worktree root. */
 	dirRel: string;
 	/** Human label for the overlay — folder basename, or "workspace root". */
 	label: string;
@@ -58,22 +58,75 @@ function resolveDropDirRel(e: React.DragEvent): string {
 	return "";
 }
 
-/** Basename of a native OS path (handles both `/` and `\` separators). */
-function nativeBasename(absPath: string): string {
-	const segments = absPath.split(/[\\/]/);
-	return segments[segments.length - 1] ?? absPath;
-}
-
 function dirLabel(dirRel: string): string {
 	return dirRel === "" ? "workspace root" : basename(dirRel);
 }
 
 /**
+ * Collect droppable files, skipping directories. We deliberately read the
+ * `File` objects (not OS paths) because the host-service filesystem is
+ * sandboxed to the worktree — an external source path would be rejected, and a
+ * path means nothing for a remote workspace. Directory detection uses the entry
+ * API; folders are reported separately since recursive upload isn't supported.
+ *
+ * Must run synchronously inside the drop handler: `getAsFile` /
+ * `webkitGetAsEntry` are only valid during event dispatch.
+ */
+function collectDroppedFiles(e: React.DragEvent): {
+	files: File[];
+	skippedDirs: number;
+} {
+	const items = Array.from(e.dataTransfer.items);
+	const supportsEntries =
+		items.length > 0 && typeof items[0].webkitGetAsEntry === "function";
+
+	if (!supportsEntries) {
+		return { files: Array.from(e.dataTransfer.files), skippedDirs: 0 };
+	}
+
+	const files: File[] = [];
+	let skippedDirs = 0;
+	for (const item of items) {
+		if (item.kind !== "file") continue;
+		if (item.webkitGetAsEntry()?.isDirectory) {
+			skippedDirs += 1;
+			continue;
+		}
+		const file = item.getAsFile();
+		if (file) files.push(file);
+	}
+	return { files, skippedDirs };
+}
+
+/** Read a File into base64 (handles binary + large files via the reader). */
+function fileToBase64(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result;
+			if (typeof result !== "string") {
+				reject(new Error("Unexpected file reader result"));
+				return;
+			}
+			// Strip the "data:<mime>;base64," prefix.
+			const comma = result.indexOf(",");
+			resolve(comma >= 0 ? result.slice(comma + 1) : result);
+		};
+		reader.onerror = () =>
+			reject(reader.error ?? new Error("Failed to read file"));
+		reader.readAsDataURL(file);
+	});
+}
+
+/**
  * Drag-and-drop file upload for the v2 Files tab. Dropping OS files onto a
- * folder row copies them into that folder (onto a file row → its parent, onto
- * empty space → the worktree root) via `filesystem.copyPath`. The new entries
- * surface automatically through the bridge's `fs:events` reconciliation; we
- * also expand + fetch the destination so they appear without a manual refresh.
+ * folder row writes them into that folder (onto a file row → its parent, onto
+ * empty space → the worktree root). Each file's bytes are read in the renderer
+ * and written via `filesystem.writeFile` (base64) — the host sandboxes write
+ * destinations to the worktree but never sees an external source path, so this
+ * works for both local and remote workspaces. New entries surface through the
+ * bridge's `fs:events` reconciliation; we also expand + fetch the destination
+ * so they appear without a manual refresh.
  */
 export function useFilesTabDrop({
 	model,
@@ -81,7 +134,7 @@ export function useFilesTabDrop({
 	rootPath,
 	workspaceId,
 }: UseFilesTabDropOptions): FilesTabDrop {
-	const copyPath = workspaceTrpc.filesystem.copyPath.useMutation();
+	const writeFile = workspaceTrpc.filesystem.writeFile.useMutation();
 	const [dropTarget, setDropTarget] = useState<FilesTabDropTarget | null>(null);
 
 	// Clear the overlay if the drag ends outside our handlers (released over
@@ -97,33 +150,45 @@ export function useFilesTabDrop({
 	}, []);
 
 	const uploadFiles = useCallback(
-		async (dirRel: string, sources: string[]): Promise<void> => {
+		async (
+			dirRel: string,
+			files: File[],
+			skippedDirs: number,
+		): Promise<void> => {
 			const destDirAbs = toAbs(rootPath, dirRel);
 			const versionToken = bridge.getVersion();
 
 			const results = await Promise.allSettled(
-				sources.map((sourceAbsolutePath) =>
-					copyPath.mutateAsync({
+				files.map(async (file) => {
+					const data = await fileToBase64(file);
+					const result = await writeFile.mutateAsync({
 						workspaceId,
-						sourceAbsolutePath,
-						destinationAbsolutePath: `${destDirAbs}/${nativeBasename(sourceAbsolutePath)}`,
-					}),
-				),
+						absolutePath: `${destDirAbs}/${file.name}`,
+						content: { kind: "base64", data },
+						options: { create: true, overwrite: false },
+					});
+					// The host resolves "already exists" to `{ ok: false }` rather
+					// than throwing — surface it as a failure for this file.
+					if (result && result.ok === false) {
+						throw new Error(result.reason ?? "write failed");
+					}
+					return result;
+				}),
 			);
 
-			// User switched workspaces mid-copy — don't toast/expand against the
+			// User switched workspaces mid-upload — don't toast/expand against the
 			// new tree.
 			if (!bridge.isCurrent(versionToken)) return;
 
-			const copied = results.filter((r) => r.status === "fulfilled").length;
-			const failed = results.length - copied;
+			const added = results.filter((r) => r.status === "fulfilled").length;
+			const failed = results.length - added;
 
-			if (copied > 0) {
+			if (added > 0) {
 				const where = dirLabel(dirRel);
 				toast.success(
-					copied === 1
+					added === 1
 						? `Added 1 file to ${where}`
-						: `Added ${copied} files to ${where}`,
+						: `Added ${added} files to ${where}`,
 				);
 				// Surface the new entries immediately. fs:events also reconciles,
 				// but expanding + fetching avoids waiting on the watcher and shows
@@ -141,8 +206,15 @@ export function useFilesTabDrop({
 						: `Failed to add ${failed} files`,
 				);
 			}
+			if (skippedDirs > 0) {
+				toast.info(
+					skippedDirs === 1
+						? "Skipped a folder — only files can be dropped"
+						: `Skipped ${skippedDirs} folders — only files can be dropped`,
+				);
+			}
 		},
-		[model, bridge, copyPath, rootPath, workspaceId],
+		[model, bridge, writeFile, rootPath, workspaceId],
 	);
 
 	const onDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
@@ -180,25 +252,21 @@ export function useFilesTabDrop({
 			setDropTarget(null);
 			if (!rootPath || !workspaceId) return;
 
-			// Read everything off the event synchronously — composedPath() and
-			// getPathForFile are only valid during dispatch, before any await.
+			// Read everything off the event synchronously — composedPath() and the
+			// entry/file accessors are only valid during dispatch, before any await.
 			const dirRel = resolveDropDirRel(e);
-			const sources: string[] = [];
-			for (const file of Array.from(e.dataTransfer.files)) {
-				try {
-					const path = window.webUtils.getPathForFile(file);
-					if (path) sources.push(path);
-				} catch {
-					// Skip entries we can't resolve to a filesystem path.
-				}
-			}
+			const { files, skippedDirs } = collectDroppedFiles(e);
 
-			if (sources.length === 0) {
-				toast.error("Could not read the dropped files");
+			if (files.length === 0) {
+				toast.error(
+					skippedDirs > 0
+						? "Only files can be dropped, not folders"
+						: "Could not read the dropped files",
+				);
 				return;
 			}
 
-			void uploadFiles(dirRel, sources);
+			void uploadFiles(dirRel, files, skippedDirs);
 		},
 		[rootPath, workspaceId, uploadFiles],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -158,8 +158,15 @@ export function useFilesTabDrop({
 			const destDirAbs = toAbs(rootPath, dirRel);
 			const versionToken = bridge.getVersion();
 
-			const results = await Promise.allSettled(
-				files.map(async (file) => {
+			// Upload one file at a time: encoding everything up front would hold
+			// every base64 payload (~1.33x each) in memory at once, and a per-file
+			// version check lets a workspace switch stop the remaining writes
+			// instead of dribbling them into a worktree the user has left.
+			let added = 0;
+			let failed = 0;
+			for (const file of files) {
+				if (!bridge.isCurrent(versionToken)) break;
+				try {
 					const data = await fileToBase64(file);
 					const result = await writeFile.mutateAsync({
 						workspaceId,
@@ -172,16 +179,15 @@ export function useFilesTabDrop({
 					if (result && result.ok === false) {
 						throw new Error(result.reason ?? "write failed");
 					}
-					return result;
-				}),
-			);
+					added += 1;
+				} catch {
+					failed += 1;
+				}
+			}
 
 			// User switched workspaces mid-upload — don't toast/expand against the
 			// new tree.
 			if (!bridge.isCurrent(versionToken)) return;
-
-			const added = results.filter((r) => r.status === "fulfilled").length;
-			const failed = results.length - added;
 
 			if (added > 0) {
 				const where = dirLabel(dirRel);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -34,6 +34,19 @@ export interface FilesTabDrop {
 	onDrop(e: React.DragEvent<HTMLDivElement>): void;
 }
 
+/** A file to upload, keyed by its path relative to the drop destination. */
+interface DroppedFile {
+	relPath: string;
+	file: File;
+}
+
+/** Flattened drop payload: files to write + directories to (re)create. */
+interface DroppedTree {
+	files: DroppedFile[];
+	/** Directory paths relative to the drop destination (includes empty dirs). */
+	dirs: string[];
+}
+
 /** True when the drag carries OS files (vs. an internal/text drag). */
 function dragHasFiles(e: React.DragEvent): boolean {
 	return Array.from(e.dataTransfer.types).includes("Files");
@@ -63,39 +76,84 @@ function dirLabel(dirRel: string): string {
 }
 
 /**
- * Collect droppable files, skipping directories. We deliberately read the
- * `File` objects (not OS paths) because the host-service filesystem is
- * sandboxed to the worktree — an external source path would be rejected, and a
- * path means nothing for a remote workspace. Directory detection uses the entry
- * API; folders are reported separately since recursive upload isn't supported.
- *
- * Must run synchronously inside the drop handler: `getAsFile` /
- * `webkitGetAsEntry` are only valid during event dispatch.
+ * Capture the dropped entries synchronously. `webkitGetAsEntry` and the items
+ * list are only valid during event dispatch, but the returned entry handles
+ * stay usable across the later async traversal. Falls back to the flat file
+ * list when the entry API is unavailable (no folder support in that case).
  */
-function collectDroppedFiles(e: React.DragEvent): {
-	files: File[];
-	skippedDirs: number;
+function collectDroppedEntries(e: React.DragEvent): {
+	entries: FileSystemEntry[];
+	fallbackFiles: File[];
 } {
 	const items = Array.from(e.dataTransfer.items);
 	const supportsEntries =
 		items.length > 0 && typeof items[0].webkitGetAsEntry === "function";
 
 	if (!supportsEntries) {
-		return { files: Array.from(e.dataTransfer.files), skippedDirs: 0 };
+		return { entries: [], fallbackFiles: Array.from(e.dataTransfer.files) };
 	}
 
-	const files: File[] = [];
-	let skippedDirs = 0;
+	const entries: FileSystemEntry[] = [];
 	for (const item of items) {
 		if (item.kind !== "file") continue;
-		if (item.webkitGetAsEntry()?.isDirectory) {
-			skippedDirs += 1;
-			continue;
-		}
-		const file = item.getAsFile();
-		if (file) files.push(file);
+		const entry = item.webkitGetAsEntry();
+		if (entry) entries.push(entry);
 	}
-	return { files, skippedDirs };
+	return { entries, fallbackFiles: [] };
+}
+
+function getFile(entry: FileSystemFileEntry): Promise<File> {
+	return new Promise((resolve, reject) => entry.file(resolve, reject));
+}
+
+/** Drain a directory reader — `readEntries` yields entries in batches. */
+async function readAllEntries(
+	reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> {
+	const all: FileSystemEntry[] = [];
+	while (true) {
+		const batch = await new Promise<FileSystemEntry[]>((resolve, reject) =>
+			reader.readEntries(resolve, reject),
+		);
+		if (batch.length === 0) break;
+		all.push(...batch);
+	}
+	return all;
+}
+
+/** Recursively flatten one dropped entry into files + directory paths. */
+async function flattenEntry(
+	entry: FileSystemEntry,
+	prefix: string,
+): Promise<DroppedTree> {
+	if (entry.isFile) {
+		const file = await getFile(entry as FileSystemFileEntry);
+		return { files: [{ relPath: `${prefix}${entry.name}`, file }], dirs: [] };
+	}
+
+	const dirRel = `${prefix}${entry.name}`;
+	const children = await readAllEntries(
+		(entry as FileSystemDirectoryEntry).createReader(),
+	);
+	const subtrees = await Promise.all(
+		children.map((child) => flattenEntry(child, `${dirRel}/`)),
+	);
+	return {
+		files: subtrees.flatMap((t) => t.files),
+		dirs: [dirRel, ...subtrees.flatMap((t) => t.dirs)],
+	};
+}
+
+async function flattenEntries(
+	entries: FileSystemEntry[],
+): Promise<DroppedTree> {
+	const trees = await Promise.all(
+		entries.map((entry) => flattenEntry(entry, "")),
+	);
+	return {
+		files: trees.flatMap((t) => t.files),
+		dirs: trees.flatMap((t) => t.dirs),
+	};
 }
 
 /** Read a File into base64 (handles binary + large files via the reader). */
@@ -119,14 +177,15 @@ function fileToBase64(file: File): Promise<string> {
 }
 
 /**
- * Drag-and-drop file upload for the v2 Files tab. Dropping OS files onto a
- * folder row writes them into that folder (onto a file row → its parent, onto
- * empty space → the worktree root). Each file's bytes are read in the renderer
- * and written via `filesystem.writeFile` (base64) — the host sandboxes write
- * destinations to the worktree but never sees an external source path, so this
- * works for both local and remote workspaces. New entries surface through the
- * bridge's `fs:events` reconciliation; we also expand + fetch the destination
- * so they appear without a manual refresh.
+ * Drag-and-drop file upload for the v2 Files tab. Dropping OS files/folders onto
+ * a folder row writes them into that folder (onto a file row → its parent, onto
+ * empty space → the worktree root), preserving any nested folder structure.
+ * Each file's bytes are read in the renderer and written via
+ * `filesystem.writeFile` (base64) — the host sandboxes write destinations to the
+ * worktree but never sees an external source path, so this works for both local
+ * and remote workspaces. New entries surface through the bridge's `fs:events`
+ * reconciliation; we also expand + fetch the destination so they appear without
+ * a manual refresh.
  */
 export function useFilesTabDrop({
 	model,
@@ -135,6 +194,8 @@ export function useFilesTabDrop({
 	workspaceId,
 }: UseFilesTabDropOptions): FilesTabDrop {
 	const writeFile = workspaceTrpc.filesystem.writeFile.useMutation();
+	const createDirectory =
+		workspaceTrpc.filesystem.createDirectory.useMutation();
 	const [dropTarget, setDropTarget] = useState<FilesTabDropTarget | null>(null);
 
 	// Clear the overlay if the drag ends outside our handlers (released over
@@ -149,14 +210,54 @@ export function useFilesTabDrop({
 		};
 	}, []);
 
-	const uploadFiles = useCallback(
+	const uploadDropped = useCallback(
 		async (
 			dirRel: string,
-			files: File[],
-			skippedDirs: number,
+			entries: FileSystemEntry[],
+			fallbackFiles: File[],
 		): Promise<void> => {
 			const destDirAbs = toAbs(rootPath, dirRel);
 			const versionToken = bridge.getVersion();
+
+			const tree =
+				entries.length > 0
+					? await flattenEntries(entries)
+					: {
+							files: fallbackFiles.map((file) => ({
+								relPath: file.name,
+								file,
+							})),
+							dirs: [],
+						};
+
+			if (!bridge.isCurrent(versionToken)) return;
+
+			if (tree.files.length === 0 && tree.dirs.length === 0) {
+				toast.error("Could not read the dropped files");
+				return;
+			}
+
+			// Create directories shallowest-first so parents exist before
+			// children; recursive makes the calls idempotent. Failures are left
+			// uncounted — files underneath will fail and be reported below.
+			const dirs = Array.from(new Set(tree.dirs)).sort(
+				(a, b) => a.split("/").length - b.split("/").length,
+			);
+			for (const relDir of dirs) {
+				if (!bridge.isCurrent(versionToken)) return;
+				try {
+					await createDirectory.mutateAsync({
+						workspaceId,
+						absolutePath: `${destDirAbs}/${relDir}`,
+						recursive: true,
+					});
+				} catch (error) {
+					console.error("[v2 FilesTab] createDirectory failed", {
+						relDir,
+						error,
+					});
+				}
+			}
 
 			// Upload one file at a time: encoding everything up front would hold
 			// every base64 payload (~1.33x each) in memory at once, and a per-file
@@ -164,13 +265,13 @@ export function useFilesTabDrop({
 			// instead of dribbling them into a worktree the user has left.
 			let added = 0;
 			let failed = 0;
-			for (const file of files) {
+			for (const { relPath, file } of tree.files) {
 				if (!bridge.isCurrent(versionToken)) break;
 				try {
 					const data = await fileToBase64(file);
 					const result = await writeFile.mutateAsync({
 						workspaceId,
-						absolutePath: `${destDirAbs}/${file.name}`,
+						absolutePath: `${destDirAbs}/${relPath}`,
 						content: { kind: "base64", data },
 						options: { create: true, overwrite: false },
 					});
@@ -189,21 +290,19 @@ export function useFilesTabDrop({
 			// new tree.
 			if (!bridge.isCurrent(versionToken)) return;
 
+			const where = dirLabel(dirRel);
 			if (added > 0) {
-				const where = dirLabel(dirRel);
 				toast.success(
 					added === 1
 						? `Added 1 file to ${where}`
 						: `Added ${added} files to ${where}`,
 				);
-				// Surface the new entries immediately. fs:events also reconciles,
-				// but expanding + fetching avoids waiting on the watcher and shows
-				// results inside a collapsed destination folder.
-				if (dirRel) {
-					const handle = asDirectoryHandle(model.getItem(`${dirRel}/`));
-					if (handle && !handle.isExpanded()) handle.expand();
-				}
-				void bridge.fetchDir(dirRel);
+			} else if (failed === 0 && dirs.length > 0) {
+				toast.success(
+					dirs.length === 1
+						? `Created 1 folder in ${where}`
+						: `Created ${dirs.length} folders in ${where}`,
+				);
 			}
 			if (failed > 0) {
 				toast.error(
@@ -212,15 +311,19 @@ export function useFilesTabDrop({
 						: `Failed to add ${failed} files`,
 				);
 			}
-			if (skippedDirs > 0) {
-				toast.info(
-					skippedDirs === 1
-						? "Skipped a folder — only files can be dropped"
-						: `Skipped ${skippedDirs} folders — only files can be dropped`,
-				);
+
+			// Surface the new entries immediately. fs:events also reconciles, but
+			// expanding + fetching avoids waiting on the watcher and shows results
+			// inside a collapsed destination folder.
+			if (added > 0 || dirs.length > 0) {
+				if (dirRel) {
+					const handle = asDirectoryHandle(model.getItem(`${dirRel}/`));
+					if (handle && !handle.isExpanded()) handle.expand();
+				}
+				void bridge.fetchDir(dirRel);
 			}
 		},
-		[model, bridge, writeFile, rootPath, workspaceId],
+		[model, bridge, writeFile, createDirectory, rootPath, workspaceId],
 	);
 
 	const onDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
@@ -261,20 +364,16 @@ export function useFilesTabDrop({
 			// Read everything off the event synchronously — composedPath() and the
 			// entry/file accessors are only valid during dispatch, before any await.
 			const dirRel = resolveDropDirRel(e);
-			const { files, skippedDirs } = collectDroppedFiles(e);
+			const { entries, fallbackFiles } = collectDroppedEntries(e);
 
-			if (files.length === 0) {
-				toast.error(
-					skippedDirs > 0
-						? "Only files can be dropped, not folders"
-						: "Could not read the dropped files",
-				);
+			if (entries.length === 0 && fallbackFiles.length === 0) {
+				toast.error("Could not read the dropped files");
 				return;
 			}
 
-			void uploadFiles(dirRel, files, skippedDirs);
+			void uploadDropped(dirRel, entries, fallbackFiles);
 		},
-		[rootPath, workspaceId, uploadFiles],
+		[rootPath, workspaceId, uploadDropped],
 	);
 
 	return { dropTarget, onDragOver, onDragLeave, onDrop };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -19,11 +19,24 @@ interface UseFilesTabDropOptions {
 	workspaceId: string;
 }
 
+/** Position of the destination folder's row, relative to the tree wrapper. */
+export interface DropRowRect {
+	top: number;
+	left: number;
+	width: number;
+	height: number;
+}
+
 export interface FilesTabDropTarget {
 	/** Relative directory the dropped files write into. "" = worktree root. */
 	dirRel: string;
 	/** Human label for the overlay — folder basename, or "workspace root". */
 	label: string;
+	/**
+	 * The destination folder row to highlight, or null when dropping into the
+	 * root (no row represents it) — the overlay then frames the whole tree.
+	 */
+	rect: DropRowRect | null;
 }
 
 export interface FilesTabDrop {
@@ -53,26 +66,90 @@ function dragHasFiles(e: React.DragEvent): boolean {
 }
 
 /**
- * Resolve which directory a drag is over by walking `composedPath()` for the
- * nearest row's `data-item-path` (stamped by `@pierre/trees`, lives in an open
- * shadow root). Directory rows carry a trailing slash → drop into that folder;
- * file rows → drop into their parent; nothing under the cursor → worktree root.
+ * The tree row under the cursor. `@pierre/trees` stamps `data-item-path` and
+ * renders rows in an open shadow root, so we walk `composedPath()` to find it.
  */
-function resolveDropDirRel(e: React.DragEvent): string {
+function findRowUnderCursor(e: React.DragEvent): HTMLElement | null {
 	for (const node of e.nativeEvent.composedPath()) {
-		if (!(node instanceof HTMLElement)) continue;
-		const itemPath = node.getAttribute("data-item-path");
-		if (itemPath) {
-			return itemPath.endsWith("/")
-				? stripTrailingSlash(itemPath)
-				: parentRel(itemPath);
+		if (node instanceof HTMLElement && node.getAttribute("data-item-path")) {
+			return node;
 		}
 	}
-	return "";
+	return null;
+}
+
+/**
+ * Destination directory for a row: directory rows carry a trailing slash → drop
+ * into that folder; file rows → their parent; no row → worktree root.
+ */
+function rowToDirRel(row: HTMLElement | null): string {
+	const itemPath = row?.getAttribute("data-item-path");
+	if (!itemPath) return "";
+	return itemPath.endsWith("/")
+		? stripTrailingSlash(itemPath)
+		: parentRel(itemPath);
+}
+
+function resolveDropDirRel(e: React.DragEvent): string {
+	return rowToDirRel(findRowUnderCursor(e));
 }
 
 function dirLabel(dirRel: string): string {
 	return dirRel === "" ? "workspace root" : basename(dirRel);
+}
+
+/** Locate the rendered row element for a directory within the same tree. */
+function findDirRow(sibling: HTMLElement, dirRel: string): HTMLElement | null {
+	const root = sibling.getRootNode();
+	if (!(root instanceof ShadowRoot || root instanceof Document)) return null;
+	return root.querySelector<HTMLElement>(
+		`[data-item-path=${CSS.escape(`${dirRel}/`)}]`,
+	);
+}
+
+/**
+ * Resolve the full drop target — destination directory + the screen rect of the
+ * folder row to highlight (relative to the tree wrapper, so the overlay can
+ * position itself). Returns a null rect for root drops.
+ */
+function resolveDropTarget(
+	e: React.DragEvent<HTMLDivElement>,
+): FilesTabDropTarget {
+	const row = findRowUnderCursor(e);
+	const dirRel = rowToDirRel(row);
+	const destRow = dirRel && row ? findDirRow(row, dirRel) : null;
+
+	let rect: DropRowRect | null = null;
+	if (destRow) {
+		const wrapper = e.currentTarget.getBoundingClientRect();
+		const r = destRow.getBoundingClientRect();
+		rect = {
+			top: r.top - wrapper.top,
+			left: r.left - wrapper.left,
+			width: r.width,
+			height: r.height,
+		};
+	}
+
+	return { dirRel, label: dirLabel(dirRel), rect };
+}
+
+function rectsEqual(a: DropRowRect | null, b: DropRowRect | null): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	return (
+		a.top === b.top &&
+		a.left === b.left &&
+		a.width === b.width &&
+		a.height === b.height
+	);
+}
+
+function targetsEqual(
+	a: FilesTabDropTarget | null,
+	b: FilesTabDropTarget,
+): boolean {
+	return a !== null && a.dirRel === b.dirRel && rectsEqual(a.rect, b.rect);
 }
 
 /**
@@ -343,8 +420,10 @@ export function useFilesTabDrop({
 		e.preventDefault();
 		e.stopPropagation();
 		e.dataTransfer.dropEffect = "copy";
-		const dirRel = resolveDropDirRel(e);
-		setDropTarget({ dirRel, label: dirLabel(dirRel) });
+		// dragover fires continuously; bail out of state updates while the
+		// destination (and its row position) is unchanged to avoid re-renders.
+		const next = resolveDropTarget(e);
+		setDropTarget((prev) => (targetsEqual(prev, next) ? prev : next));
 	}, []);
 
 	const onDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -297,16 +297,26 @@ export function useFilesTabDrop({
 			const destDirAbs = toAbs(rootPath, dirRel);
 			const versionToken = bridge.getVersion();
 
-			const tree =
-				entries.length > 0
-					? await flattenEntries(entries)
-					: {
-							files: fallbackFiles.map((file) => ({
-								relPath: file.name,
-								file,
-							})),
-							dirs: [],
-						};
+			let tree: DroppedTree;
+			try {
+				tree =
+					entries.length > 0
+						? await flattenEntries(entries)
+						: {
+								files: fallbackFiles.map((file) => ({
+									relPath: file.name,
+									file,
+								})),
+								dirs: [],
+							};
+			} catch {
+				// A single unreadable entry rejects the whole traversal; surface it
+				// instead of failing silently as an unhandled rejection.
+				if (bridge.isCurrent(versionToken)) {
+					toast.error("Could not read the dropped files");
+				}
+				return;
+			}
 
 			if (!bridge.isCurrent(versionToken)) return;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -1,0 +1,207 @@
+import type { FileTree } from "@pierre/trees";
+import { toast } from "@superset/ui/sonner";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useCallback, useEffect, useState } from "react";
+import {
+	asDirectoryHandle,
+	basename,
+	parentRel,
+	stripTrailingSlash,
+	toAbs,
+} from "../../utils/treePath";
+import type { FilesTabBridge } from "../useFilesTabBridge";
+
+interface UseFilesTabDropOptions {
+	model: FileTree;
+	bridge: FilesTabBridge;
+	/** Workspace worktree root (absolute). */
+	rootPath: string;
+	workspaceId: string;
+}
+
+export interface FilesTabDropTarget {
+	/** Relative directory the dropped files copy into. "" = worktree root. */
+	dirRel: string;
+	/** Human label for the overlay — folder basename, or "workspace root". */
+	label: string;
+}
+
+export interface FilesTabDrop {
+	/** Non-null while an external file drag hovers the tree. */
+	dropTarget: FilesTabDropTarget | null;
+	onDragOver(e: React.DragEvent<HTMLDivElement>): void;
+	onDragLeave(e: React.DragEvent<HTMLDivElement>): void;
+	onDrop(e: React.DragEvent<HTMLDivElement>): void;
+}
+
+/** True when the drag carries OS files (vs. an internal/text drag). */
+function dragHasFiles(e: React.DragEvent): boolean {
+	return Array.from(e.dataTransfer.types).includes("Files");
+}
+
+/**
+ * Resolve which directory a drag is over by walking `composedPath()` for the
+ * nearest row's `data-item-path` (stamped by `@pierre/trees`, lives in an open
+ * shadow root). Directory rows carry a trailing slash → drop into that folder;
+ * file rows → drop into their parent; nothing under the cursor → worktree root.
+ */
+function resolveDropDirRel(e: React.DragEvent): string {
+	for (const node of e.nativeEvent.composedPath()) {
+		if (!(node instanceof HTMLElement)) continue;
+		const itemPath = node.getAttribute("data-item-path");
+		if (itemPath) {
+			return itemPath.endsWith("/")
+				? stripTrailingSlash(itemPath)
+				: parentRel(itemPath);
+		}
+	}
+	return "";
+}
+
+/** Basename of a native OS path (handles both `/` and `\` separators). */
+function nativeBasename(absPath: string): string {
+	const segments = absPath.split(/[\\/]/);
+	return segments[segments.length - 1] ?? absPath;
+}
+
+function dirLabel(dirRel: string): string {
+	return dirRel === "" ? "workspace root" : basename(dirRel);
+}
+
+/**
+ * Drag-and-drop file upload for the v2 Files tab. Dropping OS files onto a
+ * folder row copies them into that folder (onto a file row → its parent, onto
+ * empty space → the worktree root) via `filesystem.copyPath`. The new entries
+ * surface automatically through the bridge's `fs:events` reconciliation; we
+ * also expand + fetch the destination so they appear without a manual refresh.
+ */
+export function useFilesTabDrop({
+	model,
+	bridge,
+	rootPath,
+	workspaceId,
+}: UseFilesTabDropOptions): FilesTabDrop {
+	const copyPath = workspaceTrpc.filesystem.copyPath.useMutation();
+	const [dropTarget, setDropTarget] = useState<FilesTabDropTarget | null>(null);
+
+	// Clear the overlay if the drag ends outside our handlers (released over
+	// another window, dropped elsewhere, or canceled with Esc).
+	useEffect(() => {
+		const clear = () => setDropTarget(null);
+		window.addEventListener("dragend", clear);
+		window.addEventListener("drop", clear);
+		return () => {
+			window.removeEventListener("dragend", clear);
+			window.removeEventListener("drop", clear);
+		};
+	}, []);
+
+	const uploadFiles = useCallback(
+		async (dirRel: string, sources: string[]): Promise<void> => {
+			const destDirAbs = toAbs(rootPath, dirRel);
+			const versionToken = bridge.getVersion();
+
+			const results = await Promise.allSettled(
+				sources.map((sourceAbsolutePath) =>
+					copyPath.mutateAsync({
+						workspaceId,
+						sourceAbsolutePath,
+						destinationAbsolutePath: `${destDirAbs}/${nativeBasename(sourceAbsolutePath)}`,
+					}),
+				),
+			);
+
+			// User switched workspaces mid-copy — don't toast/expand against the
+			// new tree.
+			if (!bridge.isCurrent(versionToken)) return;
+
+			const copied = results.filter((r) => r.status === "fulfilled").length;
+			const failed = results.length - copied;
+
+			if (copied > 0) {
+				const where = dirLabel(dirRel);
+				toast.success(
+					copied === 1
+						? `Added 1 file to ${where}`
+						: `Added ${copied} files to ${where}`,
+				);
+				// Surface the new entries immediately. fs:events also reconciles,
+				// but expanding + fetching avoids waiting on the watcher and shows
+				// results inside a collapsed destination folder.
+				if (dirRel) {
+					const handle = asDirectoryHandle(model.getItem(`${dirRel}/`));
+					if (handle && !handle.isExpanded()) handle.expand();
+				}
+				void bridge.fetchDir(dirRel);
+			}
+			if (failed > 0) {
+				toast.error(
+					failed === 1
+						? "Failed to add 1 file"
+						: `Failed to add ${failed} files`,
+				);
+			}
+		},
+		[model, bridge, copyPath, rootPath, workspaceId],
+	);
+
+	const onDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+		if (!dragHasFiles(e)) return;
+		e.preventDefault();
+		e.stopPropagation();
+		e.dataTransfer.dropEffect = "copy";
+		const dirRel = resolveDropDirRel(e);
+		setDropTarget({ dirRel, label: dirLabel(dirRel) });
+	}, []);
+
+	const onDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+		if (!dragHasFiles(e)) return;
+		e.preventDefault();
+		e.stopPropagation();
+		// Ignore leaves into child rows — only clear when the cursor exits the
+		// tree's bounds.
+		const rect = e.currentTarget.getBoundingClientRect();
+		const { clientX, clientY } = e;
+		if (
+			clientX < rect.left ||
+			clientX > rect.right ||
+			clientY < rect.top ||
+			clientY > rect.bottom
+		) {
+			setDropTarget(null);
+		}
+	}, []);
+
+	const onDrop = useCallback(
+		(e: React.DragEvent<HTMLDivElement>) => {
+			if (!dragHasFiles(e)) return;
+			e.preventDefault();
+			e.stopPropagation();
+			setDropTarget(null);
+			if (!rootPath || !workspaceId) return;
+
+			// Read everything off the event synchronously — composedPath() and
+			// getPathForFile are only valid during dispatch, before any await.
+			const dirRel = resolveDropDirRel(e);
+			const sources: string[] = [];
+			for (const file of Array.from(e.dataTransfer.files)) {
+				try {
+					const path = window.webUtils.getPathForFile(file);
+					if (path) sources.push(path);
+				} catch {
+					// Skip entries we can't resolve to a filesystem path.
+				}
+			}
+
+			if (sources.length === 0) {
+				toast.error("Could not read the dropped files");
+				return;
+			}
+
+			void uploadFiles(dirRel, sources);
+		},
+		[rootPath, workspaceId, uploadFiles],
+	);
+
+	return { dropTarget, onDragOver, onDragLeave, onDrop };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -238,11 +238,12 @@ export function useFilesTabDrop({
 			}
 
 			// Create directories shallowest-first so parents exist before
-			// children; recursive makes the calls idempotent. Failures are left
-			// uncounted — files underneath will fail and be reported below.
+			// children; recursive makes the calls idempotent.
 			const dirs = Array.from(new Set(tree.dirs)).sort(
 				(a, b) => a.split("/").length - b.split("/").length,
 			);
+			let createdDirs = 0;
+			let failedDirs = 0;
 			for (const relDir of dirs) {
 				if (!bridge.isCurrent(versionToken)) return;
 				try {
@@ -251,7 +252,9 @@ export function useFilesTabDrop({
 						absolutePath: `${destDirAbs}/${relDir}`,
 						recursive: true,
 					});
+					createdDirs += 1;
 				} catch (error) {
+					failedDirs += 1;
 					console.error("[v2 FilesTab] createDirectory failed", {
 						relDir,
 						error,
@@ -297,25 +300,34 @@ export function useFilesTabDrop({
 						? `Added 1 file to ${where}`
 						: `Added ${added} files to ${where}`,
 				);
-			} else if (failed === 0 && dirs.length > 0) {
+			} else if (createdDirs > 0 && failed === 0 && failedDirs === 0) {
 				toast.success(
-					dirs.length === 1
+					createdDirs === 1
 						? `Created 1 folder in ${where}`
-						: `Created ${dirs.length} folders in ${where}`,
+						: `Created ${createdDirs} folders in ${where}`,
 				);
 			}
+			// A failed directory cascades into failures for its files, so prefer
+			// the file count; only fall back to the folder count when nothing but
+			// directory creation failed (e.g. an empty folder).
 			if (failed > 0) {
 				toast.error(
 					failed === 1
 						? "Failed to add 1 file"
 						: `Failed to add ${failed} files`,
 				);
+			} else if (failedDirs > 0) {
+				toast.error(
+					failedDirs === 1
+						? "Failed to create 1 folder"
+						: `Failed to create ${failedDirs} folders`,
+				);
 			}
 
 			// Surface the new entries immediately. fs:events also reconciles, but
 			// expanding + fetching avoids waiting on the watcher and shows results
 			// inside a collapsed destination folder.
-			if (added > 0 || dirs.length > 0) {
+			if (added > 0 || createdDirs > 0) {
 				if (dirRel) {
 					const handle = asDirectoryHandle(model.getItem(`${dirRel}/`));
 					if (handle && !handle.isExpanded()) handle.expand();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -1,4 +1,5 @@
 import type { FileTree } from "@pierre/trees";
+import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useCallback, useEffect, useState } from "react";
@@ -339,28 +340,44 @@ export function useFilesTabDrop({
 				}
 			}
 
+			// Write a single dropped file. Returns "exists" when the host reports a
+			// name collision (only possible with overwrite off); throws otherwise.
+			const writeOneFile = async (
+				relPath: string,
+				file: File,
+				overwrite: boolean,
+			): Promise<"ok" | "exists"> => {
+				const data = await fileToBase64(file);
+				const result = await writeFile.mutateAsync({
+					workspaceId,
+					absolutePath: `${destDirAbs}/${relPath}`,
+					content: { kind: "base64", data },
+					options: { create: true, overwrite },
+				});
+				if (result && result.ok === false) {
+					if (!overwrite && result.reason === "exists") return "exists";
+					throw new Error(result.reason ?? "write failed");
+				}
+				return "ok";
+			};
+
 			// Upload one file at a time: encoding everything up front would hold
 			// every base64 payload (~1.33x each) in memory at once, and a per-file
 			// version check lets a workspace switch stop the remaining writes
-			// instead of dribbling them into a worktree the user has left.
+			// instead of dribbling them into a worktree the user has left. Files
+			// whose names already exist are collected (not overwritten) and the
+			// user is asked to confirm replacement below.
 			let added = 0;
 			let failed = 0;
+			const collisions: DroppedFile[] = [];
 			for (const { relPath, file } of tree.files) {
 				if (!bridge.isCurrent(versionToken)) break;
 				try {
-					const data = await fileToBase64(file);
-					const result = await writeFile.mutateAsync({
-						workspaceId,
-						absolutePath: `${destDirAbs}/${relPath}`,
-						content: { kind: "base64", data },
-						options: { create: true, overwrite: false },
-					});
-					// The host resolves "already exists" to `{ ok: false }` rather
-					// than throwing — surface it as a failure for this file.
-					if (result && result.ok === false) {
-						throw new Error(result.reason ?? "write failed");
+					if ((await writeOneFile(relPath, file, false)) === "exists") {
+						collisions.push({ relPath, file });
+					} else {
+						added += 1;
 					}
-					added += 1;
 				} catch {
 					failed += 1;
 				}
@@ -411,6 +428,54 @@ export function useFilesTabDrop({
 				}
 				void bridge.fetchDir(dirRel);
 			}
+
+			// Name collisions: the host left these untouched (overwrite off), so
+			// confirm before replacing. Replacing only overwrites existing rows —
+			// no tree-shape change — so no refresh is needed afterward.
+			if (collisions.length === 0) return;
+			const many = collisions.length > 1;
+			const firstName = basename(collisions[0].relPath);
+			alert({
+				title: many
+					? `${collisions.length} files already exist in ${where}. Do you want to replace them?`
+					: `A file named '${firstName}' already exists in ${where}. Do you want to replace it?`,
+				description: "This action is irreversible.",
+				actions: [
+					{
+						label: many ? "Replace All" : "Replace",
+						variant: "destructive",
+						onClick: async () => {
+							let replaced = 0;
+							let replaceFailed = 0;
+							for (const { relPath, file } of collisions) {
+								if (!bridge.isCurrent(versionToken)) break;
+								try {
+									await writeOneFile(relPath, file, true);
+									replaced += 1;
+								} catch {
+									replaceFailed += 1;
+								}
+							}
+							if (!bridge.isCurrent(versionToken)) return;
+							if (replaced > 0) {
+								toast.success(
+									replaced === 1
+										? `Replaced 1 file in ${where}`
+										: `Replaced ${replaced} files in ${where}`,
+								);
+							}
+							if (replaceFailed > 0) {
+								toast.error(
+									replaceFailed === 1
+										? "Failed to replace 1 file"
+										: `Failed to replace ${replaceFailed} files`,
+								);
+							}
+						},
+					},
+					{ label: "Cancel", variant: "ghost" },
+				],
+			});
 		},
 		[model, bridge, writeFile, createDirectory, rootPath, workspaceId],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabDrop/useFilesTabDrop.ts
@@ -388,8 +388,9 @@ export function useFilesTabDrop({
 					} else {
 						added += 1;
 					}
-				} catch {
+				} catch (error) {
 					failed += 1;
+					console.error("[v2 FilesTab] upload failed", { relPath, error });
 				}
 			}
 
@@ -462,8 +463,12 @@ export function useFilesTabDrop({
 								try {
 									await writeOneFile(relPath, file, true);
 									replaced += 1;
-								} catch {
+								} catch (error) {
 									replaceFailed += 1;
+									console.error("[v2 FilesTab] replace failed", {
+										relPath,
+										error,
+									});
 								}
 							}
 							if (!bridge.isCurrent(versionToken)) return;

--- a/packages/ui/src/atoms/Alert/Alert.tsx
+++ b/packages/ui/src/atoms/Alert/Alert.tsx
@@ -67,7 +67,7 @@ const Alerter = () => {
 			open={isOpen}
 			onOpenChange={(open) => !open && handleClose()}
 		>
-			<DialogContent>
+			<DialogContent showCloseButton={false}>
 				<DialogHeader>
 					<DialogTitle>{alertOptions.title}</DialogTitle>
 					<DialogDescription>{alertOptions.description}</DialogDescription>

--- a/packages/workspace-fs/src/fs.ts
+++ b/packages/workspace-fs/src/fs.ts
@@ -641,6 +641,10 @@ export async function createDirectory({
 	recursive?: boolean;
 }): Promise<{ absolutePath: string; kind: "directory" }> {
 	const targetPath = ensureWithinRoot({ rootPath, absolutePath });
+	// Lexical containment isn't enough: a symlinked ancestor (e.g. `link ->
+	// /outside`) would let `mkdir` create directories outside the workspace.
+	// Resolve the real path / ancestry the same way writes do before creating.
+	await assertRealpathWithinRoot(rootPath, targetPath);
 	try {
 		await fs.mkdir(targetPath, { recursive });
 	} catch (error) {


### PR DESCRIPTION
## What

Adds drag-and-drop file upload to the **v2 Files tab** (`@pierre/trees` sidebar). Drag OS files (from Finder/Explorer or another app) onto the sidebar to copy them into the workspace worktree.

Files land in the **folder under the cursor**:
- folder row → into that folder
- file row → into its parent folder
- empty space → worktree root

A live overlay shows the destination ("Copy into _\<folder\>_") while dragging.

## How

- **`hooks/useFilesTabDrop`** — resolves the destination by walking the drop event's `composedPath()` for the nearest row's `data-item-path` (same shadow-DOM technique as `usePierreRowClickPolicy`). Reads dropped paths via `window.webUtils.getPathForFile` and copies each through `workspaceTrpc.filesystem.copyPath`. Guards on `dataTransfer.types.includes("Files")` so internal tree drags are untouched, and uses the bridge's `getVersion`/`isCurrent` to bail on a mid-copy workspace switch.
- **`components/FilesTabDropOverlay`** — non-interactive dashed-border overlay with the live destination label.
- **`FilesTab.tsx`** — wires the hook's `onDragOver`/`onDragLeave`/`onDrop` onto the wrapper and renders the overlay.

New entries surface automatically through the bridge's existing `fs:events` reconciliation; the hook also expands + `fetchDir`s the destination so they appear immediately even inside a collapsed folder.

Reuses v1's `SidebarDropZone` drag pattern (`getPathForFile` + bounding-rect `dragLeave`), retargeted to copy into the worktree instead of opening a project.

## Notes

- Desktop-only (relies on Electron `webUtils`).
- Name collisions follow `copyPath`'s host-service semantics; a rejected copy surfaces as a "Failed to add" toast. Explicit collision handling (e.g. `file (1).txt`) is not included.

## Test plan

- [ ] Drag a file from Finder onto a folder row → copies into that folder, toast confirms
- [ ] Drag onto a file row → copies into its parent folder
- [ ] Drag onto empty space → copies into worktree root
- [ ] Overlay label tracks the folder under the cursor and clears on drop/leave/Esc
- [ ] Internal tree interactions (selection, rename DnD) are unaffected

Typecheck (desktop) and Biome lint pass locally.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5082">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add drag-and-drop file and folder upload to the v2 Files tab on desktop. Highlights the exact destination while dragging, preserves structure, and confirms on name collisions.

- New Features
  - Drop OS files/folders onto the Files tab to upload into the folder under the cursor (folder row → that folder, file row → its parent, empty space → workspace root), resolved from `data-item-path` in `@pierre/trees`.
  - Overlay highlights the destination row and shows “Drop into <folder>”; root drops frame the whole tree; dragover skips state updates when unchanged to avoid re-renders.
  - Preserves structure (incl. empty folders) via `workspaceTrpc.filesystem.createDirectory`; uploads files sequentially via `workspaceTrpc.filesystem.writeFile` (base64) with per-file abort on workspace switch; prompts Replace/Cancel on name collisions; auto-expands + refreshes the destination; success/error toasts; desktop-only and internal tree drags are unaffected.

- Bug Fixes
  - Hardened `createDirectory` against symlink escapes with a realpath-within-root check; guarded folder-drop traversal to show a “Could not read” toast on unreadable entries.
  - Folder-only drops report success only when directories are actually created; removed the redundant close (X) on the shared alert dialog.
  - Improved error logs for upload/replace failures with the failing `relPath`.

<sup>Written for commit df710199af92f32d9e1a12f61e1b720a72f7e027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop file upload: drag files or folders from your OS into the Files tab and drop into a folder to add content.
  * Visual drop zone: shows the destination folder name as an overlay while dragging.
  * Folder-aware uploads: preserves relative paths, creates missing folders, uploads items, and auto-expands + refreshes the destination.
* **Bug Fixes**
  * Cancels in-progress uploads if the workspace changes to prevent incorrect updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->