### PR TITLE
chore(cli): bump version to 0.2.23 — fix #5294 stale binary version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.22",
+	"version": "0.2.23",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## What

Bumps `@superset/cli` to **0.2.23** and cuts a clean release.

## Why (#5294)

The `cli-v0.2.22` release shipped binaries that report `0.2.19` (verified by downloading the darwin-arm64 asset: `superset --version` → `0.2.19`). Root cause: at that tag, `packages/cli/cli.config.ts` had a **hardcoded** `const VERSION = "0.2.19"` that had drifted from `package.json`. Because the rolling `cli-latest/version.txt` is derived from the *tag* (correctly `0.2.22`), `superset update --check` compares `0.2.19` (binary) vs `0.2.22` (latest) and is permanently stuck on 'update available'.

The hardcode is **already fixed on `main`** — `cli.config.ts` now derives `const VERSION = pkg.version`. So all that's needed to unstick users is a clean version bump + fresh tag: the build will bake the correct version, the new `version.txt` will advertise it, and stuck `0.2.19` binaries will update normally.

## Release

After merge, cut the `cli-v0.2.23` tag to trigger `release-cli.yml`.

Closes #5294

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@superset/cli` to 0.2.23 to ship a clean binary that reports the correct version. This resolves stale update checks from `cli-v0.2.22` and unblocks users stuck on binaries reporting 0.2.19 (fixes #5294).

<sup>Written for commit 3d8693f4156b232e731f260ee4192ebf8b9e2836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->