### PR TITLE
revert(desktop): drop desktop_version renderer super property (#5117)

### DIFF
--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -27,7 +27,6 @@ export function initPostHog(deviceId?: string) {
 			ph.register({
 				app_name: "desktop",
 				platform: window.navigator.platform,
-				desktop_version: window.App.appVersion,
 				...(deviceId && { device_id: deviceId }),
 			});
 		},


### PR DESCRIPTION
## What

Reverts the one-line change from #5117 that registered `desktop_version` as a renderer super property in `apps/desktop/src/renderer/lib/posthog.ts`.

## Why

The "Desktop users by app version" insights break down by the `desktop_version` **person** property (set via `identify()` in `PostHogUserIdentifier`), not by an event property. #5117 attached the version as an **event** super property riding on `desktop_opened` — but `desktop_opened` fires at app startup *before* `identify()` runs, so it's overwhelmingly anonymous (~16% identified vs ~51% for desktop events generally). The super property therefore never reached the insights.

Investigation of the live data confirmed:
- The `desktop_version` person property has ~100% coverage among identified weekly-active desktop users (10,894 / 10,900). Version capture was never broken.
- The dashboards were just querying it wrong (anchored on `desktop_opened`, and reading a POE snapshot frozen at the anonymous pre-identify moment).

The insights have been fixed separately to read the live person property via a `persons` join over any active user. With that in place, the event super property is redundant — so this drops it to keep a single source of truth.

No behavior change for users; PostHog-only.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5164">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `desktop_version` super property from desktop renderer events so version remains a person property via `identify()`, matching how “Desktop users by app version” reads it. No user-facing change.

- **Bug Fixes**
  - `desktop_opened` fires before `identify()`, so the event super property was mostly anonymous and didn’t reach insights.
  - Dashboards now read the person property; removing the event property avoids duplication and keeps a single source of truth.

<sup>Written for commit b28f1f5a42c00e6353e7bcf84a29f0d7e98d60cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated telemetry data collection to refine tracked information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->