### PR TITLE
fix(desktop): reopen closed tabs in v2 workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -10,6 +10,7 @@ const EMPTY_STATE: WorkspaceState<PaneViewerData> = {
 	version: 1,
 	tabs: [],
 	activeTabId: null,
+	closedTabsStack: [],
 };
 
 function getSnapshot(state: WorkspaceState<PaneViewerData>): string {
@@ -83,6 +84,7 @@ export function useV2WorkspacePaneLayout() {
 				version: nextStore.version,
 				tabs: nextStore.tabs,
 				activeTabId: nextStore.activeTabId,
+				closedTabsStack: nextStore.closedTabsStack,
 			};
 			const nextSnapshot = getSnapshot(nextWorkspaceState);
 			if (nextSnapshot === syncStateRef.current.lastSyncedSnapshot) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -129,6 +129,10 @@ export function useWorkspaceHotkeys({
 		}
 	});
 
+	useHotkey("REOPEN_TAB", () => {
+		store.getState().reopenClosedTab();
+	});
+
 	useHotkey("PREV_TAB", () => {
 		const state = store.getState();
 		if (!state.activeTabId || state.tabs.length === 0) return;

--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -75,6 +75,49 @@ describe("tab operations", () => {
 		expect(store.getState().activeTabId).toBeNull();
 	});
 
+	it("tracks closed tabs and reopens the most recent tab at its original index", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+
+		store.getState().removeTab("t1");
+		expect(
+			store.getState().closedTabsStack.map((entry) => entry.tab.id),
+		).toEqual(["t1"]);
+
+		store.getState().reopenClosedTab();
+
+		expect(store.getState().tabs.map((tab) => tab.id)).toEqual(["t1", "t2"]);
+		expect(store.getState().activeTabId).toBe("t1");
+		expect(store.getState().closedTabsStack).toHaveLength(0);
+	});
+
+	it("activates an already-open tab when reopening a duplicate closed entry", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().removeTab("t1");
+		store.getState().addTab({ id: "t1", panes: [tp("p1b")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+
+		store.getState().reopenClosedTab();
+
+		expect(store.getState().tabs.map((tab) => tab.id)).toEqual(["t1", "t2"]);
+		expect(store.getState().activeTabId).toBe("t1");
+		expect(store.getState().closedTabsStack).toHaveLength(0);
+	});
+
+	it("keeps the closed-tabs stack bounded", () => {
+		const store = makeStore();
+		for (let index = 0; index < 21; index += 1) {
+			store.getState().addTab({ id: `t${index}`, panes: [tp(`p${index}`)] });
+			store.getState().removeTab(`t${index}`);
+		}
+
+		expect(store.getState().closedTabsStack).toHaveLength(20);
+		expect(store.getState().closedTabsStack[0]?.tab.id).toBe("t20");
+		expect(store.getState().closedTabsStack[19]?.tab.id).toBe("t1");
+	});
+
 	it("sets active tab", () => {
 		const store = makeStore();
 		store.getState().addTab({ id: "t1", panes: [tp("p1")] });

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -107,9 +107,12 @@ export type CreateTabInput<TData> = {
 	activePaneId?: string;
 };
 
+const MAX_CLOSED_TABS = 20;
+
 export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 	addTab: (args: CreateTabInput<TData>) => void;
 	removeTab: (tabId: string) => void;
+	reopenClosedTab: () => void;
 	setActiveTab: (tabId: string) => void;
 	setTabTitleOverride: (args: {
 		tabId: string;
@@ -189,6 +192,7 @@ export function createWorkspaceStore<TData>(
 		version: 1,
 		tabs: options?.initialState?.tabs ?? [],
 		activeTabId: options?.initialState?.activeTabId ?? null,
+		closedTabsStack: options?.initialState?.closedTabsStack ?? [],
 
 		addTab: (args) => {
 			const builtPanes = args.panes.map(buildPane) as [
@@ -204,6 +208,10 @@ export function createWorkspaceStore<TData>(
 
 		removeTab: (tabId) => {
 			set((s) => {
+				const removedTabIndex = s.tabs.findIndex((t) => t.id === tabId);
+				const removedTab = s.tabs[removedTabIndex];
+				if (!removedTab) return s;
+
 				const nextTabs = s.tabs.filter((t) => t.id !== tabId);
 				return {
 					tabs: nextTabs,
@@ -212,6 +220,32 @@ export function createWorkspaceStore<TData>(
 						s.activeTabId,
 						tabId,
 					),
+					closedTabsStack: [
+						{ tab: removedTab, index: removedTabIndex },
+						...s.closedTabsStack.filter((entry) => entry.tab.id !== tabId),
+					].slice(0, MAX_CLOSED_TABS),
+				};
+			});
+		},
+
+		reopenClosedTab: () => {
+			set((s) => {
+				const [entry, ...remainingClosedTabs] = s.closedTabsStack;
+				if (!entry) return s;
+				if (s.tabs.some((tab) => tab.id === entry.tab.id)) {
+					return {
+						activeTabId: entry.tab.id,
+						closedTabsStack: remainingClosedTabs,
+					};
+				}
+
+				const nextTabs = [...s.tabs];
+				const insertIndex = Math.max(0, Math.min(entry.index, nextTabs.length));
+				nextTabs.splice(insertIndex, 0, entry.tab);
+				return {
+					tabs: nextTabs,
+					activeTabId: entry.tab.id,
+					closedTabsStack: remainingClosedTabs,
 				};
 			});
 		},
@@ -871,18 +905,18 @@ export function createWorkspaceStore<TData>(
 
 		replaceState: (next) => {
 			set((s) => {
-				const resolved =
-					typeof next === "function"
-						? next({
-								version: s.version,
-								tabs: s.tabs,
-								activeTabId: s.activeTabId,
-							})
-						: next;
+				const currentState = {
+					version: s.version,
+					tabs: s.tabs,
+					activeTabId: s.activeTabId,
+					closedTabsStack: s.closedTabsStack,
+				};
+				const resolved = typeof next === "function" ? next(currentState) : next;
 				return {
 					version: resolved.version,
 					tabs: resolved.tabs,
 					activeTabId: resolved.activeTabId,
+					closedTabsStack: resolved.closedTabsStack ?? [],
 				};
 			});
 		},

--- a/packages/panes/src/types.ts
+++ b/packages/panes/src/types.ts
@@ -33,8 +33,14 @@ export interface Tab<TData> {
 	panes: Record<string, Pane<TData>>;
 }
 
+export interface ClosedTabEntry<TData> {
+	tab: Tab<TData>;
+	index: number;
+}
+
 export interface WorkspaceState<TData> {
 	version: 1;
 	tabs: Tab<TData>[];
 	activeTabId: string | null;
+	closedTabsStack: ClosedTabEntry<TData>[];
 }


### PR DESCRIPTION
## Summary
- add a bounded closed-tab stack to the generic panes workspace store
- persist the v2 closed-tab stack with pane layout state
- wire the `REOPEN_TAB` hotkey in v2 workspaces

## Linked issue
- Fixes #5125

## Related issues
- #4850
- #3992
- #3240
- #2877
- #2124
- #5124

## Test plan
- `bun test packages/panes/src/core/store/store.test.ts` — 44/44 pass
- `bunx @biomejs/biome@2.4.2 check` on changed files via `bun run lint:fix`

## Known verification note
- `bun run --cwd apps/desktop typecheck` currently fails in existing `packages/trpc` Drizzle duplicate-private-type errors unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reopen recently closed tabs with a convenient new keyboard shortcut. The system automatically remembers up to 20 closed tabs per workspace and seamlessly restores them to their original position with focus. Your closed tab history is persisted and fully restored whenever you restart the application, ensuring no tabs are ever lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->