### PR TITLE
fix(desktop): stop idle tanstack-db.sqlite writes that churn disk and bloat the file

### DIFF
--- a/apps/desktop/src/main/lib/persistence/persistence.ts
+++ b/apps/desktop/src/main/lib/persistence/persistence.ts
@@ -41,7 +41,7 @@ function reclaimBloatedDatabaseFile(target: Database.Database): void {
 }
 
 function stripVolatileResumeFields(value: unknown): unknown {
-	if (value === null || typeof value !== "object") {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
 		return value;
 	}
 	const { updatedAt, ...stableFields } = value as Record<string, unknown>;
@@ -98,16 +98,17 @@ function suppressIdleResumeWrites(
 					transaction: CommittedTransaction,
 				): Promise<void> => {
 					const resumeSignature = getRedundantResumeSignature(transaction);
-					if (resumeSignature !== null) {
-						if (
-							lastForwardedResumeByCollection.get(collectionId) ===
+					if (
+						resumeSignature !== null &&
+						lastForwardedResumeByCollection.get(collectionId) ===
 							resumeSignature
-						) {
-							return;
-						}
-						lastForwardedResumeByCollection.set(collectionId, resumeSignature);
+					) {
+						return;
 					}
 					await target.applyCommittedTx(collectionId, transaction);
+					if (resumeSignature !== null) {
+						lastForwardedResumeByCollection.set(collectionId, resumeSignature);
+					}
 				};
 			},
 		});

--- a/apps/desktop/src/main/lib/persistence/persistence.ts
+++ b/apps/desktop/src/main/lib/persistence/persistence.ts
@@ -3,23 +3,151 @@ import { exposeElectronSQLitePersistence } from "@tanstack/electron-db-sqlite-pe
 import { createNodeSQLitePersistence } from "@tanstack/node-db-sqlite-persistence";
 import Database from "better-sqlite3";
 import { ipcMain } from "electron";
+import log from "electron-log/main";
 import {
 	ensureSupersetHomeDirExists,
 	SUPERSET_HOME_DIR,
 } from "../app-environment";
 
+type SQLitePersistence = ReturnType<typeof createNodeSQLitePersistence>;
+type SQLitePersistenceAdapter = SQLitePersistence["adapter"];
+type CommittedTransaction = Parameters<
+	SQLitePersistenceAdapter["applyCommittedTx"]
+>[1];
+
+const VACUUM_RECLAIM_THRESHOLD_BYTES = 64 * 1024 * 1024;
+
 let dispose: (() => void) | null = null;
 let database: Database.Database | null = null;
+
+function reclaimBloatedDatabaseFile(target: Database.Database): void {
+	try {
+		target.pragma("wal_checkpoint(TRUNCATE)");
+		const pageSize = target.pragma("page_size", { simple: true }) as number;
+		const freelistCount = target.pragma("freelist_count", {
+			simple: true,
+		}) as number;
+		if (pageSize * freelistCount < VACUUM_RECLAIM_THRESHOLD_BYTES) {
+			return;
+		}
+		target.exec("VACUUM");
+		target.pragma("wal_checkpoint(TRUNCATE)");
+	} catch (error) {
+		log.warn(
+			"[persistence] Failed to reclaim tanstack-db.sqlite space:",
+			error,
+		);
+	}
+}
+
+function stripVolatileResumeFields(value: unknown): unknown {
+	if (value === null || typeof value !== "object") {
+		return value;
+	}
+	const { updatedAt, ...stableFields } = value as Record<string, unknown>;
+	return stableFields;
+}
+
+function getRedundantResumeSignature(
+	transaction: CommittedTransaction,
+): string | null {
+	if (transaction.truncate || transaction.mutations.length > 0) {
+		return null;
+	}
+	if ((transaction.rowMetadataMutations?.length ?? 0) > 0) {
+		return null;
+	}
+	const metadataMutations = transaction.collectionMetadataMutations ?? [];
+	if (metadataMutations.length === 0) {
+		return null;
+	}
+	const stableResumeValues: unknown[] = [];
+	for (const mutation of metadataMutations) {
+		if (mutation.type !== "set" || mutation.key !== "electric:resume") {
+			return null;
+		}
+		stableResumeValues.push(stripVolatileResumeFields(mutation.value));
+	}
+	return JSON.stringify(stableResumeValues);
+}
+
+function suppressIdleResumeWrites(
+	persistence: SQLitePersistence,
+): SQLitePersistence {
+	const lastForwardedResumeByCollection = new Map<string, string>();
+	const wrappedAdapters = new WeakMap<
+		SQLitePersistenceAdapter,
+		SQLitePersistenceAdapter
+	>();
+
+	const wrapAdapter = (
+		adapter: SQLitePersistenceAdapter,
+	): SQLitePersistenceAdapter => {
+		const alreadyWrapped = wrappedAdapters.get(adapter);
+		if (alreadyWrapped) {
+			return alreadyWrapped;
+		}
+		const wrapped = new Proxy(adapter, {
+			get(target, property, receiver) {
+				if (property !== "applyCommittedTx") {
+					const value = Reflect.get(target, property, receiver);
+					return typeof value === "function" ? value.bind(target) : value;
+				}
+				return async (
+					collectionId: string,
+					transaction: CommittedTransaction,
+				): Promise<void> => {
+					const resumeSignature = getRedundantResumeSignature(transaction);
+					if (resumeSignature !== null) {
+						if (
+							lastForwardedResumeByCollection.get(collectionId) ===
+							resumeSignature
+						) {
+							return;
+						}
+						lastForwardedResumeByCollection.set(collectionId, resumeSignature);
+					}
+					await target.applyCommittedTx(collectionId, transaction);
+				};
+			},
+		});
+		wrappedAdapters.set(adapter, wrapped);
+		return wrapped;
+	};
+
+	const wrapResolved = (resolved: SQLitePersistence): SQLitePersistence => ({
+		...resolved,
+		adapter: wrapAdapter(resolved.adapter),
+	});
+
+	const resolveForCollection = persistence.resolvePersistenceForCollection;
+	const resolveForMode = persistence.resolvePersistenceForMode;
+
+	return {
+		...persistence,
+		adapter: wrapAdapter(persistence.adapter),
+		resolvePersistenceForCollection: resolveForCollection
+			? (options) => wrapResolved(resolveForCollection(options))
+			: undefined,
+		resolvePersistenceForMode: resolveForMode
+			? (mode) => wrapResolved(resolveForMode(mode))
+			: undefined,
+	};
+}
 
 export function initTanstackDbPersistence(): void {
 	ensureSupersetHomeDirExists();
 	database = new Database(join(SUPERSET_HOME_DIR, "tanstack-db.sqlite"));
+	reclaimBloatedDatabaseFile(database);
 	const persistence = createNodeSQLitePersistence({
 		database,
 		appliedTxPruneMaxRows: 1_000,
 		appliedTxPruneMaxAgeSeconds: 24 * 60 * 60,
 	});
-	dispose = exposeElectronSQLitePersistence({ ipcMain, persistence });
+	dispose = exposeElectronSQLitePersistence({
+		ipcMain,
+		persistence: suppressIdleResumeWrites(persistence),
+	});
 }
 
 export function shutdownTanstackDbPersistence(): void {

--- a/bun.lock
+++ b/bun.lock
@@ -1108,6 +1108,7 @@
   "overrides": {
     "axios": "1.14.0",
     "hono": "4.12.23",
+    "kysely": "0.28.17",
   },
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
@@ -4558,7 +4559,7 @@
 
     "koffi": ["koffi@2.15.2", "", {}, "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g=="],
 
-    "kysely": ["kysely@0.29.2", "", {}, "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg=="],
+    "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
     "lan-network": ["lan-network@0.2.1", "", { "bin": { "lan-network": "dist/lan-network-cli.js" } }, "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 	],
 	"overrides": {
 		"axios": "1.14.0",
-		"hono": "4.12.23"
+		"hono": "4.12.23",
+		"kysely": "0.28.17"
 	},
 	"trustedDependencies": [
 		"better-sqlite3",


### PR DESCRIPTION
## Problem

Users reported laptops running hot with the app open. Root cause: the desktop app's TanStack/Electric SQLite persistence (`~/.superset/tanstack-db.sqlite`) **commits a transaction on every idle long-poll cycle, per collection** — resume-metadata only, no data change — ~once/sec across ~20 collections. That constant disk churn keeps endpoint security / file-integrity agents (EDR, DLP, antivirus) re-hashing the file. Freed pages were never reclaimed (`auto_vacuum=NONE`, no VACUUM), so the file bloated to **462 MB** (68% of which was the `applied_tx` replay log, ~88% free pages).

A scanner's CPU cost ≈ *write frequency × file size* — and both were maxed: a multi-hundred-MB file modified every second.

## Fix (all in `apps/desktop/.../persistence/persistence.ts` — no node_modules patching)

1. **Suppress idle writes** — wrap the persistence adapter's `applyCommittedTx` (the single main-process chokepoint all collections funnel through) and drop resume-only transactions whose Electric `offset`/`handle` are unchanged. Idle → ~0 writes; real data still persists normally.
2. **Reclaim bloat** — `wal_checkpoint(TRUNCATE)` + gated `VACUUM` on launch when the freelist exceeds 64 MB, so already-bloated installs shrink on next update.

Plus a dependency fix that was blocking the dev/auth build (`fix(deps)` commit): `@better-auth/kysely-adapter@1.6.13` imports `DEFAULT_MIGRATION_LOCK_TABLE`/`DEFAULT_MIGRATION_TABLE` from kysely's root, which 0.29.x dropped — pinned kysely to `0.28.17` (within the adapter's supported range, still exports them).

## Verification

| | Before | After |
|---|---|---|
| Idle `applied_tx` writes / 60s | ~29 (WAL constantly rewritten) | **0 (WAL static)** |
| File size (real install) | 462 MB | **51 MB** after VACUUM, `integrity_check` ok |

- Suppression measured on the **real Electron build** with live Electric sync, idle — 0 writes/min, WAL unchanged, real data synced first (confirming only redundant idle writes are dropped).
- VACUUM run against a backup of a real 462 MB DB: 462 → 51 MB, data intact.
- `lint` 0, `typecheck` 28/28, `sherif` clean.

## Follow-up (separate, not in this PR)

The 51 MB is ~68% replay-log overhead + ~14 MB user data (GitHub PRs > tasks, across ~5 orgs). The local-first model syncs the **full org shape to every client**, which won't scale to large orgs. Tracking separately: filtered/windowed Electric shapes + payload trimming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Automatic SQLite maintenance runs on startup to reclaim space and reduce database bloat.

* **Bug Fixes**
  * Redundant resume commits are detected and suppressed to avoid unnecessary/no-op writes; failures during maintenance are logged as warnings.

* **Chores**
  * Added a package override to pin a database library version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->