### PR TITLE
fix(desktop): use custom theme for diff view syntax highlighting

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
@@ -206,6 +206,19 @@ const terminalColorsSchema = z.object({
 });
 
 /**
+ * Zod schema for editor/diff color + syntax overrides (Theme.editor).
+ *
+ * Persisted faithfully via record() so imported custom themes keep their
+ * editor/diff syntax colors across reloads. Omitting this previously stripped
+ * `editor` on save (Zod drops unknown keys), so on reload getEditorTheme fell
+ * back to the derived terminal palette and diff/editor syntax lost its theme.
+ */
+const editorThemeSchema = z.object({
+	colors: z.record(z.string(), z.string()).optional(),
+	syntax: z.record(z.string(), z.string()).optional(),
+});
+
+/**
  * Zod schema for Theme
  */
 const themeSchema = z.object({
@@ -217,6 +230,7 @@ const themeSchema = z.object({
 	type: z.enum(["dark", "light"]),
 	ui: uiColorsSchema,
 	terminal: terminalColorsSchema,
+	editor: editorThemeSchema.optional(),
 	isBuiltIn: z.boolean().optional(),
 	isCustom: z.boolean().optional(),
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
+	DIFF_POOL_RENDER_OPTIONS,
 	getDiffsTheme,
 	getDiffViewerStyle,
 } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
@@ -69,12 +70,13 @@ export function useDiffCodeViewTheme() {
 				paddingBottom: 8,
 				gap: 0,
 			},
-			// Degrade gracefully on lockfiles / minified bundles instead of
-			// blocking the worker. Pierre's defaults are 100k for whole-file
-			// tokenization and unbounded for the rest.
-			tokenizeMaxLineLength: 5_000,
+			// Diff/tokenize options shared with the diff worker pool
+			// (DIFF_POOL_RENDER_OPTIONS / buildDiffPoolRenderOptions) so the
+			// per-item and pool configs can't diverge. They degrade gracefully
+			// on lockfiles / minified bundles instead of blocking the worker.
+			...DIFF_POOL_RENDER_OPTIONS,
+			// tokenizeMaxLength is not a pool option, so it stays per-item.
 			tokenizeMaxLength: 200_000,
-			maxLineDiffLength: 5_000,
 			unsafeCSS: `
 				* { user-select: text; -webkit-user-select: text; }
 				/* Query container for slotted PR-comment bubbles

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/DiffThemeSync.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/DiffThemeSync.tsx
@@ -14,7 +14,14 @@ export function DiffThemeSync() {
 	const activeTheme = useResolvedTheme();
 
 	useEffect(() => {
-		void poolManager?.setRenderOptions(buildDiffPoolRenderOptions(activeTheme));
+		poolManager
+			?.setRenderOptions(buildDiffPoolRenderOptions(activeTheme))
+			.catch((error) => {
+				console.error(
+					"[DiffThemeSync] Failed to apply theme to diff pool:",
+					error,
+				);
+			});
 	}, [poolManager, activeTheme]);
 
 	return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/DiffThemeSync.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/DiffThemeSync.tsx
@@ -1,0 +1,22 @@
+import { useWorkerPool } from "@pierre/diffs/react";
+import { useEffect } from "react";
+import { useResolvedTheme } from "renderer/stores/theme";
+import { buildDiffPoolRenderOptions } from "./buildDiffPoolRenderOptions";
+
+/**
+ * Drives the @pierre/diffs worker pool's theme from the active Superset theme.
+ * Under a worker pool the renderer ignores each CodeView item's `theme`, so it
+ * must be pushed onto the pool via setRenderOptions. Must be mounted inside
+ * WorkerPoolContextProvider.
+ */
+export function DiffThemeSync() {
+	const poolManager = useWorkerPool();
+	const activeTheme = useResolvedTheme();
+
+	useEffect(() => {
+		if (!poolManager) return;
+		void poolManager.setRenderOptions(buildDiffPoolRenderOptions(activeTheme));
+	}, [poolManager, activeTheme]);
+
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/DiffThemeSync.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/DiffThemeSync.tsx
@@ -14,8 +14,7 @@ export function DiffThemeSync() {
 	const activeTheme = useResolvedTheme();
 
 	useEffect(() => {
-		if (!poolManager) return;
-		void poolManager.setRenderOptions(buildDiffPoolRenderOptions(activeTheme));
+		void poolManager?.setRenderOptions(buildDiffPoolRenderOptions(activeTheme));
 	}, [poolManager, activeTheme]);
 
 	return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/buildDiffPoolRenderOptions.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/buildDiffPoolRenderOptions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { getDiffsTheme } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
+import { darkTheme, monokaiTheme } from "shared/themes";
+import { buildDiffPoolRenderOptions } from "./buildDiffPoolRenderOptions";
+
+describe("buildDiffPoolRenderOptions", () => {
+	it("uses the diffs theme name for the active theme", () => {
+		const options = buildDiffPoolRenderOptions(darkTheme);
+		expect(options.theme).toBe(getDiffsTheme(darkTheme));
+	});
+
+	it("derives a distinct theme name per theme", () => {
+		expect(buildDiffPoolRenderOptions(darkTheme).theme).not.toBe(
+			buildDiffPoolRenderOptions(monokaiTheme).theme,
+		);
+	});
+
+	it("restates the tokenize/diff intent from useDiffCodeViewTheme", () => {
+		const options = buildDiffPoolRenderOptions(darkTheme);
+		expect(options.lineDiffType).toBe("word-alt");
+		expect(options.maxLineDiffLength).toBe(5_000);
+		expect(options.tokenizeMaxLineLength).toBe(5_000);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/buildDiffPoolRenderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/buildDiffPoolRenderOptions.ts
@@ -1,27 +1,23 @@
-import { getDiffsTheme } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
+import {
+	DIFF_POOL_RENDER_OPTIONS,
+	getDiffsTheme,
+} from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
 import type { Theme } from "shared/themes";
 
 /**
  * Builds the render options the @pierre/diffs worker pool should run with for a
  * given Superset theme.
  *
- * Under a worker pool, the renderer ignores the per-CodeView-item options and
- * uses the pool's render options instead (see DiffHunksRenderer.getRenderOptions).
- * So these values must be driven onto the pool via WorkerPoolManager.setRenderOptions
- * to take effect. The tokenize/diff fields restate Superset's intent from
- * useDiffCodeViewTheme so the pool matches the per-item config it would otherwise
- * use without a pool.
- *
- * `tokenizeMaxLength` is intentionally omitted: it is not part of the pool's
- * render options (setRenderOptions only accepts theme/useTokenTransformer/
- * lineDiffType/maxLineDiffLength/tokenizeMaxLineLength), so passing it would be
- * silently ignored.
+ * Under a worker pool the renderer ignores the per-CodeView-item options and
+ * uses the pool's render options instead (see DiffHunksRenderer.getRenderOptions),
+ * so these must be driven onto the pool via WorkerPoolManager.setRenderOptions to
+ * take effect. The diff/tokenize options come from DIFF_POOL_RENDER_OPTIONS — the
+ * same source useDiffCodeViewTheme uses for its per-item config — so the pool and
+ * per-item options can't silently diverge.
  */
 export function buildDiffPoolRenderOptions(activeTheme: Theme) {
 	return {
 		theme: getDiffsTheme(activeTheme),
-		lineDiffType: "word-alt" as const,
-		maxLineDiffLength: 5_000,
-		tokenizeMaxLineLength: 5_000,
+		...DIFF_POOL_RENDER_OPTIONS,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/buildDiffPoolRenderOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/buildDiffPoolRenderOptions.ts
@@ -1,0 +1,27 @@
+import { getDiffsTheme } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
+import type { Theme } from "shared/themes";
+
+/**
+ * Builds the render options the @pierre/diffs worker pool should run with for a
+ * given Superset theme.
+ *
+ * Under a worker pool, the renderer ignores the per-CodeView-item options and
+ * uses the pool's render options instead (see DiffHunksRenderer.getRenderOptions).
+ * So these values must be driven onto the pool via WorkerPoolManager.setRenderOptions
+ * to take effect. The tokenize/diff fields restate Superset's intent from
+ * useDiffCodeViewTheme so the pool matches the per-item config it would otherwise
+ * use without a pool.
+ *
+ * `tokenizeMaxLength` is intentionally omitted: it is not part of the pool's
+ * render options (setRenderOptions only accepts theme/useTokenTransformer/
+ * lineDiffType/maxLineDiffLength/tokenizeMaxLineLength), so passing it would be
+ * silently ignored.
+ */
+export function buildDiffPoolRenderOptions(activeTheme: Theme) {
+	return {
+		theme: getDiffsTheme(activeTheme),
+		lineDiffType: "word-alt" as const,
+		maxLineDiffLength: 5_000,
+		tokenizeMaxLineLength: 5_000,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DiffThemeSync/index.ts
@@ -1,0 +1,1 @@
+export { DiffThemeSync } from "./DiffThemeSync";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -24,6 +24,7 @@ import { showWorkspaceAutoNameWarningToast } from "renderer/lib/workspaces/showW
 import { InitGitDialog } from "renderer/react-query/projects/InitGitDialog";
 import { DaemonAutoUpdateFailureDialog } from "renderer/routes/_authenticated/components/DaemonAutoUpdateFailureDialog";
 import { DashboardNewWorkspaceModal } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal";
+import { DiffThemeSync } from "renderer/routes/_authenticated/components/DiffThemeSync";
 import { V1ImportModal } from "renderer/routes/_authenticated/components/V1ImportModal";
 import { WorkspaceInitEffects } from "renderer/screens/main/components/WorkspaceInitEffects";
 import { useSettingsStore } from "renderer/stores/settings-state";
@@ -216,6 +217,7 @@ function AuthenticatedLayout() {
 							poolOptions={{ workerFactory: createPierreWorker, poolSize: 8 }}
 							highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}
 						>
+							<DiffThemeSync />
 							<AgentHooks />
 							<FileMenuListener />
 							<V2NotificationController />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/diff-render-options.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/diff-render-options.ts
@@ -1,3 +1,5 @@
+import type { RenderDiffOptions } from "@pierre/diffs";
+
 /**
  * Diff render options governed by the @pierre/diffs worker pool.
  *
@@ -16,4 +18,4 @@ export const DIFF_POOL_RENDER_OPTIONS = {
 	lineDiffType: "word-alt",
 	maxLineDiffLength: 5_000,
 	tokenizeMaxLineLength: 5_000,
-} as const;
+} as const satisfies Partial<RenderDiffOptions>;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/diff-render-options.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/diff-render-options.ts
@@ -1,0 +1,19 @@
+/**
+ * Diff render options governed by the @pierre/diffs worker pool.
+ *
+ * Under a worker pool the renderer ignores each CodeView item's copy of these
+ * options and uses the pool's values instead. Keeping them in one place lets the
+ * per-item config (useDiffCodeViewTheme) and the pool config
+ * (buildDiffPoolRenderOptions) share a single source of truth so they can't
+ * silently diverge.
+ *
+ * - `lineDiffType: "word-alt"` matches the library default; kept explicit so the
+ *   pool and per-item paths provably agree.
+ * - The length caps degrade gracefully on lockfiles / minified bundles instead
+ *   of blocking the worker.
+ */
+export const DIFF_POOL_RENDER_OPTIONS = {
+	lineDiffType: "word-alt",
+	maxLineDiffLength: 5_000,
+	tokenizeMaxLineLength: 5_000,
+} as const;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/utils/code-theme/index.ts
@@ -1,3 +1,4 @@
+export { DIFF_POOL_RENDER_OPTIONS } from "./diff-render-options";
 export { getDiffsTheme } from "./diff-theme";
 export { getDiffViewerStyle } from "./diff-viewer-style";
 export { getCodeSyntaxHighlighting } from "./syntax-highlighting";


### PR DESCRIPTION
## Summary

The v2 diff viewer ignored the active app theme — its syntax highlighting always used the diff library's built-in default colors, even for Superset's own built-in themes. (The code editor themed fine; only diffs were affected.) Separately, custom themes imported with their own syntax colors looked right in the moment but reverted after an app restart.

This makes diffs use the active theme, and keeps custom themes across restarts.

## Type of Change

- [x] Bug fix

## Root cause

Two independent issues, both ending in "the diff doesn't use the theme's colors":

**1. The theme never reached the diff renderer.** The v2 diff view renders through `@pierre/diffs`, which does its syntax highlighting on a shared background worker pool. That pool keeps its own theme and only picks it up at creation or when explicitly updated — it ignores the per-diff `theme` option the app was passing. We never set a theme on the pool, so it stayed on the library's defaults (`pierre-dark`/`pierre-light`) and the app's theme was dropped. This may have regressed in #4898, which moved diffs onto the pool; the previous diff path had no pool, so it may have themed correctly.

**2. Custom theme colors weren't persisted.** Theme state is saved through the `uiState.theme.set` tRPC endpoint, whose Zod schema listed every `Theme` field except `editor` (the editor/diff color + syntax overrides). Zod strips unknown keys, so each save silently dropped `editor`. Imported themes looked correct during the session but reloaded without their syntax colors after a restart, falling back to a generated palette — in both the editor and the diff.

(Distinct from #3013 / #3567 / #2684 / #3569, which are about the `+`/`-` line-change colors, not syntax highlighting or persistence.)

## Fix

**Sync the theme to the pool** — a small `DiffThemeSync` component, mounted next to the diff worker-pool provider, updates the pool's theme whenever the app theme changes. The library resolves the theme on the main thread, ships it to the workers, and re-renders open diffs.

**Persist `editor`** — added the missing `editor` field to the theme persistence schema so custom themes keep their colors across restarts.

> Themes saved before this change must be re-imported once to restore their `editor` colors.

## Testing

- `bun test` — added a unit test for the pool theme options
- `bun run typecheck` and `bun run lint` — clean
- Manual: imported a custom theme with distinct syntax colors → diff tokens render in the theme's colors instead of the library default; switching themes updates open diffs live; colors now survive an app restart

## How to reproduce

1. Download [`monokai-pro-superset-theme.json`](https://github.com/user-attachments/files/29543193/monokai-pro-superset-theme.json) — a custom theme with a full `editor.syntax` block.
2. Settings → Appearance → Import theme → select it → activate.
3. Open any diff → syntax tokens render in the theme's colors (pink keywords `#FF6188`, yellow strings `#FFD866`, green functions `#A9DC76`), not the library default.
4. Reload (Cmd-R) → colors persist.

## Screenshots

Here's how the diff viewer looks with the custom Monokai Pro theme

### Theme applied correctly
<img width="3456" height="2234" alt="CleanShot 2026-07-01 at 14 59 19@2x" src="https://github.com/user-attachments/assets/a06967e4-08ee-4edb-9c61-79530568f18b" />

### Theme survives cmd+r reload
<img width="800" height="464" alt="CleanShot 2026-07-01 at 15 00 31" src="https://github.com/user-attachments/assets/742c228d-6dda-487a-9b47-461ee797e662" />

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5404">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes diff syntax theming by applying the active app theme to the `@pierre/diffs` worker pool and persisting `Theme.editor`. Diff views now use the right colors for custom and built-in themes, survive reloads, and pool/per-item diff options stay in sync; if you saved a custom theme before this change, re-import it once to restore editor syntax colors.

- **Bug Fixes**
  - Sync the active theme to the `@pierre/diffs` worker pool via `DiffThemeSync`, calling `setRenderOptions` on theme changes and sharing diff/tokenize options through `DIFF_POOL_RENDER_OPTIONS` so `CodeView` items and the pool use the same settings.
  - Persist `Theme.editor` by adding an `editor` field to the Zod `themeSchema` (`colors` and `syntax` as records), fixing custom theme syntax being dropped on save and lost after restart.
  - Guard the pool call with optional chaining and log `setRenderOptions` rejections with `console.error` to avoid unhandled promise rejections.

- **Refactors**
  - Constrain `DIFF_POOL_RENDER_OPTIONS` with `satisfies Partial<RenderDiffOptions>` to catch invalid or renamed render-option keys at build time.

<sup>Written for commit e0b5cc21de92e99f12d4c5e5c7cad6260c630655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Diff views now synchronize with the active app theme for more consistent styling.

* **Bug Fixes**
  * Custom theme editor color/syntax overrides now persist correctly after reopening.
  * Improved diff rendering consistency by applying shared worker-pool diff render options so tokenization stays aligned.

* **Tests**
  * Added unit tests to verify diff theme naming and core diff render-option settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->