### PR TITLE
[codex] Handle binary and video file changes

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/utils/apply-numstat.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/apply-numstat.ts
@@ -18,6 +18,7 @@ export async function applyNumstatToFiles(
 			if (fileStat) {
 				file.additions = fileStat.additions;
 				file.deletions = fileStat.deletions;
+				file.isBinary = fileStat.isBinary;
 			}
 		}
 	} catch {}

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/parse-status.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/parse-status.test.ts
@@ -98,8 +98,16 @@ describe("parseDiffNumstat", () => {
 
 		const stats = parseDiffNumstat(numstatOutput);
 
-		expect(stats.get("src/file1.ts")).toEqual({ additions: 10, deletions: 5 });
-		expect(stats.get("src/file2.ts")).toEqual({ additions: 20, deletions: 3 });
+		expect(stats.get("src/file1.ts")).toEqual({
+			additions: 10,
+			deletions: 5,
+			isBinary: false,
+		});
+		expect(stats.get("src/file2.ts")).toEqual({
+			additions: 20,
+			deletions: 3,
+			isBinary: false,
+		});
 	});
 
 	test("handles binary files with dash markers", () => {
@@ -108,8 +116,16 @@ describe("parseDiffNumstat", () => {
 
 		const stats = parseDiffNumstat(numstatOutput);
 
-		expect(stats.get("image.png")).toEqual({ additions: 0, deletions: 0 });
-		expect(stats.get("src/code.ts")).toEqual({ additions: 10, deletions: 5 });
+		expect(stats.get("image.png")).toEqual({
+			additions: 0,
+			deletions: 0,
+			isBinary: true,
+		});
+		expect(stats.get("src/code.ts")).toEqual({
+			additions: 10,
+			deletions: 5,
+			isBinary: false,
+		});
 	});
 
 	test("handles renamed files with arrow format", () => {
@@ -118,8 +134,16 @@ describe("parseDiffNumstat", () => {
 		const stats = parseDiffNumstat(numstatOutput);
 
 		// Should be accessible by both old and new paths
-		expect(stats.get("new/path.ts")).toEqual({ additions: 5, deletions: 2 });
-		expect(stats.get("old/path.ts")).toEqual({ additions: 5, deletions: 2 });
+		expect(stats.get("new/path.ts")).toEqual({
+			additions: 5,
+			deletions: 2,
+			isBinary: false,
+		});
+		expect(stats.get("old/path.ts")).toEqual({
+			additions: 5,
+			deletions: 2,
+			isBinary: false,
+		});
 	});
 
 	test("handles copied files with arrow format", () => {
@@ -127,8 +151,16 @@ describe("parseDiffNumstat", () => {
 
 		const stats = parseDiffNumstat(numstatOutput);
 
-		expect(stats.get("copy.ts")).toEqual({ additions: 0, deletions: 0 });
-		expect(stats.get("source.ts")).toEqual({ additions: 0, deletions: 0 });
+		expect(stats.get("copy.ts")).toEqual({
+			additions: 0,
+			deletions: 0,
+			isBinary: false,
+		});
+		expect(stats.get("source.ts")).toEqual({
+			additions: 0,
+			deletions: 0,
+			isBinary: false,
+		});
 	});
 
 	test("handles paths with spaces in rename format", () => {
@@ -136,8 +168,16 @@ describe("parseDiffNumstat", () => {
 
 		const stats = parseDiffNumstat(numstatOutput);
 
-		expect(stats.get("new file.ts")).toEqual({ additions: 3, deletions: 1 });
-		expect(stats.get("old file.ts")).toEqual({ additions: 3, deletions: 1 });
+		expect(stats.get("new file.ts")).toEqual({
+			additions: 3,
+			deletions: 1,
+			isBinary: false,
+		});
+		expect(stats.get("old file.ts")).toEqual({
+			additions: 3,
+			deletions: 1,
+			isBinary: false,
+		});
 	});
 
 	test("returns empty map for empty input", () => {
@@ -153,7 +193,11 @@ describe("parseDiffNumstat", () => {
 		const stats = parseDiffNumstat(numstatOutput);
 
 		expect(stats.size).toBe(1);
-		expect(stats.get("valid/path.ts")).toEqual({ additions: 20, deletions: 3 });
+		expect(stats.get("valid/path.ts")).toEqual({
+			additions: 20,
+			deletions: 3,
+			isBinary: false,
+		});
 	});
 
 	test("handles non-numeric additions/deletions gracefully", () => {
@@ -161,7 +205,11 @@ describe("parseDiffNumstat", () => {
 
 		const stats = parseDiffNumstat(numstatOutput);
 
-		expect(stats.get("file.ts")).toEqual({ additions: 0, deletions: 0 });
+		expect(stats.get("file.ts")).toEqual({
+			additions: 0,
+			deletions: 0,
+			isBinary: false,
+		});
 	});
 });
 

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/parse-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/parse-status.ts
@@ -118,8 +118,11 @@ export function parseGitLog(logOutput: string): CommitInfo[] {
 
 export function parseDiffNumstat(
 	numstatOutput: string,
-): Map<string, { additions: number; deletions: number }> {
-	const stats = new Map<string, { additions: number; deletions: number }>();
+): Map<string, { additions: number; deletions: number; isBinary: boolean }> {
+	const stats = new Map<
+		string,
+		{ additions: number; deletions: number; isBinary: boolean }
+	>();
 
 	for (const line of numstatOutput.trim().split("\n")) {
 		if (!line.trim()) continue;
@@ -132,7 +135,11 @@ export function parseDiffNumstat(
 
 		const additions = addStr === "-" ? 0 : Number.parseInt(addStr, 10) || 0;
 		const deletions = delStr === "-" ? 0 : Number.parseInt(delStr, 10) || 0;
-		const statEntry = { additions, deletions };
+		const statEntry = {
+			additions,
+			deletions,
+			isBinary: addStr === "-" && delStr === "-",
+		};
 
 		const renameMatch = rawPath.match(/^(.+) => (.+)$/);
 		if (renameMatch) {

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -1,7 +1,10 @@
-import { open, readFile, realpath, stat } from "node:fs/promises";
+import { open, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
+import {
+	BINARY_SNIFF_BYTES,
+	isBinaryMediaFile,
+} from "@superset/shared/media-files";
 import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
-import { isImageFile, isVideoFile } from "shared/file-types";
 import type { SimpleGit, StatusResult } from "simple-git";
 import { getStatusNoLock } from "../../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../../workspaces/utils/git-client";
@@ -31,7 +34,9 @@ interface TrackingStatus {
 }
 
 const MAX_LINE_COUNT_SIZE = 1 * 1024 * 1024;
-const BINARY_SNIFF_BYTES = 8192;
+// Chunk size for streaming untracked files when counting lines, so a file is
+// never fully held in memory. Comfortably covers the binary sniff window.
+const LINE_COUNT_CHUNK_SIZE = 64 * 1024;
 const WORKER_DEBUG = process.env.SUPERSET_WORKER_DEBUG === "1";
 
 function logWorkerWarning(message: string, error: unknown): void {
@@ -93,46 +98,67 @@ async function applyUntrackedLineCount(
 			const stats = await stat(fileReal);
 			if (!stats.isFile()) continue;
 
-			const sample = await readBinarySniffSample(fileReal);
-			if (
-				sample.includes(0) ||
-				isImageFile(file.path) ||
-				isVideoFile(file.path)
-			) {
+			if (isBinaryMediaFile(file.path)) {
 				file.isBinary = true;
 				file.additions = 0;
 				file.deletions = 0;
 				continue;
 			}
 
-			if (stats.size > MAX_LINE_COUNT_SIZE) continue;
+			// Stream in fixed chunks rather than slurping: readFile would pin
+			// the whole file in memory and, decoded as utf-8, would turn binary
+			// into U+FFFDs and report a bogus line count. Reuse one buffer,
+			// sniff the first 8KB for NULs (git's binary heuristic), and tally
+			// newlines as we go.
+			const handle = await open(fileReal, "r");
+			try {
+				const buf = Buffer.allocUnsafe(LINE_COUNT_CHUNK_SIZE);
+				let { bytesRead } = await handle.read(buf, 0, buf.length, 0);
 
-			const content = await readFile(fileReal, "utf-8");
-			const lineCount =
-				content === ""
-					? 0
-					: content.endsWith("\n")
-						? content.split(/\r?\n/).length - 1
-						: content.split(/\r?\n/).length;
-			file.additions = lineCount;
-			file.deletions = 0;
+				const sniffEnd = Math.min(bytesRead, BINARY_SNIFF_BYTES);
+				let isBinary = false;
+				for (let i = 0; i < sniffEnd; i++) {
+					if (buf[i] === 0) {
+						isBinary = true;
+						break;
+					}
+				}
+				if (isBinary) {
+					file.isBinary = true;
+					file.additions = 0;
+					file.deletions = 0;
+					continue;
+				}
+
+				// Over the budget: skip the LOC signal without reading the rest.
+				if (stats.size > MAX_LINE_COUNT_SIZE) continue;
+
+				let newlines = 0;
+				let lastByte = -1;
+				let offset = 0;
+				while (bytesRead > 0) {
+					for (let i = 0; i < bytesRead; i++) {
+						if (buf[i] === 0x0a) newlines++;
+					}
+					lastByte = buf[bytesRead - 1] ?? lastByte;
+					offset += bytesRead;
+					({ bytesRead } = await handle.read(buf, 0, buf.length, offset));
+				}
+				// Match `content.split(/\r?\n/)`: a trailing newline doesn't add
+				// a line, but a final non-empty line without one does. (\r\n
+				// shares the \n, so counting \n bytes is equivalent.)
+				file.additions =
+					lastByte === -1 ? 0 : lastByte === 0x0a ? newlines : newlines + 1;
+				file.deletions = 0;
+			} finally {
+				await handle.close();
+			}
 		} catch (error) {
 			logWorkerDebug(
 				`failed untracked line count for "${file.path}" in "${worktreePath}"`,
 				error,
 			);
 		}
-	}
-}
-
-async function readBinarySniffSample(filePath: string): Promise<Buffer> {
-	const fileHandle = await open(filePath, "r");
-	try {
-		const buffer = Buffer.alloc(BINARY_SNIFF_BYTES);
-		const { bytesRead } = await fileHandle.read(buffer, 0, buffer.length, 0);
-		return buffer.subarray(0, bytesRead);
-	} finally {
-		await fileHandle.close();
 	}
 }
 

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -1,7 +1,7 @@
 import { open, readFile, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
-import { isVideoFile } from "shared/file-types";
+import { isImageFile, isVideoFile } from "shared/file-types";
 import type { SimpleGit, StatusResult } from "simple-git";
 import { getStatusNoLock } from "../../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../../workspaces/utils/git-client";
@@ -94,7 +94,11 @@ async function applyUntrackedLineCount(
 			if (!stats.isFile()) continue;
 
 			const sample = await readBinarySniffSample(fileReal);
-			if (sample.includes(0) || isVideoFile(file.path)) {
+			if (
+				sample.includes(0) ||
+				isImageFile(file.path) ||
+				isVideoFile(file.path)
+			) {
 				file.isBinary = true;
 				file.additions = 0;
 				file.deletions = 0;

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -1,6 +1,7 @@
-import { readFile, realpath, stat } from "node:fs/promises";
+import { open, readFile, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
+import { isVideoFile } from "shared/file-types";
 import type { SimpleGit, StatusResult } from "simple-git";
 import { getStatusNoLock } from "../../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../../workspaces/utils/git-client";
@@ -30,6 +31,7 @@ interface TrackingStatus {
 }
 
 const MAX_LINE_COUNT_SIZE = 1 * 1024 * 1024;
+const BINARY_SNIFF_BYTES = 8192;
 const WORKER_DEBUG = process.env.SUPERSET_WORKER_DEBUG === "1";
 
 function logWorkerWarning(message: string, error: unknown): void {
@@ -89,7 +91,17 @@ async function applyUntrackedLineCount(
 			if (!isPathWithinWorktree(worktreeReal, fileReal)) continue;
 
 			const stats = await stat(fileReal);
-			if (!stats.isFile() || stats.size > MAX_LINE_COUNT_SIZE) continue;
+			if (!stats.isFile()) continue;
+
+			const sample = await readBinarySniffSample(fileReal);
+			if (sample.includes(0) || isVideoFile(file.path)) {
+				file.isBinary = true;
+				file.additions = 0;
+				file.deletions = 0;
+				continue;
+			}
+
+			if (stats.size > MAX_LINE_COUNT_SIZE) continue;
 
 			const content = await readFile(fileReal, "utf-8");
 			const lineCount =
@@ -106,6 +118,17 @@ async function applyUntrackedLineCount(
 				error,
 			);
 		}
+	}
+}
+
+async function readBinarySniffSample(filePath: string): Promise<Buffer> {
+	const fileHandle = await open(filePath, "r");
+	try {
+		const buffer = Buffer.alloc(BINARY_SNIFF_BYTES);
+		const { bytesRead } = await fileHandle.read(buffer, 0, buffer.length, 0);
+		return buffer.subarray(0, bytesRead);
+	} finally {
+		await fileHandle.close();
 	}
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/types.ts
@@ -17,5 +17,6 @@ export interface ChangesetFile {
 	status: FileStatus;
 	additions: number;
 	deletions: number;
+	isBinary?: boolean;
 	source: DiffFileSource;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
@@ -43,6 +43,7 @@ export function useChangeset({
 				status: file.status as FileStatus,
 				additions: file.additions,
 				deletions: file.deletions,
+				isBinary: file.isBinary,
 				source: {
 					kind: "commit",
 					commitHash: ref.commitHash,
@@ -62,6 +63,7 @@ export function useChangeset({
 					status: file.status as FileStatus,
 					additions: file.additions,
 					deletions: file.deletions,
+					isBinary: file.isBinary,
 					source: { kind: "unstaged" },
 				})),
 				...status.staged.map<ChangesetFile>((file) => ({
@@ -70,6 +72,7 @@ export function useChangeset({
 					status: file.status as FileStatus,
 					additions: file.additions,
 					deletions: file.deletions,
+					isBinary: file.isBinary,
 					source: { kind: "staged" },
 				})),
 			];
@@ -86,6 +89,7 @@ export function useChangeset({
 				status: file.status as FileStatus,
 				additions: file.additions,
 				deletions: file.deletions,
+				isBinary: file.isBinary,
 				source: { kind: "unstaged" },
 			});
 		}
@@ -97,6 +101,7 @@ export function useChangeset({
 				status: file.status as FileStatus,
 				additions: file.additions,
 				deletions: file.deletions,
+				isBinary: file.isBinary,
 				source: { kind: "staged" },
 			});
 		}
@@ -108,6 +113,7 @@ export function useChangeset({
 				status: file.status as FileStatus,
 				additions: file.additions,
 				deletions: file.deletions,
+				isBinary: file.isBinary,
 				source: { kind: "against-base", baseBranch: ref.baseBranch },
 			});
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -5,7 +5,9 @@ import type {
 } from "@pierre/diffs";
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import type { RendererContext } from "@superset/panes";
+import { Button } from "@superset/ui/button";
 import { useCallback, useMemo, useRef } from "react";
+import { LuFileCode } from "react-icons/lu";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import { type ChangesetFile, useChangeset } from "../../../useChangeset";
 import { useOpenInExternalEditor } from "../../../useOpenInExternalEditor";
@@ -181,8 +183,14 @@ export function DiffPane({
 				| DiffLineAnnotation<DiffAnnotationMetadata>,
 			item: CodeViewItem<DiffAnnotationMetadata>,
 		) => {
-			if (item.type !== "diff") return null;
 			const m = annotation.metadata;
+			if (item.type === "file") {
+				if (m.kind !== "binary-placeholder") return null;
+				const file = fileByItemId.get(item.id);
+				if (!file) return null;
+				return <BinaryDiffPlaceholder file={file} onOpenFile={onOpenFile} />;
+			}
+			if (item.type !== "diff") return null;
 			if (m.kind === "composer") {
 				return (
 					<AgentCommentComposer
@@ -194,6 +202,7 @@ export function DiffPane({
 					/>
 				);
 			}
+			if (m.kind !== "thread") return null;
 			const annotationSide = "side" in annotation ? annotation.side : undefined;
 			const focused =
 				item.id === targetItemId &&
@@ -221,6 +230,8 @@ export function DiffPane({
 			data.focusTick,
 			clearComposer,
 			submitComposer,
+			fileByItemId,
+			onOpenFile,
 		],
 	);
 
@@ -255,5 +266,31 @@ export function DiffPane({
 			renderHeaderMetadata={renderHeaderMetadata}
 			renderAnnotation={renderAnnotation}
 		/>
+	);
+}
+
+function BinaryDiffPlaceholder({
+	file,
+	onOpenFile,
+}: {
+	file: ChangesetFile;
+	onOpenFile: (path: string, openInNewTab?: boolean) => void;
+}) {
+	const canOpen = file.status !== "deleted";
+
+	return (
+		<div className="flex flex-col items-center justify-center gap-3 bg-muted/30 py-8 text-muted-foreground">
+			<LuFileCode className="size-8" />
+			<p className="text-sm">Binary file hidden</p>
+			{canOpen ? (
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={() => onOpenFile(file.path)}
+				>
+					Open file
+				</Button>
+			) : null}
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -184,14 +184,14 @@ export function DiffPane({
 			item: CodeViewItem<DiffAnnotationMetadata>,
 		) => {
 			const m = annotation.metadata;
-			if (item.type === "file") {
-				if (m.kind !== "binary-placeholder") return null;
+			if (m.kind === "binary-placeholder") {
+				if (item.type !== "file") return null;
 				const file = fileByItemId.get(item.id);
 				if (!file) return null;
 				return <BinaryDiffPlaceholder file={file} onOpenFile={onOpenFile} />;
 			}
-			if (item.type !== "diff") return null;
 			if (m.kind === "composer") {
+				if (item.type !== "diff") return null;
 				return (
 					<AgentCommentComposer
 						workspaceId={workspaceId}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -204,10 +204,11 @@ export function DiffPane({
 			}
 			if (m.kind !== "thread") return null;
 			const annotationSide = "side" in annotation ? annotation.side : undefined;
+			const focusLine = m.sourceLine ?? annotation.lineNumber;
 			const focused =
 				item.id === targetItemId &&
 				data.focusLine != null &&
-				annotation.lineNumber === data.focusLine &&
+				focusLine === data.focusLine &&
 				(data.focusSide == null || annotationSide === data.focusSide);
 
 			return (
@@ -281,7 +282,7 @@ function BinaryDiffPlaceholder({
 	return (
 		<div className="flex flex-col items-center justify-center gap-3 bg-muted/30 py-8 text-muted-foreground">
 			<LuFileCode className="size-8" />
-			<p className="text-sm">Binary file hidden</p>
+			<p className="cursor-text select-text text-sm">Binary file hidden</p>
 			{canOpen ? (
 				<Button
 					variant="outline"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
@@ -88,6 +88,7 @@ export function DiffHeaderMetadata({
 	}, [discardMutation, workspaceId, file.path]);
 	const isDeleteAction = file.status === "untracked" || file.status === "added";
 	const basename = file.path.split("/").pop() ?? file.path;
+	const openLabel = file.isBinary ? "Open preview" : "Open in file viewer";
 
 	return (
 		<>
@@ -97,14 +98,22 @@ export function DiffHeaderMetadata({
 						<button
 							type="button"
 							onClick={handleOpenClick}
-							aria-label="Open in file viewer"
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+							aria-label={openLabel}
+							className={
+								file.isBinary
+									? "h-6 rounded border border-border bg-background px-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+									: "rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+							}
 						>
-							<LuArrowUpRight className="size-3.5" />
+							{file.isBinary ? (
+								openLabel
+							) : (
+								<LuArrowUpRight className="size-3.5" />
+							)}
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom" showArrow={false}>
-						{policy.hint}
+						{file.isBinary ? openLabel : policy.hint}
 					</TooltipContent>
 				</Tooltip>
 				<Tooltip>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
@@ -88,7 +88,6 @@ export function DiffHeaderMetadata({
 	}, [discardMutation, workspaceId, file.path]);
 	const isDeleteAction = file.status === "untracked" || file.status === "added";
 	const basename = file.path.split("/").pop() ?? file.path;
-	const openLabel = file.isBinary ? "Open preview" : "Open in file viewer";
 
 	return (
 		<>
@@ -98,22 +97,14 @@ export function DiffHeaderMetadata({
 						<button
 							type="button"
 							onClick={handleOpenClick}
-							aria-label={openLabel}
-							className={
-								file.isBinary
-									? "h-6 rounded border border-border bg-background px-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-									: "rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
-							}
+							aria-label="Open in file viewer"
+							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
 						>
-							{file.isBinary ? (
-								openLabel
-							) : (
-								<LuArrowUpRight className="size-3.5" />
-							)}
+							<LuArrowUpRight className="size-3.5" />
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom" showArrow={false}>
-						{file.isBinary ? openLabel : policy.hint}
+						{policy.hint}
 					</TooltipContent>
 				</Tooltip>
 				<Tooltip>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffAnnotations/useDiffAnnotations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffAnnotations/useDiffAnnotations.ts
@@ -31,7 +31,8 @@ export interface DiffAgentComposer {
 
 export type DiffAnnotationMetadata =
 	| ({ kind: "thread" } & DiffCommentThread)
-	| ({ kind: "composer" } & DiffAgentComposer);
+	| ({ kind: "composer" } & DiffAgentComposer)
+	| { kind: "binary-placeholder" };
 
 interface UseDiffAnnotationsByPathOptions {
 	workspaceId: string;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffAnnotations/useDiffAnnotations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffAnnotations/useDiffAnnotations.ts
@@ -18,6 +18,7 @@ export interface DiffCommentThread {
 	isResolved: boolean;
 	isOutdated: boolean;
 	url?: string;
+	sourceLine?: number;
 }
 
 /** Local-only metadata for a draft composer pinned to the end of a selection. */

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -103,7 +103,7 @@ export function useDiffCodeViewItems({
 					type: "file",
 					file: {
 						name: file.path,
-						contents: "Binary file — cannot display diff",
+						contents: "",
 					},
 					annotations: [
 						{

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -103,7 +103,7 @@ export function useDiffCodeViewItems({
 					type: "file",
 					file: {
 						name: file.path,
-						contents: "",
+						contents: " ",
 					},
 					annotations: [
 						{

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -98,6 +98,20 @@ export function useDiffCodeViewItems({
 			const collapsed = collapsedSet.has(file.path);
 
 			if (file.isBinary) {
+				// The placeholder item only has a single line, so re-anchor any
+				// existing review threads onto line 1 — otherwise they'd point at
+				// diff lines that don't exist here and silently disappear.
+				const threadAnnotations = (
+					getAnnotationsForFile(annotationsByPath, file) ?? []
+				).map((annotation) => ({ ...annotation, lineNumber: 1 }));
+				const annotations: DiffLineAnnotation<DiffAnnotationMetadata>[] = [
+					{
+						side: "additions",
+						lineNumber: 1,
+						metadata: { kind: "binary-placeholder" },
+					},
+					...threadAnnotations,
+				];
 				nextItems.push({
 					id: itemId,
 					type: "file",
@@ -105,12 +119,7 @@ export function useDiffCodeViewItems({
 						name: file.path,
 						contents: " ",
 					},
-					annotations: [
-						{
-							lineNumber: 1,
-							metadata: { kind: "binary-placeholder" },
-						},
-					],
+					annotations,
 					collapsed,
 					version: hashString(
 						[
@@ -121,6 +130,7 @@ export function useDiffCodeViewItems({
 							file.deletions,
 							"binary",
 							collapsed ? "1" : "0",
+							getAnnotationsVersion(annotations),
 						].join("\0"),
 					),
 				});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -105,6 +105,12 @@ export function useDiffCodeViewItems({
 						name: file.path,
 						contents: "Binary file — cannot display diff",
 					},
+					annotations: [
+						{
+							lineNumber: 1,
+							metadata: { kind: "binary-placeholder" },
+						},
+					],
 					collapsed,
 					version: hashString(
 						[
@@ -256,6 +262,7 @@ function getAnnotationsVersion(
 					m.endSide,
 				].join(",");
 			}
+			if (m.kind !== "thread") return "local";
 			return [
 				"t",
 				annotation.side,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -1,6 +1,7 @@
 import {
 	type CodeViewItem,
 	type DiffLineAnnotation,
+	type LineAnnotation,
 	parseDiffFromFile,
 } from "@pierre/diffs";
 import type { AppRouter } from "@superset/host-service";
@@ -103,20 +104,24 @@ export function useDiffCodeViewItems({
 				// diff lines that don't exist here and silently disappear.
 				const threadAnnotations = (
 					getAnnotationsForFile(annotationsByPath, file) ?? []
-				).map((annotation) => ({
-					...annotation,
-					lineNumber: 1,
-					metadata:
-						annotation.metadata.kind === "thread"
-							? {
-									...annotation.metadata,
-									sourceLine: annotation.lineNumber,
-								}
-							: annotation.metadata,
-				}));
-				const annotations: DiffLineAnnotation<DiffAnnotationMetadata>[] = [
+				).map((annotation): LineAnnotation<DiffAnnotationMetadata> => {
+					const metadata = annotation.metadata;
+					if (metadata.kind === "thread") {
+						return {
+							lineNumber: 1,
+							metadata: {
+								...metadata,
+								sourceLine: annotation.lineNumber,
+							},
+						};
+					}
+					if (metadata.kind === "composer") {
+						return { lineNumber: 1, metadata };
+					}
+					return { lineNumber: 1, metadata };
+				});
+				const annotations: LineAnnotation<DiffAnnotationMetadata>[] = [
 					{
-						side: "additions",
 						lineNumber: 1,
 						metadata: { kind: "binary-placeholder" },
 					},
@@ -265,16 +270,22 @@ function getAnnotationsForFile(
 }
 
 function getAnnotationsVersion(
-	annotations: DiffLineAnnotation<DiffAnnotationMetadata>[] | undefined,
+	annotations:
+		| (
+				| DiffLineAnnotation<DiffAnnotationMetadata>
+				| LineAnnotation<DiffAnnotationMetadata>
+		  )[]
+		| undefined,
 ): string {
 	if (!annotations?.length) return "";
 	return annotations
 		.map((annotation) => {
 			const m = annotation.metadata;
+			const side = "side" in annotation ? annotation.side : "file";
 			if (m.kind === "composer") {
 				return [
 					"c",
-					annotation.side,
+					side,
 					annotation.lineNumber,
 					m.startLine,
 					m.endLine,
@@ -285,7 +296,7 @@ function getAnnotationsVersion(
 			if (m.kind !== "thread") return "local";
 			return [
 				"t",
-				annotation.side,
+				side,
 				annotation.lineNumber,
 				m.threadId,
 				m.isResolved ? "1" : "0",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -103,7 +103,17 @@ export function useDiffCodeViewItems({
 				// diff lines that don't exist here and silently disappear.
 				const threadAnnotations = (
 					getAnnotationsForFile(annotationsByPath, file) ?? []
-				).map((annotation) => ({ ...annotation, lineNumber: 1 }));
+				).map((annotation) => ({
+					...annotation,
+					lineNumber: 1,
+					metadata:
+						annotation.metadata.kind === "thread"
+							? {
+									...annotation.metadata,
+									sourceLine: annotation.lineNumber,
+								}
+							: annotation.metadata,
+				}));
 				const annotations: DiffLineAnnotation<DiffAnnotationMetadata>[] = [
 					{
 						side: "additions",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -49,10 +49,12 @@ export function useDiffCodeViewItems({
 
 	const diffRequests = useMemo(
 		() =>
-			files.map((file) => ({
-				file,
-				input: createGetDiffInput(workspaceId, file),
-			})),
+			files
+				.filter((file) => !file.isBinary)
+				.map((file) => ({
+					file,
+					input: createGetDiffInput(workspaceId, file),
+				})),
 		[files, workspaceId],
 	);
 
@@ -84,14 +86,44 @@ export function useDiffCodeViewItems({
 
 	const items = useMemo<CodeViewItem<DiffAnnotationMetadata>[]>(() => {
 		const nextItems: CodeViewItem<DiffAnnotationMetadata>[] = [];
+		const queryByItemId = new Map(
+			diffRequests.map((request, index) => [
+				getDiffItemId(request.file),
+				diffQueries[index],
+			]),
+		);
 
-		for (let index = 0; index < diffRequests.length; index++) {
-			const request = diffRequests[index];
-			const query = diffQueries[index];
-			if (!request || !query?.data) continue;
-
-			const { file } = request;
+		for (const file of files) {
 			const itemId = getDiffItemId(file);
+			const collapsed = collapsedSet.has(file.path);
+
+			if (file.isBinary) {
+				nextItems.push({
+					id: itemId,
+					type: "file",
+					file: {
+						name: file.path,
+						contents: "Binary file — cannot display diff",
+					},
+					collapsed,
+					version: hashString(
+						[
+							file.path,
+							file.oldPath ?? "",
+							file.status,
+							file.additions,
+							file.deletions,
+							"binary",
+							collapsed ? "1" : "0",
+						].join("\0"),
+					),
+				});
+				continue;
+			}
+
+			const query = queryByItemId.get(itemId);
+			if (!query?.data) continue;
+
 			const baseAnnotations = getAnnotationsForFile(annotationsByPath, file);
 			const extra = extraAnnotationsByItemId?.get(itemId);
 			const annotations =
@@ -108,7 +140,6 @@ export function useDiffCodeViewItems({
 					name: file.path,
 				},
 			);
-			const collapsed = collapsedSet.has(file.path);
 			const version = hashString(
 				[
 					query.dataUpdatedAt,
@@ -134,6 +165,7 @@ export function useDiffCodeViewItems({
 
 		return nextItems;
 	}, [
+		files,
 		diffRequests,
 		diffQueries,
 		annotationsByPath,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
@@ -56,8 +56,9 @@ export function useDiffCodeViewScroll({
 		].join(":");
 		if (lastScrollTargetRef.current === scrollKey) return;
 
+		const targetItem = itemById.get(targetItemId);
 		const target: CodeViewScrollTarget =
-			data.focusLine != null
+			data.focusLine != null && targetItem?.type === "diff"
 				? {
 						type: "line",
 						id: targetItemId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/allViews.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/allViews.ts
@@ -6,7 +6,7 @@ import { markdownPreviewView } from "./views/MarkdownPreviewView";
 import { videoView } from "./views/VideoView";
 
 // Order is preserved as a stable tiebreaker for equal-priority views.
-// Exclusives (image, binary-warning) short-circuit resolution when matched.
+// Exclusive views short-circuit resolution when matched.
 export const ALL_VIEWS: FileView[] = [
 	imageView,
 	videoView,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/allViews.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/allViews.ts
@@ -3,11 +3,13 @@ import { binaryWarningView } from "./views/BinaryWarningView";
 import { codeView } from "./views/CodeView";
 import { imageView } from "./views/ImageView";
 import { markdownPreviewView } from "./views/MarkdownPreviewView";
+import { videoView } from "./views/VideoView";
 
 // Order is preserved as a stable tiebreaker for equal-priority views.
 // Exclusives (image, binary-warning) short-circuit resolution when matched.
 export const ALL_VIEWS: FileView[] = [
 	imageView,
+	videoView,
 	binaryWarningView,
 	markdownPreviewView,
 	codeView,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/VideoView/VideoView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/VideoView/VideoView.tsx
@@ -4,29 +4,37 @@ import { getVideoMimeType } from "shared/file-types";
 import type { ViewProps } from "../../types";
 
 export function VideoView({ document, filePath }: ViewProps) {
-	const [objectUrl, setObjectUrl] = useState<string | null>(null);
+	const [source, setSource] = useState<{
+		key: string;
+		url: string;
+	} | null>(null);
+
+	const sourceKey =
+		document.content.kind === "bytes"
+			? `${filePath}\0${document.content.revision}`
+			: null;
 
 	useEffect(() => {
 		if (document.content.kind !== "bytes") {
-			setObjectUrl(null);
+			setSource(null);
 			return;
 		}
 		const mimeType = getVideoMimeType(filePath) ?? "video/mp4";
 		const url = URL.createObjectURL(
 			new Blob([document.content.value as BlobPart], { type: mimeType }),
 		);
-		setObjectUrl(url);
+		setSource({ key: `${filePath}\0${document.content.revision}`, url });
 		return () => URL.revokeObjectURL(url);
 	}, [document.content, filePath]);
 
-	if (!objectUrl) {
+	if (!source || source.key !== sourceKey) {
 		return null;
 	}
 
 	return (
 		<div className="flex h-full items-center justify-center overflow-auto bg-background p-4">
 			<video
-				src={objectUrl}
+				src={source.url}
 				controls
 				preload="metadata"
 				className="max-h-full max-w-full rounded-md bg-black"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/VideoView/VideoView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/VideoView/VideoView.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { getBaseName } from "renderer/lib/pathBasename";
+import { getVideoMimeType } from "shared/file-types";
+import type { ViewProps } from "../../types";
+
+export function VideoView({ document, filePath }: ViewProps) {
+	const [objectUrl, setObjectUrl] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (document.content.kind !== "bytes") {
+			setObjectUrl(null);
+			return;
+		}
+		const mimeType = getVideoMimeType(filePath) ?? "video/mp4";
+		const url = URL.createObjectURL(
+			new Blob([document.content.value as BlobPart], { type: mimeType }),
+		);
+		setObjectUrl(url);
+		return () => URL.revokeObjectURL(url);
+	}, [document.content, filePath]);
+
+	if (!objectUrl) {
+		return null;
+	}
+
+	return (
+		<div className="flex h-full items-center justify-center overflow-auto bg-background p-4">
+			<video
+				src={objectUrl}
+				controls
+				preload="metadata"
+				className="max-h-full max-w-full rounded-md bg-black"
+				aria-label={getBaseName(filePath)}
+			>
+				<track kind="captions" />
+			</video>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/VideoView/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/VideoView/index.ts
@@ -1,11 +1,11 @@
-import { isVideoFile } from "shared/file-types";
+import { isPreviewableVideoFile } from "shared/file-types";
 import type { FileView } from "../../types";
 import { VideoView } from "./VideoView";
 
 export const videoView: FileView = {
 	id: "video",
 	label: "Video",
-	match: (filePath) => isVideoFile(filePath),
+	match: (filePath) => isPreviewableVideoFile(filePath),
 	priority: "exclusive",
 	documentKind: "bytes",
 	Renderer: VideoView,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/VideoView/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/VideoView/index.ts
@@ -1,0 +1,12 @@
+import { isVideoFile } from "shared/file-types";
+import type { FileView } from "../../types";
+import { VideoView } from "./VideoView";
+
+export const videoView: FileView = {
+	id: "video",
+	label: "Video",
+	match: (filePath) => isVideoFile(filePath),
+	priority: "exclusive",
+	documentKind: "bytes",
+	Renderer: VideoView,
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceFileNavigation/useWorkspaceFileNavigation.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceFileNavigation/useWorkspaceFileNavigation.ts
@@ -151,9 +151,8 @@ export function useWorkspaceFileNavigation({
 		[store, worktreePath, recordView],
 	);
 
-	// Sidebar tree clicks layer the VS-Code-style "click an already-active row
-	// to pin it" pattern on top of openFilePane. The picker and other callers
-	// stay on plain openFilePane so re-picks just refocus without pinning.
+	// User-facing file opens from the workspace sidebar layer the VS-Code-style
+	// "click an already-active row to pin it" pattern on top of openFilePane.
 	const openFilePaneFromTreeClick = useCallback(
 		(filePath: string, openInNewTab?: boolean) => {
 			if (openInNewTab) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -155,7 +155,6 @@ function V2WorkspaceContent() {
 	});
 
 	const {
-		openFilePane,
 		openFilePaneFromTreeClick,
 		revealPath,
 		selectedFilePath,
@@ -169,7 +168,7 @@ function V2WorkspaceContent() {
 	});
 
 	const paneRegistry = usePaneRegistry({
-		onOpenFile: openFilePane,
+		onOpenFile: openFilePaneFromTreeClick,
 		onRevealPath: revealPath,
 		launcher,
 		store,
@@ -207,15 +206,14 @@ function V2WorkspaceContent() {
 		[closeQuickOpen],
 	);
 	// Picking a file from Quick Open should surface the sidebar/Files tab so
-	// the reveal (expand + highlight + scroll) is actually visible. Tree
-	// clicks and other openFilePane callers already have the sidebar open.
+	// the reveal (expand + highlight + scroll) is actually visible.
 	const handleQuickOpenSelectFile = useCallback(
 		(filePath: string, openInNewTab?: boolean) => {
 			setRightSidebarOpen(true);
 			setRightSidebarTab("files");
-			openFilePane(filePath, openInNewTab);
+			openFilePaneFromTreeClick(filePath, openInNewTab);
 		},
-		[openFilePane, setRightSidebarOpen, setRightSidebarTab],
+		[openFilePaneFromTreeClick, setRightSidebarOpen, setRightSidebarTab],
 	);
 	const defaultPaneActions = useDefaultPaneActions({ launcher });
 	const onBeforeCloseTab = useDirtyTabCloseGuard();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/fileDocumentStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/fileDocumentStore.ts
@@ -103,6 +103,7 @@ async function loadEntry(
 		});
 
 		entry.byteSize = result.byteLength;
+		entry.isBinary = readAsBinary ? true : entry.isBinary;
 		entry.orphaned = false;
 		entry.hasExternalChange = false;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/fileDocumentStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/fileDocumentStore.ts
@@ -1,6 +1,6 @@
 import type { workspaceTrpc } from "@superset/workspace-client";
 import type { FsWatchEvent } from "@superset/workspace-fs/client";
-import { isImageFile } from "shared/file-types";
+import { isImageFile, isVideoFile } from "shared/file-types";
 import type {
 	ConflictResolution,
 	ConflictState,
@@ -91,7 +91,8 @@ async function loadEntry(
 	options: { unlimited?: boolean } = {},
 ): Promise<void> {
 	const client = entry.trpcClient;
-	const readAsBinary = isImageFile(entry.absolutePath);
+	const readAsBinary =
+		isImageFile(entry.absolutePath) || isVideoFile(entry.absolutePath);
 	const maxBytes = options.unlimited ? undefined : DEFAULT_MAX_BYTES;
 	try {
 		const result = await client.filesystem.readFile.query({

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/FileDiffSection/FileDiffSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/FileDiffSection/FileDiffSection.tsx
@@ -11,6 +11,7 @@ import { useChangesStore } from "renderer/stores/changes";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import type { ChangeCategory, ChangedFile } from "shared/changes-types";
 import { detectLanguage } from "shared/detect-language";
+import { isVideoFile } from "shared/file-types";
 import {
 	getStatusColor,
 	getStatusIndicator,
@@ -123,9 +124,11 @@ export function FileDiffSection({
 		});
 
 	const totalChanges = file.additions + file.deletions;
+	const isVideo = isVideoFile(file.path);
+	const isBinaryFile = file.isBinary === true || isVideo;
 	const isLargeDiff = totalChanges > LARGE_DIFF_THRESHOLD;
 	const isGenerated = isGeneratedFile(file.path);
-	const isHiddenByDefault = isLargeDiff || isGenerated;
+	const isHiddenByDefault = !isBinaryFile && (isLargeDiff || isGenerated);
 
 	const fileKey = createFileKey(file, category, commitHash, worktreePath);
 	const isViewed = viewedFiles.has(fileKey);
@@ -241,9 +244,12 @@ export function FileDiffSection({
 
 	const statusBadgeColor = getStatusColor(file.status);
 	const statusIndicator = getStatusIndicator(file.status);
-	const showStats = file.additions > 0 || file.deletions > 0;
+	const showStats = !isBinaryFile && (file.additions > 0 || file.deletions > 0);
 	const canShowDiffBody =
-		isExpanded && (!isHiddenByDefault || loadHiddenDiff) && !!worktreePath;
+		isExpanded &&
+		!isBinaryFile &&
+		(!isHiddenByDefault || loadHiddenDiff) &&
+		!!worktreePath;
 	const shouldLoadDiff =
 		canShowDiffBody && hasBeenVisible && (isInLoadRange || isEditing);
 
@@ -406,6 +412,22 @@ export function FileDiffSection({
 		</div>
 	);
 
+	const binaryFilePreview = (
+		<div
+			className="flex flex-col items-center justify-center gap-1 bg-background px-4 text-center text-sm text-muted-foreground"
+			style={{ minHeight: FILE_DIFF_SECTION_PLACEHOLDER_HEIGHT }}
+		>
+			<span className="select-text cursor-text">
+				{isVideo
+					? "Video file — cannot display diff"
+					: "Binary file — cannot display diff"}
+			</span>
+			<span className="max-w-md text-xs">
+				Use the file header to open this file outside the diff viewer.
+			</span>
+		</div>
+	);
+
 	return (
 		<div
 			ref={sectionRef}
@@ -426,7 +448,7 @@ export function FileDiffSection({
 					onCopyPath={handleCopyPath}
 					isCopied={isCopied}
 					isEditing={isEditing}
-					onToggleEdit={handleToggleEdit}
+					onToggleEdit={isBinaryFile ? undefined : handleToggleEdit}
 					onStage={onStage}
 					onUnstage={onUnstage}
 					onDiscard={onDiscard}
@@ -434,7 +456,9 @@ export function FileDiffSection({
 				/>
 
 				<CollapsibleContent>
-					{isHiddenByDefault && !loadHiddenDiff ? (
+					{isBinaryFile ? (
+						binaryFilePreview
+					) : isHiddenByDefault && !loadHiddenDiff ? (
 						<div className="flex flex-col items-center justify-center gap-3 py-8 text-muted-foreground bg-muted/30">
 							<LuFileCode className="w-8 h-8" />
 							<p className="text-sm">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/FileDiffSection/FileDiffSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/FileDiffSection/FileDiffSection.tsx
@@ -418,9 +418,7 @@ export function FileDiffSection({
 			style={{ minHeight: FILE_DIFF_SECTION_PLACEHOLDER_HEIGHT }}
 		>
 			<span className="select-text cursor-text">
-				{isVideo
-					? "Video file — cannot display diff"
-					: "Binary file — cannot display diff"}
+				Binary file — cannot display diff
 			</span>
 			<span className="max-w-md text-xs">
 				Use the file header to open this file outside the diff viewer.

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/utils/getEstimatedFileDiffSectionHeight.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/utils/getEstimatedFileDiffSectionHeight.test.ts
@@ -61,4 +61,22 @@ describe("getEstimatedFileDiffSectionHeight", () => {
 			}),
 		).toBe(420);
 	});
+
+	it("uses the unsupported diff placeholder for binary files", () => {
+		expect(
+			getEstimatedFileDiffSectionHeight({
+				file: createFile("assets/logo.png", { isBinary: true }),
+				isCollapsed: false,
+			}),
+		).toBe(340);
+	});
+
+	it("uses the unsupported diff placeholder for videos", () => {
+		expect(
+			getEstimatedFileDiffSectionHeight({
+				file: createFile("assets/demo.mp4", { isBinary: true }),
+				isCollapsed: false,
+			}),
+		).toBe(340);
+	});
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/utils/getEstimatedFileDiffSectionHeight.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/utils/getEstimatedFileDiffSectionHeight.test.ts
@@ -74,7 +74,7 @@ describe("getEstimatedFileDiffSectionHeight", () => {
 	it("uses the unsupported diff placeholder for videos", () => {
 		expect(
 			getEstimatedFileDiffSectionHeight({
-				file: createFile("assets/demo.mp4", { isBinary: true }),
+				file: createFile("assets/demo.mp4"),
 				isCollapsed: false,
 			}),
 		).toBe(340);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/utils/getEstimatedFileDiffSectionHeight.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/utils/getEstimatedFileDiffSectionHeight.ts
@@ -1,4 +1,5 @@
 import type { ChangedFile } from "shared/changes-types";
+import { isVideoFile } from "shared/file-types";
 import {
 	FILE_DIFF_SECTION_COLLAPSED_HEIGHT,
 	FILE_DIFF_SECTION_PLACEHOLDER_HEIGHT,
@@ -41,6 +42,14 @@ function isGeneratedFile(filePath: string): boolean {
 
 function getPlaceholderHeight(file: ChangedFile): number {
 	const changedLineCount = file.additions + file.deletions;
+
+	if (isVideoFile(file.path)) {
+		return LARGE_PLACEHOLDER_HEIGHT;
+	}
+
+	if (file.isBinary) {
+		return LARGE_PLACEHOLDER_HEIGHT;
+	}
 
 	if (isGeneratedFile(file.path)) {
 		return XL_PLACEHOLDER_HEIGHT;

--- a/apps/desktop/src/shared/changes-types.ts
+++ b/apps/desktop/src/shared/changes-types.ts
@@ -25,6 +25,7 @@ export interface ChangedFile {
 	status: FileStatus;
 	additions: number;
 	deletions: number;
+	isBinary?: boolean;
 }
 
 /** A commit summary for the committed changes section */

--- a/apps/desktop/src/shared/file-types.test.ts
+++ b/apps/desktop/src/shared/file-types.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
 	getImageExtensionFromMimeType,
 	getImageMimeType,
+	getVideoMimeType,
+	isVideoFile,
 	parseBase64DataUrl,
 } from "./file-types";
 
@@ -21,6 +23,20 @@ describe("file-types", () => {
 		);
 		expect(getImageExtensionFromMimeType("image/webp")).toBe("webp");
 		expect(getImageExtensionFromMimeType("image/avif")).toBeNull();
+	});
+
+	test("detects supported video file paths", () => {
+		expect(isVideoFile("demo.mp4")).toBe(true);
+		expect(isVideoFile("clips/intro.webm")).toBe(true);
+		expect(isVideoFile("clips/INTRO.MOV")).toBe(true);
+		expect(isVideoFile("archive.zip")).toBe(false);
+	});
+
+	test("maps video file paths to MIME types", () => {
+		expect(getVideoMimeType("demo.mp4")).toBe("video/mp4");
+		expect(getVideoMimeType("demo.webm")).toBe("video/webm");
+		expect(getVideoMimeType("demo.mov")).toBe("video/quicktime");
+		expect(getVideoMimeType("demo.avi")).toBeNull();
 	});
 
 	test("parses base64 data URLs with extra MIME parameters", () => {

--- a/apps/desktop/src/shared/file-types.test.ts
+++ b/apps/desktop/src/shared/file-types.test.ts
@@ -3,6 +3,8 @@ import {
 	getImageExtensionFromMimeType,
 	getImageMimeType,
 	getVideoMimeType,
+	isImageFile,
+	isPreviewableVideoFile,
 	isVideoFile,
 	parseBase64DataUrl,
 } from "./file-types";
@@ -13,7 +15,14 @@ describe("file-types", () => {
 	test("maps image file paths to MIME types", () => {
 		expect(getImageMimeType("logo.svg")).toBe("image/svg+xml");
 		expect(getImageMimeType("logo.ico")).toBe("image/x-icon");
+		expect(getImageMimeType("logo.tiff")).toBe("image/tiff");
 		expect(getImageMimeType("logo.unknown")).toBeNull();
+	});
+
+	test("detects supported image file paths", () => {
+		expect(isImageFile("sample.bmp")).toBe(true);
+		expect(isImageFile("sample.tiff")).toBe(true);
+		expect(isImageFile("sample.txt")).toBe(false);
 	});
 
 	test("maps image MIME types to preferred extensions", () => {
@@ -29,7 +38,16 @@ describe("file-types", () => {
 		expect(isVideoFile("demo.mp4")).toBe(true);
 		expect(isVideoFile("clips/intro.webm")).toBe(true);
 		expect(isVideoFile("clips/INTRO.MOV")).toBe(true);
+		expect(isVideoFile("clips/intro.avi")).toBe(true);
+		expect(isVideoFile("clips/intro.mkv")).toBe(true);
 		expect(isVideoFile("archive.zip")).toBe(false);
+	});
+
+	test("detects browser-previewable video file paths", () => {
+		expect(isPreviewableVideoFile("demo.mp4")).toBe(true);
+		expect(isPreviewableVideoFile("demo.webm")).toBe(true);
+		expect(isPreviewableVideoFile("demo.avi")).toBe(false);
+		expect(isPreviewableVideoFile("demo.mkv")).toBe(false);
 	});
 
 	test("maps video file paths to MIME types", () => {

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -111,7 +111,9 @@ export function getImageMimeType(filePath: string): string | null {
 }
 
 /**
- * Checks if a file is a browser-previewable video based on extension
+ * Checks if a file is a video based on extension. Covers all known video
+ * extensions, not just browser-playable ones — use isPreviewableVideoFile
+ * to gate the inline <video> preview.
  */
 export function isVideoFile(filePath: string): boolean {
 	return VIDEO_EXTENSIONS.has(getFileExtension(filePath));

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -27,6 +27,18 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 	ico: "image/x-icon",
 };
 
+/** Supported browser-playable video extensions */
+const VIDEO_EXTENSIONS = new Set(["mp4", "m4v", "mov", "ogv", "webm"]);
+
+/** MIME types for supported video extensions */
+const VIDEO_MIME_TYPES: Record<string, string> = {
+	mp4: "video/mp4",
+	m4v: "video/mp4",
+	mov: "video/quicktime",
+	ogv: "video/ogg",
+	webm: "video/webm",
+};
+
 /** Extensions for supported image MIME types */
 const IMAGE_MIME_TYPE_EXTENSIONS: Record<string, string> = {
 	"image/png": "png",
@@ -46,15 +58,20 @@ const MARKDOWN_EXTENSIONS = new Set(["md", "markdown", "mdx"]);
 /**
  * Gets the file extension from a path (lowercase, without dot)
  */
-function getExtension(filePath: string): string {
-	return filePath.split(".").pop()?.toLowerCase() ?? "";
+export function getFileExtension(filePath: string): string {
+	const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+	const dotIndex = fileName.lastIndexOf(".");
+	if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
+		return "";
+	}
+	return fileName.slice(dotIndex + 1).toLowerCase();
 }
 
 /**
  * Checks if a file is an image based on extension
  */
 export function isImageFile(filePath: string): boolean {
-	return IMAGE_EXTENSIONS.has(getExtension(filePath));
+	return IMAGE_EXTENSIONS.has(getFileExtension(filePath));
 }
 
 /**
@@ -62,8 +79,24 @@ export function isImageFile(filePath: string): boolean {
  * Returns null if not a supported image type
  */
 export function getImageMimeType(filePath: string): string | null {
-	const ext = getExtension(filePath);
+	const ext = getFileExtension(filePath);
 	return IMAGE_MIME_TYPES[ext] ?? null;
+}
+
+/**
+ * Checks if a file is a browser-previewable video based on extension
+ */
+export function isVideoFile(filePath: string): boolean {
+	return VIDEO_EXTENSIONS.has(getFileExtension(filePath));
+}
+
+/**
+ * Gets the MIME type for a video file
+ * Returns null if not a supported video type
+ */
+export function getVideoMimeType(filePath: string): string | null {
+	const ext = getFileExtension(filePath);
+	return VIDEO_MIME_TYPES[ext] ?? null;
 }
 
 /**
@@ -102,7 +135,7 @@ export function parseBase64DataUrl(dataUrl: string): {
  * Checks if a file is markdown based on extension
  */
 export function isMarkdownFile(filePath: string): boolean {
-	return MARKDOWN_EXTENSIONS.has(getExtension(filePath));
+	return MARKDOWN_EXTENSIONS.has(getFileExtension(filePath));
 }
 
 /**

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -3,6 +3,12 @@
  * Used by both main and renderer processes.
  */
 
+import { getFileExtension, isVideoFile } from "@superset/shared/media-files";
+
+// Re-exported so renderer/main code can keep importing extension helpers from
+// `shared/file-types`; the canonical definitions live in `@superset/shared`.
+export { getFileExtension, isVideoFile };
+
 /** Supported image extensions */
 const IMAGE_EXTENSIONS = new Set([
 	"png",
@@ -30,22 +36,6 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 	tif: "image/tiff",
 	tiff: "image/tiff",
 };
-
-/** Common video extensions */
-const VIDEO_EXTENSIONS = new Set([
-	"3g2",
-	"3gp",
-	"avi",
-	"m4v",
-	"mkv",
-	"mov",
-	"mp4",
-	"mpeg",
-	"mpg",
-	"ogv",
-	"webm",
-	"wmv",
-]);
 
 /** Browser-playable video extensions */
 const PREVIEWABLE_VIDEO_EXTENSIONS = new Set([
@@ -83,18 +73,6 @@ const IMAGE_MIME_TYPE_EXTENSIONS: Record<string, string> = {
 const MARKDOWN_EXTENSIONS = new Set(["md", "markdown", "mdx"]);
 
 /**
- * Gets the file extension from a path (lowercase, without dot)
- */
-export function getFileExtension(filePath: string): string {
-	const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
-	const dotIndex = fileName.lastIndexOf(".");
-	if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
-		return "";
-	}
-	return fileName.slice(dotIndex + 1).toLowerCase();
-}
-
-/**
  * Checks if a file is an image based on extension
  */
 export function isImageFile(filePath: string): boolean {
@@ -108,15 +86,6 @@ export function isImageFile(filePath: string): boolean {
 export function getImageMimeType(filePath: string): string | null {
 	const ext = getFileExtension(filePath);
 	return IMAGE_MIME_TYPES[ext] ?? null;
-}
-
-/**
- * Checks if a file is a video based on extension. Covers all known video
- * extensions, not just browser-playable ones — use isPreviewableVideoFile
- * to gate the inline <video> preview.
- */
-export function isVideoFile(filePath: string): boolean {
-	return VIDEO_EXTENSIONS.has(getFileExtension(filePath));
 }
 
 /**

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -13,6 +13,8 @@ const IMAGE_EXTENSIONS = new Set([
 	"svg",
 	"bmp",
 	"ico",
+	"tif",
+	"tiff",
 ]);
 
 /** MIME types for supported image extensions */
@@ -25,10 +27,34 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 	svg: "image/svg+xml",
 	bmp: "image/bmp",
 	ico: "image/x-icon",
+	tif: "image/tiff",
+	tiff: "image/tiff",
 };
 
-/** Supported browser-playable video extensions */
-const VIDEO_EXTENSIONS = new Set(["mp4", "m4v", "mov", "ogv", "webm"]);
+/** Common video extensions */
+const VIDEO_EXTENSIONS = new Set([
+	"3g2",
+	"3gp",
+	"avi",
+	"m4v",
+	"mkv",
+	"mov",
+	"mp4",
+	"mpeg",
+	"mpg",
+	"ogv",
+	"webm",
+	"wmv",
+]);
+
+/** Browser-playable video extensions */
+const PREVIEWABLE_VIDEO_EXTENSIONS = new Set([
+	"m4v",
+	"mov",
+	"mp4",
+	"ogv",
+	"webm",
+]);
 
 /** MIME types for supported video extensions */
 const VIDEO_MIME_TYPES: Record<string, string> = {
@@ -48,6 +74,7 @@ const IMAGE_MIME_TYPE_EXTENSIONS: Record<string, string> = {
 	"image/webp": "webp",
 	"image/svg+xml": "svg",
 	"image/bmp": "bmp",
+	"image/tiff": "tiff",
 	"image/x-icon": "ico",
 	"image/vnd.microsoft.icon": "ico",
 };
@@ -88,6 +115,13 @@ export function getImageMimeType(filePath: string): string | null {
  */
 export function isVideoFile(filePath: string): boolean {
 	return VIDEO_EXTENSIONS.has(getFileExtension(filePath));
+}
+
+/**
+ * Checks if a video file can be previewed by the browser video element.
+ */
+export function isPreviewableVideoFile(filePath: string): boolean {
+	return PREVIEWABLE_VIDEO_EXTENSIONS.has(getFileExtension(filePath));
 }
 
 /**

--- a/packages/host-service/src/trpc/router/git/types.ts
+++ b/packages/host-service/src/trpc/router/git/types.ts
@@ -122,6 +122,7 @@ export interface ChangedFile {
 	status: FileStatus;
 	additions: number;
 	deletions: number;
+	isBinary?: boolean;
 }
 
 export interface Commit {

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, test } from "bun:test";
-import { parseNameStatus, parseNumstat } from "./git-helpers";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChangedFile } from "../types";
+import {
+	countUntrackedFileLines,
+	parseNameStatus,
+	parseNumstat,
+} from "./git-helpers";
 
 describe("parseNumstat", () => {
 	test("regular file entry", () => {
@@ -190,5 +198,75 @@ describe("parseNameStatus", () => {
 
 	test("empty input returns empty array", () => {
 		expect(parseNameStatus("")).toEqual([]);
+	});
+});
+
+describe("countUntrackedFileLines", () => {
+	let dir: string;
+
+	beforeAll(async () => {
+		dir = await mkdtemp(join(tmpdir(), "untracked-lines-"));
+	});
+
+	afterAll(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	const SENTINEL = -999;
+	function makeFile(path: string): ChangedFile {
+		return { path, status: "untracked", additions: SENTINEL, deletions: 0 };
+	}
+
+	async function count(name: string, contents: Buffer | string) {
+		await writeFile(join(dir, name), contents);
+		const file = makeFile(name);
+		await countUntrackedFileLines(dir, [file]);
+		return file;
+	}
+
+	test("counts lines with a trailing newline", async () => {
+		const file = await count("trailing.txt", "a\nb\nc\n");
+		expect(file.additions).toBe(3);
+		expect(file.isBinary).toBeUndefined();
+	});
+
+	test("counts a final line with no trailing newline", async () => {
+		const file = await count("no-trailing.txt", "a\nb\nc");
+		expect(file.additions).toBe(3);
+	});
+
+	test("empty file is zero lines", async () => {
+		const file = await count("empty.txt", "");
+		expect(file.additions).toBe(0);
+	});
+
+	test("CRLF counts the same as LF", async () => {
+		const file = await count("crlf.txt", "a\r\nb\r\nc\r\n");
+		expect(file.additions).toBe(3);
+	});
+
+	test("counts correctly across read-chunk boundaries", async () => {
+		// 64KB chunk size; 20000 short lines spans several chunks.
+		const lineCount = 20000;
+		const file = await count("big.txt", `${"x".repeat(8)}\n`.repeat(lineCount));
+		expect(file.additions).toBe(lineCount);
+	});
+
+	test("flags a NUL byte in the first 8KB as binary", async () => {
+		const file = await count("nul.bin", Buffer.from([0x61, 0x00, 0x62, 0x0a]));
+		expect(file.isBinary).toBe(true);
+		expect(file.additions).toBe(0);
+	});
+
+	test("flags by media extension without reading content", async () => {
+		const file = await count("clip.mp4", "not really a video\n");
+		expect(file.isBinary).toBe(true);
+		expect(file.additions).toBe(0);
+	});
+
+	test("skips the LOC signal for files over the size budget", async () => {
+		const file = await count("huge.txt", "a\n".repeat(600_000)); // ~1.2MB
+		expect(file.additions).toBe(SENTINEL);
+		expect(file.isBinary).toBeUndefined();
 	});
 });

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.test.ts
@@ -5,28 +5,56 @@ describe("parseNumstat", () => {
 	test("regular file entry", () => {
 		const raw = "5\t2\tsrc/foo.ts\0";
 		const result = parseNumstat(raw);
-		expect(result.get("src/foo.ts")).toEqual({ additions: 5, deletions: 2 });
+		expect(result.get("src/foo.ts")).toEqual({
+			additions: 5,
+			deletions: 2,
+			isBinary: false,
+		});
 	});
 
 	test("multiple regular entries", () => {
 		const raw = "5\t2\tsrc/foo.ts\x003\t0\tsrc/bar.ts\x00";
 		const result = parseNumstat(raw);
-		expect(result.get("src/foo.ts")).toEqual({ additions: 5, deletions: 2 });
-		expect(result.get("src/bar.ts")).toEqual({ additions: 3, deletions: 0 });
+		expect(result.get("src/foo.ts")).toEqual({
+			additions: 5,
+			deletions: 2,
+			isBinary: false,
+		});
+		expect(result.get("src/bar.ts")).toEqual({
+			additions: 3,
+			deletions: 0,
+			isBinary: false,
+		});
 	});
 
 	test("exact rename with edits indexes both paths", () => {
 		const raw = "4\t3\t\x00src/old.ts\x00src/new.ts\x00";
 		const result = parseNumstat(raw);
-		expect(result.get("src/new.ts")).toEqual({ additions: 4, deletions: 3 });
-		expect(result.get("src/old.ts")).toEqual({ additions: 4, deletions: 3 });
+		expect(result.get("src/new.ts")).toEqual({
+			additions: 4,
+			deletions: 3,
+			isBinary: false,
+		});
+		expect(result.get("src/old.ts")).toEqual({
+			additions: 4,
+			deletions: 3,
+			isBinary: false,
+		});
 	});
 
 	test("pure rename with zero line changes", () => {
 		const raw = "0\t0\t\x00src/old.ts\x00src/new.ts\x00";
 		const result = parseNumstat(raw);
-		expect(result.get("src/new.ts")).toEqual({ additions: 0, deletions: 0 });
-		expect(result.get("src/old.ts")).toEqual({ additions: 0, deletions: 0 });
+		expect(result.get("src/new.ts")).toEqual({
+			additions: 0,
+			deletions: 0,
+			isBinary: false,
+		});
+		expect(result.get("src/old.ts")).toEqual({
+			additions: 0,
+			deletions: 0,
+			isBinary: false,
+		});
 	});
 
 	test("binary file with dash markers", () => {
@@ -35,6 +63,7 @@ describe("parseNumstat", () => {
 		expect(result.get("assets/image.png")).toEqual({
 			additions: 0,
 			deletions: 0,
+			isBinary: true,
 		});
 	});
 
@@ -44,12 +73,25 @@ describe("parseNumstat", () => {
 			"4\t3\t\x00src/old.ts\x00src/new.ts\x00" +
 			"-\t-\tassets/image.png\x00";
 		const result = parseNumstat(raw);
-		expect(result.get("src/foo.ts")).toEqual({ additions: 5, deletions: 2 });
-		expect(result.get("src/new.ts")).toEqual({ additions: 4, deletions: 3 });
-		expect(result.get("src/old.ts")).toEqual({ additions: 4, deletions: 3 });
+		expect(result.get("src/foo.ts")).toEqual({
+			additions: 5,
+			deletions: 2,
+			isBinary: false,
+		});
+		expect(result.get("src/new.ts")).toEqual({
+			additions: 4,
+			deletions: 3,
+			isBinary: false,
+		});
+		expect(result.get("src/old.ts")).toEqual({
+			additions: 4,
+			deletions: 3,
+			isBinary: false,
+		});
 		expect(result.get("assets/image.png")).toEqual({
 			additions: 0,
 			deletions: 0,
+			isBinary: true,
 		});
 	});
 
@@ -63,20 +105,33 @@ describe("parseNumstat", () => {
 		expect(result.get("weird\tpath.ts")).toEqual({
 			additions: 1,
 			deletions: 1,
+			isBinary: false,
 		});
 	});
 
 	test("rename where both paths contain tabs", () => {
 		const raw = "2\t1\t\x00weird\told.ts\x00weird\tnew.ts\x00";
 		const result = parseNumstat(raw);
-		expect(result.get("weird\told.ts")).toEqual({ additions: 2, deletions: 1 });
-		expect(result.get("weird\tnew.ts")).toEqual({ additions: 2, deletions: 1 });
+		expect(result.get("weird\told.ts")).toEqual({
+			additions: 2,
+			deletions: 1,
+			isBinary: false,
+		});
+		expect(result.get("weird\tnew.ts")).toEqual({
+			additions: 2,
+			deletions: 1,
+			isBinary: false,
+		});
 	});
 
 	test("non-ASCII path (raw UTF-8)", () => {
 		const raw = "3\t1\tsrc/日本語.ts\0";
 		const result = parseNumstat(raw);
-		expect(result.get("src/日本語.ts")).toEqual({ additions: 3, deletions: 1 });
+		expect(result.get("src/日本語.ts")).toEqual({
+			additions: 3,
+			deletions: 1,
+			isBinary: false,
+		});
 	});
 });
 

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -337,6 +337,7 @@ export interface DetectedRename {
 	status: "renamed";
 	additions: number;
 	deletions: number;
+	isBinary: boolean;
 }
 
 /**
@@ -406,6 +407,7 @@ export async function detectUnstagedRenames(
 				status: "renamed",
 				additions: stats.additions,
 				deletions: stats.deletions,
+				isBinary: stats.isBinary,
 			});
 		}
 		return result;

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -23,6 +23,30 @@ const MAX_UNTRACKED_LINE_COUNT_SIZE = 1 * 1024 * 1024;
 // doesn't exhaust the process file-descriptor limit.
 const UNTRACKED_IO_CONCURRENCY = 64;
 
+const BINARY_MEDIA_EXTENSIONS = new Set([
+	"3g2",
+	"3gp",
+	"avi",
+	"bmp",
+	"gif",
+	"ico",
+	"jpeg",
+	"jpg",
+	"m4v",
+	"mkv",
+	"mov",
+	"mp4",
+	"mpeg",
+	"mpg",
+	"ogv",
+	"png",
+	"tif",
+	"tiff",
+	"webm",
+	"webp",
+	"wmv",
+]);
+
 async function mapWithConcurrency<T>(
 	items: T[],
 	limit: number,
@@ -72,8 +96,11 @@ export function mapGitStatus(code: string): FileStatus {
  */
 export function parseNumstat(
 	raw: string,
-): Map<string, { additions: number; deletions: number }> {
-	const result = new Map<string, { additions: number; deletions: number }>();
+): Map<string, { additions: number; deletions: number; isBinary: boolean }> {
+	const result = new Map<
+		string,
+		{ additions: number; deletions: number; isBinary: boolean }
+	>();
 	const entries = raw.split("\0");
 	for (let i = 0; i < entries.length; i++) {
 		const entry = entries[i];
@@ -87,6 +114,7 @@ export function parseNumstat(
 		const stats = {
 			additions: add === "-" ? 0 : Number.parseInt(add || "0", 10),
 			deletions: del === "-" ? 0 : Number.parseInt(del || "0", 10),
+			isBinary: add === "-" && del === "-",
 		};
 		if (pathMaybe === "") {
 			const oldPath = entries[++i] ?? "";
@@ -98,6 +126,19 @@ export function parseNumstat(
 		}
 	}
 	return result;
+}
+
+function getFileExtension(filePath: string): string {
+	const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+	const dotIndex = fileName.lastIndexOf(".");
+	if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
+		return "";
+	}
+	return fileName.slice(dotIndex + 1).toLowerCase();
+}
+
+function isBinaryMediaFile(filePath: string): boolean {
+	return BINARY_MEDIA_EXTENSIONS.has(getFileExtension(filePath));
 }
 
 /**
@@ -266,7 +307,14 @@ export async function countUntrackedFileLines(
 			if (!isPathWithinWorktree(worktreeReal, fileReal)) return;
 
 			const stats = await stat(fileReal);
-			if (!stats.isFile() || stats.size > MAX_UNTRACKED_LINE_COUNT_SIZE) {
+			if (!stats.isFile()) {
+				return;
+			}
+
+			if (isBinaryMediaFile(file.path)) {
+				file.isBinary = true;
+				file.additions = 0;
+				file.deletions = 0;
 				return;
 			}
 
@@ -276,7 +324,16 @@ export async function countUntrackedFileLines(
 			const buf = await readFile(fileReal);
 			const sniffEnd = Math.min(buf.length, 8192);
 			for (let i = 0; i < sniffEnd; i++) {
-				if (buf[i] === 0) return;
+				if (buf[i] === 0) {
+					file.isBinary = true;
+					file.additions = 0;
+					file.deletions = 0;
+					return;
+				}
+			}
+
+			if (stats.size > MAX_UNTRACKED_LINE_COUNT_SIZE) {
+				return;
 			}
 
 			const content = buf.toString("utf-8");
@@ -354,7 +411,11 @@ export async function detectUnstagedRenames(
 			if (!entry.oldPath) continue;
 			const code = entry.status[0];
 			if (code !== "R") continue;
-			const stats = numstat.get(entry.path) ?? { additions: 0, deletions: 0 };
+			const stats = numstat.get(entry.path) ?? {
+				additions: 0,
+				deletions: 0,
+				isBinary: false,
+			};
 			result.push({
 				oldPath: entry.oldPath,
 				newPath: entry.path,
@@ -395,6 +456,7 @@ export async function getChangedFilesForDiff(
 				status: mapGitStatus(f.status),
 				additions: (numstat.get(f.path) ?? { additions: 0 }).additions,
 				deletions: (numstat.get(f.path) ?? { deletions: 0 }).deletions,
+				isBinary: (numstat.get(f.path) ?? { isBinary: false }).isBinary,
 			}));
 	} catch {
 		return [];

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -1,6 +1,7 @@
 import {
 	copyFile,
 	mkdtemp,
+	open,
 	readFile,
 	realpath,
 	rm,
@@ -319,12 +320,20 @@ export async function countUntrackedFileLines(
 			}
 
 			// `readFile(file, "utf-8")` happily turns binary into U+FFFDs
-			// and returns a non-zero line count, so sniff first 8KB for
-			// NULs the way git's own binary heuristic does.
-			const buf = await readFile(fileReal);
-			const sniffEnd = Math.min(buf.length, 8192);
-			for (let i = 0; i < sniffEnd; i++) {
-				if (buf[i] === 0) {
+			// and returns a non-zero line count, so sniff the first 8KB for
+			// NULs the way git's own binary heuristic does. Read only that
+			// prefix so a large file is never fully loaded just to skip it.
+			const sniffEnd = Math.min(stats.size, 8192);
+			const sniffBuf = Buffer.allocUnsafe(sniffEnd);
+			const handle = await open(fileReal, "r");
+			let bytesRead: number;
+			try {
+				({ bytesRead } = await handle.read(sniffBuf, 0, sniffEnd, 0));
+			} finally {
+				await handle.close();
+			}
+			for (let i = 0; i < bytesRead; i++) {
+				if (sniffBuf[i] === 0) {
 					file.isBinary = true;
 					file.additions = 0;
 					file.deletions = 0;
@@ -336,7 +345,7 @@ export async function countUntrackedFileLines(
 				return;
 			}
 
-			const content = buf.toString("utf-8");
+			const content = await readFile(fileReal, "utf-8");
 			file.additions =
 				content === ""
 					? 0

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -1,14 +1,10 @@
-import {
-	copyFile,
-	mkdtemp,
-	open,
-	readFile,
-	realpath,
-	rm,
-	stat,
-} from "node:fs/promises";
+import { copyFile, mkdtemp, open, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+	BINARY_SNIFF_BYTES,
+	isBinaryMediaFile,
+} from "@superset/shared/media-files";
 import type { SimpleGit } from "simple-git";
 import { resolveUpstream } from "../../../../runtime/git/refs";
 import { createUserSimpleGit } from "../../../../runtime/git/simple-git";
@@ -24,29 +20,10 @@ const MAX_UNTRACKED_LINE_COUNT_SIZE = 1 * 1024 * 1024;
 // doesn't exhaust the process file-descriptor limit.
 const UNTRACKED_IO_CONCURRENCY = 64;
 
-const BINARY_MEDIA_EXTENSIONS = new Set([
-	"3g2",
-	"3gp",
-	"avi",
-	"bmp",
-	"gif",
-	"ico",
-	"jpeg",
-	"jpg",
-	"m4v",
-	"mkv",
-	"mov",
-	"mp4",
-	"mpeg",
-	"mpg",
-	"ogv",
-	"png",
-	"tif",
-	"tiff",
-	"webm",
-	"webp",
-	"wmv",
-]);
+// Chunk size for streaming untracked files when counting lines. Bounds
+// per-file memory to this × UNTRACKED_IO_CONCURRENCY instead of the full
+// file size, and comfortably covers the 8KB binary sniff window.
+const UNTRACKED_READ_CHUNK_SIZE = 64 * 1024;
 
 async function mapWithConcurrency<T>(
 	items: T[],
@@ -127,19 +104,6 @@ export function parseNumstat(
 		}
 	}
 	return result;
-}
-
-function getFileExtension(filePath: string): string {
-	const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
-	const dotIndex = fileName.lastIndexOf(".");
-	if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
-		return "";
-	}
-	return fileName.slice(dotIndex + 1).toLowerCase();
-}
-
-function isBinaryMediaFile(filePath: string): boolean {
-	return BINARY_MEDIA_EXTENSIONS.has(getFileExtension(filePath));
 }
 
 /**
@@ -319,39 +283,50 @@ export async function countUntrackedFileLines(
 				return;
 			}
 
-			// `readFile(file, "utf-8")` happily turns binary into U+FFFDs
-			// and returns a non-zero line count, so sniff the first 8KB for
-			// NULs the way git's own binary heuristic does. Read only that
-			// prefix so a large file is never fully loaded just to skip it.
-			const sniffEnd = Math.min(stats.size, 8192);
-			const sniffBuf = Buffer.allocUnsafe(sniffEnd);
+			// Stream the file in fixed-size chunks rather than slurping it:
+			// readFile would pin the whole file in memory (×UNTRACKED_IO_CONCURRENCY)
+			// and, read as utf-8, would turn binary into U+FFFDs and report a
+			// bogus line count. We reuse one buffer, sniff the first 8KB for NULs
+			// (git's binary heuristic), and tally newlines as we go.
 			const handle = await open(fileReal, "r");
-			let bytesRead: number;
 			try {
-				({ bytesRead } = await handle.read(sniffBuf, 0, sniffEnd, 0));
+				const buf = Buffer.allocUnsafe(UNTRACKED_READ_CHUNK_SIZE);
+				let { bytesRead } = await handle.read(buf, 0, buf.length, 0);
+
+				const sniffEnd = Math.min(bytesRead, BINARY_SNIFF_BYTES);
+				for (let i = 0; i < sniffEnd; i++) {
+					if (buf[i] === 0) {
+						file.isBinary = true;
+						file.additions = 0;
+						file.deletions = 0;
+						return;
+					}
+				}
+
+				// Over the budget: skip the LOC signal without reading the rest.
+				if (stats.size > MAX_UNTRACKED_LINE_COUNT_SIZE) {
+					return;
+				}
+
+				let newlines = 0;
+				let lastByte = -1;
+				let offset = 0;
+				while (bytesRead > 0) {
+					for (let i = 0; i < bytesRead; i++) {
+						if (buf[i] === 0x0a) newlines++;
+					}
+					lastByte = buf[bytesRead - 1] ?? lastByte;
+					offset += bytesRead;
+					({ bytesRead } = await handle.read(buf, 0, buf.length, offset));
+				}
+				// Match `content.split(/\r?\n/)`: a trailing newline doesn't add a
+				// line, but a final non-empty line without one does. (\r\n shares
+				// the \n, so counting \n bytes is equivalent.)
+				file.additions =
+					lastByte === -1 ? 0 : lastByte === 0x0a ? newlines : newlines + 1;
 			} finally {
 				await handle.close();
 			}
-			for (let i = 0; i < bytesRead; i++) {
-				if (sniffBuf[i] === 0) {
-					file.isBinary = true;
-					file.additions = 0;
-					file.deletions = 0;
-					return;
-				}
-			}
-
-			if (stats.size > MAX_UNTRACKED_LINE_COUNT_SIZE) {
-				return;
-			}
-
-			const content = await readFile(fileReal, "utf-8");
-			file.additions =
-				content === ""
-					? 0
-					: content.endsWith("\n")
-						? content.split(/\r?\n/).length - 1
-						: content.split(/\r?\n/).length;
 		} catch {}
 	});
 }

--- a/packages/host-service/src/trpc/router/git/utils/git-status.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-status.ts
@@ -153,6 +153,7 @@ export async function getGitStatusSnapshot({
 				status: rename.status,
 				additions: rename.additions,
 				deletions: rename.deletions,
+				isBinary: rename.isBinary,
 			});
 		}
 	}

--- a/packages/host-service/src/trpc/router/git/utils/git-status.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-status.ts
@@ -77,6 +77,7 @@ export async function getGitStatusSnapshot({
 			const stats = stagedNumstat.get(file.path) ?? {
 				additions: 0,
 				deletions: 0,
+				isBinary: false,
 			};
 			staged.push({
 				path: file.path,
@@ -84,6 +85,7 @@ export async function getGitStatusSnapshot({
 				status: mapGitStatus(idx),
 				additions: stats.additions,
 				deletions: stats.deletions,
+				isBinary: stats.isBinary,
 			});
 		}
 	}
@@ -108,12 +110,14 @@ export async function getGitStatusSnapshot({
 			const stats = unstagedNumstat.get(file.path) ?? {
 				additions: 0,
 				deletions: 0,
+				isBinary: false,
 			};
 			unstaged.push({
 				path: file.path,
 				status: mapGitStatus(wd),
 				additions: stats.additions,
 				deletions: stats.deletions,
+				isBinary: stats.isBinary,
 			});
 		}
 	}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,10 @@
 			"types": "./src/dev-credentials.ts",
 			"default": "./src/dev-credentials.ts"
 		},
+		"./media-files": {
+			"types": "./src/media-files.ts",
+			"default": "./src/media-files.ts"
+		},
 		"./v2-only-user": {
 			"types": "./src/v2-only-user.ts",
 			"default": "./src/v2-only-user.ts"

--- a/packages/shared/src/media-files.test.ts
+++ b/packages/shared/src/media-files.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getFileExtension,
+	isBinaryMediaFile,
+	isVideoFile,
+} from "./media-files";
+
+describe("media-files", () => {
+	test("extracts lowercase extensions and ignores directory dots", () => {
+		expect(getFileExtension("clips/INTRO.MOV")).toBe("mov");
+		expect(getFileExtension("a.b.c/file.TS")).toBe("ts");
+		expect(getFileExtension("noext")).toBe("");
+		expect(getFileExtension(".gitignore")).toBe("");
+		expect(getFileExtension("trailing.")).toBe("");
+	});
+
+	test("detects video files across container formats", () => {
+		expect(isVideoFile("demo.mp4")).toBe(true);
+		expect(isVideoFile("clips/intro.mkv")).toBe(true);
+		expect(isVideoFile("archive.zip")).toBe(false);
+	});
+
+	test("flags raster images and videos as binary media", () => {
+		expect(isBinaryMediaFile("logo.png")).toBe(true);
+		expect(isBinaryMediaFile("photo.JPG")).toBe(true);
+		expect(isBinaryMediaFile("demo.webm")).toBe(true);
+		expect(isBinaryMediaFile("notes.txt")).toBe(false);
+	});
+
+	test("treats svg as text so its diff stays visible", () => {
+		expect(isBinaryMediaFile("icon.svg")).toBe(false);
+	});
+});

--- a/packages/shared/src/media-files.ts
+++ b/packages/shared/src/media-files.ts
@@ -1,0 +1,80 @@
+/**
+ * Single source of truth for extension-based file classification shared by the
+ * host-service git path and the desktop main/renderer code. Keeping these here
+ * stops the two sides from drifting on questions like whether `.svg` counts as
+ * binary (it does not — it is text and should stay diffable).
+ */
+
+/** Gets the file extension from a path (lowercase, without dot). */
+export function getFileExtension(filePath: string): string {
+	const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+	const dotIndex = fileName.lastIndexOf(".");
+	if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
+		return "";
+	}
+	return fileName.slice(dotIndex + 1).toLowerCase();
+}
+
+/**
+ * Raster image extensions. Excludes `svg`, which is text: it renders as an
+ * image but is better shown as a diff than hidden behind a binary placeholder.
+ */
+export const RASTER_IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
+	"bmp",
+	"gif",
+	"ico",
+	"jpeg",
+	"jpg",
+	"png",
+	"tif",
+	"tiff",
+	"webp",
+]);
+
+/** Video container extensions. */
+export const VIDEO_EXTENSIONS: ReadonlySet<string> = new Set([
+	"3g2",
+	"3gp",
+	"avi",
+	"m4v",
+	"mkv",
+	"mov",
+	"mp4",
+	"mpeg",
+	"mpg",
+	"ogv",
+	"webm",
+	"wmv",
+]);
+
+/**
+ * Extensions that are always binary media (raster images + videos). These are
+ * never diffable as text, so the changes pane shows a placeholder/preview
+ * instead of attempting a line diff.
+ */
+export const BINARY_MEDIA_EXTENSIONS: ReadonlySet<string> = new Set([
+	...RASTER_IMAGE_EXTENSIONS,
+	...VIDEO_EXTENSIONS,
+]);
+
+/**
+ * Number of leading bytes to sniff for NUL when deciding whether an untracked
+ * file is binary, mirroring git's own heuristic.
+ */
+export const BINARY_SNIFF_BYTES = 8192;
+
+/**
+ * Checks if a file is a video based on extension. Covers all known video
+ * extensions, not just browser-playable ones.
+ */
+export function isVideoFile(filePath: string): boolean {
+	return VIDEO_EXTENSIONS.has(getFileExtension(filePath));
+}
+
+/**
+ * Checks if a file is binary media (raster image or video) purely from its
+ * extension, so a line diff is never attempted for it.
+ */
+export function isBinaryMediaFile(filePath: string): boolean {
+	return BINARY_MEDIA_EXTENSIONS.has(getFileExtension(filePath));
+}


### PR DESCRIPTION
## Summary

Adds explicit binary-file handling for the desktop Changes view so binary blobs are not loaded into the text diff renderer. Videos are treated as non-diffable in Changes and can now be previewed in the v2 FilePane using the same registry pattern as images.

## Details

- Propagates git `--numstat` binary markers through `ChangedFile.isBinary`.
- Adds binary sniffing for untracked files before UTF-8 line counting.
- Adds shared video file detection and MIME helpers.
- Adds a v2 FilePane `VideoView` registered alongside `ImageView`.
- Updates Changes diff rows to show a simple unsupported-diff state for binary/video files.
- Updates virtualized row height estimates and focused tests.

## Validation

- `bun test apps/desktop/src/shared/file-types.test.ts apps/desktop/src/lib/trpc/routers/changes/utils/parse-status.test.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/utils/getEstimatedFileDiffSectionHeight.test.ts`
- `bun run typecheck --filter=@superset/desktop`
- `bun run lint`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5385">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds binary handling to Changes and the v2 DiffPane with a single placeholder that preserves review threads, and adds video previews to the v2 FilePane. Media detection is unified in `@superset/shared/media-files`, and untracked files are streamed to detect binaries and count lines with constant memory.

- **New Features**
  - Propagates git `--numstat` binary markers into `ChangedFile.isBinary` (including renames); shares extension-based media detection via `@superset/shared/media-files` (raster images incl. TIFF, all video containers; SVG remains text).
  - Skips diff requests for binaries and shows a unified “Binary file hidden” placeholder with an “Open file” button; keeps review threads visible by re-anchoring to line 1; focuses/scrolls only for real diff items; disables editing and hides stats for binaries.
  - Adds video preview in the v2 FilePane (`VideoView`); includes helpers (`isVideoFile`, `isPreviewableVideoFile`, `getVideoMimeType`, `getFileExtension`) and reads videos as bytes.

- **Bug Fixes**
  - Streams untracked files in 64KB chunks, sniffs the first 8KB for NULs, flags media by extension before reading, skips LOC for files >1MB, and counts lines correctly across chunk boundaries and CRLF.
  - Ensures `isBinary` propagates through host-service `numstat`, status snapshots, rename detection, desktop change lists, and parse-status; removes duplicate binary placeholder text; aligns Quick Open with the tree-click open flow for consistent reveal/pinning.
  - Updates virtualized heights and placeholders for binary/video files.

<sup>Written for commit 4f4ffbb92f70b3d100a5ee2fd5609dd5df5e9e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Binary diffs now show a dedicated “Binary file hidden” placeholder, with an optional “Open file” action.
  * Video files are now supported with a preview player and appropriate diff/placeholder behavior.
* **Bug Fixes**
  * Binary/video status is propagated consistently across change lists, diff stats, and untracked file line counting (including safer binary detection and correct zeroed line counts).
  * Focus-line scrolling now targets only valid diff items; placeholder anchoring is more accurate.
  * Quick Open file selection now uses the tree-click open flow for consistent navigation.
* **Tests**
  * Updated and expanded coverage for binary/video classification, numstat parsing, and untracked file line counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->