### PR TITLE
feat: add merge queue PR status icon

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -27,6 +27,7 @@ const PR_STATE_LABEL: Record<
 	merged: "Merged",
 	closed: "Closed",
 	draft: "Draft",
+	queued: "Queued",
 };
 
 interface DashboardSidebarExpandedWorkspaceRowProps

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/DashboardSidebarWorkspaceHoverCardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/DashboardSidebarWorkspaceHoverCardContent.tsx
@@ -125,12 +125,14 @@ export function DashboardSidebarWorkspaceHoverCardContent({
 								#{pullRequest.number}
 							</span>
 							<PullRequestStatusBadge state={pullRequest.state} />
-							{pullRequest.state === "open" && pullRequest.reviewDecision && (
-								<ReviewStatus
-									status={pullRequest.reviewDecision}
-									requestedReviewers={pullRequest.requestedReviewers}
-								/>
-							)}
+							{(pullRequest.state === "open" ||
+								pullRequest.state === "queued") &&
+								pullRequest.reviewDecision && (
+									<ReviewStatus
+										status={pullRequest.reviewDecision}
+										requestedReviewers={pullRequest.requestedReviewers}
+									/>
+								)}
 						</div>
 						{diffStats && (
 							<div className="flex items-center gap-1.5 text-xs font-mono shrink-0">
@@ -146,7 +148,7 @@ export function DashboardSidebarWorkspaceHoverCardContent({
 						{pullRequest.title}
 					</p>
 
-					{pullRequest.state === "open" && (
+					{(pullRequest.state === "open" || pullRequest.state === "queued") && (
 						<div className="space-y-2 pt-1">
 							<div className="flex items-center gap-2 text-xs">
 								<ChecksSummary

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/PullRequestStatusBadge/PullRequestStatusBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/PullRequestStatusBadge/PullRequestStatusBadge.tsx
@@ -1,5 +1,5 @@
 interface PullRequestStatusBadgeProps {
-	state: "open" | "draft" | "merged" | "closed";
+	state: "open" | "draft" | "merged" | "closed" | "queued";
 }
 
 export function PullRequestStatusBadge({ state }: PullRequestStatusBadgeProps) {
@@ -8,6 +8,7 @@ export function PullRequestStatusBadge({ state }: PullRequestStatusBadgeProps) {
 		draft: "bg-muted text-muted-foreground",
 		merged: "bg-violet-500/15 text-violet-500",
 		closed: "bg-destructive/15 text-destructive-foreground",
+		queued: "bg-amber-500/15 text-amber-500",
 	};
 
 	const labels = {
@@ -15,6 +16,7 @@ export function PullRequestStatusBadge({ state }: PullRequestStatusBadgeProps) {
 		draft: "Draft",
 		merged: "Merged",
 		closed: "Closed",
+		queued: "Queued",
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -5,6 +5,7 @@ import {
 	LuGitPullRequest,
 	LuGitPullRequestClosed,
 	LuGitPullRequestDraft,
+	LuListChecks,
 } from "react-icons/lu";
 import { RxDot } from "react-icons/rx";
 import { TbCloud, TbCloudOff } from "react-icons/tb";
@@ -38,6 +39,7 @@ const PR_ICON_BY_STATE = {
 	merged: LuGitMerge,
 	closed: LuGitPullRequestClosed,
 	draft: LuGitPullRequestDraft,
+	queued: LuListChecks,
 } as const;
 
 const PR_COLOR_BY_STATE = {
@@ -45,6 +47,7 @@ const PR_COLOR_BY_STATE = {
 	merged: "text-purple-500",
 	closed: "text-destructive",
 	draft: "text-muted-foreground",
+	queued: "text-amber-500",
 } as const;
 
 export function DashboardSidebarWorkspaceIcon({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceStatusBadge/DashboardSidebarWorkspaceStatusBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceStatusBadge/DashboardSidebarWorkspaceStatusBadge.tsx
@@ -1,5 +1,10 @@
 import { cn } from "@superset/ui/utils";
-import { LuCircleDot, LuGitMerge, LuGitPullRequest } from "react-icons/lu";
+import {
+	LuCircleDot,
+	LuGitMerge,
+	LuGitPullRequest,
+	LuListChecks,
+} from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { DashboardSidebarWorkspacePullRequest } from "../../../../types";
 
@@ -55,6 +60,15 @@ export function DashboardSidebarWorkspaceStatusBadge({
 				/>
 			),
 			bgColor: "bg-muted",
+		},
+		queued: {
+			icon: (
+				<LuListChecks
+					className={cn(iconClass, "text-amber-500")}
+					strokeWidth={1.75}
+				/>
+			),
+			bgColor: "bg-amber-500/10",
 		},
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -17,7 +17,7 @@ export interface DashboardSidebarWorkspacePullRequest {
 	url: string;
 	number: number;
 	title: string;
-	state: "open" | "merged" | "closed" | "draft";
+	state: "open" | "merged" | "closed" | "draft" | "queued";
 	reviewDecision: "approved" | "changes_requested" | "pending" | null;
 	requestedReviewers?: string[];
 	checksStatus: "success" | "failure" | "pending" | "none";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/components/PRStatusGroup/PRStatusGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/components/PRStatusGroup/PRStatusGroup.tsx
@@ -93,9 +93,12 @@ export function PRStatusGroup({
 			? "merged"
 			: pr.state === "closed"
 				? "closed"
-				: "open";
+				: pr.state === "queued"
+					? "queued"
+					: "open";
 	const canMerge = pr.state === "open" && !pr.isDraft;
-	const showIndicators = pr.state === "open"; // includes draft
+	// Queued PRs are still actively running checks, so keep CI/review indicators.
+	const showIndicators = pr.state === "open" || pr.state === "queued";
 
 	const handleMerge = (mergeMethod: "merge" | "squash" | "rebase") => {
 		mergePRMutation.mutate({
@@ -238,6 +241,12 @@ function stateTintClasses(state: PRState): {
 				container: "border-border bg-muted/40",
 				hover: "hover:bg-muted/60 focus-visible:bg-muted/60",
 				divider: "bg-border",
+			};
+		case "queued":
+			return {
+				container: "border-amber-500/30 bg-amber-500/10",
+				hover: "hover:bg-amber-500/15 focus-visible:bg-amber-500/15",
+				divider: "bg-amber-500/30",
 			};
 	}
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/components/PRStatusGroup/components/PRDetailCard/PRDetailCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/components/PRStatusGroup/components/PRDetailCard/PRDetailCard.tsx
@@ -30,7 +30,9 @@ export function PRDetailCard({ pr, checks, linkState }: PRDetailCardProps) {
 			? "Merged"
 			: pr.state === "closed"
 				? "Closed"
-				: "Open";
+				: pr.state === "queued"
+					? "Queued"
+					: "Open";
 	const statePillClass = stateLabelToPillClass(linkState);
 
 	const updatedRelative = pr.updatedAt
@@ -185,5 +187,7 @@ function stateLabelToPillClass(state: PRState): string {
 			return "bg-rose-500/10 text-rose-600 dark:text-rose-400";
 		case "draft":
 			return "bg-muted text-muted-foreground";
+		case "queued":
+			return "bg-amber-500/10 text-amber-600 dark:text-amber-400";
 	}
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/utils/getPRFlowState/getPRFlowState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PRActionHeader/utils/getPRFlowState/getPRFlowState.ts
@@ -91,7 +91,7 @@ export type PRLinkVariant =
 	| { kind: "none" }
 	| {
 			kind: "pr-link";
-			state: "open" | "draft" | "merged" | "closed";
+			state: "open" | "draft" | "merged" | "closed" | "queued";
 			number: number;
 			url: string;
 	  };
@@ -105,7 +105,9 @@ export function selectPRLink(state: PRFlowState): PRLinkVariant {
 			? "merged"
 			: pr.state === "closed"
 				? "closed"
-				: "open";
+				: pr.state === "queued"
+					? "queued"
+					: "open";
 	return {
 		kind: "pr-link",
 		state: linkState,
@@ -126,6 +128,7 @@ export function selectStatusBadge(state: PRFlowState): string | null {
 			if (state.pr.isDraft) return "Draft";
 			if (state.pr.state === "merged") return "Merged";
 			if (state.pr.state === "closed") return "Closed";
+			if (state.pr.state === "queued") return "Queued";
 			return "Open";
 		case "busy":
 			return "Agent working…";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useReviewTab/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useReviewTab/types.ts
@@ -3,7 +3,7 @@ export interface NormalizedPR {
 	number: number;
 	url: string;
 	title: string;
-	state: "open" | "closed" | "merged" | "draft";
+	state: "open" | "closed" | "merged" | "draft" | "queued";
 	reviewDecision: "approved" | "changes_requested" | "pending";
 	checksStatus: "success" | "failure" | "pending" | "none";
 	checks: NormalizedCheck[];

--- a/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
@@ -1,7 +1,12 @@
 import { cn } from "@superset/ui/utils";
-import { LuCircleDot, LuGitMerge, LuGitPullRequest } from "react-icons/lu";
+import {
+	LuCircleDot,
+	LuGitMerge,
+	LuGitPullRequest,
+	LuListChecks,
+} from "react-icons/lu";
 
-export type PRState = "open" | "merged" | "closed" | "draft";
+export type PRState = "open" | "merged" | "closed" | "draft" | "queued";
 
 interface PRIconProps {
 	state: PRState;
@@ -13,6 +18,7 @@ const stateStyles: Record<PRState, string> = {
 	merged: "text-violet-500",
 	closed: "text-red-500",
 	draft: "text-muted-foreground",
+	queued: "text-amber-500",
 };
 
 /**
@@ -21,6 +27,7 @@ const stateStyles: Record<PRState, string> = {
  * - merged: purple/violet merge icon
  * - closed: red dot icon
  * - draft: muted pull request icon
+ * - queued: amber queue icon (PR waiting in the merge queue)
  */
 export function PRIcon({ state, className }: PRIconProps) {
 	const baseClass = cn(stateStyles[state], className);
@@ -31,6 +38,10 @@ export function PRIcon({ state, className }: PRIconProps) {
 
 	if (state === "closed") {
 		return <LuCircleDot className={baseClass} />;
+	}
+
+	if (state === "queued") {
+		return <LuListChecks className={baseClass} />;
 	}
 
 	// open or draft

--- a/apps/desktop/src/renderer/screens/main/components/PRIcon/normalizePRState.ts
+++ b/apps/desktop/src/renderer/screens/main/components/PRIcon/normalizePRState.ts
@@ -3,11 +3,13 @@ import type { PRState } from "./PRIcon";
 /**
  * Map a raw GitHub PR state string + draft flag to the canonical PRState
  * used by PRIcon and the rest of the renderer. Draft trumps merged/closed/open.
+ * "queued" (PR in a merge queue) is already canonical and passes through.
  */
 export function normalizePRState(state: string, isDraft: boolean): PRState {
 	if (isDraft) return "draft";
 	const lower = state.toLowerCase();
 	if (lower === "merged") return "merged";
 	if (lower === "closed") return "closed";
+	if (lower === "queued") return "queued";
 	return "open";
 }

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -12,6 +12,8 @@ import {
 	fetchPullRequestByHeadFromGh,
 	fetchPullRequestChecks,
 	fetchPullRequestChecksFromGh,
+	fetchPullRequestMergeQueueState,
+	fetchPullRequestMergeQueueStateFromGh,
 	fetchPullRequestReviewDecision,
 	fetchPullRequestReviewDecisionFromGh,
 } from "./utils/github-query";
@@ -976,7 +978,14 @@ export class PullRequestRuntimeManager {
 			number,
 			GitHubPullRequestReviewDecision
 		>();
+		// Only open, non-draft PRs can sit in a merge queue, so skip the extra
+		// GraphQL round-trip for everything else.
+		const mergeQueueByNumber = new Map<number, boolean>();
 		let octokitPromise: Promise<Octokit> | null = null;
+		const getOctokit = () => {
+			octokitPromise ??= this.github();
+			return octokitPromise;
+		};
 		await Promise.all(
 			Array.from(latestByKey.values()).map(async (node) => {
 				try {
@@ -993,8 +1002,7 @@ export class PullRequestRuntimeManager {
 					checksByNumber.set(node.number, checks);
 				} catch (ghError) {
 					try {
-						octokitPromise ??= this.github();
-						const octokit = await octokitPromise;
+						const octokit = await getOctokit();
 						const [reviewDecision, checks] = await Promise.all([
 							fetchPullRequestReviewDecision(
 								octokit,
@@ -1020,6 +1028,45 @@ export class PullRequestRuntimeManager {
 						);
 					}
 				}
+
+				// Merge-queue detection stays on its own error boundary: only open,
+				// non-draft PRs can be queued, and the `mergeQueueEntry` GraphQL field
+				// is absent on older GitHub Enterprise schemas. Coupling it with the
+				// review/checks fetch above would let that failure stale their data.
+				if (node.state !== "OPEN" || node.isDraft) return;
+				try {
+					mergeQueueByNumber.set(
+						node.number,
+						await fetchPullRequestMergeQueueStateFromGh(
+							this.execGh,
+							repo,
+							node.number,
+						),
+					);
+				} catch (ghError) {
+					try {
+						mergeQueueByNumber.set(
+							node.number,
+							await fetchPullRequestMergeQueueState(
+								await getOctokit(),
+								repo,
+								node.number,
+							),
+						);
+					} catch (error) {
+						console.warn(
+							"[host-service:pull-request-runtime] Failed to fetch PR merge-queue state",
+							{
+								projectId,
+								owner: repo.owner,
+								name: repo.name,
+								prNumber: node.number,
+								ghError,
+								error,
+							},
+						);
+					}
+				}
 			}),
 		);
 
@@ -1031,6 +1078,9 @@ export class PullRequestRuntimeManager {
 			const reviewDecision = reviewDecisionByNumber.has(node.number)
 				? mapReviewDecision(reviewDecisionByNumber.get(node.number) ?? null)
 				: coerceReviewDecision(existing?.reviewDecision ?? null);
+			const isInMergeQueue = mergeQueueByNumber.has(node.number)
+				? (mergeQueueByNumber.get(node.number) ?? false)
+				: coercePullRequestState(existing?.state ?? null) === "queued";
 			const rowId = this.upsertPullRequestRow({
 				existing,
 				projectId,
@@ -1038,7 +1088,7 @@ export class PullRequestRuntimeManager {
 				repo,
 				url: node.url,
 				title: node.title,
-				state: mapPullRequestState(node.state, node.isDraft),
+				state: mapPullRequestState(node.state, node.isDraft, isInMergeQueue),
 				isDraft: node.isDraft,
 				headBranch: node.headRefName,
 				headSha: node.headRefOid,

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	fetchPullRequestByHeadFromGh,
 	fetchPullRequestChecksFromGh,
+	fetchPullRequestMergeQueueStateFromGh,
 	fetchPullRequestReviewDecisionFromGh,
 } from "./github-query";
 
@@ -274,5 +275,53 @@ describe("GitHub pull request REST queries", () => {
 				],
 			},
 		]);
+	});
+
+	test("detects a PR sitting in the merge queue via GraphQL", async () => {
+		const { calls, execGh } = createExecGh([
+			{
+				data: {
+					repository: { pullRequest: { mergeQueueEntry: { id: "MQE_1" } } },
+				},
+			},
+		]);
+
+		const result = await fetchPullRequestMergeQueueStateFromGh(
+			execGh,
+			{ owner: "superset-sh", name: "superset" },
+			42,
+		);
+
+		expect(result).toBe(true);
+		expect(calls).toEqual([
+			{
+				args: [
+					"api",
+					"graphql",
+					"-f",
+					"query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){mergeQueueEntry{id}}}}",
+					"-f",
+					"owner=superset-sh",
+					"-f",
+					"name=superset",
+					"-F",
+					"number=42",
+				],
+			},
+		]);
+	});
+
+	test("reports not-queued when mergeQueueEntry is null", async () => {
+		const { execGh } = createExecGh([
+			{ data: { repository: { pullRequest: { mergeQueueEntry: null } } } },
+		]);
+
+		const result = await fetchPullRequestMergeQueueStateFromGh(
+			execGh,
+			{ owner: "superset-sh", name: "superset" },
+			42,
+		);
+
+		expect(result).toBe(false);
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -251,6 +251,65 @@ export async function fetchPullRequestByHead(
 	return normalizePullRequestCandidates(response.data, head);
 }
 
+// GitHub's REST PR payloads don't expose merge-queue membership, so detect it
+// via GraphQL: a non-null `mergeQueueEntry` means the PR is sitting in the
+// repo's merge queue waiting its turn. Repos without a queue simply return null.
+const MERGE_QUEUE_ENTRY_QUERY =
+	"query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){mergeQueueEntry{id}}}}";
+
+function hasMergeQueueEntry(data: unknown): boolean {
+	if (!isRecord(data)) return false;
+	const repository = isRecord(data.repository) ? data.repository : null;
+	const pullRequest =
+		repository && isRecord(repository.pullRequest)
+			? repository.pullRequest
+			: null;
+	return Boolean(pullRequest && isRecord(pullRequest.mergeQueueEntry));
+}
+
+export async function fetchPullRequestMergeQueueStateFromGh(
+	execGh: ExecGh,
+	repository: {
+		owner: string;
+		name: string;
+	},
+	number: number,
+): Promise<boolean> {
+	const raw = await execGh([
+		"api",
+		"graphql",
+		"-f",
+		`query=${MERGE_QUEUE_ENTRY_QUERY}`,
+		"-f",
+		`owner=${repository.owner}`,
+		"-f",
+		`name=${repository.name}`,
+		"-F",
+		`number=${number}`,
+	]);
+
+	// `gh api graphql` wraps the payload in `{ data: ... }`; Octokit unwraps it.
+	const data = isRecord(raw) && isRecord(raw.data) ? raw.data : raw;
+	return hasMergeQueueEntry(data);
+}
+
+export async function fetchPullRequestMergeQueueState(
+	octokit: Octokit,
+	repository: {
+		owner: string;
+		name: string;
+	},
+	number: number,
+): Promise<boolean> {
+	const data = await octokit.graphql(MERGE_QUEUE_ENTRY_QUERY, {
+		owner: repository.owner,
+		name: repository.name,
+		number,
+	});
+
+	return hasMergeQueueEntry(data);
+}
+
 export async function fetchPullRequestReviewDecisionFromGh(
 	execGh: ExecGh,
 	repository: {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/index.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/index.ts
@@ -3,6 +3,8 @@ export {
 	fetchPullRequestByHeadFromGh,
 	fetchPullRequestChecks,
 	fetchPullRequestChecksFromGh,
+	fetchPullRequestMergeQueueState,
+	fetchPullRequestMergeQueueStateFromGh,
 	fetchPullRequestReviewDecision,
 	fetchPullRequestReviewDecisionFromGh,
 } from "./github-query";

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+	coercePullRequestState,
+	mapPullRequestState,
+} from "./pull-request-mappers";
+
+describe("mapPullRequestState", () => {
+	test("maps merged and closed states regardless of other flags", () => {
+		expect(mapPullRequestState("MERGED", false, true)).toBe("merged");
+		expect(mapPullRequestState("CLOSED", true, true)).toBe("closed");
+	});
+
+	test("draft trumps merge-queue membership", () => {
+		expect(mapPullRequestState("OPEN", true, true)).toBe("draft");
+	});
+
+	test("an open PR in the merge queue is queued", () => {
+		expect(mapPullRequestState("OPEN", false, true)).toBe("queued");
+	});
+
+	test("an open PR not in the queue stays open", () => {
+		expect(mapPullRequestState("OPEN", false, false)).toBe("open");
+		expect(mapPullRequestState("OPEN", false)).toBe("open");
+	});
+});
+
+describe("coercePullRequestState", () => {
+	test("round-trips the queued state", () => {
+		expect(coercePullRequestState("queued")).toBe("queued");
+	});
+
+	test("falls back to open for unknown values", () => {
+		expect(coercePullRequestState("nonsense")).toBe("open");
+		expect(coercePullRequestState(null)).toBe("open");
+	});
+});

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
@@ -4,7 +4,12 @@ import type {
 	GitHubPullRequestReviewDecision,
 } from "../github-query";
 
-export type PullRequestState = "open" | "draft" | "merged" | "closed";
+export type PullRequestState =
+	| "open"
+	| "draft"
+	| "merged"
+	| "closed"
+	| "queued";
 export type ReviewDecision =
 	| "approved"
 	| "changes_requested"
@@ -22,10 +27,12 @@ export interface PullRequestCheck {
 export function mapPullRequestState(
 	state: GitHubPullRequestNode["state"],
 	isDraft: boolean,
+	isInMergeQueue = false,
 ): PullRequestState {
 	if (state === "MERGED") return "merged";
 	if (state === "CLOSED") return "closed";
 	if (isDraft) return "draft";
+	if (isInMergeQueue) return "queued";
 	return "open";
 }
 
@@ -89,7 +96,12 @@ export function computeChecksStatus(checks: PullRequestCheck[]): ChecksStatus {
 }
 
 export function coercePullRequestState(value: string | null): PullRequestState {
-	if (value === "merged" || value === "closed" || value === "draft") {
+	if (
+		value === "merged" ||
+		value === "closed" ||
+		value === "draft" ||
+		value === "queued"
+	) {
 		return value;
 	}
 	return "open";

--- a/packages/host-service/src/trpc/router/git/types.ts
+++ b/packages/host-service/src/trpc/router/git/types.ts
@@ -22,8 +22,11 @@ export type PatchStatus =
 /** GitHub GraphQL: DiffSide */
 export type DiffSide = "LEFT" | "RIGHT";
 
-/** GitHub GraphQL: PullRequestState */
-export type PullRequestState = "open" | "closed" | "merged";
+/**
+ * GitHub GraphQL: PullRequestState, plus the Superset-derived "queued" state
+ * for PRs sitting in a repo's merge queue (not a GitHub PullRequestState value).
+ */
+export type PullRequestState = "open" | "closed" | "merged" | "queued";
 
 /** GitHub GraphQL: PullRequestReviewDecision */
 export type PullRequestReviewDecision =


### PR DESCRIPTION
## Description

- surface PRs sitting in a GitHub merge queue as a distinct "queued" state, rendered with an amber `LuListChecks` icon across the workspace and dashboard sidebars
- fetch merge-queue membership via GraphQL `pullRequest.mergeQueueEntry` since REST PR payloads don't expose it; only query open, non-draft PRs and keep the existing gh -> Octokit fallback
- map membership to `"queued"` in `mapPullRequestState`; the local SQLite `state` column is unconstrained text so no migration is needed
- thread `"queued"` through the renderer unions, selectors, badges and tints so every PR surface stays exhaustive

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Local agent testing.

## Screenshots (if applicable)

Don't have any handy.

## Additional Notes

First PR attempt, please feel free to destroy me 😁 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5249">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a distinct queued state for PRs in a GitHub merge queue, shown with an amber list-checks icon and badges across the dashboard, hover cards, and workspace. Queue membership is detected via GraphQL pullRequest.mergeQueueEntry with a `gh` → `Octokit` fallback, isolated from review/checks fetches; the new state is threaded through renderer/TRPC types with no DB migration needed.

- **New Features**
  - Show “Queued” state with amber badge/icon in sidebars, hover cards, and PR detail cards; keep CI/review indicators visible.
  - Extend unions/types and selectors (renderer + TRPC) to include `queued`; normalize passes it through; update tints and labels.
  - Query queue membership only for open, non-draft PRs; add tests for GraphQL detection and state mapping; keep the fallback.

<sup>Written for commit 678473d010834316facca80a57f82f9c1f7352cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new "Queued" PR state: displayed across dashboard, sidebars, icons, badges, and PR detail views with amber styling and a queue icon; hover cards and indicators treat queued PRs like open where applicable.
  * Backend now detects merge-queue membership and surfaces it so queued PRs display consistently in the UI.
* **Tests**
  * Added unit tests for merge-queue detection and PR state mapping (including "queued").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->