### PR TITLE
fix(plugin): make `repository` a string in plugin manifest

### DIFF
--- a/plugins/superset/.claude-plugin/plugin.json
+++ b/plugins/superset/.claude-plugin/plugin.json
@@ -7,10 +7,7 @@
 		"url": "https://superset.sh"
 	},
 	"homepage": "https://docs.superset.sh",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/superset-sh/superset"
-	},
+	"repository": "https://github.com/superset-sh/superset",
 	"license": "MIT",
 	"keywords": [
 		"superset",


### PR DESCRIPTION
## Problem

`/plugin install superset@superset` fails manifest validation:

```
Failed to install: Plugin temp_local_… has an invalid manifest file at
…/plugins/cache/temp_local_…/.claude-plugin/plugin.json.

Validation errors: repository: Invalid input: expected string, received object
```

`plugins/superset/.claude-plugin/plugin.json` declares `repository` as an
npm-style **object**:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/superset-sh/superset"
}
```

But Claude Code's plugin manifest schema requires `repository` to be a **string**
(a source code URL). The object form is rejected at load time, so the plugin
cannot be installed from the marketplace.

## Fix

Change `repository` to the string form the schema expects:

```json
"repository": "https://github.com/superset-sh/superset"
```

## Reference

Per the [Claude Code plugin reference → Metadata fields](https://code.claude.com/docs/en/plugins-reference#metadata-fields):

| Field | Type | Description | Example |
|-------|------|-------------|---------|
| `homepage` | string | Documentation URL | `"https://docs.example.com"` |
| `repository` | **string** | Source code URL | `"https://github.com/user/plugin"` |
| `license` | string | License identifier | `"MIT"`, `"Apache-2.0"` |
| `keywords` | array | Discovery tags | `["deployment", "ci-cd"]` |

> Screenshot of the official "Metadata fields" table (transcribed above):

<!-- Maintainers: the row that matters is `repository` → Type `string`, "Source code URL". -->

## Testing

After the change, `/plugin install superset@superset` validates and installs
cleanly. Verified locally by patching the cached marketplace copy with the same
one-line change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes install validation for the Superset plugin by changing the manifest `repository` from an object to a string URL. This makes `/plugin install superset@superset` pass schema validation and install successfully.

<sup>Written for commit 6217aa6432eda2ffe13f7a768af64202a1f98885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin manifest configuration format for improved standardization and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->