### PR TITLE
feat(desktop): pinned source-group sections in the diff pane

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -43,6 +43,7 @@ interface WorkspaceSidebarProps {
 		openInNewTab?: boolean,
 		line?: number,
 		side?: DiffFocusSide,
+		changeKey?: string,
 	) => void;
 	onOpenComment?: (comment: CommentPaneData) => void;
 	onOpenChat?: OpenChatFn;
@@ -129,7 +130,10 @@ export function WorkspaceSidebar({
 	const changesTabDef = useChangesTab({
 		workspaceId,
 		selectedFilePath,
-		onSelectFile: onSelectDiffFile,
+		onSelectFile: onSelectDiffFile
+			? (path, openInNewTab, changeKey) =>
+					onSelectDiffFile(path, openInNewTab, undefined, undefined, changeKey)
+			: undefined,
 		onOpenFile: onSelectFile,
 	});
 	const changesTab: SidebarTabDefinition = {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -19,7 +19,11 @@ interface ChangesFileListProps {
 	worktreePath?: string;
 	selectedFilePath?: string;
 	foldSignal: FoldSignal;
-	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onSelectFile?: (
+		path: string,
+		openInNewTab?: boolean,
+		changeKey?: string,
+	) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesFoldersView/ChangesFoldersView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesFoldersView/ChangesFoldersView.tsx
@@ -1,5 +1,8 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+import {
+	type ChangesetFile,
+	getChangesetFileKey,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import type { FoldSignal } from "../../ChangesFileList";
 import { FileRow } from "../FileRow";
 import { FolderHeader } from "./components/FolderHeader";
@@ -13,7 +16,11 @@ interface ChangesFoldersViewProps {
 	worktreePath?: string;
 	/** Bumped by the toolbar's expand-all / collapse-all buttons. */
 	foldSignal: FoldSignal;
-	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onSelectFile?: (
+		path: string,
+		openInNewTab?: boolean,
+		changeKey?: string,
+	) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
@@ -90,7 +97,7 @@ export const ChangesFoldersView = memo(function ChangesFoldersView({
 						{isOpen &&
 							group.files.map((file) => (
 								<FileRow
-									key={`${file.source.kind}:${file.path}`}
+									key={getChangesetFileKey(file)}
 									file={file}
 									workspaceId={workspaceId}
 									worktreePath={worktreePath}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
@@ -28,7 +28,10 @@ import {
 } from "renderer/lib/pierreTree";
 import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
 import { PierreRowContextMenu } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PierreRowContextMenu";
-import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+import {
+	type ChangesetFile,
+	getChangesetFileKey,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import {
 	toAbsoluteWorkspacePath,
 	toRelativeWorkspacePath,
@@ -64,7 +67,11 @@ interface ChangesTreeViewProps {
 	selectedFilePath?: string;
 	/** Bumped by the toolbar's expand-all / collapse-all buttons. */
 	foldSignal: FoldSignal;
-	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onSelectFile?: (
+		path: string,
+		openInNewTab?: boolean,
+		changeKey?: string,
+	) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
@@ -198,7 +205,12 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 
 	handlersRef.current.onSelect = (treePath) => {
 		lastUserSelectRef.current = treePath;
-		onSelectFile?.(treePath, false);
+		const file = fileByPath.get(treePath);
+		onSelectFile?.(
+			treePath,
+			false,
+			file ? getChangesetFileKey(file) : undefined,
+		);
 	};
 	// Pierre's row decoration accepts text or icon, not arbitrary JSX. The
 	// status indicator is already painted by `setGitStatus` (row tint + icon),
@@ -221,7 +233,12 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 			getFileIntent: filePolicy.getIntent,
 			onSelectDiff: (rel, openInNewTab) => {
 				lastUserSelectRef.current = rel;
-				onSelectFile?.(rel, openInNewTab);
+				const file = fileByPath.get(rel);
+				onSelectFile?.(
+					rel,
+					openInNewTab,
+					file ? getChangesetFileKey(file) : undefined,
+				);
 			},
 			onOpenFile: (rel, openInNewTab) => {
 				if (!worktreePath) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
@@ -16,14 +16,21 @@ import {
 	useChangesSidebarFilePolicy,
 } from "renderer/lib/clickPolicy";
 import { PathActionsMenuItems } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PathActionsMenuItems";
-import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+import {
+	type ChangesetFile,
+	getChangesetFileKey,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 
 interface FileRowContextMenuItemsProps {
 	file: ChangesetFile;
 	worktreePath?: string;
 	sectionKind: "unstaged" | "staged" | "against-base" | "commit";
-	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onSelectFile?: (
+		path: string,
+		openInNewTab?: boolean,
+		changeKey?: string,
+	) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 	/**
@@ -54,6 +61,7 @@ export function FileRowContextMenuItems({
 		: undefined;
 	const canDiscard = sectionKind === "unstaged";
 	const isDeleteAction = file.status === "untracked" || file.status === "added";
+	const changeKey = getChangesetFileKey(file);
 
 	const policy = useChangesSidebarFilePolicy();
 	const diffNewTabTier = policy.tierForIntent("diffNewTab");
@@ -62,11 +70,15 @@ export function FileRowContextMenuItems({
 
 	return (
 		<>
-			<DropdownMenuItem onSelect={() => onSelectFile?.(file.path)}>
+			<DropdownMenuItem
+				onSelect={() => onSelectFile?.(file.path, false, changeKey)}
+			>
 				<GitCompare />
 				Open Diff
 			</DropdownMenuItem>
-			<DropdownMenuItem onSelect={() => onSelectFile?.(file.path, true)}>
+			<DropdownMenuItem
+				onSelect={() => onSelectFile?.(file.path, true, changeKey)}
+			>
 				<SquarePlus />
 				Open Diff in New Tab
 				{diffNewTabTier && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -34,7 +34,10 @@ import { FileIcon } from "renderer/lib/fileIcons";
 import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
 import { PathActionsMenuItems } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/PathActionsMenuItems";
-import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+import {
+	type ChangesetFile,
+	getChangesetFileKey,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 
 function splitPath(path: string): { dir: string; basename: string } {
@@ -52,7 +55,7 @@ interface FileRowProps {
 	worktreePath?: string;
 	/** Hide the directory prefix — used when the row sits under a folder group. */
 	hideDir?: boolean;
-	onSelect?: (path: string, openInNewTab?: boolean) => void;
+	onSelect?: (path: string, openInNewTab?: boolean, changeKey?: string) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
@@ -75,6 +78,7 @@ export const FileRow = memo(function FileRow({
 	const absolutePath = worktreePath
 		? toAbsoluteWorkspacePath(worktreePath, file.path)
 		: undefined;
+	const changeKey = getChangesetFileKey(file);
 	const canDiscard = file.source.kind === "unstaged";
 	const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 	const isDeleteAction = file.status === "untracked" || file.status === "added";
@@ -108,8 +112,9 @@ export const FileRow = memo(function FileRow({
 					if (intent === "external") onOpenInEditor?.(file.path);
 					else if (intent === "file" && absolutePath)
 						onOpenFile?.(absolutePath, false);
-					else if (intent === "diffNewTab") onSelect?.(file.path, true);
-					else if (intent === "diff") onSelect?.(file.path, false);
+					else if (intent === "diffNewTab")
+						onSelect?.(file.path, true, changeKey);
+					else if (intent === "diff") onSelect?.(file.path, false, changeKey);
 				}}
 			>
 				<FileIcon fileName={basename} className="size-3.5 shrink-0" />
@@ -171,11 +176,15 @@ export const FileRow = memo(function FileRow({
 						</button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="end" className="w-64">
-						<DropdownMenuItem onSelect={() => onSelect?.(file.path)}>
+						<DropdownMenuItem
+							onSelect={() => onSelect?.(file.path, false, changeKey)}
+						>
 							<GitCompare />
 							Open Diff
 						</DropdownMenuItem>
-						<DropdownMenuItem onSelect={() => onSelect?.(file.path, true)}>
+						<DropdownMenuItem
+							onSelect={() => onSelect?.(file.path, true, changeKey)}
+						>
 							<SquarePlus />
 							Open Diff in New Tab
 							{diffNewTabTier && (
@@ -230,11 +239,15 @@ export const FileRow = memo(function FileRow({
 				<TooltipContent side="right">{policy.hint}</TooltipContent>
 			</Tooltip>
 			<ContextMenuContent className="w-64">
-				<ContextMenuItem onSelect={() => onSelect?.(file.path)}>
+				<ContextMenuItem
+					onSelect={() => onSelect?.(file.path, false, changeKey)}
+				>
 					<GitCompare />
 					Open Diff
 				</ContextMenuItem>
-				<ContextMenuItem onSelect={() => onSelect?.(file.path, true)}>
+				<ContextMenuItem
+					onSelect={() => onSelect?.(file.path, true, changeKey)}
+				>
 					<SquarePlus />
 					Open Diff in New Tab
 					{diffNewTabTier && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -31,7 +31,11 @@ interface ChangesTabContentProps {
 	totalDeletions: number;
 	worktreePath?: string;
 	selectedFilePath?: string;
-	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onSelectFile?: (
+		path: string,
+		openInNewTab?: boolean,
+		changeKey?: string,
+	) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 	onFilterChange: (filter: ChangesFilter) => void;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -24,7 +24,11 @@ interface UseChangesTabParams {
 	workspaceId: string;
 	/** Absolute path of the file whose diff/preview is currently open. */
 	selectedFilePath?: string;
-	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onSelectFile?: (
+		path: string,
+		openInNewTab?: boolean,
+		changeKey?: string,
+	) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/buildChangesetFiles.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/buildChangesetFiles.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { buildChangesetFiles } from "./buildChangesetFiles";
+import { getChangesetFileKey } from "./changesetFileKey";
+
+describe("buildChangesetFiles", () => {
+	test("keeps against-base files visible in all changes when paths overlap dirty buckets", () => {
+		const files = buildChangesetFiles(
+			{
+				againstBase: [
+					{
+						path: "src/file.ts",
+						status: "modified",
+						additions: 10,
+						deletions: 1,
+					},
+					{
+						path: "src/branch-only.ts",
+						status: "added",
+						additions: 4,
+						deletions: 0,
+					},
+				],
+				staged: [
+					{
+						path: "src/file.ts",
+						status: "modified",
+						additions: 2,
+						deletions: 0,
+					},
+				],
+				unstaged: [
+					{
+						path: "src/file.ts",
+						status: "modified",
+						additions: 1,
+						deletions: 3,
+					},
+				],
+			},
+			{ kind: "against-base", baseBranch: "main" },
+		);
+
+		expect(files.map((file) => [file.source.kind, file.path])).toEqual([
+			["unstaged", "src/file.ts"],
+			["staged", "src/file.ts"],
+			["against-base", "src/file.ts"],
+			["against-base", "src/branch-only.ts"],
+		]);
+		expect(new Set(files.map(getChangesetFileKey)).size).toBe(files.length);
+	});
+
+	test("uncommitted filter excludes against-base files", () => {
+		const files = buildChangesetFiles(
+			{
+				againstBase: [
+					{
+						path: "src/branch-only.ts",
+						status: "added",
+						additions: 4,
+						deletions: 0,
+					},
+				],
+				staged: [
+					{
+						path: "src/staged.ts",
+						status: "modified",
+						additions: 2,
+						deletions: 0,
+					},
+				],
+				unstaged: [
+					{
+						path: "src/unstaged.ts",
+						status: "modified",
+						additions: 1,
+						deletions: 3,
+					},
+				],
+			},
+			{ kind: "uncommitted" },
+		);
+
+		expect(files.map((file) => file.source.kind)).toEqual([
+			"unstaged",
+			"staged",
+		]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/buildChangesetFiles.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/buildChangesetFiles.ts
@@ -1,0 +1,61 @@
+import type { FileStatus } from "../../components/StatusIndicator";
+import type { ChangesetFile, DiffRef } from "./types";
+
+interface GitChangedFile {
+	path: string;
+	oldPath?: string;
+	status: string;
+	additions: number;
+	deletions: number;
+}
+
+interface GitStatusChanges {
+	againstBase: GitChangedFile[];
+	staged: GitChangedFile[];
+	unstaged: GitChangedFile[];
+}
+
+function toChangesetFile(
+	file: GitChangedFile,
+	source: ChangesetFile["source"],
+): ChangesetFile {
+	return {
+		path: file.path,
+		oldPath: file.oldPath,
+		status: file.status as FileStatus,
+		additions: file.additions,
+		deletions: file.deletions,
+		source,
+	};
+}
+
+export function buildChangesetFiles(
+	status: GitStatusChanges,
+	ref: DiffRef,
+): ChangesetFile[] {
+	if (ref.kind === "uncommitted") {
+		return [
+			...status.unstaged.map((file) =>
+				toChangesetFile(file, { kind: "unstaged" }),
+			),
+			...status.staged.map((file) => toChangesetFile(file, { kind: "staged" })),
+		];
+	}
+
+	if (ref.kind !== "against-base") {
+		return [];
+	}
+
+	return [
+		...status.unstaged.map((file) =>
+			toChangesetFile(file, { kind: "unstaged" }),
+		),
+		...status.staged.map((file) => toChangesetFile(file, { kind: "staged" })),
+		...status.againstBase.map((file) =>
+			toChangesetFile(file, {
+				kind: "against-base",
+				baseBranch: ref.baseBranch,
+			}),
+		),
+	];
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/buildChangesetFiles.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/buildChangesetFiles.ts
@@ -29,33 +29,39 @@ function toChangesetFile(
 	};
 }
 
+/** Refs whose files come from the working tree. Commit refs are resolved from a
+ *  separate query in `useChangeset`, so they never reach this builder. */
+type WorkingTreeRef = Exclude<DiffRef, { kind: "commit" }>;
+
 export function buildChangesetFiles(
 	status: GitStatusChanges,
-	ref: DiffRef,
+	ref: WorkingTreeRef,
 ): ChangesetFile[] {
-	if (ref.kind === "uncommitted") {
-		return [
-			...status.unstaged.map((file) =>
-				toChangesetFile(file, { kind: "unstaged" }),
-			),
-			...status.staged.map((file) => toChangesetFile(file, { kind: "staged" })),
-		];
-	}
-
-	if (ref.kind !== "against-base") {
-		return [];
-	}
-
-	return [
+	const dirty = [
 		...status.unstaged.map((file) =>
 			toChangesetFile(file, { kind: "unstaged" }),
 		),
 		...status.staged.map((file) => toChangesetFile(file, { kind: "staged" })),
-		...status.againstBase.map((file) =>
-			toChangesetFile(file, {
-				kind: "against-base",
-				baseBranch: ref.baseBranch,
-			}),
-		),
 	];
+
+	switch (ref.kind) {
+		case "uncommitted":
+			return dirty;
+		case "against-base":
+			return [
+				...dirty,
+				...status.againstBase.map((file) =>
+					toChangesetFile(file, {
+						kind: "against-base",
+						baseBranch: ref.baseBranch,
+					}),
+				),
+			];
+		default: {
+			// Compile-time exhaustiveness: a new working-tree ref kind must be
+			// handled here rather than silently yielding an empty list.
+			const exhaustive: never = ref;
+			return exhaustive;
+		}
+	}
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/changesetFileKey.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/changesetFileKey.ts
@@ -1,0 +1,12 @@
+import type { ChangesetFile } from "./types";
+
+export function getChangesetFileKey(file: ChangesetFile): string {
+	const { source } = file;
+	if (source.kind === "against-base") {
+		return `against-base:${source.baseBranch ?? ""}:${file.path}`;
+	}
+	if (source.kind === "commit") {
+		return `commit:${source.fromHash ?? ""}:${source.commitHash}:${file.path}`;
+	}
+	return `${source.kind}:${file.path}`;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/index.ts
@@ -1,2 +1,3 @@
+export { getChangesetFileKey } from "./changesetFileKey";
 export type { ChangesetFile, DiffFileSource, DiffRef } from "./types";
 export { useChangeset } from "./useChangeset";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset/useChangeset.ts
@@ -2,6 +2,7 @@ import { workspaceTrpc } from "@superset/workspace-client";
 import { useMemo } from "react";
 import type { FileStatus } from "../../components/StatusIndicator";
 import { useWorkspaceGitStatus } from "../../providers/WorkspaceGitStatusProvider";
+import { buildChangesetFiles } from "./buildChangesetFiles";
 import type { ChangesetFile, DiffRef } from "./types";
 
 interface UseChangesetArgs {
@@ -54,64 +55,7 @@ export function useChangeset({
 		const status = gitStatus.data;
 		if (!status) return [];
 
-		if (ref.kind === "uncommitted") {
-			return [
-				...status.unstaged.map<ChangesetFile>((file) => ({
-					path: file.path,
-					oldPath: file.oldPath,
-					status: file.status as FileStatus,
-					additions: file.additions,
-					deletions: file.deletions,
-					source: { kind: "unstaged" },
-				})),
-				...status.staged.map<ChangesetFile>((file) => ({
-					path: file.path,
-					oldPath: file.oldPath,
-					status: file.status as FileStatus,
-					additions: file.additions,
-					deletions: file.deletions,
-					source: { kind: "staged" },
-				})),
-			];
-		}
-
-		// against-base: merge committed + dirty by path in the same order the
-		// sidebar renders sections. Dirty files win over committed files so
-		// downstream getDiff fetches the right bucket.
-		const seen = new Map<string, ChangesetFile>();
-		for (const file of status.unstaged) {
-			seen.set(file.path, {
-				path: file.path,
-				oldPath: file.oldPath,
-				status: file.status as FileStatus,
-				additions: file.additions,
-				deletions: file.deletions,
-				source: { kind: "unstaged" },
-			});
-		}
-		for (const file of status.staged) {
-			if (seen.has(file.path)) continue;
-			seen.set(file.path, {
-				path: file.path,
-				oldPath: file.oldPath,
-				status: file.status as FileStatus,
-				additions: file.additions,
-				deletions: file.deletions,
-				source: { kind: "staged" },
-			});
-		}
-		for (const file of status.againstBase) {
-			if (seen.has(file.path)) continue;
-			seen.set(file.path, {
-				path: file.path,
-				oldPath: file.oldPath,
-				status: file.status as FileStatus,
-				additions: file.additions,
-				deletions: file.deletions,
-				source: { kind: "against-base", baseBranch: ref.baseBranch },
-			});
-		}
-		return Array.from(seen.values());
+		return buildChangesetFiles(status, ref);
 	}, [ref, gitStatus.data, commitQuery.data?.files]);
 
 	const activeQuery = ref.kind === "commit" ? commitQuery : gitStatus;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -126,10 +126,9 @@ export function DiffPane({
 		setCollapsed,
 	});
 
-	// Pin a single section bar above the scroll area and update it to whichever
-	// source group the topmost visible file belongs to. A body-less section item
-	// can't stay pinned across its group (Pierre pins one header at a time,
-	// within its own box), so the bar lives outside the scroller instead.
+	// The section bar lives outside the scroller: Pierre pins one header at a
+	// time within its own box, so a body-less in-flow section item couldn't stay
+	// pinned across its group.
 	const { currentSection, onScroll } = useDiffActiveSection({
 		codeViewRef,
 		items,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -6,7 +6,7 @@ import type {
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import type { RendererContext } from "@superset/panes";
 import { Button } from "@superset/ui/button";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { LuFileCode } from "react-icons/lu";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import {
@@ -22,6 +22,7 @@ import { CommentThread } from "./components/CommentThread";
 import { DiffHeaderMetadata } from "./components/DiffHeaderMetadata";
 import { DiffHeaderPrefix } from "./components/DiffHeaderPrefix";
 import { DiffSectionBar } from "./components/DiffSectionBar";
+import { useDiffActiveSection } from "./hooks/useDiffActiveSection";
 import {
 	type DiffAnnotationMetadata,
 	useDiffAnnotationsByPath,
@@ -125,74 +126,16 @@ export function DiffPane({
 		setCollapsed,
 	});
 
-	// Group the concatenated diff into unstaged / staged / committed … sections
-	// like the sidebar. A body-less section item can't stay pinned across its
-	// group (Pierre pins one header at a time, within its own box), so instead
-	// we render a single sticky section bar above the scroll area and update it
-	// to whichever source group the topmost visible file belongs to.
-	const { sectionByItemId, firstSection } = useMemo(() => {
-		const counts = new Map<ChangesetFile["source"]["kind"], number>();
-		for (const file of files) {
-			counts.set(file.source.kind, (counts.get(file.source.kind) ?? 0) + 1);
-		}
-		const byItemId = new Map<
-			string,
-			{ kind: ChangesetFile["source"]["kind"]; count: number }
-		>();
-		let first: { kind: ChangesetFile["source"]["kind"]; count: number } | null =
-			null;
-		for (const item of items) {
-			const kind = fileByItemId.get(item.id)?.source.kind;
-			if (!kind) continue;
-			const entry = { kind, count: counts.get(kind) ?? 0 };
-			byItemId.set(item.id, entry);
-			first ??= entry;
-		}
-		return { sectionByItemId: byItemId, firstSection: first };
-	}, [items, fileByItemId, files]);
-
-	const [topItemId, setTopItemId] = useState<string | null>(null);
-	const currentSection =
-		(topItemId != null ? sectionByItemId.get(topItemId) : undefined) ??
-		firstSection;
-
-	// Track the topmost item by geometry rather than `getRenderedItems()[0]`,
-	// which can lag by the virtualization buffer. Items stack top→bottom with
-	// monotonically increasing offsets, so binary-search for the last one whose
-	// top has passed the viewport top: its header is the pinned one.
-	const rafRef = useRef<number | null>(null);
-	const updateActiveSection = useCallback(() => {
-		rafRef.current = null;
-		const instance = codeViewRef.current?.getInstance();
-		if (!instance) return;
-		const scrollTop = instance.getScrollTop();
-		let lo = 0;
-		let hi = items.length - 1;
-		let nextTopId: string | null = null;
-		while (lo <= hi) {
-			const mid = (lo + hi) >> 1;
-			const top = instance.getTopForItem(items[mid].id);
-			if (top != null && top <= scrollTop + 1) {
-				nextTopId = items[mid].id;
-				lo = mid + 1;
-			} else {
-				hi = mid - 1;
-			}
-		}
-		setTopItemId((prev) => (prev === nextTopId ? prev : nextTopId));
-	}, [items]);
-
-	// Coalesce bursts of scroll events into one measurement per frame.
-	const handleScroll = useCallback(() => {
-		if (rafRef.current != null) return;
-		rafRef.current = requestAnimationFrame(updateActiveSection);
-	}, [updateActiveSection]);
-
-	useEffect(() => {
-		return () => {
-			if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
-		};
-	}, []);
+	// Pin a single section bar above the scroll area and update it to whichever
+	// source group the topmost visible file belongs to. A body-less section item
+	// can't stay pinned across its group (Pierre pins one header at a time,
+	// within its own box), so the bar lives outside the scroller instead.
+	const { currentSection, onScroll } = useDiffActiveSection({
+		codeViewRef,
+		items,
+		fileByItemId,
+		files,
+	});
 
 	const { options, style } = useDiffCodeViewTheme();
 
@@ -345,7 +288,7 @@ export function DiffPane({
 				style={style}
 				items={items}
 				options={codeViewOptions}
-				onScroll={handleScroll}
+				onScroll={onScroll}
 				renderHeaderPrefix={renderHeaderPrefix}
 				renderHeaderMetadata={renderHeaderMetadata}
 				renderAnnotation={renderAnnotation}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -7,7 +7,11 @@ import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import type { RendererContext } from "@superset/panes";
 import { useCallback, useMemo, useRef } from "react";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
-import { type ChangesetFile, useChangeset } from "../../../useChangeset";
+import {
+	type ChangesetFile,
+	getChangesetFileKey,
+	useChangeset,
+} from "../../../useChangeset";
 import { useOpenInExternalEditor } from "../../../useOpenInExternalEditor";
 import { useSidebarDiffRef } from "../../../useSidebarDiffRef";
 import { useViewedFiles } from "../../../useViewedFiles";
@@ -63,14 +67,14 @@ export function DiffPane({
 	dataRef.current = data;
 	const updateData = context.actions.updateData;
 	const setCollapsed = useCallback(
-		(path: string, value: boolean) => {
+		(changeKey: string, value: boolean) => {
 			const current = dataRef.current;
 			const collapsed = current.collapsedFiles ?? [];
-			const has = collapsed.includes(path);
+			const has = collapsed.includes(changeKey);
 			if (value === has) return;
 			const next = value
-				? [...collapsed, path]
-				: collapsed.filter((p) => p !== path);
+				? [...collapsed, changeKey]
+				: collapsed.filter((key) => key !== changeKey);
 			updateData({ ...current, collapsedFiles: next } as PaneViewerData);
 		},
 		[updateData],
@@ -99,7 +103,7 @@ export function DiffPane({
 		onCreateNewAgentSession,
 	});
 
-	const { items, fileByItemId, pathToItemId, hasPendingDiff, hasDiffError } =
+	const { items, fileByItemId, hasPendingDiff, hasDiffError } =
 		useDiffCodeViewItems({
 			workspaceId,
 			files,
@@ -113,7 +117,6 @@ export function DiffPane({
 		codeViewRef,
 		data,
 		fileByItemId,
-		pathToItemId,
 		items,
 		collapsedSet,
 		setCollapsed,
@@ -136,11 +139,12 @@ export function DiffPane({
 		(item: CodeViewItem<DiffAnnotationMetadata>) => {
 			const file = fileByItemId.get(item.id);
 			if (!file) return null;
+			const changeKey = getChangesetFileKey(file);
 			return (
 				<DiffHeaderPrefix
 					file={file}
-					collapsed={collapsedSet.has(file.path)}
-					onSetCollapsed={setCollapsed}
+					collapsed={collapsedSet.has(changeKey)}
+					onSetCollapsed={(value) => setCollapsed(changeKey, value)}
 				/>
 			);
 		},
@@ -151,11 +155,12 @@ export function DiffPane({
 		(item: CodeViewItem<DiffAnnotationMetadata>) => {
 			const file = fileByItemId.get(item.id);
 			if (!file) return null;
+			const changeKey = getChangesetFileKey(file);
 			return (
 				<DiffHeaderMetadata
 					file={file}
 					workspaceId={workspaceId}
-					onSetCollapsed={setCollapsed}
+					onSetCollapsed={(value) => setCollapsed(changeKey, value)}
 					viewed={viewedSet.has(file.path)}
 					onSetViewed={setViewed}
 					onOpenFile={onOpenFile}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -5,7 +5,7 @@ import type {
 } from "@pierre/diffs";
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import type { RendererContext } from "@superset/panes";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import {
 	type ChangesetFile,
@@ -154,10 +154,42 @@ export function DiffPane({
 		(topItemId != null ? sectionByItemId.get(topItemId) : undefined) ??
 		firstSection;
 
-	const handleScroll = useCallback(() => {
-		const rendered = codeViewRef.current?.getInstance()?.getRenderedItems();
-		const nextTopId = rendered?.[0]?.id ?? null;
+	// Track the topmost item by geometry rather than `getRenderedItems()[0]`,
+	// which can lag by the virtualization buffer. Items stack top→bottom with
+	// monotonically increasing offsets, so binary-search for the last one whose
+	// top has passed the viewport top: its header is the pinned one.
+	const rafRef = useRef<number | null>(null);
+	const updateActiveSection = useCallback(() => {
+		rafRef.current = null;
+		const instance = codeViewRef.current?.getInstance();
+		if (!instance) return;
+		const scrollTop = instance.getScrollTop();
+		let lo = 0;
+		let hi = items.length - 1;
+		let nextTopId: string | null = null;
+		while (lo <= hi) {
+			const mid = (lo + hi) >> 1;
+			const top = instance.getTopForItem(items[mid].id);
+			if (top != null && top <= scrollTop + 1) {
+				nextTopId = items[mid].id;
+				lo = mid + 1;
+			} else {
+				hi = mid - 1;
+			}
+		}
 		setTopItemId((prev) => (prev === nextTopId ? prev : nextTopId));
+	}, [items]);
+
+	// Coalesce bursts of scroll events into one measurement per frame.
+	const handleScroll = useCallback(() => {
+		if (rafRef.current != null) return;
+		rafRef.current = requestAnimationFrame(updateActiveSection);
+	}, [updateActiveSection]);
+
+	useEffect(() => {
+		return () => {
+			if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+		};
 	}, []);
 
 	const { options, style } = useDiffCodeViewTheme();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -5,7 +5,7 @@ import type {
 } from "@pierre/diffs";
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import type { RendererContext } from "@superset/panes";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import {
 	type ChangesetFile,
@@ -19,6 +19,7 @@ import { AgentCommentComposer } from "./components/AgentCommentComposer";
 import { CommentThread } from "./components/CommentThread";
 import { DiffHeaderMetadata } from "./components/DiffHeaderMetadata";
 import { DiffHeaderPrefix } from "./components/DiffHeaderPrefix";
+import { DiffSectionBar } from "./components/DiffSectionBar";
 import {
 	type DiffAnnotationMetadata,
 	useDiffAnnotationsByPath,
@@ -121,6 +122,43 @@ export function DiffPane({
 		collapsedSet,
 		setCollapsed,
 	});
+
+	// Group the concatenated diff into unstaged / staged / committed … sections
+	// like the sidebar. A body-less section item can't stay pinned across its
+	// group (Pierre pins one header at a time, within its own box), so instead
+	// we render a single sticky section bar above the scroll area and update it
+	// to whichever source group the topmost visible file belongs to.
+	const { sectionByItemId, firstSection } = useMemo(() => {
+		const counts = new Map<ChangesetFile["source"]["kind"], number>();
+		for (const file of files) {
+			counts.set(file.source.kind, (counts.get(file.source.kind) ?? 0) + 1);
+		}
+		const byItemId = new Map<
+			string,
+			{ kind: ChangesetFile["source"]["kind"]; count: number }
+		>();
+		let first: { kind: ChangesetFile["source"]["kind"]; count: number } | null =
+			null;
+		for (const item of items) {
+			const kind = fileByItemId.get(item.id)?.source.kind;
+			if (!kind) continue;
+			const entry = { kind, count: counts.get(kind) ?? 0 };
+			byItemId.set(item.id, entry);
+			first ??= entry;
+		}
+		return { sectionByItemId: byItemId, firstSection: first };
+	}, [items, fileByItemId, files]);
+
+	const [topItemId, setTopItemId] = useState<string | null>(null);
+	const currentSection =
+		(topItemId != null ? sectionByItemId.get(topItemId) : undefined) ??
+		firstSection;
+
+	const handleScroll = useCallback(() => {
+		const rendered = codeViewRef.current?.getInstance()?.getRenderedItems();
+		const nextTopId = rendered?.[0]?.id ?? null;
+		setTopItemId((prev) => (prev === nextTopId ? prev : nextTopId));
+	}, []);
 
 	const { options, style } = useDiffCodeViewTheme();
 
@@ -250,15 +288,24 @@ export function DiffPane({
 	}
 
 	return (
-		<CodeView<DiffAnnotationMetadata>
-			ref={codeViewRef}
-			className="h-full w-full overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
-			style={style}
-			items={items}
-			options={codeViewOptions}
-			renderHeaderPrefix={renderHeaderPrefix}
-			renderHeaderMetadata={renderHeaderMetadata}
-			renderAnnotation={renderAnnotation}
-		/>
+		<div className="flex h-full w-full flex-col">
+			{currentSection ? (
+				<DiffSectionBar
+					kind={currentSection.kind}
+					count={currentSection.count}
+				/>
+			) : null}
+			<CodeView<DiffAnnotationMetadata>
+				ref={codeViewRef}
+				className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
+				style={style}
+				items={items}
+				options={codeViewOptions}
+				onScroll={handleScroll}
+				renderHeaderPrefix={renderHeaderPrefix}
+				renderHeaderMetadata={renderHeaderMetadata}
+				renderAnnotation={renderAnnotation}
+			/>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderMetadata/DiffHeaderMetadata.tsx
@@ -13,7 +13,7 @@ import type { ChangesetFile } from "../../../../../useChangeset";
 interface DiffHeaderMetadataProps {
 	file: ChangesetFile;
 	workspaceId: string;
-	onSetCollapsed: (path: string, value: boolean) => void;
+	onSetCollapsed: (value: boolean) => void;
 	viewed: boolean;
 	onSetViewed: (path: string, next: boolean) => void;
 	onOpenFile: (path: string, openInNewTab?: boolean) => void;
@@ -36,7 +36,7 @@ export function DiffHeaderMetadata({
 	const handleToggleViewed = useCallback(() => {
 		const next = !viewed;
 		onSetViewed(file.path, next);
-		onSetCollapsed(file.path, next);
+		onSetCollapsed(next);
 	}, [viewed, file.path, onSetViewed, onSetCollapsed]);
 
 	const showDeletedFileToast = useCallback(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderPrefix/DiffHeaderPrefix.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffHeaderPrefix/DiffHeaderPrefix.tsx
@@ -6,7 +6,7 @@ import type { ChangesetFile } from "../../../../../useChangeset";
 interface DiffHeaderPrefixProps {
 	file: ChangesetFile;
 	collapsed: boolean;
-	onSetCollapsed: (path: string, value: boolean) => void;
+	onSetCollapsed: (value: boolean) => void;
 }
 
 export function DiffHeaderPrefix({
@@ -15,8 +15,8 @@ export function DiffHeaderPrefix({
 	onSetCollapsed,
 }: DiffHeaderPrefixProps) {
 	const onToggle = useCallback(
-		() => onSetCollapsed(file.path, !collapsed),
-		[onSetCollapsed, file.path, collapsed],
+		() => onSetCollapsed(!collapsed),
+		[onSetCollapsed, collapsed],
 	);
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffSectionBar/DiffSectionBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffSectionBar/DiffSectionBar.tsx
@@ -1,0 +1,33 @@
+import type { ChangesetFile } from "../../../../../useChangeset";
+
+type GroupKey = ChangesetFile["source"]["kind"];
+
+const GROUP_TITLES: Record<GroupKey, string> = {
+	unstaged: "Unstaged",
+	staged: "Staged",
+	"against-base": "Against base",
+	commit: "Committed",
+};
+
+interface DiffSectionBarProps {
+	kind: GroupKey;
+	count: number;
+}
+
+/**
+ * Sticky section bar above the diff scroll area. Shows the source group
+ * (unstaged / staged / committed …) of the topmost visible file so the current
+ * section stays pinned — like the sidebar's ChangesSection — while you scroll.
+ */
+export function DiffSectionBar({ kind, count }: DiffSectionBarProps) {
+	return (
+		<div className="flex shrink-0 items-center gap-2 border-border border-b bg-muted/40 px-4 py-1.5">
+			<span className="font-medium text-[11px] text-muted-foreground uppercase tracking-wider">
+				{GROUP_TITLES[kind]}
+			</span>
+			<span className="text-[11px] text-muted-foreground/60 tabular-nums">
+				{count}
+			</span>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffSectionBar/DiffSectionBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffSectionBar/DiffSectionBar.tsx
@@ -21,7 +21,11 @@ interface DiffSectionBarProps {
  */
 export function DiffSectionBar({ kind, count }: DiffSectionBarProps) {
 	return (
-		<div className="flex shrink-0 items-center gap-2 border-border border-b bg-muted/40 px-4 py-1.5">
+		// Announce section changes (e.g. Unstaged → Staged) as they scroll past.
+		<div
+			aria-live="polite"
+			className="flex shrink-0 items-center gap-2 border-border border-b bg-muted/40 px-4 py-1.5"
+		>
 			<span className="font-medium text-[11px] text-muted-foreground uppercase tracking-wider">
 				{GROUP_TITLES[kind]}
 			</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffSectionBar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffSectionBar/index.ts
@@ -1,0 +1,1 @@
+export { DiffSectionBar } from "./DiffSectionBar";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffActiveSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffActiveSection/index.ts
@@ -1,0 +1,1 @@
+export { useDiffActiveSection } from "./useDiffActiveSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffActiveSection/useDiffActiveSection.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffActiveSection/useDiffActiveSection.ts
@@ -66,27 +66,23 @@ export function useDiffActiveSection({
 		firstSection;
 
 	// Track the topmost item by geometry rather than `getRenderedItems()[0]`,
-	// which can lag by the virtualization buffer. Items stack top→bottom with
-	// monotonically increasing offsets, so binary-search for the last one whose
-	// top has passed the viewport top: its header is the pinned one.
+	// which can lag by the virtualization buffer. Items stack top→bottom, so the
+	// last one whose top has passed the viewport top is the pinned header. A
+	// linear scan (one item per changed file — few) stays correct even while
+	// some items are momentarily unmeasured mid-reflow, where a binary search
+	// could discard the visible half on a `null` midpoint.
 	const rafRef = useRef<number | null>(null);
 	const updateActiveSection = useCallback(() => {
 		rafRef.current = null;
 		const instance = codeViewRef.current?.getInstance();
 		if (!instance) return;
 		const scrollTop = instance.getScrollTop();
-		let lo = 0;
-		let hi = items.length - 1;
 		let nextTopId: string | null = null;
-		while (lo <= hi) {
-			const mid = (lo + hi) >> 1;
-			const top = instance.getTopForItem(items[mid].id);
-			if (top != null && top <= scrollTop + 1) {
-				nextTopId = items[mid].id;
-				lo = mid + 1;
-			} else {
-				hi = mid - 1;
-			}
+		for (const item of items) {
+			const top = instance.getTopForItem(item.id);
+			if (top == null) continue;
+			if (top > scrollTop + 1) break;
+			nextTopId = item.id;
 		}
 		setTopItemId((prev) => (prev === nextTopId ? prev : nextTopId));
 	}, [codeViewRef, items]);
@@ -97,11 +93,15 @@ export function useDiffActiveSection({
 		rafRef.current = requestAnimationFrame(updateActiveSection);
 	}, [updateActiveSection]);
 
+	// Resync when the item list changes (collapse, filter, changeset update)
+	// even without a scroll, and drop any frame queued against the old list —
+	// `updateActiveSection` is recreated whenever `items` change.
 	useEffect(() => {
+		updateActiveSection();
 		return () => {
 			if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
 		};
-	}, []);
+	}, [updateActiveSection]);
 
 	return { currentSection, onScroll };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffActiveSection/useDiffActiveSection.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffActiveSection/useDiffActiveSection.ts
@@ -1,0 +1,107 @@
+import type { CodeViewItem } from "@pierre/diffs";
+import type { CodeViewHandle } from "@pierre/diffs/react";
+import {
+	type RefObject,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import type { ChangesetFile } from "../../../../../useChangeset";
+import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
+
+type GroupKind = ChangesetFile["source"]["kind"];
+
+export interface DiffSection {
+	kind: GroupKind;
+	count: number;
+}
+
+interface UseDiffActiveSectionOptions {
+	codeViewRef: RefObject<CodeViewHandle<DiffAnnotationMetadata> | null>;
+	items: CodeViewItem<DiffAnnotationMetadata>[];
+	fileByItemId: ReadonlyMap<string, ChangesetFile>;
+	files: ChangesetFile[];
+}
+
+interface UseDiffActiveSectionResult {
+	/** Source group of the topmost visible file, for the pinned section bar. */
+	currentSection: DiffSection | null;
+	/** Wire to CodeView's `onScroll`. */
+	onScroll: () => void;
+}
+
+/**
+ * Tracks which source group (unstaged / staged / committed …) the topmost
+ * visible file belongs to, so the diff pane can pin a single section bar and
+ * update it as the user scrolls across group boundaries.
+ */
+export function useDiffActiveSection({
+	codeViewRef,
+	items,
+	fileByItemId,
+	files,
+}: UseDiffActiveSectionOptions): UseDiffActiveSectionResult {
+	const { sectionByItemId, firstSection } = useMemo(() => {
+		const counts = new Map<GroupKind, number>();
+		for (const file of files) {
+			counts.set(file.source.kind, (counts.get(file.source.kind) ?? 0) + 1);
+		}
+		const byItemId = new Map<string, DiffSection>();
+		let first: DiffSection | null = null;
+		for (const item of items) {
+			const kind = fileByItemId.get(item.id)?.source.kind;
+			if (!kind) continue;
+			const entry: DiffSection = { kind, count: counts.get(kind) ?? 0 };
+			byItemId.set(item.id, entry);
+			first ??= entry;
+		}
+		return { sectionByItemId: byItemId, firstSection: first };
+	}, [items, fileByItemId, files]);
+
+	const [topItemId, setTopItemId] = useState<string | null>(null);
+	const currentSection =
+		(topItemId != null ? sectionByItemId.get(topItemId) : undefined) ??
+		firstSection;
+
+	// Track the topmost item by geometry rather than `getRenderedItems()[0]`,
+	// which can lag by the virtualization buffer. Items stack top→bottom with
+	// monotonically increasing offsets, so binary-search for the last one whose
+	// top has passed the viewport top: its header is the pinned one.
+	const rafRef = useRef<number | null>(null);
+	const updateActiveSection = useCallback(() => {
+		rafRef.current = null;
+		const instance = codeViewRef.current?.getInstance();
+		if (!instance) return;
+		const scrollTop = instance.getScrollTop();
+		let lo = 0;
+		let hi = items.length - 1;
+		let nextTopId: string | null = null;
+		while (lo <= hi) {
+			const mid = (lo + hi) >> 1;
+			const top = instance.getTopForItem(items[mid].id);
+			if (top != null && top <= scrollTop + 1) {
+				nextTopId = items[mid].id;
+				lo = mid + 1;
+			} else {
+				hi = mid - 1;
+			}
+		}
+		setTopItemId((prev) => (prev === nextTopId ? prev : nextTopId));
+	}, [codeViewRef, items]);
+
+	// Coalesce bursts of scroll events into one measurement per frame.
+	const onScroll = useCallback(() => {
+		if (rafRef.current != null) return;
+		rafRef.current = requestAnimationFrame(updateActiveSection);
+	}, [updateActiveSection]);
+
+	useEffect(() => {
+		return () => {
+			if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+		};
+	}, []);
+
+	return { currentSection, onScroll };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewItems/useDiffCodeViewItems.ts
@@ -9,7 +9,10 @@ import { useQueries } from "@tanstack/react-query";
 import { getQueryKey } from "@trpc/react-query";
 import type { inferRouterInputs } from "@trpc/server";
 import { useMemo } from "react";
-import type { ChangesetFile } from "../../../../../useChangeset";
+import {
+	type ChangesetFile,
+	getChangesetFileKey,
+} from "../../../../../useChangeset";
 import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
 
 type GetDiffInput = inferRouterInputs<AppRouter>["git"]["getDiff"];
@@ -33,7 +36,6 @@ interface UseDiffCodeViewItemsOptions {
 interface UseDiffCodeViewItemsResult {
 	items: CodeViewItem<DiffAnnotationMetadata>[];
 	fileByItemId: Map<string, ChangesetFile>;
-	pathToItemId: Map<string, string>;
 	hasPendingDiff: boolean;
 	hasDiffError: boolean;
 }
@@ -72,16 +74,6 @@ export function useDiffCodeViewItems({
 		return map;
 	}, [files]);
 
-	const pathToItemId = useMemo(() => {
-		const map = new Map<string, string>();
-		for (const file of files) {
-			const itemId = getDiffItemId(file);
-			if (!map.has(file.path)) map.set(file.path, itemId);
-			if (file.oldPath && !map.has(file.oldPath)) map.set(file.oldPath, itemId);
-		}
-		return map;
-	}, [files]);
-
 	const items = useMemo<CodeViewItem<DiffAnnotationMetadata>[]>(() => {
 		const nextItems: CodeViewItem<DiffAnnotationMetadata>[] = [];
 
@@ -108,7 +100,7 @@ export function useDiffCodeViewItems({
 					name: file.path,
 				},
 			);
-			const collapsed = collapsedSet.has(file.path);
+			const collapsed = collapsedSet.has(getChangesetFileKey(file));
 			const version = hashString(
 				[
 					query.dataUpdatedAt,
@@ -144,7 +136,6 @@ export function useDiffCodeViewItems({
 	return {
 		items,
 		fileByItemId,
-		pathToItemId,
 		hasPendingDiff: diffQueries.some((query) => query.isPending),
 		hasDiffError: diffQueries.some((query) => query.isError),
 	};
@@ -180,14 +171,7 @@ function createGetDiffInput(
 }
 
 function getDiffItemId(file: ChangesetFile): string {
-	const { source } = file;
-	if (source.kind === "against-base") {
-		return `diff:against-base:${source.baseBranch ?? ""}:${file.path}`;
-	}
-	if (source.kind === "commit") {
-		return `diff:commit:${source.fromHash ?? ""}:${source.commitHash}:${file.path}`;
-	}
-	return `diff:${source.kind}:${file.path}`;
+	return `diff:${getChangesetFileKey(file)}`;
 }
 
 function getAnnotationsForFile(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
@@ -37,7 +37,17 @@ export function useDiffCodeViewScroll({
 		}
 		return map;
 	}, [items]);
-	const targetItemId = data.changeKey ? `diff:${data.changeKey}` : undefined;
+	// Prefer the change key (disambiguates a path that appears in several source
+	// groups). Fall back to matching on path for diff panes persisted before
+	// change-key tracking, which only carry `path`.
+	const targetItemId = useMemo(() => {
+		if (data.changeKey) return `diff:${data.changeKey}`;
+		if (!data.path) return undefined;
+		for (const item of items) {
+			if (fileByItemId.get(item.id)?.path === data.path) return item.id;
+		}
+		return undefined;
+	}, [data.changeKey, data.path, items, fileByItemId]);
 
 	useEffect(() => {
 		if (!targetItemId) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
@@ -2,14 +2,16 @@ import type { CodeViewItem, CodeViewScrollTarget } from "@pierre/diffs";
 import type { CodeViewHandle } from "@pierre/diffs/react";
 import { type RefObject, useEffect, useMemo, useRef } from "react";
 import type { DiffPaneData } from "../../../../../../types";
-import type { ChangesetFile } from "../../../../../useChangeset";
+import {
+	type ChangesetFile,
+	getChangesetFileKey,
+} from "../../../../../useChangeset";
 import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
 
 interface UseDiffCodeViewScrollOptions {
 	codeViewRef: RefObject<CodeViewHandle<DiffAnnotationMetadata> | null>;
 	data: DiffPaneData;
 	fileByItemId: ReadonlyMap<string, ChangesetFile>;
-	pathToItemId: ReadonlyMap<string, string>;
 	items: CodeViewItem<DiffAnnotationMetadata>[];
 	collapsedSet: ReadonlySet<string>;
 	setCollapsed: (path: string, value: boolean) => void;
@@ -23,7 +25,6 @@ export function useDiffCodeViewScroll({
 	codeViewRef,
 	data,
 	fileByItemId,
-	pathToItemId,
 	items,
 	collapsedSet,
 	setCollapsed,
@@ -36,15 +37,16 @@ export function useDiffCodeViewScroll({
 		}
 		return map;
 	}, [items]);
-	const targetItemId = data.path ? pathToItemId.get(data.path) : undefined;
+	const targetItemId = data.changeKey ? `diff:${data.changeKey}` : undefined;
 
 	useEffect(() => {
-		if (!data.path || !targetItemId) return;
+		if (!targetItemId) return;
 		const file = fileByItemId.get(targetItemId);
 		if (!file) return;
 		if (!itemById.has(targetItemId)) return;
-		if (collapsedSet.has(file.path)) {
-			setCollapsed(file.path, false);
+		const changeKey = getChangesetFileKey(file);
+		if (collapsedSet.has(changeKey)) {
+			setCollapsed(changeKey, false);
 			return;
 		}
 
@@ -77,7 +79,6 @@ export function useDiffCodeViewScroll({
 		lastScrollTargetRef.current = scrollKey;
 	}, [
 		codeViewRef,
-		data.path,
 		data.focusLine,
 		data.focusSide,
 		data.focusTick,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -32,6 +32,7 @@ export function useWorkspacePaneOpeners({
 		openInNewTab?: boolean,
 		line?: number,
 		side?: DiffFocusSide,
+		changeKey?: string,
 	) => void;
 	addTerminalTab: () => Promise<void>;
 	addChatTab: () => void;
@@ -44,6 +45,7 @@ export function useWorkspacePaneOpeners({
 			openInNewTab?: boolean,
 			line?: number,
 			side?: DiffFocusSide,
+			changeKey?: string,
 		) => {
 			const state = store.getState();
 			// Bump tick on every request so the scroll effect re-fires on repeat
@@ -64,6 +66,7 @@ export function useWorkspacePaneOpeners({
 							kind: "diff",
 							data: {
 								path: filePath,
+								changeKey,
 								collapsedFiles: [],
 								...focusFields,
 							} as DiffPaneData,
@@ -81,8 +84,9 @@ export function useWorkspacePaneOpeners({
 						data: {
 							...prev,
 							path: filePath,
+							changeKey,
 							collapsedFiles: (prev.collapsedFiles ?? []).filter(
-								(p) => p !== filePath,
+								(key) => key !== changeKey,
 							),
 							...focusFields,
 						} as PaneViewerData,
@@ -97,6 +101,7 @@ export function useWorkspacePaneOpeners({
 					kind: "diff",
 					data: {
 						path: filePath,
+						changeKey,
 						collapsedFiles: [],
 						...focusFields,
 					} as DiffPaneData,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -85,9 +85,11 @@ export function useWorkspacePaneOpeners({
 							...prev,
 							path: filePath,
 							changeKey,
-							collapsedFiles: (prev.collapsedFiles ?? []).filter(
-								(key) => key !== changeKey,
-							),
+							// Only the navigated file's key can be pruned; without a
+							// change key we can't identify it, so leave the set intact.
+							collapsedFiles: changeKey
+								? (prev.collapsedFiles ?? []).filter((key) => key !== changeKey)
+								: (prev.collapsedFiles ?? []),
 							...focusFields,
 						} as PaneViewerData,
 					});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -44,6 +44,7 @@ export type DiffFocusSide = "deletions" | "additions";
 
 export interface DiffPaneData {
 	path: string;
+	changeKey?: string;
 	collapsedFiles: string[];
 	/** Line to scroll to within `path`. `focusTick` bumps on each request
 	 *  so repeated clicks of the same line still re-scroll. */

--- a/bun.lock
+++ b/bun.lock
@@ -3436,7 +3436,7 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
+    "ajv-keywords": ["ajv-keywords@5.1.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "ajv": "^8.8.2" } }, "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw=="],
 
     "anser": ["anser@1.4.10", "", {}, "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="],
 
@@ -6722,6 +6722,8 @@
 
     "@develar/schema-utils/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
+    "@develar/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
+
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
     "@electron/asar/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -7097,8 +7099,6 @@
     "agent-browser/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
-
-    "ajv-keywords/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -7593,8 +7593,6 @@
     "rollup-plugin-inject-process-env/magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
 
     "schema-utils/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
-
-    "schema-utils/ajv-keywords": ["ajv-keywords@5.1.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "ajv": "^8.8.2" } }, "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw=="],
 
     "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -8269,8 +8267,6 @@
     "@wdio/types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@wdio/utils/@puppeteer/browsers/tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
-
-    "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "app-builder-lib/@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 


### PR DESCRIPTION
## What

Groups the workspace diff pane into **source-group sections** (Unstaged / Staged / Committed / Against base), matching the sidebar's `ChangesSection`, and keeps the current section **pinned** at the top of the pane as you scroll.

## How

- A sticky **`DiffSectionBar`** renders above the diff scroll area. It shows the group + count of the topmost visible file and updates as you scroll (e.g. `UNSTAGED → STAGED` at a boundary).
- The top group is detected from the CodeView's `getInstance().getRenderedItems()[0]` on scroll; state only changes when the top item crosses into a new group, so there's no per-pixel churn.
- The bar lives *above* the scroller (flex column), so it never covers Pierre's own sticky file headers and there's no layout shift.

### Why a bar instead of in-flow band rows
Pierre's `CodeView` pins one header at a time, each within its own item box, and a body-less "section" item's box is only ~1 row tall — so an in-flow band can't stay pinned across its group. `renderCustomHeader` is also global (would wipe every default header), and per-file shadow DOM blocks styling a full-width band above a file header. A single sticky bar driven by scroll position is the clean way to keep the section pinned.

## Notes
- There are no longer in-flow divider rows *between* groups; the pinned bar changing text marks the boundary. Easy to add thin flow dividers back if wanted.
- Section detection uses the topmost rendered item, which can be buffered ~one item above the fold, so a boundary flip may land a hair early/late.

## Test plan
- `bun run typecheck` ✅
- `bun run lint` ✅
- Manual: open a workspace with unstaged + staged (+ committed) changes, open the diff pane, scroll — the section bar stays pinned and updates at group boundaries.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sticky diff section bar that groups diff content by change type and updates as you scroll.
* **Bug Fixes**
  * Improved diff selection, navigation, and scrolling when multiple changes share overlapping paths.
  * Diff pane collapse/open behavior now stays consistent per changeset variant, including when opening diffs in new tabs.
* **Tests**
  * Added Bun tests for changeset file building, uncommitted filtering, and uniqueness of generated keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->