### PR TITLE
fix(desktop): Cmd+Backspace sends bare Ctrl-U in terminal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/line-edit-translations.ts
+++ b/apps/desktop/src/renderer/lib/terminal/line-edit-translations.ts
@@ -32,7 +32,7 @@ export function translateLineEditChord(
 	const { key } = event;
 
 	if (isMac && onlyMod(event, "meta")) {
-		if (key === "Backspace") return "\x15\x1b[D";
+		if (key === "Backspace") return "\x15";
 		if (key === "ArrowLeft") return "\x01";
 		if (key === "ArrowRight") return "\x05";
 		// Chat TUIs parse ESC+CR as Shift+Enter/newline in kitty mode.


### PR DESCRIPTION
## Problem

`Cmd+Backspace` in the v2 terminal has a stray Left arrow appended, which breaks line deletion (intermittently leaves the newline/last character behind).

## Cause

The chord translated to `"\x15\x1b[D"` (Ctrl-U + Left arrow). The trailing `"\x1b[D"` is not intentional. Ghostty's default macOS keybind sends a bare Ctrl-U (`super+backspace = text:\x15`), with no Left arrow.

## Fix

```diff
-		if (key === "Backspace") return "\x15\x1b[D";
+		if (key === "Backspace") return "\x15";
```

Confirmed fixed on a local build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how a macOS Backspace shortcut is translated in the terminal, so it now sends the expected input and behaves more consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->