### PR TITLE
fix(cli): stop truncating workspace IDs in workspaces list output

### DIFF
--- a/packages/cli-framework/src/output.ts
+++ b/packages/cli-framework/src/output.ts
@@ -68,25 +68,27 @@ export function table(
 	data: Record<string, unknown>[],
 	columns: string[],
 	headers?: string[],
-	maxColWidth = 60,
+	maxColWidth: number | (number | undefined)[] = 60,
 ): string {
 	if (data.length === 0) return "No results.";
 
+	const caps = columns.map((_, i) =>
+		Array.isArray(maxColWidth) ? (maxColWidth[i] ?? 60) : maxColWidth,
+	);
 	const hdrs = headers ?? columns.map((c) => c.toUpperCase());
 	const rows = data.map((row) =>
-		columns.map((col) => {
+		columns.map((col, i) => {
 			const val = getNestedValue(row, col);
 			const str = val === null || val === undefined ? "—" : String(val);
-			return str.length > maxColWidth
-				? `${str.slice(0, maxColWidth - 1)}…`
-				: str;
+			const cap = caps[i]!;
+			return str.length > cap ? `${str.slice(0, cap - 1)}…` : str;
 		}),
 	);
 
 	// Calculate column widths (capped by terminal width heuristic)
 	const widths = hdrs.map((h, i) =>
 		Math.min(
-			maxColWidth,
+			caps[i]!,
 			Math.max(h.length, ...rows.map((r) => r[i]?.length ?? 0)),
 		),
 	);

--- a/packages/cli/src/commands/workspaces/list/command.ts
+++ b/packages/cli/src/commands/workspaces/list/command.ts
@@ -20,7 +20,6 @@ export default command({
 			data as Record<string, unknown>[],
 			["name", "branch", "projectName", "hostName", "id"],
 			["NAME", "BRANCH", "PROJECT", "HOST", "ID"],
-			30,
 		),
 	run: async ({ ctx, options }) => {
 		const organizationId = ctx.config.organizationId;

--- a/packages/cli/src/commands/workspaces/list/command.ts
+++ b/packages/cli/src/commands/workspaces/list/command.ts
@@ -20,6 +20,7 @@ export default command({
 			data as Record<string, unknown>[],
 			["name", "branch", "projectName", "hostName", "id"],
 			["NAME", "BRANCH", "PROJECT", "HOST", "ID"],
+			[30, 30, 30, 30, 36],
 		),
 	run: async ({ ctx, options }) => {
 		const organizationId = ctx.config.organizationId;


### PR DESCRIPTION
Fixes #5153

## Summary

`superset workspaces list` passed an explicit `maxColWidth` of `30` to the `table()` helper, truncating 36-character UUIDs at 29 chars (`8f3ed762-b3fe-4520-ab71-0bb47…`), which made the displayed IDs unusable in other commands like `superset terminals create --workspace <id>`.

The `30` override predates the ID column: it was added in the #3920 polish pass when the table only showed name/branch/project, and the ID column added later in #4463 inherited it.

Simply dropping the cap fixed the IDs but let long workspace/branch names blow the table out to 200-char rows. So `table()` now accepts per-column width caps (`number | (number | undefined)[]`, scalar default of 60 unchanged for all other callers), and `workspaces list` keeps 30 for the text columns with 36 for the ID column.

The issue's second suggestion (accepting unique UUID prefixes as command arguments) is a separate feature and not included here.

## Test Plan

Verified against the production API with real data (141 workspaces):

- [x] Reproduced the bug on installed CLI v0.2.22 (`…`-truncated IDs)
- [x] Fixed CLI (`cli-framework dev workspaces list --no-json`): all 141 rows show full 36-char UUIDs
- [x] Widest row is 152 chars (vs ~145 before the fix, 200 with a naive cap removal) — no table blowout
- [x] Round-trip: `superset workspaces open <listed-id> --print` resolves the workspace and prints the deep link
- [x] `hosts list` (scalar default path) renders unchanged
- [x] `bun run lint` clean, `tsc --noEmit` clean in `packages/cli` and `packages/cli-framework`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected workspace list table rendering so columns display with intended widths.
* **Enhancements**
  * Table output now supports per-column width settings, improving alignment and truncation for CLI tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->