### PR TITLE
fix(desktop): forward line/column to external editor when opening terminal file links

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -586,6 +586,209 @@ describe("stripPathWrappers", () => {
 	});
 });
 
+describe("getAppCommand — line/column jump", () => {
+	const originalPlatform = process.platform;
+
+	beforeEach(() => {
+		Object.defineProperty(process, "platform", { value: "linux" });
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: originalPlatform });
+	});
+
+	describe("Linux VS Code family", () => {
+		test("vscode: line and column → -g path:line:col", () => {
+			const result = getAppCommand("vscode", "/path/to/file", "linux", 10, 5);
+			expect(result).toEqual([
+				{ command: "code", args: ["-g", "/path/to/file:10:5"] },
+			]);
+		});
+
+		test("vscode: line only, no column → -g path:line", () => {
+			const result = getAppCommand(
+				"vscode",
+				"/path/to/file",
+				"linux",
+				10,
+				undefined,
+			);
+			expect(result).toEqual([
+				{ command: "code", args: ["-g", "/path/to/file:10"] },
+			]);
+		});
+
+		test("cursor: line and column → -g path:line:col", () => {
+			const result = getAppCommand("cursor", "/path/to/file", "linux", 1, 1);
+			expect(result).toEqual([
+				{ command: "cursor", args: ["-g", "/path/to/file:1:1"] },
+			]);
+		});
+	});
+
+	describe("Linux Sublime/Zed family", () => {
+		test("sublime: line and column → path:line:col", () => {
+			const result = getAppCommand("sublime", "/path/to/file", "linux", 42, 8);
+			expect(result).toEqual([
+				{ command: "subl", args: ["/path/to/file:42:8"] },
+			]);
+		});
+
+		test("sublime: line only, no column → path:line", () => {
+			const result = getAppCommand(
+				"sublime",
+				"/path/to/file",
+				"linux",
+				42,
+				undefined,
+			);
+			expect(result).toEqual([{ command: "subl", args: ["/path/to/file:42"] }]);
+		});
+
+		test("zed: line and column → path:line:col", () => {
+			const result = getAppCommand("zed", "/path/to/file", "linux", 5, 3);
+			expect(result).toEqual([{ command: "zed", args: ["/path/to/file:5:3"] }]);
+		});
+	});
+
+	describe("Linux JetBrains family", () => {
+		test("webstorm: line and column → --line line --column col path", () => {
+			const result = getAppCommand("webstorm", "/path/to/file", "linux", 20, 1);
+			expect(result).toEqual([
+				{
+					command: "webstorm",
+					args: ["--line", "20", "--column", "1", "/path/to/file"],
+				},
+			]);
+		});
+
+		test("webstorm: line only, no column → --line line path", () => {
+			const result = getAppCommand(
+				"webstorm",
+				"/path/to/file",
+				"linux",
+				20,
+				undefined,
+			);
+			expect(result).toEqual([
+				{ command: "webstorm", args: ["--line", "20", "/path/to/file"] },
+			]);
+		});
+
+		test("intellij (multi-edition): line and column → each candidate gets --line --column path", () => {
+			const result = getAppCommand("intellij", "/path/to/file", "linux", 10, 2);
+			expect(result).toEqual([
+				{
+					command: "idea",
+					args: ["--line", "10", "--column", "2", "/path/to/file"],
+				},
+				{
+					command: "intellij-idea-ultimate",
+					args: ["--line", "10", "--column", "2", "/path/to/file"],
+				},
+				{
+					command: "intellij-idea-community",
+					args: ["--line", "10", "--column", "2", "/path/to/file"],
+				},
+			]);
+		});
+	});
+
+	describe("Linux coordinate-ignored apps", () => {
+		test("warp: line provided → coordinate ignored, args is [path]", () => {
+			const result = getAppCommand("warp", "/path/to/file", "linux", 10);
+			expect(result).toEqual([
+				{ command: "warp-terminal", args: ["/path/to/file"] },
+			]);
+		});
+
+		test("antigravity: line provided → coordinate ignored, args is [path]", () => {
+			const result = getAppCommand("antigravity", "/path/to/file", "linux", 10);
+			expect(result).toEqual([
+				{ command: "antigravity", args: ["/path/to/file"] },
+			]);
+		});
+
+		test("devin: line provided → coordinate ignored, args is [path]", () => {
+			const result = getAppCommand("devin", "/path/to/file", "linux", 10);
+			expect(result).toEqual([
+				{ command: "devin-desktop", args: ["/path/to/file"] },
+			]);
+		});
+
+		test("fleet: line provided → coordinate ignored, args is [path]", () => {
+			const result = getAppCommand("fleet", "/path/to/file", "linux", 10);
+			expect(result).toEqual([{ command: "fleet", args: ["/path/to/file"] }]);
+		});
+	});
+
+	describe("macOS regression — coordinates always ignored", () => {
+		test("darwin + cursor: line and column → unchanged open -a args", () => {
+			const result = getAppCommand("cursor", "/path/to/file", "darwin", 10, 5);
+			expect(result).toEqual([
+				{ command: "open", args: ["-a", "Cursor", "/path/to/file"] },
+			]);
+		});
+
+		test("darwin + webstorm: line and column → unchanged open -a args", () => {
+			const result = getAppCommand(
+				"webstorm",
+				"/path/to/file",
+				"darwin",
+				10,
+				5,
+			);
+			expect(result).toEqual([
+				{ command: "open", args: ["-a", "WebStorm", "/path/to/file"] },
+			]);
+		});
+
+		test("darwin + intellij: line provided → unchanged open -b bundle ID candidates", () => {
+			const result = getAppCommand("intellij", "/path/to/file", "darwin", 10);
+			expect(result).toEqual([
+				{
+					command: "open",
+					args: ["-b", "com.jetbrains.intellij", "/path/to/file"],
+				},
+				{
+					command: "open",
+					args: ["-b", "com.jetbrains.intellij.ce", "/path/to/file"],
+				},
+			]);
+		});
+	});
+
+	describe("regression — no coordinates means identical to existing behavior", () => {
+		test("vscode: no line/column → same as before", () => {
+			const result = getAppCommand("vscode", "/path/to/file", "linux");
+			expect(result).toEqual([{ command: "code", args: ["/path/to/file"] }]);
+		});
+
+		test("webstorm: no line/column → same as before", () => {
+			const result = getAppCommand("webstorm", "/path/to/file", "linux");
+			expect(result).toEqual([
+				{ command: "webstorm", args: ["/path/to/file"] },
+			]);
+		});
+
+		test("intellij: no line/column → same as before", () => {
+			const result = getAppCommand("intellij", "/path/to/file", "linux");
+			expect(result).toEqual([
+				{ command: "idea", args: ["/path/to/file"] },
+				{ command: "intellij-idea-ultimate", args: ["/path/to/file"] },
+				{ command: "intellij-idea-community", args: ["/path/to/file"] },
+			]);
+		});
+
+		test("darwin + cursor: no line/column → same as before", () => {
+			const result = getAppCommand("cursor", "/path/to/file", "darwin");
+			expect(result).toEqual([
+				{ command: "open", args: ["-a", "Cursor", "/path/to/file"] },
+			]);
+		});
+	});
+});
+
 describe("resolvePath guards against process.cwd() fallback", () => {
 	test("throws RelativePathWithoutCwdError for a relative path with no cwd", () => {
 		expect(() => resolvePath("apps/desktop/src/index.ts")).toThrow(

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -42,6 +42,35 @@ const BUNDLE_ID_CANDIDATES: Partial<Record<ExternalApp, string[]>> = {
 	pycharm: ["com.jetbrains.pycharm", "com.jetbrains.pycharm.ce"],
 };
 
+/** VS Code-family apps that support the `-g <path>:<line>[:<column>]` goto flag on Linux */
+const VSCODE_GOTO_APPS = new Set<ExternalApp>([
+	"vscode",
+	"vscode-insiders",
+	"cursor",
+]);
+
+/** Sublime Text and Zed: accept `<path>:<line>[:<column>]` directly as the first argument */
+const SUBLIME_ZED_GOTO_APPS = new Set<ExternalApp>(["sublime", "zed"]);
+
+/**
+ * JetBrains IDEs that support `--line <line> [--column <column>] <path>` on Linux.
+ * Includes both single-edition apps (direct CLI) and multi-edition apps (LINUX_CLI_CANDIDATES).
+ */
+const JETBRAINS_LINE_APPS = new Set<ExternalApp>([
+	"intellij",
+	"webstorm",
+	"pycharm",
+	"phpstorm",
+	"rubymine",
+	"goland",
+	"clion",
+	"rider",
+	"datagrip",
+	"appcode",
+	"rustrover",
+	"android-studio",
+]);
+
 /** Map of app IDs to their Linux CLI commands */
 const LINUX_CLI_COMMANDS: Record<ExternalApp, string | null> = {
 	finder: null, // Handled specially with shell.showItemInFolder
@@ -83,17 +112,62 @@ const LINUX_CLI_CANDIDATES: Partial<Record<ExternalApp, string[]>> = {
 };
 
 /**
+ * Build the Linux args array for editors that support line/column goto.
+ * When `line` is undefined the returned args are byte-for-byte identical to
+ * the legacy `[targetPath]` baseline so existing callers are unaffected.
+ */
+function buildLinuxArgs(
+	app: ExternalApp,
+	targetPath: string,
+	line?: number,
+	column?: number,
+): string[] {
+	if (line === undefined) {
+		return [targetPath];
+	}
+
+	if (VSCODE_GOTO_APPS.has(app)) {
+		const loc =
+			column !== undefined
+				? `${targetPath}:${line}:${column}`
+				: `${targetPath}:${line}`;
+		return ["-g", loc];
+	}
+
+	if (SUBLIME_ZED_GOTO_APPS.has(app)) {
+		const loc =
+			column !== undefined
+				? `${targetPath}:${line}:${column}`
+				: `${targetPath}:${line}`;
+		return [loc];
+	}
+
+	if (JETBRAINS_LINE_APPS.has(app)) {
+		if (column !== undefined) {
+			return ["--line", String(line), "--column", String(column), targetPath];
+		}
+		return ["--line", String(line), targetPath];
+	}
+
+	return [targetPath];
+}
+
+/**
  * Get candidate commands to open a path in the specified app.
  * Returns an array of commands to try in order — for multi-edition apps (IntelliJ, PyCharm),
  * multiple candidates are returned so the caller can fall back if one isn't installed.
  *
  * macOS: Uses `open -b` (bundle ID) for multi-edition apps and `open -a` (app name) for others.
+ *   Line/column coordinates are ignored on macOS.
  * Linux: Uses direct CLI commands (e.g. `code`, `cursor`, `zed`).
+ *   When `line` is provided, editor-specific goto syntax is used.
  */
 export function getAppCommand(
 	app: ExternalApp,
 	targetPath: string,
 	platform: NodeJS.Platform = process.platform,
+	line?: number,
+	column?: number,
 ): { command: string; args: string[] }[] | null {
 	if (platform === "darwin") {
 		const bundleIds = BUNDLE_ID_CANDIDATES[app];
@@ -112,15 +186,21 @@ export function getAppCommand(
 	// Linux (and other non-macOS platforms)
 	const linuxCandidates = LINUX_CLI_CANDIDATES[app];
 	if (linuxCandidates) {
+		const args = buildLinuxArgs(app, targetPath, line, column);
 		return linuxCandidates.map((cmd) => ({
 			command: cmd,
-			args: [targetPath],
+			args,
 		}));
 	}
 
 	const cliCommand = LINUX_CLI_COMMANDS[app];
 	if (!cliCommand) return null;
-	return [{ command: cliCommand, args: [targetPath] }];
+	return [
+		{
+			command: cliCommand,
+			args: buildLinuxArgs(app, targetPath, line, column),
+		},
+	];
 }
 
 /**

--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -19,8 +19,6 @@ import {
 } from "./helpers";
 import { ExternalAppSchema, openFileInEditorInputSchema } from "./schemas";
 
-export { openFileInEditorInputSchema };
-
 /**
  * Wraps a tRPC handler so a `RelativePathWithoutCwdError` (thrown by
  * `resolvePath` when a relative path arrives without a `worktreePath`)

--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -78,13 +78,15 @@ export function resolveDefaultEditor(projectId?: string): ExternalApp | null {
 async function openPathInApp(
 	filePath: string,
 	app: ExternalApp,
+	line?: number,
+	column?: number,
 ): Promise<void> {
 	if (app === "finder") {
 		shell.showItemInFolder(filePath);
 		return;
 	}
 
-	const candidates = getAppCommand(app, filePath);
+	const candidates = getAppCommand(app, filePath, undefined, line, column);
 	if (candidates) {
 		let lastError: Error | undefined;
 		for (const cmd of candidates) {
@@ -273,7 +275,7 @@ export const createExternalRouter = () => {
 						return;
 					}
 
-					await openPathInApp(filePath, app);
+					await openPathInApp(filePath, app, input.line, input.column);
 				}),
 			),
 	});

--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -1,11 +1,6 @@
 import fs from "node:fs";
 import nodePath from "node:path";
-import {
-	EXTERNAL_APPS,
-	NON_EDITOR_APPS,
-	projects,
-	settings,
-} from "@superset/local-db";
+import { NON_EDITOR_APPS, projects, settings } from "@superset/local-db";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { clipboard, shell } from "electron";
@@ -22,6 +17,9 @@ import {
 	resolvePath,
 	spawnAsync,
 } from "./helpers";
+import { ExternalAppSchema, openFileInEditorInputSchema } from "./schemas";
+
+export { openFileInEditorInputSchema };
 
 /**
  * Wraps a tRPC handler so a `RelativePathWithoutCwdError` (thrown by
@@ -39,8 +37,6 @@ async function withResolveGuard<T>(fn: () => Promise<T> | T): Promise<T> {
 		throw err;
 	}
 }
-
-const ExternalAppSchema = z.enum(EXTERNAL_APPS);
 
 const nonEditorSet = new Set<ExternalApp>(NON_EDITOR_APPS);
 
@@ -238,30 +234,7 @@ export const createExternalRouter = () => {
 			),
 
 		openFileInEditor: publicProcedure
-			.input(
-				z.object({
-					path: z.string(),
-					line: z.number().optional(),
-					column: z.number().optional(),
-					/**
-					 * Absolute workspace worktree path. Required when `path` is
-					 * relative; ignored when `path` is already absolute. Using the
-					 * workspace's worktreePath (rather than an arbitrary cwd) means
-					 * relative diff/tree paths always resolve against the workspace
-					 * the user is in, never Electron's process cwd.
-					 */
-					worktreePath: z.string().optional(),
-					projectId: z.string().optional(),
-					/**
-					 * Explicit app override from the caller (e.g. the v2 CMD+O
-					 * choice stored client-side in tanstack-db). When provided,
-					 * bypasses the server-side `resolveDefaultEditor` lookup —
-					 * which only knows about v1 localDb tables and would
-					 * otherwise return a stale global default for v2 projects.
-					 */
-					app: ExternalAppSchema.optional(),
-				}),
-			)
+			.input(openFileInEditorInputSchema)
 			.mutation(({ input }) =>
 				withResolveGuard(async () => {
 					const filePath = resolvePath(input.path, input.worktreePath);

--- a/apps/desktop/src/lib/trpc/routers/external/openFileInEditor.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/openFileInEditor.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { openFileInEditorInputSchema } from "./schemas";
+
+describe("openFileInEditor input schema — line/column validation", () => {
+	describe("valid inputs are accepted", () => {
+		test("valid line and column (positive integers) → success", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: 42,
+				column: 10,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test("line=1, column=1 (minimum valid) → success", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: 1,
+				column: 1,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test("line only, no column → success", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: 42,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test("neither line nor column (both omitted) → success", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test("line undefined, column undefined → success", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: undefined,
+				column: undefined,
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("invalid line values are rejected", () => {
+		test("line=0 → rejected", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: 0,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		test("line=-1 (negative) → rejected", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: -1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		test("line=1.5 (fractional) → rejected", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: 1.5,
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("invalid column values are rejected", () => {
+		test("column=0 → rejected", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: 10,
+				column: 0,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		test("column=-1 (negative) → rejected", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: 10,
+				column: -1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		test("column=1.5 (fractional) → rejected", () => {
+			const result = openFileInEditorInputSchema.safeParse({
+				path: "/some/file.ts",
+				line: 10,
+				column: 1.5,
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/external/openFileInEditor.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/openFileInEditor.test.ts
@@ -1,24 +1,32 @@
 import { describe, expect, test } from "bun:test";
 import { openFileInEditorInputSchema } from "./schemas";
 
-describe("openFileInEditor input schema — line/column validation", () => {
-	describe("valid inputs are accepted", () => {
-		test("valid line and column (positive integers) → success", () => {
+describe("openFileInEditor input schema — line/column coordinate handling", () => {
+	describe("valid positive integers pass through unchanged", () => {
+		test("valid line and column (positive integers) → success with values preserved", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: 42,
 				column: 10,
 			});
 			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.line).toBe(42);
+				expect(result.data.column).toBe(10);
+			}
 		});
 
-		test("line=1, column=1 (minimum valid) → success", () => {
+		test("line=1, column=1 (minimum valid) → success with values preserved", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: 1,
 				column: 1,
 			});
 			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.line).toBe(1);
+				expect(result.data.column).toBe(1);
+			}
 		});
 
 		test("line only, no column → success", () => {
@@ -27,77 +35,109 @@ describe("openFileInEditor input schema — line/column validation", () => {
 				line: 42,
 			});
 			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.line).toBe(42);
+				expect(result.data.column).toBeUndefined();
+			}
 		});
 
-		test("neither line nor column (both omitted) → success", () => {
+		test("neither line nor column (both omitted) → success, both undefined", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 			});
 			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.line).toBeUndefined();
+				expect(result.data.column).toBeUndefined();
+			}
 		});
 
-		test("line undefined, column undefined → success", () => {
+		test("line undefined, column undefined → success, both undefined", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: undefined,
 				column: undefined,
 			});
 			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.line).toBeUndefined();
+				expect(result.data.column).toBeUndefined();
+			}
 		});
 	});
 
-	describe("invalid line values are rejected", () => {
-		test("line=0 → rejected", () => {
+	// Invalid coordinates must NOT throw — parsing succeeds and the bad coordinate is
+	// dropped to undefined so the file still opens (just without line/column jumping).
+	describe("invalid line values are silently dropped (not rejected)", () => {
+		test("line=0 → parse succeeds, line dropped to undefined", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: 0,
 			});
-			expect(result.success).toBe(false);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.line).toBeUndefined();
+			}
 		});
 
-		test("line=-1 (negative) → rejected", () => {
+		test("line=-1 (negative) → parse succeeds, line dropped to undefined", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: -1,
 			});
-			expect(result.success).toBe(false);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.line).toBeUndefined();
+			}
 		});
 
-		test("line=1.5 (fractional) → rejected", () => {
+		test("line=1.5 (fractional) → parse succeeds, line dropped to undefined", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: 1.5,
 			});
-			expect(result.success).toBe(false);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.line).toBeUndefined();
+			}
 		});
 	});
 
-	describe("invalid column values are rejected", () => {
-		test("column=0 → rejected", () => {
+	describe("invalid column values are silently dropped (not rejected)", () => {
+		test("column=0 → parse succeeds, column dropped to undefined", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: 10,
 				column: 0,
 			});
-			expect(result.success).toBe(false);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.column).toBeUndefined();
+			}
 		});
 
-		test("column=-1 (negative) → rejected", () => {
+		test("column=-1 (negative) → parse succeeds, column dropped to undefined", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: 10,
 				column: -1,
 			});
-			expect(result.success).toBe(false);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.column).toBeUndefined();
+			}
 		});
 
-		test("column=1.5 (fractional) → rejected", () => {
+		test("column=1.5 (fractional) → parse succeeds, column dropped to undefined", () => {
 			const result = openFileInEditorInputSchema.safeParse({
 				path: "/some/file.ts",
 				line: 10,
 				column: 1.5,
 			});
-			expect(result.success).toBe(false);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.column).toBeUndefined();
+			}
 		});
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/external/schemas.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/schemas.ts
@@ -1,0 +1,27 @@
+import { EXTERNAL_APPS } from "@superset/local-db";
+import { z } from "zod";
+
+export const ExternalAppSchema = z.enum(EXTERNAL_APPS);
+
+export const openFileInEditorInputSchema = z.object({
+	path: z.string(),
+	line: z.number().int().min(1).optional(),
+	column: z.number().int().min(1).optional(),
+	/**
+	 * Absolute workspace worktree path. Required when `path` is
+	 * relative; ignored when `path` is already absolute. Using the
+	 * workspace's worktreePath (rather than an arbitrary cwd) means
+	 * relative diff/tree paths always resolve against the workspace
+	 * the user is in, never Electron's process cwd.
+	 */
+	worktreePath: z.string().optional(),
+	projectId: z.string().optional(),
+	/**
+	 * Explicit app override from the caller (e.g. the v2 CMD+O
+	 * choice stored client-side in tanstack-db). When provided,
+	 * bypasses the server-side `resolveDefaultEditor` lookup —
+	 * which only knows about v1 localDb tables and would
+	 * otherwise return a stale global default for v2 projects.
+	 */
+	app: ExternalAppSchema.optional(),
+});

--- a/apps/desktop/src/lib/trpc/routers/external/schemas.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/schemas.ts
@@ -3,10 +3,22 @@ import { z } from "zod";
 
 export const ExternalAppSchema = z.enum(EXTERNAL_APPS);
 
+/**
+ * Accepts any number but drops non-positive-integers to `undefined`
+ * instead of throwing — invalid coordinates degrade gracefully so the
+ * file still opens (e.g. terminal links that emit row=0).
+ */
+const positiveCoordinate = z
+	.number()
+	.optional()
+	.transform((value) =>
+		value != null && Number.isInteger(value) && value > 0 ? value : undefined,
+	);
+
 export const openFileInEditorInputSchema = z.object({
 	path: z.string(),
-	line: z.number().int().min(1).optional(),
-	column: z.number().int().min(1).optional(),
+	line: positiveCoordinate,
+	column: positiveCoordinate,
 	/**
 	 * Absolute workspace worktree path. Required when `path` is
 	 * relative; ignored when `path` is already absolute. Using the


### PR DESCRIPTION
## Description

- `external.openFileInEditor` already accepts `line`/`column` and callers pass them (terminal links forward `link.row`/`link.col`), but the mutation only forwarded the path — it called `openPathInApp(filePath, app)`, and neither `openPathInApp` nor `getAppCommand` took the coordinates, so they were silently dropped and the editor always opened at line 1.
- Thread `line`/`column` through `openPathInApp` → `getAppCommand` and build editor-specific goto args on Linux:
  - VS Code family (`vscode`, `vscode-insiders`, `cursor`): `-g <path>:<line>[:<column>]`
  - Sublime Text / Zed: `<path>:<line>[:<column>]`
  - JetBrains IDEs: `--line <line> [--column <column>] <path>` (including multi-edition candidates)
- All other apps (terminals, Finder, etc.) ignore the coordinates and keep their existing args.
- **Invariant:** when `line`/`column` are both undefined the generated args are byte-for-byte identical to before, so existing behavior and tests are unaffected.

### Known limitation (macOS)

On macOS the editors are launched via `open -a <App>` / `open -b <bundleId>`, which can't reliably deliver a line argument to an already-running app (`--args` isn't applied when the app is already open). So this change enables line/column jump on the Linux CLI paths and intentionally leaves the macOS `open` behavior unchanged (coordinates ignored) rather than adding a flaky best-effort path. Happy to follow up on a reliable macOS approach (e.g. preferring the editor's PATH CLI) if you'd like it in scope.

## Related Issues

Resolves #5309

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `bun test apps/desktop/src/lib/trpc/routers/external/` — 126 pass / 0 fail (20 new line/column cases covering all editor groups on Linux + macOS regression that coordinates stay ignored).
- `bunx tsc --noEmit` on `apps/desktop` — clean.
- `biome check` on the changed files — clean.

## Additional Notes

The in-app File viewer already uses the same `link.row`/`link.col` and jumps correctly, which is how the gap surfaced — only the external-editor path discarded the coordinates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal file links opening editors at line 1. We now pass and honor line/column on Linux editors, and drop invalid coordinates so files still open; macOS stays unchanged.

- **Bug Fixes**
  - Forward `line`/`column` through `external.openFileInEditor` → `openPathInApp` → `getAppCommand`.
  - Add Linux goto args per editor: VS Code family (`vscode`, `vscode-insiders`, `cursor`) uses `-g path:line[:column]`; Sublime/Zed use `path:line[:column]`; JetBrains IDEs use `--line <line> [--column <column>] <path>`.
  - Input schema drops non-positive or fractional `line`/`column` to `undefined` (no error); only positive integers generate goto args.
  - Other apps ignore coordinates; no change when none are provided. macOS keeps using `open` and ignores coordinates.

<sup>Written for commit aa48c0090675b3fbb96d98feba7d79407e71cbe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional line/column support when opening files in external editors/IDEs, enabling precise “go to” navigation across supported editor families (with macOS behavior unchanged).
* **Refactor**
  * Centralized the external-app and open-in-editor input validation via shared schemas.
* **Tests**
  * Added coverage for line/column parsing (invalid values are dropped, not rejected) and for platform-specific command/argument generation, including regression checks for existing macOS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->