### PR TITLE
feat(workspace-fs): allow viewing files outside the workspace root

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/security/path-validation.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/security/path-validation.ts
@@ -23,9 +23,12 @@ import { localDb } from "main/lib/local-db";
  *
  * SYMLINK PROTECTION:
  * - Filesystem operations should delegate to `workspace-fs`. Mutations are
- *   confined to the workspace root; reads are host-wide but still reject
- *   in-workspace symlinks that resolve outside the root, so a malicious repo
- *   can't disguise a sensitive host file as a workspace file.
+ *   confined to the workspace root; reads are host-wide, but file-content
+ *   reads (`readFile`) still reject in-workspace symlinks that resolve
+ *   outside the root, so a malicious repo can't disguise a sensitive host
+ *   file's contents as a workspace file. `listDirectory`/`getMetadata` don't
+ *   apply this check: `getMetadata` lstats (never follows links) and
+ *   directory listings only expose entry names.
  * - This module remains focused on registered-worktree and relative-path validation.
  */
 

--- a/apps/desktop/src/lib/trpc/routers/changes/security/path-validation.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/security/path-validation.ts
@@ -22,8 +22,10 @@ import { localDb } from "main/lib/local-db";
  * - Defense in depth against path manipulation
  *
  * SYMLINK PROTECTION:
- * - Filesystem operations should delegate to `workspace-fs`, which enforces
- *   workspace-boundary and symlink-escape checks for reads and writes.
+ * - Filesystem operations should delegate to `workspace-fs`. Mutations are
+ *   confined to the workspace root; reads are host-wide but still reject
+ *   in-workspace symlinks that resolve outside the root, so a malicious repo
+ *   can't disguise a sensitive host file as a workspace file.
  * - This module remains focused on registered-worktree and relative-path validation.
  */
 

--- a/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
@@ -3,8 +3,6 @@ import {
 	createFsHostService,
 	type FsHostService,
 	FsWatcherManager,
-	toRelativePath,
-	type WorkspaceFsPathError,
 } from "@superset/workspace-fs/host";
 import { shell } from "electron";
 import { getWorkspace } from "./workspaces/utils/db-helpers";
@@ -86,6 +84,3 @@ export function toRegisteredWorktreeRelativePath(
 
 	return relativePath.replace(/\\/g, "/");
 }
-
-export { toRelativePath };
-export type { WorkspaceFsPathError };

--- a/packages/host-service/test/integration/bug-hunt.integration.test.ts
+++ b/packages/host-service/test/integration/bug-hunt.integration.test.ts
@@ -13,7 +13,13 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { TRPCClientError } from "@trpc/client";
 import { eq } from "drizzle-orm";
@@ -78,7 +84,6 @@ describe("bug-hunt: filesystem sandbox", () => {
 			expect(result.kind).toBe("text");
 			expect(result.content).toBe("outside content");
 		} finally {
-			const { rmSync } = await import("node:fs");
 			rmSync(sibling, { force: true });
 		}
 	});
@@ -87,7 +92,6 @@ describe("bug-hunt: filesystem sandbox", () => {
 		const outside = join(repo.repoPath, "..", `symlink-target-${randomUUID()}`);
 		writeFileSync(outside, "secret");
 		const link = join(repo.repoPath, "innocent-looking.txt");
-		const { symlinkSync, rmSync } = await import("node:fs");
 		symlinkSync(outside, link);
 		try {
 			await expect(
@@ -117,8 +121,6 @@ describe("bug-hunt: filesystem sandbox", () => {
 		).rejects.toThrow();
 		expect(existsSync(join(sibling, "marker"))).toBe(true);
 
-		// Cleanup
-		const { rmSync } = await import("node:fs");
 		rmSync(sibling, { recursive: true, force: true });
 	});
 

--- a/packages/host-service/test/integration/bug-hunt.integration.test.ts
+++ b/packages/host-service/test/integration/bug-hunt.integration.test.ts
@@ -64,15 +64,43 @@ describe("bug-hunt: filesystem sandbox", () => {
 		expect(existsSync(escapeWritePath)).toBe(false);
 	});
 
-	test("readFile rejects paths outside the workspace root", async () => {
-		// Try to read the test repo's parent /etc/hostname-equivalent
-		await expect(
-			host.trpc.filesystem.readFile.query({
+	test("readFile allows viewing paths outside the workspace root", async () => {
+		// Reads are deliberately host-wide (viewing files a terminal/agent
+		// referenced outside the workspace); only mutations are confined.
+		const sibling = join(repo.repoPath, "..", `outside-read-${randomUUID()}`);
+		writeFileSync(sibling, "outside content");
+		try {
+			const result = await host.trpc.filesystem.readFile.query({
 				workspaceId,
-				absolutePath: `${repo.repoPath}/../../../etc/hosts`,
+				absolutePath: sibling,
 				encoding: "utf8",
-			}),
-		).rejects.toThrow();
+			});
+			expect(result.kind).toBe("text");
+			expect(result.content).toBe("outside content");
+		} finally {
+			const { rmSync } = await import("node:fs");
+			rmSync(sibling, { force: true });
+		}
+	});
+
+	test("readFile still rejects in-workspace symlinks that escape the root", async () => {
+		const outside = join(repo.repoPath, "..", `symlink-target-${randomUUID()}`);
+		writeFileSync(outside, "secret");
+		const link = join(repo.repoPath, "innocent-looking.txt");
+		const { symlinkSync, rmSync } = await import("node:fs");
+		symlinkSync(outside, link);
+		try {
+			await expect(
+				host.trpc.filesystem.readFile.query({
+					workspaceId,
+					absolutePath: link,
+					encoding: "utf8",
+				}),
+			).rejects.toThrow();
+		} finally {
+			rmSync(link, { force: true });
+			rmSync(outside, { force: true });
+		}
 	});
 
 	test("deletePath rejects targets outside the workspace root", async () => {
@@ -128,13 +156,14 @@ describe("bug-hunt: filesystem sandbox", () => {
 		}
 	});
 
-	test("listDirectory rejects absolute paths outside workspace root", async () => {
-		await expect(
-			host.trpc.filesystem.listDirectory.query({
-				workspaceId,
-				absolutePath: "/etc",
-			}),
-		).rejects.toThrow();
+	test("listDirectory allows absolute paths outside workspace root", async () => {
+		const { entries } = await host.trpc.filesystem.listDirectory.query({
+			workspaceId,
+			absolutePath: join(repo.repoPath, ".."),
+		});
+		expect(entries.some((entry) => entry.absolutePath === repo.repoPath)).toBe(
+			true,
+		);
 	});
 });
 

--- a/packages/host-service/test/integration/bug-hunt.integration.test.ts
+++ b/packages/host-service/test/integration/bug-hunt.integration.test.ts
@@ -3,6 +3,12 @@
  * defend against. A passing test = defense holds; a failing test = real
  * bug worth fixing.
  *
+ * The filesystem section also pins the intended sandbox policy in both
+ * directions: reads are host-wide (viewing files a terminal/agent referenced
+ * outside the workspace), mutations are confined to the workspace root. An
+ * "allows" test failing means the read policy regressed, not that a defense
+ * appeared.
+ *
  * Categories:
  *   - sandbox / path traversal in workspace-fs operations
  *   - shell-arg / git-flag injection through user-controlled refs
@@ -27,7 +33,7 @@ import { projects, workspaces } from "../../src/db/schema";
 import { createTestHost, type TestHost } from "../helpers/createTestHost";
 import { createGitFixture, type GitFixture } from "../helpers/git-fixture";
 
-describe("bug-hunt: filesystem sandbox", () => {
+describe("bug-hunt: filesystem sandbox (mutations confined, reads host-wide)", () => {
 	let host: TestHost;
 	let repo: GitFixture;
 	const projectId = randomUUID();
@@ -71,8 +77,6 @@ describe("bug-hunt: filesystem sandbox", () => {
 	});
 
 	test("readFile allows viewing paths outside the workspace root", async () => {
-		// Reads are deliberately host-wide (viewing files a terminal/agent
-		// referenced outside the workspace); only mutations are confined.
 		const sibling = join(repo.repoPath, "..", `outside-read-${randomUUID()}`);
 		writeFileSync(sibling, "outside content");
 		try {

--- a/packages/workspace-fs/src/fs.test.ts
+++ b/packages/workspace-fs/src/fs.test.ts
@@ -99,6 +99,41 @@ describe("readFile", () => {
 		expect(result.exceededLimit).toEqual(false);
 	});
 
+	it("reads files outside the workspace root", async () => {
+		const rootPath = await createTempRoot();
+		const outsideRoot = await createTempRoot();
+		const absolutePath = path.join(outsideRoot, "outside.txt");
+		await fs.writeFile(absolutePath, "outside");
+
+		const result = await readFile({
+			rootPath,
+			absolutePath,
+			encoding: "utf-8",
+		});
+
+		expect(result.kind).toEqual("text");
+		if (result.kind === "text") {
+			expect(result.content).toEqual("outside");
+		}
+	});
+
+	it("rejects in-root symlinks that resolve outside the workspace root", async () => {
+		const rootPath = await createTempRoot();
+		const outsideRoot = await createTempRoot();
+		const targetPath = path.join(outsideRoot, "secret.txt");
+		await fs.writeFile(targetPath, "secret");
+		const linkPath = path.join(rootPath, "innocent.txt");
+		await fs.symlink(targetPath, linkPath);
+
+		await expect(
+			readFile({
+				rootPath,
+				absolutePath: linkPath,
+				encoding: "utf-8",
+			}),
+		).rejects.toThrow("outside workspace root");
+	});
+
 	it("reads small file without exceeding limit", async () => {
 		const rootPath = await createTempRoot();
 		const absolutePath = path.join(rootPath, "notes.txt");
@@ -118,6 +153,20 @@ describe("readFile", () => {
 });
 
 describe("writeFile", () => {
+	it("rejects paths outside the workspace root", async () => {
+		const rootPath = await createTempRoot();
+		const outsideRoot = await createTempRoot();
+		const absolutePath = path.join(outsideRoot, "escape.txt");
+
+		await expect(
+			writeFile({
+				rootPath,
+				absolutePath,
+				content: "should not exist",
+			}),
+		).rejects.toThrow("outside workspace root");
+	});
+
 	it("returns a conflict when revision does not match", async () => {
 		const rootPath = await createTempRoot();
 		const absolutePath = path.join(rootPath, "notes.txt");

--- a/packages/workspace-fs/src/fs.ts
+++ b/packages/workspace-fs/src/fs.ts
@@ -12,10 +12,7 @@ import type {
 	FsWriteResult,
 } from "./types";
 
-export type WorkspaceFsPathErrorCode =
-	| "OUTSIDE_ROOT"
-	| "INVALID_TARGET"
-	| "SYMLINK_ESCAPE";
+export type WorkspaceFsPathErrorCode = "INVALID_TARGET" | "SYMLINK_ESCAPE";
 
 export class WorkspaceFsPathError extends Error {
 	constructor(
@@ -373,16 +370,19 @@ async function writeAtomically({
 // per-entry stat calls bounds how much zombie work continues after an abort.
 const LIST_DIRECTORY_STAT_BATCH_SIZE = 16;
 
+// Read-only operations (listDirectory, readFile, getMetadata) are not
+// confined to the workspace root: terminals and agents routinely reference
+// files anywhere on the host, and viewing them is within the caller's trust
+// model (statPath/browseHost already expose arbitrary host paths). Mutations
+// remain strictly confined to the root.
 export async function listDirectory({
-	rootPath,
 	absolutePath,
 	signal,
 }: {
-	rootPath: string;
 	absolutePath: string;
 	signal?: AbortSignal;
 }): Promise<FsEntry[]> {
-	const targetPath = ensureWithinRoot({ rootPath, absolutePath });
+	const targetPath = normalizeAbsolutePath(absolutePath);
 	signal?.throwIfAborted();
 	const entries = await fs.readdir(targetPath, { withFileTypes: true });
 
@@ -437,8 +437,14 @@ export async function readFile({
 	maxBytes?: number;
 	encoding?: string;
 }): Promise<FsReadResult> {
-	const targetPath = ensureWithinRoot({ rootPath, absolutePath });
-	await assertRealpathWithinRoot(rootPath, targetPath);
+	const targetPath = normalizeAbsolutePath(absolutePath);
+	// Explicit outside-root paths are readable, but a path that lexically sits
+	// inside the workspace must also physically resolve there — otherwise a
+	// malicious repo symlink (docs/config.yml -> ~/.ssh/id_rsa) could disguise
+	// a sensitive host file as a workspace file.
+	if (isPathWithinRoot(rootPath, targetPath)) {
+		await assertRealpathWithinRoot(rootPath, targetPath);
+	}
 
 	const fileHandle = await fs.open(targetPath, "r");
 	try {
@@ -508,13 +514,11 @@ export async function readFile({
 }
 
 export async function getMetadata({
-	rootPath,
 	absolutePath,
 }: {
-	rootPath: string;
 	absolutePath: string;
 }): Promise<FsMetadata | null> {
-	const targetPath = ensureWithinRoot({ rootPath, absolutePath });
+	const targetPath = normalizeAbsolutePath(absolutePath);
 
 	try {
 		const stats = await fs.lstat(targetPath);

--- a/packages/workspace-fs/src/host/service.ts
+++ b/packages/workspace-fs/src/host/service.ts
@@ -138,7 +138,6 @@ export function createFsHostService(
 	return {
 		async listDirectory(input, options) {
 			const entries = await listDirectory({
-				rootPath,
 				absolutePath: input.absolutePath,
 				signal: options?.signal,
 			});
@@ -157,7 +156,6 @@ export function createFsHostService(
 
 		async getMetadata(input) {
 			return await getMetadata({
-				rootPath,
 				absolutePath: input.absolutePath,
 			});
 		},


### PR DESCRIPTION
## Summary

Opening a file the terminal or an agent referenced outside the workspace (e.g. `~/Downloads/foo.dmg`) failed with `Path is outside workspace root`. `statPath` already resolves such paths so terminal links render as clickable, but the viewer's read then rejected them.

- `readFile`, `getMetadata`, and `listDirectory` in `workspace-fs` no longer confine paths to the workspace root; all mutations (`writeFile`, `createDirectory`, `deletePath`, `movePath`, `copyPath`) remain strictly confined.
- The symlink-escape defense is kept for reads: a path that lexically sits inside the workspace must still physically resolve there, so a malicious repo symlink (`docs/config.yml -> ~/.ssh/id_rsa`) can't disguise a sensitive host file as a workspace file. Explicitly-referenced outside paths are readable — consistent with the existing `browseHost`/`statPath` trust model behind the same auth.
- Applies to both the v2 host-service path and the v1 Electron tRPC path (shared functions).
- Cleanup: dropped the never-constructed `OUTSIDE_ROOT` error code and two dead re-exports in `workspace-fs-service.ts`; updated the stale threat-model comment in `path-validation.ts`.

Known limitation (accepted): files outside the root don't get live external-change notifications — the fs watcher stays scoped to the workspace root.

## Test Plan

- [x] New unit tests: outside-root read succeeds; in-root symlink escaping the root is rejected; outside-root write is rejected
- [x] Verified each new test fails when its guard/behavior is reverted (mutation-checked)
- [x] Updated bug-hunt integration tests to pin the new read policy; mutation tests unchanged and passing
- [x] `turbo typecheck` for `workspace-fs`, `host-service`, `desktop`; Biome clean; full `workspace-fs` suite (44) and bug-hunt suite (17) pass

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5427">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem access rules: read-only operations (like directory listing and metadata) can work across the host, while write/mutation operations remain confined to the workspace.
  * Strengthened protection against symlinks that resolve outside the workspace, and tightened path validation for `readFile`/`writeFile`.
  * Normalized computed worktree-relative paths to use forward slashes for more consistent display.
* **Tests**
  * Updated and expanded filesystem sandbox integration and unit tests to verify the revised access and symlink-escape behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->