### PR TITLE
feat(desktop): route new signups to v1 for experiment, hide v2 banner

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -24,7 +24,6 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { HiOutlineCog6Tooth } from "react-icons/hi2";
-import { V2AvailableBanner } from "renderer/components/V2AvailableBanner";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -238,7 +237,6 @@ export function DashboardSidebar({
 								projectName={activeV2Project.name}
 							/>
 						)}
-						{!isCollapsed && <V2AvailableBanner />}
 						<div
 							className={cn(
 								"border-t border-border",

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
@@ -49,6 +50,7 @@ function OnboardingFlowLayout() {
 	const chatClient = useMemo(() => createChatServiceIpcClient(), []);
 	const location = useLocation();
 	const navigate = useNavigate();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const [skipping, setSkipping] = useState(false);
 	const { rerun } = Route.useSearch();
 
@@ -94,7 +96,10 @@ function OnboardingFlowLayout() {
 			setSkipping(false);
 			return;
 		}
-		await navigate({ to: "/v2-workspaces", replace: true });
+		await navigate({
+			to: isV2CloudEnabled ? "/v2-workspaces" : "/workspaces",
+			replace: true,
+		});
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
@@ -5,6 +5,7 @@ import { toast } from "@superset/ui/sonner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { type FormEvent, type ReactNode, useState } from "react";
 import { LuFolderOpen, LuGitBranch } from "react-icons/lu";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
@@ -21,6 +22,7 @@ export const Route = createFileRoute("/_authenticated/onboarding/project/")({
 
 function OnboardingProjectPage() {
 	const navigate = useNavigate();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { refetch: refetchSession } = authClient.useSession();
 	const { activeHostUrl } = useLocalHostService();
 	const hostReady = activeHostUrl !== null;
@@ -53,7 +55,10 @@ function OnboardingProjectPage() {
 		// Land on the dashboard first, then open the modal. Opening it in the same
 		// tick as navigate mounts the Dialog mid-route-transition, which thrashes
 		// Radix's ref composition into a "Maximum update depth" loop.
-		await navigate({ to: "/v2-workspaces", replace: true });
+		await navigate({
+			to: isV2CloudEnabled ? "/v2-workspaces" : "/workspaces",
+			replace: true,
+		});
 		openNewWorkspaceModal(projectId);
 	};
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { V2AvailableBanner } from "renderer/components/V2AvailableBanner";
 import { useWorkspaceShortcuts } from "renderer/hooks/useWorkspaceShortcuts";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
 import { MultiDragPreview } from "./MultiDragPreview";
@@ -115,8 +114,6 @@ export function WorkspaceSidebar({
 				projectId={activeProjectId}
 				projectName={activeProjectName}
 			/>
-
-			{!isCollapsed && <V2AvailableBanner />}
 
 			<WorkspaceSidebarFooter isCollapsed={isCollapsed} />
 			<MultiDragPreview />

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -59,12 +59,17 @@ export const TEARDOWN_TIMEOUT_MS = 60_000;
 // PostHog
 export const POSTHOG_COOKIE_NAME = "superset";
 
-// Users whose account was created at or after this instant are v2-only:
-// the v1↔v2 surface switch is hidden and v2 cloud is forced on. Pre-cutoff
-// users keep the existing opt-in toggle. Stored as an ISO string so the
-// value is identical on server, desktop renderer, web, and admin.
+// Users whose account was created within the window
+// [V2_ONLY_USER_CUTOFF, V2_NEW_USER_V1_EXPERIMENT_START) are v2-only: the v1↔v2
+// surface switch is hidden and v2 cloud is forced on. Pre-cutoff users keep the
+// existing opt-in toggle. Accounts created at or after the experiment start are
+// sent to v1 (the new-users-v1 experiment) and are never forced into v2. Stored
+// as ISO strings so the values are identical on server, desktop renderer, web,
+// and admin.
 // 2026-05-15 14:00 UTC = Fri 07:00 PDT / 10:00 EDT.
 export const V2_ONLY_USER_CUTOFF = "2026-05-15T14:00:00.000Z";
+// 2026-06-06 15:00 UTC = Sat 08:00 PDT.
+export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-06T15:00:00.000Z";
 
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -68,8 +68,8 @@ export const POSTHOG_COOKIE_NAME = "superset";
 // and admin.
 // 2026-05-15 14:00 UTC = Fri 07:00 PDT / 10:00 EDT.
 export const V2_ONLY_USER_CUTOFF = "2026-05-15T14:00:00.000Z";
-// 2026-06-06 15:00 UTC = Sat 08:00 PDT.
-export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-06T15:00:00.000Z";
+// 2026-06-07 03:00 UTC = Sat 20:00 PDT (8pm Pacific).
+export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-07T03:00:00.000Z";
 
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */

--- a/packages/shared/src/v2-only-user.ts
+++ b/packages/shared/src/v2-only-user.ts
@@ -1,4 +1,7 @@
-import { V2_ONLY_USER_CUTOFF } from "./constants";
+import {
+	V2_NEW_USER_V1_EXPERIMENT_START,
+	V2_ONLY_USER_CUTOFF,
+} from "./constants";
 
 export function isV2OnlyUser(
 	createdAt: Date | string | number | null | undefined,
@@ -9,5 +12,8 @@ export function isV2OnlyUser(
 			? createdAt.getTime()
 			: new Date(createdAt).getTime();
 	if (Number.isNaN(created)) return false;
-	return created >= new Date(V2_ONLY_USER_CUTOFF).getTime();
+	return (
+		created >= new Date(V2_ONLY_USER_CUTOFF).getTime() &&
+		created < new Date(V2_NEW_USER_V1_EXPERIMENT_START).getTime()
+	);
 }


### PR DESCRIPTION
## What

Experiment: send **new** users to **v1** instead of v2, and remove the banner nudging users into v2.

Implemented as a half-open v2-only window so **no existing users are affected**:

\`\`\`
v2-only window = [V2_ONLY_USER_CUTOFF, V2_NEW_USER_V1_EXPERIMENT_START)
              = [2026-05-15T14:00Z,   2026-06-07T20:00Z)
\`\`\`

| Cohort (by \`created_at\`) | Result |
|---|---|
| before 2026-05-15 14:00Z | v1 / opt-in (unchanged) |
| 2026-05-15 14:00Z → 2026-06-07 20:00Z | **v2 — preserved** |
| **on/after 2026-06-07 20:00Z (1pm PDT)** | **v1 (the experiment)** |

## Changes

- \`packages/shared/src/constants.ts\` — add \`V2_NEW_USER_V1_EXPERIMENT_START\` (\`2026-06-07T20:00:00Z\` = 1pm PDT); update the (now half-open) window comment.
- \`packages/shared/src/v2-only-user.ts\` — \`isV2OnlyUser\` requires \`createdAt\` to be **within** the window (adds the upper bound). This single function drives desktop, web, admin, and server.
- \`onboarding/layout.tsx\` + \`onboarding/project/page.tsx\` — onboarding completion routes v1 users to \`/workspaces\` instead of the hardcoded \`/v2-workspaces\`.
- \`WorkspaceSidebar.tsx\` + \`DashboardSidebar.tsx\` — remove \`V2AvailableBanner\` so the v1 cohort isn't nudged toward v2.

## Notes

- The Settings → Experimental **"Try Superset v2" toggle is intentionally kept** for the v1 cohort (they're \`!isV2OnlyUser\`), so users can still opt into v2 themselves.
- **To end the experiment:** delete the upper-bound clause in \`v2-only-user.ts\` (and the constant), and re-add the two banner mounts.
- 100% flip of new signups (not an A/B split); compare cohorts via \`created_at\` windows in PostHog.

## Verified

- Boundary cases pass against the real function (incl. \`20:00:00Z−1s → v2\`, \`20:00:00Z → v1\`).
- E2E in the dev app by flipping a user's \`created_at\` across the boundary: v2 cohort → v2 sidebar/modal/no banner; v1 cohort → v1 sidebar, no banner, onboarding → \`/workspaces\`, toggle present.
- \`bun run lint\` and \`typecheck\` clean.