### PR TITLE
feat(desktop): show v1/v2 toggle for all users

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -4,7 +4,7 @@ import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 /**
  * True for accounts created on/after V2_ONLY_USER_CUTOFF — these users
- * never see the v1↔v2 switch.
+ * default to v2.
  */
 export function useIsV2OnlyUser(): boolean {
 	const { data: session } = authClient.useSession();
@@ -15,5 +15,5 @@ export function useIsV2OnlyUser(): boolean {
 export function useIsV2CloudEnabled(): boolean {
 	const v2Only = useIsV2OnlyUser();
 	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
-	return v2Only || optInV2 === true;
+	return optInV2 ?? v2Only;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -44,7 +44,7 @@ export function ExperimentalSettings({
 			</div>
 
 			<div className="space-y-6">
-				{showSupersetV2 && !isV2OnlyUser && (
+				{showSupersetV2 && (
 					<div className="flex items-center justify-between gap-6">
 						<div className="min-w-0 flex-1 space-y-0.5">
 							<Label htmlFor="superset-v2" className="text-sm font-medium">


### PR DESCRIPTION
## What

Show the v1↔v2 toggle in **Settings → Experimental** for every user, and make it actually work for v2-only accounts.

## Why

The toggle was hidden for "v2-only" users — accounts created in the `[V2_ONLY_USER_CUTOFF, V2_NEW_USER_V1_EXPERIMENT_START)` window. Those users were forced to v2 with no way back to v1. (This is what surfaced the `eran@clyr.io` report: a work-email account created in that window had no toggle.)

## Changes

- **`ExperimentalSettings.tsx`** — drop the `!isV2OnlyUser` gate on the switch so it renders for everyone.
- **`useIsV2CloudEnabled.ts`** — `isV2CloudEnabled` now returns `optInV2 ?? v2Only` instead of `v2Only || optInV2 === true`. Without this, a v2-only user could flip the switch off but `v2Only` would OR it back on (dead switch). Now an explicit choice wins over the `createdAt`-derived default.

## Behavior

Unchanged for anyone who hasn't touched the toggle:

| cohort | default | can toggle now? |
|---|---|---|
| legacy v1 (pre-cutoff) | v1 | yes (already could) |
| v2-only (in window) | v2 | **yes — can now flip to v1** |
| experiment (post-cutoff) | v1 | yes |

The override remains local-only (`v2-local-override-v2` in localStorage), per-device — no cross-machine sync, which matches current behavior.

## Test plan

- [ ] As a v2-only account, open Settings → Experimental, confirm the "Try Superset v2" toggle is visible and on.
- [ ] Flip it off → lands on v1 and stays there across reloads.
- [ ] Flip back on → returns to v2.
- [ ] Legacy v1 and post-cutoff experiment accounts behave as before.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5191">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the v1↔v2 toggle in Settings → Experimental for all users and honor the local override so v2‑only accounts can switch to v1 and have it stick.

- **Bug Fixes**
  - Always render the toggle by removing `!isV2OnlyUser` in `ExperimentalSettings.tsx`.
  - Make the switch effective by returning `optInV2 ?? v2Only` in `useIsV2CloudEnabled`, fixing the dead switch for v2‑only users.

<sup>Written for commit cecdb8481f2c0a3c09aaaccdc0e7bffab6b21932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

