### PR TITLE
feat(desktop): add model picker to workspace create dialog

### DIFF
--- a/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
@@ -1,0 +1,58 @@
+import type { AgentModelOption } from "@superset/shared/agent-models";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
+
+// Radix Select reserves "" for clearing, so "Default" needs a sentinel.
+const DEFAULT_MODEL_VALUE = "__default_model__";
+
+interface AgentModelSelectProps {
+	models: AgentModelOption[];
+	value: string | null;
+	onValueChange: (model: string | null) => void;
+	disabled?: boolean;
+	triggerClassName?: string;
+	contentClassName?: string;
+}
+
+export function AgentModelSelect({
+	models,
+	value,
+	onValueChange,
+	disabled,
+	triggerClassName,
+	contentClassName,
+}: AgentModelSelectProps) {
+	const selectedValue =
+		value !== null && models.some((model) => model.id === value)
+			? value
+			: DEFAULT_MODEL_VALUE;
+
+	const handleValueChange = (nextValue: string) => {
+		onValueChange(nextValue === DEFAULT_MODEL_VALUE ? null : nextValue);
+	};
+
+	return (
+		<Select
+			value={selectedValue}
+			onValueChange={handleValueChange}
+			disabled={disabled}
+		>
+			<SelectTrigger className={triggerClassName}>
+				<SelectValue placeholder="Default" />
+			</SelectTrigger>
+			<SelectContent className={contentClassName}>
+				<SelectItem value={DEFAULT_MODEL_VALUE}>Default</SelectItem>
+				{models.map((model) => (
+					<SelectItem key={model.id} value={model.id}>
+						{model.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/apps/desktop/src/renderer/components/AgentModelSelect/index.ts
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/index.ts
@@ -1,0 +1,1 @@
+export { AgentModelSelect } from "./AgentModelSelect";

--- a/apps/desktop/src/renderer/hooks/useAgentModelPreference/index.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentModelPreference/index.ts
@@ -1,0 +1,1 @@
+export { useAgentModelPreference } from "./useAgentModelPreference";

--- a/apps/desktop/src/renderer/hooks/useAgentModelPreference/useAgentModelPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentModelPreference/useAgentModelPreference.ts
@@ -1,0 +1,69 @@
+import { getAgentModelSupport } from "@superset/shared/agent-models";
+import { useCallback, useEffect, useState } from "react";
+
+function readStoredMap(storageKey: string): Record<string, string> {
+	if (typeof window === "undefined") return {};
+	try {
+		const raw = window.localStorage.getItem(storageKey);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
+			return {};
+		return Object.fromEntries(
+			Object.entries(parsed).filter(
+				(entry): entry is [string, string] => typeof entry[1] === "string",
+			),
+		);
+	} catch {
+		return {};
+	}
+}
+
+function readStoredModel(
+	storageKey: string,
+	presetId: string | null,
+): string | null {
+	if (!presetId) return null;
+	const stored = readStoredMap(storageKey)[presetId];
+	if (!stored) return null;
+	// Drop ids that fell out of the curated registry — "Default" beats a
+	// flag value the CLI no longer accepts.
+	const support = getAgentModelSupport(presetId);
+	return support?.models.some((model) => model.id === stored) ? stored : null;
+}
+
+/**
+ * Last-selected model per agent preset, persisted as a JSON map in
+ * localStorage. Keyed by presetId (not config UUID) so the preference
+ * survives host switches and agent-config re-creation. `null` means
+ * "Default" — no stored entry, no model flag at launch.
+ */
+export function useAgentModelPreference(
+	storageKey: string,
+	presetId: string | null,
+) {
+	const [selectedModel, setSelectedModelState] = useState<string | null>(() =>
+		readStoredModel(storageKey, presetId),
+	);
+
+	useEffect(() => {
+		setSelectedModelState(readStoredModel(storageKey, presetId));
+	}, [storageKey, presetId]);
+
+	const setSelectedModel = useCallback(
+		(model: string | null) => {
+			setSelectedModelState(model);
+			if (typeof window === "undefined" || !presetId) return;
+			const map = readStoredMap(storageKey);
+			if (model) {
+				map[presetId] = model;
+			} else {
+				delete map[presetId];
+			}
+			window.localStorage.setItem(storageKey, JSON.stringify(map));
+		},
+		[storageKey, presetId],
+	);
+
+	return { selectedModel, setSelectedModel };
+}

--- a/apps/desktop/src/renderer/hooks/useAgentModelPreference/useAgentModelPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentModelPreference/useAgentModelPreference.ts
@@ -60,7 +60,12 @@ export function useAgentModelPreference(
 			} else {
 				delete map[presetId];
 			}
-			window.localStorage.setItem(storageKey, JSON.stringify(map));
+			try {
+				window.localStorage.setItem(storageKey, JSON.stringify(map));
+			} catch {
+				// Quota/security errors only cost persistence of the preference;
+				// the in-memory selection above still applies to this dialog.
+			}
 		},
 		[storageKey, presetId],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -1,3 +1,4 @@
+import { getAgentModelSupport } from "@superset/shared/agent-models";
 import { sanitizeUserBranchName } from "@superset/shared/workspace-launch";
 import {
 	PromptInput,
@@ -19,12 +20,14 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { GoIssueOpened } from "react-icons/go";
 import { LuGitPullRequest } from "react-icons/lu";
 import { SiLinear } from "react-icons/si";
+import { AgentModelSelect } from "renderer/components/AgentModelSelect";
 import { AgentSelect } from "renderer/components/AgentSelect";
 import { LinkedIssuePill } from "renderer/components/Chat/ChatInterface/components/ChatInputFooter/components/LinkedIssuePill";
 import { IssueLinkCommand } from "renderer/components/Chat/ChatInterface/components/IssueLinkCommand";
 import { MarkdownEditor } from "renderer/components/MarkdownEditor";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
+import { useAgentModelPreference } from "renderer/hooks/useAgentModelPreference";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
 import { PLATFORM } from "renderer/hotkeys";
@@ -54,6 +57,7 @@ import {
 } from "./hooks/useUploadAttachments";
 import {
 	AGENT_STORAGE_KEY,
+	MODEL_STORAGE_KEY,
 	PILL_BUTTON_CLASS,
 	type ProjectOption,
 	type WorkspaceCreateAgent,
@@ -152,6 +156,20 @@ export function PromptGroup({
 			validAgents: ["none", ...selectableAgentIds],
 			agentsReady: v2AgentsFetched,
 		});
+
+	// ── Model picker (per agent preset) ──────────────────────────────
+	// `iconId` carries the presetId for v2 agents ("superset" for chat).
+	const selectedPresetId = useMemo(
+		() => v2Agents.find((agent) => agent.id === selectedAgent)?.iconId ?? null,
+		[v2Agents, selectedAgent],
+	);
+	const modelSupport = selectedPresetId
+		? getAgentModelSupport(selectedPresetId)
+		: undefined;
+	const { selectedModel, setSelectedModel } = useAgentModelPreference(
+		MODEL_STORAGE_KEY,
+		modelSupport ? selectedPresetId : null,
+	);
 
 	// Promote the placeholder "none" → first configured agent whenever the
 	// current selection isn't a real agent and the user hasn't explicitly
@@ -270,6 +288,7 @@ export function PromptGroup({
 	const createWorkspace = useSubmitWorkspace(
 		projectId,
 		selectedAgent,
+		modelSupport ? selectedModel : null,
 		uploadAttachments,
 		promptContext,
 	);
@@ -460,6 +479,14 @@ export function PromptGroup({
 							noneLabel="No agent"
 							noneValue="none"
 						/>
+						{modelSupport && (
+							<AgentModelSelect
+								models={modelSupport.models}
+								value={selectedModel}
+								onValueChange={setSelectedModel}
+								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
+							/>
+						)}
 					</PromptInputTools>
 					<div className="flex items-center gap-2">
 						<AttachmentButtons

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -19,6 +19,7 @@ import { resolveNames } from "./resolveNames";
 export function useSubmitWorkspace(
 	projectId: string | null,
 	selectedAgent: WorkspaceCreateAgent,
+	selectedModel: string | null,
 	uploadAttachments: UseUploadAttachmentsApi,
 	promptContext: NewWorkspacePromptContextApi,
 ) {
@@ -88,6 +89,7 @@ export function useSubmitWorkspace(
 						agent: selectedAgent,
 						prompt: finalPrompt ?? "",
 						attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+						model: selectedModel ?? undefined,
 					},
 				]
 			: undefined;
@@ -161,6 +163,7 @@ export function useSubmitWorkspace(
 		projectId,
 		promptContext,
 		selectedAgent,
+		selectedModel,
 		submit,
 		uploadAttachments,
 	]);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
@@ -4,6 +4,10 @@ export type WorkspaceCreateAgent = string;
 // New key — old one held v1 preset slugs that won't match v2 UUIDs.
 export const AGENT_STORAGE_KEY = "lastSelectedV2WorkspaceCreateAgent";
 
+// JSON map of presetId → model id; keyed by preset (not config UUID) so the
+// preference survives host switches.
+export const MODEL_STORAGE_KEY = "lastSelectedV2WorkspaceCreateModelByPreset";
+
 export const PILL_BUTTON_CLASS =
 	"!h-[22px] min-h-0 rounded-md border-[0.5px] border-border bg-foreground/[0.04] shadow-none text-[11px]";
 

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { buildAgentCommandString } from "./agents";
+
+const argvConfig = {
+	id: "00000000-0000-0000-0000-000000000001",
+	presetId: "claude",
+	label: "Claude",
+	command: "claude",
+	args: ["--dangerously-skip-permissions"],
+	promptTransport: "argv" as const,
+	promptArgs: [],
+	env: {},
+};
+
+const stdinConfig = {
+	id: "00000000-0000-0000-0000-000000000002",
+	presetId: "amp",
+	label: "Amp",
+	command: "amp",
+	args: [],
+	promptTransport: "stdin" as const,
+	promptArgs: [],
+	env: {},
+};
+
+describe("buildAgentCommandString", () => {
+	it("is unchanged when no model args are given", () => {
+		expect(buildAgentCommandString(argvConfig, "do the thing")).toBe(
+			"'claude' '--dangerously-skip-permissions' 'do the thing'",
+		);
+	});
+
+	it("inserts model args between base args and the prompt (argv transport)", () => {
+		expect(
+			buildAgentCommandString(argvConfig, "do the thing", [
+				"--model",
+				"sonnet",
+			]),
+		).toBe(
+			"'claude' '--dangerously-skip-permissions' '--model' 'sonnet' 'do the thing'",
+		);
+	});
+
+	it("inserts model args before the heredoc (stdin transport)", () => {
+		expect(
+			buildAgentCommandString(stdinConfig, "do the thing", [
+				"--model",
+				"sonnet",
+			]),
+		).toBe(
+			"'amp' '--model' 'sonnet' <<'SUPERSET_PROMPT'\ndo the thing\nSUPERSET_PROMPT",
+		);
+	});
+
+	it("shell-quotes hostile model values", () => {
+		expect(
+			buildAgentCommandString(argvConfig, "p", ["--model", "x'; rm -rf /"]),
+		).toBe(
+			"'claude' '--dangerously-skip-permissions' '--model' 'x'\\''; rm -rf /' 'p'",
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { buildAgentModelArgs } from "@superset/shared/agent-models";
 import { TRPCError } from "@trpc/server";
 import { asc, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -114,8 +115,14 @@ function buildArgvCommand(argv: string[]): string {
 export function buildAgentCommandString(
 	config: ResolvedHostAgentConfig,
 	prompt: string,
+	modelArgs: string[] = [],
 ): string {
-	const baseArgv = [config.command, ...config.args, ...config.promptArgs];
+	const baseArgv = [
+		config.command,
+		...config.args,
+		...modelArgs,
+		...config.promptArgs,
+	];
 
 	if (config.promptTransport === "argv") {
 		return buildArgvCommand([...baseArgv, prompt]);
@@ -157,6 +164,7 @@ export interface AgentRunInput {
 	agent: string;
 	prompt: string;
 	attachmentIds?: string[];
+	model?: string;
 }
 
 export type AgentRunResult =
@@ -212,6 +220,7 @@ async function runChatAgent(
 				content: input.prompt,
 				...(files.length > 0 ? { files } : {}),
 			},
+			...(input.model ? { metadata: { model: input.model } } : {}),
 		})
 		.catch((error) => {
 			console.error(
@@ -248,7 +257,8 @@ async function runTerminalAgent(
 	}
 
 	const prompt = buildAttachmentBlock(input.prompt, resolvedAttachments);
-	const command = buildAgentCommandString(config, prompt);
+	const modelArgs = buildAgentModelArgs(config.presetId, input.model);
+	const command = buildAgentCommandString(config, prompt, modelArgs);
 	const fullCommand = `${envOverlayPrefix(config.env)}${command}`;
 
 	const terminalId = crypto.randomUUID();
@@ -292,6 +302,7 @@ export const agentsRouter = router({
 				agent: z.string().min(1),
 				prompt: z.string().min(1),
 				attachmentIds: z.array(z.string().uuid()).optional(),
+				model: z.string().min(1).optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => runAgentInWorkspace(ctx, input)),

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -53,6 +53,7 @@ const agentLaunchSchema = z
 		agent: z.string().min(1),
 		prompt: z.string(),
 		attachmentIds: z.array(z.string().uuid()).optional(),
+		model: z.string().min(1).optional(),
 	})
 	.refine(
 		(value) =>
@@ -516,6 +517,7 @@ async function dispatchSugarAgents(
 					agent: entry.agent,
 					prompt: entry.prompt,
 					attachmentIds: entry.attachmentIds,
+					model: entry.model,
 				});
 				return { ok: true as const, ...result };
 			} catch (err) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -64,6 +64,10 @@
 			"types": "./src/agent-custom.ts",
 			"default": "./src/agent-custom.ts"
 		},
+		"./agent-models": {
+			"types": "./src/agent-models.ts",
+			"default": "./src/agent-models.ts"
+		},
 		"./billing": {
 			"types": "./src/billing.ts",
 			"default": "./src/billing.ts"

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -62,6 +62,11 @@ describe("buildAgentModelArgs", () => {
 		expect(buildAgentModelArgs("amp", "sonnet")).toEqual([]);
 	});
 
+	it("returns [] for model ids outside the preset's curated list", () => {
+		expect(buildAgentModelArgs("claude", "bad-model")).toEqual([]);
+		expect(buildAgentModelArgs("codex", "sonnet")).toEqual([]);
+	});
+
 	it("returns [] for superset (model travels via chat metadata)", () => {
 		expect(
 			buildAgentModelArgs("superset", "anthropic/claude-opus-4-8"),

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import {
+	AGENT_MODEL_SUPPORT,
+	buildAgentModelArgs,
+	getAgentModelSupport,
+} from "./agent-models";
+import { BUILTIN_TERMINAL_AGENT_TYPES } from "./builtin-terminal-agents";
+
+describe("AGENT_MODEL_SUPPORT", () => {
+	it("only references builtin presets (or the superset chat agent)", () => {
+		const validIds = new Set<string>([
+			...BUILTIN_TERMINAL_AGENT_TYPES,
+			"superset",
+		]);
+		for (const entry of AGENT_MODEL_SUPPORT) {
+			expect(validIds.has(entry.presetId)).toBe(true);
+		}
+	});
+
+	it("has a CLI flag for every terminal preset and none for superset", () => {
+		for (const entry of AGENT_MODEL_SUPPORT) {
+			if (entry.presetId === "superset") {
+				expect(entry.modelFlag).toBeNull();
+			} else {
+				expect(entry.modelFlag).toBe("--model");
+			}
+		}
+	});
+
+	it("lists at least one model per entry", () => {
+		for (const entry of AGENT_MODEL_SUPPORT) {
+			expect(entry.models.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("getAgentModelSupport", () => {
+	it("returns the entry for a supported preset", () => {
+		expect(getAgentModelSupport("claude")?.modelFlag).toBe("--model");
+	});
+
+	it("returns undefined for presets without model support", () => {
+		expect(getAgentModelSupport("amp")).toBeUndefined();
+		expect(getAgentModelSupport("nonexistent")).toBeUndefined();
+	});
+});
+
+describe("buildAgentModelArgs", () => {
+	it("builds flag + value tokens", () => {
+		expect(buildAgentModelArgs("claude", "sonnet")).toEqual([
+			"--model",
+			"sonnet",
+		]);
+	});
+
+	it("returns [] when no model is set", () => {
+		expect(buildAgentModelArgs("claude", undefined)).toEqual([]);
+		expect(buildAgentModelArgs("claude", "")).toEqual([]);
+	});
+
+	it("returns [] for unsupported presets", () => {
+		expect(buildAgentModelArgs("amp", "sonnet")).toEqual([]);
+	});
+
+	it("returns [] for superset (model travels via chat metadata)", () => {
+		expect(
+			buildAgentModelArgs("superset", "anthropic/claude-opus-4-8"),
+		).toEqual([]);
+	});
+});

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -102,8 +102,10 @@ export function getAgentModelSupport(
 /**
  * Argv tokens that select `model` for the given preset, e.g.
  * `["--model", "sonnet"]`. Returns `[]` for unknown presets, presets without
- * a CLI flag (superset chat), or an unset model — callers can spread the
- * result unconditionally.
+ * a CLI flag (superset chat), an unset model, or a model id that isn't in
+ * the preset's curated list — callers can spread the result unconditionally
+ * and a stale or arbitrary model id degrades to the CLI default instead of
+ * a broken launch.
  */
 export function buildAgentModelArgs(
 	presetId: string,
@@ -112,5 +114,6 @@ export function buildAgentModelArgs(
 	if (!model) return [];
 	const support = getAgentModelSupport(presetId);
 	if (!support?.modelFlag) return [];
+	if (!support.models.some((option) => option.id === model)) return [];
 	return [support.modelFlag, model];
 }

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -24,6 +24,35 @@ export interface AgentModelSupport {
 	models: AgentModelOption[];
 }
 
+export interface SupersetChatModel extends AgentModelOption {
+	provider: string;
+}
+
+/**
+ * Canonical model catalog for the Superset chat agent. This is the single
+ * source of truth — `tRPC chat.getModels` re-shapes it for its API and the
+ * `"superset"` entry in `AGENT_MODEL_SUPPORT` reuses it for the picker. Keep
+ * model edits here so the two never drift.
+ */
+export const SUPERSET_CHAT_MODELS: readonly SupersetChatModel[] = [
+	{ id: "anthropic/claude-opus-4-8", label: "Opus 4.8", provider: "Anthropic" },
+	{ id: "anthropic/claude-opus-4-7", label: "Opus 4.7", provider: "Anthropic" },
+	{ id: "anthropic/claude-fable-5", label: "Fable 5", provider: "Anthropic" },
+	{
+		id: "anthropic/claude-sonnet-4-6",
+		label: "Sonnet 4.6",
+		provider: "Anthropic",
+	},
+	{
+		id: "anthropic/claude-haiku-4-5",
+		label: "Haiku 4.5",
+		provider: "Anthropic",
+	},
+	{ id: "openai/gpt-5.5", label: "GPT-5.5", provider: "OpenAI" },
+	{ id: "openai/gpt-5.4", label: "GPT-5.4", provider: "OpenAI" },
+	{ id: "openai/gpt-5.3-codex", label: "GPT-5.3 Codex", provider: "OpenAI" },
+];
+
 export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 	{
 		presetId: "claude",
@@ -80,16 +109,7 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 	{
 		presetId: "superset",
 		modelFlag: null,
-		models: [
-			{ id: "anthropic/claude-opus-4-8", label: "Opus 4.8" },
-			{ id: "anthropic/claude-opus-4-7", label: "Opus 4.7" },
-			{ id: "anthropic/claude-fable-5", label: "Fable 5" },
-			{ id: "anthropic/claude-sonnet-4-6", label: "Sonnet 4.6" },
-			{ id: "anthropic/claude-haiku-4-5", label: "Haiku 4.5" },
-			{ id: "openai/gpt-5.5", label: "GPT-5.5" },
-			{ id: "openai/gpt-5.4", label: "GPT-5.4" },
-			{ id: "openai/gpt-5.3-codex", label: "GPT-5.3 Codex" },
-		],
+		models: SUPERSET_CHAT_MODELS.map(({ id, label }) => ({ id, label })),
 	},
 ];
 

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -1,0 +1,116 @@
+/**
+ * Curated per-agent model catalogs for the workspace-create model picker.
+ *
+ * Entries are keyed by terminal-agent presetId (see
+ * `builtin-terminal-agents.ts`) plus the virtual `"superset"` chat agent.
+ * Agents absent from this list don't support model selection and render no
+ * picker. Model ids are the exact values the CLI accepts after `modelFlag`
+ * (opencode requires `provider/model`, so the provider is baked into the id);
+ * for `"superset"` the id is passed as chat-session metadata instead and
+ * `modelFlag` is null.
+ *
+ * The lists are hand-maintained and expected to drift with CLI releases —
+ * update them here when a tool adds or retires models.
+ */
+
+export interface AgentModelOption {
+	id: string;
+	label: string;
+}
+
+export interface AgentModelSupport {
+	presetId: string;
+	modelFlag: string | null;
+	models: AgentModelOption[];
+}
+
+export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
+	{
+		presetId: "claude",
+		modelFlag: "--model",
+		models: [
+			{ id: "opus", label: "Opus" },
+			{ id: "sonnet", label: "Sonnet" },
+			{ id: "haiku", label: "Haiku" },
+		],
+	},
+	{
+		presetId: "codex",
+		modelFlag: "--model",
+		models: [
+			{ id: "gpt-5.5", label: "GPT-5.5" },
+			{ id: "gpt-5.4", label: "GPT-5.4" },
+			{ id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+		],
+	},
+	{
+		presetId: "gemini",
+		modelFlag: "--model",
+		models: [
+			{ id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+			{ id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+		],
+	},
+	{
+		presetId: "copilot",
+		modelFlag: "--model",
+		models: [
+			{ id: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
+			{ id: "gpt-5.1", label: "GPT-5.1" },
+		],
+	},
+	{
+		presetId: "cursor-agent",
+		modelFlag: "--model",
+		models: [
+			{ id: "opus", label: "Opus" },
+			{ id: "sonnet-4.5", label: "Sonnet 4.5" },
+			{ id: "gpt-5", label: "GPT-5" },
+			{ id: "composer-1", label: "Composer 1" },
+		],
+	},
+	{
+		presetId: "opencode",
+		modelFlag: "--model",
+		models: [
+			{ id: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+			{ id: "openai/gpt-5", label: "GPT-5" },
+		],
+	},
+	{
+		presetId: "superset",
+		modelFlag: null,
+		models: [
+			{ id: "anthropic/claude-opus-4-8", label: "Opus 4.8" },
+			{ id: "anthropic/claude-opus-4-7", label: "Opus 4.7" },
+			{ id: "anthropic/claude-fable-5", label: "Fable 5" },
+			{ id: "anthropic/claude-sonnet-4-6", label: "Sonnet 4.6" },
+			{ id: "anthropic/claude-haiku-4-5", label: "Haiku 4.5" },
+			{ id: "openai/gpt-5.5", label: "GPT-5.5" },
+			{ id: "openai/gpt-5.4", label: "GPT-5.4" },
+			{ id: "openai/gpt-5.3-codex", label: "GPT-5.3 Codex" },
+		],
+	},
+];
+
+export function getAgentModelSupport(
+	presetId: string,
+): AgentModelSupport | undefined {
+	return AGENT_MODEL_SUPPORT.find((entry) => entry.presetId === presetId);
+}
+
+/**
+ * Argv tokens that select `model` for the given preset, e.g.
+ * `["--model", "sonnet"]`. Returns `[]` for unknown presets, presets without
+ * a CLI flag (superset chat), or an unset model — callers can spread the
+ * result unconditionally.
+ */
+export function buildAgentModelArgs(
+	presetId: string,
+	model: string | undefined,
+): string[] {
+	if (!model) return [];
+	const support = getAgentModelSupport(presetId);
+	if (!support?.modelFlag) return [];
+	return [support.modelFlag, model];
+}

--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -1,6 +1,7 @@
 import { db, dbWs } from "@superset/db/client";
 import { chatSessions } from "@superset/db/schema";
 import { getCurrentTxid } from "@superset/db/utils";
+import { SUPERSET_CHAT_MODELS } from "@superset/shared/agent-models";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
@@ -8,48 +9,13 @@ import { z } from "zod";
 import { protectedProcedure } from "../../trpc";
 import { uploadChatAttachment } from "./utils/upload-chat-attachment";
 
-const AVAILABLE_MODELS = [
-	{
-		id: "anthropic/claude-opus-4-8",
-		name: "Opus 4.8",
-		provider: "Anthropic",
-	},
-	{
-		id: "anthropic/claude-opus-4-7",
-		name: "Opus 4.7",
-		provider: "Anthropic",
-	},
-	{
-		id: "anthropic/claude-fable-5",
-		name: "Fable 5",
-		provider: "Anthropic",
-	},
-	{
-		id: "anthropic/claude-sonnet-4-6",
-		name: "Sonnet 4.6",
-		provider: "Anthropic",
-	},
-	{
-		id: "anthropic/claude-haiku-4-5",
-		name: "Haiku 4.5",
-		provider: "Anthropic",
-	},
-	{
-		id: "openai/gpt-5.5",
-		name: "GPT-5.5",
-		provider: "OpenAI",
-	},
-	{
-		id: "openai/gpt-5.4",
-		name: "GPT-5.4",
-		provider: "OpenAI",
-	},
-	{
-		id: "openai/gpt-5.3-codex",
-		name: "GPT-5.3 Codex",
-		provider: "OpenAI",
-	},
-];
+// Re-shaped from the canonical catalog in `@superset/shared/agent-models` so
+// the chat API and the workspace-create model picker never drift.
+const AVAILABLE_MODELS = SUPERSET_CHAT_MODELS.map((model) => ({
+	id: model.id,
+	name: model.label,
+	provider: model.provider,
+}));
 
 export const chatRouter = {
 	getModels: protectedProcedure.query(() => {


### PR DESCRIPTION
## Description

Adds a model dropdown next to the agent picker in the v2 new-workspace dialog so a session can start on a specific model (e.g. `claude --model sonnet`) without touching the agent's CLI config.

- The dropdown appears only for agents that support model selection: `claude`, `codex`, `gemini`, `copilot`, `cursor-agent`, `opencode` (via their `--model` flag) plus the built-in Superset chat agent (via the existing `metadata.model` → `harness.switchModel` path). Agents without known model support (amp, pi, droid, mastracode) show no dropdown.
- First option is **Default** → no `--model` flag is passed, the CLI keeps its own default.
- The last selected model is remembered per agent preset (localStorage map keyed by presetId, so it survives host switches); stale model ids fall back to Default.

Implementation:

- `packages/shared/src/agent-models.ts` — curated, hand-maintained per-preset model registry (`AGENT_MODEL_SUPPORT`, `getAgentModelSupport`, `buildAgentModelArgs`) shared by the renderer (dropdown options) and host-service (flag injection).
- `packages/host-service` — optional `model` field on the `workspaces.create` agent-launch sugar and `agents.run`; `buildAgentCommandString` inserts the model args between the base args and the prompt, covering both argv and stdin/heredoc transports, shell-quoted. Unknown preset/model degrades to no flag rather than a broken launch.
- `apps/desktop` — new `AgentModelSelect` pill component (same `@superset/ui/select` pattern as `AgentSelect`) and a `useAgentModelPreference` hook, wired into the dialog's `PromptGroup` and `useSubmitWorkspace`. The renderer type for the new field flows automatically from the host router's inferred input type.

## Related Issues

Closes #5247

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- Unit tests added: `packages/shared/src/agent-models.test.ts` (registry validity, arg building) and `packages/host-service/src/trpc/router/agents/agents.test.ts` (`buildAgentCommandString` with model args for argv transport, stdin/heredoc transport, empty model args unchanged, shell-quoting of hostile values). Full `bun test` suites for both packages pass.
- `turbo typecheck` green for `@superset/shared`, `@superset/host-service`, `@superset/desktop`; `bun run lint` exits 0.
- Manually tested against the local Docker dev stack (`setup.local.sh` + `bun run dev:desktop`): Claude + Sonnet launches the terminal with `claude --dangerously-skip-permissions --model sonnet '<prompt>'`; Default passes no flag; Amp shows no dropdown; the Superset chat agent starts on the selected model; the per-agent choice is restored when reopening the dialog.

## Additional Notes

The model lists are intentionally curated and hand-maintained in a single file (`agent-models.ts`); they will drift with CLI releases and are easy to update. Claude uses the stable `opus`/`sonnet`/`haiku` CLI aliases to minimize drift. Happy to adjust scope, model lists, or placement based on review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a model picker to the new workspace dialog so sessions can start on a specific model without editing CLI configs. Also centralizes the Superset chat model catalog in `@superset/shared/agent-models` so the picker and `chat.getModels` stay in sync.

- **New Features**
  - Desktop: Added `AgentModelSelect` next to the agent picker; shown for `claude`, `codex`, `gemini`, `copilot`, `cursor-agent`, `opencode`, and the built-in Superset chat agent. “Default” passes no flag.
  - Preference: Remembers the last selected model per agent preset in localStorage; stale or out‑of‑registry model IDs fall back to Default.
  - Shared (`@superset/shared/agent-models`): Curated registry and helpers (`AGENT_MODEL_SUPPORT`, `getAgentModelSupport`, `buildAgentModelArgs`) for supported models and CLI flags.
  - Host Service (`@superset/host-service`): Optional `model` on `workspaces.create` and `agents.run`. For terminal agents, inserts model args between base args and the prompt (argv and stdin/heredoc, shell-quoted). For the Superset chat agent, sets `metadata.model`.

- **Bug Fixes**
  - Rejects model ids outside the curated registry in `buildAgentModelArgs`, degrading to no flag instead of a broken launch.
  - Guards localStorage writes in the preference hook; quota/security errors only skip persistence.

<sup>Written for commit 0864c9cdd1961aadb17d2851bc79ff0a295e7d64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI model picker to the new workspace flow, including a “Default” option, and forward the chosen model when launching agents.
  * Persist the last-selected model per preset and restore it on subsequent workspace creations.
  * Enable model-aware agent runs for both chat and terminal executions.
* **Tests**
  * Added coverage for curated model support catalogs, model-to-CLI argument construction, and safe model injection/quoting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->