### PR TITLE
fix(desktop): restore PostHog identity stitching for pre-sign-in events

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
+++ b/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
+import {
+	ACTIVE_ORG_ID_KEY,
+	AUTH_COMPLETED_KEY,
+} from "renderer/hooks/useSignOut";
 import { track } from "renderer/lib/analytics";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { posthog } from "../../lib/posthog";
-
-const AUTH_COMPLETED_KEY = "superset_auth_completed";
-const ACTIVE_ORG_ID_KEY = "active_organization_id";
 
 export function PostHogUserIdentifier() {
 	const { data: session } = authClient.useSession();
@@ -14,28 +15,21 @@ export function PostHogUserIdentifier() {
 	const { mutate: setUserId } = electronTrpc.analytics.setUserId.useMutation();
 
 	useEffect(() => {
-		if (user) {
-			posthog.identify(user.id, {
-				email: user.email,
-				name: user.name,
-				desktop_version: window.App.appVersion,
-			});
-			posthog.reloadFeatureFlags();
-			setUserId({ userId: user.id });
+		if (!user) return;
+		posthog.identify(user.id, {
+			email: user.email,
+			name: user.name,
+			desktop_version: window.App.appVersion,
+		});
+		posthog.reloadFeatureFlags();
+		setUserId({ userId: user.id });
 
-			const trackedUserId = localStorage.getItem(AUTH_COMPLETED_KEY);
-			if (trackedUserId !== user.id) {
-				track("auth_completed");
-				localStorage.setItem(AUTH_COMPLETED_KEY, user.id);
-			}
-		} else if (session !== undefined && !user) {
-			// Session loaded but no user - user is signed out
-			posthog.reset();
-			setUserId({ userId: null });
-			localStorage.removeItem(AUTH_COMPLETED_KEY);
-			localStorage.removeItem(ACTIVE_ORG_ID_KEY);
+		const trackedUserId = localStorage.getItem(AUTH_COMPLETED_KEY);
+		if (trackedUserId !== user.id) {
+			track("auth_completed");
+			localStorage.setItem(AUTH_COMPLETED_KEY, user.id);
 		}
-	}, [user, session, setUserId]);
+	}, [user, setUserId]);
 
 	useEffect(() => {
 		if (session === undefined) return;

--- a/apps/desktop/src/renderer/hooks/useSignOut/index.ts
+++ b/apps/desktop/src/renderer/hooks/useSignOut/index.ts
@@ -1,0 +1,5 @@
+export {
+	ACTIVE_ORG_ID_KEY,
+	AUTH_COMPLETED_KEY,
+	useSignOut,
+} from "./useSignOut";

--- a/apps/desktop/src/renderer/hooks/useSignOut/useSignOut.ts
+++ b/apps/desktop/src/renderer/hooks/useSignOut/useSignOut.ts
@@ -1,0 +1,20 @@
+import { authClient } from "renderer/lib/auth-client";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { posthog } from "renderer/lib/posthog";
+
+export const AUTH_COMPLETED_KEY = "superset_auth_completed";
+export const ACTIVE_ORG_ID_KEY = "active_organization_id";
+
+export function useSignOut() {
+	const signOutMutation = electronTrpc.auth.signOut.useMutation();
+	const setAnalyticsUserId = electronTrpc.analytics.setUserId.useMutation();
+
+	return async () => {
+		posthog.reset();
+		setAnalyticsUserId.mutate({ userId: null });
+		localStorage.removeItem(AUTH_COMPLETED_KEY);
+		localStorage.removeItem(ACTIVE_ORG_ID_KEY);
+		await authClient.signOut();
+		signOutMutation.mutate();
+	};
+}

--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -5,7 +5,7 @@ import { env } from "../env.renderer";
 // Cast to standard PostHog type for compatibility with posthog-js/react
 export const posthog = posthogFull as unknown as PostHog;
 
-export function initPostHog(deviceId?: string) {
+export function initPostHog() {
 	if (!env.NEXT_PUBLIC_POSTHOG_KEY) {
 		console.log("[posthog] No key configured, skipping");
 		return;
@@ -20,14 +20,10 @@ export function initPostHog(deviceId?: string) {
 		person_profiles: "identified_only",
 		persistence: "localStorage",
 		debug: false,
-		...(deviceId && {
-			bootstrap: { distinctID: deviceId, isIdentifiedID: false },
-		}),
 		loaded: (ph) => {
 			ph.register({
 				app_name: "desktop",
 				platform: window.navigator.platform,
-				...(deviceId && { device_id: deviceId }),
 			});
 		},
 	});

--- a/apps/desktop/src/renderer/providers/PostHogProvider/PostHogProvider.tsx
+++ b/apps/desktop/src/renderer/providers/PostHogProvider/PostHogProvider.tsx
@@ -3,7 +3,6 @@ import type React from "react";
 import { useEffect, useState } from "react";
 import { track } from "renderer/lib/analytics";
 import { initPostHog, posthog } from "renderer/lib/posthog";
-import { electronTrpcClient } from "renderer/lib/trpc-client";
 
 interface PostHogProviderProps {
 	children: React.ReactNode;
@@ -13,32 +12,14 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
 	const [isInitialized, setIsInitialized] = useState(false);
 
 	useEffect(() => {
-		let cancelled = false;
-
-		(async () => {
-			let deviceId: string | undefined;
-			try {
-				deviceId = (await electronTrpcClient.device.getMachineId.query())
-					.machineId;
-			} catch (error) {
-				console.error("[posthog] Failed to resolve device id:", error);
-			}
-
-			if (cancelled) return;
-
-			try {
-				initPostHog(deviceId);
-				track("desktop_opened");
-			} catch (error) {
-				console.error("[posthog] Failed to initialize:", error);
-			} finally {
-				setIsInitialized(true);
-			}
-		})();
-
-		return () => {
-			cancelled = true;
-		};
+		try {
+			initPostHog();
+			track("desktop_opened");
+		} catch (error) {
+			console.error("[posthog] Failed to initialize:", error);
+		} finally {
+			setIsInitialized(true);
+		}
 	}, []);
 
 	if (!isInitialized) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -23,8 +23,8 @@ import {
 } from "react-icons/hi2";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
 import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
+import { useSignOut } from "renderer/hooks/useSignOut";
 import { authClient } from "renderer/lib/auth-client";
-import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
 export function OrganizationDropdown({
@@ -34,7 +34,7 @@ export function OrganizationDropdown({
 }) {
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
-	const signOutMutation = electronTrpc.auth.signOut.useMutation();
+	const signOut = useSignOut();
 	const navigate = useNavigate();
 
 	const activeOrganizationId = session?.session?.activeOrganizationId;
@@ -51,8 +51,7 @@ export function OrganizationDropdown({
 	const userEmail = session?.user?.email;
 
 	async function handleSignOut(): Promise<void> {
-		await authClient.signOut();
-		signOutMutation.mutate();
+		await signOut();
 	}
 
 	const userName = session?.user?.name;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/AccountSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/AccountSettings.tsx
@@ -4,6 +4,7 @@ import { Input } from "@superset/ui/input";
 import { toast } from "@superset/ui/sonner";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useState } from "react";
+import { useSignOut } from "renderer/hooks/useSignOut";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -47,9 +48,7 @@ export function AccountSettings({ visibleItems }: AccountSettingsProps) {
 
 	const user = usersData?.find((u) => u.id === currentUserId);
 
-	const signOutMutation = electronTrpc.auth.signOut.useMutation({
-		onSuccess: () => toast.success("Signed out"),
-	});
+	const signOut = useSignOut();
 
 	const selectImageMutation = electronTrpc.window.selectImageFile.useMutation();
 
@@ -162,7 +161,10 @@ export function AccountSettings({ visibleItems }: AccountSettingsProps) {
 						>
 							<Button
 								variant="outline"
-								onClick={() => signOutMutation.mutate()}
+								onClick={async () => {
+									await signOut();
+									toast.success("Signed out");
+								}}
 							>
 								Sign out
 							</Button>

--- a/apps/desktop/src/renderer/routes/create-organization/page.tsx
+++ b/apps/desktop/src/renderer/routes/create-organization/page.tsx
@@ -16,9 +16,9 @@ import { createFileRoute, Navigate, useNavigate } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import { useSignOut } from "renderer/hooks/useSignOut";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
-import { electronTrpc } from "renderer/lib/electron-trpc";
 import { z } from "zod";
 
 export const Route = createFileRoute("/create-organization/")({
@@ -45,7 +45,7 @@ export function CreateOrganization() {
 	const { data: session } = authClient.useSession();
 	const isSignedIn = !!session?.user;
 	const activeOrganizationId = session?.session?.activeOrganizationId;
-	const signOutMutation = electronTrpc.auth.signOut.useMutation();
+	const signOut = useSignOut();
 	const navigate = useNavigate();
 
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -99,8 +99,7 @@ export function CreateOrganization() {
 	}, [slugValue]);
 
 	async function handleSignOut(): Promise<void> {
-		await authClient.signOut();
-		signOutMutation.mutate();
+		await signOut();
 	}
 
 	function renderSlugStatus(): ReactNode {


### PR DESCRIPTION
## Problem

The top of the activation funnel was blind: anonymous pre-sign-in events (`desktop_opened`, `/sign-in` pageview) weren't stitching to the user they later identify as. Of people who signed in, the share with a `desktop_opened` linked to their person **crashed from ~77% to ~4%** the week of 2026-05-24.

Two compounding bugs:

1. **Device-id bootstrap (#4858, 2026-05-22).** `posthog-js` was bootstrapped with the machine id as the anonymous `distinctID`. A stable, shared device id doesn't follow the normal anonymous→identified merge on `identify()`, so the merge silently failed for ~96% of users. This is what tipped stitching from ~77% to ~4%.

2. **`reset()` on initial load.** `PostHogUserIdentifier` called `posthog.reset()` whenever the session resolved to "no user" — including the *initial* signed-out load, not just real sign-outs. `reset()` mints a fresh anonymous id, so every launch rotated the id and orphaned that launch's `desktop_opened` / `/sign-in` from the eventual user. (This is also the ~23% leak that predated #4858, and the original anon-id rotation #4858 was trying to fix.)

Net effect: active, signed-in users showed up in the new-user funnel as anonymous "saw sign-in, never signed in" drop-offs (verified in event logs — users on `/workspace/...` pages with a phantom sub-second `/sign-in` blip).

## Fix

- **`posthog.ts`** — drop `bootstrap: { distinctID: deviceId }`. Back to PostHog's persistent localStorage anonymous id, which merges correctly on `identify()`.
- **`PostHogProvider.tsx`** — remove the `getMachineId` fetch; `initPostHog()` is synchronous again.
- **`PostHogUserIdentifier.tsx`** — gate `posthog.reset()` to real sign-out transitions only (track prior signed-in state via a ref).

Together these stop the anonymous id from rotating and let pre-sign-in events merge into the user on sign-in, restoring stitching toward ~100% — and fixing the original rotation #4858 targeted, without the broken bootstrap.

## Notes

- Forward-only; historical orphaned events stay orphaned.
- `desktop_opened` is intentionally kept (still used by `packages/trpc` admin funnels + the DAU / version / engagement dashboards) — this just un-breaks its stitching.
- Verified: `bun run typecheck` (@superset/desktop) and Biome pass.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5207">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore identity stitching for pre-sign-in desktop events by using PostHog’s local anonymous ID and resetting analytics only on explicit sign-out. This fixes broken attribution at the top of the activation funnel.

- **Bug Fixes**
  - Remove device-id bootstrap in `initPostHog()`; no `bootstrap.distinctID` so `identify()` merges the localStorage anon ID (`posthog-js`).
  - Make `PostHogProvider` init sync; drop machine-id fetch; still track `desktop_opened`.
  - Add `useSignOut()`; move `posthog.reset()` and analytics cleanup to explicit sign-outs; used in AccountSettings, OrgDropdown, and Create Org.
  - Simplify `PostHogUserIdentifier` to identify-only; remove reset-on-signed-out; keep one-time `auth_completed`.

<sup>Written for commit ea11758dde5d7c75935de792c92f170d4f4fb477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified analytics initialization and unified sign-out flow across the app.

* **Bug Fixes**
  * Stops clearing analytics/auth keys for anonymous sessions to avoid orphaned events.
  * Ensures user identification only runs for signed-in users to prevent accidental resets.

* **Behavior**
  * Initialization runs synchronously and always marks analytics as initialized; app open is tracked.
  * Active organization ID is kept in sync in localStorage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->