### PR TITLE
feat(analytics): tag workspace_created with host_kind local/remote

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -392,6 +392,7 @@ async function handleNewWorktree({
 		source: "pr",
 		pr_number: prInfo.number,
 		is_fork: prInfo.isCrossRepository,
+		host_kind: "local",
 	});
 
 	await setBranchBaseConfig({
@@ -676,6 +677,7 @@ export const createCreateProcedures = () => {
 					branch: branch,
 					base_branch: compareBaseBranch,
 					use_existing_branch: input.useExistingBranch ?? false,
+					host_kind: "local",
 				});
 
 				await setBranchBaseConfig({

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-creation.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-creation.ts
@@ -257,6 +257,7 @@ export async function createWorkspaceFromExternalWorktree({
 			branch,
 			base_branch: compareBaseBranch,
 			source: "external_import_auto",
+			host_kind: "local",
 		});
 
 		return {
@@ -558,6 +559,7 @@ export async function openExternalWorktree({
 		branch,
 		base_branch: compareBaseBranch,
 		source: "external_import",
+		host_kind: "local",
 	});
 
 	await setBranchBaseConfig({

--- a/apps/desktop/src/renderer/lib/host-service-auth.ts
+++ b/apps/desktop/src/renderer/lib/host-service-auth.ts
@@ -2,6 +2,12 @@ import { getJwt } from "./auth-client";
 
 const secrets = new Map<string, string>();
 
+let clientMachineId: string | null = null;
+
+export function setClientMachineId(machineId: string): void {
+	clientMachineId = machineId;
+}
+
 export function setHostServiceSecret(hostUrl: string, secret: string): void {
 	secrets.set(hostUrl, secret);
 }
@@ -11,11 +17,18 @@ export function removeHostServiceSecret(hostUrl: string): void {
 }
 
 export function getHostServiceHeaders(hostUrl: string): Record<string, string> {
+	const headers: Record<string, string> = clientMachineId
+		? { "x-superset-client-machine-id": clientMachineId }
+		: {};
 	const secret = secrets.get(hostUrl);
-	if (secret) return { Authorization: `Bearer ${secret}` };
+	if (secret) {
+		headers.Authorization = `Bearer ${secret}`;
+		return headers;
+	}
 	// Relay: use JWT
 	const jwt = getJwt();
-	return jwt ? { Authorization: `Bearer ${jwt}` } : {};
+	if (jwt) headers.Authorization = `Bearer ${jwt}`;
+	return headers;
 }
 
 export function getHostServiceWsToken(hostUrl: string): string | null {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -9,7 +9,10 @@ import {
 import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { setHostServiceSecret } from "renderer/lib/host-service-auth";
+import {
+	setClientMachineId,
+	setHostServiceSecret,
+} from "renderer/lib/host-service-auth";
 import type { HostServiceAvailabilityStatus } from "renderer/lib/host-service-unavailable";
 import { MOCK_ORG_ID } from "shared/constants";
 import { useCollections } from "../CollectionsProvider";
@@ -59,6 +62,12 @@ export function LocalHostServiceProvider({
 		undefined,
 		{ staleTime: Number.POSITIVE_INFINITY },
 	);
+
+	useEffect(() => {
+		if (machineIdData?.machineId) {
+			setClientMachineId(machineIdData.machineId);
+		}
+	}, [machineIdData]);
 
 	const { data: activeConnection } =
 		electronTrpc.hostServiceCoordinator.getConnection.useQuery(

--- a/packages/cli/src/lib/host-target/resolveHostTarget.ts
+++ b/packages/cli/src/lib/host-target/resolveHostTarget.ts
@@ -57,7 +57,10 @@ export function resolveHostTarget(
 					httpBatchLink({
 						url: `${manifest.endpoint}/trpc`,
 						transformer: SuperJSON,
-						headers: { Authorization: `Bearer ${manifest.authToken}` },
+						headers: {
+							Authorization: `Bearer ${manifest.authToken}`,
+							"x-superset-client-machine-id": localHostId,
+						},
 					}),
 				],
 			}),
@@ -73,7 +76,10 @@ export function resolveHostTarget(
 				httpBatchLink({
 					url: `${env.RELAY_URL}/hosts/${routingKey}/trpc`,
 					transformer: SuperJSON,
-					headers: { Authorization: `Bearer ${options.userJwt}` },
+					headers: {
+						Authorization: `Bearer ${options.userJwt}`,
+						"x-superset-client-machine-id": localHostId,
+					},
 				}),
 			],
 		}),

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -123,7 +123,12 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		"*",
 		cors({
 			origin: config.allowedOrigins,
-			allowHeaders: ["Content-Type", "Authorization", "trpc-accept"],
+			allowHeaders: [
+				"Content-Type",
+				"Authorization",
+				"trpc-accept",
+				"x-superset-client-machine-id",
+			],
 		}),
 	);
 

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -180,6 +180,8 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 					terminalAgentStore,
 					organizationId: config.organizationId,
 					isAuthenticated,
+					clientMachineId:
+						c.req.header("x-superset-client-machine-id") ?? undefined,
 				} as Record<string, unknown>;
 			},
 		}),

--- a/packages/host-service/src/trpc/router/project/utils/ensure-main-workspace.ts
+++ b/packages/host-service/src/trpc/router/project/utils/ensure-main-workspace.ts
@@ -82,7 +82,7 @@ export async function ensureMainWorkspaceStrict(
 		branch,
 		hostId: host.machineId,
 		type: "main",
-		clientMachineId: ctx.clientMachineId,
+		clientMachineId: ctx.clientMachineId ?? getHostId(),
 	});
 
 	ctx.db

--- a/packages/host-service/src/trpc/router/project/utils/ensure-main-workspace.ts
+++ b/packages/host-service/src/trpc/router/project/utils/ensure-main-workspace.ts
@@ -5,7 +5,7 @@ import type { HostServiceContext } from "../../../../types";
 
 export type EnsureMainWorkspaceContext = Pick<
 	HostServiceContext,
-	"api" | "db" | "git" | "organizationId"
+	"api" | "db" | "git" | "organizationId" | "clientMachineId"
 >;
 
 async function getCurrentBranchName(
@@ -82,6 +82,7 @@ export async function ensureMainWorkspaceStrict(
 		branch,
 		hostId: host.machineId,
 		type: "main",
+		clientMachineId: ctx.clientMachineId,
 	});
 
 	ctx.db

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/adopt-existing-worktree.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/adopt-existing-worktree.ts
@@ -165,6 +165,7 @@ export async function adoptExistingWorktree(
 			hostId: host.machineId,
 			id: idempotencyId,
 			taskId,
+			clientMachineId: ctx.clientMachineId,
 		})
 		.catch((err) => {
 			if (err instanceof TRPCError) throw err;

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -458,6 +458,7 @@ async function registerCloudAndLocal(args: {
 			hostId: host.machineId,
 			taskId: args.taskId,
 			id: args.id,
+			clientMachineId: ctx.clientMachineId,
 		})
 		.catch(async (err) => {
 			await args.rollbackWorktree();

--- a/packages/host-service/src/types.ts
+++ b/packages/host-service/src/types.ts
@@ -31,4 +31,5 @@ export interface HostServiceContext {
 	terminalAgentStore: TerminalAgentStore;
 	organizationId: string;
 	isAuthenticated: boolean;
+	clientMachineId?: string;
 }

--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -197,6 +197,7 @@ export const v2WorkspaceRouter = {
 				type: z.enum(v2WorkspaceTypeValues).default("worktree"),
 				taskId: z.string().uuid().optional(),
 				id: z.string().uuid().optional(),
+				clientMachineId: z.string().optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -262,6 +263,12 @@ export const v2WorkspaceRouter = {
 							host_id: inserted.hostId,
 							branch: inserted.branch,
 							type: inserted.type,
+							host_kind:
+								input.clientMachineId &&
+								input.clientMachineId === inserted.hostId
+									? "local"
+									: "remote",
+							client_machine_id: input.clientMachineId ?? null,
 						},
 					});
 					const txid = await getCurrentTxid(tx);


### PR DESCRIPTION
## Why

We want to measure **remote workspace usage per organization** — how often users create/use workspaces on a machine that isn't their own. Today that's only inferable through noisy machineId archaeology in Postgres: counting users who span >1 host false-positives on laptop+desktop (two of their own machines) and on ephemeral cloud hosts that churn machineIds. This annotates the event at creation time instead.

## What

`workspace_created` now carries `host_kind: "local" | "remote"` (plus `client_machine_id` for debuggability).

**Determination rule (uniform):** any client co-located with a potential host (desktop, CLI) sends its own machineId via an `x-superset-client-machine-id` header. The host-service surfaces it on the request context and forwards it to the single cloud `v2Workspace.create` fire site, which computes:

```ts
host_kind = clientMachineId && clientMachineId === inserted.hostId ? "local" : "remote"
```

Anything that omits the header (web browser, Slack bot, automation cron, SDK, MCP) defaults to `"remote"` — correct, since none run co-located with the host.

Because the header rides on the request context, the **main-workspace** creation path (`ensureMainWorkspaceStrict`, ~54% of all v2 workspaces) is tagged correctly with no per-call-site plumbing. The startup sweep re-runs `ensureMainWorkspaceStrict` but hits `onConflictDoNothing` → no insert → no event, so only the first (user-initiated) creation fires.

v1 desktop workspaces are always local git worktrees (no host concept), so their four `track()` sites get a constant `host_kind: "local"`.

### Surfaces

| Surface | Path | Tagging |
|---|---|---|
| Desktop v2 (workspace + project/main) | renderer → host-service → cloud | header → compared to hostId |
| Desktop v1 | local `track()` | constant `"local"` |
| CLI (`--local` / `--host`) | CLI → host-service → cloud | header (own machineId) → compared to hostId |
| Web `/workspaces` | calls cloud directly | omits field → `"remote"` |
| Slack / automation / SDK / MCP | relay → host-service → cloud (headless) | omits header → `"remote"` |

No DB/schema change.

## Testing

- `bun run typecheck` — 28/28 pass
- `bun run lint` — exits 0

Runtime verification (post-build): create v2 workspaces locally vs. on a relay host, a new local project (main workspace → `"local"`), a v1 workspace, and a Slack/automation trigger (→ `"remote"`); confirm each `workspace_created` event's `host_kind` in PostHog (Production, project 264803). Org breakdown is then `workspace_created` filtered to `host_kind = "remote"`, split by `organization_id`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5198">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tag `workspace_created` events with `host_kind: "local" | "remote"` and include `client_machine_id` to measure remote workspace usage per org. Desktop and CLI send a machine ID header; the cloud computes `host_kind`, and headless callers default to `"remote"`.

- **New Features**
  - Cloud `v2Workspace.create` accepts `clientMachineId`, sets `host_kind` and `client_machine_id`.
  - Rule: local if `clientMachineId === hostId`; otherwise remote; missing header => remote.
  - Desktop v2 and CLI send `x-superset-client-machine-id`; `host-service` forwards it via request context, including main-workspace creation. Desktop v1 always tags `"local"`.
  - No DB/schema changes.

- **Bug Fixes**
  - Added `x-superset-client-machine-id` to CORS `allowHeaders` so Electron preflight doesn’t drop it and mislabel local creates as `"remote"`.
  - In `ensureMainWorkspaceStrict`, fall back to the host’s ID when `clientMachineId` is missing so startup backfills that insert a main workspace tag it `"local"`; user-initiated creates still use the real header.

<sup>Written for commit f92e3d4a882c1c9d332e87d6ff7f3d8e714e3f83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client machine identity is now included with host requests and persisted so workspace actions can be attributed to a specific machine.

* **Chores**
  * Workspace creation analytics now classify events as local or remote and include the client machine identifier.
  * Request handling and service context updated to propagate the client machine ID across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->