### PR TITLE
fix(terminal): prevent resize from bricking the parser mid inline-image decode

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/font-settle.ts
+++ b/apps/desktop/src/renderer/lib/terminal/font-settle.ts
@@ -50,20 +50,11 @@ export async function waitForFontReady({
 	}
 }
 
-/**
- * Wait for the terminal's configured font to load, then run a refit.
- * Shared between v1 and v2 — both need identical
- * "measured-too-early" recovery after `terminal.open()` and after
- * font-setting changes. `refit` should return true iff terminal dimensions
- * changed (so the caller can propagate to the PTY). `isAlive` is checked
- * after the await to bail when the terminal has been disposed/detached
- * while the font was loading.
- */
+/** Wait for the configured font to load, then run a refit if still attached. */
 export function scheduleFontSettleRefit(
 	terminal: XTerm,
 	isAlive: () => boolean,
-	refit: () => boolean,
-	onDimensionsChanged?: () => void,
+	refit: () => void,
 ): void {
 	const fontFamily = String(terminal.options.fontFamily ?? "").trim();
 	if (!fontFamily) return;
@@ -71,7 +62,6 @@ export function scheduleFontSettleRefit(
 
 	void waitForFontReady({ fontFamily, fontSize }).then(() => {
 		if (!isAlive()) return;
-		const changed = refit();
-		if (changed) onDimensionsChanged?.();
+		refit();
 	});
 }

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createParserIdleGate,
+	runWhenParserIdle,
+	wrapWrite,
+} from "./parser-idle-gate";
+
+// Stand in for xterm's write: holds each write's callback instead of firing it,
+// mirroring how xterm holds a write's callback until that chunk (and any async
+// parser handler it triggered) has fully parsed. `drain()` fires the queued
+// callbacks, simulating the parser returning to GROUND.
+function fakeWrite() {
+	const pending: Array<() => void> = [];
+	const raw = (_data: string | Uint8Array, cb?: () => void) => {
+		if (cb) pending.push(cb);
+	};
+	return {
+		raw,
+		hasPending: () => pending.length > 0,
+		drain() {
+			const cbs = pending.splice(0, pending.length);
+			for (const cb of cbs) cb();
+		},
+	};
+}
+
+const flushMicrotasks = () => new Promise<void>((r) => queueMicrotask(r));
+
+describe("runWhenParserIdle", () => {
+	test("runs synchronously when no writes are in flight", () => {
+		const gate = createParserIdleGate();
+		let ran = false;
+		runWhenParserIdle(gate, () => {
+			ran = true;
+		});
+		expect(ran).toBe(true);
+	});
+
+	test("defers until in-flight writes drain (parser back in GROUND)", async () => {
+		const gate = createParserIdleGate();
+		const fake = fakeWrite();
+		const write = wrapWrite(gate, fake.raw);
+
+		// An inline-image write is mid-decode: its callback hasn't fired yet, so
+		// the parser is paused. Resizing now would re-enter parse and throw.
+		write("\x1b]1337;image-data\x07");
+		expect(fake.hasPending()).toBe(true);
+
+		let ran = false;
+		runWhenParserIdle(gate, () => {
+			ran = true;
+		});
+
+		// Must NOT run while the async write is still pending.
+		await flushMicrotasks();
+		expect(ran).toBe(false);
+
+		// Parser drains → the parked work runs (after the settling microtask).
+		fake.drain();
+		await flushMicrotasks();
+		expect(ran).toBe(true);
+	});
+
+	test("runs the parked work exactly once", async () => {
+		const gate = createParserIdleGate();
+		const fake = fakeWrite();
+		const write = wrapWrite(gate, fake.raw);
+		write("img");
+
+		let runs = 0;
+		runWhenParserIdle(gate, () => {
+			runs++;
+		});
+
+		fake.drain();
+		await flushMicrotasks();
+		await flushMicrotasks();
+		expect(runs).toBe(1);
+	});
+
+	test("coalesces resizes parked during the same busy window", async () => {
+		const gate = createParserIdleGate();
+		const fake = fakeWrite();
+		const write = wrapWrite(gate, fake.raw);
+		write("img");
+
+		const ran: string[] = [];
+		runWhenParserIdle(gate, () => ran.push("first"));
+		runWhenParserIdle(gate, () => ran.push("second"));
+
+		fake.drain();
+		await flushMicrotasks();
+		await flushMicrotasks();
+		// Only the latest fit-to-container matters; the earlier one is superseded.
+		expect(ran).toEqual(["second"]);
+	});
+
+	test("preserves the caller's own write callback", () => {
+		const gate = createParserIdleGate();
+		const fake = fakeWrite();
+		const write = wrapWrite(gate, fake.raw);
+
+		let called = false;
+		write("data", () => {
+			called = true;
+		});
+		fake.drain();
+		expect(called).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
@@ -117,6 +117,29 @@ describe("runWhenParserIdle", () => {
 		expect(ran).toEqual(["idle"]);
 	});
 
+	test("re-parks when a write lands between drain and the microtask flush", async () => {
+		const gate = createParserIdleGate();
+		const fake = fakeWrite();
+		const write = wrapWrite(gate, fake.raw);
+		write("first");
+
+		let runs = 0;
+		runWhenParserIdle(gate, () => {
+			runs++;
+		});
+
+		// First write drains (queuing the flush microtask), but a new write
+		// arrives before that microtask runs — the flush must bail and re-arm.
+		fake.drain();
+		write("second");
+		await flushMicrotasks();
+		expect(runs).toBe(0);
+
+		fake.drain();
+		await flushMicrotasks();
+		expect(runs).toBe(1);
+	});
+
 	test("cancels parked work before in-flight writes drain", async () => {
 		const gate = createParserIdleGate();
 		const fake = fakeWrite();

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	cancelParserIdleWork,
 	createParserIdleGate,
 	runWhenParserIdle,
 	wrapWrite,
@@ -93,6 +94,24 @@ describe("runWhenParserIdle", () => {
 		await flushMicrotasks();
 		// Only the latest fit-to-container matters; the earlier one is superseded.
 		expect(ran).toEqual(["second"]);
+	});
+
+	test("cancels parked work before in-flight writes drain", async () => {
+		const gate = createParserIdleGate();
+		const fake = fakeWrite();
+		const write = wrapWrite(gate, fake.raw);
+		write("img");
+
+		let ran = false;
+		runWhenParserIdle(gate, () => {
+			ran = true;
+		});
+
+		cancelParserIdleWork(gate);
+		fake.drain();
+		await flushMicrotasks();
+		await flushMicrotasks();
+		expect(ran).toBe(false);
 	});
 
 	test("preserves the caller's own write callback", () => {

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
@@ -96,6 +96,27 @@ describe("runWhenParserIdle", () => {
 		expect(ran).toEqual(["second"]);
 	});
 
+	test("keeps the gate closed until the write callback unwinds", async () => {
+		const gate = createParserIdleGate();
+		const fake = fakeWrite();
+		const write = wrapWrite(gate, fake.raw);
+
+		const ran: string[] = [];
+		write("first", () => {
+			runWhenParserIdle(gate, () => ran.push("idle"));
+			write("second");
+		});
+
+		fake.drain();
+		await flushMicrotasks();
+		expect(ran).toEqual([]);
+		expect(fake.hasPending()).toBe(true);
+
+		fake.drain();
+		await flushMicrotasks();
+		expect(ran).toEqual(["idle"]);
+	});
+
 	test("cancels parked work before in-flight writes drain", async () => {
 		const gate = createParserIdleGate();
 		const fake = fakeWrite();

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
@@ -40,6 +40,10 @@ export function createParserIdleGate(): ParserIdleGate {
 	return { pending: 0, queued: null };
 }
 
+export function cancelParserIdleWork(gate: ParserIdleGate): void {
+	gate.queued = null;
+}
+
 function flushQueued(gate: ParserIdleGate): void {
 	// A write may have snuck in after the count last hit zero; its own callback
 	// will re-trigger this once it settles, so just wait.

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
@@ -28,11 +28,14 @@ export function wrapWrite(gate: ParserIdleGate, write: WriteFn): WriteFn {
 	return (data, callback) => {
 		gate.pending++;
 		write(data, () => {
-			gate.pending--;
-			if (gate.pending === 0 && gate.queued) {
-				queueMicrotask(() => flushQueued(gate));
+			try {
+				callback?.();
+			} finally {
+				gate.pending--;
+				if (gate.pending === 0 && gate.queued) {
+					queueMicrotask(() => flushQueued(gate));
+				}
 			}
-			callback?.();
 		});
 	};
 }

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
@@ -1,38 +1,10 @@
-/**
- * Parser-safe resize coordination for xterm.
- *
- * `terminal.resize()` (reached via `FitAddon.fit()`) calls
- * `WriteBuffer.flushSync()` internally, which re-enters the escape-sequence
- * parser *synchronously*. If an async parser handler is mid-flight, that
- * re-entry throws
- *
- *   "improper continuation due to previous async handler, giving up parsing"
- *
- * and leaves the parser permanently FAILed — every later write throws too, so
- * the terminal is bricked. The image addon hits this: inline images (iTerm
- * OSC 1337 / Kitty) decode via `createImageBitmap(...).then(...)`, an async
- * handler that keeps the parser paused while the bitmap decodes. A resize
- * landing in that window (window/sidebar resize, font change, attach) trips it.
- *
- * So we never resize while a write is still being parsed. `wrapWrite` decorates
- * the terminal's own `write` once, counting in-flight writes — xterm fires a
- * write's callback only after that chunk (and its async handlers) has fully
- * parsed, so `pending === 0` means the parser is back in GROUND. Wrapping the
- * instance method means every write is counted; nothing can bypass it.
- * `runWhenParserIdle` then runs the resize immediately when nothing is pending,
- * or parks it until the count drops back to zero (flushed from the settling
- * write's callback, on a microtask so the eventual `flushSync` never runs
- * re-entrantly inside xterm's own write loop).
- *
- * This module is intentionally free of xterm imports so it stays trivially
- * unit-testable; the caller supplies the raw `write` to decorate.
- */
+// xterm resize re-enters the parser. If an async parser handler is paused
+// mid-write (inline image decode), wait for the write callback before resizing.
 
 type WriteFn = (data: string | Uint8Array, callback?: () => void) => void;
 
 export interface ParserIdleGate {
 	pending: number;
-	/** Latest resize parked while writes were in flight; newer ones supersede. */
 	queued: (() => void) | null;
 }
 
@@ -45,8 +17,6 @@ export function cancelParserIdleWork(gate: ParserIdleGate): void {
 }
 
 function flushQueued(gate: ParserIdleGate): void {
-	// A write may have snuck in after the count last hit zero; its own callback
-	// will re-trigger this once it settles, so just wait.
 	if (gate.pending !== 0) return;
 	const fn = gate.queued;
 	if (!fn) return;
@@ -54,18 +24,11 @@ function flushQueued(gate: ParserIdleGate): void {
 	fn();
 }
 
-/**
- * Decorate a terminal's `write` so every call feeds the gate. Returns the
- * wrapped function to assign back onto the terminal instance.
- */
 export function wrapWrite(gate: ParserIdleGate, write: WriteFn): WriteFn {
 	return (data, callback) => {
 		gate.pending++;
 		write(data, () => {
 			gate.pending--;
-			// Defer to a microtask so a parked resize never runs re-entrantly from
-			// inside xterm's `_innerWrite` loop (a nested `flushSync` corrupts the
-			// write buffer).
 			if (gate.pending === 0 && gate.queued) {
 				queueMicrotask(() => flushQueued(gate));
 			}
@@ -74,12 +37,6 @@ export function wrapWrite(gate: ParserIdleGate, write: WriteFn): WriteFn {
 	};
 }
 
-/**
- * Run `fn` (which may call `terminal.resize()`/`fit()`) only when the parser is
- * idle. Runs synchronously if no writes are in flight; otherwise parks it until
- * they drain. Only the most recent parked `fn` runs — intermediate resizes are
- * superseded, which is what we want for a fit-to-container.
- */
 export function runWhenParserIdle(gate: ParserIdleGate, fn: () => void): void {
 	if (gate.pending === 0) {
 		fn();

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
@@ -1,0 +1,85 @@
+/**
+ * Parser-safe resize coordination for xterm.
+ *
+ * `terminal.resize()` (reached via `FitAddon.fit()`) calls
+ * `WriteBuffer.flushSync()` internally, which re-enters the escape-sequence
+ * parser *synchronously*. If an async parser handler is mid-flight, that
+ * re-entry throws
+ *
+ *   "improper continuation due to previous async handler, giving up parsing"
+ *
+ * and leaves the parser permanently FAILed — every later write throws too, so
+ * the terminal is bricked. The image addon hits this: inline images (iTerm
+ * OSC 1337 / Kitty) decode via `createImageBitmap(...).then(...)`, an async
+ * handler that keeps the parser paused while the bitmap decodes. A resize
+ * landing in that window (window/sidebar resize, font change, attach) trips it.
+ *
+ * So we never resize while a write is still being parsed. `wrapWrite` decorates
+ * the terminal's own `write` once, counting in-flight writes — xterm fires a
+ * write's callback only after that chunk (and its async handlers) has fully
+ * parsed, so `pending === 0` means the parser is back in GROUND. Wrapping the
+ * instance method means every write is counted; nothing can bypass it.
+ * `runWhenParserIdle` then runs the resize immediately when nothing is pending,
+ * or parks it until the count drops back to zero (flushed from the settling
+ * write's callback, on a microtask so the eventual `flushSync` never runs
+ * re-entrantly inside xterm's own write loop).
+ *
+ * This module is intentionally free of xterm imports so it stays trivially
+ * unit-testable; the caller supplies the raw `write` to decorate.
+ */
+
+type WriteFn = (data: string | Uint8Array, callback?: () => void) => void;
+
+export interface ParserIdleGate {
+	pending: number;
+	/** Latest resize parked while writes were in flight; newer ones supersede. */
+	queued: (() => void) | null;
+}
+
+export function createParserIdleGate(): ParserIdleGate {
+	return { pending: 0, queued: null };
+}
+
+function flushQueued(gate: ParserIdleGate): void {
+	// A write may have snuck in after the count last hit zero; its own callback
+	// will re-trigger this once it settles, so just wait.
+	if (gate.pending !== 0) return;
+	const fn = gate.queued;
+	if (!fn) return;
+	gate.queued = null;
+	fn();
+}
+
+/**
+ * Decorate a terminal's `write` so every call feeds the gate. Returns the
+ * wrapped function to assign back onto the terminal instance.
+ */
+export function wrapWrite(gate: ParserIdleGate, write: WriteFn): WriteFn {
+	return (data, callback) => {
+		gate.pending++;
+		write(data, () => {
+			gate.pending--;
+			// Defer to a microtask so a parked resize never runs re-entrantly from
+			// inside xterm's `_innerWrite` loop (a nested `flushSync` corrupts the
+			// write buffer).
+			if (gate.pending === 0 && gate.queued) {
+				queueMicrotask(() => flushQueued(gate));
+			}
+			callback?.();
+		});
+	};
+}
+
+/**
+ * Run `fn` (which may call `terminal.resize()`/`fit()`) only when the parser is
+ * idle. Runs synchronously if no writes are in flight; otherwise parks it until
+ * they drain. Only the most recent parked `fn` runs — intermediate resizes are
+ * superseded, which is what we want for a fit-to-container.
+ */
+export function runWhenParserIdle(gate: ParserIdleGate, fn: () => void): void {
+	if (gate.pending === 0) {
+		fn();
+		return;
+	}
+	gate.queued = fn;
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -239,20 +239,15 @@ class TerminalRuntimeRegistryImpl {
 		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 
-		const prevCols = entry.runtime.terminal.cols;
-		const prevRows = entry.runtime.terminal.rows;
-
+		// The refit may be deferred until the parser drains, so we can't read the
+		// new dimensions synchronously here — `updateRuntimeAppearance` notifies
+		// via the callback whenever a fit actually changes them (sync or async).
 		const transport = entry.transport;
 		updateRuntimeAppearance(entry.runtime, appearance, () => {
 			const runtime = entry.runtime;
 			if (!runtime) return;
 			sendResize(transport, runtime.terminal.cols, runtime.terminal.rows);
 		});
-
-		const { cols, rows } = entry.runtime.terminal;
-		if (cols !== prevCols || rows !== prevRows) {
-			sendResize(entry.transport, cols, rows);
-		}
 	}
 
 	private disposeEntry(

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -239,9 +239,7 @@ class TerminalRuntimeRegistryImpl {
 		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 
-		// The refit may be deferred until the parser drains, so we can't read the
-		// new dimensions synchronously here — `updateRuntimeAppearance` notifies
-		// via the callback whenever a fit actually changes them (sync or async).
+		// The refit may defer until the parser drains; the callback reports it.
 		const transport = entry.transport;
 		updateRuntimeAppearance(entry.runtime, appearance, () => {
 			const runtime = entry.runtime;

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -133,11 +133,6 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 	return container.clientWidth > 0 && container.clientHeight > 0;
 }
 
-// `fit()` calls `terminal.resize()`, which `flushSync()`s the write buffer and
-// re-enters the parser. Doing that while an async parser handler (inline image
-// decode) is in flight throws "improper continuation ..." and bricks the
-// terminal, so the actual fit is gated through `runWhenParserIdle`. `onResize`
-// fires (sync or deferred) only when the dimensions actually change.
 function measureAndResize(
 	runtime: TerminalRuntime,
 	onResize?: () => void,
@@ -146,8 +141,6 @@ function measureAndResize(
 	const { terminal } = runtime;
 
 	runWhenParserIdle(runtime.gate, () => {
-		// Re-check visibility: the host may have been hidden or detached while we
-		// waited for the parser to drain.
 		if (!hostIsVisible(runtime.container)) return;
 
 		const buffer = terminal.buffer.active;
@@ -230,8 +223,6 @@ export function createRuntime(
 		appearance,
 	);
 
-	// Count every write through this terminal so resizes can wait for the parser
-	// to drain (see parser-idle-gate). Installed before any write below.
 	const gate = createParserIdleGate();
 	terminal.write = wrapWrite(gate, terminal.write.bind(terminal));
 
@@ -298,10 +289,7 @@ export function attachToContainer(
 	scheduleFontSettleRefit(
 		runtime.terminal,
 		() => hostIsVisible(runtime.container),
-		() => {
-			measureAndResize(runtime, onResize);
-			return false;
-		},
+		() => measureAndResize(runtime, onResize),
 	);
 
 	runtime._disposeResizeObserver?.();
@@ -356,10 +344,7 @@ export function updateRuntimeAppearance(
 		scheduleFontSettleRefit(
 			runtime.terminal,
 			() => hostIsVisible(runtime.container),
-			() => {
-				measureAndResize(runtime, onResize);
-				return false;
-			},
+			() => measureAndResize(runtime, onResize),
 		);
 	}
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -336,9 +336,7 @@ export function updateRuntimeAppearance(
 		applyTerminalFontFamilyCssVariable(runtime.wrapper, appearance.fontFamily);
 		terminal.options.fontFamily = appearance.fontFamily;
 		terminal.options.fontSize = appearance.fontSize;
-		if (hostIsVisible(runtime.container)) {
-			measureAndResize(runtime, onResize);
-		}
+		measureAndResize(runtime, onResize);
 		// The freshly-selected font may still be loading — schedule a follow-up
 		// refit once it resolves so dimensions track the rendered glyphs.
 		scheduleFontSettleRefit(

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -9,6 +9,12 @@ import {
 	type TerminalAppearance,
 } from "./appearance";
 import { scheduleFontSettleRefit } from "./font-settle";
+import {
+	createParserIdleGate,
+	type ParserIdleGate,
+	runWhenParserIdle,
+	wrapWrite,
+} from "./parser-idle-gate";
 import { loadAddons } from "./terminal-addons";
 import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
@@ -30,6 +36,7 @@ export interface TerminalRuntime {
 	progressAddon: ProgressAddon | null;
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
+	gate: ParserIdleGate;
 	resizeObserver: ResizeObserver | null;
 	_disposeResizeObserver: (() => void) | null;
 	lastCols: number;
@@ -125,31 +132,48 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 	return container.clientWidth > 0 && container.clientHeight > 0;
 }
 
-function measureAndResize(runtime: TerminalRuntime): boolean {
-	if (!hostIsVisible(runtime.container)) return false;
+// `fit()` calls `terminal.resize()`, which `flushSync()`s the write buffer and
+// re-enters the parser. Doing that while an async parser handler (inline image
+// decode) is in flight throws "improper continuation ..." and bricks the
+// terminal, so the actual fit is gated through `runWhenParserIdle`. `onResize`
+// fires (sync or deferred) only when the dimensions actually change.
+function measureAndResize(
+	runtime: TerminalRuntime,
+	onResize?: () => void,
+): void {
+	if (!hostIsVisible(runtime.container)) return;
 	const { terminal } = runtime;
-	const buffer = terminal.buffer.active;
-	const wasPinnedToBottom = buffer.viewportY >= buffer.baseY;
-	const savedViewportY = buffer.viewportY;
-	const prevCols = terminal.cols;
-	const prevRows = terminal.rows;
 
-	runtime.fitAddon.fit();
-	runtime.lastCols = terminal.cols;
-	runtime.lastRows = terminal.rows;
+	runWhenParserIdle(runtime.gate, () => {
+		// Re-check visibility: the host may have been hidden or detached while we
+		// waited for the parser to drain.
+		if (!hostIsVisible(runtime.container)) return;
 
-	if (wasPinnedToBottom) {
-		terminal.scrollToBottom();
-	} else {
-		const targetY = Math.min(savedViewportY, terminal.buffer.active.baseY);
-		if (terminal.buffer.active.viewportY !== targetY) {
-			terminal.scrollToLine(targetY);
+		const buffer = terminal.buffer.active;
+		const wasPinnedToBottom = buffer.viewportY >= buffer.baseY;
+		const savedViewportY = buffer.viewportY;
+		const prevCols = terminal.cols;
+		const prevRows = terminal.rows;
+
+		runtime.fitAddon.fit();
+		runtime.lastCols = terminal.cols;
+		runtime.lastRows = terminal.rows;
+
+		if (wasPinnedToBottom) {
+			terminal.scrollToBottom();
+		} else {
+			const targetY = Math.min(savedViewportY, terminal.buffer.active.baseY);
+			if (terminal.buffer.active.viewportY !== targetY) {
+				terminal.scrollToLine(targetY);
+			}
 		}
-	}
 
-	terminal.refresh(0, Math.max(0, terminal.rows - 1));
+		terminal.refresh(0, Math.max(0, terminal.rows - 1));
 
-	return terminal.cols !== prevCols || terminal.rows !== prevRows;
+		if (terminal.cols !== prevCols || terminal.rows !== prevRows) {
+			onResize?.();
+		}
+	});
 }
 
 function createResizeScheduler(
@@ -170,8 +194,7 @@ function createResizeScheduler(
 
 	const run = () => {
 		timeoutId = null;
-		const changed = measureAndResize(runtime);
-		if (changed) onResize?.();
+		measureAndResize(runtime, onResize);
 	};
 
 	const observe: ResizeObserverCallback = (entries) => {
@@ -206,6 +229,11 @@ export function createRuntime(
 		appearance,
 	);
 
+	// Count every write through this terminal so resizes can wait for the parser
+	// to drain (see parser-idle-gate). Installed before any write below.
+	const gate = createParserIdleGate();
+	terminal.write = wrapWrite(gate, terminal.write.bind(terminal));
+
 	const wrapper = document.createElement("div");
 	wrapper.style.width = "100%";
 	wrapper.style.height = "100%";
@@ -237,6 +265,7 @@ export function createRuntime(
 		progressAddon: addonsResult.progressAddon,
 		wrapper,
 		container: null,
+		gate,
 		resizeObserver: null,
 		_disposeResizeObserver: null,
 		lastCols: cols,
@@ -264,12 +293,14 @@ export function attachToContainer(
 
 	runtime.container = container;
 	container.appendChild(runtime.wrapper);
-	if (measureAndResize(runtime)) onResize?.();
+	measureAndResize(runtime, onResize);
 	scheduleFontSettleRefit(
 		runtime.terminal,
 		() => hostIsVisible(runtime.container),
-		() => measureAndResize(runtime),
-		onResize,
+		() => {
+			measureAndResize(runtime, onResize);
+			return false;
+		},
 	);
 
 	runtime._disposeResizeObserver?.();
@@ -316,15 +347,17 @@ export function updateRuntimeAppearance(
 		terminal.options.fontFamily = appearance.fontFamily;
 		terminal.options.fontSize = appearance.fontSize;
 		if (hostIsVisible(runtime.container)) {
-			measureAndResize(runtime);
+			measureAndResize(runtime, onResize);
 		}
 		// The freshly-selected font may still be loading — schedule a follow-up
 		// refit once it resolves so dimensions track the rendered glyphs.
 		scheduleFontSettleRefit(
 			runtime.terminal,
 			() => hostIsVisible(runtime.container),
-			() => measureAndResize(runtime),
-			onResize,
+			() => {
+				measureAndResize(runtime, onResize);
+				return false;
+			},
 		);
 	}
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -10,6 +10,7 @@ import {
 } from "./appearance";
 import { scheduleFontSettleRefit } from "./font-settle";
 import {
+	cancelParserIdleWork,
 	createParserIdleGate,
 	type ParserIdleGate,
 	runWhenParserIdle,
@@ -324,6 +325,7 @@ export function detachFromContainer(runtime: TerminalRuntime) {
 	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
+	cancelParserIdleWork(runtime.gate);
 	// Park instead of .remove() so xterm survives the React unmount —
 	// see getTerminalParkingContainer.
 	getTerminalParkingContainer().appendChild(runtime.wrapper);
@@ -379,6 +381,8 @@ export function disposeRuntime(
 	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
+	cancelParserIdleWork(runtime.gate);
+	runtime.container = null;
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
 	if (clearPersistedState) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -412,15 +412,9 @@ export const Terminal = memo(function Terminal({
 		if (!fontSettings) return;
 		const family = sanitizeTerminalFontFamily(fontSettings.terminalFontFamily);
 		const size = fontSettings.terminalFontSize ?? DEFAULT_TERMINAL_FONT_SIZE;
-		const result = v1TerminalCache.updateAppearance(
-			paneId,
-			family,
-			size,
-			({ cols, rows }) => resizeRef.current({ paneId, cols, rows }),
+		v1TerminalCache.updateAppearance(paneId, family, size, ({ cols, rows }) =>
+			resizeRef.current({ paneId, cols, rows }),
 		);
-		if (result?.changed) {
-			resizeRef.current({ paneId, cols: result.cols, rows: result.rows });
-		}
 	}, [paneId, fontSettings]);
 
 	const terminalBg = terminalTheme?.background ?? getDefaultTerminalBg();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -11,6 +11,11 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { applyTerminalFontFamilyCssVariable } from "renderer/lib/terminal/appearance";
 import { Utf8Base64 } from "renderer/lib/terminal/clipboard-base64";
 import type { DetectedLink } from "renderer/lib/terminal/links";
+import {
+	createParserIdleGate,
+	type ParserIdleGate,
+	wrapWrite,
+} from "renderer/lib/terminal/parser-idle-gate";
 import { TerminalLinkManager } from "renderer/lib/terminal/terminal-link-manager";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { toXtermTheme } from "renderer/stores/theme/utils";
@@ -84,6 +89,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	xterm: XTerm;
 	fitAddon: FitAddon;
 	searchAddon: SearchAddon;
+	gate: ParserIdleGate;
 	wrapper: HTMLDivElement;
 	linkManager: TerminalLinkManager;
 	cleanup: () => void;
@@ -98,6 +104,8 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const theme = initialTheme ?? getDefaultTerminalTheme();
 	const terminalOptions = { ...TERMINAL_OPTIONS, theme };
 	const xterm = new XTerm(terminalOptions);
+	const gate = createParserIdleGate();
+	xterm.write = wrapWrite(gate, xterm.write.bind(xterm));
 	const fitAddon = new FitAddon();
 	const searchAddon = new SearchAddon();
 
@@ -209,6 +217,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 		xterm,
 		fitAddon,
 		searchAddon,
+		gate,
 		wrapper,
 		linkManager,
 		cleanup: () => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -5,6 +5,7 @@ import type { MutableRefObject, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { writeCommandInPane } from "renderer/lib/terminal/launch-command";
 import type { DetectedLink } from "renderer/lib/terminal/links";
+import { runWhenParserIdle } from "renderer/lib/terminal/parser-idle-gate";
 import {
 	clearTerminalSessionReady,
 	markTerminalSessionReady,
@@ -264,24 +265,19 @@ export function useTerminalLifecycle({
 		// terminal-ws-transport sendResize-on-open.
 		const syncBackendDimensions = () => {
 			if (container.clientWidth === 0 || container.clientHeight === 0) return;
-			fitAddon.fit();
-			resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
+			runWhenParserIdle(cached.gate, () => {
+				if (container.clientWidth === 0 || container.clientHeight === 0) return;
+				fitAddon.fit();
+				resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
+			});
 		};
 
 		// Attach the wrapper div to the live container.
-		// The cache creates a ResizeObserver that calls fitAddon.fit() and
-		// forwards resize events to the backend — no separate resize handler needed.
-		const prevCols = xterm.cols;
-		const prevRows = xterm.rows;
+		// The cache fits on attach and on container resizes (ResizeObserver),
+		// invoking the callback whenever dimensions actually change.
 		v1TerminalCache.attachToContainer(paneId, container, () => {
 			resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
 		});
-		// If dimensions changed during attach (container resized while hidden),
-		// notify the backend PTY immediately — the ResizeObserver only fires on
-		// subsequent changes, not the initial fit.
-		if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
-			resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
-		}
 
 		const scheduleScrollToBottom = () => {
 			requestAnimationFrame(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -4,6 +4,11 @@ import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { applyTerminalFontFamilyCssVariable } from "renderer/lib/terminal/appearance";
 import { scheduleFontSettleRefit } from "renderer/lib/terminal/font-settle";
+import {
+	cancelParserIdleWork,
+	type ParserIdleGate,
+	runWhenParserIdle,
+} from "renderer/lib/terminal/parser-idle-gate";
 import { getTerminalParkingContainer } from "renderer/lib/terminal/terminal-parking";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { DEBUG_TERMINAL } from "./config";
@@ -23,6 +28,8 @@ export interface CachedTerminal {
 	xterm: XTerm;
 	fitAddon: FitAddon;
 	searchAddon: SearchAddon;
+	/** Counts in-flight writes so fits can wait out async image decodes. */
+	gate: ParserIdleGate;
 	wrapper: HTMLDivElement;
 	/** Disposes renderer RAF, query suppression, GPU renderer, etc. */
 	cleanupCreation: () => void;
@@ -95,6 +102,19 @@ function fitAndRefresh(entry: CachedTerminal): boolean {
 	return dimensionsChanged;
 }
 
+/** Fit once the parser is idle — xterm's resize re-enters the parser and
+ * bricks it if an async image decode is mid-flight (see parser-idle-gate). */
+function scheduleFitAndRefresh(
+	entry: CachedTerminal,
+	onChanged?: () => void,
+): void {
+	runWhenParserIdle(entry.gate, () => {
+		if (fitAndRefresh(entry)) {
+			onChanged?.();
+		}
+	});
+}
+
 export function has(paneId: string): boolean {
 	return cache.has(paneId);
 }
@@ -114,13 +134,14 @@ export function getOrCreate(
 		console.log(`[v1-terminal-cache] Creating new terminal: ${paneId}`);
 	}
 
-	const { xterm, fitAddon, searchAddon, wrapper, cleanup } =
+	const { xterm, fitAddon, searchAddon, gate, wrapper, cleanup } =
 		createTerminalInWrapper(options);
 
 	const entry: CachedTerminal = {
 		xterm,
 		fitAddon,
 		searchAddon,
+		gate,
 		wrapper,
 		cleanupCreation: cleanup,
 		subscription: null,
@@ -153,8 +174,9 @@ export function attachToContainer(
 	container.appendChild(entry.wrapper);
 
 	// Refit and repaint on reattach because the wrapper may have been parked
-	// while its live container changed size.
-	fitAndRefresh(entry);
+	// while its live container changed size. Reports through onResize since a
+	// gated fit may run after this call returns.
+	scheduleFitAndRefresh(entry, onResize);
 	// xterm's initial cell-width measurement may have run before the configured
 	// font finished loading, baking wrong glyph metrics into the renderer
 	// (#4617). Refit once fonts are ready so the layout matches the rendered
@@ -162,20 +184,14 @@ export function attachToContainer(
 	scheduleFontSettleRefit(
 		entry.xterm,
 		() => cache.get(paneId) === entry && hostIsVisible(entry.container),
-		() => {
-			if (fitAndRefresh(entry)) {
-				onResize?.();
-			}
-		},
+		() => scheduleFitAndRefresh(entry, onResize),
 	);
 
 	// Manage ResizeObserver lifecycle in the cache, not in React.
 	entry.resizeObserver?.disconnect();
-	const observer = new ResizeObserver(() => {
-		if (fitAndRefresh(entry)) {
-			onResize?.();
-		}
-	});
+	const observer = new ResizeObserver(() =>
+		scheduleFitAndRefresh(entry, onResize),
+	);
 	observer.observe(container);
 	entry.resizeObserver = observer;
 }
@@ -187,6 +203,7 @@ export function detachFromContainer(paneId: string): void {
 	if (DEBUG_TERMINAL) {
 		console.log(`[v1-terminal-cache] detachFromContainer: ${paneId}`);
 	}
+	cancelParserIdleWork(entry.gate);
 	entry.resizeObserver?.disconnect();
 	entry.resizeObserver = null;
 	entry.container = null;
@@ -198,48 +215,39 @@ export function detachFromContainer(paneId: string): void {
 // --- Appearance ---
 
 /**
- * Update font settings on a cached terminal. If font changed and the
- * terminal is visible, re-fit and return true so the caller can send
- * a backend resize if needed.
+ * Update font settings on a cached terminal. If the font changed and the
+ * terminal is visible, re-fits (once the parser is idle) and reports any
+ * dimension change through onResize so the caller can send a backend resize.
  */
 export function updateAppearance(
 	paneId: string,
 	fontFamily: string,
 	fontSize: number,
-	onDeferredResize?: (dims: { cols: number; rows: number }) => void,
-): { cols: number; rows: number; changed: boolean } | null {
+	onResize?: (dims: { cols: number; rows: number }) => void,
+): void {
 	const entry = cache.get(paneId);
-	if (!entry) return null;
+	if (!entry) return;
 
 	const { xterm } = entry;
 	const fontChanged =
 		xterm.options.fontFamily !== fontFamily ||
 		xterm.options.fontSize !== fontSize;
-	if (!fontChanged) return null;
+	if (!fontChanged) return;
 
 	applyTerminalFontFamilyCssVariable(entry.wrapper, fontFamily);
 	xterm.options.fontFamily = fontFamily;
 	xterm.options.fontSize = fontSize;
 
-	const changed = fitAndRefresh(entry);
+	const reportResize = () => onResize?.({ cols: xterm.cols, rows: xterm.rows });
+	scheduleFitAndRefresh(entry, reportResize);
 
 	// The new font may still be loading — schedule a second refit once it
 	// resolves so dimensions match the actually-rendered glyphs.
 	scheduleFontSettleRefit(
 		xterm,
 		() => cache.get(paneId) === entry && hostIsVisible(entry.container),
-		() => {
-			if (fitAndRefresh(entry)) {
-				onDeferredResize?.({ cols: xterm.cols, rows: xterm.rows });
-			}
-		},
+		() => scheduleFitAndRefresh(entry, reportResize),
 	);
-
-	return {
-		cols: xterm.cols,
-		rows: xterm.rows,
-		changed,
-	};
 }
 
 // --- Stream subscription ---
@@ -365,6 +373,7 @@ export function dispose(paneId: string): void {
 		console.log(`[v1-terminal-cache] Disposing: ${paneId}`);
 	}
 
+	cancelParserIdleWork(entry.gate);
 	entry.resizeObserver?.disconnect();
 	entry.subscription?.unsubscribe();
 	entry.cleanupCreation();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -162,8 +162,11 @@ export function attachToContainer(
 	scheduleFontSettleRefit(
 		entry.xterm,
 		() => cache.get(paneId) === entry && hostIsVisible(entry.container),
-		() => fitAndRefresh(entry),
-		onResize,
+		() => {
+			if (fitAndRefresh(entry)) {
+				onResize?.();
+			}
+		},
 	);
 
 	// Manage ResizeObserver lifecycle in the cache, not in React.
@@ -225,10 +228,11 @@ export function updateAppearance(
 	scheduleFontSettleRefit(
 		xterm,
 		() => cache.get(paneId) === entry && hostIsVisible(entry.container),
-		() => fitAndRefresh(entry),
-		onDeferredResize
-			? () => onDeferredResize({ cols: xterm.cols, rows: xterm.rows })
-			: undefined,
+		() => {
+			if (fitAndRefresh(entry)) {
+				onDeferredResize?.({ cols: xterm.cols, rows: xterm.rows });
+			}
+		},
 	);
 
 	return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -33,9 +33,6 @@ export interface CachedTerminal {
 	wrapper: HTMLDivElement;
 	/** Disposes renderer RAF, query suppression, GPU renderer, etc. */
 	cleanupCreation: () => void;
-	/** Last known dimensions — used to skip no-op resize events. */
-	lastCols: number;
-	lastRows: number;
 
 	// --- Stream management ---
 
@@ -84,8 +81,6 @@ function fitAndRefresh(entry: CachedTerminal): boolean {
 	const prevRows = xterm.rows;
 
 	entry.fitAddon.fit();
-	entry.lastCols = xterm.cols;
-	entry.lastRows = xterm.rows;
 
 	if (wasPinnedToBottom) {
 		xterm.scrollToBottom();
@@ -152,8 +147,6 @@ export function getOrCreate(
 		subscriptionErrorHandler: null,
 		resizeObserver: null,
 		container: null,
-		lastCols: xterm.cols,
-		lastRows: xterm.rows,
 	};
 
 	cache.set(paneId, entry);


### PR DESCRIPTION
## Problem

Terminals were crashing with:

```
Error: improper continuation due to previous async handler, giving up parsing
    at ur.parse (addon-webgl…)        ← EscapeSequenceParser.parse
    at _r.flushSync (…)                ← WriteBuffer.flushSync
    at vr.resize (…)                   ← CoreTerminal.resize
    at l.fit (terminal-parking…)       ← FitAddon.fit
    at measureAndResize (terminal-runtime…)
    at updateRuntimeAppearance (…)
    at TerminalRuntimeRegistryImpl.updateAppearance (…)
    at commitHookEffectListMount (react…)
```

This isn't a recoverable error: when it throws, xterm sets the parser to `FAIL`, so **every subsequent write throws too** — the terminal is bricked until reload.

## Root cause

`@xterm/addon-image` registers **async** parser handlers for inline images. iTerm2 (OSC 1337) and Kitty (APC) decode via `createImageBitmap(...).then(...)`, which keeps the escape-sequence parser paused while the bitmap decodes. (SIXEL's handler is synchronous and never triggers this.)

During that paused window, any resize → `FitAddon.fit()` → `terminal.resize()`, and xterm's `CoreTerminal.resize()` unconditionally calls `WriteBuffer.flushSync()`, which re-enters `parser.parse()` **synchronously**. The parser detects an improper continuation and throws + permanently fails. `flushSync` is documented as "unreliable with async parser handlers."

The reported trace is the mount path: right after `createRuntime` replays the serialized scrollback (which can contain an inline image), the mount effect fires `updateAppearance` → fit while that image is still decoding.

## Fix

Never resize while a write is still being parsed.

- **`parser-idle-gate.ts`** (new, xterm-free pure logic): `wrapWrite` decorates the terminal's `write` to count in-flight writes — xterm fires a write's callback only after that chunk *and its async handlers* fully parse, so `pending === 0` means the parser is back in `GROUND`. `runWhenParserIdle` runs the resize immediately when nothing is pending, or parks it (latest-wins) and flushes from the settling write's callback on a microtask, so the eventual `flushSync` never runs while a handler is paused — nor re-entrantly inside xterm's own write loop.
- **`terminal-runtime.ts`**: install the wrap once in `createRuntime` (before any write), so *every* write — live firehose, buffer restore, status notices — is counted and nothing can bypass it. `measureAndResize` gates the fit on the runtime's gate.
- **`terminal-runtime-registry.ts`**: drop the now-redundant post-fit dimension check (dimensions can settle asynchronously; the `onResize` callback covers it).
- **v1 terminal** (`helpers.ts`, `v1-terminal-cache.ts`, `useTerminalLifecycle.ts`): same gating for the legacy terminal, which loads the same `ImageAddon` — wrap `xterm.write` at creation, route every fit (attach, ResizeObserver, font-settle, appearance, post-attach backend sync) through the gate, and cancel parked work on detach/dispose. `updateAppearance` now reports dimension changes via callback instead of a synchronous return, since a gated fit can run after the call returns.

Full inline-image support (iTerm2/Kitty/SIXEL) is retained.

## Testing

- `parser-idle-gate.test.ts`: runs-when-idle, defers-until-drain, runs-once, coalesces, preserves caller callback.
- Mutation-checked: forcing a synchronous resize (the bricking behavior) fails the defer/coalesce tests.
- `bun run typecheck` and Biome clean.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5352">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents terminal crashes when a resize lands during inline image decoding by deferring fits until the parser is idle. This removes “improper continuation” errors and keeps inline images (iTerm2/Kitty/SIXEL) working.

- Bug Fixes
  - Gate resizes on parser idleness and cancel parked work on detach/dispose; wrap `terminal.write` to count in‑flight parses from `@xterm/addon-image` and defer `fit()` until write callbacks unwind (latest‑wins, microtask flush, re‑park when a new write arrives before the flush).
  - Route all fits through the gate in `measureAndResize` and the v1 cache; only call `onResize` when size changes, preserve scroll position; remove redundant post‑fit dimension check in the registry and the extra host‑visibility guard before `measureAndResize`; drop dead v1 `lastCols/lastRows`; font‑settle refits now report via the gated callback.
  - Add unit tests for the gate (runs‑when‑idle, defers, coalesces, cancels, preserves callbacks, keeps gate closed until callback unwinds, re‑parks on drain→microtask races).

<sup>Written for commit 00db74fd281bff1ef6af4c58dbcc19efd430b501. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal resizing and refitting by deferring fit/refresh and coordinating it with terminal write activity until the terminal parser is idle.
  * Coalesces multiple idle-gated resize requests so only the latest queued action runs, including during rapid updates.
* **Bug Fixes**
  * Prevents resizing/fit during in-flight terminal writes (including nested write scenarios) to reduce flicker and inconsistent updates.
  * Ensures callbacks for resize notifications fire only when dimensions actually change, and pending work is cancelled on detach/dispose.
* **Tests**
  * Added automated coverage for idle-gated execution, coalescing, cancellation, and write-drain timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
