### PR TITLE
fix(desktop): keep v2 sidebar top-row icons a constant size under page zoom

### DIFF
--- a/apps/desktop/src/renderer/components/ZoomStable/ZoomStable.tsx
+++ b/apps/desktop/src/renderer/components/ZoomStable/ZoomStable.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { useZoomFactor } from "renderer/hooks/useZoomFactor";
+
+interface ZoomStableProps {
+	/**
+	 * When true, counter-scale the children by `1 / zoomFactor` so they keep a
+	 * constant physical size under page zoom. Typically gated on macOS, where the
+	 * surrounding chrome is pinned to the fixed traffic lights and must not scale.
+	 */
+	enabled: boolean;
+	className?: string;
+	children: ReactNode;
+}
+
+/**
+ * Keeps its children a constant physical size under Electron page zoom by
+ * applying `zoom: 1 / zoomFactor`. Use it inside chrome whose height/inset is
+ * pinned to the fixed macOS traffic lights, so icon controls don't grow past
+ * the pinned row and overflow when the user zooms the page in.
+ *
+ * Keep the wrapper content-sized — avoid `w-full` / `h-full` / `flex-1` on it.
+ * CSS `zoom` scales percentage-based sizes too, so a stretched child would
+ * under/overflow. Percentage sizing and the traffic-light inset belong on the
+ * surrounding row, which stays in the normal (un-zoomed) coordinate space.
+ */
+export function ZoomStable({ enabled, className, children }: ZoomStableProps) {
+	const zoomFactor = useZoomFactor();
+	return (
+		<div
+			className={className}
+			style={enabled ? { zoom: 1 / zoomFactor } : undefined}
+		>
+			{children}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/components/ZoomStable/index.ts
+++ b/apps/desktop/src/renderer/components/ZoomStable/index.ts
@@ -1,0 +1,1 @@
+export { ZoomStable } from "./ZoomStable";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -232,7 +232,10 @@ export function DashboardSidebarHeader({
 		>
 			{/* -mx-2 cancels the parent's px-2 so this row owns the 80px traffic-light
 			    inset; inset and height are counter-scaled to a constant physical size
-			    so the fixed macOS traffic lights stay aligned under page zoom. */}
+			    so the fixed macOS traffic lights stay aligned under page zoom. The
+			    control clusters below use `zoom: 1 / zoomFactor` so the collapse/nav
+			    icons and usage badge keep a constant physical size instead of scaling
+			    with page zoom and overflowing this fixed-height row. */}
 			<div
 				className="drag -mx-2 flex h-8 items-center gap-1.5 pr-2"
 				style={
@@ -244,9 +247,16 @@ export function DashboardSidebarHeader({
 						: { paddingLeft: "8px" }
 				}
 			>
-				<SidebarToggle />
-				<NavigationControls />
-				<ResourceConsumption surface="v2" className="ml-auto" />
+				<div
+					className="flex items-center gap-1.5"
+					style={{ zoom: 1 / zoomFactor }}
+				>
+					<SidebarToggle />
+					<NavigationControls />
+				</div>
+				<div className="ml-auto" style={{ zoom: 1 / zoomFactor }}>
+					<ResourceConsumption surface="v2" />
+				</div>
 			</div>
 			<OrganizationDropdown variant="expanded" />
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -232,10 +232,12 @@ export function DashboardSidebarHeader({
 		>
 			{/* -mx-2 cancels the parent's px-2 so this row owns the 80px traffic-light
 			    inset; inset and height are counter-scaled to a constant physical size
-			    so the fixed macOS traffic lights stay aligned under page zoom. The
-			    control clusters below use `zoom: 1 / zoomFactor` so the collapse/nav
+			    so the fixed macOS traffic lights stay aligned under page zoom. On Mac
+			    the control clusters below use `zoom: 1 / zoomFactor` so the collapse/nav
 			    icons and usage badge keep a constant physical size instead of scaling
-			    with page zoom and overflowing this fixed-height row. */}
+			    with page zoom and overflowing this fixed-height row. The zoom is Mac-only
+			    because the pinned row height it matches is Mac-only; elsewhere the row
+			    height (h-8) scales with zoom, so the controls should scale with it. */}
 			<div
 				className="drag -mx-2 flex h-8 items-center gap-1.5 pr-2"
 				style={
@@ -249,12 +251,15 @@ export function DashboardSidebarHeader({
 			>
 				<div
 					className="flex items-center gap-1.5"
-					style={{ zoom: 1 / zoomFactor }}
+					style={isMac ? { zoom: 1 / zoomFactor } : undefined}
 				>
 					<SidebarToggle />
 					<NavigationControls />
 				</div>
-				<div className="ml-auto" style={{ zoom: 1 / zoomFactor }}>
+				<div
+					className="ml-auto"
+					style={isMac ? { zoom: 1 / zoomFactor } : undefined}
+				>
 					<ResourceConsumption surface="v2" />
 				</div>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -18,6 +18,7 @@ import {
 	LuPlus,
 } from "react-icons/lu";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
+import { ZoomStable } from "renderer/components/ZoomStable";
 import { useZoomFactor } from "renderer/hooks/useZoomFactor";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -233,11 +234,11 @@ export function DashboardSidebarHeader({
 			{/* -mx-2 cancels the parent's px-2 so this row owns the 80px traffic-light
 			    inset; inset and height are counter-scaled to a constant physical size
 			    so the fixed macOS traffic lights stay aligned under page zoom. On Mac
-			    the control clusters below use `zoom: 1 / zoomFactor` so the collapse/nav
-			    icons and usage badge keep a constant physical size instead of scaling
-			    with page zoom and overflowing this fixed-height row. The zoom is Mac-only
-			    because the pinned row height it matches is Mac-only; elsewhere the row
-			    height (h-8) scales with zoom, so the controls should scale with it. */}
+			    the control clusters below use ZoomStable so the collapse/nav icons and
+			    usage badge keep a constant physical size instead of scaling with page
+			    zoom and overflowing this fixed-height row. It's Mac-only because the
+			    pinned row height it matches is Mac-only; elsewhere the row height (h-8)
+			    scales with zoom, so the controls should scale with it. */}
 			<div
 				className="drag -mx-2 flex h-8 items-center gap-1.5 pr-2"
 				style={
@@ -249,19 +250,13 @@ export function DashboardSidebarHeader({
 						: { paddingLeft: "8px" }
 				}
 			>
-				<div
-					className="flex items-center gap-1.5"
-					style={isMac ? { zoom: 1 / zoomFactor } : undefined}
-				>
+				<ZoomStable enabled={isMac} className="flex items-center gap-1.5">
 					<SidebarToggle />
 					<NavigationControls />
-				</div>
-				<div
-					className="ml-auto"
-					style={isMac ? { zoom: 1 / zoomFactor } : undefined}
-				>
+				</ZoomStable>
+				<ZoomStable enabled={isMac} className="ml-auto">
 					<ResourceConsumption surface="v2" />
-				</div>
+				</ZoomStable>
 			</div>
 			<OrganizationDropdown variant="expanded" />
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -1,5 +1,6 @@
 import { useMatchRoute, useParams } from "@tanstack/react-router";
 import { HiOutlineWifi } from "react-icons/hi2";
+import { ZoomStable } from "renderer/components/ZoomStable";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { useZoomFactor } from "renderer/hooks/useZoomFactor";
@@ -55,15 +56,15 @@ export function TopBar() {
 			style={barStyle}
 		>
 			<div
-				className="flex items-center gap-1.5 h-full"
+				className="flex items-center h-full"
 				style={{ paddingLeft: trafficLightInset }}
 			>
 				{!sidebarHostsChrome && (
-					<>
+					<ZoomStable enabled={isMac} className="flex items-center gap-1.5">
 						<SidebarToggle />
 						<NavigationControls />
 						{!isV2CloudEnabled && <ResourceConsumption surface="v1" />}
-					</>
+					</ZoomStable>
 				)}
 			</div>
 


### PR DESCRIPTION
## Problem

When zooming the desktop app in/out, the collapse icon and buttons in the top section of the v2 sidebar scaled with the page zoom and the layout got weird.

The top drag row in `DashboardSidebarHeader` already pins its **height** and macOS traffic-light **inset** to a constant physical size (`32 / zoomFactor`, `80 / zoomFactor`). But the controls inside it — `SidebarToggle` (collapse icon), `NavigationControls` (back/forward/history/search), and the `ResourceConsumption` badge — used plain Tailwind sizes (`size-8`, `size-7`, `size-4`). Those scaled with zoom, so on zoom-in the buttons grew past the pinned row height and overflowed.

## Fix

Wrap the control clusters in `zoom: 1 / zoomFactor` containers so the icons/buttons keep a constant physical size and match the already-pinned row height.

- Left cluster (`SidebarToggle` + `NavigationControls`) → one zoom-locked wrapper.
- `ResourceConsumption` → its own zoom-locked wrapper, keeping `ml-auto` for right alignment.

The row box itself stays in logical space, so the `-mx-2` full-bleed (which cancels the parent's `px-2`) and the traffic-light inset math are unaffected — putting `zoom` on the row would have scaled its margins and broken that alignment. The clusters are content-sized, so `zoom` doesn't cause any flex-fill issues.

## Notes

- Scoped to the **expanded** top row, where the fixed-height overflow actually happened. The collapsed rail scales uniformly with zoom (no fixed-height container, no overflow) and is intentionally left as-is.
- `bun run lint` and `bun run typecheck` pass.

## Test plan

- [ ] Open the v2 sidebar, zoom in/out (Cmd +/−); top-row collapse/nav icons and usage badge stay a constant size and the row no longer overflows.
- [ ] On macOS, traffic lights stay aligned with the row at all zoom levels.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop dashboard header behavior on macOS so sidebar and top bar controls maintain consistent physical sizing when page zoom changes.
  * Refined the expanded header layout to keep navigation controls, collapse icons, and the usage indicator aligned more reliably, including in zoomed views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->