### PR TITLE
fix(desktop): detect if users onboarded on v1 vs v2

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx
+++ b/apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from "react";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { authClient } from "renderer/lib/auth-client";
 import { posthog } from "renderer/lib/posthog";
 
 export function PostHogSurfaceTagger() {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const { data: session } = authClient.useSession();
+	const userId = session?.user?.id;
 
 	useEffect(() => {
 		const surface = isV2CloudEnabled ? "v2" : "v1";
@@ -11,14 +14,17 @@ export function PostHogSurfaceTagger() {
 
 		posthog.register({ surface, surface_source });
 
+		if (!userId) return;
+
 		posthog.people.set({ surface });
+		posthog.people.set_once({ onboarded_surface: surface });
 		if (isV2CloudEnabled) {
 			posthog.people.set_once({
 				surface_first_v2_at: new Date().toISOString(),
 				surface_ever_v2: true,
 			});
 		}
-	}, [isV2CloudEnabled]);
+	}, [isV2CloudEnabled, userId]);
 
 	return null;
 }


### PR DESCRIPTION
## Problem

We were unsure whether the v1-vs-v2 user split was instrumented correctly. It wasn't.

`PostHogSurfaceTagger` called `posthog.people.set({ surface })` on **every** run — including signed-out / pre-auth. PostHog is configured `person_profiles: "identified_only"`, but `people.set` **force-creates a person profile anyway**, so every app launch before sign-in minted an *anonymous* person tagged with a surface. Signed-out defaults to `v1`, so the pollution was lopsided toward v1.

Prod data confirmed it: ~4,900 anonymous person profiles carried a surface (3,997 `v1` / 908 `v2`, ~4:1 toward v1). A naive `GROUP BY surface` gave v2 = **38.3%**; restricted to identified persons (the real answer) it's **43.3%**.

## Changes

- **Gate the person-property writes on an authenticated `userId`.** No more anonymous profiles minted by surface tagging. Super properties (`register`) stay unconditional — they tag events without creating profiles.
- **`set_once({ onboarded_surface })`** — an immutable record of the surface a user started on, so onboarding-cohort retention can be distinguished from the user's *current* (mutable) `surface`. (The existing `surface` person property reflects current surface, which made historical v1/v2 cohorts mix both surfaces.)

## Caveats

- `onboarded_surface` is only accurate for users whose first authenticated session is **after** this ships; existing users get backfilled with their current surface on first post-deploy run. Clean onboarding cohorts accrue from the deploy date forward.
- The already-polluted anonymous profiles won't self-heal — keep the `is_identified` filter when computing the split (which the new "V1 vs V2 Surface" dashboard already does).

## Verification

- `bun run lint` ✅
- `bun run typecheck --filter=@superset/desktop` ✅

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops creating anonymous PostHog person profiles by only tagging surface person properties after authentication. Adds an immutable `onboarded_surface` to separate a user’s first surface from their current one, improving v1/v2 split accuracy.

- **Bug Fixes**
  - Gate `posthog.people.set({ surface })` behind `userId`; `posthog.register({ surface, surface_source })` remains unconditional.
  - Add `posthog.people.set_once({ onboarded_surface })`; when on v2 also set `surface_first_v2_at` and `surface_ever_v2`. Include `userId` in effect deps.

- **Migration**
  - Keep the `is_identified` filter in dashboards and queries.
  - `onboarded_surface` is clean for new users post-deploy; existing users get their current surface on first run.

<sup>Written for commit fc0c363c7e727f6f24f57ebcd7e646751a230f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostHog analytics now only records data for authenticated users, preventing tracking information from being written for unauthenticated sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->