### PR TITLE
fix(desktop): match diff pane file header background to section bar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme/useDiffCodeViewTheme.ts
@@ -96,6 +96,20 @@ export function useDiffCodeViewTheme() {
 				[data-diffs-header='default'] [data-change-icon] {
 					display: none;
 				}
+				/* Match the file header bar to the DiffSectionBar background
+				 * (bg-muted/40 flattened over the pane background) so the
+				 * pinned section strip and the file title strip read as one.
+				 * Pierre paints these with --diffs-bg (the diff surface
+				 * color); the [data-sticky] selector is needed to out-rank
+				 * Pierre's own two-attribute sticky rule. */
+				[data-diffs-header='default'],
+				[data-diffs-header='default'][data-sticky] {
+					background-color: color-mix(
+						in srgb,
+						var(--muted) 40%,
+						var(--background)
+					);
+				}
 				[data-diffs-header='default'] [data-additions-count] {
 					color: ${additionColor};
 				}


### PR DESCRIPTION
## Summary

In the v2 diff pane, the sticky per-file header (rendered by Pierre's CodeView) was painted with the diff surface color (`--diffs-bg`, black on dark themes), while the pinned `DiffSectionBar` above it uses `bg-muted/40`. The two strips stack directly on top of each other and read as mismatched.

This overrides the file header background inside the CodeView shadow DOM to `color-mix(in srgb, var(--muted) 40%, var(--background))` — the flattened equivalent of the section bar's `bg-muted/40` — kept opaque so diff lines don't bleed through the sticky header. The override includes a `[data-sticky]` selector variant to out-rank Pierre's own two-attribute sticky rule.

## Test Plan

- [ ] Open a workspace with changes, open the Changes diff pane
- [ ] File title bars render in the same gray as the pinned section bar (Unstaged / Staged / Against base / Committed)
- [ ] Scroll a long diff: the sticky file header stays opaque (no content bleeding through) in both light and dark themes

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5424">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match the v2 diff pane file header background to the section bar so they read as one and the sticky header stays opaque across themes. Override the CodeView header styles in the shadow DOM to a flattened bg-muted/40 and include a [data-sticky] selector to ensure specificity.

<sup>Written for commit 08b0af295a6ef53cb4f81ee8656dc44576ecd3a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the diff view’s header appearance so the file title bar blends smoothly with the section/pane background.
  * Fixed the styling so the pinned header state matches the normal header, creating a more consistent look while scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->