### PR TITLE
fix(relay): close terminal channel when host control tunnel isn't open

### DIFF
--- a/apps/relay/src/tunnel.ts
+++ b/apps/relay/src/tunnel.ts
@@ -385,6 +385,13 @@ export class TunnelManager {
 		const tunnel = this.tunnels.get(hostId);
 		if (!tunnel) throw new Error("Host not connected");
 
+		// The host control tunnel must be open. Otherwise `send()` below silently
+		// drops the `ws:open` (it no-ops when `readyState !== 1`) and the client is
+		// left attached to a channel the host never creates — the terminal hangs on
+		// a permanent "Disconnected" and no `ws:close` is ever delivered. Throw so
+		// the caller closes the client socket and it reconnects to a live tunnel.
+		if (tunnel.ws.readyState !== 1) throw new Error("Host tunnel not open");
+
 		const id = crypto.randomUUID();
 		tunnel.activeChannels.set(id, clientWs);
 		this.send(tunnel.ws, { type: "ws:open", id, path, query });


### PR DESCRIPTION
## Description

Fixes a relay bug where a remote-host terminal/agent pane can hang on a permanent **"Disconnected"** even though the host's PTY is alive.

When a client opens a `/hosts/:hostId/*` WebSocket (terminal or agent) while the host's control tunnel is **not `OPEN`**, `TunnelManager.send()` silently no-ops the `ws:open` frame — it only sends when `readyState === 1`:

```ts
private send(ws: WsSocket, message: ...): void {
  if (ws.readyState === 1) ws.send(JSON.stringify(message));
}
```

But `openWsChannel` has already stored the client socket in `activeChannels`. So the host never creates the channel, no `ws:close` is ever delivered back, and the client is stranded on a dead channel — the terminal shows "Disconnected" forever while the host PTY keeps running.

This adds a guard in `openWsChannel` that throws when the control tunnel isn't open, **reusing the existing caller `catch`** in the `/hosts/:hostId/*` upgrade handler (`apps/relay/src/index.ts`, `onOpen` → `ws.close(1011, "Failed to open channel")`). The client then reconnects to a live tunnel instead of being stranded. It mirrors the `if (!tunnel) throw new Error("Host not connected")` guard one line above.

## Related Issues

Related to #5380

## Type of Change

- [x] Bug fix

## Testing

- Reuses the established `openWsChannel` throw → `onOpen` catch → `ws.close(1011)` path that already exists for the "host not connected" case, so the client transport treats it as a normal reconnectable close (not a permanent failure).
- No new imports or types — `tunnel.ws.readyState` is already read by `send()` in the same class.
- I could not stand up the full Fly relay topology locally, so this is a minimal defensive guard verified by reading the call sites (`apps/relay/src/tunnel.ts` `openWsChannel`/`send`; `apps/relay/src/index.ts` `/hosts/:hostId/*` upgrade handler). CI typecheck/lint/build covers the rest.

## Additional Notes

Surfaced while diagnosing #5380 (host online + PTY alive, but every terminal/agent stuck "Disconnected"). #5380 also discusses a likely-related root cause — `fly-replay` not being transparent on the WebSocket upgrade — which is a larger relay-routing change and intentionally out of scope for this small fix.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5382">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent stranded terminal/agent channels by refusing to open a channel when the host control tunnel isn’t OPEN. We now throw in `openWsChannel` so the upgrade handler closes the client socket with code 1011, prompting a clean reconnect instead of a permanent “Disconnected”.

<sup>Written for commit 3d55b952237205cd5eb4c3ee09ab03c3365f6ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket tunnel handling by checking that the host connection is open before creating a client channel.
  * Prevents silent failures when a channel open request can’t be delivered, helping client connections recover cleanly instead of getting stuck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->