### PR TITLE
feat(panes): drag a tab into a pane to merge its panes as a split

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -769,7 +769,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.18",
+      "version": "0.8.19",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",

--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -640,6 +640,88 @@ describe("movePaneToNewTab", () => {
 	});
 });
 
+describe("moveTabToSplit", () => {
+	it("grafts all panes from the source tab next to the target pane and removes the source tab", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		// t2 holds a vertical split of p2/p3 that should survive the merge intact.
+		store
+			.getState()
+			.addTab({ id: "t2", panes: [tp("p2")], activePaneId: "p2" });
+		store.getState().splitPane({
+			tabId: "t2",
+			paneId: "p2",
+			position: "bottom",
+			newPane: tp("p3"),
+		});
+		store.getState().setActiveTab("t1");
+
+		store.getState().moveTabToSplit({
+			sourceTabId: "t2",
+			targetPaneId: "p1",
+			position: "right",
+		});
+
+		const tabs = store.getState().tabs;
+		expect(tabs.map((t) => t.id)).toEqual(["t1"]);
+
+		const t1 = tabs[0];
+		expect(t1?.panes.p1).toBeDefined();
+		expect(t1?.panes.p2).toBeDefined();
+		expect(t1?.panes.p3).toBeDefined();
+		// p1 on the left, the source tab's p2/p3 split grafted on the right.
+		expect(t1?.layout).toEqual({
+			type: "split",
+			direction: "horizontal",
+			first: { type: "pane", paneId: "p1" },
+			second: {
+				type: "split",
+				direction: "vertical",
+				first: { type: "pane", paneId: "p2" },
+				second: { type: "pane", paneId: "p3" },
+			},
+		});
+		// The dragged tab's active pane carries over (splitPane focused p3).
+		expect(t1?.activePaneId).toBe("p3");
+		expect(store.getState().activeTabId).toBe("t1");
+	});
+
+	it("is a no-op when dropping a tab onto one of its own panes", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1"), tp("p2")] });
+
+		const before = structuredClone({
+			tabs: store.getState().tabs,
+			activeTabId: store.getState().activeTabId,
+		});
+
+		store.getState().moveTabToSplit({
+			sourceTabId: "t1",
+			targetPaneId: "p2",
+			position: "right",
+		});
+
+		expect({
+			tabs: store.getState().tabs,
+			activeTabId: store.getState().activeTabId,
+		}).toEqual(before);
+	});
+
+	it("is a no-op when the target pane does not exist", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+
+		store.getState().moveTabToSplit({
+			sourceTabId: "t2",
+			targetPaneId: "missing",
+			position: "right",
+		});
+
+		expect(store.getState().tabs.map((t) => t.id)).toEqual(["t1", "t2"]);
+	});
+});
+
 describe("edge cases", () => {
 	it("invalid IDs are no-ops", () => {
 		const store = makeStore();

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -14,6 +14,7 @@ import {
 	generateId,
 	getActiveIdAfterRemoval,
 	getPaneIdsInLayout,
+	graftSubtreeAtPane,
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
@@ -168,6 +169,11 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 
 	movePaneToTab: (args: { paneId: string; targetTabId: string }) => void;
 	movePaneToNewTab: (args: { paneId: string; toIndex?: number }) => void;
+	moveTabToSplit: (args: {
+		sourceTabId: string;
+		targetPaneId: string;
+		position: SplitPosition;
+	}) => void;
 
 	reorderTab: (args: { tabId: string; toIndex: number }) => void;
 
@@ -852,6 +858,44 @@ export function createWorkspaceStore<TData>(
 				nextTabs.splice(insertIndex, 0, newTab);
 
 				return { tabs: nextTabs, activeTabId: newTab.id };
+			});
+		},
+
+		moveTabToSplit: (args) => {
+			set((s) => {
+				const sourceTab = s.tabs.find((t) => t.id === args.sourceTabId);
+				if (!sourceTab || !sourceTab.layout) return s;
+
+				const targetTab = s.tabs.find((t) => t.panes[args.targetPaneId]);
+				if (!targetTab || !targetTab.layout) return s;
+				// Merging a tab into one of its own panes is a no-op.
+				if (sourceTab.id === targetTab.id) return s;
+				if (!findPaneInLayout(targetTab.layout, args.targetPaneId)) return s;
+
+				// Graft the source tab's entire layout next to the target pane,
+				// preserving the source's internal split arrangement, then drop the
+				// now-empty source tab.
+				const nextTargetLayout = graftSubtreeAtPane(
+					targetTab.layout,
+					args.targetPaneId,
+					sourceTab.layout,
+					args.position,
+				);
+
+				const nextTabs = s.tabs
+					.filter((t) => t.id !== sourceTab.id)
+					.map((t) =>
+						t.id === targetTab.id
+							? {
+									...t,
+									layout: nextTargetLayout,
+									panes: { ...t.panes, ...sourceTab.panes },
+									activePaneId: sourceTab.activePaneId ?? t.activePaneId,
+								}
+							: t,
+					);
+
+				return { tabs: nextTabs, activeTabId: targetTab.id };
 			});
 		},
 

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -872,9 +872,8 @@ export function createWorkspaceStore<TData>(
 				if (sourceTab.id === targetTab.id) return s;
 				if (!findPaneInLayout(targetTab.layout, args.targetPaneId)) return s;
 
-				// Graft the source tab's entire layout next to the target pane,
-				// preserving the source's internal split arrangement, then drop the
-				// now-empty source tab.
+				// Graft the source's whole layout subtree so its internal split
+				// arrangement is preserved, rather than re-adding panes one by one.
 				const nextTargetLayout = graftSubtreeAtPane(
 					targetTab.layout,
 					args.targetPaneId,

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -11,6 +11,7 @@ export {
 	getPaneIdsInLayout,
 	getPaneParentDirection,
 	getSpatialNeighborPaneId,
+	graftSubtreeAtPane,
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,

--- a/packages/panes/src/core/store/utils/utils.test.ts
+++ b/packages/panes/src/core/store/utils/utils.test.ts
@@ -9,6 +9,7 @@ import {
 	getOtherBranch,
 	getPaneIdsInLayout,
 	getSpatialNeighborPaneId,
+	graftSubtreeAtPane,
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
@@ -230,6 +231,56 @@ describe("splitPaneInLayout", () => {
 				expect(nested.second).toEqual({ type: "pane", paneId: "c" });
 			}
 		}
+	});
+});
+
+describe("graftSubtreeAtPane", () => {
+	it("grafts a whole subtree next to the target pane, preserving its shape", () => {
+		const subtree: LayoutNode = {
+			type: "split",
+			direction: "vertical",
+			first: { type: "pane", paneId: "x" },
+			second: { type: "pane", paneId: "y" },
+		};
+
+		const result = graftSubtreeAtPane(SINGLE, "a", subtree, "right");
+
+		expect(result).toEqual({
+			type: "split",
+			direction: "horizontal",
+			first: { type: "pane", paneId: "a" },
+			second: subtree,
+		});
+	});
+
+	it("places the subtree first for left/top positions", () => {
+		const subtree: LayoutNode = { type: "pane", paneId: "x" };
+		const result = graftSubtreeAtPane(SINGLE, "a", subtree, "top");
+
+		expect(result).toEqual({
+			type: "split",
+			direction: "vertical",
+			first: subtree,
+			second: { type: "pane", paneId: "a" },
+		});
+	});
+
+	it("grafts at a nested target pane and leaves siblings untouched", () => {
+		const subtree: LayoutNode = { type: "pane", paneId: "x" };
+		const result = graftSubtreeAtPane(NESTED, "c", subtree, "right");
+
+		// a stays as-is; the b/c vertical split keeps b, c becomes c|x
+		if (result.type !== "split") throw new Error("expected split");
+		expect(result.first).toEqual({ type: "pane", paneId: "a" });
+		const inner = result.second;
+		if (inner.type !== "split") throw new Error("expected nested split");
+		expect(inner.first).toEqual({ type: "pane", paneId: "b" });
+		expect(inner.second).toEqual({
+			type: "split",
+			direction: "horizontal",
+			first: { type: "pane", paneId: "c" },
+			second: subtree,
+		});
 	});
 });
 

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -86,32 +86,48 @@ export function replacePaneIdInLayout(
 	};
 }
 
-export function splitPaneInLayout(
+// Splits the target pane, placing `subtree` (a single pane or a whole layout
+// tree) on the side given by `position`. Used both to split in a new pane and
+// to graft an entire tab's layout next to a pane when merging tabs.
+export function graftSubtreeAtPane(
 	node: LayoutNode,
 	targetPaneId: string,
-	newPaneId: string,
+	subtree: LayoutNode,
 	position: SplitPosition,
 ): LayoutNode {
 	if (node.type === "pane") {
 		if (node.paneId !== targetPaneId) return node;
 
 		const direction = positionToDirection(position);
-		const newPaneNode: LayoutNode = { type: "pane", paneId: newPaneId };
 		const isFirst = position === "left" || position === "top";
 
 		return {
 			type: "split",
 			direction,
-			first: isFirst ? newPaneNode : node,
-			second: isFirst ? node : newPaneNode,
+			first: isFirst ? subtree : node,
+			second: isFirst ? node : subtree,
 		};
 	}
 
 	return {
 		...node,
-		first: splitPaneInLayout(node.first, targetPaneId, newPaneId, position),
-		second: splitPaneInLayout(node.second, targetPaneId, newPaneId, position),
+		first: graftSubtreeAtPane(node.first, targetPaneId, subtree, position),
+		second: graftSubtreeAtPane(node.second, targetPaneId, subtree, position),
 	};
+}
+
+export function splitPaneInLayout(
+	node: LayoutNode,
+	targetPaneId: string,
+	newPaneId: string,
+	position: SplitPosition,
+): LayoutNode {
+	return graftSubtreeAtPane(
+		node,
+		targetPaneId,
+		{ type: "pane", paneId: newPaneId },
+		position,
+	);
 }
 
 export function getNodeAtPath(

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -171,8 +171,7 @@ export function Pane<TData>({
 		() => ({
 			accept: [PANE_DRAG_TYPE, TAB_DRAG_TYPE],
 			canDrop: (item: PaneDropItem, monitor) => {
-				// A tab can be dropped onto any pane outside itself (merges all its
-				// panes here); a pane can be dropped onto any pane but itself.
+				// Can't drop a tab onto a pane it already owns, or a pane onto itself.
 				if (monitor.getItemType() === TAB_DRAG_TYPE) {
 					return "tabId" in item && item.tabId !== tab.id;
 				}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -14,11 +14,14 @@ import type {
 	RendererContext,
 } from "../../../../../../types";
 import { PaneHeaderActions } from "../../../../../PaneHeaderActions";
+import { TAB_DRAG_TYPE } from "../../../TabBar/components/TabItem";
 import { PANE_MIN_SIZE_CLASS_NAME } from "../../constants";
 import { DropZoneOverlay } from "./components/DropZoneOverlay";
 import { PaneContent } from "./components/PaneContent";
 import { PaneContextMenu } from "./components/PaneContextMenu";
 import { PANE_DRAG_TYPE, PaneHeader } from "./components/PaneHeader";
+
+type PaneDropItem = { paneId: string } | { tabId: string; index: number };
 
 interface PaneComponentProps<TData> {
 	store: StoreApi<WorkspaceStore<TData>>;
@@ -166,8 +169,15 @@ export function Pane<TData>({
 
 	const [{ isOver, canDrop }, connectDrop] = useDrop(
 		() => ({
-			accept: PANE_DRAG_TYPE,
-			canDrop: (item: { paneId: string }) => item.paneId !== pane.id,
+			accept: [PANE_DRAG_TYPE, TAB_DRAG_TYPE],
+			canDrop: (item: PaneDropItem, monitor) => {
+				// A tab can be dropped onto any pane outside itself (merges all its
+				// panes here); a pane can be dropped onto any pane but itself.
+				if (monitor.getItemType() === TAB_DRAG_TYPE) {
+					return "tabId" in item && item.tabId !== tab.id;
+				}
+				return "paneId" in item && item.paneId !== pane.id;
+			},
 			hover: (_item, monitor) => {
 				const offset = monitor.getClientOffset();
 				const el = dropRef.current;
@@ -179,14 +189,24 @@ export function Pane<TData>({
 					setDropPosition(pos);
 				}
 			},
-			drop: (item: { paneId: string }) => {
+			drop: (item: PaneDropItem, monitor) => {
 				const pos = dropPositionRef.current;
 				if (!pos) return;
-				store.getState().movePaneToSplit({
-					sourcePaneId: item.paneId,
-					targetPaneId: pane.id,
-					position: pos,
-				});
+				if (monitor.getItemType() === TAB_DRAG_TYPE && "tabId" in item) {
+					store.getState().moveTabToSplit({
+						sourceTabId: item.tabId,
+						targetPaneId: pane.id,
+						position: pos,
+					});
+					return;
+				}
+				if ("paneId" in item) {
+					store.getState().movePaneToSplit({
+						sourcePaneId: item.paneId,
+						targetPaneId: pane.id,
+						position: pos,
+					});
+				}
 			},
 			collect: (monitor) => ({
 				isOver: monitor.isOver(),

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -111,7 +111,8 @@ export function TabItem<TData>({
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
-				{/* biome-ignore lint/a11y/noStaticElementInteractions: mousedown selects tab immediately before drag threshold */}
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: clicking a tab selects it */}
+				{/* biome-ignore lint/a11y/useKeyWithClickEvents: tabs are pointer-driven; keyboard nav is out of scope here */}
 				<div
 					ref={setRef}
 					className={cn(
@@ -122,12 +123,10 @@ export function TabItem<TData>({
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",
 					)}
-					onMouseDown={(event) => {
-						// No preventDefault: this node is the react-dnd drag source, and
-						// preventing the mousedown default cancels the native HTML5 drag.
-						// Focus is kept off the tab via the non-focusable title <div> below.
-						if (event.button === 0) onSelect();
-					}}
+					// Select on click, not mousedown: the browser suppresses click after a
+					// drag, so starting a drag (reorder, or merging a tab into a pane) no
+					// longer switches the active tab mid-gesture.
+					onClick={() => onSelect()}
 				>
 					{isEditing ? (
 						<div className="flex h-full w-full shrink-0 items-center px-2">


### PR DESCRIPTION
## Summary

You can already drag a **pane** onto another pane to split it. This extends the same gesture to **tabs**: drag a tab from the tab bar onto any pane in the workspace, drop it on a left/right/top/bottom zone, and **all panes from the dragged tab are merged in as a split at that position**. The source tab's internal split arrangement is preserved, and the now-empty source tab is removed.

Requested behavior: "allow dragging a tab into another split pane like how you drop a pane, but with a tab we move *all* panes from the previous tab into the new place."

Tab-bar **reordering is unchanged** — the merge only triggers when dropping onto a pane in the content area, never onto the tab bar, so there's no conflict between reorder and merge.

## Changes

- **store** — new `moveTabToSplit({ sourceTabId, targetPaneId, position })`:
  - Grafts the source tab's entire `layout` subtree next to the target pane (preserving its splits), merges the `panes` maps, carries over the source tab's active pane, and drops the source tab.
  - No-ops when dropping a tab onto one of its own panes, or when the target pane doesn't exist.
- **utils** — extracted `graftSubtreeAtPane` (insert an arbitrary subtree at a pane); `splitPaneInLayout` now delegates to it (a single-pane graft), so there's one code path for both.
- **Pane** drop target now accepts `TAB_DRAG_TYPE` alongside `PANE_DRAG_TYPE`, discriminating on `monitor.getItemType()` and reusing the existing directional `DropZoneOverlay`.

## How it works

When you drag a non-active tab, the workspace still shows the active tab's panes — you drop onto one of those, and the dragged tab's panes merge into the active tab at the chosen edge. Dropping a tab onto a pane it already owns is a no-op.

## Testing

- New unit tests: `moveTabToSplit` (graft + preserve layout + active-pane carry-over + remove source; no-op on self; no-op on missing target) and `graftSubtreeAtPane`.
- Verified each new test fails under a corresponding implementation mutation (source-tab-not-removed; self-merge guard removed).
- `bun test packages/panes`: 100 pass. `bun run typecheck --filter=@superset/panes` and `bun run lint`: clean.
- Manual smoke test recommended: with two tabs (one holding a split), drag the second tab onto a pane in the first and confirm its panes graft in at the hovered edge and the source tab disappears.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5160">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drag a tab onto any pane to merge all panes from that tab as a split at the hovered edge. The source tab’s split layout and active pane are preserved, the source tab is removed, and tab-bar reordering is unchanged.

- **New Features**
  - Store: `moveTabToSplit({ sourceTabId, targetPaneId, position })` grafts the source tab’s layout next to the target pane, merges pane maps, carries over the active pane, and removes the source tab.
  - UI: Pane drop target now accepts `TAB_DRAG_TYPE` alongside `PANE_DRAG_TYPE` and uses the existing directional drop zones.
  - Guards: No-op when dropping a tab onto one of its own panes or when the target pane is missing.

- **Bug Fixes**
  - Tab selection switches on click instead of mousedown to avoid changing the active tab when starting a drag, keeping the current workspace as a valid drop target.

<sup>Written for commit 0e3e92722333dfa2548e150914020e136d859f2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop now supports moving entire tabs into splits, preserving the tab’s internal layout.

* **UX Improvements**
  * Pane drop targets accept both pane and tab drags for more flexible rearranging.
  * Tab selection now happens on click to avoid accidental switches during drag gestures.

* **Tests**
  * Added tests covering tab-to-split moves and the new grafting utility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->