### PR TITLE
fix(desktop): keep traffic-light chrome constant under page zoom

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/window.ts
+++ b/apps/desktop/src/lib/trpc/routers/window.ts
@@ -43,6 +43,15 @@ export const createWindowRouter = (getWindow: () => BrowserWindow | null) => {
 			return process.platform;
 		}),
 
+		// Authoritative page-zoom factor (1 = 100%). Top chrome that must stay
+		// aligned with macOS native traffic lights reads this to counter-scale,
+		// since native traffic lights don't move under Electron page zoom.
+		getZoomFactor: publicProcedure.query(() => {
+			const window = getWindow();
+			if (!window) return 1;
+			return window.webContents.getZoomFactor();
+		}),
+
 		getHomeDir: publicProcedure.query(() => {
 			return homedir();
 		}),

--- a/apps/desktop/src/lib/trpc/routers/window.ts
+++ b/apps/desktop/src/lib/trpc/routers/window.ts
@@ -43,9 +43,7 @@ export const createWindowRouter = (getWindow: () => BrowserWindow | null) => {
 			return process.platform;
 		}),
 
-		// Authoritative page-zoom factor (1 = 100%). Top chrome that must stay
-		// aligned with macOS native traffic lights reads this to counter-scale,
-		// since native traffic lights don't move under Electron page zoom.
+		// Authoritative page-zoom factor (1 = 100%); see useZoomFactor.
 		getZoomFactor: publicProcedure.query(() => {
 			const window = getWindow();
 			if (!window) return 1;

--- a/apps/desktop/src/renderer/hooks/useZoomFactor.ts
+++ b/apps/desktop/src/renderer/hooks/useZoomFactor.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+/**
+ * Tracks the current Electron page-zoom factor (1 = 100%).
+ *
+ * Electron page zoom scales renderer CSS pixels, but macOS native traffic
+ * lights stay fixed in native window coordinates. Chrome that reserves space
+ * for the traffic lights counter-scales that reserved inset by `1 / zoomFactor`
+ * so it keeps a constant physical width across zoom levels.
+ *
+ * Page zoom always changes `window.devicePixelRatio`, so every zoom change
+ * (menu, keyboard, or wheel) is detected with a `matchMedia` resolution
+ * listener; on each change we re-read the authoritative factor from the main
+ * process. Reading from main on change also means the renderer can't miss the
+ * persisted zoom that main applies on `did-finish-load`.
+ */
+export function useZoomFactor(): number {
+	const utils = electronTrpc.useUtils();
+	const [zoomFactor, setZoomFactor] = useState(1);
+
+	useEffect(() => {
+		let cancelled = false;
+		let media: MediaQueryList | null = null;
+
+		const refresh = async () => {
+			const factor = await utils.window.getZoomFactor.fetch();
+			if (!cancelled && factor > 0) setZoomFactor(factor);
+		};
+
+		const handleChange = () => {
+			void refresh();
+			arm();
+		};
+
+		// Re-arm a media query keyed to the current devicePixelRatio; it fires
+		// as soon as the resolution (i.e. the zoom factor) moves away from it.
+		const arm = () => {
+			media?.removeEventListener("change", handleChange);
+			media = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+			media.addEventListener("change", handleChange);
+		};
+
+		void refresh();
+		arm();
+
+		return () => {
+			cancelled = true;
+			media?.removeEventListener("change", handleChange);
+		};
+	}, [utils]);
+
+	return zoomFactor;
+}

--- a/apps/desktop/src/renderer/hooks/useZoomFactor.ts
+++ b/apps/desktop/src/renderer/hooks/useZoomFactor.ts
@@ -2,18 +2,9 @@ import { useEffect, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
 /**
- * Tracks the current Electron page-zoom factor (1 = 100%).
- *
- * Electron page zoom scales renderer CSS pixels, but macOS native traffic
- * lights stay fixed in native window coordinates. Chrome that reserves space
- * for the traffic lights counter-scales that reserved inset by `1 / zoomFactor`
- * so it keeps a constant physical width across zoom levels.
- *
- * Page zoom always changes `window.devicePixelRatio`, so every zoom change
- * (menu, keyboard, or wheel) is detected with a `matchMedia` resolution
- * listener; on each change we re-read the authoritative factor from the main
- * process. Reading from main on change also means the renderer can't miss the
- * persisted zoom that main applies on `did-finish-load`.
+ * Tracks the Electron page-zoom factor (1 = 100%), re-read from main on every
+ * zoom change. Lets chrome counter-scale by `1 / zoomFactor` to stay aligned
+ * with the macOS traffic lights, which don't move under page zoom.
  */
 export function useZoomFactor(): number {
 	const utils = electronTrpc.useUtils();
@@ -33,8 +24,8 @@ export function useZoomFactor(): number {
 			arm();
 		};
 
-		// Re-arm a media query keyed to the current devicePixelRatio; it fires
-		// as soon as the resolution (i.e. the zoom factor) moves away from it.
+		// Re-arm a media query at the current resolution; it fires as soon as
+		// the zoom factor moves away from it.
 		const arm = () => {
 			media?.removeEventListener("change", handleChange);
 			media = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -18,6 +18,7 @@ import {
 	LuPlus,
 } from "react-icons/lu";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
+import { useZoomFactor } from "renderer/hooks/useZoomFactor";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
@@ -73,6 +74,7 @@ export function DashboardSidebarHeader({
 	const { data: platform } = electronTrpc.window.getPlatform.useQuery();
 	// Default to Mac while loading so we don't briefly cover the traffic lights.
 	const isMac = platform === undefined || platform === "darwin";
+	const zoomFactor = useZoomFactor();
 	const matchRoute = useMatchRoute();
 	const { gateFeature } = usePaywall();
 	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
@@ -223,12 +225,13 @@ export function DashboardSidebarHeader({
 
 	return (
 		<div className="flex flex-col gap-1 border-b border-border px-2 pt-2 pb-2">
-			{/* -mx-2 cancels the parent's px-2 so this row owns its own
-			    horizontal inset — keeps traffic-light alignment matching the
-			    TopBar's 80px pad regardless of parent padding changes. */}
+			{/* -mx-2 cancels the parent's px-2 so this row owns its own horizontal
+			    inset, matching the TopBar's 80px traffic-light pad. The inset is
+			    counter-scaled to stay a constant physical 80px under page zoom
+			    (macOS traffic lights don't move with zoom). See useZoomFactor. */}
 			<div
 				className="drag -mx-2 flex h-8 items-center gap-1.5 pr-2"
-				style={{ paddingLeft: isMac ? "80px" : "8px" }}
+				style={{ paddingLeft: isMac ? `${80 / zoomFactor}px` : "8px" }}
 			>
 				<SidebarToggle />
 				<NavigationControls />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -225,10 +225,8 @@ export function DashboardSidebarHeader({
 
 	return (
 		<div className="flex flex-col gap-1 border-b border-border px-2 pt-2 pb-2">
-			{/* -mx-2 cancels the parent's px-2 so this row owns its own horizontal
-			    inset, matching the TopBar's 80px traffic-light pad. The inset is
-			    counter-scaled to stay a constant physical 80px under page zoom
-			    (macOS traffic lights don't move with zoom). See useZoomFactor. */}
+			{/* -mx-2 cancels the parent's px-2 so this row owns the 80px traffic-light
+			    inset; counter-scaled to stay a constant physical 80px under page zoom. */}
 			<div
 				className="drag -mx-2 flex h-8 items-center gap-1.5 pr-2"
 				style={{ paddingLeft: isMac ? `${80 / zoomFactor}px` : "8px" }}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -224,12 +224,25 @@ export function DashboardSidebarHeader({
 	}
 
 	return (
-		<div className="flex flex-col gap-1 border-b border-border px-2 pt-2 pb-2">
+		<div
+			className="flex flex-col gap-1 border-b border-border px-2 pt-2 pb-2"
+			// Pin the top inset so the traffic-light row stays a constant physical
+			// distance from the window top under page zoom (see the row below).
+			style={isMac ? { paddingTop: `${8 / zoomFactor}px` } : undefined}
+		>
 			{/* -mx-2 cancels the parent's px-2 so this row owns the 80px traffic-light
-			    inset; counter-scaled to stay a constant physical 80px under page zoom. */}
+			    inset; inset and height are counter-scaled to a constant physical size
+			    so the fixed macOS traffic lights stay aligned under page zoom. */}
 			<div
 				className="drag -mx-2 flex h-8 items-center gap-1.5 pr-2"
-				style={{ paddingLeft: isMac ? `${80 / zoomFactor}px` : "8px" }}
+				style={
+					isMac
+						? {
+								paddingLeft: `${80 / zoomFactor}px`,
+								height: `${32 / zoomFactor}px`,
+							}
+						: { paddingLeft: "8px" }
+				}
 			>
 				<SidebarToggle />
 				<NavigationControls />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -43,12 +43,17 @@ export function TopBar() {
 	const sidebarHostsChrome =
 		isV2CloudEnabled && isSidebarOpen && !isSidebarCollapsed;
 
-	// Counter-scale so the inset stays a constant physical 80px under page zoom.
+	// Counter-scale the inset and bar height so both stay a constant physical
+	// size under page zoom, keeping the fixed macOS traffic lights aligned.
 	const trafficLightInset =
 		isMac && !sidebarHostsChrome ? `${80 / zoomFactor}px` : "16px";
+	const barStyle = isMac ? { height: `${48 / zoomFactor}px` } : undefined;
 
 	return (
-		<div className="drag gap-2 h-12 w-full flex items-center justify-between bg-muted/45 border-b border-border relative dark:bg-muted/35">
+		<div
+			className="drag gap-2 h-12 w-full flex items-center justify-between bg-muted/45 border-b border-border relative dark:bg-muted/35"
+			style={barStyle}
+		>
 			<div
 				className="flex items-center gap-1.5 h-full"
 				style={{ paddingLeft: trafficLightInset }}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -2,6 +2,7 @@ import { useMatchRoute, useParams } from "@tanstack/react-router";
 import { HiOutlineWifi } from "react-icons/hi2";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
+import { useZoomFactor } from "renderer/hooks/useZoomFactor";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceSidebarStore } from "renderer/stores/workspace-sidebar-state";
 import { NavigationControls } from "../NavigationControls";
@@ -29,6 +30,7 @@ export function TopBar() {
 		{ enabled: !!workspaceId && !isV2WorkspaceRoute },
 	);
 	const isOnline = useOnlineStatus();
+	const zoomFactor = useZoomFactor();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const isSidebarOpen = useWorkspaceSidebarStore((s) => s.isOpen);
 	const isSidebarCollapsed = useWorkspaceSidebarStore((s) => s.isCollapsed());
@@ -41,13 +43,16 @@ export function TopBar() {
 	const sidebarHostsChrome =
 		isV2CloudEnabled && isSidebarOpen && !isSidebarCollapsed;
 
+	// Counter-scale the traffic-light inset so it stays a constant physical 80px
+	// under page zoom (macOS traffic lights don't move with zoom). See useZoomFactor.
+	const trafficLightInset =
+		isMac && !sidebarHostsChrome ? `${80 / zoomFactor}px` : "16px";
+
 	return (
 		<div className="drag gap-2 h-12 w-full flex items-center justify-between bg-muted/45 border-b border-border relative dark:bg-muted/35">
 			<div
 				className="flex items-center gap-1.5 h-full"
-				style={{
-					paddingLeft: isMac && !sidebarHostsChrome ? "80px" : "16px",
-				}}
+				style={{ paddingLeft: trafficLightInset }}
 			>
 				{!sidebarHostsChrome && (
 					<>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -43,8 +43,7 @@ export function TopBar() {
 	const sidebarHostsChrome =
 		isV2CloudEnabled && isSidebarOpen && !isSidebarCollapsed;
 
-	// Counter-scale the traffic-light inset so it stays a constant physical 80px
-	// under page zoom (macOS traffic lights don't move with zoom). See useZoomFactor.
+	// Counter-scale so the inset stays a constant physical 80px under page zoom.
 	const trafficLightInset =
 		isMac && !sidebarHostsChrome ? `${80 / zoomFactor}px` : "16px";
 


### PR DESCRIPTION
## What

macOS draws the window traffic lights at a fixed native offset (`{ x: 16, y: 16 }`) that does **not** move or scale under Electron page zoom. The TopBar and v2 sidebar header reserve space for them with an 80px CSS inset and a fixed bar height — but those scaled with page zoom, so when zoomed out the reserved space shrank below the lights and content slid under (or beside) them; when zoomed in they drifted out of alignment.

## Change

- Add a `getZoomFactor` window tRPC query returning the authoritative page-zoom factor from the main process.
- Add a `useZoomFactor` hook that reads it and re-reads on every zoom change (detected via a `matchMedia` resolution listener).
- Counter-scale **only the reserved traffic-light chrome** by `1 / zoomFactor` so it stays a constant *physical* size:
  - `TopBar` — left inset (80px) and bar height (48px).
  - `DashboardSidebarHeader` — left inset (80px), row height (32px), and top padding (8px) so the row stays centered on the lights.

The text and buttons inside still scale with zoom as normal content; only the chrome reserving the traffic-light footprint is pinned. macOS-only (no native traffic lights elsewhere).

## Test

- `bun run typecheck` and `bun run lint` pass.
- Manually: zoom the desktop app in/out (⌘+ / ⌘-); traffic lights stay clear of and aligned with TopBar and sidebar-header content at every zoom level.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5390">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS traffic-light overlap under page zoom by keeping the TopBar and sidebar header chrome a constant physical size. Prevents content from sliding under the lights and keeps alignment at any zoom.

- **Bug Fixes**
  - Added `window.getZoomFactor` tRPC query and a `useZoomFactor` hook that refreshes on zoom changes.
  - Counter-scaled traffic-light reserved space by `1/zoomFactor` in `TopBar` and `DashboardSidebarHeader` (macOS only), while normal content continues to scale.

<sup>Written for commit b777ae75317df633e4d60088a246414b1ad064cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and reading the app’s current page zoom level.
  * Updated key desktop UI areas to scale spacing and height correctly when zoom changes, especially on macOS.

* **Bug Fixes**
  * Improved layout consistency so the sidebar header and top bar stay aligned and sized properly at different zoom levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->