### PR TITLE
fix(desktop): spinner for v2 changes loading + delayed file/change tree tooltips

### DIFF
--- a/apps/desktop/src/renderer/lib/clickPolicy/components/ShadowClickHint/ShadowClickHint.tsx
+++ b/apps/desktop/src/renderer/lib/clickPolicy/components/ShadowClickHint/ShadowClickHint.tsx
@@ -1,9 +1,19 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Match the radix Tooltip `delayDuration` used elsewhere in the sidebar. */
+const DEFAULT_HINT_DELAY_MS = 500;
 
 interface ShadowClickHintProps {
 	hint: string;
 	side?: "top" | "right" | "bottom" | "left";
+	/**
+	 * Delay before the hint appears after a row is hovered, in ms. Mirrors the
+	 * radix Tooltip delay used by the changes tree rows so both trees feel the
+	 * same. This tooltip is forced `open`, so the delay lives in the hover
+	 * timer rather than in radix's `delayDuration`.
+	 */
+	delayMs?: number;
 	/**
 	 * Walk an event's composed path to find the row to anchor on. Return null
 	 * to dismiss. Pierre's open shadow root retargets event.target to the
@@ -22,11 +32,20 @@ interface ShadowClickHintProps {
 export function ShadowClickHint({
 	hint,
 	side = "right",
+	delayMs = DEFAULT_HINT_DELAY_MS,
 	findRow,
 	children,
 }: ShadowClickHintProps) {
 	const [hoverRect, setHoverRect] = useState<DOMRect | null>(null);
 	const hoverRowRef = useRef<HTMLElement | null>(null);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const clearTimer = useCallback(() => {
+		if (timerRef.current) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+	}, []);
 
 	const handleMouseOver = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
@@ -34,21 +53,32 @@ export function ShadowClickHint({
 			if (!row) {
 				if (hoverRowRef.current) {
 					hoverRowRef.current = null;
+					clearTimer();
 					setHoverRect(null);
 				}
 				return;
 			}
 			if (hoverRowRef.current === row) return;
 			hoverRowRef.current = row;
-			setHoverRect(row.getBoundingClientRect());
+			clearTimer();
+			setHoverRect(null);
+			timerRef.current = setTimeout(() => {
+				// Re-read the rect on fire in case the row shifted during the delay.
+				if (hoverRowRef.current === row) {
+					setHoverRect(row.getBoundingClientRect());
+				}
+			}, delayMs);
 		},
-		[findRow],
+		[findRow, delayMs, clearTimer],
 	);
 
 	const handleMouseLeave = useCallback(() => {
 		hoverRowRef.current = null;
+		clearTimer();
 		setHoverRect(null);
-	}, []);
+	}, [clearTimer]);
+
+	useEffect(() => clearTimer, [clearTimer]);
 
 	return (
 		// biome-ignore lint/a11y/noStaticElementInteractions: wraps a custom-element host with its own keyboard nav

--- a/apps/desktop/src/renderer/lib/clickPolicy/components/ShadowClickHint/ShadowClickHint.tsx
+++ b/apps/desktop/src/renderer/lib/clickPolicy/components/ShadowClickHint/ShadowClickHint.tsx
@@ -1,18 +1,11 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-/** Match the radix Tooltip `delayDuration` used elsewhere in the sidebar. */
 const DEFAULT_HINT_DELAY_MS = 500;
 
 interface ShadowClickHintProps {
 	hint: string;
 	side?: "top" | "right" | "bottom" | "left";
-	/**
-	 * Delay before the hint appears after a row is hovered, in ms. Mirrors the
-	 * radix Tooltip delay used by the changes tree rows so both trees feel the
-	 * same. This tooltip is forced `open`, so the delay lives in the hover
-	 * timer rather than in radix's `delayDuration`.
-	 */
 	delayMs?: number;
 	/**
 	 * Walk an event's composed path to find the row to anchor on. Return null
@@ -63,7 +56,6 @@ export function ShadowClickHint({
 			clearTimer();
 			setHoverRect(null);
 			timerRef.current = setTimeout(() => {
-				// Re-read the rect on fire in case the row shifted during the delay.
 				if (hoverRowRef.current === row) {
 					setHoverRect(row.getBoundingClientRect());
 				}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
@@ -62,7 +62,7 @@ export function SidebarHeader({
 
 					if (compact) {
 						return (
-							<Tooltip key={tab.id} delayDuration={500}>
+							<Tooltip key={tab.id}>
 								<TooltipTrigger asChild>{btn}</TooltipTrigger>
 								<TooltipContent side="bottom" showArrow={false}>
 									{label}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
@@ -62,7 +62,7 @@ export function SidebarHeader({
 
 					if (compact) {
 						return (
-							<Tooltip key={tab.id}>
+							<Tooltip key={tab.id} delayDuration={500}>
 								<TooltipTrigger asChild>{btn}</TooltipTrigger>
 								<TooltipContent side="bottom" showArrow={false}>
 									{label}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -223,7 +223,7 @@ export const FileRow = memo(function FileRow({
 
 	return (
 		<ContextMenu>
-			<Tooltip>
+			<Tooltip delayDuration={500}>
 				<ContextMenuTrigger asChild>
 					<TooltipTrigger asChild>{rowButton}</TooltipTrigger>
 				</ContextMenuTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -1,6 +1,6 @@
 import type { AppRouter } from "@superset/host-service";
+import { Spinner } from "@superset/ui/spinner";
 import type { inferRouterOutputs } from "@trpc/server";
-import { Loader2 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
 import type {
 	ChangesFilter,
@@ -87,7 +87,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 	if (status.isLoading) {
 		return (
 			<div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-				<Loader2 className="size-3.5 animate-spin" />
+				<Spinner className="size-3.5" />
 				<span>Loading changes...</span>
 			</div>
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -1,5 +1,6 @@
 import type { AppRouter } from "@superset/host-service";
 import type { inferRouterOutputs } from "@trpc/server";
+import { Loader2 } from "lucide-react";
 import { memo, useCallback, useState } from "react";
 import type {
 	ChangesFilter,
@@ -85,8 +86,9 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 
 	if (status.isLoading) {
 		return (
-			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-				Loading changes...
+			<div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+				<Loader2 className="size-3.5 animate-spin" />
+				<span>Loading changes...</span>
 			</div>
 		);
 	}


### PR DESCRIPTION
## Summary

Small polish to the v2 workspace sidebar:

- **Spinner for "Loading changes…"** — the changes tab loading state showed plain text while the files tab showed a spinner. It now renders the shared `Spinner` (`@superset/ui/spinner`), sized to match the files loading spinner.
- **Delayed tooltips on file/change tree rows** — row hint tooltips popped instantly. They now wait 500ms:
  - Changes tree (`FileRow`): `delayDuration={500}` on the row `<Tooltip>`.
  - File tree (`ShadowClickHint`): this hint is a forced-`open` tooltip, so `delayDuration` doesn't apply — added a hover timer (default 500ms) before the hint anchors, cleared on row-change/leave/unmount.

## Test Plan

- [ ] Open a v2 workspace, Changes tab — a spinner shows next to "Loading changes…", matching the Files tab.
- [ ] Hover a row in the changes tree — the hint tooltip appears after a short delay, not instantly.
- [ ] Hover a row in the file tree — same delayed behavior.
- [ ] Move between rows quickly — no premature/flickering tooltips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer loading state for changes, with a centered spinner and loading message.
  * Introduced a short hover delay before tooltips appear, reducing accidental popups.
* **Bug Fixes**
  * Improved tooltip behavior so it only appears when hovering remains on the same item, and closes cleanly when the pointer leaves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->