### PR TITLE
feat(desktop): add Quit Superset Completely to the macOS app menu

### DIFF
--- a/apps/desktop/src/main/lib/menu.ts
+++ b/apps/desktop/src/main/lib/menu.ts
@@ -9,6 +9,7 @@ import {
 	simulateUpdateReady,
 } from "./auto-updater";
 import { menuEmitter } from "./menu-events";
+import { confirmAndQuitCompletely } from "./quit-completely";
 
 export function createApplicationMenu() {
 	const reloadAccelerator = "CmdOrCtrl+R";
@@ -184,6 +185,12 @@ export function createApplicationMenu() {
 				{ role: "unhide" },
 				{ type: "separator" },
 				{ role: "quit" },
+				{
+					label: "Quit Superset Completely",
+					click: () => {
+						void confirmAndQuitCompletely();
+					},
+				},
 			],
 		});
 	}

--- a/apps/desktop/src/main/lib/quit-completely.ts
+++ b/apps/desktop/src/main/lib/quit-completely.ts
@@ -1,0 +1,22 @@
+import { dialog } from "electron";
+import { quitAppCompletely } from "main/index";
+
+export async function confirmAndQuitCompletely(): Promise<void> {
+	try {
+		const { response } = await dialog.showMessageBox({
+			type: "warning",
+			buttons: ["Quit Completely", "Cancel"],
+			defaultId: 1,
+			cancelId: 1,
+			title: "Quit Superset Completely",
+			message: "Quit Superset and stop all background services?",
+			detail:
+				"All open terminal sessions will be killed and any running host-services will be stopped. Use “Close Superset” instead if you want services to keep running for the next launch.",
+		});
+		if (response === 0) {
+			quitAppCompletely();
+		}
+	} catch (error) {
+		console.error("[quit] Quit-completely confirmation failed:", error);
+	}
+}

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -2,7 +2,6 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import {
 	app,
-	dialog,
 	Menu,
 	type MenuItemConstructorOptions,
 	nativeImage,
@@ -10,12 +9,13 @@ import {
 } from "electron";
 import { loadToken } from "lib/trpc/routers/auth/utils/auth-functions";
 import { env } from "main/env.main";
-import { focusMainWindow, quitApp, quitAppCompletely } from "main/index";
+import { focusMainWindow, quitApp } from "main/index";
 import {
 	getHostServiceCoordinator,
 	type HostServiceStatusEvent,
 } from "main/lib/host-service-coordinator";
 import { menuEmitter } from "main/lib/menu-events";
+import { confirmAndQuitCompletely } from "main/lib/quit-completely";
 
 /** Must have "Template" suffix for macOS dark/light mode support */
 const TRAY_ICON_FILENAME = "iconTemplate.png";
@@ -82,26 +82,6 @@ function createTrayIcon(): Electron.NativeImage | null {
 function openSettings(): void {
 	focusMainWindow();
 	menuEmitter.emit("open-settings");
-}
-
-async function confirmAndQuitCompletely(): Promise<void> {
-	try {
-		const { response } = await dialog.showMessageBox({
-			type: "warning",
-			buttons: ["Quit Completely", "Cancel"],
-			defaultId: 1,
-			cancelId: 1,
-			title: "Quit Superset Completely",
-			message: "Quit Superset and stop all background services?",
-			detail:
-				"All open terminal sessions will be killed and any running host-services will be stopped. Use “Close Superset” instead if you want services to keep running for the next launch.",
-		});
-		if (response === 0) {
-			quitAppCompletely();
-		}
-	} catch (error) {
-		console.error("[Tray] Quit-completely confirmation failed:", error);
-	}
 }
 
 interface HostInfo {


### PR DESCRIPTION
## Summary
- Add "Quit Superset Completely" to the macOS application menu (the app-name menu in the menu bar), right below the standard Quit item, so full quit is reachable without opening the tray menu.
- Extract the tray's quit-completely confirmation dialog into a shared `main/lib/quit-completely.ts` helper used by both the tray and the app menu — same dialog, same `quitAppCompletely()` behavior.

## Why / Context
"Quit Superset Completely" (quit + stop all host-services and terminal sessions) only existed in the tray menu. Users expect it in the standard macOS app menu too; plain Cmd+Q ("Quit Superset") intentionally keeps background services alive for the next launch.

## Testing
- `bun run lint` (clean)
- `bunx tsc --noEmit` in `apps/desktop` — no errors in the changed main-process files (pre-existing renderer errors from missing `routeTree.gen` codegen are unrelated)
- Manual: not exercised in a running app; the menu item calls the exact confirmation + quit path already shipped in the tray, with no logic changes.

## Notes
- No accelerator on the new item — full quit is destructive (kills terminals), so it stays click + confirm only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Quit Superset Completely” to the macOS app menu so users can fully quit (stop background services and terminals) without opening the tray. Extracts the confirmation dialog into a shared helper for consistent behavior.

- **New Features**
  - Added “Quit Superset Completely” below the standard Quit in the macOS app menu; no accelerator (click + confirm only).

- **Refactors**
  - Moved the quit-completely confirmation into `main/lib/quit-completely.ts` and reused it in both the tray and app menu.

<sup>Written for commit 526e2b4816ae9ccf60e4fc0bf5810c8222f30570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS menu option to fully quit the app with a confirmation prompt before closing.
  * The same “Quit Completely” option is now available from the tray menu for a consistent exit experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->