### PR TITLE
fix(desktop): paste images into the new workspace prompt

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -175,6 +175,25 @@ function isMarkdownTable(text: string): boolean {
 	return /^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(lines[1]);
 }
 
+function getClipboardFiles(data: DataTransfer | null): File[] {
+	if (!data) return [];
+
+	const files = Array.from(data.files ?? []);
+	const fileKeys = new Set(files.map((file) => `${file.name}:${file.size}`));
+
+	for (const item of Array.from(data.items ?? [])) {
+		if (item.kind !== "file") continue;
+		const file = item.getAsFile();
+		if (!file) continue;
+		const key = `${file.name}:${file.size}`;
+		if (fileKeys.has(key)) continue;
+		fileKeys.add(key);
+		files.push(file);
+	}
+
+	return files;
+}
+
 export function MarkdownEditor({
 	content,
 	onSave,
@@ -339,10 +358,7 @@ export function MarkdownEditor({
 			handlePaste: (_, event) => {
 				const onPasteFiles = onPasteFilesRef.current;
 				if (onPasteFiles) {
-					const files = Array.from(event.clipboardData?.items ?? [])
-						.filter((item) => item.kind === "file")
-						.map((item) => item.getAsFile())
-						.filter((file): file is File => file != null);
+					const files = getClipboardFiles(event.clipboardData);
 					if (files.length > 0) {
 						event.preventDefault();
 						onPasteFiles(files);

--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -143,6 +143,8 @@ interface MarkdownEditorProps {
 	onModEnter?: () => void;
 	/** If provided, enables @-mention file search for the editor. */
 	searchFiles?: FileMentionSearchFn;
+	/** If provided, pasted file items (e.g. clipboard images) are forwarded here. */
+	onPasteFiles?: (files: File[]) => void;
 	/** Toggle optional affordances. Each defaults to enabled. */
 	features?: {
 		slashCommand?: boolean;
@@ -183,6 +185,7 @@ export function MarkdownEditor({
 	editorClassName,
 	onModEnter,
 	searchFiles,
+	onPasteFiles,
 	features,
 }: MarkdownEditorProps) {
 	const showSlashCommand = features?.slashCommand ?? true;
@@ -194,6 +197,8 @@ export function MarkdownEditor({
 	// Thread through a ref so the extension reads the live callback each fire.
 	const searchFilesRef = useRef(searchFiles);
 	searchFilesRef.current = searchFiles;
+	const onPasteFilesRef = useRef(onPasteFiles);
+	onPasteFilesRef.current = onPasteFiles;
 	const editorRef = useRef<Editor | null>(null);
 
 	const urlPolicy = useInlineUrlPolicy();
@@ -332,6 +337,18 @@ export function MarkdownEditor({
 				return false;
 			},
 			handlePaste: (_, event) => {
+				const onPasteFiles = onPasteFilesRef.current;
+				if (onPasteFiles) {
+					const files = Array.from(event.clipboardData?.items ?? [])
+						.filter((item) => item.kind === "file")
+						.map((item) => item.getAsFile())
+						.filter((file): file is File => file != null);
+					if (files.length > 0) {
+						event.preventDefault();
+						onPasteFiles(files);
+						return true;
+					}
+				}
 				const text = event.clipboardData?.getData("text/plain") ?? "";
 				const currentEditor = editorRef.current;
 				if (!currentEditor || !isMarkdownTable(text)) {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -435,6 +435,7 @@ export function PromptGroup({
 					key={resetKey}
 					content={prompt}
 					onChange={(markdown) => updateDraft({ prompt: markdown })}
+					onPasteFiles={(files) => attachments.add(files)}
 					autoFocus="start"
 					placeholder="What do you want to do?"
 					className="flex flex-col min-h-[100px] max-h-[200px] px-3 pt-3"


### PR DESCRIPTION
## Description

pasting a screenshot into the dashboard "New Workspace" prompt (the "What do you want to do?" box) did nothing. This adds an optional onPasteFiles hook to the MarkdownEditor that pulls file items off the clipboard, and wires it into the modal so pasted images go to the same attachments.add the paperclip button uses. 

Now, a pasted screenshot shows up as an attachment pill, same as picking it from the file dialog. 18 lines, the editor change is gated behind an optional prop so the ~12 other call sites are untouched.

## Related Issues

fixes #5282 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

take a look at the image below: open the dashboard New Workspace modal, paste a screenshot into "What do you want to do?", it renders as a attachment pill. Created a workspace from it and confirmed the agent received the image and could describe it back.

## Screenshots (if applicable)

<img width="946" height="564" alt="image" src="https://github.com/user-attachments/assets/3ec7bd25-cfaf-42df-93bc-c26f3644c16d" />
<img width="880" height="688" alt="image" src="https://github.com/user-attachments/assets/f0279e12-a153-4c1f-8eb9-4dcf85688c50" />

## Additional Notes

consdier making pasted images come in as a native [Image #1] instead of a file ref, but that's a bigger agent-specific change, so I left it as the file-ref path that already works across every agent.

<!-- Add any other context about the PR here -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5283">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable pasting images into the dashboard “New Workspace” prompt. Pasted screenshots show as attachment pills and send like files from the paperclip.

- **Bug Fixes**
  - Added optional `onPasteFiles` to the Markdown editor to read clipboard files from `DataTransfer.files` and `DataTransfer.items` and de‑dupe.
  - Wired it in the New Workspace prompt to call `attachments.add(files)`.
  - Opt-in only; other editor instances are unchanged.

<sup>Written for commit fab3b5bd2787f992f87c7040d11aee09658f41e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pasting files into markdown editors via an optional file-paste handler.
  * When files are present in the clipboard, paste is intercepted to add those files directly to the editor’s attachment flow (with duplicates filtered), improving reliability during composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->