### PR TITLE
fix(desktop): bump shell-quote to 1.8.4 (Dependabot #166)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -223,7 +223,7 @@
 		"remark-parse": "11.0.0",
 		"semver": "7.7.4",
 		"shell-env": "4.0.3",
-		"shell-quote": "1.8.3",
+		"shell-quote": "1.8.4",
 		"shiki": "3.23.0",
 		"simple-git": "3.36.0",
 		"streamdown": "2.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -299,7 +299,7 @@
         "remark-parse": "11.0.0",
         "semver": "7.7.4",
         "shell-env": "4.0.3",
-        "shell-quote": "1.8.3",
+        "shell-quote": "1.8.4",
         "shiki": "3.23.0",
         "simple-git": "3.36.0",
         "streamdown": "2.5.0",
@@ -1133,6 +1133,7 @@
     "axios": "1.14.0",
     "hono": "4.12.23",
     "kysely": "0.28.17",
+    "shell-quote": "1.8.4",
   },
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
@@ -5857,7 +5858,7 @@
 
     "shell-env": ["shell-env@4.0.3", "", { "dependencies": { "default-shell": "^2.0.0", "execa": "^5.1.1", "strip-ansi": "^7.0.1" } }, "sha512-Ioe5h+hCDZ7pKL5+JGzbtPvZ5ESMHePZ8nLxohlDL+twmlcmutttMhRkrQOed8DeLT8mkYBgbwZfohe8pqaA3g=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "sherif": ["sherif@1.11.0", "", { "optionalDependencies": { "sherif-darwin-arm64": "1.11.0", "sherif-darwin-x64": "1.11.0", "sherif-linux-arm64": "1.11.0", "sherif-linux-arm64-musl": "1.11.0", "sherif-linux-x64": "1.11.0", "sherif-linux-x64-musl": "1.11.0", "sherif-windows-arm64": "1.11.0", "sherif-windows-x64": "1.11.0" }, "bin": { "sherif": "index.js" } }, "sha512-JrStUXvTM4vZmeiF55/LczheOgKFvKMrtqbeTs7pCmQCKcAiD/9Jvv8/6fuhldt85clllDIJCQujijlBm72CTA=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
 	"overrides": {
 		"axios": "1.14.0",
 		"hono": "4.12.23",
-		"kysely": "0.28.17"
+		"kysely": "0.28.17",
+		"shell-quote": "1.8.4"
 	},
 	"trustedDependencies": [
 		"better-sqlite3",


### PR DESCRIPTION
## Summary

Resolves Dependabot critical alert #166: `shell-quote`'s `quote()` does not escape newlines in object `.op` values. Fixed in `shell-quote@1.8.4`.

- Bumped the direct dependency in `apps/desktop/package.json` from `1.8.3` → `1.8.4`.
- Added a root `overrides` entry forcing `shell-quote` to `1.8.4`, since transitive deps (`react-devtools-core`, `teen_process`) still pulled in `1.8.3`.
- Regenerated `bun.lock` — now resolves to a single `shell-quote@1.8.4`, zero `1.8.3` references.

No source changes needed — `1.8.4` is API-compatible, so existing `quote()`/`parse()` call sites are unaffected.

## Test Plan

- [ ] `bun install` resolves cleanly with no `shell-quote@1.8.3` in `bun.lock`
- [ ] Desktop app builds and terminal/preset launch commands work as before
- [ ] Dependabot alert #166 auto-closes after merge

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5267">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `shell-quote` to 1.8.4 to patch newline escaping in `quote()` and prevent malformed command construction in Desktop. Enforce the patched version via a root override so no packages resolve to 1.8.3 (addresses Dependabot alert #166).

- **Dependencies**
  - Bumped `apps/desktop` direct dep: `shell-quote` `1.8.3` → `1.8.4`.
  - Added root `overrides` for `shell-quote@1.8.4` and updated `bun.lock` to a single version.

<sup>Written for commit d381347672de4afee44e3aeacbba9907f4399339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to their latest patch versions for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->