### PR TITLE
fix(host-service): isolate dev pty-daemons from the packaged app

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -11,6 +11,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as childProcess from "node:child_process";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as net from "node:net";
 import * as os from "node:os";
@@ -1037,3 +1038,39 @@ function isProcessAliveForTest(pid: number): boolean {
 		return (err as NodeJS.ErrnoException).code === "EPERM";
 	}
 }
+
+describe("ptyDaemonSocketPath", () => {
+	const ORG = "org-socket-path";
+	const legacyPath = () => {
+		const shortId = createHash("sha256").update(ORG).digest("hex").slice(0, 12);
+		return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
+	};
+
+	test("default home keeps the legacy org-only path", () => {
+		expect(ptyDaemonSocketPath(ORG, {})).toBe(legacyPath());
+		expect(
+			ptyDaemonSocketPath(ORG, {
+				SUPERSET_HOME_DIR: path.join(os.homedir(), ".superset"),
+			}),
+		).toBe(legacyPath());
+	});
+
+	test("non-default homes get their own stable daemon socket", () => {
+		const a = ptyDaemonSocketPath(ORG, { SUPERSET_HOME_DIR: "/tmp/home-a" });
+		const b = ptyDaemonSocketPath(ORG, { SUPERSET_HOME_DIR: "/tmp/home-b" });
+		expect(a).not.toBe(legacyPath());
+		expect(b).not.toBe(legacyPath());
+		expect(a).not.toBe(b);
+		expect(ptyDaemonSocketPath(ORG, { SUPERSET_HOME_DIR: "/tmp/home-a" })).toBe(
+			a,
+		);
+	});
+
+	test("stays under Darwin's 104-byte sun_path limit for long worktree homes", () => {
+		const socket = ptyDaemonSocketPath("a1b2c3d4-e5f6-7890-abcd-ef1234567890", {
+			SUPERSET_HOME_DIR:
+				"/Users/someone/.superset/worktrees/0123456789abcdef-0123/very-long-branch-name-for-a-feature/superset-dev-data",
+		});
+		expect(Buffer.byteLength(socket)).toBeLessThan(104);
+	});
+});

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -98,19 +98,29 @@ export function shouldKillStaleDaemonForDev(
 }
 
 /**
- * Per-organization socket path. **Must stay short** — Darwin's `sun_path`
+ * Per-instance socket path. **Must stay short** — Darwin's `sun_path`
  * is 104 bytes, and `$SUPERSET_HOME_DIR/host/{orgId}/pty-daemon.sock` blows
- * past that in dev (worktree-relative SUPERSET_HOME_DIR + 36-char UUID).
- *
- * We put the socket in `os.tmpdir()` with a hash of the org id. Owner-only
+ * past that in dev (worktree-relative SUPERSET_HOME_DIR + 36-char UUID), so
+ * the socket lives in `os.tmpdir()` under a fixed-length hash. Owner-only
  * file mode (0600, set by the daemon's Server.listen) is the auth boundary;
  * the directory permissions don't matter.
+ *
+ * The hash covers the org id and, for non-default homes, `SUPERSET_HOME_DIR`.
+ * Daemon manifests are per-home, so a home-agnostic socket let a dev
+ * instance (worktree-local home) adopt the packaged app's daemon through the
+ * manifest-missing socket-probe fallback — its kill/adopt bookkeeping never
+ * saw the other home's manifest. Keying by home gives every home its own
+ * daemon; the default home keeps the legacy org-only path so packaged apps
+ * don't orphan their existing daemon on update.
  */
-export function ptyDaemonSocketPath(organizationId: string): string {
-	const shortId = createHash("sha256")
-		.update(organizationId)
-		.digest("hex")
-		.slice(0, 12);
+export function ptyDaemonSocketPath(
+	organizationId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	const home = env.SUPERSET_HOME_DIR;
+	const isDefaultHome = !home || home === path.join(os.homedir(), ".superset");
+	const key = isDefaultHome ? organizationId : `${organizationId}:${home}`;
+	const shortId = createHash("sha256").update(key).digest("hex").slice(0, 12);
 	return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
 }
 
@@ -695,17 +705,23 @@ export class DaemonSupervisor {
 	}
 
 	private async start(organizationId: string): Promise<DaemonInstance> {
-		// Dev mode: never adopt. A leftover detached daemon from a previous
-		// `bun dev` session would mask code changes — devs hit Update or
-		// open a session and see stale-bundle behavior with no obvious
-		// reason. Kill any running daemon for the org and spawn fresh.
-		// Production keeps the adopt path so PTY sessions survive
-		// host-service restarts (the original Phase 1 promise).
-		if (shouldKillStaleDaemonForDev()) {
+		// Dev mode: never adopt. Dev daemons spawn attached (they die with the
+		// app), so there is never a legitimately surviving dev daemon — a
+		// leftover from a killed `bun dev` session would only mask code
+		// changes. Kill any leftover recorded in this home's manifest and
+		// spawn fresh; skipping tryAdopt entirely also keeps the
+		// manifest-missing socket-probe fallback from re-attaching a daemon
+		// this home never spawned. Production keeps the adopt path so PTY
+		// sessions survive host-service restarts (the original Phase 1
+		// promise).
+		const spawnFreshForDev = shouldKillStaleDaemonForDev();
+		if (spawnFreshForDev) {
 			await this.killStaleDaemonForDev(organizationId);
 		}
 
-		const adopted = await this.tryAdopt(organizationId);
+		const adopted = spawnFreshForDev
+			? null
+			: await this.tryAdopt(organizationId);
 		if (adopted) {
 			this.instances.set(organizationId, adopted);
 			console.log(

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -98,20 +98,17 @@ export function shouldKillStaleDaemonForDev(
 }
 
 /**
- * Per-instance socket path. **Must stay short** — Darwin's `sun_path`
- * is 104 bytes, and `$SUPERSET_HOME_DIR/host/{orgId}/pty-daemon.sock` blows
- * past that in dev (worktree-relative SUPERSET_HOME_DIR + 36-char UUID), so
- * the socket lives in `os.tmpdir()` under a fixed-length hash. Owner-only
- * file mode (0600, set by the daemon's Server.listen) is the auth boundary;
- * the directory permissions don't matter.
+ * Per-instance socket path. **Must stay short** — Darwin's `sun_path` is
+ * 104 bytes, so the socket lives in `os.tmpdir()` under a fixed-length hash
+ * rather than beneath (possibly worktree-deep) `SUPERSET_HOME_DIR`.
+ * Owner-only file mode (0600, set by the daemon's Server.listen) is the
+ * auth boundary; directory permissions don't matter.
  *
- * The hash covers the org id and, for non-default homes, `SUPERSET_HOME_DIR`.
- * Daemon manifests are per-home, so a home-agnostic socket let a dev
- * instance (worktree-local home) adopt the packaged app's daemon through the
- * manifest-missing socket-probe fallback — its kill/adopt bookkeeping never
- * saw the other home's manifest. Keying by home gives every home its own
- * daemon; the default home keeps the legacy org-only path so packaged apps
- * don't orphan their existing daemon on update.
+ * The hash keys on org id plus, for non-default homes, `SUPERSET_HOME_DIR`:
+ * manifests are per-home, so a home-agnostic socket let dev instances adopt
+ * the packaged app's daemon via the manifest-missing socket-probe fallback.
+ * The default home keeps the legacy org-only path so packaged apps don't
+ * orphan their existing daemon on update.
  */
 export function ptyDaemonSocketPath(
 	organizationId: string,
@@ -705,15 +702,12 @@ export class DaemonSupervisor {
 	}
 
 	private async start(organizationId: string): Promise<DaemonInstance> {
-		// Dev mode: never adopt. Dev daemons spawn attached (they die with the
-		// app), so there is never a legitimately surviving dev daemon — a
-		// leftover from a killed `bun dev` session would only mask code
-		// changes. Kill any leftover recorded in this home's manifest and
-		// spawn fresh; skipping tryAdopt entirely also keeps the
-		// manifest-missing socket-probe fallback from re-attaching a daemon
-		// this home never spawned. Production keeps the adopt path so PTY
-		// sessions survive host-service restarts (the original Phase 1
-		// promise).
+		// Dev mode: never adopt. Dev daemons spawn attached and die with the
+		// app, so a surviving dev daemon is only ever a leftover from a killed
+		// session masking code changes — kill it and spawn fresh. Skipping
+		// tryAdopt entirely also keeps the manifest-missing socket-probe
+		// fallback from re-attaching a daemon this home never spawned.
+		// Production keeps adoption so PTY sessions survive restarts.
 		const spawnFreshForDev = shouldKillStaleDaemonForDev();
 		if (spawnFreshForDev) {
 			await this.killStaleDaemonForDev(organizationId);


### PR DESCRIPTION
## Summary
- Dev instances no longer share (or adopt) the packaged app's pty-daemon. The socket path is now keyed by `sha256(orgId + SUPERSET_HOME_DIR)` for non-default homes, and dev mode skips adoption entirely — dev daemons are attached, die with the app, and never touch prod's terminals.

## Why / Context
Dev isolation was already designed in (`detached: !isDev`, no `unref`, "Dev mode: never adopt — kill stale and spawn fresh") but was defeated by a path mismatch, verified live: daemon **manifests** are per-home (`SUPERSET_HOME_DIR/host/<org>/pty-daemon-manifest.json`; dev homes are worktree-local `superset-dev-data/`), while the **socket** hashed only the org id (`tmpdir + sha256(orgId)`). On dev startup:

1. `killStaleDaemonForDev` reads the *dev home's* manifest → none exists (the packaged app's manifest lives in `~/.superset`) → kills nothing.
2. `tryAdopt` → manifest missing → `tryAdoptFromSocket` on the org-global path → finds the packaged app's live daemon → adopts it.

Consequences observed while debugging the sidebar agent-chip issue: dev terminals running as children of Canary's daemon, both instances' host DBs accumulating diverging session/binding rows for the same shared terminals, both reapers (post-#5438) operating on one substrate, and — worst case — the adopted-daemon auto-update path could hand a *prod* daemon off to a *dev* bundle via fd-handoff.

## How It Works
- **`ptyDaemonSocketPath`** hashes `orgId + ":" + SUPERSET_HOME_DIR` when the home isn't the default `~/.superset`. The default home keeps the exact legacy org-only path, so packaged apps never orphan an existing daemon on update — zero migration. Fixed-length hash keeps the path far under Darwin's 104-byte `sun_path` limit regardless of worktree-home length.
- **Dev skips `tryAdopt` entirely.** Dev daemons spawn attached and die with the app, so a surviving dev daemon is never legitimate — only a leftover from a killed `bun dev` (still cleaned via the home's manifest). Skipping adoption also closes the socket-probe fallback that did the cross-instance re-attach. `SUPERSET_PTY_DAEMON_ADOPT_IN_DEV=1` still restores production-like adoption for handoff testing.

Two dev worktrees of the same org also stop sharing a daemon (each has its own home → own socket).

## Testing
- `bun test packages/host-service/src/daemon` — 50 pass, including new `ptyDaemonSocketPath` cases (legacy path for default home, distinct + stable per home, `sun_path` length bound); the home-keying mutation makes the new test fail
- `bun run test:integration:daemon` (node, real daemon spawn/adopt/handoff) — 18 pass
- `bun run typecheck` (host-service), Biome clean
- Not exercised live: a `bun dev` session side-by-side with the packaged app post-fix. QA: launch both for the same org → two daemons (`superset-ptyd-*.sock` × 2), dev terminals die with `bun dev`, Canary terminals untouched.

## Risks / Rollout
- Risk: dev-only behavior change; the packaged app's socket path and adoption semantics are byte-identical.
- One-time dev effect: the first `bun dev` after this lands spawns a fresh daemon at the new path; any terminals a dev instance previously created inside the *shared* daemon remain owned by the packaged app's daemon (visible in Canary, not in dev). That's the corrected ownership, but it will look like dev "lost" its old terminals once.
- Rollback: revert; paths return to the shared org-only socket.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5447">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon socket path handling so non-default home directories use distinct, stable paths.
  * Preserved existing behavior for the default home directory to avoid unexpected changes.
  * Prevented socket paths from exceeding macOS path length limits in long home-directory setups.
  * In development mode, the app now starts a fresh daemon more reliably and avoids adopting stale daemon instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->