### PR TITLE
feat(web,desktop): show "Last used" badge on sign-in method

### DIFF
--- a/apps/desktop/src/renderer/routes/sign-in/page.tsx
+++ b/apps/desktop/src/renderer/routes/sign-in/page.tsx
@@ -21,12 +21,24 @@ export const Route = createFileRoute("/sign-in/")({
 	component: SignInPage,
 });
 
+const LAST_USED_METHOD_KEY = "superset-last-auth-method";
+
+type AuthMethod = AuthProvider | "dev";
+
+function readLastUsedMethod(): AuthMethod | null {
+	const stored = window.localStorage.getItem(LAST_USED_METHOD_KEY);
+	return stored === "github" || stored === "google" || stored === "dev"
+		? stored
+		: null;
+}
+
 function SignInPage() {
 	const signInMutation = electronTrpc.auth.signIn.useMutation();
 	const persistToken = electronTrpc.auth.persistToken.useMutation();
 	const navigate = useNavigate();
 	const [isLoadingDev, setIsLoadingDev] = useState(false);
 	const [devError, setDevError] = useState<string | null>(null);
+	const [lastUsedMethod, setLastUsedMethod] = useState(readLastUsedMethod);
 	const { hasLocalToken, isPending, session } = useSessionRecovery();
 
 	// Dev bypass: skip sign-in entirely
@@ -48,14 +60,21 @@ function SignInPage() {
 		return <Navigate to="/workspace" replace />;
 	}
 
+	const rememberLastUsedMethod = (method: AuthMethod) => {
+		window.localStorage.setItem(LAST_USED_METHOD_KEY, method);
+		setLastUsedMethod(method);
+	};
+
 	const signIn = (provider: AuthProvider) => {
 		track("auth_started", { provider });
+		rememberLastUsedMethod(provider);
 		signInMutation.mutate({ provider });
 	};
 
 	const signInAsDev = async () => {
 		setIsLoadingDev(true);
 		setDevError(null);
+		rememberLastUsedMethod("dev");
 
 		const postAuth = async (path: string, body: Record<string, unknown>) => {
 			const response = await fetch(`${env.NEXT_PUBLIC_API_URL}${path}`, {
@@ -114,6 +133,12 @@ function SignInPage() {
 		}
 	};
 
+	const lastUsedBadge = (
+		<span className="absolute right-3 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+			Last used
+		</span>
+	);
+
 	return (
 		<div className="flex flex-col h-full w-full bg-background">
 			<div className="h-12 w-full drag shrink-0" />
@@ -141,12 +166,13 @@ function SignInPage() {
 								variant="outline"
 								size="lg"
 								onClick={signInAsDev}
-								className="w-full gap-3"
+								className="relative w-full gap-3"
 								disabled={isLoadingDev}
 							>
 								{isLoadingDev
 									? "Signing in..."
 									: "Sign in as Local Admin (dev)"}
+								{lastUsedMethod === "dev" && lastUsedBadge}
 							</Button>
 						)}
 						{devError && (
@@ -158,22 +184,24 @@ function SignInPage() {
 							variant="outline"
 							size="lg"
 							onClick={() => signIn("github")}
-							className="w-full gap-3"
+							className="relative w-full gap-3"
 							disabled={signInMutation.isPending}
 						>
 							<FaGithub className="size-5" />
 							Continue with GitHub
+							{lastUsedMethod === "github" && lastUsedBadge}
 						</Button>
 
 						<Button
 							variant="outline"
 							size="lg"
 							onClick={() => signIn("google")}
-							className="w-full gap-3"
+							className="relative w-full gap-3"
 							disabled={signInMutation.isPending}
 						>
 							<FcGoogle className="size-5" />
 							Continue with Google
+							{lastUsedMethod === "google" && lastUsedBadge}
 						</Button>
 					</div>
 

--- a/apps/web/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -9,10 +9,33 @@ import {
 import { Button } from "@superset/ui/button";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FaGithub } from "react-icons/fa";
 import { FcGoogle } from "react-icons/fc";
 import { env } from "@/env";
+
+const LAST_USED_METHOD_KEY = "superset-last-auth-method";
+
+type AuthMethod = "github" | "google" | "dev";
+
+function readLastUsedMethod(): AuthMethod | null {
+	try {
+		const stored = window.localStorage.getItem(LAST_USED_METHOD_KEY);
+		return stored === "github" || stored === "google" || stored === "dev"
+			? stored
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function rememberLastUsedMethod(method: AuthMethod) {
+	try {
+		window.localStorage.setItem(LAST_USED_METHOD_KEY, method);
+	} catch {
+		// localStorage unavailable; skip persisting
+	}
+}
 
 export default function SignInPage() {
 	const searchParams = useSearchParams();
@@ -24,10 +47,16 @@ export default function SignInPage() {
 	const [isLoadingGoogle, setIsLoadingGoogle] = useState(false);
 	const [isLoadingGithub, setIsLoadingGithub] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [lastUsedMethod, setLastUsedMethod] = useState<AuthMethod | null>(null);
+
+	useEffect(() => {
+		setLastUsedMethod(readLastUsedMethod());
+	}, []);
 
 	const signInWithGoogle = async () => {
 		setIsLoadingGoogle(true);
 		setError(null);
+		rememberLastUsedMethod("google");
 
 		try {
 			await authClient.signIn.social({
@@ -44,6 +73,7 @@ export default function SignInPage() {
 	const signInWithGithub = async () => {
 		setIsLoadingGithub(true);
 		setError(null);
+		rememberLastUsedMethod("github");
 
 		try {
 			await authClient.signIn.social({
@@ -62,6 +92,7 @@ export default function SignInPage() {
 	const signInAsDev = async () => {
 		setIsLoadingDev(true);
 		setError(null);
+		rememberLastUsedMethod("dev");
 
 		try {
 			let res = await authClient.signIn.email({
@@ -91,6 +122,12 @@ export default function SignInPage() {
 
 	const isLoading = isLoadingGoogle || isLoadingGithub || isLoadingDev;
 
+	const lastUsedBadge = (
+		<span className="bg-muted text-muted-foreground absolute right-3 rounded-full px-2 py-0.5 text-xs">
+			Last used
+		</span>
+	);
+
 	return (
 		<div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
 			<div className="flex flex-col space-y-2 text-center">
@@ -108,28 +145,31 @@ export default function SignInPage() {
 						variant="outline"
 						disabled={isLoading}
 						onClick={signInAsDev}
-						className="w-full"
+						className="relative w-full"
 					>
 						{isLoadingDev ? "Signing in..." : "Sign in as Local Admin (dev)"}
+						{lastUsedMethod === "dev" && lastUsedBadge}
 					</Button>
 				)}
 				<Button
 					variant="outline"
 					disabled={isLoading}
 					onClick={signInWithGithub}
-					className="w-full"
+					className="relative w-full"
 				>
 					<FaGithub className="mr-2 size-4" />
 					{isLoadingGithub ? "Loading..." : "Sign in with GitHub"}
+					{lastUsedMethod === "github" && lastUsedBadge}
 				</Button>
 				<Button
 					variant="outline"
 					disabled={isLoading}
 					onClick={signInWithGoogle}
-					className="w-full"
+					className="relative w-full"
 				>
 					<FcGoogle className="mr-2 size-4" />
 					{isLoadingGoogle ? "Loading..." : "Sign in with Google"}
+					{lastUsedMethod === "google" && lastUsedBadge}
 				</Button>
 				<p className="text-muted-foreground px-8 text-center text-sm">
 					By clicking continue, you agree to our{" "}


### PR DESCRIPTION
## Summary
- Both auth screens (web + desktop) now show a small "Last used" pill on the sign-in method the user last picked, covering GitHub, Google, and the dev-only Local Admin button.

## Why / Context
Returning users often forget which provider they originally signed up with; picking the wrong one can create a second account or fail account linking. A "last used" hint is the standard fix for this.

## How It Works
- Clicking a sign-in button stores the method under a `superset-last-auth-method` localStorage key; on the next visit, the matching button renders a muted pill on its right edge.
- Web (`apps/web/.../sign-in/page.tsx`): the stored value is read in a `useEffect` (not during render) to avoid an SSR hydration mismatch; localStorage access is wrapped in try/catch for private-browsing edge cases.
- Desktop (`apps/desktop/src/renderer/routes/sign-in/page.tsx`): read via a lazy `useState` initializer (no SSR in the renderer); the badge also moves immediately on click.
- The two screens don't share a sign-in component, so the badge is implemented in each file following its local style.

## Manual QA Checklist
- [ ] Web: sign in with a provider, sign out, return to /sign-in — badge shows on that provider's button
- [ ] Web: no hydration warning in console on first load
- [ ] Desktop: sign in, sign out, relaunch — badge shows on the last-used button
- [ ] Badge doesn't overlap the button label at default widths (350px web, max-w-xs desktop)
- [ ] Dev-only Local Admin button shows the badge when it was last used

## Testing
- `bun run lint` (clean)
- `tsc --noEmit` in apps/web and `bun run typecheck` in apps/desktop (clean)
- Manual QA not yet run — badge is render-only and gated on localStorage; checklist above covers it

## Known Limitations
- The method is recorded at click time (OAuth redirects away before success is observable), so an abandoned OAuth attempt still moves the badge. This matches common "last used" implementations.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-in screens now remember the last successful login method and highlight it with a “Last used” badge.
  * The saved method is restored automatically when the sign-in page opens.

* **Bug Fixes**
  * Improved the sign-in button layout so the new badge displays correctly without affecting existing login flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->