### PR TITLE
feat(desktop): hide sidebar agent chips unless multiple agents are running

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
@@ -44,6 +44,9 @@ const STAGGER_STEP_MS = 25;
  * into the individual port pills with a slight stagger — and retracts the
  * same way in reverse. Everything is one layer, so the motion is real
  * geometry, not a cross-fade.
+ *
+ * Agent chips appear only when more than one agent is running; a lone agent
+ * is the norm for a workspace and showing it adds no signal.
  */
 export function DashboardSidebarWorkspaceDetails({
 	workspaceId,
@@ -61,7 +64,9 @@ export function DashboardSidebarWorkspaceDetails({
 		workspaceId,
 		workspaceAgentsRowEnabled,
 	);
-	const agents = workspaceAgentsRowEnabled ? runningAgents : [];
+	const hasMultipleAgents = runningAgents.length > 1;
+	const showAgentChips = workspaceAgentsRowEnabled && hasMultipleAgents;
+	const agents = showAgentChips ? runningAgents : [];
 
 	if (ports.length === 0 && agents.length === 0) {
 		return null;

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.12.5",
+      "version": "1.13.0",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -789,7 +789,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.21",
+      "version": "0.8.23",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",


### PR DESCRIPTION
## Summary
- The v2 sidebar activity strip now renders inline agent chips only when a workspace has more than one running agent; a lone agent is the norm and showing it added no signal.
- The rule is expressed as named conditions (`hasMultipleAgents`, `showAgentChips`) in `DashboardSidebarWorkspaceDetails` and documented in the component JSDoc.
- Port pills are unaffected: with chips hidden the existing logic already drops the agent-adjacent margin, and the strip still renders null when there are no ports and no visible agents.
- Also syncs `bun.lock` with the 1.13.0 / host-service 0.8.23 version bumps from main.

## Test Plan
- [ ] Workspace with one running agent: no agent chip in the activity strip; port pills render as before
- [ ] Workspace with two or more agents: chips appear and morph into labeled pills on hover
- [ ] Workspace with one agent and no ports: no strip rendered
- [ ] `bunx biome check` passes on the touched file

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5445">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show agent chips in the sidebar only when a workspace has multiple running agents. This reduces noise; ports behave the same, and the strip hides when there are no ports and no visible agents.

- **New Features**
  - Gate agent chips on multiple agents via `hasMultipleAgents` and `showAgentChips` in `DashboardSidebarWorkspaceDetails`.
  - Hide chip for a single agent; show chips for 2+ and morph to labeled pills on hover.
  - Keep existing port pill layout; strip returns null when empty.

- **Dependencies**
  - Sync `bun.lock` with `@superset/desktop@1.13.0` and `@superset/host-service@0.8.23`.

<sup>Written for commit f5c676f0f4f415f2f63fc6e801886fd69af44bc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace agent chips now appear only when the workspace agents row feature is enabled and there are multiple running agents.
  * A single running agent is now treated as the default and no longer shows chips, creating a cleaner workspace view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->