### PR TITLE
fix(trpc): repair CI Test job — add verifyOrgOwner to v2-project test mock

### DIFF
--- a/packages/trpc/src/router/task/task.test.ts
+++ b/packages/trpc/src/router/task/task.test.ts
@@ -7,6 +7,9 @@ const syncTaskMock = mock(() => undefined);
 const verifyOrgAdminMock = mock(async () => ({
 	membership: { role: "owner" },
 }));
+const verifyOrgOwnerMock = mock(async () => ({
+	membership: { role: "owner" },
+}));
 const verifyOrgMembershipMock = mock(async () => ({
 	membership: { role: "member" },
 }));
@@ -195,6 +198,7 @@ mock.module("../../lib/integrations/sync", () => ({
 
 mock.module("../integration/utils", () => ({
 	verifyOrgAdmin: verifyOrgAdminMock,
+	verifyOrgOwner: verifyOrgOwnerMock,
 	verifyOrgMembership: verifyOrgMembershipMock,
 	verifyOrgMembershipWithSubscription: verifyOrgMembershipWithSubscriptionMock,
 }));

--- a/packages/trpc/src/router/v2-project/v2-project.test.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.test.ts
@@ -19,6 +19,9 @@ const verifyOrgMembershipMock = mock(async () => ({
 const verifyOrgAdminMock = mock(async () => ({
 	membership: { role: "owner" },
 }));
+const verifyOrgOwnerMock = mock(async () => ({
+	membership: { role: "owner" },
+}));
 const verifyOrgMembershipWithSubscriptionMock = mock(async () => ({
 	membership: { role: "member" },
 	subscription: null,
@@ -178,6 +181,7 @@ mock.module("../../lib/upload", () => ({
 
 mock.module("../integration/utils", () => ({
 	verifyOrgAdmin: verifyOrgAdminMock,
+	verifyOrgOwner: verifyOrgOwnerMock,
 	verifyOrgMembership: verifyOrgMembershipMock,
 	verifyOrgMembershipWithSubscription: verifyOrgMembershipWithSubscriptionMock,
 }));
@@ -300,6 +304,10 @@ beforeEach(() => {
 	}));
 	verifyOrgAdminMock.mockReset();
 	verifyOrgAdminMock.mockImplementation(async () => ({
+		membership: { role: "owner" },
+	}));
+	verifyOrgOwnerMock.mockReset();
+	verifyOrgOwnerMock.mockImplementation(async () => ({
 		membership: { role: "owner" },
 	}));
 
@@ -546,8 +554,14 @@ describe("v2Project.delete", () => {
 		});
 	});
 
-	it("rejects when the caller is not a member of the organization", async () => {
-		setMembershipForJwt(OTHER_ORG_ID);
+	it("rejects when the caller is not an owner of the organization", async () => {
+		setMembershipForJwt();
+		verifyOrgOwnerMock.mockImplementationOnce(async () => {
+			throw new TRPCError({
+				code: "FORBIDDEN",
+				message: "Only owners can delete projects",
+			});
+		});
 		const caller = createCaller(authedContext());
 
 		await expect(caller.v2Project.delete(input)).rejects.toMatchObject({


### PR DESCRIPTION
## What

CI's **Test** job has been red on \`main\` since **2026-06-03**. Every failing run traces to one error:

\`\`\`
SyntaxError: Export named 'verifyOrgOwner' not found in module '.../packages/trpc/src/router/integration/utils.ts'
\`\`\`

\`verifyOrgOwner\` *is* exported from \`utils.ts\`. The real cause: PR #5066 ("restrict project deletion to organization owners") made \`v2-project.ts\` import and call \`verifyOrgOwner\`, but didn't update \`v2-project.test.ts\`, which \`mock.module()\`s the **entire** \`../integration/utils\` module. The mock omitted \`verifyOrgOwner\`, so the named import in the source crashed at load time and took down the whole \`@superset/trpc\` test run.

Because turbo aborts on the first failing task, this single error masked the rest of the suite — which is why CI had been red "for a while" with no other signal.

## Fix

In \`packages/trpc/src/router/v2-project/v2-project.test.ts\`:
- Add \`verifyOrgOwnerMock\` (default resolves as owner), register it in the \`mock.module("../integration/utils", ...)\`, and reset it in \`beforeEach\` — mirroring the existing \`verifyOrgAdminMock\` pattern.
- Update the delete authorization test to drive the gate through \`verifyOrgOwner\` (the new source gate) instead of the removed \`ctx.organizationIds\` check.

## Verification

- \`@superset/trpc\` tests: **44 pass, 0 fail** (previously failed to even load).
- Biome lint on the changed file: clean.
- \`@superset/trpc\` typecheck: clean.

This was the **only** thing breaking CI — confirmed by checking every failing run since the break landed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5136">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red CI Test job by completing `verifyOrgOwner` mocks in both `v2-project` and `task` tests, and updating delete auth to use it. Restores `@superset/trpc` test runs and enforces owner-only deletion.

- **Bug Fixes**
  - Added `verifyOrgOwnerMock` to the `../integration/utils` mock in both tests; reset in `beforeEach` where used.
  - Updated `v2Project.delete` test to use `verifyOrgOwner` and reject non-owners.
  - Resolved process-global mock ordering that crashed module load; result: `@superset/trpc` tests pass (44 pass, 0 fail).

<sup>Written for commit a46b3bde0e0c10e6808108805c0791589fdfd2fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated authorization tests to distinguish organization owners from admins/members and to validate owner-only deletion behavior.
  * Extended mocked verification scenarios for organization roles to cover owner-specific cases.
* **Chores**
  * Test-only changes; no user-facing changes or new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->