### PR TITLE
fix(ports): stop spurious "Failed to close N port(s)" toast on close-all

### DIFF
--- a/packages/port-scanner/src/port-manager.test.ts
+++ b/packages/port-scanner/src/port-manager.test.ts
@@ -290,6 +290,85 @@ describe("PortManager — port identity updates", () => {
 	});
 });
 
+describe("PortManager — killPort", () => {
+	it("kills a tracked port and reports success", async () => {
+		const killed: number[] = [];
+		const killManager = new PortManager({
+			killFn: async ({ pid }) => {
+				killed.push(pid);
+				return { success: true };
+			},
+		});
+
+		killManager.upsertSession("p1", "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 1001, address: "127.0.0.1", processName: "node" },
+		];
+		await killManager.forceScan();
+
+		const result = await killManager.killPort({
+			terminalId: "p1",
+			workspaceId: "ws1",
+			port: 3000,
+		});
+
+		expect(result.success).toBe(true);
+		expect(killed).toEqual([1001]);
+		killManager.stopPeriodicScan();
+	});
+
+	it("reports success when the port is no longer tracked (already closed)", async () => {
+		// Regression: closing several ports at once kills a shared process tree, and
+		// a scan removes the now-dead sibling ports before their own kill calls run.
+		// A port that is no longer tracked is already closed, so killPort must report
+		// success rather than the spurious "Failed to close N port(s)" toast.
+		const result = await manager.killPort({
+			terminalId: "p1",
+			workspaceId: "ws1",
+			port: 3000,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	it("refuses to kill the terminal's own shell process", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 1000, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+
+		const result = await manager.killPort({
+			terminalId: "p1",
+			workspaceId: "ws1",
+			port: 3000,
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("Cannot kill the terminal shell process");
+	});
+
+	it("rejects a kill whose workspace does not match the tracked port", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 1001, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+
+		const result = await manager.killPort({
+			terminalId: "p1",
+			workspaceId: "wrong-ws",
+			port: 3000,
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe(
+			"Port does not belong to the requested workspace",
+		);
+	});
+});
+
 describe("PortManager — #3372 hint regex narrowing", () => {
 	beforeEach(() => {
 		manager.upsertSession("p1", "ws1", 1000);

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -515,10 +515,14 @@ export class PortManager extends EventEmitter {
 		const detectedPort = this.ports.get(key);
 
 		if (!detectedPort) {
-			return Promise.resolve({
-				success: false,
-				error: "Port not found in tracked ports",
-			});
+			// The port is no longer tracked — nothing is listening on it, which is
+			// exactly the outcome a kill aims for. Treat it as success rather than a
+			// failure. This is the common case when closing several ports at once
+			// (e.g. "Close all"): killing one tears down a shared process tree, and a
+			// scan removes the now-dead sibling ports before their own kill calls run.
+			// Reporting failure here produced a spurious "Failed to close N port(s)"
+			// toast even though the ports were genuinely closed.
+			return Promise.resolve({ success: true });
 		}
 
 		if (detectedPort.workspaceId !== workspaceId) {


### PR DESCRIPTION
## Summary
- Closing several ports at once (the workspace **"Close all ports"** X) succeeded but spuriously toasted **"Failed to close 1 port — Port not found in tracked ports."**
- `PortManager.killPort` now treats a no-longer-tracked port as **already closed → success**, eliminating the false-failure toast. Fixes both desktop-local and host-service kill paths (shared `port-scanner` package).

## Why / Context
"Close all" calls `killPorts(group.ports)`, which fires every kill **concurrently** (`Promise.all`). The first kill runs `treeKillWithEscalation(pid)`, which tears down the entire **process tree** — so when two of a workspace's ports share a process tree (common: a dev server plus its HMR/websocket/inspector port), killing one also kills the process behind the sibling port. A port scan (the periodic interval, or a hint scan triggered by the dying process's terminal output) then removes the now-dead sibling from the tracked `ports` map.

By the time the sibling's own kill call reaches its synchronous map lookup, the entry is gone, so it returned `{ success: false, error: "Port not found in tracked ports" }`. The renderer counted one failed result and showed the toast — even though the port really was closed, which is why it "seems to work fine."

## How It Works
A port that is no longer tracked is, by definition, already closed — exactly the outcome a kill aims for. The `!detectedPort` branch in `killPort` now returns `{ success: true }` instead of an error. This mirrors `treeKillWithEscalation`, which already treats an already-dead process (`ESRCH`) as success; the change just aligns the map-lookup path with that behavior. The workspace-mismatch and shell-process guards are unchanged.

## Manual QA Checklist
- [ ] Start a workspace with a dev server that listens on multiple ports (e.g. Vite/Next with HMR).
- [ ] Click the workspace "Close all ports" X — ports close and **no** error toast appears.
- [ ] Single per-port X still closes the port with no error toast.
- [ ] Closing a port that is still genuinely listening returns success (process killed).

> Not yet verified live in the running app — this is a code-path fix with unit coverage. Happy to run `/verify` against the desktop app if desired.

## Testing
- `bun test packages/port-scanner/src/port-manager.test.ts` — 26 pass (4 new `killPort` regression tests: tracked kill, untracked = success, shell-process guard, workspace mismatch)
- `bun run lint`
- `bun run typecheck`

## Risks / Rollback
- Risk: low. Narrows a single error path to success; the kill itself (`treeKillWithEscalation`) is unchanged and already idempotent for dead processes. The only behavior change is that a kill targeting an untracked port no longer reports failure.
- Rollback: revert this commit.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5339">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the false "Failed to close N port(s)" toast when using Close all ports. `PortManager.killPort` now treats an untracked port as already closed so concurrent kills complete without errors.

- **Bug Fixes**
  - Sibling kills after a shared process tree is terminated now return success instead of "Port not found in tracked ports".
  - Applies to both desktop-local and host-service paths via shared `port-scanner`.

<sup>Written for commit 04c8f5f74cb6ca6fbe392439f31a5af5bd8e4df7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated port termination logic to report success when targeting an untracked port, rather than reporting failure.

* **Tests**
  * Added comprehensive test coverage for port termination scenarios, including successful termination, untracked port handling, shell process protection, and workspace validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->