### PR TITLE
fix(desktop): keep diff-pane PR comments from overflowing the pane

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/comment-thread.css
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/comment-thread.css
@@ -1,6 +1,11 @@
 .diff-comment {
 	display: block;
-	max-width: min(100%, 720px);
+	/* Size to the visible code column. The bubble is slotted into a
+	 * shrink-to-fit flex item ([data-annotation-content]), so a plain 100%
+	 * resolved against an indefinite width and let wide content overflow the
+	 * pane. cqi queries the [data-line-annotation] cell (made a container in
+	 * useDiffCodeViewTheme's unsafeCSS); 1.5rem is this rule's mx-3 margins. */
+	max-width: min(calc(100cqi - 1.5rem), 720px);
 	min-width: 0;
 	box-sizing: border-box;
 	overflow-wrap: anywhere;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
@@ -77,6 +77,14 @@ export function useDiffCodeViewTheme() {
 			maxLineDiffLength: 5_000,
 			unsafeCSS: `
 				* { user-select: text; -webkit-user-select: text; }
+				/* Query container for slotted PR-comment bubbles
+				 * (.diff-comment): lets them size to the visible code
+				 * column via 100cqi instead of overflowing the pane. The
+				 * cell width comes from the grid, so inline-size
+				 * containment doesn't collapse it. */
+				[data-line-annotation] {
+					container-type: inline-size;
+				}
 				/* Container query host for the "Viewed" label visibility rule
 				 * (see DiffHeaderMetadata: @min-[380px]/diff-header:inline). */
 				[data-diffs-header='default'] {


### PR DESCRIPTION
## What

Inline PR review comments in the v2 diff pane could overflow the pane horizontally when a comment contained long content. This makes the comment bubble **reactive** — it now wraps to the visible code column and reflows live as the pane resizes.

## Why it overflowed

`CommentThread` (`.diff-comment`) is rendered by `@pierre/diffs` as a **slot** projected into the diff's shadow DOM:

```
<div data-line-annotation>        ← code-column cell, definite width = visible code area
  <div data-annotation-content>   ← flow-root flex item, shrink-to-fit (indefinite width)
    <slot> → .diff-comment        ← the comment bubble
```

The bubble capped itself with `max-width: min(100%, 720px)`, but that `100%` resolves against `[data-annotation-content]` — a **content-sized (indefinite) flex item** — so the percentage never clamped to the visible pane. Long content stretched the flex item and the bubble rode past the diff's right edge.

## Fix

1. **`useDiffCodeViewTheme.ts`** — make the annotation cell a container-query host via the diff's `unsafeCSS`:
   ```css
   [data-line-annotation] { container-type: inline-size; }
   ```
   The cell's width comes from the diff grid (= visible code column), so inline-size containment doesn't collapse it.

2. **`comment-thread.css`** — size the bubble to that container instead of the indefinite percentage:
   ```css
   max-width: min(calc(100cqi - 1.5rem), 720px);
   ```
   `100cqi` = visible code-column width, `- 1.5rem` accounts for the bubble's `mx-3` margins, `720px` keeps wide panes readable.

**Safe failure mode:** if the container ever doesn't resolve, `cqi` falls back to the viewport and the `720px` cap still applies — never worse than today.

## Testing

CSS/layout-only change reasoned through from the shadow-DOM flex structure; not yet observed live. Worth a visual check on a PR diff that has inline comments with long content (long URLs, wide code blocks) on both narrow and wide panes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow of inline PR comments in the v2 diff pane by sizing bubbles to the visible code column. Long content now wraps and reflows on resize.

- **Bug Fixes**
  - Made `[data-line-annotation]` a container-query host in `useDiffCodeViewTheme.ts` (`container-type: inline-size`).
  - Set `.diff-comment` `max-width` to `min(calc(100cqi - 1.5rem), 720px)` to keep bubbles within the visible column with a safe fallback.

<sup>Written for commit 54657e1045ddb835a6e5776c9d472ace84eeda27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved diff viewer responsiveness: inline comments and line annotations now use container-based sizing so comment bubbles and annotations adapt to the visible code column width, preserving max width limits and improving spacing and alignment across window sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->