### PR TITLE
fix(analytics): stop counting auto-created main workspace as activation

### DIFF
--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -253,24 +253,26 @@ export const v2WorkspaceRouter = {
 					.returning();
 
 				if (inserted) {
-					posthog.capture({
-						distinctId: ctx.userId,
-						event: "workspace_created",
-						properties: {
-							workspace_id: inserted.id,
-							project_id: inserted.projectId,
-							organization_id: inserted.organizationId,
-							host_id: inserted.hostId,
-							branch: inserted.branch,
-							type: inserted.type,
-							host_kind:
-								input.clientMachineId &&
-								input.clientMachineId === inserted.hostId
-									? "local"
-									: "remote",
-							client_machine_id: input.clientMachineId ?? null,
-						},
-					});
+					if (inserted.type !== "main") {
+						posthog.capture({
+							distinctId: ctx.userId,
+							event: "workspace_created",
+							properties: {
+								workspace_id: inserted.id,
+								project_id: inserted.projectId,
+								organization_id: inserted.organizationId,
+								host_id: inserted.hostId,
+								branch: inserted.branch,
+								type: inserted.type,
+								host_kind:
+									input.clientMachineId &&
+									input.clientMachineId === inserted.hostId
+										? "local"
+										: "remote",
+								client_machine_id: input.clientMachineId ?? null,
+							},
+						});
+					}
 					const txid = await getCurrentTxid(tx);
 					return { workspace: inserted, txid };
 				}


### PR DESCRIPTION
## What

Suppress the `workspace_created` PostHog event for the auto-created `type:"main"` v2 workspace (created by `ensureMainWorkspace` on every project-add). The event now only fires for deliberate workspace creations, so it cleanly means **the user created a workspace** — matching how we define activation.

## Why

`workspace_created` was our activation signal, but the v2 cloud path fired it for the `main` workspace that the system auto-creates when a project is added. That's not a user action, and the data shows it badly inflated the metric:

- **New-user activation looked like ~71%**, but ~24 of those points were phantom: users who only ever got a `main` auto-created and never made a real workspace.
- Bucketing new users (30d cohort) by what they created, and checking whether they did real work (terminal / chat / agent) within 14d:
  - Created a real workspace (worktree/v1): **27.5%** did real work
  - **`main` only: 9.0%** — i.e. ~91% are dead
  - No workspace at all: 2.0%
- So `main`-only users behave like the no-workspace bucket, not like real-workspace users. Excluding them gives the true **new-user activation rate of ~47–48%**.

Filtering `main` in analysis costs at most ~2 points (the ~9% of main-only users who do work in the main checkout without creating a worktree) versus the ~23-point overcount it removes — and by our literal definition, a system-auto-created main shouldn't count anyway.

## Scope

One-line behavioral change: gate the existing `posthog.capture` on `inserted.type !== "main"`. v1 desktop events are unaffected (they only ever fire for real worktree creations). No schema or other property changes.

## Dashboards

Canonical charts added to the [Onboarding Activation dashboard](https://us.posthog.com/project/264803/dashboard/1618640):
- [New-user activation funnel (excl. main, 14d)](https://us.posthog.com/project/264803/insights/Es6Yu3Lr)
- [New-user activation rate over time (weekly, excl. main)](https://us.posthog.com/project/264803/insights/lOD1C8JK)

Both filter `type != main`, so they read correctly for historical data too (before this fix deploys) and going forward (after, when `main` simply stops emitting).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5199">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop emitting `workspace_created` for auto-created `type:"main"` v2 workspaces. This makes activation reflect real, user-created workspaces and removes inflated counts.

- **Bug Fixes**
  - Gate `posthog.capture('workspace_created')` behind `inserted.type !== "main"` in `v2WorkspaceRouter`.
  - No schema or property changes; v1 worktree events remain unchanged.

<sup>Written for commit f8f6781c67a177eb7e4656c4b0d527653a98680c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined analytics event tracking for workspace creation to exclude default workspace types from event reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->