### PR TITLE
fix(terminal): set TERM_THEME so cursor-agent detects light/dark theme

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -765,5 +765,22 @@ describe("env", () => {
 				expect(result.COLORFGBG).toBe("0;15");
 			});
 		});
+
+		describe("TERM_THEME hint for TUI light/dark detection", () => {
+			it("should set TERM_THEME to dark by default", () => {
+				const result = buildTerminalEnv(baseParams);
+				expect(result.TERM_THEME).toBe("dark");
+			});
+
+			it("should set TERM_THEME to dark when themeType is dark", () => {
+				const result = buildTerminalEnv({ ...baseParams, themeType: "dark" });
+				expect(result.TERM_THEME).toBe("dark");
+			});
+
+			it("should set TERM_THEME to light when themeType is light", () => {
+				const result = buildTerminalEnv({ ...baseParams, themeType: "light" });
+				expect(result.TERM_THEME).toBe("light");
+			});
+		});
 	});
 });

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -460,6 +460,12 @@ export function buildTerminalEnv(params: {
 
 	// COLORFGBG: "foreground;background" ANSI color indices — TUI apps use this to detect light/dark
 	const colorFgBg = themeType === "light" ? "0;15" : "15;0";
+	// TERM_THEME: explicit light/dark hint that cursor-agent (and other TUIs)
+	// read before falling back to an OSC 11 background probe. Our PTY output
+	// round-trips through the renderer's xterm, so that probe routinely exceeds
+	// cursor-agent's ~100ms timeout and defaults to dark on a light theme.
+	// Setting it here resolves the theme without the probe race.
+	const termTheme = themeType === "light" ? "light" : "dark";
 
 	const terminalEnv: Record<string, string> = {
 		...baseEnv,
@@ -468,6 +474,7 @@ export function buildTerminalEnv(params: {
 		TERM_PROGRAM_VERSION: process.env.npm_package_version || "1.0.0",
 		COLORTERM: "truecolor",
 		COLORFGBG: colorFgBg,
+		TERM_THEME: termTheme,
 		LANG: locale,
 		SUPERSET_PANE_ID: paneId,
 		SUPERSET_TAB_ID: tabId,

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -472,6 +472,19 @@ describe("buildV2TerminalEnv", () => {
 		expect(env.COLORFGBG).toBe("0;15");
 	});
 
+	test("defaults TERM_THEME to dark", () => {
+		const env = buildV2TerminalEnv(baseParams);
+		expect(env.TERM_THEME).toBe("dark");
+	});
+
+	test("sets TERM_THEME to light when themeType is light", () => {
+		const env = buildV2TerminalEnv({
+			...baseParams,
+			themeType: "light",
+		});
+		expect(env.TERM_THEME).toBe("light");
+	});
+
 	test("drops removed v1 metadata while preserving user shell vars", () => {
 		const env = buildV2TerminalEnv({
 			...baseParams,

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -477,6 +477,14 @@ describe("buildV2TerminalEnv", () => {
 		expect(env.TERM_THEME).toBe("dark");
 	});
 
+	test("sets TERM_THEME to dark when themeType is dark", () => {
+		const env = buildV2TerminalEnv({
+			...baseParams,
+			themeType: "dark",
+		});
+		expect(env.TERM_THEME).toBe("dark");
+	});
+
 	test("sets TERM_THEME to light when themeType is light", () => {
 		const env = buildV2TerminalEnv({
 			...baseParams,

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -178,6 +178,12 @@ export function buildV2TerminalEnv(
 	env.TERM_PROGRAM_VERSION = hostServiceVersion;
 	env.COLORTERM = "truecolor";
 	env.COLORFGBG = themeType === "light" ? "0;15" : "15;0";
+	// TERM_THEME is an explicit light/dark hint that cursor-agent (and other
+	// TUIs) read before falling back to an OSC 11 background probe. Our PTY
+	// output round-trips through the renderer's xterm, so that probe routinely
+	// exceeds cursor-agent's ~100ms timeout and defaults to dark on a light
+	// theme. Setting it here resolves the theme without the probe race.
+	env.TERM_THEME = themeType === "light" ? "light" : "dark";
 	env.LANG = normalizeUtf8Locale(baseEnv);
 	env.PWD = cwd;
 


### PR DESCRIPTION
## Problem

In Superset's light theme, the **cursor-agent** TUI renders its input box and message blocks in dark mode (see below) even though the terminal background is correctly light.

## Root cause

Confirmed from cursor-agent's own bundle: its primary theme detection is an **OSC 11 background query with a ~100ms timeout**, falling back to `COLORFGBG` only if the query fails. In Superset that query has to round-trip renderer ↔ websocket ↔ PTY, so it routinely exceeds the timeout and defaults to **dark** on a light theme.

Superset already advertises the theme correctly via `COLORFGBG`, the xterm `theme.background`, OSC 11, and DEC-2031 — but cursor-agent's probe loses the race before reaching the `COLORFGBG` fallback.

Before running the probe, cursor-agent checks an explicit env hint:

```js
if (process.env.ANSI_LIGHT === "1") return true;
if (TERM_THEME === "light") return true;
if (TERM_THEME === "dark")  return false;   // used before any OSC probe
```

## Fix

Set **`TERM_THEME=light|dark`** (from the same `themeType` that already drives `COLORFGBG`) in both terminal env builders:

- `packages/host-service/src/terminal/env.ts` (v2)
- `apps/desktop/src/main/lib/terminal/env.ts` (v1)

cursor-agent resolves the theme from the hint and skips the flaky probe entirely.

### Why this approach

An earlier attempt swapped `TERM_PROGRAM` from `kitty` → `ghostty`, which *did* fix cursor-agent — but inspecting claude-code's bundle showed it keys real behavior off the terminal name: `ghostty` is in claude-code's "Shift+Enter needs a config-file keybinding" list (kitty is not), and it switches notification protocol (OSC 99 → OSC 777). So a `TERM_PROGRAM` change risks regressing claude-code's multiline input. `TERM_THEME` avoids all of that:

- ✅ **claude-code untouched** — `TERM_PROGRAM` stays `kitty`
- ✅ **No probe race** — theme resolved from the env hint
- ✅ **Zero regression risk** — additive env var; agents that don't read it ignore it

### Known limitation

Like `COLORFGBG`, the env is set at PTY spawn, so toggling app theme while cursor-agent is already running won't recolor it until relaunch — consistent with the existing "PTY env is spawn-time only" design.

## Testing

- `bun test apps/desktop/src/main/lib/terminal/env.test.ts packages/host-service/src/terminal/env.test.ts` → **122 pass / 0 fail** (5 new tests covering `TERM_THEME` light/dark/default)
- `biome check` clean

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5338">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cursor-agent` rendering the wrong theme by setting `TERM_THEME` at PTY spawn so TUIs pick light/dark immediately and skip the flaky OSC 11 probe.

- **Bug Fixes**
  - Set `TERM_THEME=light|dark` from `themeType` in both env builders (`apps/desktop/src/main/lib/terminal/env.ts`, `packages/host-service/src/terminal/env.ts`), defaulting to dark.
  - Skips the OSC 11 background probe; `cursor-agent` resolves theme at startup.
  - Keeps `TERM_PROGRAM=kitty` to avoid `claude-code` behavior changes.
  - Added tests for `TERM_THEME` default/dark/light in both desktop and host-service suites.

<sup>Written for commit 045f999afc4aed0f841c13887d74f529cab63b44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal theme handling now honors the selected theme (light or dark) and defaults to dark mode when no theme is provided.

* **Tests**
  * Added/expanded unit tests in both desktop and host-service to verify terminal theme environment behavior and correct defaulting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->