### PR TITLE
fix(panes): restore v2 tab drag-to-reorder broken by focus fix

### DIFF
--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -123,10 +123,10 @@ export function TabItem<TData>({
 						isDragging && "opacity-30",
 					)}
 					onMouseDown={(event) => {
-						if (event.button === 0) {
-							event.preventDefault();
-							onSelect();
-						}
+						// No preventDefault: this node is the react-dnd drag source, and
+						// preventing the mousedown default cancels the native HTML5 drag.
+						// Focus is kept off the tab via the non-focusable title <div> below.
+						if (event.button === 0) onSelect();
 					}}
 				>
 					{isEditing ? (
@@ -147,7 +147,8 @@ export function TabItem<TData>({
 								open={isDragging ? false : undefined}
 							>
 								<TooltipTrigger asChild>
-									<button
+									{/* biome-ignore lint/a11y/noStaticElementInteractions: tab selection is handled by the wrapper's mousedown; this title element is intentionally a non-focusable div so clicking a tab never steals focus from the active pane (issue #4967) */}
+									<div
 										className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-colors"
 										onAuxClick={(event) => {
 											if (event.button === 1) {
@@ -156,13 +157,12 @@ export function TabItem<TData>({
 											}
 										}}
 										onDoubleClick={startEditing}
-										type="button"
 									>
 										{icon && <span className="shrink-0">{icon}</span>}
 										<OverflowFadeText className="flex-1">
 											{title}
 										</OverflowFadeText>
-									</button>
+									</div>
 								</TooltipTrigger>
 								<TooltipContent side="bottom" showArrow={false}>
 									{title}


### PR DESCRIPTION
## Summary

v2 workspace tabs could no longer be dragged to reorder. This was a regression from PR #5025 ("Prevent tab button from stealing focus", addressing #4967).

That PR added `event.preventDefault()` to the tab wrapper's `onMouseDown` to stop the inner tab button from stealing keyboard focus from the active terminal/chat pane. But that wrapper `<div>` is the **react-dnd HTML5 drag source** — calling `preventDefault()` on `mousedown` cancels the browser's native drag initiation, so tabs stopped being draggable.

The two requirements share the same `mousedown` gesture, and `preventDefault()` can't be applied selectively (it lives on the event and affects the whole bubble path). So this fixes the actual source of the focus theft instead.

## Changes

`packages/panes/.../TabBar/components/TabItem/TabItem.tsx`:
- Removed `event.preventDefault()` from the wrapper's `onMouseDown` — restores native HTML5 drag. Left-click selection via `onSelect()` is unchanged.
- Changed the inner title `<button>` to a non-focusable `<div>`. Selection already runs through the wrapper's mousedown, so the title never needed to be a focusable button. A `<div>` doesn't take focus on click, so focus stays on the active pane — preserving the #4967 fix without `preventDefault`.

Close button and rename input are unaffected (they already `stopPropagation` on their own mousedown).

## Testing

- `bun run lint` / Biome: clean
- `bun run typecheck --filter=@superset/panes`: passes
- Manual smoke test recommended in the desktop app: (1) drag a v2 tab to reorder; (2) click a tab while a terminal is focused and confirm typing still goes to the terminal.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5159">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores drag-to-reorder for v2 workspace tabs without breaking focus behavior. Tabs can be reordered again, and clicking a tab no longer steals focus from the active pane.

- **Bug Fixes**
  - Removed preventDefault() from the tab wrapper’s onMouseDown so native drag can start.
  - Replaced the inner title button with a non-focusable div; selection still runs on the wrapper.

<sup>Written for commit 1c4f0f78beb6f7fa7b10bb537879918a2c1fa319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab selection mouse interaction and responsiveness when switching tabs.
  * Enhanced accessibility support in tab navigation.

* **Refactor**
  * Optimized tab component markup and interaction handling for better maintainability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->