### PR TITLE
feat(desktop): add agy lifecycle hook integration

### DIFF
--- a/apps/desktop/docs/20260601-antigravity-builtin-agent-design.md
+++ b/apps/desktop/docs/20260601-antigravity-builtin-agent-design.md
@@ -2,7 +2,7 @@
 
 - **Status:** Approved (sections 1–7 reviewed 2026-06-01)
 - **Source issue:** [superset-sh/superset#4986](https://github.com/superset-sh/superset/issues/4986)
-- **Scope:** Full first-class desktop integration (manifest + wrapper + setup registry + icon + tests). Notification hooks deferred.
+- **Scope:** Full first-class desktop integration (manifest + wrapper + setup registry + icon + tests), including lifecycle hook integration.
 - **Worktree:** `apps/desktop`
 
 ## Problem
@@ -14,18 +14,18 @@ Google's Antigravity CLI (`agy`) is a production-grade terminal agent (Gemini 3.
 - The Superset-managed binary at `~/.superset/bin/agy` (and the `SUPERSET_AGENT_ID=agy` identity env var that wires the agent to future hook integrations)
 - A documented configuration path for first-class features
 
-The fix is a 5-touchpoint integration matching the existing pattern for built-in terminal agents. Antigravity CLI is brand new (v1.0.4 released 2026-06-01) and has no documented hook system yet, so notification hook integration is explicitly deferred to a follow-up.
+The fix is a 5-touchpoint integration matching the existing pattern for built-in terminal agents. Antigravity CLI is brand new (v1.0.4 released 2026-06-01), and this implementation includes Superset-managed lifecycle hooks via `~/.gemini/config/hooks.json` plus a generated `agy-hook.sh` template.
 
 ## Goals
 
 1. Make `agy` a first-class, selectable built-in agent matching the UX of Claude/Codex/Amp/OpenCode.
 2. Use the same 5-touchpoint pattern as every other built-in agent (manifest, wrapper, setup registry, icon, tests).
-3. Set the stage for future hook integration by exporting `SUPERSET_AGENT_ID=agy` from the wrapper today.
-4. Defer speculative code: do not invent a hook integration that does not yet have a documented format upstream.
+3. Ship lifecycle hook integration for `agy` while preserving `SUPERSET_AGENT_ID=agy` identity wiring.
+4. Keep hook wiring additive and resilient across worktree moves by replacing only Superset-managed hook entries.
 
 ## Non-goals
 
-- Notification hook integration. Antigravity CLI v1.0.4 has no `settings.json`, plugin, or extension model. Adding hooks would require guessing at a format that may change.
+- Additional plugin- or extension-based integrations beyond `hooks.json` + `agy-hook.sh`.
 - A custom icon. Reuse the existing `antigravity.svg` asset; the CLI and editor are the same product family.
 - Fixing antigravity-cli#76 (the `agy -p` no-output bug in non-TTY mode). That's an upstream issue.
 - A new agent picker component. The existing pickers consume `BUILTIN_TERMINAL_AGENTS` and `PRESET_ICONS` at render time and need no changes.
@@ -34,7 +34,7 @@ The fix is a 5-touchpoint integration matching the existing pattern for built-in
 
 The integration follows the existing 5-touchpoint pattern. Every layer is auto-derived from the manifest except for the wrapper, setup runner, and icon registration.
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ packages/shared/src/builtin-terminal-agents.ts (manifest row)               │
 │   id: "agy", label: "Antigravity", command: "agy", promptCommand: "agy -p"  │
@@ -66,7 +66,7 @@ The integration follows the existing 5-touchpoint pattern. Every layer is auto-d
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ packages/ui/src/assets/icons/preset-icons/                                  │
-│   agy.svg, agy-dark.svg (copies of antigravity.svg)                         │
+│   agy.svg, agy-white.svg (copies of antigravity.svg)                        │
 │   PRESET_ICONS += agy: { light, dark }                                      │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -198,19 +198,19 @@ Add the runner to the `DESKTOP_AGENT_SETUP_RUNNERS` map:
 **Asset creation:** copy `apps/desktop/src/renderer/assets/app-icons/antigravity.svg` to two new files in the preset-icons directory:
 
 - `packages/ui/src/assets/icons/preset-icons/agy.svg` (light variant)
-- `packages/ui/src/assets/icons/preset-icons/agy-dark.svg` (dark variant — copy of the same file for now)
+- `packages/ui/src/assets/icons/preset-icons/agy-white.svg` (dark variant — copy of the same file for now)
 
 **Registration** in `packages/ui/src/assets/icons/preset-icons/index.ts:24-36`:
 
 ```ts
 import agyIcon from "./agy.svg";
-import agyDarkIcon from "./agy-dark.svg";
+import agyWhiteIcon from "./agy-white.svg";
 
 export const PRESET_ICONS: Record<string, PresetIconSet> = {
   // ...existing 11
-  agy: { light: agyIcon, dark: agyDarkIcon },
+  agy: { light: agyIcon, dark: agyWhiteIcon },
 };
-```
+```text
 
 **Why reuse the existing `antigravity.svg`:** the Antigravity CLI and Antigravity editor are the same product family with the same branding. The existing SVG is the only Antigravity icon asset in the repo. Reusing it is consistent with how the codebase already represents Antigravity. If the team later wants distinct icons, the light/dark pair can be replaced without code changes.
 
@@ -232,13 +232,13 @@ it("creates agy wrapper passthrough", () => {
   expect(wrapper).toContain('export SUPERSET_AGENT_ID="agy"');
   expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
 });
-```
+```text
 
 **Test infrastructure reuse:** the file's existing `mock.module` setup (lines 26-48) and `TEST_BIN_DIR` (line 89) cover the new file. The barrel re-export in touchpoint 2 means `createAgyWrapper` is importable via the existing `await import("./agent-wrappers")` at line 89. No new test setup.
 
-**No new tests required for:**
-- `agent-wrappers-gemini.ts` / `agent-wrappers-copilot.ts` per-agent hook script patterns (we don't ship a hook script)
-- `notify-hook.test.ts` (no per-agent hook template to parameterize over)
+**No additional tests required for:**
+- `agent-wrappers-gemini.ts` / `agent-wrappers-copilot.ts` beyond existing per-agent hook template coverage
+- `notify-hook.test.ts` beyond adding `agy-hook.template.sh` to the shared per-agent assertion loop
 - `agent-command.test.ts` (no non-default `promptTransport` or `--` separator; `promptCommand: "agy -p"` is the simple `argv` form)
 - `agent-launch-request.test.ts` (no unusual task launch behavior)
 
@@ -250,7 +250,7 @@ it("creates agy wrapper passthrough", () => {
 
 ### Launch path (user clicks "Antigravity" in agent picker)
 
-```
+```text
 User picks "Antigravity" in DiffPane/AgentPicker/Settings/etc.
   ↓
 Terminal pane spawns ~/.superset/bin/agy
@@ -266,7 +266,7 @@ agy launches interactive TUI
 
 ### Setup path (user adds Antigravity via Settings → Agents)
 
-```
+```text
 User clicks "Set up" in Settings → Agents
   ↓
 tRPC setupAgent({ agentId: "agy" })
@@ -282,29 +282,27 @@ createAgyWrapper() writes ~/.superset/bin/agy
 writeFileIfChanged no-ops if content matches
 ```
 
-### Identity flow (today, hookless)
+### Identity and hook flow
 
-```
+```text
 agy process has env: SUPERSET_AGENT_ID=agy
-  ↓ (when agy ships hooks, they read this env)
-Future hook handler reads SUPERSET_AGENT_ID
   ↓
-POSTs to SUPERSET_HOST_AGENT_HOOK_URL with { agentId: "agy" }
+agy invokes hooks from ~/.gemini/config/hooks.json
+  ↓
+Superset-managed agy-hook.sh receives event + payload JSON
+  ↓
+POSTs to SUPERSET_HOST_AGENT_HOOK_URL with { agentId: "agy", eventType, sessionId }
   ↓
 Host service normalizes + broadcasts agent:lifecycle
   ↓
 Renderer shows working indicator
 ```
 
-## Deferred work
+## Hook behavior notes
 
-**Notification hook integration is deferred** until antigravity-cli ships a documented hook system. When that happens:
-
-1. The `SUPERSET_AGENT_ID=agy` env var is already in place. The notify script's v2 payload will carry `agentId: "agy"` automatically for any agy invocation through the wrapper.
-2. The new hook integration is purely additive: a new file under `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts` (e.g. `createAgySettingsJson()`), a new `templates/agy-hook.template.sh` if needed, and a new setup action id.
-3. No schema migration. The receiver accepts any string for `agentId` and the renderer's `usePresetIcon` returns `undefined` for unknowns, so the picker and pane-header fall back gracefully.
-
-The `apps/desktop/plans/20260601-antigravity-builtin-agent.md` plan file documents this as a follow-up, with a link to the upstream tracking issue.
+1. `SUPERSET_AGENT_ID=agy` is exported by the wrapper and forwarded in v2 payloads.
+2. `hooks.json` registration is idempotent and replaces stale Superset-managed paths from old worktrees.
+3. The receiver accepts any string for `agentId`; picker/icon fallback remains safe for unknown IDs.
 
 ## Files changed (summary)
 
@@ -312,7 +310,7 @@ The `apps/desktop/plans/20260601-antigravity-builtin-agent.md` plan file documen
 |---|---|---|
 | NEW | `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts` | Wrapper generator for `~/.superset/bin/agy` |
 | NEW | `packages/ui/src/assets/icons/preset-icons/agy.svg` | Light variant of Antigravity icon |
-| NEW | `packages/ui/src/assets/icons/preset-icons/agy-dark.svg` | Dark variant of Antigravity icon |
+| NEW | `packages/ui/src/assets/icons/preset-icons/agy-white.svg` | Dark variant of Antigravity icon |
 | EDIT | `apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts` | Barrel re-export of the new wrapper module |
 | EDIT | `apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts` | Add `agy-wrapper` action and `agy` target |
 | EDIT | `apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts` | Register `createAgyWrapper` runner |
@@ -320,7 +318,7 @@ The `apps/desktop/plans/20260601-antigravity-builtin-agent.md` plan file documen
 | EDIT | `packages/ui/src/assets/icons/preset-icons/index.ts` | Register agy icon in `PRESET_ICONS` |
 | EDIT | `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` | Add wrapper passthrough test |
 | EDIT | `apps/desktop/docs/EXTERNAL_FILES.md` | Add `agy` row to `bin/` section |
-| NEW | `apps/desktop/plans/20260601-antigravity-builtin-agent.md` | Plan file documenting ship + deferred hooks |
+| NEW | `apps/desktop/plans/20260601-antigravity-builtin-agent.md` | Plan file documenting ship details |
 
 ## Verification
 
@@ -341,4 +339,4 @@ Manual verification on the desktop app:
 
 ## Open questions
 
-None at ship time. The deferred hook work may surface new questions when antigravity-cli ships a hook format.
+None at ship time.

--- a/apps/desktop/docs/20260601-antigravity-builtin-agent-design.md
+++ b/apps/desktop/docs/20260601-antigravity-builtin-agent-design.md
@@ -1,0 +1,344 @@
+# Design: Add Antigravity CLI (`agy`) as a Built-in Terminal Agent
+
+- **Status:** Approved (sections 1–7 reviewed 2026-06-01)
+- **Source issue:** [superset-sh/superset#4986](https://github.com/superset-sh/superset/issues/4986)
+- **Scope:** Full first-class desktop integration (manifest + wrapper + setup registry + icon + tests). Notification hooks deferred.
+- **Worktree:** `apps/desktop`
+
+## Problem
+
+Google's Antigravity CLI (`agy`) is a production-grade terminal agent (Gemini 3.x models, multi-step reasoning, parallel sub-agents, project-level `AGENTS.md` context) but it does not appear in Superset's built-in terminal agent list. Users can run `agy` as a generic CLI agent in any Superset terminal, but they lose:
+
+- The branded "Antigravity" entry in the agent picker UI
+- A preset template in Settings → Agents
+- The Superset-managed binary at `~/.superset/bin/agy` (and the `SUPERSET_AGENT_ID=agy` identity env var that wires the agent to future hook integrations)
+- A documented configuration path for first-class features
+
+The fix is a 5-touchpoint integration matching the existing pattern for built-in terminal agents. Antigravity CLI is brand new (v1.0.4 released 2026-06-01) and has no documented hook system yet, so notification hook integration is explicitly deferred to a follow-up.
+
+## Goals
+
+1. Make `agy` a first-class, selectable built-in agent matching the UX of Claude/Codex/Amp/OpenCode.
+2. Use the same 5-touchpoint pattern as every other built-in agent (manifest, wrapper, setup registry, icon, tests).
+3. Set the stage for future hook integration by exporting `SUPERSET_AGENT_ID=agy` from the wrapper today.
+4. Defer speculative code: do not invent a hook integration that does not yet have a documented format upstream.
+
+## Non-goals
+
+- Notification hook integration. Antigravity CLI v1.0.4 has no `settings.json`, plugin, or extension model. Adding hooks would require guessing at a format that may change.
+- A custom icon. Reuse the existing `antigravity.svg` asset; the CLI and editor are the same product family.
+- Fixing antigravity-cli#76 (the `agy -p` no-output bug in non-TTY mode). That's an upstream issue.
+- A new agent picker component. The existing pickers consume `BUILTIN_TERMINAL_AGENTS` and `PRESET_ICONS` at render time and need no changes.
+
+## Architecture
+
+The integration follows the existing 5-touchpoint pattern. Every layer is auto-derived from the manifest except for the wrapper, setup runner, and icon registration.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ packages/shared/src/builtin-terminal-agents.ts (manifest row)               │
+│   id: "agy", label: "Antigravity", command: "agy", promptCommand: "agy -p"  │
+│                                                                             │
+│   Auto-derives:                                                             │
+│   - BUILTIN_TERMINAL_AGENT_TYPES, BUILTIN_AGENT_LABELS                      │
+│   - HOST_AGENT_PRESETS (host-service install catalog)                       │
+│   - DEFAULT_TERMINAL_PRESET_AGENT_TYPES                                     │
+│   - ManagedBinary union (typechecks DESKTOP_AGENT_SETUP_TARGETS)            │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts (NEW)          │
+│   createAgyWrapper() — emits ~/.superset/bin/agy via buildWrapperScript()  │
+│   v3 pass-through template + export SUPERSET_AGENT_ID="agy"                 │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts         │
+│   DESKTOP_AGENT_SETUP_ACTIONS += "agy-wrapper"                              │
+│   DESKTOP_AGENT_SETUP_TARGETS += { id: "agy", setupActions: [...],         │
+│                                     managedBinary: true }                   │
+│   → SUPERSET_MANAGED_BINARIES auto-derives "agy"                            │
+│     → shell-wrappers.ts forces user-facing "agy" → ~/.superset/bin/agy      │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ packages/ui/src/assets/icons/preset-icons/                                  │
+│   agy.svg, agy-dark.svg (copies of antigravity.svg)                         │
+│   PRESET_ICONS += agy: { light, dark }                                      │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Touchpoint 1 — Manifest entry
+
+**File:** `packages/shared/src/builtin-terminal-agents.ts`
+
+Add to `BUILTIN_TERMINAL_AGENTS` (alphabetical, between `amp` and `claude`):
+
+```ts
+createBuiltinTerminalAgent({
+  id: "agy",
+  label: "Antigravity",
+  description: "Google's agentic development platform — multi-step reasoning, parallel sub-agents, and project context via AGENTS.md.",
+  command: "agy",
+  promptCommand: "agy -p",
+  includeInDefaultTerminalPresets: true,
+}),
+```
+
+**Field rationale:**
+
+- `id: "agy"` — wire-level identity. Must match `SUPERSET_AGENT_ID` exactly. Type-checks against `BuiltinAgentId` via the `ManagedBinary` type alias.
+- `label: "Antigravity"` — matches the product name. Used in pickers, terminal pane header, settings list.
+- `description` — one-liner that names the three distinguishing features (multi-step reasoning, parallel sub-agents, AGENTS.md context).
+- `command: "agy"` — default interactive launch. No `--dangerously-skip-permissions` by default; users opt in via Settings → Permissions.
+- `promptCommand: "agy -p"` — headless print mode used by the task agent transport. Matches the issue's note that `agy` uses `-p`/`--print` for non-interactive mode. **Known issue:** antigravity-cli#76 documents that `agy -p` in non-TTY mode currently produces no output. We still register the command because that's the documented headless flag; the upstream fix is out of scope.
+- `includeInDefaultTerminalPresets: true` — shows in Settings → Agents by default, matching the bar set by Claude/Codex/Amp/Copilot.
+
+**Auto-derives** (no extra edits):
+- `BUILTIN_TERMINAL_AGENT_TYPES` includes `"agy"`
+- `BUILTIN_TERMINAL_AGENT_LABELS.agy === "Antigravity"`
+- `BUILTIN_AGENT_LABELS.agy === "Antigravity"` (via `agent-catalog.ts:34-39`)
+- `BUILTIN_AGENT_DEFINITIONS` includes the agy definition (`agent-catalog.ts:54-57`)
+- `HOST_AGENT_PRESETS` (host-service install catalog) includes agy (`host-agent-presets.ts:41-55`)
+- `DEFAULT_TERMINAL_PRESET_AGENT_TYPES` includes `"agy"`
+
+## Touchpoint 2 — Wrapper script
+
+**New file:** `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts`
+
+```ts
+import path from "node:path";
+import { BIN_DIR, WRITE_MODE } from "./paths";
+import { buildWrapperScript, writeFileIfChanged } from "./agent-wrappers-common";
+
+export const AGY_WRAPPER_MARKER = "# Superset agent-wrapper v3";
+
+export function createAgyWrapper(): void {
+  const wrapperPath = path.join(BIN_DIR, "agy");
+  const execLine = 'exec "$REAL_BIN" "$@"';
+  const content = buildWrapperScript({
+    agentId: "agy",
+    binaryName: "agy",
+    execLine,
+    extraEnv: {},
+  });
+  writeFileIfChanged(wrapperPath, content, WRITE_MODE.WRAPPER);
+}
+```
+
+The generated wrapper at `~/.superset/bin/agy` is byte-identical (modulo path) to the wrappers for `claude`/`amp`/`droid`/`gemini`/`mastracode`/`opencode`:
+
+```bash
+#!/bin/bash
+# Superset agent-wrapper v3
+# Superset wrapper for agy
+find_real_binary() { ... }   # standard v3 helper
+REAL_BIN="$(find_real_binary "agy")"
+if [ -z "$REAL_BIN" ]; then
+  echo "Superset: agy not found in PATH. Install it and ensure it is on PATH, then retry." >&2
+  exit 127
+fi
+export SUPERSET_AGENT_ID="agy"
+exec "$REAL_BIN" "$@"
+```
+
+**Why this works for agy even without hooks:**
+
+- `SUPERSET_AGENT_ID=agy` is exported into the agy process environment. Any future antigravity-cli hook system that reads the parent-process identity will see the correct value automatically.
+- The wrapper is a **managed binary** (touchpoint 3), so `shell-wrappers.ts` routes the user's `agy` invocations through `~/.superset/bin/agy` even if shell config rewrites `$PATH`.
+- The wrapper does not add `--dangerously-skip-permissions`. The manifest's `command` is the source of truth, and that default is `agy` (no flags).
+
+**Re-export in barrel** (`apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts:1-84`):
+
+```ts
+export * from "./agent-wrappers-agy";
+```
+
+The existing `await import("./agent-wrappers")` at line 89 of the test file picks up the new export automatically.
+
+**No template file** — `buildWrapperScript()` produces the v3 marker content from code. The `templates/` directory only holds heavyweight per-agent scripts (Codex wrapper, Copilot hook, Gemini hook) that genuinely need template files.
+
+## Touchpoint 3 — Setup registry
+
+**File A:** `apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts`
+
+1. Add `"agy-wrapper"` to `DESKTOP_AGENT_SETUP_ACTIONS` (alphabetical, between `"amp-wrapper"` and `"claude-settings-json"`):
+   ```ts
+   "agy-wrapper",
+   "amp-wrapper",
+   ```
+
+2. Add `agy` target to `DESKTOP_AGENT_SETUP_TARGETS` (alphabetical, between `amp` and `claude`):
+   ```ts
+   {
+     id: "agy",
+     setupActions: ["agy-wrapper"],
+     managedBinary: true,
+   },
+   ```
+
+3. `SUPERSET_MANAGED_BINARIES` (lines 104-106) auto-derives from targets with `managedBinary: true` — no edit needed. This is what tells `shell-wrappers.ts` to force the user-facing `agy` to route through `~/.superset/bin/agy`.
+
+**File B:** `apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts:32-57`
+
+Add the runner to the `DESKTOP_AGENT_SETUP_RUNNERS` map:
+```ts
+"agy-wrapper": createAgyWrapper,
+```
+
+**Bootstrap actions:** no change. `DESKTOP_AGENT_SETUP_BOOTSTRAP_ACTIONS` (lines 40-43) only runs `cleanup-global-opencode-plugin` and `notify-script`, neither of which is relevant for agy.
+
+**`setupSingleAgent(agentId)` flow** (lines 76-86): when an existing user calls `setupAgent({ agentId: "agy" })` via tRPC (from Settings → Agents "set up" button), the runner walks through bootstrap actions then the `["agy-wrapper"]` list and writes the wrapper. `writeFileIfChanged` makes this a no-op when the file is already current.
+
+## Touchpoint 4 — Icon
+
+**Asset creation:** copy `apps/desktop/src/renderer/assets/app-icons/antigravity.svg` to two new files in the preset-icons directory:
+
+- `packages/ui/src/assets/icons/preset-icons/agy.svg` (light variant)
+- `packages/ui/src/assets/icons/preset-icons/agy-dark.svg` (dark variant — copy of the same file for now)
+
+**Registration** in `packages/ui/src/assets/icons/preset-icons/index.ts:24-36`:
+
+```ts
+import agyIcon from "./agy.svg";
+import agyDarkIcon from "./agy-dark.svg";
+
+export const PRESET_ICONS: Record<string, PresetIconSet> = {
+  // ...existing 11
+  agy: { light: agyIcon, dark: agyDarkIcon },
+};
+```
+
+**Why reuse the existing `antigravity.svg`:** the Antigravity CLI and Antigravity editor are the same product family with the same branding. The existing SVG is the only Antigravity icon asset in the repo. Reusing it is consistent with how the codebase already represents Antigravity. If the team later wants distinct icons, the light/dark pair can be replaced without code changes.
+
+**No fallback risk:** `getPresetIcon()` in `index.ts:38-46` already does `.toLowerCase().trim()` and returns `undefined` for unknown names; the pickers show a generic `TerminalSquare` icon in that case. Adding the entry just makes the branded icon resolve.
+
+## Touchpoint 5 — Tests
+
+**File:** `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`
+
+Add to the existing `describe("passthrough wrappers", ...)` block (the same block that contains tests for `amp`, `claude`, `droid`, etc.):
+
+```ts
+it("creates agy wrapper passthrough", () => {
+  createAgyWrapper();
+  const wrapperPath = path.join(TEST_BIN_DIR, "agy");
+  const wrapper = readFileSync(wrapperPath, "utf-8");
+  expect(wrapper).toContain("# Superset wrapper for agy");
+  expect(wrapper).toContain('REAL_BIN="$(find_real_binary "agy")"');
+  expect(wrapper).toContain('export SUPERSET_AGENT_ID="agy"');
+  expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
+});
+```
+
+**Test infrastructure reuse:** the file's existing `mock.module` setup (lines 26-48) and `TEST_BIN_DIR` (line 89) cover the new file. The barrel re-export in touchpoint 2 means `createAgyWrapper` is importable via the existing `await import("./agent-wrappers")` at line 89. No new test setup.
+
+**No new tests required for:**
+- `agent-wrappers-gemini.ts` / `agent-wrappers-copilot.ts` per-agent hook script patterns (we don't ship a hook script)
+- `notify-hook.test.ts` (no per-agent hook template to parameterize over)
+- `agent-command.test.ts` (no non-default `promptTransport` or `--` separator; `promptCommand: "agy -p"` is the simple `argv` form)
+- `agent-launch-request.test.ts` (no unusual task launch behavior)
+
+**Typecheck coverage:** adding the manifest row exercises the `BuiltinAgentId` union (auto-derived), the `ManagedBinary` type alias (`agy` flows through `SUPERSET_MANAGED_BINARIES`), and the new `agy` target's `setupActions: ["agy-wrapper"]` type against `DESKTOP_AGENT_SETUP_ACTIONS`. If any of these don't align, `bun run typecheck` fails — a strong correctness signal.
+
+**Lint coverage:** Biome runs at root, will catch any unused imports added to `agent-wrappers.ts` or `desktop-agent-capabilities.ts`.
+
+## Data flow
+
+### Launch path (user clicks "Antigravity" in agent picker)
+
+```
+User picks "Antigravity" in DiffPane/AgentPicker/Settings/etc.
+  ↓
+Terminal pane spawns ~/.superset/bin/agy
+  ↓ (wrapper v3)
+find_real_binary("agy") → /usr/local/bin/agy
+  ↓
+export SUPERSET_AGENT_ID="agy"
+  ↓
+exec /usr/local/bin/agy
+  ↓
+agy launches interactive TUI
+```
+
+### Setup path (user adds Antigravity via Settings → Agents)
+
+```
+User clicks "Set up" in Settings → Agents
+  ↓
+tRPC setupAgent({ agentId: "agy" })
+  ↓
+setupSingleAgent("agy")
+  ↓
+DESKTOP_AGENT_SETUP_BOOTSTRAP_ACTIONS run first
+  ↓
+DESKTOP_AGENT_SETUP_TARGETS.agy.setupActions = ["agy-wrapper"] runs
+  ↓
+createAgyWrapper() writes ~/.superset/bin/agy
+  ↓
+writeFileIfChanged no-ops if content matches
+```
+
+### Identity flow (today, hookless)
+
+```
+agy process has env: SUPERSET_AGENT_ID=agy
+  ↓ (when agy ships hooks, they read this env)
+Future hook handler reads SUPERSET_AGENT_ID
+  ↓
+POSTs to SUPERSET_HOST_AGENT_HOOK_URL with { agentId: "agy" }
+  ↓
+Host service normalizes + broadcasts agent:lifecycle
+  ↓
+Renderer shows working indicator
+```
+
+## Deferred work
+
+**Notification hook integration is deferred** until antigravity-cli ships a documented hook system. When that happens:
+
+1. The `SUPERSET_AGENT_ID=agy` env var is already in place. The notify script's v2 payload will carry `agentId: "agy"` automatically for any agy invocation through the wrapper.
+2. The new hook integration is purely additive: a new file under `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts` (e.g. `createAgySettingsJson()`), a new `templates/agy-hook.template.sh` if needed, and a new setup action id.
+3. No schema migration. The receiver accepts any string for `agentId` and the renderer's `usePresetIcon` returns `undefined` for unknowns, so the picker and pane-header fall back gracefully.
+
+The `apps/desktop/plans/20260601-antigravity-builtin-agent.md` plan file documents this as a follow-up, with a link to the upstream tracking issue.
+
+## Files changed (summary)
+
+| Status | File | Purpose |
+|---|---|---|
+| NEW | `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts` | Wrapper generator for `~/.superset/bin/agy` |
+| NEW | `packages/ui/src/assets/icons/preset-icons/agy.svg` | Light variant of Antigravity icon |
+| NEW | `packages/ui/src/assets/icons/preset-icons/agy-dark.svg` | Dark variant of Antigravity icon |
+| EDIT | `apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts` | Barrel re-export of the new wrapper module |
+| EDIT | `apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts` | Add `agy-wrapper` action and `agy` target |
+| EDIT | `apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts` | Register `createAgyWrapper` runner |
+| EDIT | `packages/shared/src/builtin-terminal-agents.ts` | Add agy manifest row |
+| EDIT | `packages/ui/src/assets/icons/preset-icons/index.ts` | Register agy icon in `PRESET_ICONS` |
+| EDIT | `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` | Add wrapper passthrough test |
+| EDIT | `apps/desktop/docs/EXTERNAL_FILES.md` | Add `agy` row to `bin/` section |
+| NEW | `apps/desktop/plans/20260601-antigravity-builtin-agent.md` | Plan file documenting ship + deferred hooks |
+
+## Verification
+
+After implementation, run from repo root:
+
+```bash
+bun run typecheck          # catches manifest/setup/ManagedBinary misalignment
+bun run lint               # catches unused imports, format drift
+bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+```
+
+Manual verification on the desktop app:
+
+1. Launch Superset desktop. Confirm `~/.superset/bin/agy` exists and is executable.
+2. Open Settings → Agents. Confirm "Antigravity" appears in the agent list with the icon.
+3. Open a terminal pane. Pick "Antigravity" from the agent picker. Confirm `agy` launches interactively.
+4. `echo $SUPERSET_AGENT_ID` inside the launched terminal — should print `agy`.
+
+## Open questions
+
+None at ship time. The deferred hook work may surface new questions when antigravity-cli ships a hook format.

--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -17,6 +17,7 @@ This separation prevents multiple instances from interfering with each other.
 
 | File | Purpose |
 |------|---------|
+| `agy` | Wrapper for Antigravity CLI that preserves Superset terminal context |
 | `amp` | Wrapper for Amp CLI that preserves Superset terminal context |
 | `claude` | Wrapper for Claude Code CLI that injects notification hooks |
 | `codex` | Wrapper for Codex CLI that injects notification hooks |

--- a/apps/desktop/plans/20260601-antigravity-builtin-agent.md
+++ b/apps/desktop/plans/20260601-antigravity-builtin-agent.md
@@ -1,0 +1,565 @@
+# Antigravity CLI (`agy`) Built-in Agent — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Google's Antigravity CLI (`agy`) as a first-class built-in terminal agent in the Superset desktop app, matching the existing 5-touchpoint pattern used by Claude/Codex/Amp/OpenCode.
+
+**Architecture:** One new wrapper module + manifest row + setup registry entries + icon asset + test. Notification hook integration is deferred because antigravity-cli v1.0.4 has no documented hook system yet. The `SUPERSET_AGENT_ID=agy` env var is exported by the wrapper so future hook integration is purely additive.
+
+**Tech Stack:** TypeScript, Bun, Biome, shadcn-style SVG icons, `~/.superset/bin/agy` shell wrapper, Drizzle/Zustand/TanStack DB at the data layer (no DB changes).
+
+**Spec:** `apps/desktop/docs/20260601-antigravity-builtin-agent-design.md`
+
+**Worktree:** `apps/desktop`
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts` | Wrapper generator for `~/.superset/bin/agy` |
+| `packages/ui/src/assets/icons/preset-icons/agy.svg` | Light-variant Antigravity icon |
+| `packages/ui/src/assets/icons/preset-icons/agy-white.svg` | Dark-variant Antigravity icon |
+| `apps/desktop/plans/20260601-antigravity-builtin-agent.md` | Plan file documenting ship + deferred hooks |
+
+### Modified files
+
+| Path | What changes |
+|---|---|
+| `packages/shared/src/builtin-terminal-agents.ts` | One new row in `BUILTIN_TERMINAL_AGENTS` array |
+| `apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts` | Barrel re-export of new wrapper module |
+| `apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts` | Add `agy-wrapper` action + `agy` target |
+| `apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts` | Register `createAgyWrapper` runner |
+| `packages/ui/src/assets/icons/preset-icons/index.ts` | Register agy icon in `PRESET_ICONS` + re-exports |
+| `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` | One new `it("creates agy wrapper passthrough", ...)` test |
+| `apps/desktop/docs/EXTERNAL_FILES.md` | Add `agy` row to `bin/` section |
+
+### Order of changes
+
+The order matters because the manifest must exist before the setup target references the new id, and the test must run against code that compiles.
+
+1. **Wrapper + test (Task 1):** wrapper module + test. The test runs against the wrapper generator directly; the manifest/setup/registry are not yet wired.
+2. **Setup registry (Task 2):** `desktop-agent-capabilities.ts` + `desktop-agent-setup.ts`. Order: capabilities first (defines types), then setup (uses them).
+3. **Manifest (Task 3):** `builtin-terminal-agents.ts`. After this point, `agy` is a valid `BuiltinAgentId` and the `managedBinary` type-check in Task 2's `agy` target is satisfied.
+4. **Barrel re-export (Task 4):** `agent-wrappers.ts`. Wires the new module into the test's `await import`.
+5. **Icon (Task 5):** SVG files + `preset-icons/index.ts`.
+6. **Docs (Task 6):** `EXTERNAL_FILES.md` table update + plan file.
+
+Tasks are intentionally small and self-contained. Each ends with a `git commit`.
+
+---
+
+## Task 1: Wrapper module + test
+
+**Files:**
+- Create: `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts`
+- Modify: `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`
+
+- [ ] **Step 1.1: Add failing test in `agent-wrappers.test.ts`**
+
+Open `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`. Find the `it("creates droid wrapper passthrough", ...)` block (around line 553-563). Add the new test **immediately after it**:
+
+```ts
+it("creates agy wrapper passthrough", () => {
+  createAgyWrapper();
+
+  const wrapperPath = path.join(TEST_BIN_DIR, "agy");
+  const wrapper = readFileSync(wrapperPath, "utf-8");
+
+  expect(wrapper).toContain("# Superset wrapper for agy");
+  expect(wrapper).toContain('REAL_BIN="$(find_real_binary "agy")"');
+  expect(wrapper).toContain('export SUPERSET_AGENT_ID="agy"');
+  expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
+});
+```
+
+Add `createAgyWrapper` to the destructured import at lines 59-89 of the test file. Insert it alphabetically between `createAmpPlugin` and `createAmpWrapper`:
+
+```ts
+const {
+  // ... existing imports
+  createAgyWrapper,  // NEW
+  createAmpPlugin,
+  createAmpWrapper,
+  // ... rest
+} = await import("./agent-wrappers");
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run from repo root:
+```bash
+bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts -t "creates agy wrapper passthrough"
+```
+
+Expected: FAIL with `TypeError: createAgyWrapper is not a function` (or similar — the import resolves to `undefined`).
+
+- [ ] **Step 1.3: Create the wrapper module**
+
+Create `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts`:
+
+```ts
+import {
+  buildWrapperScript,
+  createWrapper,
+} from "./agent-wrappers-common";
+
+/**
+ * Creates the Antigravity CLI wrapper that preserves Superset's terminal
+ * environment and exports SUPERSET_AGENT_ID="agy" so the agent process
+ * inherits the wrapper-level identity. When antigravity-cli ships a hook
+ * system, hooks reading the parent-process identity will pick up "agy"
+ * automatically.
+ */
+export function createAgyWrapper(): void {
+  const script = buildWrapperScript("agy", `exec "$REAL_BIN" "$@"`, {
+    agentId: "agy",
+  });
+  createWrapper("agy", script);
+}
+```
+
+- [ ] **Step 1.4: Re-run test to verify it still fails (wrapper exists, but barrel re-export missing)**
+
+Run from repo root:
+```bash
+bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts -t "creates agy wrapper passthrough"
+```
+
+Expected: FAIL with `TypeError: undefined is not a function` or `createAgyWrapper is not a function` — the test imports from `./agent-wrappers` (the barrel), not from `./agent-wrappers-agy` directly.
+
+- [ ] **Step 1.5: Commit wrapper module + failing test**
+
+```bash
+git add apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+git commit -m "feat(desktop): add agy wrapper generator and passthrough test"
+```
+
+---
+
+## Task 2: Wire wrapper into barrel re-export
+
+**Files:**
+- Modify: `apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts:1-84`
+
+- [ ] **Step 2.1: Add barrel re-export**
+
+Open `apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts`. The existing re-exports are grouped by source file, ordered alphabetically by source filename. Add a new `export { createAgyWrapper } from "./agent-wrappers-agy";` block at the **top** of the file (before `agent-wrappers-amp`), since "agy" < "amp" alphabetically:
+
+```ts
+export { createAgyWrapper } from "./agent-wrappers-agy";
+export {
+  AMP_PLUGIN_FILE,
+  AMP_PLUGIN_MARKER,
+  createAmpPlugin,
+  // ... existing
+} from "./agent-wrappers-amp";
+```
+
+- [ ] **Step 2.2: Run test to verify it passes**
+
+Run from repo root:
+```bash
+bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts -t "creates agy wrapper passthrough"
+```
+
+Expected: PASS. The test asserts that the wrapper at `TEST_BIN_DIR/agy` contains the expected strings.
+
+- [ ] **Step 2.3: Commit barrel re-export**
+
+```bash
+git add apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+git commit -m "feat(desktop): re-export createAgyWrapper from agent-wrappers barrel"
+```
+
+---
+
+## Task 3: Add `agy` to setup registry
+
+**Files:**
+- Modify: `apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts:5-29, 45-102`
+- Modify: `apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts:1-86`
+
+- [ ] **Step 3.1: Add `agy-wrapper` action to `DESKTOP_AGENT_SETUP_ACTIONS`**
+
+In `desktop-agent-capabilities.ts`, the `DESKTOP_AGENT_SETUP_ACTIONS` array (lines 5-29) is **not strictly alphabetical** — it groups bootstrap actions first (`notify-script`, `cleanup-global-opencode-plugin`) then per-agent actions. Insert `"agy-wrapper"` immediately before `"amp-plugin"` (line 8) to match the existing convention of per-agent actions ordered alphabetically after bootstrap:
+
+```ts
+export const DESKTOP_AGENT_SETUP_ACTIONS = [
+  "notify-script",
+  "cleanup-global-opencode-plugin",
+  "agy-wrapper",       // NEW
+  "amp-plugin",
+  "amp-wrapper",
+  // ... rest unchanged
+] as const;
+```
+
+- [ ] **Step 3.2: Add `agy` target to `DESKTOP_AGENT_SETUP_TARGETS`**
+
+In the same file, `DESKTOP_AGENT_SETUP_TARGETS` (lines 45-102) is **mostly alphabetical with `cursor-agent` and `pi` inserted later** (likely historical). The first three targets are `amp, claude, codex`. Insert the `agy` target **before** `amp` (the `a`-group is alphabetical, so `agy` < `amp`):
+
+```ts
+export const DESKTOP_AGENT_SETUP_TARGETS = [
+  {
+    id: "agy",
+    setupActions: ["agy-wrapper"],
+    managedBinary: true,
+  },
+  {
+    id: "amp",
+    setupActions: ["amp-plugin", "amp-wrapper"],
+    managedBinary: true,
+  },
+  // ... rest unchanged
+] as const satisfies readonly DesktopAgentSetupTarget[];
+```
+
+- [ ] **Step 3.3: Run typecheck to verify the new target typechecks**
+
+Run from repo root:
+```bash
+bun run typecheck
+```
+
+Expected: PASS. The `id: "agy"` field is checked against `AgentType` (from `@superset/shared/agent-command`). At this point the manifest row (Task 4) does **not** exist yet, so the type `AgentType` does **not** include `"agy"`. The typecheck may fail with `Type '"agy"' is not assignable to type 'AgentType'`. This is expected — the type-check is the next task's signal.
+
+If the typecheck fails because `"agy"` is not in `AgentType`:
+- Note the error and continue. The error is the cross-task type dependency the next task resolves.
+
+If the typecheck passes (i.e. `AgentType` is a `string` at this point and accepts any string):
+- Continue to step 3.4.
+
+- [ ] **Step 3.4: Add the runner to `DESKTOP_AGENT_SETUP_RUNNERS`**
+
+In `apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts`, the import block at lines 1-24 is grouped by source file. Add `createAgyWrapper` to the import from `./agent-wrappers`, **alphabetically** before `createAmpPlugin` and `createAmpWrapper`:
+
+```ts
+import {
+  cleanupGlobalOpenCodePlugin,
+  createAgyWrapper,        // NEW
+  createAmpPlugin,
+  createAmpWrapper,
+  // ... rest
+} from "./agent-wrappers";
+```
+
+Then in the `DESKTOP_AGENT_SETUP_RUNNERS` record (lines 32-57), insert `"agy-wrapper"` immediately after `"cleanup-global-opencode-plugin"` (matching the position in the actions array):
+
+```ts
+const DESKTOP_AGENT_SETUP_RUNNERS: Record<DesktopAgentSetupAction, () => void> =
+  {
+    "notify-script": createNotifyScript,
+    "cleanup-global-opencode-plugin": cleanupGlobalOpenCodePlugin,
+    "agy-wrapper": createAgyWrapper,    // NEW
+    "amp-plugin": createAmpPlugin,
+    "amp-wrapper": createAmpWrapper,
+    // ... rest unchanged
+  };
+```
+
+- [ ] **Step 3.5: Re-run typecheck**
+
+Run from repo root:
+```bash
+bun run typecheck
+```
+
+Expected: still failing on `Type '"agy"' is not assignable to type 'AgentType'` (same as step 3.3). This is the cross-task signal that the manifest row in Task 4 is needed.
+
+- [ ] **Step 3.6: Commit setup registry changes**
+
+```bash
+git add apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts
+git commit -m "feat(desktop): register agy-wrapper setup action and target"
+```
+
+---
+
+## Task 4: Add `agy` row to manifest
+
+**Files:**
+- Modify: `packages/shared/src/builtin-terminal-agents.ts:59-140`
+
+- [ ] **Step 4.1: Add `agy` row to `BUILTIN_TERMINAL_AGENTS`**
+
+In `packages/shared/src/builtin-terminal-agents.ts`, the `BUILTIN_TERMINAL_AGENTS` array (lines 59-140) is **not strictly alphabetical** — it follows the order `claude, amp, codex, gemini, mastracode, opencode, pi, copilot, cursor-agent, droid`. The natural place for `agy` is **immediately after `claude`** (alphabetical, "agy" comes after "claude" only because "ag" < "cl" — actually "agy" < "amp" < "claude" alphabetically). Insert `agy` between `claude` and `amp` to maintain alphabetical order in the "a" prefix group:
+
+```ts
+export const BUILTIN_TERMINAL_AGENTS = [
+  createBuiltinTerminalAgent({
+    id: "claude",
+    // ... existing
+  }),
+  createBuiltinTerminalAgent({
+    id: "agy",
+    label: "Antigravity",
+    description:
+      "Google's agentic development platform — multi-step reasoning, parallel sub-agents, and project context via AGENTS.md.",
+    command: "agy",
+    promptCommand: "agy -p",
+    includeInDefaultTerminalPresets: true,
+  }),
+  createBuiltinTerminalAgent({
+    id: "amp",
+    // ... existing
+  }),
+  // ... rest unchanged
+] as const;
+```
+
+**Field rationale (no changes from the spec):**
+- `id: "agy"` — wire-level identity; must match `SUPERSET_AGENT_ID` exactly.
+- `label: "Antigravity"` — product name used in pickers, settings list, pane header.
+- `description` — names the three distinguishing features (multi-step reasoning, parallel sub-agents, AGENTS.md context).
+- `command: "agy"` — default interactive launch. No `--dangerously-skip-permissions` (user opts in via Settings → Permissions).
+- `promptCommand: "agy -p"` — headless print mode. **Known issue:** antigravity-cli#76 documents that `agy -p` in non-TTY mode currently produces no output. Upstream fix is out of scope.
+- `includeInDefaultTerminalPresets: true` — shows in Settings → Agents by default, matching Claude/Codex/Amp/Copilot.
+
+- [ ] **Step 4.2: Run typecheck to verify the new row typechecks against `AgentType`**
+
+Run from repo root:
+```bash
+bun run typecheck
+```
+
+Expected: PASS. The new `"agy"` literal flows through `AgentType` (the union derived from `BUILTIN_AGENT_IDS` in `agent-catalog.ts:23`), which means the `agy` target added in Task 3 now typechecks.
+
+- [ ] **Step 4.3: Run the wrapper test to confirm nothing regressed**
+
+Run from repo root:
+```bash
+bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+```
+
+Expected: PASS. All existing tests still pass, and the new `agy` test passes.
+
+- [ ] **Step 4.4: Commit manifest row**
+
+```bash
+git add packages/shared/src/builtin-terminal-agents.ts
+git commit -m "feat(shared): add agy to BUILTIN_TERMINAL_AGENTS manifest"
+```
+
+---
+
+## Task 5: Add icon assets
+
+**Files:**
+- Create: `packages/ui/src/assets/icons/preset-icons/agy.svg`
+- Create: `packages/ui/src/assets/icons/preset-icons/agy-white.svg`
+- Modify: `packages/ui/src/assets/icons/preset-icons/index.ts:1-66`
+
+- [ ] **Step 5.1: Copy the source SVG to both new files**
+
+The Antigravity CLI and Antigravity editor share the same product branding. The existing icon is at `apps/desktop/src/renderer/assets/app-icons/antigravity.svg`. Copy its contents verbatim to two new files in the preset-icons directory:
+
+```bash
+cp apps/desktop/src/renderer/assets/app-icons/antigravity.svg packages/ui/src/assets/icons/preset-icons/agy.svg
+cp apps/desktop/src/renderer/assets/app-icons/antigravity.svg packages/ui/src/assets/icons/preset-icons/agy-white.svg
+```
+
+This matches the existing `pi.svg` / `pi-white.svg` and `droid.svg` / `droid-white.svg` naming pattern: `<name>.svg` for the light variant, `<name>-white.svg` for the dark variant. (Note: the spec draft called the dark variant `agy-dark.svg`; this plan corrects that to match existing convention.)
+
+- [ ] **Step 5.2: Add imports to `preset-icons/index.ts`**
+
+In `packages/ui/src/assets/icons/preset-icons/index.ts`, add two new imports at the **top** of the import block (alphabetical, `agyIcon` and `agyWhiteIcon` come before `ampIcon`):
+
+```ts
+import agyIcon from "./agy.svg";
+import agyWhiteIcon from "./agy-white.svg";
+import ampIcon from "./amp.svg";
+// ... rest unchanged
+```
+
+- [ ] **Step 5.3: Register agy in `PRESET_ICONS`**
+
+In the same file, `PRESET_ICONS` (lines 24-36) is in a "by name" order, with `cursor-agent` and `droid` after the alphabetical group. Insert `agy` **before** `amp` to maintain alphabetical order in the leading group:
+
+```ts
+export const PRESET_ICONS: Record<string, PresetIconSet> = {
+  agy: { light: agyIcon, dark: agyWhiteIcon },  // NEW
+  amp: { light: ampIcon, dark: ampIcon },
+  // ... rest unchanged
+};
+```
+
+- [ ] **Step 5.4: Add icon re-exports**
+
+The file re-exports individual icon imports at the bottom (lines 48-66) so callers can import them by name. Add `agyIcon` and `agyWhiteIcon` to that re-export block in alphabetical position:
+
+```ts
+export {
+  agyIcon,        // NEW
+  agyWhiteIcon,   // NEW
+  ampIcon,
+  // ... rest unchanged
+};
+```
+
+- [ ] **Step 5.5: Run typecheck to verify icon registration typechecks**
+
+Run from repo root:
+```bash
+bun run typecheck
+```
+
+Expected: PASS. The new imports resolve to SVG modules.
+
+- [ ] **Step 5.6: Commit icon assets + registration**
+
+```bash
+git add packages/ui/src/assets/icons/preset-icons/agy.svg packages/ui/src/assets/icons/preset-icons/agy-white.svg packages/ui/src/assets/icons/preset-icons/index.ts
+git commit -m "feat(ui): add agy preset icon (light + dark variants)"
+```
+
+---
+
+## Task 6: Documentation + plan file
+
+**Files:**
+- Modify: `apps/desktop/docs/EXTERNAL_FILES.md:16-25`
+- Create: `apps/desktop/plans/20260601-antigravity-builtin-agent.md`
+
+- [ ] **Step 6.1: Add `agy` row to `EXTERNAL_FILES.md` bin/ table**
+
+In `apps/desktop/docs/EXTERNAL_FILES.md`, the `bin/` table at lines 18-24 lists existing wrappers. Insert a new row for `agy` **immediately after** `amp` (alphabetical with the other `a`-prefix wrappers). The new row is:
+
+```md
+| `agy` | Wrapper for Antigravity CLI that preserves Superset terminal context |
+```
+
+The full table after the edit:
+
+```md
+| File | Purpose |
+|------|---------|
+| `agy` | Wrapper for Antigravity CLI that preserves Superset terminal context |
+| `amp` | Wrapper for Amp CLI that preserves Superset terminal context |
+| `claude` | Wrapper for Claude Code CLI that injects notification hooks |
+| `codex` | Wrapper for Codex CLI that injects notification hooks |
+| `droid` | Wrapper for Factory Droid CLI that preserves Superset hook integration |
+| `opencode` | Wrapper for OpenCode CLI that sets `OPENCODE_CONFIG_DIR` |
+```
+
+- [ ] **Step 6.2: Create the plan file**
+
+Create `apps/desktop/plans/20260601-antigravity-builtin-agent.md` with the following content:
+
+```md
+# Ship: Antigravity CLI (`agy`) built-in agent
+
+- **Status:** Shipped
+- **Date:** 2026-06-01
+- **Source issue:** https://github.com/superset-sh/superset/issues/4986
+- **Design:** `apps/desktop/docs/20260601-antigravity-builtin-agent-design.md`
+
+## What shipped
+
+Five-touchpoint integration matching the existing pattern for built-in terminal agents:
+
+1. `packages/shared/src/builtin-terminal-agents.ts` — `agy` row in `BUILTIN_TERMINAL_AGENTS` (`command: "agy"`, `promptCommand: "agy -p"`, `includeInDefaultTerminalPresets: true`)
+2. `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts` — pass-through wrapper emitting `~/.superset/bin/agy` with `SUPERSET_AGENT_ID="agy"`
+3. `apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts` + `desktop-agent-setup.ts` — `agy-wrapper` setup action and `agy` target with `managedBinary: true`
+4. `packages/ui/src/assets/icons/preset-icons/agy.svg` + `agy-white.svg` and registration in `PRESET_ICONS`
+5. `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` — passthrough wrapper test
+
+## What did NOT ship (deferred)
+
+**Notification hook integration.** antigravity-cli v1.0.4 (released 2026-06-01) does not expose a `settings.json`, plugin, or extension model. There is no documented hook format to integrate against.
+
+When antigravity-cli ships a hook system, the migration is purely additive:
+
+- `SUPERSET_AGENT_ID=agy` is already exported by the wrapper. Any hook handler that reads the parent-process identity will see the correct value automatically.
+- The notify script's v2 payload will carry `agentId: "agy"` without further wiring.
+- The new integration is one new file (e.g. `createAgySettingsJson()`) and one new setup action id, with no schema migration.
+
+The renderer and host-service already accept any string for `agentId`; the `usePresetIcon` hook returns `undefined` for unknown names so pickers degrade gracefully.
+
+## Known issue
+
+`agy -p` in non-TTY mode currently produces no output. See https://github.com/google-antigravity/antigravity-cli/issues/76. The manifest still registers `promptCommand: "agy -p"` because that's the documented headless flag. Upstream fix is out of scope for this ship.
+
+## Verification
+
+- `bun run typecheck` — passes
+- `bun run lint` — passes
+- `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` — passes
+- Manual: launch Superset desktop, confirm `~/.superset/bin/agy` exists, "Antigravity" appears in agent pickers, `echo $SUPERSET_AGENT_ID` inside the launched terminal prints `agy`.
+```
+
+- [ ] **Step 6.3: Commit documentation + plan**
+
+```bash
+git add apps/desktop/docs/EXTERNAL_FILES.md apps/desktop/plans/20260601-antigravity-builtin-agent.md
+git commit -m "docs(desktop): document agy wrapper and ship plan"
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 7.1: Run typecheck, lint, and tests from repo root**
+
+```bash
+bun run typecheck
+bun run lint
+bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+```
+
+Expected: all three commands exit 0 with no output (or with non-error output).
+
+- [ ] **Step 7.2: Verify the wrapper file would be generated correctly**
+
+Sanity-check the wrapper content by inspecting the installed wrapper file (if available) or by running the test in verbose mode:
+
+```bash
+ls -la ~/.superset/bin/agy 2>/dev/null || echo "wrapper not yet installed (expected on a fresh worktree)"
+bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts -t "creates agy wrapper passthrough" --verbose
+```
+
+Expected: the test passes, confirming the generated wrapper at `TEST_BIN_DIR/agy` contains all four expected strings. The installed `~/.superset/bin/agy` only exists after the desktop app has been launched at least once in this worktree — that's a manual verification, not a unit-test concern.
+
+- [ ] **Step 7.3: Inspect final git log**
+
+```bash
+git log --oneline -10
+```
+
+Expected: 6 commits (one per task), all with conventional commit prefixes (`feat(...)` or `docs(...)`).
+
+---
+
+## Notes
+
+### TDD ordering
+
+Each task that has a test follows the red-green-refactor cycle:
+- Test written first
+- Test fails (imports / function missing)
+- Implementation added
+- Test passes
+
+The manifest (Task 4) is intentionally **not** TDD-driven because it has no meaningful test target — it's a data row whose correctness is exercised indirectly by `bun run typecheck` and by manual UI verification (Antigravity appears in pickers).
+
+### Cross-task type dependencies
+
+`AgentType` (from `agent-catalog.ts:23`) is derived from `BUILTIN_AGENT_IDS = [...BUILTIN_TERMINAL_AGENT_TYPES, "superset"]`. This means:
+
+- Adding `agy` to `BUILTIN_TERMINAL_AGENTS` (Task 4) is what makes the `id: "agy"` field in the setup target (Task 3) typecheck.
+- The typecheck intentionally fails at the end of Task 3 and passes at the end of Task 4 — that's the cross-task signal.
+
+If `AgentType` is `string` (not a union), the typecheck passes at Task 3. Either way, the work is correct; the typecheck is a signal, not a gate.
+
+### Worktree isolation
+
+Per AGENTS.md, worktrees set `SUPERSET_HOME_DIR` per-worktree (e.g. `superset-dev-data` instead of `~/.superset`). The wrapper marker regex in `agent-wrappers-common.ts:12-13` already recognizes both `~/.superset-*/` and `*/superset-dev-data/` variants, so the wrapper works correctly in worktree dev mode.
+
+### Verification before completion
+
+Per the verification-before-completion skill, do not claim completion until all three commands in Step 7.1 have been run and have exited 0 with the expected output. Capture the output for the PR description.

--- a/apps/desktop/plans/20260601-antigravity-builtin-agent.md
+++ b/apps/desktop/plans/20260601-antigravity-builtin-agent.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add Google's Antigravity CLI (`agy`) as a first-class built-in terminal agent in the Superset desktop app, matching the existing 5-touchpoint pattern used by Claude/Codex/Amp/OpenCode.
 
-**Architecture:** One new wrapper module + manifest row + setup registry entries + icon asset + test. Notification hook integration is deferred because antigravity-cli v1.0.4 has no documented hook system yet. The `SUPERSET_AGENT_ID=agy` env var is exported by the wrapper so future hook integration is purely additive.
+**Architecture:** One new wrapper module + manifest row + setup registry entries + icon asset + test, plus lifecycle hook integration via `agy-hook.sh` + `~/.gemini/config/hooks.json`. The `SUPERSET_AGENT_ID=agy` env var remains exported by the wrapper for end-to-end identity wiring.
 
 **Tech Stack:** TypeScript, Bun, Biome, shadcn-style SVG icons, `~/.superset/bin/agy` shell wrapper, Drizzle/Zustand/TanStack DB at the data layer (no DB changes).
 
@@ -23,7 +23,7 @@
 | `apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts` | Wrapper generator for `~/.superset/bin/agy` |
 | `packages/ui/src/assets/icons/preset-icons/agy.svg` | Light-variant Antigravity icon |
 | `packages/ui/src/assets/icons/preset-icons/agy-white.svg` | Dark-variant Antigravity icon |
-| `apps/desktop/plans/20260601-antigravity-builtin-agent.md` | Plan file documenting ship + deferred hooks |
+| `apps/desktop/plans/20260601-antigravity-builtin-agent.md` | Plan file documenting ship details |
 
 ### Modified files
 
@@ -467,17 +467,13 @@ Five-touchpoint integration matching the existing pattern for built-in terminal 
 4. `packages/ui/src/assets/icons/preset-icons/agy.svg` + `agy-white.svg` and registration in `PRESET_ICONS`
 5. `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` — passthrough wrapper test
 
-## What did NOT ship (deferred)
+## Hook integration shipped
 
-**Notification hook integration.** antigravity-cli v1.0.4 (released 2026-06-01) does not expose a `settings.json`, plugin, or extension model. There is no documented hook format to integrate against.
+The ship now includes `agy-hook.sh` generation and `~/.gemini/config/hooks.json` registration, with stale Superset-managed hook entries replaced during setup and user-defined entries preserved.
 
-When antigravity-cli ships a hook system, the migration is purely additive:
-
-- `SUPERSET_AGENT_ID=agy` is already exported by the wrapper. Any hook handler that reads the parent-process identity will see the correct value automatically.
-- The notify script's v2 payload will carry `agentId: "agy"` without further wiring.
-- The new integration is one new file (e.g. `createAgySettingsJson()`) and one new setup action id, with no schema migration.
-
-The renderer and host-service already accept any string for `agentId`; the `usePresetIcon` hook returns `undefined` for unknown names so pickers degrade gracefully.
+- `SUPERSET_AGENT_ID=agy` is exported by the wrapper and forwarded in v2 payloads.
+- Hook commands are generated as quoted shell paths to support spaces in home/worktree paths.
+- The renderer and host-service already accept any string for `agentId`; the `usePresetIcon` hook returns `undefined` for unknown names so pickers degrade gracefully.
 
 ## Known issue
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts
@@ -1,12 +1,161 @@
-import { buildWrapperScript, createWrapper } from "./agent-wrappers-common";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { env } from "shared/env.shared";
+import {
+	buildWrapperScript,
+	createWrapper,
+	isSupersetManagedHookCommand,
+	writeFileIfChanged,
+} from "./agent-wrappers-common";
+import { HOOKS_DIR } from "./paths";
+
+export const AGY_HOOK_SCRIPT_NAME = "agy-hook.sh";
+
+const AGY_HOOK_SIGNATURE = "# Superset agy hook";
+const AGY_HOOK_VERSION = "v2";
+export const AGY_HOOK_MARKER = `${AGY_HOOK_SIGNATURE} ${AGY_HOOK_VERSION}`;
+
+const AGY_HOOK_TEMPLATE_PATH = path.join(
+	__dirname,
+	"templates",
+	"agy-hook.template.sh",
+);
+
+// Named key we write into hooks.json. Arbitrary but stable — used to identify
+// and replace our entry across worktree moves without touching user entries.
+const AGY_HOOKS_JSON_KEY = "superset-lifecycle";
+
+interface AgyHookCommand {
+	command: string;
+}
+
+interface AgyToolHookEntry {
+	matcher: string;
+	hooks: AgyHookCommand[];
+}
+
+interface AgyHookSpec {
+	PreInvocation?: AgyHookCommand[];
+	PostInvocation?: AgyHookCommand[];
+	PreToolUse?: AgyToolHookEntry[];
+	PostToolUse?: AgyToolHookEntry[];
+	Stop?: AgyHookCommand[];
+	enabled?: boolean;
+}
+
+type AgyHooksJson = Record<string, AgyHookSpec>;
+
+export function getAgyHookScriptPath(): string {
+	return path.join(HOOKS_DIR, AGY_HOOK_SCRIPT_NAME);
+}
+
+// agy reads hooks from ~/.gemini/config/hooks.json (SharedConfigPath), not
+// from ~/.gemini/antigravity-cli/settings.json.
+export function getAgyHooksJsonPath(): string {
+	return path.join(os.homedir(), ".gemini", "config", "hooks.json");
+}
+
+export function getAgyHookScriptContent(): string {
+	const template = fs.readFileSync(AGY_HOOK_TEMPLATE_PATH, "utf-8");
+	return template
+		.replace("{{MARKER}}", AGY_HOOK_MARKER)
+		.replaceAll("{{DEFAULT_PORT}}", String(env.DESKTOP_NOTIFICATIONS_PORT));
+}
 
 /**
- * Creates the Antigravity CLI wrapper that preserves Superset's terminal
- * environment and exports SUPERSET_AGENT_ID="agy" so the agent process
- * inherits the wrapper-level identity. When antigravity-cli ships a hook
- * system, hooks reading the parent-process identity will pick up "agy"
- * automatically.
+ * Reads existing ~/.gemini/config/hooks.json, removes any stale Superset-managed
+ * entries (identified by hook script name), and writes a fresh "superset-lifecycle"
+ * entry pointing at the current hook script path.
+ *
+ * agy hooks.json format: { [namedKey: string]: AgyHookSpec }
+ * Each hook spec registers per-event command arrays with the event type passed
+ * as $1 so the hook script doesn't need to parse the payload for it.
  */
+export function getAgyHooksJsonContent(hookScriptPath: string): string {
+	const globalPath = getAgyHooksJsonPath();
+
+	let existing: AgyHooksJson = {};
+	try {
+		if (fs.existsSync(globalPath)) {
+			existing = JSON.parse(fs.readFileSync(globalPath, "utf-8"));
+		}
+	} catch {
+		console.warn(
+			"[agent-setup] Could not parse existing ~/.gemini/config/hooks.json, merging carefully",
+		);
+	}
+
+	// Remove all entries whose commands reference our hook script (covers key
+	// renames and stale worktree paths from older installs).
+	for (const [key, spec] of Object.entries(existing)) {
+		const invocationCommands = [
+			...(spec.PreInvocation ?? []),
+			...(spec.PostInvocation ?? []),
+			...(spec.Stop ?? []),
+		].map((h) => h.command);
+
+		// Tool-use entries use matcher+hooks format now, but may be flat {command}
+		// in legacy installs — handle both defensively.
+		const toolEntries = [
+			...(spec.PreToolUse ?? []),
+			...(spec.PostToolUse ?? []),
+		] as Array<AgyToolHookEntry & { command?: string }>;
+		const toolCommands = toolEntries.flatMap((entry) =>
+			entry.command != null
+				? [entry.command]
+				: (entry.hooks ?? []).map((h) => h.command),
+		);
+
+		if (
+			[...invocationCommands, ...toolCommands].some((cmd) =>
+				isSupersetManagedHookCommand(cmd, AGY_HOOK_SCRIPT_NAME),
+			)
+		) {
+			delete existing[key];
+		}
+	}
+
+	// Write event type as $1 so the hook script doesn't need to infer it from
+	// the payload (which differs per hook proto type).
+	// Tool-use hooks require a matcher; invocation/stop hooks are flat commands.
+	existing[AGY_HOOKS_JSON_KEY] = {
+		PreInvocation: [{ command: `${hookScriptPath} PreInvocation` }],
+		PostInvocation: [{ command: `${hookScriptPath} PostInvocation` }],
+		PreToolUse: [
+			{ matcher: ".*", hooks: [{ command: `${hookScriptPath} PreToolUse` }] },
+		],
+		PostToolUse: [
+			{ matcher: ".*", hooks: [{ command: `${hookScriptPath} PostToolUse` }] },
+		],
+		Stop: [{ command: `${hookScriptPath} Stop` }],
+	};
+
+	return JSON.stringify(existing, null, 2);
+}
+
+export function createAgyHookScript(): void {
+	const scriptPath = getAgyHookScriptPath();
+	const content = getAgyHookScriptContent();
+	const changed = writeFileIfChanged(scriptPath, content, 0o755);
+	console.log(
+		`[agent-setup] ${changed ? "Updated" : "Verified"} agy hook script`,
+	);
+}
+
+export function createAgyHooksJson(): void {
+	const hookScriptPath = getAgyHookScriptPath();
+	const globalPath = getAgyHooksJsonPath();
+	const content = getAgyHooksJsonContent(hookScriptPath);
+
+	const dir = path.dirname(globalPath);
+	fs.mkdirSync(dir, { recursive: true });
+	const changed = writeFileIfChanged(globalPath, content, 0o644);
+	console.log(
+		`[agent-setup] ${changed ? "Updated" : "Verified"} agy hooks.json`,
+	);
+}
+
 export function createAgyWrapper(): void {
 	const script = buildWrapperScript("agy", `exec "$REAL_BIN" "$@"`, {
 		agentId: "agy",

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts
@@ -13,7 +13,7 @@ import { HOOKS_DIR } from "./paths";
 export const AGY_HOOK_SCRIPT_NAME = "agy-hook.sh";
 
 const AGY_HOOK_SIGNATURE = "# Superset agy hook";
-const AGY_HOOK_VERSION = "v2";
+const AGY_HOOK_VERSION = "v3";
 export const AGY_HOOK_MARKER = `${AGY_HOOK_SIGNATURE} ${AGY_HOOK_VERSION}`;
 
 const AGY_HOOK_TEMPLATE_PATH = path.join(
@@ -44,7 +44,72 @@ interface AgyHookSpec {
 	enabled?: boolean;
 }
 
-type AgyHooksJson = Record<string, AgyHookSpec>;
+type AgyHooksJson = Record<string, unknown>;
+
+function quoteShellPath(filePath: string): string {
+	return `'${filePath.replaceAll("'", "'\\''")}'`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAgyHookCommand(value: unknown): value is AgyHookCommand {
+	return isRecord(value) && typeof value.command === "string";
+}
+
+function extractHookCommands(entries: unknown): string[] {
+	if (!Array.isArray(entries)) return [];
+	return entries
+		.filter(isAgyHookCommand)
+		.map((entry) => entry.command);
+}
+
+function extractToolHookCommands(entries: unknown): string[] {
+	if (!Array.isArray(entries)) return [];
+	const commands: string[] = [];
+
+	for (const entry of entries) {
+		if (isAgyHookCommand(entry)) {
+			commands.push(entry.command);
+			continue;
+		}
+		if (!isRecord(entry) || !Array.isArray(entry.hooks)) continue;
+
+		for (const hook of entry.hooks) {
+			if (isAgyHookCommand(hook)) {
+				commands.push(hook.command);
+			}
+		}
+	}
+
+	return commands;
+}
+
+function readExistingAgyHooksJson(globalPath: string): AgyHooksJson {
+	if (!fs.existsSync(globalPath)) {
+		return {};
+	}
+
+	const rawContent = fs.readFileSync(globalPath, "utf-8");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawContent);
+	} catch (error) {
+		throw new Error(
+			"[agent-setup] Invalid ~/.gemini/config/hooks.json; refusing to overwrite malformed file.",
+			{ cause: error },
+		);
+	}
+
+	if (!isRecord(parsed)) {
+		throw new Error(
+			"[agent-setup] Expected ~/.gemini/config/hooks.json to contain a JSON object.",
+		);
+	}
+
+	return parsed;
+}
 
 export function getAgyHookScriptPath(): string {
 	return path.join(HOOKS_DIR, AGY_HOOK_SCRIPT_NAME);
@@ -74,38 +139,22 @@ export function getAgyHookScriptContent(): string {
  */
 export function getAgyHooksJsonContent(hookScriptPath: string): string {
 	const globalPath = getAgyHooksJsonPath();
-
-	let existing: AgyHooksJson = {};
-	try {
-		if (fs.existsSync(globalPath)) {
-			existing = JSON.parse(fs.readFileSync(globalPath, "utf-8"));
-		}
-	} catch {
-		console.warn(
-			"[agent-setup] Could not parse existing ~/.gemini/config/hooks.json, merging carefully",
-		);
-	}
+	const existing = readExistingAgyHooksJson(globalPath);
 
 	// Remove all entries whose commands reference our hook script (covers key
 	// renames and stale worktree paths from older installs).
 	for (const [key, spec] of Object.entries(existing)) {
-		const invocationCommands = [
-			...(spec.PreInvocation ?? []),
-			...(spec.PostInvocation ?? []),
-			...(spec.Stop ?? []),
-		].map((h) => h.command);
+		if (!isRecord(spec)) continue;
 
-		// Tool-use entries use matcher+hooks format now, but may be flat {command}
-		// in legacy installs — handle both defensively.
-		const toolEntries = [
-			...(spec.PreToolUse ?? []),
-			...(spec.PostToolUse ?? []),
-		] as Array<AgyToolHookEntry & { command?: string }>;
-		const toolCommands = toolEntries.flatMap((entry) =>
-			entry.command != null
-				? [entry.command]
-				: (entry.hooks ?? []).map((h) => h.command),
-		);
+		const invocationCommands = [
+			...extractHookCommands(spec.PreInvocation),
+			...extractHookCommands(spec.PostInvocation),
+			...extractHookCommands(spec.Stop),
+		];
+		const toolCommands = [
+			...extractToolHookCommands(spec.PreToolUse),
+			...extractToolHookCommands(spec.PostToolUse),
+		];
 
 		if (
 			[...invocationCommands, ...toolCommands].some((cmd) =>
@@ -119,17 +168,24 @@ export function getAgyHooksJsonContent(hookScriptPath: string): string {
 	// Write event type as $1 so the hook script doesn't need to infer it from
 	// the payload (which differs per hook proto type).
 	// Tool-use hooks require a matcher; invocation/stop hooks are flat commands.
+	const quotedHookScriptPath = quoteShellPath(hookScriptPath);
 	existing[AGY_HOOKS_JSON_KEY] = {
-		PreInvocation: [{ command: `${hookScriptPath} PreInvocation` }],
-		PostInvocation: [{ command: `${hookScriptPath} PostInvocation` }],
+		PreInvocation: [{ command: `${quotedHookScriptPath} PreInvocation` }],
+		PostInvocation: [{ command: `${quotedHookScriptPath} PostInvocation` }],
 		PreToolUse: [
-			{ matcher: ".*", hooks: [{ command: `${hookScriptPath} PreToolUse` }] },
+			{
+				matcher: ".*",
+				hooks: [{ command: `${quotedHookScriptPath} PreToolUse` }],
+			},
 		],
 		PostToolUse: [
-			{ matcher: ".*", hooks: [{ command: `${hookScriptPath} PostToolUse` }] },
+			{
+				matcher: ".*",
+				hooks: [{ command: `${quotedHookScriptPath} PostToolUse` }],
+			},
 		],
-		Stop: [{ command: `${hookScriptPath} Stop` }],
-	};
+		Stop: [{ command: `${quotedHookScriptPath} Stop` }],
+	} satisfies AgyHookSpec;
 
 	return JSON.stringify(existing, null, 2);
 }

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts
@@ -1,0 +1,18 @@
+import {
+	buildWrapperScript,
+	createWrapper,
+} from "./agent-wrappers-common";
+
+/**
+ * Creates the Antigravity CLI wrapper that preserves Superset's terminal
+ * environment and exports SUPERSET_AGENT_ID="agy" so the agent process
+ * inherits the wrapper-level identity. When antigravity-cli ships a hook
+ * system, hooks reading the parent-process identity will pick up "agy"
+ * automatically.
+ */
+export function createAgyWrapper(): void {
+	const script = buildWrapperScript("agy", `exec "$REAL_BIN" "$@"`, {
+		agentId: "agy",
+	});
+	createWrapper("agy", script);
+}

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-agy.ts
@@ -1,7 +1,4 @@
-import {
-	buildWrapperScript,
-	createWrapper,
-} from "./agent-wrappers-common";
+import { buildWrapperScript, createWrapper } from "./agent-wrappers-common";
 
 /**
  * Creates the Antigravity CLI wrapper that preserves Superset's terminal

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -58,6 +58,7 @@ mock.module("node:os", () => ({
 
 const {
 	AMP_PLUGIN_MARKER,
+	createAgyWrapper,
 	createAmpPlugin,
 	createAmpWrapper,
 	buildCodexWrapperExecLine,
@@ -559,6 +560,18 @@ exit 0
 		expect(wrapper).toContain("# Superset wrapper for droid");
 		expect(wrapper).toContain('REAL_BIN="$(find_real_binary "droid")"');
 		expect(wrapper).toContain('export SUPERSET_AGENT_ID="droid"');
+		expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
+	});
+
+	it("creates agy wrapper passthrough", () => {
+		createAgyWrapper();
+
+		const wrapperPath = path.join(TEST_BIN_DIR, "agy");
+		const wrapper = readFileSync(wrapperPath, "utf-8");
+
+		expect(wrapper).toContain("# Superset wrapper for agy");
+		expect(wrapper).toContain('REAL_BIN="$(find_real_binary "agy")"');
+		expect(wrapper).toContain('export SUPERSET_AGENT_ID="agy"');
 		expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -591,10 +591,13 @@ exit 0
 		expect(script).toContain("PostInvocation");
 		expect(script).toContain("PreToolUse");
 		expect(script).toContain("PostToolUse");
+		expect(script).toContain('PostToolUse)    EVENT_TYPE="Stop" ;;');
+		expect(script).toContain("jq -r 'try (.session_id // empty) catch empty'");
 	});
 
 	it("creates agy hooks.json with all lifecycle event arrays", () => {
 		const hookScriptPath = "/tmp/.superset-new/hooks/agy-hook.sh";
+		const quotedHookScriptPath = `'${hookScriptPath}'`;
 		const content = getAgyHooksJsonContent(hookScriptPath);
 		const parsed = JSON.parse(content) as Record<
 			string,
@@ -616,18 +619,18 @@ exit 0
 		const spec = parsed["superset-lifecycle"];
 		expect(spec).toBeDefined();
 		expect(spec.PreInvocation?.[0]?.command).toBe(
-			`${hookScriptPath} PreInvocation`,
+			`${quotedHookScriptPath} PreInvocation`,
 		);
 		expect(spec.PostInvocation?.[0]?.command).toBe(
-			`${hookScriptPath} PostInvocation`,
+			`${quotedHookScriptPath} PostInvocation`,
 		);
 		expect(spec.PreToolUse?.[0]?.hooks?.[0]?.command).toBe(
-			`${hookScriptPath} PreToolUse`,
+			`${quotedHookScriptPath} PreToolUse`,
 		);
 		expect(spec.PostToolUse?.[0]?.hooks?.[0]?.command).toBe(
-			`${hookScriptPath} PostToolUse`,
+			`${quotedHookScriptPath} PostToolUse`,
 		);
-		expect(spec.Stop?.[0]?.command).toBe(`${hookScriptPath} Stop`);
+		expect(spec.Stop?.[0]?.command).toBe(`${quotedHookScriptPath} Stop`);
 	});
 
 	it("replaces stale agy hook commands from old superset paths", () => {
@@ -639,6 +642,7 @@ exit 0
 		);
 		const staleHookPath = "/tmp/.superset-old/hooks/agy-hook.sh";
 		const currentHookPath = "/tmp/.superset-new/hooks/agy-hook.sh";
+		const quotedCurrentHookPath = `'${currentHookPath}'`;
 
 		mkdirSync(path.dirname(agyHooksPath), { recursive: true });
 		writeFileSync(
@@ -689,18 +693,72 @@ exit 0
 		const spec = parsed["superset-lifecycle"];
 		expect(spec).toBeDefined();
 		expect(spec.PreInvocation?.[0]?.command).toBe(
-			`${currentHookPath} PreInvocation`,
+			`${quotedCurrentHookPath} PreInvocation`,
 		);
 		// Tool-use hooks now use matcher+hooks format
 		expect(spec.PreToolUse?.[0]?.hooks?.[0]?.command).toBe(
-			`${currentHookPath} PreToolUse`,
+			`${quotedCurrentHookPath} PreToolUse`,
 		);
 		expect(spec.PostToolUse?.[0]?.hooks?.[0]?.command).toBe(
-			`${currentHookPath} PostToolUse`,
+			`${quotedCurrentHookPath} PostToolUse`,
 		);
 		expect(JSON.stringify(parsed).includes(staleHookPath)).toBe(false);
 
 		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
+	});
+
+	it("throws when existing agy hooks.json is malformed", () => {
+		const agyHooksPath = path.join(
+			mockedHomeDir,
+			".gemini",
+			"config",
+			"hooks.json",
+		);
+		mkdirSync(path.dirname(agyHooksPath), { recursive: true });
+		writeFileSync(agyHooksPath, "{invalid-json");
+
+		expect(() => {
+			getAgyHooksJsonContent("/tmp/.superset-new/hooks/agy-hook.sh");
+		}).toThrow("Invalid ~/.gemini/config/hooks.json");
+	});
+
+	it("ignores malformed agy hook entries when cleaning stale commands", () => {
+		const agyHooksPath = path.join(
+			mockedHomeDir,
+			".gemini",
+			"config",
+			"hooks.json",
+		);
+		mkdirSync(path.dirname(agyHooksPath), { recursive: true });
+		writeFileSync(
+			agyHooksPath,
+			JSON.stringify(
+				{
+					"bad-null": null,
+					"bad-array": [],
+					"bad-number": 123,
+					"user-custom-hook": {
+						PreInvocation: [{ command: "/opt/custom-hook.sh" }],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const content = getAgyHooksJsonContent("/tmp/.superset-new/hooks/agy-hook.sh");
+		const parsed = JSON.parse(content) as Record<string, unknown>;
+		expect(parsed["bad-null"]).toBeNull();
+		expect(parsed["bad-array"]).toEqual([]);
+		expect(parsed["bad-number"]).toBe(123);
+		expect(
+			(
+				parsed["user-custom-hook"] as {
+					PreInvocation: Array<{ command: string }>;
+				}
+			).PreInvocation[0]?.command,
+		).toBe("/opt/custom-hook.sh");
+		expect(parsed["superset-lifecycle"]).toBeDefined();
 	});
 
 	it("replaces stale Cursor hook commands from old superset paths", () => {

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -57,8 +57,11 @@ mock.module("node:os", () => ({
 }));
 
 const {
+	AGY_HOOK_MARKER,
 	AMP_PLUGIN_MARKER,
+	createAgyHookScript,
 	createAgyWrapper,
+	getAgyHooksJsonContent,
 	createAmpPlugin,
 	createAmpWrapper,
 	buildCodexWrapperExecLine,
@@ -575,6 +578,131 @@ exit 0
 		expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
 	});
 
+	it("creates agy hook script with correct marker", () => {
+		createAgyHookScript();
+
+		const scriptPath = path.join(TEST_HOOKS_DIR, "agy-hook.sh");
+		const script = readFileSync(scriptPath, "utf-8");
+
+		expect(script).toContain(AGY_HOOK_MARKER);
+		expect(script).not.toContain("{{MARKER}}");
+		expect(script).not.toContain("{{DEFAULT_PORT}}");
+		expect(script).toContain("PreInvocation");
+		expect(script).toContain("PostInvocation");
+		expect(script).toContain("PreToolUse");
+		expect(script).toContain("PostToolUse");
+	});
+
+	it("creates agy hooks.json with all lifecycle event arrays", () => {
+		const hookScriptPath = "/tmp/.superset-new/hooks/agy-hook.sh";
+		const content = getAgyHooksJsonContent(hookScriptPath);
+		const parsed = JSON.parse(content) as Record<
+			string,
+			{
+				PreInvocation?: Array<{ command: string }>;
+				PostInvocation?: Array<{ command: string }>;
+				PreToolUse?: Array<{
+					matcher: string;
+					hooks: Array<{ command: string }>;
+				}>;
+				PostToolUse?: Array<{
+					matcher: string;
+					hooks: Array<{ command: string }>;
+				}>;
+				Stop?: Array<{ command: string }>;
+			}
+		>;
+
+		const spec = parsed["superset-lifecycle"];
+		expect(spec).toBeDefined();
+		expect(spec.PreInvocation?.[0]?.command).toBe(
+			`${hookScriptPath} PreInvocation`,
+		);
+		expect(spec.PostInvocation?.[0]?.command).toBe(
+			`${hookScriptPath} PostInvocation`,
+		);
+		expect(spec.PreToolUse?.[0]?.hooks?.[0]?.command).toBe(
+			`${hookScriptPath} PreToolUse`,
+		);
+		expect(spec.PostToolUse?.[0]?.hooks?.[0]?.command).toBe(
+			`${hookScriptPath} PostToolUse`,
+		);
+		expect(spec.Stop?.[0]?.command).toBe(`${hookScriptPath} Stop`);
+	});
+
+	it("replaces stale agy hook commands from old superset paths", () => {
+		const agyHooksPath = path.join(
+			mockedHomeDir,
+			".gemini",
+			"config",
+			"hooks.json",
+		);
+		const staleHookPath = "/tmp/.superset-old/hooks/agy-hook.sh";
+		const currentHookPath = "/tmp/.superset-new/hooks/agy-hook.sh";
+
+		mkdirSync(path.dirname(agyHooksPath), { recursive: true });
+		writeFileSync(
+			agyHooksPath,
+			JSON.stringify(
+				{
+					"user-custom-hook": {
+						PreInvocation: [{ command: "/opt/custom-hook.sh" }],
+					},
+					"superset-lifecycle": {
+						PreInvocation: [{ command: `${staleHookPath} PreInvocation` }],
+						// Legacy flat format for tool hooks (written by older installs)
+						PreToolUse: [{ command: `${staleHookPath} PreToolUse` }],
+						Stop: [{ command: `${staleHookPath} Stop` }],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const content = getAgyHooksJsonContent(currentHookPath);
+		writeFileSync(agyHooksPath, content);
+		const content2 = getAgyHooksJsonContent(currentHookPath);
+
+		const parsed = JSON.parse(content) as Record<
+			string,
+			{
+				PreInvocation?: Array<{ command: string }>;
+				PreToolUse?: Array<{
+					matcher: string;
+					hooks: Array<{ command: string }>;
+				}>;
+				PostToolUse?: Array<{
+					matcher: string;
+					hooks: Array<{ command: string }>;
+				}>;
+			}
+		>;
+
+		// Preserves user-defined entries
+		expect(parsed["user-custom-hook"]).toBeDefined();
+		expect(parsed["user-custom-hook"].PreInvocation?.[0]?.command).toBe(
+			"/opt/custom-hook.sh",
+		);
+
+		// Stale superset entry replaced with current path
+		const spec = parsed["superset-lifecycle"];
+		expect(spec).toBeDefined();
+		expect(spec.PreInvocation?.[0]?.command).toBe(
+			`${currentHookPath} PreInvocation`,
+		);
+		// Tool-use hooks now use matcher+hooks format
+		expect(spec.PreToolUse?.[0]?.hooks?.[0]?.command).toBe(
+			`${currentHookPath} PreToolUse`,
+		);
+		expect(spec.PostToolUse?.[0]?.hooks?.[0]?.command).toBe(
+			`${currentHookPath} PostToolUse`,
+		);
+		expect(JSON.stringify(parsed).includes(staleHookPath)).toBe(false);
+
+		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
+	});
+
 	it("replaces stale Cursor hook commands from old superset paths", () => {
 		const cursorHooksPath = path.join(mockedHomeDir, ".cursor", "hooks.json");
 		const staleHookPath =
@@ -759,6 +887,7 @@ exit 0
 	});
 
 	it("bumps hook script markers when hook semantics change", () => {
+		expect(AGY_HOOK_MARKER).toBe("# Superset agy hook v2");
 		expect(COPILOT_HOOK_MARKER).toBe("# Superset copilot hook v2");
 		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v3");
 		expect(GEMINI_HOOK_MARKER).toBe("# Superset gemini hook v3");

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -1,3 +1,4 @@
+export { createAgyWrapper } from "./agent-wrappers-agy";
 export {
 	AMP_PLUGIN_FILE,
 	AMP_PLUGIN_MARKER,

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -1,4 +1,14 @@
-export { createAgyWrapper } from "./agent-wrappers-agy";
+export {
+	AGY_HOOK_MARKER,
+	AGY_HOOK_SCRIPT_NAME,
+	createAgyHookScript,
+	createAgyHooksJson,
+	createAgyWrapper,
+	getAgyHookScriptContent,
+	getAgyHookScriptPath,
+	getAgyHooksJsonContent,
+	getAgyHooksJsonPath,
+} from "./agent-wrappers-agy";
 export {
 	AMP_PLUGIN_FILE,
 	AMP_PLUGIN_MARKER,

--- a/apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts
+++ b/apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts
@@ -5,6 +5,7 @@ export type SupersetManagedBinary = AgentType;
 export const DESKTOP_AGENT_SETUP_ACTIONS = [
 	"notify-script",
 	"cleanup-global-opencode-plugin",
+	"agy-wrapper",
 	"amp-plugin",
 	"amp-wrapper",
 	"claude-settings-json",
@@ -43,6 +44,11 @@ export const DESKTOP_AGENT_SETUP_BOOTSTRAP_ACTIONS = [
 ] as const satisfies readonly DesktopAgentSetupAction[];
 
 export const DESKTOP_AGENT_SETUP_TARGETS = [
+	{
+		id: "agy",
+		setupActions: ["agy-wrapper"],
+		managedBinary: true,
+	},
 	{
 		id: "amp",
 		setupActions: ["amp-plugin", "amp-wrapper"],

--- a/apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts
+++ b/apps/desktop/src/main/lib/agent-setup/desktop-agent-capabilities.ts
@@ -5,7 +5,9 @@ export type SupersetManagedBinary = AgentType;
 export const DESKTOP_AGENT_SETUP_ACTIONS = [
 	"notify-script",
 	"cleanup-global-opencode-plugin",
+	"agy-hook-script",
 	"agy-wrapper",
+	"agy-hooks-json",
 	"amp-plugin",
 	"amp-wrapper",
 	"claude-settings-json",
@@ -46,7 +48,7 @@ export const DESKTOP_AGENT_SETUP_BOOTSTRAP_ACTIONS = [
 export const DESKTOP_AGENT_SETUP_TARGETS = [
 	{
 		id: "agy",
-		setupActions: ["agy-wrapper"],
+		setupActions: ["agy-hook-script", "agy-wrapper", "agy-hooks-json"],
 		managedBinary: true,
 	},
 	{

--- a/apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts
+++ b/apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts
@@ -1,5 +1,7 @@
 import {
 	cleanupGlobalOpenCodePlugin,
+	createAgyHookScript,
+	createAgyHooksJson,
 	createAgyWrapper,
 	createAmpPlugin,
 	createAmpWrapper,
@@ -34,7 +36,9 @@ const DESKTOP_AGENT_SETUP_RUNNERS: Record<DesktopAgentSetupAction, () => void> =
 	{
 		"notify-script": createNotifyScript,
 		"cleanup-global-opencode-plugin": cleanupGlobalOpenCodePlugin,
+		"agy-hook-script": createAgyHookScript,
 		"agy-wrapper": createAgyWrapper,
+		"agy-hooks-json": createAgyHooksJson,
 		"amp-plugin": createAmpPlugin,
 		"amp-wrapper": createAmpWrapper,
 		"claude-settings-json": createClaudeSettingsJson,

--- a/apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts
+++ b/apps/desktop/src/main/lib/agent-setup/desktop-agent-setup.ts
@@ -1,5 +1,6 @@
 import {
 	cleanupGlobalOpenCodePlugin,
+	createAgyWrapper,
 	createAmpPlugin,
 	createAmpWrapper,
 	createClaudeSettingsJson,
@@ -33,6 +34,7 @@ const DESKTOP_AGENT_SETUP_RUNNERS: Record<DesktopAgentSetupAction, () => void> =
 	{
 		"notify-script": createNotifyScript,
 		"cleanup-global-opencode-plugin": cleanupGlobalOpenCodePlugin,
+		"agy-wrapper": createAgyWrapper,
 		"amp-plugin": createAmpPlugin,
 		"amp-wrapper": createAmpWrapper,
 		"claude-settings-json": createClaudeSettingsJson,

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -60,6 +60,7 @@ describe("per-agent hook scripts dispatch to v2", () => {
 		'PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$SUPERSET_AGENT_ID")\\",\\"sessionId\\":\\"$(json_escape "$HOOK_SESSION_ID")\\"}}}"';
 
 	for (const template of [
+		"agy-hook.template.sh",
 		"cursor-hook.template.sh",
 		"copilot-hook.template.sh",
 		"gemini-hook.template.sh",

--- a/apps/desktop/src/main/lib/agent-setup/templates/agy-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/agy-hook.template.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+{{MARKER}}
+# Antigravity CLI lifecycle hook. Each hook array in hooks.json passes the
+# event type as $1. JSON may arrive via stdin. PreToolUse must print
+# {"decision":"allow"} to stdout to permit execution; other events print {}.
+
+INPUT=$(cat)
+
+# PreToolUse gates execution — must allow explicitly; other hooks just ack.
+case "$1" in
+  PreToolUse) printf '{"decision":"allow"}\n' ;;
+  *)          printf '{}\n' ;;
+esac
+
+EVENT_TYPE="$1"
+HOOK_SESSION_ID=$(printf '%s' "$INPUT" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+
+# Map agy event names to Superset event types.
+case "$EVENT_TYPE" in
+  PreInvocation)  EVENT_TYPE="Start" ;;
+  PostInvocation) EVENT_TYPE="Stop" ;;
+  PreToolUse)     EVENT_TYPE="PermissionRequest" ;;
+  PostToolUse)    EVENT_TYPE="Start" ;;
+  Stop)           ;;
+  *)              exit 0 ;;
+esac
+
+V1_EVENT_TYPE="$EVENT_TYPE"
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -n "$SUPERSET_TERMINAL_ID" ]; then
+  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\"}}}"
+
+  STATUS_CODE=$(curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL" \
+    --connect-timeout 2 --max-time 5 \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    -o /dev/null -w "%{http_code}" 2>/dev/null)
+
+  case "$STATUS_CODE" in
+    2*) exit 0 ;;
+    *) echo "[agy-hook] host-service dispatch failed status=$STATUS_CODE; falling back to v1" >&2 ;;
+  esac
+fi
+
+[ -z "$SUPERSET_TAB_ID" ] && [ -z "$SUPERSET_TERMINAL_ID" ] && exit 0
+
+curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
+  --connect-timeout 1 --max-time 2 \
+  --data-urlencode "paneId=$SUPERSET_PANE_ID" \
+  --data-urlencode "tabId=$SUPERSET_TAB_ID" \
+  --data-urlencode "workspaceId=$SUPERSET_WORKSPACE_ID" \
+  --data-urlencode "terminalId=$SUPERSET_TERMINAL_ID" \
+  --data-urlencode "sessionId=$HOOK_SESSION_ID" \
+  --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
+  --data-urlencode "eventType=$V1_EVENT_TYPE" \
+  --data-urlencode "env=$SUPERSET_ENV" \
+  --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
+  > /dev/null 2>&1
+
+exit 0

--- a/apps/desktop/src/main/lib/agent-setup/templates/agy-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/agy-hook.template.sh
@@ -13,14 +13,27 @@ case "$1" in
 esac
 
 EVENT_TYPE="$1"
-HOOK_SESSION_ID=$(printf '%s' "$INPUT" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+
+extract_session_id() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$INPUT" | jq -r 'try (.session_id // empty) catch empty' 2>/dev/null
+    return
+  fi
+
+  printf '%s' "$INPUT" \
+    | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | grep -oE '"[^"]*"$' \
+    | tr -d '"'
+}
+
+HOOK_SESSION_ID="$(extract_session_id)"
 
 # Map agy event names to Superset event types.
 case "$EVENT_TYPE" in
   PreInvocation)  EVENT_TYPE="Start" ;;
   PostInvocation) EVENT_TYPE="Stop" ;;
   PreToolUse)     EVENT_TYPE="PermissionRequest" ;;
-  PostToolUse)    EVENT_TYPE="Start" ;;
+  PostToolUse)    EVENT_TYPE="Stop" ;;
   Stop)           ;;
   *)              exit 0 ;;
 esac
@@ -28,7 +41,20 @@ esac
 V1_EVENT_TYPE="$EVENT_TYPE"
 
 json_escape() {
-  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -Rs . 2>/dev/null | sed -e 's/^"//' -e 's/"$//'
+    return
+  fi
+
+  local escaped="$1"
+  escaped=${escaped//\\/\\\\}
+  escaped=${escaped//\"/\\\"}
+  escaped=${escaped//$'\n'/\\n}
+  escaped=${escaped//$'\r'/\\r}
+  escaped=${escaped//$'\t'/\\t}
+  escaped=${escaped//$'\f'/\\f}
+  escaped=${escaped//$'\b'/\\b}
+  printf '%s' "$escaped"
 }
 
 if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -n "$SUPERSET_TERMINAL_ID" ]; then

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -66,6 +66,15 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
+		id: "agy",
+		label: "Antigravity",
+		description:
+			"Google's agentic development platform — multi-step reasoning, parallel sub-agents, and project context via AGENTS.md.",
+		command: "agy",
+		promptCommand: "agy -p",
+		includeInDefaultTerminalPresets: true,
+	}),
+	createBuiltinTerminalAgent({
 		id: "amp",
 		label: "Amp",
 		description:

--- a/packages/ui/src/assets/icons/preset-icons/agy-white.svg
+++ b/packages/ui/src/assets/icons/preset-icons/agy-white.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 434 400" width="32" height="32">
+  <defs>
+    <linearGradient id="ag" x1="0" y1="0.5" x2="1" y2="0.5">
+      <stop offset="0%" stop-color="#4285F4"/>
+      <stop offset="33%" stop-color="#34A853"/>
+      <stop offset="66%" stop-color="#FBBC04"/>
+      <stop offset="100%" stop-color="#EA4335"/>
+    </linearGradient>
+  </defs>
+  <path d="M392.71,390.14c24.17,18.13,60.42,6.04,27.19-27.2C320.21,266.25,341.35.34,217.5.34S114.79,266.25,15.1,362.94c-36.25,36.26,3.02,45.33,27.19,27.2C135.93,326.68,129.89,214.88,217.5,214.88s81.56,111.8,175.21,175.26Z" fill="url(#ag)"/>
+</svg>

--- a/packages/ui/src/assets/icons/preset-icons/agy.svg
+++ b/packages/ui/src/assets/icons/preset-icons/agy.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 434 400" width="32" height="32">
+  <defs>
+    <linearGradient id="ag" x1="0" y1="0.5" x2="1" y2="0.5">
+      <stop offset="0%" stop-color="#4285F4"/>
+      <stop offset="33%" stop-color="#34A853"/>
+      <stop offset="66%" stop-color="#FBBC04"/>
+      <stop offset="100%" stop-color="#EA4335"/>
+    </linearGradient>
+  </defs>
+  <path d="M392.71,390.14c24.17,18.13,60.42,6.04,27.19-27.2C320.21,266.25,341.35.34,217.5.34S114.79,266.25,15.1,362.94c-36.25,36.26,3.02,45.33,27.19,27.2C135.93,326.68,129.89,214.88,217.5,214.88s81.56,111.8,175.21,175.26Z" fill="url(#ag)"/>
+</svg>

--- a/packages/ui/src/assets/icons/preset-icons/index.ts
+++ b/packages/ui/src/assets/icons/preset-icons/index.ts
@@ -1,3 +1,5 @@
+import agyIcon from "./agy.svg";
+import agyWhiteIcon from "./agy-white.svg";
 import ampIcon from "./amp.svg";
 import claudeIcon from "./claude.svg";
 import codexIcon from "./codex.svg";
@@ -23,6 +25,7 @@ export interface PresetIconSet {
 
 export const PRESET_ICONS: Record<string, PresetIconSet> = {
 	amp: { light: ampIcon, dark: ampIcon },
+	agy: { light: agyIcon, dark: agyWhiteIcon },
 	claude: { light: claudeIcon, dark: claudeIcon },
 	codex: { light: codexIcon, dark: codexWhiteIcon },
 	copilot: { light: copilotIcon, dark: copilotWhiteIcon },
@@ -46,6 +49,8 @@ export function getPresetIcon(
 }
 
 export {
+	agyIcon,
+	agyWhiteIcon,
 	ampIcon,
 	claudeIcon,
 	codexIcon,


### PR DESCRIPTION
## Summary

Fixes #4986

Augments the Antigravity CLI (`agy`) agent integration to properly fire lifecycle hooks into Superset's notification system.

- Writes `~/.gemini/config/hooks.json` with a `"superset-lifecycle"` named entry on app start, registering all five hook events (`PreInvocation`, `PostInvocation`, `PreToolUse`, `PostToolUse`, `Stop`)
- Installs `agy-hook.sh` which maps agy event names to Superset lifecycle events (`PreInvocation`→`Start`, `PostInvocation`→`Stop`, `PreToolUse`→`PermissionRequest`, `PostToolUse`→`Start`, `Stop`→`Stop`)
- Tool-use hooks (`PreToolUse`/`PostToolUse`) use the `matcher`+`hooks` nested format required by agy; invocation/stop hooks use the flat command format
- `PreToolUse` responds with `{"decision":"allow"}` on stdout to avoid blocking execution
- Stale hook entries from previous installs (including old flat-format tool-use entries) are cleaned up on each app start

## Test plan

- [ ] Restart dev desktop app and verify `~/.gemini/config/hooks.json` is written with PascalCase keys and matcher+hooks structure for tool-use events
- [ ] Run `agy` and confirm hooks settings shows hooks as registered
- [ ] Trigger a tool use in agy and confirm it is not blocked
- [ ] Confirm Superset receives `PermissionRequest`/`Start`/`Stop` lifecycle events from agy sessions
- [ ] Run `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` — 39/39 pass

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5096">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds desktop integration for Antigravity CLI (`agy`) and connects its lifecycle hooks to Superset notifications. Installs a managed wrapper, registers `agy` as a built-in agent with icons, and sets up hooks under `~/.gemini`.

- **New Features**
  - Writes `~/.gemini/config/hooks.json` with a `"superset-lifecycle"` entry registering `PreInvocation`, `PostInvocation`, `PreToolUse`, `PostToolUse`, and `Stop`.
  - Installs `agy-hook.sh` and maps events to Superset: `PreInvocation`→`Start`, `PostInvocation`→`Stop`, `PreToolUse`→`PermissionRequest`, `PostToolUse`→`Stop`, `Stop`→`Stop`. `PreToolUse` prints `{"decision":"allow"}`.
  - Uses the `matcher`+`hooks` format for tool-use; quotes hook paths; cleans stale/legacy Superset entries on each app start.
  - Adds a managed wrapper at `~/.superset/bin/agy` that exports `SUPERSET_AGENT_ID=agy`.
  - Adds `agy` to `BUILTIN_TERMINAL_AGENTS` and registers preset icons for the agent picker; extends tests for the wrapper, hook script marker, and `hooks.json` generation.

- **Migration**
  - Restart the desktop app; hooks and wrapper are created automatically.
  - Ensure `agy` is on `PATH`. Pick “Antigravity” in the agent picker; lifecycle events should appear in Superset.

<sup>Written for commit 68235b8a8eaae27fa048f3bd247c53b5f3b319a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Antigravity CLI (agy) added as a built-in terminal agent with light/dark icons and included in default terminal presets.
  * Desktop now installs a managed agy wrapper and lifecycle hook integration so agy invocations preserve app terminal context and event dispatch.

* **Documentation**
  * Design, plan, and external files updated with implementation and manual verification steps.

* **Tests**
  * Automated tests added to validate wrapper, hook, and setup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->