### PR TITLE
fix(desktop): attach desktop_version as a renderer super property

### DIFF
--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -27,6 +27,7 @@ export function initPostHog(deviceId?: string) {
 			ph.register({
 				app_name: "desktop",
 				platform: window.navigator.platform,
+				desktop_version: window.App.appVersion,
 				...(deviceId && { device_id: deviceId }),
 			});
 		},


### PR DESCRIPTION
## Problem

In PostHog, the **desktop users by app version** breakdown suddenly went all **"none"**.

## Root cause

Commit c7883c79a (*"anchor desktop_opened to a stable device id"*, #4858) made `desktop_opened` fire as a stable **anonymous** identity at startup — **before** `identify()` runs. The project has **person-on-events** + `person_profiles: "identified_only"`, so the `desktop_version` **person** property the breakdown relied on is snapshotted at ingestion time, when it isn't set yet. The anonymous opens (now the bulk of the event) all carry `desktop_version = none`, collapsing the breakdown.

`desktop_opened` has always been a renderer/posthog-js event and never carried a version *event* property — the renderer only registered `app_name` / `platform` / `device_id`.

## Fix

Register `desktop_version` as a **super property** in `initPostHog`, alongside the existing super props, so every renderer event (including `desktop_opened`) carries the version directly — independent of identify timing and POE snapshotting. `desktop_version` is the same name already used by the main-process event property and the `identify()` person property, so the existing insight keeps working with no graph change.

```ts
ph.register({
    app_name: "desktop",
    platform: window.navigator.platform,
    desktop_version: window.App.appVersion,   // ← added
    ...(deviceId && { device_id: deviceId }),
});
```

## Notes

- Takes effect for builds shipping this change; historical "none" events won't backfill.
- Could not verify against live PostHog data — the PostHog MCP token is currently expired (`403 Invalid access token`).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck --filter=@superset/desktop` passes
- [ ] After a build ships, confirm `desktop_opened` events carry `desktop_version` and the breakdown populates

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5117">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach `desktop_version` as a renderer super property so all renderer events (including `desktop_opened`) include the app version, restoring the “desktop users by app version” breakdown that was showing “none”.

- **Bug Fixes**
  - Register `desktop_version` in `initPostHog` alongside `app_name`, `platform`, and optional `device_id` to avoid relying on `identify()` timing.
  - Effective for new builds only; historical events won’t backfill.

<sup>Written for commit 54d285baf84fca8bbf69eba53c020598a60bce66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced app analytics to track desktop version information for improved telemetry data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->