### PR TITLE
fix(desktop): clean up stale closed worktree directories

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -27,6 +27,7 @@ import {
 	worktreeExists,
 } from "../utils/git";
 import { removeWorktreeFromDisk, runTeardown } from "../utils/teardown";
+import { shouldRemoveWorktreeDirectory } from "../utils/worktree-delete-policy";
 
 const normalizePath = (p: string): string => {
 	try {
@@ -511,6 +512,10 @@ export const createDeleteProcedures = () => {
 							worktree_path: worktree.path,
 							reason: "untracked_worktree_detected",
 						});
+					} else if (!shouldRemoveWorktreeDirectory(worktree)) {
+						console.warn(
+							`[worktree/delete] Preserving imported worktree directory at ${worktree.path}`,
+						);
 					} else {
 						if (exists) {
 							const teardownResult = await runTeardown({
@@ -535,7 +540,7 @@ export const createDeleteProcedures = () => {
 							}
 						}
 
-						if (exists) {
+						if (exists || existsSync(worktree.path)) {
 							const removeResult = await removeWorktreeFromDisk({
 								mainRepoPath: project.mainRepoPath,
 								worktreePath: worktree.path,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -550,7 +550,7 @@ export const createDeleteProcedures = () => {
 							}
 						} else {
 							console.warn(
-								`Worktree ${worktree.path} not found in git, skipping removal`,
+								`Worktree ${worktree.path} not found in git or on disk, skipping removal`,
 							);
 						}
 					}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -20,6 +20,7 @@ import {
 	isUnbornHeadError,
 	parsePorcelainStatusV2,
 	parsePrUrl,
+	removeWorktree,
 } from "./git";
 
 const TEST_DIR = join(
@@ -976,6 +977,42 @@ describe("hasUnpushedCommits", () => {
 			warnSpy.mockRestore();
 		}
 	});
+});
+
+describe("removeWorktree", () => {
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
+
+	test("removes stale leftover directory when git no longer tracks the worktree", async () => {
+		const repoPath = createTestRepo("remove-stale-worktree");
+		seedCommit(repoPath);
+
+		const worktreePath = join(TEST_DIR, "remove-stale-worktree-wt");
+		execSync(`git worktree add "${worktreePath}" -b feature/remove-stale`, {
+			cwd: repoPath,
+			stdio: "ignore",
+		});
+
+		rmSync(worktreePath, { recursive: true, force: true });
+		mkdirSync(join(worktreePath, ".vite"), { recursive: true });
+		writeFileSync(join(worktreePath, ".vite", "cache"), "leftover");
+
+		await removeWorktree(repoPath, worktreePath);
+
+		expect(existsSync(worktreePath)).toBe(false);
+		const worktreeList = execSync("git worktree list --porcelain", {
+			cwd: repoPath,
+			encoding: "utf-8",
+		});
+		expect(worktreeList).not.toContain(worktreePath);
+	}, 10_000);
 });
 
 describe("parsePrUrl", () => {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree-delete-policy.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree-delete-policy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { shouldRemoveWorktreeDirectory } from "./worktree-delete-policy";
+
+describe("shouldRemoveWorktreeDirectory", () => {
+	test("removes Superset-created worktrees from disk", () => {
+		expect(shouldRemoveWorktreeDirectory({ createdBySuperset: true })).toBe(
+			true,
+		);
+	});
+
+	test("preserves imported external worktrees on disk", () => {
+		expect(shouldRemoveWorktreeDirectory({ createdBySuperset: false })).toBe(
+			false,
+		);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree-delete-policy.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree-delete-policy.ts
@@ -1,0 +1,7 @@
+import type { SelectWorktree } from "@superset/local-db";
+
+export function shouldRemoveWorktreeDirectory(
+	worktree: Pick<SelectWorktree, "createdBySuperset">,
+): boolean {
+	return worktree.createdBySuperset;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -73,7 +73,9 @@ export function DeleteWorktreeDialog({
 							{isLoading ? (
 								"Checking status..."
 							) : !canDelete ? (
-								<span className="text-destructive">{reason}</span>
+								<span className="text-destructive select-text cursor-text">
+									{reason}
+								</span>
 							) : deletePresentation.isImported ? (
 								<span className="block">
 									This will remove the imported worktree from Superset. Its

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -11,6 +11,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useDeleteWorktree } from "renderer/react-query/workspaces/useDeleteWorktree";
 import { deleteWithToast } from "renderer/routes/_authenticated/components/TeardownLogsDialog";
+import { getWorktreeDeletePresentation } from "./worktree-delete-presentation";
 
 interface DeleteWorktreeDialogProps {
 	worktreeId: string;
@@ -52,10 +53,13 @@ export function DeleteWorktreeDialog({
 	const reason = canDeleteData?.reason;
 	const hasChanges = canDeleteData?.hasChanges ?? false;
 	const hasUnpushedCommits = canDeleteData?.hasUnpushedCommits ?? false;
-	const isImportedWorktree =
-		(canDeleteData?.worktree?.createdBySuperset ?? createdBySuperset) === false;
-	const hasWarnings = !isImportedWorktree && (hasChanges || hasUnpushedCommits);
-	const actionVerb = isImportedWorktree ? "Remove" : "Delete";
+	const deletePresentation = getWorktreeDeletePresentation(
+		canDeleteData?.worktree?.createdBySuperset ?? createdBySuperset,
+	);
+	const hasWarnings =
+		deletePresentation.removesFilesFromDisk &&
+		(hasChanges || hasUnpushedCommits);
+	const actionVerb = deletePresentation.actionVerb;
 
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -70,10 +74,15 @@ export function DeleteWorktreeDialog({
 								"Checking status..."
 							) : !canDelete ? (
 								<span className="text-destructive">{reason}</span>
-							) : isImportedWorktree ? (
+							) : deletePresentation.isImported ? (
 								<span className="block">
 									This will remove the imported worktree from Superset. Its
 									files will stay on disk.
+								</span>
+							) : deletePresentation.isUnknown ? (
+								<span className="block">
+									This will remove the worktree from Superset. Files will stay
+									on disk unless Superset confirms it owns this worktree.
 								</span>
 							) : (
 								<span className="block">
@@ -119,9 +128,11 @@ export function DeleteWorktreeDialog({
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent side="top" className="text-xs max-w-[200px]">
-							{isImportedWorktree
+							{deletePresentation.isImported
 								? "Remove imported worktree from Superset."
-								: "Permanently delete worktree from disk."}
+								: deletePresentation.isUnknown
+									? "Remove worktree from Superset."
+									: "Permanently delete worktree from disk."}
 						</TooltipContent>
 					</Tooltip>
 				</AlertDialogFooter>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -15,6 +15,7 @@ import { deleteWithToast } from "renderer/routes/_authenticated/components/Teard
 interface DeleteWorktreeDialogProps {
 	worktreeId: string;
 	worktreeName: string;
+	createdBySuperset: boolean | null;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }
@@ -22,6 +23,7 @@ interface DeleteWorktreeDialogProps {
 export function DeleteWorktreeDialog({
 	worktreeId,
 	worktreeName,
+	createdBySuperset,
 	open,
 	onOpenChange,
 }: DeleteWorktreeDialogProps) {
@@ -51,13 +53,16 @@ export function DeleteWorktreeDialog({
 	const hasChanges = canDeleteData?.hasChanges ?? false;
 	const hasUnpushedCommits = canDeleteData?.hasUnpushedCommits ?? false;
 	const hasWarnings = hasChanges || hasUnpushedCommits;
+	const isImportedWorktree =
+		(canDeleteData?.worktree?.createdBySuperset ?? createdBySuperset) === false;
+	const actionVerb = isImportedWorktree ? "Remove" : "Delete";
 
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
 			<AlertDialogContent className="max-w-[340px] gap-0 p-0">
 				<AlertDialogHeader className="px-4 pt-4 pb-2">
 					<AlertDialogTitle className="font-medium">
-						Delete worktree "{worktreeName}"?
+						{actionVerb} worktree "{worktreeName}"?
 					</AlertDialogTitle>
 					<AlertDialogDescription asChild>
 						<div className="text-muted-foreground space-y-1.5">
@@ -65,6 +70,11 @@ export function DeleteWorktreeDialog({
 								"Checking status..."
 							) : !canDelete ? (
 								<span className="text-destructive">{reason}</span>
+							) : isImportedWorktree ? (
+								<span className="block">
+									This will remove the imported worktree from Superset. Its
+									files will stay on disk.
+								</span>
 							) : (
 								<span className="block">
 									This will permanently delete the worktree and its files from
@@ -105,11 +115,13 @@ export function DeleteWorktreeDialog({
 								onClick={handleDelete}
 								disabled={!canDelete || isLoading}
 							>
-								Delete
+								{actionVerb}
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent side="top" className="text-xs max-w-[200px]">
-							Permanently delete worktree from disk.
+							{isImportedWorktree
+								? "Remove imported worktree from Superset."
+								: "Permanently delete worktree from disk."}
 						</TooltipContent>
 					</Tooltip>
 				</AlertDialogFooter>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -52,9 +52,9 @@ export function DeleteWorktreeDialog({
 	const reason = canDeleteData?.reason;
 	const hasChanges = canDeleteData?.hasChanges ?? false;
 	const hasUnpushedCommits = canDeleteData?.hasUnpushedCommits ?? false;
-	const hasWarnings = hasChanges || hasUnpushedCommits;
 	const isImportedWorktree =
 		(canDeleteData?.worktree?.createdBySuperset ?? createdBySuperset) === false;
+	const hasWarnings = !isImportedWorktree && (hasChanges || hasUnpushedCommits);
 	const actionVerb = isImportedWorktree ? "Remove" : "Delete";
 
 	return (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
@@ -22,6 +22,7 @@ import { DeleteWorkspaceDialog } from "../../WorkspaceSidebar/WorkspaceListItem/
 import type { WorkspaceItem } from "../types";
 import { getRelativeTime } from "../utils";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
+import { getWorktreeDeletePresentation } from "./worktree-delete-presentation";
 
 interface WorkspaceRowProps {
 	workspace: WorkspaceItem;
@@ -186,14 +187,13 @@ export function WorkspaceRow({
 	// Determine the delete/close action label based on workspace type and state
 	const isOpenWorkspace = workspace.workspaceId !== null;
 	const isClosedWorktree = !isOpenWorkspace && workspace.worktreeId !== null;
-	const isImportedClosedWorktree =
-		isClosedWorktree && workspace.createdBySuperset === false;
+	const deletePresentation = getWorktreeDeletePresentation(
+		workspace.createdBySuperset,
+	);
 	const actionLabel = isBranch
 		? "Close workspace"
 		: isClosedWorktree
-			? isImportedClosedWorktree
-				? "Remove worktree"
-				: "Delete worktree"
+			? deletePresentation.actionLabel
 			: "Delete workspace";
 
 	// Can delete open workspaces or closed worktrees

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
@@ -186,10 +186,14 @@ export function WorkspaceRow({
 	// Determine the delete/close action label based on workspace type and state
 	const isOpenWorkspace = workspace.workspaceId !== null;
 	const isClosedWorktree = !isOpenWorkspace && workspace.worktreeId !== null;
+	const isImportedClosedWorktree =
+		isClosedWorktree && workspace.createdBySuperset === false;
 	const actionLabel = isBranch
 		? "Close workspace"
 		: isClosedWorktree
-			? "Delete worktree"
+			? isImportedClosedWorktree
+				? "Remove worktree"
+				: "Delete worktree"
 			: "Delete workspace";
 
 	// Can delete open workspaces or closed worktrees
@@ -233,6 +237,7 @@ export function WorkspaceRow({
 				<DeleteWorktreeDialog
 					worktreeId={workspace.worktreeId}
 					worktreeName={workspace.name}
+					createdBySuperset={workspace.createdBySuperset}
 					open={showDeleteDialog}
 					onOpenChange={setShowDeleteDialog}
 				/>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/worktree-delete-presentation.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/worktree-delete-presentation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { getWorktreeDeletePresentation } from "./worktree-delete-presentation";
+
+describe("getWorktreeDeletePresentation", () => {
+	test("treats Superset-created worktrees as destructive deletes", () => {
+		expect(getWorktreeDeletePresentation(true)).toEqual({
+			actionLabel: "Delete worktree",
+			actionVerb: "Delete",
+			isImported: false,
+			isUnknown: false,
+			removesFilesFromDisk: true,
+		});
+	});
+
+	test("treats imported worktrees as non-destructive removes", () => {
+		expect(getWorktreeDeletePresentation(false)).toEqual({
+			actionLabel: "Remove worktree",
+			actionVerb: "Remove",
+			isImported: true,
+			isUnknown: false,
+			removesFilesFromDisk: false,
+		});
+	});
+
+	test("treats unknown ownership as non-destructive remove wording", () => {
+		expect(getWorktreeDeletePresentation(null)).toEqual({
+			actionLabel: "Remove worktree",
+			actionVerb: "Remove",
+			isImported: false,
+			isUnknown: true,
+			removesFilesFromDisk: false,
+		});
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/worktree-delete-presentation.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/worktree-delete-presentation.ts
@@ -1,0 +1,38 @@
+export interface WorktreeDeletePresentation {
+	actionLabel: "Remove worktree" | "Delete worktree";
+	actionVerb: "Remove" | "Delete";
+	isImported: boolean;
+	isUnknown: boolean;
+	removesFilesFromDisk: boolean;
+}
+
+export function getWorktreeDeletePresentation(
+	createdBySuperset: boolean | null | undefined,
+): WorktreeDeletePresentation {
+	switch (createdBySuperset) {
+		case true:
+			return {
+				actionLabel: "Delete worktree",
+				actionVerb: "Delete",
+				isImported: false,
+				isUnknown: false,
+				removesFilesFromDisk: true,
+			};
+		case false:
+			return {
+				actionLabel: "Remove worktree",
+				actionVerb: "Remove",
+				isImported: true,
+				isUnknown: false,
+				removesFilesFromDisk: false,
+			};
+		default:
+			return {
+				actionLabel: "Remove worktree",
+				actionVerb: "Remove",
+				isImported: false,
+				isUnknown: true,
+				removesFilesFromDisk: false,
+			};
+	}
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspacesListView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspacesListView.tsx
@@ -69,6 +69,7 @@ export function WorkspacesListView() {
 					createdAt: ws.createdAt,
 					isUnread: ws.isUnread,
 					isOpen: true,
+					createdBySuperset: ws.createdBySuperset,
 				});
 			}
 		}
@@ -98,6 +99,7 @@ export function WorkspacesListView() {
 					createdAt: wt.createdAt,
 					isUnread: false,
 					isOpen: false,
+					createdBySuperset: wt.createdBySuperset,
 				});
 			}
 		}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/types.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/types.ts
@@ -15,6 +15,7 @@ export interface WorkspaceItem {
 	createdAt: number;
 	isUnread: boolean;
 	isOpen: boolean;
+	createdBySuperset: boolean | null;
 }
 
 export interface ProjectGroup {


### PR DESCRIPTION
## Summary

- remove stale Superset-created closed worktree directories even when Git no longer tracks them as worktrees
- preserve imported/external worktree directories on delete and update the closed-worktree copy to say `Remove` instead of `Delete`
- add focused regression coverage for stale-directory cleanup and Superset-created vs imported worktree deletion policy

## Why

Desktop can keep a closed worktree row after Git's worktree registry and the on-disk folder drift apart. In that state, `git worktree list` no longer reports the path, but the directory still exists on disk, so the existing delete path skips filesystem cleanup and only removes Superset's record. Users then get stuck with leftover folders such as `.vite`/build-artifact remnants.

The fallback filesystem delete is intentionally limited to worktrees created by Superset. Imported worktrees are still removed only from Superset's local record and remain on disk.

## Scope and non-goals

This PR fixes the desktop/local closed-worktree delete path while Superset still has a `worktrees` DB row. In that covered state, Superset can now remove the leftover on-disk directory even if Git no longer reports it as a worktree.

This PR does not add a broader orphan-reconciliation system. If a previous release already removed Superset's DB row but left a Git worktree registered on disk, the closed-worktree UI no longer has a record to act on. Cleaning those already-orphaned entries would require a separate safe reconciliation flow that scans `git worktree list` and/or `~/.superset/worktrees`, then offers cleanup without risking imported user-owned checkouts.

## Related issue and PRs

Closes #4941 for the desktop/local closed-worktree delete path.

Related to #4942 and #5075, which cover host-service/v2 cleanup. This PR does not touch that host-service route; it covers the desktop tRPC closed-worktree route plus the renderer copy/safety around imported worktrees.

## Validation

- `bun test apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts -t "removes stale leftover directory when git no longer tracks the worktree"`
- `bun test apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree-delete-policy.test.ts`
- `bun run lint`
- `bun run --cwd apps/desktop typecheck`
- `bun run build`

Manual desktop repro:

- inserted a closed Superset-created worktree row whose path existed on disk but was absent from `git worktree list`
- opened Workspaces > Closed in the desktop app and deleted the stale row
- verified the row was removed from the local DB and the stale folder was removed from disk

Known local environment note: root `bun run typecheck` is blocked by unrelated `@superset/mobile` missing module/type-resolution errors in this checkout; the desktop package typecheck passes.
