### PR TITLE
feat(host-service): prefer upstream over origin for worktree start point

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-start-point.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-start-point.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit from "simple-git";
 import { resolveStartPoint } from "./resolve-start-point";
 
 /**
@@ -157,6 +162,168 @@ describe("resolveStartPoint", () => {
 		if (result.kind === "local") {
 			expect(result.shortName).toBe("origin/foo");
 			expect(result.fullRef).toBe("refs/heads/origin/foo");
+		}
+	});
+
+	// Fork workflow (#958): `origin` is the user's fork (often behind),
+	// `upstream` is the canonical repo. When the base branch only exists as
+	// a remote-tracking ref, prefer `upstream/<branch>` over `origin/<branch>`
+	// so new work forks from the canonical source, not the stale fork.
+	test("prefers upstream remote over origin when both exist (no local branch)", async () => {
+		const git = createMockGit(
+			new Set(["refs/remotes/upstream/main", "refs/remotes/origin/main"]),
+		);
+		const result = await resolveStartPoint(git, "main");
+
+		expect(result.kind).toBe("remote-tracking");
+		if (result.kind === "remote-tracking") {
+			expect(result.remote).toBe("upstream");
+			expect(result.shortName).toBe("main");
+			expect(result.fullRef).toBe("refs/remotes/upstream/main");
+			expect(result.remoteShortName).toBe("upstream/main");
+		}
+	});
+
+	test("uses upstream remote-tracking ref when only upstream exists", async () => {
+		const git = createMockGit(new Set(["refs/remotes/upstream/feature"]));
+		const result = await resolveStartPoint(git, "feature");
+
+		expect(result.kind).toBe("remote-tracking");
+		if (result.kind === "remote-tracking") {
+			expect(result.remote).toBe("upstream");
+			expect(result.fullRef).toBe("refs/remotes/upstream/feature");
+		}
+	});
+
+	test("local branch still wins over both upstream and origin", async () => {
+		const git = createMockGit(
+			new Set([
+				"refs/heads/main",
+				"refs/remotes/upstream/main",
+				"refs/remotes/origin/main",
+			]),
+		);
+		const result = await resolveStartPoint(git, "main");
+
+		expect(result.kind).toBe("local");
+		if (result.kind === "local") {
+			expect(result.fullRef).toBe("refs/heads/main");
+		}
+	});
+});
+
+// Real-git integration: exercises resolveStartPoint against actual repos with
+// `origin` + `upstream` remotes, proving the fork-workflow preference (#958)
+// end-to-end rather than against the mocked `raw` shim above.
+describe("resolveStartPoint — real git (upstream vs origin)", () => {
+	let workRoot: string;
+
+	function initRepo(name: string): string {
+		const repo = join(workRoot, name);
+		mkdirSync(repo, { recursive: true });
+		execSync("git init -b main", { cwd: repo, stdio: "ignore" });
+		execSync('git config user.email "test@superset.local"', {
+			cwd: repo,
+			stdio: "ignore",
+		});
+		execSync('git config user.name "Superset Test"', {
+			cwd: repo,
+			stdio: "ignore",
+		});
+		execSync("git config commit.gpgsign false", { cwd: repo, stdio: "ignore" });
+		return repo;
+	}
+
+	function commit(repo: string, file: string, body: string, message: string) {
+		writeFileSync(join(repo, file), body);
+		execSync(`git add ${file}`, { cwd: repo, stdio: "ignore" });
+		execSync(`git commit -m "${message}"`, { cwd: repo, stdio: "ignore" });
+	}
+
+	function sha(repo: string, rev: string): string {
+		return execSync(`git rev-parse ${rev}`, {
+			cwd: repo,
+			encoding: "utf8",
+		}).trim();
+	}
+
+	beforeEach(() => {
+		workRoot = mkdtempSync(join(tmpdir(), "superset-resolve-start-point-"));
+	});
+
+	afterEach(() => {
+		rmSync(workRoot, { recursive: true, force: true });
+	});
+
+	test("forks a non-local branch from upstream, not the stale origin fork", async () => {
+		// upstream (canonical) has `shared` at commit U.
+		const upstream = initRepo("upstream");
+		commit(upstream, "README.md", "base\n", "base");
+		execSync("git checkout -b shared", { cwd: upstream, stdio: "ignore" });
+		commit(upstream, "shared.txt", "upstream\n", "upstream shared");
+		execSync("git checkout main", { cwd: upstream, stdio: "ignore" });
+
+		// origin (the fork) clones upstream, then advances `shared` to commit O.
+		execSync(`git clone "${upstream}" origin`, {
+			cwd: workRoot,
+			stdio: "ignore",
+		});
+		const origin = join(workRoot, "origin");
+		execSync('git config user.email "test@superset.local"', {
+			cwd: origin,
+			stdio: "ignore",
+		});
+		execSync('git config user.name "Superset Test"', {
+			cwd: origin,
+			stdio: "ignore",
+		});
+		execSync("git checkout shared", { cwd: origin, stdio: "ignore" });
+		commit(origin, "shared.txt", "origin fork\n", "origin shared");
+		execSync("git checkout main", { cwd: origin, stdio: "ignore" });
+
+		// The working repo clones origin (so `origin/shared` = O) and adds the
+		// upstream remote (so `upstream/shared` = U). `shared` is NOT a local
+		// branch here — only main is checked out.
+		execSync(`git clone "${origin}" clone`, { cwd: workRoot, stdio: "ignore" });
+		const clone = join(workRoot, "clone");
+		execSync(`git remote add upstream "${upstream}"`, {
+			cwd: clone,
+			stdio: "ignore",
+		});
+		execSync("git fetch upstream", { cwd: clone, stdio: "ignore" });
+
+		const git = simpleGit(clone);
+		const result = await resolveStartPoint(git, "shared");
+
+		expect(result.kind).toBe("remote-tracking");
+		if (result.kind === "remote-tracking") {
+			expect(result.remote).toBe("upstream");
+			expect(result.fullRef).toBe("refs/remotes/upstream/shared");
+		}
+
+		// e2e proof: the resolved ref points at upstream's commit, not the fork's.
+		const resolvedSha = (
+			await git.raw(["rev-parse", "refs/remotes/upstream/shared"])
+		).trim();
+		expect(resolvedSha).toBe(sha(upstream, "shared"));
+		expect(resolvedSha).not.toBe(sha(origin, "shared"));
+	});
+
+	test("falls back to origin when there is no upstream remote (non-fork repo)", async () => {
+		const source = initRepo("source");
+		commit(source, "README.md", "base\n", "base");
+		execSync("git branch feature", { cwd: source, stdio: "ignore" });
+
+		execSync(`git clone "${source}" clone`, { cwd: workRoot, stdio: "ignore" });
+		const clone = join(workRoot, "clone");
+
+		const git = simpleGit(clone);
+		const result = await resolveStartPoint(git, "feature");
+
+		expect(result.kind).toBe("remote-tracking");
+		if (result.kind === "remote-tracking") {
+			expect(result.remote).toBe("origin");
+			expect(result.fullRef).toBe("refs/remotes/origin/feature");
 		}
 	});
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-start-point.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-start-point.test.ts
@@ -218,6 +218,7 @@ describe("resolveStartPoint", () => {
 describe("resolveStartPoint — real git (upstream vs origin)", () => {
 	let workRoot: string;
 
+	/** Init a fresh git repo under `workRoot` with a committable identity. */
 	function initRepo(name: string): string {
 		const repo = join(workRoot, name);
 		mkdirSync(repo, { recursive: true });
@@ -234,12 +235,14 @@ describe("resolveStartPoint — real git (upstream vs origin)", () => {
 		return repo;
 	}
 
+	/** Write `file` and commit it in `repo`. */
 	function commit(repo: string, file: string, body: string, message: string) {
 		writeFileSync(join(repo, file), body);
 		execSync(`git add ${file}`, { cwd: repo, stdio: "ignore" });
 		execSync(`git commit -m "${message}"`, { cwd: repo, stdio: "ignore" });
 	}
 
+	/** Full commit SHA of `rev` in `repo`. */
 	function sha(repo: string, rev: string): string {
 		return execSync(`git rev-parse ${rev}`, {
 			cwd: repo,

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-start-point.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-start-point.ts
@@ -20,7 +20,8 @@ async function refExists(git: SimpleGit, fullRef: string): Promise<boolean> {
 
 /**
  * Resolve the best start point for a new worktree. Prefers a local branch
- * when it exists, falls back to a remote-tracking ref, then HEAD.
+ * when it exists, then a remote-tracking ref (`upstream` before `origin`
+ * for the fork workflow), then HEAD.
  *
  * Why local-first: users pick branches from a list of refs they can see
  * locally — they expect to fork from that exact local state, not from a
@@ -28,6 +29,12 @@ async function refExists(git: SimpleGit, fullRef: string): Promise<boolean> {
  * a pruned commit). Workspace branches in particular are local-only and
  * an incidental `refs/remotes/origin/<name>` cache (from a one-off push
  * etc.) would silently win and then break `git worktree add`.
+ *
+ * Why upstream-before-origin: when contributing to a project via a fork,
+ * `origin` is the user's fork (which lags behind) and `upstream` is the
+ * canonical repo, by convention. A new branch should fork from the latest
+ * canonical state, so probe `upstream/<branch>` before `origin/<branch>`.
+ * Falls through to `origin` for the common single-remote case. See #958.
  *
  * Picker-side `refresh` already runs `git fetch --prune` on modal open,
  * so remote staleness for branches we *do* want fresh is bounded.
@@ -41,22 +48,26 @@ export async function resolveStartPoint(
 	baseBranch: string | undefined,
 ): Promise<ResolvedRef> {
 	const branch = baseBranch?.trim() || (await resolveDefaultBranchName(git));
-	const remote = "origin";
 
 	const localRef = asLocalRef(branch);
 	if (await refExists(git, localRef)) {
 		return { kind: "local", fullRef: localRef, shortName: branch };
 	}
 
-	const remoteRef = asRemoteRef(remote, branch);
-	if (await refExists(git, remoteRef)) {
-		return {
-			kind: "remote-tracking",
-			fullRef: remoteRef,
-			shortName: branch,
-			remote,
-			remoteShortName: `${remote}/${branch}`,
-		};
+	// Fork workflow: prefer the canonical `upstream` remote over the user's
+	// `origin` fork. Probes against full refnames, so a remote literally
+	// named `upstream` is matched structurally, never by shortname guessing.
+	for (const remote of ["upstream", "origin"]) {
+		const remoteRef = asRemoteRef(remote, branch);
+		if (await refExists(git, remoteRef)) {
+			return {
+				kind: "remote-tracking",
+				fullRef: remoteRef,
+				shortName: branch,
+				remote,
+				remoteShortName: `${remote}/${branch}`,
+			};
+		}
 	}
 
 	return { kind: "head" };


### PR DESCRIPTION
## Description

When resolving the start point for a new workspace worktree, `resolveStartPoint` only probed `origin` for the base branch's remote-tracking ref:

```ts
const remote = "origin";
// ...
const remoteRef = asRemoteRef(remote, branch);
```

In a fork workflow `origin` is the user's fork (which lags behind) while `upstream` is the canonical repo by convention. As a result new branches were forked from the **stale fork** — or missed entirely (falling through to `HEAD`) when the branch existed only on `upstream`.

This change probes `upstream/<branch>` **before** `origin/<branch>`, falling through to `origin` for the common single-remote case:

```ts
for (const remote of ["upstream", "origin"]) {
  const remoteRef = asRemoteRef(remote, branch);
  if (await refExists(git, remoteRef)) {
    return { kind: "remote-tracking", fullRef: remoteRef, /* ... */ remote };
  }
}
```

Notes on the approach:

- **Local-first is unchanged** — a local branch still always wins, so workspace branches and locally-picked refs behave exactly as before.
- **No-op for non-fork repos** — without an `upstream` remote, `refs/remotes/upstream/<branch>` doesn't resolve and it falls straight through to `origin`. Zero behavior change for the single-remote case.
- Probes use **full refnames** (via `asRemoteRef`), so a remote literally named `upstream` is matched structurally, consistent with the `GIT_REFS.md` rationale — never by shortname guessing.
- This complements the existing per-branch upstream-tracking logic in `resolveNewBranchStartPoint`; it covers the lower-level resolver's remote-ref path, which previously had no upstream preference.

Happy to switch to enumerating `git remote` (rather than the `upstream` convention) if maintainers prefer — but the conventional `upstream` name matches what `gh repo fork` sets up and what this issue asks for. Edits from maintainers are enabled.

## Related Issues

Closes #958

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

`resolve-start-point.test.ts` (16 tests, all passing):

- **Mock-based unit cases** (matching the file's existing harness): prefers `upstream` over `origin` when both remote-tracking refs exist; uses `upstream` when it's the only remote ref; local branch still wins over both.
- **Real-git integration test**: creates actual `origin` (fork) and `upstream` (canonical) repos with `shared` at distinct commits, clones the fork, adds the upstream remote, and asserts the resolved start point is `refs/remotes/upstream/shared` whose SHA matches upstream's commit and **not** the fork's. Plus a graceful-fallback case proving a repo with no `upstream` remote still resolves to `origin`.

Verified locally:

```
bun test src/.../resolve-start-point.test.ts   # 16 pass / 0 fail
bun run lint                                    # exit 0 (biome + git-ref / simple-git guards)
bunx sherif                                     # No issues found
bun run typecheck (host-service)                # exit 0
```

## Screenshots (if applicable)

N/A — backend git-resolution logic.

## Additional Notes

Found this while setting up to contribute to Superset via a fork. The diff is intentionally small and confined to `resolveStartPoint`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5402">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer `upstream` over `origin` when resolving the start point for new worktrees so forked repos branch from the canonical repo; local-first behavior is unchanged. Closes #958.

- **New Features**
  - In `resolveStartPoint`, probe `refs/remotes/upstream/<branch>` before `refs/remotes/origin/<branch>`.
  - Fall back to `origin` when `upstream` is absent; `HEAD` remains the final fallback.
  - Use full refnames via `asRemoteRef`; no change for single-remote repos.

- **Refactors**
  - Added docstrings to real-git test helpers for clarity (no behavior change).

<sup>Written for commit 9deeeca48f12c84b0924607e171a0c6b25a56ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch selection for workspace setup: when using fork workflows, the app now prefers the matching `upstream` remote-tracking branch over `origin` when a local branch is not present.
  * Local branches continue to take priority over any remote-tracking branch.
  * If no `upstream` remote exists, it falls back to the `origin` branch as before.
* **Tests**
  * Expanded end-to-end verification with real Git repositories for fork and non-fork scenarios, covering correct branch selection and expected commit targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->