### PR TITLE
fix(desktop): close the sidebar gap under the workspace activity strip

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -144,8 +144,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 					}}
 					onDoubleClick={onDoubleClick}
 					className={cn(
-						// pb collapses when the details strip renders below the row.
-						"group relative flex w-full items-center py-2 pr-2 [&:not(:last-child)]:pb-0.5",
+						"group relative flex w-full items-center py-2 pr-2",
 						isInSection ? "pl-7" : "pl-5",
 						onClick && "cursor-pointer",
 					)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -144,7 +144,8 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 					}}
 					onDoubleClick={onDoubleClick}
 					className={cn(
-						"group relative flex w-full items-center py-2 pr-2",
+						// pb collapses when the details strip renders below the row.
+						"group relative flex w-full items-center py-2 pr-2 [&:not(:last-child)]:pb-0.5",
 						isInSection ? "pl-7" : "pl-5",
 						onClick && "cursor-pointer",
 					)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
@@ -80,7 +80,7 @@ export function DashboardSidebarWorkspaceDetails({
 			observeChildren
 			className={cn(
 				// group/details scopes the menu-open half of `details-expanded`.
-				"group/details mb-0.5 flex h-[22px] items-center overflow-x-auto hide-scrollbar pr-2",
+				"group/details flex h-[22px] items-center overflow-x-auto hide-scrollbar pr-2",
 				isInSection ? "pl-[58px]" : "pl-[50px]",
 				onClick && "cursor-pointer",
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/DashboardSidebarWorkspaceDetails.tsx
@@ -80,7 +80,7 @@ export function DashboardSidebarWorkspaceDetails({
 			observeChildren
 			className={cn(
 				// group/details scopes the menu-open half of `details-expanded`.
-				"group/details flex h-[22px] items-center overflow-x-auto hide-scrollbar pr-2 mb-1.5",
+				"group/details mb-0.5 flex h-[22px] items-center overflow-x-auto hide-scrollbar pr-2",
 				isInSection ? "pl-[58px]" : "pl-[50px]",
 				onClick && "cursor-pointer",
 			)}


### PR DESCRIPTION
## Summary
- The v2 sidebar activity strip (#5439) carried a `mb-1.5` bottom margin on top of the row's own padding, which read as a gap between workspaces that have agent/port chips. Remove the margin — the strip's 2px inner padding is the only space below the chips, same edge as a plain row.

## Manual QA Checklist
- [ ] Workspace with running agents/ports: no gap before the next workspace
- [ ] Workspace without agents/ports: row spacing unchanged
- [ ] Hover morph (circles → labeled pills) and strip click-to-open still work

## Testing
- `bun run lint`
- `bun turbo run typecheck --filter=@superset/desktop`