### PR TITLE
fix(desktop): guard terminal resume against in-flight connect

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -205,11 +205,13 @@ function handleResume(transport: TerminalTransport) {
 	if (transport._terminated) return;
 	if (!transport.currentUrl || !transport._terminal) return;
 	transport._reconnectAttempt = 0;
+	// Bail if a connect is already in flight. State "connecting" also covers the
+	// /hosts/ pre-flight window, where transport.socket is still null but
+	// reconnecting would orphan the socket the pending pre-flight is about to open.
 	const socket = transport.socket;
 	if (
-		socket &&
-		(socket.readyState === WebSocket.OPEN ||
-			socket.readyState === WebSocket.CONNECTING)
+		transport.connectionState === "connecting" ||
+		socket?.readyState === WebSocket.OPEN
 	) {
 		return;
 	}


### PR DESCRIPTION
Follow-up to #5135, addressing the race flagged by Greptile (P1) and cubic (P2) in review.

## Problem

`handleResume` only bailed when `transport.socket` was `OPEN`/`CONNECTING`. But for remote `/hosts/` URLs, `connect()` runs `primeRelayAffinity` asynchronously before opening the socket, so there's a window where `transport.socket` is `null` while `connectionState` is `"connecting"`.

Wake-time sequence that orphans a socket:
1. watchdog fires → `reconnectNow` → `connect()` starts the async pre-flight → `transport.socket` is `null`, state `"connecting"`
2. an `online`/`focus`/`visibilitychange` event fires → `handleResume` sees the `null` socket, skips the early-return, calls `reconnectNow` again
3. both pre-flights resolve and each calls `openSocket()` (both pass the `currentUrl`/`connectionState` guards), opening two WebSockets — the first is overwritten in `transport.socket` without being closed, leaving it orphaned on client and server.

## Fix

Bail out of `handleResume` when `connectionState === "connecting"` too, covering the pre-flight window. `reconnectNow` is deliberately left unguarded so the watchdog can still force-recycle a genuinely half-open socket (which reports `"open"`) or a hung connect.

## Testing

`bun test` (3 pass), `bun run lint` (clean), `bun run typecheck` (pass).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5137">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent double WebSocket openings during terminal resume by bailing out when a connect is already in flight. This avoids orphaned sockets on remote `/hosts/` connections.

- **Bug Fixes**
  - In `handleResume`, return early when `connectionState === "connecting"` or the socket is `OPEN`, covering the pre-flight window before `transport.socket` is set.

<sup>Written for commit e2d2cb7035aa8f4d38528475c5ada28c17840413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal connection handling to prevent duplicate reconnections by better checking the connection state before attempting to reconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->