### PR TITLE
fix(desktop): open tanstack-db.sqlite in WAL mode for crash durability

### DIFF
--- a/apps/desktop/src/main/lib/persistence/persistence.ts
+++ b/apps/desktop/src/main/lib/persistence/persistence.ts
@@ -139,6 +139,13 @@ function suppressIdleResumeWrites(
 export function initTanstackDbPersistence(): void {
 	ensureSupersetHomeDirExists();
 	database = new Database(join(SUPERSET_HOME_DIR, "tanstack-db.sqlite"));
+	// Crash durability: WAL keeps the main DB file intact across a kill mid-commit
+	// (auto-update restart / OS crash) because writes go to a -wal file and the
+	// main file is only touched by an atomic checkpoint. Default DELETE journal
+	// rewrites the main file in place and can truncate it -> SQLITE_CORRUPT.
+	database.pragma("journal_mode = WAL");
+	database.pragma("synchronous = NORMAL");
+	database.pragma("busy_timeout = 5000");
 	reclaimBloatedDatabaseFile(database);
 	const persistence = createNodeSQLitePersistence({
 		database,


### PR DESCRIPTION
## Summary

Makes `~/.superset/tanstack-db.sqlite` crash-durable to stop auto-update truncation/corruption (#5084, #4610).

After opening the database in `initTanstackDbPersistence`, we now set `journal_mode = WAL`, `synchronous = NORMAL`, and `busy_timeout = 5000` — mirroring `apps/desktop/src/main/lib/local-db/index.ts`, which already runs in WAL.

**Root cause:** the DB was opening in SQLite's default DELETE rollback-journal mode, which rewrites the main `.sqlite` file in place during a commit. A kill mid-commit (auto-update restart / OS crash) truncates the main file → `SQLITE_CORRUPT` on next launch → windowless zombie. WAL routes writes to a separate `-wal` file and only touches the main DB via an atomic checkpoint, so an interrupted write can never corrupt the main file.

Small, standalone, independently-mergeable. The #5085 recovery-guard work is intentionally left out as a separate layer-2 PR.

## Test Plan

- [x] Reproduced the crash scenario via the `sqlite3` CLI: seed an ~82 MB DB, start a large in-place write transaction, `kill -9` mid-commit, reopen the main file. In WAL mode, across 3 runs: `integrity_check=ok`, seeded rows intact, main file untouched.
- [x] `bun run lint` passes on the changed file.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5155">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open `~/.superset/tanstack-db.sqlite` in WAL mode for crash-safe persistence, preventing truncation/corruption during auto-update restarts or OS crashes. Sets SQLite pragmas `journal_mode=WAL`, `synchronous=NORMAL`, and `busy_timeout=5000` in `initTanstackDbPersistence` (matching `apps/desktop/src/main/lib/local-db/index.ts`).

<sup>Written for commit de2d43e747c474a18cd55bcf86d10cbe4a2c9bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database crash durability with enhanced protection against data loss during unexpected shutdowns.
  * Enhanced database performance through optimized configuration settings.
  * Improved timeout handling for concurrent database access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->