### PR TITLE
feat(desktop): show a restored-session separator when a v2 terminal cold-restores

### DIFF
--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -834,9 +834,7 @@ async function waitForOutput(
 }
 
 function sessionBufferText(session: { buffer: Uint8Array[] }): string {
-	return Buffer.concat(session.buffer.map((b) => Buffer.from(b))).toString(
-		"utf8",
-	);
+	return Buffer.concat(session.buffer).toString("utf8");
 }
 
 function makeCaptureSocket() {
@@ -851,7 +849,6 @@ function makeCaptureSocket() {
 			close: () => {},
 			readyState: 1, // SOCKET_OPEN
 		},
-		received: () =>
-			Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8"),
+		received: () => Buffer.concat(chunks).toString("utf8"),
 	};
 }

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -343,6 +343,62 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		await disposeSessionAndWait(terminalId, db);
 	});
 
+	test("restoredNotice on a fresh spawn puts the separator first in the replay buffer", async () => {
+		const terminalId = `e2e-notice-${randomUUID().slice(0, 8)}`;
+		const result = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			restoredNotice: true,
+		});
+		assert.ok(!("error" in result));
+		if ("error" in result) return;
+
+		assert.ok(result.buffer.length > 0, "replay buffer should not be empty");
+		assert.match(
+			new TextDecoder().decode(result.buffer[0]),
+			/Session Contents Restored/,
+			"first buffered chunk should be the restored-session separator",
+		);
+
+		await disposeSessionAndWait(terminalId, db);
+	});
+
+	test("restoredNotice is skipped when the daemon session is adopted", async () => {
+		const terminalId = `e2e-notice-adopt-${randomUUID().slice(0, 8)}`;
+		const first = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+		});
+		assert.ok(!("error" in first));
+
+		__resetSessionsForTesting();
+		await disposeDaemonClient();
+
+		const second = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			restoredNotice: true,
+		});
+		assert.ok(!("error" in second));
+		if ("error" in second) return;
+
+		const decoder = new TextDecoder();
+		assert.ok(
+			second.buffer.every(
+				(chunk) => !decoder.decode(chunk).includes("Session Contents Restored"),
+			),
+			"adopted (still-live) session should not get the restored separator",
+		);
+
+		await disposeSessionAndWait(terminalId, db);
+	});
+
 	test("adopted session keeps listed/exited bookkeeping", async () => {
 		const terminalId = `e2e-bookkeeping-${randomUUID().slice(0, 8)}`;
 		const first = await createTerminalSessionInternal({

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -34,6 +34,7 @@ import {
 	createTerminalSessionInternal,
 	disposeSessionAndWait,
 	listTerminalSessions,
+	replayBuffer,
 } from "./terminal.ts";
 import { __setAccountShellForTesting } from "./user-shell.ts";
 
@@ -343,7 +344,7 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		await disposeSessionAndWait(terminalId, db);
 	});
 
-	test("restoredNotice on a fresh spawn puts the separator first in the replay buffer", async () => {
+	test("restoredNotice delivers the separator ahead of shell output on first replay only", async () => {
 		const terminalId = `e2e-notice-${randomUUID().slice(0, 8)}`;
 		const result = await createTerminalSessionInternal({
 			terminalId,
@@ -355,11 +356,55 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		assert.ok(!("error" in result));
 		if ("error" in result) return;
 
-		assert.ok(result.buffer.length > 0, "replay buffer should not be empty");
+		const first = makeCaptureSocket();
+		replayBuffer(result, first.socket);
 		assert.match(
-			new TextDecoder().decode(result.buffer[0]),
+			first.received(),
 			/Session Contents Restored/,
-			"first buffered chunk should be the restored-session separator",
+			"first replay should carry the restored-session separator",
+		);
+
+		const second = makeCaptureSocket();
+		replayBuffer(result, second.socket);
+		assert.doesNotMatch(
+			second.received(),
+			/Session Contents Restored/,
+			"separator should not repeat on later replays",
+		);
+
+		await disposeSessionAndWait(terminalId, db);
+	});
+
+	test("restoredNotice survives FIFO eviction when the shell floods output before attach", async () => {
+		const terminalId = `e2e-notice-flood-${randomUUID().slice(0, 8)}`;
+		const suffix = randomUUID().slice(0, 6);
+		const result = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			restoredNotice: true,
+			// > MAX_BUFFER_BYTES (64 KiB) so the FIFO drops its oldest chunks
+			// before any socket attaches. The marker is assembled by printf so
+			// the PTY echo of the command line doesn't match it.
+			initialCommand: `head -c 200000 /dev/zero | tr '\\0' x; printf 'flood-done-%s\\n' "${suffix}"`,
+		});
+		assert.ok(!("error" in result));
+		if ("error" in result) return;
+
+		await waitFor(
+			() => sessionBufferText(result).includes(`flood-done-${suffix}`),
+			15_000,
+		);
+
+		const capture = makeCaptureSocket();
+		replayBuffer(result, capture.socket);
+		const replayed = capture.received();
+		const noticeIndex = replayed.indexOf("Session Contents Restored");
+		assert.ok(noticeIndex >= 0, "separator should survive buffer eviction");
+		assert.ok(
+			noticeIndex < replayed.indexOf("xxxx"),
+			"separator should precede the flooded shell output",
 		);
 
 		await disposeSessionAndWait(terminalId, db);
@@ -388,11 +433,11 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		assert.ok(!("error" in second));
 		if ("error" in second) return;
 
-		const decoder = new TextDecoder();
-		assert.ok(
-			second.buffer.every(
-				(chunk) => !decoder.decode(chunk).includes("Session Contents Restored"),
-			),
+		const capture = makeCaptureSocket();
+		replayBuffer(second, capture.socket);
+		assert.doesNotMatch(
+			capture.received(),
+			/Session Contents Restored/,
 			"adopted (still-live) session should not get the restored separator",
 		);
 
@@ -792,4 +837,21 @@ function sessionBufferText(session: { buffer: Uint8Array[] }): string {
 	return Buffer.concat(session.buffer.map((b) => Buffer.from(b))).toString(
 		"utf8",
 	);
+}
+
+function makeCaptureSocket() {
+	const chunks: Uint8Array[] = [];
+	return {
+		socket: {
+			send: (data: string | Uint8Array) => {
+				chunks.push(
+					typeof data === "string" ? Buffer.from(data, "utf8") : data,
+				);
+			},
+			close: () => {},
+			readyState: 1, // SOCKET_OPEN
+		},
+		received: () =>
+			Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8"),
+	};
 }

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -551,6 +551,9 @@ function broadcastBytes(session: TerminalSession, bytes: Uint8Array): number {
 }
 
 export function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
+	// sendBytes below no-ops on a non-open socket — bail before clearing the
+	// buffer/notice so the next attach can still replay them.
+	if (socket.readyState !== SOCKET_OPEN) return;
 	// Preamble first, then the restored notice, then FIFO. Mode-setting
 	// escapes (kitty keyboard, bracketed paste, focus, …) are typically
 	// emitted once at startup and broadcast away rather than buffered, so a

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -160,6 +160,12 @@ type TerminalServerMessage =
 	| { type: "title"; title: string | null };
 
 const MAX_BUFFER_BYTES = 64 * 1024;
+// Dim separator delivered ahead of a respawned shell's output so users can
+// tell restored scrollback from the fresh session (cf. VS Code's "History
+// restored" line).
+const SESSION_RESTORED_NOTICE = new TextEncoder().encode(
+	"\r\n\x1b[90m─── Session Contents Restored ───\x1b[0m\r\n\r\n",
+);
 // Cap on a single renderer socket's unflushed WebSocket send buffer. With no
 // ACK flow control, a renderer that stops draining (slow paint, pinned main
 // thread, dead tab) would let this buffer grow without bound → host OOM (the
@@ -820,6 +826,12 @@ interface CreateTerminalSessionOptions {
 	 * the WS-down window are dropped (sub-second on a daemon swap).
 	 */
 	replayOnAdoption?: boolean;
+	/**
+	 * Prefix the replay buffer with a "session restored" separator. Set on the
+	 * cold-restore respawn path, where the renderer paints stale scrollback
+	 * above a brand-new shell.
+	 */
+	restoredNotice?: boolean;
 }
 
 function resolveTerminalCwd(
@@ -867,6 +879,7 @@ export async function createTerminalSessionInternal({
 	rows: requestedRows,
 	adoptOnly = false,
 	replayOnAdoption = true,
+	restoredNotice = false,
 }: CreateTerminalSessionOptions): Promise<TerminalSession | { error: string }> {
 	const existing = sessions.get(terminalId);
 	if (existing) {
@@ -1075,6 +1088,12 @@ export async function createTerminalSessionInternal({
 	};
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
+
+	// Buffer is empty here (subscribe hasn't started), so the notice lands
+	// before the new shell's first output on replay.
+	if (restoredNotice && !isAdopted) {
+		bufferOutput(session, SESSION_RESTORED_NOTICE);
+	}
 
 	// If the marker never arrives (broken wrapper, unsupported config),
 	// the timeout unblocks so the session degrades gracefully.
@@ -1352,6 +1371,7 @@ export function registerWorkspaceTerminalRoute({
 					themeType,
 					db,
 					eventBus,
+					restoredNotice: true,
 				});
 			};
 

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -225,6 +225,12 @@ interface TerminalSession {
 	 */
 	buffer: Uint8Array[];
 	bufferBytes: number;
+	/**
+	 * Deliver SESSION_RESTORED_NOTICE ahead of the next replay. Kept out of
+	 * the FIFO so MAX_BUFFER_BYTES eviction can't drop it before a client
+	 * attaches. Cleared on first replay.
+	 */
+	restoredNoticePending: boolean;
 	createdAt: number;
 	exited: boolean;
 	exitCode: number;
@@ -544,27 +550,35 @@ function broadcastBytes(session: TerminalSession, bytes: Uint8Array): number {
 	return sent;
 }
 
-function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
-	// Preamble first, then FIFO. Mode-setting escapes (kitty keyboard,
-	// bracketed paste, focus, …) are typically emitted once at startup and
-	// broadcast away rather than buffered, so a fresh xterm needs them
-	// re-asserted on every attach — even when the FIFO is empty.
+export function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
+	// Preamble first, then the restored notice, then FIFO. Mode-setting
+	// escapes (kitty keyboard, bracketed paste, focus, …) are typically
+	// emitted once at startup and broadcast away rather than buffered, so a
+	// fresh xterm needs them re-asserted on every attach — even when the
+	// FIFO is empty.
 	const preamble = session.modeTracker.buildPreamble();
+	const notice = session.restoredNoticePending ? SESSION_RESTORED_NOTICE : null;
 	let bufferTotal = 0;
 	for (const b of session.buffer) bufferTotal += b.byteLength;
 	const preambleLen = preamble?.byteLength ?? 0;
-	if (preambleLen === 0 && bufferTotal === 0) return;
+	const noticeLen = notice?.byteLength ?? 0;
+	if (preambleLen === 0 && noticeLen === 0 && bufferTotal === 0) return;
 
-	const combined = new Uint8Array(preambleLen + bufferTotal);
+	const combined = new Uint8Array(preambleLen + noticeLen + bufferTotal);
 	let offset = 0;
 	if (preamble) {
 		combined.set(preamble, offset);
 		offset += preamble.byteLength;
 	}
+	if (notice) {
+		combined.set(notice, offset);
+		offset += notice.byteLength;
+	}
 	for (const b of session.buffer) {
 		combined.set(b, offset);
 		offset += b.byteLength;
 	}
+	session.restoredNoticePending = false;
 	session.buffer.length = 0;
 	session.bufferBytes = 0;
 	sendBytes(socket, combined);
@@ -827,8 +841,8 @@ interface CreateTerminalSessionOptions {
 	 */
 	replayOnAdoption?: boolean;
 	/**
-	 * Prefix the replay buffer with a "session restored" separator. Set on the
-	 * cold-restore respawn path, where the renderer paints stale scrollback
+	 * Deliver a "session restored" separator ahead of the first replay. Set on
+	 * the cold-restore respawn path, where the renderer paints stale scrollback
 	 * above a brand-new shell.
 	 */
 	restoredNotice?: boolean;
@@ -1064,6 +1078,8 @@ export async function createTerminalSessionInternal({
 		sockets: new Set(),
 		buffer: [],
 		bufferBytes: 0,
+		// Adopted sessions kept a live shell — nothing was restored.
+		restoredNoticePending: restoredNotice && !isAdopted,
 		createdAt,
 		exited: false,
 		exitCode: 0,
@@ -1088,12 +1104,6 @@ export async function createTerminalSessionInternal({
 	};
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
-
-	// Buffer is empty here (subscribe hasn't started), so the notice lands
-	// before the new shell's first output on replay.
-	if (restoredNotice && !isAdopted) {
-		bufferOutput(session, SESSION_RESTORED_NOTICE);
-	}
 
 	// If the marker never arrives (broken wrapper, unsupported config),
 	// the timeout unblocks so the session degrades gracefully.


### PR DESCRIPTION
## Summary
- When host-service respawns a lost terminal session (reboot, pty-daemon loss), it now injects a dim `─── Session Contents Restored ───` separator into the replay buffer ahead of the new shell's first output — so users can tell restored scrollback from the fresh session instead of a new prompt silently appearing under dead content.

## Why / Context
In v2, a cold restore is host-side: the renderer paints its persisted scrollback, then the WS attach finds an `active` session row whose PTY the daemon no longer owns, and host-service respawns a fresh shell (`packages/host-service/src/terminal/terminal.ts` WS route fallback). Previously nothing marked the boundary — users saw their old content with a brand-new prompt below and no hint the session had died. Other terminal apps mark this (VS Code's "History restored", iTerm2's session-restored banner).

## How It Works
- New `restoredNotice` option on `createTerminalSessionInternal`, set only by the WS respawn fallback.
- The separator bytes are appended to the session's replay buffer immediately after session registration — the buffer is empty at that point (daemon subscribe hasn't started), so the notice is guaranteed to precede the new shell's first output on replay.
- Injecting inside `createTerminalSessionInternal` (not at the call site) dedupes concurrent attaches racing into the respawn path, and the `!isAdopted` guard suppresses the notice when the daemon still owns a live shell (host-service restart adoption) — nothing died, so no separator.
- Host-side injection means any client (desktop renderer, future web) gets it with no renderer changes, and it persists into xterm scrollback/localStorage like ordinary output.

## Manual QA Checklist
Verified end-to-end in the dev desktop app over CDP:
- [x] Cold restore: killed host-service + the terminal's shell, reloaded the renderer → reattach respawned the shell and the dim separator rendered between the restored scrollback (marker output intact) and the fresh prompt
- [x] Adoption path: reattaching to a still-live daemon session shows no separator
- [x] Fresh terminals (POST /terminal/sessions) unaffected — no separator

## Testing
- `bun run lint` (clean)
- `bun run typecheck` for `@superset/host-service` (clean)
- `node --experimental-strip-types --test src/terminal/terminal.adoption.node-test.ts` — 17/17 pass, including two new tests: separator is first in the replay buffer on a respawn; absent on adoption. Both were mutation-verified (breaking the guard or removing the injection fails the corresponding test). Note: these run under node ABI; a `node_modules` currently rebuilt for Electron will ERR_DLOPEN until rebuilt for node.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5448">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dim "─── Session Contents Restored ───" separator on v2 terminal cold-restore so users see where restored scrollback ends and the new shell begins. Skipped when adopting a still-live daemon session; survives buffer eviction and closed-socket attaches.

- New Features
  - Host-service prepends the notice on the first replay, after the mode preamble and before the new shell’s output.
  - Added `restoredNotice` to `createTerminalSessionInternal`; set only by the WS respawn path and ignored when `isAdopted` is true.
  - Injected server-side so all clients get it, and it persists in scrollback.

- Bug Fixes
  - Kept the separator out of the bounded replay FIFO; `replayBuffer` now prepends it on first attach so large output bursts can’t evict it.
  - Ensured the separator appears only on the first replay; added tests for flood and adoption, and cleaned up redundant test buffer copies.
  - Avoided losing the notice when an attach socket is already closed; `replayBuffer` now bails early instead of clearing replay state.

<sup>Written for commit 5595d16b1e89338b946675b56f3dc86a5df83e86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Session Contents Restored” separator to terminal scrollback during cold restores/respawns, inserted before the recreated session’s replayed output.
* **Bug Fixes**
  * Ensured the separator appears only once per restore, remains ahead of any flooded output, and is omitted when attaching to an already-active adopted session.
* **Tests**
  * Added end-to-end coverage for restored-notice ordering and presence/absence across restore scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->