### PR TITLE
fix(billing): read invoices from the org's canonical Stripe customer

### DIFF
--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -1,9 +1,9 @@
 import { stripeClient } from "@superset/auth/stripe";
 import { db } from "@superset/db/client";
-import { members, subscriptions } from "@superset/db/schema";
+import { members, organizations, subscriptions } from "@superset/db/schema";
 import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, desc, eq, inArray, isNotNull } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import type Stripe from "stripe";
 import { z } from "zod";
 import { env } from "../../env";
@@ -39,19 +39,16 @@ async function requireOwnerWithCustomer(ctx: {
 		});
 	}
 
-	const [member, subscription] = await Promise.all([
+	const [member, organization] = await Promise.all([
 		db.query.members.findFirst({
 			where: and(
 				eq(members.userId, ctx.session.user.id),
 				eq(members.organizationId, activeOrgId),
 			),
 		}),
-		db.query.subscriptions.findFirst({
-			where: and(
-				eq(subscriptions.referenceId, activeOrgId),
-				isNotNull(subscriptions.stripeCustomerId),
-			),
-			orderBy: desc(subscriptions.createdAt),
+		db.query.organizations.findFirst({
+			where: eq(organizations.id, activeOrgId),
+			columns: { stripeCustomerId: true },
 		}),
 	]);
 
@@ -62,11 +59,7 @@ async function requireOwnerWithCustomer(ctx: {
 		});
 	}
 
-	if (!subscription?.stripeCustomerId) {
-		return null;
-	}
-
-	return subscription.stripeCustomerId;
+	return organization?.stripeCustomerId ?? null;
 }
 
 export const billingRouter = {
@@ -98,47 +91,25 @@ export const billingRouter = {
 			});
 		}
 
-		// The subscriptions table is the only org -> Stripe customer mapping, so
-		// gather every customer this org has ever billed under. Intentionally
-		// unfiltered by status so invoices stay accessible after a downgrade, and
-		// an org can accumulate more than one customer over its lifetime.
-		const subscriptionRows = await db.query.subscriptions.findMany({
-			where: and(
-				eq(subscriptions.referenceId, activeOrgId),
-				isNotNull(subscriptions.stripeCustomerId),
-			),
+		const organization = await db.query.organizations.findFirst({
+			where: eq(organizations.id, activeOrgId),
 			columns: { stripeCustomerId: true },
 		});
 
-		const customerIds = [
-			...new Set(
-				subscriptionRows
-					.map((row) => row.stripeCustomerId)
-					.filter((id): id is string => id !== null),
-			),
-		];
-
-		if (customerIds.length === 0) {
+		if (!organization?.stripeCustomerId) {
 			return [];
 		}
 
 		const twelveMonthsAgo = subtractMonthsClamped(new Date(), 12);
 
-		// A paid invoice belongs to exactly one customer, so merging across
-		// customers never produces duplicates.
-		const invoiceLists = await Promise.all(
-			customerIds.map((customer) =>
-				stripeClient.invoices.list({
-					customer,
-					limit: 100,
-					status: "paid",
-					created: { gte: Math.floor(twelveMonthsAgo.getTime() / 1000) },
-				}),
-			),
-		);
+		const invoiceList = await stripeClient.invoices.list({
+			customer: organization.stripeCustomerId,
+			limit: 100,
+			status: "paid",
+			created: { gte: Math.floor(twelveMonthsAgo.getTime() / 1000) },
+		});
 
-		return invoiceLists
-			.flatMap((list) => list.data)
+		return invoiceList.data
 			.sort((a, b) => b.created - a.created)
 			.map((invoice) => ({
 				id: invoice.id,


### PR DESCRIPTION
## Problem

Free-tier users couldn't see invoices in the desktop app (Settings → Billing) — and, it turns out, **neither could some paying orgs**. The `billing.invoices` endpoint sourced the Stripe customer id from `subscriptions.stripeCustomerId`, which is unreliable.

## Root cause (verified against live Stripe)

There were two columns holding "the org's Stripe customer":
- `organizations.stripeCustomerId` — created per org, and what the rest of the billing code already keys off (dunning in `onEvent`, cancel-on-delete, customer email/name sync).
- `subscriptions.stripeCustomerId` — written by the better-auth stripe plugin, and **frequently wrong**: for many orgs it points at a near-sequential duplicate customer that was created during checkout but never actually billed (the real subscription + invoices live on the org customer). In at least one case it points at a customer belonging to a *different* org.

I confirmed this directly in Stripe: for every divergent org with a live subscription, the actual `subscription.customer` equals `organizations.stripeCustomerId`, and the invoices live there — not on `subscriptions.stripeCustomerId`. So the endpoint was querying empty/duplicate customers and returning `[]`.

## Fix

Read `organizations.stripeCustomerId` — the authoritative billing customer — in both `invoices` and `requireOwnerWithCustomer` (details/portal). One canonical lookup instead of two, and the corrupt column is no longer read. Union logic removed (net −39 lines).

**No data migration required.** `organizations.stripeCustomerId` was already correct for every paying org (verified: zero orgs have a live subscription with a null/mismatched org customer).

### Separate billing-data issues found (not addressed here — need a human, not code)
- One org has **two active pro subscriptions on two customers** (genuine double-billing) — cancel the duplicate + refund.
- One phantom org carries a **bogus active-enterprise subscription row** (`stripe_subscription_id = null`) duplicating another org's real enterprise sub — should be deleted so it stops showing as enterprise in `activePlan`.

## Testing

Verified the endpoint against live Stripe for the affected orgs (subscription + paid invoices resolve on `organizations.stripeCustomerId`), and simulated end-to-end on the dev branch for a free-tier org with seeded paid invoices. `bun run lint` ✅, `bun run typecheck --filter=@superset/trpc` ✅.