### PR TITLE
fix(desktop): drop setup-script prompt from new-workspace modal on dismiss

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/V2SetupScriptCard/V2SetupScriptCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/V2SetupScriptCard/V2SetupScriptCard.tsx
@@ -41,9 +41,7 @@ export function V2SetupScriptCard({
 	// the agent through writing setup/teardown scripts for this project, rather
 	// than sending the user to the settings page to hand-write config.json.
 	const handleConfigure = () => {
-		const draftStore = useNewWorkspaceDraftStore.getState();
-		draftStore.resetDraft();
-		draftStore.updateDraft({ prompt: setupScriptPrompt });
+		useNewWorkspaceDraftStore.getState().seedSetupPrompt(setupScriptPrompt);
 		openNewWorkspaceModal(projectId);
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext.tsx
@@ -67,6 +67,7 @@ export function useDashboardNewWorkspaceDraft() {
 			linkedPR: store.linkedPR,
 			selectedAgentId: store.selectedAgentId,
 			attachments: store.attachments,
+			promptSeededFromSetupCard: store.promptSeededFromSetupCard,
 		})),
 	);
 	const updateDraft = useNewWorkspaceDraftStore((store) => store.updateDraft);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -10,7 +10,6 @@ import {
 	DialogTitle,
 } from "@superset/ui/dialog";
 import { useEffect, useRef } from "react";
-import { useNewWorkspaceDraftStore } from "renderer/stores/new-workspace-draft";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
@@ -42,16 +41,7 @@ function PromptInputResetSync() {
 export function DashboardNewWorkspaceModal() {
 	const isOpen = useNewWorkspaceModalOpen();
 	const closeModal = useCloseNewWorkspaceModal();
-	const resetDraft = useNewWorkspaceDraftStore((store) => store.resetDraft);
 	const preSelectedProjectId = usePreSelectedProjectId();
-
-	// Drop an unedited setup-card seed on dismiss; configure-agents/go-to-setup use closeModal() directly and keep it.
-	const handleDismiss = () => {
-		if (useNewWorkspaceDraftStore.getState().promptSeededFromSetupCard) {
-			resetDraft();
-		}
-		closeModal();
-	};
 
 	return (
 		<DashboardNewWorkspaceDraftProvider onClose={closeModal}>
@@ -60,7 +50,7 @@ export function DashboardNewWorkspaceModal() {
 				<Dialog
 					modal
 					open={isOpen}
-					onOpenChange={(open) => !open && handleDismiss()}
+					onOpenChange={(open) => !open && closeModal()}
 				>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -10,6 +10,7 @@ import {
 	DialogTitle,
 } from "@superset/ui/dialog";
 import { useEffect, useRef } from "react";
+import { useNewWorkspaceDraftStore } from "renderer/stores/new-workspace-draft";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
@@ -41,7 +42,16 @@ function PromptInputResetSync() {
 export function DashboardNewWorkspaceModal() {
 	const isOpen = useNewWorkspaceModalOpen();
 	const closeModal = useCloseNewWorkspaceModal();
+	const resetDraft = useNewWorkspaceDraftStore((store) => store.resetDraft);
 	const preSelectedProjectId = usePreSelectedProjectId();
+
+	// Drop an unedited setup-card seed on dismiss; configure-agents/go-to-setup use closeModal() directly and keep it.
+	const handleDismiss = () => {
+		if (useNewWorkspaceDraftStore.getState().promptSeededFromSetupCard) {
+			resetDraft();
+		}
+		closeModal();
+	};
 
 	return (
 		<DashboardNewWorkspaceDraftProvider onClose={closeModal}>
@@ -50,7 +60,7 @@ export function DashboardNewWorkspaceModal() {
 				<Dialog
 					modal
 					open={isOpen}
-					onOpenChange={(open) => !open && closeModal()}
+					onOpenChange={(open) => !open && handleDismiss()}
 				>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.test.ts
@@ -45,6 +45,14 @@ describe("useNewWorkspaceDraftStore — setup-card seeded prompt", () => {
 		expect(draft().promptSeededFromSetupCard).toBe(false);
 	});
 
+	test("re-applying the same seeded prompt value keeps the flag (no real edit)", () => {
+		draft().seedSetupPrompt("seed");
+
+		draft().updateDraft({ prompt: "seed" });
+
+		expect(draft().promptSeededFromSetupCard).toBe(true);
+	});
+
 	test("updating a non-prompt field keeps the seed flag intact", () => {
 		draft().seedSetupPrompt("seed");
 

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { useNewWorkspaceDraftStore } from "./new-workspace-draft";
+
+const draft = () => useNewWorkspaceDraftStore.getState();
+
+describe("useNewWorkspaceDraftStore — setup-card seeded prompt", () => {
+	beforeEach(() => {
+		draft().resetDraft();
+	});
+
+	test("a fresh draft is not flagged as seeded from the setup card", () => {
+		expect(draft().prompt).toBe("");
+		expect(draft().promptSeededFromSetupCard).toBe(false);
+	});
+
+	test("seedSetupPrompt stores the prompt and marks it ephemeral", () => {
+		draft().seedSetupPrompt("## Goal\nwrite config");
+
+		expect(draft().prompt).toBe("## Goal\nwrite config");
+		expect(draft().promptSeededFromSetupCard).toBe(true);
+	});
+
+	test("seedSetupPrompt bumps resetKey so the editor remounts with the seed", () => {
+		const before = draft().resetKey;
+
+		draft().seedSetupPrompt("seed");
+
+		expect(draft().resetKey).toBe(before + 1);
+	});
+
+	test("seedSetupPrompt clears any leftover draft fields first", () => {
+		draft().updateDraft({ workspaceName: "leftover", selectedProjectId: "p1" });
+
+		draft().seedSetupPrompt("seed");
+
+		expect(draft().workspaceName).toBe("");
+		expect(draft().selectedProjectId).toBeNull();
+	});
+
+	test("editing the prompt clears the ephemeral seed flag (now user-authored)", () => {
+		draft().seedSetupPrompt("seed");
+
+		draft().updateDraft({ prompt: "seed + my own edits" });
+
+		expect(draft().promptSeededFromSetupCard).toBe(false);
+	});
+
+	test("updating a non-prompt field keeps the seed flag intact", () => {
+		draft().seedSetupPrompt("seed");
+
+		draft().updateDraft({ selectedProjectId: "p1" });
+
+		expect(draft().promptSeededFromSetupCard).toBe(true);
+	});
+
+	test("resetDraft clears both the seeded prompt and its flag", () => {
+		draft().seedSetupPrompt("seed");
+
+		draft().resetDraft();
+
+		expect(draft().prompt).toBe("");
+		expect(draft().promptSeededFromSetupCard).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.ts
@@ -41,6 +41,8 @@ export interface NewWorkspaceDraft {
 	linkedPR: LinkedPR | null;
 	selectedAgentId: string | null;
 	attachments: DraftAttachment[];
+	/** True while `prompt` is the unedited setup-card seed; dropped on dismiss, cleared on edit. */
+	promptSeededFromSetupCard: boolean;
 }
 
 interface NewWorkspaceDraftState extends NewWorkspaceDraft {
@@ -50,6 +52,7 @@ interface NewWorkspaceDraftState extends NewWorkspaceDraft {
 	updateAttachment: (localId: string, patch: Partial<DraftAttachment>) => void;
 	removeAttachment: (localId: string) => void;
 	resetDraft: () => void;
+	seedSetupPrompt: (prompt: string) => void;
 }
 
 function buildInitialDraft(): NewWorkspaceDraft {
@@ -67,14 +70,23 @@ function buildInitialDraft(): NewWorkspaceDraft {
 		linkedPR: null,
 		selectedAgentId: null,
 		attachments: [],
+		promptSeededFromSetupCard: false,
 	};
 }
 
 export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
-	(set) => ({
+	(set, get) => ({
 		...buildInitialDraft(),
 		resetKey: 0,
-		updateDraft: (patch) => set((state) => ({ ...state, ...patch })),
+		updateDraft: (patch) =>
+			set((state) => ({
+				...state,
+				...patch,
+				// A prompt edit is user content; seeding bypasses updateDraft, so this only ever clears the flag.
+				...(patch.prompt !== undefined
+					? { promptSeededFromSetupCard: false }
+					: {}),
+			})),
 		addAttachment: (attachment) =>
 			set((state) => ({
 				...state,
@@ -103,6 +115,12 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 				updateAttachment: state.updateAttachment,
 				removeAttachment: state.removeAttachment,
 				resetDraft: state.resetDraft,
+				seedSetupPrompt: state.seedSetupPrompt,
 			})),
+		seedSetupPrompt: (prompt) => {
+			// resetDraft clears + bumps resetKey (remounts the editor); the shallow merge keeps the flag.
+			get().resetDraft();
+			set({ prompt, promptSeededFromSetupCard: true });
+		},
 	}),
 );

--- a/apps/desktop/src/renderer/stores/new-workspace-draft.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-draft.ts
@@ -82,8 +82,8 @@ export const useNewWorkspaceDraftStore = create<NewWorkspaceDraftState>(
 			set((state) => ({
 				...state,
 				...patch,
-				// A prompt edit is user content; seeding bypasses updateDraft, so this only ever clears the flag.
-				...(patch.prompt !== undefined
+				// A real prompt edit is user content; seeding bypasses updateDraft, so this only ever clears the flag.
+				...(patch.prompt !== undefined && patch.prompt !== state.prompt
 					? { promptSeededFromSetupCard: false }
 					: {}),
 			})),

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { useNewWorkspaceDraftStore } from "./new-workspace-draft";
+import { useNewWorkspaceModalStore } from "./new-workspace-modal";
+
+const draft = () => useNewWorkspaceDraftStore.getState();
+const modal = () => useNewWorkspaceModalStore.getState();
+
+describe("closeModal — setup-card seed cleanup", () => {
+	beforeEach(() => {
+		draft().resetDraft();
+		modal().closeModal();
+	});
+
+	test("closing the modal drops an unedited setup-card seed", () => {
+		draft().seedSetupPrompt("seed");
+		modal().openModal("p1");
+
+		modal().closeModal();
+
+		expect(draft().prompt).toBe("");
+		expect(draft().promptSeededFromSetupCard).toBe(false);
+	});
+
+	test("closing the modal keeps a prompt the user has edited", () => {
+		draft().seedSetupPrompt("seed");
+		draft().updateDraft({ prompt: "my edits" });
+		modal().openModal("p1");
+
+		modal().closeModal();
+
+		expect(draft().prompt).toBe("my edits");
+	});
+
+	test("closing the modal leaves a plain (unseeded) draft untouched", () => {
+		draft().updateDraft({ prompt: "typed from scratch" });
+		modal().openModal("p1");
+
+		modal().closeModal();
+
+		expect(draft().prompt).toBe("typed from scratch");
+	});
+});

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.test.ts
@@ -31,6 +31,20 @@ describe("closeModal — setup-card seed cleanup", () => {
 		expect(draft().prompt).toBe("my edits");
 	});
 
+	test("closing the modal drops the seed but keeps other fields the user filled in", () => {
+		draft().seedSetupPrompt("seed");
+		// User fills in non-prompt fields but leaves the seeded prompt untouched.
+		draft().updateDraft({ workspaceName: "my-ws", selectedProjectId: "p1" });
+		modal().openModal("p1");
+
+		modal().closeModal();
+
+		expect(draft().prompt).toBe("");
+		expect(draft().promptSeededFromSetupCard).toBe(false);
+		expect(draft().workspaceName).toBe("my-ws");
+		expect(draft().selectedProjectId).toBe("p1");
+	});
+
 	test("closing the modal leaves a plain (unseeded) draft untouched", () => {
 		draft().updateDraft({ prompt: "typed from scratch" });
 		modal().openModal("p1");

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.ts
@@ -54,9 +54,9 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 			},
 
 			closeModal: () => {
-				// Drop an unedited setup-card seed on any close so it can't resurface in a later, unrelated open. Edited prompts cleared the flag and survive.
+				// Clear an unedited setup-card seed on any close so it can't resurface in a later, unrelated open. Only the prompt is dropped; other draft fields the user filled in are kept (and editing the prompt already cleared the flag).
 				const draft = useNewWorkspaceDraftStore.getState();
-				if (draft.promptSeededFromSetupCard) draft.resetDraft();
+				if (draft.promptSeededFromSetupCard) draft.updateDraft({ prompt: "" });
 				set({ isOpen: false, preSelectedProjectId: null });
 			},
 

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
+import { useNewWorkspaceDraftStore } from "./new-workspace-draft";
 
 interface PendingWorkspace {
 	id: string;
@@ -53,6 +54,9 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 			},
 
 			closeModal: () => {
+				// Drop an unedited setup-card seed on any close so it can't resurface in a later, unrelated open. Edited prompts cleared the flag and survive.
+				const draft = useNewWorkspaceDraftStore.getState();
+				if (draft.promptSeededFromSetupCard) draft.resetDraft();
 				set({ isOpen: false, preSelectedProjectId: null });
 			},
 


### PR DESCRIPTION
## Description

**Configure** on the "Setup scripts" card seeds a setup-script prompt into the new-workspace draft. The draft was only cleared on a successful create, so dismissing the modal left the prompt behind, and the next New Workspace open showed it. The seed is now flagged ephemeral and dropped on dismiss. Prompts you type yourself still persist across reopen.

## Related Issues

closes #5372

## Type of Change

- [x] Bug fix

## Testing

- Added unit tests for the draft store seed flag lifecycle (7 tests).
- `bun test`, `bun run typecheck`, and `biome check` pass.
- Verified at unit level. Not yet clicked through the running Electron app.

## Video

<!-- drag the .mov here -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5373">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a bug where the setup-script prompt from the “Setup scripts” card stuck around after closing the New Workspace modal. Seeded prompts are now ephemeral and dropped on any modal close; user-typed prompts and other draft fields persist.

- **Bug Fixes**
  - Seeding uses `seedSetupPrompt` + `promptSeededFromSetupCard`; `closeModal` clears only an unedited seed across all close paths, dropping just the prompt and keeping other fields.
  - Guarded `updateDraft` to clear the seed flag only when the prompt actually changes; same-value writes keep it.
  - Added store tests for close-path cleanup, seed-flag lifecycle, persistence of other fields, and the same-value regression.

<sup>Written for commit 567022b3f7f47e9af224d6a81502420964a10676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace drafts seeded from the setup card now track whether the prompt is auto-filled or user-edited.
  * Added support for seeding the draft prompt from the setup card as a dedicated draft action.

* **Bug Fixes**
  * Closing the new workspace modal now clears only an untouched, setup-seeded prompt.
  * User-edited prompts are preserved, and manually entered prompts remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->