### PR TITLE
perf(terminal): coalesce PTY output into one xterm.write per animation frame (v2 transport)

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -120,26 +120,29 @@ afterEach(() => {
 });
 
 describe("PTY output write coalescing", () => {
-	let frameCallbacks: FrameRequestCallback[];
+	let frameCallbacks: Map<number, FrameRequestCallback>;
+	let nextFrameId: number;
 	const originalRaf = globalThis.requestAnimationFrame;
 	const originalCancelRaf = globalThis.cancelAnimationFrame;
 
 	function fireFrame() {
-		const callbacks = [...frameCallbacks];
-		frameCallbacks = [];
+		const callbacks = [...frameCallbacks.values()];
+		frameCallbacks.clear();
 		for (const callback of callbacks) {
 			callback(performance.now());
 		}
 	}
 
 	beforeEach(() => {
-		frameCallbacks = [];
+		frameCallbacks = new Map();
+		nextFrameId = 1;
 		globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
-			frameCallbacks.push(callback);
-			return frameCallbacks.length;
+			const id = nextFrameId++;
+			frameCallbacks.set(id, callback);
+			return id;
 		};
-		globalThis.cancelAnimationFrame = () => {
-			frameCallbacks = [];
+		globalThis.cancelAnimationFrame = (id: number) => {
+			frameCallbacks.delete(id);
 		};
 	});
 
@@ -203,6 +206,18 @@ describe("PTY output write coalescing", () => {
 			"write:final output",
 			"writeln:\r\n[terminal] exited with code 0 (signal 0)",
 		]);
+	});
+
+	test("does not flush pending PTY bytes for non-writing control messages", () => {
+		const { writes, socket } = connectWithRecordingTerminal();
+
+		socket.message(binaryFrame("prompt"));
+		socket.message(JSON.stringify({ type: "title", title: "agent" }));
+		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+		expect(writes).toEqual([]);
+
+		fireFrame();
+		expect(writes).toEqual(["prompt"]);
 	});
 
 	test("flushes pending PTY bytes when the socket closes", () => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -119,6 +119,102 @@ afterEach(() => {
 	jest.useRealTimers();
 });
 
+describe("PTY output write coalescing", () => {
+	let frameCallbacks: FrameRequestCallback[];
+	const originalRaf = globalThis.requestAnimationFrame;
+	const originalCancelRaf = globalThis.cancelAnimationFrame;
+
+	function fireFrame() {
+		const callbacks = [...frameCallbacks];
+		frameCallbacks = [];
+		for (const callback of callbacks) {
+			callback(performance.now());
+		}
+	}
+
+	beforeEach(() => {
+		frameCallbacks = [];
+		globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
+			frameCallbacks.push(callback);
+			return frameCallbacks.length;
+		};
+		globalThis.cancelAnimationFrame = () => {
+			frameCallbacks = [];
+		};
+	});
+
+	afterEach(() => {
+		globalThis.requestAnimationFrame = originalRaf;
+		globalThis.cancelAnimationFrame = originalCancelRaf;
+	});
+
+	function connectWithRecordingTerminal() {
+		const transport = createTransport();
+		const terminal = createMockTerminal();
+		const writes: string[] = [];
+		const events: string[] = [];
+		(terminal as unknown as { write: (d: Uint8Array) => void }).write = (
+			data: Uint8Array,
+		) => {
+			const text = new TextDecoder().decode(data);
+			writes.push(text);
+			events.push(`write:${text}`);
+		};
+		(terminal as unknown as { writeln: (s: string) => void }).writeln = (
+			line: string,
+		) => {
+			events.push(`writeln:${line}`);
+		};
+		connect(transport, terminal, "ws://host/terminal/t1");
+		const socket = MockWebSocket.instances[0];
+		if (!socket) throw new Error("expected websocket instance");
+		socket.open();
+		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+		return { transport, socket, writes, events };
+	}
+
+	function binaryFrame(text: string): ArrayBuffer {
+		const bytes = new TextEncoder().encode(text);
+		return bytes.buffer.slice(
+			bytes.byteOffset,
+			bytes.byteOffset + bytes.byteLength,
+		) as ArrayBuffer;
+	}
+
+	test("coalesces binary frames into one terminal.write per frame", () => {
+		const { writes, socket } = connectWithRecordingTerminal();
+
+		socket.message(binaryFrame("chunk1"));
+		socket.message(binaryFrame("chunk2"));
+		socket.message(binaryFrame("chunk3"));
+		expect(writes).toEqual([]);
+
+		fireFrame();
+		expect(writes).toEqual(["chunk1chunk2chunk3"]);
+	});
+
+	test("flushes pending PTY bytes before writing the exit notice", () => {
+		const { events, socket } = connectWithRecordingTerminal();
+
+		socket.message(binaryFrame("final output"));
+		socket.message(JSON.stringify({ type: "exit", exitCode: 0, signal: 0 }));
+
+		expect(events).toEqual([
+			"write:final output",
+			"writeln:\r\n[terminal] exited with code 0 (signal 0)",
+		]);
+	});
+
+	test("flushes pending PTY bytes when the socket closes", () => {
+		const { writes, socket } = connectWithRecordingTerminal();
+
+		socket.message(binaryFrame("tail"));
+		socket.close(1006, "host restart");
+
+		expect(writes).toEqual(["tail"]);
+	});
+});
+
 describe("terminal-ws-transport", () => {
 	test("server-sent error routes to logs, not xterm, and stops reconnect", () => {
 		const transport = createTransport();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,5 +1,6 @@
 import { primeRelayAffinity } from "@superset/workspace-client";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { createWriteCoalescer, type WriteCoalescer } from "./write-coalescer";
 
 export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
 
@@ -64,6 +65,12 @@ export interface TerminalTransport {
 	/** Internal: bound resume handler shared by the online/focus/visibility
 	 * listeners, so they can be removed on teardown. */
 	_resumeListener: (() => void) | null;
+	/**
+	 * Internal: batches PTY output into one xterm.write per animation frame.
+	 * Agent CLIs emit repaints as many small chunks; per-chunk writes trigger
+	 * a parse/render cycle each and overwhelm the renderer (#2241, #2244).
+	 */
+	_writeCoalescer: WriteCoalescer | null;
 }
 
 const MAX_LOG_ENTRIES = 200;
@@ -163,6 +170,7 @@ export function createTransport(): TerminalTransport {
 		_livenessTimer: null,
 		_lastLivenessTick: 0,
 		_resumeListener: null,
+		_writeCoalescer: null,
 	};
 }
 
@@ -337,6 +345,12 @@ export function connect(
 	cancelReconnect(transport);
 	transport.currentUrl = wsUrl;
 	transport._terminal = terminal;
+	// Recreate per connect so the coalescer always targets the current
+	// terminal; dispose flushes anything the previous socket left pending.
+	transport._writeCoalescer?.dispose();
+	transport._writeCoalescer = createWriteCoalescer((data) =>
+		terminal.write(data),
+	);
 	transport._terminated = false;
 	setupLiveness(transport);
 	setConnectionState(transport, "connecting");
@@ -411,15 +425,20 @@ function attachSocketListeners(
 		// channel; renderer treats them identically). Pipe straight into
 		// xterm without any decoding step.
 		if (event.data instanceof ArrayBuffer) {
-			// Pipe PTY bytes straight into xterm. There's no output ACK back to
-			// host-service: back-pressure lives entirely on the host side, which
-			// bounds this socket's send buffer and drops us (we reconnect and
-			// replay) if we fall hopelessly behind. That means a slow/stalled
-			// renderer can never wedge the shell — it just loses some scrollback.
-			terminal.write(new Uint8Array(event.data));
+			// Queue PTY bytes; the coalescer batches them into one xterm.write
+			// per animation frame. There's no output ACK back to host-service:
+			// back-pressure lives entirely on the host side, which bounds this
+			// socket's send buffer and drops us (we reconnect and replay) if we
+			// fall hopelessly behind. That means a slow/stalled renderer can
+			// never wedge the shell — it just loses some scrollback.
+			transport._writeCoalescer?.push(new Uint8Array(event.data));
 			transport._hasReceivedBytes = true;
 			return;
 		}
+
+		// Control messages may write to the terminal (exit notice, invalid
+		// payload); flush queued PTY bytes first so output stays ordered.
+		transport._writeCoalescer?.flushSync();
 
 		let message: TerminalServerMessage;
 		try {
@@ -459,6 +478,9 @@ function attachSocketListeners(
 
 	socket.addEventListener("close", (event) => {
 		if (transport.socket !== socket) return;
+		// Render whatever arrived before the close instead of holding it for a
+		// frame that may never come (e.g. hidden window).
+		transport._writeCoalescer?.flushSync();
 		setConnectionState(transport, "closed");
 		transport.socket = null;
 		if (!transport._terminated && event.code !== 1000) {
@@ -500,6 +522,8 @@ export function disconnect(transport: TerminalTransport) {
 		transport.socket.close();
 		transport.socket = null;
 	}
+	transport._writeCoalescer?.dispose();
+	transport._writeCoalescer = null;
 	transport.currentUrl = null;
 	transport._terminal = null;
 	transport._reconnectAttempt = 0;
@@ -540,6 +564,8 @@ export function disposeTransport(transport: TerminalTransport) {
 		transport.socket.close();
 		transport.socket = null;
 	}
+	transport._writeCoalescer?.dispose();
+	transport._writeCoalescer = null;
 	transport.currentUrl = null;
 	transport._terminal = null;
 	transport._reconnectAttempt = 0;

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -436,14 +436,11 @@ function attachSocketListeners(
 			return;
 		}
 
-		// Control messages may write to the terminal (exit notice, invalid
-		// payload); flush queued PTY bytes first so output stays ordered.
-		transport._writeCoalescer?.flushSync();
-
 		let message: TerminalServerMessage;
 		try {
 			message = JSON.parse(String(event.data)) as TerminalServerMessage;
 		} catch {
+			transport._writeCoalescer?.flushSync();
 			terminal.writeln("\r\n[terminal] invalid server payload");
 			return;
 		}
@@ -468,6 +465,7 @@ function attachSocketListeners(
 		}
 
 		if (message.type === "exit") {
+			transport._writeCoalescer?.flushSync();
 			transport._terminated = true;
 			cancelReconnect(transport);
 			terminal.writeln(

--- a/apps/desktop/src/renderer/lib/terminal/write-coalescer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/write-coalescer.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createWriteCoalescer, MAX_PENDING_BYTES } from "./write-coalescer";
+
+// Capture rAF callbacks so tests control frame timing deterministically.
+let frameCallbacks: Map<number, FrameRequestCallback>;
+let nextFrameId: number;
+
+const originalRaf = globalThis.requestAnimationFrame;
+const originalCancelRaf = globalThis.cancelAnimationFrame;
+
+function fireFrame() {
+	const callbacks = [...frameCallbacks.values()];
+	frameCallbacks.clear();
+	for (const callback of callbacks) {
+		callback(performance.now());
+	}
+}
+
+beforeEach(() => {
+	frameCallbacks = new Map();
+	nextFrameId = 1;
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
+		const id = nextFrameId++;
+		frameCallbacks.set(id, callback);
+		return id;
+	};
+	globalThis.cancelAnimationFrame = (id: number) => {
+		frameCallbacks.delete(id);
+	};
+});
+
+afterEach(() => {
+	globalThis.requestAnimationFrame = originalRaf;
+	globalThis.cancelAnimationFrame = originalCancelRaf;
+});
+
+function bytes(text: string): Uint8Array {
+	return new TextEncoder().encode(text);
+}
+
+describe("createWriteCoalescer", () => {
+	test("coalesces chunks arriving in the same frame into one write", () => {
+		const writes: Uint8Array[] = [];
+		const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+		coalescer.push(bytes("foo"));
+		coalescer.push(bytes("bar"));
+		coalescer.push(bytes("baz"));
+		expect(writes).toHaveLength(0);
+
+		fireFrame();
+		expect(writes).toHaveLength(1);
+		expect(new TextDecoder().decode(writes[0])).toBe("foobarbaz");
+	});
+
+	test("schedules a new frame for data arriving after a flush", () => {
+		const writes: Uint8Array[] = [];
+		const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+		coalescer.push(bytes("first"));
+		fireFrame();
+		coalescer.push(bytes("second"));
+		fireFrame();
+
+		expect(writes).toHaveLength(2);
+		expect(new TextDecoder().decode(writes[1])).toBe("second");
+	});
+
+	test("flushSync writes pending bytes immediately and cancels the scheduled frame", () => {
+		const writes: Uint8Array[] = [];
+		const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+		coalescer.push(bytes("pending"));
+		coalescer.flushSync();
+		expect(writes).toHaveLength(1);
+		expect(new TextDecoder().decode(writes[0])).toBe("pending");
+
+		// The previously scheduled frame must not produce a second write.
+		fireFrame();
+		expect(writes).toHaveLength(1);
+	});
+
+	test("flushSync with nothing pending writes nothing", () => {
+		const writes: Uint8Array[] = [];
+		const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+		coalescer.flushSync();
+		expect(writes).toHaveLength(0);
+	});
+
+	test("flushes immediately when pending bytes exceed the cap", () => {
+		const writes: Uint8Array[] = [];
+		const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+		coalescer.push(new Uint8Array(MAX_PENDING_BYTES + 1));
+		expect(writes).toHaveLength(1);
+		expect(writes[0]).toHaveLength(MAX_PENDING_BYTES + 1);
+
+		// Nothing left for the frame to write.
+		fireFrame();
+		expect(writes).toHaveLength(1);
+	});
+
+	test("dispose flushes pending bytes and ignores later pushes", () => {
+		const writes: Uint8Array[] = [];
+		const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+		coalescer.push(bytes("tail"));
+		coalescer.dispose();
+		expect(writes).toHaveLength(1);
+		expect(new TextDecoder().decode(writes[0])).toBe("tail");
+
+		coalescer.push(bytes("ignored"));
+		fireFrame();
+		expect(writes).toHaveLength(1);
+	});
+
+	test("preserves byte order across many small chunks", () => {
+		const writes: Uint8Array[] = [];
+		const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+		const parts = Array.from({ length: 100 }, (_, i) => `${i},`);
+		for (const part of parts) {
+			coalescer.push(bytes(part));
+		}
+		fireFrame();
+
+		expect(writes).toHaveLength(1);
+		expect(new TextDecoder().decode(writes[0])).toBe(parts.join(""));
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/write-coalescer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/write-coalescer.ts
@@ -1,0 +1,86 @@
+/**
+ * Coalesces PTY output chunks into one xterm.write() per animation frame.
+ *
+ * Agent CLIs (Claude Code especially) emit full-screen repaints as many small
+ * PTY chunks. Writing each chunk individually triggers an xterm parse/render
+ * cycle per chunk, which overwhelms the renderer during streaming output.
+ * Batching to the display refresh rate makes the cost per frame constant
+ * regardless of chunk count. See issues #2241 / #2244.
+ */
+
+/**
+ * Pending-byte ceiling. requestAnimationFrame stalls while the window is
+ * hidden (Electron throttles backgrounded renderers), so without a cap the
+ * buffer could grow unboundedly during a background firehose. Exceeding the
+ * cap flushes synchronously, bounding memory at the cost of one early write.
+ */
+export const MAX_PENDING_BYTES = 1024 * 1024;
+
+export interface WriteCoalescer {
+	/** Queue PTY bytes for the next frame's write. */
+	push(chunk: Uint8Array): void;
+	/**
+	 * Write everything pending right now. Call before writing anything else
+	 * to the terminal (exit notices, error lines) so output stays ordered.
+	 */
+	flushSync(): void;
+	/** Flush remaining bytes and stop accepting new ones. */
+	dispose(): void;
+}
+
+export function createWriteCoalescer(
+	write: (data: Uint8Array) => void,
+): WriteCoalescer {
+	let pending: Uint8Array[] = [];
+	let pendingBytes = 0;
+	let frameId: number | null = null;
+	let disposed = false;
+
+	function flushSync() {
+		if (frameId !== null) {
+			cancelAnimationFrame(frameId);
+			frameId = null;
+		}
+		if (pendingBytes === 0) return;
+		let batch: Uint8Array;
+		if (pending.length === 1) {
+			batch = pending[0] as Uint8Array;
+		} else {
+			batch = new Uint8Array(pendingBytes);
+			let offset = 0;
+			for (const chunk of pending) {
+				batch.set(chunk, offset);
+				offset += chunk.length;
+			}
+		}
+		pending = [];
+		pendingBytes = 0;
+		write(batch);
+	}
+
+	function push(chunk: Uint8Array) {
+		if (disposed) return;
+		pending.push(chunk);
+		pendingBytes += chunk.length;
+		if (pendingBytes > MAX_PENDING_BYTES) {
+			flushSync();
+			return;
+		}
+		if (frameId === null) {
+			frameId = requestAnimationFrame(() => {
+				frameId = null;
+				flushSync();
+			});
+		}
+	}
+
+	return {
+		push,
+		flushSync,
+		dispose() {
+			if (disposed) return;
+			flushSync();
+			disposed = true;
+		},
+	};
+}


### PR DESCRIPTION
## Problem

Addresses #2241 / #2244 for the v2 WebSocket terminal path.

Agent CLIs — Claude Code especially — emit full-screen repaints as many small PTY chunks. The v2 transport currently calls `terminal.write()` once per WebSocket frame with no batching anywhere in the pipeline (unlike the v1 IPC path, which at least has 16ms batching in the main process via `DataBatcher`). Each chunk triggers an xterm parse/render cycle, so during streaming output the renderer falls behind and scrolling turns visibly janky.

Real-world report: running Claude Code inside the Superset 2 beta, scrolling is laggy while the same session in a native GPU terminal (Warp) is smooth. Markdown/code views in Superset scroll fine — only the embedded terminal struggles, and only under streaming TUI output.

## Fix

Adds a small `write-coalescer` module and wires it into `terminal-ws-transport`:

- Incoming binary PTY frames are buffered and written to xterm as **one `write()` per `requestAnimationFrame`**, aligning parse/render cost with the display refresh rate regardless of chunk count — the fix suggested in #2241, applied to the v2 path.
- **Ordering is preserved**: control messages that write to the terminal (exit notice, invalid-payload line) and socket close flush pending bytes synchronously first.
- **Memory is bounded**: a 1MB pending cap flushes synchronously if rAF stalls (e.g. hidden window, where Electron throttles the renderer).
- Coalescer is recreated per `connect()` and disposed (with a final flush) on `disconnect`/`disposeTransport`.

## Tests

- 7 unit tests for the coalescer (same-frame coalescing, re-scheduling, sync flush, byte cap, dispose semantics, byte-order preservation).
- 3 transport-level tests (binary frames coalesce into one write; exit notice ordering; flush on socket close).
- `bun test src/renderer/lib/terminal/`: 234 pass / 1 fail — the failure ("recovers a half-open socket after the machine resumes from sleep") also fails on an untouched checkout of `main` in my environment, so it appears unrelated.
- Biome clean.

## Notes

- v1 (`useTerminalStream`) renderer-side coalescing is a natural follow-up using the same module; left out to keep this reviewable.
- The other half of the lag story for multi-tab users appears to be the module-level `suggestedRendererType` WebGL fallback (one context loss permanently downgrades all terminals to the DOM renderer until restart) — happy to look at that separately if useful.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces PTY output in the v2 WebSocket terminal path into one `xterm.write()` per animation frame to reduce parse/render churn and smooth scrolling. Addresses #2241 / #2244 by aligning terminal work with display refresh.

- **New Features**
  - Added a `write-coalescer` that batches incoming binary PTY frames and writes once per `requestAnimationFrame`.
  - Preserves output order by flushing before control messages that write to the terminal (exit notice, invalid-payload line) and on socket close; does not flush for non-writing controls.
  - Bounded memory with a 1 MB cap; cancels any scheduled frame on sync flush; coalescer is recreated on `connect()` and disposed on `disconnect`/`disposeTransport`.

<sup>Written for commit 895bb2eb8454c577ee938ff2a5f5ad5c6b1c57d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal PTY output handling by batching writes per animation frame, preserving output ordering during control messages and ensuring queued output flushes correctly on disconnect/close.

* **New Features**
  * Added a write coalescing utility to efficiently batch terminal writes and cap queued data to avoid excessive buffering.

* **Tests**
  * Added deterministic test suites covering write coalescing behavior and PTY output coalescing/flush ordering in the WebSocket transport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->