### PR TITLE
fix(host-service): detect ports for terminals without an attached renderer

### DIFF
--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import { planPortScanSync } from "./reaper.ts";
+
+const noneLive = () => false;
+
+describe("planPortScanSync", () => {
+	it("registers alive daemon sessions that map to an active workspace row", () => {
+		const plan = planPortScanSync({
+			liveSessions: [{ id: "term-1", pid: 4242 }],
+			rowById: new Map([
+				["term-1", { status: "active", originWorkspaceId: "ws-1" }],
+			]),
+			registeredTerminalIds: [],
+			isLive: noneLive,
+		});
+
+		expect(plan.register).toEqual([
+			{ terminalId: "term-1", workspaceId: "ws-1", pid: 4242 },
+		]);
+		expect(plan.unregister).toEqual([]);
+	});
+
+	it("skips sessions already owned by a live in-memory session", () => {
+		const plan = planPortScanSync({
+			liveSessions: [{ id: "term-1", pid: 4242 }],
+			rowById: new Map([
+				["term-1", { status: "active", originWorkspaceId: "ws-1" }],
+			]),
+			registeredTerminalIds: [],
+			isLive: (id) => id === "term-1",
+		});
+
+		expect(plan.register).toEqual([]);
+	});
+
+	it("skips sessions without a row, without a workspace, or not active", () => {
+		const plan = planPortScanSync({
+			liveSessions: [
+				{ id: "rowless", pid: 1 },
+				{ id: "no-workspace", pid: 2 },
+				{ id: "exited", pid: 3 },
+				{ id: "disposed", pid: 4 },
+			],
+			rowById: new Map([
+				["no-workspace", { status: "active", originWorkspaceId: null }],
+				["exited", { status: "exited", originWorkspaceId: "ws-1" }],
+				["disposed", { status: "disposed", originWorkspaceId: "ws-1" }],
+			]),
+			registeredTerminalIds: [],
+			isLive: noneLive,
+		});
+
+		expect(plan.register).toEqual([]);
+	});
+
+	it("unregisters scanned terminals the daemon no longer reports", () => {
+		const plan = planPortScanSync({
+			liveSessions: [{ id: "term-1", pid: 4242 }],
+			rowById: new Map([
+				["term-1", { status: "active", originWorkspaceId: "ws-1" }],
+			]),
+			registeredTerminalIds: ["term-1", "dead-term"],
+			isLive: noneLive,
+		});
+
+		expect(plan.unregister).toEqual(["dead-term"]);
+	});
+
+	it("clears every adopted scan when the daemon reports no live sessions", () => {
+		const plan = planPortScanSync({
+			liveSessions: [],
+			rowById: new Map(),
+			registeredTerminalIds: ["term-1", "term-2"],
+			isLive: noneLive,
+		});
+
+		expect(plan.unregister).toEqual(["term-1", "term-2"]);
+	});
+
+	it("keeps scanning a renderer-attached session momentarily absent from daemon.list", () => {
+		const plan = planPortScanSync({
+			liveSessions: [],
+			rowById: new Map(),
+			registeredTerminalIds: ["attached-term"],
+			isLive: (id) => id === "attached-term",
+		});
+
+		expect(plan.unregister).toEqual([]);
+	});
+});

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -1,7 +1,8 @@
 import type { HostDb } from "../../db/index.ts";
 import { terminalSessions } from "../../db/schema.ts";
+import { portManager } from "../../ports/port-manager.ts";
 import { getDaemonClient } from "../daemon-client-singleton.ts";
-import { disposeSessionAndWait } from "../terminal.ts";
+import { disposeSessionAndWait, isLiveTerminalSession } from "../terminal.ts";
 
 interface ReapResult {
 	reaped: number;
@@ -10,16 +11,96 @@ interface ReapResult {
 
 const REAP_INTERVAL_MS = 5 * 60 * 1000;
 
+interface TerminalRow {
+	status: string;
+	originWorkspaceId: string | null;
+}
+
+export interface PortScanSyncPlan {
+	register: { terminalId: string; workspaceId: string; pid: number }[];
+	unregister: string[];
+}
+
+/**
+ * Decide which terminals the port scanner should start and stop watching,
+ * given the daemon's live sessions and this host's session rows. Pure so the
+ * policy is unit testable without a daemon, database, or port manager.
+ *
+ * Register every alive daemon session that maps to an active workspace row and
+ * isn't already owned by a live in-memory session. This is what makes a
+ * workspace's dev-server ports appear before any renderer attaches to the
+ * terminal — e.g. sessions the daemon kept alive across a host-service restart.
+ * v1 desktop did this in its startup reconcile; v2 previously only registered
+ * terminals a renderer had explicitly opened, so ports were detected less
+ * completely.
+ *
+ * Unregister every currently-watched terminal the daemon no longer reports and
+ * that no live in-memory session owns. Sessions adopted here never get the
+ * daemon exit subscription that normally unregisters them, so without this they
+ * would be scanned forever after the process exits. The `isLive` guard keeps a
+ * renderer-attached session from being dropped if it's momentarily absent from
+ * a racy `daemon.list()`.
+ */
+export function planPortScanSync({
+	liveSessions,
+	rowById,
+	registeredTerminalIds,
+	isLive,
+}: {
+	liveSessions: { id: string; pid: number }[];
+	rowById: Map<string, TerminalRow>;
+	registeredTerminalIds: string[];
+	isLive: (terminalId: string) => boolean;
+}): PortScanSyncPlan {
+	const aliveIds = new Set(liveSessions.map((session) => session.id));
+
+	const register: PortScanSyncPlan["register"] = [];
+	for (const session of liveSessions) {
+		if (isLive(session.id)) continue;
+		const row = rowById.get(session.id);
+		if (!row?.originWorkspaceId) continue;
+		if (row.status !== "active") continue;
+		register.push({
+			terminalId: session.id,
+			workspaceId: row.originWorkspaceId,
+			pid: session.pid,
+		});
+	}
+
+	const unregister: string[] = [];
+	for (const terminalId of registeredTerminalIds) {
+		if (aliveIds.has(terminalId)) continue;
+		if (isLive(terminalId)) continue;
+		unregister.push(terminalId);
+	}
+
+	return { register, unregister };
+}
+
+function applyPortScanSync(
+	liveSessions: { id: string; pid: number }[],
+	rowById: Map<string, TerminalRow>,
+): void {
+	const plan = planPortScanSync({
+		liveSessions,
+		rowById,
+		registeredTerminalIds: portManager.getRegisteredTerminalIds(),
+		isLive: isLiveTerminalSession,
+	});
+	for (const entry of plan.register) {
+		portManager.upsertSession(entry.terminalId, entry.workspaceId, entry.pid);
+	}
+	for (const terminalId of plan.unregister) {
+		portManager.unregisterSession(terminalId);
+	}
+}
+
 async function reapOrphanedSessions(
 	db: HostDb,
 	rowlessPendingSecondPass: Set<string>,
 ): Promise<ReapResult> {
 	const daemon = await getDaemonClient();
 	const liveSessions = (await daemon.list()).filter((session) => session.alive);
-	if (liveSessions.length === 0) {
-		rowlessPendingSecondPass.clear();
-		return { reaped: 0, failed: 0 };
-	}
 
 	const rows = db
 		.select({
@@ -30,6 +111,17 @@ async function reapOrphanedSessions(
 		.from(terminalSessions)
 		.all();
 	const rowById = new Map(rows.map((row) => [row.id, row]));
+
+	// Keep the port scanner in sync with the daemon's live sessions on the same
+	// pass that lists them — registers ports for terminals running without an
+	// attached renderer, and drops scans for ones the daemon has dropped. Runs
+	// before the empty-list short-circuit so an empty daemon clears stale scans.
+	applyPortScanSync(liveSessions, rowById);
+
+	if (liveSessions.length === 0) {
+		rowlessPendingSecondPass.clear();
+		return { reaped: 0, failed: 0 };
+	}
 
 	const orphans: { id: string; rowless: boolean }[] = [];
 	const stillRowless = new Set<string>();

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -77,21 +77,39 @@ export function planPortScanSync({
 	return { register, unregister };
 }
 
+function loadTerminalRowsById(db: HostDb): Map<string, TerminalRow> {
+	const rows = db
+		.select({
+			id: terminalSessions.id,
+			status: terminalSessions.status,
+			originWorkspaceId: terminalSessions.originWorkspaceId,
+		})
+		.from(terminalSessions)
+		.all();
+	return new Map(rows.map((row) => [row.id, row]));
+}
+
+// Isolated from the reaper's main flow: port scanning is best-effort, so a
+// port-manager error must not abort the orphan cleanup that follows it.
 function applyPortScanSync(
 	liveSessions: { id: string; pid: number }[],
 	rowById: Map<string, TerminalRow>,
 ): void {
-	const plan = planPortScanSync({
-		liveSessions,
-		rowById,
-		registeredTerminalIds: portManager.getRegisteredTerminalIds(),
-		isLive: isLiveTerminalSession,
-	});
-	for (const entry of plan.register) {
-		portManager.upsertSession(entry.terminalId, entry.workspaceId, entry.pid);
-	}
-	for (const terminalId of plan.unregister) {
-		portManager.unregisterSession(terminalId);
+	try {
+		const plan = planPortScanSync({
+			liveSessions,
+			rowById,
+			registeredTerminalIds: portManager.getRegisteredTerminalIds(),
+			isLive: isLiveTerminalSession,
+		});
+		for (const entry of plan.register) {
+			portManager.upsertSession(entry.terminalId, entry.workspaceId, entry.pid);
+		}
+		for (const terminalId of plan.unregister) {
+			portManager.unregisterSession(terminalId);
+		}
+	} catch (err) {
+		console.warn("[host-service] port-scan sync failed:", err);
 	}
 }
 
@@ -102,18 +120,16 @@ async function reapOrphanedSessions(
 	const daemon = await getDaemonClient();
 	const liveSessions = (await daemon.list()).filter((session) => session.alive);
 
-	const rows = db
-		.select({
-			id: terminalSessions.id,
-			status: terminalSessions.status,
-			originWorkspaceId: terminalSessions.originWorkspaceId,
-		})
-		.from(terminalSessions)
-		.all();
-	const rowById = new Map(rows.map((row) => [row.id, row]));
+	// An idle daemon still needs a sync pass to drop stale scans, but the row
+	// join is only consulted to register live sessions — skip the DB hit when
+	// there are none.
+	const rowById =
+		liveSessions.length > 0
+			? loadTerminalRowsById(db)
+			: new Map<string, TerminalRow>();
 
-	// Reuse the list + row join the reaper already did. Must run before the
-	// empty-list short-circuit so an empty daemon still clears stale scans.
+	// Must run before the empty-list short-circuit so an empty daemon still
+	// clears stale scans.
 	applyPortScanSync(liveSessions, rowById);
 
 	if (liveSessions.length === 0) {

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -120,16 +120,13 @@ async function reapOrphanedSessions(
 	const daemon = await getDaemonClient();
 	const liveSessions = (await daemon.list()).filter((session) => session.alive);
 
-	// An idle daemon still needs a sync pass to drop stale scans, but the row
-	// join is only consulted to register live sessions — skip the DB hit when
-	// there are none.
+	// Sync the port scanner before the empty-list short-circuit below so an idle
+	// daemon still drops stale scans. rowById is only consulted to register live
+	// sessions, so skip the DB hit when there are none.
 	const rowById =
 		liveSessions.length > 0
 			? loadTerminalRowsById(db)
 			: new Map<string, TerminalRow>();
-
-	// Must run before the empty-list short-circuit so an empty daemon still
-	// clears stale scans.
 	applyPortScanSync(liveSessions, rowById);
 
 	if (liveSessions.length === 0) {

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -112,10 +112,8 @@ async function reapOrphanedSessions(
 		.all();
 	const rowById = new Map(rows.map((row) => [row.id, row]));
 
-	// Keep the port scanner in sync with the daemon's live sessions on the same
-	// pass that lists them — registers ports for terminals running without an
-	// attached renderer, and drops scans for ones the daemon has dropped. Runs
-	// before the empty-list short-circuit so an empty daemon clears stale scans.
+	// Reuse the list + row join the reaper already did. Must run before the
+	// empty-list short-circuit so an empty daemon still clears stale scans.
 	applyPortScanSync(liveSessions, rowById);
 
 	if (liveSessions.length === 0) {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -325,9 +325,9 @@ export function __resetSessionsForTesting(): void {
 /**
  * Whether a terminal id has a live in-memory session on this host-service
  * process. Such sessions already drive their own port scanning and unregister
- * themselves via the daemon exit subscription, so the port-scan reconciler
- * must leave them alone. Returns false for sessions the daemon still owns but
- * that this process hasn't re-created since its last restart.
+ * themselves via the daemon exit subscription, so the port-scan sync must leave
+ * them alone. Returns false for sessions the daemon still owns but that this
+ * process hasn't re-created since its last restart.
  */
 export function isLiveTerminalSession(terminalId: string): boolean {
 	const session = sessions.get(terminalId);

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -322,6 +322,18 @@ export function __resetSessionsForTesting(): void {
 	sessions.clear();
 }
 
+/**
+ * Whether a terminal id has a live in-memory session on this host-service
+ * process. Such sessions already drive their own port scanning and unregister
+ * themselves via the daemon exit subscription, so the port-scan reconciler
+ * must leave them alone. Returns false for sessions the daemon still owns but
+ * that this process hasn't re-created since its last restart.
+ */
+export function isLiveTerminalSession(terminalId: string): boolean {
+	const session = sessions.get(terminalId);
+	return session !== undefined && !session.exited;
+}
+
 function pruneAndCountOpenSockets(session: TerminalSession): number {
 	let openSockets = 0;
 	for (const socket of session.sockets) {

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -485,6 +485,15 @@ export class PortManager extends EventEmitter {
 		);
 	}
 
+	/**
+	 * Terminal IDs currently registered for scanning. Lets a host reconcile its
+	 * registered set against ground truth (e.g. the live daemon session list)
+	 * and unregister sessions it adopted but that have since exited.
+	 */
+	getRegisteredTerminalIds(): string[] {
+		return Array.from(this.sessions.keys());
+	}
+
 	getPortsByWorkspace(workspaceId: string): DetectedPort[] {
 		return this.getAllPorts().filter((p) => p.workspaceId === workspaceId);
 	}


### PR DESCRIPTION
## Problem

Ports were detected less completely in v2 than in v1. Both use the same shared `@superset/port-scanner` `PortManager` (2.5s periodic scan of registered terminal sessions, keyed by PID tree), so the gap was in **what gets registered**:

- **v1** (desktop `daemon-manager.ts` → `reconcileOnStartup`) pre-registers **every alive daemon session** with `portManager.upsertSession(...)` at startup, before any renderer attaches.
- **v2** host-service only called `upsertSession` inside `createTerminalSessionInternal` — i.e. **only when a renderer creates or attaches to a terminal**. Terminals the daemon is running but nobody has opened (notably sessions adopted after a host-service restart) were never scanned, so their ports never appeared in the v2 sidebar.

## Fix

Fold a port-scan sync into the existing **terminal reaper** (`reaper.ts`) instead of adding a parallel module. The reaper already calls `daemon.list()` and joins `terminalSessions` (for `terminalId → workspaceId`) on the same pass, immediately at startup and on its interval — so there's no extra daemon call, DB query, or timer.

- `planPortScanSync()` — pure decision function:
  - **register** every alive daemon session that maps to an active workspace row and isn't already owned by a live in-memory session;
  - **unregister** every watched terminal the daemon no longer reports and no live in-memory session owns (adopted sessions never get the daemon exit subscription that normally unregisters them).
- `applyPortScanSync()` applies the plan to `portManager` on each reaper pass, before the empty-list short-circuit so an empty daemon clears stale scans.
- Supporting helpers: `PortManager.getRegisteredTerminalIds()` and `terminal.ts isLiveTerminalSession()` (the latter guards a renderer-attached session against being dropped during a racy `daemon.list()`).

The `terminalId → workspaceId` join is irreducible: `daemon.list()` returns `{id, pid, alive}` only, and the sidebar groups ports by workspace — that mapping lives in the host DB, which the reaper already reads.

## End-to-end

- **On start:** `eventBus.start()` (in `createApp`) wires `portManager` → `port:changed` broadcast; the reaper's immediate first pass registers live sessions → periodic scan begins. Bridge is wired before registration, so no early events drop.
- **Renderer reads:** `ports.getAll` returns `portManager.getAllPorts()`, now populated for unattached terminals.
- **Renderer subscribes:** the event-bus `port:changed` stream delivers live add/remove for all live terminals, attached or not.

## Notes

- Self-heal cleanup of adopted-but-exited registrations rides the reaper's 5-min cadence; their ports still vanish within 2.5s via the empty-tree scan, only the no-op registration lingers. Attached terminals unregister instantly on the daemon exit event.

## Testing

- New `reaper.test.ts` covers `planPortScanSync` (register/skip/unregister/empty-daemon/race-guard); verified each case fails under impl mutation.
- `bun run lint` exits 0; typecheck passes for `@superset/host-service` and `@superset/port-scanner`; existing `port-scanner` tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing port detection for terminals running without an attached renderer by syncing the port scanner with daemon sessions during reaper passes. Ports now appear for adopted/live terminals right after start and stay accurate.

- **Bug Fixes**
  - Sync `portManager` with alive daemon sessions on each reaper pass: register mapped active rows not owned by a live in-memory session; unregister watched terminals the daemon no longer reports; guard renderer-attached sessions via `isLiveTerminalSession`.
  - Skip the DB join when the daemon reports no live sessions while still dropping stale scans; isolate the sync in try/catch so reaper cleanup can’t be blocked.
  - Added `PortManager.getRegisteredTerminalIds()`, `planPortScanSync`, and tests.

<sup>Written for commit 9c940ac33c3650645104a44444f310d201ef0513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved port scan management by reconciling with the daemon’s active terminal sessions: newly live terminals are registered, stale ones are unregistered, and previously adopted scans are cleared when no live sessions are reported.
  * Added a helper to treat only non-exited in-memory terminal sessions as “live” for reconciliation.
  * Exposed a method to retrieve currently registered terminal IDs for port scanning.

* **Tests**
  * Added Bun coverage for port-scan synchronization scenarios, including adoption, skipping owned sessions, handling missing/inactive rows, unregistering removed terminals, clearing when none are live, and temporary daemon absence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->