### PR TITLE
refactor(desktop): cleaner, compact inline agent/port sections in v2 sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarChipStrip/DashboardSidebarChipStrip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarChipStrip/DashboardSidebarChipStrip.tsx
@@ -65,7 +65,11 @@ export function DashboardSidebarChipStrip({
 			ref={containerRef}
 			observeChildren
 			className={cn(
-				isTwoRows ? "grid auto-cols-max grid-flow-col grid-rows-2" : "flex",
+				// justify-items-start keeps chips at natural width in grid mode;
+				// stretched chips would inflate the offsetWidths measure() sums.
+				isTwoRows
+					? "grid auto-cols-max grid-flow-col grid-rows-2 justify-items-start"
+					: "flex",
 				"items-center gap-1.5 overflow-x-auto hide-scrollbar",
 				className,
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarChipStrip/DashboardSidebarChipStrip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarChipStrip/DashboardSidebarChipStrip.tsx
@@ -1,0 +1,76 @@
+import { OverflowFadeContainer } from "@superset/ui/overflow-fade-container";
+import { cn } from "@superset/ui/utils";
+import {
+	type ReactNode,
+	useCallback,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
+
+/** Must match the `gap-1.5` class on the container below. */
+const CHIP_GAP_PX = 6;
+
+interface DashboardSidebarChipStripProps {
+	className?: string;
+	children: ReactNode;
+}
+
+/**
+ * Strip of chips (ports, agents) that stays a single row while everything
+ * fits, wraps into a two-row grid once it doesn't, and scrolls horizontally
+ * (two rows deep) beyond that.
+ *
+ * Layout is chosen by comparing the chips' natural widths against the
+ * container, re-measured on every render and on container resizes. Pure-CSS
+ * child growth (e.g. a chip revealing hover actions) deliberately doesn't
+ * trigger a re-measure, so hovering can't flip the layout.
+ */
+export function DashboardSidebarChipStrip({
+	className,
+	children,
+}: DashboardSidebarChipStripProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [isTwoRows, setIsTwoRows] = useState(false);
+
+	const measure = useCallback(() => {
+		const node = containerRef.current;
+		if (!node) return;
+		const styles = getComputedStyle(node);
+		const available =
+			node.clientWidth -
+			Number.parseFloat(styles.paddingLeft) -
+			Number.parseFloat(styles.paddingRight);
+		let needed = -CHIP_GAP_PX;
+		for (const child of Array.from(node.children)) {
+			needed += (child as HTMLElement).offsetWidth + CHIP_GAP_PX;
+		}
+		setIsTwoRows(needed > available);
+	}, []);
+
+	// No dependency array: chips mounting/unmounting re-renders this component,
+	// and re-measuring is cheap (setState bails when the boolean is unchanged).
+	useLayoutEffect(measure);
+
+	useLayoutEffect(() => {
+		const node = containerRef.current;
+		if (!node) return;
+		const observer = new ResizeObserver(measure);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [measure]);
+
+	return (
+		<OverflowFadeContainer
+			ref={containerRef}
+			observeChildren
+			className={cn(
+				isTwoRows ? "grid auto-cols-max grid-flow-col grid-rows-2" : "flex",
+				"items-center gap-1.5 overflow-x-auto hide-scrollbar",
+				className,
+			)}
+		>
+			{children}
+		</OverflowFadeContainer>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarChipStrip/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarChipStrip/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarChipStrip } from "./DashboardSidebarChipStrip";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/components/DashboardSidebarPortBadge/DashboardSidebarPortBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/components/DashboardSidebarPortBadge/DashboardSidebarPortBadge.tsx
@@ -9,6 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import {
+	LuAppWindow,
 	LuEllipsisVertical,
 	LuExternalLink,
 	LuLoaderCircle,
@@ -46,25 +47,34 @@ export function DashboardSidebarPortBadge({
 		});
 	};
 
-	const handleOpenInBrowser = () => {
+	const portUrl = `http://localhost:${port.port}`;
+
+	const handleOpenExternal = () => {
+		if (!canOpenInBrowser || openUrl.isPending) return;
+		openUrl.mutate(portUrl);
+	};
+
+	const handleOpenInApp = (target: "new-tab" | "current-tab") => {
 		if (!canOpenInBrowser) return;
-
-		// Where the port opens is configurable under Settings → Links → Ports.
-		const url = `http://localhost:${port.port}`;
-		if (preferences.portOpenAction === "external") {
-			if (openUrl.isPending) return;
-			openUrl.mutate(url);
-			return;
-		}
-
 		void navigateToV2Workspace(port.workspaceId, navigate, {
 			search: {
-				openUrl: url,
-				openUrlTarget:
-					preferences.portOpenAction === "newTab" ? "new-tab" : "current-tab",
+				openUrl: portUrl,
+				openUrlTarget: target,
 				openUrlRequestId: crypto.randomUUID(),
 			},
 		});
+	};
+
+	// Where a plain click opens the port is configurable under
+	// Settings → Links → Ports.
+	const handleOpenInBrowser = () => {
+		if (preferences.portOpenAction === "external") {
+			handleOpenExternal();
+			return;
+		}
+		handleOpenInApp(
+			preferences.portOpenAction === "newTab" ? "new-tab" : "current-tab",
+		);
 	};
 
 	// Opening the port is the primary action; remote ports can't open a local
@@ -156,13 +166,27 @@ export function DashboardSidebarPortBadge({
 					onCloseAutoFocus={(event) => event.preventDefault()}
 				>
 					{canOpenInBrowser && (
-						<DropdownMenuItem
-							onSelect={handleOpenInBrowser}
-							disabled={openUrl.isPending}
-						>
-							<LuExternalLink />
-							Open in Browser
-						</DropdownMenuItem>
+						<>
+							<DropdownMenuItem
+								onSelect={handleOpenExternal}
+								disabled={openUrl.isPending}
+							>
+								<LuExternalLink />
+								Open in External Browser
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onSelect={() =>
+									handleOpenInApp(
+										preferences.portOpenAction === "pane"
+											? "current-tab"
+											: "new-tab",
+									)
+								}
+							>
+								<LuAppWindow />
+								Open in Superset Browser
+							</DropdownMenuItem>
+						</>
 					)}
 					<DropdownMenuItem onSelect={handleWorkspaceClick}>
 						<LuSquareTerminal />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/components/DashboardSidebarPortBadge/DashboardSidebarPortBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/components/DashboardSidebarPortBadge/DashboardSidebarPortBadge.tsx
@@ -1,3 +1,9 @@
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
@@ -60,88 +66,82 @@ export function DashboardSidebarPortBadge({
 	};
 
 	return (
-		<Tooltip delayDuration={700}>
-			<TooltipTrigger asChild>
-				<div
-					className={cn(
-						"group relative mb-1 inline-flex max-w-full items-center gap-1 rounded-md",
-						"bg-primary/10 text-xs text-primary transition-colors hover:bg-primary/20",
-						isPending && "opacity-70",
-					)}
-				>
-					<button
-						type="button"
-						onClick={handleWorkspaceClick}
-						className="flex max-w-40 min-w-0 items-center gap-1 rounded-md px-2 py-1 font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-					>
-						{port.label ? (
-							<>
-								<span className="min-w-0 truncate">{port.label}</span>
-								<span className="shrink-0 font-mono font-normal text-muted-foreground">
-									{port.port}
-								</span>
-							</>
-						) : (
-							<span className="font-mono text-muted-foreground">
-								{port.port}
-							</span>
-						)}
-					</button>
-					{canOpenInBrowser && (
+		<ContextMenu>
+			<Tooltip delayDuration={700}>
+				<ContextMenuTrigger asChild>
+					<TooltipTrigger asChild>
 						<button
 							type="button"
-							onClick={handleOpenInBrowser}
-							disabled={openUrl.isPending}
-							aria-label={`Open ${port.label || `port ${port.port}`} in browser`}
-							className="text-muted-foreground opacity-0 transition-opacity hover:text-primary focus-visible:opacity-100 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 group-hover:opacity-100"
+							onClick={handleWorkspaceClick}
+							disabled={isPending}
+							aria-busy={isPending}
+							className={cn(
+								"flex max-w-40 min-w-0 shrink-0 items-center gap-1 rounded px-1.5 py-0.5",
+								"bg-muted/60 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+								"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+								isPending && "opacity-70",
+							)}
 						>
-							<LuExternalLink className="size-3.5" strokeWidth={STROKE_WIDTH} />
+							{port.label ? (
+								<>
+									<span className="min-w-0 truncate">{port.label}</span>
+									<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/60">
+										{port.port}
+									</span>
+								</>
+							) : (
+								<span className="font-mono tabular-nums">{port.port}</span>
+							)}
+							{isPending && (
+								<LuLoaderCircle
+									className="size-3 shrink-0 animate-spin"
+									strokeWidth={STROKE_WIDTH}
+								/>
+							)}
 						</button>
-					)}
-					<button
-						type="button"
-						onClick={handleClose}
-						disabled={isPending}
-						aria-busy={isPending}
-						aria-label={`Close ${port.label || `port ${port.port}`}`}
-						className="pr-1 text-muted-foreground opacity-0 transition-opacity hover:text-primary focus-visible:opacity-100 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-70 group-hover:opacity-100"
-					>
-						{isPending ? (
-							<LuLoaderCircle
-								className="size-3.5 animate-spin"
-								strokeWidth={STROKE_WIDTH}
-							/>
-						) : (
-							<LuX className="size-3.5" strokeWidth={STROKE_WIDTH} />
+					</TooltipTrigger>
+				</ContextMenuTrigger>
+				<TooltipContent side="top" sideOffset={6} showArrow={false}>
+					<div className="space-y-1 text-xs">
+						{port.label && <div className="font-medium">{port.label}</div>}
+						<div
+							className={`font-mono ${port.label ? "text-background/70" : "font-medium"}`}
+						>
+							localhost:{port.port}
+						</div>
+						<div className="text-background/70">{hostLabel}</div>
+						{(port.processName || port.pid != null) && (
+							<div className="text-background/70">
+								{port.processName}
+								{port.pid != null && ` (pid ${port.pid})`}
+							</div>
 						)}
-					</button>
-				</div>
-			</TooltipTrigger>
-			<TooltipContent side="top" sideOffset={6} showArrow={false}>
-				<div className="space-y-1 text-xs">
-					{port.label && <div className="font-medium">{port.label}</div>}
-					<div
-						className={`font-mono ${port.label ? "text-background/70" : "font-medium"}`}
-					>
-						localhost:{port.port}
-					</div>
-					<div className="text-background/70">{hostLabel}</div>
-					{(port.processName || port.pid != null) && (
-						<div className="text-background/70">
-							{port.processName}
-							{port.pid != null && ` (pid ${port.pid})`}
-						</div>
-					)}
-					{!canOpenInBrowser && (
+						{!canOpenInBrowser && (
+							<div className="text-[10px] text-background/60">
+								Browser open unavailable from this device
+							</div>
+						)}
 						<div className="text-[10px] text-background/60">
-							Browser open unavailable from this device
+							Click to open workspace · Right-click for actions
 						</div>
-					)}
-					<div className="text-[10px] text-background/60">
-						Click to open workspace
 					</div>
-				</div>
-			</TooltipContent>
-		</Tooltip>
+				</TooltipContent>
+			</Tooltip>
+			<ContextMenuContent>
+				{canOpenInBrowser && (
+					<ContextMenuItem
+						onSelect={handleOpenInBrowser}
+						disabled={openUrl.isPending}
+					>
+						<LuExternalLink className="size-4 mr-2" />
+						Open in Browser
+					</ContextMenuItem>
+				)}
+				<ContextMenuItem onSelect={handleClose} disabled={isPending}>
+					<LuX className="size-4 mr-2" />
+					Close Port
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/components/DashboardSidebarPortBadge/DashboardSidebarPortBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/components/DashboardSidebarPortBadge/DashboardSidebarPortBadge.tsx
@@ -1,13 +1,20 @@
 import {
-	ContextMenu,
-	ContextMenuContent,
-	ContextMenuItem,
-	ContextMenuTrigger,
-} from "@superset/ui/context-menu";
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
-import { LuExternalLink, LuLoaderCircle, LuX } from "react-icons/lu";
+import {
+	LuEllipsisVertical,
+	LuExternalLink,
+	LuLoaderCircle,
+	LuSquareTerminal,
+	LuX,
+} from "react-icons/lu";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
@@ -60,47 +67,46 @@ export function DashboardSidebarPortBadge({
 		});
 	};
 
+	// Opening the port is the primary action; remote ports can't open a local
+	// browser tab, so clicking those jumps to the workspace instead.
+	const handlePrimaryClick = canOpenInBrowser
+		? handleOpenInBrowser
+		: handleWorkspaceClick;
+
 	const handleClose = () => {
 		if (isPending) return;
 		void killPort(port);
 	};
 
 	return (
-		<ContextMenu>
+		<div
+			className={cn(
+				"group flex max-w-44 shrink-0 items-center rounded",
+				"bg-muted/60 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+				isPending && "opacity-70",
+			)}
+		>
 			<Tooltip delayDuration={700}>
-				<ContextMenuTrigger asChild>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={handleWorkspaceClick}
-							disabled={isPending}
-							aria-busy={isPending}
-							className={cn(
-								"flex max-w-40 min-w-0 shrink-0 items-center gap-1 rounded px-1.5 py-0.5",
-								"bg-muted/60 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
-								"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-								isPending && "opacity-70",
-							)}
-						>
-							{port.label ? (
-								<>
-									<span className="min-w-0 truncate">{port.label}</span>
-									<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/60">
-										{port.port}
-									</span>
-								</>
-							) : (
-								<span className="font-mono tabular-nums">{port.port}</span>
-							)}
-							{isPending && (
-								<LuLoaderCircle
-									className="size-3 shrink-0 animate-spin"
-									strokeWidth={STROKE_WIDTH}
-								/>
-							)}
-						</button>
-					</TooltipTrigger>
-				</ContextMenuTrigger>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={handlePrimaryClick}
+						disabled={isPending}
+						aria-busy={isPending}
+						className="flex min-w-0 items-center gap-1 rounded-l py-0.5 pl-1.5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					>
+						{port.label ? (
+							<>
+								<span className="min-w-0 truncate">{port.label}</span>
+								<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/60">
+									{port.port}
+								</span>
+							</>
+						) : (
+							<span className="font-mono tabular-nums">{port.port}</span>
+						)}
+					</button>
+				</TooltipTrigger>
 				<TooltipContent side="top" sideOffset={6} showArrow={false}>
 					<div className="space-y-1 text-xs">
 						{port.label && <div className="font-medium">{port.label}</div>}
@@ -116,32 +122,63 @@ export function DashboardSidebarPortBadge({
 								{port.pid != null && ` (pid ${port.pid})`}
 							</div>
 						)}
-						{!canOpenInBrowser && (
-							<div className="text-[10px] text-background/60">
-								Browser open unavailable from this device
-							</div>
-						)}
 						<div className="text-[10px] text-background/60">
-							Click to open workspace · Right-click for actions
+							{canOpenInBrowser
+								? "Click to open in browser"
+								: "Click to open workspace"}
 						</div>
 					</div>
 				</TooltipContent>
 			</Tooltip>
-			<ContextMenuContent>
-				{canOpenInBrowser && (
-					<ContextMenuItem
-						onSelect={handleOpenInBrowser}
-						disabled={openUrl.isPending}
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						aria-label={`Actions for ${port.label || `port ${port.port}`}`}
+						disabled={isPending}
+						className="flex shrink-0 items-center self-stretch rounded-r px-1 text-muted-foreground/50 opacity-0 transition-[opacity,color] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100 data-[state=open]:text-foreground data-[state=open]:opacity-100"
 					>
-						<LuExternalLink className="size-4 mr-2" />
-						Open in Browser
-					</ContextMenuItem>
-				)}
-				<ContextMenuItem onSelect={handleClose} disabled={isPending}>
-					<LuX className="size-4 mr-2" />
-					Close Port
-				</ContextMenuItem>
-			</ContextMenuContent>
-		</ContextMenu>
+						{isPending ? (
+							<LuLoaderCircle
+								className="size-3 animate-spin"
+								strokeWidth={STROKE_WIDTH}
+							/>
+						) : (
+							<LuEllipsisVertical
+								className="size-3"
+								strokeWidth={STROKE_WIDTH}
+							/>
+						)}
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent
+					align="start"
+					onCloseAutoFocus={(event) => event.preventDefault()}
+				>
+					{canOpenInBrowser && (
+						<DropdownMenuItem
+							onSelect={handleOpenInBrowser}
+							disabled={openUrl.isPending}
+						>
+							<LuExternalLink />
+							Open in Browser
+						</DropdownMenuItem>
+					)}
+					<DropdownMenuItem onSelect={handleWorkspaceClick}>
+						<LuSquareTerminal />
+						Go to Workspace
+					</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem
+						variant="destructive"
+						onSelect={handleClose}
+						disabled={isPending}
+					>
+						<LuX />
+						Close Port
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/components/DashboardSidebarPortGroup/DashboardSidebarPortGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/components/DashboardSidebarPortGroup/DashboardSidebarPortGroup.tsx
@@ -1,10 +1,10 @@
-import { OverflowFadeContainer } from "@superset/ui/overflow-fade-container";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { LuLoaderCircle, LuX } from "react-icons/lu";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
+import { DashboardSidebarChipStrip } from "../../../DashboardSidebarChipStrip";
 import { useDashboardSidebarPortKill } from "../../hooks/useDashboardSidebarPortKill";
 import type { DashboardSidebarPortGroup as DashboardSidebarPortGroupType } from "../../hooks/useDashboardSidebarPortsData";
 import { DashboardSidebarPortBadge } from "../DashboardSidebarPortBadge";
@@ -69,17 +69,14 @@ export function DashboardSidebarPortGroup({
 					</TooltipContent>
 				</Tooltip>
 			</div>
-			<OverflowFadeContainer
-				observeChildren
-				className="grid auto-cols-max grid-flow-col grid-rows-2 gap-1 overflow-x-auto px-3 pb-1 hide-scrollbar"
-			>
+			<DashboardSidebarChipStrip className="px-3 pb-1">
 				{group.ports.map((port) => (
 					<DashboardSidebarPortBadge
 						key={`${port.hostId}:${port.terminalId}:${port.port}`}
 						port={port}
 					/>
 				))}
-			</OverflowFadeContainer>
+			</DashboardSidebarChipStrip>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/DashboardSidebarWorkspaceAgentsRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/DashboardSidebarWorkspaceAgentsRow.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@superset/ui/utils";
+import { DashboardSidebarChipStrip } from "../../../../components/DashboardSidebarChipStrip";
 import { DashboardSidebarWorkspaceAgentBadge } from "./components/DashboardSidebarWorkspaceAgentBadge";
 import { useDashboardSidebarWorkspaceRunningAgents } from "./hooks/useDashboardSidebarWorkspaceRunningAgents";
 
@@ -18,11 +19,9 @@ export function DashboardSidebarWorkspaceAgentsRow({
 	}
 
 	return (
-		<div
-			className={cn(
-				"flex flex-wrap gap-1 pr-2 pb-1",
-				isInSection ? "pl-14" : "pl-12",
-			)}
+		<DashboardSidebarChipStrip
+			// pl lines the chips up with the summary label text above.
+			className={cn("pr-2", isInSection ? "pl-11" : "pl-9")}
 		>
 			{agents.map((agent) => (
 				<DashboardSidebarWorkspaceAgentBadge
@@ -31,6 +30,6 @@ export function DashboardSidebarWorkspaceAgentsRow({
 					agent={agent}
 				/>
 			))}
-		</div>
+		</DashboardSidebarChipStrip>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/components/DashboardSidebarWorkspaceAgentBadge/DashboardSidebarWorkspaceAgentBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceAgentsRow/components/DashboardSidebarWorkspaceAgentBadge/DashboardSidebarWorkspaceAgentBadge.tsx
@@ -42,17 +42,17 @@ export function DashboardSidebarWorkspaceAgentBadge({
 					type="button"
 					onClick={handleClick}
 					className={cn(
-						"inline-flex max-w-40 items-center gap-1 rounded-md px-1.5 py-0.5",
-						"bg-primary/10 text-xs font-medium text-primary transition-colors hover:bg-primary/20",
+						"inline-flex max-w-40 shrink-0 items-center gap-1 rounded px-1.5 py-0.5",
+						"bg-muted/60 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
 						"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
 					)}
 				>
-					<span className="flex size-3.5 shrink-0 items-center justify-center">
+					<span className="flex size-3 shrink-0 items-center justify-center">
 						{agent.status === "idle" ? (
 							iconUrl ? (
-								<img src={iconUrl} alt="" className="size-3.5 object-contain" />
+								<img src={iconUrl} alt="" className="size-3 object-contain" />
 							) : (
-								<LuBot className="size-3.5" strokeWidth={STROKE_WIDTH} />
+								<LuBot className="size-3" strokeWidth={STROKE_WIDTH} />
 							)
 						) : (
 							<StatusIndicator status={agent.status} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { LuX } from "react-icons/lu";
 import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import { useWorkspaceDetailsStore } from "renderer/stores";
@@ -30,19 +30,21 @@ interface DashboardSidebarWorkspaceDetailsProps {
 
 /**
  * Collapsible area rendered beneath a workspace row. It hosts the per-workspace
- * "detail" rows (ports today, running agents / other status rows in future).
+ * "detail" sections (ports today, running agents / other status rows in
+ * future). Each section renders its own toggle row and collapses
+ * independently, keyed by `${workspaceId}:${sectionKey}`.
  *
- * To add a new detail row: call its data hook unconditionally in the section
- * registry below, then push a {@link WorkspaceDetailSection} when it has
- * something to show. Everything else — the toggle, summary, header actions,
- * persisted collapse state — is handled here.
+ * To add a new detail section: call its data hook unconditionally in the
+ * section registry below, then push a {@link WorkspaceDetailSection} when it
+ * has something to show. Everything else — the toggle, summary, header
+ * actions, persisted collapse state — is handled here.
  */
 export function DashboardSidebarWorkspaceDetails({
 	workspaceId,
 	isInSection = false,
 }: DashboardSidebarWorkspaceDetailsProps) {
-	const isCollapsed = useWorkspaceDetailsStore(
-		(state) => !!state.collapsedWorkspaceIds[workspaceId],
+	const collapsedSectionKeys = useWorkspaceDetailsStore(
+		(state) => state.collapsedSectionKeys,
 	);
 	const toggleExpanded = useWorkspaceDetailsStore(
 		(state) => state.toggleExpanded,
@@ -101,9 +103,6 @@ export function DashboardSidebarWorkspaceDetails({
 		return null;
 	}
 
-	const isExpanded = !isCollapsed;
-	const headerActions = sections.filter((section) => section.headerAction);
-
 	return (
 		// Stop pointer/touch starts from bubbling to the sortable workspace item's
 		// drag listeners, so scrolling overflowing ports or pressing a port control
@@ -114,28 +113,28 @@ export function DashboardSidebarWorkspaceDetails({
 			onMouseDown={(event) => event.stopPropagation()}
 			onTouchStart={(event) => event.stopPropagation()}
 		>
-			<div className="group/details flex items-center">
-				<DashboardSidebarWorkspaceDetailsToggle
-					isExpanded={isExpanded}
-					summary={sections.map((section) => section.summary).join(" · ")}
-					isInSection={isInSection}
-					onToggle={() => toggleExpanded(workspaceId)}
-				/>
-				{headerActions.length > 0 && (
-					<div className="ml-auto flex items-center gap-0.5 pr-2 opacity-0 transition-opacity group-hover/details:opacity-100 group-focus-within/details:opacity-100">
-						{headerActions.map((section) => (
-							<Fragment key={section.key}>{section.headerAction}</Fragment>
-						))}
+			{sections.map((section) => {
+				const sectionKey = `${workspaceId}:${section.key}`;
+				const isExpanded = !collapsedSectionKeys[sectionKey];
+				return (
+					<div key={section.key}>
+						<div className="group/details flex items-center">
+							<DashboardSidebarWorkspaceDetailsToggle
+								isExpanded={isExpanded}
+								summary={section.summary}
+								isInSection={isInSection}
+								onToggle={() => toggleExpanded(sectionKey)}
+							/>
+							{section.headerAction && (
+								<div className="ml-auto flex items-center pr-2 opacity-0 transition-opacity group-hover/details:opacity-100 group-focus-within/details:opacity-100">
+									{section.headerAction}
+								</div>
+							)}
+						</div>
+						{isExpanded && <div className="mt-0.5 mb-1">{section.content}</div>}
 					</div>
-				)}
-			</div>
-			{isExpanded && (
-				<div className="mt-1 space-y-1">
-					{sections.map((section) => (
-						<div key={section.key}>{section.content}</div>
-					))}
-				</div>
-			)}
+				);
+			})}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
@@ -4,6 +4,7 @@ import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/
 import { useWorkspaceDetailsStore } from "renderer/stores";
 import { useInlineWorkspacePortsEnabled } from "renderer/stores/inline-workspace-ports";
 import { useWorkspaceAgentsRowEnabled } from "renderer/stores/workspace-agents-row";
+import { useShallow } from "zustand/react/shallow";
 import { useDashboardSidebarWorkspacePorts } from "../../../../providers/DashboardSidebarPortsProvider";
 import { useDashboardSidebarPortKill } from "../../../DashboardSidebarPortsList/hooks/useDashboardSidebarPortKill";
 import { DashboardSidebarWorkspaceAgentsRow } from "../DashboardSidebarWorkspaceAgentsRow";
@@ -43,8 +44,15 @@ export function DashboardSidebarWorkspaceDetails({
 	workspaceId,
 	isInSection = false,
 }: DashboardSidebarWorkspaceDetailsProps) {
+	// Narrowed to this workspace's section keys (matching the registry below)
+	// so toggling one workspace's sections doesn't re-render every other panel.
 	const collapsedSectionKeys = useWorkspaceDetailsStore(
-		(state) => state.collapsedSectionKeys,
+		useShallow((state) => ({
+			[`${workspaceId}:ports`]:
+				state.collapsedSectionKeys[`${workspaceId}:ports`],
+			[`${workspaceId}:agents`]:
+				state.collapsedSectionKeys[`${workspaceId}:agents`],
+		})),
 	);
 	const toggleExpanded = useWorkspaceDetailsStore(
 		(state) => state.toggleExpanded,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/components/DashboardSidebarWorkspaceDetailsToggle/DashboardSidebarWorkspaceDetailsToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/components/DashboardSidebarWorkspaceDetailsToggle/DashboardSidebarWorkspaceDetailsToggle.tsx
@@ -30,7 +30,7 @@ export function DashboardSidebarWorkspaceDetailsToggle({
 		>
 			<LuChevronRight
 				className={cn(
-					"size-3 shrink-0 transition-transform",
+					"size-3 shrink-0 opacity-0 transition-[opacity,transform] group-hover/details:opacity-100 group-focus-within/details:opacity-100",
 					isExpanded && "rotate-90",
 				)}
 				strokeWidth={STROKE_WIDTH}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspacePortsRow/DashboardSidebarWorkspacePortsRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspacePortsRow/DashboardSidebarWorkspacePortsRow.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@superset/ui/utils";
+import { DashboardSidebarChipStrip } from "../../../../components/DashboardSidebarChipStrip";
 import { useDashboardSidebarWorkspacePorts } from "../../../../providers/DashboardSidebarPortsProvider";
 import { DashboardSidebarPortBadge } from "../../../DashboardSidebarPortsList/components/DashboardSidebarPortBadge";
 
@@ -18,11 +19,9 @@ export function DashboardSidebarWorkspacePortsRow({
 	}
 
 	return (
-		<div
-			className={cn(
-				"flex flex-wrap gap-1 pr-2 pb-1",
-				isInSection ? "pl-14" : "pl-12",
-			)}
+		<DashboardSidebarChipStrip
+			// pl lines the chips up with the summary label text above.
+			className={cn("pr-2", isInSection ? "pl-11" : "pl-9")}
 		>
 			{group.ports.map((port) => (
 				<DashboardSidebarPortBadge
@@ -30,6 +29,6 @@ export function DashboardSidebarWorkspacePortsRow({
 					port={port}
 				/>
 			))}
-		</div>
+		</DashboardSidebarChipStrip>
 	);
 }

--- a/apps/desktop/src/renderer/stores/workspace-details/store.ts
+++ b/apps/desktop/src/renderer/stores/workspace-details/store.ts
@@ -35,6 +35,25 @@ export const useWorkspaceDetailsStore = create<WorkspaceDetailsState>()(
 			}),
 			{
 				name: "workspace-details-store",
+				version: 1,
+				// v0 persisted one `collapsedWorkspaceIds[workspaceId]` flag for the
+				// whole details area; expand it to every per-section key.
+				migrate: (persisted, version) => {
+					if (version === 0) {
+						const old = persisted as {
+							collapsedWorkspaceIds?: Record<string, true>;
+						};
+						const collapsedSectionKeys: Record<string, true> = {};
+						for (const workspaceId of Object.keys(
+							old.collapsedWorkspaceIds ?? {},
+						)) {
+							collapsedSectionKeys[`${workspaceId}:ports`] = true;
+							collapsedSectionKeys[`${workspaceId}:agents`] = true;
+						}
+						return { collapsedSectionKeys };
+					}
+					return persisted as { collapsedSectionKeys: Record<string, true> };
+				},
 				partialize: (state) => ({
 					collapsedSectionKeys: state.collapsedSectionKeys,
 				}),

--- a/apps/desktop/src/renderer/stores/workspace-details/store.ts
+++ b/apps/desktop/src/renderer/stores/workspace-details/store.ts
@@ -2,41 +2,41 @@ import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
 interface WorkspaceDetailsState {
-	// Workspaces are expanded by default; we only persist the ones the user has
-	// explicitly collapsed so the map stays small and new workspaces show their
-	// details automatically.
-	collapsedWorkspaceIds: Record<string, true>;
+	// Sections are expanded by default; we only persist the ones the user has
+	// explicitly collapsed so the map stays small and new sections show their
+	// details automatically. Keys are `${workspaceId}:${sectionKey}`.
+	collapsedSectionKeys: Record<string, true>;
 
-	setExpanded: (workspaceId: string, expanded: boolean) => void;
-	toggleExpanded: (workspaceId: string) => void;
+	setExpanded: (sectionKey: string, expanded: boolean) => void;
+	toggleExpanded: (sectionKey: string) => void;
 }
 
 export const useWorkspaceDetailsStore = create<WorkspaceDetailsState>()(
 	devtools(
 		persist(
 			(set, get) => ({
-				collapsedWorkspaceIds: {},
+				collapsedSectionKeys: {},
 
-				setExpanded: (workspaceId, expanded) =>
+				setExpanded: (sectionKey, expanded) =>
 					set((state) => {
-						const next = { ...state.collapsedWorkspaceIds };
+						const next = { ...state.collapsedSectionKeys };
 						if (expanded) {
-							delete next[workspaceId];
+							delete next[sectionKey];
 						} else {
-							next[workspaceId] = true;
+							next[sectionKey] = true;
 						}
-						return { collapsedWorkspaceIds: next };
+						return { collapsedSectionKeys: next };
 					}),
 
-				toggleExpanded: (workspaceId) => {
-					const isCollapsed = !!get().collapsedWorkspaceIds[workspaceId];
-					get().setExpanded(workspaceId, isCollapsed);
+				toggleExpanded: (sectionKey) => {
+					const isCollapsed = !!get().collapsedSectionKeys[sectionKey];
+					get().setExpanded(sectionKey, isCollapsed);
 				},
 			}),
 			{
 				name: "workspace-details-store",
 				partialize: (state) => ({
-					collapsedWorkspaceIds: state.collapsedWorkspaceIds,
+					collapsedSectionKeys: state.collapsedSectionKeys,
 				}),
 			},
 		),


### PR DESCRIPTION
## Summary
- Restyles the inline agent and port pills under workspace rows (and the bottom Ports section) as compact, neutral Linear/Notion-style tags, replacing the tinted `bg-primary` chips.
- Splits ports and agents into separate collapsible sections with independently persisted collapse state, instead of one merged "2 ports · 1 agent" toggle.
- Adds adaptive chip layout: one row while chips fit, a two-row grid on overflow, then horizontal scroll two rows deep.
- Reworks port pill interactions: click opens the port in the browser; a hover-revealed ⋮ menu holds Open in External Browser / Open in Superset Browser / Go to Workspace / Close Port.

## Why / Context
The inline agent/port UI read as loud colored CTAs, pills were oversized with phantom trailing space (invisible hover icons reserved ~28px each), rows misaligned with the section toggle, and hover made pills grow and push their neighbors.

## How It Works
- **Pills** (`DashboardSidebarPortBadge`, `DashboardSidebarWorkspaceAgentBadge`): `bg-muted/60` neutral tags at `text-[11px]` with mono tabular port numbers; status color is reserved for the agent status dot.
- **Sections** (`DashboardSidebarWorkspaceDetails`): each detail section renders its own toggle row; `useWorkspaceDetailsStore` now keys collapse state by `${workspaceId}:${sectionKey}` (previously per-workspace); a persist migration (v0 → v1) expands each old per-workspace collapsed flag into both section keys.
- **Layout** (new `DashboardSidebarChipStrip`): measures chips' natural widths against the container (every render + ResizeObserver) and toggles between a flex row and a `grid-rows-2` column-flow grid, wrapped in `OverflowFadeContainer` for the scroll fade. Pure-CSS child growth intentionally doesn't re-measure, so hover can't flip the layout.
- **Port actions**: the ⋮ trigger is always rendered and hidden via opacity, so pill geometry never changes on hover. Kill-pending swaps ⋮ for a spinner and dims the pill.
- Section chevrons are hidden until hover (opacity, slot reserved); chip rows are left-aligned with the section summary label.

## Manual QA Checklist
- [ ] Ports and agents show as separate "N ports" / "N agents" sections under a workspace row
- [ ] Collapsing one section leaves the other open; state persists after app restart
- [ ] Chips: single row when few, two rows when overflowing, horizontal scroll (with right fade) beyond that; resizing the sidebar reflows correctly
- [ ] Hovering a port pill reveals ⋮ without any pill/neighbor movement
- [ ] Click on a local port opens per Settings → Links → Ports preference; remote port click jumps to the workspace
- [ ] ⋮ menu: Open in External Browser + Open in Superset Browser (local only), Go to Workspace, Close Port (destructive); Close shows spinner while pending
- [ ] Collapse state from a pre-PR build carries over (v0 → v1 store migration)
- [ ] "Close all ports" hover action still works on the ports section header
- [ ] Agent pill click focuses the bound terminal; status dot shows working/permission/review
- [ ] Bottom "Ports" list groups behave the same (adaptive rows, new pill styling)

## Testing
- `bun run typecheck`
- `bunx biome check .` (root `bun run lint` additionally shells out to ripgrep, which isn't installed on this machine; Biome itself is clean)
- Manual testing in dev mode

## Design Decisions
- **⋮ menu instead of inline hover icons**: inline icons either reserve phantom width (misaligned idle pills) or expand on hover (layout shift). An opacity-revealed ⋮ keeps geometry constant; destructive close moves behind a menu.
- **Measured 1→2-row layout instead of pure CSS**: CSS can't express "wrap once, then scroll horizontally", so `DashboardSidebarChipStrip` compares natural chip widths to the container width.

## Known Limitations
- The ⋮ slot is ~20px of invisible space at the end of each idle port pill (the cost of shift-free hover).
- Menu wording ("External Browser" / "Superset Browser") differs from Settings → Links wording ("default browser" / "in-app browser").

## Follow-ups
- v1 `WorkspaceSidebar` ports UI intentionally untouched (v1 is sunset).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5426">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the v2 sidebar ports/agents UI with compact neutral tags, per-section collapsible groups, and a measured two-row chip layout. Port pills open per preference on click; the menu separates External vs Superset in‑app open, and existing collapse state is preserved.

- **New Features**
  - Compact neutral tags for ports and agents; agent status stays a colored dot.
  - Separate collapsible “Ports” and “Agents” with per‑section persisted state.
  - Port click opens per Settings → Links → Ports; remote ports open the workspace. Menu: Open in External Browser, Open in Superset Browser, Go to Workspace, Close.
  - Adaptive chip layout via `DashboardSidebarChipStrip`: single row, then two‑row grid on overflow, then horizontal scroll without hover shifts.

- **Refactors**
  - Added `DashboardSidebarChipStrip` to measure chip widths and choose 1‑row/2‑row/scroll; bottom “Ports” list uses the same layout. Grid uses justify‑items‑start to avoid stretched chips inflating measurements.
  - Chevron appears on hover; chips align with the section summary label.
  - Persisted state keys are now `${workspaceId}:${sectionKey}` with a migration from v0 `collapsedWorkspaceIds` to per‑section keys (existing collapsed workspaces map to collapsed Ports and Agents).
  - Narrowed store selector to this workspace’s section keys to avoid sidebar‑wide re‑renders.

<sup>Written for commit 2fc582fce96b9dcb9f90ec50356ab44218450d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar lists now use an adaptive chip strip that automatically switches between multi-row and single-row layouts, scrolling horizontally when space is limited.
  * Workspace details are now expandable/collapsible independently per section (instead of one shared state).

* **Bug Fixes / UX Improvements**
  * Port badge interactions are simplified to a primary click plus a dropdown with “open” options and “Go to Workspace”, with updated tooltip text and a pending-safe “Close Port”.

* **Style**
  * Improved badge and chevron presentation for a cleaner, more consistent sidebar look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
