### PR TITLE
feat(desktop): add delete + pin toggle to v2 Workspaces rows

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/ui/RemoveFromSidebarMount/RemoveFromSidebarMount.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/RemoveFromSidebarMount/RemoveFromSidebarMount.tsx
@@ -20,6 +20,10 @@ export function RemoveFromSidebarMount() {
 
 	useEffect(() => {
 		if (!target) return;
+		// One-shot consumer. No cleanup/cancel guard is needed: the body is fully
+		// synchronous (no awaited continuation that could land after unmount) and
+		// the collection writes are idempotent. clear() resets the intent so each
+		// request is handled exactly once.
 		navigateAwayFromWorkspace(target.workspaceId);
 		if (target.isMain) {
 			hideWorkspaceInSidebar(target.workspaceId, target.projectId);

--- a/apps/desktop/src/renderer/commandPalette/ui/RemoveFromSidebarMount/RemoveFromSidebarMount.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/RemoveFromSidebarMount/RemoveFromSidebarMount.tsx
@@ -1,17 +1,16 @@
-import {
-	AlertDialog,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-} from "@superset/ui/alert-dialog";
-import { Button } from "@superset/ui/button";
-import { useCallback } from "react";
+import { useEffect } from "react";
 import { useNavigateAwayFromWorkspace } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useRemoveFromSidebarIntent } from "renderer/stores/remove-workspace-from-sidebar-intent";
 
+/**
+ * Headless effect that unpins a workspace from the sidebar as soon as a
+ * removal is requested. Unpinning is reversible — the workspace itself is not
+ * deleted and can be re-pinned from the Workspaces page or sidebar — so it runs
+ * immediately with no confirmation dialog. Lives here (rather than at each call
+ * site) because callers like the command palette fire imperatively and can't
+ * use the router/collections hooks the removal needs.
+ */
 export function RemoveFromSidebarMount() {
 	const target = useRemoveFromSidebarIntent((s) => s.target);
 	const clear = useRemoveFromSidebarIntent((s) => s.clear);
@@ -19,14 +18,7 @@ export function RemoveFromSidebarMount() {
 		useDashboardSidebarState();
 	const { navigateAwayFromWorkspace } = useNavigateAwayFromWorkspace();
 
-	const handleOpenChange = useCallback(
-		(open: boolean) => {
-			if (!open) clear();
-		},
-		[clear],
-	);
-
-	const handleConfirm = useCallback(() => {
+	useEffect(() => {
 		if (!target) return;
 		navigateAwayFromWorkspace(target.workspaceId);
 		if (target.isMain) {
@@ -43,37 +35,5 @@ export function RemoveFromSidebarMount() {
 		clear,
 	]);
 
-	return (
-		<AlertDialog open={!!target} onOpenChange={handleOpenChange}>
-			<AlertDialogContent className="max-w-[360px] gap-0 p-0">
-				<AlertDialogHeader className="px-4 pt-4 pb-2">
-					<AlertDialogTitle className="font-medium">
-						Remove "{target?.workspaceName ?? "workspace"}" from sidebar?
-					</AlertDialogTitle>
-					<AlertDialogDescription>
-						The workspace itself isn't deleted — you can always add it back from
-						the Workspaces page.
-					</AlertDialogDescription>
-				</AlertDialogHeader>
-				<AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
-					<Button
-						variant="ghost"
-						size="sm"
-						className="h-7 px-3 text-xs"
-						onClick={() => handleOpenChange(false)}
-					>
-						Cancel
-					</Button>
-					<Button
-						variant="destructive"
-						size="sm"
-						className="h-7 px-3 text-xs"
-						onClick={handleConfirm}
-					>
-						Remove
-					</Button>
-				</AlertDialogFooter>
-			</AlertDialogContent>
-		</AlertDialog>
-	);
+	return null;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -7,7 +7,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { CgLaptop } from "react-icons/cg";
 import {
 	LuCircleCheck,
@@ -15,7 +15,6 @@ import {
 	LuCircleX,
 	LuGitBranch,
 	LuLaptop,
-	LuLoaderCircle,
 	LuMonitor,
 	LuTrash2,
 } from "react-icons/lu";
@@ -286,25 +285,17 @@ export function V2WorkspaceRow({
 
 				<div className="flex items-center justify-center">
 					{deleting ? (
-						<LuLoaderCircle
-							className="size-4 animate-spin text-muted-foreground"
-							aria-label="Deleting workspace"
-						/>
+						<AsciiSpinner />
 					) : !isMainWorkspace ? (
-						<Tooltip delayDuration={300}>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									onClick={handleDeleteClick}
-									aria-label="Delete workspace"
-									className="size-7 text-muted-foreground opacity-0 transition-opacity hover:bg-transparent hover:text-destructive focus-visible:opacity-100 group-hover/row:opacity-100 dark:hover:bg-transparent"
-								>
-									<LuTrash2 className="size-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent side="left">Delete workspace</TooltipContent>
-						</Tooltip>
+						<Button
+							size="icon"
+							variant="ghost"
+							onClick={handleDeleteClick}
+							aria-label="Delete workspace"
+							className="size-7 text-muted-foreground opacity-0 transition-opacity hover:bg-transparent hover:text-destructive focus-visible:opacity-100 group-hover/row:opacity-100 dark:hover:bg-transparent"
+						>
+							<LuTrash2 className="size-3.5" />
+						</Button>
 					) : null}
 				</div>
 			</div>
@@ -367,4 +358,27 @@ function ChecksDot({ status }: ChecksDotProps) {
 		return <LuCircleCheck className="size-3 text-emerald-500" />;
 	}
 	return <LuCircleX className="size-3 text-red-500" />;
+}
+
+const ASCII_SPINNER_FRAMES = ["◰", "◳", "◲", "◱"];
+const ASCII_SPINNER_INTERVAL_MS = 120;
+
+function AsciiSpinner() {
+	const [frame, setFrame] = useState(0);
+
+	useEffect(() => {
+		const id = setInterval(() => {
+			setFrame((prev) => (prev + 1) % ASCII_SPINNER_FRAMES.length);
+		}, ASCII_SPINNER_INTERVAL_MS);
+		return () => clearInterval(id);
+	}, []);
+
+	return (
+		<output
+			aria-label="Deleting workspace"
+			className="select-none font-mono text-base leading-none tabular-nums text-muted-foreground"
+		>
+			{ASCII_SPINNER_FRAMES[frame]}
+		</output>
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -299,7 +299,11 @@ export function V2WorkspaceRow({
 					) : null}
 				</div>
 			</div>
-			{!isMainWorkspace ? (
+			{/* Mount the dialog (and its per-workspace live-query subscription) only
+			    while it's open or a delete is in flight — not idle for every row.
+			    `|| deleting` keeps it mounted through the destroy so a
+			    teardown-failure can re-open it to offer force-delete. */}
+			{!isMainWorkspace && (isDeleteDialogOpen || deleting) ? (
 				<DashboardSidebarDeleteDialog
 					workspaceId={workspace.id}
 					workspaceName={workspace.name || workspace.branch}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -7,7 +7,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { CgLaptop } from "react-icons/cg";
 import {
 	LuCircleCheck,
@@ -15,11 +15,13 @@ import {
 	LuCircleX,
 	LuGitBranch,
 	LuLaptop,
-	LuMinus,
+	LuLoaderCircle,
 	LuMonitor,
-	LuPlus,
+	LuTrash2,
 } from "react-icons/lu";
+import { RiPushpinFill, RiPushpinLine } from "react-icons/ri";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
+import { DashboardSidebarDeleteDialog } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { V2WorkspacePrHoverCardContent } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent";
 import type {
@@ -28,9 +30,9 @@ import type {
 	V2WorkspacePrSummary,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 import { PRIcon } from "renderer/screens/main/components/PRIcon/PRIcon";
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
-import { useRemoveFromSidebarIntent } from "renderer/stores/remove-workspace-from-sidebar-intent";
 import { V2_WORKSPACES_ROW_GRID } from "../../constants";
 
 interface V2WorkspaceRowProps {
@@ -48,8 +50,15 @@ export function V2WorkspaceRow({
 }: V2WorkspaceRowProps) {
 	const navigate = useNavigate();
 	const { gateFeature } = usePaywall();
-	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
+	const {
+		ensureWorkspaceInSidebar,
+		removeWorkspaceFromSidebar,
+		hideWorkspaceInSidebar,
+	} = useDashboardSidebarState();
 	const isMainWorkspace = workspace.type === "main";
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+	const { isDeleting } = useDeletingWorkspaces();
+	const deleting = isDeleting(workspace.id);
 
 	const HostIcon = hostIconFor(workspace.hostType);
 
@@ -92,21 +101,34 @@ export function V2WorkspaceRow({
 				event.preventDefault();
 				return;
 			}
-			useRemoveFromSidebarIntent.getState().request({
-				workspaceId: workspace.id,
-				workspaceName: workspace.name,
-				projectId: workspace.projectId,
-				isMain: isMainWorkspace,
-			});
+			// Unpin directly (synchronous optimistic write) rather than routing
+			// through the intent store + RemoveFromSidebarMount effect, which adds
+			// an extra render cycle of latency. The list view is never a workspace
+			// route, so there's no active workspace to navigate away from.
+			if (isMainWorkspace) {
+				hideWorkspaceInSidebar(workspace.id, workspace.projectId);
+			} else {
+				removeWorkspaceFromSidebar(workspace.id);
+			}
 		},
 		[
 			isCurrentRoute,
 			isMainWorkspace,
+			hideWorkspaceInSidebar,
+			removeWorkspaceFromSidebar,
 			workspace.id,
-			workspace.name,
 			workspace.projectId,
 		],
 	);
+
+	const handleDeleteClick = useCallback((event: React.MouseEvent) => {
+		event.stopPropagation();
+		setIsDeleteDialogOpen(true);
+	}, []);
+
+	const handleDeleted = useCallback(() => {
+		removeWorkspaceFromSidebar(workspace.id);
+	}, [removeWorkspaceFromSidebar, workspace.id]);
 
 	const creatorLabel = workspace.isCreatedByCurrentUser
 		? "you"
@@ -154,7 +176,8 @@ export function V2WorkspaceRow({
 			{/* biome-ignore lint/a11y/useSemanticElements: interactive row needs nested buttons, so the outer element is a div with role/tabIndex */}
 			<div
 				role="button"
-				tabIndex={0}
+				tabIndex={deleting ? -1 : 0}
+				aria-busy={deleting}
 				onClick={handleOpen}
 				onKeyDown={handleRowKeyDown}
 				className={cn(
@@ -165,6 +188,7 @@ export function V2WorkspaceRow({
 					isCurrentRoute
 						? "bg-muted hover:bg-muted focus-visible:bg-muted"
 						: "hover:bg-accent/50 focus-visible:bg-accent/50",
+					deleting && "pointer-events-none opacity-50",
 				)}
 			>
 				<div className="flex items-center justify-center">
@@ -176,19 +200,20 @@ export function V2WorkspaceRow({
 									variant="ghost"
 									onClick={handleRemoveFromSidebar}
 									aria-disabled={isCurrentRoute}
-									aria-label="Remove from sidebar"
+									aria-pressed
+									aria-label="Unpin from sidebar"
 									className={cn(
-										"size-7",
+										"size-7 text-foreground hover:bg-transparent hover:text-muted-foreground dark:hover:bg-transparent",
 										isCurrentRoute && "cursor-not-allowed opacity-50",
 									)}
 								>
-									<LuMinus className="size-3.5" />
+									<RiPushpinFill className="size-4" />
 								</Button>
 							</TooltipTrigger>
 							<TooltipContent side="right">
 								{isCurrentRoute
-									? "Can't remove the current workspace"
-									: "Remove from sidebar"}
+									? "Can't unpin the current workspace"
+									: "Unpin from sidebar"}
 							</TooltipContent>
 						</Tooltip>
 					) : (
@@ -198,13 +223,14 @@ export function V2WorkspaceRow({
 									size="icon"
 									variant="ghost"
 									onClick={handleAddToSidebar}
-									aria-label="Add to sidebar"
-									className="size-7"
+									aria-pressed={false}
+									aria-label="Pin to sidebar"
+									className="size-7 text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent"
 								>
-									<LuPlus className="size-3.5" />
+									<RiPushpinLine className="size-4" />
 								</Button>
 							</TooltipTrigger>
-							<TooltipContent side="right">Add to sidebar</TooltipContent>
+							<TooltipContent side="right">Pin to sidebar</TooltipContent>
 						</Tooltip>
 					)}
 				</div>
@@ -257,7 +283,40 @@ export function V2WorkspaceRow({
 				>
 					{timeLabel} · {creatorLabel}
 				</span>
+
+				<div className="flex items-center justify-center">
+					{deleting ? (
+						<LuLoaderCircle
+							className="size-4 animate-spin text-muted-foreground"
+							aria-label="Deleting workspace"
+						/>
+					) : !isMainWorkspace ? (
+						<Tooltip delayDuration={300}>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={handleDeleteClick}
+									aria-label="Delete workspace"
+									className="size-7 text-muted-foreground opacity-0 transition-opacity hover:bg-transparent hover:text-destructive focus-visible:opacity-100 group-hover/row:opacity-100 dark:hover:bg-transparent"
+								>
+									<LuTrash2 className="size-3.5" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="left">Delete workspace</TooltipContent>
+						</Tooltip>
+					) : null}
+				</div>
 			</div>
+			{!isMainWorkspace ? (
+				<DashboardSidebarDeleteDialog
+					workspaceId={workspace.id}
+					workspaceName={workspace.name || workspace.branch}
+					open={isDeleteDialogOpen}
+					onOpenChange={setIsDeleteDialogOpen}
+					onDeleted={handleDeleted}
+				/>
+			) : null}
 		</li>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts
@@ -1,5 +1,6 @@
 // Shared grid template used by the column header row and every workspace row
-// so the Sidebar action / Name / Host / Branch / Created columns align across
-// the whole view. Columns hide progressively on narrower viewports.
+// so the Sidebar action / Name / Host / Branch / Created / Actions columns
+// align across the whole view. Columns hide progressively on narrower
+// viewports; the trailing 2.5rem column reserves space for the delete action.
 export const V2_WORKSPACES_ROW_GRID =
-	"grid grid-cols-[2.5rem_minmax(0,1fr)] gap-4 md:grid-cols-[2.5rem_minmax(0,1fr)_12rem] lg:grid-cols-[2.5rem_minmax(0,1fr)_12rem_14rem] xl:grid-cols-[2.5rem_minmax(0,1fr)_12rem_14rem_11rem] items-center";
+	"grid grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] gap-4 md:grid-cols-[2.5rem_minmax(0,1fr)_12rem_2.5rem] lg:grid-cols-[2.5rem_minmax(0,1fr)_12rem_14rem_2.5rem] xl:grid-cols-[2.5rem_minmax(0,1fr)_12rem_14rem_11rem_2.5rem] items-center";


### PR DESCRIPTION
## Summary
Adds workspace management actions to the **v2 Workspaces** page rows so workspaces can be deleted (and pinned) directly from the all-devices list, not just the sidebar.

## Changes
- **Delete button** — each non-main workspace row gets a trash action (revealed on hover) that opens the existing `DashboardSidebarDeleteDialog` (full destroy-confirm flow: dirty-worktree / unpushed-commit warnings, "also delete local branch", teardown-failure handling). Reuses the sidebar's delete path; no new backend.
- **In-progress feedback** — the v2 list row is driven by the cloud `v2Workspaces` collection, so a row only disappears after the destroy round-trips and Electric syncs back. That window used to be silent. The row now reads `useDeletingWorkspaces` and, while a delete is in flight, **dims + disables the row and shows a spinner** where the trash sat. Clears automatically (row vanishes on sync; returns to normal if the delete fails).
- **Pin/unpin toggle** — replaces the old `+`/`−` add/remove-from-sidebar icons with a clearer pin toggle (Remix pushpin, outline → fill for the pinned state). Action buttons no longer paint a filled hover box; only the icon color shifts (the row keeps its own hover highlight).
- **One-click unpin** — unpinning is reversible, so the confirmation modal is removed app-wide: `RemoveFromSidebarMount` is now a headless instant-execute effect instead of an `AlertDialog`. The row also unpins **directly** (synchronous optimistic write) instead of bouncing through the intent store + a post-paint effect, removing the noticeable lag. The intent-store path remains for the command palette (which fires imperatively and can't call the router/collections hooks).

## Files
- `v2-workspaces/.../V2WorkspaceRow/V2WorkspaceRow.tsx` — delete button + dialog, deleting state, pin toggle, direct unpin
- `v2-workspaces/.../V2WorkspacesList/constants.ts` — trailing grid column for the action
- `commandPalette/ui/RemoveFromSidebarMount/RemoveFromSidebarMount.tsx` — dialog → headless instant-execute effect

## Testing
- `bun run lint` ✅ · `bun run typecheck` ✅ (28/28) · `bunx sherif` ✅
- `bun test` for touched areas ✅ (3/3). The broader local suite has ~147 pre-existing failures unrelated to this change (Slack route mocks, missing `electronTRPC` preload global in the renderer test env) — none in touched files.
- Manually verified in the dev app: delete shows the spinner immediately and the row clears after sync; pin/unpin is instant.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5146">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add delete and pin/unpin controls to v2 Workspaces list rows. Manage workspaces directly from the list with instant pin actions, clear delete state, and lower idle overhead.

- **New Features**
  - Delete action on each non‑main workspace row; opens existing `DashboardSidebarDeleteDialog`.
  - During delete, the row dims, disables, and shows a monospace ASCII spinner (◰ ◳ ◲ ◱) via `useDeletingWorkspaces`; clears after sync or on failure.
  - Replaced +/- with a pushpin toggle (`RiPushpinLine`/`RiPushpinFill`).
  - Grid updated to reserve a trailing actions column for delete.

- **Refactors**
  - Unpin is now one click with an optimistic write; no confirmation dialog. `RemoveFromSidebarMount` is a headless, immediate effect.
  - Unpin executes directly from the row to remove intent-store latency.
  - Mount the delete dialog only while open or deleting to avoid idle per-row live-query subscriptions.
  - Removed the tooltip from the row delete icon.

<sup>Written for commit c58f9fa49e1119193c52c1d81679b47b77c5e33d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace deletion support for non-main workspaces.

* **Improvements**
  * Deletions use optimistic updates and immediately remove workspaces from the sidebar.
  * Workspace rows show a clear deleting/loading state and become non-interactive during deletion.
  * Updated pin/unpin icons and tooltips for clarity.
  * Layout updated to reserve space for the delete action across responsive sizes.
  * Confirmation dialog removed for sidebar removals; removals now occur immediately when triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->