### PR TITLE
fix(desktop): extend auto-name fallback toast duration to 15s

### DIFF
--- a/apps/desktop/src/renderer/lib/workspaces/showWorkspaceAutoNameWarningToast.ts
+++ b/apps/desktop/src/renderer/lib/workspaces/showWorkspaceAutoNameWarningToast.ts
@@ -9,6 +9,8 @@ export function showWorkspaceAutoNameWarningToast({
 }) {
 	toast.warning("Workspace used a fallback name", {
 		description,
+		// Give users time to read the warning and click through to settings.
+		duration: 15_000,
 		action: {
 			label: "Open Models",
 			onClick: onOpenModelAuthSettings,


### PR DESCRIPTION
## Summary

The v2 workspace auto-name fallback warning toast (added in #5323) used Sonner's default ~4s duration, which is too short to read the warning and click through to the **Open Models** settings action. Extend it to 15s.

## Test Plan

- [ ] Trigger a workspace create that falls back to auto-naming
- [ ] Confirm the "Workspace used a fallback name" toast stays visible for ~15s
- [ ] Confirm the "Open Models" action still navigates to `/settings/models`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the "Workspace used a fallback name" warning toast to 15s (up from ~4s) in the desktop app. This gives users time to read the message and click "Open Models" to go to /settings/models.

<sup>Written for commit 7af5ee3ff39f9ed8a9bed1f9a53c677bb05debad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the duration of the workspace auto-name warning notification to 15 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->