### PR TITLE
feat(shared,desktop): Fable model + reasoning-effort support for agent launches

### DIFF
--- a/apps/desktop/src/renderer/hooks/useAgentEffortPreference/index.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentEffortPreference/index.ts
@@ -1,0 +1,1 @@
+export { useAgentEffortPreference } from "./useAgentEffortPreference";

--- a/apps/desktop/src/renderer/hooks/useAgentEffortPreference/useAgentEffortPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentEffortPreference/useAgentEffortPreference.ts
@@ -1,0 +1,76 @@
+import { getAgentEffortSupport } from "@superset/shared/agent-models";
+import { useCallback, useEffect, useState } from "react";
+
+function readStoredMap(storageKey: string): Record<string, string> {
+	if (typeof window === "undefined") return {};
+	try {
+		const raw = window.localStorage.getItem(storageKey);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
+			return {};
+		return Object.fromEntries(
+			Object.entries(parsed).filter(
+				(entry): entry is [string, string] => typeof entry[1] === "string",
+			),
+		);
+	} catch {
+		return {};
+	}
+}
+
+function readStoredEffort(
+	storageKey: string,
+	presetId: string | null,
+): string | null {
+	if (!presetId) return null;
+	const stored = readStoredMap(storageKey)[presetId];
+	if (!stored) return null;
+	// Drop ids that fell out of the curated registry — "Default" beats a
+	// flag value the CLI no longer accepts.
+	const support = getAgentEffortSupport(presetId);
+	return support?.efforts.some((effort) => effort.id === stored)
+		? stored
+		: null;
+}
+
+/**
+ * Last-selected reasoning effort per agent preset, persisted as a JSON map in
+ * localStorage. Same contract as `useAgentModelPreference`: keyed by presetId
+ * so the preference survives host switches; `null` means "Default" — no
+ * stored entry, no effort flag at launch.
+ */
+export function useAgentEffortPreference(
+	storageKey: string,
+	presetId: string | null,
+) {
+	const [selectedEffort, setSelectedEffortState] = useState<string | null>(() =>
+		readStoredEffort(storageKey, presetId),
+	);
+
+	useEffect(() => {
+		setSelectedEffortState(readStoredEffort(storageKey, presetId));
+	}, [storageKey, presetId]);
+
+	const setSelectedEffort = useCallback(
+		(effort: string | null) => {
+			setSelectedEffortState(effort);
+			if (typeof window === "undefined" || !presetId) return;
+			const map = readStoredMap(storageKey);
+			if (effort) {
+				map[presetId] = effort;
+			} else {
+				delete map[presetId];
+			}
+			try {
+				window.localStorage.setItem(storageKey, JSON.stringify(map));
+			} catch {
+				// Quota/security errors only cost persistence of the preference;
+				// the in-memory selection above still applies to this dialog.
+			}
+		},
+		[storageKey, presetId],
+	);
+
+	return { selectedEffort, setSelectedEffort };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -1,4 +1,7 @@
-import { getAgentModelSupport } from "@superset/shared/agent-models";
+import {
+	getAgentEffortSupport,
+	getAgentModelSupport,
+} from "@superset/shared/agent-models";
 import { sanitizeUserBranchName } from "@superset/shared/workspace-launch";
 import {
 	PromptInput,
@@ -26,6 +29,7 @@ import { LinkedIssuePill } from "renderer/components/Chat/ChatInterface/componen
 import { IssueLinkCommand } from "renderer/components/Chat/ChatInterface/components/IssueLinkCommand";
 import { MarkdownEditor } from "renderer/components/MarkdownEditor";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { useAgentEffortPreference } from "renderer/hooks/useAgentEffortPreference";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
 import { useAgentModelPreference } from "renderer/hooks/useAgentModelPreference";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
@@ -57,6 +61,7 @@ import {
 } from "./hooks/useUploadAttachments";
 import {
 	AGENT_STORAGE_KEY,
+	EFFORT_STORAGE_KEY,
 	MODEL_STORAGE_KEY,
 	PILL_BUTTON_CLASS,
 	type ProjectOption,
@@ -169,6 +174,13 @@ export function PromptGroup({
 	const { selectedModel, setSelectedModel } = useAgentModelPreference(
 		MODEL_STORAGE_KEY,
 		modelSupport ? selectedPresetId : null,
+	);
+	const effortSupport = selectedPresetId
+		? getAgentEffortSupport(selectedPresetId)
+		: undefined;
+	const { selectedEffort, setSelectedEffort } = useAgentEffortPreference(
+		EFFORT_STORAGE_KEY,
+		effortSupport ? selectedPresetId : null,
 	);
 
 	// Promote the placeholder "none" → first configured agent whenever the
@@ -289,6 +301,7 @@ export function PromptGroup({
 		projectId,
 		selectedAgent,
 		modelSupport ? selectedModel : null,
+		effortSupport ? selectedEffort : null,
 		uploadAttachments,
 		promptContext,
 	);
@@ -485,6 +498,14 @@ export function PromptGroup({
 								models={modelSupport.models}
 								value={selectedModel}
 								onValueChange={setSelectedModel}
+								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
+							/>
+						)}
+						{effortSupport && (
+							<AgentModelSelect
+								models={effortSupport.efforts}
+								value={selectedEffort}
+								onValueChange={setSelectedEffort}
 								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							/>
 						)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -21,6 +21,7 @@ export function useSubmitWorkspace(
 	projectId: string | null,
 	selectedAgent: WorkspaceCreateAgent,
 	selectedModel: string | null,
+	selectedEffort: string | null,
 	uploadAttachments: UseUploadAttachmentsApi,
 	promptContext: NewWorkspacePromptContextApi,
 ) {
@@ -91,6 +92,7 @@ export function useSubmitWorkspace(
 						prompt: finalPrompt ?? "",
 						attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
 						model: selectedModel ?? undefined,
+						effort: selectedEffort ?? undefined,
 					},
 				]
 			: undefined;
@@ -177,6 +179,7 @@ export function useSubmitWorkspace(
 		promptContext,
 		selectedAgent,
 		selectedModel,
+		selectedEffort,
 		submit,
 		uploadAttachments,
 	]);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
@@ -8,6 +8,9 @@ export const AGENT_STORAGE_KEY = "lastSelectedV2WorkspaceCreateAgent";
 // preference survives host switches.
 export const MODEL_STORAGE_KEY = "lastSelectedV2WorkspaceCreateModelByPreset";
 
+// JSON map of presetId → effort id; same contract as MODEL_STORAGE_KEY.
+export const EFFORT_STORAGE_KEY = "lastSelectedV2WorkspaceCreateEffortByPreset";
+
 export const PILL_BUTTON_CLASS =
 	"!h-[22px] min-h-0 rounded-md border-[0.5px] border-border bg-foreground/[0.04] shadow-none text-[11px]";
 

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -1,5 +1,8 @@
 import { readFileSync } from "node:fs";
-import { buildAgentModelArgs } from "@superset/shared/agent-models";
+import {
+	buildAgentEffortArgs,
+	buildAgentModelArgs,
+} from "@superset/shared/agent-models";
 import { TRPCError } from "@trpc/server";
 import { asc, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -165,6 +168,7 @@ export interface AgentRunInput {
 	prompt: string;
 	attachmentIds?: string[];
 	model?: string;
+	effort?: string;
 }
 
 export type AgentRunResult =
@@ -258,7 +262,11 @@ async function runTerminalAgent(
 
 	const prompt = buildAttachmentBlock(input.prompt, resolvedAttachments);
 	const modelArgs = buildAgentModelArgs(config.presetId, input.model);
-	const command = buildAgentCommandString(config, prompt, modelArgs);
+	const effortArgs = buildAgentEffortArgs(config.presetId, input.effort);
+	const command = buildAgentCommandString(config, prompt, [
+		...modelArgs,
+		...effortArgs,
+	]);
 	const fullCommand = `${envOverlayPrefix(config.env)}${command}`;
 
 	const terminalId = crypto.randomUUID();
@@ -303,6 +311,7 @@ export const agentsRouter = router({
 				prompt: z.string().min(1),
 				attachmentIds: z.array(z.string().uuid()).optional(),
 				model: z.string().min(1).optional(),
+				effort: z.string().min(1).optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => runAgentInWorkspace(ctx, input)),

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -62,6 +62,7 @@ const agentLaunchSchema = z
 		prompt: z.string(),
 		attachmentIds: z.array(z.string().uuid()).optional(),
 		model: z.string().min(1).optional(),
+		effort: z.string().min(1).optional(),
 	})
 	.refine(
 		(value) =>
@@ -526,6 +527,7 @@ async function dispatchSugarAgents(
 					prompt: entry.prompt,
 					attachmentIds: entry.attachmentIds,
 					model: entry.model,
+					effort: entry.effort,
 				});
 				return { ok: true as const, ...result };
 			} catch (err) {

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
+	AGENT_EFFORT_SUPPORT,
 	AGENT_MODEL_SUPPORT,
+	buildAgentEffortArgs,
 	buildAgentModelArgs,
+	getAgentEffortSupport,
 	getAgentModelSupport,
 } from "./agent-models";
 import { BUILTIN_TERMINAL_AGENT_TYPES } from "./builtin-terminal-agents";
@@ -71,5 +74,68 @@ describe("buildAgentModelArgs", () => {
 		expect(
 			buildAgentModelArgs("superset", "anthropic/claude-opus-4-8"),
 		).toEqual([]);
+	});
+
+	it("includes fable in claude's curated list", () => {
+		expect(buildAgentModelArgs("claude", "fable")).toEqual([
+			"--model",
+			"fable",
+		]);
+	});
+});
+
+describe("AGENT_EFFORT_SUPPORT", () => {
+	it("only references builtin presets", () => {
+		const validIds = new Set<string>(BUILTIN_TERMINAL_AGENT_TYPES);
+		for (const entry of AGENT_EFFORT_SUPPORT) {
+			expect(validIds.has(entry.presetId)).toBe(true);
+		}
+	});
+
+	it("lists at least one effort per entry", () => {
+		for (const entry of AGENT_EFFORT_SUPPORT) {
+			expect(entry.efforts.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("getAgentEffortSupport", () => {
+	it("returns the entry for a supported preset", () => {
+		expect(getAgentEffortSupport("claude")?.effortFlag).toBe("--effort");
+	});
+
+	it("returns undefined for presets without effort support", () => {
+		expect(getAgentEffortSupport("gemini")).toBeUndefined();
+		expect(getAgentEffortSupport("superset")).toBeUndefined();
+	});
+});
+
+describe("buildAgentEffortArgs", () => {
+	it("builds flag + value tokens", () => {
+		expect(buildAgentEffortArgs("claude", "high")).toEqual([
+			"--effort",
+			"high",
+		]);
+	});
+
+	it("prefixes the value for codex config overrides", () => {
+		expect(buildAgentEffortArgs("codex", "high")).toEqual([
+			"-c",
+			"model_reasoning_effort=high",
+		]);
+	});
+
+	it("returns [] when no effort is set", () => {
+		expect(buildAgentEffortArgs("claude", undefined)).toEqual([]);
+		expect(buildAgentEffortArgs("claude", "")).toEqual([]);
+	});
+
+	it("returns [] for unsupported presets", () => {
+		expect(buildAgentEffortArgs("gemini", "high")).toEqual([]);
+	});
+
+	it("returns [] for effort ids outside the preset's curated list", () => {
+		expect(buildAgentEffortArgs("claude", "bogus")).toEqual([]);
+		expect(buildAgentEffortArgs("copilot", "max")).toEqual([]);
 	});
 });

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -58,6 +58,7 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "claude",
 		modelFlag: "--model",
 		models: [
+			{ id: "fable", label: "Fable" },
 			{ id: "opus", label: "Opus" },
 			{ id: "sonnet", label: "Sonnet" },
 			{ id: "haiku", label: "Haiku" },

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -1,5 +1,6 @@
 /**
- * Curated per-agent model catalogs for the workspace-create model picker.
+ * Curated per-agent model and effort catalogs for the workspace-create
+ * pickers.
  *
  * Entries are keyed by terminal-agent presetId (see
  * `builtin-terminal-agents.ts`) plus the virtual `"superset"` chat agent.
@@ -114,10 +115,123 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 	},
 ];
 
+export interface AgentEffortSupport {
+	presetId: string;
+	effortFlag: string;
+	/**
+	 * Prepended to the selected effort id to form the flag's value token.
+	 * Codex has no dedicated effort flag, so effort rides a config override:
+	 * `-c model_reasoning_effort=high`.
+	 */
+	effortValuePrefix?: string;
+	efforts: AgentModelOption[];
+}
+
+/**
+ * Curated per-agent reasoning-effort catalogs, mirroring
+ * `AGENT_MODEL_SUPPORT`. Flags and accepted values were verified against each
+ * CLI's `--help` (or its own validator) — agents absent from this list
+ * (gemini, opencode, cursor-agent, droid, superset chat) expose no effort
+ * control on their interactive launch command.
+ */
+export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
+	{
+		presetId: "claude",
+		effortFlag: "--effort",
+		efforts: [
+			{ id: "low", label: "Low" },
+			{ id: "medium", label: "Medium" },
+			{ id: "high", label: "High" },
+			{ id: "xhigh", label: "xHigh" },
+			{ id: "max", label: "Max" },
+		],
+	},
+	{
+		presetId: "amp",
+		effortFlag: "--effort",
+		efforts: [
+			{ id: "none", label: "None" },
+			{ id: "minimal", label: "Minimal" },
+			{ id: "low", label: "Low" },
+			{ id: "medium", label: "Medium" },
+			{ id: "high", label: "High" },
+			{ id: "xhigh", label: "xHigh" },
+			{ id: "max", label: "Max" },
+		],
+	},
+	{
+		presetId: "codex",
+		effortFlag: "-c",
+		effortValuePrefix: "model_reasoning_effort=",
+		efforts: [
+			{ id: "low", label: "Low" },
+			{ id: "medium", label: "Medium" },
+			{ id: "high", label: "High" },
+			{ id: "xhigh", label: "xHigh" },
+		],
+	},
+	{
+		presetId: "mastracode",
+		effortFlag: "--thinking-level",
+		efforts: [
+			{ id: "off", label: "Off" },
+			{ id: "low", label: "Low" },
+			{ id: "medium", label: "Medium" },
+			{ id: "high", label: "High" },
+			{ id: "xhigh", label: "xHigh" },
+		],
+	},
+	{
+		presetId: "pi",
+		effortFlag: "--thinking",
+		efforts: [
+			{ id: "off", label: "Off" },
+			{ id: "minimal", label: "Minimal" },
+			{ id: "low", label: "Low" },
+			{ id: "medium", label: "Medium" },
+			{ id: "high", label: "High" },
+			{ id: "xhigh", label: "xHigh" },
+		],
+	},
+	{
+		presetId: "copilot",
+		effortFlag: "--effort",
+		efforts: [
+			{ id: "low", label: "Low" },
+			{ id: "medium", label: "Medium" },
+			{ id: "high", label: "High" },
+			{ id: "xhigh", label: "xHigh" },
+		],
+	},
+];
+
 export function getAgentModelSupport(
 	presetId: string,
 ): AgentModelSupport | undefined {
 	return AGENT_MODEL_SUPPORT.find((entry) => entry.presetId === presetId);
+}
+
+export function getAgentEffortSupport(
+	presetId: string,
+): AgentEffortSupport | undefined {
+	return AGENT_EFFORT_SUPPORT.find((entry) => entry.presetId === presetId);
+}
+
+/**
+ * Argv tokens that select `effort` for the given preset, e.g.
+ * `["--effort", "high"]` (codex: `["-c", "model_reasoning_effort=high"]`).
+ * Same degrade-to-default contract as `buildAgentModelArgs`: unknown presets
+ * or effort ids outside the curated list return `[]`.
+ */
+export function buildAgentEffortArgs(
+	presetId: string,
+	effort: string | undefined,
+): string[] {
+	if (!effort) return [];
+	const support = getAgentEffortSupport(presetId);
+	if (!support) return [];
+	if (!support.efforts.some((option) => option.id === effort)) return [];
+	return [support.effortFlag, `${support.effortValuePrefix ?? ""}${effort}`];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `{ id: "fable", label: "Fable" }` to the `claude` preset in `AGENT_MODEL_SUPPORT`, so the workspace-create model picker offers Fable for Claude Code and launches pass `--model fable`.
- Add reasoning-effort support across the builtin CLI agents: a new `AGENT_EFFORT_SUPPORT` catalog + `buildAgentEffortArgs` in `packages/shared/src/agent-models.ts`, threaded through `workspaces.create` → `agents.run` on the host service, with an effort picker (persisted per preset, same contract as the model picker) in the workspace-create form.

## How It Works
- Effort flags were verified against each installed CLI (`--help` output / binary validators):
  - `claude --effort` (low, medium, high, xhigh, max)
  - `amp --effort` (none, minimal, low, medium, high, xhigh, max)
  - `copilot --effort` (low, medium, high, xhigh)
  - `pi --thinking` (off, minimal, low, medium, high, xhigh)
  - `mastracode --thinking-level` (off, low, medium, high, xhigh)
  - `codex` has no dedicated flag; effort rides a config override `-c model_reasoning_effort=<v>` via the entry's `effortValuePrefix`
  - gemini, opencode, cursor-agent, and droid expose no effort control on their interactive launch commands (droid only has it on `droid exec`), so they have no entry and render no picker.
- `buildAgentEffortArgs` has the same degrade-to-default contract as `buildAgentModelArgs`: unknown preset or effort id → `[]` → CLI default, never a broken launch.
- The renderer reuses `AgentModelSelect` for the effort dropdown and persists the last selection per preset under a new localStorage key (`useAgentEffortPreference`, mirroring `useAgentModelPreference`).

## Manual QA Checklist
- [x] `claude --model fable --effort low -p …` accepted both flags; response self-identified as Claude Fable 5 (`claude-fable-5`)
- [ ] Workspace-create form shows the effort picker only for presets with an entry (claude, amp, codex, mastracode, pi, copilot)
- [ ] Effort selection persists across modal reopen and host switches
- [ ] Launch with "Default" effort omits the flag entirely

## Testing
- `bun test agent-models` in `packages/shared` — 20 pass (new suites for `AGENT_EFFORT_SUPPORT`, `getAgentEffortSupport`, `buildAgentEffortArgs` incl. the codex prefix shape, plus a fable registry assertion)
- `bun turbo run typecheck --filter=@superset/shared --filter=@superset/host-service --filter=@superset/desktop` — clean
- `biome check` on all changed files — clean
- Live CLI test of the exact argv Superset generates for Claude Code (see QA above)

## Notes
- `fable` is the short alias the Claude Code CLI accepts after `--model`, matching the existing `opus`/`sonnet`/`haiku` entries. Listed first as the most capable tier.
- The superset chat agent has no effort entry — chat metadata carries only a model id today.
- codex does not validate `model_reasoning_effort` client-side (a bogus value is echoed into the session header), so the curated list is the only guard on that path — same as for models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Claude preset model picker with an additional option.
  * Added “reasoning effort” selection for supported v2 agents in the new workspace flow, including persistence of the last choice.
* **Changes**
  * Workspace and agent run requests now accept an optional reasoning effort value and apply it during execution.
* **Bug Fixes**
  * Improved validation so only supported effort values are used.
* **Tests**
  * Added/extended coverage for effort support and argument building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->