### PR TITLE
feat(desktop): add copy-logs button to failed CI checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ bun run clean:workspaces   # Clean all workspace node_modules
 7. **Always fix lint warnings before pushing** - CI fails on Biome warnings, not just errors (the lint script treats warnings as errors). Run `bun run lint:fix` after edits and verify `bun run lint` exits 0 before `git push`. Never push code that produces lint output, even auto-fixable formatting.
 8. **Linear ticket format** - all tickets (creation, drafting, grooming) follow `.agents/skills/ticket-format/SKILL.md`. Read that file before creating or grooming a ticket.
 9. **TanStack DB / Electric live queries are cache-first** - `useLiveQuery` can return persisted rows in `data` while the collection is still not `isReady`. Always render existing rows first. Use `isReady` only to decide what to show when no row/data exists yet: no data + not ready = loading/skeleton/null; no data + ready = empty/not-found. Never hide, blank, or replace existing `data` just because `isReady` is false or `isLoading` is true. This cache-first rendering rule does not apply to write/seeding side effects: wait for strict readiness before deriving missing rows or writing defaults, unless the write is provably idempotent.
+10. **PR titles are conventional commits** - PRs are squash-merged using the PR title as the commit subject, so every title needs a conventional-commit type and scope, e.g. `feat(desktop): add copy-logs button to failed CI checks` or `fix(host-service): guard against missing PR`.
 
 
 ---

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useReviewTab/components/ChecksSection/ChecksSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useReviewTab/components/ChecksSection/ChecksSection.tsx
@@ -4,10 +4,12 @@ import {
 	CollapsibleTrigger,
 } from "@superset/ui/collapsible";
 import { cn } from "@superset/ui/utils";
-import { useMemo, useState } from "react";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
 	LuArrowUpRight,
 	LuCheck,
+	LuClipboard,
 	LuLoaderCircle,
 	LuMinus,
 	LuX,
@@ -37,12 +39,14 @@ const checkSummaryIconConfig = {
 } as const;
 
 interface ChecksSectionProps {
+	workspaceId: string;
 	checks: NormalizedCheck[];
 	checksStatus: NormalizedPR["checksStatus"];
 	prUrl: string;
 }
 
 export function ChecksSection({
+	workspaceId,
 	checks,
 	checksStatus,
 	prUrl,
@@ -113,6 +117,7 @@ export function ChecksSection({
 					relevantChecks.map((check, index) => (
 						<CheckRow
 							key={`${check.name}-${index}`}
+							workspaceId={workspaceId}
 							check={check}
 							prUrl={prUrl}
 						/>
@@ -133,12 +138,28 @@ function resolveCheckUrl(
 	return undefined;
 }
 
-function CheckRow({ check, prUrl }: { check: NormalizedCheck; prUrl: string }) {
+function CheckRow({
+	workspaceId,
+	check,
+	prUrl,
+}: {
+	workspaceId: string;
+	check: NormalizedCheck;
+	prUrl: string;
+}) {
 	const { icon: CheckIcon, className } = checkIconConfig[check.status];
 	const checkUrl = resolveCheckUrl(check, prUrl);
+	// Mirror the server's guard: only failed github.com Actions job URLs have
+	// downloadable logs, so don't offer copy for non-GitHub CI checks.
+	const canCopyLogs =
+		check.status === "failure" &&
+		!!check.url &&
+		URL.canParse(check.url) &&
+		new URL(check.url).hostname === "github.com" &&
+		/\/job\/\d+/.test(check.url);
 
-	const inner = (
-		<div className="flex min-w-0 items-center gap-1 rounded-sm px-1.5 py-1 text-xs transition-colors hover:bg-accent/50">
+	const rowContent = (
+		<div className="flex min-w-0 flex-1 items-center gap-1 rounded-sm px-1.5 py-1 text-xs transition-colors hover:bg-accent/50">
 			<CheckIcon
 				className={cn(
 					"size-3 shrink-0",
@@ -160,16 +181,85 @@ function CheckRow({ check, prUrl }: { check: NormalizedCheck; prUrl: string }) {
 		</div>
 	);
 
-	return checkUrl ? (
-		<a
-			href={checkUrl}
-			target="_blank"
-			rel="noopener noreferrer"
-			className="group block"
+	// Keep the copy button a sibling of the link, never a child: nesting an
+	// interactive element inside an <a> is invalid HTML and breaks AT focus.
+	return (
+		<div className="group flex min-w-0 items-center gap-0.5">
+			{checkUrl ? (
+				<a
+					href={checkUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="block min-w-0 flex-1"
+				>
+					{rowContent}
+				</a>
+			) : (
+				rowContent
+			)}
+			{canCopyLogs && check.url && (
+				<CopyLogsButton workspaceId={workspaceId} detailsUrl={check.url} />
+			)}
+		</div>
+	);
+}
+
+function CopyLogsButton({
+	workspaceId,
+	detailsUrl,
+}: {
+	workspaceId: string;
+	detailsUrl: string;
+}) {
+	const utils = workspaceTrpc.useUtils();
+	const [state, setState] = useState<"idle" | "loading" | "copied" | "error">(
+		"idle",
+	);
+	const resetTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+	useEffect(() => () => clearTimeout(resetTimer.current), []);
+
+	const handleCopy = async () => {
+		if (state === "loading") return;
+		// Cancel a pending reset so it can't fire mid-flight on a quick re-click.
+		clearTimeout(resetTimer.current);
+		setState("loading");
+		try {
+			const { logs } = await utils.git.getCheckJobLogs.fetch({
+				workspaceId,
+				detailsUrl,
+			});
+			await navigator.clipboard.writeText(logs);
+			setState("copied");
+		} catch {
+			setState("error");
+		}
+		resetTimer.current = setTimeout(() => setState("idle"), 2000);
+	};
+
+	const Icon =
+		state === "loading"
+			? LuLoaderCircle
+			: state === "copied"
+				? LuCheck
+				: state === "error"
+					? LuX
+					: LuClipboard;
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			title="Copy job logs to clipboard"
+			aria-label="Copy job logs to clipboard"
+			className={cn(
+				"shrink-0 rounded-sm p-0.5 text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground",
+				"opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100",
+				state !== "idle" && "opacity-100",
+				state === "copied" && "text-emerald-600 dark:text-emerald-400",
+				state === "error" && "text-red-600 dark:text-red-400",
+			)}
 		>
-			{inner}
-		</a>
-	) : (
-		inner
+			<Icon className={cn("size-3", state === "loading" && "animate-spin")} />
+		</button>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useReviewTab/components/ReviewTabContent/ReviewTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useReviewTab/components/ReviewTabContent/ReviewTabContent.tsx
@@ -62,6 +62,7 @@ export const ReviewTabContent = memo(function ReviewTabContent({
 			<div className="my-1 border-b border-border/70" />
 
 			<ChecksSection
+				workspaceId={workspaceId}
 				checks={pr.checks}
 				checksStatus={pr.checksStatus}
 				prUrl={pr.url}

--- a/packages/host-service/src/trpc/router/git/get-check-job-logs.test.ts
+++ b/packages/host-service/src/trpc/router/git/get-check-job-logs.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import { TRPCError } from "@trpc/server";
+import type { HostServiceContext } from "../../../types";
+import { gitRouter } from "./git";
+
+const ACTIONS_URL =
+	"https://github.com/acme/widgets/actions/runs/42/job/123456";
+
+function createCaller(opts: {
+	workspace?: { pullRequestId: string | null };
+	pr?: { repoOwner: string; repoName: string };
+	logs?: string;
+}) {
+	const downloadCalls: Array<{ owner: string; repo: string; job_id: number }> =
+		[];
+	const ctx = {
+		isAuthenticated: true,
+		db: {
+			query: {
+				workspaces: {
+					findFirst: () => ({ sync: () => opts.workspace }),
+				},
+				pullRequests: {
+					findFirst: () => ({ sync: () => opts.pr }),
+				},
+			},
+		},
+		github: async () => ({
+			rest: {
+				actions: {
+					downloadJobLogsForWorkflowRun: async (args: {
+						owner: string;
+						repo: string;
+						job_id: number;
+					}) => {
+						downloadCalls.push(args);
+						return { data: opts.logs ?? "" };
+					},
+				},
+			},
+		}),
+	} as unknown as HostServiceContext;
+	return { caller: gitRouter.createCaller(ctx), downloadCalls };
+}
+
+async function expectTrpcError(promise: Promise<unknown>, code: string) {
+	try {
+		await promise;
+		throw new Error("expected the call to reject");
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+	}
+}
+
+describe("gitRouter.getCheckJobLogs", () => {
+	it("downloads logs for the PR's repo using the job id from the URL", async () => {
+		const { caller, downloadCalls } = createCaller({
+			workspace: { pullRequestId: "pr-1" },
+			pr: { repoOwner: "acme", repoName: "widgets" },
+			logs: "::group::build\nboom\n::endgroup::",
+		});
+
+		const result = await caller.getCheckJobLogs({
+			workspaceId: "ws-1",
+			detailsUrl: ACTIONS_URL,
+		});
+
+		expect(result.logs).toBe("::group::build\nboom\n::endgroup::");
+		expect(downloadCalls).toEqual([
+			{ owner: "acme", repo: "widgets", job_id: 123456 },
+		]);
+	});
+
+	it("rejects URLs that are not hosted on github.com", async () => {
+		const { caller, downloadCalls } = createCaller({
+			workspace: { pullRequestId: "pr-1" },
+			pr: { repoOwner: "acme", repoName: "widgets" },
+		});
+
+		await expectTrpcError(
+			caller.getCheckJobLogs({
+				workspaceId: "ws-1",
+				detailsUrl: "https://evil.example.com/acme/widgets/job/999",
+			}),
+			"BAD_REQUEST",
+		);
+		expect(downloadCalls).toHaveLength(0);
+	});
+
+	it("rejects github URLs without a job id", async () => {
+		const { caller } = createCaller({
+			workspace: { pullRequestId: "pr-1" },
+			pr: { repoOwner: "acme", repoName: "widgets" },
+		});
+
+		await expectTrpcError(
+			caller.getCheckJobLogs({
+				workspaceId: "ws-1",
+				detailsUrl: "https://github.com/acme/widgets/runs/42",
+			}),
+			"BAD_REQUEST",
+		);
+	});
+
+	it("returns NOT_FOUND when the workspace has no pull request", async () => {
+		const { caller } = createCaller({ workspace: { pullRequestId: null } });
+
+		await expectTrpcError(
+			caller.getCheckJobLogs({ workspaceId: "ws-1", detailsUrl: ACTIONS_URL }),
+			"NOT_FOUND",
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -572,6 +572,56 @@ export const gitRouter = router({
 			};
 		}),
 
+	getCheckJobLogs: queryProcedure
+		.meta({ timeoutMs: 30_000 })
+		.input(z.object({ workspaceId: z.string(), detailsUrl: z.string() }))
+		.query(async ({ ctx, input }) => {
+			const workspace = ctx.db.query.workspaces
+				.findFirst({ where: eq(workspaces.id, input.workspaceId) })
+				.sync();
+			if (!workspace?.pullRequestId) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace has no associated pull request",
+				});
+			}
+
+			const pr = ctx.db.query.pullRequests
+				.findFirst({ where: eq(pullRequests.id, workspace.pullRequestId) })
+				.sync();
+			if (!pr) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Pull request ${workspace.pullRequestId} not found in database`,
+				});
+			}
+
+			// GitHub Actions check details URLs look like
+			// https://github.com/<owner>/<repo>/actions/runs/<run_id>/job/<job_id>
+			const isGithubUrl =
+				URL.canParse(input.detailsUrl) &&
+				new URL(input.detailsUrl).hostname === "github.com";
+			const jobId = isGithubUrl
+				? input.detailsUrl.match(/\/job\/(\d+)/)?.[1]
+				: undefined;
+			if (!jobId) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Check is not a GitHub Actions job with downloadable logs",
+				});
+			}
+
+			const octokit = await ctx.github();
+			const { data } = await octokit.rest.actions.downloadJobLogsForWorkflowRun(
+				{
+					owner: pr.repoOwner,
+					repo: pr.repoName,
+					job_id: Number(jobId),
+				},
+			);
+			return { logs: typeof data === "string" ? data : String(data) };
+		}),
+
 	getPullRequestThreads: queryProcedure
 		.meta({ timeoutMs: 30_000 })
 		.input(z.object({ workspaceId: z.string() }))


### PR DESCRIPTION
## Description

- lets users copy a failed GitHub Actions job's logs to the clipboard from the review sidebar for pasting into a prompt
- adds a `getCheckJobLogs` query that parses the job id from the check `detailsUrl` and downloads logs via Octokit
- gated to failed Actions jobs; external CI checks lack downloadable logs so no button is shown

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Added/ran a unit test. Not figured out how to do manual testing/verification locally: would be grateful for pointers.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Copy logs” button to failed GitHub Actions checks in the review sidebar. Lets reviewers copy job logs to the clipboard for quick debugging.

- **New Features**
  - Show the button only for failed Actions jobs on `github.com` with a `/job/<id>` URL; hidden for external CI.
  - Added `git.getCheckJobLogs` to parse the `job_id`, validate the URL on the server, and download logs via Octokit; covered by unit tests.
  - UI shows loading/copied/error states, keeps the button as a sibling of the link for valid HTML and focus, and safely resets state with cleared timers on re-click/unmount.

<sup>Written for commit 4d035528dc44fc31d0827422a63f862f6b929b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Copy logs” action for failed checks to copy CI job logs directly to your clipboard, with clear visual states (loading, copied, error).
* **Bug Fixes**
  * Improved when the “Copy logs” option appears by validating the job URL format and ensuring it’s only offered for eligible GitHub-hosted job links; refined placement alongside the external link.
* **Tests**
  * Added backend and URL-eligibility test coverage for job log retrieval, including missing job IDs and missing associated pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->