### PR TITLE
fix(desktop): recover notifications when port is busy

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/auth/index.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/index.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const openExternalMock = mock((_url: string) => Promise.resolve());
+const stopAllMock = mock(() => {});
+const notificationsPortMock = mock(() => 43123);
+
+const realSharedConstants = await import("shared/constants");
+const realHostInfo = await import("@superset/shared/host-info");
+mock.module("shared/constants", () => ({
+	...realSharedConstants,
+	PLATFORM: {
+		...realSharedConstants.PLATFORM,
+		IS_LINUX: true,
+	},
+}));
+
+mock.module("electron", () => ({
+	shell: {
+		openExternal: openExternalMock,
+	},
+}));
+
+mock.module("main/env.main", () => ({
+	env: {
+		NEXT_PUBLIC_API_URL: "https://api.example.com",
+	},
+}));
+
+mock.module("main/lib/host-service-coordinator", () => ({
+	getHostServiceCoordinator: () => ({
+		stopAll: stopAllMock,
+	}),
+}));
+
+mock.module("main/lib/notifications/runtime-port", () => ({
+	getNotificationsPort: notificationsPortMock,
+}));
+
+mock.module("@superset/shared/host-info", () => ({
+	...realHostInfo,
+	getHostId: () => "host-1",
+	getHostName: () => "host-name",
+}));
+
+const { createAuthRouter } = await import("./index");
+
+describe("createAuthRouter signIn", () => {
+	beforeEach(() => {
+		openExternalMock.mockClear();
+		stopAllMock.mockClear();
+		notificationsPortMock.mockClear();
+	});
+
+	afterEach(() => {
+		openExternalMock.mockClear();
+		stopAllMock.mockClear();
+		notificationsPortMock.mockClear();
+	});
+
+	it("uses the runtime notifications port for the Linux local callback", async () => {
+		const caller = createAuthRouter().createCaller({});
+
+		const result = await caller.signIn({ provider: "github" });
+
+		expect(result).toEqual({ success: true });
+		expect(notificationsPortMock).toHaveBeenCalledTimes(1);
+		expect(openExternalMock).toHaveBeenCalledTimes(1);
+
+		const openedUrl = openExternalMock.mock.calls.at(0)?.[0];
+		expect(openedUrl).toBeDefined();
+
+		const connectUrl = new URL(String(openedUrl));
+
+		expect(connectUrl.searchParams.get("provider")).toBe("github");
+		expect(connectUrl.searchParams.get("local_callback")).toBe(
+			"http://127.0.0.1:43123/auth/callback",
+		);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/auth/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/index.ts
@@ -6,8 +6,8 @@ import { observable } from "@trpc/server/observable";
 import { shell } from "electron";
 import { env } from "main/env.main";
 import { getHostServiceCoordinator } from "main/lib/host-service-coordinator";
+import { getNotificationsPort } from "main/lib/notifications/runtime-port";
 import { PLATFORM, PROTOCOL_SCHEME } from "shared/constants";
-import { env as sharedEnv } from "shared/env.shared";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import {
@@ -94,7 +94,7 @@ export const createAuthRouter = () => {
 					if (PLATFORM.IS_LINUX) {
 						connectUrl.searchParams.set(
 							"local_callback",
-							`http://127.0.0.1:${sharedEnv.DESKTOP_NOTIFICATIONS_PORT}/auth/callback`,
+							`http://127.0.0.1:${getNotificationsPort()}/auth/callback`,
 						);
 					}
 					await shell.openExternal(connectUrl.toString());

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -25,6 +25,7 @@ import {
 	pollHealthCheck,
 } from "./host-service-utils";
 import { localDb } from "./local-db";
+import { getNotificationsPort } from "./notifications/runtime-port";
 import { getRelayUrl } from "./relay-url";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
 
@@ -465,7 +466,7 @@ export class HostServiceCoordinator extends EventEmitter {
 			DESKTOP_VITE_PORT: String(sharedEnv.DESKTOP_VITE_PORT),
 			SUPERSET_HOME_DIR: SUPERSET_HOME_DIR,
 			SUPERSET_LEGACY_WORKTREE_BASE_DIR: row?.worktreeBaseDir ?? "",
-			SUPERSET_AGENT_HOOK_PORT: String(sharedEnv.DESKTOP_NOTIFICATIONS_PORT),
+			SUPERSET_AGENT_HOOK_PORT: String(getNotificationsPort()),
 			SUPERSET_AGENT_HOOK_VERSION: HOOK_PROTOCOL_VERSION,
 			AUTH_TOKEN: config.authToken,
 			SUPERSET_AUTH_CONFIG_PATH: path.join(SUPERSET_HOME_DIR, "config.json"),

--- a/apps/desktop/src/main/lib/notifications/runtime-port.ts
+++ b/apps/desktop/src/main/lib/notifications/runtime-port.ts
@@ -1,0 +1,15 @@
+import { env } from "shared/env.shared";
+
+let notificationsPort = env.DESKTOP_NOTIFICATIONS_PORT;
+
+export function getNotificationsPort(): number {
+	return notificationsPort;
+}
+
+export function setNotificationsPort(port: number): void {
+	notificationsPort = port;
+}
+
+export function resetNotificationsPortForTests(): void {
+	notificationsPort = env.DESKTOP_NOTIFICATIONS_PORT;
+}

--- a/apps/desktop/src/main/lib/notifications/runtime-port.ts
+++ b/apps/desktop/src/main/lib/notifications/runtime-port.ts
@@ -9,7 +9,3 @@ export function getNotificationsPort(): number {
 export function setNotificationsPort(port: number): void {
 	notificationsPort = port;
 }
-
-export function resetNotificationsPortForTests(): void {
-	notificationsPort = env.DESKTOP_NOTIFICATIONS_PORT;
-}

--- a/apps/desktop/src/main/lib/notifications/start-server.test.ts
+++ b/apps/desktop/src/main/lib/notifications/start-server.test.ts
@@ -1,11 +1,9 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { createServer, type Server as NetServer } from "node:net";
 import express from "express";
+import { env } from "shared/env.shared";
 import { findFreePort } from "../host-service-utils";
-import {
-	getNotificationsPort,
-	resetNotificationsPortForTests,
-} from "./runtime-port";
+import { getNotificationsPort, setNotificationsPort } from "./runtime-port";
 import { startNotificationsServer } from "./start-server";
 
 const listeningServers: Array<{
@@ -44,13 +42,26 @@ function createNotificationsTestApp() {
 }
 
 afterEach(async () => {
+	const closeErrors: Error[] = [];
+
 	while (listeningServers.length > 0) {
 		const server = listeningServers.pop();
 		if (server) {
-			await closeServer(server);
+			try {
+				await closeServer(server);
+			} catch (error) {
+				closeErrors.push(
+					error instanceof Error ? error : new Error(String(error)),
+				);
+			}
 		}
 	}
-	resetNotificationsPortForTests();
+
+	setNotificationsPort(env.DESKTOP_NOTIFICATIONS_PORT);
+
+	if (closeErrors.length > 0) {
+		throw closeErrors[0];
+	}
 });
 
 describe("startNotificationsServer", () => {

--- a/apps/desktop/src/main/lib/notifications/start-server.test.ts
+++ b/apps/desktop/src/main/lib/notifications/start-server.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createServer, type Server as NetServer } from "node:net";
+import express from "express";
+import { findFreePort } from "../host-service-utils";
+import {
+	getNotificationsPort,
+	resetNotificationsPortForTests,
+} from "./runtime-port";
+import { startNotificationsServer } from "./start-server";
+
+const listeningServers: Array<{
+	close: (cb?: (error?: Error) => void) => void;
+}> = [];
+
+async function occupyPort(port: number): Promise<NetServer> {
+	const server = createServer();
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => resolve());
+	});
+	return server;
+}
+
+async function closeServer(server: {
+	close: (cb?: (error?: Error) => void) => void;
+}): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		server.close((error?: Error) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		});
+	});
+}
+
+function createNotificationsTestApp() {
+	const app = express();
+	app.get("/health", (_req, res) => {
+		res.json({ status: "ok" });
+	});
+	return app;
+}
+
+afterEach(async () => {
+	while (listeningServers.length > 0) {
+		const server = listeningServers.pop();
+		if (server) {
+			await closeServer(server);
+		}
+	}
+	resetNotificationsPortForTests();
+});
+
+describe("startNotificationsServer", () => {
+	it("binds the preferred port when it is available", async () => {
+		const preferredPort = await findFreePort();
+		const result = await startNotificationsServer(
+			createNotificationsTestApp(),
+			preferredPort,
+		);
+		listeningServers.push(result.server);
+
+		expect(result.port).toBe(preferredPort);
+		expect(result.usedFallbackPort).toBe(false);
+		expect(getNotificationsPort()).toBe(preferredPort);
+
+		const response = await fetch(`http://127.0.0.1:${result.port}/health`);
+		expect(response.ok).toBe(true);
+		expect(await response.json()).toEqual({ status: "ok" });
+	});
+
+	it("falls back to a free port when the preferred port is already in use", async () => {
+		const preferredPort = await findFreePort();
+		const blocker = await occupyPort(preferredPort);
+		listeningServers.push(blocker);
+
+		const result = await startNotificationsServer(
+			createNotificationsTestApp(),
+			preferredPort,
+		);
+		listeningServers.push(result.server);
+
+		expect(result.port).not.toBe(preferredPort);
+		expect(result.usedFallbackPort).toBe(true);
+		expect(getNotificationsPort()).toBe(result.port);
+
+		const response = await fetch(`http://127.0.0.1:${result.port}/health`);
+		expect(response.ok).toBe(true);
+		expect(await response.json()).toEqual({ status: "ok" });
+	});
+});

--- a/apps/desktop/src/main/lib/notifications/start-server.ts
+++ b/apps/desktop/src/main/lib/notifications/start-server.ts
@@ -70,7 +70,17 @@ export async function startNotificationsServer(
 		}
 
 		const retryPort = await findFreePort([preferredPort]);
-		const server = await listenOnPort(app, retryPort);
+		let server: Server;
+		try {
+			server = await listenOnPort(app, retryPort);
+		} catch (retryError) {
+			console.error(
+				`[notifications] Failed to start on fallback port ${retryPort}:`,
+				retryError,
+			);
+			throw retryError;
+		}
+
 		const port = getBoundPort(server);
 		setNotificationsPort(port);
 

--- a/apps/desktop/src/main/lib/notifications/start-server.ts
+++ b/apps/desktop/src/main/lib/notifications/start-server.ts
@@ -1,0 +1,95 @@
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Express } from "express";
+import { env } from "shared/env.shared";
+import { findFreePort } from "../host-service-utils";
+import { setNotificationsPort } from "./runtime-port";
+
+export interface NotificationsServerStartResult {
+	server: Server;
+	port: number;
+	preferredPort: number;
+	usedFallbackPort: boolean;
+}
+
+function getBoundPort(server: Server): number {
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("[notifications] Could not determine bound port");
+	}
+	return (address as AddressInfo).port;
+}
+
+function listenOnPort(app: Express, port: number): Promise<Server> {
+	return new Promise((resolve, reject) => {
+		const server = app.listen(port, "127.0.0.1");
+
+		const handleError = (error: Error) => {
+			server.off("listening", handleListening);
+			reject(error);
+		};
+
+		const handleListening = () => {
+			server.off("error", handleError);
+			resolve(server);
+		};
+
+		server.once("error", handleError);
+		server.once("listening", handleListening);
+	});
+}
+
+function isAddressInUse(error: unknown): error is NodeJS.ErrnoException {
+	return (
+		error instanceof Error && "code" in error && error.code === "EADDRINUSE"
+	);
+}
+
+export async function startNotificationsServer(
+	app: Express,
+	preferredPort = env.DESKTOP_NOTIFICATIONS_PORT,
+): Promise<NotificationsServerStartResult> {
+	try {
+		const server = await listenOnPort(app, preferredPort);
+		const port = getBoundPort(server);
+		setNotificationsPort(port);
+		console.log(`[notifications] Listening on http://127.0.0.1:${port}`);
+		return {
+			server,
+			port,
+			preferredPort,
+			usedFallbackPort: port !== preferredPort,
+		};
+	} catch (error) {
+		if (!isAddressInUse(error)) {
+			console.error(
+				`[notifications] Failed to start on port ${preferredPort}:`,
+				error,
+			);
+			throw error;
+		}
+
+		const retryPort = await findFreePort([preferredPort]);
+		const server = await listenOnPort(app, retryPort);
+		const port = getBoundPort(server);
+		setNotificationsPort(port);
+
+		if (port === preferredPort) {
+			console.warn(
+				`[notifications] Port ${preferredPort} was busy on first attempt but became available on retry`,
+			);
+		} else {
+			console.warn(
+				`[notifications] Port ${preferredPort} is in use; falling back to http://127.0.0.1:${port}`,
+			);
+		}
+
+		console.log(`[notifications] Listening on http://127.0.0.1:${port}`);
+		return {
+			server,
+			port,
+			preferredPort,
+			usedFallbackPort: port !== preferredPort,
+		};
+	}
+}

--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { setNotificationsPort } from "../notifications/runtime-port";
 import {
 	buildSafeEnv,
 	buildTerminalEnv,
@@ -706,6 +707,12 @@ describe("env", () => {
 				const result = buildTerminalEnv(baseParams);
 				expect(result.SUPERSET_PORT).toBeDefined();
 				expect(typeof result.SUPERSET_PORT).toBe("string");
+			});
+
+			it("should use the runtime notifications port", () => {
+				setNotificationsPort(43123);
+				const result = buildTerminalEnv(baseParams);
+				expect(result.SUPERSET_PORT).toBe("43123");
 			});
 
 			it("should preserve SUPERSET_HOME_DIR for app-launched hooks", () => {

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -6,7 +6,7 @@ import { env } from "shared/env.shared";
 import { getShellEnv } from "../agent-setup/shell-wrappers";
 import {
 	getNotificationsPort,
-	resetNotificationsPortForTests,
+	setNotificationsPort,
 } from "../notifications/runtime-port";
 
 const MACOS_SYSTEM_CERT_FILE = "/etc/ssl/cert.pem";
@@ -178,7 +178,7 @@ export function resetTerminalEnvCachesForTests(): void {
 	cachedMacosSystemCertAvailable = null;
 	cachedUtf8Locale = null;
 	localeProbeInFlight = false;
-	resetNotificationsPortForTests();
+	setNotificationsPort(env.DESKTOP_NOTIFICATIONS_PORT);
 }
 
 /**

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -4,6 +4,10 @@ import os from "node:os";
 import defaultShell from "default-shell";
 import { env } from "shared/env.shared";
 import { getShellEnv } from "../agent-setup/shell-wrappers";
+import {
+	getNotificationsPort,
+	resetNotificationsPortForTests,
+} from "../notifications/runtime-port";
 
 const MACOS_SYSTEM_CERT_FILE = "/etc/ssl/cert.pem";
 let cachedUtf8Locale: string | null = null;
@@ -174,6 +178,7 @@ export function resetTerminalEnvCachesForTests(): void {
 	cachedMacosSystemCertAvailable = null;
 	cachedUtf8Locale = null;
 	localeProbeInFlight = false;
+	resetNotificationsPortForTests();
 }
 
 /**
@@ -475,7 +480,7 @@ export function buildTerminalEnv(params: {
 		SUPERSET_WORKSPACE_NAME: workspaceName || "",
 		SUPERSET_WORKSPACE_PATH: workspacePath || "",
 		SUPERSET_ROOT_PATH: rootPath || "",
-		SUPERSET_PORT: String(env.DESKTOP_NOTIFICATIONS_PORT),
+		SUPERSET_PORT: String(getNotificationsPort()),
 		// Environment identifier for dev/prod separation
 		SUPERSET_ENV: env.NODE_ENV === "development" ? "development" : "production",
 		// Hook protocol version for forward compatibility

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -24,6 +24,7 @@ import {
 	notificationsApp,
 	notificationsEmitter,
 } from "../lib/notifications/server";
+import { startNotificationsServer } from "../lib/notifications/start-server";
 import {
 	extractWorkspaceIdFromUrl,
 	getNotificationTitle,
@@ -179,15 +180,7 @@ export async function MainWindow() {
 		});
 	}
 
-	const server = notificationsApp.listen(
-		env.DESKTOP_NOTIFICATIONS_PORT,
-		"127.0.0.1",
-		() => {
-			console.log(
-				`[notifications] Listening on http://127.0.0.1:${env.DESKTOP_NOTIFICATIONS_PORT}`,
-			);
-		},
-	);
+	const { server } = await startNotificationsServer(notificationsApp);
 
 	const notificationManager = new NotificationManager({
 		isSupported: () => Notification.isSupported(),


### PR DESCRIPTION
Closes #4133

## Summary
- add a resilient desktop notifications server startup helper that retries on `EADDRINUSE` and falls back to a free localhost port
- store the live notifications port in a main-process runtime registry instead of assuming `DESKTOP_NOTIFICATIONS_PORT` always won the bind
- propagate that runtime port into terminal env, Linux OAuth `local_callback`, and host-service child env so agent hooks target the listener that is actually running
- add focused regression coverage for notifications startup fallback, terminal env propagation, and Linux auth callback generation

## Why
Desktop currently starts the local notifications server with a fixed port and no recovery path when that port is already busy. In the reproduced failure mode, the app still launches, but the hook server never owns the requested port, so agent completion notifications silently stop working for that app session.

## User Impact
- desktop no longer comes up in a silently broken notifications state when the preferred notifications port is occupied
- newly spawned terminal sessions target the live hook server instead of timing out against the dead/preempted port
- Linux OAuth callback URLs also target the live listener, so the localhost fallback stays aligned with the running server

## Root Cause
The main process bound the notifications Express app directly to `env.DESKTOP_NOTIFICATIONS_PORT` and other code paths independently reused that same static env value. When the preferred port was unavailable, the listener never recovered, while downstream hook producers still targeted the stale configured port.

## Related
- related to #3931, which covers the companion v2 hook URL propagation issue

## Validation
- `bun test apps/desktop/src/main/lib/notifications/start-server.test.ts apps/desktop/src/main/lib/terminal/env.test.ts apps/desktop/src/lib/trpc/routers/auth/index.test.ts`
- `bun run lint`
- `bun run --cwd apps/desktop typecheck`
- `bun run build`

## Manual Repro
- occupied the configured notifications port locally with a dummy Python listener before launching desktop
- verified the old occupied port still timed out on `/health`
- launched desktop on this branch and confirmed Superset rebound notifications onto a fallback localhost port
- verified the fallback port responded successfully on `/health`
- verified a real `/hook/complete` request succeeded against the fallback port


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Desktop notifications server now dynamically starts on an available local port, automatically falling back if the preferred port is in use.
  * Terminal and authentication flows now align with the same runtime-managed notifications port for consistent local callback and environment configuration.
* **Tests**
  * Added Bun tests for the notifications server startup behavior and Linux sign-in URL construction, including verification of provider and local callback query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->