### PR TITLE
fix(desktop): batch folder-level Discard All to avoid git index.lock races

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/security/git-commands.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/security/git-commands.ts
@@ -88,21 +88,27 @@ export async function gitSwitchBranch(
 }
 
 /**
- * Checkout (restore) a file path, discarding local changes.
+ * Checkout (restore) file paths in a single git command,
+ * discarding local changes.
  *
- * Uses `git checkout -- <path>` - the `--` is REQUIRED here
- * to indicate path mode (not branch mode).
+ * Uses `git checkout -- <paths...>` - the `--` is REQUIRED here
+ * to indicate path mode (not branch mode). A single command avoids
+ * index.lock races when discarding multiple files.
  */
-export async function gitCheckoutFile(
+export async function gitCheckoutFiles(
 	worktreePath: string,
-	filePath: string,
+	filePaths: string[],
 ): Promise<void> {
+	if (filePaths.length === 0) {
+		throw new Error("filePaths must not be empty");
+	}
 	assertRegisteredWorktree(worktreePath);
-	assertValidGitPath(filePath);
+	for (const filePath of filePaths) {
+		assertValidGitPath(filePath);
+	}
 
 	const git = await getGitWithShellPath(worktreePath);
-	// `--` is correct here - we want path semantics
-	await git.checkout(["--", filePath]);
+	await git.checkout(["--", ...filePaths]);
 }
 
 /**

--- a/apps/desktop/src/lib/trpc/routers/changes/staging.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/staging.ts
@@ -4,7 +4,7 @@ import { publicProcedure, router } from "../..";
 import { getServiceForRootPath } from "../workspace-fs-service";
 import { getSimpleGitWithShellPath } from "../workspaces/utils/git-client";
 import {
-	gitCheckoutFile,
+	gitCheckoutFiles,
 	gitDiscardAllStaged,
 	gitDiscardAllUnstaged,
 	gitStageAll,
@@ -88,7 +88,20 @@ export const createStagingRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitCheckoutFile(input.worktreePath, input.filePath);
+				await gitCheckoutFiles(input.worktreePath, [input.filePath]);
+				clearStatusCacheForWorktree(input.worktreePath);
+				return { success: true };
+			}),
+
+		discardFiles: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					filePaths: z.array(z.string()).min(1),
+				}),
+			)
+			.mutation(async ({ input }): Promise<{ success: boolean }> => {
+				await gitCheckoutFiles(input.worktreePath, input.filePaths);
 				clearStatusCacheForWorktree(input.worktreePath);
 				return { success: true };
 			}),

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -173,17 +173,16 @@ export function ChangesView({
 		},
 	});
 
-	const discardChangesMutation =
-		electronTrpc.changes.discardChanges.useMutation({
-			onSuccess: () => refetch(),
-			onError: (error, variables) => {
-				console.error(
-					`Failed to discard changes for ${variables.filePath}:`,
-					error,
-				);
-				toast.error(`Failed to discard changes: ${error.message}`);
-			},
-		});
+	const discardFilesMutation = electronTrpc.changes.discardFiles.useMutation({
+		onSuccess: () => refetch(),
+		onError: (error, variables) => {
+			console.error(
+				`Failed to discard changes for ${variables.filePaths.join(", ")}:`,
+				error,
+			);
+			toast.error(`Failed to discard changes: ${error.message}`);
+		},
+	});
 
 	const deleteUntrackedMutation =
 		electronTrpc.changes.deleteUntracked.useMutation({
@@ -299,17 +298,25 @@ export function ChangesView({
 		}
 	};
 
-	const handleDiscard = (file: ChangedFile) => {
+	const handleDiscardFiles = (files: ChangedFile[]) => {
 		if (!worktreePath) return;
-		if (file.status === "untracked" || file.status === "added") {
+		const isUntracked = (file: ChangedFile) =>
+			file.status === "untracked" || file.status === "added";
+		// Untracked/added files are deleted from disk; git never touches the
+		// index for them, so per-file deletes can't race on index.lock.
+		for (const file of files.filter(isUntracked)) {
 			deleteUntrackedMutation.mutate({
 				worktreePath,
 				filePath: file.path,
 			});
-		} else {
-			discardChangesMutation.mutate({
+		}
+		const trackedPaths = files
+			.filter((file) => !isUntracked(file))
+			.map((file) => file.path);
+		if (trackedPaths.length > 0) {
+			discardFilesMutation.mutate({
 				worktreePath,
-				filePath: file.path,
+				filePaths: trackedPaths,
 			});
 		}
 	};
@@ -631,7 +638,7 @@ export function ChangesView({
 				worktreePath: worktreePath || "",
 				filePaths: files.map((f) => f.path),
 			}),
-		onDiscardFile: handleDiscard,
+		onDiscardFiles: handleDiscardFiles,
 		onShowDiscardUnstagedDialog: () => setShowDiscardUnstagedDialog(true),
 		onStageAll: () =>
 			stageAllMutation.mutate({
@@ -643,7 +650,7 @@ export function ChangesView({
 			stageFileMutation.isPending ||
 			stageFilesMutation.isPending ||
 			stageAllMutation.isPending ||
-			discardChangesMutation.isPending ||
+			discardFilesMutation.isPending ||
 			deleteUntrackedMutation.isPending ||
 			discardAllUnstagedMutation.isPending,
 	});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileList.tsx
@@ -22,7 +22,7 @@ interface FileListProps {
 	onUnstageFiles?: (files: ChangedFile[]) => void;
 	isActioning?: boolean;
 	worktreePath: string;
-	onDiscard?: (file: ChangedFile) => void;
+	onDiscardFiles?: (files: ChangedFile[]) => void;
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
@@ -42,7 +42,7 @@ export function FileList({
 	onUnstageFiles,
 	isActioning,
 	worktreePath,
-	onDiscard,
+	onDiscardFiles,
 	category,
 	commitHash,
 	isExpandedView,
@@ -75,7 +75,7 @@ export function FileList({
 					onUnstageFiles={onUnstageFiles}
 					isActioning={isActioning}
 					worktreePath={worktreePath}
-					onDiscard={onDiscard}
+					onDiscardFiles={onDiscardFiles}
 					category={category}
 					commitHash={commitHash}
 					isExpandedView={isExpandedView}
@@ -98,7 +98,7 @@ export function FileList({
 				onUnstageFiles={onUnstageFiles}
 				isActioning={isActioning}
 				worktreePath={worktreePath}
-				onDiscard={onDiscard}
+				onDiscardFiles={onDiscardFiles}
 				category={category}
 				commitHash={commitHash}
 				isExpandedView={isExpandedView}
@@ -122,7 +122,7 @@ export function FileList({
 				onUnstageFiles={onUnstageFiles}
 				isActioning={isActioning}
 				worktreePath={worktreePath}
-				onDiscard={onDiscard}
+				onDiscardFiles={onDiscardFiles}
 				category={category}
 				commitHash={commitHash}
 				isExpandedView={isExpandedView}
@@ -145,7 +145,7 @@ export function FileList({
 			onUnstageFiles={onUnstageFiles}
 			isActioning={isActioning}
 			worktreePath={worktreePath}
-			onDiscard={onDiscard}
+			onDiscardFiles={onDiscardFiles}
 			category={category}
 			commitHash={commitHash}
 			isExpandedView={isExpandedView}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGrouped.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGrouped.tsx
@@ -16,7 +16,7 @@ interface FileListGroupedProps {
 	onUnstageFiles?: (files: ChangedFile[]) => void;
 	isActioning?: boolean;
 	worktreePath: string;
-	onDiscard?: (file: ChangedFile) => void;
+	onDiscardFiles?: (files: ChangedFile[]) => void;
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
@@ -74,7 +74,7 @@ interface FolderGroupItemProps {
 	onUnstageFiles?: (files: ChangedFile[]) => void;
 	isActioning?: boolean;
 	worktreePath: string;
-	onDiscard?: (file: ChangedFile) => void;
+	onDiscardFiles?: (files: ChangedFile[]) => void;
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
@@ -93,7 +93,7 @@ function FolderGroupItem({
 	onUnstageFiles,
 	isActioning,
 	worktreePath,
-	onDiscard,
+	onDiscardFiles,
 	category,
 	commitHash,
 	isExpandedView,
@@ -124,11 +124,8 @@ function FolderGroupItem({
 	}, [group.files, onUnstage, onUnstageFiles]);
 
 	const handleDiscardAll = useCallback(() => {
-		if (!onDiscard) return;
-		for (const file of group.files) {
-			onDiscard(file);
-		}
-	}, [group.files, onDiscard]);
+		onDiscardFiles?.(group.files);
+	}, [group.files, onDiscardFiles]);
 
 	return (
 		<FolderRow
@@ -143,7 +140,7 @@ function FolderGroupItem({
 			defaultApp={defaultApp}
 			onStageAll={onStage || onStageFiles ? handleStageAll : undefined}
 			onUnstageAll={onUnstage || onUnstageFiles ? handleUnstageAll : undefined}
-			onDiscardAll={onDiscard ? handleDiscardAll : undefined}
+			onDiscardAll={onDiscardFiles ? handleDiscardAll : undefined}
 			isActioning={isActioning}
 		>
 			{group.files.map((file) => (
@@ -159,7 +156,7 @@ function FolderGroupItem({
 					worktreePath={worktreePath}
 					projectId={projectId}
 					defaultApp={defaultApp}
-					onDiscard={onDiscard ? () => onDiscard(file) : undefined}
+					onDiscard={onDiscardFiles ? () => onDiscardFiles([file]) : undefined}
 					category={category}
 					commitHash={commitHash}
 					isExpandedView={isExpandedView}
@@ -180,7 +177,7 @@ export function FileListGrouped({
 	onUnstageFiles,
 	isActioning,
 	worktreePath,
-	onDiscard,
+	onDiscardFiles,
 	category,
 	commitHash,
 	isExpandedView,
@@ -204,7 +201,7 @@ export function FileListGrouped({
 					onUnstageFiles={onUnstageFiles}
 					isActioning={isActioning}
 					worktreePath={worktreePath}
-					onDiscard={onDiscard}
+					onDiscardFiles={onDiscardFiles}
 					category={category}
 					commitHash={commitHash}
 					isExpandedView={isExpandedView}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGroupedVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGroupedVirtualized.tsx
@@ -20,7 +20,7 @@ interface FileListGroupedVirtualizedProps {
 	onUnstageFiles?: (files: ChangedFile[]) => void;
 	isActioning?: boolean;
 	worktreePath: string;
-	onDiscard?: (file: ChangedFile) => void;
+	onDiscardFiles?: (files: ChangedFile[]) => void;
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
@@ -77,7 +77,7 @@ export function FileListGroupedVirtualized({
 	onUnstageFiles,
 	isActioning,
 	worktreePath,
-	onDiscard,
+	onDiscardFiles,
 	category,
 	commitHash,
 	isExpandedView,
@@ -194,12 +194,8 @@ export function FileListGroupedVirtualized({
 											: undefined
 									}
 									onDiscardAll={
-										onDiscard
-											? () => {
-													for (const file of row.group.files) {
-														onDiscard(file);
-													}
-												}
+										onDiscardFiles
+											? () => onDiscardFiles(row.group.files)
 											: undefined
 									}
 									isActioning={isActioning}
@@ -225,7 +221,9 @@ export function FileListGroupedVirtualized({
 										projectId={projectId}
 										defaultApp={defaultApp}
 										onDiscard={
-											onDiscard ? () => onDiscard(row.file) : undefined
+											onDiscardFiles
+												? () => onDiscardFiles([row.file])
+												: undefined
 										}
 										category={category}
 										commitHash={commitHash}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTree.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTree.tsx
@@ -41,7 +41,7 @@ interface FileListTreeProps {
 	onUnstageFiles?: (files: ChangedFile[]) => void;
 	isActioning?: boolean;
 	worktreePath: string;
-	onDiscard?: (file: ChangedFile) => void;
+	onDiscardFiles?: (files: ChangedFile[]) => void;
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
@@ -114,7 +114,7 @@ interface TreeNodeComponentProps {
 	onUnstageFiles?: (files: ChangedFile[]) => void;
 	isActioning?: boolean;
 	worktreePath: string;
-	onDiscard?: (file: ChangedFile) => void;
+	onDiscardFiles?: (files: ChangedFile[]) => void;
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
@@ -135,7 +135,7 @@ function TreeNodeComponent({
 	onUnstageFiles,
 	isActioning,
 	worktreePath,
-	onDiscard,
+	onDiscardFiles,
 	category,
 	commitHash,
 	isExpandedView,
@@ -168,12 +168,8 @@ function TreeNodeComponent({
 	}, [node, onUnstage, onUnstageFiles]);
 
 	const handleDiscardAll = useCallback(() => {
-		if (!onDiscard) return;
-		const files = collectFilesFromNode(node);
-		for (const file of files) {
-			onDiscard(file);
-		}
-	}, [node, onDiscard]);
+		onDiscardFiles?.(collectFilesFromNode(node));
+	}, [node, onDiscardFiles]);
 
 	if (hasChildren) {
 		return (
@@ -191,7 +187,7 @@ function TreeNodeComponent({
 				onUnstageAll={
 					onUnstage || onUnstageFiles ? handleUnstageAll : undefined
 				}
-				onDiscardAll={onDiscard ? handleDiscardAll : undefined}
+				onDiscardAll={onDiscardFiles ? handleDiscardAll : undefined}
 				isActioning={isActioning}
 			>
 				{node.children?.map((child) => (
@@ -209,7 +205,7 @@ function TreeNodeComponent({
 						onUnstageFiles={onUnstageFiles}
 						isActioning={isActioning}
 						worktreePath={worktreePath}
-						onDiscard={onDiscard}
+						onDiscardFiles={onDiscardFiles}
 						category={category}
 						commitHash={commitHash}
 						isExpandedView={isExpandedView}
@@ -236,7 +232,7 @@ function TreeNodeComponent({
 				worktreePath={worktreePath}
 				projectId={projectId}
 				defaultApp={defaultApp}
-				onDiscard={onDiscard ? () => onDiscard(file) : undefined}
+				onDiscard={onDiscardFiles ? () => onDiscardFiles([file]) : undefined}
 				category={category}
 				commitHash={commitHash}
 				isExpandedView={isExpandedView}
@@ -259,7 +255,7 @@ export function FileListTree({
 	onUnstageFiles,
 	isActioning,
 	worktreePath,
-	onDiscard,
+	onDiscardFiles,
 	category,
 	commitHash,
 	isExpandedView,
@@ -284,7 +280,7 @@ export function FileListTree({
 					onUnstageFiles={onUnstageFiles}
 					isActioning={isActioning}
 					worktreePath={worktreePath}
-					onDiscard={onDiscard}
+					onDiscardFiles={onDiscardFiles}
 					category={category}
 					commitHash={commitHash}
 					isExpandedView={isExpandedView}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTreeVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTreeVirtualized.tsx
@@ -29,7 +29,7 @@ interface FileListTreeVirtualizedProps {
 	onUnstageFiles?: (files: ChangedFile[]) => void;
 	isActioning?: boolean;
 	worktreePath: string;
-	onDiscard?: (file: ChangedFile) => void;
+	onDiscardFiles?: (files: ChangedFile[]) => void;
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
@@ -167,7 +167,7 @@ export function FileListTreeVirtualized({
 	onUnstageFiles,
 	isActioning,
 	worktreePath,
-	onDiscard,
+	onDiscardFiles,
 	category,
 	commitHash,
 	isExpandedView,
@@ -267,14 +267,9 @@ export function FileListTreeVirtualized({
 											: undefined
 									}
 									onDiscardAll={
-										onDiscard
-											? () => {
-													const folderFiles =
-														folderFileMap.get(row.node.id) ?? [];
-													for (const file of folderFiles) {
-														onDiscard(file);
-													}
-												}
+										onDiscardFiles
+											? () =>
+													onDiscardFiles(folderFileMap.get(row.node.id) ?? [])
 											: undefined
 									}
 									isActioning={isActioning}
@@ -296,7 +291,11 @@ export function FileListTreeVirtualized({
 									worktreePath={worktreePath}
 									projectId={projectId}
 									defaultApp={defaultApp}
-									onDiscard={onDiscard ? () => onDiscard(row.file) : undefined}
+									onDiscard={
+										onDiscardFiles
+											? () => onDiscardFiles([row.file])
+											: undefined
+									}
 									category={category}
 									commitHash={commitHash}
 									isExpandedView={isExpandedView}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.test.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.test.tsx
@@ -53,7 +53,7 @@ const emptyArgs = {
 	onUnstagedFileSelect: () => {},
 	onStageFile: () => {},
 	onStageFiles: () => {},
-	onDiscardFile: () => {},
+	onDiscardFiles: () => {},
 	onShowDiscardUnstagedDialog: () => {},
 	onStageAll: () => {},
 	isDiscardAllUnstagedPending: false,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
@@ -52,7 +52,7 @@ interface UseOrderedSectionsInput {
 	onUnstagedFileSelect: (file: ChangedFile) => void;
 	onStageFile: (file: ChangedFile) => void;
 	onStageFiles: (files: ChangedFile[]) => void;
-	onDiscardFile: (file: ChangedFile) => void;
+	onDiscardFiles: (files: ChangedFile[]) => void;
 	onShowDiscardUnstagedDialog: () => void;
 	onStageAll: () => void;
 	isDiscardAllUnstagedPending: boolean;
@@ -90,7 +90,7 @@ export function useOrderedSections({
 	onUnstagedFileSelect,
 	onStageFile,
 	onStageFiles,
-	onDiscardFile,
+	onDiscardFiles,
 	onShowDiscardUnstagedDialog,
 	onStageAll,
 	isDiscardAllUnstagedPending,
@@ -246,7 +246,7 @@ export function useOrderedSections({
 					isActioning={isUnstagedActioning}
 					worktreePath={worktreePath}
 					projectId={projectId}
-					onDiscard={onDiscardFile}
+					onDiscardFiles={onDiscardFiles}
 					category="unstaged"
 					isExpandedView={isExpandedView}
 				/>


### PR DESCRIPTION
**Links**
- Issue: [SUPER-1154](https://linear.app/superset/issue/SUPER-1154)

## Summary
- Fixes folder-level **Discard All** in the v1 Changes sidebar failing with `Unable to create '.git/index.lock': File exists` and leaving some files undiscarded.
- Discarding a folder's tracked files now runs as a single `git checkout -- <paths...>` instead of one git process per file.

## Why / Context
Folder rows' "Discard All" (hover action and context menu) looped over the folder's files and fired one `discardChanges` tRPC mutation per file. Each mutation spawns its own `git checkout` process; running concurrently they race on `.git/index.lock` — the first grabs the lock, the rest fail. The section-level "Discard all unstaged/staged" buttons (the "first option" in the ticket) never hit this because they already use a single git command. Reproduced at the git level: 5 parallel per-file checkouts → 3 failed on index.lock; one batched checkout of the same paths → clean.

Stage/unstage got batch procedures (`gitStageFiles`/`gitUnstageFiles`) for exactly this reason; discard never did.

## How It Works
- New `gitCheckoutFiles()` + `changes.discardFiles` procedure discard N tracked files in one git command. The single-file `discardChanges` procedure (still used by the expanded diff view) now delegates to it, and `gitCheckoutFile` is deleted.
- The per-file `onDiscard` prop on `FileList` and its four variants is **replaced** by `onDiscardFiles(files[])` — file rows pass `[file]`, folder rows pass the whole folder. All three per-file discard loops are removed with no fallback path.
- `ChangesView`'s `handleDiscardFiles` splits the batch: tracked files → one `discardFiles` mutation; untracked/added files → per-file `deleteUntracked` (filesystem-only, never touches the git index, so it can't race).

## Manual QA Checklist
- [ ] Folder-row Discard All on a directory with multiple modified files discards all of them, no index.lock toast (grouped and tree view)
- [ ] Same on a second/third directory after the first (the original repro)
- [ ] Folder containing a mix of modified + untracked files: modified restored, untracked deleted
- [ ] Single-file discard from a file row still works (modified and untracked)
- [ ] Section-level "Discard all unstaged/staged" unchanged
- [ ] Virtualized lists (200+ changed files) folder Discard All works

## Testing
- `bun run typecheck`
- `bun run lint`
- `bun test useOrderedSections`
- Git-level race repro in a scratch repo confirming parallel per-file checkouts fail on index.lock while a single batched checkout succeeds
- Not manually validated in the running app (checklist above covers it)

## Design Decisions
- **Replace `onDiscard` instead of adding `onDiscardFiles` alongside it**: keeping the per-file loop as a fallback would preserve the racy path; the batch callback is now the only discard route in this tree.
- **Untracked deletes stay per-file**: `deleteUntracked` is a filesystem delete with no git index involvement, so batching isn't needed for correctness; kept as-is to limit scope.
- **v2 untouched**: v2's changes tab only discards single files (no folder-level fan-out), so it doesn't have this race.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes folder-level Discard All in the v1 Changes sidebar by batching tracked file restores into a single git command to prevent `.git/index.lock` races and ensure all files are discarded. Addresses SUPER-1154.

- **Bug Fixes**
  - Added `gitCheckoutFiles()` and `changes.discardFiles` to run `git checkout -- <paths...>` once per batch; single-file `discardChanges` now delegates.
  - Replaced `onDiscard(file)` with `onDiscardFiles(files[])` across file list components; folder rows pass all files, file rows pass `[file]`.
  - In `ChangesView`, tracked files use `discardFiles`; untracked/added files still use per-file `deleteUntracked` (no index). Section-level discard remains unchanged.

<sup>Written for commit 4706a6f8382eaeb16e81e492658dc11252b3ac34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk discard support for changed files, including discarding multiple files or an entire folder at once.
  * The changes panel now handles grouped and tree views consistently with multi-file discard actions.

* **Bug Fixes**
  * Discard actions now work more efficiently by applying changes in a single operation for tracked files.
  * Improved handling of empty or invalid file selections to prevent unexpected discard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->