### PR TITLE
fix(desktop): confirm before closing active terminal sessions

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/confirmTerminalClose.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/confirmTerminalClose.ts
@@ -1,0 +1,28 @@
+import type { Pane } from "@superset/panes";
+import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import type { PaneViewerData, TerminalPaneData } from "../types";
+
+function getActiveTerminalPanes(panes: Iterable<Pane<PaneViewerData>>) {
+	return Array.from(panes).filter((pane) => {
+		if (pane.kind !== "terminal") return false;
+		const { terminalId } = pane.data as TerminalPaneData;
+		if (!terminalId) return false;
+		return (
+			terminalRuntimeRegistry.getConnectionState(terminalId, pane.id) === "open"
+		);
+	});
+}
+
+export function confirmCloseActiveTerminalPanes(
+	panes: Iterable<Pane<PaneViewerData>>,
+): boolean {
+	const activeTerminalPanes = getActiveTerminalPanes(panes);
+	if (activeTerminalPanes.length === 0) return true;
+
+	const message =
+		activeTerminalPanes.length === 1
+			? "Close active terminal session?\n\nThis will stop the terminal session and may lose an in-progress agent run."
+			: `Close ${activeTerminalPanes.length} active terminal sessions?\n\nThis will stop these terminal sessions and may lose in-progress agent runs.`;
+
+	return window.confirm(message);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDirtyTabCloseGuard/useDirtyTabCloseGuard.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDirtyTabCloseGuard/useDirtyTabCloseGuard.ts
@@ -5,6 +5,7 @@ import { getBaseName } from "renderer/lib/pathBasename";
 import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { getDocument } from "../../state/fileDocumentStore";
 import type { FilePaneData, PaneViewerData } from "../../types";
+import { confirmCloseActiveTerminalPanes } from "../confirmTerminalClose";
 
 type OnBeforeCloseTab = NonNullable<
 	WorkspaceProps<PaneViewerData>["onBeforeCloseTab"]
@@ -14,7 +15,12 @@ export function useDirtyTabCloseGuard(): OnBeforeCloseTab {
 	const { workspace } = useWorkspace();
 	const workspaceId = workspace.id;
 	return useCallback<OnBeforeCloseTab>(
-		(tab) => {
+		async (tab) => {
+			const activeTerminalCloseAllowed = await confirmCloseActiveTerminalPanes(
+				Object.values(tab.panes),
+			);
+			if (!activeTerminalCloseAllowed) return false;
+
 			const dirtyPanes = Object.values(tab.panes).filter((pane) => {
 				if (pane.kind !== "file") return false;
 				const filePath = (pane.data as FilePaneData).filePath;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -43,6 +43,7 @@ import type {
 	PaneViewerData,
 	TerminalPaneData,
 } from "../../types";
+import { confirmCloseActiveTerminalPanes } from "../confirmTerminalClose";
 import type { TerminalLauncher } from "../useV2TerminalLauncher";
 import { BrowserPane, BrowserPaneToolbar } from "./components/BrowserPane";
 import { ChatPane } from "./components/ChatPane";
@@ -299,6 +300,7 @@ export function usePaneRegistry({
 					),
 			},
 			terminal: {
+				onBeforeClose: (pane) => confirmCloseActiveTerminalPanes([pane]),
 				getIcon: (ctx) => {
 					const { terminalId } = ctx.pane.data as TerminalPaneData;
 					return (


### PR DESCRIPTION
## Summary
- prompts before closing active terminal panes in v2 workspaces
- applies to tab close and direct pane close paths via existing close guards
- helps prevent accidental loss of Claude/Codex/OpenCode terminal sessions

## Related issues
- #3992
- #3240
- #2877
- #2124
- #4850

## Test plan
- `bunx @biomejs/biome@2.4.2 check` on changed files

## Notes
- Uses the existing alert UI and terminal runtime registry; no new persistence or settings are introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Features**
  * Added confirmation prompts when closing terminal panes with active connections. Users are now prompted before closing terminals or tabs containing active terminal sessions, preventing accidental loss of work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->