### PR TITLE
feat(desktop): configurable multi-line workspace cards

### DIFF
--- a/apps/desktop/plans/20260607-configurable-workspace-cards.md
+++ b/apps/desktop/plans/20260607-configurable-workspace-cards.md
@@ -1,0 +1,78 @@
+# Configurable multi-line workspace cards
+
+**Goal:** Sidebar workspace items become multi-line cards that surface PR title/status/checks, diff stats, agent status, and (optionally) the Linear ticket — visible at a glance instead of hover-only, with the field set configurable per project.
+
+## Problem
+
+Today `WorkspaceListItem` shows name, branch subtitle, diff counts, and a PR badge, but the PR title, check status, and review state only appear in the hover card. GitHub data is fetched lazily on hover (`useHoverGitHubStatus`, `githubQueryPolicy.ts` hover surfaces). Nothing about the row content is configurable, and there is no Linear integration at all.
+
+## Design
+
+### Config (per project, mirrors setup scripts)
+
+A `workspaceCard` block in the project's `.superset/config.json`, managed through the existing config router (`src/lib/trpc/routers/config/config.ts`) the same way `setup`/`teardown` are:
+
+```json
+{ "workspaceCard": { "prTitle": true, "prChecks": true, "diffStats": true, "status": true, "linearTicket": true } }
+```
+
+All fields default to `true` (cards are multi-line out of the box). `getWorkspaceCardConfig` returns defaults when the block is absent; `updateWorkspaceCardConfig` merge-writes, preserving unrelated keys exactly like `updateConfig` does.
+
+### Card rendering
+
+`WorkspaceListItem` gains optional lines under the existing name/branch rows, each gated by config:
+
+- **PR line** — PR title (truncated) plus check rollup / review decision badge. Data already exists on `getGitHubStatus` (`pr-resolution.ts` requests `title,…,reviewDecision,statusCheckRollup`).
+- **Status line** — textual form of the existing pane-status aggregation (working / needs review / permission).
+- **Linear line** — ticket key + state, when the integration is configured.
+- **Diff stats** — existing `WorkspaceDiffStats`, now gated by the `diffStats` flag.
+
+GitHub fetch policy: a new `workspace-card` surface in `githubQueryPolicy.ts` that is enabled eagerly (no hover requirement) but does not poll — long stale time, refetch on window focus, hover still triggers the existing refresh path. This keeps `gh` CLI calls bounded: one per visible workspace per staleness window.
+
+### Custom script lines (user-created)
+
+`workspaceCard.customLines` is an array of `{ id, label, command, enabled }`. Each command runs through `workspaces.getCardLineOutput` in the workspace folder (`/bin/sh -lc`, 5s timeout, 30s result cache in main) and the first line of its output renders on the card — e.g. `git log -1 --format=%s` for the last commit subject. Same trust model as setup/run scripts: the user authored the command.
+
+### Context-menu configuration (primary surface)
+
+Right-clicking any workspace card (v1 `WorkspaceContextMenu` and v2 `DashboardSidebarWorkspaceContextMenu`) offers:
+- **Customize Card…** — opens `WorkspaceCardDialog` (screens/main/components): built-in line toggles + custom-line editor (add/toggle/remove).
+- **Configure Card with Agent** — pre-fills the new-workspace prompt (`useConfigureCardWithAgent`, mirroring the setup/teardown flow via `useNewWorkspaceDraftStore` + `useNewWorkspaceModalStore`) and opens the creation modal; nothing starts until the user submits.
+
+### Settings UI + agent shortcut
+
+A "Workspace cards" section on `/settings/projects/$projectId` with a switch per field, writing through `updateWorkspaceCardConfig`. Next to it, a **Configure with agent** button opens a chat tab (`addChatTab(workspaceId, { launchConfig: { initialPrompt } })`) in the project's most recently active workspace, pre-prompted to edit the `workspaceCard` block of `.superset/config.json` — the same "agent configures the project file" pattern users know from setup scripts.
+
+### Linear (via the existing org integration — no new API surface)
+
+**Finding during implementation:** the app already syncs Linear through the org-level integration — the `tasks` table carries `externalProvider` / `externalKey` ("SUPER-172") / `externalUrl` / `branch` / `statusId`, and tasks arrive in the renderer through Electric collections (`CollectionsProvider`). So no API key, no new router, no direct Linear calls.
+
+`useWorkspaceLinkedTask(branch)` resolves the ticket from the local tasks collection: primary match on the task's recorded `branch`, fallback on a ticket key extracted from the branch name (`/[a-z][a-z0-9]+-\d+/i`, uppercased). Status name joins from the synced `taskStatuses` collection. The card line renders the key + status when the field is enabled and a linked task exists.
+
+### Component card lines (extension)
+
+`customLines` entries are now a union discriminated by `type`: `"command"` (the original shape — `type` may be omitted, so pre-existing configs keep parsing) and `"component"`, where `component` names an entry in the renderer-side registry (`WorkspaceCardLineComponents.tsx`). Registered components receive `{ workspaceId, projectId, branch, workspaceName }` and may use electronTrpc hooks freely. Built-ins: `pomodoro` (elapsed since `workspaces.get` `createdAt`, 25-minute cycles, 30s local tick), `clock` (local HH:MM, 30s tick), `pr-checks-inline` (compact checks summary via the existing `useHoverGitHubStatus` workspace-card surface; renders nothing without a PR). Unknown keys render nothing. Full schema reference: `docs/WORKSPACE_CARDS.md`.
+
+### v2 repo-config resolution (extension)
+
+**Finding:** v2 cloud projects never enter the local `projects` table, but whenever any of their workspaces runs on this machine, the per-organization host service records the project's local checkout in its own DB — `~/.superset/host/<orgId>/host.db`, `projects.repo_path`, keyed by the cloud project id (see `persist-project.ts` in `packages/host-service`). `resolveWorkspaceCardRepoPath` (config router, `workspace-card-source.ts`) therefore resolves v1 via localDb `mainRepoPath` and v2 by opening each org's `host.db` read-only with better-sqlite3 and selecting `repo_path` by project id. Chosen over a host-service tRPC round trip because it needs no organizationId input, no auth token, and works while the service is stopped; the desktop app already links better-sqlite3 for its own local DB. Genuinely unresolvable projects (no local checkout) fall back to defaults as before.
+
+### Live reload (extension)
+
+Chosen path: main-process `fs.watch` pushed over an electron-trpc subscription — the codebase already uses `publicProcedure.subscription` + `observable` (e.g. `hostServiceCoordinator.onStatusChange`, `filesystem.watchPath`), so no new transport was introduced. `config.watchWorkspaceCardConfig` watches `<repo>/.superset` (or the repo root until `.superset` exists), debounced 250ms; `useWorkspaceCardConfigSync` subscribes once per project (mounted in `ProjectSection` and `DashboardSidebarProjectSection`) and invalidates the `getWorkspaceCardConfig`/`getWorkspaceCardConfigSource` queries. The stale-time/refetch-interval fallback was not needed; the 30s card-line output cache is untouched because a config edit changes the query key (`workspaceId` + `command`) anyway.
+
+### Override shadowing fix (extension)
+
+`updateWorkspaceCardConfig` previously stored the submitted config unconditionally, so opening the dialog and toggling nothing pinned pure defaults into appState and permanently shadowed later file edits. It now deletes the projectId key when the submitted config deep-equals the file-resolved one (`workspaceCardConfigsEqual` in shared/workspace-card-config.ts), keeping the file authoritative; `resetWorkspaceCardConfig` clears the override explicitly and the settings UI shows "Reset to repo config" whenever `getWorkspaceCardConfigSource` reports `"override"`.
+
+## Non-goals
+
+- Per-user (as opposed to per-project) card config — `.superset/config.json` is the single source, consistent with setup scripts.
+- Linear ticket pickers/search; association is branch-name-driven only.
+- Virtualized list support (the sidebar list isn't virtualized; rows already vary in height).
+
+## Verification
+
+- Unit: config defaults + merge preservation; ticket-key extraction.
+- `bun test`, `bun run lint`, `bun run typecheck` clean.
+- Live: toggles change card content; PR line shows without hover; hover refresh still works.

--- a/apps/desktop/src/lib/trpc/routers/config/config.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/config.ts
@@ -2,12 +2,36 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { access } from "node:fs/promises";
 import { join } from "node:path";
 import { projects, type SelectProject } from "@superset/local-db";
+import { observable } from "@trpc/server/observable";
 import { eq } from "drizzle-orm";
+import { appState } from "main/lib/app-state";
 import { localDb } from "main/lib/local-db";
 import type { SetupAction, SetupDetectionResult } from "shared/types/config";
+import {
+	DEFAULT_WORKSPACE_CARD_CONFIG,
+	parseWorkspaceCardConfig,
+	type WorkspaceCardConfig,
+	workspaceCardConfigSchema,
+	workspaceCardConfigsEqual,
+} from "shared/workspace-card-config";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { loadSetupConfig } from "../workspaces/utils/setup";
+import { readRepoWorkspaceCardBlock } from "./workspace-card-config-read";
+import {
+	resolveWorkspaceCardRepoPath,
+	watchWorkspaceCardConfigFile,
+} from "./workspace-card-source";
+import {
+	commandSetHash,
+	resolveGatedWorkspaceCardConfig,
+} from "./workspace-card-trust";
+
+/**
+ * Validated projectId — rejects path traversal attempts before they reach
+ * any filesystem join. Used on all workspace-card procedures.
+ */
+const projectIdSchema = z.string().regex(/^[\w-]{1,64}$/);
 
 function hasConfiguredScripts(
 	project: Pick<SelectProject, "id" | "mainRepoPath">,
@@ -342,6 +366,16 @@ function getConfigPath(mainRepoPath: string): string {
 	return join(mainRepoPath, ".superset", "config.json");
 }
 
+/** What getWorkspaceCardConfig resolves to when no appState override exists. */
+function resolveRepoWorkspaceCardConfig(
+	projectId: string,
+): WorkspaceCardConfig {
+	const block = readRepoWorkspaceCardBlock(projectId);
+	return block !== undefined
+		? parseWorkspaceCardConfig(block)
+		: DEFAULT_WORKSPACE_CARD_CONFIG;
+}
+
 function ensureConfigExists(mainRepoPath: string): string {
 	const configPath = getConfigPath(mainRepoPath);
 	const supersetDir = join(mainRepoPath, ".superset");
@@ -391,6 +425,144 @@ export const createConfigRouter = () => {
 					.where(eq(projects.id, input.projectId))
 					.run();
 				return { success: true };
+			}),
+
+		// Sidebar workspace-card field visibility for a project. The repo's
+		// .superset/config.json "workspaceCard" block is the authoritative
+		// source (resolved for v1 projects via the local DB, for v2 cloud
+		// projects via the host-service DB -- see workspace-card-source.ts);
+		// the local appState only carries a per-machine override when the
+		// user diverged from the file through the in-app settings.
+		//
+		// Repo-sourced command lines are gated by the consent mechanism:
+		// they are stripped until the user explicitly approves the current
+		// command set via trustCardCommands. Component lines are always safe.
+		getWorkspaceCardConfig: publicProcedure
+			.input(z.object({ projectId: projectIdSchema }))
+			.query(({ input }): WorkspaceCardConfig => {
+				return resolveGatedWorkspaceCardConfig(input.projectId);
+			}),
+
+		// Where the effective card config comes from -- drives the settings
+		// UI's "Reset to repo config" affordance and the trust banner.
+		getWorkspaceCardConfigSource: publicProcedure
+			.input(z.object({ projectId: projectIdSchema }))
+			.query(({ input }): "override" | "repo" | "defaults" => {
+				if (appState.data.workspaceCardConfigs?.[input.projectId]) {
+					return "override";
+				}
+				return readRepoWorkspaceCardBlock(input.projectId) !== undefined
+					? "repo"
+					: "defaults";
+			}),
+
+		// Returns the trust state for repo-sourced command lines. When
+		// pendingCommandCount > 0 the UI should show the consent banner.
+		getWorkspaceCardTrustState: publicProcedure
+			.input(z.object({ projectId: projectIdSchema }))
+			.query(({ input }): { trusted: boolean; pendingCommandCount: number } => {
+				// Only relevant when source is "repo".
+				if (appState.data.workspaceCardConfigs?.[input.projectId]) {
+					return { trusted: true, pendingCommandCount: 0 };
+				}
+				const block = readRepoWorkspaceCardBlock(input.projectId);
+				if (block === undefined) {
+					return { trusted: true, pendingCommandCount: 0 };
+				}
+				const config = parseWorkspaceCardConfig(block);
+				const commandCount = config.customLines.filter(
+					(l) => l.type === "command" && l.enabled,
+				).length;
+				if (commandCount === 0) {
+					return { trusted: true, pendingCommandCount: 0 };
+				}
+				const trusted =
+					(appState.data.trustedCardCommandProjects?.[input.projectId] ??
+						null) === commandSetHash(config);
+				return {
+					trusted,
+					pendingCommandCount: trusted ? 0 : commandCount,
+				};
+			}),
+
+		// Approve the current repo command set for this project.
+		trustCardCommands: publicProcedure
+			.input(z.object({ projectId: projectIdSchema }))
+			.mutation(async ({ input }) => {
+				const block = readRepoWorkspaceCardBlock(input.projectId);
+				if (block === undefined) return { success: true };
+				const config = parseWorkspaceCardConfig(block);
+				const next = { ...appState.data.trustedCardCommandProjects };
+				next[input.projectId] = commandSetHash(config);
+				appState.data.trustedCardCommandProjects = next;
+				await appState.write();
+				return { success: true };
+			}),
+
+		// Revoke trust for this project's repo command lines.
+		untrustCardCommands: publicProcedure
+			.input(z.object({ projectId: projectIdSchema }))
+			.mutation(async ({ input }) => {
+				const next = { ...appState.data.trustedCardCommandProjects };
+				delete next[input.projectId];
+				appState.data.trustedCardCommandProjects = next;
+				await appState.write();
+				return { success: true };
+			}),
+
+		updateWorkspaceCardConfig: publicProcedure
+			.input(
+				z.object({
+					projectId: projectIdSchema,
+					workspaceCard: workspaceCardConfigSchema,
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const next = { ...appState.data.workspaceCardConfigs };
+				// When the submitted config still matches what the repo file
+				// resolves to, don't store an override -- otherwise a no-op save
+				// would permanently shadow future edits to the file.
+				if (
+					workspaceCardConfigsEqual(
+						input.workspaceCard,
+						resolveRepoWorkspaceCardConfig(input.projectId),
+					)
+				) {
+					delete next[input.projectId];
+				} else {
+					next[input.projectId] = input.workspaceCard;
+				}
+				appState.data.workspaceCardConfigs = next;
+				await appState.write();
+				return { success: true };
+			}),
+
+		// Drop the per-machine override so the repo file (or defaults) applies.
+		resetWorkspaceCardConfig: publicProcedure
+			.input(z.object({ projectId: projectIdSchema }))
+			.mutation(async ({ input }) => {
+				const next = { ...appState.data.workspaceCardConfigs };
+				delete next[input.projectId];
+				appState.data.workspaceCardConfigs = next;
+				await appState.write();
+				return { success: true };
+			}),
+
+		// Emits whenever the project's .superset/config.json changes on disk,
+		// so card configs live-reload without an app restart. Same
+		// observable-subscription pattern as hostServiceCoordinator.onStatusChange.
+		watchWorkspaceCardConfig: publicProcedure
+			.input(z.object({ projectId: projectIdSchema }))
+			.subscription(({ input }) => {
+				return observable<{ changedAt: number }>((emit) => {
+					const repoPath = resolveWorkspaceCardRepoPath(input.projectId);
+					if (!repoPath) {
+						return () => {};
+					}
+					return watchWorkspaceCardConfigFile(repoPath, () =>
+						emit.next({ changedAt: Date.now() }),
+					);
+				});
 			}),
 
 		// Get the config file path (creates it if it doesn't exist)

--- a/apps/desktop/src/lib/trpc/routers/config/workspace-card-config-read.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/workspace-card-config-read.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { resolveWorkspaceCardRepoPath } from "./workspace-card-source";
+
+function getConfigPath(repoPath: string): string {
+	return join(repoPath, ".superset", "config.json");
+}
+
+function readProjectConfigFile(configPath: string): Record<string, unknown> {
+	try {
+		const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+	} catch {
+		// Missing or invalid file -- caller falls back to defaults.
+	}
+	return {};
+}
+
+/**
+ * The raw "workspaceCard" block of the project's .superset/config.json, or
+ * undefined when the project has no local repo path or the file lacks the
+ * block. Shared between config.ts and workspace-card-trust.ts to avoid
+ * circular imports.
+ */
+export function readRepoWorkspaceCardBlock(projectId: string): unknown {
+	const repoPath = resolveWorkspaceCardRepoPath(projectId);
+	if (!repoPath) return undefined;
+	return readProjectConfigFile(getConfigPath(repoPath)).workspaceCard;
+}

--- a/apps/desktop/src/lib/trpc/routers/config/workspace-card-source.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/workspace-card-source.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { join, resolve, sep } from "node:path";
+import { extractMainRepoFromGitdir } from "./workspace-card-source";
+
+describe("extractMainRepoFromGitdir", () => {
+	it("extracts main repo path from standard gitdir line", () => {
+		const content =
+			"gitdir: /Users/adelinb/Documents/Meta-Vault/.git/worktrees/my-worktree";
+		expect(extractMainRepoFromGitdir(content)).toBe(
+			"/Users/adelinb/Documents/Meta-Vault",
+		);
+	});
+
+	it("trims leading/trailing whitespace before matching", () => {
+		const content =
+			"  gitdir: /home/user/projects/repo/.git/worktrees/feature-branch\n";
+		expect(extractMainRepoFromGitdir(content)).toBe("/home/user/projects/repo");
+	});
+
+	it("returns null for a bare .git directory reference (not a worktree)", () => {
+		const content = "gitdir: /some/path/.git";
+		expect(extractMainRepoFromGitdir(content)).toBeNull();
+	});
+
+	it("returns null for an empty string", () => {
+		expect(extractMainRepoFromGitdir("")).toBeNull();
+	});
+
+	it("returns null for unrelated file content", () => {
+		expect(extractMainRepoFromGitdir("ref: refs/heads/main")).toBeNull();
+	});
+
+	it("handles nested paths with multiple segments correctly", () => {
+		const content = "gitdir: /a/b/c/d/.git/worktrees/ws-name";
+		expect(extractMainRepoFromGitdir(content)).toBe("/a/b/c/d");
+	});
+});
+
+// Inline the containment check logic so this test file has no Electron imports.
+// Must stay in sync with resolveWorktreeProjectRepoPath in workspace-card-source.ts.
+function worktreeDirIsContained(
+	worktreesRoot: string,
+	projectId: string,
+): boolean {
+	const worktreesDir = join(worktreesRoot, projectId);
+	const resolvedDir = resolve(worktreesDir);
+	const resolvedRoot = resolve(worktreesRoot);
+	return (
+		resolvedDir === resolvedRoot || resolvedDir.startsWith(resolvedRoot + sep)
+	);
+}
+
+describe("projectId containment check", () => {
+	const root = "/home/user/.superset/worktrees";
+
+	it("allows a normal UUID-shaped projectId", () => {
+		expect(
+			worktreeDirIsContained(root, "914758f0-9f44-4362-be7f-cda39e86ea73"),
+		).toBe(true);
+	});
+
+	it("allows an alphanumeric projectId", () => {
+		expect(worktreeDirIsContained(root, "abc123")).toBe(true);
+	});
+
+	it("rejects ../ path traversal", () => {
+		expect(worktreeDirIsContained(root, "../../../etc")).toBe(false);
+	});
+
+	it("rejects a projectId that steps outside the worktrees root", () => {
+		expect(worktreeDirIsContained(root, "../../passwd")).toBe(false);
+	});
+
+	it("allows a path that looks absolute but is joined safely by path.join", () => {
+		// path.join(root, "/etc/shadow") on POSIX appends rather than replacing
+		// root, so the result stays within the worktrees directory. The real
+		// guard against absolute/special ids is the projectIdSchema regex on
+		// the tRPC procedure boundary (rejects anything that isn't [a-zA-Z0-9_-]).
+		expect(worktreeDirIsContained(root, "/etc/shadow")).toBe(true);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/config/workspace-card-source.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/workspace-card-source.ts
@@ -1,0 +1,205 @@
+import {
+	existsSync,
+	type FSWatcher,
+	readdirSync,
+	readFileSync,
+	watch,
+} from "node:fs";
+import { join, resolve, sep } from "node:path";
+import { projects } from "@superset/local-db";
+import Database from "better-sqlite3";
+import { eq } from "drizzle-orm";
+import { SUPERSET_HOME_DIR } from "main/lib/app-environment";
+import { localDb } from "main/lib/local-db";
+
+/**
+ * Resolves the local repo path that owns a project's .superset/config.json.
+ *
+ * v1 local projects live in the local DB with an explicit mainRepoPath. v2
+ * cloud projects don't — but whenever any of their workspaces runs on this
+ * machine, the per-organization host service records the project's local
+ * checkout in its own DB (~/.superset/host/<orgId>/host.db, projects table,
+ * repo_path keyed by the cloud project id). Reading that DB directly
+ * (read-only) is cheap, needs no host-service round trip, and works even
+ * while the service is stopped. Returns null when the project has no local
+ * checkout anywhere — callers fall back to defaults.
+ */
+export function resolveWorkspaceCardRepoPath(projectId: string): string | null {
+	const project = localDb
+		.select()
+		.from(projects)
+		.where(eq(projects.id, projectId))
+		.get();
+	if (project?.mainRepoPath) {
+		return project.mainRepoPath;
+	}
+	return (
+		resolveV2ProjectRepoPath(projectId) ??
+		resolveWorktreeProjectRepoPath(projectId)
+	);
+}
+
+function resolveV2ProjectRepoPath(projectId: string): string | null {
+	const hostRoot = join(SUPERSET_HOME_DIR, "host");
+	let orgIds: string[];
+	try {
+		orgIds = readdirSync(hostRoot);
+	} catch {
+		return null;
+	}
+
+	for (const orgId of orgIds) {
+		const dbPath = join(hostRoot, orgId, "host.db");
+		if (!existsSync(dbPath)) continue;
+		try {
+			const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+			try {
+				const row = db
+					.prepare("SELECT repo_path AS repoPath FROM projects WHERE id = ?")
+					.get(projectId) as { repoPath?: string } | undefined;
+				if (row?.repoPath && existsSync(row.repoPath)) {
+					return row.repoPath;
+				}
+			} finally {
+				db.close();
+			}
+		} catch {
+			// Locked, corrupt, or schema-less DB — try the next organization.
+		}
+	}
+	return null;
+}
+
+/**
+ * Extracts the main repo path from the contents of a git worktree `.git` file.
+ * The file format is: `gitdir: <mainRepo>/.git/worktrees/<name>`
+ * Returns null if the content doesn't match the expected pattern.
+ */
+export function extractMainRepoFromGitdir(content: string): string | null {
+	const match = /^gitdir: (.*)\/\.git\/worktrees\//.exec(content.trim());
+	return match?.[1] ?? null;
+}
+
+/**
+ * Third-tier fallback: scans ~/.superset/worktrees/<projectId>/ for any local
+ * worktree that belongs to this project. For each subdirectory:
+ *   1. If it has a .superset/config.json, return the subdirectory directly
+ *      (branch-local copy of the shared config is acceptable).
+ *   2. Otherwise read the .git file and parse the main repo path from the
+ *      standard `gitdir: <mainRepo>/.git/worktrees/<name>` format.
+ * Returns null when nothing resolves.
+ */
+function resolveWorktreeProjectRepoPath(projectId: string): string | null {
+	const worktreesDir = join(SUPERSET_HOME_DIR, "worktrees", projectId);
+
+	// Containment check: projectId must not escape the worktrees root directory.
+	const resolvedDir = resolve(worktreesDir);
+	const worktreesRoot = resolve(join(SUPERSET_HOME_DIR, "worktrees"));
+	if (
+		resolvedDir !== worktreesRoot &&
+		!resolvedDir.startsWith(worktreesRoot + sep)
+	) {
+		return null;
+	}
+
+	let entries: string[];
+	try {
+		entries = readdirSync(worktreesDir);
+	} catch {
+		return null;
+	}
+
+	for (const entry of entries) {
+		const worktreePath = join(worktreesDir, entry);
+
+		// Prefer a subdirectory with its own .superset/config.json.
+		if (existsSync(join(worktreePath, ".superset", "config.json"))) {
+			return worktreePath;
+		}
+
+		// Fall back to parsing the .git file for the main repo path.
+		const gitFilePath = join(worktreePath, ".git");
+		try {
+			const gitContent = readFileSync(gitFilePath, "utf8");
+			const mainRepo = extractMainRepoFromGitdir(gitContent);
+			if (mainRepo && existsSync(mainRepo)) {
+				return mainRepo;
+			}
+		} catch {
+			// Not a file, or not readable — skip.
+		}
+	}
+	return null;
+}
+
+const CONFIG_FILE_NAME = "config.json";
+const WATCH_DEBOUNCE_MS = 250;
+
+/**
+ * Watches <repoPath>/.superset/config.json for changes, debounced. When the
+ * .superset directory doesn't exist yet, watches the repo root for its
+ * creation and re-arms. Returns a cleanup function.
+ */
+export function watchWorkspaceCardConfigFile(
+	repoPath: string,
+	onChange: () => void,
+): () => void {
+	const supersetDir = join(repoPath, ".superset");
+	let configWatcher: FSWatcher | null = null;
+	let repoWatcher: FSWatcher | null = null;
+	let debounce: NodeJS.Timeout | null = null;
+	let closed = false;
+
+	const fire = () => {
+		if (debounce) clearTimeout(debounce);
+		debounce = setTimeout(() => {
+			debounce = null;
+			onChange();
+		}, WATCH_DEBOUNCE_MS);
+	};
+
+	const watchConfigDir = () => {
+		if (closed || configWatcher) return;
+		try {
+			configWatcher = watch(supersetDir, (_event, filename) => {
+				// Some platforms omit the filename — treat that as a possible hit.
+				if (filename && filename !== CONFIG_FILE_NAME) return;
+				fire();
+			});
+			configWatcher.on("error", () => {
+				configWatcher?.close();
+				configWatcher = null;
+			});
+		} catch {
+			// Directory vanished between the existence check and the watch.
+		}
+	};
+
+	if (existsSync(supersetDir)) {
+		watchConfigDir();
+	} else {
+		try {
+			repoWatcher = watch(repoPath, (_event, filename) => {
+				if (filename !== ".superset" || !existsSync(supersetDir)) return;
+				watchConfigDir();
+				// Release the repo-level watcher now that configWatcher is armed.
+				repoWatcher?.close();
+				repoWatcher = null;
+				fire();
+			});
+			repoWatcher.on("error", () => {
+				repoWatcher?.close();
+				repoWatcher = null;
+			});
+		} catch {
+			// Repo path itself is gone — nothing to watch.
+		}
+	}
+
+	return () => {
+		closed = true;
+		if (debounce) clearTimeout(debounce);
+		configWatcher?.close();
+		repoWatcher?.close();
+	};
+}

--- a/apps/desktop/src/lib/trpc/routers/config/workspace-card-trust.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/workspace-card-trust.ts
@@ -1,0 +1,78 @@
+import { appState } from "main/lib/app-state";
+import {
+	commandSetHash,
+	DEFAULT_WORKSPACE_CARD_CONFIG,
+	parseWorkspaceCardConfig,
+	type WorkspaceCardConfig,
+} from "shared/workspace-card-config";
+import { readRepoWorkspaceCardBlock } from "./workspace-card-config-read";
+
+export { commandSetHash };
+
+/**
+ * Pure helper: given a repo-sourced config and the stored trust hash for this
+ * project (or undefined if never trusted), returns the gated config.
+ *
+ * - Override source: caller handles separately (not repo-sourced).
+ * - Repo source + trusted hash matches: all lines pass through.
+ * - Repo source + untrusted: command-type lines stripped; component lines
+ *   always pass (they are app code, no shell exec).
+ *
+ * Exported for unit testing without Electron main-process dependencies.
+ */
+export function applyCommandGating(
+	config: WorkspaceCardConfig,
+	storedHash: string | undefined,
+): WorkspaceCardConfig {
+	const currentHash = commandSetHash(config);
+	const trusted = storedHash !== undefined && storedHash === currentHash;
+	if (trusted) return config;
+	return {
+		...config,
+		customLines: config.customLines.filter((l) => l.type !== "command"),
+	};
+}
+
+/**
+ * Returns true when the project's repo-sourced command lines are trusted for
+ * the current command set.
+ */
+export function isCommandSetTrusted(
+	projectId: string,
+	config: WorkspaceCardConfig,
+): boolean {
+	const stored = appState.data.trustedCardCommandProjects?.[projectId];
+	return stored !== undefined && stored === commandSetHash(config);
+}
+
+/**
+ * The gated config returned to the renderer (and used by card-lines.ts).
+ * - When source === "override": user authored it in-app, all lines pass through.
+ * - When source === "repo" AND commands untrusted: command-type lines stripped.
+ * - When source === "defaults": no custom lines, nothing to strip.
+ */
+export function resolveGatedWorkspaceCardConfig(
+	projectId: string,
+): WorkspaceCardConfig {
+	const stored = appState.data.workspaceCardConfigs?.[projectId];
+
+	// Override: user authored these in-app; trust all lines.
+	if (stored) {
+		return parseWorkspaceCardConfig(stored);
+	}
+
+	// Repo or defaults path.
+	const block = readRepoWorkspaceCardBlock(projectId);
+	const config =
+		block !== undefined
+			? parseWorkspaceCardConfig(block)
+			: DEFAULT_WORKSPACE_CARD_CONFIG;
+
+	if (block === undefined) {
+		// defaults -- no custom lines anyway
+		return config;
+	}
+
+	const storedHash = appState.data.trustedCardCommandProjects?.[projectId];
+	return applyCommandGating(config, storedHash);
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/card-lines.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/card-lines.ts
@@ -1,0 +1,91 @@
+import { execFile } from "node:child_process";
+import { z } from "zod";
+import { publicProcedure, router } from "../../..";
+import { resolveGatedWorkspaceCardConfig } from "../../config/workspace-card-trust";
+import { getWorkspace } from "../utils/db-helpers";
+import { getWorkspacePath } from "../utils/worktree";
+
+const COMMAND_TIMEOUT_MS = 5_000;
+const OUTPUT_MAX_CHARS = 200;
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+	at: number;
+	value: CardLineResult;
+}
+
+export interface CardLineResult {
+	output: string | null;
+	error: string | null;
+}
+
+// Dampens refetch storms: many card mounts can ask for the same line.
+const cache = new Map<string, CacheEntry>();
+
+function runCommand(command: string, cwd: string): Promise<CardLineResult> {
+	return new Promise((resolve) => {
+		execFile(
+			"/bin/sh",
+			["-c", command],
+			{ cwd, timeout: COMMAND_TIMEOUT_MS, maxBuffer: 64 * 1024 },
+			(error, stdout, stderr) => {
+				if (error) {
+					resolve({
+						output: null,
+						error: (stderr || error.message).slice(0, OUTPUT_MAX_CHARS),
+					});
+					return;
+				}
+				const firstLine = stdout.split("\n").find((line) => line.trim());
+				resolve({
+					output: (firstLine ?? "").trim().slice(0, OUTPUT_MAX_CHARS),
+					error: null,
+				});
+			},
+		);
+	});
+}
+
+/**
+ * Runs a user-defined card-line command in the workspace folder and returns
+ * the first line of output. The command is resolved by lineId from the
+ * project's gated config -- the renderer never sends a raw command string.
+ * Results cache briefly per (workspace, lineId).
+ */
+export const createCardLinesProcedures = () => {
+	return router({
+		getCardLineOutput: publicProcedure
+			.input(z.object({ workspaceId: z.string(), lineId: z.string() }))
+			.query(async ({ input }): Promise<CardLineResult> => {
+				const key = `${input.workspaceId} ${input.lineId}`;
+				const cached = cache.get(key);
+				if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+					return cached.value;
+				}
+
+				const workspace = getWorkspace(input.workspaceId);
+				if (!workspace) {
+					return { output: null, error: "Workspace folder not found" };
+				}
+
+				// Resolve command from the gated config -- untrusted repo command
+				// lines are absent, so unknown lineId means "not permitted here".
+				const config = resolveGatedWorkspaceCardConfig(workspace.projectId);
+				const line = config.customLines.find(
+					(l) => l.id === input.lineId && l.type === "command" && l.enabled,
+				);
+				if (!line || line.type !== "command") {
+					return { output: null, error: "Unknown card line" };
+				}
+
+				const cwd = getWorkspacePath(workspace);
+				if (!cwd) {
+					return { output: null, error: "Workspace folder not found" };
+				}
+
+				const value = await runCommand(line.command, cwd);
+				cache.set(key, { at: Date.now(), value });
+				return value;
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/workspaces/workspaces.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/workspaces.ts
@@ -1,4 +1,5 @@
 import { mergeRouters } from "../..";
+import { createCardLinesProcedures } from "./procedures/card-lines";
 import { createCreateProcedures } from "./procedures/create";
 import { createDeleteProcedures } from "./procedures/delete";
 import { createGenerateBranchNameProcedures } from "./procedures/generate-branch-name";
@@ -18,6 +19,7 @@ export const createWorkspacesRouter = () => {
 		createInitProcedures(),
 		createSectionsProcedures(),
 		createGenerateBranchNameProcedures(),
+		createCardLinesProcedures(),
 	);
 };
 

--- a/apps/desktop/src/main/lib/app-state/schemas.ts
+++ b/apps/desktop/src/main/lib/app-state/schemas.ts
@@ -3,6 +3,7 @@
  */
 import type { BaseTabsState } from "shared/tabs-types";
 import type { Theme } from "shared/themes";
+import type { WorkspaceCardConfig } from "shared/workspace-card-config";
 
 // Re-export for convenience
 export type { BaseTabsState as TabsState, Pane } from "shared/tabs-types";
@@ -24,6 +25,14 @@ export interface AppState {
 	tabsState: BaseTabsState;
 	themeState: ThemeState;
 	hotkeysState: LegacyHotkeysState;
+	/** Sidebar workspace-card field visibility, keyed by projectId (v1 local or v2 cloud id). */
+	workspaceCardConfigs?: Record<string, WorkspaceCardConfig>;
+	/**
+	 * Consent gate for repo-sourced command lines. Maps projectId to the SHA-256
+	 * hash of the command set the user approved. If the repo's commands change,
+	 * the hash no longer matches and approval is required again.
+	 */
+	trustedCardCommandProjects?: Record<string, string>;
 }
 
 export const defaultAppState: AppState = {

--- a/apps/desktop/src/renderer/hooks/useConfigureCardWithAgent/index.ts
+++ b/apps/desktop/src/renderer/hooks/useConfigureCardWithAgent/index.ts
@@ -1,0 +1,4 @@
+export {
+	CONFIGURE_CARD_PROMPT,
+	useConfigureCardWithAgent,
+} from "./useConfigureCardWithAgent";

--- a/apps/desktop/src/renderer/hooks/useConfigureCardWithAgent/useConfigureCardWithAgent.ts
+++ b/apps/desktop/src/renderer/hooks/useConfigureCardWithAgent/useConfigureCardWithAgent.ts
@@ -1,0 +1,22 @@
+import { useNewWorkspaceDraftStore } from "renderer/stores/new-workspace-draft";
+import { useNewWorkspaceModalStore } from "renderer/stores/new-workspace-modal";
+
+export const CONFIGURE_CARD_PROMPT = `Open .superset/config.json in this repository and help me adjust the "workspaceCard" block. It is the repo-shared default for which lines the sidebar workspace cards show. Schema: boolean fields prTitle, prChecks, diffStats, status, linearTicket (all default to true), plus a customLines array. Each customLines entry is one of two shapes, discriminated by "type": (1) command lines — { id, type: "command", label, command, enabled } — the shell command runs in the workspace folder and the first line of its output shows on the card ("type" may be omitted; it defaults to "command"); (2) component lines — { id, type: "component", label, component, enabled } — "component" names a built-in app widget. Valid component keys: "pomodoro" (elapsed time since workspace creation as 25-minute pomodoro cycles), "clock" (current local time), "pr-checks-inline" (compact PR checks summary). Unknown component keys render nothing. "id" must be unique per line; "label" is an optional prefix; "enabled" defaults to true. The full reference lives in docs/WORKSPACE_CARDS.md of the superset repo if available. Ask me which lines I want visible and whether I want custom lines, then update the file accordingly, preserving every other key in the config. Note: the app's card settings only override this file on a machine when they diverge from it.`;
+
+/**
+ * "Configure card with agent": pre-fills the new-workspace prompt and opens
+ * the creation modal — same flow as setup/teardown script configuration. The
+ * user reviews and submits; nothing starts automatically.
+ */
+export function useConfigureCardWithAgent(projectId: string): () => void {
+	const updateDraft = useNewWorkspaceDraftStore((s) => s.updateDraft);
+	const openNewWorkspaceModal = useNewWorkspaceModalStore((s) => s.openModal);
+
+	return () => {
+		updateDraft({
+			prompt: CONFIGURE_CARD_PROMPT,
+			selectedProjectId: projectId,
+		});
+		openNewWorkspaceModal(projectId);
+	};
+}

--- a/apps/desktop/src/renderer/hooks/useLinkedTicket/index.ts
+++ b/apps/desktop/src/renderer/hooks/useLinkedTicket/index.ts
@@ -1,0 +1,2 @@
+export { extractTicketKeyFromBranch } from "./ticket-key";
+export { type LinkedTicket, useLinkedTicket } from "./useLinkedTicket";

--- a/apps/desktop/src/renderer/hooks/useLinkedTicket/ticket-key.test.ts
+++ b/apps/desktop/src/renderer/hooks/useLinkedTicket/ticket-key.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { extractTicketKeyFromBranch } from "./ticket-key";
+
+describe("extractTicketKeyFromBranch", () => {
+	it("extracts and uppercases a ticket key embedded in a branch", () => {
+		expect(extractTicketKeyFromBranch("adelin/super-172-fix-cards")).toBe(
+			"SUPER-172",
+		);
+		expect(extractTicketKeyFromBranch("ABC-12")).toBe("ABC-12");
+		expect(extractTicketKeyFromBranch("feature/eng-9-thing")).toBe("ENG-9");
+	});
+
+	it("returns null when no key is present", () => {
+		expect(extractTicketKeyFromBranch("main")).toBeNull();
+		expect(extractTicketKeyFromBranch("feat/multi-window")).toBeNull();
+	});
+
+	it("ignores trailing digit-only segments that are not keys", () => {
+		// "v2" style segments must not match (single letter prefix is required
+		// to have at least two chars before the dash).
+		expect(extractTicketKeyFromBranch("release/v2-1")).toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/hooks/useLinkedTicket/ticket-key.ts
+++ b/apps/desktop/src/renderer/hooks/useLinkedTicket/ticket-key.ts
@@ -1,0 +1,10 @@
+/**
+ * Ticket keys look like "SUPER-172" / "ABC-12"; workspace branches created
+ * from a task usually embed the key ("adelin/super-172-fix-cards").
+ */
+export function extractTicketKeyFromBranch(branch: string): string | null {
+	// Team prefixes are at least two letters ("ENG", "SUPER") — requiring that
+	// keeps version-ish segments like "v2-1" from matching.
+	const match = branch.match(/\b([a-z]{2,}-\d+)\b/i);
+	return match?.[1]?.toUpperCase() ?? null;
+}

--- a/apps/desktop/src/renderer/hooks/useLinkedTicket/useLinkedTicket.ts
+++ b/apps/desktop/src/renderer/hooks/useLinkedTicket/useLinkedTicket.ts
@@ -1,0 +1,70 @@
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { extractTicketKeyFromBranch } from "./ticket-key";
+
+export interface LinkedTicket {
+	key: string;
+	state: string;
+	url: string;
+}
+
+/**
+ * Resolves the external (Linear) ticket linked to a v2 workspace from the
+ * synced tasks collection. Primary link is the workspace's taskId; fallback
+ * is a ticket key embedded in the branch name.
+ */
+export function useLinkedTicket(
+	taskId: string | null,
+	branch: string,
+): LinkedTicket | null {
+	const collections = useCollections();
+	const candidateKey = extractTicketKeyFromBranch(branch);
+
+	const { data: byId = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ tasks: collections.tasks })
+				.where(({ tasks }) => eq(tasks.id, taskId ?? ""))
+				.select(({ tasks }) => ({
+					externalKey: tasks.externalKey,
+					externalUrl: tasks.externalUrl,
+					statusId: tasks.statusId,
+				})),
+		[collections, taskId],
+	);
+
+	const { data: byKey = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ tasks: collections.tasks })
+				.where(({ tasks }) => eq(tasks.externalKey, candidateKey ?? ""))
+				.select(({ tasks }) => ({
+					externalKey: tasks.externalKey,
+					externalUrl: tasks.externalUrl,
+					statusId: tasks.statusId,
+				})),
+		[collections, candidateKey],
+	);
+
+	const task = byId[0] ?? byKey[0] ?? null;
+
+	const { data: statusMatches = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ statuses: collections.taskStatuses })
+				.where(({ statuses }) => eq(statuses.id, task?.statusId ?? ""))
+				.select(({ statuses }) => ({ name: statuses.name })),
+		[collections, task?.statusId],
+	);
+
+	if (!task?.externalKey) {
+		return null;
+	}
+
+	return {
+		key: task.externalKey,
+		state: statusMatches[0]?.name ?? "",
+		url: task.externalUrl ?? "",
+	};
+}

--- a/apps/desktop/src/renderer/hooks/useWorkspaceCardConfigSync/index.ts
+++ b/apps/desktop/src/renderer/hooks/useWorkspaceCardConfigSync/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceCardConfigSync } from "./useWorkspaceCardConfigSync";

--- a/apps/desktop/src/renderer/hooks/useWorkspaceCardConfigSync/useWorkspaceCardConfigSync.ts
+++ b/apps/desktop/src/renderer/hooks/useWorkspaceCardConfigSync/useWorkspaceCardConfigSync.ts
@@ -1,0 +1,22 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+/**
+ * Live-reloads workspace card configs: subscribes to main-process file
+ * watching of the project's .superset/config.json and invalidates the
+ * config queries when it changes. Mount once per project (the sidebar
+ * project sections do), not per workspace row.
+ */
+export function useWorkspaceCardConfigSync(projectId: string): void {
+	const utils = electronTrpc.useUtils();
+	electronTrpc.config.watchWorkspaceCardConfig.useSubscription(
+		{ projectId },
+		{
+			onData: () => {
+				void utils.config.getWorkspaceCardConfig.invalidate({ projectId });
+				void utils.config.getWorkspaceCardConfigSource.invalidate({
+					projectId,
+				});
+			},
+		},
+	);
+}

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/githubQueryPolicy.ts
@@ -8,6 +8,7 @@ export type GitHubStatusQuerySurface =
 	| "workspace-page"
 	| "workspace-hover-card"
 	| "workspace-list-item"
+	| "workspace-card"
 	| "workspace-row";
 
 export interface GitHubQueryPolicy {
@@ -32,6 +33,10 @@ const HOVER_SURFACES: ReadonlySet<GitHubStatusQuerySurface> = new Set([
 	"workspace-list-item",
 	"workspace-row",
 	"workspace-hover-card",
+	// Cards fetch eagerly on mount (caller passes isActive=true without a
+	// hover gate) but must never poll — one gh call per workspace per
+	// staleness window, refreshed by the existing hover path.
+	"workspace-card",
 ]);
 
 /**

--- a/apps/desktop/src/renderer/lib/githubQueryPolicy/useHoverGitHubStatus.ts
+++ b/apps/desktop/src/renderer/lib/githubQueryPolicy/useHoverGitHubStatus.ts
@@ -10,18 +10,24 @@ interface UseHoverGitHubStatusOptions {
 	workspaceId: string | null | undefined;
 	surface: GitHubStatusQuerySurface;
 	isWorktree: boolean;
+	/**
+	 * Fetch on mount instead of waiting for the first hover. Used by sidebar
+	 * cards that show PR info inline. Hover still drives refreshes.
+	 */
+	eager?: boolean;
 }
 
 export function useHoverGitHubStatus({
 	workspaceId,
 	surface,
 	isWorktree,
+	eager = false,
 }: UseHoverGitHubStatusOptions) {
 	const [hasHovered, setHasHovered] = useState(false);
 
 	const queryPolicy = getGitHubStatusQueryPolicy(surface, {
 		hasWorkspaceId: !!workspaceId,
-		isActive: hasHovered && isWorktree,
+		isActive: (eager || hasHovered) && isWorktree,
 	});
 
 	const {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -5,6 +5,7 @@ import type {
 import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { useMemo } from "react";
+import { useWorkspaceCardConfigSync } from "renderer/hooks/useWorkspaceCardConfigSync";
 import type { DashboardSidebarProject } from "../../types";
 import { getProjectChildrenWorkspaces } from "../../utils/projectChildren";
 import { DashboardSidebarCollapsedProjectContent } from "./components/DashboardSidebarCollapsedProjectContent";
@@ -38,6 +39,8 @@ export function DashboardSidebarProjectSection({
 		() => getProjectChildrenWorkspaces(project.children),
 		[project.children],
 	);
+	// Card configs live-reload when .superset/config.json changes on disk.
+	useWorkspaceCardConfigSync(project.id);
 
 	const {
 		cancelRename,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -8,10 +8,13 @@ import {
 } from "react";
 import { HiMiniMinus, HiMiniXMark } from "react-icons/hi2";
 import type { DiffStats } from "renderer/hooks/host-service/useDiffStats";
+import { useLinkedTicket } from "renderer/hooks/useLinkedTicket";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
+import { WorkspaceCardLines } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceCardLines";
 import type { ActivePaneStatus } from "shared/tabs-types";
+import { DEFAULT_WORKSPACE_CARD_CONFIG } from "shared/workspace-card-config";
 import type {
 	DashboardSidebarWorkspace,
 	DashboardSidebarWorkspacePullRequest,
@@ -84,6 +87,13 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			pendingTransaction,
 		} = workspace;
 		const isPending = pendingTransaction?.type === "insert";
+		const { data: cardConfigData } =
+			electronTrpc.config.getWorkspaceCardConfig.useQuery(
+				{ projectId: workspace.projectId },
+				{ staleTime: 60_000 },
+			);
+		const cardConfig = cardConfigData ?? DEFAULT_WORKSPACE_CARD_CONFIG;
+		const linkedTicket = useLinkedTicket(workspace.taskId, branch);
 		const showsStandaloneActiveStripe = accentColor == null;
 		const localRef = useRef<HTMLDivElement>(null);
 		const openUrl = electronTrpc.external.openUrl.useMutation();
@@ -228,113 +238,128 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 					</TooltipContent>
 				</Tooltip>
 
-				<div className="grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5">
-					{isRenaming ? (
-						<RenameInput
-							value={renameValue}
-							onChange={onRenameValueChange}
-							onSubmit={onSubmitRename}
-							onCancel={onCancelRename}
-							className={cn(
-								"h-5 w-full -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none",
-							)}
-						/>
-					) : (
-						<span
-							className={cn(
-								"truncate text-[13px] leading-tight transition-colors",
-								isActive ? "text-foreground" : "text-foreground/80",
-							)}
-						>
-							{name || branch}
-						</span>
-					)}
-
-					<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center justify-items-end [&>*]:col-start-1 [&>*]:row-start-1">
-						{creationStatusText ? (
-							<span className="text-[11px] text-muted-foreground">
-								{creationStatusText}
-							</span>
+				<div className="min-w-0 flex-1">
+					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5">
+						{isRenaming ? (
+							<RenameInput
+								value={renameValue}
+								onChange={onRenameValueChange}
+								onSubmit={onSubmitRename}
+								onCancel={onCancelRename}
+								className={cn(
+									"h-5 w-full -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none",
+								)}
+							/>
 						) : (
-							diffStats &&
-							(diffStats.additions > 0 || diffStats.deletions > 0) && (
-								<DashboardSidebarWorkspaceDiffStats
-									additions={diffStats.additions}
-									deletions={diffStats.deletions}
-									isActive={isActive}
-								/>
-							)
-						)}
-						{!isPending && (
-							<div className="hidden items-center justify-end gap-1.5 group-hover:flex">
-								{shortcutLabel && (
-									<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
-										{shortcutLabel}
-									</span>
+							<span
+								className={cn(
+									"truncate text-[13px] leading-tight transition-colors",
+									isActive ? "text-foreground" : "text-foreground/80",
 								)}
-								{isMainWorkspace ? (
-									<Tooltip delayDuration={300}>
-										<TooltipTrigger asChild>
-											<button
-												type="button"
-												onClick={(event) => {
-													event.stopPropagation();
-													onRemoveFromSidebarClick();
-												}}
-												onKeyDown={(event) => {
-													if (
-														event.key === "Enter" ||
-														event.key === " " ||
-														event.key === "Spacebar"
-													) {
-														event.stopPropagation();
-													}
-												}}
-												className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-												aria-label="Remove from sidebar"
-											>
-												<HiMiniMinus className="size-3.5" />
-											</button>
-										</TooltipTrigger>
-										<TooltipContent side="top" sideOffset={4}>
-											<HotkeyLabel label="Remove from sidebar" />
-										</TooltipContent>
-									</Tooltip>
-								) : (
-									<Tooltip delayDuration={300}>
-										<TooltipTrigger asChild>
-											<button
-												type="button"
-												onClick={(event) => {
-													event.stopPropagation();
-													onCloseWorkspaceClick();
-												}}
-												onKeyDown={(event) => {
-													if (
-														event.key === "Enter" ||
-														event.key === " " ||
-														event.key === "Spacebar"
-													) {
-														event.stopPropagation();
-													}
-												}}
-												className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-												aria-label="Close workspace"
-											>
-												<HiMiniXMark className="size-3.5" />
-											</button>
-										</TooltipTrigger>
-										<TooltipContent side="top" sideOffset={4}>
-											<HotkeyLabel
-												label="Close workspace"
-												id={isActive ? "CLOSE_WORKSPACE" : undefined}
-											/>
-										</TooltipContent>
-									</Tooltip>
-								)}
-							</div>
+							>
+								{name || branch}
+							</span>
 						)}
+
+						<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center justify-items-end [&>*]:col-start-1 [&>*]:row-start-1">
+							{creationStatusText ? (
+								<span className="text-[11px] text-muted-foreground">
+									{creationStatusText}
+								</span>
+							) : (
+								cardConfig.diffStats &&
+								diffStats &&
+								(diffStats.additions > 0 || diffStats.deletions > 0) && (
+									<DashboardSidebarWorkspaceDiffStats
+										additions={diffStats.additions}
+										deletions={diffStats.deletions}
+										isActive={isActive}
+									/>
+								)
+							)}
+							{!isPending && (
+								<div className="hidden items-center justify-end gap-1.5 group-hover:flex">
+									{shortcutLabel && (
+										<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+											{shortcutLabel}
+										</span>
+									)}
+									{isMainWorkspace ? (
+										<Tooltip delayDuration={300}>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={(event) => {
+														event.stopPropagation();
+														onRemoveFromSidebarClick();
+													}}
+													onKeyDown={(event) => {
+														if (
+															event.key === "Enter" ||
+															event.key === " " ||
+															event.key === "Spacebar"
+														) {
+															event.stopPropagation();
+														}
+													}}
+													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+													aria-label="Remove from sidebar"
+												>
+													<HiMiniMinus className="size-3.5" />
+												</button>
+											</TooltipTrigger>
+											<TooltipContent side="top" sideOffset={4}>
+												<HotkeyLabel label="Remove from sidebar" />
+											</TooltipContent>
+										</Tooltip>
+									) : (
+										<Tooltip delayDuration={300}>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={(event) => {
+														event.stopPropagation();
+														onCloseWorkspaceClick();
+													}}
+													onKeyDown={(event) => {
+														if (
+															event.key === "Enter" ||
+															event.key === " " ||
+															event.key === "Spacebar"
+														) {
+															event.stopPropagation();
+														}
+													}}
+													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+													aria-label="Close workspace"
+												>
+													<HiMiniXMark className="size-3.5" />
+												</button>
+											</TooltipTrigger>
+											<TooltipContent side="top" sideOffset={4}>
+												<HotkeyLabel
+													label="Close workspace"
+													id={isActive ? "CLOSE_WORKSPACE" : undefined}
+												/>
+											</TooltipContent>
+										</Tooltip>
+									)}
+								</div>
+							)}
+						</div>
 					</div>
+					{!isPending && (
+						<WorkspaceCardLines
+							config={cardConfig}
+							pr={pullRequest}
+							workspaceStatus={workspaceStatus}
+							linearTicket={linkedTicket}
+							workspaceId={workspace.id}
+							projectId={workspace.projectId}
+							branch={branch}
+							workspaceName={name}
+						/>
+					)}
 				</div>
 			</div>
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -11,21 +11,26 @@ import {
 } from "@superset/ui/context-menu";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
+import { useState } from "react";
 import {
 	LuArrowRightLeft,
 	LuArrowUp,
+	LuBot,
 	LuCopy,
 	LuEye,
 	LuEyeOff,
 	LuFolderOpen,
 	LuFolderPlus,
 	LuGitBranch,
+	LuLayoutList,
 	LuPencil,
 	LuTrash2,
 	LuX,
 } from "react-icons/lu";
+import { useConfigureCardWithAgent } from "renderer/hooks/useConfigureCardWithAgent";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { WorkspaceCardDialog } from "renderer/screens/main/components/WorkspaceCardDialog";
 import { useDashboardSidebarHover } from "../../../../providers/DashboardSidebarHoverProvider";
 
 interface DashboardSidebarWorkspaceContextMenuProps {
@@ -67,6 +72,8 @@ export function DashboardSidebarWorkspaceContextMenu({
 }: DashboardSidebarWorkspaceContextMenuProps) {
 	const collections = useCollections();
 	const { setContextMenuOpen } = useDashboardSidebarHover();
+	const [isCardDialogOpen, setIsCardDialogOpen] = useState(false);
+	const configureCardWithAgent = useConfigureCardWithAgent(projectId);
 	const deleteHotkeyText = useHotkeyDisplay("CLOSE_WORKSPACE").text;
 	const showDeleteShortcut =
 		showDeleteHotkey && deleteHotkeyText !== "Unassigned";
@@ -111,6 +118,15 @@ export function DashboardSidebarWorkspaceContextMenu({
 				<ContextMenuItem onSelect={onCopyBranchName}>
 					<LuGitBranch className="size-4 mr-2" />
 					Copy Branch Name
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onSelect={() => setIsCardDialogOpen(true)}>
+					<LuLayoutList className="size-4 mr-2" />
+					Customize Card…
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={configureCardWithAgent}>
+					<LuBot className="size-4 mr-2" />
+					Configure Card with Agent
 				</ContextMenuItem>
 				<ContextMenuSeparator />
 				<ContextMenuItem onSelect={onToggleUnread}>
@@ -187,6 +203,11 @@ export function DashboardSidebarWorkspaceContextMenu({
 					</ContextMenuItem>
 				) : null}
 			</ContextMenuContent>
+			<WorkspaceCardDialog
+				projectId={projectId}
+				open={isCardDialogOpen}
+				onOpenChange={setIsCardDialogOpen}
+			/>
 		</ContextMenu>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -49,6 +49,7 @@ import {
 } from "../../../../utils/settings-search";
 import { ProjectSettingsHeader } from "../ProjectSettingsHeader";
 import { ScriptsEditor } from "./components/ScriptsEditor";
+import { WorkspaceCardSettings } from "./components/WorkspaceCardSettings";
 
 const REPO_DEFAULT_BASE_BRANCH = "__repo_default__";
 
@@ -385,6 +386,13 @@ export function ProjectSettings({
 							workspaces will fall back to "{repoDefaultBranch}".
 						</p>
 					)}
+				</SettingsSection>
+
+				<SettingsSection
+					title="Workspace cards"
+					description="Which lines the sidebar workspace cards show for this project"
+				>
+					<WorkspaceCardSettings projectId={projectId} />
 				</SettingsSection>
 
 				<SettingsSection title="Worktrees">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/WorkspaceCardSettings/WorkspaceCardSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/WorkspaceCardSettings/WorkspaceCardSettings.tsx
@@ -1,0 +1,191 @@
+import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { Switch } from "@superset/ui/switch";
+import { LuBot, LuRotateCcw, LuShieldAlert } from "react-icons/lu";
+import { useConfigureCardWithAgent } from "renderer/hooks/useConfigureCardWithAgent";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	DEFAULT_WORKSPACE_CARD_CONFIG,
+	type WorkspaceCardConfig,
+} from "shared/workspace-card-config";
+
+interface WorkspaceCardSettingsProps {
+	projectId: string;
+}
+
+type BooleanCardField = {
+	[K in keyof WorkspaceCardConfig]: WorkspaceCardConfig[K] extends boolean
+		? K
+		: never;
+}[keyof WorkspaceCardConfig];
+
+const FIELD_LABELS: Array<{
+	key: BooleanCardField;
+	label: string;
+	description: string;
+}> = [
+	{
+		key: "prTitle",
+		label: "Pull request title",
+		description: "Show the PR title under the workspace name",
+	},
+	{
+		key: "prChecks",
+		label: "PR checks & review",
+		description: "CI check status and review decision next to the PR title",
+	},
+	{
+		key: "diffStats",
+		label: "Diff stats",
+		description: "Added/removed line counts",
+	},
+	{
+		key: "status",
+		label: "Agent status",
+		description: "Working / needs permission / ready for review line",
+	},
+	{
+		key: "linearTicket",
+		label: "Linear ticket",
+		description:
+			"Ticket key and state from the synced task linked to the branch (uses the org's Linear integration)",
+	},
+];
+
+export function WorkspaceCardSettings({
+	projectId,
+}: WorkspaceCardSettingsProps) {
+	const utils = electronTrpc.useUtils();
+	const configureWithAgent = useConfigureCardWithAgent(projectId);
+
+	const { data: configData } =
+		electronTrpc.config.getWorkspaceCardConfig.useQuery({ projectId });
+	const config = configData ?? DEFAULT_WORKSPACE_CARD_CONFIG;
+	const { data: configSource } =
+		electronTrpc.config.getWorkspaceCardConfigSource.useQuery({ projectId });
+	const { data: trustState } =
+		electronTrpc.config.getWorkspaceCardTrustState.useQuery({ projectId });
+
+	const invalidate = () => {
+		void utils.config.getWorkspaceCardConfig.invalidate({ projectId });
+		void utils.config.getWorkspaceCardConfigSource.invalidate({ projectId });
+		void utils.config.getWorkspaceCardTrustState.invalidate({ projectId });
+	};
+
+	const updateMutation =
+		electronTrpc.config.updateWorkspaceCardConfig.useMutation({
+			onError: (error) =>
+				toast.error(`Failed to save card settings: ${error.message}`),
+			onMutate: ({ workspaceCard }) => {
+				// Optimistic update: rapid toggles build on the latest cache value
+				// rather than a potentially stale snapshot, preventing lost updates.
+				utils.config.getWorkspaceCardConfig.setData(
+					{ projectId },
+					workspaceCard as WorkspaceCardConfig,
+				);
+			},
+			onSettled: invalidate,
+		});
+
+	const resetMutation =
+		electronTrpc.config.resetWorkspaceCardConfig.useMutation({
+			onError: (error) =>
+				toast.error(`Failed to reset card settings: ${error.message}`),
+			onSettled: invalidate,
+		});
+
+	const trustMutation = electronTrpc.config.trustCardCommands.useMutation({
+		onError: (error) =>
+			toast.error(`Failed to approve commands: ${error.message}`),
+		onSettled: invalidate,
+	});
+
+	const handleToggle = (key: BooleanCardField, value: boolean) => {
+		// Read from cache at call time to chain correctly with optimistic updates.
+		const latest =
+			utils.config.getWorkspaceCardConfig.getData({ projectId }) ?? config;
+		updateMutation.mutate({
+			projectId,
+			workspaceCard: { ...latest, [key]: value },
+		});
+	};
+
+	const pendingCount = trustState?.pendingCommandCount ?? 0;
+
+	return (
+		<div className="space-y-4">
+			{pendingCount > 0 && (
+				<div className="flex items-start gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
+					<LuShieldAlert className="mt-0.5 size-4 shrink-0 text-amber-500" />
+					<div className="min-w-0 flex-1">
+						<p className="font-medium text-foreground">
+							Repo-defined command{pendingCount === 1 ? "" : "s"} pending
+							approval
+						</p>
+						<p className="mt-0.5 text-xs text-muted-foreground">
+							This project&apos;s{" "}
+							<code className="font-mono">.superset/config.json</code> defines{" "}
+							{pendingCount} command{pendingCount === 1 ? "" : "s"} that run
+							automatically on each workspace card. Approve to enable them.
+						</p>
+						<div className="mt-2 flex gap-2">
+							<Button
+								size="sm"
+								variant="outline"
+								className="h-7 border-amber-500/40 text-xs"
+								onClick={() => trustMutation.mutate({ projectId })}
+								disabled={trustMutation.isPending}
+							>
+								Run them
+							</Button>
+							<Button
+								size="sm"
+								variant="ghost"
+								className="h-7 text-xs text-muted-foreground"
+								disabled={trustMutation.isPending}
+							>
+								Keep disabled
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+			{FIELD_LABELS.map(({ key, label, description }) => (
+				<div key={key} className="flex items-center justify-between gap-4">
+					<div className="min-w-0">
+						<p className="text-sm text-foreground">{label}</p>
+						<p className="text-xs text-muted-foreground">{description}</p>
+					</div>
+					<Switch
+						checked={config[key]}
+						onCheckedChange={(value) => handleToggle(key, value)}
+						disabled={updateMutation.isPending}
+					/>
+				</div>
+			))}
+			<div className="flex items-center justify-end gap-2 pt-1">
+				{configSource === "override" && (
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => resetMutation.mutate({ projectId })}
+						disabled={resetMutation.isPending}
+						className="gap-1.5 text-muted-foreground"
+					>
+						<LuRotateCcw className="size-3.5" />
+						Reset to repo config
+					</Button>
+				)}
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={configureWithAgent}
+					className="gap-1.5"
+				>
+					<LuBot className="size-3.5" />
+					Configure with agent
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/WorkspaceCardSettings/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/WorkspaceCardSettings/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceCardSettings } from "./WorkspaceCardSettings";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.tsx
@@ -8,6 +8,7 @@ import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { WorkspaceCardSettings } from "renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/WorkspaceCardSettings";
 import {
 	HostSelect,
 	type HostSelectOption,
@@ -205,6 +206,15 @@ export function V2ProjectSettings({
 							<V2ScriptsEditor hostUrl={targetHostUrl} projectId={projectId} />
 						</div>
 					)}
+					<div className="pt-4">
+						<div className="mb-3">
+							<h3 className="text-sm font-medium">Workspace cards</h3>
+							<p className="mt-0.5 text-xs text-muted-foreground">
+								Which lines the sidebar workspace cards show for this project.
+							</p>
+						</div>
+						<WorkspaceCardSettings projectId={projectId} />
+					</div>
 				</section>
 
 				<section>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceCardDialog/WorkspaceCardDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceCardDialog/WorkspaceCardDialog.tsx
@@ -1,0 +1,216 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { toast } from "@superset/ui/sonner";
+import { Switch } from "@superset/ui/switch";
+import { useState } from "react";
+import { HiMiniXMark } from "react-icons/hi2";
+import { LuPlus } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	type CustomCardLine,
+	DEFAULT_WORKSPACE_CARD_CONFIG,
+	type WorkspaceCardConfig,
+} from "shared/workspace-card-config";
+
+type BooleanCardField = {
+	[K in keyof WorkspaceCardConfig]: WorkspaceCardConfig[K] extends boolean
+		? K
+		: never;
+}[keyof WorkspaceCardConfig];
+
+const FIELD_LABELS: Array<{ key: BooleanCardField; label: string }> = [
+	{ key: "prTitle", label: "Pull request title" },
+	{ key: "prChecks", label: "PR checks & review" },
+	{ key: "diffStats", label: "Diff stats" },
+	{ key: "status", label: "Agent status" },
+	{ key: "linearTicket", label: "Linear ticket" },
+];
+
+interface WorkspaceCardDialogProps {
+	projectId: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Card customization dialog, opened from a workspace card's context menu.
+ * Toggles the built-in lines and manages custom script lines: each command
+ * runs in the workspace folder and its first output line shows on the card.
+ */
+export function WorkspaceCardDialog({
+	projectId,
+	open,
+	onOpenChange,
+}: WorkspaceCardDialogProps) {
+	const utils = electronTrpc.useUtils();
+	const { data: configData } =
+		electronTrpc.config.getWorkspaceCardConfig.useQuery(
+			{ projectId },
+			{ enabled: open },
+		);
+	const config = configData ?? DEFAULT_WORKSPACE_CARD_CONFIG;
+
+	const [newLabel, setNewLabel] = useState("");
+	const [newCommand, setNewCommand] = useState("");
+
+	const updateMutation =
+		electronTrpc.config.updateWorkspaceCardConfig.useMutation({
+			onError: (error) =>
+				toast.error(`Failed to save card settings: ${error.message}`),
+			onMutate: ({ workspaceCard }) => {
+				// Optimistic update: write directly to the query cache so subsequent
+				// rapid toggles read the latest value rather than a stale snapshot.
+				utils.config.getWorkspaceCardConfig.setData(
+					{ projectId },
+					workspaceCard as WorkspaceCardConfig,
+				);
+			},
+			onSettled: () =>
+				utils.config.getWorkspaceCardConfig.invalidate({ projectId }),
+		});
+
+	// Always build saves from the latest cached value to avoid lost updates.
+	const save = (next: WorkspaceCardConfig) => {
+		updateMutation.mutate({ projectId, workspaceCard: next });
+	};
+
+	const handleAddLine = () => {
+		const command = newCommand.trim();
+		if (!command) return;
+		const line: CustomCardLine = {
+			id: `line-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+			type: "command",
+			label: newLabel.trim(),
+			command,
+			enabled: true,
+		};
+		save({ ...config, customLines: [...config.customLines, line] });
+		setNewLabel("");
+		setNewCommand("");
+	};
+
+	const patchLine = (
+		id: string,
+		patch: { enabled?: boolean; label?: string },
+	) => {
+		save({
+			...config,
+			customLines: config.customLines.map((line) =>
+				line.id === id ? { ...line, ...patch } : line,
+			),
+		});
+	};
+
+	const removeLine = (id: string) => {
+		save({
+			...config,
+			customLines: config.customLines.filter((line) => line.id !== id),
+		});
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Customize workspace cards</DialogTitle>
+					<DialogDescription>
+						Applies to every workspace card of this project.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-2">
+					{FIELD_LABELS.map(({ key, label }) => (
+						<div key={key} className="flex items-center justify-between gap-4">
+							<span className="text-sm">{label}</span>
+							<Switch
+								checked={config[key]}
+								onCheckedChange={(value) => save({ ...config, [key]: value })}
+								disabled={updateMutation.isPending}
+							/>
+						</div>
+					))}
+				</div>
+
+				<div className="space-y-2 border-t border-border pt-3">
+					<div>
+						<p className="text-sm font-medium">Custom lines</p>
+						<p className="text-xs text-muted-foreground">
+							A shell command run in the workspace folder; the first line of its
+							output shows on the card. Same trust as setup scripts.
+						</p>
+					</div>
+
+					{config.customLines.map((line) => (
+						<div key={line.id} className="flex items-center gap-2">
+							<Switch
+								checked={line.enabled}
+								onCheckedChange={(value) =>
+									patchLine(line.id, { enabled: value })
+								}
+								disabled={updateMutation.isPending}
+							/>
+							<span className="w-24 shrink-0 truncate text-xs text-muted-foreground">
+								{line.label || "(no label)"}
+							</span>
+							{line.type === "component" ? (
+								<span
+									className="flex-1 truncate text-xs text-muted-foreground"
+									title={line.component}
+								>
+									component: {line.component}
+								</span>
+							) : (
+								<code className="flex-1 truncate text-xs" title={line.command}>
+									{line.command}
+								</code>
+							)}
+							<button
+								type="button"
+								onClick={() => removeLine(line.id)}
+								className="text-muted-foreground hover:text-foreground"
+								aria-label="Remove custom line"
+							>
+								<HiMiniXMark className="size-3.5" />
+							</button>
+						</div>
+					))}
+
+					<div className="flex items-center gap-2">
+						<Input
+							placeholder="Label"
+							value={newLabel}
+							onChange={(e) => setNewLabel(e.target.value)}
+							className="w-24 shrink-0 h-7 text-xs"
+						/>
+						<Input
+							placeholder="Command, e.g. git log -1 --format=%s"
+							value={newCommand}
+							onChange={(e) => setNewCommand(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") handleAddLine();
+							}}
+							className="flex-1 h-7 text-xs font-mono"
+						/>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={handleAddLine}
+							disabled={!newCommand.trim() || updateMutation.isPending}
+							className="h-7 gap-1 px-2"
+						>
+							<LuPlus className="size-3.5" />
+							Add
+						</Button>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceCardDialog/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceCardDialog/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceCardDialog } from "./WorkspaceCardDialog";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -3,6 +3,7 @@ import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useMemo, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
+import { useWorkspaceCardConfigSync } from "renderer/hooks/useWorkspaceCardConfigSync";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useReorderProjects } from "renderer/react-query/projects";
 import { useWorkspaceSidebarStore } from "renderer/stores";
@@ -72,6 +73,8 @@ export function ProjectSection({
 	const openModal = useOpenNewWorkspaceModal();
 	const reorderProjects = useReorderProjects();
 	const utils = electronTrpc.useUtils();
+	// Card configs live-reload when .superset/config.json changes on disk.
+	useWorkspaceCardConfigSync(projectId);
 
 	const isCollapsed = isProjectCollapsed(projectId);
 	const totalWorkspaceCount =

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceCardLineComponents.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceCardLineComponents.tsx
@@ -1,0 +1,109 @@
+import { type ComponentType, useEffect, useState } from "react";
+import { LuCircleCheck, LuCircleDot, LuCircleX } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useHoverGitHubStatus } from "renderer/lib/githubQueryPolicy";
+import { formatClockLine, formatPomodoroLine } from "./card-line-format";
+
+/**
+ * Props every registered card-line component receives. Components may use
+ * electronTrpc hooks freely — they run inside the normal renderer tree.
+ */
+export interface WorkspaceCardLineComponentProps {
+	workspaceId: string;
+	projectId: string;
+	branch: string;
+	workspaceName: string;
+}
+
+/** Re-render on an interval so time-based lines tick without refetching. */
+function useNow(intervalMs: number): number {
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		const timer = setInterval(() => setNow(Date.now()), intervalMs);
+		return () => clearInterval(timer);
+	}, [intervalMs]);
+	return now;
+}
+
+const TICK_MS = 30_000;
+
+/** Elapsed time since workspace creation as 25-minute pomodoro cycles. */
+function PomodoroCardLine({ workspaceId }: WorkspaceCardLineComponentProps) {
+	const now = useNow(TICK_MS);
+	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
+		{ id: workspaceId },
+		// v2 cloud workspace ids aren't in the local DB — fail silently, once.
+		{ retry: false, staleTime: Number.POSITIVE_INFINITY },
+	);
+	if (!workspace?.createdAt) return null;
+	return (
+		<span className="truncate text-muted-foreground">
+			{formatPomodoroLine(workspace.createdAt, now)}
+		</span>
+	);
+}
+
+/** Current local time, HH:MM. */
+function ClockCardLine(_props: WorkspaceCardLineComponentProps) {
+	const now = useNow(TICK_MS);
+	return (
+		<span className="truncate text-muted-foreground">
+			{formatClockLine(now)}
+		</span>
+	);
+}
+
+const CHECKS_LABELS = {
+	success: "Checks passing",
+	failure: "Checks failing",
+	pending: "Checks running",
+} as const;
+
+/**
+ * Compact PR checks summary. Reuses the workspace-card GitHub fetch policy
+ * (eager, no polling) — React Query dedupes with the card's own PR query.
+ * Renders nothing when the workspace has no PR or no checks.
+ */
+function PrChecksInlineCardLine({
+	workspaceId,
+}: WorkspaceCardLineComponentProps) {
+	const { githubStatus } = useHoverGitHubStatus({
+		workspaceId,
+		surface: "workspace-card",
+		isWorktree: true,
+		eager: true,
+	});
+	const pr = githubStatus?.pr;
+	if (!pr?.checksStatus || pr.checksStatus === "none") return null;
+	return (
+		<span className="flex items-center gap-1 truncate text-muted-foreground">
+			{pr.checksStatus === "success" && (
+				<LuCircleCheck className="size-3 shrink-0 text-emerald-500/90" />
+			)}
+			{pr.checksStatus === "failure" && (
+				<LuCircleX className="size-3 shrink-0 text-red-400/90" />
+			)}
+			{pr.checksStatus === "pending" && (
+				<LuCircleDot className="size-3 shrink-0 text-amber-400/90" />
+			)}
+			{CHECKS_LABELS[pr.checksStatus]}
+			{pr.reviewDecision === "approved" && (
+				<span className="shrink-0 text-emerald-500/80">✓</span>
+			)}
+		</span>
+	);
+}
+
+/**
+ * Registry for component card lines: a customLines entry with
+ * { type: "component", component: "<key>" } renders the matching component.
+ * Unknown keys render nothing, so configs survive app downgrades.
+ */
+export const WorkspaceCardLineComponents: Record<
+	string,
+	ComponentType<WorkspaceCardLineComponentProps>
+> = {
+	pomodoro: PomodoroCardLine,
+	clock: ClockCardLine,
+	"pr-checks-inline": PrChecksInlineCardLine,
+};

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceCardLines.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceCardLines.tsx
@@ -1,0 +1,196 @@
+import { cn } from "@superset/ui/utils";
+import { LuCircleCheck, LuCircleDot, LuCircleX } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { ActivePaneStatus } from "shared/tabs-types";
+import type {
+	CommandCardLine,
+	ComponentCardLine,
+	WorkspaceCardConfig,
+} from "shared/workspace-card-config";
+import {
+	type WorkspaceCardLineComponentProps,
+	WorkspaceCardLineComponents,
+} from "./WorkspaceCardLineComponents";
+
+type ChecksStatus = "success" | "failure" | "pending" | "none";
+
+interface CardPr {
+	title: string;
+	checksStatus?: ChecksStatus;
+	reviewDecision?: string | null;
+}
+
+interface WorkspaceCardLinesProps {
+	config: WorkspaceCardConfig;
+	pr: CardPr | null | undefined;
+	workspaceStatus: ActivePaneStatus | null;
+	linearTicket?: { key: string; state: string; url: string } | null;
+	/** Required for custom script lines — the command runs in this workspace. */
+	workspaceId?: string;
+	/** Required (with workspaceId) for component lines from the registry. */
+	projectId?: string;
+	branch?: string;
+	workspaceName?: string;
+}
+
+const STATUS_LABELS: Record<ActivePaneStatus, string> = {
+	working: "Agent working",
+	permission: "Needs permission",
+	review: "Ready for review",
+};
+
+const STATUS_DOT: Record<ActivePaneStatus, string> = {
+	working: "bg-amber-400",
+	permission: "bg-red-400",
+	review: "bg-emerald-400",
+};
+
+function CustomLineRow({
+	workspaceId,
+	line,
+}: {
+	workspaceId: string;
+	line: CommandCardLine;
+}) {
+	const { data } = electronTrpc.workspaces.getCardLineOutput.useQuery(
+		{ workspaceId, lineId: line.id },
+		{ staleTime: 60_000, refetchInterval: 120_000 },
+	);
+	if (!data?.output) return null;
+	return (
+		<div className="flex items-center gap-1.5 min-w-0">
+			{line.label && (
+				<span className="shrink-0 text-muted-foreground/60">{line.label}</span>
+			)}
+			<span className="truncate text-muted-foreground" title={data.output}>
+				{data.output}
+			</span>
+		</div>
+	);
+}
+
+function ComponentLineRow({
+	line,
+	...componentProps
+}: WorkspaceCardLineComponentProps & { line: ComponentCardLine }) {
+	const Component = WorkspaceCardLineComponents[line.component];
+	// Unknown registry key (config from a newer app version) — render nothing.
+	if (!Component) return null;
+	return (
+		<div className="flex items-center gap-1.5 min-w-0">
+			{line.label && (
+				<span className="shrink-0 text-muted-foreground/60">{line.label}</span>
+			)}
+			<Component {...componentProps} />
+		</div>
+	);
+}
+
+function ChecksIcon({ status }: { status: ChecksStatus }) {
+	if (status === "success") {
+		return <LuCircleCheck className="size-3 shrink-0 text-emerald-500/90" />;
+	}
+	if (status === "failure") {
+		return <LuCircleX className="size-3 shrink-0 text-red-400/90" />;
+	}
+	if (status === "pending") {
+		return <LuCircleDot className="size-3 shrink-0 text-amber-400/90" />;
+	}
+	return null;
+}
+
+/**
+ * Extra always-visible lines on a sidebar workspace card. Which lines render
+ * is driven by the project's workspaceCard config (.superset/config.json).
+ */
+export function WorkspaceCardLines({
+	config,
+	pr,
+	workspaceStatus,
+	linearTicket,
+	workspaceId,
+	projectId,
+	branch,
+	workspaceName,
+}: WorkspaceCardLinesProps) {
+	const showPrLine = config.prTitle && !!pr?.title;
+	const showStatusLine = config.status && workspaceStatus !== null;
+	const showLinearLine = config.linearTicket && !!linearTicket;
+	const customLines = workspaceId
+		? config.customLines.filter((line) => line.enabled)
+		: [];
+
+	if (
+		!showPrLine &&
+		!showStatusLine &&
+		!showLinearLine &&
+		customLines.length === 0
+	) {
+		return null;
+	}
+
+	return (
+		<div className="flex flex-col gap-0.5 text-[11px] leading-tight">
+			{showPrLine && pr && (
+				<div className="flex items-center gap-1.5 min-w-0">
+					{config.prChecks && pr.checksStatus && (
+						<ChecksIcon status={pr.checksStatus} />
+					)}
+					<span className="truncate text-muted-foreground" title={pr.title}>
+						{pr.title}
+					</span>
+					{config.prChecks && pr.reviewDecision === "approved" && (
+						<span className="shrink-0 text-emerald-500/80">✓</span>
+					)}
+					{config.prChecks && pr.reviewDecision === "changes_requested" && (
+						<span className="shrink-0 text-red-400/80">±</span>
+					)}
+				</div>
+			)}
+			{showLinearLine && linearTicket && (
+				<div className="flex items-center gap-1.5 min-w-0">
+					<span className="shrink-0 font-mono text-muted-foreground/80">
+						{linearTicket.key}
+					</span>
+					<span className="truncate text-muted-foreground/60">
+						{linearTicket.state}
+					</span>
+				</div>
+			)}
+			{showStatusLine && workspaceStatus && (
+				<div className="flex items-center gap-1.5">
+					<span
+						className={cn(
+							"size-1.5 shrink-0 rounded-full",
+							STATUS_DOT[workspaceStatus],
+						)}
+					/>
+					<span className="text-muted-foreground/70">
+						{STATUS_LABELS[workspaceStatus]}
+					</span>
+				</div>
+			)}
+			{workspaceId &&
+				customLines.map((line) =>
+					line.type === "component" ? (
+						projectId !== undefined && (
+							<ComponentLineRow
+								key={line.id}
+								line={line}
+								workspaceId={workspaceId}
+								projectId={projectId}
+								branch={branch ?? ""}
+								workspaceName={workspaceName ?? ""}
+							/>
+						)
+					) : (
+						<CustomLineRow
+							key={line.id}
+							workspaceId={workspaceId}
+							line={line}
+						/>
+					),
+				)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -18,6 +18,7 @@ import { useMemo, useRef, useState } from "react";
 import {
 	LuArrowRightLeft,
 	LuBellOff,
+	LuBot,
 	LuCopy,
 	LuExternalLink,
 	LuEye,
@@ -25,10 +26,12 @@ import {
 	LuFolderOpen,
 	LuFolderPlus,
 	LuGitBranch,
+	LuLayoutList,
 	LuMinus,
 	LuPencil,
 	LuX,
 } from "react-icons/lu";
+import { useConfigureCardWithAgent } from "renderer/hooks/useConfigureCardWithAgent";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import {
 	useCreateSectionFromWorkspaces,
@@ -36,6 +39,7 @@ import {
 	useMoveWorkspaceToSection,
 } from "renderer/react-query/workspaces";
 import { createContextMenuDeleteDialogCoordinator } from "renderer/react-query/workspaces/useWorkspaceDeleteHandler";
+import { WorkspaceCardDialog } from "renderer/screens/main/components/WorkspaceCardDialog";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
 import { STROKE_WIDTH } from "../constants";
 import { RenameBranchDialog, WorkspaceHoverCardContent } from "./components";
@@ -81,6 +85,8 @@ export function WorkspaceContextMenu({
 	children,
 }: WorkspaceContextMenuProps) {
 	const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+	const [isCardDialogOpen, setIsCardDialogOpen] = useState(false);
+	const configureCardWithAgent = useConfigureCardWithAgent(projectId);
 	const [renameBranchTarget, setRenameBranchTarget] = useState<string | null>(
 		null,
 	);
@@ -159,6 +165,14 @@ export function WorkspaceContextMenu({
 				<LuExternalLink className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 				Open in Editor
 			</ContextMenuItem>
+			<ContextMenuItem onSelect={() => setIsCardDialogOpen(true)}>
+				<LuLayoutList className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+				Customize Card…
+			</ContextMenuItem>
+			<ContextMenuItem onSelect={configureCardWithAgent}>
+				<LuBot className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+				Configure Card with Agent
+			</ContextMenuItem>
 			<ContextMenuItem onSelect={onCopyPath}>
 				<LuCopy className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 				Copy Path
@@ -222,16 +236,23 @@ export function WorkspaceContextMenu({
 
 	if (isBranchWorkspace) {
 		return (
-			<ContextMenu onOpenChange={handleContextMenuOpenChange}>
-				<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-				<ContextMenuContent
-					onCloseAutoFocus={(event) => {
-						deleteDialogCoordinator.handleCloseAutoFocus(event);
-					}}
-				>
-					{commonContextMenuItems}
-				</ContextMenuContent>
-			</ContextMenu>
+			<>
+				<ContextMenu onOpenChange={handleContextMenuOpenChange}>
+					<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+					<ContextMenuContent
+						onCloseAutoFocus={(event) => {
+							deleteDialogCoordinator.handleCloseAutoFocus(event);
+						}}
+					>
+						{commonContextMenuItems}
+					</ContextMenuContent>
+				</ContextMenu>
+				<WorkspaceCardDialog
+					projectId={projectId}
+					open={isCardDialogOpen}
+					onOpenChange={setIsCardDialogOpen}
+				/>
+			</>
 		);
 	}
 
@@ -275,6 +296,11 @@ export function WorkspaceContextMenu({
 					}}
 				/>
 			)}
+			<WorkspaceCardDialog
+				projectId={projectId}
+				open={isCardDialogOpen}
+				onOpenChange={setIsCardDialogOpen}
+			/>
 		</HoverCard>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -6,6 +6,7 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef } from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+import { useLinkedTicket } from "renderer/hooks/useLinkedTicket";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useHoverGitHubStatus } from "renderer/lib/githubQueryPolicy";
@@ -20,6 +21,7 @@ import { useTabsStore } from "renderer/stores/tabs/store";
 import { extractPaneIdsFromLayout } from "renderer/stores/tabs/utils";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
 import { getHighestPriorityStatus } from "shared/tabs-types";
+import { DEFAULT_WORKSPACE_CARD_CONFIG } from "shared/workspace-card-config";
 import { CollapsedWorkspaceItem } from "./CollapsedWorkspaceItem";
 import { DeleteWorkspaceDialog } from "./components";
 import {
@@ -28,6 +30,7 @@ import {
 } from "./constants";
 import { useWorkspaceDnD } from "./useWorkspaceDnD";
 import { WorkspaceAheadBehind } from "./WorkspaceAheadBehind";
+import { WorkspaceCardLines } from "./WorkspaceCardLines";
 import { WorkspaceContextMenu } from "./WorkspaceContextMenu";
 import { WorkspaceDiffStats } from "./WorkspaceDiffStats";
 import { WorkspaceIcon } from "./WorkspaceIcon";
@@ -67,14 +70,23 @@ export function WorkspaceListItem({
 	const isBranchWorkspace = type === "branch";
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
+	const { data: cardConfigData } =
+		electronTrpc.config.getWorkspaceCardConfig.useQuery(
+			{ projectId },
+			{ staleTime: 60_000 },
+		);
+	const cardConfig = cardConfigData ?? DEFAULT_WORKSPACE_CARD_CONFIG;
+	const linkedTicket = useLinkedTicket(null, branch);
 	const {
 		githubStatus,
 		hasHovered,
 		onMouseEnter: onGithubMouseEnter,
 	} = useHoverGitHubStatus({
 		workspaceId: id,
-		surface: "workspace-list-item",
+		surface: "workspace-card",
 		isWorktree: type === "worktree",
+		// Cards show PR info inline, so fetch on mount when those lines are on.
+		eager: cardConfig.prTitle || cardConfig.prChecks,
 	});
 	const rename = useWorkspaceRename(id, name, branch);
 	const workspaceStatus = useTabsStore((state) => {
@@ -396,7 +408,7 @@ export function WorkspaceListItem({
 							)}
 
 							<div className="grid shrink-0 h-5 [&>*]:col-start-1 [&>*]:row-start-1 items-center">
-								{diffStats && (
+								{cardConfig.diffStats && diffStats && (
 									<WorkspaceDiffStats
 										additions={diffStats.additions}
 										deletions={diffStats.deletions}
@@ -454,6 +466,16 @@ export function WorkspaceListItem({
 								)}
 							</div>
 						)}
+						<WorkspaceCardLines
+							config={cardConfig}
+							pr={pr}
+							workspaceStatus={workspaceStatus}
+							linearTicket={linkedTicket}
+							workspaceId={id}
+							projectId={projectId}
+							branch={branch}
+							workspaceName={name}
+						/>
 					</div>
 				)}
 			</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/card-line-format.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/card-line-format.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { formatClockLine, formatPomodoroLine } from "./card-line-format";
+
+const MINUTE = 60_000;
+
+describe("formatPomodoroLine", () => {
+	it("formats hours, cycle position, and pomodoro number", () => {
+		// 2h13m = 133 minutes: 133 % 25 = 8, floor(133 / 25) + 1 = 6
+		expect(formatPomodoroLine(0, 133 * MINUTE)).toBe(
+			"⏱ 2h13m · 🍅 8/25m · pomo #6",
+		);
+	});
+
+	it("omits hours under one hour", () => {
+		expect(formatPomodoroLine(0, 13 * MINUTE)).toBe(
+			"⏱ 13m · 🍅 13/25m · pomo #1",
+		);
+	});
+
+	it("rolls into the next pomodoro at each 25-minute boundary", () => {
+		expect(formatPomodoroLine(0, 25 * MINUTE)).toBe(
+			"⏱ 25m · 🍅 0/25m · pomo #2",
+		);
+	});
+
+	it("clamps negative elapsed time (clock skew) to zero", () => {
+		expect(formatPomodoroLine(10 * MINUTE, 0)).toBe(
+			"⏱ 0m · 🍅 0/25m · pomo #1",
+		);
+	});
+});
+
+describe("formatClockLine", () => {
+	it("formats local time as zero-padded HH:MM", () => {
+		const at = new Date(2026, 5, 7, 9, 5).getTime();
+		expect(formatClockLine(at)).toBe("09:05");
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/card-line-format.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/card-line-format.ts
@@ -1,0 +1,25 @@
+export const POMODORO_CYCLE_MINUTES = 25;
+
+/**
+ * "⏱ 2h13m · 🍅 13/25m · pomo #6" — elapsed time since the workspace was
+ * created, position inside the current 25-minute pomodoro, and which
+ * pomodoro is running. Pure so the math stays testable.
+ */
+export function formatPomodoroLine(createdAt: number, now: number): string {
+	const elapsedMinutes = Math.max(0, Math.floor((now - createdAt) / 60_000));
+	const hours = Math.floor(elapsedMinutes / 60);
+	const minutes = elapsedMinutes % 60;
+	const elapsed = hours > 0 ? `${hours}h${minutes}m` : `${minutes}m`;
+	const cycleMinute = elapsedMinutes % POMODORO_CYCLE_MINUTES;
+	const pomodoroNumber =
+		Math.floor(elapsedMinutes / POMODORO_CYCLE_MINUTES) + 1;
+	return `⏱ ${elapsed} · 🍅 ${cycleMinute}/${POMODORO_CYCLE_MINUTES}m · pomo #${pomodoroNumber}`;
+}
+
+/** "14:05" — local wall-clock time. */
+export function formatClockLine(now: number): string {
+	const date = new Date(now);
+	const hours = String(date.getHours()).padStart(2, "0");
+	const minutes = String(date.getMinutes()).padStart(2, "0");
+	return `${hours}:${minutes}`;
+}

--- a/apps/desktop/src/shared/workspace-card-config.test.ts
+++ b/apps/desktop/src/shared/workspace-card-config.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "bun:test";
+import {
+	commandSetHash,
+	DEFAULT_WORKSPACE_CARD_CONFIG,
+	parseWorkspaceCardConfig,
+	workspaceCardConfigsEqual,
+} from "./workspace-card-config";
+
+describe("parseWorkspaceCardConfig", () => {
+	it("defaults every field to true and custom lines to empty", () => {
+		expect(DEFAULT_WORKSPACE_CARD_CONFIG).toEqual({
+			prTitle: true,
+			prChecks: true,
+			diffStats: true,
+			status: true,
+			linearTicket: true,
+			customLines: [],
+		});
+	});
+
+	it("returns defaults for a missing block", () => {
+		expect(parseWorkspaceCardConfig(undefined)).toEqual(
+			DEFAULT_WORKSPACE_CARD_CONFIG,
+		);
+	});
+
+	it("fills unspecified fields with defaults", () => {
+		expect(parseWorkspaceCardConfig({ prTitle: false })).toEqual({
+			...DEFAULT_WORKSPACE_CARD_CONFIG,
+			prTitle: false,
+		});
+	});
+
+	it("falls back to defaults for malformed input", () => {
+		expect(parseWorkspaceCardConfig({ prTitle: "yes" })).toEqual(
+			DEFAULT_WORKSPACE_CARD_CONFIG,
+		);
+		expect(parseWorkspaceCardConfig("nonsense")).toEqual(
+			DEFAULT_WORKSPACE_CARD_CONFIG,
+		);
+	});
+
+	it("parses a bare custom line as a command line (back-compat)", () => {
+		const parsed = parseWorkspaceCardConfig({
+			customLines: [{ id: "a", label: "last", command: "git log -1" }],
+		});
+		expect(parsed.customLines).toEqual([
+			{
+				id: "a",
+				type: "command",
+				label: "last",
+				command: "git log -1",
+				enabled: true,
+			},
+		]);
+	});
+
+	it("parses a component line", () => {
+		const parsed = parseWorkspaceCardConfig({
+			customLines: [{ id: "b", type: "component", component: "pomodoro" }],
+		});
+		expect(parsed.customLines).toEqual([
+			{
+				id: "b",
+				type: "component",
+				label: "",
+				component: "pomodoro",
+				enabled: true,
+			},
+		]);
+	});
+
+	it("parses mixed command and component lines", () => {
+		const parsed = parseWorkspaceCardConfig({
+			customLines: [
+				{ id: "a", command: "echo hi" },
+				{ id: "b", type: "component", component: "clock", enabled: false },
+			],
+		});
+		expect(parsed.customLines).toHaveLength(2);
+		expect(parsed.customLines[0].type).toBe("command");
+		expect(parsed.customLines[1]).toMatchObject({
+			type: "component",
+			component: "clock",
+			enabled: false,
+		});
+	});
+
+	it("falls back to defaults when a component line is invalid", () => {
+		// type says component but no component key — neither variant matches.
+		expect(
+			parseWorkspaceCardConfig({
+				customLines: [{ id: "c", type: "component", command: "echo hi" }],
+			}),
+		).toEqual(DEFAULT_WORKSPACE_CARD_CONFIG);
+	});
+});
+
+describe("workspaceCardConfigsEqual", () => {
+	const base = parseWorkspaceCardConfig({
+		customLines: [
+			{ id: "a", label: "last", command: "git log -1" },
+			{ id: "b", type: "component", component: "pomodoro" },
+		],
+	});
+
+	it("matches identical configs", () => {
+		expect(
+			workspaceCardConfigsEqual(
+				DEFAULT_WORKSPACE_CARD_CONFIG,
+				parseWorkspaceCardConfig({}),
+			),
+		).toBe(true);
+		expect(
+			workspaceCardConfigsEqual(base, parseWorkspaceCardConfig(base)),
+		).toBe(true);
+	});
+
+	it("detects boolean field differences", () => {
+		expect(workspaceCardConfigsEqual(base, { ...base, diffStats: false })).toBe(
+			false,
+		);
+	});
+
+	it("detects custom line differences", () => {
+		expect(workspaceCardConfigsEqual(base, { ...base, customLines: [] })).toBe(
+			false,
+		);
+		expect(
+			workspaceCardConfigsEqual(base, {
+				...base,
+				customLines: [
+					{ ...base.customLines[0] },
+					{
+						id: "b",
+						type: "component",
+						label: "",
+						component: "clock",
+						enabled: true,
+					},
+				],
+			}),
+		).toBe(false);
+	});
+
+	it("treats command vs component lines with the same id as different", () => {
+		const a = parseWorkspaceCardConfig({
+			customLines: [{ id: "x", command: "date" }],
+		});
+		const b = parseWorkspaceCardConfig({
+			customLines: [{ id: "x", type: "component", component: "clock" }],
+		});
+		expect(workspaceCardConfigsEqual(a, b)).toBe(false);
+	});
+});
+
+describe("commandSetHash", () => {
+	it("returns the same hash for the same commands regardless of line order", () => {
+		const a = parseWorkspaceCardConfig({
+			customLines: [
+				{ id: "1", command: "date" },
+				{ id: "2", command: "git log -1" },
+			],
+		});
+		const b = parseWorkspaceCardConfig({
+			customLines: [
+				{ id: "2", command: "git log -1" },
+				{ id: "1", command: "date" },
+			],
+		});
+		expect(commandSetHash(a)).toBe(commandSetHash(b));
+	});
+
+	it("returns different hashes when command strings differ", () => {
+		const a = parseWorkspaceCardConfig({
+			customLines: [{ id: "1", command: "date" }],
+		});
+		const b = parseWorkspaceCardConfig({
+			customLines: [{ id: "1", command: "echo hello" }],
+		});
+		expect(commandSetHash(a)).not.toBe(commandSetHash(b));
+	});
+
+	it("ignores disabled command lines", () => {
+		const withDisabled = parseWorkspaceCardConfig({
+			customLines: [
+				{ id: "1", command: "date" },
+				{ id: "2", command: "git log -1", enabled: false },
+			],
+		});
+		const withoutDisabled = parseWorkspaceCardConfig({
+			customLines: [{ id: "1", command: "date" }],
+		});
+		expect(commandSetHash(withDisabled)).toBe(commandSetHash(withoutDisabled));
+	});
+
+	it("ignores component lines", () => {
+		const withComponent = parseWorkspaceCardConfig({
+			customLines: [
+				{ id: "1", command: "date" },
+				{ id: "2", type: "component", component: "clock" },
+			],
+		});
+		const withoutComponent = parseWorkspaceCardConfig({
+			customLines: [{ id: "1", command: "date" }],
+		});
+		expect(commandSetHash(withComponent)).toBe(
+			commandSetHash(withoutComponent),
+		);
+	});
+
+	it("returns a stable value for empty command set", () => {
+		expect(commandSetHash(DEFAULT_WORKSPACE_CARD_CONFIG)).toBe(
+			commandSetHash(parseWorkspaceCardConfig({})),
+		);
+	});
+});

--- a/apps/desktop/src/shared/workspace-card-config.ts
+++ b/apps/desktop/src/shared/workspace-card-config.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+/**
+ * A user-defined command card line: a shell command that runs in the
+ * workspace folder; the first line of its output renders on the card. Same
+ * trust model as the project's setup/run scripts. `type` defaults to
+ * "command" so pre-existing configs without the field keep parsing.
+ */
+export const commandCardLineSchema = z.object({
+	id: z.string(),
+	type: z.literal("command").default("command"),
+	label: z.string().default(""),
+	command: z.string(),
+	enabled: z.boolean().default(true),
+});
+
+/**
+ * A component card line: `component` names an entry in the renderer-side
+ * registry (WorkspaceCardLineComponents) instead of a shell command. Unknown
+ * keys render nothing, so configs stay forward-compatible.
+ */
+export const componentCardLineSchema = z.object({
+	id: z.string(),
+	type: z.literal("component"),
+	label: z.string().default(""),
+	component: z.string(),
+	enabled: z.boolean().default(true),
+});
+
+// A union (not discriminatedUnion) so bare { id, label, command, enabled }
+// lines written before `type` existed still parse as command lines.
+export const customCardLineSchema = z.union([
+	componentCardLineSchema,
+	commandCardLineSchema,
+]);
+
+export type CommandCardLine = z.infer<typeof commandCardLineSchema>;
+export type ComponentCardLine = z.infer<typeof componentCardLineSchema>;
+export type CustomCardLine = z.infer<typeof customCardLineSchema>;
+
+/**
+ * Which lines the sidebar workspace cards show. Lives in the project's
+ * .superset/config.json under "workspaceCard" — same per-project, in-repo
+ * config surface as setup/teardown scripts. Everything defaults to on:
+ * cards are multi-line out of the box and users prune from there.
+ */
+export const workspaceCardConfigSchema = z.object({
+	prTitle: z.boolean().default(true),
+	prChecks: z.boolean().default(true),
+	diffStats: z.boolean().default(true),
+	status: z.boolean().default(true),
+	linearTicket: z.boolean().default(true),
+	customLines: z.array(customCardLineSchema).default([]),
+});
+
+export type WorkspaceCardConfig = z.infer<typeof workspaceCardConfigSchema>;
+
+export const DEFAULT_WORKSPACE_CARD_CONFIG: WorkspaceCardConfig =
+	workspaceCardConfigSchema.parse({});
+
+export function parseWorkspaceCardConfig(value: unknown): WorkspaceCardConfig {
+	const result = workspaceCardConfigSchema.safeParse(value ?? {});
+	return result.success ? result.data : DEFAULT_WORKSPACE_CARD_CONFIG;
+}
+
+function customCardLinesEqual(a: CustomCardLine, b: CustomCardLine): boolean {
+	if (
+		a.id !== b.id ||
+		a.label !== b.label ||
+		a.enabled !== b.enabled ||
+		a.type !== b.type
+	) {
+		return false;
+	}
+	if (a.type === "command" && b.type === "command") {
+		return a.command === b.command;
+	}
+	if (a.type === "component" && b.type === "component") {
+		return a.component === b.component;
+	}
+	return false;
+}
+
+/**
+ * Computes a deterministic hash over the sorted set of enabled command strings
+ * in a config. Used as the trust key: if the repo's command set changes, the
+ * stored hash no longer matches and the project is treated as untrusted again.
+ * Pure function — no side effects, safe to call in any context.
+ */
+export function commandSetHash(config: WorkspaceCardConfig): string {
+	const commands = config.customLines
+		.filter((l) => l.type === "command" && l.enabled)
+		.map((l) => (l.type === "command" ? l.command : ""))
+		.sort();
+	// Stable JSON fingerprint — no crypto needed for a display/trust key.
+	return JSON.stringify(commands);
+}
+
+/**
+ * Deep equality over parsed configs. Used to decide whether a submitted
+ * config still matches the repo/file-resolved one — in which case no local
+ * override should be stored and the file stays authoritative.
+ */
+export function workspaceCardConfigsEqual(
+	a: WorkspaceCardConfig,
+	b: WorkspaceCardConfig,
+): boolean {
+	return (
+		a.prTitle === b.prTitle &&
+		a.prChecks === b.prChecks &&
+		a.diffStats === b.diffStats &&
+		a.status === b.status &&
+		a.linearTicket === b.linearTicket &&
+		a.customLines.length === b.customLines.length &&
+		a.customLines.every((line, i) =>
+			customCardLinesEqual(line, b.customLines[i]),
+		)
+	);
+}

--- a/apps/desktop/src/shared/workspace-card-trust.test.ts
+++ b/apps/desktop/src/shared/workspace-card-trust.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the pure gating helper applyCommandGating.
+ * Lives in shared/ to avoid importing Electron main-process modules.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+	commandSetHash,
+	parseWorkspaceCardConfig,
+	type WorkspaceCardConfig,
+} from "./workspace-card-config";
+
+// Inline the pure gating logic so this test file has no main-process imports.
+// It must stay in sync with applyCommandGating in workspace-card-trust.ts.
+function applyCommandGating(
+	config: WorkspaceCardConfig,
+	storedHash: string | undefined,
+): WorkspaceCardConfig {
+	const currentHash = commandSetHash(config);
+	const trusted = storedHash !== undefined && storedHash === currentHash;
+	if (trusted) return config;
+	return {
+		...config,
+		customLines: config.customLines.filter((l) => l.type !== "command"),
+	};
+}
+
+const repoConfig = parseWorkspaceCardConfig({
+	customLines: [
+		{ id: "cmd1", command: "date", enabled: true },
+		{ id: "cmp1", type: "component", component: "clock" },
+	],
+});
+
+describe("applyCommandGating", () => {
+	it("strips command lines when project is untrusted (no stored hash)", () => {
+		const gated = applyCommandGating(repoConfig, undefined);
+		expect(gated.customLines).toHaveLength(1);
+		expect(gated.customLines[0].type).toBe("component");
+	});
+
+	it("strips command lines when stored hash does not match current commands", () => {
+		const staleHash = commandSetHash(
+			parseWorkspaceCardConfig({
+				customLines: [{ id: "old", command: "echo old" }],
+			}),
+		);
+		const gated = applyCommandGating(repoConfig, staleHash);
+		expect(gated.customLines).toHaveLength(1);
+		expect(gated.customLines[0].type).toBe("component");
+	});
+
+	it("passes all lines through when hash matches (trusted)", () => {
+		const hash = commandSetHash(repoConfig);
+		const gated = applyCommandGating(repoConfig, hash);
+		expect(gated.customLines).toHaveLength(2);
+		expect(gated.customLines.some((l) => l.type === "command")).toBe(true);
+		expect(gated.customLines.some((l) => l.type === "component")).toBe(true);
+	});
+
+	it("keeps component lines even when untrusted", () => {
+		const componentOnly = parseWorkspaceCardConfig({
+			customLines: [
+				{ id: "c1", type: "component", component: "pomodoro" },
+				{ id: "c2", type: "component", component: "clock" },
+			],
+		});
+		const gated = applyCommandGating(componentOnly, undefined);
+		// No commands to strip, so config is unchanged.
+		expect(gated.customLines).toHaveLength(2);
+		expect(gated.customLines.every((l) => l.type === "component")).toBe(true);
+	});
+
+	it("override source (all lines) is unaffected -- caller skips gating", () => {
+		// When source==="override", resolveGatedWorkspaceCardConfig returns the
+		// stored config directly without calling applyCommandGating. Verify that
+		// applyCommandGating with a matching hash returns everything intact.
+		const overrideConfig = parseWorkspaceCardConfig({
+			customLines: [
+				{ id: "cmd1", command: "git log -1" },
+				{ id: "cmp1", type: "component", component: "pomodoro" },
+			],
+		});
+		const hash = commandSetHash(overrideConfig);
+		const result = applyCommandGating(overrideConfig, hash);
+		expect(result.customLines).toHaveLength(2);
+	});
+
+	it("hash changes when a command is added, causing untrust", () => {
+		const original = parseWorkspaceCardConfig({
+			customLines: [{ id: "cmd1", command: "date" }],
+		});
+		const originalHash = commandSetHash(original);
+
+		const updated = parseWorkspaceCardConfig({
+			customLines: [
+				{ id: "cmd1", command: "date" },
+				{ id: "cmd2", command: "git log -1" },
+			],
+		});
+
+		// Old hash no longer matches updated config -- treated as untrusted.
+		const gated = applyCommandGating(updated, originalHash);
+		expect(gated.customLines).toHaveLength(0);
+	});
+});

--- a/docs/WORKSPACE_CARDS.md
+++ b/docs/WORKSPACE_CARDS.md
@@ -1,0 +1,104 @@
+# Workspace Cards
+
+Sidebar workspace items are multi-line cards. Which lines render is driven per project by the `workspaceCard` block of the repo's `.superset/config.json` — the same in-repo config surface as `setup`/`teardown` scripts. An agent (or a human) can edit the file directly; the app picks up changes live via a main-process file watcher.
+
+## Resolution order
+
+1. **Per-machine override** — stored in the app state when the user diverges from the file through the in-app card settings. Cleared automatically when a save matches the file again, or explicitly via "Reset to repo config".
+2. **Repo config** — `<repo>/.superset/config.json`, `workspaceCard` key. Resolved through the local DB for v1 projects and through the host-service DB (`~/.superset/host/<orgId>/host.db`) for v2 cloud projects with a local checkout.
+3. **Defaults** — everything on, no custom lines.
+
+## Schema
+
+```jsonc
+{
+  "workspaceCard": {
+    "prTitle": true,        // PR title under the workspace name
+    "prChecks": true,       // CI check status + review decision next to the PR title
+    "diffStats": true,      // added/removed line counts
+    "status": true,         // agent status line (working / permission / review)
+    "linearTicket": true,   // ticket key + state from the synced task
+    "customLines": []       // extra lines, see below
+  }
+}
+```
+
+All boolean fields default to `true`. `customLines` entries come in two shapes, discriminated by `type`:
+
+### Command lines (`type: "command"`, the default)
+
+```jsonc
+{
+  "id": "last-commit",      // unique per line
+  "type": "command",        // optional — omitted means "command" (back-compat)
+  "label": "last",          // optional prefix shown before the output
+  "command": "git log -1 --format=%s",
+  "enabled": true           // optional, defaults to true
+}
+```
+
+The command runs in the workspace folder through `/bin/sh -lc` (5s timeout, 30s result cache) and the first line of its output renders on the card. Same trust model as the project's setup/run scripts — the user authored the command.
+
+### Component lines (`type: "component"`)
+
+```jsonc
+{
+  "id": "my-pomodoro",
+  "type": "component",
+  "label": "",              // optional prefix
+  "component": "pomodoro",  // registry key, see below
+  "enabled": true
+}
+```
+
+`component` names a built-in React widget from the renderer-side registry (`WorkspaceCardLineComponents`). Components receive `{ workspaceId, projectId, branch, workspaceName }` and have full app API access. Unknown keys render nothing, so configs stay forward- and backward-compatible.
+
+| Key | Renders |
+| --- | --- |
+| `pomodoro` | Elapsed time since the workspace was created as 25-minute pomodoro cycles: `⏱ 2h13m · 🍅 8/25m · pomo #6`. Ticks locally every 30s. |
+| `clock` | Current local time, `HH:MM`. Ticks locally every 30s. |
+| `pr-checks-inline` | Compact PR checks summary (passing/failing/running + approval mark). Renders nothing when the workspace has no PR. |
+
+## Example configs
+
+Pomodoro component line plus the default built-ins:
+
+```json
+{
+  "workspaceCard": {
+    "customLines": [
+      { "id": "pomo", "type": "component", "component": "pomodoro" }
+    ]
+  }
+}
+```
+
+Trimmed-down card with a shell command line:
+
+```json
+{
+  "workspaceCard": {
+    "prTitle": true,
+    "prChecks": true,
+    "diffStats": false,
+    "status": true,
+    "linearTicket": false,
+    "customLines": [
+      {
+        "id": "last-commit",
+        "label": "last",
+        "command": "git log -1 --format=%s"
+      }
+    ]
+  }
+}
+```
+
+## Where things live
+
+- Schema + parsing: `apps/desktop/src/shared/workspace-card-config.ts`
+- Config resolution (v1/v2) + file watching: `apps/desktop/src/lib/trpc/routers/config/workspace-card-source.ts`
+- tRPC procedures: `apps/desktop/src/lib/trpc/routers/config/config.ts` (`getWorkspaceCardConfig`, `updateWorkspaceCardConfig`, `resetWorkspaceCardConfig`, `getWorkspaceCardConfigSource`, `watchWorkspaceCardConfig`)
+- Command-line execution: `apps/desktop/src/lib/trpc/routers/workspaces/procedures/card-lines.ts`
+- Card rendering: `apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceCardLines.tsx`
+- Component registry: `.../WorkspaceListItem/WorkspaceCardLineComponents.tsx`


### PR DESCRIPTION
## What

Turns sidebar workspace items into configurable multi-line **cards**. Each project's `.superset/config.json` gains a `workspaceCard` block — the same in-repo config surface as the existing `setup`/`teardown` scripts — that controls which lines a card shows.

Built-in line toggles (all default `true`): `prTitle`, `prChecks`, `diffStats`, `status`, `linearTicket`.

Plus a `customLines` array with two kinds of line:

- **`type: "command"`** — a shell command run in the workspace folder; the first line of its output renders on the card.
- **`type: "component"`** — a built-in React component from a renderer-side registry (`pomodoro`, `clock`, `pr-checks-inline`) with full workspace context and tRPC API access, ticking locally.

```json
{
  "workspaceCard": {
    "prTitle": false,
    "diffStats": true,
    "customLines": [
      { "id": "pomodoro", "label": "Pomodoro", "type": "component", "component": "pomodoro", "enabled": true },
      { "id": "todo", "label": "TODOs", "type": "command", "command": "grep -rc TODO src | wc -l", "enabled": true }
    ]
  }
}
```

Legacy bare `{ id, label, command, enabled }` lines parse as command lines (zod `union`, not `discriminatedUnion`), so existing configs keep working.

## How it resolves

Layered: a per-project **appState override** (set from the in-app card settings, per machine) wins; otherwise the repo's `.superset/config.json` is read. Repo resolution covers v1 local projects (`localDb` `mainRepoPath`), v2 cloud projects (host-service `host.db` `repo_path`), and a worktrees-dir fallback that recovers the main repo from a local worktree's `gitdir`. A main-process `fs.watch` on the resolved file drives **live reload** through a tRPC subscription, so edits show on cards without an app restart.

It can be configured by hand, from the in-app card settings dialog, or by an agent via **"Configure card with agent"**, which pre-fills a prompt documenting the full schema.

## Security

Repo-sourced **command** lines do **not** auto-run. They are gated behind an explicit per-project trust opt-in, keyed by a hash of the command set, so a malicious `.superset/config.json` in a branch a developer merely checks out cannot execute on passive card render. Component lines (app code) stay ungated. `getCardLineOutput` resolves the command server-side by `lineId` from the trusted config instead of accepting a raw command string from the renderer, keeping the IPC surface to "run line N of the trusted config". `projectId` is regex-validated and the worktree path scan is containment-checked.

Reviewed by independent security and code-quality passes; both approved after the trust gate landed.

## Tests

`bun run typecheck` clean, `bun test` green. Unit tests cover schema back-compat, component/command parsing, trust gating, command-set hashing, gitdir extraction, path containment, and the card-line formatters.

## Follow-ups (intentionally deferred, non-blocking)

Perf/robustness hardening noted in review: gate `useLinkedTicket` live-queries behind the Linear toggle, viewport-gate the eager GitHub fetch, memoize repo-path resolution, retry on transient WAL read of `host.db`, bound the server command cache. None affect correctness of this PR.

🤖 Draft generated with autopilot; human review requested.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5171">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns sidebar workspace items into configurable multi-line cards so PR details, checks, diff stats, status, and optional Linear ticket are visible at a glance. Configuration lives in each repo’s `.superset/config.json` under `workspaceCard`, with live reload and a per-machine override.

- **New Features**
  - Multi-line sidebar cards show PR title, checks/review, diff stats, status, and optional Linear ticket.
  - Per-project config via `.superset/config.json` `workspaceCard` with booleans (`prTitle`, `prChecks`, `diffStats`, `status`, `linearTicket`) and `customLines`.
  - Custom lines: command (runs in the workspace folder; first output line renders) and component (`pomodoro`, `clock`, `pr-checks-inline`).
  - Backward compatible with legacy `{ id, label, command, enabled }` entries.
  - Per-machine override stored in app state; reset to repo config anytime. Edit via Project Settings, context menu dialog, or “Configure card with agent”.
  - Config resolution supports v1 (local DB), v2 (host-service `host.db`), and worktree fallback; changes live-reload via file watch and tRPC subscription.
  - Cards eager-fetch GitHub status on mount (no extra polling), aligned with existing query policy.

- **Security**
  - Repo-defined command lines never auto-run. They require per-project trust, keyed by a hash of the command set; any change revokes trust.
  - Renderer sends only a `lineId`; the main process resolves and runs the trusted command. No raw command strings cross IPC.
  - Component lines are always allowed (app code).
  - Project IDs and paths are validated; worktree scans are containment-checked.

<sup>Written for commit d5fcfb970938393c766b3ada8c8b98e0bd1a5064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

