### PR TITLE
perf(host-service): quiet the git watcher (filter .git events + adaptive debounce)

### DIFF
--- a/packages/host-service/src/events/git-watcher.test.ts
+++ b/packages/host-service/src/events/git-watcher.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
+import {
+	DEBOUNCE_MS,
+	GIT_DIR_DEBOUNCE_MS,
+	type GitChangedEvent,
+	GitWatcher,
+	isStatusRelevantGitDirEvent,
+} from "./git-watcher";
+
+/**
+ * The dispatch seams the `.git/` watcher callback and the worktree fs stream
+ * feed into. Driving them directly lets us assert emit/debounce behavior
+ * without spinning a real `fs.watch` over a scratch repo.
+ */
+interface GitWatcherInternals {
+	handleGitDirEvent(workspaceId: string, filename: string | null): void;
+	addWorktreePaths(workspaceId: string, paths: Iterable<string>): void;
+	getOrCreateBatch(workspaceId: string): unknown;
+	scheduleFlush(workspaceId: string): void;
+}
+
+function createWatcher(): GitWatcher {
+	// `start()` is never called, so the dispatch methods under test never touch
+	// the db or filesystem — empty stand-ins are enough.
+	return new GitWatcher(
+		{} as unknown as ConstructorParameters<typeof GitWatcher>[0],
+		{} as unknown as ConstructorParameters<typeof GitWatcher>[1],
+	);
+}
+
+function internals(watcher: GitWatcher): GitWatcherInternals {
+	return watcher as unknown as GitWatcherInternals;
+}
+
+describe("isStatusRelevantGitDirEvent", () => {
+	test("ignores `.git/` paths whose churn can't change `git status`", () => {
+		const ignored = [
+			"objects",
+			"objects/ab/cdef0123456789",
+			"objects/pack/pack-abc.pack",
+			"objects/pack/pack-abc.idx",
+			"lfs",
+			"lfs/objects/aa/bb/ccdd",
+			"logs",
+			"logs/HEAD",
+			"logs/refs/heads/main",
+			"FETCH_HEAD",
+		];
+		for (const path of ignored) {
+			expect(isStatusRelevantGitDirEvent(path)).toBe(false);
+		}
+	});
+
+	test("keeps status-relevant `.git/` paths", () => {
+		const relevant = [
+			"HEAD",
+			"index",
+			"refs/heads/main",
+			"refs/remotes/origin/main",
+			"packed-refs",
+			"MERGE_HEAD",
+			"ORIG_HEAD",
+			"config",
+		];
+		for (const path of relevant) {
+			expect(isStatusRelevantGitDirEvent(path)).toBe(true);
+		}
+	});
+
+	test("fails open when the watcher can't say what changed", () => {
+		expect(isStatusRelevantGitDirEvent(null)).toBe(true);
+		expect(isStatusRelevantGitDirEvent(undefined)).toBe(true);
+		expect(isStatusRelevantGitDirEvent("")).toBe(true);
+	});
+
+	test("does not confuse a top-level file that merely starts with an ignored name", () => {
+		expect(isStatusRelevantGitDirEvent("objects-are-cool")).toBe(true);
+		expect(isStatusRelevantGitDirEvent("logspam")).toBe(true);
+	});
+});
+
+describe("GitWatcher .git event filtering", () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	test("ignored `.git/` events never emit, even past the widest window", () => {
+		const watcher = createWatcher();
+		const events: GitChangedEvent[] = [];
+		watcher.onChanged((event) => events.push(event));
+
+		for (const path of [
+			"objects/ab/cdef",
+			"objects/pack/pack-x.pack",
+			"lfs/objects/aa/bb",
+			"logs/HEAD",
+			"FETCH_HEAD",
+		]) {
+			internals(watcher).handleGitDirEvent("workspace-1", path);
+		}
+
+		jest.advanceTimersByTime(GIT_DIR_DEBOUNCE_MS + DEBOUNCE_MS);
+		expect(events).toEqual([]);
+	});
+
+	test("status-relevant `.git/` events emit a broad change signal", () => {
+		const watcher = createWatcher();
+		const events: GitChangedEvent[] = [];
+		watcher.onChanged((event) => events.push(event));
+
+		internals(watcher).handleGitDirEvent("workspace-1", "index");
+		jest.advanceTimersByTime(GIT_DIR_DEBOUNCE_MS);
+
+		expect(events).toEqual([{ workspaceId: "workspace-1" }]);
+	});
+});
+
+describe("GitWatcher adaptive debounce", () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	test("a `.git/`-only batch waits the wide window", () => {
+		const watcher = createWatcher();
+		const events: GitChangedEvent[] = [];
+		watcher.onChanged((event) => events.push(event));
+
+		internals(watcher).handleGitDirEvent("workspace-1", "index");
+
+		// Still pending after the short (worktree) window.
+		jest.advanceTimersByTime(DEBOUNCE_MS);
+		expect(events).toEqual([]);
+
+		// Flushes once the wide window elapses.
+		jest.advanceTimersByTime(GIT_DIR_DEBOUNCE_MS - DEBOUNCE_MS);
+		expect(events).toEqual([{ workspaceId: "workspace-1" }]);
+	});
+
+	test("a worktree-path batch flushes on the short window", () => {
+		const watcher = createWatcher();
+		const events: GitChangedEvent[] = [];
+		watcher.onChanged((event) => events.push(event));
+
+		internals(watcher).addWorktreePaths("workspace-1", ["src/app.ts"]);
+
+		jest.advanceTimersByTime(DEBOUNCE_MS);
+		expect(events).toEqual([
+			{ workspaceId: "workspace-1", paths: ["src/app.ts"] },
+		]);
+	});
+
+	test("a worktree edit joining a `.git/` batch restores the short window", () => {
+		const watcher = createWatcher();
+		const events: GitChangedEvent[] = [];
+		watcher.onChanged((event) => events.push(event));
+
+		// Starts as `.git/`-only (wide window)...
+		internals(watcher).handleGitDirEvent("workspace-1", "index");
+		// ...then a user edit joins, which should shorten the window.
+		internals(watcher).addWorktreePaths("workspace-1", ["src/app.ts"]);
+
+		jest.advanceTimersByTime(DEBOUNCE_MS);
+		// Broad signal (no `paths`) because the batch saw `.git/` activity.
+		expect(events).toEqual([{ workspaceId: "workspace-1" }]);
+	});
+
+	test("rapid `.git/`-only events ride the first wide window instead of resetting it", () => {
+		const watcher = createWatcher();
+		const events: GitChangedEvent[] = [];
+		watcher.onChanged((event) => events.push(event));
+
+		// First `.git/` event arms the wide window at t=0.
+		internals(watcher).handleGitDirEvent("workspace-1", "index");
+		jest.advanceTimersByTime(GIT_DIR_DEBOUNCE_MS - DEBOUNCE_MS);
+
+		// A later `.git/`-only event must NOT push the flush out, or a rapid
+		// metadata sequence (rebase, `git am`) would keep resetting the clock.
+		internals(watcher).handleGitDirEvent("workspace-1", "HEAD");
+		expect(events).toEqual([]);
+
+		// The window armed by the first event still elapses on schedule.
+		jest.advanceTimersByTime(DEBOUNCE_MS);
+		expect(events).toEqual([{ workspaceId: "workspace-1" }]);
+	});
+
+	test("a batch with neither `.git/` activity nor worktree paths uses the short window", () => {
+		const watcher = createWatcher();
+		const events: GitChangedEvent[] = [];
+		watcher.onChanged((event) => events.push(event));
+
+		// Mirrors the worktree-fs branch that fires with no decodable paths:
+		// the wide `.git/`-only window must not leak to it.
+		internals(watcher).getOrCreateBatch("workspace-1");
+		internals(watcher).scheduleFlush("workspace-1");
+
+		jest.advanceTimersByTime(DEBOUNCE_MS);
+		expect(events).toEqual([{ workspaceId: "workspace-1" }]);
+	});
+});

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -9,7 +9,47 @@ import type { WorkspaceFilesystemManager } from "../runtime/filesystem/index.ts"
 const execFileAsync = promisify(execFile);
 
 const RESCAN_INTERVAL_MS = 30_000;
-const DEBOUNCE_MS = 300;
+
+/** Debounce window for batches with worktree edits — flush fast, latency matters. */
+export const DEBOUNCE_MS = 300;
+
+/**
+ * Wider window for `.git/`-only batches: coalesces metadata bursts (commit, fetch
+ * ref update, branch switch) that survive the path filter, trading ~1s of refresh
+ * latency for fewer idle git subprocesses (#4198). Leading-anchored (see
+ * `scheduleFlush`) so a rapid sequence can't starve the flush past this bound.
+ */
+export const GIT_DIR_DEBOUNCE_MS = 1_000;
+
+/**
+ * `.git/` top-level dirs whose churn never changes `git status`: `objects/**`
+ * (fetch/gc/repack blobs — the bulk of idle churn), `lfs/**` (object cache),
+ * `logs/**` (reflog). A real state change always touches refs/index/HEAD too.
+ */
+const IGNORED_GIT_DIR_TOP_LEVELS = new Set(["objects", "lfs", "logs"]);
+
+/**
+ * `.git/` files whose churn never changes `git status`: `FETCH_HEAD`, rewritten
+ * by every fetch (status-affecting ref updates land in `refs/`/`packed-refs`).
+ */
+const IGNORED_GIT_DIR_FILES = new Set(["FETCH_HEAD"]);
+
+/**
+ * Whether a `.git/`-relative path could affect `git status`. Fails open on a
+ * null/empty filename so a real change is never dropped.
+ */
+export function isStatusRelevantGitDirEvent(
+	filename: string | null | undefined,
+): boolean {
+	if (filename == null) return true;
+	const normalized = filename.replace(/\\/g, "/");
+	if (normalized === "") return true;
+	if (IGNORED_GIT_DIR_FILES.has(normalized)) return false;
+	const firstSlash = normalized.indexOf("/");
+	const topLevel =
+		firstSlash === -1 ? normalized : normalized.slice(0, firstSlash);
+	return !IGNORED_GIT_DIR_TOP_LEVELS.has(topLevel);
+}
 
 export interface GitChangedEvent {
 	workspaceId: string;
@@ -47,8 +87,10 @@ interface WatchedWorkspace {
  * Two sources feed into the same debounced emit per workspace:
  *
  * 1. `.git/` directory (via `node:fs.watch`) — catches commits, staging,
- *    branch switches, fetches — anything that writes git metadata, including
- *    operations from an external terminal.
+ *    branch switches, fetches, including from an external terminal. Paths that
+ *    can't change `git status` (`objects/**`, `lfs/**`, `logs/**`, `FETCH_HEAD`)
+ *    are filtered via `isStatusRelevantGitDirEvent`; `.git/`-only batches use
+ *    the wider `GIT_DIR_DEBOUNCE_MS` window.
  * 2. Worktree root (via `@superset/workspace-fs` watcher manager) — catches
  *    working-tree file edits that change `git status` output. The underlying
  *    watcher honors `DEFAULT_IGNORE_PATTERNS`, which excludes `.git/`,
@@ -120,6 +162,18 @@ export class GitWatcher {
 		return batch;
 	}
 
+	/**
+	 * Handle a raw `.git/` watcher event, marking the workspace dirty only if it
+	 * could affect `git status` (drops `objects/**` fetch/gc/pack churn).
+	 */
+	private handleGitDirEvent(
+		workspaceId: string,
+		filename: string | null,
+	): void {
+		if (!isStatusRelevantGitDirEvent(filename)) return;
+		this.markGitDirDirty(workspaceId);
+	}
+
 	private markGitDirDirty(workspaceId: string): void {
 		this.getOrCreateBatch(workspaceId).hasGitDir = true;
 		this.scheduleFlush(workspaceId);
@@ -135,7 +189,15 @@ export class GitWatcher {
 
 	private scheduleFlush(workspaceId: string): void {
 		const existing = this.debounceTimers.get(workspaceId);
+		const batch = this.getOrCreateBatch(workspaceId);
+		// `.git/`-only batches use the wide window, leading-anchored: the first
+		// event arms it and later `.git/`-only events ride it rather than resetting,
+		// so a rapid metadata sequence (rebase, `git am`) can't push the flush past
+		// GIT_DIR_DEBOUNCE_MS. A worktree edit joining reverts to the short window.
+		const gitDirOnly = batch.hasGitDir && batch.paths.size === 0;
+		if (gitDirOnly && existing) return;
 		if (existing) clearTimeout(existing);
+		const delay = gitDirOnly ? GIT_DIR_DEBOUNCE_MS : DEBOUNCE_MS;
 		this.debounceTimers.set(
 			workspaceId,
 			setTimeout(() => {
@@ -158,7 +220,7 @@ export class GitWatcher {
 						});
 					}
 				}
-			}, DEBOUNCE_MS),
+			}, delay),
 		);
 	}
 
@@ -231,8 +293,8 @@ export class GitWatcher {
 
 		let watcher: FSWatcher;
 		try {
-			watcher = watch(gitDir, { recursive: true }, () => {
-				this.markGitDirDirty(workspaceId);
+			watcher = watch(gitDir, { recursive: true }, (_event, filename) => {
+				this.handleGitDirEvent(workspaceId, filename);
 			});
 		} catch {
 			// fs.watch failed (e.g. directory doesn't exist)


### PR DESCRIPTION
## Description

Quiets the host-service git watcher, which spawns a storm of idle git subprocesses that keeps endpoint-security agents (Jamf/Defender) hot and shows up as system-wide input lag.

Two changes in `GitWatcher`:

- **Path filter** — drop `.git/` events that can't change `git status` output (`objects/**`, `lfs/**`, `logs/**`, `FETCH_HEAD` — the bulk of idle fetch/gc/repack churn). These no longer wake a status snapshot.
- **Adaptive debounce** — `.git/`-only batches debounce on a wider, leading-anchored 1s window (vs 300ms for worktree edits), so surviving metadata bursts coalesce without a rapid sequence starving the flush.

Partial fix — first PR in a series. Does not yet reduce the per-snapshot subprocess fan-out (~17 spawns incl. `git ls-files --others --ignored`).

## Related Issues

Related to #4198. Complementary to #4938, which rate-limits the snapshot at the limiter layer; this PR reduces how often an invalidation is generated at the source. Both introduce a ~1s throttle, so they're worth a coordinated look to avoid one being "simplified" away if they land together.

## Type of Change

- [x] Bug fix (performance)

## Testing

- Added unit tests for the path filter (`isStatusRelevantGitDirEvent`) and the adaptive-debounce behavior; pass locally.
- `bun run lint`, `bun run typecheck`, `bunx sherif` — clean.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5239">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiet the `host-service` git watcher by filtering non-status `.git/` events and using an adaptive debounce, reducing idle git subprocess churn and input lag. Related to #4198; complements #4938 by cutting invalidations at the source.

- **Bug Fixes**
  - Filter `.git/` events that cannot change `git status` (`objects/**`, `lfs/**`, `logs/**`, `FETCH_HEAD`).
  - Adaptive debounce: `.git/`-only batches use a leading 1s window; worktree edits remain at 300ms.
  - Added unit tests for the path filter and debounce behavior.

<sup>Written for commit 0fb821dc01ab25e8237773af543b3a124d350a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for git file system event monitoring and debounce behavior.

* **Bug Fixes**
  * Improved accuracy of git status change detection by filtering out irrelevant internal git directory events.
  * Optimized file system event debouncing with adaptive timing based on change type, reducing unnecessary workspace refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->