### PR TITLE
chore(desktop): title and make terminal daemon searchable in settings

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SessionsSection.tsx
@@ -132,7 +132,7 @@ export function SessionsSection() {
 			<div className="rounded-md border border-border/60 p-4 space-y-3">
 				<div className="space-y-0.5">
 					<div className="flex items-center justify-between">
-						<Label className="text-sm font-medium">Manage sessions</Label>
+						<Label className="text-sm font-medium">Terminal daemon</Label>
 						<Button
 							variant="ghost"
 							size="sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2SessionsSection/V2SessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2SessionsSection/V2SessionsSection.tsx
@@ -44,7 +44,7 @@ export function V2SessionsSection() {
 	if (!activeHostUrl) {
 		return (
 			<div className="space-y-1">
-				<h3 className="text-sm font-medium">Manage daemon</h3>
+				<h3 className="text-sm font-medium">Terminal daemon</h3>
 				<p className="text-sm text-muted-foreground">
 					Host service is starting…
 				</p>
@@ -176,7 +176,7 @@ function V2SessionsSectionInner() {
 				<div className="flex items-start justify-between gap-4">
 					<div>
 						<h3 className="text-sm font-medium flex items-baseline gap-2">
-							Manage daemon
+							Terminal daemon
 							{versionLabel ? (
 								<span className="text-xs font-mono font-normal text-muted-foreground/80">
 									{versionLabel}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -717,10 +717,16 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 	{
 		id: SETTING_ITEM_ID.TERMINAL_SESSIONS,
 		section: "terminal",
-		title: "Active Sessions",
-		description: "View and manage active terminal sessions",
+		title: "Terminal Daemon",
+		description: "Manage the terminal daemon and active sessions",
 		keywords: [
 			"terminal",
+			"daemon",
+			"pty daemon",
+			"supervisor",
+			"restart daemon",
+			"update daemon",
+			"background",
 			"sessions",
 			"active",
 			"running",


### PR DESCRIPTION
## What

The terminal daemon controls live inside the Terminal settings section but were easy to miss and weren't discoverable via settings search.

This PR:
- **Adds a clear title.** The daemon section now reads **"Terminal daemon"** in both the v1 (`SessionsSection`) and v2 (`V2SessionsSection`) settings UIs, so people don't miss it. (v2 previously said "Manage daemon"; v1 said "Manage sessions".)
- **Makes it searchable.** Searching "daemon" in settings previously returned nothing. The shared `TERMINAL_SESSIONS` registry entry is retitled to **"Terminal Daemon"** and gains daemon-related keywords (`daemon`, `pty daemon`, `supervisor`, `restart daemon`, `update daemon`, `background`) while keeping all existing session keywords.

## Scope

Covers both v1 and v2 — the search registry entry is `variant: "shared"`, so it powers search in both UIs.

## Testing

- `bun run lint` — clean
- `bun run typecheck` — all 28 packages pass (desktop built fresh)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Terminal daemon controls with a clear title and makes them searchable in Settings. Applies to both v1 and v2 UIs to improve discoverability.

- **New Features**
  - Title updated to "Terminal daemon" in both `SessionsSection` and `V2SessionsSection`.
  - Settings search: item retitled to "Terminal Daemon" with keywords added (daemon, pty daemon, supervisor, restart/update daemon, background) while keeping existing session keywords.

<sup>Written for commit b8ac516a75b9e9e39aabfdbd67224c6387f23236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated terminal daemon settings labels and descriptions for consistency across the application.
  * Enhanced settings search with improved keywords related to terminal daemon functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->