### PR TITLE
fix(host-service): keep v2 preset commands alive during shell init

### DIFF
--- a/packages/host-service/src/terminal/terminal-mode-tracker.ts
+++ b/packages/host-service/src/terminal/terminal-mode-tracker.ts
@@ -24,6 +24,15 @@ export interface ModeTracker {
 	resize(cols: number, rows: number): void;
 	buildPreamble(): Uint8Array | null;
 	dispose(): void;
+	/**
+	 * Register a handler for the headless xterm's automatic replies to
+	 * terminal queries the program emits (primary/secondary device
+	 * attributes, cursor-position reports, …). Lets the host answer the
+	 * shell's startup queries itself rather than depending on an attached
+	 * renderer. Mirrors the v1 headless emulator (apps/desktop/src/main/
+	 * lib/terminal-host).
+	 */
+	onData(callback: (data: string) => void): void;
 }
 
 // Reaches into private xterm internals: synchronous parsing and kitty
@@ -118,6 +127,9 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 		return new TextEncoder().encode(parts.join(""));
 	};
 
+	let onDataCallback: ((data: string) => void) | undefined;
+	term.onData((data) => onDataCallback?.(data));
+
 	return {
 		feed(bytes) {
 			writeBuffer.writeSync(bytes);
@@ -127,6 +139,9 @@ export function createModeTracker(cols: number, rows: number): ModeTracker {
 			term.resize(nextCols, nextRows);
 		},
 		buildPreamble,
+		onData(callback) {
+			onDataCallback = callback;
+		},
 		dispose() {
 			term.dispose();
 		},

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -420,6 +420,14 @@ export function writeInputToSession({
 		return { error: "Terminal session has exited" };
 	}
 
+	// Drop terminal query responses (DA/DSR, `\x1b`-prefixed) while the shell
+	// is initializing. The host answers those queries itself (see
+	// modeTracker.onData); forwarding the renderer's duplicate here would
+	// inject it as typed text and displace the queued preset command.
+	if (session.shellReadyState === "pending" && data.startsWith("\x1b")) {
+		return { success: true };
+	}
+
 	session.pty.write(data);
 	return { success: true };
 }
@@ -1064,6 +1072,19 @@ export async function createTerminalSessionInternal({
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
 
+	// Answer the shell's startup terminal queries (DA/DSR) server-side while
+	// it is still initializing. The renderer also answers these, but its
+	// replies arrive as stdin and are dropped during `pending` (see
+	// writeInputToSession and the "input" socket handler) — otherwise they
+	// surface as typed text like `?62;4;9;22c` and displace the queued preset
+	// command. Gated on `pending` so the renderer is the sole responder once
+	// the shell is interactive. Mirrors the v1 headless emulator.
+	session.modeTracker.onData((data) => {
+		if (session.shellReadyState === "pending") {
+			session.pty.write(data);
+		}
+	});
+
 	// If the marker never arrives (broken wrapper, unsupported config),
 	// the timeout unblocks so the session degrades gracefully.
 	if (session.shellReadyState === "pending") {
@@ -1393,6 +1414,14 @@ export function registerWorkspaceTerminalRoute({
 					if (session.exited) return;
 
 					if (message.type === "input") {
+						// See writeInputToSession: drop the renderer's query
+						// responses while the shell is still initializing.
+						if (
+							session.shellReadyState === "pending" &&
+							message.data.startsWith("\x1b")
+						) {
+							return;
+						}
 						session.pty.write(message.data);
 						return;
 					}


### PR DESCRIPTION
## Problem

In **v2 workspaces**, launching a terminal preset (e.g. `claude`) loses the command when the shell is still initializing (direnv / nvm / oh-my-zsh / powerlevel10k). This is the same class of bug [#2469](https://github.com/superset-sh/superset/pull/2469) fixed for the **v1** terminal stack (`apps/desktop/src/main/terminal-host`) — but v2 workspaces run an entirely separate terminal stack in `packages/host-service`, which never received the fix.

Reported in Slack ("command doesn't live… thought we fixed this… v2 needs this I guess").

## Root cause

During startup the shell emits terminal capability queries (DA `\x1b[c`, DSR/CPR `\x1b[6n`). The renderer's xterm answers them, and those replies arrive back as **PTY stdin**. The host-service stack forwarded all stdin unconditionally, so responses like `?62;4;9;22c` landed on the command line ahead of the queued preset command and displaced it — the command never ran.

v1 already solved this. v2 was missing both halves of the solution:
- v1 drops `\x1b`-prefixed stdin while the shell is `pending` (`terminal-host/session.ts`).
- v1's **headless emulator** answers the shell's startup queries server-side, so dropping the renderer's duplicate is safe.

v2 had the `shellReadyState` machine and the OSC 133;A scanner wired for **output**, but never gated **input**, and its per-session headless xterm (`modeTracker`) only tracked modes — it never answered queries.

## Fix

Mirror v1's two-part mechanism in the host-service stack:

1. **Drop query responses during init** — `\x1b`-prefixed stdin is dropped while `shellReadyState === "pending"`, in both input paths (`writeInputToSession` and the WebSocket `"input"` handler).
2. **Answer queries server-side during init** — wire `onData` on the existing per-session headless xterm (`modeTracker`) and, while `pending`, write its DA/DSR replies back to the PTY. Gated on `pending` so the renderer stays the sole responder once the shell is interactive. This is the v2 analogue of v1's headless emulator.

The preset command itself is **still written immediately** (`queueInitialCommand` unchanged) — readiness only gates query responses, not the command. A broken/missing marker can't stall the launch, which is the failure mode earlier marker-gating attempts kept hitting ([#3478](https://github.com/superset-sh/superset/pull/3478) / [#4963](https://github.com/superset-sh/superset/pull/4963)).

## Files changed

| File | Change |
|---|---|
| `packages/host-service/src/terminal/terminal-mode-tracker.ts` | Add `onData` to `ModeTracker` — surface the headless xterm's auto-replies to terminal queries |
| `packages/host-service/src/terminal/terminal.ts` | Answer startup queries server-side during `pending`; drop `\x1b`-prefixed stdin during `pending` in both input paths |

## Verification

- Confirmed the per-session headless xterm answers DA → `\x1b[?1;2c` and CPR → `\x1b[1;1R` via `onData` when fed via `writeSync` (the path `modeTracker.feed` uses).
- `bun test src/terminal` — 69 pass / 0 fail.
- `typecheck` and `lint` clean.

## Test plan

- [ ] Open a v2 workspace whose repo has a slow shell init (`.envrc` + direnv, or oh-my-zsh/powerlevel10k) and launch a preset — command renders immediately and runs once the prompt appears, with no `?62;...c` garbage on the line.
- [ ] Repeat with a fast shell (no direnv) — command runs promptly.
- [ ] Re-attach to an existing (already-ready) terminal — input flows normally, escape sequences not dropped.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5177">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep v2 terminal preset commands alive during slow shell init by filtering escape-sequence responses and answering startup queries server-side in `packages/host-service`. Preset commands now run reliably once the prompt is ready, without `?62;...c` noise.

- **Bug Fixes**
  - Drop `\x1b`-prefixed stdin while `shellReadyState === "pending"` in both input paths (`writeInputToSession`, WebSocket `"input"`).
  - Add `onData` to `ModeTracker` and, while pending, write its DA/DSR replies to the PTY so the host answers queries during init.
  - Leave command queuing unchanged; readiness gates only query responses.

<sup>Written for commit 57f28116ffecf26390bb52a2c010cc72b4f024a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal callback mechanism to register handlers for automatic reply data from terminal queries.

* **Bug Fixes**
  * Improved terminal session initialization by handling startup queries on the server side, preventing escape sequences from being incorrectly forwarded as user input during shell startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->