### PR TITLE
fix(host-service): create missing parent dir on project create/clone

### DIFF
--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
@@ -392,12 +392,18 @@ describe("cloneRepoInto", () => {
 		expect(existsSync(join(targetPath, "keep-me.txt"))).toBe(true);
 	});
 
-	test("rejects when parent directory does not exist", async () => {
-		const missingParent = join(workRoot, "no-such-parent");
+	test("creates the parent directory (and ancestors) when it does not exist", async () => {
+		// Mirrors the default `~/.superset/projects` location not existing on a
+		// fresh machine: clone should mkdir -p the parent rather than erroring.
+		const missingParent = join(workRoot, "deeply", "nested", "projects");
+		expect(existsSync(missingParent)).toBe(false);
 
-		await expect(cloneRepoInto(source, missingParent)).rejects.toThrow(
-			/Parent directory does not exist/,
-		);
+		const resolved = await cloneRepoInto(source, missingParent);
+
+		expect(existsSync(missingParent)).toBe(true);
+		expect(
+			eqRealpath(resolved.repoPath, join(missingParent, "source-repo")),
+		).toBe(true);
 	});
 
 	test("rejects when parent directory points at a file", async () => {

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -46,6 +46,36 @@ export function validateDirectoryPath(path: string, label: string): void {
 }
 
 /**
+ * Ensure the parent directory we're about to create a project under exists,
+ * creating it (and any missing ancestors) when it doesn't. Unlike
+ * `validateDirectoryPath`, a missing parent is a recoverable condition: the
+ * default project location (e.g. `~/.superset/projects`) won't exist on a
+ * fresh machine, and the user shouldn't have to pre-create it before their
+ * first clone. Still rejects when the path exists but is a file.
+ */
+function ensureParentDirectory(path: string): void {
+	if (existsSync(path)) {
+		if (!statSync(path).isDirectory()) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Parent directory is not a directory: ${path}`,
+			});
+		}
+		return;
+	}
+	try {
+		mkdirSync(path, { recursive: true });
+	} catch (err) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Could not create parent directory: ${path}: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		});
+	}
+}
+
+/**
  * Atomic claim: `mkdir` without `recursive` throws EEXIST when the path is
  * present, which avoids the TOCTOU window between an `existsSync` check
  * and the work that follows. If anything fails after this, the caller
@@ -246,7 +276,7 @@ export async function initEmptyRepo(
 	}
 
 	const resolvedParentDir = resolvePath(parentDir);
-	validateDirectoryPath(resolvedParentDir, "Parent directory");
+	ensureParentDirectory(resolvedParentDir);
 	const targetPath = join(resolvedParentDir, dirName);
 	claimEmptyTargetDir(targetPath);
 
@@ -289,7 +319,7 @@ export async function cloneTemplateInto(
 	}
 
 	const resolvedParentDir = resolvePath(parentDir);
-	validateDirectoryPath(resolvedParentDir, "Parent directory");
+	ensureParentDirectory(resolvedParentDir);
 	const targetPath = join(resolvedParentDir, dirName);
 	claimEmptyTargetDir(targetPath);
 
@@ -352,7 +382,7 @@ export async function cloneRepoInto(
 	const repoName = parsedUrl?.name ?? deriveCloneDirectoryName(repoCloneUrl);
 
 	const resolvedParentDir = resolvePath(parentDir);
-	validateDirectoryPath(resolvedParentDir, "Parent directory");
+	ensureParentDirectory(resolvedParentDir);
 
 	const targetPath = join(resolvedParentDir, repoName);
 	claimEmptyTargetDir(targetPath);

--- a/packages/trpc/src/router/task/task.test.ts
+++ b/packages/trpc/src/router/task/task.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+// Captured before any mock.module registers, so it holds the real schema
+// exports. Spread into the schema mock below so this partial mock doesn't
+// drop barrel exports other test files rely on (bun's mock.module is global
+// and never restored between files).
+import * as realDbSchema from "@superset/db/schema";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 
 const getCurrentTxidMock = mock(async () => "txid-123");
@@ -112,6 +117,7 @@ mock.module("@superset/db/client", () => ({
 }));
 
 mock.module("@superset/db/schema", () => ({
+	...realDbSchema,
 	members: {
 		organizationId: "members.organizationId",
 		userId: "members.userId",

--- a/packages/trpc/src/router/v2-project/v2-project.test.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+// Captured before any mock.module registers, so it holds the real schema
+// exports. Spread into the schema mock below so this partial mock doesn't
+// drop barrel exports other test files rely on (bun's mock.module is global
+// and never restored between files).
+import * as realDbSchema from "@superset/db/schema";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 
 const getCurrentTxidMock = mock(async () => 123);
@@ -106,6 +111,7 @@ mock.module("@superset/db/client", () => ({
 }));
 
 mock.module("@superset/db/schema", () => ({
+	...realDbSchema,
 	v2Projects: {
 		id: "v2_projects.id",
 		organizationId: "v2_projects.organization_id",


### PR DESCRIPTION
## Problem

Cloning a repository / creating a project from the desktop **Clone a repository** dialog failed when the parent directory for the chosen location did not exist:

> Could not create project — Parent directory does not exist: /Users/vikram/.superset/projects
> Create failed: Parent directory does not exist: /Users/vikram/.superset/projects

This happens on a fresh machine because the default location `~/.superset/projects` does not exist yet, and the user is forced to pre-create it before their first clone.

## Root cause

`packages/host-service/src/trpc/router/project/utils/resolve-repo.ts` validated the parent directory with `validateDirectoryPath(resolvedParentDir, "Parent directory")`, which throws a `BAD_REQUEST` `TRPCError` (`Parent directory does not exist: …`) whenever the parent is absent. This guard is shared by `cloneRepoInto`, `initEmptyRepo`, and `cloneTemplateInto`. The renderer toasts (`Could not create project`, `Create failed: …`) just surface that message verbatim.

A missing parent is a recoverable condition — there's no reason to refuse rather than create it.

## Fix

Introduce `ensureParentDirectory(path)`, used by all three create/clone entry points instead of the strict existence check. It:
- recursively creates the parent directory (and any missing ancestors, `mkdir -p` semantics) when it's absent, and
- still rejects when the path exists but is a **file** (`Parent directory is not a directory: …`).

The atomic per-project `claimEmptyTargetDir` (EEXIST guard against clobbering an existing project) and post-failure cleanup are unchanged, so the recovery only affects the parent, never the target.

## Tests

Updated `resolve-repo.test.ts`:
- replaced the "rejects when parent directory does not exist" case with one asserting the parent (and nested ancestors) is created and the clone succeeds,
- kept the "parent points at a file" rejection case.

All 30 tests in the file pass; lint + typecheck clean.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5397">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix project create/clone failures when the parent directory doesn’t exist by auto-creating it. Users can now clone or create a project on fresh machines without manually creating `~/.superset/projects`.

- **Bug Fixes**
  - Added `ensureParentDirectory` to `host-service` to `mkdir -p` the parent (and ancestors) when absent.
  - Applied to `cloneRepoInto`, `initEmptyRepo`, and `cloneTemplateInto`; still rejects if the parent path is a file; target dir claim remains atomic.
  - Updated tests to assert parent creation and keep the file-path rejection case.
  - Stabilized TRPC tests by spreading real exports into partial `@superset/db/schema` mocks to avoid missing barrel exports across files.

<sup>Written for commit 281c4c467901bdaef60bd7bda938be3ba765e72f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository setup and cloning now automatically create missing destination parent folders, including any required ancestor levels.
  * If the destination parent path already exists but is not a folder, the operation still stops with a clear error.
  * Template and repo clone destinations have been updated to follow the same folder-creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->