### PR TITLE
feat(marketing): add Reddit Pixel tracking with download conversions

### DIFF
--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -10,6 +10,7 @@ import {
 	SoftwareApplicationJsonLd,
 	WebsiteJsonLd,
 } from "@/components/JsonLd";
+import { REDDIT_PIXEL_ID } from "@/lib/constants";
 
 import { CTAButtons } from "./components/CTAButtons";
 import { Footer } from "./components/Footer";
@@ -141,6 +142,14 @@ export default function RootLayout({
 						function gtag(){dataLayer.push(arguments);}
 						gtag('js', new Date());
 						gtag('config', 'AW-18209336001');
+					`}
+				</Script>
+				{/* Reddit Pixel */}
+				<Script id="reddit-pixel" strategy="afterInteractive">
+					{`
+						!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js?pixel_id=${REDDIT_PIXEL_ID}",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);
+						rdt('init','${REDDIT_PIXEL_ID}');
+						rdt('track','PageVisit');
 					`}
 				</Script>
 			</head>

--- a/apps/marketing/src/lib/analytics/index.ts
+++ b/apps/marketing/src/lib/analytics/index.ts
@@ -1,8 +1,25 @@
 import posthog from "posthog-js";
 
+import { trackReddit } from "./reddit";
+
+/**
+ * PostHog events that should also be forwarded to the Reddit Pixel as
+ * conversion events. Keyed by PostHog event name → Reddit standard event.
+ * `download_clicked` fires whenever a visitor hits a download CTA (across all
+ * platforms), which is the conversion we optimize Reddit ads toward.
+ */
+const REDDIT_EVENT_MAP: Record<string, string> = {
+	download_clicked: "Purchase",
+};
+
 export function track(
 	event: string,
 	properties?: Record<string, unknown>,
 ): void {
 	posthog.capture(event, properties);
+
+	const redditEvent = REDDIT_EVENT_MAP[event];
+	if (redditEvent) {
+		trackReddit(redditEvent, properties);
+	}
 }

--- a/apps/marketing/src/lib/analytics/reddit.ts
+++ b/apps/marketing/src/lib/analytics/reddit.ts
@@ -1,0 +1,36 @@
+declare global {
+	interface Window {
+		rdt?: (...args: unknown[]) => void;
+	}
+}
+
+/** Unique id so Reddit can dedupe a conversion sent more than once. */
+function generateConversionId(): string {
+	if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+		return crypto.randomUUID();
+	}
+	return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Fire a Reddit Pixel conversion event. No-ops on the server or before the
+ * base pixel (injected in the root layout) has defined `window.rdt`. Reddit
+ * standard events include "PageVisit", "Lead", "SignUp", and "Purchase".
+ *
+ * A unique `conversionId` is attached for deduplication; pass an explicit
+ * `conversionId` in `properties` to override (e.g. to match a server-side
+ * Conversions API call for the same conversion).
+ */
+export function trackReddit(
+	event: string,
+	properties?: Record<string, unknown>,
+): void {
+	if (typeof window === "undefined" || typeof window.rdt !== "function") {
+		return;
+	}
+
+	window.rdt("track", event, {
+		conversionId: generateConversionId(),
+		...properties,
+	});
+}

--- a/apps/marketing/src/lib/analytics/reddit.ts
+++ b/apps/marketing/src/lib/analytics/reddit.ts
@@ -29,8 +29,14 @@ export function trackReddit(
 		return;
 	}
 
-	window.rdt("track", event, {
-		conversionId: generateConversionId(),
-		...properties,
-	});
+	// Best-effort: a throw from the third-party pixel must never escape into the
+	// caller (e.g. a download click handler that navigates right after).
+	try {
+		window.rdt("track", event, {
+			conversionId: generateConversionId(),
+			...properties,
+		});
+	} catch (error) {
+		console.warn("Reddit Pixel track failed", error);
+	}
 }

--- a/apps/marketing/src/lib/constants.ts
+++ b/apps/marketing/src/lib/constants.ts
@@ -1,1 +1,4 @@
 export const ANALYTICS_CONSENT_KEY = "superset-analytics-consent" as const;
+
+// Reddit Pixel (Advertiser) ID from Reddit Ads Manager → Events Manager.
+export const REDDIT_PIXEL_ID = "a2_j3wusi5rxx6o" as const;


### PR DESCRIPTION
## What

Adds Reddit Pixel tracking to the marketing site (superset.sh).

- **Base pixel** loaded site-wide in the root layout (`a2_j3wusi5rxx6o`), firing `PageVisit` on every page — same `next/script` pattern as the existing Google Ads tag.
- **Download conversion**: the existing `download_clicked` event is forwarded to Reddit as a `Purchase` conversion through the shared `track()` helper, so every download CTA across all platforms is attributed without changing any call sites.
- **Dedup**: every conversion carries a unique `conversionId` (Reddit's recommended dedup field), with an override hook ready for a future server-side Conversions API.

## Files

| File | Change |
|------|--------|
| `app/layout.tsx` | Inject base Reddit pixel script (`PageVisit`) |
| `lib/constants.ts` | `REDDIT_PIXEL_ID` constant |
| `lib/analytics/reddit.ts` | New `trackReddit()` helper + `conversionId` generation |
| `lib/analytics/index.ts` | Map `download_clicked → Purchase`, forward via `track()` |

## Decisions

- **Loads unconditionally** (not gated by the cookie-consent banner), matching the current Google Ads pixel. Easy to move behind consent if desired.
- **`download_clicked`** (the button) is the tracked conversion, per the goal of "track anyone hitting the download button" — fires across all platforms, before navigation. The Windows/Linux button fires `waitlist_clicked` and correctly does not count.
- **`Purchase`** is the Reddit standard event used; set the campaign's optimization goal to Purchase. Swappable to `Lead`/`SignUp` in one line.
- **Advanced matching** (email/phone match keys) intentionally not wired up — would send PII and isn't available at download-click time. Natural future home is the waitlist form.

## Testing

- `bun run lint:fix`, `bun run typecheck` (28/28), `bunx sherif` all pass.
- Test suite exits 0; the 151 failures are pre-existing `apps/desktop` `electronTRPC` env failures, unrelated to this marketing-only change.
- Manual: run `cd apps/marketing && bun dev` → http://localhost:3002, verify `PageVisit` fires on load and `Purchase` fires (with a `conversionId`) on clicking a download button, via the Reddit Pixel Helper extension, DevTools Network, or Reddit Events Manager → Test Events.

## Before merge / launch

- Confirm in Reddit Events Manager that `PageVisit` and `Purchase` are received for pixel `a2_j3wusi5rxx6o`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Reddit Pixel (`a2_j3wusi5rxx6o`) to the marketing site. Tracks `PageVisit` on every page and forwards download clicks as `Purchase` conversions with dedup; forwarding is guarded so it can’t break navigation.

- **New Features**
  - Injected pixel in the root layout via `next/script`; loads unconditionally.
  - Mapped `download_clicked → Purchase` in `track()` with `conversionId` dedup, and wrapped the forward in try/catch to avoid blocking download navigation.

<sup>Written for commit 92e5e708e924e2450393599cc3cb247caa2c0db1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reddit Pixel has been added to the marketing site to enable Reddit ad tracking.
  * Analytics now forwards mapped events to Reddit for campaign measurement.
  * Events emit a conversion identifier for deduplication and consistent attribution (includes automatic PageVisit tracking).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->