### PR TITLE
fix: use detached:false in DaemonSupervisor.spawn() to preserve Aqua bootstrap namespace

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -965,7 +965,7 @@ export class DaemonSupervisor {
 				// namespace and causing GUI subprocesses (Chromium/Playwright/Lighthouse) to
 				// abort with SIGABRT (bootstrap_check_in error 141). On other platforms the
 				// original prod/dev split is preserved. See: https://github.com/superset-sh/superset/issues/5423
-				detached: process.platform === 'darwin' ? false : !isDev,
+				detached: process.platform === "darwin" ? false : !isDev,
 				stdio,
 				env: childEnv,
 				windowsHide: true,

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -959,7 +959,12 @@ export class DaemonSupervisor {
 						`--socket=${socketPath}`,
 					];
 			child = childProcess.spawn(command, commandArgs, {
-				detached: !isDev,
+				// macOS: do NOT use detached:true (setsid) here. It detaches the daemon from
+				// the Aqua launchd bootstrap namespace, breaking GUI subprocess launch
+				// (Chromium, Playwright, Lighthouse) with SIGABRT (bootstrap_check_in error 141).
+				// child.unref() below is sufficient for PTY survival across Electron quit+relaunch.
+				// See: https://github.com/superset-sh/superset/issues/5423
+				detached: false,
 				stdio,
 				env: childEnv,
 				windowsHide: true,

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -939,9 +939,11 @@ export class DaemonSupervisor {
 
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
-			// Prod: detached so PTYs survive host-service restarts via socket
-			// adoption. Dev: attached as defense-in-depth in case serve.ts's
-			// dev shutdown doesn't fire (e.g. host-service crash).
+			// PTY survival: child.unref() (below) is sufficient on all platforms —
+			// the OS reparents the daemon to launchd/init on parent exit, preserving
+			// open PTYs without a new process session. On macOS, detached:true calls
+			// setsid() which severs the Aqua bootstrap namespace (see issue #5423).
+			// Dev: keep attached as defense-in-depth (serve.ts shutdown may not fire).
 			// Raise RLIMIT_NOFILE before exec: macOS's 256 soft default starves a
 			// daemon hosting many worktrees' PTYs and surfaces as node-pty
 			// "posix_spawnp failed" (EMFILE). The raised limit is inherited by
@@ -959,12 +961,11 @@ export class DaemonSupervisor {
 						`--socket=${socketPath}`,
 					];
 			child = childProcess.spawn(command, commandArgs, {
-				// macOS: do NOT use detached:true (setsid) here. It detaches the daemon from
-				// the Aqua launchd bootstrap namespace, breaking GUI subprocess launch
-				// (Chromium, Playwright, Lighthouse) with SIGABRT (bootstrap_check_in error 141).
-				// child.unref() below is sufficient for PTY survival across Electron quit+relaunch.
-				// See: https://github.com/superset-sh/superset/issues/5423
-				detached: false,
+				// macOS: detached:true triggers setsid(), severing the Aqua launchd bootstrap
+				// namespace and causing GUI subprocesses (Chromium/Playwright/Lighthouse) to
+				// abort with SIGABRT (bootstrap_check_in error 141). On other platforms the
+				// original prod/dev split is preserved. See: https://github.com/superset-sh/superset/issues/5423
+				detached: process.platform === 'darwin' ? false : !isDev,
 				stdio,
 				env: childEnv,
 				windowsHide: true,


### PR DESCRIPTION
## Problem

When `detached: true` is passed to `childProcess.spawn()` in `DaemonSupervisor.ts`, Node.js calls `setsid()`, which creates a new process session and disconnects the process from the **macOS Aqua launchd bootstrap namespace**. This causes any GUI subprocess (Chromium via Playwright/Lighthouse) to fail with `SIGABRT (bootstrap_check_in error 141)`.

Confirmed via `launchctl managername` returning `"Could not get manager name"` inside Superset terminal shells.

## Root cause

Introduced in the April 2026 migration of the daemon supervisor from the Electron main process into `packages/host-service`. Previously spawned from Electron (Aqua session). Now spawned from `host-service` (ELECTRON_RUN_AS_NODE=1), and the additional `setsid()` from `detached: true` fully removes the Aqua bootstrap context.

The `detached: true` was intentional for PTY survival, but `child.unref()` (already called below) is sufficient — the daemon is reparented to launchd without needing a new session. `setsid()` is not needed and actively harmful here.

## Change

`detached: !isDev` → `detached: false` (with explanatory comment)

Closes superset-sh/superset#5423

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5429">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS daemon startup to ensure GUI-related subprocesses launch reliably under the system’s process launcher.
  * Refined process/session behavior so PTY and terminal interactions remain stable, without relying on macOS background detachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->