### PR TITLE
fix(desktop): recover remote terminal after laptop sleep/wake

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	jest,
+	setSystemTime,
+	test,
+} from "bun:test";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { connect, createTransport } from "./terminal-ws-transport";
 
@@ -90,6 +98,8 @@ beforeEach(() => {
 
 afterEach(() => {
 	globalThis.WebSocket = originalWebSocket;
+	setSystemTime();
+	jest.useRealTimers();
 });
 
 describe("terminal-ws-transport", () => {
@@ -155,5 +165,29 @@ describe("terminal-ws-transport", () => {
 			{ type: "resize", cols: 101, rows: 27 },
 			{ type: "input", data: "b" },
 		]);
+	});
+
+	test("recovers a half-open socket after the machine resumes from sleep", () => {
+		jest.useFakeTimers();
+		setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		const transport = createTransport();
+		connect(transport, createMockTerminal(), "ws://host/terminal/t1");
+
+		const socket = MockWebSocket.instances[0];
+		if (!socket) throw new Error("expected websocket instance");
+		socket.open();
+		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+		expect(transport.connectionState).toBe("open");
+
+		// Laptop sleeps: the socket dies but never observes it. readyState stays
+		// OPEN and no `close` is delivered — that silent death is the bug. Two
+		// minutes pass (clock jumps), then the watchdog tick runs on wake.
+		setSystemTime(new Date("2026-01-01T00:02:00Z"));
+		jest.advanceTimersByTime(120_000);
+
+		// Recovery: the wall-clock-gap watchdog drops the wedged socket and dials
+		// a fresh one. Without it, only the original socket would ever exist.
+		expect(MockWebSocket.instances.length).toBe(2);
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -57,6 +57,13 @@ export interface TerminalTransport {
 	 * with no output still gets replay on the next connect.
 	 */
 	_hasReceivedBytes: boolean;
+	/** Internal: wall-clock-gap watchdog for laptop sleep/wake detection. */
+	_livenessTimer: ReturnType<typeof setInterval> | null;
+	/** Internal: Date.now() at the last watchdog tick. */
+	_lastLivenessTick: number;
+	/** Internal: bound resume handler shared by the online/focus/visibility
+	 * listeners, so they can be removed on teardown. */
+	_resumeListener: (() => void) | null;
 }
 
 const MAX_LOG_ENTRIES = 200;
@@ -153,7 +160,101 @@ export function createTransport(): TerminalTransport {
 		_terminal: null,
 		_hasReceivedBytes: false,
 		_terminated: false,
+		_livenessTimer: null,
+		_lastLivenessTick: 0,
+		_resumeListener: null,
 	};
+}
+
+// Wall-clock watchdog cadence and the gap that counts as a suspend. A tick gap
+// far larger than the interval means the process was paused (laptop sleep), so
+// any socket still reporting OPEN is almost certainly half-open — dead, but
+// without a `close` event ever firing. This is the dependable desktop signal:
+// app-suspend doesn't reliably fire focus/visibility when the window was
+// focused both before and after sleep.
+const LIVENESS_CHECK_INTERVAL_MS = 5_000;
+const LIVENESS_SUSPEND_GAP_MS = 20_000;
+
+// Drop the current socket and immediately reconnect, without waiting for a
+// `close` event that a half-open socket will never deliver. The host keeps the
+// PTY alive, so this just re-attaches (and replays anything missed).
+function reconnectNow(transport: TerminalTransport) {
+	if (transport._terminated) return;
+	if (!transport.currentUrl || !transport._terminal) return;
+	cancelReconnect(transport);
+	if (transport.socket) {
+		const dead = transport.socket;
+		transport.socket = null;
+		try {
+			dead.close();
+		} catch {
+			// best-effort; the close handler is a no-op once socket is detached
+		}
+	}
+	transport._reconnectAttempt = 0;
+	// connect() is idempotent while "open"/"connecting"; force "closed" so it
+	// actually re-dials the now-detached socket.
+	setConnectionState(transport, "closed");
+	connect(transport, transport._terminal, transport.currentUrl);
+}
+
+// DOM resume signal (online/focus/visibilitychange). Reset backoff and
+// reconnect only if the socket is actually dead — a healthy or still-connecting
+// socket is left alone. Mirrors TerminalConnection.handleResume on web.
+function handleResume(transport: TerminalTransport) {
+	if (transport._terminated) return;
+	if (!transport.currentUrl || !transport._terminal) return;
+	transport._reconnectAttempt = 0;
+	const socket = transport.socket;
+	if (
+		socket &&
+		(socket.readyState === WebSocket.OPEN ||
+			socket.readyState === WebSocket.CONNECTING)
+	) {
+		return;
+	}
+	reconnectNow(transport);
+}
+
+function setupLiveness(transport: TerminalTransport) {
+	if (transport._livenessTimer === null) {
+		transport._lastLivenessTick = Date.now();
+		transport._livenessTimer = setInterval(() => {
+			const now = Date.now();
+			const gap = now - transport._lastLivenessTick;
+			transport._lastLivenessTick = now;
+			if (gap > LIVENESS_SUSPEND_GAP_MS) reconnectNow(transport);
+		}, LIVENESS_CHECK_INTERVAL_MS);
+	}
+	if (!transport._resumeListener) {
+		const listener = () => handleResume(transport);
+		transport._resumeListener = listener;
+		if (typeof window !== "undefined") {
+			window.addEventListener("online", listener);
+			window.addEventListener("focus", listener);
+		}
+		if (typeof document !== "undefined") {
+			document.addEventListener("visibilitychange", listener);
+		}
+	}
+}
+
+function teardownLiveness(transport: TerminalTransport) {
+	if (transport._livenessTimer !== null) {
+		clearInterval(transport._livenessTimer);
+		transport._livenessTimer = null;
+	}
+	const listener = transport._resumeListener;
+	if (listener) {
+		if (typeof window !== "undefined") {
+			window.removeEventListener("online", listener);
+			window.removeEventListener("focus", listener);
+		}
+		if (typeof document !== "undefined") {
+			document.removeEventListener("visibilitychange", listener);
+		}
+		transport._resumeListener = null;
+	}
 }
 
 function scheduleReconnect(transport: TerminalTransport) {
@@ -235,6 +336,7 @@ export function connect(
 	transport.currentUrl = wsUrl;
 	transport._terminal = terminal;
 	transport._terminated = false;
+	setupLiveness(transport);
 	setConnectionState(transport, "connecting");
 	const actualUrl = transport._hasReceivedBytes
 		? appendQueryParam(wsUrl, "replay", "0")
@@ -391,6 +493,7 @@ function attachSocketListeners(
 
 export function disconnect(transport: TerminalTransport) {
 	cancelReconnect(transport);
+	teardownLiveness(transport);
 	if (transport.socket) {
 		transport.socket.close();
 		transport.socket = null;
@@ -430,6 +533,7 @@ export function sendDispose(transport: TerminalTransport) {
 
 export function disposeTransport(transport: TerminalTransport) {
 	cancelReconnect(transport);
+	teardownLiveness(transport);
 	if (transport.socket) {
 		transport.socket.close();
 		transport.socket = null;


### PR DESCRIPTION
Fixes #5130.

## Problem

A desktop workspace terminal on a **remote** host freezes after the laptop sleeps and wakes — no output, keystrokes do nothing, and the only fix is to kill the pane and open a new one. The PTY itself keeps running in `pty-daemon` on the host; the break is client-side.

On suspend the terminal WebSocket goes **half-open**: the TCP connection is dead but `readyState` stays `OPEN` and no `close` event ever fires. `terminal-ws-transport.ts` only reconnects from its `close` handler (`scheduleReconnect()` is reached from a WS construction failure and the `close` handler, nowhere else), so it sat wedged on the dead pipe reporting `connectionState === "open"`.

The web workspace terminal (`apps/web/.../WebTerminal/TerminalConnection.ts`) already recovers on resume via `visibilitychange`/`resume`/`pageshow`/`online` + a backoff reset in `handleResume`. The desktop transport never got the equivalent — and DOM resume events alone aren't enough on desktop, since app-suspend doesn't reliably fire `visibilitychange`/`focus` when the window was focused both before and after sleep. The dependable signal is a wall-clock gap.

## Fix

Add a liveness/wake path to the transport, set up in `connect()` and torn down in `disconnect()` / `disposeTransport()`:

1. **Wall-clock-gap watchdog** — a 5s `setInterval` compares `Date.now()` between ticks; a gap > 20s means the process was suspended, so it force-recycles the (presumed half-open) socket. This catches the dead-but-`OPEN` case.
2. **`online` / `focus` / `visibilitychange` listeners** — reset backoff and reconnect a *dead* socket immediately (a healthy/connecting one is left alone), mirroring `TerminalConnection.handleResume` on web.

`reconnectNow()` drops the dead socket without waiting for a `close` and re-dials. Re-attach is cheap: the host keeps the PTY alive, so reconnecting just re-subscribes and the protocol replays anything missed. The existing `transport.socket !== socket` guard means a late OS-delivered `close` on the old socket is harmless.

## Testing

- Folded the issue's sleep/wake repro into `terminal-ws-transport.test.ts`. It drives the real watchdog `setInterval` + `Date.now()`-gap path: **fails on `main`** (`Expected: 2, Received: 1` — only one socket ever created) and **passes with the fix**.
- `bun test` (3 pass), `bun run lint` (clean), `bun run typecheck` (pass).

Manual verification (real half-open socket) is a lid-close test: open a remote-host terminal running `top`, close the lid ≥1 min, reopen → recovers within ~5s.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5135">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover remote desktop terminals after laptop sleep/wake by detecting suspension and force-reconnecting the WebSocket. Fixes frozen panes caused by half-open sockets where output and keystrokes stopped.

- **Bug Fixes**
  - Added a wall-clock watchdog (checks every 5s); a >20s gap triggers a socket recycle.
  - Added resume listeners (`online`, `focus`, `visibilitychange`) to reset backoff and reconnect only if the socket is dead.
  - Introduced `reconnectNow()` and wired liveness setup/teardown in `connect()` and `disconnect()`/`disposeTransport()`; added a test that simulates half-open recovery.

<sup>Written for commit e352f3d124cd01c0d24c9a1b754390d673e48d53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal websocket resilience when machines wake from sleep or experience network changes. The transport now detects stale connections and automatically establishes a fresh websocket to restore terminal connectivity.

* **Tests**
  * Added test cases validating proper websocket recovery following machine sleep and network resume events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->