### PR TITLE
fix(desktop): scope v2 notifications and ports to sidebar-visible workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.ts
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from "react";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceWsToken } from "renderer/lib/host-service-auth";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useVisibleSidebarWorkspaceIds } from "renderer/routes/_authenticated/hooks/useVisibleSidebarWorkspaceIds";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import {
@@ -37,6 +38,7 @@ export function useDashboardSidebarPortsData(): {
 	const queryClient = useQueryClient();
 	const { activeHostUrl, machineId } = useLocalHostService();
 	const relayUrl = useRelayUrl();
+	const visibleWorkspaceIds = useVisibleSidebarWorkspaceIds();
 
 	const { data: hosts = [] } = useLiveQuery(
 		(q) =>
@@ -48,7 +50,7 @@ export function useDashboardSidebarPortsData(): {
 		[collections],
 	);
 
-	const { data: workspaces = [] } = useLiveQuery(
+	const { data: allWorkspaces = [] } = useLiveQuery(
 		(q) =>
 			q
 				.from({ workspaces: collections.v2Workspaces })
@@ -58,6 +60,13 @@ export function useDashboardSidebarPortsData(): {
 					hostId: workspaces.hostId,
 				})),
 		[collections],
+	);
+	const workspaces = useMemo(
+		() =>
+			allWorkspaces.filter((workspace) =>
+				visibleWorkspaceIds.has(workspace.id),
+			),
+		[allWorkspaces, visibleWorkspaceIds],
 	);
 
 	const hostsToQuery = useMemo(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -6,7 +6,10 @@ import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import { getVisibleSidebarWorkspaces } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import {
+	getVisibleSidebarWorkspaces,
+	isAutoIncludedLocalMainWorkspace,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useWorkspaceTransactionsStore } from "renderer/stores/workspace-creates";
 import type {
@@ -308,11 +311,12 @@ export function useDashboardSidebarData() {
 		const sidebarProjectIds = new Set(
 			sidebarProjects.map((project) => project.id),
 		);
-		const autoLocalMainWorkspaces = localMainWorkspaces.filter(
-			(workspace) =>
-				!localStateWorkspaceIds.has(workspace.id) &&
-				workspace.hostId === machineId &&
-				sidebarProjectIds.has(workspace.projectId),
+		const autoLocalMainWorkspaces = localMainWorkspaces.filter((workspace) =>
+			isAutoIncludedLocalMainWorkspace(workspace, {
+				localStateWorkspaceIds,
+				sidebarProjectIds,
+				machineId,
+			}),
 		);
 
 		return [...autoLocalMainWorkspaces, ...sidebarWorkspaces];

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
@@ -5,6 +5,7 @@ import { useEffectEvent, useMemo } from "react";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { useVisibleSidebarWorkspaceIds } from "renderer/routes/_authenticated/hooks/useVisibleSidebarWorkspaceIds";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { NOTIFICATION_EVENTS } from "shared/constants";
@@ -57,7 +58,8 @@ export function V2NotificationController() {
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const relayUrl = useRelayUrl();
-	const { data: workspaceHosts = [] } = useLiveQuery(
+	const visibleWorkspaceIds = useVisibleSidebarWorkspaceIds();
+	const { data: allWorkspaceHosts = [] } = useLiveQuery(
 		(q) =>
 			q
 				.from({ v2Workspaces: collections.v2Workspaces })
@@ -70,7 +72,7 @@ export function V2NotificationController() {
 				})),
 		[collections],
 	);
-	const { data: localWorkspaceRows = [] } = useLiveQuery(
+	const { data: allLocalWorkspaceRows = [] } = useLiveQuery(
 		(q) =>
 			q
 				.from({ v2WorkspaceLocalState: collections.v2WorkspaceLocalState })
@@ -79,6 +81,20 @@ export function V2NotificationController() {
 					paneLayout: v2WorkspaceLocalState.paneLayout,
 				})),
 		[collections],
+	);
+	const workspaceHosts = useMemo(
+		() =>
+			allWorkspaceHosts.filter((workspace) =>
+				visibleWorkspaceIds.has(workspace.workspaceId),
+			),
+		[allWorkspaceHosts, visibleWorkspaceIds],
+	);
+	const localWorkspaceRows = useMemo(
+		() =>
+			allLocalWorkspaceRows.filter((workspace) =>
+				visibleWorkspaceIds.has(workspace.workspaceId),
+			),
+		[allLocalWorkspaceRows, visibleWorkspaceIds],
 	);
 	const workspaceStatesById = useMemo(
 		() =>

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useVisibleSidebarWorkspaceIds/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useVisibleSidebarWorkspaceIds/index.ts
@@ -1,0 +1,1 @@
+export { useVisibleSidebarWorkspaceIds } from "./useVisibleSidebarWorkspaceIds";

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useVisibleSidebarWorkspaceIds/useVisibleSidebarWorkspaceIds.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useVisibleSidebarWorkspaceIds/useVisibleSidebarWorkspaceIds.ts
@@ -1,0 +1,96 @@
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useMemo } from "react";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import {
+	getSidebarWorkspaceIsHidden,
+	isAutoIncludedLocalMainWorkspace,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+
+/**
+ * The set of workspace ids that actually appear in the user's v2 dashboard
+ * sidebar. This is the per-user, per-org "my workspaces" view: explicitly
+ * placed (and not hidden) workspaces plus auto-included local `main`
+ * workspaces, both gated on the projects the user added to their sidebar.
+ *
+ * Notifications and ports filter against this so a user is never bothered by a
+ * coworker's workspace that merely shares the org's Electric stream.
+ */
+export function useVisibleSidebarWorkspaceIds(): Set<string> {
+	const collections = useCollections();
+	const { machineId } = useLocalHostService();
+
+	const { data: sidebarProjects = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ sidebarProjects: collections.v2SidebarProjects })
+				.innerJoin(
+					{ projects: collections.v2Projects },
+					({ sidebarProjects, projects }) =>
+						eq(sidebarProjects.projectId, projects.id),
+				)
+				.select(({ projects }) => ({ id: projects.id })),
+		[collections],
+	);
+
+	const { data: localStateWorkspaces = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ sidebarWorkspaces: collections.v2WorkspaceLocalState })
+				.innerJoin(
+					{ workspaces: collections.v2Workspaces },
+					({ sidebarWorkspaces, workspaces }) =>
+						eq(sidebarWorkspaces.workspaceId, workspaces.id),
+				)
+				.select(({ sidebarWorkspaces, workspaces }) => ({
+					id: workspaces.id,
+					projectId: sidebarWorkspaces.sidebarState.projectId,
+					isHidden: sidebarWorkspaces.sidebarState.isHidden,
+				})),
+		[collections],
+	);
+
+	const { data: mainWorkspaces = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ workspaces: collections.v2Workspaces })
+				.where(({ workspaces }) => eq(workspaces.type, "main"))
+				.select(({ workspaces }) => ({
+					id: workspaces.id,
+					projectId: workspaces.projectId,
+					hostId: workspaces.hostId,
+				})),
+		[collections],
+	);
+
+	return useMemo(() => {
+		const sidebarProjectIds = new Set(
+			sidebarProjects.map((project) => project.id),
+		);
+		const localStateWorkspaceIds = new Set(
+			localStateWorkspaces.map((workspace) => workspace.id),
+		);
+		const visibleIds = new Set<string>();
+
+		for (const workspace of localStateWorkspaces) {
+			if (getSidebarWorkspaceIsHidden(workspace)) continue;
+			if (!sidebarProjectIds.has(workspace.projectId)) continue;
+			visibleIds.add(workspace.id);
+		}
+
+		for (const workspace of mainWorkspaces) {
+			if (
+				isAutoIncludedLocalMainWorkspace(workspace, {
+					localStateWorkspaceIds,
+					sidebarProjectIds,
+					machineId,
+				})
+			) {
+				visibleIds.add(workspace.id);
+			}
+		}
+
+		return visibleIds;
+	}, [sidebarProjects, localStateWorkspaces, mainWorkspaces, machineId]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/sidebarVisibility.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/sidebarVisibility.ts
@@ -22,3 +22,29 @@ export function getVisibleSidebarWorkspaces<
 >(workspaces: readonly Workspace[]): Workspace[] {
 	return workspaces.filter(isSidebarWorkspaceVisible);
 }
+
+/**
+ * A `main` workspace is auto-included in the sidebar when the user hasn't
+ * explicitly placed it (no local-state row), it lives on this machine, and its
+ * project is one the user added to their sidebar. Shared by the sidebar tree
+ * builder and the notification/ports visibility filters so they agree on what
+ * "in the sidebar" means.
+ */
+export function isAutoIncludedLocalMainWorkspace(
+	workspace: { id: string; hostId: string; projectId: string },
+	{
+		localStateWorkspaceIds,
+		sidebarProjectIds,
+		machineId,
+	}: {
+		localStateWorkspaceIds: ReadonlySet<string>;
+		sidebarProjectIds: ReadonlySet<string>;
+		machineId: string | null;
+	},
+): boolean {
+	return (
+		!localStateWorkspaceIds.has(workspace.id) &&
+		workspace.hostId === machineId &&
+		sidebarProjectIds.has(workspace.projectId)
+	);
+}


### PR DESCRIPTION
## Problem

V2 notifications and the dashboard sidebar **Ports** list both queried `collections.v2Workspaces` with **no filter**. That Electric shape is scoped to the whole organization, so users were getting native notifications (and seeing forwarded ports) for **coworkers' workspaces they never added to their sidebar** — workspaces that merely shared the org's Electric stream.

The v2 sidebar itself shows a per-user, filtered set ("my pinned workspaces"), but notifications/ports didn't honor that filter — they were two divergent definitions of "my workspaces."

## Fix

Introduce one shared source of truth for "what's in my sidebar" and gate both features on it.

- **`useVisibleSidebarWorkspaceIds`** (new hook) — returns the `Set<string>` of workspace IDs actually visible in the v2 sidebar, using the same rules as the sidebar tree: project pinned in `v2SidebarProjects` + not hidden, plus auto-included local `main` workspaces.
- **`sidebarVisibility.ts`** — extracted the auto-included-main predicate (`isAutoIncludedLocalMainWorkspace`) so the sidebar tree and the new hook share one definition instead of drifting.
- **`useDashboardSidebarData`** — refactored to consume that shared predicate (no behavior change).
- **`V2NotificationController`** — filters workspace + local-state rows to the visible set before grouping by host. The local-fallback path only ever adds visible workspaces now.
- **`useDashboardSidebarPortsData`** — filters workspaces to the visible set before deriving host query targets; the existing local-host "tolerance" broadening is now capped to the visible set.

Behavior matches the sidebar exactly: a workspace that's hidden or whose project isn't pinned gets no notifications and no ports. Renderer-only — no schema, IPC, or host-service changes.

## Testing

Verified manually in the desktop app: an agent running in an in-sidebar workspace still notifies + shows ports; the same agent, once its workspace is removed from the sidebar (agent kept alive on the host), produces no notification, no sound, and its port disappears. Re-adding the workspace reconnects the still-running agent.

`bun run lint` and desktop `bun run typecheck` pass.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5134">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes v2 desktop notifications and the dashboard Ports list to workspaces visible in the v2 sidebar, matching each user’s pinned/hidden settings. Prevents alerts and ports from coworkers’ workspaces that aren’t in your sidebar.

- **Bug Fixes**
  - Added `useVisibleSidebarWorkspaceIds` to compute the exact visible set (pinned + not hidden + auto-included local `main`).
  - `V2NotificationController` and `useDashboardSidebarPortsData` now filter to that set before deriving hosts/rows.

- **Refactors**
  - Extracted `isAutoIncludedLocalMainWorkspace` to `sidebarVisibility.ts` and reused in `useDashboardSidebarData`.
  - Renderer-only change; no schema, IPC, or host-service updates.

<sup>Written for commit 42c0f86bdd14bf7583b1adba6d774c5167a06f3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in workspace visibility filtering across the dashboard sidebar, notifications, and workspace lists to ensure only your selected workspaces appear in relevant interface areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->