### PR TITLE
fix(automations): keep device and workspace host in sync

### DIFF
--- a/apps/desktop/src/renderer/components/PickerTrigger/PickerTrigger.tsx
+++ b/apps/desktop/src/renderer/components/PickerTrigger/PickerTrigger.tsx
@@ -25,7 +25,10 @@ export function PickerTrigger({
 		<Button
 			variant={variant}
 			{...props}
-			className={cn("justify-between gap-1 px-2 text-xs", className)}
+			className={cn(
+				"min-w-0 max-w-full justify-between gap-1 px-2 text-xs",
+				className,
+			)}
 		>
 			<span className="flex min-w-0 flex-1 items-center gap-1.5">
 				{icon}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailSidebar/AutomationDetailSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailSidebar/AutomationDetailSidebar.tsx
@@ -123,7 +123,7 @@ export function AutomationDetailSidebar({
 						value={
 							<WorkspacePicker
 								className="-mr-4"
-								hostId={automation.targetHostId ?? null}
+								hostId={hostId}
 								projectId={automation.v2ProjectId}
 								value={automation.v2WorkspaceId}
 								onChange={(v2WorkspaceId) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailSidebar/components/Row/Row.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailSidebar/components/Row/Row.tsx
@@ -2,9 +2,9 @@ import type { ReactNode } from "react";
 
 export function Row({ label, value }: { label: string; value: ReactNode }) {
 	return (
-		<div className="flex min-h-8 items-center justify-between gap-4 text-sm">
-			<span className="text-muted-foreground">{label}</span>
-			<div className="flex min-w-0 justify-end">{value}</div>
+		<div className="flex min-h-8 items-center gap-4 text-sm">
+			<span className="shrink-0 text-muted-foreground">{label}</span>
+			<div className="flex min-w-0 flex-1 justify-end">{value}</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/WorkspacePicker/WorkspacePicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/WorkspacePicker/WorkspacePicker.tsx
@@ -1,4 +1,4 @@
-import type { SelectV2Workspace } from "@superset/db/schema";
+import type { SelectV2Host, SelectV2Workspace } from "@superset/db/schema";
 import {
 	Command,
 	CommandGroup,
@@ -7,10 +7,11 @@ import {
 	CommandList,
 } from "@superset/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { cn } from "@superset/ui/utils";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo, useState } from "react";
 import { HiCheck } from "react-icons/hi2";
-import { LuGitBranch, LuSparkles } from "react-icons/lu";
+import { LuGitBranch, LuSparkles, LuTriangleAlert } from "react-icons/lu";
 import { PickerTrigger } from "renderer/components/PickerTrigger";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
@@ -41,22 +42,43 @@ export function WorkspacePicker({
 		[collections.v2Workspaces],
 	);
 
+	const { data: allHosts = [] } = useLiveQuery(
+		(q) => q.from({ h: collections.v2Hosts }).select(({ h }) => ({ ...h })),
+		[collections.v2Hosts],
+	);
+
 	const workspaces = useMemo(() => {
 		const rows = allWorkspaces as SelectV2Workspace[];
 		if (!hostId || !projectId) return [];
 		return rows.filter((w) => w.hostId === hostId && w.projectId === projectId);
 	}, [allWorkspaces, hostId, projectId]);
 
-	const selected = value ? workspaces.find((w) => w.id === value) : null;
+	// Resolve the pinned workspace from the FULL list, not the host-scoped
+	// subset: a workspace pinned to a different device must stay visible here
+	// instead of silently masquerading as "New workspace" (which hides the
+	// mismatch and lets dispatch keep failing with "Workspace not found").
+	const selected = value
+		? ((allWorkspaces as SelectV2Workspace[]).find((w) => w.id === value) ??
+			null)
+		: null;
+	const offScope =
+		!!selected &&
+		(selected.hostId !== hostId || selected.projectId !== projectId);
+	const offScopeHostName = offScope
+		? ((allHosts as SelectV2Host[]).find((h) => h.machineId === selected.hostId)
+				?.name ?? "another device")
+		: null;
 	const label = selected ? selected.name : "New workspace";
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild>
 				<PickerTrigger
-					className={className}
+					className={cn(offScope && "text-amber-500", className)}
 					icon={
-						selected ? (
+						offScope ? (
+							<LuTriangleAlert className="size-4 shrink-0" />
+						) : selected ? (
 							<LuGitBranch className="size-4 shrink-0" />
 						) : (
 							<LuSparkles className="size-4 shrink-0" />
@@ -86,6 +108,22 @@ export function WorkspacePicker({
 								<span>New workspace</span>
 								{!selected && <HiCheck className="ml-auto size-4" />}
 							</CommandItem>
+							{offScope && selected && (
+								<CommandItem
+									value={`__pinned__${selected.id}`}
+									onSelect={() => setOpen(false)}
+									className="text-amber-500"
+								>
+									<LuTriangleAlert className="size-4" />
+									<span className="flex min-w-0 flex-col">
+										<span className="truncate">{selected.name}</span>
+										<span className="truncate text-[10px] text-amber-500/70">
+											on {offScopeHostName} — won't run here
+										</span>
+									</span>
+									<HiCheck className="ml-auto size-4" />
+								</CommandItem>
+							)}
 							{workspaces.map((workspace) => (
 								<CommandItem
 									key={workspace.id}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/WorkspacePicker/WorkspacePicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/WorkspacePicker/WorkspacePicker.tsx
@@ -33,7 +33,7 @@ export function WorkspacePicker({
 	const [open, setOpen] = useState(false);
 	const collections = useCollections();
 
-	const { data: allWorkspaces = [] } = useLiveQuery(
+	const { data: allWorkspaces = [], isReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ w: collections.v2Workspaces })
@@ -68,7 +68,14 @@ export function WorkspacePicker({
 		? ((allHosts as SelectV2Host[]).find((h) => h.machineId === selected.hostId)
 				?.name ?? "another device")
 		: null;
-	const label = selected ? selected.name : "New workspace";
+	// A pinned value we can't resolve yet (live query still hydrating) is loading,
+	// not an empty "New workspace" selection — don't flash the wrong label/warning.
+	const resolving = !!value && !selected && !isReady;
+	const label = selected
+		? selected.name
+		: resolving
+			? "Loading…"
+			: "New workspace";
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
@@ -78,7 +85,7 @@ export function WorkspacePicker({
 					icon={
 						offScope ? (
 							<LuTriangleAlert className="size-4 shrink-0" />
-						) : selected ? (
+						) : selected || resolving ? (
 							<LuGitBranch className="size-4 shrink-0" />
 						) : (
 							<LuSparkles className="size-4 shrink-0" />
@@ -106,11 +113,14 @@ export function WorkspacePicker({
 							>
 								<LuSparkles className="size-4" />
 								<span>New workspace</span>
-								{!selected && <HiCheck className="ml-auto size-4" />}
+								{!selected && !resolving && (
+									<HiCheck className="ml-auto size-4" />
+								)}
 							</CommandItem>
 							{offScope && selected && (
 								<CommandItem
 									value={`__pinned__${selected.id}`}
+									keywords={[selected.name]}
 									onSelect={() => setOpen(false)}
 									className="text-amber-500"
 								>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/WorkspacePicker/WorkspacePicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/WorkspacePicker/WorkspacePicker.tsx
@@ -47,26 +47,32 @@ export function WorkspacePicker({
 		[collections.v2Hosts],
 	);
 
-	const workspaces = useMemo(() => {
-		const rows = allWorkspaces as SelectV2Workspace[];
-		if (!hostId || !projectId) return [];
-		return rows.filter((w) => w.hostId === hostId && w.projectId === projectId);
-	}, [allWorkspaces, hostId, projectId]);
+	const workspaceRows = allWorkspaces as SelectV2Workspace[];
+	const hostRows = allHosts as SelectV2Host[];
+
+	const workspaces = useMemo(
+		() =>
+			hostId && projectId
+				? workspaceRows.filter(
+						(w) => w.hostId === hostId && w.projectId === projectId,
+					)
+				: [],
+		[workspaceRows, hostId, projectId],
+	);
 
 	// Resolve the pinned workspace from the FULL list, not the host-scoped
 	// subset: a workspace pinned to a different device must stay visible here
 	// instead of silently masquerading as "New workspace" (which hides the
 	// mismatch and lets dispatch keep failing with "Workspace not found").
 	const selected = value
-		? ((allWorkspaces as SelectV2Workspace[]).find((w) => w.id === value) ??
-			null)
+		? (workspaceRows.find((w) => w.id === value) ?? null)
 		: null;
 	const offScope =
 		!!selected &&
 		(selected.hostId !== hostId || selected.projectId !== projectId);
 	const offScopeHostName = offScope
-		? ((allHosts as SelectV2Host[]).find((h) => h.machineId === selected.hostId)
-				?.name ?? "another device")
+		? (hostRows.find((h) => h.machineId === selected.hostId)?.name ??
+			"another device")
 		: null;
 	// A pinned value we can't resolve yet (live query still hydrating) is loading,
 	// not an empty "New workspace" selection — don't flash the wrong label/warning.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "turbo run dev dev:caddy --filter=@superset/api --filter=@superset/web --filter=@superset/desktop --filter=electric-proxy --filter=//",
-		"dev:all": "turbo dev",
+		"dev:all": "turbo dev --concurrency=15",
 		"dev:desktop": "turbo run dev dev:caddy --filter=@superset/api --filter=@superset/desktop --filter=electric-proxy --filter=//",
 		"dev:caddy": "dotenv -- caddy run --config Caddyfile",
 		"dev:docs": "turbo dev --filter=@superset/docs",

--- a/packages/trpc/src/router/automation/automation.test.ts
+++ b/packages/trpc/src/router/automation/automation.test.ts
@@ -272,6 +272,36 @@ describe("automation.update host/workspace reconciliation", () => {
 		});
 	});
 
+	it("derives the project from the workspace when moving across projects", async () => {
+		getAutomationForUserMock.mockResolvedValue({ ...existing });
+		// W2 lives in a different project (PROJECT_X) and on a different host
+		dbSelectResults.push([
+			{
+				id: WORKSPACE_W2,
+				organizationId: ORGANIZATION_ID,
+				projectId: PROJECT_X,
+				hostId: HOST_B,
+			},
+		]);
+		pushHostAccessOk(HOST_B);
+		updateResults.push([
+			{ id: AUTOMATION_ID, rrule: "FREQ=DAILY", timezone: "UTC" },
+		]);
+
+		const caller = createCaller(createContext());
+		await caller.automation.update({
+			id: AUTOMATION_ID,
+			v2WorkspaceId: WORKSPACE_W2,
+		});
+
+		expect(updateSetMock).toHaveBeenCalledTimes(1);
+		expect(updateSetMock.mock.calls[0]?.[0]).toMatchObject({
+			targetHostId: HOST_B,
+			v2ProjectId: PROJECT_X,
+			v2WorkspaceId: WORKSPACE_W2,
+		});
+	});
+
 	it("rejects re-pinning a workspace whose host disagrees with an explicit targetHostId", async () => {
 		getAutomationForUserMock.mockResolvedValue({ ...existing });
 		pushHostAccessOk(HOST_X); // verifyHostAccess(input.targetHostId)

--- a/packages/trpc/src/router/automation/automation.test.ts
+++ b/packages/trpc/src/router/automation/automation.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { TRPCRouterRecord } from "@trpc/server";
+
+// --- ids -------------------------------------------------------------------
+const ACTOR_USER_ID = "11111111-1111-4111-8111-111111111111";
+const ORGANIZATION_ID = "33333333-3333-4333-8333-333333333333";
+const AUTOMATION_ID = "55555555-5555-4555-8555-555555555555";
+const PROJECT_P = "66666666-6666-4666-8666-666666666666";
+const PROJECT_X = "77777777-7777-4777-8777-777777777777";
+const WORKSPACE_W = "88888888-8888-4888-8888-888888888888";
+const WORKSPACE_W2 = "99999999-9999-4999-8999-999999999999";
+// host machine ids are opaque hex strings, not uuids
+const HOST_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HOST_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const HOST_X = "cccccccccccccccccccccccccccccccc";
+
+// --- queued db results -----------------------------------------------------
+let dbSelectResults: unknown[][] = [];
+let insertResults: unknown[][] = [];
+let updateResults: unknown[][] = [];
+
+const insertValuesMock = mock((_values: unknown) => ({
+	returning: mock(async () => insertResults.shift() ?? []),
+}));
+const updateSetMock = mock((_values: unknown) => ({
+	where: mock(() => ({
+		returning: mock(async () => updateResults.shift() ?? []),
+	})),
+}));
+
+function createDb() {
+	const limitMock = mock(async () => dbSelectResults.shift() ?? []);
+	const orderByMock = mock(async () => dbSelectResults.shift() ?? []);
+	const whereMock = mock(() => ({ limit: limitMock, orderBy: orderByMock }));
+	const fromMock = mock(() => ({ where: whereMock }));
+	const selectMock = mock(() => ({ from: fromMock }));
+	return { selectMock };
+}
+
+let dbState = createDb();
+const dbSelectProxyMock = mock((...args: unknown[]) =>
+	(dbState.selectMock as (...a: unknown[]) => unknown)(...args),
+);
+
+const transactionMock = mock(async (callback: (tx: unknown) => unknown) =>
+	callback({ insert: mock(() => ({ values: insertValuesMock })) }),
+);
+
+// --- module mocks ----------------------------------------------------------
+mock.module("@superset/db/client", () => ({
+	db: { select: dbSelectProxyMock },
+	dbWs: {
+		transaction: transactionMock,
+		update: mock(() => ({ set: updateSetMock })),
+	},
+}));
+
+mock.module("@superset/shared/rrule", () => ({
+	parseRrule: mock(() => ({ nextRunAt: new Date(0) })),
+	describeSchedule: mock(() => "every day"),
+	nextOccurrences: mock(() => []),
+}));
+
+mock.module("../../env", () => ({ env: { RELAY_URL: "http://relay.test" } }));
+
+const requireActiveOrgMembershipMock = mock(async () => ORGANIZATION_ID);
+mock.module("../utils/active-org", () => ({
+	requireActiveOrgMembership: requireActiveOrgMembershipMock,
+}));
+
+const getAutomationForUserMock = mock(
+	async () => ({}) as Record<string, unknown>,
+);
+mock.module("./helpers", () => ({
+	getAutomationForUser: getAutomationForUserMock,
+	recordPromptVersion: mock(async () => undefined),
+	promptSourceFromSession: mock(() => "ui"),
+}));
+
+mock.module("./dispatch", () => ({
+	dispatchAutomation: mock(async () => ({ status: "dispatched", runId: "r" })),
+}));
+
+mock.module("./versions", () => ({ automationVersionsRouter: {} }));
+
+const { createCallerFactory, createTRPCRouter } = await import("../../trpc");
+const { automationRouter } = await import("./automation");
+
+const createCaller = createCallerFactory(
+	createTRPCRouter({ automation: automationRouter } satisfies TRPCRouterRecord),
+);
+
+function createContext() {
+	return {
+		session: {
+			user: { id: ACTOR_USER_ID, email: "actor@example.com" },
+			session: { activeOrganizationId: ORGANIZATION_ID },
+		} as never,
+		auth: {} as never,
+		headers: new Headers(),
+	};
+}
+
+const baseCreateInput = {
+	name: "Daily triage",
+	prompt: "do the thing",
+	agent: "claude",
+	rrule: "FREQ=DAILY",
+	timezone: "America/Los_Angeles",
+};
+
+// host-access checks read two rows: the host, then the membership
+function pushHostAccessOk(hostId: string) {
+	dbSelectResults.push([{ machineId: hostId }]);
+	dbSelectResults.push([{ hostId }]);
+}
+
+beforeEach(() => {
+	dbSelectResults = [];
+	insertResults = [];
+	updateResults = [];
+	dbState = createDb();
+	insertValuesMock.mockClear();
+	updateSetMock.mockClear();
+	getAutomationForUserMock.mockReset();
+});
+
+describe("automation.create host/workspace reconciliation", () => {
+	it("pins targetHostId and v2ProjectId to the workspace's host and project", async () => {
+		// verifyWorkspaceInOrg, then verifyHostAccess(workspace.host)
+		dbSelectResults.push([
+			{
+				id: WORKSPACE_W,
+				organizationId: ORGANIZATION_ID,
+				projectId: PROJECT_P,
+				hostId: HOST_A,
+			},
+		]);
+		pushHostAccessOk(HOST_A);
+		insertResults.push([
+			{
+				id: AUTOMATION_ID,
+				rrule: "FREQ=DAILY",
+				timezone: "America/Los_Angeles",
+			},
+		]);
+
+		const caller = createCaller(createContext());
+		await caller.automation.create({
+			...baseCreateInput,
+			v2WorkspaceId: WORKSPACE_W,
+		});
+
+		expect(insertValuesMock).toHaveBeenCalledTimes(1);
+		expect(insertValuesMock.mock.calls[0]?.[0]).toMatchObject({
+			targetHostId: HOST_A,
+			v2ProjectId: PROJECT_P,
+			v2WorkspaceId: WORKSPACE_W,
+		});
+	});
+
+	it("rejects a targetHostId that disagrees with the workspace's host", async () => {
+		pushHostAccessOk(HOST_X); // verifyHostAccess(input.targetHostId)
+		dbSelectResults.push([
+			{
+				id: WORKSPACE_W,
+				organizationId: ORGANIZATION_ID,
+				projectId: PROJECT_P,
+				hostId: HOST_A,
+			},
+		]);
+
+		const caller = createCaller(createContext());
+		await expect(
+			caller.automation.create({
+				...baseCreateInput,
+				targetHostId: HOST_X,
+				v2WorkspaceId: WORKSPACE_W,
+			}),
+		).rejects.toMatchObject({
+			code: "BAD_REQUEST",
+			message: "targetHostId does not match the workspace's host",
+		});
+		expect(insertValuesMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects a v2ProjectId that disagrees with the workspace's project", async () => {
+		dbSelectResults.push([
+			{
+				id: WORKSPACE_W,
+				organizationId: ORGANIZATION_ID,
+				projectId: PROJECT_P,
+				hostId: HOST_A,
+			},
+		]);
+
+		const caller = createCaller(createContext());
+		await expect(
+			caller.automation.create({
+				...baseCreateInput,
+				v2ProjectId: PROJECT_X,
+				v2WorkspaceId: WORKSPACE_W,
+			}),
+		).rejects.toMatchObject({
+			code: "BAD_REQUEST",
+			message: "v2ProjectId does not match the workspace's project",
+		});
+		expect(insertValuesMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("automation.update host/workspace reconciliation", () => {
+	const existing = {
+		id: AUTOMATION_ID,
+		ownerUserId: ACTOR_USER_ID,
+		name: "Daily triage",
+		agent: "claude",
+		targetHostId: HOST_A,
+		v2ProjectId: PROJECT_P,
+		v2WorkspaceId: WORKSPACE_W,
+		rrule: "FREQ=DAILY",
+		dtstart: new Date(0),
+		timezone: "America/Los_Angeles",
+		mcpScope: [],
+		nextRunAt: new Date(0),
+	};
+
+	it("clears the stale workspace when the device changes without a new workspace", async () => {
+		getAutomationForUserMock.mockResolvedValue({ ...existing });
+		pushHostAccessOk(HOST_B); // verifyHostAccess(input.targetHostId)
+		updateResults.push([
+			{ id: AUTOMATION_ID, rrule: "FREQ=DAILY", timezone: "UTC" },
+		]);
+
+		const caller = createCaller(createContext());
+		await caller.automation.update({ id: AUTOMATION_ID, targetHostId: HOST_B });
+
+		expect(updateSetMock).toHaveBeenCalledTimes(1);
+		expect(updateSetMock.mock.calls[0]?.[0]).toMatchObject({
+			targetHostId: HOST_B,
+			v2ProjectId: PROJECT_P,
+			v2WorkspaceId: null,
+		});
+	});
+
+	it("re-pins targetHostId to the new workspace's host", async () => {
+		getAutomationForUserMock.mockResolvedValue({ ...existing });
+		// verifyWorkspaceInOrg(W2), then verifyHostAccess(W2.host)
+		dbSelectResults.push([
+			{
+				id: WORKSPACE_W2,
+				organizationId: ORGANIZATION_ID,
+				projectId: PROJECT_P,
+				hostId: HOST_B,
+			},
+		]);
+		pushHostAccessOk(HOST_B);
+		updateResults.push([
+			{ id: AUTOMATION_ID, rrule: "FREQ=DAILY", timezone: "UTC" },
+		]);
+
+		const caller = createCaller(createContext());
+		await caller.automation.update({
+			id: AUTOMATION_ID,
+			v2WorkspaceId: WORKSPACE_W2,
+		});
+
+		expect(updateSetMock).toHaveBeenCalledTimes(1);
+		expect(updateSetMock.mock.calls[0]?.[0]).toMatchObject({
+			targetHostId: HOST_B,
+			v2WorkspaceId: WORKSPACE_W2,
+		});
+	});
+
+	it("rejects re-pinning a workspace whose host disagrees with an explicit targetHostId", async () => {
+		getAutomationForUserMock.mockResolvedValue({ ...existing });
+		pushHostAccessOk(HOST_X); // verifyHostAccess(input.targetHostId)
+		dbSelectResults.push([
+			{
+				id: WORKSPACE_W2,
+				organizationId: ORGANIZATION_ID,
+				projectId: PROJECT_P,
+				hostId: HOST_B,
+			},
+		]);
+
+		const caller = createCaller(createContext());
+		await expect(
+			caller.automation.update({
+				id: AUTOMATION_ID,
+				targetHostId: HOST_X,
+				v2WorkspaceId: WORKSPACE_W2,
+			}),
+		).rejects.toMatchObject({
+			code: "BAD_REQUEST",
+			message: "targetHostId does not match the workspace's host",
+		});
+		expect(updateSetMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -320,7 +320,7 @@ export const automationRouter = {
 				input.targetHostId === undefined
 					? existing.targetHostId
 					: input.targetHostId;
-			const nextProjectId = input.v2ProjectId ?? existing.v2ProjectId;
+			let nextProjectId = input.v2ProjectId ?? existing.v2ProjectId;
 			let nextWorkspaceId =
 				input.v2WorkspaceId === undefined
 					? existing.v2WorkspaceId
@@ -343,12 +343,20 @@ export const automationRouter = {
 					organizationId,
 					nextWorkspaceId,
 				);
-				if (nextProjectId !== workspace.projectId) {
+				// Mirror create: derive the project from the workspace and only
+				// reject when the caller *explicitly* passed a conflicting project.
+				// Otherwise a legitimate cross-project workspace move (sending only
+				// v2WorkspaceId) would be wrongly rejected as a mismatch.
+				if (
+					input.v2ProjectId !== undefined &&
+					input.v2ProjectId !== workspace.projectId
+				) {
 					throw new TRPCError({
 						code: "BAD_REQUEST",
 						message: "v2ProjectId does not match the workspace's project",
 					});
 				}
+				nextProjectId = workspace.projectId;
 				if (
 					input.targetHostId !== undefined &&
 					input.targetHostId !== null &&

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -83,12 +83,13 @@ async function verifyHostAccess(
 async function verifyWorkspaceInOrg(
 	organizationId: string,
 	workspaceId: string,
-): Promise<{ id: string; projectId: string }> {
+): Promise<{ id: string; projectId: string; hostId: string }> {
 	const [workspace] = await db
 		.select({
 			id: v2Workspaces.id,
 			organizationId: v2Workspaces.organizationId,
 			projectId: v2Workspaces.projectId,
+			hostId: v2Workspaces.hostId,
 		})
 		.from(v2Workspaces)
 		.where(eq(v2Workspaces.id, workspaceId))
@@ -100,7 +101,11 @@ async function verifyWorkspaceInOrg(
 			message: "Workspace not found",
 		});
 	}
-	return { id: workspace.id, projectId: workspace.projectId };
+	return {
+		id: workspace.id,
+		projectId: workspace.projectId,
+		hostId: workspace.hostId,
+	};
 }
 
 async function verifyProjectInOrg(organizationId: string, projectId: string) {
@@ -206,12 +211,20 @@ export const automationRouter = {
 				);
 			}
 
+			let targetHostId = input.targetHostId ?? null;
 			let v2ProjectId = input.v2ProjectId;
 			if (input.v2WorkspaceId) {
 				const workspace = await verifyWorkspaceInOrg(
 					organizationId,
 					input.v2WorkspaceId,
 				);
+				if (targetHostId && targetHostId !== workspace.hostId) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "targetHostId does not match the workspace's host",
+					});
+				}
+				targetHostId = workspace.hostId;
 				if (v2ProjectId && v2ProjectId !== workspace.projectId) {
 					throw new TRPCError({
 						code: "BAD_REQUEST",
@@ -228,6 +241,13 @@ export const automationRouter = {
 					code: "BAD_REQUEST",
 					message: "v2ProjectId required when v2WorkspaceId is not provided",
 				});
+			}
+			if (targetHostId && targetHostId !== input.targetHostId) {
+				await verifyHostAccess(
+					ctx.session.user.id,
+					organizationId,
+					targetHostId,
+				);
 			}
 
 			const dtstart = input.dtstart ?? new Date();
@@ -246,7 +266,7 @@ export const automationRouter = {
 						name: input.name,
 						prompt: input.prompt,
 						agent: input.agent,
-						targetHostId: input.targetHostId ?? null,
+						targetHostId,
 						v2ProjectId,
 						v2WorkspaceId: input.v2WorkspaceId ?? null,
 						rrule: input.rrule,
@@ -295,8 +315,67 @@ export const automationRouter = {
 					input.targetHostId,
 				);
 			}
-			if (input.v2WorkspaceId) {
-				await verifyWorkspaceInOrg(organizationId, input.v2WorkspaceId);
+
+			let nextTargetHostId =
+				input.targetHostId === undefined
+					? existing.targetHostId
+					: input.targetHostId;
+			const nextProjectId = input.v2ProjectId ?? existing.v2ProjectId;
+			let nextWorkspaceId =
+				input.v2WorkspaceId === undefined
+					? existing.v2WorkspaceId
+					: input.v2WorkspaceId;
+
+			if (input.v2WorkspaceId === undefined) {
+				const targetHostChanged =
+					input.targetHostId !== undefined &&
+					input.targetHostId !== existing.targetHostId;
+				const projectChanged =
+					input.v2ProjectId !== undefined &&
+					input.v2ProjectId !== existing.v2ProjectId;
+				if (targetHostChanged || projectChanged) {
+					nextWorkspaceId = null;
+				}
+			}
+
+			if (nextWorkspaceId) {
+				const workspace = await verifyWorkspaceInOrg(
+					organizationId,
+					nextWorkspaceId,
+				);
+				if (nextProjectId !== workspace.projectId) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "v2ProjectId does not match the workspace's project",
+					});
+				}
+				if (
+					input.targetHostId !== undefined &&
+					input.targetHostId !== null &&
+					input.targetHostId !== workspace.hostId
+				) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "targetHostId does not match the workspace's host",
+					});
+				}
+				nextTargetHostId = workspace.hostId;
+			} else if (
+				input.v2ProjectId !== undefined &&
+				input.v2ProjectId !== existing.v2ProjectId
+			) {
+				await verifyProjectInOrg(organizationId, input.v2ProjectId);
+			}
+			if (
+				nextTargetHostId &&
+				nextTargetHostId !== existing.targetHostId &&
+				nextTargetHostId !== input.targetHostId
+			) {
+				await verifyHostAccess(
+					ctx.session.user.id,
+					organizationId,
+					nextTargetHostId,
+				);
 			}
 
 			const nextRrule = input.rrule ?? existing.rrule;
@@ -320,15 +399,9 @@ export const automationRouter = {
 				.set({
 					name: input.name ?? existing.name,
 					agent: input.agent ?? existing.agent,
-					targetHostId:
-						input.targetHostId === undefined
-							? existing.targetHostId
-							: input.targetHostId,
-					v2ProjectId: input.v2ProjectId ?? existing.v2ProjectId,
-					v2WorkspaceId:
-						input.v2WorkspaceId === undefined
-							? existing.v2WorkspaceId
-							: input.v2WorkspaceId,
+					targetHostId: nextTargetHostId,
+					v2ProjectId: nextProjectId,
+					v2WorkspaceId: nextWorkspaceId,
 					rrule: nextRrule,
 					dtstart: nextDtstart,
 					timezone: nextTimezone,

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -59,7 +59,7 @@ function TooltipContent({
 				data-slot="tooltip-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+					"bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance break-words",
 					className,
 				)}
 				{...props}


### PR DESCRIPTION
## Problem

An automation could end up with its **device** (`targetHostId`) pointed at one host while its **workspace** (`v2WorkspaceId`) lived on a *different* host. Dispatch resolves the device, then runs the agent against the pinned workspace on that device — which has never seen it — so every run failed with an opaque:

```
dispatch: relay 500: {"message":"Workspace not found", ...}
```

The desktop UI made this invisible: the workspace picker filtered workspaces to the selected device, so an off-host pin silently rendered as **"New workspace"**, with no way to tell the row was actually pinned to a stale/offline host.

## Changes

**Backend (`packages/trpc/automation`)**
- `verifyWorkspaceInOrg` now returns the workspace's `hostId`.
- `create`/`update` reconcile `targetHostId` / `v2ProjectId` / `v2WorkspaceId` so device and workspace can never disagree (force-pin to the workspace's host, reject explicit mismatches, and clear a stale workspace when host/project change without re-specifying it).

**Desktop UI**
- **WorkspacePicker** resolves the pinned workspace from the full list, not the host-scoped subset. An off-host pin now shows an amber ⚠ warning — *"<name> · on <host> — won't run here"* — instead of masquerading as "New workspace".
- **PickerTrigger** adds `min-w-0 max-w-full` so its existing `truncate` actually engages instead of overflowing the row.
- **Row** uses a `flex-1` value column so values fill the column and only ellipsize when genuinely too long (no more needlessly-short truncation).
- **TooltipContent** (shared `packages/ui`) caps width (`max-w-xs`) and `break-words` so long error tooltips wrap instead of running off-screen.

**Tooling**
- Bump `dev:all` turbo concurrency past the default 10 so the full local stack (incl. `@superset/relay`, which the default dev filter omits) can run to exercise automations end-to-end.

## Testing
- `bun run lint` — clean
- `bun run typecheck` (api, desktop, trpc, ui) — clean
- Verified against the real failing automation: device = Kiets-Spaceship, workspace = "Town Hall" (host = Town-Hall, offline) → reproduced "Workspace not found"; picker now surfaces the mismatch instead of hiding it.

> Note: pre-existing automation rows created before this fix still carry the mismatch in the DB — they need to be re-pointed/cleared in the UI. Runtime dispatch still trusts the row (no defensive guard yet); a follow-up could validate workspace-host at dispatch and fail fast / fall back to a fresh workspace.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5394">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents automations from targeting a device on one host while the pinned workspace lives on another. Backend now keeps `targetHostId` in sync with the workspace’s host, and the UI clearly shows off‑host pins without flashing “New workspace”.

- **Bug Fixes**
  - On create/update: pin `targetHostId` to the workspace’s `hostId`; derive `v2ProjectId` from the workspace; reject only explicit host/project mismatches; clear a stale `v2WorkspaceId` when host/project change without reselecting.
  - WorkspacePicker resolves the pinned workspace from all workspaces and shows an amber warning (on <host> — won't run here); shows a loading state while hydrating; keeps the off‑host item searchable; the sidebar passes the resolved `hostId` so lists scope correctly.
  - Fix overflow in picker rows; cap tooltip width and wrap long text.
  - Add unit tests for create/update host–workspace reconciliation and mismatch guards.

- **Migration**
  - Existing automations with mismatched device/workspace need to be reselected or cleared in the UI.

<sup>Written for commit 3a9aed8a9cc4a3f6c69a78ec1a51893a8c94665a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation workspace selection now surfaces pinned workspaces that belong to another device, with a clear warning that they won’t run here.
  * Better visual feedback in automation details and picker controls for more consistent layout and readability.

* **Bug Fixes**
  * Improved workspace and host handling when creating or updating automations, reducing mismatches between selected workspace, project, and target device.
  * Tooltips now wrap more cleanly, making longer help text easier to read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->