### PR TITLE
fix(desktop): move v1 Resources button after recently viewed in topbar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -55,6 +55,7 @@ export function TopBar() {
 					<>
 						<SidebarToggle />
 						<NavigationControls />
+						{!isV2CloudEnabled && <ResourceConsumption surface="v1" />}
 					</>
 				)}
 			</div>
@@ -84,8 +85,8 @@ export function TopBar() {
 			)}
 
 			<div className="flex items-center gap-3 h-full pr-4 shrink-0">
-				{!sidebarHostsChrome && (
-					<ResourceConsumption surface={isV2CloudEnabled ? "v2" : "v1"} />
+				{!sidebarHostsChrome && isV2CloudEnabled && (
+					<ResourceConsumption surface="v2" />
 				)}
 				{!isOnline && (
 					<div className="no-drag flex items-center gap-1.5 text-xs text-muted-foreground bg-muted px-2 py-1 rounded">

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.12.3",
+      "version": "1.12.4",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -769,7 +769,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.19",
+      "version": "0.8.20",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",


### PR DESCRIPTION
## What

In v1 workspaces, the Resources button (`ResourceConsumption`) now renders in the left side of the topbar, immediately after the recently-viewed navigation controls, instead of on the right side before the "Open in external workspace" button.

v2 behavior is unchanged — the Resources chip stays on the right.

## Why

Better grouping: Resources sits next to the other navigation controls at the start of the topbar.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5192">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the v1 Resources button (`ResourceConsumption`) to the left side of the topbar, right after the recently viewed navigation controls. v2 remains unchanged; the Resources chip stays on the right.

<sup>Written for commit 3c2b3c5a90b1c7a12a3895ee60292b9371762095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Resource consumption display now adapts its position and appearance based on cloud feature configuration, ensuring consistent layout across different settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->