### PR TITLE
fix(host-service): release workspace runtime state on delete

### DIFF
--- a/packages/host-service/src/events/git-watcher.test.ts
+++ b/packages/host-service/src/events/git-watcher.test.ts
@@ -17,14 +17,15 @@ type GitWatcherInternals = {
 };
 
 describe("GitWatcher.removeWorkspace", () => {
-	test("closes removed workspace watchers and clears pending debounce state", () => {
+	test("closes removed workspace watchers and clears pending debounce state", async () => {
 		const watcher = new GitWatcher({} as never, {} as never);
 		const internals = watcher as unknown as GitWatcherInternals;
 		const closeRemoved = mock(() => {});
 		const disposeRemoved = mock(() => {});
 		const closeActive = mock(() => {});
 		const disposeActive = mock(() => {});
-		const timer = setTimeout(() => {}, 60_000);
+		const timerFired = mock(() => {});
+		const timer = setTimeout(timerFired, 10);
 
 		try {
 			internals.watched.set("deleted-workspace", {
@@ -57,6 +58,9 @@ describe("GitWatcher.removeWorkspace", () => {
 			expect(internals.watched.has("active-workspace")).toBe(true);
 			expect(closeActive).not.toHaveBeenCalled();
 			expect(disposeActive).not.toHaveBeenCalled();
+
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			expect(timerFired).not.toHaveBeenCalled();
 
 			watcher.removeWorkspace("deleted-workspace");
 			expect(closeRemoved).toHaveBeenCalledTimes(1);

--- a/packages/host-service/src/events/git-watcher.test.ts
+++ b/packages/host-service/src/events/git-watcher.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, mock, test } from "bun:test";
+import { GitWatcher } from "./git-watcher";
+
+type GitWatcherInternals = {
+	watched: Map<
+		string,
+		{
+			workspaceId: string;
+			worktreePath: string;
+			gitDir: string;
+			watcher: { close: () => void };
+			disposeWorktreeWatch: () => void;
+		}
+	>;
+	debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
+	pendingBatches: Map<string, { hasGitDir: boolean; paths: Set<string> }>;
+};
+
+describe("GitWatcher.removeWorkspace", () => {
+	test("closes removed workspace watchers and clears pending debounce state", () => {
+		const watcher = new GitWatcher({} as never, {} as never);
+		const internals = watcher as unknown as GitWatcherInternals;
+		const closeRemoved = mock(() => {});
+		const disposeRemoved = mock(() => {});
+		const closeActive = mock(() => {});
+		const disposeActive = mock(() => {});
+		const timer = setTimeout(() => {}, 60_000);
+
+		try {
+			internals.watched.set("deleted-workspace", {
+				workspaceId: "deleted-workspace",
+				worktreePath: "/tmp/deleted",
+				gitDir: "/tmp/deleted/.git",
+				watcher: { close: closeRemoved },
+				disposeWorktreeWatch: disposeRemoved,
+			});
+			internals.watched.set("active-workspace", {
+				workspaceId: "active-workspace",
+				worktreePath: "/tmp/active",
+				gitDir: "/tmp/active/.git",
+				watcher: { close: closeActive },
+				disposeWorktreeWatch: disposeActive,
+			});
+			internals.debounceTimers.set("deleted-workspace", timer);
+			internals.pendingBatches.set("deleted-workspace", {
+				hasGitDir: true,
+				paths: new Set(["src/index.ts"]),
+			});
+
+			watcher.removeWorkspace("deleted-workspace");
+
+			expect(closeRemoved).toHaveBeenCalledTimes(1);
+			expect(disposeRemoved).toHaveBeenCalledTimes(1);
+			expect(internals.watched.has("deleted-workspace")).toBe(false);
+			expect(internals.debounceTimers.has("deleted-workspace")).toBe(false);
+			expect(internals.pendingBatches.has("deleted-workspace")).toBe(false);
+			expect(internals.watched.has("active-workspace")).toBe(true);
+			expect(closeActive).not.toHaveBeenCalled();
+			expect(disposeActive).not.toHaveBeenCalled();
+
+			watcher.removeWorkspace("deleted-workspace");
+			expect(closeRemoved).toHaveBeenCalledTimes(1);
+			expect(disposeRemoved).toHaveBeenCalledTimes(1);
+		} finally {
+			clearTimeout(timer);
+			watcher.close();
+		}
+	});
+});

--- a/packages/host-service/src/events/git-watcher.test.ts
+++ b/packages/host-service/src/events/git-watcher.test.ts
@@ -10,10 +10,22 @@ type GitWatcherInternals = {
 			gitDir: string;
 			watcher: { close: () => void };
 			disposeWorktreeWatch: () => void;
+			disposed: boolean;
 		}
 	>;
 	debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
 	pendingBatches: Map<string, { hasGitDir: boolean; paths: Set<string> }>;
+	handleWatcherError: (
+		workspaceId: string,
+		entry: {
+			workspaceId: string;
+			worktreePath: string;
+			gitDir: string;
+			watcher: { close: () => void };
+			disposeWorktreeWatch: () => void;
+			disposed: boolean;
+		},
+	) => void;
 };
 
 describe("GitWatcher.removeWorkspace", () => {
@@ -34,6 +46,7 @@ describe("GitWatcher.removeWorkspace", () => {
 				gitDir: "/tmp/deleted/.git",
 				watcher: { close: closeRemoved },
 				disposeWorktreeWatch: disposeRemoved,
+				disposed: false,
 			});
 			internals.watched.set("active-workspace", {
 				workspaceId: "active-workspace",
@@ -41,6 +54,7 @@ describe("GitWatcher.removeWorkspace", () => {
 				gitDir: "/tmp/active/.git",
 				watcher: { close: closeActive },
 				disposeWorktreeWatch: disposeActive,
+				disposed: false,
 			});
 			internals.debounceTimers.set("deleted-workspace", timer);
 			internals.pendingBatches.set("deleted-workspace", {
@@ -65,6 +79,46 @@ describe("GitWatcher.removeWorkspace", () => {
 			watcher.removeWorkspace("deleted-workspace");
 			expect(closeRemoved).toHaveBeenCalledTimes(1);
 			expect(disposeRemoved).toHaveBeenCalledTimes(1);
+		} finally {
+			clearTimeout(timer);
+			watcher.close();
+		}
+	});
+
+	test("cleans up watcher errors before workspace registration", () => {
+		const watcher = new GitWatcher({} as never, {} as never);
+		const internals = watcher as unknown as GitWatcherInternals;
+		const close = mock(() => {});
+		const dispose = mock(() => {});
+		const timer = setTimeout(() => {}, 10_000);
+		const entry = {
+			workspaceId: "early-error-workspace",
+			worktreePath: "/tmp/early-error",
+			gitDir: "/tmp/early-error/.git",
+			watcher: { close },
+			disposeWorktreeWatch: dispose,
+			disposed: false,
+		};
+
+		try {
+			internals.debounceTimers.set("early-error-workspace", timer);
+			internals.pendingBatches.set("early-error-workspace", {
+				hasGitDir: true,
+				paths: new Set(["package.json"]),
+			});
+
+			internals.handleWatcherError("early-error-workspace", entry);
+
+			expect(entry.disposed).toBe(true);
+			expect(close).toHaveBeenCalledTimes(1);
+			expect(dispose).toHaveBeenCalledTimes(1);
+			expect(internals.watched.has("early-error-workspace")).toBe(false);
+			expect(internals.debounceTimers.has("early-error-workspace")).toBe(false);
+			expect(internals.pendingBatches.has("early-error-workspace")).toBe(false);
+
+			internals.handleWatcherError("early-error-workspace", entry);
+			expect(close).toHaveBeenCalledTimes(1);
+			expect(dispose).toHaveBeenCalledTimes(1);
 		} finally {
 			clearTimeout(timer);
 			watcher.close();

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -257,10 +257,8 @@ export class GitWatcher {
 		}
 
 		watcher.on("error", () => {
-			// Watcher died — clean up so rescan can re-add
-			disposeWorktreeWatch();
-			this.watched.delete(workspaceId);
-			watcher.close();
+			// Watcher died — clean up so rescan can re-add.
+			this.removeWorkspace(workspaceId);
 		});
 
 		this.watched.set(workspaceId, {

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -36,6 +36,7 @@ interface WatchedWorkspace {
 	gitDir: string;
 	watcher: FSWatcher;
 	disposeWorktreeWatch: () => void;
+	disposed: boolean;
 }
 
 /**
@@ -104,11 +105,11 @@ export class GitWatcher {
 		}
 		this.debounceTimers.clear();
 		this.pendingBatches.clear();
-		for (const entry of this.watched.values()) {
-			entry.watcher.close();
-			entry.disposeWorktreeWatch();
-		}
+		const entries = [...this.watched.values()];
 		this.watched.clear();
+		for (const entry of entries) {
+			this.disposeWorkspaceEntry(entry);
+		}
 	}
 
 	removeWorkspace(workspaceId: string): void {
@@ -117,9 +118,29 @@ export class GitWatcher {
 		const entry = this.watched.get(workspaceId);
 		if (!entry) return;
 
+		this.watched.delete(workspaceId);
+		this.disposeWorkspaceEntry(entry);
+	}
+
+	private handleWatcherError(
+		workspaceId: string,
+		entry: WatchedWorkspace,
+	): void {
+		const watchedEntry = this.watched.get(workspaceId);
+		if (!watchedEntry || watchedEntry === entry) {
+			this.clearPendingFlush(workspaceId);
+		}
+		if (watchedEntry === entry) {
+			this.watched.delete(workspaceId);
+		}
+		this.disposeWorkspaceEntry(entry);
+	}
+
+	private disposeWorkspaceEntry(entry: WatchedWorkspace): void {
+		if (entry.disposed) return;
+		entry.disposed = true;
 		entry.watcher.close();
 		entry.disposeWorktreeWatch();
-		this.watched.delete(workspaceId);
 	}
 
 	private getOrCreateBatch(workspaceId: string): PendingBatch {
@@ -256,18 +277,27 @@ export class GitWatcher {
 			return;
 		}
 
-		watcher.on("error", () => {
-			// Watcher died — clean up so rescan can re-add.
-			this.removeWorkspace(workspaceId);
-		});
-
-		this.watched.set(workspaceId, {
+		const entry: WatchedWorkspace = {
 			workspaceId,
 			worktreePath,
 			gitDir,
 			watcher,
 			disposeWorktreeWatch,
+			disposed: false,
+		};
+
+		watcher.on("error", () => {
+			// Watcher died — clean up so rescan can re-add. The entry may not be
+			// registered yet if fs.watch errors immediately after listener attach.
+			this.handleWatcherError(workspaceId, entry);
 		});
+
+		if (entry.disposed || this.closed || this.watched.has(workspaceId)) {
+			this.handleWatcherError(workspaceId, entry);
+			return;
+		}
+
+		this.watched.set(workspaceId, entry);
 	}
 
 	/**

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -111,6 +111,17 @@ export class GitWatcher {
 		this.watched.clear();
 	}
 
+	removeWorkspace(workspaceId: string): void {
+		this.clearPendingFlush(workspaceId);
+
+		const entry = this.watched.get(workspaceId);
+		if (!entry) return;
+
+		entry.watcher.close();
+		entry.disposeWorktreeWatch();
+		this.watched.delete(workspaceId);
+	}
+
 	private getOrCreateBatch(workspaceId: string): PendingBatch {
 		let batch = this.pendingBatches.get(workspaceId);
 		if (!batch) {
@@ -162,6 +173,13 @@ export class GitWatcher {
 		);
 	}
 
+	private clearPendingFlush(workspaceId: string): void {
+		const timer = this.debounceTimers.get(workspaceId);
+		if (timer) clearTimeout(timer);
+		this.debounceTimers.delete(workspaceId);
+		this.pendingBatches.delete(workspaceId);
+	}
+
 	private async rescan(): Promise<void> {
 		if (this.closed) return;
 
@@ -181,11 +199,9 @@ export class GitWatcher {
 		const currentIds = new Set(rows.map((r) => r.id));
 
 		// Remove watchers for workspaces that no longer exist
-		for (const [id, entry] of this.watched) {
+		for (const id of this.watched.keys()) {
 			if (!currentIds.has(id)) {
-				entry.watcher.close();
-				entry.disposeWorktreeWatch();
-				this.watched.delete(id);
+				this.removeWorkspace(id);
 			}
 		}
 

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { pullRequests, workspaces } from "../../db/schema";
 import {
 	PullRequestRuntimeManager,
@@ -145,7 +145,7 @@ function createFakeDb(state: FakeState) {
 function createManager(
 	state: FakeState,
 	overrides: Partial<
-		Pick<PullRequestRuntimeManagerOptions, "execGh" | "github">
+		Pick<PullRequestRuntimeManagerOptions, "execGh" | "github" | "gitWatcher">
 	> = {},
 ) {
 	return new PullRequestRuntimeManager({
@@ -163,9 +163,42 @@ function createManager(
 			(async () => {
 				throw new Error("github should not be used for direct PR linking");
 			}),
-		gitWatcher: { onChanged: () => () => {} } as never,
+		gitWatcher:
+			overrides.gitWatcher ??
+			({ onChanged: () => () => {}, removeWorkspace: () => {} } as never),
 	});
 }
+
+describe("PullRequestRuntimeManager workspace cleanup", () => {
+	test("drops pending reruns and removes git watchers for a deleted workspace", () => {
+		const state = makeState("feature");
+		const removeWorkspace = mock(() => {});
+		const manager = createManager(state, {
+			gitWatcher: {
+				onChanged: () => () => {},
+				removeWorkspace,
+			} as never,
+		});
+		const internals = manager as unknown as {
+			workspaceSyncState: Map<
+				string,
+				{ running: Promise<void>; rerunPending: boolean }
+			>;
+		};
+
+		internals.workspaceSyncState.set(WORKSPACE_ID, {
+			running: Promise.resolve(),
+			rerunPending: true,
+		});
+
+		manager.removeWorkspace(WORKSPACE_ID);
+
+		expect(internals.workspaceSyncState.get(WORKSPACE_ID)?.rerunPending).toBe(
+			false,
+		);
+		expect(removeWorkspace).toHaveBeenCalledWith(WORKSPACE_ID);
+	});
+});
 
 describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 	test("links a fork PR workspace to the selected PR and records fork upstream", async () => {

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -145,7 +145,10 @@ function createFakeDb(state: FakeState) {
 function createManager(
 	state: FakeState,
 	overrides: Partial<
-		Pick<PullRequestRuntimeManagerOptions, "execGh" | "github" | "gitWatcher">
+		Pick<
+			PullRequestRuntimeManagerOptions,
+			"execGh" | "git" | "github" | "gitWatcher"
+		>
 	> = {},
 ) {
 	return new PullRequestRuntimeManager({
@@ -155,9 +158,11 @@ function createManager(
 			(async () => {
 				throw new Error("gh should not be used for direct PR linking");
 			}),
-		git: async () => {
-			throw new Error("git should not be used when project metadata is set");
-		},
+		git:
+			overrides.git ??
+			(async () => {
+				throw new Error("git should not be used when project metadata is set");
+			}),
 		github:
 			overrides.github ??
 			(async () => {
@@ -170,7 +175,7 @@ function createManager(
 }
 
 describe("PullRequestRuntimeManager workspace cleanup", () => {
-	test("drops pending reruns and removes git watchers for a deleted workspace", () => {
+	test("drops pending sync state and removes git watchers for a deleted workspace", () => {
 		const state = makeState("feature");
 		const removeWorkspace = mock(() => {});
 		const manager = createManager(state, {
@@ -184,6 +189,7 @@ describe("PullRequestRuntimeManager workspace cleanup", () => {
 				string,
 				{ running: Promise<void>; rerunPending: boolean }
 			>;
+			cancelledWorkspaceSyncs: Set<string>;
 		};
 
 		internals.workspaceSyncState.set(WORKSPACE_ID, {
@@ -193,10 +199,27 @@ describe("PullRequestRuntimeManager workspace cleanup", () => {
 
 		manager.removeWorkspace(WORKSPACE_ID);
 
-		expect(internals.workspaceSyncState.get(WORKSPACE_ID)?.rerunPending).toBe(
-			false,
-		);
+		expect(internals.workspaceSyncState.has(WORKSPACE_ID)).toBe(false);
+		expect(internals.cancelledWorkspaceSyncs.has(WORKSPACE_ID)).toBe(true);
 		expect(removeWorkspace).toHaveBeenCalledWith(WORKSPACE_ID);
+	});
+
+	test("cancelled in-flight workspace syncs no-op before opening git", async () => {
+		const state = makeState("feature");
+		const git = mock(async () => {
+			throw new Error("git should not be opened for a cancelled workspace");
+		});
+		const manager = createManager(state, { git: git as never });
+		const internals = manager as unknown as {
+			cancelledWorkspaceSyncs: Set<string>;
+			syncOneWorkspace: (workspaceId: string) => Promise<void>;
+		};
+
+		internals.cancelledWorkspaceSyncs.add(WORKSPACE_ID);
+
+		await internals.syncOneWorkspace(WORKSPACE_ID);
+
+		expect(git).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -327,6 +327,12 @@ export class PullRequestRuntimeManager {
 		this.unsubscribeFromGitWatcher = null;
 	}
 
+	removeWorkspace(workspaceId: string): void {
+		const syncState = this.workspaceSyncState.get(workspaceId);
+		if (syncState) syncState.rerunPending = false;
+		this.gitWatcher.removeWorkspace(workspaceId);
+	}
+
 	async getPullRequestsByWorkspaces(
 		workspaceIds: string[],
 	): Promise<PullRequestWorkspaceSnapshot[]> {

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -273,6 +273,7 @@ export class PullRequestRuntimeManager {
 		string,
 		{ running: Promise<void>; rerunPending: boolean }
 	>();
+	private readonly cancelledWorkspaceSyncs = new Set<string>();
 	private readonly pullRequestHeadCache = new Map<
 		string,
 		{ promise: Promise<GitHubPullRequestNode | null>; fetchedAt: number }
@@ -329,8 +330,12 @@ export class PullRequestRuntimeManager {
 
 	removeWorkspace(workspaceId: string): void {
 		const syncState = this.workspaceSyncState.get(workspaceId);
-		if (syncState) syncState.rerunPending = false;
 		this.gitWatcher.removeWorkspace(workspaceId);
+		if (syncState) {
+			syncState.rerunPending = false;
+			this.cancelledWorkspaceSyncs.add(workspaceId);
+		}
+		this.workspaceSyncState.delete(workspaceId);
 	}
 
 	async getPullRequestsByWorkspaces(
@@ -474,6 +479,10 @@ export class PullRequestRuntimeManager {
 	}
 
 	private enqueueWorkspaceSync(workspaceId: string): Promise<void> {
+		if (this.cancelledWorkspaceSyncs.has(workspaceId)) {
+			return Promise.resolve();
+		}
+
 		// Coalesce: if a sync is already running for this workspace, just mark
 		// "rerun pending" — there's no value in queuing N back-to-back syncs
 		// when only the final state matters. At most one sync runs and one
@@ -487,12 +496,17 @@ export class PullRequestRuntimeManager {
 		const run = async (): Promise<void> => {
 			try {
 				do {
+					if (this.cancelledWorkspaceSyncs.has(workspaceId)) return;
 					const state = this.workspaceSyncState.get(workspaceId);
 					if (state) state.rerunPending = false;
 					await this.syncOneWorkspace(workspaceId);
-				} while (this.workspaceSyncState.get(workspaceId)?.rerunPending);
+				} while (
+					!this.cancelledWorkspaceSyncs.has(workspaceId) &&
+					this.workspaceSyncState.get(workspaceId)?.rerunPending
+				);
 			} finally {
 				this.workspaceSyncState.delete(workspaceId);
+				this.cancelledWorkspaceSyncs.delete(workspaceId);
 			}
 		};
 
@@ -505,6 +519,8 @@ export class PullRequestRuntimeManager {
 	}
 
 	private async syncOneWorkspace(workspaceId: string): Promise<void> {
+		if (this.cancelledWorkspaceSyncs.has(workspaceId)) return;
+
 		// Look up the row fresh — the workspace may have been deleted between
 		// the GitWatcher event firing and this handler running. That's expected
 		// during teardown / workspace removal; silently no-op.
@@ -514,21 +530,28 @@ export class PullRequestRuntimeManager {
 			.where(eq(workspaces.id, workspaceId))
 			.get();
 		if (!workspace) return;
+		if (this.cancelledWorkspaceSyncs.has(workspaceId)) return;
 
 		const projectId = await this.syncWorkspaceRow(workspace);
-		if (projectId) await this.refreshProject(projectId);
+		if (projectId && !this.cancelledWorkspaceSyncs.has(workspaceId)) {
+			await this.refreshProject(projectId);
+		}
 	}
 
 	private async syncWorkspaceRow(
 		workspace: typeof workspaces.$inferSelect,
 	): Promise<string | null> {
+		if (this.cancelledWorkspaceSyncs.has(workspace.id)) return null;
+
 		try {
 			const git = await this.git(workspace.worktreePath);
+			if (this.cancelledWorkspaceSyncs.has(workspace.id)) return null;
 			const branch = await getCurrentBranchName(git);
 			if (!branch) return null;
 
 			const headSha = await getHeadSha(git);
 			const upstream = await resolveWorkspaceUpstream(git, branch);
+			if (this.cancelledWorkspaceSyncs.has(workspace.id)) return null;
 			const upstreamOwner = upstream?.owner ?? null;
 			const upstreamRepo = upstream?.name ?? null;
 			const upstreamBranch = upstream?.branch ?? null;
@@ -549,6 +572,8 @@ export class PullRequestRuntimeManager {
 				return null;
 			}
 
+			if (this.cancelledWorkspaceSyncs.has(workspace.id)) return null;
+
 			this.db
 				.update(workspaces)
 				.set({
@@ -564,6 +589,7 @@ export class PullRequestRuntimeManager {
 
 			return workspace.projectId;
 		} catch (error) {
+			if (this.cancelledWorkspaceSyncs.has(workspace.id)) return null;
 			console.warn(
 				"[host-service:pull-request-runtime] Failed to sync workspace branch",
 				{

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -407,6 +407,12 @@ async function runDestroy(
 			warnings.push(`Failed to invalidate label cache: ${message}`);
 		}
 	}
+	try {
+		ctx.runtime.pullRequests.removeWorkspace(input.workspaceId);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		warnings.push(`Failed to clear workspace runtime state: ${message}`);
+	}
 
 	return {
 		success: true,

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -40,6 +40,7 @@ interface ContextSpec {
 	branchExists?: boolean;
 	dbDeleteThrows?: boolean;
 	noApi?: boolean;
+	runtimeRemoveWorkspace?: (workspaceId: string) => void;
 }
 
 function makeCtx(spec: ContextSpec): HostServiceContext {
@@ -95,6 +96,9 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 	});
 	const dbDeleteWhere = mock(() => ({ run: dbDeleteRun }));
 	const terminalSelectAll = mock(() => []);
+	const runtimeRemoveWorkspace = mock(
+		spec.runtimeRemoveWorkspace ?? (() => undefined),
+	);
 
 	return {
 		isAuthenticated: true,
@@ -121,7 +125,9 @@ function makeCtx(spec: ContextSpec): HostServiceContext {
 			}),
 			delete: () => ({ where: dbDeleteWhere }),
 		} as never,
-		runtime: {} as never,
+		runtime: {
+			pullRequests: { removeWorkspace: runtimeRemoveWorkspace },
+		} as never,
 		eventBus: {} as never,
 	};
 }
@@ -580,5 +586,65 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 				w.includes("Failed to remove local workspace row"),
 			),
 		).toBe(true);
+	});
+
+	test("clears host runtime state after workspace delete commits", async () => {
+		const runtimeRemoveWorkspace = mock(() => {});
+		const ctx = makeCtx({
+			workspace: {
+				id: "ws-1",
+				projectId: "p-1",
+				worktreePath: "/branch/wt",
+				branch: "feature",
+			},
+			project: { id: "p-1", repoPath: "/repo" },
+			cloudType: "worktree",
+			runtimeRemoveWorkspace,
+		});
+		const caller = workspaceCleanupRouter.createCaller(ctx);
+
+		const result = await caller.destroy({
+			workspaceId: "ws-1",
+			deleteBranch: false,
+			force: true,
+		});
+
+		expect(result.success).toBe(true);
+		expect(runtimeRemoveWorkspace).toHaveBeenCalledWith("ws-1");
+	});
+
+	test("clears stale host runtime state even when local row is already absent", async () => {
+		const runtimeRemoveWorkspace = mock(() => {});
+		const ctx = makeCtx({ runtimeRemoveWorkspace });
+		const caller = workspaceCleanupRouter.createCaller(ctx);
+
+		const result = await caller.destroy({
+			workspaceId: "already-deleted",
+			deleteBranch: false,
+			force: true,
+		});
+
+		expect(result.success).toBe(true);
+		expect(runtimeRemoveWorkspace).toHaveBeenCalledWith("already-deleted");
+	});
+
+	test("does not clear host runtime state before cloud delete succeeds", async () => {
+		const runtimeRemoveWorkspace = mock(() => {});
+		const ctx = makeCtx({
+			cloudDelete: async () => {
+				throw new Error("cloud delete boom");
+			},
+			runtimeRemoveWorkspace,
+		});
+		const caller = workspaceCleanupRouter.createCaller(ctx);
+
+		await expect(
+			caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			}),
+		).rejects.toThrow("cloud delete boom");
+		expect(runtimeRemoveWorkspace).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Summary
- add an explicit GitWatcher.removeWorkspace cleanup path that closes deleted workspace watchers and clears pending debounce batches
- add PullRequestRuntimeManager.removeWorkspace to drop pending reruns and delegate watcher cleanup
- call runtime cleanup from workspaceCleanup.destroy after the delete commit point, including already-absent local rows
- add regression coverage for watcher cleanup, PR runtime cleanup, and workspace delete lifecycle ordering

Why
Issue #5076 reports deleted workspaces continuing to produce host-service daemon errors until the app/daemon is restarted. The local DB can be consistent while long-running host-service memory still contains PR-runtime sync state and FSEvents watchers for removed workspaces.

Root Cause
workspaceCleanup.destroy removed workspace rows and disk/cloud state but did not explicitly release host-service runtime/watch state keyed by the deleted workspace id. GitWatcher eventually reconciles on interval, but pending debounce batches and active watchers can remain long enough to emit stale syncs, and PullRequestRuntimeManager had no lifecycle cleanup hook for deleted workspaces.

User Impact
Deleting a workspace now immediately releases host-service PR runtime and watcher state, which should stop stale "Workspace not found" restore paths and repeated pull-request-runtime/FSEvents errors for deleted workspaces without requiring a full daemon restart.

Relation to #5279
This is intentionally separate from #5279. PR #5279 handles stale closed-worktree directories in the desktop/local closed-worktree delete route. This PR handles the long-running host-service daemon cleanup path for deleted workspaces.

Validation
- bun test packages/host-service/src/events/git-watcher.test.ts
- bun test packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
- bun test packages/host-service/test/workspace-cleanup.test.ts
- bun run --cwd packages/host-service test
- bun run --cwd packages/host-service typecheck
- bun run --cwd packages/host-service build:host
- bun run lint
- bun run typecheck
- git diff --check

Build Note
- bun run build progressed through host-service bundling and desktop native-runtime validation, then failed in local electron-builder packaging because this checkout's Bun node_modules layout could not resolve the production dependency @superset/chat -> hono. That packaging dependency-collection failure appears environment/layout related and unrelated to this host-service cleanup diff.

Fixes #5076

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Immediately release host-service PR runtime state and file watchers when a workspace is deleted, and cancel in-flight syncs so nothing runs after delete — stopping stale syncs and “Workspace not found” errors without restarting the daemon. Fixes #5076.

- **Bug Fixes**
  - Added `GitWatcher.removeWorkspace` to close watchers, dispose worktree watch, and clear debounce timers/batches; used by rescan and error paths.
  - Hardened watcher error cleanup to handle races during registration; prevent double-dispose with a `disposed` flag and always clear pending timers/batches.
  - Added `PullRequestRuntimeManager.removeWorkspace` to drop pending reruns, mark the workspace cancelled, and delegate watcher cleanup.
  - Guarded sync scheduling/execution with a cancelled set to no-op before opening git or refreshing a project, and clear cancellation on completion.
  - `workspaceCleanup.destroy` now calls runtime cleanup after the delete commit (even if the local row is already missing) and never before cloud delete succeeds; added regression tests for cleanup, watcher error races, and ordering.

<sup>Written for commit 3871079677a3a3b48d5d0840ef2e50b1fdf37ea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace-removal support to the git watcher and pull-request runtime, including full teardown and sync-state cancellation.
  * Workspace cleanup now clears runtime state as part of the deletion flow, recording any cleanup failures as warnings.
* **Bug Fixes**
  * Prevents further watcher/sync activity after cancellation, with idempotent cleanup and improved error-path teardown.
* **Tests**
  * Expanded tests for watcher disposal, idempotency, early-termination on cancellation/errors, and correct timing of runtime cleanup during workspace destroy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->