### PR TITLE
feat(desktop): default dev builds to v2

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -1,4 +1,5 @@
 import { isV2OnlyUser } from "@superset/shared/v2-only-user";
+import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
@@ -15,5 +16,6 @@ export function useIsV2OnlyUser(): boolean {
 export function useIsV2CloudEnabled(): boolean {
 	const v2Only = useIsV2OnlyUser();
 	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
-	return optInV2 ?? v2Only;
+	// Dev builds default to v2; an explicit opt-out (optInV2 === false) still wins.
+	return optInV2 ?? (v2Only || env.NODE_ENV === "development");
 }


### PR DESCRIPTION
## What

`useIsV2CloudEnabled()` now falls back to v2 when `env.NODE_ENV === "development"`, so dev builds land in the v2 experience without manually flipping the **Settings → Experimental → Try Superset v2** toggle.

## Why

Previously the default was `optInV2 ?? v2Only`. In a dev build `optInV2` starts `null` (localStorage is per-origin, so a packaged-build opt-in never carries to the Vite `localhost` origin) and a typical dev account falls outside the `v2Only` cutoff window — so dev always defaulted to v1.

## Behavior

```ts
return optInV2 ?? (v2Only || env.NODE_ENV === "development");
```

- Dev builds default to v2.
- An explicit opt-out (`optInV2 === false`) still wins.
- Production / packaged builds are unchanged (still `optInV2 ?? v2Only`).

The account-age `v2Only` logic is left untouched for now.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5391">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dev desktop builds now default to v2. `useIsV2CloudEnabled()` falls back to v2 when `env.NODE_ENV === "development"`, while explicit opt-out still wins and production builds are unchanged.

<sup>Written for commit 657ba182789222801836d0c7f213ebf88da911b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development builds now default to the updated cloud experience unless it has been explicitly turned off.
* **Bug Fixes**
  * Existing opt-out settings continue to be respected, so manual preferences still take priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->