### PR TITLE
fix(desktop): re-mint terminal JWT on every reconnect

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -23,6 +23,7 @@ import {
 	sendDispose,
 	sendInput,
 	sendResize,
+	stripUrlToken,
 	type TerminalLogEntry,
 	type TerminalTransport,
 } from "./terminal-ws-transport";
@@ -176,10 +177,15 @@ class TerminalRuntimeRegistryImpl {
 	 *
 	 * Idempotent: no-op if already connected/connecting to the same URL.
 	 */
-	connect(terminalId: string, wsUrl: string, instanceId = terminalId) {
+	connect(
+		terminalId: string,
+		wsUrl: string,
+		instanceId = terminalId,
+		getToken?: () => string | null,
+	) {
 		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
-		connect(entry.transport, entry.runtime.terminal, wsUrl);
+		connect(entry.transport, entry.runtime.terminal, wsUrl, getToken);
 	}
 
 	/**
@@ -194,12 +200,19 @@ class TerminalRuntimeRegistryImpl {
 	 * `"closed"` (previously live and mid-auto-reconnect — swap the URL so the
 	 * reconnect targets the new endpoint).
 	 */
-	reconnect(terminalId: string, wsUrl: string, instanceId = terminalId) {
+	reconnect(
+		terminalId: string,
+		wsUrl: string,
+		instanceId = terminalId,
+		getToken?: () => string | null,
+	) {
 		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 		if (entry.transport.connectionState === "disconnected") return;
-		if (entry.transport.currentUrl === wsUrl) return;
-		connect(entry.transport, entry.runtime.terminal, wsUrl);
+		// currentUrl is token-less, so compare against the stripped incoming URL:
+		// a token refresh alone must not tear down a live shell.
+		if (entry.transport.currentUrl === stripUrlToken(wsUrl)) return;
+		connect(entry.transport, entry.runtime.terminal, wsUrl, getToken);
 	}
 
 	/**

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -27,8 +27,13 @@ type TerminalServerMessage =
 export interface TerminalTransport {
 	socket: WebSocket | null;
 	connectionState: ConnectionState;
-	/** The URL the socket is currently connected (or connecting) to. */
+	/** The token-less URL the socket is currently connected (or connecting) to.
+	 * The auth token is appended per-dial (see _getToken), never stored here. */
 	currentUrl: string | null;
+	/** Mints a fresh auth token for each (re)dial. Kept separate from currentUrl
+	 * so a reconnect after the JWT's 1h expiry presents a valid token instead of
+	 * replaying the stale one baked in at first connect. */
+	_getToken: (() => string | null) | null;
 	title: string | null | undefined;
 	onDataDisposable: { dispose(): void } | null;
 	stateListeners: Set<() => void>;
@@ -155,6 +160,7 @@ export function createTransport(): TerminalTransport {
 		socket: null,
 		connectionState: "disconnected",
 		currentUrl: null,
+		_getToken: null,
 		title: undefined,
 		onDataDisposable: null,
 		stateListeners: new Set(),
@@ -326,16 +332,30 @@ function appendQueryParam(url: string, key: string, value: string): string {
 	}
 }
 
+export function stripUrlToken(url: string): string {
+	try {
+		const u = new URL(url);
+		u.searchParams.delete("token");
+		return u.toString();
+	} catch {
+		return url;
+	}
+}
+
 export function connect(
 	transport: TerminalTransport,
 	terminal: XTerm,
 	wsUrl: string,
+	getToken?: () => string | null,
 ) {
+	if (getToken !== undefined) transport._getToken = getToken;
+	const baseUrl = stripUrlToken(wsUrl);
+
 	// Idempotent: skip if already connected/connecting to the same endpoint.
 	const isActive =
 		transport.connectionState === "open" ||
 		transport.connectionState === "connecting";
-	if (isActive && transport.currentUrl === wsUrl) return;
+	if (isActive && transport.currentUrl === baseUrl) return;
 
 	if (transport.socket) {
 		transport.socket.close();
@@ -343,7 +363,7 @@ export function connect(
 	}
 
 	cancelReconnect(transport);
-	transport.currentUrl = wsUrl;
+	transport.currentUrl = baseUrl;
 	transport._terminal = terminal;
 	// Recreate per connect so the coalescer always targets the current
 	// terminal; dispose flushes anything the previous socket left pending.
@@ -354,27 +374,36 @@ export function connect(
 	transport._terminated = false;
 	setupLiveness(transport);
 	setConnectionState(transport, "connecting");
-	const actualUrl = transport._hasReceivedBytes
-		? appendQueryParam(wsUrl, "replay", "0")
-		: wsUrl;
+	const replayUrl = transport._hasReceivedBytes
+		? appendQueryParam(baseUrl, "replay", "0")
+		: baseUrl;
+
+	// Mint the auth token here rather than reading it off currentUrl: the JWT
+	// lives 1h, so a reconnect that replayed a baked token would be rejected 401
+	// by the relay. Every (re)dial — including the affinity pre-flight — gets a
+	// fresh token.
+	const buildDialUrl = () => {
+		const token = transport._getToken?.() ?? null;
+		return token ? appendQueryParam(replayUrl, "token", token) : replayUrl;
+	};
 
 	const openSocket = () => {
 		// Bail if the transport raced into a different URL or was disconnected
 		// while the pre-flight was in flight.
 		if (
-			transport.currentUrl !== wsUrl ||
+			transport.currentUrl !== baseUrl ||
 			transport.connectionState !== "connecting"
 		) {
 			return;
 		}
 		let socket: WebSocket;
 		try {
-			socket = new WebSocket(actualUrl);
+			socket = new WebSocket(buildDialUrl());
 		} catch (err) {
 			pushLog(
 				transport,
 				"error",
-				`WebSocket construction failed for ${formatWsEndpoint(actualUrl)}: ${
+				`WebSocket construction failed for ${formatWsEndpoint(replayUrl)}: ${
 					err instanceof Error ? err.message : String(err)
 				}`,
 			);
@@ -397,12 +426,12 @@ export function connect(
 	// for non-/hosts URLs (tests, local dev) so connect stays synchronous.
 	let needsPreFlight = false;
 	try {
-		needsPreFlight = new URL(actualUrl).pathname.startsWith("/hosts/");
+		needsPreFlight = new URL(replayUrl).pathname.startsWith("/hosts/");
 	} catch {
 		needsPreFlight = false;
 	}
 	if (needsPreFlight) {
-		void primeRelayAffinity(actualUrl).then(openSocket);
+		void primeRelayAffinity(buildDialUrl()).then(openSocket);
 	} else {
 		openSocket();
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,6 +1,6 @@
 import type { RendererContext } from "@superset/panes";
 import { cn } from "@superset/ui/utils";
-import { workspaceTrpc } from "@superset/workspace-client";
+import { useWorkspaceClient, workspaceTrpc } from "@superset/workspace-client";
 import "@xterm/xterm/css/xterm.css";
 import {
 	useCallback,
@@ -86,6 +86,11 @@ export function TerminalPane({
 	const websocketUrl = themedUrl.toString();
 	const websocketUrlRef = useRef(websocketUrl);
 	websocketUrlRef.current = websocketUrl;
+	// The transport re-mints the token on every (re)dial, so the JWT stays fresh
+	// across reconnects instead of replaying the one baked into websocketUrl.
+	const { getWsToken } = useWorkspaceClient();
+	const getWsTokenRef = useRef(getWsToken);
+	getWsTokenRef.current = getWsToken;
 	const workspaceIdRef = useRef(workspaceId);
 	workspaceIdRef.current = workspaceId;
 
@@ -147,6 +152,7 @@ export function TerminalPane({
 			terminalId,
 			websocketUrlRef.current,
 			terminalInstanceId,
+			getWsTokenRef.current,
 		);
 
 		return () => {
@@ -205,6 +211,7 @@ export function TerminalPane({
 			terminalId,
 			websocketUrlRef.current,
 			terminalInstanceId,
+			getWsTokenRef.current,
 		);
 	}, [terminalId, terminalInstanceId, baseWebsocketUrl]);
 


### PR DESCRIPTION
## Problem

Remote-workspace **terminals fail to attach** while everything else (files, PRs, git, ports) works. Relay logs show `/hosts/<org>:<machine>/terminal/<id>?token=…` returning **HTTP 401 in ~0–1 ms at the relay edge**, at a **~71% rate across multiple users' hosts** (128× 401 vs 10× 200 on a live sample). The same host gets *both* 200 and 401 → a per-token rejection, not a per-host/version issue.

## Root cause

The terminal WebSocket URL has a **1-hour better-auth JWT baked into it at React render time** (`useWorkspaceWsUrl` → `getWsToken()`), and the desktop transport stores that full URL in `transport.currentUrl`. Every reconnect path — `reconnectNow`, `scheduleReconnect`, `handleResume` — redials `transport.currentUrl` **verbatim, never re-minting the token**. Once the JWT passes its `exp`, the relay (validating via better-auth JWKS) rejects the attach with 401. tRPC/filesystem calls are unaffected because they mint a fresh token per request.

The module-level token refresh (`setJwt` every 50 min) updates a plain variable that doesn't trigger a re-render, so the baked URL never recomputes.

**Trigger:** the sleep/wake + focus/visibility auto-reconnect machinery added in #5135 (and hardened in #5137) redials aggressively using the token-baked URL, converting a previously-latent staleness bug into a fleet-wide 401 storm. Surfacing via the recent canary / 1.12.6 builds. The relay validator and JWT signing config are unchanged — this is **not** a server/secret problem.

## Fix

Stop persisting the token in `currentUrl`; mint it fresh per dial:

- `terminal-ws-transport.ts`: store a **token-less** base URL (`stripUrlToken`) and append a freshly-minted `token` at each dial — both the WS open and the fly-affinity pre-flight — via a new optional `getToken` provider on `connect()`.
- `terminal-runtime-registry.ts`: thread `getToken` through `connect()`/`reconnect()`; compare against the stripped URL so a token refresh alone doesn't tear down a live shell.
- `TerminalPane.tsx`: pass `getWsToken` (from `useWorkspaceClient()`) as the provider.

This mirrors what web's `TerminalConnection.buildUrl()` and desktop's tRPC headers already do (fresh token per request).

## Verification

- `bun test terminal-ws-transport.test.ts` → 7 pass
- `biome check` → clean
- Typecheck: no errors from the changed files (a pre-existing duplicate-`@codemirror` dedup error in `CodeEditor.tsx` is unrelated and reproduces on `main` without this change).

## Immediate mitigation (no release needed)

Affected users can fully quit & reopen the desktop app (or reopen the terminal) to force a fresh token.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5408">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-mint the terminal JWT on every reconnect in the desktop app to stop 401s after token expiry. Store a token‑less base URL and add a fresh token for each dial (including pre-flight).

- **Bug Fixes**
  - Store a token-less `currentUrl`; append a fresh token per (re)dial in `terminal-ws-transport` (WS open and relay-affinity pre-flight).
  - Add optional `getToken` to `connect()`; thread through `terminal-runtime-registry` so reconnects use new tokens.
  - Compare against stripped URLs to avoid tearing down a live shell when only the token changes.
  - Pass `getWsToken` from `useWorkspaceClient()` in `TerminalPane` (`@superset/workspace-client`).

<sup>Written for commit 2a35f66c9f7cea9672ca8de6f4d05b5dbc06632a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal connections now refresh authentication tokens automatically during reconnects.
  * Reconnects are smarter and can reuse existing sessions when only the token changes.

* **Bug Fixes**
  * Reduced unnecessary terminal disconnects caused by token updates.
  * Improved WebSocket reconnection reliability for terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->