### PR TITLE
fix(host-service): heal trustd-degraded pty-daemons (gh x509 -26276)

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -25,6 +25,7 @@ import {
 	type ServerMessage,
 	type SessionInfo,
 } from "@superset/pty-daemon/protocol";
+import { probeTrustdHealthy } from "@superset/pty-daemon/trustd-probe";
 import semver from "semver";
 import { DaemonClient } from "../terminal/DaemonClient/index.ts";
 import { EXPECTED_DAEMON_VERSION } from "./expected-version.ts";
@@ -50,11 +51,17 @@ interface DaemonInstance {
 	updatePending: boolean;
 	/** Last failed background update attempt for this still-running daemon. */
 	autoUpdateFailure?: DaemonAutoUpdateFailure;
+	/**
+	 * macOS trustd reachability the daemon self-reported. `false` = degraded
+	 * (its terminals hit `gh -26276`); undefined = pre-probe daemon version.
+	 */
+	trustdHealthy?: boolean;
 }
 
 interface DaemonProbeResult {
 	daemonVersion: string;
 	daemonPid?: number;
+	trustdHealthy?: boolean;
 }
 
 export interface DaemonAutoUpdateFailure {
@@ -177,9 +184,45 @@ export class DaemonSupervisor {
 		string,
 		Promise<{ ok: true; successorPid: number } | { ok: false; reason: string }>
 	>();
+	/** Whether host-service itself can reach trustd; probed once, cached. */
+	private hostTrustdHealthyCache: boolean | null = null;
 
 	constructor(opts: DaemonSupervisorOptions) {
 		this.opts = opts;
+	}
+
+	/**
+	 * Whether host-service's own Mach bootstrap can reach com.apple.trustd. Used
+	 * to gate healing a trustd-degraded daemon: only worth respawning from here
+	 * if we're healthy. Cached — a process's bootstrap doesn't change under it.
+	 */
+	private hostTrustdHealthy(): boolean {
+		if (this.hostTrustdHealthyCache === null) {
+			this.hostTrustdHealthyCache = probeTrustdHealthy();
+		}
+		return this.hostTrustdHealthyCache;
+	}
+
+	/**
+	 * Terminate an adopted daemon so ensure() can respawn a fresh one. An
+	 * adopted daemon has no child handle or crash-respawn hook attached yet, so
+	 * this just kills its process tree and clears its manifest + socket. Its PTY
+	 * sessions are lost — acceptable, since a trustd-degraded daemon's shells are
+	 * already broken for `gh`/TLS.
+	 */
+	private async killAdoptedDaemon(
+		organizationId: string,
+		instance: DaemonInstance,
+	): Promise<void> {
+		await terminateProcessTreeAndGroups(instance.pid, "SIGTERM");
+		removePtyDaemonManifest(organizationId);
+		try {
+			if (fs.existsSync(instance.socketPath)) {
+				fs.unlinkSync(instance.socketPath);
+			}
+		} catch {
+			// best-effort; the fresh daemon unlinks a stale socket on bind anyway
+		}
 	}
 
 	/**
@@ -705,7 +748,26 @@ export class DaemonSupervisor {
 			await this.killStaleDaemonForDev(organizationId);
 		}
 
-		const adopted = await this.tryAdopt(organizationId);
+		let adopted = await this.tryAdopt(organizationId);
+		// Heal a trustd-degraded daemon: it inherited a Mach bootstrap that can't
+		// reach com.apple.trustd, so its terminals hit `gh: x509: OSStatus -26276`.
+		// Adopting it keeps the breakage — if WE (host-service) can reach trustd,
+		// kill it and respawn fresh from our healthy context below. If we're also
+		// degraded, a respawn wouldn't help; adopt and let the next healthy launch
+		// heal it.
+		if (
+			adopted &&
+			adopted.trustdHealthy === false &&
+			this.hostTrustdHealthy()
+		) {
+			logEvent("pty_daemon_trustd_degraded_respawn", {
+				organizationId,
+				pid: adopted.pid,
+				runningVersion: adopted.runningVersion,
+			});
+			await this.killAdoptedDaemon(organizationId, adopted);
+			adopted = null;
+		}
 		if (adopted) {
 			this.instances.set(organizationId, adopted);
 			console.log(
@@ -828,6 +890,7 @@ export class DaemonSupervisor {
 			runningVersion,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
 			updatePending,
+			trustdHealthy: probe.trustdHealthy,
 		};
 	}
 
@@ -895,6 +958,7 @@ export class DaemonSupervisor {
 				probe.daemonVersion,
 				`>=${EXPECTED_DAEMON_VERSION}`,
 			),
+			trustdHealthy: probe.trustdHealthy,
 		};
 	}
 
@@ -1085,6 +1149,9 @@ export class DaemonSupervisor {
 			runningVersion: EXPECTED_DAEMON_VERSION,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
 			updatePending: false,
+			// A freshly spawned daemon inherits host-service's bootstrap, so its
+			// trustd reachability matches ours.
+			trustdHealthy: this.hostTrustdHealthy(),
 		};
 		this.instances.set(organizationId, instance);
 		console.log(
@@ -1376,6 +1443,7 @@ function probeDaemonHello(
 						cleanup({
 							daemonVersion,
 							daemonPid: msg.daemonPid,
+							trustdHealthy: msg.trustdHealthy,
 						});
 						return;
 					}

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/pty-daemon",
-	"version": "0.2.4",
+	"version": "0.3.0",
 	"private": true,
 	"type": "module",
 	"exports": {
@@ -16,6 +16,10 @@
 			"types": "./src/process-tree.ts",
 			"default": "./src/process-tree.ts"
 		},
+		"./trustd-probe": {
+			"types": "./src/trustd-probe.ts",
+			"default": "./src/trustd-probe.ts"
+		},
 		"./package.json": "./package.json"
 	},
 	"bin": {
@@ -29,7 +33,7 @@
 		"start": "node --experimental-strip-types src/main.ts",
 		"build:daemon": "bun run build.ts",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
-		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts test/no-encoding-hops.test.ts",
+		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/trustd-probe.test.ts test/no-encoding-hops.test.ts",
 		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts"
 	},
 	"dependencies": {

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -58,11 +58,24 @@ export class Server {
 	private readonly store: SessionStore;
 	private readonly conns = new Set<ConnState>();
 	private readonly opts: ServerOptions;
+	/**
+	 * macOS trustd reachability, surfaced in the hello-ack. Mutable so the
+	 * (blocking) probe can run AFTER the socket binds / handoff-ack is sent
+	 * rather than delaying either — see main.ts. Until set, hello-ack omits it
+	 * and the supervisor treats that as "unknown" (no respawn).
+	 */
+	private trustdHealthy: boolean | undefined;
 
 	constructor(opts: ServerOptions) {
 		this.opts = opts;
+		this.trustdHealthy = opts.trustdHealthy;
 		this.store = new SessionStore({ bufferCap: opts.bufferCap });
 		this.server = net.createServer((socket) => this.onConnection(socket));
+	}
+
+	/** Update the trustd-health value reported in subsequent hello-acks. */
+	setTrustdHealthy(healthy: boolean): void {
+		this.trustdHealthy = healthy;
 	}
 
 	async listen(): Promise<void> {
@@ -375,7 +388,7 @@ export class Server {
 				protocol: negotiated,
 				daemonVersion: this.opts.daemonVersion,
 				daemonPid: process.pid,
-				trustdHealthy: this.opts.trustdHealthy,
+				trustdHealthy: this.trustdHealthy,
 			});
 			return;
 		}

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -33,6 +33,8 @@ import {
 export interface ServerOptions {
 	socketPath: string;
 	daemonVersion: string;
+	/** macOS trustd reachability, probed once at daemon startup; see main.ts. */
+	trustdHealthy?: boolean;
 	bufferCap?: number;
 	outboundBufferCap?: number;
 	/**
@@ -373,6 +375,7 @@ export class Server {
 				protocol: negotiated,
 				daemonVersion: this.opts.daemonVersion,
 				daemonPid: process.pid,
+				trustdHealthy: this.opts.trustdHealthy,
 			});
 			return;
 		}

--- a/packages/pty-daemon/src/main.ts
+++ b/packages/pty-daemon/src/main.ts
@@ -20,6 +20,7 @@ import packageJson from "../package.json" with { type: "json" };
 import type { HandoffMessage } from "./protocol/index.ts";
 import { Server } from "./Server/index.ts";
 import { clearSnapshot, readSnapshot } from "./SessionStore/index.ts";
+import { probeTrustdHealthy } from "./trustd-probe.ts";
 
 const DAEMON_VERSION: string = packageJson.version;
 
@@ -75,6 +76,7 @@ async function runFresh(): Promise<void> {
 	const server = new Server({
 		socketPath: args.socket,
 		daemonVersion,
+		trustdHealthy: probeTrustdHealthy(),
 		bufferCap: args.bufferBytes,
 	});
 	await server.listen();
@@ -136,7 +138,11 @@ async function runHandoffReceiver(): Promise<void> {
 		return;
 	}
 	log(`read snapshot: sessions=${snapshot.sessions.length}`);
-	const server = new Server({ socketPath, daemonVersion });
+	const server = new Server({
+		socketPath,
+		daemonVersion,
+		trustdHealthy: probeTrustdHealthy(),
+	});
 
 	try {
 		log(`adopting ${snapshot.sessions.length} sessions`);

--- a/packages/pty-daemon/src/main.ts
+++ b/packages/pty-daemon/src/main.ts
@@ -76,10 +76,13 @@ async function runFresh(): Promise<void> {
 	const server = new Server({
 		socketPath: args.socket,
 		daemonVersion,
-		trustdHealthy: probeTrustdHealthy(),
 		bufferCap: args.bufferBytes,
 	});
 	await server.listen();
+	// Probe AFTER binding so a slow `security` can't delay the socket coming up
+	// (the supervisor has a socket-ready timeout). The value lands before the
+	// supervisor's adoption hello, which happens well after bind.
+	server.setTrustdHealthy(probeTrustdHealthy());
 	process.stderr.write(
 		`[pty-daemon] listening on ${args.socket} (v${daemonVersion}, host=${os.hostname()})\n`,
 	);
@@ -138,11 +141,7 @@ async function runHandoffReceiver(): Promise<void> {
 		return;
 	}
 	log(`read snapshot: sessions=${snapshot.sessions.length}`);
-	const server = new Server({
-		socketPath,
-		daemonVersion,
-		trustdHealthy: probeTrustdHealthy(),
-	});
+	const server = new Server({ socketPath, daemonVersion });
 
 	try {
 		log(`adopting ${snapshot.sessions.length} sessions`);
@@ -187,6 +186,9 @@ async function runHandoffReceiver(): Promise<void> {
 	log(`predecessor disconnected, binding socket`);
 
 	await server.listenWithRetry();
+	// Probe only now: it's a blocking spawnSync, and running it earlier would
+	// delay the upgrade-ack the predecessor is waiting on (and the socket bind).
+	server.setTrustdHealthy(probeTrustdHealthy());
 	log(`bound and listening`);
 	process.stderr.write(
 		`[pty-daemon] (handoff successor) listening on ${socketPath} (v${daemonVersion}, host=${os.hostname()}, sessions=${snapshot.sessions.length})\n`,

--- a/packages/pty-daemon/src/protocol/messages.ts
+++ b/packages/pty-daemon/src/protocol/messages.ts
@@ -41,6 +41,13 @@ export interface HelloAckMessage {
 	 * missing or stale.
 	 */
 	daemonPid?: number;
+	/**
+	 * macOS only: whether the daemon's Mach bootstrap can reach `com.apple.trustd`
+	 * (Security-framework TLS trust evaluation). False means terminals it spawns
+	 * hit `gh: x509: OSStatus -26276`; the supervisor respawns such a daemon from
+	 * its own healthy context. Absent from pre-probe daemon versions.
+	 */
+	trustdHealthy?: boolean;
 }
 
 // ---------- Client -> Daemon ----------

--- a/packages/pty-daemon/src/trustd-probe.test.ts
+++ b/packages/pty-daemon/src/trustd-probe.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import { probeTrustdHealthy } from "./trustd-probe.ts";
+
+const FAKE_BUNDLE = `-----BEGIN CERTIFICATE-----\nMIIFakeCertBytes\n-----END CERTIFICATE-----\n`;
+
+describe("probeTrustdHealthy", () => {
+	it("returns true on non-darwin without running anything", () => {
+		let ran = false;
+		const healthy = probeTrustdHealthy({
+			platform: "linux",
+			run: () => {
+				ran = true;
+				return { status: 1 };
+			},
+		});
+		expect(healthy).toBe(true);
+		expect(ran).toBe(false);
+	});
+
+	it("returns true when verify-cert exits 0 (trustd reachable)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: 0 }),
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when verify-cert exits non-zero (trustd unreachable)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: 1 }),
+			}),
+		).toBe(false);
+	});
+
+	it("verifies the extracted cert (passes -c <file> to security verify-cert)", () => {
+		let cmd = "";
+		let args: string[] = [];
+		probeTrustdHealthy({
+			platform: "darwin",
+			readBundle: () => FAKE_BUNDLE,
+			pid: 999,
+			run: (c, a) => {
+				cmd = c;
+				args = a;
+				return { status: 0 };
+			},
+		});
+		expect(cmd).toBe("security");
+		expect(args[0]).toBe("verify-cert");
+		expect(args[1]).toBe("-c");
+		expect(args[2]).toMatch(/superset-trustd-probe-999\.pem$/);
+	});
+
+	it("assumes healthy when the CA bundle has no cert (can't determine)", () => {
+		let ran = false;
+		const healthy = probeTrustdHealthy({
+			platform: "darwin",
+			readBundle: () => "no certs here",
+			run: () => {
+				ran = true;
+				return { status: 1 };
+			},
+		});
+		expect(healthy).toBe(true);
+		expect(ran).toBe(false);
+	});
+
+	it("assumes healthy when the probe throws (bundle unreadable)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => {
+					throw new Error("ENOENT");
+				},
+				run: () => ({ status: 1 }),
+			}),
+		).toBe(true);
+	});
+
+	it("assumes healthy when the probe times out / errors (inconclusive)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: null, error: new Error("ETIMEDOUT") }),
+			}),
+		).toBe(true);
+	});
+
+	it("assumes healthy when the probe is killed by a signal (status null)", () => {
+		expect(
+			probeTrustdHealthy({
+				platform: "darwin",
+				readBundle: () => FAKE_BUNDLE,
+				run: () => ({ status: null }),
+			}),
+		).toBe(true);
+	});
+});

--- a/packages/pty-daemon/src/trustd-probe.test.ts
+++ b/packages/pty-daemon/src/trustd-probe.test.ts
@@ -43,7 +43,6 @@ describe("probeTrustdHealthy", () => {
 		probeTrustdHealthy({
 			platform: "darwin",
 			readBundle: () => FAKE_BUNDLE,
-			pid: 999,
 			run: (c, a) => {
 				cmd = c;
 				args = a;
@@ -53,7 +52,26 @@ describe("probeTrustdHealthy", () => {
 		expect(cmd).toBe("security");
 		expect(args[0]).toBe("verify-cert");
 		expect(args[1]).toBe("-c");
-		expect(args[2]).toMatch(/superset-trustd-probe-999\.pem$/);
+		expect(args[2]).toMatch(/superset-trustd-[^/]+\/probe\.pem$/);
+	});
+
+	it("finds the END marker after BEGIN when an earlier PEM type precedes it", () => {
+		// A "TRUSTED CERTIFICATE" block's END sits before the first plain
+		// "BEGIN CERTIFICATE"; indexOf(END, begin) must skip it.
+		const mixed =
+			"-----BEGIN TRUSTED CERTIFICATE-----\nAAA\n-----END TRUSTED CERTIFICATE-----\n" +
+			"-----BEGIN CERTIFICATE-----\nBBB\n-----END CERTIFICATE-----\n";
+		let seenArgs: string[] = [];
+		probeTrustdHealthy({
+			platform: "darwin",
+			readBundle: () => mixed,
+			run: (_c, a) => {
+				seenArgs = a;
+				return { status: 0 };
+			},
+		});
+		// Reached the run step (didn't bail on a bogus end<begin slice).
+		expect(seenArgs[0]).toBe("verify-cert");
 	});
 
 	it("assumes healthy when the CA bundle has no cert (can't determine)", () => {

--- a/packages/pty-daemon/src/trustd-probe.ts
+++ b/packages/pty-daemon/src/trustd-probe.ts
@@ -1,0 +1,89 @@
+// Detects whether the current process's macOS Mach bootstrap can reach
+// `com.apple.trustd` — i.e. whether Security-framework TLS trust evaluation
+// works. When it can't (a degraded bootstrap: updater relaunch, a dead
+// login-session port after logout/login, etc.), Go binaries like `gh` fail
+// with `x509: OSStatus -26276` and headless Chromium aborts with
+// `bootstrap_check_in error 141`.
+//
+// Node/curl can't detect this: they use their own TLS stack, not Secure
+// Transport, so they succeed even when trustd is unreachable. `security
+// verify-cert` DOES exercise the platform verifier — exit 0 when trustd is
+// reachable, non-zero when it isn't — so it's the reliable probe.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const SYSTEM_CERT_BUNDLE = "/etc/ssl/cert.pem";
+const BEGIN = "-----BEGIN CERTIFICATE-----";
+const END = "-----END CERTIFICATE-----";
+
+export interface TrustdProbeResult {
+	status: number | null;
+	error?: Error;
+}
+
+export interface TrustdProbeDeps {
+	platform?: NodeJS.Platform;
+	/** Runs a command; mirrors spawnSync's status/error. */
+	run?: (cmd: string, args: string[]) => TrustdProbeResult;
+	/** Reads the system CA bundle (source of a known-good cert to verify). */
+	readBundle?: () => string;
+	tmpDir?: string;
+	pid?: number;
+}
+
+// Bounded so a wedged `security` can't stall daemon startup (the probe runs
+// before the socket binds). Comfortably under the supervisor's socket-ready
+// timeout; a real probe takes tens of milliseconds.
+const PROBE_TIMEOUT_MS = 3_000;
+
+/**
+ * True when the platform verifier (trustd) is reachable. macOS only — other
+ * platforms have no such coupling and always return true. We only report
+ * `false` on a clean non-zero exit from `security verify-cert`; any spawn
+ * error, timeout, or signal death is inconclusive and reported healthy, so a
+ * flaky probe never triggers an unwarranted (session-destroying) respawn.
+ */
+export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
+	const platform = deps.platform ?? process.platform;
+	if (platform !== "darwin") return true;
+
+	const run =
+		deps.run ??
+		((cmd: string, args: string[]) =>
+			spawnSync(cmd, args, { timeout: PROBE_TIMEOUT_MS }));
+
+	let certPath: string | undefined;
+	try {
+		const bundle = deps.readBundle
+			? deps.readBundle()
+			: fs.readFileSync(SYSTEM_CERT_BUNDLE, "utf8");
+		const begin = bundle.indexOf(BEGIN);
+		const end = bundle.indexOf(END);
+		if (begin === -1 || end === -1 || end < begin) return true;
+		// A cert from the trust store verifies cleanly WHEN trustd is reachable,
+		// so a non-zero exit isolates "trustd unreachable" from "bad cert".
+		const cert = `${bundle.slice(begin, end + END.length)}\n`;
+		certPath = path.join(
+			deps.tmpDir ?? os.tmpdir(),
+			`superset-trustd-probe-${deps.pid ?? process.pid}.pem`,
+		);
+		fs.writeFileSync(certPath, cert, { mode: 0o600 });
+		const result = run("security", ["verify-cert", "-c", certPath]);
+		if (result.error) return true; // spawn failed / timed out → inconclusive
+		if (typeof result.status !== "number") return true; // killed by signal
+		return result.status === 0;
+	} catch {
+		return true;
+	} finally {
+		if (certPath) {
+			try {
+				fs.unlinkSync(certPath);
+			} catch {
+				// best-effort
+			}
+		}
+	}
+}

--- a/packages/pty-daemon/src/trustd-probe.ts
+++ b/packages/pty-daemon/src/trustd-probe.ts
@@ -31,7 +31,6 @@ export interface TrustdProbeDeps {
 	/** Reads the system CA bundle (source of a known-good cert to verify). */
 	readBundle?: () => string;
 	tmpDir?: string;
-	pid?: number;
 }
 
 // Bounded so a wedged `security` can't stall daemon startup (the probe runs
@@ -55,21 +54,26 @@ export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
 		((cmd: string, args: string[]) =>
 			spawnSync(cmd, args, { timeout: PROBE_TIMEOUT_MS }));
 
-	let certPath: string | undefined;
+	let certDir: string | undefined;
 	try {
 		const bundle = deps.readBundle
 			? deps.readBundle()
 			: fs.readFileSync(SYSTEM_CERT_BUNDLE, "utf8");
 		const begin = bundle.indexOf(BEGIN);
-		const end = bundle.indexOf(END);
-		if (begin === -1 || end === -1 || end < begin) return true;
+		// Search for END only from BEGIN onward so a different earlier PEM type
+		// (e.g. "BEGIN TRUSTED CERTIFICATE") whose END sits before the first
+		// "BEGIN CERTIFICATE" can't produce a bogus slice.
+		const end = bundle.indexOf(END, begin);
+		if (begin === -1 || end === -1) return true;
 		// A cert from the trust store verifies cleanly WHEN trustd is reachable,
 		// so a non-zero exit isolates "trustd unreachable" from "bad cert".
 		const cert = `${bundle.slice(begin, end + END.length)}\n`;
-		certPath = path.join(
-			deps.tmpDir ?? os.tmpdir(),
-			`superset-trustd-probe-${deps.pid ?? process.pid}.pem`,
+		// mkdtemp gives a fresh 0700 dir, so the cert path is unpredictable and
+		// can't be pre-seeded as a symlink (TOCTOU) or collide across runs.
+		certDir = fs.mkdtempSync(
+			path.join(deps.tmpDir ?? os.tmpdir(), "superset-trustd-"),
 		);
+		const certPath = path.join(certDir, "probe.pem");
 		fs.writeFileSync(certPath, cert, { mode: 0o600 });
 		const result = run("security", ["verify-cert", "-c", certPath]);
 		if (result.error) return true; // spawn failed / timed out → inconclusive
@@ -78,9 +82,9 @@ export function probeTrustdHealthy(deps: TrustdProbeDeps = {}): boolean {
 	} catch {
 		return true;
 	} finally {
-		if (certPath) {
+		if (certDir) {
 			try {
-				fs.unlinkSync(certPath);
+				fs.rmSync(certDir, { recursive: true, force: true });
 			} catch {
 				// best-effort
 			}


### PR DESCRIPTION
## Problem

`gh` (and other Go/Secure-Transport tools) fail inside Superset terminals with `tls: failed to verify certificate: x509: OSStatus -26276`, while working fine in a regular terminal.

**Root cause:** `-26276` = the process's macOS Mach bootstrap can't look up `com.apple.trustd` (the trust-evaluation daemon). The pty-daemon is detached and *adopted* across app/host-service restarts, so if it ever inherits a bootstrap that can't reach trustd (updater relaunch, a dead login-session port after logout/login), every terminal it spawns is broken — and adoption keeps the bad daemon alive indefinitely.

Reproduced deterministically with no signed build:
```
sandbox-exec -p '(deny mach-lookup (global-name "com.apple.trustd"))' gh api  →  x509: OSStatus -26276
```

Note: `SSL_CERT_FILE` is a **no-op** for `gh` here (Go uses the platform verifier), and Node/curl can't self-detect this (they don't use Secure Transport). Only `security verify-cert` exercises the same path.

## Fix (no `launchctl asuser`, no root)

host-service is a fresh `detached:false` child of the Aqua Electron app, so a plain daemon spawn from it always reaches trustd. So:

1. **Daemon self-probes** trustd at startup (`security verify-cert`) and reports `trustdHealthy` in the hello-ack.
2. **host-service**, on adopt: if the daemon reports trustd-degraded **and** host-service self-probes healthy → kill it and respawn fresh (which lands in a healthy bootstrap). If host-service is itself degraded, adopt and let the next healthy launch heal it.
3. **Migration:** daemon version `0.2.4 → 0.3.0` — existing daemons smooth-update onto the trustd-aware binary (sessions preserved via fd-handoff), then degraded ones self-report and get respawned on a later adopt. No forced mass session loss.

The probe is conservative: only a clean non-zero exit means degraded (errors/timeouts → healthy), so a flaky probe never triggers a session-destroying respawn.

## Test Plan

- [x] Reproduced `-26276` and validated `security verify-cert` as the discriminator (agrees with the real `gh` symptom)
- [x] End-to-end: real daemon spawned under a trustd-deny sandbox is detected (`pty_daemon_trustd_degraded_respawn`) and replaced with a healthy one
- [x] Probe unit tests (mutation-checked): 8
- [x] pty-daemon unit 65, integration 48
- [x] host-service unit 47, integration 18
- [x] typecheck + biome clean across pty-daemon, host-service, desktop

## Note

Supersedes the `detached:false`-on-darwin approach in #5429 — that rests on the (empirically refuted) premise that detachment severs the bootstrap, and it removes PTY signal isolation.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5450">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS reachability probe for the system trust service and exposed the result during the daemon startup/handshake.
  * Daemon servers can now report and update this “trustd healthy” flag after binding (including during handoff).

* **Bug Fixes**
  * If an adopted daemon reports it can’t reach the trust service while the host can, it’s automatically terminated and replaced with a fresh daemon.

* **Tests**
  * Added coverage for the trustd probe behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->