### PR TITLE
fix(desktop): restore native right-click edit menu for text inputs

### DIFF
--- a/apps/desktop/src/main/lib/edit-context-menu.ts
+++ b/apps/desktop/src/main/lib/edit-context-menu.ts
@@ -1,0 +1,49 @@
+import { Menu } from "electron";
+
+/**
+ * Electron shows no context menu by default, so right-clicking text inputs
+ * (textarea, contenteditable editors like the TipTap new-workspace prompt)
+ * did nothing. Restore the standard edit menu for editable elements.
+ *
+ * Custom in-page menus (Radix ContextMenu) call preventDefault on the DOM
+ * contextmenu event, which stops Chromium from emitting this webContents
+ * event, so they are unaffected. Embedded browser panes have their own
+ * handler in browser-manager.
+ */
+export function attachEditContextMenu(wc: Electron.WebContents): void {
+	wc.on("context-menu", (_event, params) => {
+		if (!params.isEditable) return;
+
+		const menuItems: Electron.MenuItemConstructorOptions[] = [];
+
+		for (const suggestion of params.dictionarySuggestions) {
+			menuItems.push({
+				label: suggestion,
+				click: () => wc.replaceMisspelling(suggestion),
+			});
+		}
+		if (params.misspelledWord) {
+			menuItems.push(
+				{
+					label: "Add to Dictionary",
+					click: () =>
+						wc.session.addWordToSpellCheckerDictionary(params.misspelledWord),
+				},
+				{ type: "separator" },
+			);
+		}
+
+		menuItems.push(
+			{ role: "undo", enabled: params.editFlags.canUndo },
+			{ role: "redo", enabled: params.editFlags.canRedo },
+			{ type: "separator" },
+			{ role: "cut", enabled: params.editFlags.canCut },
+			{ role: "copy", enabled: params.editFlags.canCopy },
+			{ role: "paste", enabled: params.editFlags.canPaste },
+			{ type: "separator" },
+			{ role: "selectAll", enabled: params.editFlags.canSelectAll },
+		);
+
+		Menu.buildFromTemplate(menuItems).popup();
+	});
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -17,6 +17,7 @@ import { createIPCHandler } from "trpc-electron/main";
 import { productName } from "~/package.json";
 import { appState } from "../lib/app-state";
 import { browserManager } from "../lib/browser/browser-manager";
+import { attachEditContextMenu } from "../lib/edit-context-menu";
 import { createApplicationMenu } from "../lib/menu";
 import { playNotificationSound } from "../lib/notification-sound";
 import { NotificationManager } from "../lib/notifications/notification-manager";
@@ -128,6 +129,8 @@ export async function MainWindow() {
 	});
 
 	createApplicationMenu();
+
+	attachEditContextMenu(window.webContents);
 
 	currentWindow = window;
 


### PR DESCRIPTION
## Summary
- Right-clicking text inputs in the main window did nothing — noticed in the new-workspace modal's TipTap prompt, but true for every input/textarea/contenteditable in the app. Electron shows no context menu by default, and we only ever built one for embedded browser panes (`browser-manager.ts`).
- Adds a native edit context menu (spellcheck suggestions + Add to Dictionary, Undo/Redo, Cut/Copy/Paste, Select All) attached to the main window's webContents, shown only when the right-clicked element is editable (`params.isEditable`), with items enabled per Chromium's `editFlags`.

## Why / Context
The v2 new-workspace prompt swapped a plain textarea for the TipTap `MarkdownEditor` (31f9421c4), which is where the missing menu got noticed and initially blamed on TipTap. The editor wasn't intercepting anything — no text input in the main window ever had a right-click menu. Fixing it at the window level restores the expected behavior everywhere, not just in the modal.

## How It Works
- New `src/main/lib/edit-context-menu.ts` listens to the webContents `context-menu` event and pops a `Menu` built from Electron edit roles; bails when the target isn't editable.
- No conflict with the app's custom Radix `ContextMenu`s (workspace rows, file tree, panes): Radix calls `preventDefault()` on the DOM `contextmenu` event, so Chromium never raises the native context-menu request for those targets — and they sit on non-editable elements anyway.

## Manual QA Checklist
- [ ] New-workspace modal prompt: right-click shows Cut/Copy/Paste/Select All; Paste inserts clipboard text
- [ ] Misspelled word in the prompt: right-click shows suggestions + Add to Dictionary; picking a suggestion replaces the word
- [ ] Plain inputs (e.g. branch name field, settings inputs) get the same menu
- [ ] Custom context menus unchanged: workspace sidebar rows, file tree, terminal pane still show their own menus (no native menu on top)
- [ ] Embedded browser panes still show their existing browser context menu

## Testing
- `bun run typecheck` (desktop, with route/icon codegen)
- `bun run lint`
- Not manually exercised in a running app — main-process change verified by review; QA checklist above covers the runtime paths.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the native right‑click edit menu for text inputs in the main window. Users now get spellcheck suggestions and standard edit actions across all inputs, including the new‑workspace TipTap prompt.

- **Bug Fixes**
  - Added `attachEditContextMenu` to the main window `webContents` to show a native edit menu only on editable elements.
  - Includes spellcheck suggestions and “Add to Dictionary,” plus Undo/Redo, Cut/Copy/Paste, Select All, enabled via Chromium `editFlags`.
  - Does not affect custom Radix context menus or embedded browser panes, which keep their existing menus.

<sup>Written for commit 4903b7447fbb15cc9a6cdeb502976b56ca85868a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Right-clicking in editable areas now shows a richer edit menu with spelling suggestions, “Add to Dictionary,” and standard editing actions.
  * Spellcheck suggestions can be applied directly from the menu.
  * Misspelled words can now be added to the dictionary from the context menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->