### PR TITLE
chore(deps): patch Dependabot security alerts (hono, vite, ua-parser-js)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -271,7 +271,7 @@
 		"tailwindcss": "4.2.2",
 		"tsx": "4.21.0",
 		"typescript": "6.0.3",
-		"vite": "7.3.2",
+		"vite": "7.3.5",
 		"vite-tsconfig-paths": "5.1.4"
 	}
 }

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -42,7 +42,7 @@
 		"simplex-noise": "4.0.3",
 		"stripe-gradient": "1.0.1",
 		"three": "0.181.2",
-		"ua-parser-js": "2.0.9",
+		"ua-parser-js": "2.0.10",
 		"zod": "4.3.6"
 	},
 	"devDependencies": {

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -18,7 +18,7 @@
 		"@t3-oss/env-core": "0.13.11",
 		"@trpc/client": "11.16.0",
 		"@upstash/redis": "1.37.0",
-		"hono": "4.12.23",
+		"hono": "4.12.25",
 		"jose": "6.2.2",
 		"lru-cache": "11.2.7",
 		"superjson": "2.2.6",

--- a/bun.lock
+++ b/bun.lock
@@ -347,7 +347,7 @@
         "tailwindcss": "4.2.2",
         "tsx": "4.21.0",
         "typescript": "6.0.3",
-        "vite": "7.3.2",
+        "vite": "7.3.5",
         "vite-tsconfig-paths": "5.1.4",
       },
     },
@@ -438,7 +438,7 @@
         "simplex-noise": "4.0.3",
         "stripe-gradient": "1.0.1",
         "three": "0.181.2",
-        "ua-parser-js": "2.0.9",
+        "ua-parser-js": "2.0.10",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -578,7 +578,7 @@
         "@t3-oss/env-core": "0.13.11",
         "@trpc/client": "11.16.0",
         "@upstash/redis": "1.37.0",
-        "hono": "4.12.23",
+        "hono": "4.12.25",
         "jose": "6.2.2",
         "lru-cache": "11.2.7",
         "superjson": "2.2.6",
@@ -687,7 +687,7 @@
         "@trpc/client": "11.16.0",
         "@trpc/server": "11.16.0",
         "ai": "6.0.141",
-        "hono": "4.12.23",
+        "hono": "4.12.25",
         "mastracode": "0.18.1",
         "superjson": "2.2.6",
         "zod": "4.3.6",
@@ -708,7 +708,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -809,7 +809,7 @@
         "@xterm/headless": "6.1.0-beta.220",
         "better-sqlite3": "12.6.2",
         "drizzle-orm": "0.45.2",
-        "hono": "4.12.23",
+        "hono": "4.12.25",
         "mastracode": "0.18.1",
         "mime-types": "3.0.2",
         "node-pty": "1.1.0",
@@ -1131,7 +1131,7 @@
   ],
   "overrides": {
     "axios": "1.14.0",
-    "hono": "4.12.23",
+    "hono": "4.12.25",
     "kysely": "0.28.17",
     "shell-quote": "1.8.4",
   },
@@ -4536,7 +4536,7 @@
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
 
     "hono-openapi": ["hono-openapi@1.3.0", "", { "peerDependencies": { "@hono/standard-validator": "^0.2.0", "@standard-community/standard-json": "^0.3.5", "@standard-community/standard-openapi": "^0.2.9", "@types/json-schema": "^7.0.15", "hono": "^4.8.3", "openapi-types": "^12.1.3" }, "optionalPeers": ["@hono/standard-validator", "hono"] }, "sha512-xDvCWpWEIv0weEmnl3EjRQzqbHIO8LnfzMuYOCmbuyE5aes6aXxLg4vM3ybnoZD5TiTUkA6PuRQPJs3R7WRBig=="],
 
@@ -6200,7 +6200,7 @@
 
     "ua-is-frozen": ["ua-is-frozen@0.1.2", "", {}, "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw=="],
 
-    "ua-parser-js": ["ua-parser-js@2.0.9", "", { "dependencies": { "detect-europe-js": "^0.1.2", "is-standalone-pwa": "^0.1.1", "ua-is-frozen": "^0.1.2" }, "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w=="],
+    "ua-parser-js": ["ua-parser-js@2.0.10", "", { "dependencies": { "detect-europe-js": "^0.1.2", "is-standalone-pwa": "^0.1.1", "ua-is-frozen": "^0.1.2" }, "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -6318,7 +6318,7 @@
 
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
 
-    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+    "vite": ["vite@7.3.5", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 
@@ -7650,6 +7650,8 @@
 
     "vite/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
+    "vite/postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
     "vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
     "wait-port/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -8767,6 +8769,8 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "wait-port/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	],
 	"overrides": {
 		"axios": "1.14.0",
-		"hono": "4.12.23",
+		"hono": "4.12.25",
 		"kysely": "0.28.17",
 		"shell-quote": "1.8.4"
 	},

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -44,7 +44,7 @@
 		"@trpc/client": "11.16.0",
 		"@trpc/server": "11.16.0",
 		"ai": "6.0.141",
-		"hono": "4.12.23",
+		"hono": "4.12.25",
 		"mastracode": "0.18.1",
 		"superjson": "2.2.6",
 		"zod": "4.3.6"

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -74,7 +74,7 @@
 		"@xterm/headless": "6.1.0-beta.220",
 		"better-sqlite3": "12.6.2",
 		"drizzle-orm": "0.45.2",
-		"hono": "4.12.23",
+		"hono": "4.12.25",
 		"mastracode": "0.18.1",
 		"mime-types": "3.0.2",
 		"node-pty": "1.1.0",


### PR DESCRIPTION
## Summary
Resolves all **18 open Dependabot alerts** on `superset-sh/superset` (#167–184) via patch-level version bumps.

| Package | Change | Manifests | Severity |
|---|---|---|---|
| `hono` | `4.12.23` → `4.12.25` | host-service, chat, relay + root `overrides` | high (CORS wildcard + credentials) + 4 medium |
| `vite` | `7.3.2` → `7.3.5` | desktop | high (`server.fs.deny` bypass) + medium (launch-editor NTLMv2) |
| `ua-parser-js` | `2.0.9` → `2.0.10` | marketing | medium (ReDoS in `withClientHints`) |

The root `overrides` block was force-pinning `hono` to `4.12.23` across the whole tree, so it had to be bumped too for the lockfile to re-resolve.

## Notes
- All bumps are patch-level within the same minor — low risk, no code changes.
- `bun install` re-resolved the lockfile; `bun run lint` passes.
- The remaining `ua-parser-js@0.7.41` in the lockfile is an unrelated transitive (outside the flagged `2.0.x` range).

## Out of scope
The 4 high-severity **Drizzle ORM** alerts (#1–4) are in the separate `superset-sh/domains` repo (`0.38.3 → 0.45.2`, a larger upgrade) and are not addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches security updates to resolve 18 Dependabot alerts by bumping `hono`, `vite`, and `ua-parser-js`. Also updates the root `overrides` for `hono` so the lockfile re-resolves; no app code changes.

- **Dependencies**
  - `hono`: 4.12.23 → 4.12.25 in `packages/host-service`, `packages/chat`, `apps/relay`, and root `overrides` (fixes CORS wildcard+credentials and related issues).
  - `vite`: 7.3.2 → 7.3.5 in `apps/desktop` (fixes `server.fs.deny` bypass and launch-editor NTLMv2 disclosure).
  - `ua-parser-js`: 2.0.9 → 2.0.10 in `apps/marketing` (fixes ReDoS in `withClientHints`).

<sup>Written for commit 1d25b3db8afa1ee11e5304467885fc0fc6dd46ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple project dependencies to their latest stable versions to enhance overall application stability and improve runtime performance across all packages and modules. This includes development build tools, user agent parser libraries, and web application server runtime packages. These updates strengthen security standards and improve reliability throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->