### PR TITLE
feat(desktop): write CLI-discoverable session location log

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -14,6 +14,10 @@ import { raceWithAbort, throwIfAborted } from "../abort";
 import { buildTerminalEnv, getDefaultShell } from "../env";
 import { TerminalKilledError } from "../errors";
 import { portManager } from "../port-manager";
+import {
+	markSessionLocationExited,
+	upsertSessionLocation,
+} from "../session-location-log";
 import type { CreateSessionParams, SessionResult } from "../types";
 import {
 	CREATE_OR_ATTACH_CONCURRENCY,
@@ -218,6 +222,7 @@ export class DaemonTerminalManager extends EventEmitter {
 				if (session) {
 					session.exitReason = reason;
 				}
+				markSessionLocationExited({ paneId, exitReason: reason });
 				this.emit(`exit:${paneId}`, exitCode, signal, reason);
 				this.emit("terminalExit", { paneId, exitCode, signal, reason });
 
@@ -509,6 +514,17 @@ export class DaemonTerminalManager extends EventEmitter {
 				pid: response.pid,
 				cols: effectiveCols,
 				rows: effectiveRows,
+			});
+			upsertSessionLocation({
+				paneId,
+				tabId,
+				workspaceId,
+				workspaceName,
+				workspacePath,
+				rootPath,
+				cwd: sessionCwd,
+				command,
+				pid: response.pid,
 			});
 
 			portManager.upsertSession(paneId, workspaceId, response.pid);

--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -613,6 +613,14 @@ describe("env", () => {
 			}
 		});
 
+		it("includes session-location metadata for terminal CLIs", () => {
+			const result = buildTerminalEnv(baseParams);
+			expect(result.SUPERSET_SESSION_LOCATIONS_PATH).toContain(
+				"session-locations.json",
+			);
+			expect(result.SUPERSET_SESSION_LOCATION_KEY).toBe("ws-1:tab-1:pane-1");
+		});
+
 		describe("excludes non-allowlisted vars from terminals", () => {
 			it("should exclude NODE_ENV from Electron's process.env", () => {
 				process.env.NODE_ENV = "production";

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -4,6 +4,10 @@ import os from "node:os";
 import defaultShell from "default-shell";
 import { env } from "shared/env.shared";
 import { getShellEnv } from "../agent-setup/shell-wrappers";
+import {
+	buildSessionLocationKey,
+	SESSION_LOCATION_LOG_PATH,
+} from "./session-location-log";
 
 const MACOS_SYSTEM_CERT_FILE = "/etc/ssl/cert.pem";
 let cachedUtf8Locale: string | null = null;
@@ -475,6 +479,12 @@ export function buildTerminalEnv(params: {
 		SUPERSET_WORKSPACE_NAME: workspaceName || "",
 		SUPERSET_WORKSPACE_PATH: workspacePath || "",
 		SUPERSET_ROOT_PATH: rootPath || "",
+		SUPERSET_SESSION_LOCATIONS_PATH: SESSION_LOCATION_LOG_PATH,
+		SUPERSET_SESSION_LOCATION_KEY: buildSessionLocationKey({
+			workspaceId,
+			tabId,
+			paneId,
+		}),
 		SUPERSET_PORT: String(env.DESKTOP_NOTIFICATIONS_PORT),
 		// Environment identifier for dev/prod separation
 		SUPERSET_ENV: env.NODE_ENV === "development" ? "development" : "production",

--- a/apps/desktop/src/main/lib/terminal/session-location-log.ts
+++ b/apps/desktop/src/main/lib/terminal/session-location-log.ts
@@ -1,0 +1,170 @@
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+	SUPERSET_HOME_DIR,
+	SUPERSET_SENSITIVE_FILE_MODE,
+} from "main/lib/app-environment";
+
+export const SESSION_LOCATION_LOG_PATH = join(
+	SUPERSET_HOME_DIR,
+	"session-locations.json",
+);
+
+interface SessionLocationEntry {
+	paneId: string;
+	tabId: string;
+	workspaceId: string;
+	workspaceName?: string;
+	workspacePath?: string;
+	rootPath?: string;
+	cwd: string;
+	command?: string;
+	pid: number | null;
+	status: "available" | "exited";
+	createdAt: number;
+	updatedAt: number;
+	exitedAt?: number;
+	exitReason?: string;
+	locationKey: string;
+}
+
+interface SessionLocationLog {
+	version: 1;
+	updatedAt: number;
+	path: string;
+	sessions: Record<string, SessionLocationEntry>;
+	locations: Record<string, string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function buildSessionLocationKey(params: {
+	workspaceId: string;
+	tabId: string;
+	paneId: string;
+}) {
+	return `${params.workspaceId}:${params.tabId}:${params.paneId}`;
+}
+
+function emptyLog(): SessionLocationLog {
+	return {
+		version: 1,
+		updatedAt: Date.now(),
+		path: SESSION_LOCATION_LOG_PATH,
+		sessions: {},
+		locations: {},
+	};
+}
+
+async function readLog(): Promise<SessionLocationLog> {
+	try {
+		const raw = await fs.readFile(SESSION_LOCATION_LOG_PATH, "utf8");
+		const parsed = JSON.parse(raw) as Partial<SessionLocationLog>;
+		return {
+			version: 1,
+			updatedAt:
+				typeof parsed.updatedAt === "number" ? parsed.updatedAt : Date.now(),
+			path: SESSION_LOCATION_LOG_PATH,
+			sessions: isRecord(parsed.sessions)
+				? (parsed.sessions as Record<string, SessionLocationEntry>)
+				: {},
+			locations: isRecord(parsed.locations)
+				? (parsed.locations as Record<string, string>)
+				: {},
+		};
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			console.warn(
+				"[session-location-log] Failed to read session location log:",
+				error,
+			);
+		}
+		return emptyLog();
+	}
+}
+
+async function writeLog(log: SessionLocationLog): Promise<void> {
+	try {
+		await fs.mkdir(dirname(SESSION_LOCATION_LOG_PATH), { recursive: true });
+		log.updatedAt = Date.now();
+		log.path = SESSION_LOCATION_LOG_PATH;
+		const tmpPath = `${SESSION_LOCATION_LOG_PATH}.tmp`;
+		await fs.writeFile(tmpPath, `${JSON.stringify(log, null, 2)}\n`, {
+			mode: SUPERSET_SENSITIVE_FILE_MODE,
+		});
+		await fs.rename(tmpPath, SESSION_LOCATION_LOG_PATH);
+		await fs.chmod(SESSION_LOCATION_LOG_PATH, SUPERSET_SENSITIVE_FILE_MODE);
+	} catch (error) {
+		console.warn(
+			"[session-location-log] Failed to write session location log:",
+			error,
+		);
+	}
+}
+
+let operationQueue = Promise.resolve();
+
+function enqueueUpdate(update: (log: SessionLocationLog) => void): void {
+	operationQueue = operationQueue
+		.then(async () => {
+			const log = await readLog();
+			update(log);
+			await writeLog(log);
+		})
+		.catch((error) => {
+			console.warn("[session-location-log] Failed to update log:", error);
+		});
+}
+
+export function upsertSessionLocation(params: {
+	paneId: string;
+	tabId: string;
+	workspaceId: string;
+	workspaceName?: string;
+	workspacePath?: string;
+	rootPath?: string;
+	cwd: string;
+	command?: string;
+	pid: number | null;
+}): void {
+	enqueueUpdate((log) => {
+		const now = Date.now();
+		const previous = log.sessions[params.paneId];
+		const locationKey = buildSessionLocationKey(params);
+		if (previous?.locationKey && previous.locationKey !== locationKey) {
+			delete log.locations[previous.locationKey];
+		}
+		log.sessions[params.paneId] = {
+			...previous,
+			...params,
+			status: "available",
+			createdAt: previous?.createdAt ?? now,
+			updatedAt: now,
+			locationKey,
+			exitedAt: undefined,
+			exitReason: undefined,
+		};
+		log.locations[locationKey] = params.paneId;
+	});
+}
+
+export function markSessionLocationExited(params: {
+	paneId: string;
+	exitReason?: string;
+}): void {
+	enqueueUpdate((log) => {
+		const entry = log.sessions[params.paneId];
+		if (!entry) return;
+		const now = Date.now();
+		log.sessions[params.paneId] = {
+			...entry,
+			status: "exited",
+			pid: null,
+			updatedAt: now,
+			exitedAt: now,
+			exitReason: params.exitReason,
+		};
+	});
+}


### PR DESCRIPTION
## Summary
- writes a durable `session-locations.json` file under the Superset home directory
- exposes `SUPERSET_SESSION_LOCATIONS_PATH` and `SUPERSET_SESSION_LOCATION_KEY` to terminal CLIs
- records session location metadata by pane and workspace/tab/pane location, and marks exited sessions without deleting them

## Linked issue
- Implements #5126

## Related issues
- #3496
- #4850
- #3992

## Test plan
- `bunx @biomejs/biome@2.4.2 check` on changed files

## Known verification note
- Direct `bun test apps/desktop/src/main/lib/terminal/env.test.ts` was blocked by workspace dependency resolution for `default-shell`; the changed files pass focused Biome checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now track and persist location information, including workspace, tab, and pane identifiers.

* **Tests**
  * Added test coverage for session location environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->