### PR TITLE
feat(chat): add experimental ACP runtime

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -43,6 +43,7 @@ import { localDb } from "main/lib/local-db";
 import {
 	DEFAULT_AUTO_APPLY_DEFAULT_PRESET,
 	DEFAULT_CONFIRM_ON_QUIT,
+	DEFAULT_EXPERIMENTAL_ACP_CHAT,
 	DEFAULT_EXPOSE_HOST_SERVICE_VIA_RELAY,
 	DEFAULT_FILE_OPEN_MODE,
 	DEFAULT_OPEN_LINKS_IN_APP,
@@ -660,6 +661,38 @@ export const createSettingsRouter = () => {
 
 				// Restart active host-service children so they pick up the new
 				// RELAY_URL from buildEnv(). No-op if the user isn't signed in.
+				const { token } = await loadToken();
+				if (!token) {
+					return { restartedOrgCount: 0 };
+				}
+
+				const coordinator = getHostServiceCoordinator();
+				const restartedOrgCount = coordinator.getActiveOrganizationIds().length;
+				await coordinator.restartAll({
+					authToken: token,
+					cloudApiUrl: env.NEXT_PUBLIC_API_URL,
+				});
+
+				return { restartedOrgCount };
+			}),
+
+		getExperimentalAcpChat: publicProcedure.query(() => {
+			const row = getSettings();
+			return row.experimentalAcpChat ?? DEFAULT_EXPERIMENTAL_ACP_CHAT;
+		}),
+
+		setExperimentalAcpChat: publicProcedure
+			.input(z.object({ enabled: z.boolean() }))
+			.mutation(async ({ input }) => {
+				localDb
+					.insert(settings)
+					.values({ id: 1, experimentalAcpChat: input.enabled })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { experimentalAcpChat: input.enabled },
+					})
+					.run();
+
 				const { token } = await loadToken();
 				if (!token) {
 					return { restartedOrgCount: 0 };

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -475,6 +475,15 @@ export class HostServiceCoordinator extends EventEmitter {
 			HOST_PARENT_PID: String(process.pid),
 		});
 
+		const experimentalAcpChat =
+			row?.experimentalAcpChat ??
+			isTruthyEnv(childEnv.SUPERSET_EXPERIMENTAL_ACP_CHAT);
+		if (experimentalAcpChat) {
+			childEnv.SUPERSET_EXPERIMENTAL_ACP_CHAT = "1";
+		} else {
+			delete childEnv.SUPERSET_EXPERIMENTAL_ACP_CHAT;
+		}
+
 		// `getProcessEnvWithShellPath` merges in the user's interactive shell env,
 		// which in dev has `RELAY_URL` set. Enforce the toggle *after* that merge
 		// so the child definitely doesn't see a relay URL when disabled. The
@@ -531,6 +540,11 @@ function pipeWithPrefix(
 		if (pending) target.write(`${tag} ${pending}\n`);
 		pending = "";
 	});
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+	const normalized = value?.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
 let coordinator: HostServiceCoordinator | null = null;

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -47,16 +47,19 @@ export function LocalHostServiceProvider({
 		[collections],
 	);
 
-	const organizationIds = useMemo(
-		() => organizations?.map((organization) => organization.id) ?? [],
-		[organizations],
-	);
+	const hostOrganizationIds = useMemo(() => {
+		const ids = new Set(
+			organizations?.map((organization) => organization.id) ?? [],
+		);
+		if (activeOrganizationId) ids.add(activeOrganizationId);
+		return [...ids];
+	}, [organizations, activeOrganizationId]);
 
 	useEffect(() => {
-		for (const organizationId of organizationIds) {
+		for (const organizationId of hostOrganizationIds) {
 			startHostService({ organizationId });
 		}
-	}, [organizationIds, startHostService]);
+	}, [hostOrganizationIds, startHostService]);
 
 	const { data: machineIdData } = electronTrpc.device.getMachineId.useQuery(
 		undefined,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -1,11 +1,13 @@
 import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
 import { Switch } from "@superset/ui/switch";
 import {
 	useIsV2CloudEnabled,
 	useIsV2OnlyUser,
 } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenV1ImportModal } from "renderer/stores/v1-import-modal";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 import {
@@ -29,10 +31,47 @@ export function ExperimentalSettings({
 		SETTING_ITEM_ID.EXPERIMENTAL_V1_MIGRATION,
 		visibleItems,
 	);
+	const showAcpChat = isItemVisible(
+		SETTING_ITEM_ID.EXPERIMENTAL_ACP_CHAT,
+		visibleItems,
+	);
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const isV2OnlyUser = useIsV2OnlyUser();
 	const setOptInV2 = useV2LocalOverrideStore((state) => state.setOptInV2);
 	const openV1ImportModal = useOpenV1ImportModal();
+	const utils = electronTrpc.useUtils();
+	const { data: acpChatEnabled = false, isLoading: isAcpChatLoading } =
+		electronTrpc.settings.getExperimentalAcpChat.useQuery();
+	const setAcpChat = electronTrpc.settings.setExperimentalAcpChat.useMutation({
+		onMutate: async ({ enabled }) => {
+			await utils.settings.getExperimentalAcpChat.cancel();
+			const previous = utils.settings.getExperimentalAcpChat.getData();
+			utils.settings.getExperimentalAcpChat.setData(undefined, enabled);
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous !== undefined) {
+				utils.settings.getExperimentalAcpChat.setData(
+					undefined,
+					context.previous,
+				);
+			}
+		},
+		onSettled: () => {
+			utils.settings.getExperimentalAcpChat.invalidate();
+		},
+	});
+	const handleAcpChatChange = (enabled: boolean) => {
+		track("experimental_acp_chat_toggled", { enabled });
+		toast.promise(setAcpChat.mutateAsync({ enabled }), {
+			loading: "Restarting host services…",
+			success: ({ restartedOrgCount }) =>
+				restartedOrgCount > 0
+					? `Restarted ${restartedOrgCount} host service${restartedOrgCount === 1 ? "" : "s"}`
+					: "Setting saved",
+			error: (err: Error) => err.message ?? "Failed to update setting",
+		});
+	};
 
 	return (
 		<div className="p-6 max-w-4xl w-full mx-auto">
@@ -64,6 +103,29 @@ export function ExperimentalSettings({
 								});
 								setOptInV2(enabled);
 							}}
+						/>
+					</div>
+				)}
+				{showAcpChat && (
+					<div className="flex items-center justify-between gap-6">
+						<div className="min-w-0 flex-1 space-y-0.5">
+							<Label
+								htmlFor="experimental-acp-chat"
+								className="text-sm font-medium"
+							>
+								Use ACP chat runtime
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Run workspace chat through the Agent Client Protocol instead of
+								the default Mastra chat runtime. Host services restart when this
+								changes.
+							</p>
+						</div>
+						<Switch
+							id="experimental-acp-chat"
+							checked={acpChatEnabled}
+							disabled={isAcpChatLoading || setAcpChat.isPending}
+							onCheckedChange={handleAcpChatChange}
 						/>
 					</div>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -51,6 +51,7 @@ export const SETTING_ITEM_ID = {
 
 	EXPERIMENTAL_SUPERSET_V2: "experimental-superset-v2",
 	EXPERIMENTAL_V1_MIGRATION: "experimental-v1-migration",
+	EXPERIMENTAL_ACP_CHAT: "experimental-acp-chat",
 
 	INTEGRATIONS_LINEAR: "integrations-linear",
 	INTEGRATIONS_GITHUB: "integrations-github",
@@ -160,6 +161,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 
 	[SETTING_ITEM_ID.EXPERIMENTAL_SUPERSET_V2]: "shared",
 	[SETTING_ITEM_ID.EXPERIMENTAL_V1_MIGRATION]: "v2",
+	[SETTING_ITEM_ID.EXPERIMENTAL_ACP_CHAT]: "v2",
 
 	[SETTING_ITEM_ID.INTEGRATIONS_LINEAR]: "shared",
 	[SETTING_ITEM_ID.INTEGRATIONS_GITHUB]: "shared",
@@ -883,6 +885,23 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"workspaces",
 			"toggle",
 			"switch",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.EXPERIMENTAL_ACP_CHAT,
+		section: "experimental",
+		title: "ACP Chat Runtime",
+		description: "Run workspace chat through Agent Client Protocol",
+		keywords: [
+			"experimental",
+			"acp",
+			"agent client protocol",
+			"chat",
+			"mastra",
+			"runtime",
+			"agent",
+			"omp",
+			"pi",
 		],
 	},
 	{

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -52,6 +52,7 @@ export const DEFAULT_TELEMETRY_ENABLED = true;
 export const DEFAULT_SHOW_RESOURCE_MONITOR = true;
 export const DEFAULT_OPEN_LINKS_IN_APP = false;
 export const DEFAULT_EXPOSE_HOST_SERVICE_VIA_RELAY = false;
+export const DEFAULT_EXPERIMENTAL_ACP_CHAT = false;
 
 // External links (documentation, help resources, etc.)
 export const EXTERNAL_LINKS = {

--- a/packages/host-service/src/runtime/chat/acp-chat-runtime.test.ts
+++ b/packages/host-service/src/runtime/chat/acp-chat-runtime.test.ts
@@ -24,32 +24,37 @@ describe("AcpChatRuntime", () => {
 			args: [script],
 		});
 
-		await runtime.initialize();
-		const result = await runtime.sendMessage({ content: "Say hi" });
+		try {
+			await runtime.initialize();
+			const result = await runtime.sendMessage({ content: "Say hi" });
 
-		expect(result.stopReason).toBe("end_turn");
-		expect(runtime.getDisplayState().isRunning).toBe(false);
-		expect(runtime.getDisplayState().currentMessage).toBeNull();
-		expect(runtime.listMessages()).toHaveLength(2);
-		expect(runtime.listMessages()[0]?.role).toBe("user");
-		const assistant = runtime.listMessages()[1];
-		expect(assistant?.role).toBe("assistant");
-		expect(assistant?.content).toEqual([
-			{ type: "text", text: "Hello world" },
-			{
-				type: "tool_call",
-				id: "tool-1",
-				name: "read",
-				args: { path: "README.md" },
-			},
-			{
-				type: "tool_result",
-				id: "tool-1",
-				name: "read",
-				result: [{ type: "content", content: { type: "text", text: "done" } }],
-			},
-		]);
-		await runtime.dispose();
+			expect(result.stopReason).toBe("end_turn");
+			expect(runtime.getDisplayState().isRunning).toBe(false);
+			expect(runtime.getDisplayState().currentMessage).toBeNull();
+			expect(runtime.listMessages()).toHaveLength(2);
+			expect(runtime.listMessages()[0]?.role).toBe("user");
+			const assistant = runtime.listMessages()[1];
+			expect(assistant?.role).toBe("assistant");
+			expect(assistant?.content).toEqual([
+				{ type: "text", text: "Hello world" },
+				{
+					type: "tool_call",
+					id: "1",
+					name: "read",
+					args: { path: "README.md" },
+				},
+				{
+					type: "tool_result",
+					id: "1",
+					name: "read",
+					result: [
+						{ type: "content", content: { type: "text", text: "done" } },
+					],
+				},
+			]);
+		} finally {
+			await runtime.dispose();
+		}
 	});
 
 	test("surfaces ACP permission requests and resolves selected options", async () => {
@@ -63,23 +68,50 @@ describe("AcpChatRuntime", () => {
 			args: [script],
 		});
 
-		await runtime.initialize();
-		const sendPromise = runtime.sendMessage({ content: "Edit file" });
-		await waitFor(() => runtime.getDisplayState().pendingApproval !== null);
+		try {
+			await runtime.initialize();
+			const sendPromise = runtime.sendMessage({ content: "Edit file" });
+			await waitFor(() => runtime.getDisplayState().pendingApproval !== null);
 
-		expect(runtime.getDisplayState().pendingApproval).toEqual({
-			toolCallId: "perm-1",
-			toolName: "Edit file",
-			args: { path: "README.md" },
+			expect(runtime.getDisplayState().pendingApproval).toEqual({
+				toolCallId: "perm-1",
+				toolName: "Edit file",
+				args: { path: "README.md" },
+			});
+			runtime.respondToApproval({ decision: "approve" });
+			await sendPromise;
+
+			expect(runtime.getDisplayState().pendingApproval).toBeNull();
+			expect(runtime.listMessages()[1]?.content).toEqual([
+				{ type: "text", text: "permission:allow-once" },
+			]);
+		} finally {
+			await runtime.dispose();
+		}
+	});
+
+	test("rejects concurrent ACP prompts for one chat session", async () => {
+		const cwd = createTempDir();
+		const script = writeAgentScript(cwd, hangingAgentScript());
+		const runtime = new AcpChatRuntime({
+			supersetSessionId: crypto.randomUUID(),
+			workspaceId: crypto.randomUUID(),
+			cwd,
+			command: process.execPath,
+			args: [script],
 		});
-		runtime.respondToApproval({ decision: "approve" });
-		await sendPromise;
 
-		expect(runtime.getDisplayState().pendingApproval).toBeNull();
-		expect(runtime.listMessages()[1]?.content).toEqual([
-			{ type: "text", text: "permission:allow-once" },
-		]);
-		await runtime.dispose();
+		try {
+			await runtime.initialize();
+			const sendPromise = runtime.sendMessage({ content: "First" });
+			await expect(runtime.sendMessage({ content: "Second" })).rejects.toThrow(
+				"ACP chat already has a prompt in progress",
+			);
+			runtime.stop();
+			await expect(sendPromise).resolves.toEqual({ stopReason: "cancelled" });
+		} finally {
+			await runtime.dispose();
+		}
 	});
 });
 
@@ -136,8 +168,8 @@ function handleMessage(message) {
   if (message.method === "session/prompt") {
     send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello " } } } });
     send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "world" } } } });
-    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "tool_call", toolCallId: "tool-1", title: "read", rawInput: { path: "README.md" } } } });
-    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "tool_call_update", toolCallId: "tool-1", status: "completed", content: [{ type: "content", content: { type: "text", text: "done" } }] } } });
+    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "tool_call", toolCallId: 1, title: "read", rawInput: { path: "README.md" } } } });
+    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "tool_call_update", toolCallId: 1, status: "completed", content: [{ type: "content", content: { type: "text", text: "done" } }] } } });
     send({ jsonrpc: "2.0", id: message.id, result: { stopReason: "end_turn" } });
   }
 }
@@ -165,6 +197,21 @@ function handleMessage(message) {
     const optionId = message.result.outcome.optionId;
     send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "permission:" + optionId } } } });
     send({ jsonrpc: "2.0", id: promptId, result: { stopReason: "end_turn" } });
+  }
+}
+`);
+}
+
+function hangingAgentScript(): string {
+	return agentHarness(`
+function handleMessage(message) {
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: { protocolVersion: 1, agentCapabilities: {}, authMethods: [] } });
+    return;
+  }
+  if (message.method === "session/new") {
+    send({ jsonrpc: "2.0", id: message.id, result: { sessionId: "acp-session" } });
+    return;
   }
 }
 `);

--- a/packages/host-service/src/runtime/chat/acp-chat-runtime.test.ts
+++ b/packages/host-service/src/runtime/chat/acp-chat-runtime.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AcpChatRuntime } from "./acp-chat-runtime";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("AcpChatRuntime", () => {
+	test("streams ACP assistant and tool updates into Superset chat state", async () => {
+		const cwd = createTempDir();
+		const script = writeAgentScript(cwd, streamingAgentScript());
+		const runtime = new AcpChatRuntime({
+			supersetSessionId: crypto.randomUUID(),
+			workspaceId: crypto.randomUUID(),
+			cwd,
+			command: process.execPath,
+			args: [script],
+		});
+
+		await runtime.initialize();
+		const result = await runtime.sendMessage({ content: "Say hi" });
+
+		expect(result.stopReason).toBe("end_turn");
+		expect(runtime.getDisplayState().isRunning).toBe(false);
+		expect(runtime.getDisplayState().currentMessage).toBeNull();
+		expect(runtime.listMessages()).toHaveLength(2);
+		expect(runtime.listMessages()[0]?.role).toBe("user");
+		const assistant = runtime.listMessages()[1];
+		expect(assistant?.role).toBe("assistant");
+		expect(assistant?.content).toEqual([
+			{ type: "text", text: "Hello world" },
+			{
+				type: "tool_call",
+				id: "tool-1",
+				name: "read",
+				args: { path: "README.md" },
+			},
+			{
+				type: "tool_result",
+				id: "tool-1",
+				name: "read",
+				result: [{ type: "content", content: { type: "text", text: "done" } }],
+			},
+		]);
+		await runtime.dispose();
+	});
+
+	test("surfaces ACP permission requests and resolves selected options", async () => {
+		const cwd = createTempDir();
+		const script = writeAgentScript(cwd, permissionAgentScript());
+		const runtime = new AcpChatRuntime({
+			supersetSessionId: crypto.randomUUID(),
+			workspaceId: crypto.randomUUID(),
+			cwd,
+			command: process.execPath,
+			args: [script],
+		});
+
+		await runtime.initialize();
+		const sendPromise = runtime.sendMessage({ content: "Edit file" });
+		await waitFor(() => runtime.getDisplayState().pendingApproval !== null);
+
+		expect(runtime.getDisplayState().pendingApproval).toEqual({
+			toolCallId: "perm-1",
+			toolName: "Edit file",
+			args: { path: "README.md" },
+		});
+		runtime.respondToApproval({ decision: "approve" });
+		await sendPromise;
+
+		expect(runtime.getDisplayState().pendingApproval).toBeNull();
+		expect(runtime.listMessages()[1]?.content).toEqual([
+			{ type: "text", text: "permission:allow-once" },
+		]);
+		await runtime.dispose();
+	});
+});
+
+function createTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "superset-acp-test-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function writeAgentScript(dir: string, content: string): string {
+	const script = join(dir, "agent.mjs");
+	writeFileSync(script, content, "utf-8");
+	return script;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (predicate()) return;
+		await nextEventLoopTurn();
+	}
+	throw new Error("Timed out waiting for condition");
+}
+
+function nextEventLoopTurn(): Promise<void> {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	setImmediate(resolve);
+	return promise;
+}
+
+function agentHarness(body: string): string {
+	return `
+import { createInterface } from "node:readline";
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+function send(message) { process.stdout.write(JSON.stringify(message) + "\\n"); }
+${body}
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  handleMessage(message);
+});
+`;
+}
+
+function streamingAgentScript(): string {
+	return agentHarness(`
+function handleMessage(message) {
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: { protocolVersion: 1, agentCapabilities: {}, authMethods: [] } });
+    return;
+  }
+  if (message.method === "session/new") {
+    send({ jsonrpc: "2.0", id: message.id, result: { sessionId: "acp-session" } });
+    return;
+  }
+  if (message.method === "session/prompt") {
+    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello " } } } });
+    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "world" } } } });
+    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "tool_call", toolCallId: "tool-1", title: "read", rawInput: { path: "README.md" } } } });
+    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "tool_call_update", toolCallId: "tool-1", status: "completed", content: [{ type: "content", content: { type: "text", text: "done" } }] } } });
+    send({ jsonrpc: "2.0", id: message.id, result: { stopReason: "end_turn" } });
+  }
+}
+`);
+}
+
+function permissionAgentScript(): string {
+	return agentHarness(`
+let promptId = null;
+function handleMessage(message) {
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: { protocolVersion: 1, agentCapabilities: {}, authMethods: [] } });
+    return;
+  }
+  if (message.method === "session/new") {
+    send({ jsonrpc: "2.0", id: message.id, result: { sessionId: "acp-session" } });
+    return;
+  }
+  if (message.method === "session/prompt") {
+    promptId = message.id;
+    send({ jsonrpc: "2.0", id: 900, method: "session/request_permission", params: { sessionId: "acp-session", toolCall: { toolCallId: "perm-1", title: "Edit file", rawInput: { path: "README.md" } }, options: [{ optionId: "allow-once", name: "Allow once", kind: "allow_once" }, { optionId: "reject", name: "Reject", kind: "reject_once" }] } });
+    return;
+  }
+  if (message.id === 900 && message.result) {
+    const optionId = message.result.outcome.optionId;
+    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "acp-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "permission:" + optionId } } } });
+    send({ jsonrpc: "2.0", id: promptId, result: { stopReason: "end_turn" } });
+  }
+}
+`);
+}

--- a/packages/host-service/src/runtime/chat/acp-chat-runtime.ts
+++ b/packages/host-service/src/runtime/chat/acp-chat-runtime.ts
@@ -56,6 +56,7 @@ export class AcpChatRuntime {
 			onPermissionRequest: (request) => this.handlePermissionRequest(request),
 			onError: (error) => {
 				this.displayState.errorMessage = error.message;
+				this.resolvePendingPermission({ outcome: { outcome: "cancelled" } });
 				if (this.displayState.isRunning) {
 					finishCurrentAssistantMessage({
 						state: this.displayState,
@@ -92,6 +93,9 @@ export class AcpChatRuntime {
 	async sendMessage(
 		payload: ChatMessagePayload,
 	): Promise<{ stopReason?: string }> {
+		if (this.promptInFlight) {
+			throw new Error("ACP chat already has a prompt in progress");
+		}
 		const acpSessionId = this.requireAcpSessionId();
 		this.displayState.errorMessage = null;
 		this.displayState.pendingApproval = null;
@@ -118,6 +122,10 @@ export class AcpChatRuntime {
 			});
 			return result;
 		} catch (error) {
+			if (isPromptCancelledError(error)) {
+				return { stopReason: "cancelled" };
+			}
+			this.resolvePendingPermission({ outcome: { outcome: "cancelled" } });
 			const message = error instanceof Error ? error.message : String(error);
 			finishCurrentAssistantMessage({
 				state: this.displayState,
@@ -191,6 +199,9 @@ export class AcpChatRuntime {
 	private handlePermissionRequest(
 		request: AcpPermissionRequest,
 	): Promise<unknown> {
+		if (this.pendingPermission) {
+			return Promise.resolve({ outcome: { outcome: "cancelled" } });
+		}
 		const toolCallId = request.toolCall.toolCallId ?? crypto.randomUUID();
 		const title = request.toolCall.title ?? request.toolCall.kind ?? "tool";
 		this.displayState.pendingApproval = {
@@ -226,13 +237,17 @@ export class AcpChatRuntime {
 	}
 }
 
+function isPromptCancelledError(error: unknown): boolean {
+	return error instanceof Error && error.message === "ACP prompt cancelled";
+}
+
 function selectPermissionOption(
 	decision: ChatApprovalPayload["decision"],
 	options: AcpPermissionOption[],
 ): AcpPermissionOption | null {
 	const preferredKinds: Record<ChatApprovalPayload["decision"], string[]> = {
 		approve: ["allow_once", "allow_always"],
-		always_allow_category: ["allow_always", "allow_once"],
+		always_allow_category: ["allow_always"],
 		decline: ["reject_once", "reject_always"],
 	};
 	for (const kind of preferredKinds[decision]) {
@@ -241,7 +256,7 @@ function selectPermissionOption(
 	}
 	const labelNeedles: Record<ChatApprovalPayload["decision"], string[]> = {
 		approve: ["allow", "yes", "approve"],
-		always_allow_category: ["always", "allow"],
+		always_allow_category: ["always"],
 		decline: ["deny", "decline", "reject", "no"],
 	};
 	return (

--- a/packages/host-service/src/runtime/chat/acp-chat-runtime.ts
+++ b/packages/host-service/src/runtime/chat/acp-chat-runtime.ts
@@ -1,0 +1,253 @@
+import {
+	type AcpPermissionOption,
+	type AcpPermissionRequest,
+	type AcpSessionNotification,
+	appendAcpUpdateToDisplayState,
+	createInitialDisplayState,
+	finishCurrentAssistantMessage,
+	payloadToAcpPrompt,
+	payloadToChatParts,
+} from "./acp-protocol";
+import type {
+	ChatApprovalPayload,
+	ChatDisplayState,
+	ChatMessage,
+	ChatMessagePayload,
+	ChatSnapshot,
+} from "./acp-types";
+import { AcpJsonRpcError, StdioAcpAgentClient } from "./stdio-acp-client";
+
+export interface AcpRuntimeCreateOptions {
+	supersetSessionId: string;
+	workspaceId: string;
+	cwd: string;
+	command: string;
+	args: string[];
+	env?: NodeJS.ProcessEnv;
+}
+
+interface PermissionWaiter {
+	requestId: string;
+	options: AcpPermissionOption[];
+	resolve: (value: unknown) => void;
+}
+
+export class AcpChatRuntime {
+	readonly sessionId: string;
+	readonly workspaceId: string;
+	readonly cwd: string;
+	private readonly client: StdioAcpAgentClient;
+	private readonly history: ChatMessage[] = [];
+	private readonly displayState: ChatDisplayState = createInitialDisplayState();
+	private acpSessionId: string | null = null;
+	private pendingPermission: PermissionWaiter | null = null;
+	private promptInFlight: Promise<unknown> | null = null;
+
+	constructor(options: AcpRuntimeCreateOptions) {
+		this.sessionId = options.supersetSessionId;
+		this.workspaceId = options.workspaceId;
+		this.cwd = options.cwd;
+		this.client = new StdioAcpAgentClient({
+			command: options.command,
+			args: options.args,
+			cwd: options.cwd,
+			env: options.env,
+			onUpdate: (notification) => this.handleUpdate(notification),
+			onPermissionRequest: (request) => this.handlePermissionRequest(request),
+			onError: (error) => {
+				this.displayState.errorMessage = error.message;
+				if (this.displayState.isRunning) {
+					finishCurrentAssistantMessage({
+						state: this.displayState,
+						history: this.history,
+						stopReason: "error",
+						errorMessage: error.message,
+					});
+				}
+			},
+		});
+	}
+
+	async initialize(): Promise<void> {
+		await this.client.initialize();
+		const session = await this.client.newSession(this.cwd);
+		this.acpSessionId = session.sessionId;
+	}
+
+	getDisplayState(): ChatDisplayState {
+		return this.displayState;
+	}
+
+	listMessages(): ChatMessage[] {
+		return this.history;
+	}
+
+	getSnapshot(): ChatSnapshot {
+		return {
+			displayState: this.displayState,
+			messages: this.history,
+		};
+	}
+
+	async sendMessage(
+		payload: ChatMessagePayload,
+	): Promise<{ stopReason?: string }> {
+		const acpSessionId = this.requireAcpSessionId();
+		this.displayState.errorMessage = null;
+		this.displayState.pendingApproval = null;
+		this.displayState.pendingQuestion = null;
+		this.history.push({
+			id: `user-${crypto.randomUUID()}`,
+			role: "user",
+			content: payloadToChatParts(payload),
+			createdAt: new Date(),
+		});
+		this.displayState.isRunning = true;
+
+		const promptPromise = this.client.prompt(
+			acpSessionId,
+			payloadToAcpPrompt(payload),
+		);
+		this.promptInFlight = promptPromise;
+		try {
+			const result = await promptPromise;
+			finishCurrentAssistantMessage({
+				state: this.displayState,
+				history: this.history,
+				stopReason: result.stopReason ?? "end_turn",
+			});
+			return result;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			finishCurrentAssistantMessage({
+				state: this.displayState,
+				history: this.history,
+				stopReason: this.isAuthRequiredError(error) ? "auth_required" : "error",
+				errorMessage: message,
+			});
+			throw error;
+		} finally {
+			if (this.promptInFlight === promptPromise) this.promptInFlight = null;
+		}
+	}
+
+	stop(): void {
+		const acpSessionId = this.acpSessionId;
+		if (!acpSessionId) return;
+		this.client.cancel(acpSessionId);
+		this.resolvePendingPermission({ outcome: { outcome: "cancelled" } });
+		finishCurrentAssistantMessage({
+			state: this.displayState,
+			history: this.history,
+			stopReason: "cancelled",
+		});
+	}
+
+	async dispose(): Promise<void> {
+		this.stop();
+		await this.client.dispose();
+	}
+
+	respondToApproval(payload: ChatApprovalPayload): void {
+		const pending = this.pendingPermission;
+		if (!pending) throw new Error("No ACP permission request is pending");
+		const option = selectPermissionOption(payload.decision, pending.options);
+		if (!option)
+			throw new Error(
+				`ACP permission request has no option for ${payload.decision}`,
+			);
+		this.resolvePendingPermission({
+			outcome: { outcome: "selected", optionId: option.optionId },
+		});
+	}
+
+	restartFromMessage(): Promise<void> {
+		throw new Error(
+			"ACP chat does not support editing or restarting prior turns yet.",
+		);
+	}
+
+	respondToQuestion(): Promise<void> {
+		throw new Error(
+			"ACP chat question responses are not available for this request.",
+		);
+	}
+
+	respondToPlan(): Promise<void> {
+		throw new Error(
+			"ACP chat plan approval is not available for this request.",
+		);
+	}
+
+	private handleUpdate(notification: AcpSessionNotification): void {
+		if (this.acpSessionId && notification.sessionId !== this.acpSessionId)
+			return;
+		appendAcpUpdateToDisplayState({
+			state: this.displayState,
+			update: notification.update,
+		});
+	}
+
+	private handlePermissionRequest(
+		request: AcpPermissionRequest,
+	): Promise<unknown> {
+		const toolCallId = request.toolCall.toolCallId ?? crypto.randomUUID();
+		const title = request.toolCall.title ?? request.toolCall.kind ?? "tool";
+		this.displayState.pendingApproval = {
+			toolCallId,
+			toolName: title,
+			args: request.toolCall.rawInput ?? request.toolCall.content ?? {},
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		this.pendingPermission = {
+			requestId: toolCallId,
+			options: request.options,
+			resolve,
+		};
+		return promise;
+	}
+
+	private resolvePendingPermission(result: unknown): void {
+		const pending = this.pendingPermission;
+		if (!pending) return;
+		this.pendingPermission = null;
+		this.displayState.pendingApproval = null;
+		pending.resolve(result);
+	}
+
+	private requireAcpSessionId(): string {
+		if (!this.acpSessionId)
+			throw new Error("ACP session has not been initialized");
+		return this.acpSessionId;
+	}
+
+	private isAuthRequiredError(error: unknown): boolean {
+		return error instanceof AcpJsonRpcError && error.code === -32001;
+	}
+}
+
+function selectPermissionOption(
+	decision: ChatApprovalPayload["decision"],
+	options: AcpPermissionOption[],
+): AcpPermissionOption | null {
+	const preferredKinds: Record<ChatApprovalPayload["decision"], string[]> = {
+		approve: ["allow_once", "allow_always"],
+		always_allow_category: ["allow_always", "allow_once"],
+		decline: ["reject_once", "reject_always"],
+	};
+	for (const kind of preferredKinds[decision]) {
+		const option = options.find((candidate) => candidate.kind === kind);
+		if (option) return option;
+	}
+	const labelNeedles: Record<ChatApprovalPayload["decision"], string[]> = {
+		approve: ["allow", "yes", "approve"],
+		always_allow_category: ["always", "allow"],
+		decline: ["deny", "decline", "reject", "no"],
+	};
+	return (
+		options.find((option) => {
+			const label = `${option.optionId} ${option.name}`.toLowerCase();
+			return labelNeedles[decision].some((needle) => label.includes(needle));
+		}) ?? null
+	);
+}

--- a/packages/host-service/src/runtime/chat/acp-protocol.test.ts
+++ b/packages/host-service/src/runtime/chat/acp-protocol.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+	appendAcpUpdateToDisplayState,
+	createInitialDisplayState,
+} from "./acp-protocol";
+
+describe("appendAcpUpdateToDisplayState", () => {
+	test("matches numeric tool ids across call and result updates", () => {
+		const state = createInitialDisplayState();
+
+		appendAcpUpdateToDisplayState({
+			state,
+			update: {
+				sessionUpdate: "tool_call",
+				toolCallId: 7,
+				title: "read",
+				rawInput: { path: "README.md" },
+			},
+		});
+		appendAcpUpdateToDisplayState({
+			state,
+			update: {
+				sessionUpdate: "tool_call_update",
+				toolCallId: 7,
+				status: "completed",
+				rawOutput: "done",
+			},
+		});
+
+		expect(state.currentMessage?.content).toEqual([
+			{
+				type: "tool_call",
+				id: "7",
+				name: "read",
+				args: { path: "README.md" },
+			},
+			{ type: "tool_result", id: "7", name: "read", result: "done" },
+		]);
+		expect(state.activeTools.has("7")).toBe(false);
+	});
+
+	test("preserves tool input when progress updates omit replacement content", () => {
+		const state = createInitialDisplayState();
+
+		appendAcpUpdateToDisplayState({
+			state,
+			update: {
+				sessionUpdate: "tool_call",
+				toolCallId: "tool-1",
+				title: "edit",
+				rawInput: { path: "README.md" },
+			},
+		});
+		appendAcpUpdateToDisplayState({
+			state,
+			update: {
+				sessionUpdate: "tool_call_update",
+				toolCallId: "tool-1",
+				status: "in_progress",
+			},
+		});
+
+		expect(state.activeTools.get("tool-1")).toEqual({
+			toolCallId: "tool-1",
+			state: "input-streaming",
+			input: { path: "README.md" },
+		});
+	});
+});

--- a/packages/host-service/src/runtime/chat/acp-protocol.ts
+++ b/packages/host-service/src/runtime/chat/acp-protocol.ts
@@ -177,7 +177,7 @@ export function appendAcpUpdateToDisplayState({
 	}
 
 	if (update.sessionUpdate === "tool_call") {
-		const toolCallId = stringValue(update.toolCallId) ?? crypto.randomUUID();
+		const toolCallId = idValue(update.toolCallId) ?? crypto.randomUUID();
 		const toolName =
 			stringValue(update.title) ?? stringValue(update.kind) ?? "tool";
 		const args = update.rawInput ?? update.content ?? {};
@@ -197,7 +197,7 @@ export function appendAcpUpdateToDisplayState({
 	}
 
 	if (update.sessionUpdate === "tool_call_update") {
-		const toolCallId = stringValue(update.toolCallId);
+		const toolCallId = idValue(update.toolCallId);
 		if (!toolCallId) return;
 		const status = stringValue(update.status) ?? "in_progress";
 		const message = ensureCurrentAssistantMessage(state, now);
@@ -214,10 +214,11 @@ export function appendAcpUpdateToDisplayState({
 			state.toolInputBuffers.delete(toolCallId);
 			return;
 		}
+		const existingTool = state.activeTools.get(toolCallId);
 		state.activeTools.set(toolCallId, {
 			toolCallId,
 			state: "input-streaming",
-			input: update.content ?? {},
+			input: update.content ?? recordProperty(existingTool, "input") ?? {},
 		});
 		return;
 	}
@@ -301,22 +302,32 @@ function findToolName(message: ChatMessage, toolCallId: string): string | null {
 
 function acpContentToText(content: unknown): string {
 	if (typeof content === "string") return content;
-	if (!content || typeof content !== "object") return "";
-	const block = content as Record<string, unknown>;
-	if (block.type === "text" && typeof block.text === "string")
-		return block.text;
-	const resource = block.resource;
-	if (block.type === "resource" && resource && typeof resource === "object") {
-		const record = resource as Record<string, unknown>;
-		return typeof record.text === "string" ? record.text : "";
+	if (!isRecord(content)) return "";
+	if (content.type === "text" && typeof content.text === "string") {
+		return content.text;
 	}
-	return "";
+	if (content.type !== "resource" || !isRecord(content.resource)) return "";
+	return typeof content.resource.text === "string" ? content.resource.text : "";
 }
 
 function stringValue(value: unknown): string | null {
 	return typeof value === "string" && value.trim().length > 0
 		? value.trim()
 		: null;
+}
+
+function idValue(value: unknown): string | null {
+	if (typeof value === "number" && Number.isFinite(value)) return String(value);
+	return stringValue(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function recordProperty(value: unknown, key: string): unknown {
+	if (!isRecord(value) || !(key in value)) return null;
+	return value[key];
 }
 
 function stripDataUrlPrefix(data: string): string {

--- a/packages/host-service/src/runtime/chat/acp-protocol.ts
+++ b/packages/host-service/src/runtime/chat/acp-protocol.ts
@@ -1,0 +1,334 @@
+import type {
+	ChatDisplayState,
+	ChatMessage,
+	ChatMessagePart,
+	ChatMessagePayload,
+} from "./acp-types";
+
+export interface AcpTextContentBlock {
+	type: "text";
+	text: string;
+}
+
+export interface AcpResourceContentBlock {
+	type: "resource";
+	resource: {
+		uri: string;
+		mimeType: string;
+		text?: string;
+		blob?: string;
+	};
+}
+
+export interface AcpImageContentBlock {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+export type AcpContentBlock =
+	| AcpTextContentBlock
+	| AcpResourceContentBlock
+	| AcpImageContentBlock;
+
+export type AcpPromptBlock = AcpContentBlock;
+
+export interface AcpSessionNotification {
+	sessionId: string;
+	update: AcpSessionUpdate;
+}
+
+export interface AcpSessionUpdate {
+	sessionUpdate: string;
+	content?: unknown;
+	toolCallId?: unknown;
+	title?: unknown;
+	kind?: unknown;
+	status?: unknown;
+	rawInput?: unknown;
+	rawOutput?: unknown;
+	planId?: unknown;
+}
+
+export interface AcpPermissionOption {
+	optionId: string;
+	name: string;
+	kind?: string;
+}
+
+export interface AcpPermissionRequest {
+	sessionId: string;
+	toolCall: {
+		toolCallId?: string;
+		title?: string;
+		kind?: string;
+		status?: string;
+		rawInput?: unknown;
+		content?: unknown;
+		[key: string]: unknown;
+	};
+	options: AcpPermissionOption[];
+}
+
+export function createInitialDisplayState(): ChatDisplayState {
+	return {
+		isRunning: false,
+		currentMessage: null,
+		pendingApproval: null,
+		pendingPlanApproval: null,
+		pendingQuestion: null,
+		activeTools: new Map(),
+		toolInputBuffers: new Map(),
+		activeSubagents: new Map(),
+		errorMessage: null,
+	};
+}
+
+export function payloadToAcpPrompt(
+	payload: ChatMessagePayload,
+): AcpPromptBlock[] {
+	const prompt: AcpPromptBlock[] = [];
+	const text = payload.content.trim();
+	if (text.length > 0) {
+		prompt.push({ type: "text", text });
+	}
+
+	for (const file of payload.files ?? []) {
+		const filename = file.filename?.trim() || "attachment";
+		if (file.mediaType.startsWith("image/")) {
+			prompt.push({
+				type: "image",
+				data: stripDataUrlPrefix(file.data),
+				mimeType: file.mediaType,
+			});
+			continue;
+		}
+
+		const isText =
+			file.mediaType.startsWith("text/") || file.mediaType.includes("json");
+		prompt.push({
+			type: "resource",
+			resource: {
+				uri: `file://${filename}`,
+				mimeType: file.mediaType,
+				...(isText
+					? { text: decodeBase64Text(stripDataUrlPrefix(file.data)) }
+					: { blob: stripDataUrlPrefix(file.data) }),
+			},
+		});
+	}
+
+	if (prompt.length === 0) {
+		prompt.push({ type: "text", text: "[non-text message]" });
+	}
+	return prompt;
+}
+
+export function payloadToChatParts(
+	payload: ChatMessagePayload,
+): ChatMessagePart[] {
+	const parts: ChatMessagePart[] = [];
+	for (const file of payload.files ?? []) {
+		if (file.mediaType.startsWith("image/")) {
+			parts.push({
+				type: "image",
+				data: stripDataUrlPrefix(file.data),
+				mimeType: file.mediaType,
+			});
+			continue;
+		}
+		parts.push({
+			type: "file",
+			data: file.data,
+			mediaType: file.mediaType,
+			...(file.filename ? { filename: file.filename } : {}),
+		});
+	}
+	const text = payload.content.trim();
+	if (text.length > 0) {
+		parts.push({ type: "text", text });
+	}
+	return parts.length > 0
+		? parts
+		: [{ type: "text", text: "[non-text message]" }];
+}
+
+export function appendAcpUpdateToDisplayState({
+	state,
+	update,
+	now = new Date(),
+}: {
+	state: ChatDisplayState;
+	update: AcpSessionUpdate;
+	now?: Date;
+}): void {
+	if (update.sessionUpdate === "agent_message_chunk") {
+		const text = acpContentToText(update.content);
+		if (text.length > 0)
+			appendTextPart(ensureCurrentAssistantMessage(state, now), text);
+		return;
+	}
+
+	if (update.sessionUpdate === "agent_thought_chunk") {
+		const text = acpContentToText(update.content);
+		if (text.length > 0)
+			appendThinkingPart(ensureCurrentAssistantMessage(state, now), text);
+		return;
+	}
+
+	if (update.sessionUpdate === "tool_call") {
+		const toolCallId = stringValue(update.toolCallId) ?? crypto.randomUUID();
+		const toolName =
+			stringValue(update.title) ?? stringValue(update.kind) ?? "tool";
+		const args = update.rawInput ?? update.content ?? {};
+		const message = ensureCurrentAssistantMessage(state, now);
+		message.content.push({
+			type: "tool_call",
+			id: toolCallId,
+			name: toolName,
+			args,
+		});
+		state.activeTools.set(toolCallId, {
+			toolCallId,
+			state: "input-available",
+			input: args,
+		});
+		return;
+	}
+
+	if (update.sessionUpdate === "tool_call_update") {
+		const toolCallId = stringValue(update.toolCallId);
+		if (!toolCallId) return;
+		const status = stringValue(update.status) ?? "in_progress";
+		const message = ensureCurrentAssistantMessage(state, now);
+		const toolName = findToolName(message, toolCallId) ?? "tool";
+		if (status === "completed" || status === "failed") {
+			message.content.push({
+				type: "tool_result",
+				id: toolCallId,
+				name: toolName,
+				result: update.rawOutput ?? update.content ?? status,
+				...(status === "failed" ? { isError: true } : {}),
+			});
+			state.activeTools.delete(toolCallId);
+			state.toolInputBuffers.delete(toolCallId);
+			return;
+		}
+		state.activeTools.set(toolCallId, {
+			toolCallId,
+			state: "input-streaming",
+			input: update.content ?? {},
+		});
+		return;
+	}
+
+	if (update.sessionUpdate === "plan") {
+		const text = [stringValue(update.title), acpContentToText(update.content)]
+			.filter(
+				(part): part is string => typeof part === "string" && part.length > 0,
+			)
+			.join("\n\n");
+		if (text.length > 0)
+			appendTextPart(ensureCurrentAssistantMessage(state, now), text);
+	}
+}
+
+export function finishCurrentAssistantMessage({
+	state,
+	history,
+	stopReason,
+	errorMessage,
+}: {
+	state: ChatDisplayState;
+	history: ChatMessage[];
+	stopReason: string;
+	errorMessage?: string;
+}): void {
+	if (state.currentMessage) {
+		state.currentMessage.stopReason = stopReason;
+		if (errorMessage) state.currentMessage.errorMessage = errorMessage;
+		history.push(state.currentMessage);
+	}
+	state.currentMessage = null;
+	state.isRunning = false;
+	state.activeTools.clear();
+	state.toolInputBuffers.clear();
+	state.pendingApproval = null;
+	state.pendingQuestion = null;
+	state.errorMessage = errorMessage ?? null;
+}
+
+function ensureCurrentAssistantMessage(
+	state: ChatDisplayState,
+	now: Date,
+): ChatMessage {
+	state.isRunning = true;
+	if (!state.currentMessage) {
+		state.currentMessage = {
+			id: `assistant-${crypto.randomUUID()}`,
+			role: "assistant",
+			content: [],
+			createdAt: now,
+		};
+	}
+	return state.currentMessage;
+}
+
+function appendTextPart(message: ChatMessage, text: string): void {
+	const last = message.content.at(-1);
+	if (last?.type === "text") {
+		last.text += text;
+		return;
+	}
+	message.content.push({ type: "text", text });
+}
+
+function appendThinkingPart(message: ChatMessage, thinking: string): void {
+	const last = message.content.at(-1);
+	if (last?.type === "thinking") {
+		last.thinking += thinking;
+		return;
+	}
+	message.content.push({ type: "thinking", thinking });
+}
+
+function findToolName(message: ChatMessage, toolCallId: string): string | null {
+	for (const part of message.content) {
+		if (part.type === "tool_call" && part.id === toolCallId) return part.name;
+	}
+	return null;
+}
+
+function acpContentToText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!content || typeof content !== "object") return "";
+	const block = content as Record<string, unknown>;
+	if (block.type === "text" && typeof block.text === "string")
+		return block.text;
+	const resource = block.resource;
+	if (block.type === "resource" && resource && typeof resource === "object") {
+		const record = resource as Record<string, unknown>;
+		return typeof record.text === "string" ? record.text : "";
+	}
+	return "";
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: null;
+}
+
+function stripDataUrlPrefix(data: string): string {
+	const marker = ";base64,";
+	const index = data.indexOf(marker);
+	return index === -1 ? data : data.slice(index + marker.length);
+}
+
+function decodeBase64Text(data: string): string {
+	try {
+		return Buffer.from(data, "base64").toString("utf-8");
+	} catch {
+		return data;
+	}
+}

--- a/packages/host-service/src/runtime/chat/acp-types.ts
+++ b/packages/host-service/src/runtime/chat/acp-types.ts
@@ -1,0 +1,133 @@
+export type ChatThinkingLevel = "off" | "low" | "medium" | "high" | "xhigh";
+
+export interface ChatSendMessageInput {
+	sessionId: string;
+	workspaceId: string;
+	payload: ChatMessagePayload;
+	metadata?: {
+		model?: string;
+		thinkingLevel?: ChatThinkingLevel;
+	};
+}
+
+export interface ChatMessagePayload {
+	content: string;
+	files?: Array<{
+		data: string;
+		mediaType: string;
+		filename?: string;
+	}>;
+}
+
+export interface RestartPayload extends ChatSendMessageInput {
+	messageId: string;
+}
+
+export interface ChatPendingQuestionOption {
+	label: string;
+	description?: string;
+}
+
+export interface ChatPendingQuestion {
+	questionId: string;
+	question: string;
+	description?: string;
+	options: ChatPendingQuestionOption[];
+}
+
+export interface ChatApprovalPayload {
+	decision: "approve" | "decline" | "always_allow_category";
+}
+
+export interface ChatQuestionPayload {
+	questionId: string;
+	answer: string;
+}
+
+export interface ChatPlanPayload {
+	planId: string;
+	response: {
+		action: "approved" | "rejected";
+		feedback?: string;
+	};
+}
+
+export type ChatRole = "user" | "assistant";
+
+export interface ChatTextPart {
+	type: "text";
+	text: string;
+}
+
+export interface ChatThinkingPart {
+	type: "thinking";
+	thinking: string;
+}
+
+export interface ChatFilePart {
+	type: "file";
+	data: string;
+	mediaType: string;
+	filename?: string;
+}
+
+export interface ChatImagePart {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+export interface ChatToolCallPart {
+	type: "tool_call";
+	id: string;
+	name: string;
+	args: unknown;
+}
+
+export interface ChatToolResultPart {
+	type: "tool_result";
+	id: string;
+	name: string;
+	result: unknown;
+	isError?: boolean;
+}
+
+export type ChatMessagePart =
+	| ChatTextPart
+	| ChatThinkingPart
+	| ChatFilePart
+	| ChatImagePart
+	| ChatToolCallPart
+	| ChatToolResultPart;
+
+export interface ChatMessage {
+	id: string;
+	role: ChatRole;
+	content: ChatMessagePart[];
+	createdAt: Date;
+	stopReason?: string;
+	errorMessage?: string;
+}
+
+export interface ChatPendingApproval {
+	toolCallId: string;
+	toolName: string;
+	args: unknown;
+}
+
+export interface ChatDisplayState {
+	isRunning: boolean;
+	currentMessage: ChatMessage | null;
+	pendingApproval: ChatPendingApproval | null;
+	pendingPlanApproval: null;
+	pendingQuestion: ChatPendingQuestion | null;
+	activeTools: Map<string, unknown>;
+	toolInputBuffers: Map<string, unknown>;
+	activeSubagents: Map<string, unknown>;
+	errorMessage: string | null;
+}
+
+export interface ChatSnapshot {
+	displayState: ChatDisplayState;
+	messages: ChatMessage[];
+}

--- a/packages/host-service/src/runtime/chat/chat.ts
+++ b/packages/host-service/src/runtime/chat/chat.ts
@@ -294,7 +294,9 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		try {
 			await runtime.initialize();
 		} catch (error) {
-			await runtime.dispose().catch(() => {});
+			await runtime.dispose().catch(() => {
+				// Best-effort cleanup after failed ACP initialization.
+			});
 			throw error;
 		}
 		this.acpRuntimes.set(sessionId, runtime);
@@ -372,12 +374,23 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		return promise;
 	}
 
-	async disposeRuntime(sessionId: string, workspaceId: string): Promise<void> {
-		if (this.shouldUseAcpChat()) {
-			await this.disposeAcpRuntime(sessionId, workspaceId);
-			return;
+	private getExistingAcpRuntime(
+		sessionId: string,
+		workspaceId: string,
+	): AcpChatRuntime | null {
+		const runtime = this.acpRuntimes.get(sessionId);
+		if (!runtime) return null;
+		if (runtime.workspaceId !== workspaceId) {
+			throw new Error(
+				`Session ${sessionId} is bound to workspace ${runtime.workspaceId}`,
+			);
 		}
+		return runtime;
+	}
+
+	async disposeRuntime(sessionId: string, workspaceId: string): Promise<void> {
 		await this.disposeMastraRuntime(sessionId, workspaceId);
+		await this.disposeAcpRuntime(sessionId, workspaceId);
 	}
 
 	private async disposeMastraRuntime(
@@ -394,6 +407,7 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 			try {
 				await inflight.promise;
 			} catch {
+				// Creation already failed; no runtime was inserted to dispose.
 				return;
 			}
 		}
@@ -406,10 +420,14 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		}
 		try {
 			runtime.harness.abort();
-		} catch {}
+		} catch {
+			// Best-effort abort; continue with MCP disconnect and map cleanup.
+		}
 		try {
 			await runtime.mcpManager?.disconnect?.();
-		} catch {}
+		} catch {
+			// Best-effort disconnect; the process may already be torn down.
+		}
 		this.mastraRuntimes.delete(sessionId);
 	}
 
@@ -427,6 +445,7 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 			try {
 				await inflight.promise;
 			} catch {
+				// Creation already failed; no runtime was inserted to dispose.
 				return;
 			}
 		}
@@ -561,12 +580,9 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 
 	async restartFromMessage(input: RestartPayload): Promise<void> {
 		if (this.shouldUseAcpChat()) {
-			const runtime = await this.getOrCreateAcpRuntime(
-				input.sessionId,
-				input.workspaceId,
+			throw new Error(
+				"ACP chat does not support editing or restarting prior turns yet.",
 			);
-			await runtime.restartFromMessage();
-			return;
 		}
 		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
@@ -578,11 +594,11 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 
 	async stop(input: { sessionId: string; workspaceId: string }): Promise<void> {
 		if (this.shouldUseAcpChat()) {
-			const runtime = await this.getOrCreateAcpRuntime(
+			const runtime = this.getExistingAcpRuntime(
 				input.sessionId,
 				input.workspaceId,
 			);
-			runtime.stop();
+			runtime?.stop();
 			return;
 		}
 		const runtime = await this.getOrCreateMastraRuntime(
@@ -598,10 +614,11 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		payload: ChatApprovalPayload;
 	}): Promise<unknown> {
 		if (this.shouldUseAcpChat()) {
-			const runtime = await this.getOrCreateAcpRuntime(
+			const runtime = this.getExistingAcpRuntime(
 				input.sessionId,
 				input.workspaceId,
 			);
+			if (!runtime) throw new Error("No ACP runtime exists for this session");
 			runtime.respondToApproval(input.payload);
 			return;
 		}
@@ -618,13 +635,10 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		payload: ChatQuestionPayload;
 	}): Promise<unknown> {
 		if (this.shouldUseAcpChat()) {
-			const runtime = await this.getOrCreateAcpRuntime(
-				input.sessionId,
-				input.workspaceId,
-			);
 			void input.payload;
-			await runtime.respondToQuestion();
-			return;
+			throw new Error(
+				"ACP chat question responses are not available for this request.",
+			);
 		}
 		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
@@ -639,13 +653,10 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		payload: ChatPlanPayload;
 	}): Promise<unknown> {
 		if (this.shouldUseAcpChat()) {
-			const runtime = await this.getOrCreateAcpRuntime(
-				input.sessionId,
-				input.workspaceId,
-			);
 			void input.payload;
-			await runtime.respondToPlan();
-			return;
+			throw new Error(
+				"ACP chat plan approval is not available for this request.",
+			);
 		}
 		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
@@ -809,7 +820,9 @@ function resolveAcpCommandConfig(): AcpCommandConfig {
 		) {
 			return { command, args: parsed };
 		}
-	} catch {}
+	} catch {
+		// Fall back to shell-style whitespace splitting below.
+	}
 	return {
 		command,
 		args: argsEnv.split(/\s+/).filter((arg) => arg.length > 0),

--- a/packages/host-service/src/runtime/chat/chat.ts
+++ b/packages/host-service/src/runtime/chat/chat.ts
@@ -11,55 +11,37 @@ import { createMastraCode } from "mastracode";
 import type { HostDb } from "../../db";
 import { workspaces } from "../../db/schema";
 import type { ModelProviderRuntimeResolver } from "../../providers/model-providers";
+import { AcpChatRuntime } from "./acp-chat-runtime";
+import type {
+	ChatDisplayState as AcpChatDisplayState,
+	ChatApprovalPayload,
+	ChatMessage,
+	ChatPlanPayload,
+	ChatQuestionPayload,
+	ChatSendMessageInput,
+	RestartPayload,
+} from "./acp-types";
 
-type RuntimeHarness = Awaited<ReturnType<typeof createMastraCode>>["harness"];
-type RuntimeMcpManager = Awaited<
-	ReturnType<typeof createMastraCode>
->["mcpManager"];
-type RuntimeHookManager = Awaited<
-	ReturnType<typeof createMastraCode>
->["hookManager"];
-type RuntimeDisplayState = ReturnType<RuntimeHarness["getDisplayState"]>;
-type RuntimeMessages = Awaited<ReturnType<RuntimeHarness["listMessages"]>>;
-type RuntimeSendMessageResult = Awaited<
-	ReturnType<RuntimeHarness["sendMessage"]>
->;
-type RuntimeApprovalResult = Awaited<
-	ReturnType<RuntimeHarness["respondToToolApproval"]>
->;
-type RuntimeQuestionResult = Awaited<
-	ReturnType<RuntimeHarness["respondToQuestion"]>
->;
-type RuntimePlanResult = Awaited<
-	ReturnType<RuntimeHarness["respondToPlanApproval"]>
->;
 type ChatThinkingLevel = "off" | "low" | "medium" | "high" | "xhigh";
 
-interface ChatSendMessageInput {
-	sessionId: string;
-	workspaceId: string;
-	payload: {
-		content: string;
-		files?: Array<{
-			data: string;
-			mediaType: string;
-			filename?: string;
-		}>;
-	};
-	metadata?: {
-		model?: string;
-		thinkingLevel?: ChatThinkingLevel;
-	};
-}
+type ChatPayload = ChatSendMessageInput["payload"];
 
-interface RestartPayload extends ChatSendMessageInput {
-	messageId: string;
-}
-
-interface PendingSandboxQuestion {
+interface MastraPendingQuestion {
 	questionId: string;
-	path: string;
-	reason: string;
+	[key: string]: unknown;
+}
+
+interface MastraDisplayState {
+	isRunning?: boolean;
+	currentMessage?: (ChatMessage & { errorMessage?: string }) | null;
+	pendingQuestion?: MastraPendingQuestion | null;
+	pendingApproval?: unknown;
+	pendingPlanApproval?: unknown;
+	activeTools?: Map<string, unknown>;
+	toolInputBuffers?: Map<string, unknown>;
+	activeSubagents?: Map<string, unknown>;
+	errorMessage?: string | null;
+	[key: string]: unknown;
 }
 
 interface ChatPendingQuestionOption {
@@ -74,87 +56,14 @@ interface ChatPendingQuestion {
 	options: ChatPendingQuestionOption[];
 }
 
-export type ChatDisplayState = RuntimeDisplayState & {
-	pendingQuestion:
-		| RuntimeDisplayState["pendingQuestion"]
-		| ChatPendingQuestion
-		| null;
+export type ChatDisplayState = (MastraDisplayState | AcpChatDisplayState) & {
+	pendingQuestion: MastraPendingQuestion | ChatPendingQuestion | null;
 	errorMessage: string | null;
 };
 
-interface ChatApprovalPayload {
-	decision: "approve" | "decline" | "always_allow_category";
-}
-
-interface ChatQuestionPayload {
-	questionId: string;
-	answer: string;
-}
-
-interface ChatPlanPayload {
-	planId: string;
-	response: {
-		action: "approved" | "rejected";
-		feedback?: string;
-	};
-}
-
-interface RuntimeSession {
-	sessionId: string;
-	workspaceId: string;
-	cwd: string;
-	harness: RuntimeHarness;
-	mcpManager: RuntimeMcpManager;
-	hookManager: RuntimeHookManager;
-	lastErrorMessage: string | null;
-	pendingSandboxQuestion: PendingSandboxQuestion | null;
-	answeredQuestionIds: Set<string>;
-	pendingQuestionResponses: Map<string, Promise<RuntimeQuestionResult>>;
-}
-
-function respondToQuestionWithOptimisticState(
-	runtime: RuntimeSession,
-	payload: ChatQuestionPayload,
-): Promise<RuntimeQuestionResult> {
-	const questionId = payload.questionId;
-	const pendingResponse = runtime.pendingQuestionResponses.get(questionId);
-	if (pendingResponse) return pendingResponse;
-
-	const wasAlreadyAnswered = runtime.answeredQuestionIds.has(questionId);
-	const previousSandboxQuestion = runtime.pendingSandboxQuestion;
-	const clearsSandboxQuestion =
-		previousSandboxQuestion?.questionId === questionId;
-
-	runtime.answeredQuestionIds.add(questionId);
-	if (clearsSandboxQuestion) {
-		runtime.pendingSandboxQuestion = null;
-	}
-
-	let responsePromise: Promise<RuntimeQuestionResult>;
-	responsePromise = Promise.resolve()
-		.then(() => runtime.harness.respondToQuestion(payload))
-		.catch((error) => {
-			if (
-				runtime.pendingQuestionResponses.get(questionId) === responsePromise
-			) {
-				if (!wasAlreadyAnswered) {
-					runtime.answeredQuestionIds.delete(questionId);
-				}
-				if (clearsSandboxQuestion && runtime.pendingSandboxQuestion === null) {
-					runtime.pendingSandboxQuestion = previousSandboxQuestion;
-				}
-			}
-			throw error;
-		})
-		.finally(() => {
-			if (
-				runtime.pendingQuestionResponses.get(questionId) === responsePromise
-			) {
-				runtime.pendingQuestionResponses.delete(questionId);
-			}
-		});
-	runtime.pendingQuestionResponses.set(questionId, responsePromise);
-	return responsePromise;
+interface RuntimeChatSnapshot {
+	displayState: ChatDisplayState;
+	messages: ChatMessage[];
 }
 
 interface RuntimeStoredMessage {
@@ -181,15 +90,26 @@ interface RuntimeMemoryStore {
 		sourceThreadId: string;
 		resourceId?: string;
 		title?: string;
-		options?: {
-			messageFilter?: {
-				messageIds?: string[];
-			};
-		};
+		options?: { messageFilter?: { messageIds?: string[] } };
 	}): Promise<{ thread: RuntimeStoredThread }>;
 }
 
-interface HarnessWithConfig {
+interface RuntimeHarness {
+	init(): Promise<void>;
+	setResourceId(input: { resourceId: string }): void;
+	selectOrCreateThread(): Promise<void>;
+	getDisplayState(): MastraDisplayState;
+	listMessages(): Promise<ChatMessage[]>;
+	sendMessage(payload: ChatPayload): Promise<unknown>;
+	abort(): void;
+	switchModel(input: { modelId: string; scope: "thread" }): Promise<void>;
+	setState(input: { thinkingLevel: ChatThinkingLevel }): Promise<void>;
+	respondToToolApproval(payload: ChatApprovalPayload): Promise<unknown>;
+	respondToQuestion(payload: ChatQuestionPayload): Promise<unknown>;
+	respondToPlanApproval(payload: ChatPlanPayload): Promise<unknown>;
+	getCurrentThreadId(): string | null;
+	switchThread(input: { threadId: string }): Promise<void>;
+	subscribe(callback: (event: unknown) => void): void;
 	config?: {
 		storage?: {
 			getStore: (domain: "memory") => Promise<RuntimeMemoryStore | null>;
@@ -197,183 +117,63 @@ interface HarnessWithConfig {
 	};
 }
 
+interface RuntimeMcpManager {
+	disconnect?(): Promise<void>;
+}
+
+interface RuntimeHookManager {
+	setSessionId?(sessionId: string): void;
+}
+
+interface MastraRuntimeSession {
+	sessionId: string;
+	workspaceId: string;
+	cwd: string;
+	harness: RuntimeHarness;
+	mcpManager: RuntimeMcpManager | null;
+	hookManager: RuntimeHookManager | null;
+	lastErrorMessage: string | null;
+	pendingSandboxQuestion: {
+		questionId: string;
+		path: string;
+		reason: string;
+	} | null;
+	answeredQuestionIds: Set<string>;
+	pendingQuestionResponses: Map<string, Promise<unknown>>;
+}
+
+interface MastraInflightRuntimeCreation {
+	workspaceId: string;
+	promise: Promise<MastraRuntimeSession>;
+}
+
+interface AcpInflightRuntimeCreation {
+	workspaceId: string;
+	promise: Promise<AcpChatRuntime>;
+}
+
 export interface ChatRuntimeManagerOptions {
 	db: HostDb;
 	runtimeResolver: ModelProviderRuntimeResolver;
 }
 
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-function isHarnessErrorEvent(
-	event: unknown,
-): event is { type: "error"; error: unknown } {
-	return isObjectRecord(event) && event.type === "error" && "error" in event;
-}
-
-function isHarnessWorkspaceErrorEvent(
-	event: unknown,
-): event is { type: "workspace_error"; error: unknown } {
-	return (
-		isObjectRecord(event) &&
-		event.type === "workspace_error" &&
-		"error" in event
-	);
-}
-
-function isHarnessSandboxAccessRequestEvent(event: unknown): event is {
-	type: "sandbox_access_request";
-	questionId: string;
-	path: string;
-	reason: string;
-} {
-	if (!isObjectRecord(event) || event.type !== "sandbox_access_request") {
-		return false;
-	}
-
-	return (
-		typeof event.questionId === "string" &&
-		typeof event.path === "string" &&
-		typeof event.reason === "string"
-	);
-}
-
-function normalizeErrorMessage(message: string): string {
-	return message.trim().replace(/^AI_APICallError\d*\s*:\s*/i, "");
-}
-
-function extractProviderMessage(error: unknown): string | null {
-	if (!isObjectRecord(error)) return null;
-
-	const data = error.data;
-	if (isObjectRecord(data)) {
-		const nestedError = data.error;
-		if (
-			isObjectRecord(nestedError) &&
-			typeof nestedError.message === "string"
-		) {
-			return normalizeErrorMessage(nestedError.message);
-		}
-	}
-
-	const nestedError = error.error;
-	if (isObjectRecord(nestedError) && typeof nestedError.message === "string") {
-		return normalizeErrorMessage(nestedError.message);
-	}
-
-	return null;
-}
-
-function toRuntimeErrorMessage(error: unknown): string {
-	const providerMessage = extractProviderMessage(error);
-	if (providerMessage) return providerMessage;
-	if (error instanceof Error && error.message.trim()) {
-		return normalizeErrorMessage(error.message);
-	}
-	if (typeof error === "string" && error.trim()) {
-		return normalizeErrorMessage(error);
-	}
-	if (isObjectRecord(error) && typeof error.message === "string") {
-		return normalizeErrorMessage(error.message);
-	}
-	return "Unexpected chat error";
-}
-
-async function getRuntimeMemoryStore(
-	runtime: RuntimeSession,
-): Promise<RuntimeMemoryStore> {
-	const harness = runtime.harness as unknown as HarnessWithConfig;
-	const storage = harness.config?.storage;
-	if (!storage) {
-		throw new Error("Mastra storage is not configured for this session");
-	}
-
-	const memoryStore = await storage.getStore("memory");
-	if (!memoryStore) {
-		throw new Error("Mastra memory storage is unavailable for this session");
-	}
-
-	return memoryStore;
-}
-
-async function restartRuntimeFromUserMessage(
-	runtime: RuntimeSession,
-	input: RestartPayload,
-): Promise<void> {
-	const threadId = runtime.harness.getCurrentThreadId();
-	if (!threadId) {
-		throw new Error("No active Mastra thread is available for editing");
-	}
-
-	const memoryStore = await getRuntimeMemoryStore(runtime);
-	const sourceThread = await memoryStore.getThreadById({ threadId });
-	if (!sourceThread) {
-		throw new Error(`Mastra thread not found: ${threadId}`);
-	}
-
-	const sourceMessages = await memoryStore.listMessages({
-		threadId,
-		perPage: false,
-		orderBy: { field: "createdAt", direction: "ASC" },
-	});
-	const targetIndex = sourceMessages.messages.findIndex(
-		(message) => message.id === input.messageId,
-	);
-	if (targetIndex === -1) {
-		throw new Error("The selected message is no longer available to edit");
-	}
-
-	const targetMessage = sourceMessages.messages[targetIndex];
-	if (targetMessage?.role !== "user") {
-		throw new Error("Only user messages can be edited or resent");
-	}
-
-	const clonedThread = await memoryStore.cloneThread({
-		sourceThreadId: threadId,
-		resourceId: sourceThread.resourceId,
-		title: sourceThread.title,
-		options: {
-			messageFilter: {
-				messageIds: sourceMessages.messages
-					.slice(0, targetIndex)
-					.map((message) => message.id),
-			},
-		},
-	});
-
-	runtime.harness.abort();
-	await runtime.harness.switchThread({ threadId: clonedThread.thread.id });
-
-	const selectedModel = input.metadata?.model?.trim();
-	if (selectedModel) {
-		await runtime.harness.switchModel({
-			modelId: selectedModel,
-			scope: "thread",
-		});
-	}
-
-	const thinkingLevel = input.metadata?.thinkingLevel;
-	if (thinkingLevel) {
-		await runtime.harness.setState({ thinkingLevel });
-	}
-
-	runtime.lastErrorMessage = null;
-	await runtime.harness.sendMessage(input.payload);
-}
-
-interface InflightRuntimeCreation {
-	workspaceId: string;
-	promise: Promise<RuntimeSession>;
+interface AcpCommandConfig {
+	command: string;
+	args: string[];
 }
 
 export class ChatRuntimeManager {
 	private readonly db: HostDb;
 	private readonly runtimeResolver: ModelProviderRuntimeResolver;
-	private readonly runtimes = new Map<string, RuntimeSession>();
-	private readonly runtimeCreations = new Map<
+	private readonly mastraRuntimes = new Map<string, MastraRuntimeSession>();
+	private readonly mastraRuntimeCreations = new Map<
 		string,
-		InflightRuntimeCreation
+		MastraInflightRuntimeCreation
+	>();
+	private readonly acpRuntimes = new Map<string, AcpChatRuntime>();
+	private readonly acpRuntimeCreations = new Map<
+		string,
+		AcpInflightRuntimeCreation
 	>();
 
 	constructor(options: ChatRuntimeManagerOptions) {
@@ -381,13 +181,18 @@ export class ChatRuntimeManager {
 		this.runtimeResolver = options.runtimeResolver;
 	}
 
-	private subscribeToSessionEvents(runtime: RuntimeSession): void {
+	private shouldUseAcpChat(): boolean {
+		const value =
+			process.env.SUPERSET_EXPERIMENTAL_ACP_CHAT?.trim().toLowerCase();
+		return value === "1" || value === "true" || value === "yes";
+	}
+
+	private subscribeToMastraSessionEvents(runtime: MastraRuntimeSession): void {
 		runtime.harness.subscribe((event: unknown) => {
 			if (isHarnessErrorEvent(event) || isHarnessWorkspaceErrorEvent(event)) {
 				runtime.lastErrorMessage = toRuntimeErrorMessage(event.error);
 				return;
 			}
-
 			if (isHarnessSandboxAccessRequestEvent(event)) {
 				runtime.pendingSandboxQuestion = {
 					questionId: event.questionId,
@@ -396,7 +201,6 @@ export class ChatRuntimeManager {
 				};
 				return;
 			}
-
 			if (isObjectRecord(event) && event.type === "agent_start") {
 				runtime.lastErrorMessage = null;
 				runtime.pendingSandboxQuestion = null;
@@ -404,7 +208,6 @@ export class ChatRuntimeManager {
 				runtime.pendingQuestionResponses.clear();
 				return;
 			}
-
 			if (isObjectRecord(event) && event.type === "agent_end") {
 				runtime.pendingSandboxQuestion = null;
 				runtime.answeredQuestionIds.clear();
@@ -413,14 +216,9 @@ export class ChatRuntimeManager {
 		});
 	}
 
-	/**
-	 * Ensures ~/.mastracode/AGENTS.md exists with Superset-specific instructions.
-	 * Only writes when the file is absent or was previously written by us (identified
-	 * by the managed-by marker). Skips silently on any filesystem error.
-	 */
 	private ensureGlobalAgentInstructions(): void {
-		const MANAGED_MARKER = "<!-- managed-by: superset -->";
-		const INSTRUCTIONS = `${MANAGED_MARKER}
+		const managedMarker = "<!-- managed-by: superset -->";
+		const instructions = `${managedMarker}
 ## Question Tool
 
 When you need to ask the user ANY question — including simple yes/no, confirmations, and clarifications — ALWAYS use the \`ask_user\` tool. Never ask questions in plain text. The Superset UI renders \`ask_user\` calls as an interactive overlay with clickable option buttons; plain-text questions will not be surfaced to the user in the same way.
@@ -430,71 +228,93 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 			const filePath = join(dir, "AGENTS.md");
 			if (existsSync(filePath)) {
 				const existing = readFileSync(filePath, "utf-8");
-				if (!existing.includes(MANAGED_MARKER)) {
-					// User-managed file — don't overwrite
-					return;
-				}
+				if (!existing.includes(managedMarker)) return;
 			}
 			mkdirSync(dir, { recursive: true });
-			writeFileSync(filePath, INSTRUCTIONS, "utf-8");
+			writeFileSync(filePath, instructions, "utf-8");
 		} catch {
-			// Non-fatal — instructions enhancement is best-effort
+			// Best-effort compatibility for existing Mastra chat.
 		}
 	}
 
-	private async createRuntime(
+	private async createMastraRuntime(
 		sessionId: string,
 		workspaceId: string,
-	): Promise<RuntimeSession> {
+	): Promise<MastraRuntimeSession> {
 		if (!(await this.runtimeResolver.hasUsableRuntimeEnv())) {
 			throw new Error("No model provider credentials available");
 		}
-
-		const workspace = this.db.query.workspaces
-			.findFirst({ where: eq(workspaces.id, workspaceId) })
-			.sync();
-
-		if (!workspace) {
-			throw new Error(`Workspace not found: ${workspaceId}`);
-		}
-
-		const cwd = workspace.worktreePath;
-
+		const cwd = this.resolveWorkspaceCwd(workspaceId);
 		this.ensureGlobalAgentInstructions();
 		await this.runtimeResolver.prepareRuntimeEnv();
-
 		const runtime = await createMastraCode({
 			cwd,
 			disableMcp: true,
 			memory: new Memory({ options: { observationalMemory: false } }),
 		});
-		runtime.hookManager?.setSessionId(sessionId);
-		await runtime.harness.init();
-		runtime.harness.setResourceId({ resourceId: sessionId });
-		await runtime.harness.selectOrCreateThread();
-
-		const sessionRuntime: RuntimeSession = {
+		const harness = runtime.harness as unknown as RuntimeHarness;
+		const mcpManager = runtime.mcpManager as RuntimeMcpManager | null;
+		const hookManager = runtime.hookManager as RuntimeHookManager | null;
+		hookManager?.setSessionId?.(sessionId);
+		await harness.init();
+		harness.setResourceId({ resourceId: sessionId });
+		await harness.selectOrCreateThread();
+		const sessionRuntime: MastraRuntimeSession = {
 			sessionId,
 			workspaceId,
 			cwd,
-			harness: runtime.harness,
-			mcpManager: runtime.mcpManager,
-			hookManager: runtime.hookManager,
+			harness,
+			mcpManager,
+			hookManager,
 			lastErrorMessage: null,
 			pendingSandboxQuestion: null,
 			answeredQuestionIds: new Set(),
 			pendingQuestionResponses: new Map(),
 		};
-		this.subscribeToSessionEvents(sessionRuntime);
-		this.runtimes.set(sessionId, sessionRuntime);
+		this.subscribeToMastraSessionEvents(sessionRuntime);
+		this.mastraRuntimes.set(sessionId, sessionRuntime);
 		return sessionRuntime;
 	}
 
-	private async getOrCreateRuntime(
+	private async createAcpRuntime(
 		sessionId: string,
 		workspaceId: string,
-	): Promise<RuntimeSession> {
-		const existing = this.runtimes.get(sessionId);
+	): Promise<AcpChatRuntime> {
+		const cwd = this.resolveWorkspaceCwd(workspaceId);
+		await this.prepareOptionalRuntimeEnv();
+		const { command, args } = resolveAcpCommandConfig();
+		const runtime = new AcpChatRuntime({
+			supersetSessionId: sessionId,
+			workspaceId,
+			cwd,
+			command,
+			args,
+			env: process.env,
+		});
+		try {
+			await runtime.initialize();
+		} catch (error) {
+			await runtime.dispose().catch(() => {});
+			throw error;
+		}
+		this.acpRuntimes.set(sessionId, runtime);
+		return runtime;
+	}
+
+	private async prepareOptionalRuntimeEnv(): Promise<void> {
+		try {
+			await this.runtimeResolver.prepareRuntimeEnv();
+		} catch {
+			// ACP chat is experimental and additive. The ACP agent owns auth; existing
+			// provider env loading is best-effort for users who already configured keys.
+		}
+	}
+
+	private async getOrCreateMastraRuntime(
+		sessionId: string,
+		workspaceId: string,
+	): Promise<MastraRuntimeSession> {
+		const existing = this.mastraRuntimes.get(sessionId);
 		if (existing) {
 			if (existing.workspaceId !== workspaceId) {
 				throw new Error(
@@ -503,8 +323,7 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 			}
 			return existing;
 		}
-
-		const inflight = this.runtimeCreations.get(sessionId);
+		const inflight = this.mastraRuntimeCreations.get(sessionId);
 		if (inflight) {
 			if (inflight.workspaceId !== workspaceId) {
 				throw new Error(
@@ -513,29 +332,59 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 			}
 			return inflight.promise;
 		}
-
-		const promise = this.createRuntime(sessionId, workspaceId).finally(() => {
-			this.runtimeCreations.delete(sessionId);
-		});
-		this.runtimeCreations.set(sessionId, { workspaceId, promise });
+		const promise = this.createMastraRuntime(sessionId, workspaceId).finally(
+			() => {
+				this.mastraRuntimeCreations.delete(sessionId);
+			},
+		);
+		this.mastraRuntimeCreations.set(sessionId, { workspaceId, promise });
 		return promise;
 	}
 
-	/**
-	 * Tear down the in-memory runtime for a session. Aborts any in-flight
-	 * work, disconnects MCP servers, removes the runtime from the manager's
-	 * map, and is a no-op for unknown session ids. Should be called after
-	 * the cloud session row is deleted, or when a workspace is deleted.
-	 *
-	 * Validates `workspaceId` against the runtime / in-flight creation so a
-	 * caller can't dispose a session bound to a different workspace.
-	 *
-	 * If a creation is in-flight for this session, awaits it first so the
-	 * just-created runtime doesn't get inserted into `runtimes` after we
-	 * delete from it (which would leak).
-	 */
+	private async getOrCreateAcpRuntime(
+		sessionId: string,
+		workspaceId: string,
+	): Promise<AcpChatRuntime> {
+		const existing = this.acpRuntimes.get(sessionId);
+		if (existing) {
+			if (existing.workspaceId !== workspaceId) {
+				throw new Error(
+					`Session ${sessionId} is already bound to workspace ${existing.workspaceId}`,
+				);
+			}
+			return existing;
+		}
+		const inflight = this.acpRuntimeCreations.get(sessionId);
+		if (inflight) {
+			if (inflight.workspaceId !== workspaceId) {
+				throw new Error(
+					`Session ${sessionId} is already being created for workspace ${inflight.workspaceId}`,
+				);
+			}
+			return inflight.promise;
+		}
+		const promise = this.createAcpRuntime(sessionId, workspaceId).finally(
+			() => {
+				this.acpRuntimeCreations.delete(sessionId);
+			},
+		);
+		this.acpRuntimeCreations.set(sessionId, { workspaceId, promise });
+		return promise;
+	}
+
 	async disposeRuntime(sessionId: string, workspaceId: string): Promise<void> {
-		const inflight = this.runtimeCreations.get(sessionId);
+		if (this.shouldUseAcpChat()) {
+			await this.disposeAcpRuntime(sessionId, workspaceId);
+			return;
+		}
+		await this.disposeMastraRuntime(sessionId, workspaceId);
+	}
+
+	private async disposeMastraRuntime(
+		sessionId: string,
+		workspaceId: string,
+	): Promise<void> {
+		const inflight = this.mastraRuntimeCreations.get(sessionId);
 		if (inflight) {
 			if (inflight.workspaceId !== workspaceId) {
 				throw new Error(
@@ -545,56 +394,64 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 			try {
 				await inflight.promise;
 			} catch {
-				// Creation failed — nothing to dispose.
 				return;
 			}
 		}
-
-		const runtime = this.runtimes.get(sessionId);
+		const runtime = this.mastraRuntimes.get(sessionId);
 		if (!runtime) return;
-
 		if (runtime.workspaceId !== workspaceId) {
 			throw new Error(
 				`Session ${sessionId} is bound to workspace ${runtime.workspaceId}`,
 			);
 		}
-
 		try {
 			runtime.harness.abort();
-		} catch {
-			// best-effort — proceed with cleanup even if abort fails
-		}
+		} catch {}
 		try {
-			await runtime.mcpManager?.disconnect();
-		} catch {
-			// best-effort — MCP servers may already be disconnected
-		}
-		this.runtimes.delete(sessionId);
+			await runtime.mcpManager?.disconnect?.();
+		} catch {}
+		this.mastraRuntimes.delete(sessionId);
 	}
 
-	/**
-	 * Shape the harness's raw display state into the shape the renderer
-	 * expects. Both getDisplayState and getSnapshot must apply the same
-	 * shaping — keep this the single source of truth so the two functions
-	 * cannot drift.
-	 */
-	private buildDisplayState(runtime: RuntimeSession): ChatDisplayState {
+	private async disposeAcpRuntime(
+		sessionId: string,
+		workspaceId: string,
+	): Promise<void> {
+		const inflight = this.acpRuntimeCreations.get(sessionId);
+		if (inflight) {
+			if (inflight.workspaceId !== workspaceId) {
+				throw new Error(
+					`Session ${sessionId} is being created for workspace ${inflight.workspaceId}`,
+				);
+			}
+			try {
+				await inflight.promise;
+			} catch {
+				return;
+			}
+		}
+		const runtime = this.acpRuntimes.get(sessionId);
+		if (!runtime) return;
+		if (runtime.workspaceId !== workspaceId) {
+			throw new Error(
+				`Session ${sessionId} is bound to workspace ${runtime.workspaceId}`,
+			);
+		}
+		await runtime.dispose();
+		this.acpRuntimes.delete(sessionId);
+	}
+
+	private buildMastraDisplayState(
+		runtime: MastraRuntimeSession,
+	): ChatDisplayState {
 		const displayState = runtime.harness.getDisplayState();
-		const currentMessage = displayState.currentMessage as {
-			role?: string;
-			errorMessage?: string;
-		} | null;
+		const currentMessage = displayState.currentMessage;
 		const currentMessageError =
 			currentMessage?.role === "assistant" &&
 			typeof currentMessage.errorMessage === "string" &&
 			currentMessage.errorMessage.trim()
 				? currentMessage.errorMessage.trim()
 				: null;
-
-		// Skip any pending question whose ID was already answered this turn.
-		// The harness only clears pendingQuestion on agent_end, so without this
-		// filter an answered ask_user question would permanently shadow the
-		// sandbox question that fired in the same turn.
 		const harnessPendingQuestion =
 			displayState.pendingQuestion &&
 			!runtime.answeredQuestionIds.has(displayState.pendingQuestion.questionId)
@@ -606,10 +463,7 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 					question: `Grant sandbox access to "${runtime.pendingSandboxQuestion.path}"?`,
 					description: runtime.pendingSandboxQuestion.reason,
 					options: [
-						{
-							label: "Yes",
-							description: "Allow access.",
-						},
+						{ label: "Yes", description: "Allow access." },
 						{ label: "No", description: "Deny access." },
 					],
 				}
@@ -618,70 +472,79 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 			...displayState,
 			pendingQuestion: harnessPendingQuestion ?? sandboxPendingQuestion,
 			errorMessage: currentMessageError ?? runtime.lastErrorMessage,
-		};
+		} as ChatDisplayState;
 	}
 
 	async getDisplayState(input: {
 		sessionId: string;
 		workspaceId: string;
 	}): Promise<ChatDisplayState> {
-		const runtime = await this.getOrCreateRuntime(
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			return runtime.getDisplayState() as ChatDisplayState;
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
-		return this.buildDisplayState(runtime);
+		return this.buildMastraDisplayState(runtime);
 	}
 
 	async listMessages(input: {
 		sessionId: string;
 		workspaceId: string;
-	}): Promise<RuntimeMessages> {
-		const runtime = await this.getOrCreateRuntime(
+	}): Promise<ChatMessage[]> {
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			return runtime.listMessages();
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
 		return runtime.harness.listMessages();
 	}
 
-	/**
-	 * Single server-side observation that returns both displayState and messages
-	 * from one runtime acquisition. This avoids the dual-poll race between
-	 * independent getDisplayState / listMessages queries on the client.
-	 *
-	 * Note: not a fully locked atomic snapshot — listMessages() is async, so
-	 * harness state can change between the displayState read and the messages
-	 * read. This still removes the *client-side* two-query race, which is the
-	 * one that caused mismatched message/display state.
-	 */
 	async getSnapshot(input: {
 		sessionId: string;
 		workspaceId: string;
-	}): Promise<{
-		displayState: ChatDisplayState;
-		messages: RuntimeMessages;
-	}> {
-		const runtime = await this.getOrCreateRuntime(
+	}): Promise<RuntimeChatSnapshot> {
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			return runtime.getSnapshot();
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
-		const displayState = this.buildDisplayState(runtime);
-		const messages = await runtime.harness.listMessages();
-		// Intentionally no observedAt: when the harness state hasn't changed,
-		// the response object is structurally identical to the previous poll's
-		// response, so React Query's structuralSharing preserves the object
-		// identity and idle polls don't trigger downstream rerenders.
-		return { displayState, messages };
+		return {
+			displayState: this.buildMastraDisplayState(runtime),
+			messages: await runtime.harness.listMessages(),
+		};
 	}
 
-	async sendMessage(
-		input: ChatSendMessageInput,
-	): Promise<RuntimeSendMessageResult> {
-		const runtime = await this.getOrCreateRuntime(
+	async sendMessage(input: ChatSendMessageInput): Promise<unknown> {
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			return runtime.sendMessage(input.payload);
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
 		runtime.lastErrorMessage = null;
-
 		const selectedModel = input.metadata?.model?.trim();
 		if (selectedModel) {
 			await runtime.harness.switchModel({
@@ -689,26 +552,40 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 				scope: "thread",
 			});
 		}
-
 		const thinkingLevel = input.metadata?.thinkingLevel;
 		if (thinkingLevel) {
 			await runtime.harness.setState({ thinkingLevel });
 		}
-
 		return runtime.harness.sendMessage(input.payload);
 	}
 
 	async restartFromMessage(input: RestartPayload): Promise<void> {
-		const runtime = await this.getOrCreateRuntime(
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			await runtime.restartFromMessage();
+			return;
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
 		runtime.lastErrorMessage = null;
-		await restartRuntimeFromUserMessage(runtime, input);
+		await restartMastraRuntimeFromUserMessage(runtime, input);
 	}
 
 	async stop(input: { sessionId: string; workspaceId: string }): Promise<void> {
-		const runtime = await this.getOrCreateRuntime(
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			runtime.stop();
+			return;
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
@@ -719,8 +596,16 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		sessionId: string;
 		workspaceId: string;
 		payload: ChatApprovalPayload;
-	}): Promise<RuntimeApprovalResult> {
-		const runtime = await this.getOrCreateRuntime(
+	}): Promise<unknown> {
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			runtime.respondToApproval(input.payload);
+			return;
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
@@ -731,12 +616,20 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		sessionId: string;
 		workspaceId: string;
 		payload: ChatQuestionPayload;
-	}): Promise<RuntimeQuestionResult> {
-		const runtime = await this.getOrCreateRuntime(
+	}): Promise<unknown> {
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			void input.payload;
+			await runtime.respondToQuestion();
+			return;
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
-
 		return respondToQuestionWithOptimisticState(runtime, input.payload);
 	}
 
@@ -744,8 +637,17 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		sessionId: string;
 		workspaceId: string;
 		payload: ChatPlanPayload;
-	}): Promise<RuntimePlanResult> {
-		const runtime = await this.getOrCreateRuntime(
+	}): Promise<unknown> {
+		if (this.shouldUseAcpChat()) {
+			const runtime = await this.getOrCreateAcpRuntime(
+				input.sessionId,
+				input.workspaceId,
+			);
+			void input.payload;
+			await runtime.respondToPlan();
+			return;
+		}
+		const runtime = await this.getOrCreateMastraRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
@@ -756,9 +658,7 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		const workspace = this.db.query.workspaces
 			.findFirst({ where: eq(workspaces.id, workspaceId) })
 			.sync();
-		if (!workspace) {
-			throw new Error(`Workspace not found: ${workspaceId}`);
-		}
+		if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
 		return workspace.worktreePath;
 	}
 
@@ -796,4 +696,193 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 	}): Promise<{ sourcePath: string | null; servers: never[] }> {
 		return { sourcePath: null, servers: [] };
 	}
+}
+
+function respondToQuestionWithOptimisticState(
+	runtime: MastraRuntimeSession,
+	payload: ChatQuestionPayload,
+): Promise<unknown> {
+	const questionId = payload.questionId;
+	const pendingResponse = runtime.pendingQuestionResponses.get(questionId);
+	if (pendingResponse) return pendingResponse;
+	const wasAlreadyAnswered = runtime.answeredQuestionIds.has(questionId);
+	const previousSandboxQuestion = runtime.pendingSandboxQuestion;
+	const clearsSandboxQuestion =
+		previousSandboxQuestion?.questionId === questionId;
+	runtime.answeredQuestionIds.add(questionId);
+	if (clearsSandboxQuestion) runtime.pendingSandboxQuestion = null;
+	let responsePromise: Promise<unknown>;
+	responsePromise = Promise.resolve()
+		.then(() => runtime.harness.respondToQuestion(payload))
+		.catch((error) => {
+			if (
+				runtime.pendingQuestionResponses.get(questionId) === responsePromise
+			) {
+				if (!wasAlreadyAnswered) runtime.answeredQuestionIds.delete(questionId);
+				if (clearsSandboxQuestion && runtime.pendingSandboxQuestion === null) {
+					runtime.pendingSandboxQuestion = previousSandboxQuestion;
+				}
+			}
+			throw error;
+		})
+		.finally(() => {
+			if (
+				runtime.pendingQuestionResponses.get(questionId) === responsePromise
+			) {
+				runtime.pendingQuestionResponses.delete(questionId);
+			}
+		});
+	runtime.pendingQuestionResponses.set(questionId, responsePromise);
+	return responsePromise;
+}
+
+async function restartMastraRuntimeFromUserMessage(
+	runtime: MastraRuntimeSession,
+	input: RestartPayload,
+): Promise<void> {
+	const threadId = runtime.harness.getCurrentThreadId();
+	if (!threadId)
+		throw new Error("No active Mastra thread is available for editing");
+	const memoryStore = await getRuntimeMemoryStore(runtime);
+	const sourceThread = await memoryStore.getThreadById({ threadId });
+	if (!sourceThread) throw new Error(`Mastra thread not found: ${threadId}`);
+	const sourceMessages = await memoryStore.listMessages({
+		threadId,
+		perPage: false,
+		orderBy: { field: "createdAt", direction: "ASC" },
+	});
+	const targetIndex = sourceMessages.messages.findIndex(
+		(message) => message.id === input.messageId,
+	);
+	if (targetIndex === -1)
+		throw new Error("The selected message is no longer available to edit");
+	const targetMessage = sourceMessages.messages[targetIndex];
+	if (targetMessage?.role !== "user")
+		throw new Error("Only user messages can be edited or resent");
+	const clonedThread = await memoryStore.cloneThread({
+		sourceThreadId: threadId,
+		resourceId: sourceThread.resourceId,
+		title: sourceThread.title,
+		options: {
+			messageFilter: {
+				messageIds: sourceMessages.messages
+					.slice(0, targetIndex)
+					.map((message) => message.id),
+			},
+		},
+	});
+	runtime.harness.abort();
+	await runtime.harness.switchThread({ threadId: clonedThread.thread.id });
+	const selectedModel = input.metadata?.model?.trim();
+	if (selectedModel)
+		await runtime.harness.switchModel({
+			modelId: selectedModel,
+			scope: "thread",
+		});
+	const thinkingLevel = input.metadata?.thinkingLevel;
+	if (thinkingLevel) await runtime.harness.setState({ thinkingLevel });
+	runtime.lastErrorMessage = null;
+	await runtime.harness.sendMessage(input.payload);
+}
+
+async function getRuntimeMemoryStore(
+	runtime: MastraRuntimeSession,
+): Promise<RuntimeMemoryStore> {
+	const storage = runtime.harness.config?.storage;
+	if (!storage)
+		throw new Error("Mastra storage is not configured for this session");
+	const memoryStore = await storage.getStore("memory");
+	if (!memoryStore)
+		throw new Error("Mastra memory storage is unavailable for this session");
+	return memoryStore;
+}
+
+function resolveAcpCommandConfig(): AcpCommandConfig {
+	const command = process.env.SUPERSET_ACP_COMMAND?.trim() || "omp";
+	const argsEnv = process.env.SUPERSET_ACP_ARGS?.trim();
+	if (!argsEnv) return { command, args: ["acp"] };
+	try {
+		const parsed = JSON.parse(argsEnv) as unknown;
+		if (
+			Array.isArray(parsed) &&
+			parsed.every((arg) => typeof arg === "string")
+		) {
+			return { command, args: parsed };
+		}
+	} catch {}
+	return {
+		command,
+		args: argsEnv.split(/\s+/).filter((arg) => arg.length > 0),
+	};
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isHarnessErrorEvent(
+	event: unknown,
+): event is { type: "error"; error: unknown } {
+	return isObjectRecord(event) && event.type === "error" && "error" in event;
+}
+
+function isHarnessWorkspaceErrorEvent(
+	event: unknown,
+): event is { type: "workspace_error"; error: unknown } {
+	return (
+		isObjectRecord(event) &&
+		event.type === "workspace_error" &&
+		"error" in event
+	);
+}
+
+function isHarnessSandboxAccessRequestEvent(event: unknown): event is {
+	type: "sandbox_access_request";
+	questionId: string;
+	path: string;
+	reason: string;
+} {
+	return (
+		isObjectRecord(event) &&
+		event.type === "sandbox_access_request" &&
+		typeof event.questionId === "string" &&
+		typeof event.path === "string" &&
+		typeof event.reason === "string"
+	);
+}
+
+function normalizeErrorMessage(message: string): string {
+	return message.trim().replace(/^AI_APICallError\d*\s*:\s*/i, "");
+}
+
+function extractProviderMessage(error: unknown): string | null {
+	if (!isObjectRecord(error)) return null;
+	const data = error.data;
+	if (isObjectRecord(data)) {
+		const nestedError = data.error;
+		if (
+			isObjectRecord(nestedError) &&
+			typeof nestedError.message === "string"
+		) {
+			return normalizeErrorMessage(nestedError.message);
+		}
+	}
+	const nestedError = error.error;
+	if (isObjectRecord(nestedError) && typeof nestedError.message === "string") {
+		return normalizeErrorMessage(nestedError.message);
+	}
+	return null;
+}
+
+function toRuntimeErrorMessage(error: unknown): string {
+	const providerMessage = extractProviderMessage(error);
+	if (providerMessage) return providerMessage;
+	if (error instanceof Error && error.message.trim())
+		return normalizeErrorMessage(error.message);
+	if (typeof error === "string" && error.trim())
+		return normalizeErrorMessage(error);
+	if (isObjectRecord(error) && typeof error.message === "string") {
+		return normalizeErrorMessage(error.message);
+	}
+	return "Unexpected chat error";
 }

--- a/packages/host-service/src/runtime/chat/stdio-acp-client.ts
+++ b/packages/host-service/src/runtime/chat/stdio-acp-client.ts
@@ -34,6 +34,7 @@ type PendingRequest = {
 	method: string;
 	resolve: (value: unknown) => void;
 	reject: (reason: unknown) => void;
+	timeout: ReturnType<typeof setTimeout>;
 };
 
 export interface AcpAgentClientOptions {
@@ -45,6 +46,8 @@ export interface AcpAgentClientOptions {
 	onPermissionRequest: (request: AcpPermissionRequest) => Promise<unknown>;
 	onError: (error: Error) => void;
 }
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 
 export class AcpJsonRpcError extends Error {
 	readonly code: number;
@@ -60,6 +63,8 @@ export class AcpJsonRpcError extends Error {
 
 export class StdioAcpAgentClient {
 	private child: ChildProcessWithoutNullStreams | null = null;
+	private exited = false;
+	private disposing = false;
 	private lines: Interface | null = null;
 	private nextRequestId = 1;
 	private readonly pending = new Map<number | string, PendingRequest>();
@@ -108,18 +113,24 @@ export class StdioAcpAgentClient {
 
 	cancel(sessionId: string): void {
 		void this.notify("session/cancel", { sessionId });
+		this.rejectPendingRequests(
+			"session/prompt",
+			new Error("ACP prompt cancelled"),
+		);
 	}
 
 	async dispose(): Promise<void> {
 		const child = this.child;
+		this.disposing = true;
 		this.child = null;
 		this.lines?.close();
 		this.lines = null;
-		for (const { reject } of this.pending.values()) {
-			reject(new Error("ACP agent process disposed"));
+		for (const pending of this.pending.values()) {
+			clearTimeout(pending.timeout);
+			pending.reject(new Error("ACP agent process disposed"));
 		}
 		this.pending.clear();
-		if (!child || child.killed) return;
+		if (!child || this.exited) return;
 
 		const { promise, resolve } = Promise.withResolvers<void>();
 		const timeout = setTimeout(resolve, 1000);
@@ -129,11 +140,13 @@ export class StdioAcpAgentClient {
 		});
 		child.kill("SIGTERM");
 		await promise;
-		if (!child.killed) child.kill("SIGKILL");
+		if (!this.exited) child.kill("SIGKILL");
 	}
 
 	private startProcess(): void {
 		if (this.child) return;
+		this.exited = false;
+		this.disposing = false;
 		const child = spawn(this.options.command, this.options.args, {
 			cwd: this.options.cwd,
 			env: this.options.env ?? process.env,
@@ -156,10 +169,13 @@ export class StdioAcpAgentClient {
 			}
 		});
 		child.once("error", (error) => {
+			this.markExited();
 			this.rejectAll(error);
 			this.options.onError(error);
 		});
 		child.once("exit", (code, signal) => {
+			this.markExited();
+			if (this.disposing) return;
 			const suffix =
 				this.stderrLines.length > 0 ? `: ${this.stderrLines.join("\n")}` : "";
 			const error = new Error(
@@ -173,11 +189,19 @@ export class StdioAcpAgentClient {
 	private async request(method: string, params: unknown): Promise<unknown> {
 		const id = this.nextRequestId++;
 		const { promise, resolve, reject } = Promise.withResolvers<unknown>();
-		this.pending.set(id, { method, resolve, reject });
+		const timeout = setTimeout(() => {
+			if (!this.pending.delete(id)) return;
+			reject(new Error(`ACP request timed out: ${method}`));
+		}, DEFAULT_REQUEST_TIMEOUT_MS);
+		this.pending.set(id, { method, resolve, reject, timeout });
 		try {
 			await this.write({ jsonrpc: "2.0", id, method, params });
 		} catch (error) {
-			this.pending.delete(id);
+			const pending = this.pending.get(id);
+			if (pending) {
+				clearTimeout(pending.timeout);
+				this.pending.delete(id);
+			}
 			reject(error);
 		}
 		return promise;
@@ -229,6 +253,7 @@ export class StdioAcpAgentClient {
 		const pending = this.pending.get(message.id);
 		if (!pending) return;
 		this.pending.delete(message.id);
+		clearTimeout(pending.timeout);
 		if (message.error) {
 			pending.reject(new AcpJsonRpcError(message.error));
 			return;
@@ -273,8 +298,27 @@ export class StdioAcpAgentClient {
 	}
 
 	private rejectAll(error: Error): void {
-		for (const { reject } of this.pending.values()) reject(error);
+		for (const pending of this.pending.values()) {
+			clearTimeout(pending.timeout);
+			pending.reject(error);
+		}
 		this.pending.clear();
+	}
+
+	private rejectPendingRequests(method: string, error: Error): void {
+		for (const [id, pending] of this.pending) {
+			if (pending.method !== method) continue;
+			clearTimeout(pending.timeout);
+			this.pending.delete(id);
+			pending.reject(error);
+		}
+	}
+
+	private markExited(): void {
+		this.exited = true;
+		this.child = null;
+		this.lines?.close();
+		this.lines = null;
 	}
 }
 

--- a/packages/host-service/src/runtime/chat/stdio-acp-client.ts
+++ b/packages/host-service/src/runtime/chat/stdio-acp-client.ts
@@ -1,0 +1,305 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { createInterface, type Interface } from "node:readline";
+import type {
+	AcpPermissionRequest,
+	AcpPromptBlock,
+	AcpSessionNotification,
+} from "./acp-protocol";
+
+interface JsonRpcRequest {
+	jsonrpc: "2.0";
+	id: number | string;
+	method: string;
+	params?: unknown;
+}
+
+interface JsonRpcNotification {
+	jsonrpc: "2.0";
+	method: string;
+	params?: unknown;
+}
+
+interface JsonRpcResponse {
+	jsonrpc: "2.0";
+	id: number | string;
+	result?: unknown;
+	error?: {
+		code: number;
+		message: string;
+		data?: unknown;
+	};
+}
+
+type PendingRequest = {
+	method: string;
+	resolve: (value: unknown) => void;
+	reject: (reason: unknown) => void;
+};
+
+export interface AcpAgentClientOptions {
+	command: string;
+	args: string[];
+	cwd: string;
+	env?: NodeJS.ProcessEnv;
+	onUpdate: (notification: AcpSessionNotification) => void;
+	onPermissionRequest: (request: AcpPermissionRequest) => Promise<unknown>;
+	onError: (error: Error) => void;
+}
+
+export class AcpJsonRpcError extends Error {
+	readonly code: number;
+	readonly data: unknown;
+
+	constructor(error: { code: number; message: string; data?: unknown }) {
+		super(error.message);
+		this.name = "AcpJsonRpcError";
+		this.code = error.code;
+		this.data = error.data;
+	}
+}
+
+export class StdioAcpAgentClient {
+	private child: ChildProcessWithoutNullStreams | null = null;
+	private lines: Interface | null = null;
+	private nextRequestId = 1;
+	private readonly pending = new Map<number | string, PendingRequest>();
+	private readonly stderrLines: string[] = [];
+
+	constructor(private readonly options: AcpAgentClientOptions) {}
+
+	async initialize(): Promise<void> {
+		this.startProcess();
+		await this.request("initialize", {
+			protocolVersion: 1,
+			clientCapabilities: {
+				auth: { terminal: false },
+			},
+			clientInfo: {
+				name: "superset",
+				title: "Superset",
+			},
+		});
+	}
+
+	async newSession(cwd: string): Promise<{ sessionId: string }> {
+		const result = await this.request("session/new", {
+			cwd,
+			mcpServers: [],
+		});
+		if (!isRecord(result) || typeof result.sessionId !== "string") {
+			throw new Error("ACP session/new returned no sessionId");
+		}
+		return { sessionId: result.sessionId };
+	}
+
+	prompt(
+		sessionId: string,
+		prompt: AcpPromptBlock[],
+	): Promise<{ stopReason?: string }> {
+		return this.request("session/prompt", { sessionId, prompt }).then(
+			(result) => {
+				if (isRecord(result) && typeof result.stopReason === "string") {
+					return { stopReason: result.stopReason };
+				}
+				return {};
+			},
+		);
+	}
+
+	cancel(sessionId: string): void {
+		void this.notify("session/cancel", { sessionId });
+	}
+
+	async dispose(): Promise<void> {
+		const child = this.child;
+		this.child = null;
+		this.lines?.close();
+		this.lines = null;
+		for (const { reject } of this.pending.values()) {
+			reject(new Error("ACP agent process disposed"));
+		}
+		this.pending.clear();
+		if (!child || child.killed) return;
+
+		const { promise, resolve } = Promise.withResolvers<void>();
+		const timeout = setTimeout(resolve, 1000);
+		child.once("exit", () => {
+			clearTimeout(timeout);
+			resolve();
+		});
+		child.kill("SIGTERM");
+		await promise;
+		if (!child.killed) child.kill("SIGKILL");
+	}
+
+	private startProcess(): void {
+		if (this.child) return;
+		const child = spawn(this.options.command, this.options.args, {
+			cwd: this.options.cwd,
+			env: this.options.env ?? process.env,
+			stdio: "pipe",
+		});
+		this.child = child;
+		this.lines = createInterface({
+			input: child.stdout,
+			crlfDelay: Number.POSITIVE_INFINITY,
+		});
+		this.lines.on("line", (line) => {
+			this.handleLine(line);
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			for (const line of chunk.toString("utf-8").split(/\r?\n/)) {
+				const trimmed = line.trim();
+				if (trimmed.length === 0) continue;
+				this.stderrLines.push(trimmed);
+				if (this.stderrLines.length > 20) this.stderrLines.shift();
+			}
+		});
+		child.once("error", (error) => {
+			this.rejectAll(error);
+			this.options.onError(error);
+		});
+		child.once("exit", (code, signal) => {
+			const suffix =
+				this.stderrLines.length > 0 ? `: ${this.stderrLines.join("\n")}` : "";
+			const error = new Error(
+				`ACP agent exited with code ${code ?? "null"} signal ${signal ?? "null"}${suffix}`,
+			);
+			this.rejectAll(error);
+			this.options.onError(error);
+		});
+	}
+
+	private async request(method: string, params: unknown): Promise<unknown> {
+		const id = this.nextRequestId++;
+		const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+		this.pending.set(id, { method, resolve, reject });
+		try {
+			await this.write({ jsonrpc: "2.0", id, method, params });
+		} catch (error) {
+			this.pending.delete(id);
+			reject(error);
+		}
+		return promise;
+	}
+
+	private notify(method: string, params: unknown): Promise<void> {
+		return this.write({ jsonrpc: "2.0", method, params });
+	}
+
+	private async write(
+		message: JsonRpcRequest | JsonRpcNotification | JsonRpcResponse,
+	): Promise<void> {
+		const child = this.child;
+		if (!child) throw new Error("ACP agent process is not running");
+		const line = `${JSON.stringify(message)}\n`;
+		if (child.stdin.write(line)) return;
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		child.stdin.once("drain", resolve);
+		child.stdin.once("error", reject);
+		return promise;
+	}
+
+	private handleLine(line: string): void {
+		let message: unknown;
+		try {
+			message = JSON.parse(line) as unknown;
+		} catch (error) {
+			this.options.onError(
+				new Error(
+					`Invalid ACP JSON line: ${error instanceof Error ? error.message : String(error)}`,
+				),
+			);
+			return;
+		}
+		if (!isRecord(message)) return;
+		if ("id" in message && ("result" in message || "error" in message)) {
+			this.handleResponse(message as unknown as JsonRpcResponse);
+			return;
+		}
+		if (typeof message.method !== "string") return;
+		if ("id" in message) {
+			void this.handleAgentRequest(message as unknown as JsonRpcRequest);
+			return;
+		}
+		this.handleNotification(message as unknown as JsonRpcNotification);
+	}
+
+	private handleResponse(message: JsonRpcResponse): void {
+		const pending = this.pending.get(message.id);
+		if (!pending) return;
+		this.pending.delete(message.id);
+		if (message.error) {
+			pending.reject(new AcpJsonRpcError(message.error));
+			return;
+		}
+		pending.resolve(message.result);
+	}
+
+	private handleNotification(message: JsonRpcNotification): void {
+		if (message.method !== "session/update") return;
+		if (!isAcpSessionNotification(message.params)) return;
+		this.options.onUpdate(message.params);
+	}
+
+	private async handleAgentRequest(message: JsonRpcRequest): Promise<void> {
+		try {
+			if (
+				message.method === "session/request_permission" &&
+				isAcpPermissionRequest(message.params)
+			) {
+				const result = await this.options.onPermissionRequest(message.params);
+				await this.write({ jsonrpc: "2.0", id: message.id, result });
+				return;
+			}
+			await this.write({
+				jsonrpc: "2.0",
+				id: message.id,
+				error: {
+					code: -32601,
+					message: `Unsupported ACP client request: ${message.method}`,
+				},
+			});
+		} catch (error) {
+			await this.write({
+				jsonrpc: "2.0",
+				id: message.id,
+				error: {
+					code: -32603,
+					message: error instanceof Error ? error.message : String(error),
+				},
+			});
+		}
+	}
+
+	private rejectAll(error: Error): void {
+		for (const { reject } of this.pending.values()) reject(error);
+		this.pending.clear();
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isAcpSessionNotification(
+	value: unknown,
+): value is AcpSessionNotification {
+	return (
+		isRecord(value) &&
+		typeof value.sessionId === "string" &&
+		isRecord(value.update) &&
+		typeof value.update.sessionUpdate === "string"
+	);
+}
+
+function isAcpPermissionRequest(value: unknown): value is AcpPermissionRequest {
+	if (!isRecord(value) || typeof value.sessionId !== "string") return false;
+	if (!isRecord(value.toolCall) || !Array.isArray(value.options)) return false;
+	return value.options.every(
+		(option) =>
+			isRecord(option) &&
+			typeof option.optionId === "string" &&
+			typeof option.name === "string",
+	);
+}

--- a/packages/local-db/drizzle/0042_spooky_mulholland_black.sql
+++ b/packages/local-db/drizzle/0042_spooky_mulholland_black.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `experimental_acp_chat` integer;

--- a/packages/local-db/drizzle/meta/0042_snapshot.json
+++ b/packages/local-db/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,1494 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e711d400-0038-4dd9-a217-aec32798fc33",
+  "prevId": "3d1d0ce7-6731-4286-970a-304b4e0a1f6a",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_permissions_migrated_at": {
+          "name": "agent_preset_permissions_migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "experimental_acp_chat": {
+          "name": "experimental_acp_chat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "v1_migration_state": {
+      "name": "v1_migration_state",
+      "columns": {
+        "v1_id": {
+          "name": "v1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v2_id": {
+          "name": "v2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "migrated_at": {
+          "name": "migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "v1_migration_state_v2_id_idx": {
+          "name": "v1_migration_state_v2_id_idx",
+          "columns": [
+            "v2_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "v1_migration_state_organization_id_v1_id_kind_pk": {
+          "columns": [
+            "organization_id",
+            "v1_id",
+            "kind"
+          ],
+          "name": "v1_migration_state_organization_id_v1_id_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1776928440569,
       "tag": "0041_v1_migration_state",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "6",
+      "when": 1782604220485,
+      "tag": "0042_spooky_mulholland_black",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -234,6 +234,9 @@ export const settings = sqliteTable("settings", {
 	exposeHostServiceViaRelay: integer("expose_host_service_via_relay", {
 		mode: "boolean",
 	}),
+	experimentalAcpChat: integer("experimental_acp_chat", {
+		mode: "boolean",
+	}),
 });
 
 export type InsertSettings = typeof settings.$inferInsert;


### PR DESCRIPTION
## Description

Adds an experimental ACP-backed chat runtime for Superset workspace chat while keeping the existing Mastra chat runtime as the default.

This PR is intentionally additive:

- `SUPERSET_EXPERIMENTAL_ACP_CHAT` remains the host-service runtime flag.
- The Desktop Experimental settings tab now exposes the flag as **Use ACP chat runtime** and restarts active host services after changes.
- The default ACP command is `omp acp`; advanced users can still override with `SUPERSET_ACP_COMMAND` and `SUPERSET_ACP_ARGS`.
- The existing renderer chat/tRPC contract is preserved.
- ACP lifecycle support covers initialize, session/new, session/prompt, streaming session/update handling, cancellation, process cleanup, timeouts, and ACP permission requests.

Research notes:

- Zed ACP reference uses stdio JSON-RPC with `initialize`, `session/new`, `session/prompt`, `session/cancel`, and `session/update` notifications.
- Pi ACP and Oh My Pi expose the same lifecycle; Oh My Pi documents `omp acp` as the stdio entrypoint.
- ACP plan updates are informational protocol updates, not approval requests. This PR keeps plan text rendering honest and does not fake plan approval support where ACP has no response path.

## Related Issues

Related to #3350
Related to #2019
Related to #4628
Related to #5326

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Ran:

```bash
bun test packages/host-service/src/runtime/chat/acp-chat-runtime.test.ts packages/host-service/src/runtime/chat/acp-protocol.test.ts packages/host-service/test/integration/chat.integration.test.ts
bun run --cwd packages/host-service typecheck
bun run lint
```

Also ran:

```bash
bun run --cwd packages/local-db generate
```

## Screenshots (if applicable)

Not included yet. The PR is draft while the ACP setting and review feedback fixes are being finalized.

## Additional Notes

This PR is draft for now.

Follow-up commit addresses review feedback from CodeRabbit/Greptile/Cubic:

- serializes ACP prompts per chat session
- settles pending prompts on `stop()`
- avoids creating ACP runtimes for stop/approval/control-only actions
- disposes both runtime maps instead of relying on the current experimental flag value
- clears pending permission state on terminal failures
- prevents overlapping permission waiters
- preserves `always_allow_category` semantics
- preserves tool input during progress updates
- supports numeric ACP tool IDs consistently
- adds ACP request timeouts
- tracks child process exit state for SIGKILL fallback and stale reference cleanup
- guarantees ACP runtime disposal in tests
