### PR TITLE
fix(host-service): recover v2 ports promptly after host-service restart

### DIFF
--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -1,7 +1,33 @@
 import { describe, expect, it } from "bun:test";
-import { planPortScanSync } from "./reaper.ts";
+import {
+	PORT_SCAN_WARMUP_DELAYS_MS,
+	planPortScanSync,
+	REAP_INTERVAL_MS,
+} from "./reaper.ts";
 
 const noneLive = () => false;
+
+describe("port-scan warm-up schedule", () => {
+	it("re-syncs multiple times after startup so ports recover without a reap tick", () => {
+		expect(PORT_SCAN_WARMUP_DELAYS_MS.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it("runs strictly increasing offsets", () => {
+		for (let i = 1; i < PORT_SCAN_WARMUP_DELAYS_MS.length; i += 1) {
+			expect(PORT_SCAN_WARMUP_DELAYS_MS[i]).toBeGreaterThan(
+				PORT_SCAN_WARMUP_DELAYS_MS[i - 1] as number,
+			);
+		}
+	});
+
+	it("fully precedes the first scheduled reap so it covers the gap", () => {
+		// Every warm-up must fire before the 5-minute reap would otherwise be the
+		// first re-sync — that's the window this fix closes.
+		for (const delay of PORT_SCAN_WARMUP_DELAYS_MS) {
+			expect(delay).toBeLessThan(REAP_INTERVAL_MS);
+		}
+	});
+});
 
 describe("planPortScanSync", () => {
 	it("registers alive daemon sessions that map to an active workspace row", () => {

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -9,7 +9,21 @@ interface ReapResult {
 	failed: number;
 }
 
-const REAP_INTERVAL_MS = 5 * 60 * 1000;
+export const REAP_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * A host-service restart begins with an empty port scanner while the detached
+ * pty-daemon keeps dev servers alive. The reap pass re-registers those sessions,
+ * but it runs only once immediately and then every {@link REAP_INTERVAL_MS} — and
+ * the just-adopted daemon may not yet list its sessions the instant that first
+ * pass runs. Re-sync the port scanner a few times over the first ~90s so restored
+ * dev-server ports appear promptly, instead of waiting for the next reap tick or
+ * a renderer attach. All offsets stay below REAP_INTERVAL_MS so the warm-up fully
+ * covers the gap before the first scheduled reap.
+ */
+export const PORT_SCAN_WARMUP_DELAYS_MS = [
+	2_000, 5_000, 10_000, 20_000, 45_000, 90_000,
+];
 
 interface TerminalRow {
 	status: string;
@@ -105,6 +119,11 @@ function applyPortScanSync(
 		for (const entry of plan.register) {
 			portManager.upsertSession(entry.terminalId, entry.workspaceId, entry.pid);
 		}
+		if (plan.register.length > 0) {
+			console.log(
+				`[host-service] port-scan sync: registered ${plan.register.length} unattached daemon session(s) for scanning`,
+			);
+		}
 		for (const terminalId of plan.unregister) {
 			portManager.unregisterSession(terminalId);
 		}
@@ -113,21 +132,31 @@ function applyPortScanSync(
 	}
 }
 
-async function reapOrphanedSessions(
-	db: HostDb,
-	rowlessPendingSecondPass: Set<string>,
-): Promise<ReapResult> {
+/**
+ * Re-register the port scanner against the daemon's live sessions. Extracted so
+ * it can run on its own cadence — decoupled from the 5-minute orphan reap —
+ * because restored dev-server ports must appear promptly after a host-service
+ * restart. Returns the daemon's live sessions so the reap pass can reuse them
+ * without a second `daemon.list()`.
+ */
+async function syncPortScans(db: HostDb) {
 	const daemon = await getDaemonClient();
 	const liveSessions = (await daemon.list()).filter((session) => session.alive);
-
-	// Sync the port scanner before the empty-list short-circuit below so an idle
-	// daemon still drops stale scans. rowById is only consulted to register live
-	// sessions, so skip the DB hit when there are none.
 	const rowById =
 		liveSessions.length > 0
 			? loadTerminalRowsById(db)
 			: new Map<string, TerminalRow>();
 	applyPortScanSync(liveSessions, rowById);
+	return { liveSessions, rowById };
+}
+
+async function reapOrphanedSessions(
+	db: HostDb,
+	rowlessPendingSecondPass: Set<string>,
+): Promise<ReapResult> {
+	// Sync the port scanner before the empty-list short-circuit below so an idle
+	// daemon still drops stale scans.
+	const { liveSessions, rowById } = await syncPortScans(db);
 
 	if (liveSessions.length === 0) {
 		rowlessPendingSecondPass.clear();
@@ -204,5 +233,20 @@ export function startTerminalReaper(db: HostDb): () => void {
 	run();
 	const interval = setInterval(run, REAP_INTERVAL_MS);
 	interval.unref();
-	return () => clearInterval(interval);
+
+	// Runs only the port-scan sync, not the full reap, so the warm-up never
+	// disturbs the reaper's two-pass rowless-orphan clock.
+	const warmupTimers = PORT_SCAN_WARMUP_DELAYS_MS.map((delay) =>
+		setTimeout(() => {
+			void syncPortScans(db).catch((err) => {
+				console.warn("[host-service] port-scan warm-up sync failed:", err);
+			});
+		}, delay),
+	);
+	for (const timer of warmupTimers) timer.unref();
+
+	return () => {
+		clearInterval(interval);
+		for (const timer of warmupTimers) clearTimeout(timer);
+	};
 }

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -103,8 +103,8 @@ function loadTerminalRowsById(db: HostDb): Map<string, TerminalRow> {
 	return new Map(rows.map((row) => [row.id, row]));
 }
 
-// Isolated from the reaper's main flow: port scanning is best-effort, so a
-// port-manager error must not abort the orphan cleanup that follows it.
+// Port scanning is best-effort: a port-manager error must not propagate to the
+// caller — the reap pass (whose orphan cleanup must still run) or a warm-up sync.
 function applyPortScanSync(
 	liveSessions: { id: string; pid: number }[],
 	rowById: Map<string, TerminalRow>,

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -132,14 +132,7 @@ function applyPortScanSync(
 	}
 }
 
-/**
- * Re-register the port scanner against the daemon's live sessions. Extracted so
- * it can run on its own cadence — decoupled from the 5-minute orphan reap —
- * because restored dev-server ports must appear promptly after a host-service
- * restart. Returns the daemon's live sessions so the reap pass can reuse them
- * without a second `daemon.list()`.
- */
-async function syncPortScans(db: HostDb) {
+async function runPortScanSync(db: HostDb) {
 	const daemon = await getDaemonClient();
 	const liveSessions = (await daemon.list()).filter((session) => session.alive);
 	const rowById =
@@ -148,6 +141,28 @@ async function syncPortScans(db: HostDb) {
 			: new Map<string, TerminalRow>();
 	applyPortScanSync(liveSessions, rowById);
 	return { liveSessions, rowById };
+}
+
+let inFlightPortScanSync: ReturnType<typeof runPortScanSync> | null = null;
+
+/**
+ * Re-register the port scanner against the daemon's live sessions. Extracted so
+ * it can run on its own cadence — decoupled from the 5-minute orphan reap —
+ * because restored dev-server ports must appear promptly after a host-service
+ * restart. Returns the daemon's live sessions so the reap pass can reuse them
+ * without a second `daemon.list()`.
+ *
+ * Coalesces concurrent callers onto one in-flight run: the warm-up timers and
+ * the reap pass both call this, and a slow `daemon.list()` right after adoption
+ * (exactly when the warm-up fires) could otherwise let a second sync observe a
+ * transiently-empty list and unregister sessions the first just registered.
+ */
+function syncPortScans(db: HostDb): ReturnType<typeof runPortScanSync> {
+	if (inFlightPortScanSync) return inFlightPortScanSync;
+	inFlightPortScanSync = runPortScanSync(db).finally(() => {
+		inFlightPortScanSync = null;
+	});
+	return inFlightPortScanSync;
 }
 
 async function reapOrphanedSessions(


### PR DESCRIPTION
## Problem

After a **host-service restart** (installed app, v1.12.6+), v2 dev-server ports don't show in the sidebar **until you select the workspace**. In production the detached pty-daemon keeps dev servers alive across the restart, so the ports genuinely exist — they're just not scanned.

## Root cause

#5325 added a reaper-driven port-scan reconcile to register daemon-adopted sessions without a renderer attach. But that reconcile runs **only once at startup and then every 5 minutes** (it's embedded in the orphan reaper's `REAP_INTERVAL_MS` loop). Right after a restart the just-adopted daemon may not yet list its sessions the instant that single startup pass runs — so nothing gets registered, and the next attempt is 5 minutes away. Selecting the workspace masks it by attaching a renderer, which registers the terminal directly.

Ruled out: the client visibility gate (all its collections are persisted and populate on cold start) and `killStaleDaemonForDev` (dev-only; production adopts the daemon).

## Fix

Decouple the port-scan sync from the 5-minute orphan-reap cadence and run it a few times over the first ~90s after startup (`2/5/10/20/45/90s`), so restored ports register promptly without waiting for the reap tick or an attach.

- Extract `syncPortScans()` (daemon.list + row join + `applyPortScanSync`); the reap pass reuses its result, so no extra `daemon.list()` there.
- Warm-up runs only the port-scan sync — never the orphan reap — so it doesn't disturb the reaper's two-pass rowless-orphan clock.
- Log `registered N unattached daemon session(s)` so post-restart recovery is observable in the field.

## Validation

- `planPortScanSync` logic unchanged (existing tests pass); added a schedule test asserting the warm-up is multi-shot, strictly increasing, and fully precedes the first reap tick.
- `bun run lint` clean, `@superset/host-service` typecheck passes.

**Caveat:** I could not end-to-end reproduce the production timing locally (dev's `killStaleDaemonForDev` destroys the daemon on restart, and an adoption-mode repro was too flaky to finish). This fix targets the most likely cause — the reconcile cadence — and the new log lets us confirm in a real build: if it logs registrations after restart and ports appear, done; if it logs nothing, the daemon isn't listing adopted sessions and we dig into adoption instead.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover v2 dev-server ports promptly after a `@superset/host-service` restart. Ports now appear within ~90s without opening the workspace.

- **Bug Fixes**
  - Decoupled port-scan sync from the 5-minute orphan reaper; run warm-up syncs at 2/5/10/20/45/90s after startup without running the orphan reap.
  - Extracted `syncPortScans()`; the reaper reuses its result to avoid an extra `daemon.list()`; logs registered unattached sessions and warns on warm-up sync failures.
  - Coalesced concurrent port-scan syncs so warm-up timers and the reap pass share one in-flight run, preventing transient empty lists from unregistering sessions.
  - On shutdown, clear the warm-up timers and interval.

- **Refactors**
  - Updated stale inline comment around port-scan sync after the warm-up refactor.

<sup>Written for commit 682d9cf1acd71a4e0c53ea97c99db249b2251811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a port-scan warm-up phase shortly after host-service restart to retry syncing open ports before the main reap cycle begins.
* **Bug Fixes**
  * Improved reliability by consolidating concurrent port-scan sync runs and ensuring all scheduled warm-up timers are cleared during shutdown.
* **Tests**
  * Added coverage validating the warm-up schedule has multiple strictly increasing offsets and that every warm-up delay occurs before the first reap interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->