### PR TITLE
fix(host-service): decide workspace-delete cleanup on git state, not error text

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -13,8 +13,8 @@ import type {
 } from "../../error-types";
 import { protectedProcedure, router } from "../../index";
 import {
-	listGitWorktrees,
 	normalizeWorktreePath,
+	parseWorktreeList,
 } from "../workspace-creation/shared/worktree-list";
 import { isMainWorkspace } from "./is-main-workspace";
 
@@ -319,7 +319,20 @@ async function runDestroy(
 				.raw(["worktree", "remove", "--force", "--force", canonicalPath])
 				.catch(() => {});
 
-			if (await isRegisteredWorktree(git, local.worktreePath)) {
+			// A `worktree list` failure here means the post-remove state is
+			// unknown — treat that like "still registered" and block rather
+			// than risk orphaning disk past the cloud commit point.
+			let stillRegistered = true;
+			try {
+				stillRegistered = await isRegisteredWorktree(git, local.worktreePath);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Failed to verify worktree removal at ${local.worktreePath}: ${message}`,
+				});
+			}
+			if (stillRegistered) {
 				// git still tracks a live worktree here — removal genuinely
 				// failed. Keep the cloud row so the workspace stays visible and
 				// retryable instead of orphaning disk past the cloud commit point.
@@ -339,18 +352,18 @@ async function runDestroy(
 	// Keep this after the cloud commit point. If cloud delete fails, the
 	// workspace stays visible/retryable and the branch pointer remains intact.
 	if (git && local?.branch && input.deleteBranch) {
-		if (!(await localBranchExists(git, local.branch))) {
-			// Ref is already gone (renamed, pruned, or never materialized) —
-			// the deleteBranch goal is met, so don't surface a scary warning.
-			branchDeleted = true;
-		} else {
-			try {
+		try {
+			// An absent ref (renamed, pruned, or never materialized) already
+			// satisfies the goal, so skip the delete without a scary warning.
+			// A thrown git failure falls through to the warning below rather
+			// than being mistaken for "already gone".
+			if (await localBranchExists(git, local.branch)) {
 				await git.raw(["branch", "-D", local.branch]);
-				branchDeleted = true;
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				warnings.push(`Failed to delete branch ${local.branch}: ${message}`);
 			}
+			branchDeleted = true;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			warnings.push(`Failed to delete branch ${local.branch}: ${message}`);
 		}
 	}
 
@@ -386,24 +399,26 @@ async function runDestroy(
 
 // Authoritative "is this still a worktree git tracks" check — reads git's own
 // registry (realpath-canonicalized) instead of parsing remove's error text.
+// Calls `git.raw` directly rather than the swallowing `listGitWorktrees` so a
+// failed `worktree list` throws (state unknown) instead of looking empty.
 async function isRegisteredWorktree(
 	git: Awaited<ReturnType<HostServiceContext["git"]>>,
 	worktreePath: string,
 ): Promise<boolean> {
 	const target = normalizeWorktreePath(worktreePath);
-	const worktrees = await listGitWorktrees(git);
-	return worktrees.some((w) => normalizeWorktreePath(w.path) === target);
+	const raw = await git.raw(["worktree", "list", "--porcelain"]);
+	return parseWorktreeList(raw).some(
+		(w) => normalizeWorktreePath(w.path) === target,
+	);
 }
 
-// Exit-code-based ref existence check — no message parsing.
+// `branch --list` exits 0 whether or not the branch exists (empty output when
+// absent), so a thrown error is a real git failure — not a missing ref — and
+// propagates instead of being misread as "already deleted".
 async function localBranchExists(
 	git: Awaited<ReturnType<HostServiceContext["git"]>>,
 	branch: string,
 ): Promise<boolean> {
-	try {
-		await git.raw(["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
-		return true;
-	} catch {
-		return false;
-	}
+	const out = await git.raw(["branch", "--list", branch]);
+	return out.trim().length > 0;
 }

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -12,6 +12,10 @@ import type {
 	TeardownFailureCause,
 } from "../../error-types";
 import { protectedProcedure, router } from "../../index";
+import {
+	listGitWorktrees,
+	normalizeWorktreePath,
+} from "../workspace-creation/shared/worktree-list";
 import { isMainWorkspace } from "./is-main-workspace";
 
 /**
@@ -303,26 +307,28 @@ async function runDestroy(
 		}
 
 		if (git) {
-			try {
-				await git.raw([
-					"worktree",
-					"remove",
-					"--force",
-					"--force",
-					local.worktreePath,
-				]);
-				worktreeRemoved = true;
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				if (!existsSync(local.worktreePath)) {
-					worktreeRemoved = true;
-				} else {
-					throw new TRPCError({
-						code: "INTERNAL_SERVER_ERROR",
-						message: `Failed to remove worktree at ${local.worktreePath}: ${message}`,
-					});
-				}
+			// Remove against git's canonical path so a symlinked stored path
+			// (macOS `/var` → `/private/var`) still matches its registration.
+			const canonicalPath = normalizeWorktreePath(local.worktreePath);
+			// Best-effort: we trust git's registry below, not the command's
+			// exit text, which is locale- and version-dependent. `--force
+			// --force` also unregisters a worktree whose directory is already
+			// gone, so no separate prune (which would clobber other stale
+			// worktrees' metadata) is needed.
+			await git
+				.raw(["worktree", "remove", "--force", "--force", canonicalPath])
+				.catch(() => {});
+
+			if (await isRegisteredWorktree(git, local.worktreePath)) {
+				// git still tracks a live worktree here — removal genuinely
+				// failed. Keep the cloud row so the workspace stays visible and
+				// retryable instead of orphaning disk past the cloud commit point.
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Failed to remove worktree at ${local.worktreePath}`,
+				});
 			}
+			worktreeRemoved = true;
 		}
 	}
 
@@ -333,12 +339,18 @@ async function runDestroy(
 	// Keep this after the cloud commit point. If cloud delete fails, the
 	// workspace stays visible/retryable and the branch pointer remains intact.
 	if (git && local?.branch && input.deleteBranch) {
-		try {
-			await git.raw(["branch", "-D", local.branch]);
+		if (!(await localBranchExists(git, local.branch))) {
+			// Ref is already gone (renamed, pruned, or never materialized) —
+			// the deleteBranch goal is met, so don't surface a scary warning.
 			branchDeleted = true;
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			warnings.push(`Failed to delete branch ${local.branch}: ${message}`);
+		} else {
+			try {
+				await git.raw(["branch", "-D", local.branch]);
+				branchDeleted = true;
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				warnings.push(`Failed to delete branch ${local.branch}: ${message}`);
+			}
 		}
 	}
 
@@ -370,4 +382,28 @@ async function runDestroy(
 		branchDeleted,
 		warnings,
 	};
+}
+
+// Authoritative "is this still a worktree git tracks" check — reads git's own
+// registry (realpath-canonicalized) instead of parsing remove's error text.
+async function isRegisteredWorktree(
+	git: Awaited<ReturnType<HostServiceContext["git"]>>,
+	worktreePath: string,
+): Promise<boolean> {
+	const target = normalizeWorktreePath(worktreePath);
+	const worktrees = await listGitWorktrees(git);
+	return worktrees.some((w) => normalizeWorktreePath(w.path) === target);
+}
+
+// Exit-code-based ref existence check — no message parsing.
+async function localBranchExists(
+	git: Awaited<ReturnType<HostServiceContext["git"]>>,
+	branch: string,
+): Promise<boolean> {
+	try {
+		await git.raw(["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -32,7 +32,12 @@ interface ContextSpec {
 	revListCount?: string | (() => Promise<string>);
 	gitFactoryThrows?: boolean;
 	worktreeRemove?: () => Promise<unknown>;
+	// Porcelain `git worktree list` output read back after the remove attempt.
+	// A path still present here means git considers the worktree live.
+	worktreeList?: string;
 	branchDelete?: () => Promise<unknown>;
+	// Whether `git show-ref` finds the branch (defaults to present).
+	branchExists?: boolean;
 	dbDeleteThrows?: boolean;
 	noApi?: boolean;
 }
@@ -57,7 +62,12 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 			: (spec.revListCount ?? "0\n"),
 	);
 	const worktreeRemove = mock(spec.worktreeRemove ?? (async () => undefined));
+	const worktreeList = mock(async () => spec.worktreeList ?? "");
 	const branchDelete = mock(spec.branchDelete ?? (async () => undefined));
+	const branchExists = mock(async () => {
+		if (spec.branchExists === false) throw new Error("ref not found");
+		return "";
+	});
 
 	const git = mock(async () => {
 		if (spec.gitFactoryThrows) throw new Error("git factory boom");
@@ -65,7 +75,12 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 			status,
 			raw: mock(async (args: string[]) => {
 				if (args[0] === "rev-list") return await revList();
-				if (args[0] === "worktree") return await worktreeRemove();
+				if (args[0] === "worktree") {
+					return args[1] === "list"
+						? await worktreeList()
+						: await worktreeRemove();
+				}
+				if (args[0] === "show-ref") return await branchExists();
 				if (args[0] === "branch") return await branchDelete();
 				throw new Error(`unexpected git raw: ${args.join(" ")}`);
 			}),
@@ -378,6 +393,9 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 				worktreeRemove: async () => {
 					throw new Error("worktree remove boom");
 				},
+				// git still lists the worktree after the failed remove — the
+				// authoritative signal that cleanup did not succeed.
+				worktreeList: `worktree ${tmp}\nHEAD 0000\nbranch refs/heads/feature\n`,
 			});
 			const caller = workspaceCleanupRouter.createCaller(ctx);
 

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -36,7 +36,7 @@ interface ContextSpec {
 	// A path still present here means git considers the worktree live.
 	worktreeList?: string;
 	branchDelete?: () => Promise<unknown>;
-	// Whether `git show-ref` finds the branch (defaults to present).
+	// Whether `git branch --list` finds the branch (defaults to present).
 	branchExists?: boolean;
 	dbDeleteThrows?: boolean;
 	noApi?: boolean;
@@ -64,10 +64,6 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 	const worktreeRemove = mock(spec.worktreeRemove ?? (async () => undefined));
 	const worktreeList = mock(async () => spec.worktreeList ?? "");
 	const branchDelete = mock(spec.branchDelete ?? (async () => undefined));
-	const branchExists = mock(async () => {
-		if (spec.branchExists === false) throw new Error("ref not found");
-		return "";
-	});
 
 	const git = mock(async () => {
 		if (spec.gitFactoryThrows) throw new Error("git factory boom");
@@ -80,8 +76,15 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 						? await worktreeList()
 						: await worktreeRemove();
 				}
-				if (args[0] === "show-ref") return await branchExists();
-				if (args[0] === "branch") return await branchDelete();
+				if (args[0] === "branch") {
+					// `branch --list <name>` is the existence probe: non-empty
+					// output means the ref exists. `branch -D` is the delete.
+					return args[1] === "--list"
+						? spec.branchExists === false
+							? ""
+							: `  ${args[2]}\n`
+						: await branchDelete();
+				}
 				throw new Error(`unexpected git raw: ${args.join(" ")}`);
 			}),
 		};


### PR DESCRIPTION
## Problem

Users have been hitting workspace-delete failures since #4801's cleanup reorder, in two distinct shapes:

1. **Hard failures** — `Failed to remove worktree at …` thrown errors that abort the whole delete. #4801 converted worktree-removal failure from a best-effort warning into a hard throw and dropped #4693's tolerant substring matcher, leaving only `existsSync` as the success signal. Any worktree state where the directory still exists but `git worktree remove` errors (locked, or — common on macOS — git registered the worktree under a realpath-resolved path like `/private/var/...` while the stored path is `/var/...`) now fails the delete outright.
2. **Scary-but-harmless warnings** — `Failed to delete branch '…' not found` toasts on deletes that *actually succeeded* (cloud row already gone, worktree already removed). The branch ref was simply already absent — which is exactly what `deleteBranch` is trying to achieve.

Both came from deciding cleanup success by inspecting git's error text, which is locale- and version-dependent and brittle by nature (the reason #4801 removed the matcher in the first place).

## Fix

Decide on git's **actual state**, never on error strings:

- **Worktree removal** — attempt `worktree remove --force --force` against the canonical (realpath) path so a symlinked stored path still matches its registration, then consult `git worktree list --porcelain`. Continue if the path is no longer registered; throw only if git still tracks a live worktree we genuinely couldn't remove (preserves #4801's no-orphan-disk guarantee). No blanket `worktree prune` — `--force --force` already unregisters a missing-dir worktree, and a global prune would clobber *other* workspaces' stale metadata (guarded by an existing integration test).
- **Branch delete** — check existence with `git show-ref --verify --quiet` (exit-code based). An absent ref → success, no warning. A ref that exists but fails `-D` → still warns.

Reuses the canonical `listGitWorktrees` / `normalizeWorktreePath` helpers (the latter already handles the `/var`↔`/private/var` realpath canonicalization).

## Tests

- Updated the `makeCtx` unit mock to model the two new git reads (`worktree list`, `show-ref`) and reworked the worktree-failure test to express failure as a *still-registered* worktree rather than a thrown remove.
- `bun test` for the 5 cleanup-touching files: **70/70 pass**. Lint clean, typecheck exit 0.

## Verified against prod

Reproduced the reported case (Roshvan's `Roshvan/eat-147-journey-transparency`): the v2 cloud row was already gone, confirming the delete had committed and only the cosmetic branch warning was left. After this change that path returns `{ success: true, branchDeleted: true, warnings: [] }` — the user just sees the workspace disappear, no warning toast.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5138">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace delete failures by deciding cleanup based on git state instead of parsing error text. Also guards against git read failures masquerading as success.

- **Bug Fixes**
  - Worktree: run `git worktree remove --force --force` on the canonical path, then verify with `git worktree list --porcelain` via `git.raw`. If the list read fails, treat state as unknown and block; continue only if unregistered. Throw if still registered. No global prune.
  - Branch: check existence with `git branch --list`. Missing ref counts as success; warn only on a real git failure or a `-D` failure when the ref exists.
  - Tests: add mocks for `worktree list` and `branch --list`; update failure case to assert on a still-registered worktree.

<sup>Written for commit f16641cef6410b029d0cf0928652c056fa62d0fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable workspace cleanup: worktree paths are canonicalized and removals are verified against Git's registry before proceeding.
  * Branch deletion now checks for local existence first and treats already-missing branches as successful removals.
  * Cleanup steps now block subsequent cloud deletion until Git confirms worktree removal.

* **Tests**
  * Updated tests to simulate Git worktree listings and branch presence, ensuring failure-handling and ordering are validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->