### PR TITLE
fix(relay): stop Sentry buffering the per-request console firehose (memory leak)

### DIFF
--- a/apps/relay/src/auth.ts
+++ b/apps/relay/src/auth.ts
@@ -35,7 +35,17 @@ export async function verifyJWT(
 
 		return { sub, email: email ?? "", organizationIds };
 	} catch (error) {
-		console.error("[relay] JWT verification failed:", error);
+		// Don't log expected hourly-rotation expiries, and log only the terse
+		// message otherwise: the full error dumped a stack trace + decoded
+		// payload (plaintext emails) on every request at relay volume.
+		const code =
+			error instanceof Error && "code" in error
+				? (error as { code?: string }).code
+				: undefined;
+		if (code !== "ERR_JWT_EXPIRED") {
+			const message = error instanceof Error ? error.message : String(error);
+			console.warn(`[relay] JWT verification failed: ${message}`);
+		}
 		return null;
 	}
 }

--- a/apps/relay/src/sentry.ts
+++ b/apps/relay/src/sentry.ts
@@ -11,11 +11,7 @@ export function initSentry(): void {
 		release: process.env.FLY_IMAGE_REF,
 		environment: process.env.FLY_APP_NAME ?? "relay-local",
 		tracesSampleRate: 0,
-		_experiments: { enableLogs: true },
 		integrations: [
-			Sentry.consoleLoggingIntegration({
-				levels: ["log", "info", "warn", "error"],
-			}),
 			Sentry.onUncaughtExceptionIntegration({
 				exitEvenIfOtherHandlersAreRegistered: false,
 			}),


### PR DESCRIPTION
## Problem

Reported symptom: the relay gets slower the longer it's up. It's a real **monotonic memory leak**, confirmed from Fly Prometheus (`mem_total − mem_available`, GB) across all 6 regions — same code, all deployed Jun 1:

| region | Jun 1 | Jun 9 | peak | Δ |
|--------|------|------|------|------|
| **fra** | 0.59 | **2.19** | 2.19 | **+1.60** |
| iad | 0.51 | 1.64 | 1.64 | +1.14 |
| sjc | 0.49 | 1.49 | 1.49 | +0.99 |
| sin | 0.44 | 1.13 | 1.15 | +0.65 |
| nrt | 0.41 | 0.69 | 0.69 | +0.28 |
| gru | 0.36 | 0.50 | 0.50 | +0.14 |

Every region climbs steadily, never recovers overnight, and current == all-time peak — the textbook leak signature. The rate is proportional to traffic, so it's a **per-request** leak. fra was at 2.2 GB / 4 GB climbing ~0.2 GB/day → OOM in ~9 days. As the heap grows, V8 spends more CPU on GC, which is the "slower the longer it's up" symptom.

## Root cause

`sentry.ts` enabled the experimental logs feature with a console integration:

```ts
_experiments: { enableLogs: true },
integrations: [ Sentry.consoleLoggingIntegration({ levels: ["log","info","warn","error"] }) ]
```

So **every** `console.*` became a retained Sentry log object. Hono's per-request `logger()` (two writes/request) plus the JWT-failure handler — which dumped a full stack trace + decoded payload on every expired token — produced ~100 console writes/sec/machine. That retention is the **only unbounded per-request path** in the relay; all other state (tunnel maps, pending requests, WS channels, LRU caches, JWKS) is bounded and torn down correctly.

## Changes

- **`sentry.ts`** — drop `enableLogs` + `consoleLoggingIntegration`. Explicit `captureException`/`captureMessage` and uncaught-exception capture are kept, so real errors still reach Sentry.
- **`auth.ts`** — stop logging expected hourly-rotation expiries; log only the terse message otherwise. The old full-error dump was both the bulk of the firehose and a **PII leak** (printed user emails in plaintext on every request).

## Verification plan

Staging won't confirm this (the leak is traffic-driven, staging has no real load). After deploy, watch the same Prometheus series — it should plateau instead of climbing ~0.2 GB/day. If it still climbs, it's a dependency-level leak and we go to a heap snapshot.

## Notes

- No SSE/routing change: `/events` is a WebSocket endpoint and routes correctly through the relay; the 503s in the logs are clients reconnecting to offline hosts, not broken streaming.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5208">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a per-request memory leak by removing `Sentry` console log buffering and trimming noisy JWT error logs. This stops RSS growth over time while keeping real error reporting.

- **Bug Fixes**
  - Disable `Sentry` log capture by removing `_experiments.enableLogs` and `consoleLoggingIntegration`; keep explicit `captureException`/`captureMessage` and uncaught-exception handling.
  - Reduce JWT log noise: ignore expected `ERR_JWT_EXPIRED` and log only a short message otherwise, avoiding stack traces and decoded payloads (PII).

<sup>Written for commit 2e22797892eeda902ee8dfdc1c75b6b070b1f98a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized JWT verification error logging: suppresses routine token expiry messages while providing clearer warnings for actual authentication issues.
  * Reduced verbose logging output from error reporting service initialization for cleaner application logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->