### PR TITLE
chore(experiment): set v1 experiment start to 3pm PDT today

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -68,8 +68,8 @@ export const POSTHOG_COOKIE_NAME = "superset";
 // and admin.
 // 2026-05-15 14:00 UTC = Fri 07:00 PDT / 10:00 EDT.
 export const V2_ONLY_USER_CUTOFF = "2026-05-15T14:00:00.000Z";
-// 2026-06-07 03:00 UTC = Sat 20:00 PDT (8pm Pacific).
-export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-07T03:00:00.000Z";
+// 2026-06-07 22:00 UTC = Sun 15:00 PDT (3pm Pacific).
+export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-07T22:00:00.000Z";
 
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */


### PR DESCRIPTION
Pushes the new-users-v1 experiment start to **3pm PDT today** so there's margin to ship before it triggers.

\`V2_NEW_USER_V1_EXPERIMENT_START\`: \`2026-06-07T03:00:00Z\` (8pm PDT Sat — already elapsed) → **\`2026-06-07T22:00:00Z\` (3pm PDT Sun)**.

Branched off \`origin/main\` (the original experiment PR is already merged). Only the constant changes; the half-open window logic and banner removal are unchanged.

- Window is now \`[2026-05-15T14:00Z, 2026-06-07T22:00Z)\` → existing users stay v2, signups from 3pm PDT onward get v1.
- lint + typecheck clean.

Note: takes effect only once this is merged and shipped to clients.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the v1 experiment for new users to start at 3pm PDT today (2026-06-07T22:00Z) to ensure it activates after we ship. Only `V2_NEW_USER_V1_EXPERIMENT_START` changes; the window is now `[2026-05-15T14:00Z, 2026-06-07T22:00Z)`, so existing users stay on v2 and signups from 3pm get v1.

<sup>Written for commit cddf8fd5e63e1a3f912bc96cbc977d61dfe2d0bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated experiment timing configuration with an adjusted start timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->