### PR TITLE
feat(shared): add Fable 5 to copilot, cursor-agent, and opencode model pickers

### DIFF
--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -91,6 +91,9 @@ describe("buildAgentModelArgs", () => {
 		expect(
 			buildAgentModelArgs("cursor-agent", "claude-fable-5-thinking-high"),
 		).toEqual(["--model", "claude-fable-5-thinking-high"]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "claude-fable-5-thinking-xhigh"),
+		).toEqual(["--model", "claude-fable-5-thinking-xhigh"]);
 		expect(buildAgentModelArgs("opencode", "anthropic/claude-fable-5")).toEqual(
 			["--model", "anthropic/claude-fable-5"],
 		);

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -82,6 +82,19 @@ describe("buildAgentModelArgs", () => {
 			"fable",
 		]);
 	});
+
+	it("includes fable for the other CLIs that support it", () => {
+		expect(buildAgentModelArgs("copilot", "claude-fable-5")).toEqual([
+			"--model",
+			"claude-fable-5",
+		]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "claude-fable-5-thinking-high"),
+		).toEqual(["--model", "claude-fable-5-thinking-high"]);
+		expect(buildAgentModelArgs("opencode", "anthropic/claude-fable-5")).toEqual(
+			["--model", "anthropic/claude-fable-5"],
+		);
+	});
 });
 
 describe("AGENT_EFFORT_SUPPORT", () => {

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -86,6 +86,7 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "copilot",
 		modelFlag: "--model",
 		models: [
+			{ id: "claude-fable-5", label: "Claude Fable 5" },
 			{ id: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
 			{ id: "gpt-5.1", label: "GPT-5.1" },
 		],
@@ -94,6 +95,10 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "cursor-agent",
 		modelFlag: "--model",
 		models: [
+			// cursor-agent has no effort flag, so Fable's thinking level is
+			// baked into the model id (`--list-models` exposes high and xhigh).
+			{ id: "claude-fable-5-thinking-high", label: "Fable 5" },
+			{ id: "claude-fable-5-thinking-xhigh", label: "Fable 5 xHigh" },
 			{ id: "opus", label: "Opus" },
 			{ id: "sonnet-4.5", label: "Sonnet 4.5" },
 			{ id: "gpt-5", label: "GPT-5" },
@@ -104,6 +109,7 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "opencode",
 		modelFlag: "--model",
 		models: [
+			{ id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
 			{ id: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
 			{ id: "openai/gpt-5", label: "GPT-5" },
 		],


### PR DESCRIPTION
## Summary
- Adds Claude Fable 5 to the new-workspace modal's model dropdown for the three remaining harnesses whose CLIs support it: **copilot** (`claude-fable-5`), **cursor-agent** (`claude-fable-5-thinking-high` / `-xhigh`), and **opencode** (`anthropic/claude-fable-5`). The `claude` preset and Superset chat already had it (#5418).

## Why / Context
Fable 5 is now GA in GitHub Copilot (re-enabled July 1 after the June suspension), available in Cursor, and listed in opencode's model registry. The workspace-create picker reads from the hand-maintained catalog in `packages/shared/src/agent-models.ts`, so those dropdowns were missing it.

Model ids were verified per the catalog's contract:
- **copilot**: `copilot --model claude-fable-5` passes the CLI's model validation (a bogus id is rejected immediately).
- **cursor-agent**: both ids taken verbatim from `cursor-agent --list-models`. Two entries because cursor-agent has no separate effort flag — the thinking level is baked into the model id. Both are flagged "NO ZDR" upstream (unavailable for zero-data-retention accounts / Privacy Mode teams; those users can keep using Default).
- **opencode**: `anthropic/claude-fable-5` per opencode's registry (models.dev), matching the existing `anthropic/claude-sonnet-4-5` id format. Not verifiable locally (no Anthropic provider configured), so this one is registry-sourced.

Not added: amp (Fable is a `--mode` plugin there, not a `--model` value), droid (BYOK only, not a managed model), codex/gemini (wrong vendor), pi/mastracode (no model picker in the catalog).

## Testing
- `bun test agent-models` — 21 pass, including a new test covering all three ids through `buildAgentModelArgs`
- `bun run typecheck`
- Biome clean on both changed files (repo-wide `bun run lint` fails only on an uncommitted local `.github/hooks/superset-notify.json`, unrelated)
- Manual: launch-flag validation against the locally installed copilot and cursor-agent CLIs as described above; did not run an end-to-end workspace launch with each CLI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude Fable 5 to the new-workspace model picker for `copilot`, `cursor-agent`, and `opencode`. Updates the shared model catalog and adds tests, including explicit coverage for the `cursor-agent` `xhigh` variant.

- **New Features**
  - `copilot`: `claude-fable-5`
  - `cursor-agent`: `claude-fable-5-thinking-high`, `claude-fable-5-thinking-xhigh` (thinking level in the model id)
  - `opencode`: `anthropic/claude-fable-5`

<sup>Written for commit 8741638b38aa1849afbb235c807b041b4a27f454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional Claude Fable 5 model options across more terminal-agent presets.
  * Expanded available model choices for Copilot, Cursor Agent, and OpenCode, including supported thinking variants.

* **Tests**
  * Added test coverage to verify the new model options are accepted and correctly mapped for the relevant presets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->