### PR TITLE
fix(desktop): keep removed projects out of the sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "bun:test";
+import {
+	removeProjectFromSidebarState,
+	tombstoneSidebarWorkspaceRecord,
+} from "./sidebarMutations";
+
+/**
+ * Minimal in-memory stand-in for a TanStack DB collection, implementing only
+ * the surface the sidebar mutations touch (`get`/`insert`/`update`/`delete`
+ * plus a `.state` Map).
+ */
+function makeCollection<T>(getKey: (item: T) => string) {
+	const state = new Map<string, T>();
+	return {
+		state,
+		get: (key: string) => state.get(key),
+		insert: (item: T) => {
+			state.set(getKey(item), structuredClone(item));
+		},
+		update: (key: string, producer: (draft: T) => void) => {
+			const existing = state.get(key);
+			if (!existing) return;
+			const draft = structuredClone(existing);
+			producer(draft);
+			state.set(key, draft);
+		},
+		delete: (keys: string | string[]) => {
+			for (const key of Array.isArray(keys) ? keys : [keys]) {
+				state.delete(key);
+			}
+		},
+	};
+}
+
+type LocalStateRow = {
+	workspaceId: string;
+	createdAt: Date;
+	sidebarState: {
+		projectId: string;
+		tabOrder: number;
+		sectionId: string | null;
+		isHidden: boolean;
+	};
+	paneLayout: { version: number; tabs: unknown[]; activeTabId: string | null };
+};
+
+function localStateRow(
+	workspaceId: string,
+	projectId: string,
+	overrides: Partial<LocalStateRow["sidebarState"]> = {},
+): LocalStateRow {
+	return {
+		workspaceId,
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		sidebarState: {
+			projectId,
+			tabOrder: 1,
+			sectionId: null,
+			isHidden: false,
+			...overrides,
+		},
+		paneLayout: { version: 1, tabs: [], activeTabId: null },
+	};
+}
+
+function makeCollections() {
+	return {
+		v2WorkspaceLocalState: makeCollection<LocalStateRow>(
+			(row) => row.workspaceId,
+		),
+		v2Workspaces: makeCollection<{
+			id: string;
+			projectId: string;
+			hostId: string;
+		}>((row) => row.id),
+		v2SidebarSections: makeCollection<{
+			sectionId: string;
+			projectId: string;
+		}>((row) => row.sectionId),
+		v2SidebarProjects: makeCollection<{ projectId: string }>(
+			(row) => row.projectId,
+		),
+	};
+}
+
+type Collections = ReturnType<typeof makeCollections>;
+
+// The functions accept the real `AppCollections` Pick; our fakes implement the
+// touched subset, so cast through the parameter type.
+function asRemoveArg(collections: Collections) {
+	return collections as unknown as Parameters<
+		typeof removeProjectFromSidebarState
+	>[0];
+}
+function asTombstoneArg(collections: Collections) {
+	return collections as unknown as Parameters<
+		typeof tombstoneSidebarWorkspaceRecord
+	>[0];
+}
+
+const noopCleanup = () => {};
+
+/** Mirrors `useAutoAddLocalWorkspacesToSidebar`: re-pins this-machine workspaces with no local-state row. */
+function workspacesAutoAddWouldRepin(
+	collections: Collections,
+	machineId: string,
+): string[] {
+	const known = new Set(collections.v2WorkspaceLocalState.state.keys());
+	return Array.from(collections.v2Workspaces.state.values())
+		.filter((w) => w.hostId === machineId && !known.has(w.id))
+		.map((w) => w.id);
+}
+
+describe("removeProjectFromSidebarState", () => {
+	it("keeps an auto-included main workspace removed (no local-state row) so the auto-add hook can't re-pin it", () => {
+		const collections = makeCollections();
+		collections.v2Workspaces.insert({
+			id: "ws-main",
+			projectId: "proj-1",
+			hostId: "machine-1",
+		});
+		collections.v2SidebarProjects.insert({ projectId: "proj-1" });
+
+		removeProjectFromSidebarState(
+			asRemoveArg(collections),
+			"proj-1",
+			"machine-1",
+			noopCleanup,
+		);
+
+		// Project record gone -> project no longer rendered.
+		expect(collections.v2SidebarProjects.get("proj-1")).toBeUndefined();
+		// A tombstone row now exists for the previously row-less main workspace.
+		const tombstone = collections.v2WorkspaceLocalState.get("ws-main");
+		expect(tombstone?.sidebarState.isHidden).toBe(true);
+		// Regression guard: the auto-add hook would NOT re-pin it.
+		expect(workspacesAutoAddWouldRepin(collections, "machine-1")).toEqual([]);
+	});
+
+	it("tombstones an explicitly-placed workspace and deletes the project's sections and record", () => {
+		const collections = makeCollections();
+		collections.v2WorkspaceLocalState.insert(
+			localStateRow("ws-1", "proj-1", { sectionId: "sec-1", tabOrder: 3 }),
+		);
+		collections.v2Workspaces.insert({
+			id: "ws-1",
+			projectId: "proj-1",
+			hostId: "machine-1",
+		});
+		collections.v2SidebarSections.insert({
+			sectionId: "sec-1",
+			projectId: "proj-1",
+		});
+		collections.v2SidebarProjects.insert({ projectId: "proj-1" });
+
+		const cleaned: string[] = [];
+		removeProjectFromSidebarState(
+			asRemoveArg(collections),
+			"proj-1",
+			"machine-1",
+			(rows) => {
+				for (const row of rows) cleaned.push(String(row.workspaceId));
+			},
+		);
+
+		const row = collections.v2WorkspaceLocalState.get("ws-1");
+		expect(row?.sidebarState.isHidden).toBe(true);
+		expect(row?.sidebarState.sectionId).toBeNull();
+		expect(collections.v2SidebarSections.get("sec-1")).toBeUndefined();
+		expect(collections.v2SidebarProjects.get("proj-1")).toBeUndefined();
+		// Existing rows have their pane runtimes cleaned up.
+		expect(cleaned).toEqual(["ws-1"]);
+	});
+
+	it("leaves workspaces from other projects and other hosts untouched", () => {
+		const collections = makeCollections();
+		collections.v2WorkspaceLocalState.insert(
+			localStateRow("ws-other", "proj-2"),
+		);
+		collections.v2Workspaces.insert({
+			id: "ws-other",
+			projectId: "proj-2",
+			hostId: "machine-1",
+		});
+		// Same project, different host, no local-state row -> must not be tombstoned.
+		collections.v2Workspaces.insert({
+			id: "ws-remote",
+			projectId: "proj-1",
+			hostId: "machine-2",
+		});
+		collections.v2SidebarProjects.insert({ projectId: "proj-1" });
+
+		removeProjectFromSidebarState(
+			asRemoveArg(collections),
+			"proj-1",
+			"machine-1",
+			noopCleanup,
+		);
+
+		expect(
+			collections.v2WorkspaceLocalState.get("ws-other")?.sidebarState.isHidden,
+		).toBe(false);
+		expect(collections.v2WorkspaceLocalState.get("ws-remote")).toBeUndefined();
+	});
+});
+
+describe("tombstoneSidebarWorkspaceRecord", () => {
+	it("inserts a hidden row when none exists and does not run pane cleanup", () => {
+		const collections = makeCollections();
+		const cleaned: string[] = [];
+
+		tombstoneSidebarWorkspaceRecord(
+			asTombstoneArg(collections),
+			"ws-new",
+			"proj-1",
+			(rows) => {
+				for (const row of rows) cleaned.push(String(row.workspaceId));
+			},
+		);
+
+		expect(
+			collections.v2WorkspaceLocalState.get("ws-new")?.sidebarState.isHidden,
+		).toBe(true);
+		expect(cleaned).toEqual([]);
+	});
+
+	it("hides an existing row, clears its section, and runs pane cleanup", () => {
+		const collections = makeCollections();
+		collections.v2WorkspaceLocalState.insert(
+			localStateRow("ws-1", "proj-1", { sectionId: "sec-1" }),
+		);
+		const cleaned: string[] = [];
+
+		tombstoneSidebarWorkspaceRecord(
+			asTombstoneArg(collections),
+			"ws-1",
+			"proj-1",
+			(rows) => {
+				for (const row of rows) cleaned.push(String(row.workspaceId));
+			},
+		);
+
+		const row = collections.v2WorkspaceLocalState.get("ws-1");
+		expect(row?.sidebarState.isHidden).toBe(true);
+		expect(row?.sidebarState.sectionId).toBeNull();
+		expect(cleaned).toEqual(["ws-1"]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.ts
@@ -61,6 +61,12 @@ export function tombstoneSidebarWorkspaceRecord(
  * via `ensureWorkspaceInSidebar`, recreate the project record). The union below
  * covers both explicitly-placed workspaces and this machine's workspaces that
  * have no local-state row yet (auto-included main/CLI workspaces).
+ *
+ * `machineId` is required (not nullable): `LocalHostServiceProvider` doesn't
+ * render the authenticated tree until it resolves, so any caller has a real id.
+ * Keeping it non-null guarantees the `hostId === machineId` filter below can't
+ * silently skip row-less workspaces (which would let the auto-add hook re-pin
+ * them once an id arrived).
  */
 export function removeProjectFromSidebarState(
 	collections: Pick<
@@ -71,7 +77,7 @@ export function removeProjectFromSidebarState(
 		| "v2SidebarProjects"
 	>,
 	projectId: string,
-	machineId: string | null,
+	machineId: string,
 	cleanupPaneRuntimes: CleanupPaneRuntimes,
 ): void {
 	const workspaceIds = new Set<string>();

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.ts
@@ -1,0 +1,108 @@
+import type { WorkspaceState } from "@superset/panes";
+import type { PaneLifecycleRow } from "renderer/routes/_authenticated/components/utils/paneLifecycleRows";
+import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+
+/**
+ * Pure sidebar local-state mutations, kept free of React/Electron imports so
+ * they can be unit-tested against an in-memory collection. Pane-runtime cleanup
+ * is injected so the registry side effects stay in the hook layer.
+ */
+
+export function createEmptyPaneLayout(): WorkspaceState<unknown> {
+	return {
+		version: 1,
+		tabs: [],
+		activeTabId: null,
+	} satisfies WorkspaceState<unknown>;
+}
+
+type CleanupPaneRuntimes = (rows: PaneLifecycleRow[]) => void;
+
+/**
+ * Removes a workspace from the sidebar without deleting its local-state row.
+ * Instead of hard-deleting, we leave a hidden "tombstone" row so
+ * `useAutoAddLocalWorkspacesToSidebar` (which treats a missing row as "never
+ * seen here") doesn't immediately re-pin a workspace the user dismissed.
+ */
+export function tombstoneSidebarWorkspaceRecord(
+	collections: Pick<AppCollections, "v2WorkspaceLocalState">,
+	workspaceId: string,
+	projectId: string,
+	cleanupPaneRuntimes: CleanupPaneRuntimes,
+): void {
+	const existing = collections.v2WorkspaceLocalState.get(workspaceId);
+	if (!existing) {
+		collections.v2WorkspaceLocalState.insert({
+			workspaceId,
+			createdAt: new Date(),
+			sidebarState: {
+				projectId,
+				tabOrder: 0,
+				sectionId: null,
+				isHidden: true,
+			},
+			paneLayout: createEmptyPaneLayout(),
+		});
+		return;
+	}
+
+	cleanupPaneRuntimes([existing]);
+	collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+		draft.sidebarState.projectId = projectId;
+		draft.sidebarState.sectionId = null;
+		draft.sidebarState.isHidden = true;
+		draft.paneLayout = createEmptyPaneLayout();
+	});
+}
+
+/**
+ * Removes a whole project from the sidebar. Workspaces are tombstoned rather
+ * than hard-deleted so the auto-add hook doesn't immediately re-pin them (and,
+ * via `ensureWorkspaceInSidebar`, recreate the project record). The union below
+ * covers both explicitly-placed workspaces and this machine's workspaces that
+ * have no local-state row yet (auto-included main/CLI workspaces).
+ */
+export function removeProjectFromSidebarState(
+	collections: Pick<
+		AppCollections,
+		| "v2WorkspaceLocalState"
+		| "v2Workspaces"
+		| "v2SidebarSections"
+		| "v2SidebarProjects"
+	>,
+	projectId: string,
+	machineId: string | null,
+	cleanupPaneRuntimes: CleanupPaneRuntimes,
+): void {
+	const workspaceIds = new Set<string>();
+	for (const row of collections.v2WorkspaceLocalState.state.values()) {
+		if (row.sidebarState.projectId === projectId) {
+			workspaceIds.add(row.workspaceId);
+		}
+	}
+	for (const workspace of collections.v2Workspaces.state.values()) {
+		if (workspace.projectId === projectId && workspace.hostId === machineId) {
+			workspaceIds.add(workspace.id);
+		}
+	}
+
+	for (const workspaceId of workspaceIds) {
+		tombstoneSidebarWorkspaceRecord(
+			collections,
+			workspaceId,
+			projectId,
+			cleanupPaneRuntimes,
+		);
+	}
+
+	const sectionIds = Array.from(collections.v2SidebarSections.state.values())
+		.filter((item) => item.projectId === projectId)
+		.map((item) => item.sectionId);
+	if (sectionIds.length > 0) {
+		collections.v2SidebarSections.delete(sectionIds);
+	}
+
+	if (collections.v2SidebarProjects.get(projectId)) {
+		collections.v2SidebarProjects.delete(projectId);
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -1,4 +1,4 @@
-import type { Pane, WorkspaceState } from "@superset/panes";
+import type { Pane } from "@superset/panes";
 import { useCallback } from "react";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
@@ -13,7 +13,13 @@ import {
 	getPrependTabOrder,
 	isSidebarWorkspaceVisible,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { PROJECT_CUSTOM_COLORS } from "shared/constants/project-colors";
+import {
+	createEmptyPaneLayout,
+	removeProjectFromSidebarState,
+	tombstoneSidebarWorkspaceRecord,
+} from "./sidebarMutations";
 
 type ProjectTopLevelItem = {
 	type: "workspace" | "section";
@@ -72,14 +78,6 @@ function getProjectTopLevelItems(
 function getFirstSectionIndex(items: ProjectTopLevelItem[]): number {
 	const firstSectionIndex = items.findIndex((item) => item.type === "section");
 	return firstSectionIndex === -1 ? items.length : firstSectionIndex;
-}
-
-function createEmptyPaneLayout(): WorkspaceState<unknown> {
-	return {
-		version: 1,
-		tabs: [],
-		activeTabId: null,
-	} satisfies WorkspaceState<unknown>;
 }
 
 /**
@@ -189,6 +187,7 @@ function cleanupWorkspacePaneRuntimes(rows: PaneLifecycleRow[]): void {
 
 export function useDashboardSidebarState() {
 	const collections = useCollections();
+	const { machineId } = useLocalHostService();
 
 	const ensureProjectInSidebar = useCallback(
 		(projectId: string) => {
@@ -455,57 +454,26 @@ export function useDashboardSidebarState() {
 
 	const hideWorkspaceInSidebar = useCallback(
 		(workspaceId: string, projectId: string) => {
-			const workspace = collections.v2WorkspaceLocalState.get(workspaceId);
-			if (!workspace) {
-				collections.v2WorkspaceLocalState.insert({
-					workspaceId,
-					createdAt: new Date(),
-					sidebarState: {
-						projectId,
-						tabOrder: 0,
-						sectionId: null,
-						isHidden: true,
-					},
-					paneLayout: createEmptyPaneLayout(),
-				});
-				return;
-			}
-
-			cleanupWorkspacePaneRuntimes([workspace]);
-			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.sidebarState.projectId = projectId;
-				draft.sidebarState.sectionId = null;
-				draft.sidebarState.isHidden = true;
-				draft.paneLayout = createEmptyPaneLayout();
-			});
+			tombstoneSidebarWorkspaceRecord(
+				collections,
+				workspaceId,
+				projectId,
+				cleanupWorkspacePaneRuntimes,
+			);
 		},
 		[collections],
 	);
 
 	const removeProjectFromSidebar = useCallback(
 		(projectId: string) => {
-			const workspaceRows = Array.from(
-				collections.v2WorkspaceLocalState.state.values(),
-			).filter((item) => item.sidebarState.projectId === projectId);
-			const workspaceIds = workspaceRows.map((item) => item.workspaceId);
-			const sectionIds = Array.from(
-				collections.v2SidebarSections.state.values(),
-			)
-				.filter((item) => item.projectId === projectId)
-				.map((item) => item.sectionId);
-
-			if (workspaceIds.length > 0) {
-				cleanupWorkspacePaneRuntimes(workspaceRows);
-				collections.v2WorkspaceLocalState.delete(workspaceIds);
-			}
-			if (sectionIds.length > 0) {
-				collections.v2SidebarSections.delete(sectionIds);
-			}
-			if (collections.v2SidebarProjects.get(projectId)) {
-				collections.v2SidebarProjects.delete(projectId);
-			}
+			removeProjectFromSidebarState(
+				collections,
+				projectId,
+				machineId,
+				cleanupWorkspacePaneRuntimes,
+			);
 		},
-		[collections],
+		[collections, machineId],
 	);
 
 	return {


### PR DESCRIPTION
## Summary
- Removing a project from the sidebar now sticks. Previously the project would reappear almost immediately and felt un-removable.
- Project removal now **tombstones** its workspaces (hidden local-state rows) instead of hard-deleting them, matching the pattern #5083 introduced for single-workspace removal.
- Extracted the pure sidebar mutations into a testable `sidebarMutations` module and added a regression test for the re-pin race.

## Why / Context
#5083 added `useAutoAddLocalWorkspacesToSidebar`, which backfills sidebar rows for workspaces on this device that have no `v2WorkspaceLocalState` row (e.g. CLI-created ones). It treats a **missing** local-state row as "never seen here → pin it".

`removeProjectFromSidebar` still **hard-deleted** the project's local-state rows. So right after removal, the auto-add hook saw those this-machine workspaces with no row, called `ensureWorkspaceInSidebar`, and — via `ensureSidebarProjectRecord` — recreated both the workspace rows and the project record. The project bounced straight back.

Single-workspace removal didn't have this problem because #5083 had already switched it to a tombstone (`isHidden: true`), which the hook sees in `knownWorkspaceIds` and skips. Project removal was simply never converted. (This regression is on `main` but has not shipped in a stable desktop release yet — latest tag `desktop-v1.12.5` predates #5083 — so it's currently canary-only.)

## How It Works
- `removeProjectFromSidebarState` tombstones the **union** of (a) existing local-state rows for the project and (b) this machine's `v2Workspaces` rows for the project. (b) is the key addition — it catches auto-included `main`/CLI workspaces that have no local-state row yet and would otherwise be re-pinned.
- Each workspace is marked `isHidden: true` (sidebar filters hidden rows out), pane runtimes are cleaned up, and the project record + sections are still deleted. Projects render only from `v2SidebarProjects`, so deleting that record removes the project; with every this-machine workspace now tombstoned, nothing recreates it.
- The mutations were lifted out of the hook into `sidebarMutations.ts` (no React/Electron imports) with pane-runtime cleanup injected as a callback, so they unit-test against a tiny in-memory collection.

## Manual QA Checklist
- [x] Remove a project from the sidebar → it stays gone (does not reappear after the auto-add hook runs)
- [x] Remove a project whose `main` workspace was auto-included (no explicit sidebar placement) → stays gone
- [x] Remove a single workspace (existing behavior) → still hidden, unchanged
- [x] Other projects and their workspaces are unaffected
- [x] Removed project stays gone after app restart
- [x] No console errors in renderer during/after removal

## Testing
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun test src/.../useDashboardSidebarState/sidebarMutations.test.ts` ✅ (5 passing) — includes the regression guard: remove a project with a row-less main workspace → simulate the auto-add hook → assert it does **not** re-pin and the project record stays deleted.

## Design Decisions
- **Tombstone vs. a project-level "dismissed" flag**: tombstoning reuses the exact mechanism #5083 already established for workspaces and needs no schema change, keeping the fix small and consistent. The auto-add hook keys off workspace-row existence, so workspace tombstones are sufficient.

## Known Limitations / Follow-ups
- Tombstones accumulate as inert localStorage rows (one per removed workspace) — same cost the existing single-workspace path already pays; bounded by workspace count. A heal step pruning tombstones whose `v2Workspaces` row no longer exists is a reasonable future cleanup, intentionally deferred to keep this PR focused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where removed projects reappeared in the desktop sidebar by tombstoning their workspaces. Also extracts pure sidebar mutations into a small module with tests and requires a non-null machineId to avoid re-pin races.

- **Bug Fixes**
  - Tombstones each workspace (`isHidden: true`), including this-machine workspaces without a local-state row, so the auto-add hook cannot re-pin them.
  - Requires a non-null machineId in project removal to ensure row-less local workspaces are tombstoned and not re-pinned when the id resolves.
  - Deletes the project and its sections, clears pane runtimes, and persists across restarts.

- **Refactors**
  - Extracted `tombstoneSidebarWorkspaceRecord` and `removeProjectFromSidebarState` into `sidebarMutations.ts` with unit tests guarding the re-pin race.

<sup>Written for commit 811bb431db2beb1ba32217c1d7ece28c149d5d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering sidebar “tombstoning” and project removal behavior, including correct handling of auto-included workspaces and cleanup of related sidebar sections/panes.

* **Refactor**
  * Extracted sidebar state mutation logic into reusable, pure helper functions for clearer, consistent updates to sidebar local state.
  * Updated the dashboard sidebar hook to delegate hide/remove actions to the new helpers, improving reliability of sidebar state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->