### PR TITLE
fix(desktop): restore window/localStorage globals leaked by persistent-hash-history tests

### DIFF
--- a/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts
+++ b/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+} from "bun:test";
 
 // Mock localStorage
 const storage = new Map<string, string>();
@@ -18,7 +26,14 @@ const mockReplaceState = mock(
 	(_state: unknown, _unused: string, _url?: string | URL | null) => {},
 );
 
-// Set up globals BEFORE importing the module (the singleton runs at import time)
+// Set up globals BEFORE importing the module (the singleton runs at import time).
+// The originals MUST be restored afterAll: later test files in the same process
+// create zustand persist stores that read `window.localStorage` at import time,
+// and a leaked bare-mock `window` makes that undefined and crashes their setState.
+const originalWindow = (globalThis as { window?: unknown }).window;
+const originalLocalStorage = (globalThis as { localStorage?: unknown })
+	.localStorage;
+
 Object.defineProperty(globalThis, "localStorage", {
 	value: mockLocalStorage,
 	writable: true,
@@ -52,6 +67,19 @@ beforeEach(() => {
 
 afterEach(() => {
 	storage.clear();
+});
+
+afterAll(() => {
+	Object.defineProperty(globalThis, "window", {
+		value: originalWindow,
+		writable: true,
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, "localStorage", {
+		value: originalLocalStorage,
+		writable: true,
+		configurable: true,
+	});
 });
 
 describe("createPersistentHashHistory", () => {


### PR DESCRIPTION
## Problem

Main CI's **Test** job has been failing all day with 4 `v2 notification store` test failures:

```
TypeError: undefined is not an object (evaluating 'storage.setItem')
    at setItem (zustand/esm/middleware.mjs:298:34)
```

## Root cause

`persistent-hash-history.test.ts` replaces `globalThis.window` with a bare mock (only `history`/`location`, no `localStorage`) at module scope and never restores it. bun runs all test files in one process, and on Linux CI the file ordering differs from macOS: the leaked `window` is still in place when `v2-notifications/store.ts` is first imported.

zustand's `persist` middleware defaults to `createJSONStorage(() => window.localStorage)`, evaluated once at store creation. It got `undefined` (without throwing, so zustand's missing-storage fallback never kicked in) and every subsequent `setState` crashed. This started when persist was added to the notification store in #5349.

The failure never reproduced locally because macOS file ordering imports the store before the polluting file runs.

## Fix

Capture the original `window`/`localStorage` and restore them in `afterAll`, so the mocks stay scoped to the file that needs them.

## Verification

- Reproduced the exact CI TypeError locally by loading the store after the leaked `window` (pre-fix), and confirmed a probe file sees the restored globals post-fix
- Full desktop suite: 2041 pass / 0 fail
- `bun run lint` and desktop typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI test failures by restoring `window` and `localStorage` after `persistent-hash-history` tests. Prevents leaked globals from breaking `zustand` persist stores that read `window.localStorage` at import time.

- **Bug Fixes**
  - Save original globals and restore them in `afterAll` so mocks stay scoped to the test file.
  - Avoids `TypeError` from `storage.setItem` when `zustand` captured an undefined storage.

<sup>Written for commit 415ec20b1b5bf2e844e8c083e9e86d07eb6aadc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for the desktop history flow by preserving and restoring the original browser-related globals during test runs.
  * Prevented crashes caused by leftover mocks affecting other tests.
  * Cleaned up import formatting in the test file for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->