### PR TITLE
feat(desktop): pop the in-app browser out into its own window

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -1,11 +1,23 @@
 import { observable } from "@trpc/server/observable";
 import { session } from "electron";
 import { browserManager } from "main/lib/browser/browser-manager";
+import { openBrowserPopout } from "main/lib/browser/browser-popout";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 
 export const createBrowserRouter = () => {
 	return router({
+		popOut: publicProcedure
+			.input(z.object({ paneId: z.string(), url: z.string().optional() }))
+			.mutation(({ input }) => {
+				// Prefer the live webview URL; fall back to the URL the renderer knows.
+				const liveUrl = browserManager.getWebContents(input.paneId)?.getURL();
+				const target =
+					liveUrl && /^https?:\/\//.test(liveUrl) ? liveUrl : input.url;
+				if (!target) return { success: false };
+				return { success: !!openBrowserPopout(target) };
+			}),
+
 		register: publicProcedure
 			.input(z.object({ paneId: z.string(), webContentsId: z.number() }))
 			.mutation(({ input }) => {

--- a/apps/desktop/src/main/lib/browser/browser-popout.ts
+++ b/apps/desktop/src/main/lib/browser/browser-popout.ts
@@ -1,0 +1,60 @@
+import { BrowserWindow, shell } from "electron";
+
+/**
+ * Standalone browser windows popped out of a browser pane. Tracked so they can
+ * be closed alongside the main window.
+ */
+const popoutWindows = new Set<BrowserWindow>();
+
+/**
+ * Open `url` in its own OS window, reusing the desktop session partition so the
+ * user stays logged in. Unlike "Open in Browser" (which hands off to the system
+ * browser via shell.openExternal and loses the session), this keeps the page
+ * inside a Superset-owned window.
+ *
+ * The page is hosted in an isolated <webview> — mirroring the in-pane browser's
+ * process isolation — rather than loaded into the window's own main frame.
+ */
+export function openBrowserPopout(url: string): BrowserWindow | null {
+	if (!/^https?:\/\//.test(url)) return null;
+
+	const window = new BrowserWindow({
+		width: 1200,
+		height: 800,
+		autoHideMenuBar: true,
+		backgroundColor: "#252525",
+		webPreferences: {
+			webviewTag: true,
+			partition: "persist:superset",
+			sandbox: true,
+			contextIsolation: true,
+		},
+	});
+
+	popoutWindows.add(window);
+	window.on("closed", () => popoutWindows.delete(window));
+
+	// Route popups / target=_blank from the hosted page to the system browser
+	// (the popout host page can't be navigated away from).
+	window.webContents.on("did-attach-webview", (_event, guest) => {
+		guest.setWindowOpenHandler(({ url: popupUrl }) => {
+			if (/^https?:\/\//.test(popupUrl)) shell.openExternal(popupUrl);
+			return { action: "deny" };
+		});
+	});
+
+	const host = `<!doctype html><html><head><meta charset="utf-8"><title>Superset Browser</title>
+<style>html,body{margin:0;height:100%;background:#252525}webview{position:absolute;inset:0;border:0}</style>
+</head><body><webview src="${encodeURI(url)}" partition="persist:superset" allowpopups></webview></body></html>`;
+	window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(host)}`);
+
+	return window;
+}
+
+/** Close every popped-out browser window (called when the main window closes). */
+export function closeAllBrowserPopouts(): void {
+	for (const window of popoutWindows) {
+		if (!window.isDestroyed()) window.close();
+	}
+	popoutWindows.clear();
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -17,6 +17,7 @@ import { createIPCHandler } from "trpc-electron/main";
 import { productName } from "~/package.json";
 import { appState } from "../lib/app-state";
 import { browserManager } from "../lib/browser/browser-manager";
+import { closeAllBrowserPopouts } from "../lib/browser/browser-popout";
 import { createApplicationMenu } from "../lib/menu";
 import { playNotificationSound } from "../lib/notification-sound";
 import { NotificationManager } from "../lib/notifications/notification-manager";
@@ -359,6 +360,7 @@ export async function MainWindow() {
 		persistedZoomLevel = zoomLevel;
 
 		browserManager.unregisterAll();
+		closeAllBrowserPopouts();
 		server.close();
 		notificationManager.dispose();
 		notificationsEmitter.removeAllListeners();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
@@ -6,6 +6,7 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import {
+	TbAppWindow,
 	TbCamera,
 	TbClock,
 	TbCopy,
@@ -50,6 +51,12 @@ export function BrowserOverflowMenu({
 		if (currentUrl) {
 			electronTrpcClient.external.openUrl.mutate(currentUrl).catch(() => {});
 		}
+	};
+
+	const handlePopOut = () => {
+		electronTrpcClient.browser.popOut
+			.mutate({ paneId, url: currentUrl || undefined })
+			.catch(() => {});
 	};
 
 	const handleClearCookies = () => {
@@ -110,6 +117,14 @@ export function BrowserOverflowMenu({
 				>
 					<TbExternalLink className="size-4" />
 					Open in Browser
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					onClick={handlePopOut}
+					disabled={!hasPage}
+					className="gap-2"
+				>
+					<TbAppWindow className="size-4" />
+					Open in New Window
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem onClick={handleClearHistory} className="gap-2">


### PR DESCRIPTION
## What

Adds an **"Open in New Window"** action to the browser pane's overflow menu that pops the current page out into its own standalone OS window — so it can live on a second monitor or beside your editor instead of only inside the main window's tiling layout.

Closes #5194.

## How

- **`browser.popOut` tRPC procedure** (`apps/desktop/src/lib/trpc/routers/browser/browser.ts`) — takes `{ paneId, url? }`, reads the pane's live URL via `browserManager.getWebContents(paneId).getURL()` (falling back to the renderer-supplied URL), and asks the main process to open it.
- **`openBrowserPopout(url)`** (`apps/desktop/src/main/lib/browser/browser-popout.ts`, new) — creates a `BrowserWindow` that hosts the page in a full-bleed `<webview>` reusing `partition: "persist:superset"`. This mirrors the in-pane browser's process isolation and keeps the user logged in (unlike "Open in Browser", which `shell.openExternal`s to the system browser and drops the session). Popups/`target=_blank` are routed to the system browser.
- **Lifecycle** — popout windows are tracked in a `Set` and closed via `closeAllBrowserPopouts()` in the main window's `close` handler, next to the existing `browserManager.unregisterAll()`.
- **UI** — a new `TbAppWindow` "Open in New Window" item in the v2 `BrowserOverflowMenu`, right under "Open in Browser".

Why a new window rather than moving the pane's webview: a `<webview>` is glued to its host window's DOM (`position: fixed` + `getBoundingClientRect()` in `browserRuntimeRegistry`) and can't be reparented across OS windows, so the popout recreates the view at the same URL. Session is shared via the partition, so it stays logged in.

## Notes / open questions

- **Not yet runtime-tested** — I authored this from reading the code and don't have a local Electron build set up. Would appreciate a maintainer verifying the popout renders and the `did-attach-webview` popup handling behaves. Opening as a **draft** for that reason and for design discussion per CONTRIBUTING.
- The popout host page is currently an inline `data:` document hosting the `<webview>`. If you'd prefer it to be a real TanStack route (consistent with the `"main"`/`"about"` window registry in `window-loader.ts`), I'm happy to switch to that — it's a small change.
- Only wired into the **v2** `BrowserOverflowMenu`; I can add the same to the v1 menu if v1 is still shipping.
- "Allow edits from maintainers" is enabled.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5195">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Open in New Window” to the in‑app browser menu to pop the current page into its own OS window while keeping the app session intact. Lets you place the page on another monitor without leaving the desktop app.

- **New Features**
  - Added `browser.popOut` tRPC mutation that takes `{ paneId, url? }`, prefers the live webview URL, and opens a popout window.
  - Implemented `openBrowserPopout(url)` to create a `BrowserWindow` hosting the page in a full-bleed `<webview>` with `partition: "persist:superset"`; `target=_blank` opens in the system browser.
  - Popout windows are tracked and closed with the main window via `closeAllBrowserPopouts()`.
  - UI: Added “Open in New Window” to the v2 `BrowserOverflowMenu` below “Open in Browser”.

<sup>Written for commit 037fbae0e91d278954705bdf6572aa9d3ac98d1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

