### PR TITLE
feat(desktop): running agents section in workspace sidebar

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/useTerminalAgentBindings.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/useTerminalAgentBindings.ts
@@ -18,6 +18,7 @@ export type TerminalAgentBinding = TerminalAgentBindings[number];
  */
 export function useTerminalAgentBindings(
 	workspaceId: string,
+	options?: { enabled?: boolean },
 ): Map<string, TerminalAgentBinding> {
 	const hostUrl = useWorkspaceHostUrl(workspaceId);
 	const queryClient = useQueryClient();
@@ -26,7 +27,8 @@ export function useTerminalAgentBindings(
 		[hostUrl, workspaceId],
 	);
 
-	const enabled = Boolean(workspaceId) && Boolean(hostUrl);
+	const enabled =
+		(options?.enabled ?? true) && Boolean(workspaceId) && Boolean(hostUrl);
 
 	const { data } = useQuery({
 		queryKey,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -3,7 +3,6 @@ import { useDiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 import { RenameBranchDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
-import { useInlineWorkspacePortsEnabled } from "renderer/stores/inline-workspace-ports";
 import { useV2WorkspaceNotificationStatus } from "renderer/stores/v2-notifications";
 import { useDashboardSidebarHover } from "../../providers/DashboardSidebarHoverProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
@@ -43,7 +42,6 @@ export function DashboardSidebarWorkspaceItem({
 	const isMainWorkspace = workspace.type === "main";
 	const diffStats = useDiffStats(id);
 	const workspaceStatus = useV2WorkspaceNotificationStatus(id);
-	const inlineWorkspacePortsEnabled = useInlineWorkspacePortsEnabled();
 	const {
 		cancelRename,
 		handleClick,
@@ -226,7 +224,7 @@ export function DashboardSidebarWorkspaceItem({
 				onSubmitRename={submitRename}
 				onCancelRename={cancelRename}
 			>
-				{!isPending && inlineWorkspacePortsEnabled && (
+				{!isPending && (
 					<DashboardSidebarWorkspaceDetails
 						workspaceId={id}
 						isInSection={isInSection}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/DashboardSidebarWorkspaceAgentsRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/DashboardSidebarWorkspaceAgentsRow.tsx
@@ -1,0 +1,38 @@
+import { OverflowFadeContainer } from "@superset/ui/overflow-fade-container";
+import { cn } from "@superset/ui/utils";
+import { DashboardSidebarWorkspaceAgentBadge } from "./components/DashboardSidebarWorkspaceAgentBadge";
+import { useDashboardSidebarWorkspaceRunningAgents } from "./hooks/useDashboardSidebarWorkspaceRunningAgents";
+
+interface DashboardSidebarWorkspaceAgentsRowProps {
+	workspaceId: string;
+	isInSection?: boolean;
+}
+
+export function DashboardSidebarWorkspaceAgentsRow({
+	workspaceId,
+	isInSection = false,
+}: DashboardSidebarWorkspaceAgentsRowProps) {
+	const agents = useDashboardSidebarWorkspaceRunningAgents(workspaceId);
+
+	if (agents.length === 0) {
+		return null;
+	}
+
+	return (
+		<OverflowFadeContainer
+			observeChildren
+			className={cn(
+				"grid auto-cols-max grid-flow-col grid-rows-2 gap-1 overflow-x-auto pr-2 pb-1 hide-scrollbar",
+				isInSection ? "pl-14" : "pl-12",
+			)}
+		>
+			{agents.map((agent) => (
+				<DashboardSidebarWorkspaceAgentBadge
+					key={agent.sourceKey}
+					workspaceId={workspaceId}
+					agent={agent}
+				/>
+			))}
+		</OverflowFadeContainer>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/DashboardSidebarWorkspaceAgentsRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/DashboardSidebarWorkspaceAgentsRow.tsx
@@ -1,4 +1,3 @@
-import { OverflowFadeContainer } from "@superset/ui/overflow-fade-container";
 import { cn } from "@superset/ui/utils";
 import { DashboardSidebarWorkspaceAgentBadge } from "./components/DashboardSidebarWorkspaceAgentBadge";
 import { useDashboardSidebarWorkspaceRunningAgents } from "./hooks/useDashboardSidebarWorkspaceRunningAgents";
@@ -19,10 +18,9 @@ export function DashboardSidebarWorkspaceAgentsRow({
 	}
 
 	return (
-		<OverflowFadeContainer
-			observeChildren
+		<div
 			className={cn(
-				"grid auto-cols-max grid-flow-col grid-rows-2 gap-1 overflow-x-auto pr-2 pb-1 hide-scrollbar",
+				"flex flex-wrap gap-1 pr-2 pb-1",
 				isInSection ? "pl-14" : "pl-12",
 			)}
 		>
@@ -33,6 +31,6 @@ export function DashboardSidebarWorkspaceAgentsRow({
 					agent={agent}
 				/>
 			))}
-		</OverflowFadeContainer>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/components/DashboardSidebarWorkspaceAgentBadge/DashboardSidebarWorkspaceAgentBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/components/DashboardSidebarWorkspaceAgentBadge/DashboardSidebarWorkspaceAgentBadge.tsx
@@ -1,0 +1,62 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
+import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import {
+	getStatusTooltip,
+	StatusIndicator,
+} from "renderer/screens/main/components/StatusIndicator";
+import type { DashboardSidebarRunningAgent } from "../../hooks/useDashboardSidebarWorkspaceRunningAgents";
+
+interface DashboardSidebarWorkspaceAgentBadgeProps {
+	workspaceId: string;
+	agent: DashboardSidebarRunningAgent;
+}
+
+export function DashboardSidebarWorkspaceAgentBadge({
+	workspaceId,
+	agent,
+}: DashboardSidebarWorkspaceAgentBadgeProps) {
+	const navigate = useNavigate();
+
+	const handleClick = () => {
+		const focusRequestId = crypto.randomUUID();
+		const search =
+			agent.source.type === "chat"
+				? { chatSessionId: agent.source.id, focusRequestId }
+				: agent.source.type === "terminal"
+					? { terminalId: agent.source.id, focusRequestId }
+					: { focusRequestId };
+		void navigateToV2Workspace(workspaceId, navigate, { search });
+	};
+
+	return (
+		<Tooltip delayDuration={700}>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={handleClick}
+					className={cn(
+						"mb-1 inline-flex max-w-40 items-center gap-1.5 rounded-md px-2 py-1",
+						"bg-primary/10 text-xs font-medium text-primary transition-colors hover:bg-primary/20",
+						"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+					)}
+				>
+					<StatusIndicator status={agent.status} />
+					<span className="min-w-0 truncate">{agent.label}</span>
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="top" sideOffset={6} showArrow={false}>
+				<div className="space-y-1 text-xs">
+					<div className="font-medium">{agent.label}</div>
+					<div className="text-background/70">
+						{getStatusTooltip(agent.status)}
+					</div>
+					<div className="text-[10px] text-background/60">
+						Click to open agent
+					</div>
+				</div>
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/components/DashboardSidebarWorkspaceAgentBadge/DashboardSidebarWorkspaceAgentBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/components/DashboardSidebarWorkspaceAgentBadge/DashboardSidebarWorkspaceAgentBadge.tsx
@@ -1,11 +1,14 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
+import { LuBot } from "react-icons/lu";
+import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import {
 	getStatusTooltip,
 	StatusIndicator,
 } from "renderer/screens/main/components/StatusIndicator";
+import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import type { DashboardSidebarRunningAgent } from "../../hooks/useDashboardSidebarWorkspaceRunningAgents";
 
 interface DashboardSidebarWorkspaceAgentBadgeProps {
@@ -18,17 +21,19 @@ export function DashboardSidebarWorkspaceAgentBadge({
 	agent,
 }: DashboardSidebarWorkspaceAgentBadgeProps) {
 	const navigate = useNavigate();
+	const iconUrl = usePresetIcon(agent.agentId);
 
 	const handleClick = () => {
-		const focusRequestId = crypto.randomUUID();
-		const search =
-			agent.source.type === "chat"
-				? { chatSessionId: agent.source.id, focusRequestId }
-				: agent.source.type === "terminal"
-					? { terminalId: agent.source.id, focusRequestId }
-					: { focusRequestId };
-		void navigateToV2Workspace(workspaceId, navigate, { search });
+		void navigateToV2Workspace(workspaceId, navigate, {
+			search: {
+				terminalId: agent.terminalId,
+				focusRequestId: crypto.randomUUID(),
+			},
+		});
 	};
+
+	const statusLabel =
+		agent.status === "idle" ? "Idle" : getStatusTooltip(agent.status);
 
 	return (
 		<Tooltip delayDuration={700}>
@@ -37,21 +42,29 @@ export function DashboardSidebarWorkspaceAgentBadge({
 					type="button"
 					onClick={handleClick}
 					className={cn(
-						"mb-1 inline-flex max-w-40 items-center gap-1.5 rounded-md px-2 py-1",
+						"inline-flex max-w-40 items-center gap-1 rounded-md px-1.5 py-0.5",
 						"bg-primary/10 text-xs font-medium text-primary transition-colors hover:bg-primary/20",
 						"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
 					)}
 				>
-					<StatusIndicator status={agent.status} />
+					<span className="flex size-3.5 shrink-0 items-center justify-center">
+						{agent.status === "idle" ? (
+							iconUrl ? (
+								<img src={iconUrl} alt="" className="size-3.5 object-contain" />
+							) : (
+								<LuBot className="size-3.5" strokeWidth={STROKE_WIDTH} />
+							)
+						) : (
+							<StatusIndicator status={agent.status} />
+						)}
+					</span>
 					<span className="min-w-0 truncate">{agent.label}</span>
 				</button>
 			</TooltipTrigger>
 			<TooltipContent side="top" sideOffset={6} showArrow={false}>
 				<div className="space-y-1 text-xs">
 					<div className="font-medium">{agent.label}</div>
-					<div className="text-background/70">
-						{getStatusTooltip(agent.status)}
-					</div>
+					<div className="text-background/70">{statusLabel}</div>
 					<div className="text-[10px] text-background/60">
 						Click to open agent
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/components/DashboardSidebarWorkspaceAgentBadge/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/components/DashboardSidebarWorkspaceAgentBadge/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarWorkspaceAgentBadge } from "./DashboardSidebarWorkspaceAgentBadge";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents/index.ts
@@ -1,0 +1,5 @@
+export {
+	type DashboardSidebarRunningAgent,
+	type RunningAgentStatus,
+	useDashboardSidebarWorkspaceRunningAgents,
+} from "./useDashboardSidebarWorkspaceRunningAgents";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
@@ -1,32 +1,42 @@
-import { eq } from "@tanstack/db";
-import { useLiveQuery } from "@tanstack/react-db";
+import {
+	BUILTIN_AGENT_LABELS,
+	type BuiltinAgentId,
+} from "@superset/shared/agent-catalog";
 import { useMemo } from "react";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useTerminalAgentBindings } from "renderer/hooks/host-service/useTerminalAgentBindings";
 import {
 	useV2NotificationStore,
 	type V2NotificationSource,
 } from "renderer/stores/v2-notifications";
+import type { PaneStatus } from "shared/tabs-types";
 import { useShallow } from "zustand/react/shallow";
 
-/** Statuses that count as a "running" agent (excludes finished `review`). */
-export type RunningAgentStatus = "working" | "permission";
+/**
+ * State of a bound agent. `idle` means the agent process is alive but not
+ * currently `working` / awaiting `permission` / ready for `review`.
+ */
+export type RunningAgentStatus = PaneStatus;
 
 export interface DashboardSidebarRunningAgent {
 	/** Stable key for React lists, derived from the notification source. */
 	sourceKey: string;
 	source: V2NotificationSource;
-	/** `working` (actively processing) or `permission` (blocked, needs input). */
+	/** Host terminal the agent is bound to. */
+	terminalId: string;
+	/** Built-in agent id (`claude`, `codex`, …) — drives label + icon. */
+	agentId: BuiltinAgentId;
+	/** `idle` | `working` | `permission` | `review`. */
 	status: RunningAgentStatus;
-	/** When the agent entered its current status (ms since epoch). */
-	occurredAt: number;
-	/** Best-effort human label — chat session title, else a generic fallback. */
+	/** When the agent process was bound (ms since epoch), used for stable order. */
+	startedAt: number;
+	/** Agent display name (e.g. "Claude"). */
 	label: string;
 }
 
 /**
- * Live list of "running" agents for a workspace: notification sources currently
- * `working` or awaiting `permission`, newest first. Chat agents resolve to their
- * session title; terminal agents fall back to a generic label.
+ * Live list of agents bound to a workspace's terminals, newest binding last.
+ * Every live agent process is included regardless of state; its `status` comes
+ * from the notification store (or `idle` when it has no active status).
  *
  * Mirrors {@link useDashboardSidebarWorkspacePorts} so a workspace detail row
  * can render agents the same way it renders ports.
@@ -34,51 +44,37 @@ export interface DashboardSidebarRunningAgent {
 export function useDashboardSidebarWorkspaceRunningAgents(
 	workspaceId: string,
 ): DashboardSidebarRunningAgent[] {
-	const entries = useV2NotificationStore(
+	const bindings = useTerminalAgentBindings(workspaceId);
+
+	const statusByTerminal = useV2NotificationStore(
 		useShallow((state) => {
-			const running = [];
+			const map: Record<string, RunningAgentStatus> = {};
 			for (const entry of Object.values(state.sources)) {
 				if (
 					entry.workspaceId === workspaceId &&
-					(entry.status === "working" || entry.status === "permission")
+					entry.source.type === "terminal"
 				) {
-					running.push(entry);
+					map[entry.source.id] = entry.status;
 				}
 			}
-			running.sort((a, b) => b.occurredAt - a.occurredAt);
-			return running;
+			return map;
 		}),
 	);
 
-	const collections = useCollections();
-	const { data: sessions } = useLiveQuery(
-		(q) =>
-			q
-				.from({ chatSessions: collections.chatSessions })
-				.where(({ chatSessions }) =>
-					eq(chatSessions.v2WorkspaceId, workspaceId),
-				)
-				.select(({ chatSessions }) => ({
-					id: chatSessions.id,
-					title: chatSessions.title,
-				})),
-		[collections.chatSessions, workspaceId],
-	);
-
 	return useMemo(() => {
-		const titleById = new Map<string, string | null>();
-		for (const session of sessions ?? []) {
-			titleById.set(session.id, session.title);
+		const agents: DashboardSidebarRunningAgent[] = [];
+		for (const binding of bindings.values()) {
+			agents.push({
+				sourceKey: `terminal:${binding.terminalId}`,
+				source: { type: "terminal", id: binding.terminalId },
+				terminalId: binding.terminalId,
+				agentId: binding.agentId,
+				status: statusByTerminal[binding.terminalId] ?? "idle",
+				startedAt: binding.startedAt,
+				label: BUILTIN_AGENT_LABELS[binding.agentId] ?? binding.agentId,
+			});
 		}
-		return entries.map((entry) => ({
-			sourceKey: entry.sourceKey,
-			source: entry.source,
-			status: entry.status as RunningAgentStatus,
-			occurredAt: entry.occurredAt,
-			label:
-				entry.source.type === "chat"
-					? titleById.get(entry.source.id)?.trim() || "Chat agent"
-					: "Agent",
-		}));
-	}, [entries, sessions]);
+		agents.sort((a, b) => a.startedAt - b.startedAt);
+		return agents;
+	}, [bindings, statusByTerminal]);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
@@ -43,8 +43,9 @@ export interface DashboardSidebarRunningAgent {
  */
 export function useDashboardSidebarWorkspaceRunningAgents(
 	workspaceId: string,
+	enabled = true,
 ): DashboardSidebarRunningAgent[] {
-	const bindings = useTerminalAgentBindings(workspaceId);
+	const bindings = useTerminalAgentBindings(workspaceId, { enabled });
 
 	const statusByTerminal = useV2NotificationStore(
 		useShallow((state) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
@@ -1,0 +1,84 @@
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useMemo } from "react";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import {
+	useV2NotificationStore,
+	type V2NotificationSource,
+} from "renderer/stores/v2-notifications";
+import { useShallow } from "zustand/react/shallow";
+
+/** Statuses that count as a "running" agent (excludes finished `review`). */
+export type RunningAgentStatus = "working" | "permission";
+
+export interface DashboardSidebarRunningAgent {
+	/** Stable key for React lists, derived from the notification source. */
+	sourceKey: string;
+	source: V2NotificationSource;
+	/** `working` (actively processing) or `permission` (blocked, needs input). */
+	status: RunningAgentStatus;
+	/** When the agent entered its current status (ms since epoch). */
+	occurredAt: number;
+	/** Best-effort human label — chat session title, else a generic fallback. */
+	label: string;
+}
+
+/**
+ * Live list of "running" agents for a workspace: notification sources currently
+ * `working` or awaiting `permission`, newest first. Chat agents resolve to their
+ * session title; terminal agents fall back to a generic label.
+ *
+ * Mirrors {@link useDashboardSidebarWorkspacePorts} so a workspace detail row
+ * can render agents the same way it renders ports.
+ */
+export function useDashboardSidebarWorkspaceRunningAgents(
+	workspaceId: string,
+): DashboardSidebarRunningAgent[] {
+	const entries = useV2NotificationStore(
+		useShallow((state) => {
+			const running = [];
+			for (const entry of Object.values(state.sources)) {
+				if (
+					entry.workspaceId === workspaceId &&
+					(entry.status === "working" || entry.status === "permission")
+				) {
+					running.push(entry);
+				}
+			}
+			running.sort((a, b) => b.occurredAt - a.occurredAt);
+			return running;
+		}),
+	);
+
+	const collections = useCollections();
+	const { data: sessions } = useLiveQuery(
+		(q) =>
+			q
+				.from({ chatSessions: collections.chatSessions })
+				.where(({ chatSessions }) =>
+					eq(chatSessions.v2WorkspaceId, workspaceId),
+				)
+				.select(({ chatSessions }) => ({
+					id: chatSessions.id,
+					title: chatSessions.title,
+				})),
+		[collections.chatSessions, workspaceId],
+	);
+
+	return useMemo(() => {
+		const titleById = new Map<string, string | null>();
+		for (const session of sessions ?? []) {
+			titleById.set(session.id, session.title);
+		}
+		return entries.map((entry) => ({
+			sourceKey: entry.sourceKey,
+			source: entry.source,
+			status: entry.status as RunningAgentStatus,
+			occurredAt: entry.occurredAt,
+			label:
+				entry.source.type === "chat"
+					? titleById.get(entry.source.id)?.trim() || "Chat agent"
+					: "Agent",
+		}));
+	}, [entries, sessions]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/index.ts
@@ -1,0 +1,5 @@
+export { DashboardSidebarWorkspaceAgentsRow } from "./DashboardSidebarWorkspaceAgentsRow";
+export {
+	type DashboardSidebarRunningAgent,
+	useDashboardSidebarWorkspaceRunningAgents,
+} from "./hooks/useDashboardSidebarWorkspaceRunningAgents";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
@@ -2,8 +2,11 @@ import { Fragment, type ReactNode } from "react";
 import { LuX } from "react-icons/lu";
 import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import { useWorkspaceDetailsStore } from "renderer/stores";
+import { useInlineWorkspacePortsEnabled } from "renderer/stores/inline-workspace-ports";
 import { useDashboardSidebarWorkspacePorts } from "../../../../providers/DashboardSidebarPortsProvider";
 import { useDashboardSidebarPortKill } from "../../../DashboardSidebarPortsList/hooks/useDashboardSidebarPortKill";
+import { DashboardSidebarWorkspaceAgentsRow } from "../DashboardSidebarWorkspaceAgentsRow";
+import { useDashboardSidebarWorkspaceRunningAgents } from "../DashboardSidebarWorkspaceAgentsRow/hooks/useDashboardSidebarWorkspaceRunningAgents";
 import { DashboardSidebarWorkspacePortsRow } from "../DashboardSidebarWorkspacePortsRow";
 import { DashboardSidebarWorkspaceDetailsAction } from "./components/DashboardSidebarWorkspaceDetailsAction";
 import { DashboardSidebarWorkspaceDetailsToggle } from "./components/DashboardSidebarWorkspaceDetailsToggle";
@@ -45,13 +48,14 @@ export function DashboardSidebarWorkspaceDetails({
 	);
 	const { isPending: isKillingPorts, killPorts } =
 		useDashboardSidebarPortKill();
+	const inlineWorkspacePortsEnabled = useInlineWorkspacePortsEnabled();
 
 	// --- Section registry -----------------------------------------------------
 	const sections: WorkspaceDetailSection[] = [];
 
 	const portGroup = useDashboardSidebarWorkspacePorts(workspaceId);
 	const portCount = portGroup?.ports.length ?? 0;
-	if (portGroup && portCount > 0) {
+	if (inlineWorkspacePortsEnabled && portGroup && portCount > 0) {
 		sections.push({
 			key: "ports",
 			summary: `${portCount} ${portCount === 1 ? "port" : "ports"}`,
@@ -72,7 +76,20 @@ export function DashboardSidebarWorkspaceDetails({
 		});
 	}
 
-	// Add more detail rows here (e.g. running agents).
+	const runningAgents = useDashboardSidebarWorkspaceRunningAgents(workspaceId);
+	const agentCount = runningAgents.length;
+	if (agentCount > 0) {
+		sections.push({
+			key: "agents",
+			summary: `${agentCount} ${agentCount === 1 ? "agent" : "agents"}`,
+			content: (
+				<DashboardSidebarWorkspaceAgentsRow
+					workspaceId={workspaceId}
+					isInSection={isInSection}
+				/>
+			),
+		});
+	}
 	// --------------------------------------------------------------------------
 
 	if (sections.length === 0) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
@@ -3,6 +3,7 @@ import { LuX } from "react-icons/lu";
 import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import { useWorkspaceDetailsStore } from "renderer/stores";
 import { useInlineWorkspacePortsEnabled } from "renderer/stores/inline-workspace-ports";
+import { useWorkspaceAgentsRowEnabled } from "renderer/stores/workspace-agents-row";
 import { useDashboardSidebarWorkspacePorts } from "../../../../providers/DashboardSidebarPortsProvider";
 import { useDashboardSidebarPortKill } from "../../../DashboardSidebarPortsList/hooks/useDashboardSidebarPortKill";
 import { DashboardSidebarWorkspaceAgentsRow } from "../DashboardSidebarWorkspaceAgentsRow";
@@ -49,6 +50,7 @@ export function DashboardSidebarWorkspaceDetails({
 	const { isPending: isKillingPorts, killPorts } =
 		useDashboardSidebarPortKill();
 	const inlineWorkspacePortsEnabled = useInlineWorkspacePortsEnabled();
+	const workspaceAgentsRowEnabled = useWorkspaceAgentsRowEnabled();
 
 	// --- Section registry -----------------------------------------------------
 	const sections: WorkspaceDetailSection[] = [];
@@ -76,9 +78,12 @@ export function DashboardSidebarWorkspaceDetails({
 		});
 	}
 
-	const runningAgents = useDashboardSidebarWorkspaceRunningAgents(workspaceId);
+	const runningAgents = useDashboardSidebarWorkspaceRunningAgents(
+		workspaceId,
+		workspaceAgentsRowEnabled,
+	);
 	const agentCount = runningAgents.length;
-	if (agentCount > 0) {
+	if (workspaceAgentsRowEnabled && agentCount > 0) {
 		sections.push({
 			key: "agents",
 			summary: `${agentCount} ${agentCount === 1 ? "agent" : "agents"}`,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspacePortsRow/DashboardSidebarWorkspacePortsRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspacePortsRow/DashboardSidebarWorkspacePortsRow.tsx
@@ -1,4 +1,3 @@
-import { OverflowFadeContainer } from "@superset/ui/overflow-fade-container";
 import { cn } from "@superset/ui/utils";
 import { useDashboardSidebarWorkspacePorts } from "../../../../providers/DashboardSidebarPortsProvider";
 import { DashboardSidebarPortBadge } from "../../../DashboardSidebarPortsList/components/DashboardSidebarPortBadge";
@@ -19,10 +18,9 @@ export function DashboardSidebarWorkspacePortsRow({
 	}
 
 	return (
-		<OverflowFadeContainer
-			observeChildren
+		<div
 			className={cn(
-				"grid auto-cols-max grid-flow-col grid-rows-2 gap-1 overflow-x-auto pr-2 pb-1 hide-scrollbar",
+				"flex flex-wrap gap-1 pr-2 pb-1",
 				isInSection ? "pl-14" : "pl-12",
 			)}
 		>
@@ -32,6 +30,6 @@ export function DashboardSidebarWorkspacePortsRow({
 					port={port}
 				/>
 			))}
-		</OverflowFadeContainer>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -13,6 +13,10 @@ import {
 import { useOpenV1ImportModal } from "renderer/stores/v1-import-modal";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 import {
+	useWorkspaceAgentsRowEnabled,
+	useWorkspaceAgentsRowStore,
+} from "renderer/stores/workspace-agents-row";
+import {
 	isItemVisible,
 	SETTING_ITEM_ID,
 	type SettingItemId,
@@ -37,12 +41,20 @@ export function ExperimentalSettings({
 		SETTING_ITEM_ID.EXPERIMENTAL_INLINE_WORKSPACE_PORTS,
 		visibleItems,
 	);
+	const showWorkspaceAgents = isItemVisible(
+		SETTING_ITEM_ID.EXPERIMENTAL_WORKSPACE_AGENTS,
+		visibleItems,
+	);
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const isV2OnlyUser = useIsV2OnlyUser();
 	const setOptInV2 = useV2LocalOverrideStore((state) => state.setOptInV2);
 	const openV1ImportModal = useOpenV1ImportModal();
 	const inlineWorkspacePortsEnabled = useInlineWorkspacePortsEnabled();
 	const setInlineWorkspacePortsEnabled = useInlineWorkspacePortsStore(
+		(state) => state.setEnabled,
+	);
+	const workspaceAgentsEnabled = useWorkspaceAgentsRowEnabled();
+	const setWorkspaceAgentsEnabled = useWorkspaceAgentsRowStore(
 		(state) => state.setEnabled,
 	);
 
@@ -123,6 +135,24 @@ export function ExperimentalSettings({
 							id="inline-workspace-ports"
 							checked={inlineWorkspacePortsEnabled}
 							onCheckedChange={setInlineWorkspacePortsEnabled}
+						/>
+					</div>
+				)}
+				{showWorkspaceAgents && (
+					<div className="flex items-center justify-between gap-6">
+						<div className="min-w-0 flex-1 space-y-0.5">
+							<Label htmlFor="workspace-agents" className="text-sm font-medium">
+								Workspace agents
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Show running agents under each workspace in the sidebar, with
+								their live status.
+							</p>
+						</div>
+						<Switch
+							id="workspace-agents"
+							checked={workspaceAgentsEnabled}
+							onCheckedChange={setWorkspaceAgentsEnabled}
 						/>
 					</div>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -53,6 +53,7 @@ export const SETTING_ITEM_ID = {
 	EXPERIMENTAL_SUPERSET_V2: "experimental-superset-v2",
 	EXPERIMENTAL_V1_MIGRATION: "experimental-v1-migration",
 	EXPERIMENTAL_INLINE_WORKSPACE_PORTS: "experimental-inline-workspace-ports",
+	EXPERIMENTAL_WORKSPACE_AGENTS: "experimental-workspace-agents",
 
 	INTEGRATIONS_LINEAR: "integrations-linear",
 	INTEGRATIONS_GITHUB: "integrations-github",
@@ -164,6 +165,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.EXPERIMENTAL_SUPERSET_V2]: "shared",
 	[SETTING_ITEM_ID.EXPERIMENTAL_V1_MIGRATION]: "v2",
 	[SETTING_ITEM_ID.EXPERIMENTAL_INLINE_WORKSPACE_PORTS]: "v2",
+	[SETTING_ITEM_ID.EXPERIMENTAL_WORKSPACE_AGENTS]: "v2",
 
 	[SETTING_ITEM_ID.INTEGRATIONS_LINEAR]: "shared",
 	[SETTING_ITEM_ID.INTEGRATIONS_GITHUB]: "shared",
@@ -949,6 +951,26 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"workspace",
 			"workspaces",
 			"dev server",
+			"toggle",
+			"switch",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.EXPERIMENTAL_WORKSPACE_AGENTS,
+		section: "experimental",
+		title: "Workspace agents",
+		description:
+			"Show running agents under each workspace in the sidebar, with their live status",
+		keywords: [
+			"experimental",
+			"agents",
+			"agent",
+			"running",
+			"inline",
+			"sidebar",
+			"workspace",
+			"workspaces",
+			"status",
 			"toggle",
 			"switch",
 		],

--- a/apps/desktop/src/renderer/stores/workspace-agents-row.ts
+++ b/apps/desktop/src/renderer/stores/workspace-agents-row.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+/**
+ * EXPERIMENT: show running agents inline under each workspace in the sidebar.
+ *
+ * Off by default. Single source of truth for the experiment — read it
+ * everywhere via {@link useWorkspaceAgentsRowEnabled}.
+ *
+ * To conclude the experiment, pick an outcome and remove the other side:
+ *   1. This store + `useWorkspaceAgentsRowEnabled`.
+ *   2. The toggle UI in `ExperimentalSettings` and its `settings-search` entry
+ *      (`EXPERIMENTAL_WORKSPACE_AGENTS`).
+ *   3. The flag branch in `DashboardSidebarWorkspaceDetails` (the `agents`
+ *      section) and the `enabled` it threads into
+ *      `useDashboardSidebarWorkspaceRunningAgents`.
+ */
+interface WorkspaceAgentsRowState {
+	// When true, running agents render inline under each workspace item.
+	enabled: boolean;
+	setEnabled: (enabled: boolean) => void;
+}
+
+export const useWorkspaceAgentsRowStore = create<WorkspaceAgentsRowState>()(
+	devtools(
+		persist(
+			(set) => ({
+				enabled: false,
+				setEnabled: (enabled) => set({ enabled }),
+			}),
+			{ name: "workspace-agents-row" },
+		),
+		{ name: "WorkspaceAgentsRowStore" },
+	),
+);
+
+/** Single read path for the workspace-agents-row experiment flag. */
+export function useWorkspaceAgentsRowEnabled(): boolean {
+	return useWorkspaceAgentsRowStore((state) => state.enabled);
+}


### PR DESCRIPTION
## What

Adds a **running agents** row beneath each workspace in the v2 dashboard sidebar, mirroring the inline ports row.

- Lists **every agent bound to the workspace's terminals** (via `useTerminalAgentBindings`), not just those currently `working`/`permission` — idle agents show too.
- Each badge resolves **name + preset icon** from the binding's `agentId` (`BUILTIN_AGENT_LABELS` + `usePresetIcon`), the same resolver the terminal pane icon uses.
- **State**: the leading glyph is the live `StatusIndicator` when the agent is `working`/`permission`/`review`, and the agent's icon when `idle` — held in a fixed-size slot so the row doesn't shift as state changes. No trailing status element.
- **Click opens the agent's terminal pane** (`terminalId` + `focusRequestId`), same as the port badge.
- Agents are ordered by `startedAt` for stable positioning; the details toggle summary counts all bound agents.

### Layout / decoupling
- The agents row is **decoupled from the experimental `inlineWorkspacePortsEnabled` flag** — the details container renders whenever it has content; only the *ports* section stays gated by the flag (so ports don't double-render against the bottom ports list).
- Both the agents and ports rows now use `flex flex-wrap` — a single row that wraps to a second only when needed (previously a forced 2-row horizontal-scroll grid), with tighter spacing.

## Notes
- This row is **terminal-agent bindings only**; the built-in "Superset" chat agent is not listed. Easy to add chat sources alongside if we want it.

## Test plan
- [ ] Bind an agent in a workspace terminal → it appears in the sidebar with icon + name.
- [ ] While the agent is working / awaiting permission / ready for review, the leading glyph reflects state; idle shows the agent icon; no layout shift on transitions.
- [ ] Clicking a badge opens the workspace and focuses that agent's terminal pane.
- [ ] Rows wrap to a second line only when they overflow; ports behavior unchanged.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a running agents row under each workspace in the v2 dashboard sidebar, showing all terminal-bound agents with live status and one-click focus to the agent’s terminal. The feature is behind an experimental “Workspace agents” toggle (off by default).

- **New Features**
  - Lists all agents bound via `useTerminalAgentBindings` (includes idle); label and icon resolved via `BUILTIN_AGENT_LABELS`/`usePresetIcon`.
  - Badge shows `StatusIndicator` when active, agent icon when idle; fixed icon slot to avoid layout shift; tooltip with name and status; click focuses the agent’s terminal (`terminalId`/`focusRequestId`).
  - Stable order by `startedAt`; summary count reflects all bound agents.

- **Refactors**
  - Agents row gated by `useWorkspaceAgentsRowEnabled` with an Experimental Settings switch and search entry; bindings query supports `{ enabled }` to skip when off.
  - Workspace details container renders when it has content; ports remain behind `inlineWorkspacePortsEnabled`.
  - Agents and ports rows use `flex flex-wrap` and wrap only when needed.

<sup>Written for commit 6cb32c61e030bf101335de8b05db7d0a25b0e6ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Workspace agents” section to the dashboard sidebar with clickable agent badges that open the workspace view.
  * Introduced an experimental “Workspace agents” toggle to enable the inline agents row in the sidebar.
* **Bug Fixes**
  * Improved dashboard sidebar workspace details so the agents section renders more reliably when agents are available (reduced unnecessary gating).
* **UI Updates**
  * Updated the ports list layout to a more compact, wrap-friendly presentation.
  * Enhanced agent badge visuals with status indicators and clearer hover tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->