### PR TITLE
fix(desktop): Shift+Enter inserts newline in terminal chat TUIs

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/line-edit-translations.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/line-edit-translations.test.ts
@@ -39,4 +39,40 @@ describe("translateLineEditChord", () => {
 			}),
 		).toBeNull();
 	});
+
+	it("maps Shift+Enter to the TUI newline sequence on Mac", () => {
+		expect(
+			translateLineEditChord(event({ key: "Enter", shiftKey: true }), {
+				isMac: true,
+				isWindows: false,
+			}),
+		).toBe("\x1b\r");
+	});
+
+	it("maps Shift+Enter to the TUI newline sequence on Windows", () => {
+		expect(
+			translateLineEditChord(event({ key: "Enter", shiftKey: true }), {
+				isMac: false,
+				isWindows: true,
+			}),
+		).toBe("\x1b\r");
+	});
+
+	it("maps Shift+Enter to the TUI newline sequence on Linux", () => {
+		expect(
+			translateLineEditChord(event({ key: "Enter", shiftKey: true }), {
+				isMac: false,
+				isWindows: false,
+			}),
+		).toBe("\x1b\r");
+	});
+
+	it("does not map plain Enter", () => {
+		expect(
+			translateLineEditChord(event({ key: "Enter" }), {
+				isMac: true,
+				isWindows: false,
+			}),
+		).toBeNull();
+	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/line-edit-translations.ts
+++ b/apps/desktop/src/renderer/lib/terminal/line-edit-translations.ts
@@ -13,6 +13,11 @@ function onlyMod(event: KeyboardEvent, mod: "meta" | "alt" | "ctrl"): boolean {
 	);
 }
 
+/** True when Shift is the only modifier held. */
+function onlyShift(event: KeyboardEvent): boolean {
+	return event.shiftKey && !event.metaKey && !event.altKey && !event.ctrlKey;
+}
+
 /**
  * Translate Mac Cmd+/Option+ and Windows Ctrl+ arrow / backspace chords into
  * the escape sequences shells expect. Returns the bytes to send, or null if
@@ -31,11 +36,16 @@ export function translateLineEditChord(
 	const { isMac, isWindows } = options;
 	const { key } = event;
 
+	// Shift+Enter and Mac Cmd+Enter both emit ESC+CR, the newline sequence
+	// Claude Code's own /terminal-setup installs; Codex, Gemini, and OpenCode
+	// parse it as Alt+Enter → insert-newline in any kitty-keyboard state.
+	// Sent directly (bypassing xterm's key encoder) so newline never depends
+	// on the kitty handshake, which TUIs skip or lose across reattach (#4008).
+	if (key === "Enter" && onlyShift(event)) return "\x1b\r";
 	if (isMac && onlyMod(event, "meta")) {
 		if (key === "Backspace") return "\x15";
 		if (key === "ArrowLeft") return "\x01";
 		if (key === "ArrowRight") return "\x05";
-		// Chat TUIs parse ESC+CR as Shift+Enter/newline in kitty mode.
 		if (key === "Enter") return "\x1b\r";
 	}
 	if (isMac && onlyMod(event, "alt")) {


### PR DESCRIPTION
## Summary

Shift+Enter in terminal panes submitted the prompt instead of inserting a newline in chat TUIs (reported for Codex; same root cause as #4008 for Claude Code). In the legacy terminal encoding Shift+Enter arrives as a bare CR — identical to Enter — and the kitty keyboard negotiation that would disambiguate it is unreliable here: Claude Code only opts in for allow-listed terminals (anthropics/claude-code#71700, Superset isn't on it), and Codex's startup support probe can go unanswered when a session starts before a renderer xterm attaches.

Fix: translate Shift+Enter (no other modifiers, all platforms) to `ESC+CR` (`\x1b\r`) in `translateLineEditChord`, before xterm's key encoder — the same treatment Cmd+Enter already gets. `ESC+CR` is the sequence Claude Code's own `/terminal-setup` installs for VS Code/WezTerm/Ghostty, and Codex (crossterm parses it as Alt+Enter regardless of kitty state, bound to `insert_newline` by default), Gemini CLI, and OpenCode all treat it as newline. The shared key handler covers both v1 and v2 terminals.

Trade-off: plain shells now receive `ESC+CR` for Shift+Enter instead of bare CR — same trade-off the shipped Cmd+Enter translation made.

## Test Plan

- [x] `bun test line-edit-translations.test.ts` — 7/7, new cases cover Shift+Enter on Mac/Windows/Linux, plain Enter untouched, Cmd+Shift+Enter untouched
- [x] Mutation check: gating the translation to Mac-only fails the Windows/Linux cases
- [x] `bun run lint` exits 0
- [ ] Manual: Shift+Enter inserts newline in a live Codex terminal pane and a Claude Code pane

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5434">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Shift+Enter in desktop terminal panes so it inserts a newline in chat TUIs instead of submitting. We now send `ESC+CR` for Shift+Enter on all platforms to avoid unreliable kitty keyboard negotiation.

- **Bug Fixes**
  - Map Shift+Enter (only Shift) to `ESC+CR` (`\x1b\r`) in `translateLineEditChord` before `xterm` encoding; matches existing Cmd+Enter behavior.
  - Leaves plain Enter and Cmd+Shift+Enter unchanged; works on macOS, Windows, and Linux; applies to both terminal versions.
  - Adds tests covering the new mapping across platforms.

<sup>Written for commit 37ce0c35aeed216c6648c2b777670f610782e971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal line-edit key handling so **Shift+Enter** now inserts the expected newline sequence in the shell across macOS, Windows, and Linux.
  * Plain **Enter** is no longer translated as a special terminal shortcut when Shift isn’t held, including on Mac.
* **Tests**
  * Expanded coverage for newline key translation behavior across platforms and key combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->