### PR TITLE
feat(desktop): add command palette search button to navigation controls

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/NavigationControls.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/NavigationControls/NavigationControls.tsx
@@ -1,13 +1,15 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useLocation, useRouter } from "@tanstack/react-router";
 import { useEffect } from "react";
-import { LuArrowLeft, LuArrowRight } from "react-icons/lu";
+import { LuArrowLeft, LuArrowRight, LuSearch } from "react-icons/lu";
+import { useFrameStackStore } from "renderer/commandPalette/core/frames";
 import { HotkeyLabel, useHotkey } from "renderer/hotkeys";
 import { HistoryDropdown } from "./components/HistoryDropdown";
 
 export function NavigationControls() {
 	const router = useRouter();
 	const location = useLocation();
+	const openCommandPalette = useFrameStackStore((s) => s.setOpen);
 
 	const canGoBack = router.history.canGoBack();
 	const canGoForward = location.state.__TSR_index < router.history.length - 1;
@@ -65,6 +67,21 @@ export function NavigationControls() {
 			</Tooltip>
 
 			<HistoryDropdown />
+
+			<Tooltip delayDuration={300}>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={() => openCommandPalette(true)}
+						className="no-drag flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+					>
+						<LuSearch className="size-3.5" strokeWidth={1.5} />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">
+					<HotkeyLabel label="Command palette" id="OPEN_COMMAND_PALETTE" />
+				</TooltipContent>
+			</Tooltip>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Adds a magnifying-glass button to the dashboard navigation controls bar, next to the "Recently Viewed" (history) button, that opens the existing command palette.

- The palette itself already existed (`Cmd+Shift+K`); this just surfaces a discoverable click-to-open entry point.
- The button calls the same `useFrameStackStore` `setOpen` that the `OPEN_COMMAND_PALETTE` hotkey uses, so click and keyboard behave identically.
- Styled to match sibling buttons (back / forward / history) with a tooltip showing the `OPEN_COMMAND_PALETTE` shortcut.

## Test Plan

- [ ] Open the desktop app dashboard
- [ ] Confirm the search (magnifying glass) button appears right of the Recently Viewed button
- [ ] Click it → command palette opens
- [ ] Hover → tooltip shows "Command palette" with the keyboard shortcut
- [ ] `Cmd+Shift+K` still opens the palette as before

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5346">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a magnifying-glass button to the dashboard navigation controls that opens the existing command palette, placed next to Recently Viewed. It uses `useFrameStackStore` `setOpen` so clicks mirror the `OPEN_COMMAND_PALETTE` shortcut, with matching tooltip and styling.

<sup>Written for commit 9ae3796b3a8d44a0d8f2817b609f1d0664ab103b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new search button in the dashboard navigation to open the command palette.
  * The button includes a tooltip and supports the existing keyboard shortcut label for opening the palette.
* **UI Improvements**
  * Kept the back and forward navigation controls unchanged while adding a quicker way to access search and commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->