### PR TITLE
fix(desktop): keep pinned v2 workspaces visible when their section is missing

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildDashboardSidebarProjects,
+	type SidebarProjectInput,
+	type SidebarSectionInput,
+	type SidebarWorkspaceInput,
+} from "./buildDashboardSidebarProjects";
+
+const MACHINE_ID = "machine-1";
+const DATE = new Date("2026-01-01T00:00:00.000Z");
+
+function makeProject(
+	overrides: Partial<SidebarProjectInput> = {},
+): SidebarProjectInput {
+	return {
+		id: "project-1",
+		name: "Project",
+		slug: "project",
+		githubRepositoryId: null,
+		githubOwner: null,
+		githubRepoName: null,
+		iconUrl: null,
+		createdAt: DATE,
+		updatedAt: DATE,
+		isCollapsed: false,
+		...overrides,
+	};
+}
+
+function makeSection(
+	overrides: Partial<SidebarSectionInput> = {},
+): SidebarSectionInput {
+	return {
+		id: "section-1",
+		projectId: "project-1",
+		name: "Section",
+		createdAt: DATE,
+		isCollapsed: false,
+		tabOrder: 1,
+		color: "#abcdef",
+		...overrides,
+	};
+}
+
+function makeWorkspace(
+	overrides: Partial<SidebarWorkspaceInput> = {},
+): SidebarWorkspaceInput {
+	return {
+		id: "workspace-1",
+		projectId: "project-1",
+		hostId: MACHINE_ID,
+		type: "worktree",
+		hostIsOnline: true,
+		name: "Workspace",
+		branch: "main",
+		taskId: null,
+		createdAt: DATE,
+		updatedAt: DATE,
+		tabOrder: 1,
+		sectionId: null,
+		pendingTransaction: null,
+		...overrides,
+	};
+}
+
+function build(params: {
+	sidebarProjects?: SidebarProjectInput[];
+	sidebarSections?: SidebarSectionInput[];
+	visibleSidebarWorkspaces?: SidebarWorkspaceInput[];
+}) {
+	return buildDashboardSidebarProjects({
+		sidebarProjects: params.sidebarProjects ?? [makeProject()],
+		sidebarSections: params.sidebarSections ?? [],
+		visibleSidebarWorkspaces: params.visibleSidebarWorkspaces ?? [],
+		machineId: MACHINE_ID,
+		pullRequestsByWorkspaceId: new Map(),
+	});
+}
+
+describe("buildDashboardSidebarProjects", () => {
+	it("places a workspace inside the section it belongs to", () => {
+		const [project] = build({
+			sidebarSections: [makeSection({ id: "section-1", tabOrder: 1 })],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "workspace-1", sectionId: "section-1" }),
+			],
+		});
+
+		expect(project.children).toHaveLength(1);
+		const [child] = project.children;
+		expect(child.type).toBe("section");
+		if (child.type !== "section") throw new Error("expected section");
+		expect(child.section.workspaces.map((workspace) => workspace.id)).toEqual([
+			"workspace-1",
+		]);
+	});
+
+	it("renders an orphaned-section workspace at top level instead of dropping it", () => {
+		const [project] = build({
+			sidebarSections: [makeSection({ id: "section-1", tabOrder: 1 })],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({
+					id: "orphan",
+					sectionId: "section-deleted",
+					tabOrder: 1,
+				}),
+			],
+		});
+
+		const topLevelWorkspaceIds = project.children
+			.filter((child) => child.type === "workspace")
+			.map((child) => (child.type === "workspace" ? child.workspace.id : null));
+		expect(topLevelWorkspaceIds).toContain("orphan");
+
+		const allRenderedIds = project.children.flatMap((child) =>
+			child.type === "section"
+				? child.section.workspaces.map((workspace) => workspace.id)
+				: [child.workspace.id],
+		);
+		expect(allRenderedIds).toContain("orphan");
+	});
+
+	it("keeps a workspace visible after its section is moved across the project", () => {
+		const sections = [
+			makeSection({ id: "section-a", name: "A", tabOrder: 2 }),
+			makeSection({ id: "section-b", name: "B", tabOrder: 1 }),
+		];
+		const [project] = build({
+			sidebarSections: sections,
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "ws-in-b", sectionId: "section-b", tabOrder: 1 }),
+			],
+		});
+
+		const sectionB = project.children.find(
+			(child) => child.type === "section" && child.section.id === "section-b",
+		);
+		expect(sectionB?.type).toBe("section");
+		if (sectionB?.type !== "section") throw new Error("expected section-b");
+		expect(
+			sectionB.section.workspaces.map((workspace) => workspace.id),
+		).toEqual(["ws-in-b"]);
+		// section-b has a lower tabOrder, so it renders before section-a
+		expect(
+			project.children
+				.filter((child) => child.type === "section")
+				.map((child) => (child.type === "section" ? child.section.id : null)),
+		).toEqual(["section-b", "section-a"]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -120,7 +120,7 @@ describe("buildDashboardSidebarProjects", () => {
 		expect(allRenderedIds).toContain("orphan");
 	});
 
-	it("keeps a workspace visible after its section is moved across the project", () => {
+	it("orders sections by tabOrder and places each workspace in its section", () => {
 		const sections = [
 			makeSection({ id: "section-a", name: "A", tabOrder: 2 }),
 			makeSection({ id: "section-b", name: "B", tabOrder: 1 }),
@@ -140,11 +140,31 @@ describe("buildDashboardSidebarProjects", () => {
 		expect(
 			sectionB.section.workspaces.map((workspace) => workspace.id),
 		).toEqual(["ws-in-b"]);
-		// section-b has a lower tabOrder, so it renders before section-a
 		expect(
 			project.children
 				.filter((child) => child.type === "section")
 				.map((child) => (child.type === "section" ? child.section.id : null)),
 		).toEqual(["section-b", "section-a"]);
+	});
+
+	it("orders multiple orphaned workspaces by tabOrder above the sections", () => {
+		const [project] = build({
+			sidebarSections: [makeSection({ id: "section-1", tabOrder: 5 })],
+			visibleSidebarWorkspaces: [
+				makeWorkspace({ id: "orphan-late", sectionId: "gone", tabOrder: 3 }),
+				makeWorkspace({ id: "orphan-early", sectionId: "gone", tabOrder: 1 }),
+			],
+		});
+
+		const renderedTopLevel = project.children.map((child) =>
+			child.type === "section"
+				? `section:${child.section.id}`
+				: child.workspace.id,
+		);
+		expect(renderedTopLevel).toEqual([
+			"orphan-early",
+			"orphan-late",
+			"section:section-1",
+		]);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -71,7 +71,10 @@ export function buildDashboardSidebarProjects({
 				tabOrder: number;
 				child: DashboardSidebarProjectChild;
 			}>;
-			orphanedWorkspaces: DashboardSidebarWorkspace[];
+			orphanedWorkspaces: Array<{
+				tabOrder: number;
+				workspace: DashboardSidebarWorkspace;
+			}>;
 		}
 	>();
 
@@ -147,7 +150,10 @@ export function buildDashboardSidebarProjects({
 				});
 				continue;
 			}
-			project.orphanedWorkspaces.push(sidebarWorkspace);
+			project.orphanedWorkspaces.push({
+				tabOrder: workspace.tabOrder,
+				workspace: sidebarWorkspace,
+			});
 			continue;
 		}
 
@@ -170,15 +176,29 @@ export function buildDashboardSidebarProjects({
 			...sidebarProject
 		} = resolvedProject;
 
-		const isLocalMain = (entry: (typeof childEntries)[number]) =>
-			entry.child.type === "workspace" &&
-			entry.child.workspace.type === "main" &&
-			entry.child.workspace.hostType === "local-device";
+		const isLocalMainWorkspace = (workspace: DashboardSidebarWorkspace) =>
+			workspace.type === "main" && workspace.hostType === "local-device";
+
+		const compareByLocalMainThenTabOrder = (
+			left: { tabOrder: number; workspace: DashboardSidebarWorkspace },
+			right: { tabOrder: number; workspace: DashboardSidebarWorkspace },
+		) => {
+			const leftLocalMain = isLocalMainWorkspace(left.workspace);
+			const rightLocalMain = isLocalMainWorkspace(right.workspace);
+			if (leftLocalMain !== rightLocalMain) {
+				return leftLocalMain ? -1 : 1;
+			}
+			return left.tabOrder - right.tabOrder;
+		};
 
 		const sortedChildren = childEntries
 			.sort((left, right) => {
-				const leftLocalMain = isLocalMain(left);
-				const rightLocalMain = isLocalMain(right);
+				const leftLocalMain =
+					left.child.type === "workspace" &&
+					isLocalMainWorkspace(left.child.workspace);
+				const rightLocalMain =
+					right.child.type === "workspace" &&
+					isLocalMainWorkspace(right.child.workspace);
 				if (leftLocalMain !== rightLocalMain) {
 					return leftLocalMain ? -1 : 1;
 				}
@@ -215,10 +235,12 @@ export function buildDashboardSidebarProjects({
 			children.splice(
 				insertIndex,
 				0,
-				...orphanedWorkspaces.map((workspace) => ({
-					type: "workspace" as const,
-					workspace,
-				})),
+				...orphanedWorkspaces
+					.sort(compareByLocalMainThenTabOrder)
+					.map(({ workspace }) => ({
+						type: "workspace" as const,
+						workspace,
+					})),
 			);
 		}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -1,0 +1,228 @@
+import type { WorkspaceTransactionSnapshot } from "renderer/stores/workspace-creates";
+import type {
+	DashboardSidebarProject,
+	DashboardSidebarProjectChild,
+	DashboardSidebarSection,
+	DashboardSidebarWorkspace,
+	DashboardSidebarWorkspaceType,
+} from "../../types";
+
+type SidebarPullRequest = DashboardSidebarWorkspace["pullRequest"];
+
+export interface SidebarProjectInput {
+	id: string;
+	name: string;
+	slug: string;
+	githubRepositoryId: string | null;
+	githubOwner: string | null;
+	githubRepoName: string | null;
+	iconUrl: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+	isCollapsed: boolean;
+}
+
+export interface SidebarSectionInput {
+	id: string;
+	projectId: string;
+	name: string;
+	createdAt: Date;
+	isCollapsed: boolean;
+	tabOrder: number;
+	color: string | null;
+}
+
+export interface SidebarWorkspaceInput {
+	id: string;
+	projectId: string;
+	hostId: string;
+	type: DashboardSidebarWorkspaceType;
+	hostIsOnline: boolean;
+	name: string;
+	branch: string;
+	taskId: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+	tabOrder: number;
+	sectionId: string | null;
+	pendingTransaction: WorkspaceTransactionSnapshot | null;
+}
+
+export interface BuildDashboardSidebarProjectsParams {
+	sidebarProjects: SidebarProjectInput[];
+	sidebarSections: SidebarSectionInput[];
+	visibleSidebarWorkspaces: SidebarWorkspaceInput[];
+	machineId: string;
+	pullRequestsByWorkspaceId: Map<string, SidebarPullRequest>;
+}
+
+export function buildDashboardSidebarProjects({
+	sidebarProjects,
+	sidebarSections,
+	visibleSidebarWorkspaces,
+	machineId,
+	pullRequestsByWorkspaceId,
+}: BuildDashboardSidebarProjectsParams): DashboardSidebarProject[] {
+	const projectsById = new Map<
+		string,
+		DashboardSidebarProject & {
+			sectionMap: Map<string, DashboardSidebarSection>;
+			childEntries: Array<{
+				tabOrder: number;
+				child: DashboardSidebarProjectChild;
+			}>;
+			orphanedWorkspaces: DashboardSidebarWorkspace[];
+		}
+	>();
+
+	for (const project of sidebarProjects) {
+		projectsById.set(project.id, {
+			...project,
+			children: [],
+			sectionMap: new Map(),
+			childEntries: [],
+			orphanedWorkspaces: [],
+		});
+	}
+
+	for (const section of sidebarSections) {
+		const project = projectsById.get(section.projectId);
+		if (!project) continue;
+
+		const sidebarSection: DashboardSidebarSection = {
+			...section,
+			workspaces: [],
+		};
+
+		project.sectionMap.set(section.id, sidebarSection);
+		project.childEntries.push({
+			tabOrder: section.tabOrder,
+			child: {
+				type: "section",
+				section: sidebarSection,
+			},
+		});
+	}
+
+	for (const workspace of visibleSidebarWorkspaces) {
+		const project = projectsById.get(workspace.projectId);
+		if (!project) continue;
+
+		const hostType: DashboardSidebarWorkspace["hostType"] =
+			workspace.hostId === machineId ? "local-device" : "remote-device";
+
+		const sidebarWorkspace: DashboardSidebarWorkspace = {
+			id: workspace.id,
+			projectId: workspace.projectId,
+			hostId: workspace.hostId,
+			hostType,
+			type: workspace.type,
+			hostIsOnline:
+				hostType === "remote-device" ? workspace.hostIsOnline : null,
+			accentColor: null,
+			name: workspace.name,
+			branch: workspace.branch,
+			pullRequest: pullRequestsByWorkspaceId.get(workspace.id) ?? null,
+			repoUrl:
+				project.githubOwner && project.githubRepoName
+					? `https://github.com/${project.githubOwner}/${project.githubRepoName}`
+					: null,
+			branchExistsOnRemote:
+				project.githubOwner !== null && project.githubRepoName !== null,
+			previewUrl: null,
+			needsRebase: null,
+			behindCount: null,
+			createdAt: workspace.createdAt,
+			updatedAt: workspace.updatedAt,
+			taskId: workspace.taskId,
+			pendingTransaction: workspace.pendingTransaction,
+		};
+
+		if (workspace.sectionId) {
+			const section = project.sectionMap.get(workspace.sectionId);
+			if (section) {
+				section.workspaces.push({
+					...sidebarWorkspace,
+					accentColor: section.color,
+				});
+				continue;
+			}
+			project.orphanedWorkspaces.push(sidebarWorkspace);
+			continue;
+		}
+
+		project.childEntries.push({
+			tabOrder: workspace.tabOrder,
+			child: {
+				type: "workspace",
+				workspace: sidebarWorkspace,
+			},
+		});
+	}
+
+	return sidebarProjects.flatMap((project) => {
+		const resolvedProject = projectsById.get(project.id);
+		if (!resolvedProject) return [];
+		const {
+			childEntries,
+			sectionMap: _sectionMap,
+			orphanedWorkspaces,
+			...sidebarProject
+		} = resolvedProject;
+
+		const isLocalMain = (entry: (typeof childEntries)[number]) =>
+			entry.child.type === "workspace" &&
+			entry.child.workspace.type === "main" &&
+			entry.child.workspace.hostType === "local-device";
+
+		const sortedChildren = childEntries
+			.sort((left, right) => {
+				const leftLocalMain = isLocalMain(left);
+				const rightLocalMain = isLocalMain(right);
+				if (leftLocalMain !== rightLocalMain) {
+					return leftLocalMain ? -1 : 1;
+				}
+				return left.tabOrder - right.tabOrder;
+			})
+			.map(({ child }) => child);
+
+		// Ungrouped workspaces rendered after a section header are visually
+		// grouped with that section (shared accent, collapse-together) and will
+		// be committed into it on next DnD. Reparent them here so section counts
+		// match what the user sees.
+		const children: DashboardSidebarProjectChild[] = [];
+		let currentSection: DashboardSidebarSection | null = null;
+		for (const child of sortedChildren) {
+			if (child.type === "section") {
+				currentSection = child.section;
+				children.push(child);
+			} else if (currentSection) {
+				currentSection.workspaces.push({
+					...child.workspace,
+					accentColor: currentSection.color,
+				});
+			} else {
+				children.push(child);
+			}
+		}
+
+		if (orphanedWorkspaces.length > 0) {
+			const firstSectionIndex = children.findIndex(
+				(child) => child.type === "section",
+			);
+			const insertIndex =
+				firstSectionIndex === -1 ? children.length : firstSectionIndex;
+			children.splice(
+				insertIndex,
+				0,
+				...orphanedWorkspaces.map((workspace) => ({
+					type: "workspace" as const,
+					workspace,
+				})),
+			);
+		}
+
+		sidebarProject.children = children;
+		return [sidebarProject];
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -14,10 +14,9 @@ import { useLocalHostService } from "renderer/routes/_authenticated/providers/Lo
 import { useWorkspaceTransactionsStore } from "renderer/stores/workspace-creates";
 import type {
 	DashboardSidebarProject,
-	DashboardSidebarProjectChild,
-	DashboardSidebarSection,
 	DashboardSidebarWorkspace,
 } from "../../types";
+import { buildDashboardSidebarProjects } from "./buildDashboardSidebarProjects";
 import {
 	derivePullRequestQueryTargets,
 	getDashboardSidebarPullRequestQueryKey,
@@ -393,154 +392,23 @@ export function useDashboardSidebarData() {
 	const pullRequestsByWorkspaceId =
 		useStablePullRequestsByWorkspaceId(pullRequestRows);
 
-	const computedGroups = useMemo<DashboardSidebarProject[]>(() => {
-		const projectsById = new Map<
-			string,
-			DashboardSidebarProject & {
-				sectionMap: Map<string, DashboardSidebarSection>;
-				childEntries: Array<{
-					tabOrder: number;
-					child: DashboardSidebarProjectChild;
-				}>;
-			}
-		>();
-
-		for (const project of sidebarProjects) {
-			projectsById.set(project.id, {
-				...project,
-				children: [],
-				sectionMap: new Map(),
-				childEntries: [],
-			});
-		}
-
-		for (const section of sidebarSections) {
-			const project = projectsById.get(section.projectId);
-			if (!project) continue;
-
-			const sidebarSection: DashboardSidebarSection = {
-				...section,
-				workspaces: [],
-			};
-
-			project.sectionMap.set(section.id, sidebarSection);
-			project.childEntries.push({
-				tabOrder: section.tabOrder,
-				child: {
-					type: "section",
-					section: sidebarSection,
-				},
-			});
-		}
-
-		for (const workspace of visibleSidebarWorkspaces) {
-			const project = projectsById.get(workspace.projectId);
-			if (!project) continue;
-
-			const hostType: DashboardSidebarWorkspace["hostType"] =
-				workspace.hostId === machineId ? "local-device" : "remote-device";
-
-			const sidebarWorkspace: DashboardSidebarWorkspace = {
-				id: workspace.id,
-				projectId: workspace.projectId,
-				hostId: workspace.hostId,
-				hostType,
-				type: workspace.type,
-				hostIsOnline:
-					hostType === "remote-device" ? workspace.hostIsOnline : null,
-				accentColor: null,
-				name: workspace.name,
-				branch: workspace.branch,
-				pullRequest: pullRequestsByWorkspaceId.get(workspace.id) ?? null,
-				repoUrl:
-					project.githubOwner && project.githubRepoName
-						? `https://github.com/${project.githubOwner}/${project.githubRepoName}`
-						: null,
-				branchExistsOnRemote:
-					project.githubOwner !== null && project.githubRepoName !== null,
-				previewUrl: null,
-				needsRebase: null,
-				behindCount: null,
-				createdAt: workspace.createdAt,
-				updatedAt: workspace.updatedAt,
-				taskId: workspace.taskId,
-				pendingTransaction: workspace.pendingTransaction,
-			};
-
-			if (workspace.sectionId) {
-				const section = project.sectionMap.get(workspace.sectionId);
-				if (section) {
-					section.workspaces.push({
-						...sidebarWorkspace,
-						accentColor: section.color,
-					});
-				}
-				continue;
-			}
-
-			project.childEntries.push({
-				tabOrder: workspace.tabOrder,
-				child: {
-					type: "workspace",
-					workspace: sidebarWorkspace,
-				},
-			});
-		}
-
-		return sidebarProjects.flatMap((project) => {
-			const resolvedProject = projectsById.get(project.id);
-			if (!resolvedProject) return [];
-			const {
-				childEntries,
-				sectionMap: _sectionMap,
-				...sidebarProject
-			} = resolvedProject;
-
-			const isLocalMain = (entry: (typeof childEntries)[number]) =>
-				entry.child.type === "workspace" &&
-				entry.child.workspace.type === "main" &&
-				entry.child.workspace.hostType === "local-device";
-
-			const sortedChildren = childEntries
-				.sort((left, right) => {
-					const leftLocalMain = isLocalMain(left);
-					const rightLocalMain = isLocalMain(right);
-					if (leftLocalMain !== rightLocalMain) {
-						return leftLocalMain ? -1 : 1;
-					}
-					return left.tabOrder - right.tabOrder;
-				})
-				.map(({ child }) => child);
-
-			// Ungrouped workspaces rendered after a section header are visually
-			// grouped with that section (shared accent, collapse-together) and will
-			// be committed into it on next DnD. Reparent them here so section counts
-			// match what the user sees.
-			const children: DashboardSidebarProjectChild[] = [];
-			let currentSection: DashboardSidebarSection | null = null;
-			for (const child of sortedChildren) {
-				if (child.type === "section") {
-					currentSection = child.section;
-					children.push(child);
-				} else if (currentSection) {
-					currentSection.workspaces.push({
-						...child.workspace,
-						accentColor: currentSection.color,
-					});
-				} else {
-					children.push(child);
-				}
-			}
-			sidebarProject.children = children;
-			return [sidebarProject];
-		});
-	}, [
-		machineId,
-		pullRequestsByWorkspaceId,
-		sidebarProjects,
-		sidebarSections,
-		visibleSidebarWorkspaces,
-	]);
+	const computedGroups = useMemo<DashboardSidebarProject[]>(
+		() =>
+			buildDashboardSidebarProjects({
+				sidebarProjects,
+				sidebarSections,
+				visibleSidebarWorkspaces,
+				machineId,
+				pullRequestsByWorkspaceId,
+			}),
+		[
+			machineId,
+			pullRequestsByWorkspaceId,
+			sidebarProjects,
+			sidebarSections,
+			visibleSidebarWorkspaces,
+		],
+	);
 	const groups = useStableDashboardSidebarProjects(computedGroups);
 
 	return {


### PR DESCRIPTION
## Problem

Reported by Kunal: workspaces drop off the sidebar after the most recent update, even though they still show as **pinned** on the workspaces page. Happens most often when moving workspaces across sidebar sections/folders.

## Root cause

The v2 dashboard sidebar tree builder (`useDashboardSidebarData`) placed each visible workspace like this:

```ts
if (workspace.sectionId) {
  const section = project.sectionMap.get(workspace.sectionId);
  if (section) {
    section.workspaces.push(...);
  }
  continue; // <- fires even when the section was NOT found
}
```

When a workspace's `sidebarState.sectionId` points at a section that no longer exists in `v2SidebarSections`, the `continue` fires unconditionally and the workspace is **never added to the tree** — it silently disappears. Since `isHidden` stays `false`, it still reads as "pinned" everywhere else, which is exactly the reported symptom.

Why a `sectionId` dangles, and why it correlates with the update / section moves:
- Section moves and reorders are what write `sectionId` values into `v2WorkspaceLocalState`.
- The sidebar reads sections and workspaces from **two independent** local-storage collections, and `withReadHeal` shows these rows persist their last-written shape across app versions — so a `sectionId` written by an older build (or transiently out of sync with the sections collection) can resolve to nothing after an update.

The **v1** sidebar already guards against this exact case — orphaned workspaces fall back to ungrouped (`workspaces/procedures/query.ts`, "Orphan: section not found, fall back to ungrouped"). v2 did not.

## Fix

Mirror the v1 behavior in v2: a workspace whose `sectionId` doesn't resolve to an existing section now renders in the **ungrouped region** (below the local-main workspace, above the sections) instead of being dropped. A pinned workspace can never become invisible. On the next drag it commits to a real location normally.

The grouping logic was extracted into a pure `buildDashboardSidebarProjects()` so it can be unit-tested; the hook now just calls it (no behavior change beyond the orphan fallback).

## Tests

`buildDashboardSidebarProjects.test.ts`:
- normal in-section placement
- **orphaned-section workspace renders at top level instead of being dropped** (regression guard)
- workspace stays visible after its section is reordered

## Verification

- `bun test` (new file) — 3 pass
- `bun run typecheck --filter=@superset/desktop` — clean
- `bun run lint:fix` — clean

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 sidebar dropping pinned workspaces when their saved section is missing. Orphaned workspaces now render ungrouped and are sorted local-main-first, then by tab order, so pinned items never disappear.

- **Bug Fixes**
  - Orphaned `sectionId` workspaces render ungrouped, sorted local-main-first then by `tabOrder`; placed below local-main and above sections.
  - Pinned items stay visible across section moves and app updates.

- **Refactors**
  - Extracted the sidebar tree builder into a pure `buildDashboardSidebarProjects` and simplified `useDashboardSidebarData` to use it.
  - Added unit tests for normal placement, orphan fallback, section ordering, and multi-orphan ordering.

<sup>Written for commit 3babab5cb703f7644f1fa491688e852e021b09c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Orphaned workspaces (those referencing missing sections) are preserved and shown at top level; workspace ordering when section positions change is more reliable.

* **New Features**
  * Added a dedicated builder to reliably construct sidebar project/section/workspace structures, improving consistency of sidebar rendering.

* **Refactor**
  * Sidebar data assembly moved into a reusable module to simplify the sidebar hook and reduce inline logic.

* **Tests**
  * Added deterministic tests covering workspace placement, section assignment, and ordering behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->