### PR TITLE
fix(host-service): make workspace delete reliably tear down terminal sessions

### DIFF
--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -17,6 +17,7 @@ import type { GitCredentialProvider } from "./runtime/git";
 import { createGitFactory } from "./runtime/git";
 import { runMainWorkspaceSweep } from "./runtime/main-workspace-sweep";
 import { PullRequestRuntimeManager } from "./runtime/pull-requests";
+import { startTerminalReaper } from "./terminal/reaper";
 import { registerWorkspaceTerminalRoute } from "./terminal/terminal";
 import { TerminalAgentStore } from "./terminal-agents";
 import { appRouter } from "./trpc/router";
@@ -162,6 +163,8 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		upgradeWebSocket,
 	});
 
+	const stopTerminalReaper = startTerminalReaper(db);
+
 	app.use(
 		"/trpc/*",
 		trpcServer({
@@ -189,6 +192,11 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		// Each step is best-effort and isolated: a throw in one cleanup must
 		// not skip the others, otherwise a flaky `.stop()` could leak the
 		// open SQLite handle for the rest of the process lifetime.
+		try {
+			stopTerminalReaper();
+		} catch (err) {
+			console.warn("[host-service] stopTerminalReaper failed:", err);
+		}
 		try {
 			pullRequestRuntime.stop();
 		} catch (err) {

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -17,7 +17,6 @@ import type { GitCredentialProvider } from "./runtime/git";
 import { createGitFactory } from "./runtime/git";
 import { runMainWorkspaceSweep } from "./runtime/main-workspace-sweep";
 import { PullRequestRuntimeManager } from "./runtime/pull-requests";
-import { startTerminalReaper } from "./terminal/reaper";
 import { registerWorkspaceTerminalRoute } from "./terminal/terminal";
 import { TerminalAgentStore } from "./terminal-agents";
 import { appRouter } from "./trpc/router";
@@ -61,6 +60,7 @@ export interface CreateAppResult {
 	app: Hono;
 	injectWebSocket: ReturnType<typeof createNodeWebSocket>["injectWebSocket"];
 	api: ApiClient;
+	db: HostDb;
 	dispose: () => Promise<void>;
 }
 
@@ -163,8 +163,6 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		upgradeWebSocket,
 	});
 
-	const stopTerminalReaper = startTerminalReaper(db);
-
 	app.use(
 		"/trpc/*",
 		trpcServer({
@@ -193,11 +191,6 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		// not skip the others, otherwise a flaky `.stop()` could leak the
 		// open SQLite handle for the rest of the process lifetime.
 		try {
-			stopTerminalReaper();
-		} catch (err) {
-			console.warn("[host-service] stopTerminalReaper failed:", err);
-		}
-		try {
 			pullRequestRuntime.stop();
 		} catch (err) {
 			console.warn("[host-service] pullRequestRuntime.stop failed:", err);
@@ -221,5 +214,5 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		}
 	};
 
-	return { app, injectWebSocket, api, dispose };
+	return { app, injectWebSocket, api, db, dispose };
 }

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -11,6 +11,7 @@ import { PskHostAuthProvider } from "./providers/host-auth";
 import { LocalModelProvider } from "./providers/model-providers";
 import { installProcessSafetyNet } from "./safety";
 import { initTerminalBaseEnv, resolveTerminalBaseEnv } from "./terminal/env";
+import { startTerminalReaper } from "./terminal/reaper";
 import { connectRelay } from "./tunnel";
 
 async function main(): Promise<void> {
@@ -45,7 +46,7 @@ async function main(): Promise<void> {
 		apiUrl: env.SUPERSET_API_URL,
 	});
 
-	const { app, injectWebSocket, api } = createApp({
+	const { app, injectWebSocket, api, db } = createApp({
 		config: {
 			organizationId: env.ORGANIZATION_ID,
 			dbPath: env.HOST_DB_PATH,
@@ -94,6 +95,8 @@ async function main(): Promise<void> {
 		// reach `main().catch(...)` and exit with a non-zero code.
 		installProcessSafetyNet();
 		console.log(`[host-service] listening on http://localhost:${info.port}`);
+
+		startTerminalReaper(db);
 
 		if (env.RELAY_URL) {
 			void connectRelay({

--- a/packages/host-service/src/terminal/reaper/index.ts
+++ b/packages/host-service/src/terminal/reaper/index.ts
@@ -1,0 +1,5 @@
+export {
+	type ReapResult,
+	reapOrphanedSessions,
+	startTerminalReaper,
+} from "./reaper.ts";

--- a/packages/host-service/src/terminal/reaper/index.ts
+++ b/packages/host-service/src/terminal/reaper/index.ts
@@ -1,5 +1,1 @@
-export {
-	type ReapResult,
-	reapOrphanedSessions,
-	startTerminalReaper,
-} from "./reaper.ts";
+export { startTerminalReaper } from "./reaper.ts";

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -1,0 +1,92 @@
+import type { HostDb } from "../../db/index.ts";
+import { terminalSessions } from "../../db/schema.ts";
+import { getDaemonClient } from "../daemon-client-singleton.ts";
+import { disposeSessionAndWait } from "../terminal.ts";
+
+export interface ReapResult {
+	reaped: number;
+	failed: number;
+}
+
+const REAP_INTERVAL_MS = 5 * 60 * 1000;
+
+const rowlessSessionsPendingSecondPass = new Set<string>();
+
+export function startTerminalReaper(db: HostDb): () => void {
+	const run = () => {
+		void reapOrphanedSessions(db)
+			.then((result) => {
+				if (result.reaped > 0 || result.failed > 0) {
+					console.log(
+						`[host-service] terminal reaper: ${result.reaped} reaped, ${result.failed} failed`,
+					);
+				}
+			})
+			.catch((err) => {
+				console.warn("[host-service] terminal reaper failed:", err);
+			});
+	};
+	run();
+	const interval = setInterval(run, REAP_INTERVAL_MS);
+	interval.unref();
+	return () => clearInterval(interval);
+}
+
+export async function reapOrphanedSessions(db: HostDb): Promise<ReapResult> {
+	const daemon = await getDaemonClient();
+	const liveSessions = (await daemon.list()).filter((session) => session.alive);
+	const liveIds = new Set(liveSessions.map((session) => session.id));
+
+	for (const id of rowlessSessionsPendingSecondPass) {
+		if (!liveIds.has(id)) rowlessSessionsPendingSecondPass.delete(id);
+	}
+
+	if (liveSessions.length === 0) return { reaped: 0, failed: 0 };
+
+	const rows = db
+		.select({
+			id: terminalSessions.id,
+			status: terminalSessions.status,
+			originWorkspaceId: terminalSessions.originWorkspaceId,
+		})
+		.from(terminalSessions)
+		.all();
+	const rowById = new Map(rows.map((row) => [row.id, row]));
+
+	const orphanIds: string[] = [];
+	const stillRowless = new Set<string>();
+	for (const session of liveSessions) {
+		const row = rowById.get(session.id);
+		if (!row) {
+			if (rowlessSessionsPendingSecondPass.has(session.id)) {
+				orphanIds.push(session.id);
+			} else {
+				stillRowless.add(session.id);
+			}
+			continue;
+		}
+		if (
+			row.status === "disposed" ||
+			row.status === "exited" ||
+			!row.originWorkspaceId
+		) {
+			orphanIds.push(session.id);
+		}
+	}
+
+	rowlessSessionsPendingSecondPass.clear();
+	for (const id of stillRowless) rowlessSessionsPendingSecondPass.add(id);
+
+	let reaped = 0;
+	let failed = 0;
+	for (const id of orphanIds) {
+		try {
+			const result = await disposeSessionAndWait(id, db);
+			if (result.daemonCloseSucceeded) reaped += 1;
+			else failed += 1;
+		} catch {
+			failed += 1;
+		}
+	}
+	return { reaped, failed };
+}

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -3,45 +3,23 @@ import { terminalSessions } from "../../db/schema.ts";
 import { getDaemonClient } from "../daemon-client-singleton.ts";
 import { disposeSessionAndWait } from "../terminal.ts";
 
-export interface ReapResult {
+interface ReapResult {
 	reaped: number;
 	failed: number;
 }
 
 const REAP_INTERVAL_MS = 5 * 60 * 1000;
 
-const rowlessSessionsPendingSecondPass = new Set<string>();
-
-export function startTerminalReaper(db: HostDb): () => void {
-	const run = () => {
-		void reapOrphanedSessions(db)
-			.then((result) => {
-				if (result.reaped > 0 || result.failed > 0) {
-					console.log(
-						`[host-service] terminal reaper: ${result.reaped} reaped, ${result.failed} failed`,
-					);
-				}
-			})
-			.catch((err) => {
-				console.warn("[host-service] terminal reaper failed:", err);
-			});
-	};
-	run();
-	const interval = setInterval(run, REAP_INTERVAL_MS);
-	interval.unref();
-	return () => clearInterval(interval);
-}
-
-export async function reapOrphanedSessions(db: HostDb): Promise<ReapResult> {
+async function reapOrphanedSessions(
+	db: HostDb,
+	rowlessPendingSecondPass: Set<string>,
+): Promise<ReapResult> {
 	const daemon = await getDaemonClient();
 	const liveSessions = (await daemon.list()).filter((session) => session.alive);
-	const liveIds = new Set(liveSessions.map((session) => session.id));
-
-	for (const id of rowlessSessionsPendingSecondPass) {
-		if (!liveIds.has(id)) rowlessSessionsPendingSecondPass.delete(id);
+	if (liveSessions.length === 0) {
+		rowlessPendingSecondPass.clear();
+		return { reaped: 0, failed: 0 };
 	}
-
-	if (liveSessions.length === 0) return { reaped: 0, failed: 0 };
 
 	const rows = db
 		.select({
@@ -53,13 +31,13 @@ export async function reapOrphanedSessions(db: HostDb): Promise<ReapResult> {
 		.all();
 	const rowById = new Map(rows.map((row) => [row.id, row]));
 
-	const orphanIds: string[] = [];
+	const orphans: { id: string; rowless: boolean }[] = [];
 	const stillRowless = new Set<string>();
 	for (const session of liveSessions) {
 		const row = rowById.get(session.id);
 		if (!row) {
-			if (rowlessSessionsPendingSecondPass.has(session.id)) {
-				orphanIds.push(session.id);
+			if (rowlessPendingSecondPass.has(session.id)) {
+				orphans.push({ id: session.id, rowless: true });
 			} else {
 				stillRowless.add(session.id);
 			}
@@ -70,23 +48,58 @@ export async function reapOrphanedSessions(db: HostDb): Promise<ReapResult> {
 			row.status === "exited" ||
 			!row.originWorkspaceId
 		) {
-			orphanIds.push(session.id);
+			orphans.push({ id: session.id, rowless: false });
 		}
 	}
-
-	rowlessSessionsPendingSecondPass.clear();
-	for (const id of stillRowless) rowlessSessionsPendingSecondPass.add(id);
 
 	let reaped = 0;
 	let failed = 0;
-	for (const id of orphanIds) {
+	for (const orphan of orphans) {
 		try {
-			const result = await disposeSessionAndWait(id, db);
-			if (result.daemonCloseSucceeded) reaped += 1;
-			else failed += 1;
+			const result = await disposeSessionAndWait(orphan.id, db);
+			if (result.daemonCloseSucceeded) {
+				reaped += 1;
+				continue;
+			}
 		} catch {
-			failed += 1;
+			// fall through to the failure path below
 		}
+		failed += 1;
+		// A failed kill on a confirmed (second-pass) rowless orphan is kept
+		// pending so the next pass retries it instead of restarting its
+		// two-pass clock.
+		if (orphan.rowless) stillRowless.add(orphan.id);
 	}
+
+	rowlessPendingSecondPass.clear();
+	for (const id of stillRowless) rowlessPendingSecondPass.add(id);
+
 	return { reaped, failed };
+}
+
+export function startTerminalReaper(db: HostDb): () => void {
+	const rowlessPendingSecondPass = new Set<string>();
+	let running = false;
+	const run = () => {
+		if (running) return;
+		running = true;
+		void reapOrphanedSessions(db, rowlessPendingSecondPass)
+			.then((result) => {
+				if (result.reaped > 0 || result.failed > 0) {
+					console.log(
+						`[host-service] terminal reaper: ${result.reaped} reaped, ${result.failed} failed`,
+					);
+				}
+			})
+			.catch((err) => {
+				console.warn("[host-service] terminal reaper failed:", err);
+			})
+			.finally(() => {
+				running = false;
+			});
+	};
+	run();
+	const interval = setInterval(run, REAP_INTERVAL_MS);
+	interval.unref();
+	return () => clearInterval(interval);
 }

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -733,14 +733,17 @@ export async function disposeSessionAndWait(
 
 	portManager.unregisterSession(terminalId);
 
-	db.update(terminalSessions)
-		.set({ status: "disposed", endedAt: Date.now() })
-		.where(eq(terminalSessions.id, terminalId))
-		.run();
-
 	const closeResult = closePromise
 		? await closePromise
 		: { attempted: false, succeeded: true };
+
+	if (closeResult.succeeded) {
+		db.update(terminalSessions)
+			.set({ status: "disposed", endedAt: Date.now() })
+			.where(eq(terminalSessions.id, terminalId))
+			.run();
+	}
+
 	return {
 		terminalId,
 		daemonCloseAttempted: closeResult.attempted,

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "node:fs";
 import { TRPCError } from "@trpc/server";
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { z } from "zod";
-import { workspaces } from "../../../db/schema";
+import { terminalSessions, workspaces } from "../../../db/schema";
 import { invalidateLabelCache } from "../../../ports/static-ports";
 import { runTeardown, type TeardownResult } from "../../../runtime/teardown";
 import { disposeSessionsByWorkspaceId } from "../../../terminal/terminal";
@@ -274,6 +274,24 @@ async function runDestroy(
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		warnings.push(`Failed to dispose terminal sessions: ${message}`);
+	}
+
+	// Drop this workspace's terminal rows so its session index dies with it
+	// rather than lingering as `set null` orphans. Confirmed-dead rows only:
+	// a still-`active` row is a failed kill we keep reachable for the reaper.
+	try {
+		ctx.db
+			.delete(terminalSessions)
+			.where(
+				and(
+					eq(terminalSessions.originWorkspaceId, input.workspaceId),
+					ne(terminalSessions.status, "active"),
+				),
+			)
+			.run();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		warnings.push(`Failed to clear terminal session rows: ${message}`);
 	}
 
 	// 2b. Worktree. Double-force unlocks the rare locked-worktree case and

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -291,7 +291,9 @@ async function runDestroy(
 			.run();
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		warnings.push(`Failed to clear terminal session rows: ${message}`);
+		warnings.push(
+			`Failed to clear terminal session rows for ${input.workspaceId}: ${message}`,
+		);
 	}
 
 	// 2b. Worktree. Double-force unlocks the rare locked-worktree case and


### PR DESCRIPTION
## Problem

A host with automated stale-workspace deletion accumulated ~400 live terminal sessions across already-deleted workspaces. Reported as "delete just removes the git worktree and leaves the sessions running."

This turned out to be a **reliability bug, not a missing feature**. The cascade already exists: CLI `delete_workspace` → host-service `workspace.delete` → `destroyWorkspace`, whose Step 2a calls `disposeSessionsByWorkspaceId` before removing the worktree. The problem is that the cascade could silently fail and orphan the PTY:

1. **`disposeSessionAndWait` marked the sqlite row `disposed` before confirming the daemon actually killed the PTY.** A transient daemon failure left a live process behind a `disposed` row — invisible to every future workspace-scoped cleanup.
2. **The pty-daemon has no workspace mapping** (`SessionInfo` is just `{id,pid,cols,rows,alive}`). The terminal→workspace link lives only in sqlite `origin_workspace_id`, and the `onDelete: "set null"` FK severs it once the workspace row is deleted — so an already-orphaned PTY can't be found by workspace at all.

Worktree removal reads git's durable on-disk registry so it always succeeds; terminal disposal trusted a mutable sqlite table and optimistically marked rows disposed — hence the asymmetry.

## Changes

- **`fix: mark disposed only after confirmed kill`** — failed kills now stay `active` and retryable/reapable instead of being lost behind a `disposed` row.
- **`fix: clear dead terminal rows when destroying a workspace`** — the destroy saga deletes the workspace's confirmed-dead terminal rows (status ≠ `active`), so its session index dies with it instead of lingering as `set null` orphans. Failed kills (`active`) are deliberately kept reachable for the reaper.
- **`feat: reap orphaned daemon PTYs`** — a reaper lists the daemon's live sessions and kills any whose row is `disposed`/`exited`/null-workspace (or row-less for two consecutive passes, so a being-born session — daemon PTY opened before the sqlite row insert — is never killed mid-creation). Runs at startup (drains the pre-existing ~400 on next host-service restart) and every 5 min; interval is `unref()`'d and cleared in `dispose()`.

### Why not `onDelete: cascade`?

An FK action fires at the DB level and can't know whether the PTY was actually killed. `cascade` would delete the row for a still-alive failed-kill PTY, turning it into a *row-less* orphan that's ambiguous with a being-born session (slower two-pass reap). `set null` leaves an unambiguous `active`+null row the reaper catches in one pass. Row lifecycle is therefore application-driven and conditional on a confirmed kill; the FK stays `set null` as a dumb integrity backstop.

## Notes for deploy

- The existing ~400 orphans drain on the **next host-service restart** (boot reaper) or within one 5-min tick after deploy.
- Dev mode kills the daemon on exit, so this matters for production/detached daemons — the affected setup.

## Verification

- `bun run typecheck` ✓
- `bun run lint` exit 0 ✓
- 352 host-service unit tests pass (bun 1.3.11)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5168">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure workspace deletion reliably tears down terminal sessions by fixing disposal semantics and adding a background reaper in `host-service`. The reaper now starts from `serve` after daemon bootstrap, avoids overlapping passes, and drains existing orphans on restart or within 5 minutes.

- **Bug Fixes**
  - Mark a session `disposed` only after the daemon kill succeeds; failed kills stay `active` and retryable.
  - Reaper robustness: start from `serve` to avoid early daemon connections; skip overlapping passes, keep pending state per process, retry failed second‑pass rowless kills; include workspace id in the terminal-row cleanup warning.
  - On workspace destroy, delete that workspace’s non-`active` terminal rows to avoid orphaned records.

- **New Features**
  - Add a terminal reaper that lists live daemon sessions and kills orphans (disposed/exited/null-workspace, or row-less on two passes). Runs on boot and every 5 minutes.

<sup>Written for commit cdb508543f5b3a205e655502cb64383dd1a291f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background reaper now runs automatically to detect and clean orphaned terminal sessions.

* **Bug Fixes**
  * Terminal sessions are marked disposed only when closure succeeds.
  * Workspace destroy now clears non-active terminal session records during local cleanup.

* **Chores**
  * Improved error handling and non-blocking logging for cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->