### PR TITLE
fix(desktop): stop terminal render lag from WebGL context exhaustion

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -4,28 +4,21 @@ import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { ProgressAddon } from "@xterm/addon-progress";
 import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
-import { WebglAddon } from "@xterm/addon-webgl";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { Utf8Base64 } from "./clipboard-base64";
 
 export interface LoadAddonsResult {
 	searchAddon: SearchAddon;
 	progressAddon: ProgressAddon;
-	dispose: () => void;
 }
 
-// Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
-let suggestedRendererType: "webgl" | "dom" | undefined;
-
 /**
- * Load optional addons onto an already-opened terminal. Returns a cleanup
- * function and addon instances. WebGL is deferred to rAF to avoid
- * racing with xterm's post-open viewport sync.
+ * Load optional addons onto an already-opened terminal. The WebGL renderer is
+ * not loaded here — it's managed per-terminal by webgl-renderer.ts, acquired
+ * on attach and released on park so live GPU contexts stay bounded to visible
+ * terminals.
  */
 export function loadAddons(terminal: XTerm): LoadAddonsResult {
-	let disposed = false;
-	let webglAddon: WebglAddon | null = null;
-
 	// Utf8Base64 replaces the addon's UTF-8-unsafe default codec (#4839).
 	terminal.loadAddon(new ClipboardAddon(new Utf8Base64()));
 
@@ -45,34 +38,8 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 		terminal.loadAddon(new LigaturesAddon());
 	} catch {}
 
-	const rafId = requestAnimationFrame(() => {
-		if (disposed || suggestedRendererType === "dom") return;
-
-		try {
-			webglAddon = new WebglAddon();
-			webglAddon.onContextLoss(() => {
-				webglAddon?.dispose();
-				webglAddon = null;
-				suggestedRendererType = "dom";
-				terminal.refresh(0, terminal.rows - 1);
-			});
-			terminal.loadAddon(webglAddon);
-		} catch {
-			suggestedRendererType = "dom";
-			webglAddon = null;
-		}
-	});
-
 	return {
 		searchAddon,
 		progressAddon,
-		dispose: () => {
-			disposed = true;
-			cancelAnimationFrame(rafId);
-			try {
-				webglAddon?.dispose();
-			} catch {}
-			webglAddon = null;
-		},
 	};
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -13,6 +13,10 @@ import { loadAddons } from "./terminal-addons";
 import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
+import {
+	createWebglRendererController,
+	type WebglRendererController,
+} from "./webgl-renderer";
 
 const SERIALIZE_SCROLLBACK = 1000;
 const STORAGE_KEY_PREFIX = "terminal-buffer:";
@@ -34,7 +38,7 @@ export interface TerminalRuntime {
 	_disposeResizeObserver: (() => void) | null;
 	lastCols: number;
 	lastRows: number;
-	_disposeAddons: (() => void) | null;
+	webglController: WebglRendererController;
 	_disposeImagePasteFallback: (() => void) | null;
 }
 
@@ -217,6 +221,9 @@ export function createRuntime(
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)
 	const addonsResult = loadAddons(terminal);
+	// WebGL is acquired on attach (not here) so parked terminals never hold a
+	// GPU context — see webgl-renderer.ts.
+	const webglController = createWebglRendererController(terminal);
 	if (options.initialBuffer !== undefined) {
 		terminal.write(options.initialBuffer);
 	} else {
@@ -241,7 +248,7 @@ export function createRuntime(
 		_disposeResizeObserver: null,
 		lastCols: cols,
 		lastRows: rows,
-		_disposeAddons: addonsResult.dispose,
+		webglController,
 		_disposeImagePasteFallback: disposeImagePasteFallback,
 	};
 }
@@ -252,6 +259,10 @@ export function attachToContainer(
 	onResize?: () => void,
 	options: { focus?: boolean } = {},
 ) {
+	// Acquire the GPU renderer whenever the terminal becomes visible — before
+	// the same-container early return, so a terminal that lost its WebGL
+	// context while attached recovers here. Idempotent while active.
+	runtime.webglController.acquire();
 	// If we're already attached to this exact container, do nothing. Prevents
 	// redundant refresh/fit from transient remounts during provider key
 	// churn — VSCode setVisible() is idempotent for the same host element.
@@ -287,6 +298,10 @@ export function attachToContainer(
 }
 
 export function detachFromContainer(runtime: TerminalRuntime) {
+	// Release the GPU context while parked: xterm pauses rendering off-viewport
+	// anyway, so a parked context is pure pressure on Chromium's ~16-context
+	// cap. Reacquired on the next attach.
+	runtime.webglController.release();
 	persistBuffer(runtime.terminalId, runtime.serializeAddon);
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime._disposeResizeObserver?.();
@@ -340,8 +355,7 @@ export function disposeRuntime(
 	}
 	runtime._disposeImagePasteFallback?.();
 	runtime._disposeImagePasteFallback = null;
-	runtime._disposeAddons?.();
-	runtime._disposeAddons = null;
+	runtime.webglController.dispose();
 	runtime._disposeResizeObserver?.();
 	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();

--- a/apps/desktop/src/renderer/lib/terminal/webgl-renderer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/webgl-renderer.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import {
+	createWebglRendererController,
+	type WebglAddonLike,
+	type WebglFallbackReason,
+} from "./webgl-renderer";
+
+// Capture rAF callbacks so tests control frame timing deterministically.
+let frameCallbacks: Map<number, FrameRequestCallback>;
+let nextFrameId: number;
+
+const originalRaf = globalThis.requestAnimationFrame;
+const originalCancelRaf = globalThis.cancelAnimationFrame;
+
+function fireFrame() {
+	const callbacks = [...frameCallbacks.values()];
+	frameCallbacks.clear();
+	for (const callback of callbacks) {
+		callback(performance.now());
+	}
+}
+
+beforeEach(() => {
+	frameCallbacks = new Map();
+	nextFrameId = 1;
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
+		const id = nextFrameId++;
+		frameCallbacks.set(id, callback);
+		return id;
+	};
+	globalThis.cancelAnimationFrame = (id: number) => {
+		frameCallbacks.delete(id);
+	};
+});
+
+afterEach(() => {
+	globalThis.requestAnimationFrame = originalRaf;
+	globalThis.cancelAnimationFrame = originalCancelRaf;
+});
+
+interface FakeAddon extends WebglAddonLike {
+	disposeCount: number;
+	loseContext: () => void;
+}
+
+function createFakeAddon(): FakeAddon {
+	let contextLossListener: (() => void) | null = null;
+	const addon: FakeAddon = {
+		disposeCount: 0,
+		activate() {},
+		dispose() {
+			addon.disposeCount++;
+		},
+		onContextLoss(listener: () => void) {
+			contextLossListener = listener;
+			return { dispose() {} };
+		},
+		loseContext() {
+			contextLossListener?.();
+		},
+	};
+	return addon;
+}
+
+function createHarness(options: { failLoad?: boolean } = {}) {
+	const created: FakeAddon[] = [];
+	const loaded: WebglAddonLike[] = [];
+	const fallbacks: WebglFallbackReason[] = [];
+	let refreshCount = 0;
+
+	const terminal = {
+		rows: 24,
+		refresh() {
+			refreshCount++;
+		},
+		loadAddon(addon: WebglAddonLike) {
+			loaded.push(addon);
+		},
+	} as unknown as XTerm;
+
+	const controller = createWebglRendererController(terminal, {
+		createAddon: () => {
+			if (options.failLoad) {
+				throw new Error("no webgl");
+			}
+			const addon = createFakeAddon();
+			created.push(addon);
+			return addon;
+		},
+		onFallback: (reason) => fallbacks.push(reason),
+	});
+
+	return {
+		controller,
+		created,
+		loaded,
+		fallbacks,
+		getRefreshCount: () => refreshCount,
+	};
+}
+
+describe("createWebglRendererController", () => {
+	test("acquire loads the addon on the next frame", () => {
+		const { controller, created, loaded } = createHarness();
+
+		controller.acquire();
+		expect(created).toHaveLength(0);
+
+		fireFrame();
+		expect(created).toHaveLength(1);
+		expect(loaded).toEqual([created[0] as WebglAddonLike]);
+	});
+
+	test("acquire is idempotent while pending and while active", () => {
+		const { controller, created } = createHarness();
+
+		controller.acquire();
+		controller.acquire();
+		fireFrame();
+		controller.acquire();
+		fireFrame();
+
+		expect(created).toHaveLength(1);
+	});
+
+	test("release before the frame fires cancels the pending load", () => {
+		const { controller, created } = createHarness();
+
+		controller.acquire();
+		controller.release();
+		fireFrame();
+
+		expect(created).toHaveLength(0);
+	});
+
+	test("release disposes the context; next acquire creates a fresh one", () => {
+		const { controller, created } = createHarness();
+
+		controller.acquire();
+		fireFrame();
+		controller.release();
+		expect((created[0] as FakeAddon).disposeCount).toBe(1);
+
+		controller.acquire();
+		fireFrame();
+		expect(created).toHaveLength(2);
+	});
+
+	test("context loss falls back for this terminal and retries on next acquire", () => {
+		const { controller, created, fallbacks, getRefreshCount } = createHarness();
+
+		controller.acquire();
+		fireFrame();
+		(created[0] as FakeAddon).loseContext();
+
+		expect((created[0] as FakeAddon).disposeCount).toBe(1);
+		expect(fallbacks).toEqual(["context-loss"]);
+		expect(getRefreshCount()).toBe(1);
+
+		controller.acquire();
+		fireFrame();
+		expect(created).toHaveLength(2);
+	});
+
+	test("load failure disables WebGL for this controller only, permanently", () => {
+		const { controller, created, fallbacks } = createHarness({
+			failLoad: true,
+		});
+
+		controller.acquire();
+		fireFrame();
+		expect(fallbacks).toEqual(["load-failed"]);
+
+		controller.acquire();
+		fireFrame();
+		expect(created).toHaveLength(0);
+		expect(fallbacks).toHaveLength(1);
+
+		// Other controllers are unaffected — no shared latch.
+		const other = createHarness();
+		other.controller.acquire();
+		fireFrame();
+		expect(other.created).toHaveLength(1);
+	});
+
+	test("dispose releases the context and blocks further acquires", () => {
+		const { controller, created } = createHarness();
+
+		controller.acquire();
+		fireFrame();
+		controller.dispose();
+		expect((created[0] as FakeAddon).disposeCount).toBe(1);
+
+		controller.acquire();
+		fireFrame();
+		expect(created).toHaveLength(1);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/webgl-renderer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/webgl-renderer.ts
@@ -1,0 +1,129 @@
+import { WebglAddon } from "@xterm/addon-webgl";
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+/**
+ * Owns the WebGL renderer lifecycle for one xterm instance.
+ *
+ * Chromium caps live WebGL contexts per renderer process (~16) and silently
+ * evicts the least-recently-used one past the cap. Terminals park off-screen
+ * indefinitely (terminal-parking.ts), so holding a context for every terminal
+ * ever opened guarantees evictions once enough panes accumulate. Instead the
+ * context is acquired on attach and released on park, bounding live contexts
+ * to visible terminals. A parked terminal falls back to the DOM renderer,
+ * which costs nothing while hidden: xterm's IntersectionObserver pauses
+ * rendering off-viewport and full-refreshes on resume.
+ *
+ * Context loss while attached falls back to the DOM renderer for this
+ * terminal only and retries WebGL on the next acquire (i.e. next attach).
+ * Load failure (no GPU support) disables WebGL for this terminal only —
+ * never globally: the old module-wide latch permanently downgraded every
+ * future terminal in the session after a single loss.
+ */
+
+export type WebglFallbackReason = "context-loss" | "load-failed";
+
+export interface WebglRendererController {
+	/**
+	 * Load the WebGL addon, deferred to rAF to avoid racing xterm's post-open
+	 * viewport sync. Idempotent while a load is pending or active.
+	 */
+	acquire(): void;
+	/** Dispose the addon (and its GPU context), or cancel a pending load. */
+	release(): void;
+	/** Release and stop accepting further acquires. */
+	dispose(): void;
+}
+
+/** Structural subset of WebglAddon, injectable for tests. */
+export interface WebglAddonLike {
+	activate(terminal: XTerm): void;
+	dispose(): void;
+	onContextLoss(listener: () => void): { dispose(): void };
+}
+
+function reportFallback(reason: WebglFallbackReason, error?: unknown) {
+	console.warn(
+		`[terminal] WebGL renderer fallback (${reason}); using DOM renderer for this terminal`,
+		error ?? "",
+	);
+	// Lazy import keeps posthog out of the module graph for tests and for the
+	// common path where WebGL never fails.
+	void import("renderer/lib/analytics")
+		.then(({ track }) => track("terminal_webgl_fallback", { reason }))
+		.catch(() => {});
+}
+
+export function createWebglRendererController(
+	terminal: XTerm,
+	options: {
+		createAddon?: () => WebglAddonLike;
+		onFallback?: (reason: WebglFallbackReason, error?: unknown) => void;
+	} = {},
+): WebglRendererController {
+	const createAddon = options.createAddon ?? (() => new WebglAddon());
+	const onFallback = options.onFallback ?? reportFallback;
+
+	let addon: WebglAddonLike | null = null;
+	let frameId: number | null = null;
+	let disposed = false;
+	// Only set on load failure (no GPU/driver support) — a lost context is
+	// transient and retried on the next acquire instead.
+	let loadFailed = false;
+
+	function release() {
+		if (frameId !== null) {
+			cancelAnimationFrame(frameId);
+			frameId = null;
+		}
+		if (addon) {
+			const current = addon;
+			addon = null;
+			try {
+				current.dispose();
+			} catch {}
+		}
+	}
+
+	function acquire() {
+		if (disposed || loadFailed) return;
+		if (addon || frameId !== null) return;
+
+		frameId = requestAnimationFrame(() => {
+			frameId = null;
+			if (disposed || loadFailed || addon) return;
+
+			try {
+				const next = createAddon();
+				next.onContextLoss(() => {
+					// GPU reset or context eviction. Drop to the DOM renderer for
+					// this terminal; the next attach retries WebGL.
+					if (addon === next) {
+						addon = null;
+					}
+					try {
+						next.dispose();
+					} catch {}
+					onFallback("context-loss");
+					if (!disposed) {
+						terminal.refresh(0, Math.max(0, terminal.rows - 1));
+					}
+				});
+				terminal.loadAddon(next);
+				addon = next;
+			} catch (error) {
+				loadFailed = true;
+				onFallback("load-failed", error);
+			}
+		});
+	}
+
+	return {
+		acquire,
+		release,
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			release();
+		},
+	};
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -5,13 +5,16 @@ import { ImageAddon } from "@xterm/addon-image";
 import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
-import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { applyTerminalFontFamilyCssVariable } from "renderer/lib/terminal/appearance";
 import { Utf8Base64 } from "renderer/lib/terminal/clipboard-base64";
 import type { DetectedLink } from "renderer/lib/terminal/links";
 import { TerminalLinkManager } from "renderer/lib/terminal/terminal-link-manager";
+import {
+	createWebglRendererController,
+	type WebglRendererController,
+} from "renderer/lib/terminal/webgl-renderer";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { toXtermTheme } from "renderer/stores/theme/utils";
 import {
@@ -58,9 +61,6 @@ export function getDefaultTerminalBg(): string {
 	return getDefaultTerminalTheme().background ?? "#151110";
 }
 
-// Once WebGL fails, skip it for all subsequent terminals (VS Code pattern).
-let suggestedRendererType: "webgl" | "dom" | undefined;
-
 export interface CreateTerminalOptions {
 	/**
 	 * Workspace id used for worktree lookup during path stat/resolution.
@@ -86,6 +86,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	searchAddon: SearchAddon;
 	wrapper: HTMLDivElement;
 	linkManager: TerminalLinkManager;
+	webglController: WebglRendererController;
 	cleanup: () => void;
 } {
 	const {
@@ -105,9 +106,6 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const clipboardAddon = new ClipboardAddon(new Utf8Base64());
 	const unicode11Addon = new Unicode11Addon();
 	const imageAddon = new ImageAddon();
-
-	let disposed = false;
-	let webglAddon: WebglAddon | null = null;
 
 	// Open into a detached wrapper div — not the live container.
 	const wrapper = document.createElement("div");
@@ -131,24 +129,9 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 		// Ligatures not supported by current font
 	}
 
-	// Defer WebGL to rAF to avoid racing xterm's post-open viewport sync.
-	const rafId = requestAnimationFrame(() => {
-		if (disposed || suggestedRendererType === "dom") return;
-
-		try {
-			webglAddon = new WebglAddon();
-			webglAddon.onContextLoss(() => {
-				webglAddon?.dispose();
-				webglAddon = null;
-				suggestedRendererType = "dom";
-				xterm.refresh(0, xterm.rows - 1);
-			});
-			xterm.loadAddon(webglAddon);
-		} catch {
-			suggestedRendererType = "dom";
-			webglAddon = null;
-		}
-	});
+	// WebGL is acquired by v1-terminal-cache on attach (not here) so parked
+	// terminals never hold a GPU context — see webgl-renderer.ts.
+	const webglController = createWebglRendererController(xterm);
 
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
 
@@ -211,15 +194,11 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 		searchAddon,
 		wrapper,
 		linkManager,
+		webglController,
 		cleanup: () => {
-			disposed = true;
-			cancelAnimationFrame(rafId);
 			cleanupQuerySuppression();
 			linkManager.dispose();
-			try {
-				webglAddon?.dispose();
-			} catch {}
-			webglAddon = null;
+			webglController.dispose();
 		},
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -5,6 +5,7 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import { applyTerminalFontFamilyCssVariable } from "renderer/lib/terminal/appearance";
 import { scheduleFontSettleRefit } from "renderer/lib/terminal/font-settle";
 import { getTerminalParkingContainer } from "renderer/lib/terminal/terminal-parking";
+import type { WebglRendererController } from "renderer/lib/terminal/webgl-renderer";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { DEBUG_TERMINAL } from "./config";
 import { type CreateTerminalOptions, createTerminalInWrapper } from "./helpers";
@@ -24,8 +25,10 @@ export interface CachedTerminal {
 	fitAddon: FitAddon;
 	searchAddon: SearchAddon;
 	wrapper: HTMLDivElement;
-	/** Disposes renderer RAF, query suppression, GPU renderer, etc. */
+	/** Disposes query suppression, link manager, GPU renderer, etc. */
 	cleanupCreation: () => void;
+	/** GPU renderer lifecycle — acquired on attach, released on park. */
+	webglController: WebglRendererController;
 	/** Last known dimensions — used to skip no-op resize events. */
 	lastCols: number;
 	lastRows: number;
@@ -114,7 +117,7 @@ export function getOrCreate(
 		console.log(`[v1-terminal-cache] Creating new terminal: ${paneId}`);
 	}
 
-	const { xterm, fitAddon, searchAddon, wrapper, cleanup } =
+	const { xterm, fitAddon, searchAddon, wrapper, webglController, cleanup } =
 		createTerminalInWrapper(options);
 
 	const entry: CachedTerminal = {
@@ -123,6 +126,7 @@ export function getOrCreate(
 		searchAddon,
 		wrapper,
 		cleanupCreation: cleanup,
+		webglController,
 		subscription: null,
 		streamReady: false,
 		pendingStreamEvents: [],
@@ -149,6 +153,9 @@ export function attachToContainer(
 	const entry = cache.get(paneId);
 	if (!entry) return;
 
+	// Acquire the GPU renderer whenever the terminal becomes visible; released
+	// again on detach so parked terminals don't hold WebGL contexts.
+	entry.webglController.acquire();
 	entry.container = container;
 	container.appendChild(entry.wrapper);
 
@@ -184,6 +191,9 @@ export function detachFromContainer(paneId: string): void {
 	if (DEBUG_TERMINAL) {
 		console.log(`[v1-terminal-cache] detachFromContainer: ${paneId}`);
 	}
+	// Parked terminals render nothing (xterm pauses off-viewport), so the GPU
+	// context is pure pressure on Chromium's ~16-context cap. Release it.
+	entry.webglController.release();
 	entry.resizeObserver?.disconnect();
 	entry.resizeObserver = null;
 	entry.container = null;


### PR DESCRIPTION
## Summary

Typing echo lagged in terminal panes (v1 and v2) once enough terminals had been opened. Root cause: every terminal ever opened held a live WebGL context while parked off-screen, and Chromium caps a renderer process at ~16 contexts — past that it silently evicts one, which tripped a **module-global** fallback latch (`suggestedRendererType`) that downgraded **every future terminal** to the slow DOM renderer for the rest of the session. Under agent streaming the DOM renderer saturates the UI thread, so typed characters render late.

- New shared `webgl-renderer.ts` controller: the WebGL addon is **acquired on attach and released on park**. Parked terminals pause rendering anyway (xterm's IntersectionObserver), so live GPU contexts now equal *visible* panes — permanently under the cap.
- Context loss falls back to the DOM renderer **for that terminal only** and retries WebGL on its next attach; addon load failure (no GPU support) disables WebGL per instance, never globally.
- Fallbacks are no longer silent: `console.warn` + `terminal_webgl_fallback` PostHog event.
- v1 (`helpers.ts` / `v1-terminal-cache.ts`) and v2 (`terminal-runtime.ts`) now share the one controller instead of duplicating the WebGL loading block.

## Test Plan

- [x] 7 new unit tests for the controller (acquire/release, pending-load cancel, context-loss retry, per-instance load-failure isolation, dispose)
- [x] All 309 terminal-related tests pass
- [x] `tsc --noEmit` and `bun run lint` clean
- [ ] Manual: open 20+ terminals across workspaces — focused pane keeps its `<canvas>`, `#terminal-parking` terminals hold no WebGL contexts, typing stays crisp while agents stream in background tabs

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5436">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal typing lag by preventing WebGL context exhaustion. WebGL is now acquired only for visible terminals and released when parked, keeping contexts under Chromium’s cap and preserving the fast renderer.

- **Bug Fixes**
  - Added a shared controller for `@xterm/addon-webgl`: acquire on attach, release on park.
  - Fallback to DOM is per-terminal; WebGL retries on next attach. Load failures disable WebGL for that instance only.
  - Logs console warnings and tracks `terminal_webgl_fallback`.
  - Unified v1 and v2 terminals to use the same controller; removed duplicate WebGL logic.
  - Added unit tests for acquire/release, cancellation, context-loss retry, and per-instance isolation.

<sup>Written for commit 595a3b8e60c5fe2ed597898d67cb398f4a8045a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal rendering now manages GPU/WebGL usage more intelligently when tabs are attached, parked, or reopened.
  * Improved fallback handling helps terminals recover more reliably when WebGL is unavailable or loses context.

* **Bug Fixes**
  * Reduced idle GPU pressure by releasing rendering resources when terminals are not visible.
  * Added safeguards so failed WebGL rendering falls back cleanly without affecting other terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->