### PR TITLE
fix(desktop): persist v2 changes-sidebar section collapse state

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -90,6 +90,7 @@ export const ChangesFileList = memo(function ChangesFileList({
 				return (
 					<ChangesSection
 						key={key}
+						sectionKey={key}
 						title={GROUP_TITLES[key]}
 						count={groupFiles.length}
 						stagingActions={

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/ChangesSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/ChangesSection.tsx
@@ -11,25 +11,36 @@ import { ChevronRight, Minus, Plus } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { LuUndo2 } from "react-icons/lu";
 import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
+import {
+	useV2ChangesSectionsStore,
+	type V2ChangesSectionKey,
+} from "renderer/stores/v2-changes-sections";
 
 type SectionKind = "unstaged" | "staged";
 
 interface ChangesSectionProps {
+	sectionKey: V2ChangesSectionKey;
 	title: string;
 	count: number;
-	defaultOpen?: boolean;
 	stagingActions?: { kind: SectionKind; workspaceId: string };
 	children: ReactNode;
 }
 
 export function ChangesSection({
+	sectionKey,
 	title,
 	count,
-	defaultOpen = true,
 	stagingActions,
 	children,
 }: ChangesSectionProps) {
-	const [open, setOpen] = useState(defaultOpen);
+	const collapsed = useV2ChangesSectionsStore(
+		(state) => state.collapsed[sectionKey] ?? false,
+	);
+	const toggle = useV2ChangesSectionsStore((state) => state.toggle);
+	const open = !collapsed;
+	const setOpen = (next: boolean) => {
+		if (next !== open) toggle(sectionKey);
+	};
 	const [showConfirm, setShowConfirm] = useState(false);
 	const utils = workspaceTrpc.useUtils();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/ChangesSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/ChangesSection.tsx
@@ -36,11 +36,8 @@ export function ChangesSection({
 	const collapsed = useV2ChangesSectionsStore(
 		(state) => state.collapsed[sectionKey] ?? false,
 	);
-	const toggle = useV2ChangesSectionsStore((state) => state.toggle);
+	const setCollapsed = useV2ChangesSectionsStore((state) => state.setCollapsed);
 	const open = !collapsed;
-	const setOpen = (next: boolean) => {
-		if (next !== open) toggle(sectionKey);
-	};
 	const [showConfirm, setShowConfirm] = useState(false);
 	const utils = workspaceTrpc.useUtils();
 
@@ -123,7 +120,10 @@ export function ChangesSection({
 	const StagingToggleIcon = isUnstaged ? Plus : Minus;
 
 	return (
-		<Collapsible open={open} onOpenChange={setOpen}>
+		<Collapsible
+			open={open}
+			onOpenChange={(next) => setCollapsed(sectionKey, !next)}
+		>
 			<div className="flex items-center">
 				<CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1 text-left text-xs hover:bg-accent/30">
 					<ChevronRight

--- a/apps/desktop/src/renderer/stores/v2-changes-sections/index.ts
+++ b/apps/desktop/src/renderer/stores/v2-changes-sections/index.ts
@@ -1,0 +1,2 @@
+export { useV2ChangesSectionsStore } from "./store";
+export type { V2ChangesSectionKey } from "./store";

--- a/apps/desktop/src/renderer/stores/v2-changes-sections/index.ts
+++ b/apps/desktop/src/renderer/stores/v2-changes-sections/index.ts
@@ -1,2 +1,2 @@
-export { useV2ChangesSectionsStore } from "./store";
 export type { V2ChangesSectionKey } from "./store";
+export { useV2ChangesSectionsStore } from "./store";

--- a/apps/desktop/src/renderer/stores/v2-changes-sections/store.ts
+++ b/apps/desktop/src/renderer/stores/v2-changes-sections/store.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+export type V2ChangesSectionKey =
+	| "unstaged"
+	| "staged"
+	| "against-base"
+	| "commit";
+
+interface V2ChangesSectionsState {
+	collapsed: Partial<Record<V2ChangesSectionKey, boolean>>;
+	toggle: (key: V2ChangesSectionKey) => void;
+}
+
+export const useV2ChangesSectionsStore = create<V2ChangesSectionsState>()(
+	devtools(
+		persist(
+			(set) => ({
+				collapsed: {},
+				toggle: (key) =>
+					set((state) => ({
+						collapsed: { ...state.collapsed, [key]: !state.collapsed[key] },
+					})),
+			}),
+			{
+				name: "v2-changes-sections-v1",
+				partialize: (state) => ({ collapsed: state.collapsed }),
+			},
+		),
+		{ name: "V2ChangesSections" },
+	),
+);

--- a/apps/desktop/src/renderer/stores/v2-changes-sections/store.ts
+++ b/apps/desktop/src/renderer/stores/v2-changes-sections/store.ts
@@ -1,11 +1,8 @@
+import type { DiffFileSource } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
-export type V2ChangesSectionKey =
-	| "unstaged"
-	| "staged"
-	| "against-base"
-	| "commit";
+export type V2ChangesSectionKey = DiffFileSource["kind"];
 
 interface V2ChangesSectionsState {
 	collapsed: Partial<Record<V2ChangesSectionKey, boolean>>;

--- a/apps/desktop/src/renderer/stores/v2-changes-sections/store.ts
+++ b/apps/desktop/src/renderer/stores/v2-changes-sections/store.ts
@@ -6,7 +6,7 @@ export type V2ChangesSectionKey = DiffFileSource["kind"];
 
 interface V2ChangesSectionsState {
 	collapsed: Partial<Record<V2ChangesSectionKey, boolean>>;
-	toggle: (key: V2ChangesSectionKey) => void;
+	setCollapsed: (key: V2ChangesSectionKey, collapsed: boolean) => void;
 }
 
 export const useV2ChangesSectionsStore = create<V2ChangesSectionsState>()(
@@ -14,9 +14,9 @@ export const useV2ChangesSectionsStore = create<V2ChangesSectionsState>()(
 		persist(
 			(set) => ({
 				collapsed: {},
-				toggle: (key) =>
+				setCollapsed: (key, collapsed) =>
 					set((state) => ({
-						collapsed: { ...state.collapsed, [key]: !state.collapsed[key] },
+						collapsed: { ...state.collapsed, [key]: collapsed },
 					})),
 			}),
 			{

--- a/apps/desktop/test-setup.ts
+++ b/apps/desktop/test-setup.ts
@@ -9,7 +9,7 @@
  * DO NOT mock internal code here - tests should use real implementations
  * or mock at the individual test level when necessary.
  */
-import { mock } from "bun:test";
+import { beforeEach, mock } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
@@ -86,6 +86,10 @@ const localStorageData = new Map<string, string>();
 		localStorageData.set(key, value);
 	},
 };
+
+beforeEach(() => {
+	localStorageData.clear();
+});
 
 // Ensure window has addEventListener/removeEventListener for react-hotkeys-hook's IIFE
 if (typeof globalThis.window !== "undefined") {

--- a/apps/desktop/test-setup.ts
+++ b/apps/desktop/test-setup.ts
@@ -67,6 +67,26 @@ const mockHead = {
 	})),
 };
 
+// zustand's persist middleware defaults to `window.localStorage`. The
+// xterm-env-polyfill preload aliases `window` to globalThis, so that lookup
+// resolves to `undefined` without throwing and persist crashes on the first
+// setState. Provide an in-memory Storage so persisted stores work in tests.
+const localStorageData = new Map<string, string>();
+(globalThis as { localStorage?: Storage }).localStorage = {
+	get length() {
+		return localStorageData.size;
+	},
+	clear: () => localStorageData.clear(),
+	getItem: (key: string) => localStorageData.get(key) ?? null,
+	key: (index: number) => [...localStorageData.keys()][index] ?? null,
+	removeItem: (key: string) => {
+		localStorageData.delete(key);
+	},
+	setItem: (key: string, value: string) => {
+		localStorageData.set(key, value);
+	},
+};
+
 // Ensure window has addEventListener/removeEventListener for react-hotkeys-hook's IIFE
 if (typeof globalThis.window !== "undefined") {
 	const win = globalThis.window as Record<string, unknown>;


### PR DESCRIPTION
## Summary

The v2 sidebar's changes section (Unstaged / Staged / Against base / Committed) used local \`useState\` for its collapsed/expanded state. Because the sidebar subtree unmounts on workspace switch, every collapse was reset back to expanded when moving between workspaces — you'd collapse "Against base" in workspace A, switch to workspace B, and see it fully expanded again.

## Fix

- New store \`renderer/stores/v2-changes-sections/\` (zustand + persist middleware) with a \`Partial<Record<V2ChangesSectionKey, boolean>>\` collapse map.
- \`ChangesSection\` reads/writes via the store instead of \`useState\`.
- \`ChangesFileList\` passes the \`sectionKey\` (\`unstaged\` | \`staged\` | \`against-base\` | \`commit\`).

Scope is **global**, not per-workspace — sections stay collapsed the same way everywhere. localStorage key: \`v2-changes-sections-v1\`.

## Test plan
- [ ] Collapse "Against base" in workspace A, switch to workspace B → still collapsed
- [ ] Collapse "Against base", quit and relaunch the app → still collapsed (localStorage rehydrates)
- [ ] Every section can be collapsed and expanded independently
- [ ] First-time users see all sections expanded (empty \`collapsed\` map → all \`open\`)
- [ ] Sections with \`count === 0\` still render \`null\` and don't add to the persisted map on their own

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted the v2 Changes sidebar section collapse state so it survives workspace switches and app restarts. Fixes sections resetting to expanded and keeps collapse behavior consistent across the app.

- **Bug Fixes**
  - Added `renderer/stores/v2-changes-sections` using `zustand` + `persist` to store a collapsed map (localStorage key `v2-changes-sections-v1`).
  - `ChangesSection` reads/writes from the store; `ChangesFileList` now passes `sectionKey` (`unstaged`, `staged`, `against-base`, `commit`).
  - Scope is global across workspaces; first-time users see all sections expanded.
  - Tests: stubbed `localStorage` and clear it between tests in `apps/desktop/test-setup.ts` so persisted stores work and don’t leak state in Bun tests.

- **Refactors**
  - Derived `V2ChangesSectionKey` from `DiffFileSource["kind"]` to ensure new kinds fail typecheck at the store level.
  - Replaced toggle logic with idempotent `setCollapsed` to avoid state mismatches.
  - Sorted `v2-changes-sections` barrel exports to satisfy Biome.

<sup>Written for commit 76d333bb0b813ea4e681a42525eacc83f9a94c03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace sidebar “Changes” sections now remember expanded/collapsed state and restore it on later visits.
* **Bug Fixes**
  * Grouped “Changes” file sections now share consistent expand/collapse behavior across the grouped view.
* **Tests**
  * Improved Bun test setup’s `localStorage` mock to better support persisted UI state during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->