### PR TITLE
fix(desktop): mermaid diagram PNG download silently fails

### DIFF
--- a/apps/desktop/src/renderer/components/CommentMarkdown/components/CommentCodeBlock/CommentCodeBlock.tsx
+++ b/apps/desktop/src/renderer/components/CommentMarkdown/components/CommentCodeBlock/CommentCodeBlock.tsx
@@ -1,4 +1,4 @@
-import { mermaid } from "@streamdown/mermaid";
+import { mermaidConfig, mermaidPlugins } from "@superset/ui/lib/mermaid";
 import type { ReactNode } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import {
@@ -7,8 +7,6 @@ import {
 } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { useTheme } from "renderer/stores";
 import { Streamdown } from "streamdown";
-
-const mermaidPlugins = { mermaid };
 
 const MERMAID_DARK_VARS = {
 	background: "#1e1e2e",
@@ -65,12 +63,10 @@ export function CommentCodeBlock({
 			<Streamdown
 				mode="static"
 				plugins={mermaidPlugins}
-				mermaid={{
-					config: {
-						theme: "base",
-						themeVariables: isDark ? MERMAID_DARK_VARS : MERMAID_LIGHT_VARS,
-					},
-				}}
+				mermaid={mermaidConfig({
+					theme: "base",
+					themeVariables: isDark ? MERMAID_DARK_VARS : MERMAID_LIGHT_VARS,
+				})}
 			>
 				{`\`\`\`mermaid\n${codeString}\n\`\`\``}
 			</Streamdown>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/CodeBlock/CodeBlock.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/CodeBlock/CodeBlock.tsx
@@ -1,10 +1,8 @@
-import { mermaid } from "@streamdown/mermaid";
 import { ShowCode } from "@superset/ui/ai-elements/show-code";
+import { mermaidConfig, mermaidPlugins } from "@superset/ui/lib/mermaid";
 import type { ReactNode } from "react";
 import { useTheme } from "renderer/stores";
 import { Streamdown } from "streamdown";
-
-const mermaidPlugins = { mermaid };
 
 interface CodeNode {
 	position?: {
@@ -43,7 +41,7 @@ export function CodeBlock({ children, className, node }: CodeBlockProps) {
 			<Streamdown
 				mode="static"
 				plugins={mermaidPlugins}
-				mermaid={{ config: { theme: isDark ? "dark" : "default" } }}
+				mermaid={mermaidConfig({ theme: isDark ? "dark" : "default" })}
 			>
 				{`\`\`\`mermaid\n${codeString}\n\`\`\``}
 			</Streamdown>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
@@ -1,10 +1,10 @@
-import { mermaid } from "@streamdown/mermaid";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { mermaidConfig, mermaidPlugins } from "@superset/ui/lib/mermaid";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import { useState } from "react";
@@ -22,8 +22,6 @@ import {
 } from "renderer/lib/tiptap/code-block-languages";
 import { useTheme } from "renderer/stores";
 import { Streamdown } from "streamdown";
-
-const mermaidPlugins = { mermaid };
 
 export function EditableCodeBlockView({
 	node,
@@ -145,7 +143,7 @@ export function EditableCodeBlockView({
 					<Streamdown
 						mode="static"
 						plugins={mermaidPlugins}
-						mermaid={{ config: { theme: isDark ? "dark" : "default" } }}
+						mermaid={mermaidConfig({ theme: isDark ? "dark" : "default" })}
 					>
 						{`\`\`\`\`mermaid\n${mermaidSource}\n\`\`\`\``}
 					</Streamdown>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/CommentPane/CommentPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/CommentPane/CommentPane.tsx
@@ -1,5 +1,4 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@superset/ui/avatar";
-import { mermaidConfig, mermaidPlugins } from "@superset/ui/lib/mermaid";
 import {
 	type ReactNode,
 	useCallback,
@@ -14,20 +13,10 @@ import {
 	LuCopy,
 	LuMessageSquare,
 } from "react-icons/lu";
-import ReactMarkdown from "react-markdown";
 import type { MosaicBranch } from "react-mosaic-component";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import {
-	oneDark,
-	oneLight,
-} from "react-syntax-highlighter/dist/esm/styles/prism";
-import rehypeRaw from "rehype-raw";
-import rehypeSanitize from "rehype-sanitize";
-import remarkGfm from "remark-gfm";
+import { CommentMarkdown } from "renderer/components/CommentMarkdown";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
-import { useTheme } from "renderer/stores/theme";
-import { Streamdown } from "streamdown";
 import { BasePaneWindow, PaneTitle, PaneToolbarActions } from "../components";
 import "./comment-pane.css";
 
@@ -180,13 +169,10 @@ export function CommentPane({
 					</div>
 					<div className="comment-pane-markdown min-h-0 flex-1 overflow-y-auto select-text">
 						<article className="w-full px-6 py-5">
-							<ReactMarkdown
-								remarkPlugins={[remarkGfm]}
-								rehypePlugins={[rehypeRaw, rehypeSanitize]}
+							<CommentMarkdown
+								body={comment.body}
 								components={commentComponents}
-							>
-								{comment.body}
-							</ReactMarkdown>
+							/>
 						</article>
 					</div>
 				</div>
@@ -195,89 +181,7 @@ export function CommentPane({
 	);
 }
 
-const MERMAID_DARK_VARS = {
-	background: "#1e1e2e",
-	primaryColor: "#313244",
-	primaryTextColor: "#cdd6f4",
-	primaryBorderColor: "#45475a",
-	secondaryColor: "#313244",
-	secondaryTextColor: "#cdd6f4",
-	secondaryBorderColor: "#45475a",
-	tertiaryColor: "#313244",
-	tertiaryTextColor: "#cdd6f4",
-	tertiaryBorderColor: "#45475a",
-	nodeBorder: "#45475a",
-	nodeTextColor: "#cdd6f4",
-	mainBkg: "#313244",
-	clusterBkg: "#1e1e2e",
-	titleColor: "#cdd6f4",
-	edgeLabelBackground: "transparent",
-	lineColor: "#6c7086",
-	textColor: "#cdd6f4",
-};
-
-const MERMAID_LIGHT_VARS = {
-	background: "#ffffff",
-	primaryColor: "#f0f0f4",
-	primaryTextColor: "#1e1e2e",
-	primaryBorderColor: "#d0d0d8",
-	lineColor: "#888",
-	textColor: "#1e1e2e",
-};
-
-function CommentCodeBlock({
-	className,
-	children,
-}: {
-	className?: string;
-	children?: ReactNode;
-}) {
-	const theme = useTheme();
-	const isDark = theme?.type !== "light";
-
-	const match = /language-(\w+)/.exec(className || "");
-	const language = match ? match[1] : undefined;
-	const codeString = String(children).replace(/\n$/, "");
-
-	if (language === "mermaid") {
-		return (
-			<Streamdown
-				mode="static"
-				plugins={mermaidPlugins}
-				mermaid={mermaidConfig({
-					theme: "base",
-					themeVariables: isDark ? MERMAID_DARK_VARS : MERMAID_LIGHT_VARS,
-				})}
-			>
-				{`\`\`\`mermaid\n${codeString}\n\`\`\``}
-			</Streamdown>
-		);
-	}
-
-	if (!language) {
-		return (
-			<code className="px-1.5 py-0.5 rounded bg-muted font-mono text-sm">
-				{children}
-			</code>
-		);
-	}
-
-	return (
-		<SyntaxHighlighter
-			style={
-				(isDark ? oneDark : oneLight) as Record<string, React.CSSProperties>
-			}
-			language={language}
-			PreTag="div"
-			className="rounded-md text-sm"
-		>
-			{codeString}
-		</SyntaxHighlighter>
-	);
-}
-
 const commentComponents = {
-	code: CommentCodeBlock,
 	table: ({ children }: { children?: ReactNode }) => (
 		<CopyableTable>{children}</CopyableTable>
 	),

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/CommentPane/CommentPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/CommentPane/CommentPane.tsx
@@ -1,5 +1,5 @@
-import { mermaid } from "@streamdown/mermaid";
 import { Avatar, AvatarFallback, AvatarImage } from "@superset/ui/avatar";
+import { mermaidConfig, mermaidPlugins } from "@superset/ui/lib/mermaid";
 import {
 	type ReactNode,
 	useCallback,
@@ -195,8 +195,6 @@ export function CommentPane({
 	);
 }
 
-const mermaidPlugins = { mermaid };
-
 const MERMAID_DARK_VARS = {
 	background: "#1e1e2e",
 	primaryColor: "#313244",
@@ -246,12 +244,10 @@ function CommentCodeBlock({
 			<Streamdown
 				mode="static"
 				plugins={mermaidPlugins}
-				mermaid={{
-					config: {
-						theme: "base",
-						themeVariables: isDark ? MERMAID_DARK_VARS : MERMAID_LIGHT_VARS,
-					},
-				}}
+				mermaid={mermaidConfig({
+					theme: "base",
+					themeVariables: isDark ? MERMAID_DARK_VARS : MERMAID_LIGHT_VARS,
+				})}
 			>
 				{`\`\`\`mermaid\n${codeString}\n\`\`\``}
 			</Streamdown>

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -12,6 +12,7 @@ import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
 import { createContext, memo, useContext, useEffect, useState } from "react";
 import type { PluginConfig } from "streamdown";
 import { Streamdown } from "streamdown";
+import { mermaidConfig } from "../../lib/mermaid";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { ButtonGroup, ButtonGroupText } from "../ui/button-group";
@@ -334,7 +335,13 @@ export const TOOL_CALL_MD_CLASSNAME =
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 export const MessageResponse = memo(
-	({ className, animated, isAnimating, ...props }: MessageResponseProps) => (
+	({
+		className,
+		animated,
+		isAnimating,
+		mermaid,
+		...props
+	}: MessageResponseProps) => (
 		<Streamdown
 			animated={animated ?? defaultMessageAnimation}
 			className={cn(
@@ -344,6 +351,7 @@ export const MessageResponse = memo(
 			controls={{ table: false }}
 			isAnimating={isAnimating}
 			linkSafety={{ enabled: false }}
+			mermaid={{ ...mermaid, ...mermaidConfig(mermaid?.config ?? {}) }}
 			mode="streaming"
 			plugins={isAnimating ? undefined : streamdownPlugins}
 			{...props}

--- a/packages/ui/src/lib/mermaid.ts
+++ b/packages/ui/src/lib/mermaid.ts
@@ -22,9 +22,9 @@ type MermaidConfig = NonNullable<MermaidProp["config"]>;
 export function mermaidConfig(config: MermaidConfig): MermaidProp {
 	return {
 		config: {
-			htmlLabels: false,
 			...config,
-			flowchart: { htmlLabels: false, ...config.flowchart },
+			htmlLabels: false,
+			flowchart: { ...config.flowchart, htmlLabels: false },
 		},
 	};
 }

--- a/packages/ui/src/lib/mermaid.ts
+++ b/packages/ui/src/lib/mermaid.ts
@@ -1,0 +1,30 @@
+import { mermaid } from "@streamdown/mermaid";
+import type { ComponentProps } from "react";
+import type { Streamdown } from "streamdown";
+
+/** Shared `plugins` prop for every `<Streamdown>` that renders mermaid. */
+export const mermaidPlugins = { mermaid };
+
+type MermaidProp = NonNullable<ComponentProps<typeof Streamdown>["mermaid"]>;
+type MermaidConfig = NonNullable<MermaidProp["config"]>;
+
+/**
+ * Build the `mermaid` prop for `<Streamdown>` with HTML labels disabled.
+ *
+ * Mermaid defaults to `htmlLabels: true`, which renders node/edge labels inside
+ * `<foreignObject>`. Streamdown's "Download as PNG" control rasterizes the
+ * diagram by loading the SVG into an `<img>` and drawing it onto a `<canvas>`;
+ * Chromium taints any canvas drawn from an `<img>` containing `<foreignObject>`,
+ * so `canvas.toBlob()` returns null and the download silently fails (Streamdown
+ * swallows the error). Forcing native SVG `<text>` labels keeps the canvas clean
+ * so PNG export works, while SVG/MMD downloads are unaffected.
+ */
+export function mermaidConfig(config: MermaidConfig): MermaidProp {
+	return {
+		config: {
+			htmlLabels: false,
+			...config,
+			flowchart: { htmlLabels: false, ...config.flowchart },
+		},
+	};
+}


### PR DESCRIPTION
## Summary

The "Download as PNG" control on rendered mermaid diagrams silently did nothing. Mermaid defaults to `htmlLabels: true`, which renders node/edge labels inside `<foreignObject>`. Streamdown's PNG export rasterizes the SVG via an `<img>` onto a `<canvas>`, and Chromium taints any canvas drawn from an image containing `<foreignObject>` — so `canvas.toBlob()` returns null and Streamdown swallows the error.

- Add `packages/ui/src/lib/mermaid.ts` with a shared `mermaidPlugins` object and a `mermaidConfig()` helper that forces `htmlLabels: false` (top-level and `flowchart`), so mermaid renders native SVG `<text>` labels and the canvas stays untainted.
- Apply the helper at all four direct `<Streamdown mermaid=...>` call sites in the desktop app (CodeBlock, EditableCodeBlockView, both CommentCodeBlocks).
- Apply it inside `MessageResponse` in `packages/ui`, covering every chat-message rendering path; the caller's `mermaid` prop is spread through so `errorComponent` is preserved.

SVG/MMD downloads were unaffected and keep working.

## Test Plan

- [x] `bun run lint` clean (4806 files)
- [x] `bun run typecheck` passes across all 28 packages
- [x] `packages/ui` message component tests pass
- [ ] Manually verify PNG download of a mermaid diagram in a chat message and in a markdown code block

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5433">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Download as PNG” for Mermaid diagrams in the desktop app and chat messages by disabling HTML labels that tainted the canvas, so PNG export now works. SVG and `.mmd` downloads are unchanged.

- **Bug Fixes**
  - Added `packages/ui/src/lib/mermaid.ts` with `mermaidPlugins` and `mermaidConfig()` that forces `htmlLabels: false` (top-level and `flowchart`) to avoid Chromium canvas tainting.
  - Applied `mermaidConfig()` at all `<Streamdown>` Mermaid call sites in desktop (CodeBlock, EditableCodeBlockView, CommentCodeBlock); CommentPane now uses `CommentMarkdown`, which includes this config.
  - Updated `packages/ui` `MessageResponse` to merge caller options but force `htmlLabels` off last, so callers can’t re-enable it.

- **Refactors**
  - Replaced inline markdown/code rendering in CommentPane with `CommentMarkdown` to remove duplicate Mermaid and syntax-highlighting logic.

<sup>Written for commit 79936d8a0bb95b80af37861db87227344129ba7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mermaid diagrams in comments, markdown, and editable code blocks are now rendered with more consistent behavior across the app.
* **Bug Fixes**
  * Mermaid previews now use unified configuration, improving reliability of embedded diagram rendering.
  * Light/dark theme handling for Mermaid is more accurate in preview paths.
* **Refactor**
  * Updated Mermaid/diagram rendering to use shared app-wide helpers for Streamdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->