### PR TITLE
fix(cli): derive baked version from package.json

### DIFF
--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,7 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
+import pkg from "./package.json" with { type: "json" };
 
-const VERSION = "0.2.19";
+const VERSION = pkg.version;
 
 export default defineConfig({
 	name: "superset",


### PR DESCRIPTION
## Problem

`superset update` reports success but `superset --version` never changes — e.g. it prints `Updated 0.2.19 → 0.2.22` while `--version` keeps saying `0.2.19`.

## Root cause

`packages/cli/cli.config.ts` hardcoded `const VERSION = "0.2.19"`, and that constant is baked into every binary as both `--version` and `process.env.SUPERSET_VERSION`. It was never bumped, while `package.json` and the `cli-v*` git tags moved on to `0.2.22`.

The two sources of truth diverged:
- `version.txt` in the `cli-latest` release is derived from the git tag → `0.2.22`
- the version baked into the binary → `0.2.19`

So the update flow: reads `version.txt` (target 0.2.22), sees baked current 0.2.19, downloads & installs today's tarball (which **is** the real 0.2.22 build), prints `Updated 0.2.19 → 0.2.22` — but the freshly installed binary still self-reports 0.2.19. Every `update` looks like a no-op and the CLI perpetually thinks an update is available.

## Fix

Read the version from `package.json` so there's a single source of truth that can't drift from the release tag.

```diff
-const VERSION = "0.2.19";
+import pkg from "./package.json" with { type: "json" };
+const VERSION = pkg.version;
```

## Notes

Takes effect once the next CLI release is cut — the `0.2.22` build already in `cli-latest` will keep reporting 0.2.19 until then.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck --filter=@superset/cli`
- [x] Verified `cli.config.ts` resolves `version` and the `SUPERSET_VERSION` define to `0.2.22`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5196">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI version reporting by deriving the baked version from package.json. `superset --version` and `SUPERSET_VERSION` now match the release tag, so updates no longer look like no-ops.

- **Bug Fixes**
  - Read version from `./package.json` in `packages/cli/cli.config.ts` instead of a hardcoded string.
  - Aligns `--version` and `process.env.SUPERSET_VERSION` with the published `cli-v*` tag.
  - Note: takes effect with the next CLI release; the current `0.2.22` build will still report `0.2.19`.

<sup>Written for commit 83d5b8011ec979b336a46a10e1dd420e0afb0172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI version management to dynamically source from package metadata instead of a hardcoded value, improving version consistency across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->