### PR TITLE
feat(desktop): emphasize live-work sections in changes sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CategorySection/CategorySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CategorySection/CategorySection.tsx
@@ -37,12 +37,20 @@ export function CategorySection({
 		return null;
 	}
 
+	const isLiveWork = id === "unstaged" || id === "staged";
+	const countBadgeClass =
+		id === "unstaged"
+			? "bg-amber-500/15 text-amber-700 dark:text-amber-300"
+			: id === "staged"
+				? "bg-green-500/15 text-green-700 dark:text-green-400"
+				: "text-muted-foreground";
+
 	return (
 		<Collapsible
 			open={isExpanded}
 			onOpenChange={onToggle}
 			className={cn(
-				"min-w-0 overflow-hidden transition-opacity",
+				"min-w-0 overflow-hidden border-t border-border/40 transition-opacity",
 				isDragging && "opacity-45",
 			)}
 		>
@@ -65,8 +73,25 @@ export function CategorySection({
 							isExpanded && "rotate-90",
 						)}
 					/>
-					<span className="text-xs font-medium truncate">{title}</span>
-					<span className="text-[10px] text-muted-foreground shrink-0">
+					<span
+						className={cn(
+							"text-xs truncate",
+							isLiveWork ? "font-semibold" : "font-medium",
+						)}
+					>
+						{title}
+					</span>
+					<span
+						className={cn(
+							"shrink-0 text-[10px] tabular-nums",
+							isLiveWork
+								? cn(
+										"rounded-full px-1.5 py-0.5 font-medium leading-none",
+										countBadgeClass,
+									)
+								: "text-muted-foreground",
+						)}
+					>
 						{count}
 					</span>
 				</CollapsibleTrigger>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CategorySection/CategorySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CategorySection/CategorySection.tsx
@@ -37,20 +37,19 @@ export function CategorySection({
 		return null;
 	}
 
-	const isLiveWork = id === "unstaged" || id === "staged";
-	const countBadgeClass =
-		id === "unstaged"
-			? "bg-amber-500/15 text-amber-700 dark:text-amber-300"
-			: id === "staged"
-				? "bg-green-500/15 text-green-700 dark:text-green-400"
-				: "text-muted-foreground";
+	const liveWorkBadgeClass: Partial<Record<ChangeCategory, string>> = {
+		unstaged: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+		staged: "bg-green-500/15 text-green-700 dark:text-green-400",
+	};
+	const countBadgeClass = liveWorkBadgeClass[id];
+	const isLiveWork = countBadgeClass !== undefined;
 
 	return (
 		<Collapsible
 			open={isExpanded}
 			onOpenChange={onToggle}
 			className={cn(
-				"min-w-0 overflow-hidden border-t border-border/40 transition-opacity",
+				"min-w-0 overflow-hidden border-t border-border/40 transition-opacity first:border-t-0",
 				isDragging && "opacity-45",
 			)}
 		>


### PR DESCRIPTION
## Summary

In the right-sidebar Changes view, the four category sections (Against base, Commits, Staged, Unstaged) all render with identical styling — same font weight, same muted count, no divider between them. This makes it easy to miss that there are uncommitted files, and hard to visually separate live work from reference material even when Against base is collapsed.

This PR:
- **Colored count pills for live work** — Unstaged count renders as an amber pill, Staged as a green pill. Against base / Commits stay muted.
- **`border-t border-border/40` between sections** — clear visual divider so collapsed sections don't blur into each other.
- **Slightly heavier title on live-work sections** (`font-semibold` vs `font-medium`) — subtle salience bump.

No logic changes — only `className` conditionals in `CategorySection.tsx`.

## Test plan
- [ ] Load a workspace with unstaged files → Unstaged section header shows amber count pill
- [ ] Stage a file → Staged section header shows green count pill
- [ ] Collapse "Against base" → clear divider between the collapsed header and the next section
- [ ] Reorder sections via drag → dividers still render correctly at new positions
- [ ] Dark mode → pill colors read clearly (uses `dark:` variants)
- [ ] Empty section (`count === 0`) still returns `null` — no orphan divider

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emphasizes live work in the Changes sidebar so uncommitted files are easier to spot.
Adds amber/green count pills for Unstaged/Staged, a top border between sections (skips the first), slightly bolder live-work titles, and deduped badge styles via a single lookup; styles-only in `CategorySection.tsx`.

<sup>Written for commit 5df673c188893727cc512334dd734233cb687ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced sidebar category section styling with live-work–specific header emphasis.
  * Improved the count/badge presentation for live-work categories, while non-live categories retain a more muted appearance.
  * Updated the collapsible section styling to add a subtle top border for a cleaner, more consistent sidebar layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->