### PR TITLE
fix(desktop): toast when v2 workspace auto-naming falls back

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -2,6 +2,7 @@ import { toast } from "@superset/ui/sonner";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { authClient } from "renderer/lib/auth-client";
+import { showWorkspaceAutoNameWarningToast } from "renderer/lib/workspaces/showWorkspaceAutoNameWarningToast";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import type { NewWorkspacePromptContextApi } from "renderer/stores/new-workspace-prompt-context";
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
@@ -138,6 +139,18 @@ export function useSubmitWorkspace(
 
 		void completed.then((outcome) => {
 			if (!outcome.ok) return;
+
+			if (outcome.autoNameWarning) {
+				showWorkspaceAutoNameWarningToast({
+					description: outcome.autoNameWarning,
+					onOpenModelAuthSettings: () => {
+						void navigate({ to: "/settings/models" });
+					},
+				});
+			}
+
+			// The server can resolve the optimistic workspace to a different
+			// canonical id; follow it only if we're still on the optimistic route.
 			if (outcome.workspaceId === workspaceId) return;
 			if (!isViewingOptimisticWorkspace()) return;
 			void navigate({

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -19,7 +19,7 @@ export interface SubmitArgs {
 }
 
 export type SubmitOutcome =
-	| { ok: true; workspaceId: string }
+	| { ok: true; workspaceId: string; autoNameWarning?: string }
 	| { ok: false; error: string };
 
 export interface SubmitHandle {
@@ -142,7 +142,11 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 					if (result.workspace.id !== workspaceId) {
 						deleteWorkspaceLocalState(workspaceId);
 					}
-					return { ok: true, workspaceId: result.workspace.id };
+					return {
+						ok: true,
+						workspaceId: result.workspace.id,
+						autoNameWarning: result.autoNameWarning,
+					};
 				})
 				.catch<SubmitOutcome>((error: unknown) => {
 					const message =

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -570,8 +570,8 @@ export const workspacesRouter = router({
 					: null;
 			aiNamesPromise?.catch(() => {});
 
-			// True only when AI naming ran and returned nothing — never on the
-			// PR / worktree-adopt paths, which don't attempt naming.
+			// Stays false on the PR / worktree-adopt paths, which never attempt
+			// naming — so those can't produce a fallback warning.
 			let autoNameFellBack = false;
 
 			await ensureMainWorkspace(ctx, input.projectId, localProject.repoPath);

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -48,6 +48,14 @@ import { derivePrLocalBranchName } from "../workspace-creation/utils/pr-branch-n
 import { resolveStartPoint } from "../workspace-creation/utils/resolve-start-point";
 import { deduplicateBranchName } from "../workspace-creation/utils/sanitize-branch";
 
+/**
+ * Returned by `create` when auto-naming was wanted but the LLM call came
+ * back empty: the workspace keeps a friendly-random fallback name (create
+ * does not fail) and the renderer shows this as a warning toast.
+ */
+const AUTO_NAME_FALLBACK_WARNING =
+	"Model naming was unavailable, so a fallback name was used.";
+
 const agentLaunchSchema = z
 	.object({
 		agent: z.string().min(1),
@@ -562,6 +570,8 @@ export const workspacesRouter = router({
 					: null;
 			aiNamesPromise?.catch(() => {});
 
+			let aiNamesResult: GeneratedWorkspaceNames | null = null;
+
 			await ensureMainWorkspace(ctx, input.projectId, localProject.repoPath);
 
 			const git = await ctx.git(localProject.repoPath);
@@ -842,6 +852,7 @@ export const workspacesRouter = router({
 						listBranchNames(ctx, localProject.repoPath),
 					]);
 					plan = planResult;
+					aiNamesResult = aiNames;
 					aiTitle = aiNames?.title ?? null;
 					// Namespace newly-created branches under the configured
 					// prefix. A typed branch that resolves to an existing ref is
@@ -872,6 +883,7 @@ export const workspacesRouter = router({
 						resolveNewBranchStartPoint(git, input.baseBranch),
 						listBranchNames(ctx, localProject.repoPath),
 					]);
+					aiNamesResult = aiNames;
 					aiTitle = aiNames?.title ?? null;
 					const prefix = await resolveProjectBranchPrefix({
 						ctx,
@@ -1080,11 +1092,17 @@ export const workspacesRouter = router({
 				});
 			}
 
+			const autoNameWarning =
+				wantAi && aiNamesResult === null
+					? AUTO_NAME_FALLBACK_WARNING
+					: undefined;
+
 			return {
 				workspace: workspaceRow,
 				terminals: terminalsResult,
 				agents: agentsResult,
 				alreadyExists,
+				autoNameWarning,
 				txid: extractCreateTxid(workspaceRow),
 			};
 		}),

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -570,7 +570,9 @@ export const workspacesRouter = router({
 					: null;
 			aiNamesPromise?.catch(() => {});
 
-			let aiNamesResult: GeneratedWorkspaceNames | null = null;
+			// True only when AI naming ran and returned nothing — never on the
+			// PR / worktree-adopt paths, which don't attempt naming.
+			let autoNameFellBack = false;
 
 			await ensureMainWorkspace(ctx, input.projectId, localProject.repoPath);
 
@@ -852,7 +854,7 @@ export const workspacesRouter = router({
 						listBranchNames(ctx, localProject.repoPath),
 					]);
 					plan = planResult;
-					aiNamesResult = aiNames;
+					autoNameFellBack = wantAi && aiNames === null;
 					aiTitle = aiNames?.title ?? null;
 					// Namespace newly-created branches under the configured
 					// prefix. A typed branch that resolves to an existing ref is
@@ -883,7 +885,7 @@ export const workspacesRouter = router({
 						resolveNewBranchStartPoint(git, input.baseBranch),
 						listBranchNames(ctx, localProject.repoPath),
 					]);
-					aiNamesResult = aiNames;
+					autoNameFellBack = wantAi && aiNames === null;
 					aiTitle = aiNames?.title ?? null;
 					const prefix = await resolveProjectBranchPrefix({
 						ctx,
@@ -1092,17 +1094,15 @@ export const workspacesRouter = router({
 				});
 			}
 
-			const autoNameWarning =
-				wantAi && aiNamesResult === null
-					? AUTO_NAME_FALLBACK_WARNING
-					: undefined;
-
 			return {
 				workspace: workspaceRow,
 				terminals: terminalsResult,
 				agents: agentsResult,
 				alreadyExists,
-				autoNameWarning,
+				autoNameWarning:
+					autoNameFellBack && !alreadyExists
+						? AUTO_NAME_FALLBACK_WARNING
+						: undefined,
 				txid: extractCreateTxid(workspaceRow),
 			};
 		}),


### PR DESCRIPTION
## Summary

When you create a v2 workspace from a prompt and leave the name/branch blank, the host auto-names it via the small model. If that naming fails (no model configured, timeout, or generation error), the workspace silently falls back to a friendly-random name.

The **legacy** create path surfaced this with a warning toast ("Workspace used a fallback name" + Open Models action). The **new optimistic** create path (`useSubmitWorkspace` → `useWorkspaceCreates` → host-service `workspaces.create`) never did — the warning was simply dropped.

This wires the warning back through the optimistic flow:

- **Host** (`workspaces.ts`): `create` returns `autoNameWarning` when auto-naming was wanted but the LLM call came back empty. Purely additive — auto-naming already can't fail the create (`aiNamesPromise` is `.catch(() => null)`), so a naming failure still just falls back to a friendly-random name.
- **Outcome** (`useWorkspaceCreates.ts`): `SubmitOutcome` carries `autoNameWarning` through.
- **Toast** (`useSubmitWorkspace.ts`): fires the existing `showWorkspaceAutoNameWarningToast` (with the Open Models action) on a successful create that fell back.

The warning is computed synchronously inside `create` (naming is awaited before the response), so a return value is the right shape — no subscription/push channel needed unless naming later moves off the create critical path.

## Test plan

- [ ] Create a workspace from a prompt with no model configured → "Workspace used a fallback name" toast appears with **Open Models** action.
- [ ] Create a workspace with a typed name/branch → no toast.
- [ ] Create a workspace with naming succeeding → no toast, AI name applied.
- [ ] Workspace is created successfully in all cases (naming failure never blocks create).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the warning toast when v2 workspace auto-naming falls back. The optimistic create now returns `autoNameWarning` so users see a fallback-name toast with an Open Models action.

- **Bug Fixes**
  - Host `workspaces.create` returns `autoNameWarning` only when AI naming was requested and produced no name; no warning on PR/worktree-adopt paths or when the workspace already existed.
  - `SubmitOutcome` propagates `autoNameWarning` through `useWorkspaceCreates`.
  - `useSubmitWorkspace` shows `showWorkspaceAutoNameWarningToast` and links to model settings.

<sup>Written for commit be176b94b4fb9c16a4fae70d4a9f750aed5f195f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Improvements**
- Enhanced workspace creation feedback for AI naming: if AI-powered naming was requested but no AI-generated names are returned, the app now shows a warning instead of silently using the default naming.
- The warning notification includes the exact warning text and a shortcut that takes you directly to model settings to help you diagnose why AI naming didn’t produce results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->