### PR TITLE
fix: stop claiming kitty terminal program to prevent Claude questions…

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -658,9 +658,9 @@ describe("env", () => {
 		});
 
 		describe("terminal metadata", () => {
-			it("should set TERM_PROGRAM to kitty", () => {
+			it("should set TERM_PROGRAM to superset", () => {
 				const result = buildTerminalEnv(baseParams);
-				expect(result.TERM_PROGRAM).toBe("kitty");
+				expect(result.TERM_PROGRAM).toBe("superset");
 			});
 
 			it("should set COLORTERM to truecolor", () => {

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -464,6 +464,10 @@ export function buildTerminalEnv(params: {
 	const terminalEnv: Record<string, string> = {
 		...baseEnv,
 		...shellEnv,
+		// We claim "superset" instead of "kitty" to prevent chat TUIs (e.g. Claude Code)
+		// from enabling the full kitty keyboard protocol, which CSI-u encodes ALL keys
+		// including arrows and corrupts interactive TUI prompts. Cmd+Enter newlines are
+		// handled via xterm's custom key event handler translating them to \x1b\r.
 		TERM_PROGRAM: "superset",
 		TERM_PROGRAM_VERSION: process.env.npm_package_version || "1.0.0",
 		COLORTERM: "truecolor",

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -464,7 +464,7 @@ export function buildTerminalEnv(params: {
 	const terminalEnv: Record<string, string> = {
 		...baseEnv,
 		...shellEnv,
-		TERM_PROGRAM: "kitty",
+		TERM_PROGRAM: "superset",
 		TERM_PROGRAM_VERSION: process.env.npm_package_version || "1.0.0",
 		COLORTERM: "truecolor",
 		COLORFGBG: colorFgBg,

--- a/apps/desktop/src/renderer/lib/terminal/line-edit-translations.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/line-edit-translations.test.ts
@@ -39,4 +39,81 @@ describe("translateLineEditChord", () => {
 			}),
 		).toBeNull();
 	});
+
+	it("Cmd+Enter translation is independent of TERM_PROGRAM", () => {
+		// This test verifies that Cmd+Enter newline handling works via xterm's
+		// custom key event handler (translateLineEditChord), which is independent
+		// of the TERM_PROGRAM environment variable. This ensures that changing
+		// TERM_PROGRAM from "kitty" to "superset" (to prevent Claude Code from
+		// enabling the full kitty keyboard protocol) does not break Cmd+Enter
+		// newline functionality in chat TUIs.
+		const result = translateLineEditChord(
+			event({ key: "Enter", metaKey: true }),
+			{ isMac: true, isWindows: false },
+		);
+		expect(result).toBe("\x1b\r");
+	});
+
+	it("maps Mac Cmd+Backspace to delete-word-left sequence", () => {
+		expect(
+			translateLineEditChord(event({ key: "Backspace", metaKey: true }), {
+				isMac: true,
+				isWindows: false,
+			}),
+		).toBe("\x15\x1b[D");
+	});
+
+	it("maps Mac Cmd+ArrowLeft to move-to-start-of-line", () => {
+		expect(
+			translateLineEditChord(event({ key: "ArrowLeft", metaKey: true }), {
+				isMac: true,
+				isWindows: false,
+			}),
+		).toBe("\x01");
+	});
+
+	it("maps Mac Cmd+ArrowRight to move-to-end-of-line", () => {
+		expect(
+			translateLineEditChord(event({ key: "ArrowRight", metaKey: true }), {
+				isMac: true,
+				isWindows: false,
+			}),
+		).toBe("\x05");
+	});
+
+	it("maps Mac Alt+ArrowLeft to backward-word", () => {
+		expect(
+			translateLineEditChord(event({ key: "ArrowLeft", altKey: true }), {
+				isMac: true,
+				isWindows: false,
+			}),
+		).toBe("\x1bb");
+	});
+
+	it("maps Mac Alt+ArrowRight to forward-word", () => {
+		expect(
+			translateLineEditChord(event({ key: "ArrowRight", altKey: true }), {
+				isMac: true,
+				isWindows: false,
+			}),
+		).toBe("\x1bf");
+	});
+
+	it("maps Windows Ctrl+ArrowLeft to backward-word", () => {
+		expect(
+			translateLineEditChord(event({ key: "ArrowLeft", ctrlKey: true }), {
+				isMac: false,
+				isWindows: true,
+			}),
+		).toBe("\x1bb");
+	});
+
+	it("maps Windows Ctrl+ArrowRight to forward-word", () => {
+		expect(
+			translateLineEditChord(event({ key: "ArrowRight", ctrlKey: true }), {
+				isMac: false,
+				isWindows: true,
+			}),
+		).toBe("\x1bf");
+	});
 });

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -420,7 +420,7 @@ describe("buildV2TerminalEnv", () => {
 		const env = buildV2TerminalEnv(baseParams);
 		expect(env).toMatchObject({
 			TERM: "xterm-256color",
-			TERM_PROGRAM: "kitty",
+			TERM_PROGRAM: "superset",
 			TERM_PROGRAM_VERSION: "2.0.0",
 			COLORTERM: "truecolor",
 			PWD: "/tmp/workspace",
@@ -432,7 +432,7 @@ describe("buildV2TerminalEnv", () => {
 			SUPERSET_AGENT_HOOK_PORT: "51741",
 			SUPERSET_AGENT_HOOK_VERSION: "2",
 		});
-		expect(env.TERM_PROGRAM).toBe("kitty");
+		expect(env.TERM_PROGRAM).toBe("superset");
 		expect(env.SHELL).toBe("/bin/zsh");
 		expect(env.LANG).toContain("UTF-8");
 	});

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -170,11 +170,13 @@ export function buildV2TerminalEnv(
 
 	env.TERM = "xterm-256color";
 	env.SHELL = shell;
-	// claude-code and similar chat TUIs only parse kitty CSI-u (e.g. Shift+Enter
-	// → \x1b[13;2u) when TERM_PROGRAM ∈ {ghostty, kitty, iTerm.app, WezTerm,
-	// WarpTerminal}. xterm.js already emits the right bytes — claim kitty so
-	// they're parsed instead of submitted as plain Enter.
-	env.TERM_PROGRAM = "kitty";
+	// We used to claim kitty here so chat TUIs would parse kitty CSI-u (Shift+Enter
+	// → \x1b[13;2u). That caused Claude Code to enable the full kitty keyboard
+	// protocol, which CSI-u encodes ALL keys including arrows, making interactive
+	// TUI prompts invisible on arrow key press. Use "superset" instead — programs
+	// won't enable the full kitty protocol, and Cmd+Enter for newlines is handled
+	// via xterm's custom key event handler translating it to \x1b\r.
+	env.TERM_PROGRAM = "superset";
 	env.TERM_PROGRAM_VERSION = hostServiceVersion;
 	env.COLORTERM = "truecolor";
 	env.COLORFGBG = themeType === "light" ? "0;15" : "15;0";


### PR DESCRIPTION
## Description

Fixes Claude Code interactive questions becoming invisible when pressing arrow down in the terminal. The root cause is that `TERM_PROGRAM=kitty` caused Claude Code to enable the full Kitty keyboard protocol, which made xterm.js CSI-u encode ALL keys including arrows. In Claude's TUI prompts, the CSI-u encoded ArrowDown corrupted the terminal state, making the question vanish.

## Related Issues

Fixes #5238

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Verified by running `biome check` across all changed files — no lint issues.

Manual verification steps:
1. Open a terminal in Superset
2. Run `claude` and wait for a question prompt (e.g., file selection)
3. Press ArrowDown to navigate options — the question stays visible and navigation works
4. Press Cmd+Enter — newline insertion still works via `line-edit-translations.ts`

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src/main/lib/terminal/env.ts:467` | `TERM_PROGRAM: "kitty"` → `"superset"` |
| `apps/desktop/src/main/lib/terminal/env.test.ts:663` | Updated assertion |
| `packages/host-service/src/terminal/env.ts:179` | `TERM_PROGRAM = "kitty"` → `"superset"` + updated comment |
| `packages/host-service/src/terminal/env.test.ts:423,435` | Updated both assertions |


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5291">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop claiming the `kitty` terminal program by setting `TERM_PROGRAM` to `superset`, fixing Claude Code prompts that disappeared when pressing ArrowDown. Cmd+Enter newline behavior remains via `xterm.js` key translation. Fixes #5238.

- **Bug Fixes**
  - Added comprehensive line-edit translation tests and an explanatory comment; verifies Cmd+Enter is independent of `TERM_PROGRAM` and covers Cmd+Backspace and Cmd/Alt/Ctrl+Arrow mappings on macOS and Windows.

<sup>Written for commit 2d3525e9c3c9c1d1b275b639c6a9b09d35370347. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated terminal environment reporting so `TERM_PROGRAM` is now set to `"superset"` (instead of `"kitty"`) across desktop and host terminal environments.
* **Tests**
  * Expanded line-edit chord translation coverage for macOS and Windows, including confirmation that `Cmd+Enter` newline behavior is independent of `TERM_PROGRAM`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->