### PR TITLE
Add CLI support for sidebar workspace groups

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -24,6 +24,7 @@ import { createProjectsRouter } from "./projects";
 import { createResourceMetricsRouter } from "./resource-metrics";
 import { createRingtoneRouter } from "./ringtone";
 import { createSettingsRouter } from "./settings";
+import { createSidebarGroupsCliRouter } from "./sidebar-groups-cli";
 import { createSystemRouter } from "./system";
 import { createTerminalRouter } from "./terminal";
 import { createUiStateRouter } from "./ui-state";
@@ -59,6 +60,7 @@ export const createAppRouter = (getWindow: () => BrowserWindow | null) => {
 		uiState: createUiStateRouter(),
 		ringtone: createRingtoneRouter(getWindow),
 		hostServiceCoordinator: createHostServiceCoordinatorRouter(),
+		sidebarGroupsCli: createSidebarGroupsCliRouter(),
 		keyboardLayout: createKeyboardLayoutRouter(),
 		migration: createMigrationRouter(),
 	});

--- a/apps/desktop/src/lib/trpc/routers/sidebar-groups-cli/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/sidebar-groups-cli/index.ts
@@ -1,0 +1,112 @@
+import {
+	acknowledgeSidebarGroupsCliOperation,
+	readNextSidebarGroupsCliOperation,
+	releaseSidebarGroupsCliOperation,
+	SidebarGroupsCliStateLockTimeoutError,
+	sidebarGroupsCliSnapshotSchema,
+	writeSidebarGroupsCliSnapshot,
+} from "@superset/shared/sidebar-groups-cli";
+import { SUPERSET_HOME_DIR } from "main/lib/app-environment";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const organizationInput = z.object({ organizationId: z.string() });
+
+export const createSidebarGroupsCliRouter = () => {
+	return router({
+		writeSnapshot: publicProcedure
+			.input(
+				z.object({
+					organizationId: z.string(),
+					snapshot: sidebarGroupsCliSnapshotSchema,
+				}),
+			)
+			.mutation(({ input }) => {
+				try {
+					writeSidebarGroupsCliSnapshot(
+						{
+							homeDir: SUPERSET_HOME_DIR,
+							organizationId: input.organizationId,
+						},
+						input.snapshot,
+						{ waitMs: 0 },
+					);
+					return { success: true };
+				} catch (error) {
+					if (error instanceof SidebarGroupsCliStateLockTimeoutError) {
+						return { success: false, reason: "locked" };
+					}
+					throw error;
+				}
+			}),
+
+		readOperation: publicProcedure
+			.input(organizationInput)
+			.mutation(({ input }) => {
+				try {
+					return {
+						operation: readNextSidebarGroupsCliOperation(
+							{
+								homeDir: SUPERSET_HOME_DIR,
+								organizationId: input.organizationId,
+							},
+							{ waitMs: 0 },
+						),
+					};
+				} catch (error) {
+					if (error instanceof SidebarGroupsCliStateLockTimeoutError) {
+						return { operation: null };
+					}
+					throw error;
+				}
+			}),
+
+		ackOperation: publicProcedure
+			.input(z.object({ organizationId: z.string(), operationId: z.string() }))
+			.mutation(({ input }) => {
+				try {
+					return {
+						success: acknowledgeSidebarGroupsCliOperation(
+							{
+								homeDir: SUPERSET_HOME_DIR,
+								organizationId: input.organizationId,
+							},
+							input.operationId,
+							{ waitMs: 0 },
+						),
+					};
+				} catch (error) {
+					if (error instanceof SidebarGroupsCliStateLockTimeoutError) {
+						return { success: false, reason: "locked" };
+					}
+					throw error;
+				}
+			}),
+
+		releaseOperation: publicProcedure
+			.input(z.object({ organizationId: z.string(), operationId: z.string() }))
+			.mutation(({ input }) => {
+				try {
+					return {
+						success: releaseSidebarGroupsCliOperation(
+							{
+								homeDir: SUPERSET_HOME_DIR,
+								organizationId: input.organizationId,
+							},
+							input.operationId,
+							{ waitMs: 0 },
+						),
+					};
+				} catch (error) {
+					if (error instanceof SidebarGroupsCliStateLockTimeoutError) {
+						return { success: false, reason: "locked" };
+					}
+					throw error;
+				}
+			}),
+	});
+};
+
+export type SidebarGroupsCliRouter = ReturnType<
+	typeof createSidebarGroupsCliRouter
+>;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useSidebarGroupsCliBridge } from "renderer/routes/_authenticated/hooks/useSidebarGroupsCliBridge/useSidebarGroupsCliBridge";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
 	getVisibleSidebarWorkspaces,
@@ -127,7 +128,8 @@ function useStableDashboardSidebarProjects(
 
 export function useDashboardSidebarData() {
 	const collections = useCollections();
-	const { machineId, activeHostUrl } = useLocalHostService();
+	const { machineId, activeHostUrl, activeOrganizationId } =
+		useLocalHostService();
 	const relayUrl = useRelayUrl();
 	const { toggleProjectCollapsed } = useDashboardSidebarState();
 	const queryClient = useQueryClient();
@@ -152,34 +154,35 @@ export function useDashboardSidebarData() {
 		[hosts],
 	);
 
-	const { data: rawSidebarProjects = [] } = useLiveQuery(
-		(q) =>
-			q
-				.from({ sidebarProjects: collections.v2SidebarProjects })
-				.innerJoin(
-					{ projects: collections.v2Projects },
-					({ sidebarProjects, projects }) =>
-						eq(sidebarProjects.projectId, projects.id),
-				)
-				.leftJoin(
-					{ repos: collections.githubRepositories },
-					({ projects, repos }) => eq(projects.githubRepositoryId, repos.id),
-				)
-				.orderBy(({ sidebarProjects }) => sidebarProjects.tabOrder, "asc")
-				.select(({ sidebarProjects, projects, repos }) => ({
-					id: projects.id,
-					name: projects.name,
-					slug: projects.slug,
-					githubRepositoryId: projects.githubRepositoryId,
-					githubOwner: repos?.owner ?? null,
-					githubRepoName: repos?.name ?? null,
-					iconUrl: projects.iconUrl,
-					createdAt: projects.createdAt,
-					updatedAt: projects.updatedAt,
-					isCollapsed: sidebarProjects.isCollapsed,
-				})),
-		[collections],
-	);
+	const { data: rawSidebarProjects = [], isReady: sidebarProjectsReady } =
+		useLiveQuery(
+			(q) =>
+				q
+					.from({ sidebarProjects: collections.v2SidebarProjects })
+					.innerJoin(
+						{ projects: collections.v2Projects },
+						({ sidebarProjects, projects }) =>
+							eq(sidebarProjects.projectId, projects.id),
+					)
+					.leftJoin(
+						{ repos: collections.githubRepositories },
+						({ projects, repos }) => eq(projects.githubRepositoryId, repos.id),
+					)
+					.orderBy(({ sidebarProjects }) => sidebarProjects.tabOrder, "asc")
+					.select(({ sidebarProjects, projects, repos }) => ({
+						id: projects.id,
+						name: projects.name,
+						slug: projects.slug,
+						githubRepositoryId: projects.githubRepositoryId,
+						githubOwner: repos?.owner ?? null,
+						githubRepoName: repos?.name ?? null,
+						iconUrl: projects.iconUrl,
+						createdAt: projects.createdAt,
+						updatedAt: projects.updatedAt,
+						isCollapsed: sidebarProjects.isCollapsed,
+					})),
+			[collections],
+		);
 
 	const sidebarProjects = useMemo(
 		() =>
@@ -191,53 +194,55 @@ export function useDashboardSidebarData() {
 		[rawSidebarProjects],
 	);
 
-	const { data: sidebarSections = [] } = useLiveQuery(
-		(q) =>
-			q
-				.from({ sidebarSections: collections.v2SidebarSections })
-				.orderBy(({ sidebarSections }) => sidebarSections.tabOrder, "asc")
-				.select(({ sidebarSections }) => ({
-					id: sidebarSections.sectionId,
-					projectId: sidebarSections.projectId,
-					name: sidebarSections.name,
-					createdAt: sidebarSections.createdAt,
-					isCollapsed: sidebarSections.isCollapsed,
-					tabOrder: sidebarSections.tabOrder,
-					color: sidebarSections.color,
-				})),
-		[collections],
-	);
+	const { data: sidebarSections = [], isReady: sidebarSectionsReady } =
+		useLiveQuery(
+			(q) =>
+				q
+					.from({ sidebarSections: collections.v2SidebarSections })
+					.orderBy(({ sidebarSections }) => sidebarSections.tabOrder, "asc")
+					.select(({ sidebarSections }) => ({
+						id: sidebarSections.sectionId,
+						projectId: sidebarSections.projectId,
+						name: sidebarSections.name,
+						createdAt: sidebarSections.createdAt,
+						isCollapsed: sidebarSections.isCollapsed,
+						tabOrder: sidebarSections.tabOrder,
+						color: sidebarSections.color,
+					})),
+			[collections],
+		);
 
-	const { data: rawSidebarWorkspaces = [] } = useLiveQuery(
-		(q) =>
-			q
-				.from({ sidebarWorkspaces: collections.v2WorkspaceLocalState })
-				.innerJoin(
-					{ workspaces: collections.v2Workspaces },
-					({ sidebarWorkspaces, workspaces }) =>
-						eq(sidebarWorkspaces.workspaceId, workspaces.id),
-				)
-				.orderBy(
-					({ sidebarWorkspaces }) => sidebarWorkspaces.sidebarState.tabOrder,
-					"asc",
-				)
-				.select(({ sidebarWorkspaces, workspaces }) => ({
-					id: workspaces.id,
-					projectId: sidebarWorkspaces.sidebarState.projectId,
-					hostId: workspaces.hostId,
-					type: workspaces.type,
-					name: workspaces.name,
-					branch: workspaces.branch,
-					taskId: workspaces.taskId,
-					createdAt: workspaces.createdAt,
-					updatedAt: workspaces.updatedAt,
-					isSynced: workspaces.$synced,
-					tabOrder: sidebarWorkspaces.sidebarState.tabOrder,
-					sectionId: sidebarWorkspaces.sidebarState.sectionId,
-					isHidden: sidebarWorkspaces.sidebarState.isHidden,
-				})),
-		[collections],
-	);
+	const { data: rawSidebarWorkspaces = [], isReady: sidebarWorkspacesReady } =
+		useLiveQuery(
+			(q) =>
+				q
+					.from({ sidebarWorkspaces: collections.v2WorkspaceLocalState })
+					.innerJoin(
+						{ workspaces: collections.v2Workspaces },
+						({ sidebarWorkspaces, workspaces }) =>
+							eq(sidebarWorkspaces.workspaceId, workspaces.id),
+					)
+					.orderBy(
+						({ sidebarWorkspaces }) => sidebarWorkspaces.sidebarState.tabOrder,
+						"asc",
+					)
+					.select(({ sidebarWorkspaces, workspaces }) => ({
+						id: workspaces.id,
+						projectId: sidebarWorkspaces.sidebarState.projectId,
+						hostId: workspaces.hostId,
+						type: workspaces.type,
+						name: workspaces.name,
+						branch: workspaces.branch,
+						taskId: workspaces.taskId,
+						createdAt: workspaces.createdAt,
+						updatedAt: workspaces.updatedAt,
+						isSynced: workspaces.$synced,
+						tabOrder: sidebarWorkspaces.sidebarState.tabOrder,
+						sectionId: sidebarWorkspaces.sidebarState.sectionId,
+						isHidden: sidebarWorkspaces.sidebarState.isHidden,
+					})),
+			[collections],
+		);
 	const rawSidebarWorkspacesWithHostStatus = useMemo(
 		() =>
 			rawSidebarWorkspaces.map((workspace) => ({
@@ -258,7 +263,10 @@ export function useDashboardSidebarData() {
 		[rawSidebarWorkspaces],
 	);
 
-	const { data: rawLocalMainWorkspaces = [] } = useLiveQuery(
+	const {
+		data: rawLocalMainWorkspaces = [],
+		isReady: localMainWorkspacesReady,
+	} = useLiveQuery(
 		(q) =>
 			q
 				.from({ workspaces: collections.v2Workspaces })
@@ -326,6 +334,20 @@ export function useDashboardSidebarData() {
 		sidebarProjects,
 		sidebarWorkspaces,
 	]);
+
+	const sidebarGroupsCliBridgeReady =
+		sidebarProjectsReady &&
+		sidebarSectionsReady &&
+		sidebarWorkspacesReady &&
+		localMainWorkspacesReady;
+
+	useSidebarGroupsCliBridge({
+		activeOrganizationId,
+		collections,
+		isReady: sidebarGroupsCliBridgeReady,
+		sections: sidebarSections,
+		workspaces: visibleSidebarWorkspaces,
+	});
 
 	const pullRequestQueryTargets = useMemo<PullRequestQueryTarget[]>(
 		() =>

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -27,7 +27,7 @@ type ProjectTopLevelItem = {
 	tabOrder: number;
 };
 
-type ProjectTopLevelCollections = Pick<
+export type ProjectTopLevelCollections = Pick<
 	AppCollections,
 	"v2SidebarSections" | "v2WorkspaceLocalState"
 >;
@@ -42,7 +42,7 @@ function compareProjectTopLevelItems(
 	return left.type === "section" ? -1 : 1;
 }
 
-function getProjectTopLevelItems(
+export function getProjectTopLevelItems(
 	collections: ProjectTopLevelCollections,
 	projectId: string,
 	options: { excludeWorkspaceId?: string; excludeSectionId?: string } = {},
@@ -75,7 +75,7 @@ function getProjectTopLevelItems(
 	].sort(compareProjectTopLevelItems);
 }
 
-function getFirstSectionIndex(items: ProjectTopLevelItem[]): number {
+export function getFirstSectionIndex(items: ProjectTopLevelItem[]): number {
 	const firstSectionIndex = items.findIndex((item) => item.type === "section");
 	return firstSectionIndex === -1 ? items.length : firstSectionIndex;
 }
@@ -84,7 +84,7 @@ function getFirstSectionIndex(items: ProjectTopLevelItem[]): number {
  * Rewrites the flat top-level project lane. Workspace items are explicitly
  * ungrouped by setting sidebarState.projectId and clearing sidebarState.sectionId.
  */
-function writeProjectTopLevelOrder(
+export function writeProjectTopLevelOrder(
 	collections: ProjectTopLevelCollections,
 	projectId: string,
 	items: ProjectTopLevelItem[],
@@ -109,7 +109,7 @@ function writeProjectTopLevelOrder(
 	});
 }
 
-function ensureSidebarProjectRecord(
+export function ensureSidebarProjectRecord(
 	collections: Pick<AppCollections, "v2SidebarProjects">,
 	projectId: string,
 ): void {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useSidebarGroupsCliBridge/useSidebarGroupsCliBridge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useSidebarGroupsCliBridge/useSidebarGroupsCliBridge.ts
@@ -1,0 +1,370 @@
+import type { SidebarGroupsCliOperation } from "@superset/shared/sidebar-groups-cli";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import {
+	getNextTabOrder,
+	isSidebarWorkspaceVisible,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { PROJECT_CUSTOM_COLORS } from "shared/constants/project-colors";
+import { createEmptyPaneLayout } from "../useDashboardSidebarState/sidebarMutations";
+import {
+	ensureSidebarProjectRecord,
+	getFirstSectionIndex,
+	getProjectTopLevelItems,
+	writeProjectTopLevelOrder,
+} from "../useDashboardSidebarState/useDashboardSidebarState";
+
+type BridgeCollections = Pick<
+	AppCollections,
+	| "v2SidebarProjects"
+	| "v2SidebarSections"
+	| "v2WorkspaceLocalState"
+	| "v2Workspaces"
+>;
+
+type SidebarSectionSnapshot = {
+	id: string;
+	projectId: string;
+	name: string;
+	createdAt: Date;
+	tabOrder: number;
+	isCollapsed: boolean;
+	color: string | null;
+};
+
+type SidebarWorkspaceSnapshot = {
+	id: string;
+	projectId: string;
+	name: string;
+	branch: string | null;
+	sectionId: string | null;
+	tabOrder: number;
+};
+
+function randomSectionColor(): string {
+	return PROJECT_CUSTOM_COLORS[
+		Math.floor(Math.random() * PROJECT_CUSTOM_COLORS.length)
+	].value;
+}
+
+function ensureWorkspaceLocalState(
+	collections: BridgeCollections,
+	workspaceId: string,
+	projectId: string,
+): void {
+	const existing = collections.v2WorkspaceLocalState.get(workspaceId);
+	if (existing && isSidebarWorkspaceVisible(existing)) return;
+
+	const topLevelItems = getProjectTopLevelItems(collections, projectId, {
+		excludeWorkspaceId: workspaceId,
+	});
+
+	if (existing) {
+		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+			draft.sidebarState.projectId = projectId;
+			draft.sidebarState.sectionId = null;
+			draft.sidebarState.tabOrder = getNextTabOrder(topLevelItems);
+			draft.sidebarState.isHidden = false;
+		});
+		return;
+	}
+
+	collections.v2WorkspaceLocalState.insert({
+		workspaceId,
+		createdAt: new Date(),
+		sidebarState: {
+			projectId,
+			tabOrder: getNextTabOrder(topLevelItems),
+			sectionId: null,
+			isHidden: false,
+		},
+		paneLayout: createEmptyPaneLayout(),
+	});
+}
+
+function moveWorkspaceToSection(
+	collections: BridgeCollections,
+	workspaceId: string,
+	sectionId: string | null,
+): boolean {
+	const workspace = collections.v2Workspaces.get(workspaceId);
+	const projectId = sectionId
+		? collections.v2SidebarSections.get(sectionId)?.projectId
+		: (collections.v2WorkspaceLocalState.get(workspaceId)?.sidebarState
+				.projectId ?? workspace?.projectId);
+	if (!projectId) return false;
+	ensureWorkspaceLocalState(collections, workspaceId, projectId);
+
+	if (sectionId === null) {
+		const topLevelItems = getProjectTopLevelItems(collections, projectId, {
+			excludeWorkspaceId: workspaceId,
+		});
+		const insertIndex = getFirstSectionIndex(topLevelItems);
+		topLevelItems.splice(insertIndex, 0, {
+			type: "workspace",
+			id: workspaceId,
+			tabOrder: 0,
+		});
+		writeProjectTopLevelOrder(collections, projectId, topLevelItems);
+		return true;
+	}
+
+	const siblingRows = Array.from(
+		collections.v2WorkspaceLocalState.state.values(),
+	)
+		.filter(
+			(item) =>
+				item.sidebarState.projectId === projectId &&
+				isSidebarWorkspaceVisible(item) &&
+				item.workspaceId !== workspaceId &&
+				item.sidebarState.sectionId === sectionId,
+		)
+		.map((item) => ({ tabOrder: item.sidebarState.tabOrder }));
+
+	collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+		draft.sidebarState.projectId = projectId;
+		draft.sidebarState.sectionId = sectionId;
+		draft.sidebarState.tabOrder = getNextTabOrder(siblingRows);
+		draft.sidebarState.isHidden = false;
+	});
+	return true;
+}
+
+function createSectionFromOperation(
+	collections: BridgeCollections,
+	operation: Extract<SidebarGroupsCliOperation, { type: "createSection" }>,
+): boolean {
+	if (!collections.v2SidebarSections.get(operation.sectionId)) {
+		ensureSidebarProjectRecord(collections, operation.projectId);
+		collections.v2SidebarSections.insert({
+			sectionId: operation.sectionId,
+			projectId: operation.projectId,
+			name: operation.name,
+			createdAt: new Date(operation.createdAt),
+			tabOrder: getNextTabOrder(
+				getProjectTopLevelItems(collections, operation.projectId),
+			),
+			isCollapsed: false,
+			color: randomSectionColor(),
+		});
+	}
+
+	for (const workspaceId of operation.workspaceIds) {
+		if (
+			!moveWorkspaceToSection(collections, workspaceId, operation.sectionId)
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function deleteSection(
+	collections: BridgeCollections,
+	sectionId: string,
+): boolean {
+	const section = collections.v2SidebarSections.get(sectionId);
+	if (!section) return true;
+
+	const topLevelItems = getProjectTopLevelItems(
+		collections,
+		section.projectId,
+		{
+			excludeSectionId: sectionId,
+		},
+	);
+	const sectionWorkspaces = Array.from(
+		collections.v2WorkspaceLocalState.state.values(),
+	)
+		.filter(
+			(item) =>
+				item.sidebarState.projectId === section.projectId &&
+				isSidebarWorkspaceVisible(item) &&
+				item.sidebarState.sectionId === sectionId,
+		)
+		.sort(
+			(left, right) => left.sidebarState.tabOrder - right.sidebarState.tabOrder,
+		);
+
+	topLevelItems.splice(
+		getFirstSectionIndex(topLevelItems),
+		0,
+		...sectionWorkspaces.map((workspace) => ({
+			type: "workspace" as const,
+			id: workspace.workspaceId,
+			tabOrder: 0,
+		})),
+	);
+	writeProjectTopLevelOrder(collections, section.projectId, topLevelItems);
+	collections.v2SidebarSections.delete(sectionId);
+	return true;
+}
+
+function applyOperation(
+	collections: BridgeCollections,
+	operation: SidebarGroupsCliOperation,
+): boolean {
+	switch (operation.type) {
+		case "createSection":
+			return createSectionFromOperation(collections, operation);
+		case "renameSection":
+			if (!collections.v2SidebarSections.get(operation.sectionId)) {
+				return false;
+			}
+			collections.v2SidebarSections.update(operation.sectionId, (draft) => {
+				draft.name = operation.name.trim();
+			});
+			return true;
+		case "deleteSection":
+			return deleteSection(collections, operation.sectionId);
+		case "moveWorkspaces":
+			for (const workspaceId of operation.workspaceIds) {
+				if (
+					!moveWorkspaceToSection(collections, workspaceId, operation.sectionId)
+				) {
+					return false;
+				}
+			}
+			return true;
+	}
+}
+
+export function useSidebarGroupsCliBridge(args: {
+	activeOrganizationId: string | null;
+	isReady: boolean;
+	collections: BridgeCollections;
+	sections: SidebarSectionSnapshot[];
+	workspaces: SidebarWorkspaceSnapshot[];
+}): void {
+	const { mutateAsync: writeSnapshot } =
+		electronTrpc.sidebarGroupsCli.writeSnapshot.useMutation();
+	const { mutateAsync: readOperation } =
+		electronTrpc.sidebarGroupsCli.readOperation.useMutation();
+	const { mutateAsync: ackOperation } =
+		electronTrpc.sidebarGroupsCli.ackOperation.useMutation();
+	const { mutateAsync: releaseOperation } =
+		electronTrpc.sidebarGroupsCli.releaseOperation.useMutation();
+	const pendingAckRef = useRef<{
+		organizationId: string;
+		operationId: string;
+	} | null>(null);
+
+	const snapshot = useMemo(
+		() => ({
+			updatedAt: new Date().toISOString(),
+			sections: args.sections.map((section) => ({
+				id: section.id,
+				projectId: section.projectId,
+				name: section.name,
+				createdAt: section.createdAt.toISOString(),
+				tabOrder: section.tabOrder,
+				isCollapsed: section.isCollapsed,
+				color: section.color,
+			})),
+			workspaces: args.workspaces.map((workspace) => ({
+				id: workspace.id,
+				projectId: workspace.projectId,
+				name: workspace.name,
+				branch: workspace.branch,
+				sectionId: workspace.sectionId,
+				tabOrder: workspace.tabOrder,
+			})),
+		}),
+		[args.sections, args.workspaces],
+	);
+
+	useEffect(() => {
+		if (!args.activeOrganizationId || !args.isReady) return;
+		const organizationId = args.activeOrganizationId;
+		let cancelled = false;
+		let retryId: number | undefined;
+
+		const persistSnapshot = async () => {
+			const result = await writeSnapshot({
+				organizationId,
+				snapshot,
+			});
+			if (!cancelled && !result.success) {
+				retryId = window.setTimeout(() => void persistSnapshot(), 1_000);
+			}
+		};
+
+		void persistSnapshot();
+		return () => {
+			cancelled = true;
+			if (retryId !== undefined) window.clearTimeout(retryId);
+		};
+	}, [args.activeOrganizationId, args.isReady, snapshot, writeSnapshot]);
+
+	const applyPendingOperations = useCallback(async () => {
+		if (!args.activeOrganizationId || !args.isReady) return;
+		try {
+			const organizationId = args.activeOrganizationId;
+			if (pendingAckRef.current) {
+				if (pendingAckRef.current.organizationId !== organizationId) {
+					pendingAckRef.current = null;
+				} else {
+					const ackResult = await ackOperation({
+						organizationId,
+						operationId: pendingAckRef.current.operationId,
+					});
+					if (!ackResult.success) return;
+					pendingAckRef.current = null;
+				}
+			}
+
+			for (let appliedCount = 0; appliedCount < 50; appliedCount += 1) {
+				const result = await readOperation({ organizationId });
+				if (!result.operation) return;
+
+				let applied = false;
+				try {
+					applied = applyOperation(args.collections, result.operation);
+				} catch (error) {
+					await releaseOperation({
+						organizationId,
+						operationId: result.operation.id,
+					});
+					throw error;
+				}
+
+				if (!applied) {
+					await releaseOperation({
+						organizationId,
+						operationId: result.operation.id,
+					});
+					return;
+				}
+
+				pendingAckRef.current = {
+					organizationId,
+					operationId: result.operation.id,
+				};
+				const ackResult = await ackOperation({
+					organizationId,
+					operationId: result.operation.id,
+				});
+				if (!ackResult.success) return;
+				pendingAckRef.current = null;
+			}
+		} catch (error) {
+			console.error("Failed to apply sidebar groups CLI operation", error);
+		}
+	}, [
+		ackOperation,
+		args.activeOrganizationId,
+		args.collections,
+		args.isReady,
+		readOperation,
+		releaseOperation,
+	]);
+
+	useEffect(() => {
+		void applyPendingOperations();
+		const intervalId = window.setInterval(() => {
+			void applyPendingOperations();
+		}, 1_000);
+		return () => window.clearInterval(intervalId);
+	}, [applyPendingOperations]);
+}

--- a/packages/cli/CLI_SPEC_CURRENT.md
+++ b/packages/cli/CLI_SPEC_CURRENT.md
@@ -102,6 +102,13 @@ terminals
 workspaces
   create
   delete
+  groups
+    create
+    delete
+    list
+    move
+    remove
+    rename
   list
   open
   update

--- a/packages/cli/src/commands/workspaces/groups/create/command.ts
+++ b/packages/cli/src/commands/workspaces/groups/create/command.ts
@@ -1,0 +1,102 @@
+import { CLIError, positional, string } from "@superset/cli-framework";
+import { command } from "../../../../lib/command";
+import {
+	assertSameProject,
+	queueSidebarOperationWithSnapshotUpdate,
+	requireOrganizationId,
+} from "../../../../lib/sidebar-groups";
+
+export default command({
+	description:
+		"Create a desktop sidebar workspace group and optionally move workspaces into it",
+	args: [positional("workspaceIds").variadic().desc("Workspace IDs to group")],
+	options: {
+		name: string().required().desc("Group name"),
+		project: string().desc("Project ID for an empty group"),
+	},
+	run: async ({ ctx, args, options }) => {
+		const organizationId = requireOrganizationId(ctx.config.organizationId);
+		const workspaceIds = (args.workspaceIds as string[] | undefined) ?? [];
+		const projectOption = options.project?.trim();
+		if (workspaceIds.length === 0 && !projectOption) {
+			throw new CLIError(
+				"Pass at least one workspace ID or --project",
+				"Example: superset workspaces groups create --name Backend <workspace-id>",
+			);
+		}
+
+		const sectionId = crypto.randomUUID();
+		const createdAt = new Date().toISOString();
+		const name = options.name.trim();
+
+		if (name.length === 0) {
+			throw new CLIError("Group name cannot be empty");
+		}
+
+		const { data } = queueSidebarOperationWithSnapshotUpdate(
+			organizationId,
+			(snapshot) => {
+				const projectId =
+					workspaceIds.length > 0
+						? assertSameProject(workspaceIds, snapshot)
+						: projectOption;
+				if (!projectId) {
+					throw new CLIError("Project ID cannot be empty");
+				}
+
+				const movedWorkspaceIds = new Set(workspaceIds);
+				const nextSnapshot = {
+					...snapshot,
+					sections: [
+						...snapshot.sections,
+						{
+							id: sectionId,
+							projectId,
+							name,
+							createdAt,
+							tabOrder:
+								Math.max(
+									0,
+									...snapshot.sections
+										.filter((section) => section.projectId === projectId)
+										.map((section) => section.tabOrder),
+								) + 1,
+							isCollapsed: false,
+							color: null,
+						},
+					],
+					workspaces: snapshot.workspaces.map((workspace) => {
+						const movedIndex = workspaceIds.indexOf(workspace.id);
+						return movedWorkspaceIds.has(workspace.id)
+							? {
+									...workspace,
+									sectionId,
+									tabOrder: movedIndex + 1,
+								}
+							: workspace;
+					}),
+					updatedAt: createdAt,
+				};
+
+				return {
+					data: { id: sectionId, name, projectId, workspaceIds },
+					operation: {
+						id: crypto.randomUUID(),
+						type: "createSection",
+						createdAt,
+						sectionId,
+						projectId,
+						name,
+						workspaceIds,
+					},
+					snapshot: nextSnapshot,
+				};
+			},
+		);
+
+		return {
+			data,
+			message: `Queued sidebar group "${name}" (${sectionId}). The desktop app applies it when running.`,
+		};
+	},
+});

--- a/packages/cli/src/commands/workspaces/groups/delete/command.ts
+++ b/packages/cli/src/commands/workspaces/groups/delete/command.ts
@@ -1,0 +1,69 @@
+import { positional } from "@superset/cli-framework";
+import { command } from "../../../../lib/command";
+import {
+	findSection,
+	queueSidebarOperationWithSnapshotUpdate,
+	requireOrganizationId,
+} from "../../../../lib/sidebar-groups";
+
+export default command({
+	description:
+		"Delete a desktop sidebar workspace group and ungroup its members",
+	args: [positional("id").required().desc("Group ID")],
+	run: async ({ ctx, args }) => {
+		const organizationId = requireOrganizationId(ctx.config.organizationId);
+		const { data } = queueSidebarOperationWithSnapshotUpdate(
+			organizationId,
+			(snapshot) => {
+				const section = findSection(snapshot, args.id as string);
+				const ungroupedWorkspaceIds = snapshot.workspaces
+					.filter((workspace) => workspace.sectionId === section.id)
+					.map((workspace) => workspace.id);
+				const nextTopLevelOrder =
+					Math.max(
+						0,
+						...snapshot.workspaces
+							.filter(
+								(workspace) =>
+									workspace.projectId === section.projectId &&
+									workspace.sectionId === null,
+							)
+							.map((workspace) => workspace.tabOrder),
+					) + 1;
+				const nextSnapshot = {
+					...snapshot,
+					updatedAt: new Date().toISOString(),
+					sections: snapshot.sections.filter(
+						(candidate) => candidate.id !== section.id,
+					),
+					workspaces: snapshot.workspaces.map((workspace) => {
+						const ungroupedIndex = ungroupedWorkspaceIds.indexOf(workspace.id);
+						return ungroupedIndex === -1
+							? workspace
+							: {
+									...workspace,
+									sectionId: null,
+									tabOrder: nextTopLevelOrder + ungroupedIndex,
+								};
+					}),
+				};
+
+				return {
+					data: { id: section.id, name: section.name },
+					operation: {
+						id: crypto.randomUUID(),
+						type: "deleteSection",
+						createdAt: new Date().toISOString(),
+						sectionId: section.id,
+					},
+					snapshot: nextSnapshot,
+				};
+			},
+		);
+
+		return {
+			data,
+			message: `Queued sidebar group deletion for "${data.name}"`,
+		};
+	},
+});

--- a/packages/cli/src/commands/workspaces/groups/list/command.ts
+++ b/packages/cli/src/commands/workspaces/groups/list/command.ts
@@ -1,0 +1,25 @@
+import { table } from "@superset/cli-framework";
+import { command } from "../../../../lib/command";
+import {
+	readSidebarState,
+	requireOrganizationId,
+	toGroupRows,
+} from "../../../../lib/sidebar-groups";
+
+export default command({
+	description:
+		"List desktop sidebar workspace groups from the latest local app snapshot",
+	display: (data) =>
+		table(
+			data as Record<string, unknown>[],
+			["name", "workspaceCount", "workspaces", "projectId", "id"],
+			["NAME", "WORKSPACES", "MEMBERS", "PROJECT", "ID"],
+			[24, 10, 42, 36, 36],
+		),
+	run: async ({ ctx }) => {
+		const organizationId = requireOrganizationId(ctx.config.organizationId);
+		const state = readSidebarState(organizationId);
+		const rows = toGroupRows(state);
+		return rows;
+	},
+});

--- a/packages/cli/src/commands/workspaces/groups/meta.ts
+++ b/packages/cli/src/commands/workspaces/groups/meta.ts
@@ -1,0 +1,4 @@
+export default {
+	description: "Manage desktop sidebar workspace groups (local to this app)",
+	aliases: ["group"],
+};

--- a/packages/cli/src/commands/workspaces/groups/move/command.ts
+++ b/packages/cli/src/commands/workspaces/groups/move/command.ts
@@ -1,0 +1,78 @@
+import { CLIError, positional } from "@superset/cli-framework";
+import { command } from "../../../../lib/command";
+import {
+	findSection,
+	queueSidebarOperationWithSnapshotUpdate,
+	requireOrganizationId,
+} from "../../../../lib/sidebar-groups";
+
+export default command({
+	description: "Move one or more workspaces into a desktop sidebar group",
+	args: [
+		positional("groupId").required().desc("Target group ID"),
+		positional("workspaceIds").required().variadic().desc("Workspace IDs"),
+	],
+	run: async ({ ctx, args }) => {
+		const organizationId = requireOrganizationId(ctx.config.organizationId);
+		const workspaceIds = args.workspaceIds as string[];
+
+		const { data } = queueSidebarOperationWithSnapshotUpdate(
+			organizationId,
+			(snapshot) => {
+				const section = findSection(snapshot, args.groupId as string);
+				for (const workspaceId of workspaceIds) {
+					const workspace = snapshot.workspaces.find(
+						(candidate) => candidate.id === workspaceId,
+					);
+					if (!workspace) {
+						throw new CLIError(`Workspace not found: ${workspaceId}`);
+					}
+					if (workspace.projectId !== section.projectId) {
+						throw new CLIError(
+							"Cannot move workspace to a group in a different project",
+							`Workspace ${workspaceId} belongs to project ${workspace.projectId}; group ${section.id} belongs to project ${section.projectId}.`,
+						);
+					}
+				}
+
+				const movedWorkspaceIds = new Set(workspaceIds);
+				const sectionWorkspaceCount = snapshot.workspaces.filter(
+					(workspace) =>
+						workspace.sectionId === section.id &&
+						!movedWorkspaceIds.has(workspace.id),
+				).length;
+				const nextSnapshot = {
+					...snapshot,
+					updatedAt: new Date().toISOString(),
+					workspaces: snapshot.workspaces.map((workspace) => {
+						const movedIndex = workspaceIds.indexOf(workspace.id);
+						return movedWorkspaceIds.has(workspace.id)
+							? {
+									...workspace,
+									sectionId: section.id,
+									tabOrder: sectionWorkspaceCount + movedIndex + 1,
+								}
+							: workspace;
+					}),
+				};
+
+				return {
+					data: { groupId: section.id, groupName: section.name, workspaceIds },
+					operation: {
+						id: crypto.randomUUID(),
+						type: "moveWorkspaces",
+						createdAt: new Date().toISOString(),
+						workspaceIds,
+						sectionId: section.id,
+					},
+					snapshot: nextSnapshot,
+				};
+			},
+		);
+
+		return {
+			data,
+			message: `Queued ${workspaceIds.length} workspace(s) to move into "${data.groupName}"`,
+		};
+	},
+});

--- a/packages/cli/src/commands/workspaces/groups/remove/command.ts
+++ b/packages/cli/src/commands/workspaces/groups/remove/command.ts
@@ -1,0 +1,79 @@
+import { CLIError, positional } from "@superset/cli-framework";
+import { command } from "../../../../lib/command";
+import {
+	queueSidebarOperationWithSnapshotUpdate,
+	requireOrganizationId,
+} from "../../../../lib/sidebar-groups";
+
+export default command({
+	description: "Remove one or more workspaces from any desktop sidebar group",
+	args: [
+		positional("workspaceIds").required().variadic().desc("Workspace IDs"),
+	],
+	run: async ({ ctx, args }) => {
+		const organizationId = requireOrganizationId(ctx.config.organizationId);
+		const workspaceIds = args.workspaceIds as string[];
+
+		const { data } = queueSidebarOperationWithSnapshotUpdate(
+			organizationId,
+			(snapshot) => {
+				for (const workspaceId of workspaceIds) {
+					if (
+						!snapshot.workspaces.some(
+							(workspace) => workspace.id === workspaceId,
+						)
+					) {
+						throw new CLIError(`Workspace not found: ${workspaceId}`);
+					}
+				}
+
+				const movedWorkspaceIds = new Set(workspaceIds);
+				const nextTabOrderByProject = new Map<string, number>();
+				for (const workspace of snapshot.workspaces) {
+					if (
+						workspace.sectionId !== null ||
+						movedWorkspaceIds.has(workspace.id)
+					) {
+						continue;
+					}
+					nextTabOrderByProject.set(
+						workspace.projectId,
+						Math.max(
+							nextTabOrderByProject.get(workspace.projectId) ?? 0,
+							workspace.tabOrder,
+						),
+					);
+				}
+
+				const nextSnapshot = {
+					...snapshot,
+					updatedAt: new Date().toISOString(),
+					workspaces: snapshot.workspaces.map((workspace) => {
+						if (!movedWorkspaceIds.has(workspace.id)) return workspace;
+						const tabOrder =
+							(nextTabOrderByProject.get(workspace.projectId) ?? 0) + 1;
+						nextTabOrderByProject.set(workspace.projectId, tabOrder);
+						return { ...workspace, sectionId: null, tabOrder };
+					}),
+				};
+
+				return {
+					data: { workspaceIds },
+					operation: {
+						id: crypto.randomUUID(),
+						type: "moveWorkspaces",
+						createdAt: new Date().toISOString(),
+						workspaceIds,
+						sectionId: null,
+					},
+					snapshot: nextSnapshot,
+				};
+			},
+		);
+
+		return {
+			data,
+			message: `Queued ${workspaceIds.length} workspace(s) to leave sidebar groups`,
+		};
+	},
+});

--- a/packages/cli/src/commands/workspaces/groups/rename/command.ts
+++ b/packages/cli/src/commands/workspaces/groups/rename/command.ts
@@ -1,0 +1,51 @@
+import { CLIError, positional, string } from "@superset/cli-framework";
+import { command } from "../../../../lib/command";
+import {
+	findSection,
+	queueSidebarOperationWithSnapshotUpdate,
+	requireOrganizationId,
+} from "../../../../lib/sidebar-groups";
+
+export default command({
+	description: "Rename a desktop sidebar workspace group",
+	args: [positional("id").required().desc("Group ID")],
+	options: {
+		name: string().required().desc("New group name"),
+	},
+	run: async ({ ctx, args, options }) => {
+		const organizationId = requireOrganizationId(ctx.config.organizationId);
+		const name = options.name.trim();
+		if (name.length === 0) throw new CLIError("Group name cannot be empty");
+
+		const { data } = queueSidebarOperationWithSnapshotUpdate(
+			organizationId,
+			(snapshot) => {
+				const section = findSection(snapshot, args.id as string);
+				const nextSnapshot = {
+					...snapshot,
+					updatedAt: new Date().toISOString(),
+					sections: snapshot.sections.map((candidate) =>
+						candidate.id === section.id ? { ...candidate, name } : candidate,
+					),
+				};
+
+				return {
+					data: { id: section.id, name },
+					operation: {
+						id: crypto.randomUUID(),
+						type: "renameSection",
+						createdAt: new Date().toISOString(),
+						sectionId: section.id,
+						name,
+					},
+					snapshot: nextSnapshot,
+				};
+			},
+		);
+
+		return {
+			data,
+			message: `Queued sidebar group rename to "${name}"`,
+		};
+	},
+});

--- a/packages/cli/src/lib/sidebar-groups.test.ts
+++ b/packages/cli/src/lib/sidebar-groups.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { CLIError } from "@superset/cli-framework";
+import { assertSameProject, toGroupRows } from "./sidebar-groups";
+
+describe("sidebar groups CLI helpers", () => {
+	test("formats groups with sorted members from the latest snapshot", () => {
+		const rows = toGroupRows({
+			version: 1,
+			organizationId: "org-1",
+			operations: [],
+			claimedOperation: null,
+			snapshot: {
+				updatedAt: "2026-01-01T00:00:00.000Z",
+				sections: [
+					{
+						id: "section-1",
+						projectId: "project-1",
+						name: "Backend",
+						createdAt: "2026-01-01T00:00:00.000Z",
+						tabOrder: 1,
+						isCollapsed: false,
+						color: null,
+					},
+				],
+				workspaces: [
+					{
+						id: "workspace-2",
+						projectId: "project-1",
+						name: "Alpha",
+						branch: "alpha",
+						sectionId: "section-1",
+						tabOrder: 2,
+					},
+					{
+						id: "workspace-1",
+						projectId: "project-1",
+						name: "Zeta",
+						branch: "zeta",
+						sectionId: "section-1",
+						tabOrder: 1,
+					},
+				],
+			},
+		});
+
+		expect(rows).toMatchObject([
+			{
+				id: "section-1",
+				workspaceCount: 2,
+				workspaces: "Zeta, Alpha",
+			},
+		]);
+	});
+
+	test("rejects creating a group across projects", () => {
+		expect(() =>
+			assertSameProject(["workspace-1", "workspace-2"], {
+				updatedAt: "2026-01-01T00:00:00.000Z",
+				sections: [],
+				workspaces: [
+					{
+						id: "workspace-1",
+						projectId: "project-1",
+						name: "First",
+						branch: "first",
+						sectionId: null,
+						tabOrder: 1,
+					},
+					{
+						id: "workspace-2",
+						projectId: "project-2",
+						name: "Second",
+						branch: "second",
+						sectionId: null,
+						tabOrder: 2,
+					},
+				],
+			}),
+		).toThrow(CLIError);
+	});
+});

--- a/packages/cli/src/lib/sidebar-groups.ts
+++ b/packages/cli/src/lib/sidebar-groups.ts
@@ -1,0 +1,136 @@
+import { CLIError } from "@superset/cli-framework";
+import {
+	mutateSidebarGroupsCliState,
+	readSidebarGroupsCliState,
+	type SidebarGroupsCliOperation,
+	type SidebarGroupsCliSection,
+	type SidebarGroupsCliSnapshot,
+	type SidebarGroupsCliState,
+} from "@superset/shared/sidebar-groups-cli";
+import { SUPERSET_HOME_DIR } from "./config";
+
+export type SidebarGroupRow = SidebarGroupsCliSection & {
+	workspaceCount: number;
+	workspaces: string;
+	pendingOperations: number;
+};
+
+export function requireOrganizationId(
+	organizationId: string | undefined,
+): string {
+	if (!organizationId) {
+		throw new CLIError("No active organization", "Run: superset auth login");
+	}
+	return organizationId;
+}
+
+export function readSidebarState(
+	organizationId: string,
+): SidebarGroupsCliState {
+	return readSidebarGroupsCliState({
+		homeDir: SUPERSET_HOME_DIR,
+		organizationId,
+	});
+}
+
+export function requireSnapshot(
+	state: SidebarGroupsCliState,
+): SidebarGroupsCliSnapshot {
+	if (!state.snapshot) {
+		throw new CLIError(
+			"No desktop sidebar snapshot is available for this organization",
+			"Open the Superset desktop app once, then rerun this command.",
+		);
+	}
+	return state.snapshot;
+}
+
+export function queueSidebarOperationWithSnapshotUpdate<TData>(
+	organizationId: string,
+	update: (snapshot: SidebarGroupsCliSnapshot) => {
+		data: TData;
+		operation: SidebarGroupsCliOperation;
+		snapshot: SidebarGroupsCliSnapshot;
+	},
+): { data: TData; state: SidebarGroupsCliState } {
+	let data: TData | undefined;
+	const state = mutateSidebarGroupsCliState(
+		{ homeDir: SUPERSET_HOME_DIR, organizationId },
+		(currentState) => {
+			const snapshot = requireSnapshot(currentState);
+			const next = update(snapshot);
+			data = next.data;
+			return {
+				...currentState,
+				operations: [...currentState.operations, next.operation],
+				snapshot: next.snapshot,
+			};
+		},
+	);
+	if (data === undefined) {
+		throw new CLIError("Sidebar group update did not produce command data");
+	}
+	return { data, state };
+}
+
+export function toGroupRows(state: SidebarGroupsCliState): SidebarGroupRow[] {
+	const snapshot = requireSnapshot(state);
+	return snapshot.sections
+		.map((section) => {
+			const members = snapshot.workspaces
+				.filter((workspace) => workspace.sectionId === section.id)
+				.sort((left, right) => left.tabOrder - right.tabOrder);
+			return {
+				...section,
+				workspaceCount: members.length,
+				workspaces: members.map((workspace) => workspace.name).join(", "),
+				pendingOperations: state.operations.length,
+			};
+		})
+		.sort((left, right) => left.tabOrder - right.tabOrder);
+}
+
+export function assertSameProject(
+	workspaceIds: string[],
+	snapshot: SidebarGroupsCliSnapshot,
+): string {
+	const workspaces = workspaceIds.map((id) => {
+		const workspace = snapshot.workspaces.find(
+			(candidate) => candidate.id === id,
+		);
+		if (!workspace) {
+			throw new CLIError(
+				`Workspace not found in desktop sidebar snapshot: ${id}`,
+				"Open the Superset desktop app so it can refresh the local sidebar snapshot.",
+			);
+		}
+		return workspace;
+	});
+	const projectIds = [
+		...new Set(workspaces.map((workspace) => workspace.projectId)),
+	];
+	const projectId = projectIds[0];
+	if (projectIds.length !== 1 || !projectId) {
+		throw new CLIError(
+			"Workspace groups cannot span projects",
+			"Pass workspace IDs from a single project.",
+		);
+	}
+	return projectId;
+}
+
+export function findSection(
+	snapshot: SidebarGroupsCliSnapshot,
+	sectionId: string,
+): SidebarGroupsCliSection {
+	const section = snapshot.sections.find(
+		(candidate) => candidate.id === sectionId,
+	);
+	if (!section) {
+		throw new CLIError(
+			`Workspace group not found: ${sectionId}`,
+			"List groups with: superset workspaces groups list",
+		);
+	}
+	return section;
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -128,6 +128,10 @@
 			"types": "./src/terminal-title-scanner.ts",
 			"default": "./src/terminal-title-scanner.ts"
 		},
+		"./sidebar-groups-cli": {
+			"types": "./src/sidebar-groups-cli.ts",
+			"default": "./src/sidebar-groups-cli.ts"
+		},
 		"./rrule": {
 			"types": "./src/rrule.ts",
 			"default": "./src/rrule.ts"

--- a/packages/shared/src/sidebar-groups-cli.test.ts
+++ b/packages/shared/src/sidebar-groups-cli.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+	acknowledgeSidebarGroupsCliOperation,
+	enqueueSidebarGroupsCliOperation,
+	getSidebarGroupsCliStatePath,
+	mutateSidebarGroupsCliState,
+	readNextSidebarGroupsCliOperation,
+	readSidebarGroupsCliState,
+	writeSidebarGroupsCliSnapshot,
+} from "./sidebar-groups-cli";
+
+let tempHome = mkdtempSync(join(tmpdir(), "sidebar-groups-cli-"));
+
+afterEach(() => {
+	rmSync(tempHome, { recursive: true, force: true });
+	tempHome = mkdtempSync(join(tmpdir(), "sidebar-groups-cli-"));
+});
+
+describe("sidebar groups CLI bridge state", () => {
+	test("stores snapshots and queues operations per organization", () => {
+		writeSidebarGroupsCliSnapshot(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			{
+				updatedAt: "2026-01-01T00:00:00.000Z",
+				sections: [
+					{
+						id: "section-1",
+						projectId: "project-1",
+						name: "Backend",
+						createdAt: "2026-01-01T00:00:00.000Z",
+						tabOrder: 1,
+						isCollapsed: false,
+						color: null,
+					},
+				],
+				workspaces: [
+					{
+						id: "workspace-1",
+						projectId: "project-1",
+						name: "Fix auth",
+						branch: "fix-auth",
+						sectionId: "section-1",
+						tabOrder: 1,
+					},
+				],
+			},
+		);
+		enqueueSidebarGroupsCliOperation(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			{
+				id: "operation-1",
+				type: "renameSection",
+				createdAt: "2026-01-01T00:00:01.000Z",
+				sectionId: "section-1",
+				name: "API",
+			},
+		);
+
+		const state = readSidebarGroupsCliState({
+			homeDir: tempHome,
+			organizationId: "org-1",
+		});
+		expect(state.snapshot?.sections[0]?.name).toBe("Backend");
+		expect(state.operations).toHaveLength(1);
+		expect(
+			readSidebarGroupsCliState({
+				homeDir: tempHome,
+				organizationId: "org-2",
+			}).snapshot,
+		).toBeNull();
+	});
+
+	test("claims and acknowledges queued operations one at a time", () => {
+		enqueueSidebarGroupsCliOperation(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			{
+				id: "operation-1",
+				type: "deleteSection",
+				createdAt: "2026-01-01T00:00:01.000Z",
+				sectionId: "section-1",
+			},
+		);
+		enqueueSidebarGroupsCliOperation(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			{
+				id: "operation-2",
+				type: "renameSection",
+				createdAt: "2026-01-01T00:00:02.000Z",
+				sectionId: "section-1",
+				name: "API",
+			},
+		);
+
+		const firstOperation = readNextSidebarGroupsCliOperation({
+			homeDir: tempHome,
+			organizationId: "org-1",
+		});
+		expect(firstOperation?.id).toBe("operation-1");
+		expect(
+			readNextSidebarGroupsCliOperation({
+				homeDir: tempHome,
+				organizationId: "org-1",
+			}),
+		).toBeNull();
+		expect(
+			acknowledgeSidebarGroupsCliOperation(
+				{ homeDir: tempHome, organizationId: "org-1" },
+				"operation-2",
+			),
+		).toBe(false);
+		expect(
+			acknowledgeSidebarGroupsCliOperation(
+				{ homeDir: tempHome, organizationId: "org-1" },
+				"operation-1",
+			),
+		).toBe(true);
+		expect(
+			readNextSidebarGroupsCliOperation({
+				homeDir: tempHome,
+				organizationId: "org-1",
+			})?.id,
+		).toBe("operation-2");
+	});
+
+	test("requeues stale claimed operations", () => {
+		enqueueSidebarGroupsCliOperation(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			{
+				id: "operation-1",
+				type: "deleteSection",
+				createdAt: "2026-01-01T00:00:01.000Z",
+				sectionId: "section-1",
+			},
+		);
+		enqueueSidebarGroupsCliOperation(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			{
+				id: "operation-2",
+				type: "renameSection",
+				createdAt: "2026-01-01T00:00:02.000Z",
+				sectionId: "section-1",
+				name: "API",
+			},
+		);
+		expect(
+			readNextSidebarGroupsCliOperation({
+				homeDir: tempHome,
+				organizationId: "org-1",
+			})?.id,
+		).toBe("operation-1");
+		mutateSidebarGroupsCliState(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			(state) => ({
+				...state,
+				claimedOperation: state.claimedOperation
+					? {
+							...state.claimedOperation,
+							claimedAt: new Date(Date.now() - 120_000).toISOString(),
+						}
+					: null,
+			}),
+		);
+
+		expect(
+			readNextSidebarGroupsCliOperation({
+				homeDir: tempHome,
+				organizationId: "org-1",
+			})?.id,
+		).toBe("operation-1");
+		expect(
+			readSidebarGroupsCliState({
+				homeDir: tempHome,
+				organizationId: "org-1",
+			}).operations.map((operation) => operation.id),
+		).toEqual(["operation-2"]);
+	});
+
+	test("uses collision-free state paths for organization IDs", () => {
+		expect(
+			getSidebarGroupsCliStatePath({
+				homeDir: tempHome,
+				organizationId: "org/a",
+			}),
+		).not.toBe(
+			getSidebarGroupsCliStatePath({
+				homeDir: tempHome,
+				organizationId: "org_a",
+			}),
+		);
+	});
+
+	test("recovers from stale lock directories", () => {
+		const path = getSidebarGroupsCliStatePath({
+			homeDir: tempHome,
+			organizationId: "org-1",
+		});
+		const lockPath = `${path}.lock`;
+		mkdirSync(lockPath, { recursive: true });
+		const staleTime = new Date(Date.now() - 120_000);
+		utimesSync(lockPath, staleTime, staleTime);
+
+		enqueueSidebarGroupsCliOperation(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			{
+				id: "operation-1",
+				type: "deleteSection",
+				createdAt: "2026-01-01T00:00:01.000Z",
+				sectionId: "section-1",
+			},
+		);
+
+		expect(
+			readSidebarGroupsCliState({
+				homeDir: tempHome,
+				organizationId: "org-1",
+			}).operations.map((operation) => operation.id),
+		).toEqual(["operation-1"]);
+	});
+
+	test("invalid JSON resets to an empty state", () => {
+		const path = getSidebarGroupsCliStatePath({
+			homeDir: tempHome,
+			organizationId: "org-1",
+		});
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, "{not-json");
+
+		expect(
+			readSidebarGroupsCliState({
+				homeDir: tempHome,
+				organizationId: "org-1",
+			}),
+		).toEqual({
+			version: 1,
+			organizationId: "org-1",
+			snapshot: null,
+			operations: [],
+			claimedOperation: null,
+		});
+	});
+
+	test("does not overwrite valid state when a mutation returns invalid data", () => {
+		enqueueSidebarGroupsCliOperation(
+			{ homeDir: tempHome, organizationId: "org-1" },
+			{
+				id: "operation-1",
+				type: "deleteSection",
+				createdAt: "2026-01-01T00:00:01.000Z",
+				sectionId: "section-1",
+			},
+		);
+
+		expect(() =>
+			mutateSidebarGroupsCliState(
+				{ homeDir: tempHome, organizationId: "org-1" },
+				(state) => ({ ...state, organizationId: "org-2" }),
+			),
+		).toThrow("Invalid sidebar groups CLI state");
+
+		expect(
+			readSidebarGroupsCliState({
+				homeDir: tempHome,
+				organizationId: "org-1",
+			}).operations.map((operation) => operation.id),
+		).toEqual(["operation-1"]);
+	});
+});

--- a/packages/shared/src/sidebar-groups-cli.ts
+++ b/packages/shared/src/sidebar-groups-cli.ts
@@ -1,0 +1,427 @@
+import { Buffer } from "node:buffer";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { z } from "zod";
+
+export const SIDEBAR_GROUPS_CLI_STATE_VERSION = 1;
+
+const LOCK_WAIT_MS = 5_000;
+const LOCK_STALE_MS = 60_000;
+const CLAIM_STALE_MS = 60_000;
+
+const sidebarWorkspaceSchema = z.object({
+	id: z.string(),
+	projectId: z.string(),
+	name: z.string(),
+	branch: z.string().nullable().optional(),
+	sectionId: z.string().nullable(),
+	tabOrder: z.number(),
+});
+
+const sidebarSectionSchema = z.object({
+	id: z.string(),
+	projectId: z.string(),
+	name: z.string(),
+	createdAt: z.string(),
+	tabOrder: z.number(),
+	isCollapsed: z.boolean(),
+	color: z.string().nullable(),
+});
+
+export const sidebarGroupsCliSnapshotSchema = z.object({
+	updatedAt: z.string(),
+	sections: z.array(sidebarSectionSchema),
+	workspaces: z.array(sidebarWorkspaceSchema),
+});
+
+export const sidebarGroupsCliOperationSchema = z.discriminatedUnion("type", [
+	z.object({
+		id: z.string(),
+		type: z.literal("createSection"),
+		createdAt: z.string(),
+		sectionId: z.string(),
+		projectId: z.string(),
+		name: z.string(),
+		workspaceIds: z.array(z.string()).default([]),
+	}),
+	z.object({
+		id: z.string(),
+		type: z.literal("renameSection"),
+		createdAt: z.string(),
+		sectionId: z.string(),
+		name: z.string(),
+	}),
+	z.object({
+		id: z.string(),
+		type: z.literal("deleteSection"),
+		createdAt: z.string(),
+		sectionId: z.string(),
+	}),
+	z.object({
+		id: z.string(),
+		type: z.literal("moveWorkspaces"),
+		createdAt: z.string(),
+		workspaceIds: z.array(z.string()).min(1),
+		sectionId: z.string().nullable(),
+	}),
+]);
+
+const claimedSidebarGroupsCliOperationSchema = z.object({
+	operation: sidebarGroupsCliOperationSchema,
+	claimedAt: z.string(),
+});
+
+export const sidebarGroupsCliStateSchema = z.object({
+	version: z.literal(SIDEBAR_GROUPS_CLI_STATE_VERSION),
+	organizationId: z.string(),
+	snapshot: sidebarGroupsCliSnapshotSchema.nullable().default(null),
+	operations: z.array(sidebarGroupsCliOperationSchema).default([]),
+	claimedOperation: claimedSidebarGroupsCliOperationSchema
+		.nullable()
+		.default(null),
+});
+
+export type SidebarGroupsCliWorkspace = z.infer<typeof sidebarWorkspaceSchema>;
+export type SidebarGroupsCliSection = z.infer<typeof sidebarSectionSchema>;
+export type SidebarGroupsCliSnapshot = z.infer<
+	typeof sidebarGroupsCliSnapshotSchema
+>;
+export type SidebarGroupsCliOperation = z.infer<
+	typeof sidebarGroupsCliOperationSchema
+>;
+export type SidebarGroupsCliState = z.infer<typeof sidebarGroupsCliStateSchema>;
+
+export type SidebarGroupsCliLockOptions = {
+	waitMs?: number;
+};
+
+export class SidebarGroupsCliStateLockTimeoutError extends Error {
+	constructor() {
+		super("Timed out waiting for sidebar groups CLI state lock");
+		this.name = "SidebarGroupsCliStateLockTimeoutError";
+	}
+}
+function isFileNotFoundError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "ENOENT"
+	);
+}
+
+function isFileExistsError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "EEXIST"
+	);
+}
+
+function encodeOrganizationId(organizationId: string): string {
+	return Buffer.from(organizationId, "utf8").toString("base64url");
+}
+
+export function getSidebarGroupsCliStatePath(args: {
+	homeDir: string;
+	organizationId: string;
+}): string {
+	return join(
+		args.homeDir,
+		"sidebar-groups-cli",
+		`${encodeOrganizationId(args.organizationId)}.json`,
+	);
+}
+
+function waitForLockRetry(): void {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+}
+
+function withSidebarGroupsCliStateLock<T>(
+	args: { homeDir: string; organizationId: string },
+	callback: () => T,
+	options: SidebarGroupsCliLockOptions = {},
+): T {
+	const statePath = getSidebarGroupsCliStatePath(args);
+	mkdirSync(dirname(statePath), { recursive: true, mode: 0o700 });
+	const lockPath = `${statePath}.lock`;
+	const waitMs = options.waitMs ?? LOCK_WAIT_MS;
+	const startedAt = Date.now();
+
+	while (true) {
+		try {
+			mkdirSync(lockPath, { mode: 0o700 });
+			break;
+		} catch (error) {
+			if (!isFileExistsError(error)) {
+				throw error;
+			}
+
+			try {
+				const lockStats = statSync(lockPath);
+				if (Date.now() - lockStats.mtimeMs > LOCK_STALE_MS) {
+					rmSync(lockPath, { recursive: true, force: true });
+					continue;
+				}
+			} catch (statError) {
+				if (isFileNotFoundError(statError)) continue;
+				throw statError;
+			}
+
+			if (waitMs === 0 || Date.now() - startedAt > waitMs) {
+				throw new SidebarGroupsCliStateLockTimeoutError();
+			}
+			waitForLockRetry();
+		}
+	}
+
+	try {
+		return callback();
+	} finally {
+		rmSync(lockPath, { recursive: true, force: true });
+	}
+}
+
+export function createEmptySidebarGroupsCliState(
+	organizationId: string,
+): SidebarGroupsCliState {
+	return {
+		version: SIDEBAR_GROUPS_CLI_STATE_VERSION,
+		organizationId,
+		snapshot: null,
+		operations: [],
+		claimedOperation: null,
+	};
+}
+
+function readSidebarGroupsCliStateUnlocked(args: {
+	homeDir: string;
+	organizationId: string;
+}): SidebarGroupsCliState {
+	const path = getSidebarGroupsCliStatePath(args);
+	if (!existsSync(path)) {
+		return createEmptySidebarGroupsCliState(args.organizationId);
+	}
+
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		return createEmptySidebarGroupsCliState(args.organizationId);
+	}
+
+	const parsed = sidebarGroupsCliStateSchema.safeParse(raw);
+	if (!parsed.success || parsed.data.organizationId !== args.organizationId) {
+		return createEmptySidebarGroupsCliState(args.organizationId);
+	}
+	return parsed.data;
+}
+
+export function readSidebarGroupsCliState(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	options: SidebarGroupsCliLockOptions = {},
+): SidebarGroupsCliState {
+	return withSidebarGroupsCliStateLock(
+		args,
+		() => readSidebarGroupsCliStateUnlocked(args),
+		options,
+	);
+}
+
+function writeSidebarGroupsCliStateUnlocked(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	state: SidebarGroupsCliState,
+): SidebarGroupsCliState {
+	const parsed = sidebarGroupsCliStateSchema.safeParse(state);
+	if (!parsed.success || parsed.data.organizationId !== args.organizationId) {
+		throw new Error("Invalid sidebar groups CLI state");
+	}
+
+	const path = getSidebarGroupsCliStatePath(args);
+	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+	const tmpPath = `${path}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`;
+	writeFileSync(tmpPath, `${JSON.stringify(parsed.data, null, "\t")}\n`, {
+		mode: 0o600,
+	});
+	renameSync(tmpPath, path);
+	return parsed.data;
+}
+
+export function mutateSidebarGroupsCliState(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	mutate: (state: SidebarGroupsCliState) => SidebarGroupsCliState,
+	options: SidebarGroupsCliLockOptions = {},
+): SidebarGroupsCliState {
+	return withSidebarGroupsCliStateLock(
+		args,
+		() => {
+			const state = readSidebarGroupsCliStateUnlocked(args);
+			const nextState = writeSidebarGroupsCliStateUnlocked(args, mutate(state));
+			return nextState;
+		},
+		options,
+	);
+}
+
+export function writeSidebarGroupsCliState(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	state: SidebarGroupsCliState,
+	options: SidebarGroupsCliLockOptions = {},
+): void {
+	mutateSidebarGroupsCliState(args, () => state, options);
+}
+
+export function enqueueSidebarGroupsCliOperation(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	operation: SidebarGroupsCliOperation,
+	options: SidebarGroupsCliLockOptions = {},
+): SidebarGroupsCliState {
+	return mutateSidebarGroupsCliState(
+		args,
+		(state) => ({
+			...state,
+			operations: [...state.operations, operation],
+		}),
+		options,
+	);
+}
+
+export function writeSidebarGroupsCliSnapshot(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	snapshot: SidebarGroupsCliSnapshot,
+	options: SidebarGroupsCliLockOptions = {},
+): SidebarGroupsCliState {
+	return mutateSidebarGroupsCliState(
+		args,
+		(state) => ({
+			...state,
+			snapshot,
+		}),
+		options,
+	);
+}
+
+export function readNextSidebarGroupsCliOperation(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	options: SidebarGroupsCliLockOptions = {},
+): SidebarGroupsCliOperation | null {
+	let claimedOperation: SidebarGroupsCliOperation | null = null;
+	mutateSidebarGroupsCliState(
+		args,
+		(state) => {
+			let nextState = state;
+			if (state.claimedOperation) {
+				const claimedAtMs = Date.parse(state.claimedOperation.claimedAt);
+				if (
+					Number.isNaN(claimedAtMs) ||
+					Date.now() - claimedAtMs <= CLAIM_STALE_MS
+				) {
+					return state;
+				}
+
+				nextState = {
+					...state,
+					operations: [state.claimedOperation.operation, ...state.operations],
+					claimedOperation: null,
+				};
+			}
+
+			const [operation, ...operations] = nextState.operations;
+			if (!operation) {
+				return nextState;
+			}
+
+			claimedOperation = operation;
+			return {
+				...nextState,
+				operations,
+				claimedOperation: {
+					operation,
+					claimedAt: new Date().toISOString(),
+				},
+			};
+		},
+		options,
+	);
+	return claimedOperation;
+}
+
+export function acknowledgeSidebarGroupsCliOperation(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	operationId: string,
+	options: SidebarGroupsCliLockOptions = {},
+): boolean {
+	let acknowledged = false;
+	mutateSidebarGroupsCliState(
+		args,
+		(state) => {
+			if (state.claimedOperation?.operation.id !== operationId) {
+				return state;
+			}
+			acknowledged = true;
+			return { ...state, claimedOperation: null };
+		},
+		options,
+	);
+	return acknowledged;
+}
+
+export function releaseSidebarGroupsCliOperation(
+	args: {
+		homeDir: string;
+		organizationId: string;
+	},
+	operationId: string,
+	options: SidebarGroupsCliLockOptions = {},
+): boolean {
+	let released = false;
+	mutateSidebarGroupsCliState(
+		args,
+		(state) => {
+			if (state.claimedOperation?.operation.id !== operationId) {
+				return state;
+			}
+			released = true;
+			return {
+				...state,
+				operations: [state.claimedOperation.operation, ...state.operations],
+				claimedOperation: null,
+			};
+		},
+		options,
+	);
+	return released;
+}


### PR DESCRIPTION
## Problem
The desktop app supports workspace sidebar groups through renderer-local `v2SidebarSections` and `v2WorkspaceLocalState`, but the public CLI only exposed workspace create/list/open/update/delete commands. Users had to use the app context menu for `New group from workspace` and `Move to group`.

## Design
- Adds `superset workspaces groups` command family:
  - `list`
  - `create --name <name> [workspace-id...]`
  - `create --name <name> --project <project-id>` for empty groups
  - `move <group-id> <workspace-id...>`
  - `remove <workspace-id...>`
  - `rename <group-id> --name <name>`
  - `delete <group-id>`
- Keeps sidebar groups desktop-local. The CLI reads/writes a per-organization bridge file under Superset Home and does not introduce cloud-side workspace group state.
- Desktop renderer remains the source of truth for sidebar collections. It writes current snapshots to the bridge file and consumes queued CLI operations into `v2SidebarSections` / `v2WorkspaceLocalState`.
- CLI commands optimistically update the bridge snapshot so `groups list` reflects queued changes before the desktop app consumes them.
- State mutations use one lock-protected transaction for validation + queueing + optimistic snapshot updates.

## Review fixes included
- Renderer waits for sidebar project, section, workspace, and local main workspace hydration before publishing snapshots or consuming queued operations.
- Auto-included local main workspaces are materialized into `v2WorkspaceLocalState` before CLI group/move operations apply.
- Queue consumption now claims one operation, applies it, then acknowledges it; failed/not-yet-hydrated operations are released for retry instead of being dropped.
- Ack retry is tracked per organization to avoid replay after lock contention or organization switches.
- Shared state writes validate schema before replacing the file and use atomic temp-file rename.
- File locking now only treats `EEXIST` as contention and removes stale lock directories after timeout-safe expiry.
- CLI delete/remove/move rewrites recalculate top-level tab ordering to avoid duplicate ordering after ungrouping.
- Helper tests use non-alphabetical names to prove `tabOrder` sorting.

## Verification
- `bun test packages/shared/src/sidebar-groups-cli.test.ts packages/cli/src/lib/sidebar-groups.test.ts` — passed, 8 tests / 15 assertions.
- `bun run --cwd packages/shared typecheck` — passed.
- `bun run --cwd packages/cli typecheck` — passed.
- `bun run --cwd apps/desktop typecheck` — passed.
- `bun run lint` — passed, checked 4754 files.

## Branch
- Base: `main`
- Head: `werkamsus:nick/sidebar-group-cli`
- Current commit: `f5bcdf49 Add CLI support for sidebar workspace groups`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end desktop sidebar workspace group support via CLI (create, rename, move, remove, delete, list).
  * Introduced backend-driven syncing of live sidebar state with locally queued operations, including snapshot writing and per-organization operation claiming/ack/release.
  * Added a desktop tRPC endpoint and a renderer bridge hook to apply incoming sidebar group updates.
  * Exposed a shared `sidebar-groups-cli` entry point for per-organization state access.
* **Bug Fixes**
  * Improved robustness around state locking/timeout handling and stale-operation recovery.
* **Tests**
  * Added Bun test coverage for snapshot conversion, validation, and operation-queue behavior.
* **Documentation**
  * Updated CLI command tree to include `workspaces groups`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->