### PR TITLE
fix(host-service): stop workspace↔PR/diff state drifting from GitHub

### DIFF
--- a/packages/host-service/src/runtime/git/refs.test.ts
+++ b/packages/host-service/src/runtime/git/refs.test.ts
@@ -180,6 +180,29 @@ describe("resolveRef — input shape contract", () => {
 		expect(await resolveRef(git, "head")).toBeNull();
 	});
 
+	// A genuine for-each-ref failure must propagate, not degrade to "no
+	// branches" — masking it would make an existing branch look absent and let
+	// a case-twin be created (the bug this module exists to prevent).
+	test("propagates a for-each-ref failure instead of returning null", async () => {
+		const git = {
+			raw: mock(async (args: string[]) => {
+				if (args[0] === "for-each-ref") {
+					throw new Error("fatal: not a git repository");
+				}
+				throw new Error(`Unexpected raw args: ${args.join(" ")}`);
+			}),
+		} as never;
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			await expect(resolveRef(git, "foo")).rejects.toThrow(
+				"not a git repository",
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
 	test("custom remote name probes that remote, not origin", async () => {
 		const git = createMockGit(new Set(["refs/remotes/upstream/foo"]));
 		const r = await resolveRef(git, "foo", { remote: "upstream" });

--- a/packages/host-service/src/runtime/git/refs.test.ts
+++ b/packages/host-service/src/runtime/git/refs.test.ts
@@ -3,12 +3,20 @@ import { asLocalRef, asRemoteRef, resolveRef } from "./refs";
 
 /**
  * Mock git that knows about a fixed set of FULL refnames. Mirrors how
- * `resolveRef` probes (always with `refs/heads/...` / `refs/remotes/.../...`
- * / `refs/tags/...`).
+ * `resolveRef` looks refs up: branch enumeration via `for-each-ref`
+ * (which reports refnames exactly as stored, case-sensitively) and tag
+ * probes via `rev-parse --verify`.
  */
 function createMockGit(existingFullRefs: Set<string>) {
 	return {
 		raw: mock(async (args: string[]) => {
+			if (args[0] === "for-each-ref") {
+				const prefixes = args.filter((arg) => arg.startsWith("refs/"));
+				const lines = [...existingFullRefs].filter((ref) =>
+					prefixes.some((prefix) => ref.startsWith(prefix)),
+				);
+				return lines.length > 0 ? `${lines.join("\n")}\n` : "";
+			}
 			if (args[0] === "rev-parse" && args[1] === "--verify") {
 				const ref = args[2]?.replace("^{commit}", "") ?? "";
 				if (existingFullRefs.has(ref)) {
@@ -119,6 +127,57 @@ describe("resolveRef — input shape contract", () => {
 		expect(await resolveRef(git, "   ")).toBeNull();
 		const r = await resolveRef(git, "", { headFallback: true });
 		expect(r?.kind).toBe("head");
+	});
+
+	// Case drift: on case-insensitive filesystems a differently-cased branch
+	// name shares the existing branch's loose-ref file, so creating a
+	// "new" case-twin silently corrupts the existing branch. resolveRef must
+	// adopt the canonical casing instead of reporting a miss.
+	test("adopts canonical casing of an existing local branch", async () => {
+		const git = createMockGit(new Set(["refs/heads/Roshvan/fix-thing"]));
+		const r = await resolveRef(git, "roshvan/fix-thing");
+		expect(r?.kind).toBe("local");
+		if (r?.kind === "local") {
+			expect(r.shortName).toBe("Roshvan/fix-thing");
+			expect(r.fullRef).toBe("refs/heads/Roshvan/fix-thing");
+		}
+	});
+
+	test("adopts canonical casing of an existing remote branch", async () => {
+		const git = createMockGit(
+			new Set(["refs/remotes/origin/Roshvan/fix-thing"]),
+		);
+		const r = await resolveRef(git, "roshvan/fix-thing");
+		expect(r?.kind).toBe("remote-tracking");
+		if (r?.kind === "remote-tracking") {
+			expect(r.shortName).toBe("Roshvan/fix-thing");
+			expect(r.remoteShortName).toBe("origin/Roshvan/fix-thing");
+			expect(r.fullRef).toBe("refs/remotes/origin/Roshvan/fix-thing");
+		}
+	});
+
+	test("exact remote match beats a case-twin local branch", async () => {
+		const git = createMockGit(
+			new Set(["refs/heads/Foo", "refs/remotes/origin/foo"]),
+		);
+		const r = await resolveRef(git, "foo");
+		expect(r?.kind).toBe("remote-tracking");
+		if (r?.kind === "remote-tracking") {
+			expect(r.shortName).toBe("foo");
+		}
+	});
+
+	test("exact tag match beats a case-twin branch", async () => {
+		const git = createMockGit(new Set(["refs/heads/Foo", "refs/tags/foo"]));
+		const r = await resolveRef(git, "foo");
+		expect(r?.kind).toBe("tag");
+	});
+
+	test("`head` does not case-insensitively match refs/remotes/origin/HEAD", async () => {
+		const git = createMockGit(
+			new Set(["refs/remotes/origin/HEAD", "refs/heads/main"]),
+		);
+		expect(await resolveRef(git, "head")).toBeNull();
 	});
 
 	test("custom remote name probes that remote, not origin", async () => {

--- a/packages/host-service/src/runtime/git/refs.ts
+++ b/packages/host-service/src/runtime/git/refs.ts
@@ -52,6 +52,50 @@ async function refExists(git: SimpleGit, fullRef: string): Promise<boolean> {
 	}
 }
 
+/**
+ * Enumerate the true branch refnames git knows about. Used instead of
+ * per-ref `rev-parse` probes for branch resolution: on case-insensitive
+ * filesystems (macOS default) a loose-ref probe like
+ * `rev-parse refs/heads/foo` happily resolves the `refs/heads/Foo` file,
+ * so probing can't distinguish exact matches from case drift.
+ * `for-each-ref` reports refnames as git stores them.
+ */
+async function listBranchShortNames(
+	git: SimpleGit,
+	remote: string,
+): Promise<{ local: string[]; remoteTracking: string[] }> {
+	const local: string[] = [];
+	const remoteTracking: string[] = [];
+	try {
+		const raw = await git.raw([
+			"for-each-ref",
+			"--format=%(refname)",
+			"refs/heads/",
+			`refs/remotes/${remote}/`,
+		]);
+		const remotePrefix = `refs/remotes/${remote}/`;
+		for (const refname of raw.trim().split("\n").filter(Boolean)) {
+			if (refname.startsWith("refs/heads/")) {
+				local.push(refname.slice("refs/heads/".length));
+			} else if (refname.startsWith(remotePrefix)) {
+				const name = refname.slice(remotePrefix.length);
+				if (name !== "HEAD") remoteTracking.push(name);
+			}
+		}
+	} catch {
+		// Unborn/empty repos have no refs; fall through with empty lists.
+	}
+	return { local, remoteTracking };
+}
+
+function findCaseInsensitiveMatch(
+	names: string[],
+	input: string,
+): string | null {
+	const lower = input.toLowerCase();
+	return names.find((name) => name.toLowerCase() === lower) ?? null;
+}
+
 export interface ResolveRefOptions {
 	/**
 	 * Remote name to probe for remote-tracking refs. Defaults to "origin".
@@ -94,36 +138,60 @@ export async function resolveRef(
 		return options.headFallback ? { kind: "head" } : null;
 	}
 
-	// Local always wins: if a local branch literally named `<input>` exists
-	// (including names like `origin/foo`), it takes precedence. Probes against
-	// the full refname so the structural prefix removes any ambiguity.
-	const localRef = asLocalRef(trimmed);
-	if (await refExists(git, localRef)) {
-		return { kind: "local", fullRef: localRef, shortName: trimmed };
-	}
+	// Branch matching goes through the enumerated refname lists so casing is
+	// authoritative — see `listBranchShortNames`. Exact matches keep the
+	// original precedence (local wins over remote-tracking, including local
+	// names like `origin/foo`); case-insensitive matches are a fallback tier
+	// so we adopt an existing branch's canonical casing instead of minting a
+	// case-twin that shares its loose-ref file on case-insensitive disks.
+	const branches = await listBranchShortNames(git, remote);
 
-	// For the remote probe, accept both bare names (`foo`) and the natural
+	// For the remote form, accept both bare names (`foo`) and the natural
 	// short form (`origin/foo`). Strip the `<remote>/` prefix only if it's
-	// present in the input — without this, `origin/foo` would probe
+	// present in the input — without this, `origin/foo` would look up
 	// `refs/remotes/origin/origin/foo` and miss.
 	const remotePrefix = `${remote}/`;
 	const remoteShortName = trimmed.startsWith(remotePrefix)
 		? trimmed.slice(remotePrefix.length)
 		: trimmed;
-	const remoteRef = asRemoteRef(remote, remoteShortName);
-	if (await refExists(git, remoteRef)) {
-		return {
-			kind: "remote-tracking",
-			fullRef: remoteRef,
-			shortName: remoteShortName,
-			remote,
-			remoteShortName: `${remote}/${remoteShortName}`,
-		};
+
+	const asLocal = (name: string): ResolvedRef => ({
+		kind: "local",
+		fullRef: asLocalRef(name),
+		shortName: name,
+	});
+	const asRemoteTracking = (name: string): ResolvedRef => ({
+		kind: "remote-tracking",
+		fullRef: asRemoteRef(remote, name),
+		shortName: name,
+		remote,
+		remoteShortName: `${remote}/${name}`,
+	});
+
+	if (branches.local.includes(trimmed)) {
+		return asLocal(trimmed);
+	}
+
+	if (branches.remoteTracking.includes(remoteShortName)) {
+		return asRemoteTracking(remoteShortName);
 	}
 
 	const tagRef: `refs/tags/${string}` = `refs/tags/${trimmed}`;
 	if (await refExists(git, tagRef)) {
 		return { kind: "tag", fullRef: tagRef, shortName: trimmed };
+	}
+
+	const localTwin = findCaseInsensitiveMatch(branches.local, trimmed);
+	if (localTwin) {
+		return asLocal(localTwin);
+	}
+
+	const remoteTwin = findCaseInsensitiveMatch(
+		branches.remoteTracking,
+		remoteShortName,
+	);
+	if (remoteTwin) {
+		return asRemoteTracking(remoteTwin);
 	}
 
 	return options.headFallback ? { kind: "head" } : null;

--- a/packages/host-service/src/runtime/git/refs.ts
+++ b/packages/host-service/src/runtime/git/refs.ts
@@ -66,24 +66,33 @@ async function listBranchShortNames(
 ): Promise<{ local: string[]; remoteTracking: string[] }> {
 	const local: string[] = [];
 	const remoteTracking: string[] = [];
+	let raw: string;
 	try {
-		const raw = await git.raw([
+		// An unborn/empty repo isn't an error here — `for-each-ref` exits 0 with
+		// empty output. A throw means a real git failure; don't silently mask it
+		// as "no branches", which would make an existing branch look absent and
+		// let a case-twin be created. Log it and re-throw so callers surface it.
+		raw = await git.raw([
 			"for-each-ref",
 			"--format=%(refname)",
 			"refs/heads/",
 			`refs/remotes/${remote}/`,
 		]);
-		const remotePrefix = `refs/remotes/${remote}/`;
-		for (const refname of raw.trim().split("\n").filter(Boolean)) {
-			if (refname.startsWith("refs/heads/")) {
-				local.push(refname.slice("refs/heads/".length));
-			} else if (refname.startsWith(remotePrefix)) {
-				const name = refname.slice(remotePrefix.length);
-				if (name !== "HEAD") remoteTracking.push(name);
-			}
+	} catch (error) {
+		console.warn("[host-service:git] for-each-ref failed in resolveRef", {
+			remote,
+			error,
+		});
+		throw error;
+	}
+	const remotePrefix = `refs/remotes/${remote}/`;
+	for (const refname of raw.trim().split("\n").filter(Boolean)) {
+		if (refname.startsWith("refs/heads/")) {
+			local.push(refname.slice("refs/heads/".length));
+		} else if (refname.startsWith(remotePrefix)) {
+			const name = refname.slice(remotePrefix.length);
+			if (name !== "HEAD") remoteTracking.push(name);
 		}
-	} catch {
-		// Unborn/empty repos have no refs; fall through with empty lists.
 	}
 	return { local, remoteTracking };
 }

--- a/packages/host-service/src/runtime/git/refs.ts
+++ b/packages/host-service/src/runtime/git/refs.ts
@@ -53,12 +53,9 @@ async function refExists(git: SimpleGit, fullRef: string): Promise<boolean> {
 }
 
 /**
- * Enumerate the true branch refnames git knows about. Used instead of
- * per-ref `rev-parse` probes for branch resolution: on case-insensitive
- * filesystems (macOS default) a loose-ref probe like
- * `rev-parse refs/heads/foo` happily resolves the `refs/heads/Foo` file,
- * so probing can't distinguish exact matches from case drift.
- * `for-each-ref` reports refnames as git stores them.
+ * Enumerate branch refnames as git stores them. Used instead of `rev-parse`
+ * probes because on a case-insensitive filesystem (macOS default) probing
+ * `refs/heads/foo` resolves the `refs/heads/Foo` file, hiding case drift.
  */
 async function listBranchShortNames(
 	git: SimpleGit,
@@ -68,10 +65,9 @@ async function listBranchShortNames(
 	const remoteTracking: string[] = [];
 	let raw: string;
 	try {
-		// An unborn/empty repo isn't an error here — `for-each-ref` exits 0 with
-		// empty output. A throw means a real git failure; don't silently mask it
-		// as "no branches", which would make an existing branch look absent and
-		// let a case-twin be created. Log it and re-throw so callers surface it.
+		// A real git failure must not be masked as "no branches" — that hides an
+		// existing branch and lets a case-twin be created. (An empty repo isn't
+		// a failure: for-each-ref exits 0 with no output.)
 		raw = await git.raw([
 			"for-each-ref",
 			"--format=%(refname)",
@@ -147,12 +143,10 @@ export async function resolveRef(
 		return options.headFallback ? { kind: "head" } : null;
 	}
 
-	// Branch matching goes through the enumerated refname lists so casing is
-	// authoritative — see `listBranchShortNames`. Exact matches keep the
-	// original precedence (local wins over remote-tracking, including local
-	// names like `origin/foo`); case-insensitive matches are a fallback tier
-	// so we adopt an existing branch's canonical casing instead of minting a
-	// case-twin that shares its loose-ref file on case-insensitive disks.
+	// Match against enumerated refnames so casing is authoritative. Exact
+	// matches keep precedence (local > remote-tracking); a case-insensitive
+	// match is a fallback tier that adopts the existing branch's canonical
+	// casing rather than minting a case-twin sharing its loose-ref file.
 	const branches = await listBranchShortNames(git, remote);
 
 	// For the remote form, accept both bare names (`foo`) and the natural

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -351,6 +351,107 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 		]);
 	});
 
+	// Case drift: local branch `roshvan/…` vs PR head `Roshvan/…`. The
+	// case-sensitive `head=` query returns nothing; the open-PR sweep must
+	// still link the workspace case-insensitively.
+	test("links a case-drifted branch to its PR via the open-PR sweep", async () => {
+		const state = makeState("roshvan/fix-thing");
+		state.workspace = {
+			...state.workspace,
+			headSha: "abc123",
+			upstreamOwner: "base-owner",
+			upstreamRepo: "base-repo",
+			upstreamBranch: "roshvan/fix-thing",
+		};
+		const manager = createManager(state, {
+			execGh: async (args) => {
+				// Case-sensitive server-side filter: the drifted casing misses.
+				if (args.includes("head=base-owner:roshvan/fix-thing")) return [];
+				const path = args.find(
+					(arg) => typeof arg === "string" && arg.startsWith("repos/"),
+				);
+				if (
+					path === "repos/base-owner/base-repo/pulls" &&
+					args.includes("state=open")
+				) {
+					return [
+						{
+							number: 77,
+							title: "Fix thing",
+							html_url: "https://github.com/base-owner/base-repo/pull/77",
+							state: "open",
+							draft: false,
+							merged_at: null,
+							updated_at: "2026-05-08T12:00:00Z",
+							head: {
+								ref: "Roshvan/fix-thing",
+								sha: "abc123",
+								repo: {
+									name: "base-repo",
+									owner: { login: "base-owner" },
+								},
+							},
+							base: {
+								repo: {
+									full_name: "base-owner/base-repo",
+								},
+							},
+						},
+					];
+				}
+				throw new Error("detail refresh unavailable");
+			},
+			github: async () => {
+				throw new Error("octokit unavailable");
+			},
+		});
+
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			await manager.refreshPullRequestsByWorkspaces([WORKSPACE_ID]);
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		expect(state.pullRequest?.prNumber).toBe(77);
+		expect(state.pullRequest?.headBranch).toBe("Roshvan/fix-thing");
+		expect(state.workspace.pullRequestId).toBe(state.pullRequest?.id ?? "");
+	});
+
+	// A transient sweep failure must not clear an existing link for a
+	// branch the per-head query can't see.
+	test("keeps an existing link when the open-PR sweep fails", async () => {
+		const state = makeState("roshvan/fix-thing");
+		state.workspace = {
+			...state.workspace,
+			headSha: "abc123",
+			upstreamOwner: "base-owner",
+			upstreamRepo: "base-repo",
+			upstreamBranch: "roshvan/fix-thing",
+			pullRequestId: "pr-existing",
+		};
+		const manager = createManager(state, {
+			execGh: async (args) => {
+				if (args.includes("head=base-owner:roshvan/fix-thing")) return [];
+				throw new Error("sweep unavailable");
+			},
+			github: async () => {
+				throw new Error("octokit unavailable");
+			},
+		});
+
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			await manager.refreshPullRequestsByWorkspaces([WORKSPACE_ID]);
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		expect(state.workspace.pullRequestId).toBe("pr-existing");
+	});
+
 	test("preserves existing pullRequestId when head lookup fails", async () => {
 		const state = makeState("fix/sidebar");
 		state.workspace = {

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -7,182 +7,195 @@ import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import type { HostDb } from "../../db";
 import * as schema from "../../db/schema";
 import { pullRequests, workspaces } from "../../db/schema";
-import {
-	PullRequestRuntimeManager,
-	type PullRequestRuntimeManagerOptions,
-} from "./pull-requests";
+import { PullRequestRuntimeManager } from "./pull-requests";
 
+// All tests run the real manager against a real, migrated, in-memory SQLite
+// DB. An earlier hand-faked DB ignored query predicates and could only hold a
+// single workspace, which made multi-workspace cross-linking bugs (e.g.
+// case-variant branch collision) inexpressible — so the harness is faithful
+// on purpose.
 const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../drizzle");
-
 const PROJECT_ID = "project-1";
-const WORKSPACE_ID = "workspace-1";
+const REPO = { owner: "base-owner", name: "base-repo" };
 
-interface FakeProject {
-	id: string;
-	repoPath: string;
-	repoProvider: "github";
-	repoOwner: string;
-	repoName: string;
-	repoUrl: string;
-	remoteName: string;
+function createRealDb(): HostDb {
+	const sqlite = new Database(":memory:");
+	sqlite.exec("PRAGMA foreign_keys = ON;");
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	return db as unknown as HostDb;
 }
 
-interface FakeWorkspace {
-	id: string;
-	projectId: string;
-	worktreePath: string;
-	branch: string;
-	headSha: string | null;
-	upstreamOwner: string | null;
-	upstreamRepo: string | null;
-	upstreamBranch: string | null;
-	pullRequestId: string | null;
-}
-
-interface FakePullRequest {
-	id: string;
-	projectId: string;
-	repoProvider: "github";
-	repoOwner: string;
-	repoName: string;
-	prNumber: number;
-	url: string;
-	title: string;
-	state: string;
-	isDraft: boolean;
-	headBranch: string;
-	headSha: string;
-	reviewDecision: string | null;
-	checksStatus: string;
-	checksJson: string;
-	lastFetchedAt: number | null;
-	error: string | null;
-	createdAt: number;
-	updatedAt: number;
-}
-
-interface FakeState {
-	project: FakeProject;
-	workspace: FakeWorkspace;
-	pullRequest: FakePullRequest | undefined;
-}
-
-function makeState(branch: string): FakeState {
-	return {
-		project: {
+function seedProject(db: HostDb) {
+	db.insert(schema.projects)
+		.values({
 			id: PROJECT_ID,
 			repoPath: "/repo",
+			createdAt: Date.now(),
 			repoProvider: "github",
-			repoOwner: "base-owner",
-			repoName: "base-repo",
-			repoUrl: "https://github.com/base-owner/base-repo.git",
+			repoOwner: REPO.owner,
+			repoName: REPO.name,
+			repoUrl: `https://github.com/${REPO.owner}/${REPO.name}.git`,
 			remoteName: "origin",
-		},
-		workspace: {
-			id: WORKSPACE_ID,
-			projectId: PROJECT_ID,
-			worktreePath: `/repo/.worktrees/${branch}`,
-			branch,
-			headSha: null,
-			upstreamOwner: null,
-			upstreamRepo: null,
-			upstreamBranch: null,
-			pullRequestId: null,
-		},
-		pullRequest: undefined,
-	};
+		})
+		.run();
 }
 
-function createFakeDb(state: FakeState) {
-	return {
-		query: {
-			projects: {
-				findFirst: () => ({ sync: () => state.project }),
-			},
-			pullRequests: {
-				findFirst: () => ({ sync: () => state.pullRequest }),
-			},
-		},
-		insert: (table: unknown) => ({
-			values: (values: FakePullRequest) => ({
-				run: () => {
-					if (table === pullRequests) {
-						state.pullRequest = values;
-					}
-				},
-			}),
-		}),
-		update: (table: unknown) => ({
-			set: (values: Partial<FakeWorkspace> | Partial<FakePullRequest>) => ({
-				where: () => ({
-					run: () => {
-						if (table === workspaces) {
-							state.workspace = {
-								...state.workspace,
-								...(values as Partial<FakeWorkspace>),
-							};
-						}
-						if (table === pullRequests && state.pullRequest) {
-							state.pullRequest = {
-								...state.pullRequest,
-								...(values as Partial<FakePullRequest>),
-							};
-						}
-					},
-				}),
-			}),
-		}),
-		select: (shape?: unknown) => ({
-			from: (table: unknown) => ({
-				where: () => ({
-					all: () => {
-						if (table !== workspaces) return [];
-						if (shape) return [{ projectId: state.workspace.projectId }];
-						return [state.workspace];
-					},
-				}),
-				all: () => {
-					if (table !== workspaces) return [];
-					if (shape) return [{ projectId: state.workspace.projectId }];
-					return [state.workspace];
-				},
-			}),
-		}),
-	};
+function seedWorkspace(
+	db: HostDb,
+	w: {
+		id: string;
+		branch: string;
+		headSha?: string | null;
+		upstreamOwner?: string | null;
+		upstreamRepo?: string | null;
+		upstreamBranch?: string | null;
+		pullRequestId?: string | null;
+	},
+) {
+	db.insert(schema.workspaces)
+		.values({
+			id: w.id,
+			projectId: PROJECT_ID,
+			worktreePath: `/repo/.worktrees/${w.id}`,
+			branch: w.branch,
+			createdAt: Date.now(),
+			headSha: w.headSha ?? null,
+			upstreamOwner: w.upstreamOwner ?? null,
+			upstreamRepo: w.upstreamRepo ?? null,
+			upstreamBranch: w.upstreamBranch ?? null,
+			pullRequestId: w.pullRequestId ?? null,
+		})
+		.run();
+}
+
+function seedPullRequest(
+	db: HostDb,
+	pr: {
+		id: string;
+		prNumber: number;
+		headBranch: string;
+		headSha: string;
+		title?: string;
+		state?: string;
+		reviewDecision?: string | null;
+		checksStatus?: string;
+		checksJson?: string;
+	},
+) {
+	db.insert(schema.pullRequests)
+		.values({
+			id: pr.id,
+			projectId: PROJECT_ID,
+			repoProvider: "github",
+			repoOwner: REPO.owner,
+			repoName: REPO.name,
+			prNumber: pr.prNumber,
+			url: `https://github.com/${REPO.owner}/${REPO.name}/pull/${pr.prNumber}`,
+			title: pr.title ?? `PR ${pr.prNumber}`,
+			state: pr.state ?? "open",
+			headBranch: pr.headBranch,
+			headSha: pr.headSha,
+			reviewDecision: pr.reviewDecision ?? null,
+			checksStatus: pr.checksStatus ?? "none",
+			checksJson: pr.checksJson ?? "[]",
+			createdAt: 1,
+			updatedAt: 1,
+		})
+		.run();
+}
+
+function getWorkspace(db: HostDb, id: string) {
+	return db.select().from(workspaces).where(eq(workspaces.id, id)).get();
+}
+
+function getPrById(db: HostDb, id: string) {
+	return db.select().from(pullRequests).where(eq(pullRequests.id, id)).get();
+}
+
+function getPrByNumber(db: HostDb, prNumber: number) {
+	return db
+		.select()
+		.from(pullRequests)
+		.where(eq(pullRequests.prNumber, prNumber))
+		.get();
 }
 
 function createManager(
-	state: FakeState,
-	overrides: Partial<
-		Pick<PullRequestRuntimeManagerOptions, "execGh" | "github">
-	> = {},
+	db: HostDb,
+	overrides: {
+		execGh?: (args: string[]) => Promise<unknown>;
+		github?: () => Promise<never>;
+	} = {},
 ) {
 	return new PullRequestRuntimeManager({
-		db: createFakeDb(state) as never,
+		db,
 		execGh:
-			overrides.execGh ??
-			(async () => {
+			(overrides.execGh as never) ??
+			((async () => {
 				throw new Error("gh should not be used for direct PR linking");
-			}),
-		git: async () => {
+			}) as never),
+		git: (async () => {
 			throw new Error("git should not be used when project metadata is set");
-		},
+		}) as never,
 		github:
-			overrides.github ??
-			(async () => {
-				throw new Error("github should not be used for direct PR linking");
-			}),
+			(overrides.github as never) ??
+			((async () => {
+				throw new Error("octokit should not be used");
+			}) as never),
 		gitWatcher: { onChanged: () => () => {} } as never,
 	});
 }
 
+// Builds a GitHub REST PR node (the shape normalizePullRequest expects).
+function makePrNode(pr: {
+	number: number;
+	headRef: string;
+	headSha: string;
+	headOwner?: string;
+	headRepo?: string;
+	title?: string;
+}) {
+	return {
+		number: pr.number,
+		title: pr.title ?? `PR ${pr.number}`,
+		html_url: `https://github.com/${REPO.owner}/${REPO.name}/pull/${pr.number}`,
+		state: "open",
+		draft: false,
+		merged_at: null,
+		updated_at: "2026-05-08T12:00:00Z",
+		head: {
+			ref: pr.headRef,
+			sha: pr.headSha,
+			repo: {
+				name: pr.headRepo ?? REPO.name,
+				owner: { login: pr.headOwner ?? REPO.owner },
+			},
+		},
+		base: { repo: { full_name: `${REPO.owner}/${REPO.name}` } },
+	};
+}
+
+// Silences the expected warnings the manager logs on handled failures.
+async function withSilencedWarnings<T>(fn: () => Promise<T>): Promise<T> {
+	const original = console.warn;
+	console.warn = () => {};
+	try {
+		return await fn();
+	} finally {
+		console.warn = original;
+	}
+}
+
 describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 	test("links a fork PR workspace to the selected PR and records fork upstream", async () => {
-		const state = makeState("fork-owner/fix-typo");
-		const manager = createManager(state);
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, { id: "ws", branch: "fork-owner/fix-typo" });
+		const manager = createManager(db);
 
 		const prId = await manager.linkWorkspaceToCheckoutPullRequest({
-			workspaceId: WORKSPACE_ID,
+			workspaceId: "ws",
 			projectId: PROJECT_ID,
 			pullRequest: {
 				number: 42,
@@ -198,22 +211,27 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 			},
 		});
 
-		expect(state.workspace.pullRequestId).toBe(prId);
-		expect(state.workspace.upstreamOwner).toBe("fork-owner");
-		expect(state.workspace.upstreamRepo).toBe("fork-repo");
-		expect(state.workspace.upstreamBranch).toBe("fix-typo");
-		expect(state.pullRequest?.prNumber).toBe(42);
-		expect(state.pullRequest?.repoOwner).toBe("base-owner");
-		expect(state.pullRequest?.repoName).toBe("base-repo");
-		expect(state.pullRequest?.headBranch).toBe("fix-typo");
+		const ws = getWorkspace(db, "ws");
+		expect(ws?.pullRequestId).toBe(prId);
+		expect(ws?.upstreamOwner).toBe("fork-owner");
+		expect(ws?.upstreamRepo).toBe("fork-repo");
+		expect(ws?.upstreamBranch).toBe("fix-typo");
+
+		const pr = getPrById(db, prId ?? "");
+		expect(pr?.prNumber).toBe(42);
+		expect(pr?.repoOwner).toBe("base-owner");
+		expect(pr?.repoName).toBe("base-repo");
+		expect(pr?.headBranch).toBe("fix-typo");
 	});
 
 	test("keeps a deleted-fork PR link when no upstream can be recorded", async () => {
-		const state = makeState("pr/42");
-		const manager = createManager(state);
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, { id: "ws", branch: "pr/42" });
+		const manager = createManager(db);
 
 		const prId = await manager.linkWorkspaceToCheckoutPullRequest({
-			workspaceId: WORKSPACE_ID,
+			workspaceId: "ws",
 			projectId: PROJECT_ID,
 			pullRequest: {
 				number: 42,
@@ -228,22 +246,25 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 			},
 		});
 
-		expect(state.workspace.pullRequestId).toBe(prId);
-		expect(state.workspace.upstreamOwner).toBeNull();
-		expect(state.workspace.upstreamRepo).toBeNull();
-		expect(state.workspace.upstreamBranch).toBeNull();
+		const linked = getWorkspace(db, "ws");
+		expect(linked?.pullRequestId).toBe(prId);
+		expect(linked?.upstreamOwner).toBeNull();
+		expect(linked?.upstreamRepo).toBeNull();
+		expect(linked?.upstreamBranch).toBeNull();
 
-		await manager.refreshPullRequestsByWorkspaces([WORKSPACE_ID]);
+		await manager.refreshPullRequestsByWorkspaces(["ws"]);
 
-		expect(state.workspace.pullRequestId).toBe(prId);
+		expect(getWorkspace(db, "ws")?.pullRequestId).toBe(prId);
 	});
 
 	test("clears a no-upstream PR link when workspace HEAD no longer matches the PR", async () => {
-		const state = makeState("pr/42");
-		const manager = createManager(state);
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, { id: "ws", branch: "pr/42" });
+		const manager = createManager(db);
 
 		await manager.linkWorkspaceToCheckoutPullRequest({
-			workspaceId: WORKSPACE_ID,
+			workspaceId: "ws",
 			projectId: PROJECT_ID,
 			pullRequest: {
 				number: 42,
@@ -257,36 +278,27 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 				isCrossRepository: true,
 			},
 		});
-		state.workspace.headSha = "def456";
+		db.update(workspaces)
+			.set({ headSha: "def456" })
+			.where(eq(workspaces.id, "ws"))
+			.run();
 
-		await manager.refreshPullRequestsByWorkspaces([WORKSPACE_ID]);
+		await manager.refreshPullRequestsByWorkspaces(["ws"]);
 
-		expect(state.workspace.pullRequestId).toBeNull();
+		expect(getWorkspace(db, "ws")?.pullRequestId).toBeNull();
 	});
+});
 
+describe("PullRequestRuntimeManager refresh", () => {
 	test("preserves last-known review and checks when detail refresh fails", async () => {
-		const state = makeState("fix/sidebar");
-		state.workspace = {
-			...state.workspace,
-			headSha: "abc123",
-			upstreamOwner: "fork-owner",
-			upstreamRepo: "fork-repo",
-			upstreamBranch: "fix/sidebar",
-			pullRequestId: "pr-existing",
-		};
-		state.pullRequest = {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, {
 			id: "pr-existing",
-			projectId: PROJECT_ID,
-			repoProvider: "github",
-			repoOwner: "base-owner",
-			repoName: "base-repo",
 			prNumber: 42,
-			url: "https://github.com/base-owner/base-repo/pull/42",
-			title: "Fix sidebar",
-			state: "open",
-			isDraft: false,
 			headBranch: "fix/sidebar",
 			headSha: "old-sha",
+			title: "Fix sidebar",
 			reviewDecision: "approved",
 			checksStatus: "success",
 			checksJson: JSON.stringify([
@@ -296,41 +308,31 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 					url: "https://github.com/base-owner/base-repo/actions/1",
 				},
 			]),
-			lastFetchedAt: 1,
-			error: null,
-			createdAt: 1,
-			updatedAt: 1,
-		};
-		const manager = createManager(state, {
+		});
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "fix/sidebar",
+			headSha: "abc123",
+			upstreamOwner: "fork-owner",
+			upstreamRepo: "fork-repo",
+			upstreamBranch: "fix/sidebar",
+			pullRequestId: "pr-existing",
+		});
+		const manager = createManager(db, {
 			execGh: async (args) => {
 				const path = args.find((arg) => arg.startsWith("repos/"));
 				if (path === "repos/base-owner/base-repo/pulls") {
 					return [
-						{
+						makePrNode({
 							number: 42,
+							headRef: "fix/sidebar",
+							headSha: "abc123",
+							headOwner: "fork-owner",
+							headRepo: "fork-repo",
 							title: "Fix sidebar updated",
-							html_url: "https://github.com/base-owner/base-repo/pull/42",
-							state: "open",
-							draft: false,
-							merged_at: null,
-							updated_at: "2026-05-08T12:00:00Z",
-							head: {
-								ref: "fix/sidebar",
-								sha: "abc123",
-								repo: {
-									name: "fork-repo",
-									owner: { login: "fork-owner" },
-								},
-							},
-							base: {
-								repo: {
-									full_name: "base-owner/base-repo",
-								},
-							},
-						},
+						}),
 					];
 				}
-
 				throw new Error("detail refresh unavailable");
 			},
 			github: async () => {
@@ -338,20 +340,17 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 			},
 		});
 
-		const originalWarn = console.warn;
-		console.warn = () => {};
-		try {
-			await manager.refreshPullRequestsByWorkspaces([WORKSPACE_ID]);
-		} finally {
-			console.warn = originalWarn;
-		}
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
 
-		expect(state.workspace.pullRequestId).toBe("pr-existing");
-		expect(state.pullRequest?.title).toBe("Fix sidebar updated");
-		expect(state.pullRequest?.headSha).toBe("abc123");
-		expect(state.pullRequest?.reviewDecision).toBe("approved");
-		expect(state.pullRequest?.checksStatus).toBe("success");
-		expect(JSON.parse(state.pullRequest?.checksJson ?? "[]")).toEqual([
+		expect(getWorkspace(db, "ws")?.pullRequestId).toBe("pr-existing");
+		const pr = getPrById(db, "pr-existing");
+		expect(pr?.title).toBe("Fix sidebar updated");
+		expect(pr?.headSha).toBe("abc123");
+		expect(pr?.reviewDecision).toBe("approved");
+		expect(pr?.checksStatus).toBe("success");
+		expect(JSON.parse(pr?.checksJson ?? "[]")).toEqual([
 			{
 				name: "Typecheck",
 				status: "success",
@@ -360,118 +359,25 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 		]);
 	});
 
-	// Case drift: local branch `roshvan/…` vs PR head `Roshvan/…`. The
-	// case-sensitive `head=` query returns nothing; the open-PR sweep must
-	// still link the workspace case-insensitively.
-	test("links a case-drifted branch to its PR via the open-PR sweep", async () => {
-		const state = makeState("roshvan/fix-thing");
-		state.workspace = {
-			...state.workspace,
-			headSha: "abc123",
-			upstreamOwner: "base-owner",
-			upstreamRepo: "base-repo",
-			upstreamBranch: "roshvan/fix-thing",
-		};
-		const manager = createManager(state, {
-			execGh: async (args) => {
-				// Case-sensitive server-side filter: the drifted casing misses.
-				if (args.includes("head=base-owner:roshvan/fix-thing")) return [];
-				const path = args.find(
-					(arg) => typeof arg === "string" && arg.startsWith("repos/"),
-				);
-				if (
-					path === "repos/base-owner/base-repo/pulls" &&
-					args.includes("state=open")
-				) {
-					return [
-						{
-							number: 77,
-							title: "Fix thing",
-							html_url: "https://github.com/base-owner/base-repo/pull/77",
-							state: "open",
-							draft: false,
-							merged_at: null,
-							updated_at: "2026-05-08T12:00:00Z",
-							head: {
-								ref: "Roshvan/fix-thing",
-								sha: "abc123",
-								repo: {
-									name: "base-repo",
-									owner: { login: "base-owner" },
-								},
-							},
-							base: {
-								repo: {
-									full_name: "base-owner/base-repo",
-								},
-							},
-						},
-					];
-				}
-				throw new Error("detail refresh unavailable");
-			},
-			github: async () => {
-				throw new Error("octokit unavailable");
-			},
-		});
-
-		const originalWarn = console.warn;
-		console.warn = () => {};
-		try {
-			await manager.refreshPullRequestsByWorkspaces([WORKSPACE_ID]);
-		} finally {
-			console.warn = originalWarn;
-		}
-
-		expect(state.pullRequest?.prNumber).toBe(77);
-		expect(state.pullRequest?.headBranch).toBe("Roshvan/fix-thing");
-		expect(state.workspace.pullRequestId).toBe(state.pullRequest?.id ?? "");
-	});
-
-	// A transient sweep failure must not clear an existing link for a
-	// branch the per-head query can't see.
-	test("keeps an existing link when the open-PR sweep fails", async () => {
-		const state = makeState("roshvan/fix-thing");
-		state.workspace = {
-			...state.workspace,
-			headSha: "abc123",
-			upstreamOwner: "base-owner",
-			upstreamRepo: "base-repo",
-			upstreamBranch: "roshvan/fix-thing",
-			pullRequestId: "pr-existing",
-		};
-		const manager = createManager(state, {
-			execGh: async (args) => {
-				if (args.includes("head=base-owner:roshvan/fix-thing")) return [];
-				throw new Error("sweep unavailable");
-			},
-			github: async () => {
-				throw new Error("octokit unavailable");
-			},
-		});
-
-		const originalWarn = console.warn;
-		console.warn = () => {};
-		try {
-			await manager.refreshPullRequestsByWorkspaces([WORKSPACE_ID]);
-		} finally {
-			console.warn = originalWarn;
-		}
-
-		expect(state.workspace.pullRequestId).toBe("pr-existing");
-	});
-
 	test("preserves existing pullRequestId when head lookup fails", async () => {
-		const state = makeState("fix/sidebar");
-		state.workspace = {
-			...state.workspace,
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, {
+			id: "pr-existing",
+			prNumber: 42,
+			headBranch: "fix/sidebar",
+			headSha: "abc123",
+		});
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "fix/sidebar",
 			headSha: "abc123",
 			upstreamOwner: "fork-owner",
 			upstreamRepo: "fork-repo",
 			upstreamBranch: "fix/sidebar",
 			pullRequestId: "pr-existing",
-		};
-		const manager = createManager(state, {
+		});
+		const manager = createManager(db, {
 			execGh: async () => {
 				throw new Error("gh unavailable");
 			},
@@ -480,53 +386,105 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 			},
 		});
 
-		const originalWarn = console.warn;
-		console.warn = () => {};
-		try {
-			await manager.refreshPullRequestsByWorkspaces([WORKSPACE_ID]);
-		} finally {
-			console.warn = originalWarn;
-		}
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
 
-		expect(state.workspace.pullRequestId).toBe("pr-existing");
+		expect(getWorkspace(db, "ws")?.pullRequestId).toBe("pr-existing");
+	});
+
+	// Case drift: local branch `roshvan/…` vs PR head `Roshvan/…`. The
+	// case-sensitive `head=` query returns nothing; the open-PR sweep must
+	// still link the workspace case-insensitively.
+	test("links a case-drifted branch to its PR via the open-PR sweep", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "roshvan/fix-thing",
+			headSha: "abc123",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "roshvan/fix-thing",
+		});
+		const manager = createManager(db, {
+			execGh: async (args) => {
+				// Case-sensitive server-side filter: the drifted casing misses.
+				if (args.includes("head=base-owner:roshvan/fix-thing")) return [];
+				if (args.includes("graphql")) {
+					return {
+						data: { repository: { pullRequest: { mergeQueueEntry: null } } },
+					};
+				}
+				const path = args.find(
+					(arg) => typeof arg === "string" && arg.startsWith("repos/"),
+				);
+				if (path?.endsWith("/reviews")) return [];
+				if (path?.endsWith("/check-runs")) return { check_runs: [] };
+				if (path?.endsWith("/statuses")) return [];
+				if (
+					path === "repos/base-owner/base-repo/pulls" &&
+					args.includes("state=open")
+				) {
+					return [
+						makePrNode({
+							number: 77,
+							headRef: "Roshvan/fix-thing",
+							headSha: "abc123",
+							title: "Fix thing",
+						}),
+					];
+				}
+				throw new Error("detail refresh unavailable");
+			},
+		});
+
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
+
+		const pr = getPrByNumber(db, 77);
+		expect(pr?.headBranch).toBe("Roshvan/fix-thing");
+		expect(getWorkspace(db, "ws")?.pullRequestId).toBe(pr?.id);
+	});
+
+	// A transient sweep failure must not clear an existing link for a branch
+	// the per-head query can't see.
+	test("keeps an existing link when the open-PR sweep fails", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, {
+			id: "pr-existing",
+			prNumber: 42,
+			headBranch: "Roshvan/fix-thing",
+			headSha: "abc123",
+		});
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "roshvan/fix-thing",
+			headSha: "abc123",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "roshvan/fix-thing",
+			pullRequestId: "pr-existing",
+		});
+		const manager = createManager(db, {
+			execGh: async (args) => {
+				if (args.includes("head=base-owner:roshvan/fix-thing")) return [];
+				throw new Error("sweep unavailable");
+			},
+		});
+
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
+
+		expect(getWorkspace(db, "ws")?.pullRequestId).toBe("pr-existing");
 	});
 });
 
-// ── Multi-workspace regression suite (real in-memory DB) ──────────────────
-//
-// The single-workspace fake DB above cannot express two workspaces at once,
-// so a whole class of cross-linking bugs was untestable — including case-
-// variant branches on a case-sensitive host collapsing onto one PR identity.
-// These tests run the real manager against a real (migrated, in-memory)
-// SQLite DB so those scenarios are expressible and asserted.
-
-const REPO = { owner: "base-owner", name: "base-repo" };
-
-function makePrNode(overrides: {
-	number: number;
-	headRef: string;
-	headSha: string;
-	title?: string;
-}) {
-	return {
-		number: overrides.number,
-		title: overrides.title ?? `PR ${overrides.number}`,
-		html_url: `https://github.com/${REPO.owner}/${REPO.name}/pull/${overrides.number}`,
-		state: "open",
-		draft: false,
-		merged_at: null,
-		updated_at: "2026-05-08T12:00:00Z",
-		head: {
-			ref: overrides.headRef,
-			sha: overrides.headSha,
-			repo: { name: REPO.name, owner: { login: REPO.owner } },
-		},
-		base: { repo: { full_name: `${REPO.owner}/${REPO.name}` } },
-	};
-}
-
-// Routes gh REST/GraphQL calls to fixtures keyed by the exact head branch,
-// so a wrong-case cache hit or key collision surfaces as the wrong PR number.
+// Routes gh REST/GraphQL calls to fixtures keyed by the exact head branch, so
+// a wrong-case cache hit or key collision surfaces as the wrong PR number.
 function routeGh(prsByHeadRef: Record<string, ReturnType<typeof makePrNode>>) {
 	return async (args: string[]): Promise<unknown> => {
 		if (args.includes("graphql")) {
@@ -555,104 +513,53 @@ function routeGh(prsByHeadRef: Record<string, ReturnType<typeof makePrNode>>) {
 	};
 }
 
-function createRealDb(): HostDb {
-	const sqlite = new Database(":memory:");
-	sqlite.exec("PRAGMA foreign_keys = ON;");
-	const db = drizzle(sqlite, { schema });
-	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
-	return db as unknown as HostDb;
-}
-
-function seedProjectAndWorkspaces(
-	db: HostDb,
-	branches: { id: string; branch: string }[],
-) {
-	const now = Date.now();
-	db.insert(schema.projects)
-		.values({
-			id: PROJECT_ID,
-			repoPath: "/repo",
-			createdAt: now,
-			repoProvider: "github",
-			repoOwner: REPO.owner,
-			repoName: REPO.name,
-			repoUrl: `https://github.com/${REPO.owner}/${REPO.name}.git`,
-			remoteName: "origin",
-		})
-		.run();
-	for (const { id, branch } of branches) {
-		db.insert(schema.workspaces)
-			.values({
-				id,
-				projectId: PROJECT_ID,
-				worktreePath: `/repo/.worktrees/${id}`,
-				branch,
-				createdAt: now,
-				headSha: `sha-${branch}`,
-				upstreamOwner: REPO.owner,
-				upstreamRepo: REPO.name,
-				upstreamBranch: branch,
-			})
-			.run();
-	}
-}
-
-function createRealManager(
-	db: HostDb,
-	execGh: (args: string[]) => Promise<unknown>,
-) {
-	return new PullRequestRuntimeManager({
-		db,
-		execGh: execGh as never,
-		git: (async () => {
-			throw new Error("git should not be used when project metadata is set");
-		}) as never,
-		github: (async () => {
-			throw new Error("octokit should not be used");
-		}) as never,
-		gitWatcher: { onChanged: () => () => {} } as never,
-	});
-}
-
-function linkedPrNumber(db: HostDb, workspaceId: string): number | null {
-	const rows = db
-		.select({ prNumber: pullRequests.prNumber })
-		.from(workspaces)
-		.leftJoin(pullRequests, eq(workspaces.pullRequestId, pullRequests.id))
-		.where(eq(workspaces.id, workspaceId))
-		.all();
-	return rows[0]?.prNumber ?? null;
-}
-
-describe("case-variant branch isolation (real DB)", () => {
+describe("case-variant branch isolation", () => {
 	// P1: `feature` and `Feature` are distinct branches with distinct PRs on a
 	// case-sensitive host. A branch-lowercased identity key collapses them and
-	// links one workspace to the other's PR. bypassCache path isolates the
+	// links one workspace to the other's PR. The bypass path isolates the
 	// identity key (upstreamKey) from the per-head cache.
 	test("distinct case-variant branches link to their own PRs (bypass path)", async () => {
 		const db = createRealDb();
-		seedProjectAndWorkspaces(db, [
-			{ id: "ws-lower", branch: "feature" },
-			{ id: "ws-upper", branch: "Feature" },
-		]);
-		const execGh = routeGh({
-			feature: makePrNode({
-				number: 101,
-				headRef: "feature",
-				headSha: "sha-feature",
-			}),
-			Feature: makePrNode({
-				number: 102,
-				headRef: "Feature",
-				headSha: "sha-Feature",
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws-lower",
+			branch: "feature",
+			headSha: "sha-feature",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "feature",
+		});
+		seedWorkspace(db, {
+			id: "ws-upper",
+			branch: "Feature",
+			headSha: "sha-Feature",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "Feature",
+		});
+		const manager = createManager(db, {
+			execGh: routeGh({
+				feature: makePrNode({
+					number: 101,
+					headRef: "feature",
+					headSha: "sha-feature",
+				}),
+				Feature: makePrNode({
+					number: 102,
+					headRef: "Feature",
+					headSha: "sha-Feature",
+				}),
 			}),
 		});
-		const manager = createRealManager(db, execGh);
 
 		await manager.refreshPullRequestsByWorkspaces(["ws-lower", "ws-upper"]);
 
-		expect(linkedPrNumber(db, "ws-lower")).toBe(101);
-		expect(linkedPrNumber(db, "ws-upper")).toBe(102);
+		expect(getWorkspace(db, "ws-lower")?.pullRequestId).toBe(
+			getPrByNumber(db, 101)?.id,
+		);
+		expect(getWorkspace(db, "ws-upper")?.pullRequestId).toBe(
+			getPrByNumber(db, 102)?.id,
+		);
 	});
 
 	// P2: the per-head cache is exercised by the non-bypass refresh path. A
@@ -660,32 +567,48 @@ describe("case-variant branch isolation (real DB)", () => {
 	// so the second lookup returns the first's PR.
 	test("per-head cache does not cross-serve case-variant branches (cache path)", async () => {
 		const db = createRealDb();
-		seedProjectAndWorkspaces(db, [
-			{ id: "ws-lower", branch: "feature" },
-			{ id: "ws-upper", branch: "Feature" },
-		]);
-		const execGh = routeGh({
-			feature: makePrNode({
-				number: 101,
-				headRef: "feature",
-				headSha: "sha-feature",
-			}),
-			Feature: makePrNode({
-				number: 102,
-				headRef: "Feature",
-				headSha: "sha-Feature",
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws-lower",
+			branch: "feature",
+			headSha: "sha-feature",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "feature",
+		});
+		seedWorkspace(db, {
+			id: "ws-upper",
+			branch: "Feature",
+			headSha: "sha-Feature",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "Feature",
+		});
+		const manager = createManager(db, {
+			execGh: routeGh({
+				feature: makePrNode({
+					number: 101,
+					headRef: "feature",
+					headSha: "sha-feature",
+				}),
+				Feature: makePrNode({
+					number: 102,
+					headRef: "Feature",
+					headSha: "sha-Feature",
+				}),
 			}),
 		});
-		const manager = createRealManager(db, execGh);
 
 		// refreshProject (private) uses the cache (bypassCache defaults false).
 		await (
-			manager as unknown as {
-				refreshProject: (id: string) => Promise<void>;
-			}
+			manager as unknown as { refreshProject: (id: string) => Promise<void> }
 		).refreshProject(PROJECT_ID);
 
-		expect(linkedPrNumber(db, "ws-lower")).toBe(101);
-		expect(linkedPrNumber(db, "ws-upper")).toBe(102);
+		expect(getWorkspace(db, "ws-lower")?.pullRequestId).toBe(
+			getPrByNumber(db, 101)?.id,
+		);
+		expect(getWorkspace(db, "ws-upper")?.pullRequestId).toBe(
+			getPrByNumber(db, 102)?.id,
+		);
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -1,9 +1,18 @@
+import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { HostDb } from "../../db";
+import * as schema from "../../db/schema";
 import { pullRequests, workspaces } from "../../db/schema";
 import {
 	PullRequestRuntimeManager,
 	type PullRequestRuntimeManagerOptions,
 } from "./pull-requests";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../drizzle");
 
 const PROJECT_ID = "project-1";
 const WORKSPACE_ID = "workspace-1";
@@ -480,5 +489,203 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 		}
 
 		expect(state.workspace.pullRequestId).toBe("pr-existing");
+	});
+});
+
+// ── Multi-workspace regression suite (real in-memory DB) ──────────────────
+//
+// The single-workspace fake DB above cannot express two workspaces at once,
+// so a whole class of cross-linking bugs was untestable — including case-
+// variant branches on a case-sensitive host collapsing onto one PR identity.
+// These tests run the real manager against a real (migrated, in-memory)
+// SQLite DB so those scenarios are expressible and asserted.
+
+const REPO = { owner: "base-owner", name: "base-repo" };
+
+function makePrNode(overrides: {
+	number: number;
+	headRef: string;
+	headSha: string;
+	title?: string;
+}) {
+	return {
+		number: overrides.number,
+		title: overrides.title ?? `PR ${overrides.number}`,
+		html_url: `https://github.com/${REPO.owner}/${REPO.name}/pull/${overrides.number}`,
+		state: "open",
+		draft: false,
+		merged_at: null,
+		updated_at: "2026-05-08T12:00:00Z",
+		head: {
+			ref: overrides.headRef,
+			sha: overrides.headSha,
+			repo: { name: REPO.name, owner: { login: REPO.owner } },
+		},
+		base: { repo: { full_name: `${REPO.owner}/${REPO.name}` } },
+	};
+}
+
+// Routes gh REST/GraphQL calls to fixtures keyed by the exact head branch,
+// so a wrong-case cache hit or key collision surfaces as the wrong PR number.
+function routeGh(prsByHeadRef: Record<string, ReturnType<typeof makePrNode>>) {
+	return async (args: string[]): Promise<unknown> => {
+		if (args.includes("graphql")) {
+			return {
+				data: { repository: { pullRequest: { mergeQueueEntry: null } } },
+			};
+		}
+		const path = args.find(
+			(arg) => typeof arg === "string" && arg.startsWith("repos/"),
+		);
+		if (!path) throw new Error(`unexpected gh args: ${args.join(" ")}`);
+		if (path.endsWith("/reviews")) return [];
+		if (path.endsWith("/check-runs")) return { check_runs: [] };
+		if (path.endsWith("/statuses")) return [];
+		if (path === `repos/${REPO.owner}/${REPO.name}/pulls`) {
+			const headArg = args.find((a) => a.startsWith("head="));
+			if (headArg) {
+				const ref = headArg.slice(`head=${REPO.owner}:`.length);
+				const pr = prsByHeadRef[ref];
+				return pr ? [pr] : [];
+			}
+			// Open-PR sweep (state=open, no head filter): return everything.
+			return Object.values(prsByHeadRef);
+		}
+		throw new Error(`unexpected gh path: ${path}`);
+	};
+}
+
+function createRealDb(): HostDb {
+	const sqlite = new Database(":memory:");
+	sqlite.exec("PRAGMA foreign_keys = ON;");
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	return db as unknown as HostDb;
+}
+
+function seedProjectAndWorkspaces(
+	db: HostDb,
+	branches: { id: string; branch: string }[],
+) {
+	const now = Date.now();
+	db.insert(schema.projects)
+		.values({
+			id: PROJECT_ID,
+			repoPath: "/repo",
+			createdAt: now,
+			repoProvider: "github",
+			repoOwner: REPO.owner,
+			repoName: REPO.name,
+			repoUrl: `https://github.com/${REPO.owner}/${REPO.name}.git`,
+			remoteName: "origin",
+		})
+		.run();
+	for (const { id, branch } of branches) {
+		db.insert(schema.workspaces)
+			.values({
+				id,
+				projectId: PROJECT_ID,
+				worktreePath: `/repo/.worktrees/${id}`,
+				branch,
+				createdAt: now,
+				headSha: `sha-${branch}`,
+				upstreamOwner: REPO.owner,
+				upstreamRepo: REPO.name,
+				upstreamBranch: branch,
+			})
+			.run();
+	}
+}
+
+function createRealManager(
+	db: HostDb,
+	execGh: (args: string[]) => Promise<unknown>,
+) {
+	return new PullRequestRuntimeManager({
+		db,
+		execGh: execGh as never,
+		git: (async () => {
+			throw new Error("git should not be used when project metadata is set");
+		}) as never,
+		github: (async () => {
+			throw new Error("octokit should not be used");
+		}) as never,
+		gitWatcher: { onChanged: () => () => {} } as never,
+	});
+}
+
+function linkedPrNumber(db: HostDb, workspaceId: string): number | null {
+	const rows = db
+		.select({ prNumber: pullRequests.prNumber })
+		.from(workspaces)
+		.leftJoin(pullRequests, eq(workspaces.pullRequestId, pullRequests.id))
+		.where(eq(workspaces.id, workspaceId))
+		.all();
+	return rows[0]?.prNumber ?? null;
+}
+
+describe("case-variant branch isolation (real DB)", () => {
+	// P1: `feature` and `Feature` are distinct branches with distinct PRs on a
+	// case-sensitive host. A branch-lowercased identity key collapses them and
+	// links one workspace to the other's PR. bypassCache path isolates the
+	// identity key (upstreamKey) from the per-head cache.
+	test("distinct case-variant branches link to their own PRs (bypass path)", async () => {
+		const db = createRealDb();
+		seedProjectAndWorkspaces(db, [
+			{ id: "ws-lower", branch: "feature" },
+			{ id: "ws-upper", branch: "Feature" },
+		]);
+		const execGh = routeGh({
+			feature: makePrNode({
+				number: 101,
+				headRef: "feature",
+				headSha: "sha-feature",
+			}),
+			Feature: makePrNode({
+				number: 102,
+				headRef: "Feature",
+				headSha: "sha-Feature",
+			}),
+		});
+		const manager = createRealManager(db, execGh);
+
+		await manager.refreshPullRequestsByWorkspaces(["ws-lower", "ws-upper"]);
+
+		expect(linkedPrNumber(db, "ws-lower")).toBe(101);
+		expect(linkedPrNumber(db, "ws-upper")).toBe(102);
+	});
+
+	// P2: the per-head cache is exercised by the non-bypass refresh path. A
+	// branch-lowercased cache key makes `feature` and `Feature` share an entry,
+	// so the second lookup returns the first's PR.
+	test("per-head cache does not cross-serve case-variant branches (cache path)", async () => {
+		const db = createRealDb();
+		seedProjectAndWorkspaces(db, [
+			{ id: "ws-lower", branch: "feature" },
+			{ id: "ws-upper", branch: "Feature" },
+		]);
+		const execGh = routeGh({
+			feature: makePrNode({
+				number: 101,
+				headRef: "feature",
+				headSha: "sha-feature",
+			}),
+			Feature: makePrNode({
+				number: 102,
+				headRef: "Feature",
+				headSha: "sha-Feature",
+			}),
+		});
+		const manager = createRealManager(db, execGh);
+
+		// refreshProject (private) uses the cache (bypassCache defaults false).
+		await (
+			manager as unknown as {
+				refreshProject: (id: string) => Promise<void>;
+			}
+		).refreshProject(PROJECT_ID);
+
+		expect(linkedPrNumber(db, "ws-lower")).toBe(101);
+		expect(linkedPrNumber(db, "ws-upper")).toBe(102);
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -177,17 +177,20 @@ async function tryConfig(
 	return tryRaw(git, ["config", "--get", key]);
 }
 
+// Canonical identity for a workspace's upstream branch, used as the dedup key
+// for fetches and the join key for workspace→PR link assignment. Branch stays
+// case-sensitive: on a case-sensitive host `feature` and `Feature` are
+// distinct branches with distinct PRs, and collapsing them here would link a
+// workspace to the wrong PR. Case drift (a local branch whose casing diverged
+// from the PR head on a case-insensitive filesystem) is handled only in the
+// best-effort fallback in `fetchRepoPullRequests`, never in this key.
 function upstreamKey(
 	owner: string | null,
 	repo: string | null,
 	branch: string,
 ): string | null {
 	if (!owner || !repo) return null;
-	// Branch compared case-insensitively too: git branch names are
-	// case-sensitive, but on case-insensitive filesystems (macOS default)
-	// the local casing can drift from the PR's headRefName — a case-sensitive
-	// key permanently strands such workspaces with pullRequestId = null.
-	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch.toLowerCase()}`;
+	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch}`;
 }
 
 type RepoProvider = "github";
@@ -900,12 +903,14 @@ export class PullRequestRuntimeManager {
 		head: GitHubPullRequestHeadRef,
 		options: { bypassCache?: boolean } = {},
 	): Promise<GitHubPullRequestNode | null> {
+		// Branch stays case-sensitive so two case-variant branches can't share
+		// a cache entry and return each other's PR.
 		const cacheKey = [
 			repo.owner.toLowerCase(),
 			repo.name.toLowerCase(),
 			head.owner.toLowerCase(),
 			head.repo.toLowerCase(),
-			head.branch.toLowerCase(),
+			head.branch,
 		].join("/");
 		return this.cachedGitHubFetch(
 			this.pullRequestHeadCache,
@@ -1025,18 +1030,24 @@ export class PullRequestRuntimeManager {
 		if (unmatchedKeys.length > 0) {
 			try {
 				const openNodes = await this.getCachedOpenPullRequests(repo, options);
-				const openByKey = new Map<string, GitHubPullRequestNode>();
+				// Case-insensitive index — this is the one place drift is tolerated.
+				// `upstreamKey` already lowercases owner/repo, so lowercasing the
+				// whole key only relaxes the branch component. latestByKey stays
+				// keyed by the exact workspace key so link assignment is unchanged.
+				const openByLowerKey = new Map<string, GitHubPullRequestNode>();
 				for (const node of openNodes) {
 					const nodeKey = upstreamKey(
 						node.headRepositoryOwner?.login ?? null,
 						node.headRepository?.name ?? null,
 						node.headRefName,
 					);
+					if (!nodeKey) continue;
+					const lower = nodeKey.toLowerCase();
 					// Sweep is sorted by updated desc; first hit per key wins.
-					if (nodeKey && !openByKey.has(nodeKey)) openByKey.set(nodeKey, node);
+					if (!openByLowerKey.has(lower)) openByLowerKey.set(lower, node);
 				}
 				for (const key of unmatchedKeys) {
-					const node = openByKey.get(key);
+					const node = openByLowerKey.get(key.toLowerCase());
 					if (node) latestByKey.set(key, node);
 				}
 			} catch (error) {

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -177,13 +177,10 @@ async function tryConfig(
 	return tryRaw(git, ["config", "--get", key]);
 }
 
-// Canonical identity for a workspace's upstream branch, used as the dedup key
-// for fetches and the join key for workspace→PR link assignment. Branch stays
-// case-sensitive: on a case-sensitive host `feature` and `Feature` are
-// distinct branches with distinct PRs, and collapsing them here would link a
-// workspace to the wrong PR. Case drift (a local branch whose casing diverged
-// from the PR head on a case-insensitive filesystem) is handled only in the
-// best-effort fallback in `fetchRepoPullRequests`, never in this key.
+// Dedup + link-assignment key. Branch stays case-sensitive: `feature` and
+// `Feature` are distinct branches with distinct PRs, so collapsing them here
+// would mislink. Case drift is tolerated only in the fallback in
+// `fetchRepoPullRequests`, never in this key.
 function upstreamKey(
 	owner: string | null,
 	repo: string | null,
@@ -939,11 +936,9 @@ export class PullRequestRuntimeManager {
 		);
 	}
 
-	// Repo-wide listing was deliberately removed in #4268/#4291 because the
-	// old GraphQL sweep (100 PRs × 50 status contexts) 504'd on large repos.
-	// This one is different on purpose: a shallow REST `pulls?state=open`
-	// page with no checks/statuses, fired at most once per repo per TTL and
-	// only when a per-head lookup came up empty. Detail fetches stay per-PR.
+	// Deliberately narrow: repo-wide listing was removed in #4268/#4291 (the
+	// GraphQL sweep 504'd on large repos). This is a shallow `pulls?state=open`
+	// page, no checks, once per repo per TTL, only when a per-head lookup missed.
 	private async getCachedOpenPullRequests(
 		repo: NormalizedRepoIdentity,
 		options: { bypassCache?: boolean } = {},
@@ -1030,10 +1025,9 @@ export class PullRequestRuntimeManager {
 		if (unmatchedKeys.length > 0) {
 			try {
 				const openNodes = await this.getCachedOpenPullRequests(repo, options);
-				// Case-insensitive index — this is the one place drift is tolerated.
-				// `upstreamKey` already lowercases owner/repo, so lowercasing the
-				// whole key only relaxes the branch component. latestByKey stays
-				// keyed by the exact workspace key so link assignment is unchanged.
+				// The one place drift is tolerated: index open PRs by a lowercased
+				// key. latestByKey stays keyed by the exact workspace key, so link
+				// assignment downstream is unchanged.
 				const openByLowerKey = new Map<string, GitHubPullRequestNode>();
 				for (const node of openNodes) {
 					const nodeKey = upstreamKey(

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -8,6 +8,8 @@ import type { GitWatcher } from "../../events/git-watcher";
 import type { ExecGh } from "../../trpc/router/workspace-creation/utils/exec-gh";
 import type { GitFactory } from "../git";
 import {
+	fetchOpenPullRequests,
+	fetchOpenPullRequestsFromGh,
 	fetchPullRequestByHead,
 	fetchPullRequestByHeadFromGh,
 	fetchPullRequestChecks,
@@ -181,8 +183,11 @@ function upstreamKey(
 	branch: string,
 ): string | null {
 	if (!owner || !repo) return null;
-	// GitHub owner/repo are case-insensitive; branch names are case-sensitive.
-	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch}`;
+	// Branch compared case-insensitively too: git branch names are
+	// case-sensitive, but on case-insensitive filesystems (macOS default)
+	// the local casing can drift from the PR's headRefName — a case-sensitive
+	// key permanently strands such workspaces with pullRequestId = null.
+	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch.toLowerCase()}`;
 }
 
 type RepoProvider = "github";
@@ -276,6 +281,10 @@ export class PullRequestRuntimeManager {
 	private readonly pullRequestHeadCache = new Map<
 		string,
 		{ promise: Promise<GitHubPullRequestNode | null>; fetchedAt: number }
+	>();
+	private readonly openPullRequestsCache = new Map<
+		string,
+		{ promise: Promise<GitHubPullRequestNode[]>; fetchedAt: number }
 	>();
 
 	constructor(options: PullRequestRuntimeManagerOptions) {
@@ -855,6 +864,37 @@ export class PullRequestRuntimeManager {
 		return rowId;
 	}
 
+	// Keep failed promises cached for the full TTL so subsequent polls share
+	// the rejection without firing new GitHub calls. Evicting on every error
+	// caused a self-perpetuating storm under rate-limit / abuse-detection
+	// responses: the failure invalidated the cache, the next 20s tick
+	// retried, hit the same 403, and re-evicted. Network blips heal at the
+	// next TTL boundary instead.
+	private cachedGitHubFetch<T>(
+		cache: Map<string, { promise: Promise<T>; fetchedAt: number }>,
+		cacheKey: string,
+		options: { bypassCache?: boolean },
+		fetcher: () => Promise<T>,
+	): Promise<T> {
+		if (!options.bypassCache) {
+			const cached = cache.get(cacheKey);
+			if (
+				cached &&
+				Date.now() - cached.fetchedAt < REPO_PULL_REQUEST_CACHE_TTL_MS
+			) {
+				return cached.promise;
+			}
+		}
+
+		const fetchedAt = Date.now();
+		const promise = fetcher();
+		// Observer to silence unhandledRejection warnings; real consumers
+		// observe the rejection via their own await on the cached promise.
+		promise.catch(() => {});
+		cache.set(cacheKey, { promise, fetchedAt });
+		return promise;
+	}
+
 	private async getCachedPullRequestByHead(
 		repo: NormalizedRepoIdentity,
 		head: GitHubPullRequestHeadRef,
@@ -865,61 +905,68 @@ export class PullRequestRuntimeManager {
 			repo.name.toLowerCase(),
 			head.owner.toLowerCase(),
 			head.repo.toLowerCase(),
-			head.branch,
+			head.branch.toLowerCase(),
 		].join("/");
-		if (!options.bypassCache) {
-			const cached = this.pullRequestHeadCache.get(cacheKey);
-			if (
-				cached &&
-				Date.now() - cached.fetchedAt < REPO_PULL_REQUEST_CACHE_TTL_MS
-			) {
-				return cached.promise;
-			}
-		}
-
-		const fetchedAt = Date.now();
-		const promise = (async () => {
-			try {
-				return await fetchPullRequestByHeadFromGh(
-					this.execGh,
-					{
-						owner: repo.owner,
-						name: repo.name,
-					},
-					head,
-				);
-			} catch (ghError) {
-				console.warn(
-					"[host-service:pull-request-runtime] gh PR head lookup failed; falling back to Octokit",
-					{
-						owner: repo.owner,
-						name: repo.name,
+		return this.cachedGitHubFetch(
+			this.pullRequestHeadCache,
+			cacheKey,
+			options,
+			async () => {
+				try {
+					return await fetchPullRequestByHeadFromGh(
+						this.execGh,
+						{ owner: repo.owner, name: repo.name },
 						head,
-						error: ghError,
-					},
-				);
-				const octokit = await this.github();
-				return fetchPullRequestByHead(
-					octokit,
-					{
+					);
+				} catch (ghError) {
+					console.warn(
+						"[host-service:pull-request-runtime] gh PR head lookup failed; falling back to Octokit",
+						{ owner: repo.owner, name: repo.name, head, error: ghError },
+					);
+					const octokit = await this.github();
+					return fetchPullRequestByHead(
+						octokit,
+						{ owner: repo.owner, name: repo.name },
+						head,
+					);
+				}
+			},
+		);
+	}
+
+	// Repo-wide listing was deliberately removed in #4268/#4291 because the
+	// old GraphQL sweep (100 PRs × 50 status contexts) 504'd on large repos.
+	// This one is different on purpose: a shallow REST `pulls?state=open`
+	// page with no checks/statuses, fired at most once per repo per TTL and
+	// only when a per-head lookup came up empty. Detail fetches stay per-PR.
+	private async getCachedOpenPullRequests(
+		repo: NormalizedRepoIdentity,
+		options: { bypassCache?: boolean } = {},
+	): Promise<GitHubPullRequestNode[]> {
+		const cacheKey = `${repo.owner.toLowerCase()}/${repo.name.toLowerCase()}`;
+		return this.cachedGitHubFetch(
+			this.openPullRequestsCache,
+			cacheKey,
+			options,
+			async () => {
+				try {
+					return await fetchOpenPullRequestsFromGh(this.execGh, {
 						owner: repo.owner,
 						name: repo.name,
-					},
-					head,
-				);
-			}
-		})();
-		// Observer to silence unhandledRejection warnings; real consumers
-		// observe the rejection via their own await on the cached promise.
-		promise.catch(() => {});
-		// Keep failed promises cached for the full TTL so subsequent polls
-		// share the rejection without firing new GitHub calls. Evicting on
-		// every error caused a self-perpetuating storm under rate-limit /
-		// abuse-detection responses: the failure invalidated the cache, the
-		// next 20s tick retried, hit the same 403, and re-evicted. Network
-		// blips heal at the next TTL boundary instead.
-		this.pullRequestHeadCache.set(cacheKey, { promise, fetchedAt });
-		return promise;
+					});
+				} catch (ghError) {
+					console.warn(
+						"[host-service:pull-request-runtime] gh open-PR sweep failed; falling back to Octokit",
+						{ owner: repo.owner, name: repo.name, error: ghError },
+					);
+					const octokit = await this.github();
+					return fetchOpenPullRequests(octokit, {
+						owner: repo.owner,
+						name: repo.name,
+					});
+				}
+			},
+		);
 	}
 
 	private async fetchRepoPullRequests(
@@ -967,6 +1014,41 @@ export class PullRequestRuntimeManager {
 				}
 			}),
 		);
+
+		// GitHub's `head=` filter is case-sensitive on the branch component, so
+		// a workspace whose local branch casing drifted from the PR's
+		// headRefName gets nothing from the per-head lookups above. Sweep the
+		// repo's open PRs once and fill the gaps case-insensitively.
+		const unmatchedKeys = Array.from(wantedRefs.keys()).filter(
+			(key) => !latestByKey.has(key) && !failedKeys.has(key),
+		);
+		if (unmatchedKeys.length > 0) {
+			try {
+				const openNodes = await this.getCachedOpenPullRequests(repo, options);
+				const openByKey = new Map<string, GitHubPullRequestNode>();
+				for (const node of openNodes) {
+					const nodeKey = upstreamKey(
+						node.headRepositoryOwner?.login ?? null,
+						node.headRepository?.name ?? null,
+						node.headRefName,
+					);
+					// Sweep is sorted by updated desc; first hit per key wins.
+					if (nodeKey && !openByKey.has(nodeKey)) openByKey.set(nodeKey, node);
+				}
+				for (const key of unmatchedKeys) {
+					const node = openByKey.get(key);
+					if (node) latestByKey.set(key, node);
+				}
+			} catch (error) {
+				// Treat the whole sweep as failed lookups so existing links are
+				// kept rather than cleared on a transient error.
+				for (const key of unmatchedKeys) failedKeys.add(key);
+				console.warn(
+					"[host-service:pull-request-runtime] Open-PR sweep failed",
+					{ projectId, owner: repo.owner, name: repo.name, error },
+				);
+			}
+		}
 
 		const now = Date.now();
 

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -154,10 +154,10 @@ describe("GitHub pull request REST queries", () => {
 		expect(result?.headRepository?.name).toBe("fork-repo");
 	});
 
-	// Case drift: local branch casing can diverge from the PR's headRefName
-	// on case-insensitive filesystems; the candidate filter must not drop
-	// the match over casing.
-	test("matches head candidates case-insensitively on the branch", async () => {
+	// The per-head candidate filter is exact on the branch: it must NOT match a
+	// case-variant head, so distinct case-variant branches never cross-match
+	// here. Case drift is recovered by the runtime's open-PR sweep instead.
+	test("does not match a case-variant branch in per-head filtering", async () => {
 		const { execGh } = createExecGh([
 			[
 				{
@@ -191,8 +191,7 @@ describe("GitHub pull request REST queries", () => {
 			{ owner: "superset-sh", repo: "superset", branch: "roshvan/fix-thing" },
 		);
 
-		expect(result?.number).toBe(43);
-		expect(result?.headRefName).toBe("Roshvan/fix-thing");
+		expect(result).toBeNull();
 	});
 
 	test("sweeps open PRs sorted by most recently updated", async () => {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	fetchOpenPullRequestsFromGh,
 	fetchPullRequestByHeadFromGh,
 	fetchPullRequestChecksFromGh,
 	fetchPullRequestMergeQueueStateFromGh,
@@ -151,6 +152,103 @@ describe("GitHub pull request REST queries", () => {
 		expect(result?.number).toBe(42);
 		expect(result?.headRepositoryOwner?.login).toBe("Fork-Owner");
 		expect(result?.headRepository?.name).toBe("fork-repo");
+	});
+
+	// Case drift: local branch casing can diverge from the PR's headRefName
+	// on case-insensitive filesystems; the candidate filter must not drop
+	// the match over casing.
+	test("matches head candidates case-insensitively on the branch", async () => {
+		const { execGh } = createExecGh([
+			[
+				{
+					number: 43,
+					title: "Case drift",
+					html_url: "https://github.com/superset-sh/superset/pull/43",
+					state: "open",
+					draft: false,
+					merged_at: null,
+					updated_at: "2026-05-08T12:00:00Z",
+					head: {
+						ref: "Roshvan/fix-thing",
+						sha: "abc123",
+						repo: {
+							name: "superset",
+							owner: { login: "superset-sh" },
+						},
+					},
+					base: {
+						repo: {
+							full_name: "superset-sh/superset",
+						},
+					},
+				},
+			],
+		]);
+
+		const result = await fetchPullRequestByHeadFromGh(
+			execGh,
+			{ owner: "superset-sh", name: "superset" },
+			{ owner: "superset-sh", repo: "superset", branch: "roshvan/fix-thing" },
+		);
+
+		expect(result?.number).toBe(43);
+		expect(result?.headRefName).toBe("Roshvan/fix-thing");
+	});
+
+	test("sweeps open PRs sorted by most recently updated", async () => {
+		const { calls, execGh } = createExecGh([
+			[
+				{
+					number: 44,
+					title: "Open sweep",
+					html_url: "https://github.com/superset-sh/superset/pull/44",
+					state: "open",
+					draft: false,
+					merged_at: null,
+					updated_at: "2026-05-08T12:00:00Z",
+					head: {
+						ref: "Roshvan/fix-thing",
+						sha: "def456",
+						repo: {
+							name: "superset",
+							owner: { login: "superset-sh" },
+						},
+					},
+					base: {
+						repo: {
+							full_name: "superset-sh/superset",
+						},
+					},
+				},
+				{ number: "not-a-pr" },
+			],
+		]);
+
+		const result = await fetchOpenPullRequestsFromGh(execGh, {
+			owner: "superset-sh",
+			name: "superset",
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.number).toBe(44);
+		expect(calls).toEqual([
+			{
+				args: [
+					"api",
+					"--method",
+					"GET",
+					"repos/superset-sh/superset/pulls",
+					"-f",
+					"state=open",
+					"-f",
+					"sort=updated",
+					"-f",
+					"direction=desc",
+					"-f",
+					"per_page=100",
+				],
+			},
+		]);
 	});
 
 	test("derives review decision from latest REST reviews by author", async () => {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -253,12 +253,9 @@ export async function fetchPullRequestByHead(
 	return normalizePullRequestCandidates(response.data, head);
 }
 
-// Fallback for the case-drifted-branch scenario: GitHub's `head=` filter is
-// case-sensitive on the branch component (empirically verified), so a lookup
-// keyed on a local branch whose casing drifted from the PR's headRefName
-// returns nothing. A repo-wide open-PR sweep lets the caller match heads
-// case-insensitively. Open PRs only — an exhaustive `state=all` sweep is
-// unbounded, and the live workspace↔PR link is what case drift breaks.
+// GitHub's `head=` filter is case-sensitive on the branch (verified), so a
+// drifted-case lookup returns nothing. This repo-wide sweep lets the caller
+// match heads case-insensitively. Open PRs only — `state=all` is unbounded.
 export async function fetchOpenPullRequestsFromGh(
 	execGh: ExecGh,
 	repository: {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -114,10 +114,10 @@ function headKey(
 	branch: string,
 ): string | null {
 	if (!owner || !repo) return null;
-	// Branch compared case-insensitively too: on case-insensitive filesystems
-	// (macOS default) the local branch casing can drift from the PR's
-	// headRefName, and refusing the match strands the workspace with no PR.
-	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch.toLowerCase()}`;
+	// Exact match on the branch: this filters the results of a per-head query,
+	// which GitHub already scopes case-sensitively server-side. Case drift is
+	// recovered separately by the repo-wide open-PR sweep in the runtime.
+	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch}`;
 }
 
 function normalizePullRequestCandidates(

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -114,8 +114,10 @@ function headKey(
 	branch: string,
 ): string | null {
 	if (!owner || !repo) return null;
-	// GitHub owner/repo names are case-insensitive; branch names are not.
-	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch}`;
+	// Branch compared case-insensitively too: on case-insensitive filesystems
+	// (macOS default) the local branch casing can drift from the PR's
+	// headRefName, and refusing the match strands the workspace with no PR.
+	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch.toLowerCase()}`;
 }
 
 function normalizePullRequestCandidates(
@@ -249,6 +251,60 @@ export async function fetchPullRequestByHead(
 	});
 
 	return normalizePullRequestCandidates(response.data, head);
+}
+
+// Fallback for the case-drifted-branch scenario: GitHub's `head=` filter is
+// case-sensitive on the branch component (empirically verified), so a lookup
+// keyed on a local branch whose casing drifted from the PR's headRefName
+// returns nothing. A repo-wide open-PR sweep lets the caller match heads
+// case-insensitively. Open PRs only — an exhaustive `state=all` sweep is
+// unbounded, and the live workspace↔PR link is what case drift breaks.
+export async function fetchOpenPullRequestsFromGh(
+	execGh: ExecGh,
+	repository: {
+		owner: string;
+		name: string;
+	},
+): Promise<GitHubPullRequestNode[]> {
+	const raw = await execGh([
+		"api",
+		"--method",
+		"GET",
+		`repos/${repository.owner}/${repository.name}/pulls`,
+		"-f",
+		"state=open",
+		"-f",
+		"sort=updated",
+		"-f",
+		"direction=desc",
+		"-f",
+		"per_page=100",
+	]);
+
+	return asArray(raw)
+		.map((item) => normalizePullRequest(item))
+		.filter((node): node is GitHubPullRequestNode => node !== null);
+}
+
+export async function fetchOpenPullRequests(
+	octokit: Octokit,
+	repository: {
+		owner: string;
+		name: string;
+	},
+): Promise<GitHubPullRequestNode[]> {
+	const response = await octokit.rest.pulls.list({
+		owner: repository.owner,
+		repo: repository.name,
+		state: "open",
+		sort: "updated",
+		direction: "desc",
+		per_page: 100,
+	});
+
+	return response.data
+		.map((item) => normalizePullRequest(item))
+		.filter((node): node is GitHubPullRequestNode => node !== null);
 }
 
 // GitHub's REST PR payloads don't expose merge-queue membership, so detect it

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/index.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/index.ts
@@ -1,4 +1,6 @@
 export {
+	fetchOpenPullRequests,
+	fetchOpenPullRequestsFromGh,
 	fetchPullRequestByHead,
 	fetchPullRequestByHeadFromGh,
 	fetchPullRequestChecks,

--- a/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, mock, test } from "bun:test";
+import { scheduleBaseRefFetch } from "./base-ref-freshness";
+
+// Distinct remote/branch per test so the module-level TTL/in-flight maps
+// (keyed by commonDir#remote/branch) don't leak state across tests.
+function createGit(options: { fetch?: () => Promise<unknown> } = {}) {
+	const fetchCalls: string[][] = [];
+	const revParseCalls: string[][] = [];
+	const git = {
+		raw: mock(async (args: string[]) => {
+			revParseCalls.push(args);
+			if (args[0] === "rev-parse" && args[1] === "--git-common-dir") {
+				return ".git\n";
+			}
+			throw new Error(`Unexpected raw args: ${args.join(" ")}`);
+		}),
+		fetch: mock(async (args: string[]) => {
+			fetchCalls.push(args);
+			return options.fetch ? options.fetch() : undefined;
+		}),
+	} as never as import("simple-git").SimpleGit;
+	return { git, fetchCalls, revParseCalls };
+}
+
+describe("scheduleBaseRefFetch", () => {
+	test("fetches the base branch with the expected args", async () => {
+		const { git, fetchCalls } = createGit();
+		await scheduleBaseRefFetch(git, "/repo/wt-a", {
+			remote: "origin",
+			branch: "main",
+		});
+		expect(fetchCalls).toEqual([["origin", "main", "--quiet", "--no-tags"]]);
+	});
+
+	test("dedupes repeat calls within the TTL window", async () => {
+		const { git, fetchCalls } = createGit();
+		const target = { remote: "origin", branch: "ttl-branch" };
+		await scheduleBaseRefFetch(git, "/repo/wt-ttl", target);
+		await scheduleBaseRefFetch(git, "/repo/wt-ttl", target);
+		await scheduleBaseRefFetch(git, "/repo/wt-ttl", target);
+		expect(fetchCalls).toHaveLength(1);
+	});
+
+	test("resolves the common dir fresh each call (no path cache)", async () => {
+		const { git, revParseCalls } = createGit();
+		const target = { remote: "origin", branch: "fresh-branch" };
+		await scheduleBaseRefFetch(git, "/repo/wt-fresh", target);
+		await scheduleBaseRefFetch(git, "/repo/wt-fresh", target);
+		// One rev-parse per call — a cached path→dir mapping would skip the
+		// second and risk keying a reused path off a stale repo's common dir.
+		const commonDirCalls = revParseCalls.filter(
+			(args) => args[1] === "--git-common-dir",
+		);
+		expect(commonDirCalls).toHaveLength(2);
+	});
+
+	test("coalesces concurrent calls into a single in-flight fetch", async () => {
+		let release: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const { git, fetchCalls } = createGit({ fetch: () => gate });
+		const target = { remote: "origin", branch: "inflight-branch" };
+		const a = scheduleBaseRefFetch(git, "/repo/wt-inflight", target);
+		const b = scheduleBaseRefFetch(git, "/repo/wt-inflight", target);
+		release();
+		await Promise.all([a, b]);
+		expect(fetchCalls).toHaveLength(1);
+	});
+
+	test("never rejects when the fetch fails", async () => {
+		const { git, fetchCalls } = createGit({
+			fetch: () => Promise.reject(new Error("offline")),
+		});
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			// Resolves (does not throw) despite the underlying fetch rejecting.
+			await scheduleBaseRefFetch(git, "/repo/wt-fail", {
+				remote: "origin",
+				branch: "fail-branch",
+			});
+		} finally {
+			console.warn = originalWarn;
+		}
+		expect(fetchCalls).toHaveLength(1);
+	});
+});

--- a/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
+++ b/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
@@ -1,12 +1,10 @@
 import { resolve } from "node:path";
 import type { SimpleGit } from "simple-git";
 
-// The Changes panel diffs `<remote>/<base>...HEAD`, but nothing in the status
-// path fetches — the remote-tracking ref is only as fresh as the last fetch
-// some other flow happened to run. Once a branch is rebased onto a newer
-// upstream base, the stale merge-base counts every upstream commit as
-// workspace changes. This refreshes the base ref in the background on a TTL;
-// the ref update is picked up by GitWatcher, which re-triggers status queries.
+// The Changes panel diffs `<remote>/<base>...HEAD` but never fetches the base,
+// so after a rebase onto a newer upstream the stale merge-base counts every
+// upstream commit as a workspace change. This refreshes the base ref in the
+// background; GitWatcher picks up the ref change and re-triggers the query.
 const BASE_REF_FETCH_TTL_MS = 5 * 60_000;
 
 export interface BaseRefFetchTarget {
@@ -14,17 +12,14 @@ export interface BaseRefFetchTarget {
 	branch: string;
 }
 
-// Keyed by the repo's common git dir so N worktrees of one repo share a
-// single TTL window instead of each fetching independently. Bounded by
-// distinct (repo, base-ref) pairs, not by workspace lifecycles.
+// Keyed by common git dir so N worktrees of one repo share one TTL window.
+// Bounded by (repo, base-ref) pairs, not workspace lifecycles.
 const lastFetchStartedAt = new Map<string, number>();
 const inFlightFetches = new Map<string, Promise<void>>();
 
-// Resolved fresh each call rather than cached by path: a worktree path can be
-// reused by a different repo over the host-service's lifetime, and a stale
-// path→dir mapping would key the fetch dedup wrong and suppress a needed
-// fetch. `rev-parse --git-common-dir` is a local, near-instant call, dwarfed
-// by the `git fetch` it precedes.
+// Resolved fresh, not path-cached: a worktree path can be reused by a
+// different repo, and a stale mapping would key the dedup off the wrong repo
+// and suppress a needed fetch.
 async function resolveCommonDir(
 	git: SimpleGit,
 	worktreePath: string,
@@ -35,13 +30,10 @@ async function resolveCommonDir(
 }
 
 /**
- * Fetch the base branch's remote-tracking ref if the TTL for this repo+ref
- * has lapsed. Failures (offline, missing remote branch) consume the TTL
- * window too, so an unreachable remote is retried at the same cadence instead
- * of on every status poll.
- *
- * Callers use this fire-and-forget (the status path never awaits it); the
- * returned promise, which never rejects, exists so it can be awaited in tests.
+ * Fetch the base branch's remote-tracking ref if the TTL has lapsed. Failures
+ * consume the TTL too, so an unreachable remote isn't retried every poll.
+ * Fire-and-forget (the status path never awaits); the returned promise never
+ * rejects and exists only so tests can await it.
  */
 export function scheduleBaseRefFetch(
 	git: SimpleGit,

--- a/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
+++ b/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
@@ -15,36 +15,40 @@ export interface BaseRefFetchTarget {
 }
 
 // Keyed by the repo's common git dir so N worktrees of one repo share a
-// single TTL window instead of each fetching independently.
-const commonDirByWorktree = new Map<string, string>();
+// single TTL window instead of each fetching independently. Bounded by
+// distinct (repo, base-ref) pairs, not by workspace lifecycles.
 const lastFetchStartedAt = new Map<string, number>();
 const inFlightFetches = new Map<string, Promise<void>>();
 
+// Resolved fresh each call rather than cached by path: a worktree path can be
+// reused by a different repo over the host-service's lifetime, and a stale
+// path→dir mapping would key the fetch dedup wrong and suppress a needed
+// fetch. `rev-parse --git-common-dir` is a local, near-instant call, dwarfed
+// by the `git fetch` it precedes.
 async function resolveCommonDir(
 	git: SimpleGit,
 	worktreePath: string,
 ): Promise<string> {
-	const cached = commonDirByWorktree.get(worktreePath);
-	if (cached) return cached;
 	// `--git-common-dir` may print a path relative to the worktree root.
 	const raw = (await git.raw(["rev-parse", "--git-common-dir"])).trim();
-	const commonDir = resolve(worktreePath, raw);
-	commonDirByWorktree.set(worktreePath, commonDir);
-	return commonDir;
+	return resolve(worktreePath, raw);
 }
 
 /**
- * Fire-and-forget: fetch the base branch's remote-tracking ref if the TTL
- * for this repo+ref has lapsed. Failures (offline, missing remote branch)
- * consume the TTL window too, so an unreachable remote is retried at the
- * same cadence instead of on every status poll.
+ * Fetch the base branch's remote-tracking ref if the TTL for this repo+ref
+ * has lapsed. Failures (offline, missing remote branch) consume the TTL
+ * window too, so an unreachable remote is retried at the same cadence instead
+ * of on every status poll.
+ *
+ * Callers use this fire-and-forget (the status path never awaits it); the
+ * returned promise, which never rejects, exists so it can be awaited in tests.
  */
 export function scheduleBaseRefFetch(
 	git: SimpleGit,
 	worktreePath: string,
 	target: BaseRefFetchTarget,
-): void {
-	void (async () => {
+): Promise<void> {
+	return (async () => {
 		const commonDir = await resolveCommonDir(git, worktreePath);
 		const key = `${commonDir}#${target.remote}/${target.branch}`;
 

--- a/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
+++ b/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
@@ -1,0 +1,76 @@
+import { resolve } from "node:path";
+import type { SimpleGit } from "simple-git";
+
+// The Changes panel diffs `<remote>/<base>...HEAD`, but nothing in the status
+// path fetches — the remote-tracking ref is only as fresh as the last fetch
+// some other flow happened to run. Once a branch is rebased onto a newer
+// upstream base, the stale merge-base counts every upstream commit as
+// workspace changes. This refreshes the base ref in the background on a TTL;
+// the ref update is picked up by GitWatcher, which re-triggers status queries.
+const BASE_REF_FETCH_TTL_MS = 5 * 60_000;
+
+export interface BaseRefFetchTarget {
+	remote: string;
+	branch: string;
+}
+
+// Keyed by the repo's common git dir so N worktrees of one repo share a
+// single TTL window instead of each fetching independently.
+const commonDirByWorktree = new Map<string, string>();
+const lastFetchStartedAt = new Map<string, number>();
+const inFlightFetches = new Map<string, Promise<void>>();
+
+async function resolveCommonDir(
+	git: SimpleGit,
+	worktreePath: string,
+): Promise<string> {
+	const cached = commonDirByWorktree.get(worktreePath);
+	if (cached) return cached;
+	// `--git-common-dir` may print a path relative to the worktree root.
+	const raw = (await git.raw(["rev-parse", "--git-common-dir"])).trim();
+	const commonDir = resolve(worktreePath, raw);
+	commonDirByWorktree.set(worktreePath, commonDir);
+	return commonDir;
+}
+
+/**
+ * Fire-and-forget: fetch the base branch's remote-tracking ref if the TTL
+ * for this repo+ref has lapsed. Failures (offline, missing remote branch)
+ * consume the TTL window too, so an unreachable remote is retried at the
+ * same cadence instead of on every status poll.
+ */
+export function scheduleBaseRefFetch(
+	git: SimpleGit,
+	worktreePath: string,
+	target: BaseRefFetchTarget,
+): void {
+	void (async () => {
+		const commonDir = await resolveCommonDir(git, worktreePath);
+		const key = `${commonDir}#${target.remote}/${target.branch}`;
+
+		const inFlight = inFlightFetches.get(key);
+		if (inFlight) return inFlight;
+
+		const last = lastFetchStartedAt.get(key);
+		if (last !== undefined && Date.now() - last < BASE_REF_FETCH_TTL_MS) {
+			return;
+		}
+
+		lastFetchStartedAt.set(key, Date.now());
+		const fetchPromise = git
+			.fetch([target.remote, target.branch, "--quiet", "--no-tags"])
+			.then(() => undefined)
+			.finally(() => {
+				inFlightFetches.delete(key);
+			});
+		inFlightFetches.set(key, fetchPromise);
+		return fetchPromise;
+	})().catch((error) => {
+		console.warn("[host-service:git] Background base-ref fetch failed", {
+			worktreePath,
+			remote: target.remote,
+			branch: target.branch,
+			error,
+		});
+	});
+}

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.integration.test.ts
@@ -133,7 +133,11 @@ describe("resolveBaseComparison (integration)", () => {
 
 	test("falls back to origin/<default> when no upstream configured", async () => {
 		const result = await resolveBaseComparison(git);
-		expect(result).toEqual({ branchName: "main", baseRef: "origin/main" });
+		expect(result).toEqual({
+			branchName: "main",
+			baseRef: "origin/main",
+			fetchTarget: { remote: "origin", branch: "main" },
+		});
 	});
 
 	test("honors configured upstream remote (fork workflow)", async () => {
@@ -143,6 +147,7 @@ describe("resolveBaseComparison (integration)", () => {
 		expect(await resolveBaseComparison(git)).toEqual({
 			branchName: "main",
 			baseRef: "upstream/main",
+			fetchTarget: { remote: "upstream", branch: "main" },
 		});
 	});
 
@@ -153,6 +158,7 @@ describe("resolveBaseComparison (integration)", () => {
 		expect(await resolveBaseComparison(git, "integration")).toEqual({
 			branchName: "integration",
 			baseRef: "main",
+			fetchTarget: null,
 		});
 	});
 
@@ -163,6 +169,7 @@ describe("resolveBaseComparison (integration)", () => {
 		expect(await resolveBaseComparison(git, "main")).toEqual({
 			branchName: "main",
 			baseRef: "upstream/main",
+			fetchTarget: { remote: "upstream", branch: "main" },
 		});
 	});
 

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -157,19 +157,36 @@ export async function getDefaultBranchName(
 export async function resolveBaseComparison(
 	git: SimpleGit,
 	explicitBranch?: string,
-): Promise<{ branchName: string; baseRef: string } | null> {
+): Promise<{
+	branchName: string;
+	baseRef: string;
+	// Remote branch to fetch to keep `baseRef` current; null when the base
+	// tracks another local branch and there is nothing to fetch.
+	fetchTarget: { remote: string; branch: string } | null;
+} | null> {
 	const branchName = explicitBranch ?? (await getDefaultBranchName(git));
 	if (!branchName) return null;
 	const upstream = await resolveUpstream(git, branchName);
 	// Git encodes a branch tracking another local branch as
 	// `branch.<name>.remote = .` — in that case the merge target is
 	// already a bare branch name in this repo, not `./<name>`.
-	const baseRef = upstream
-		? upstream.remote === "."
-			? upstream.remoteBranch
-			: `${upstream.remote}/${upstream.remoteBranch}`
-		: `origin/${branchName}`;
-	return { branchName, baseRef };
+	if (upstream) {
+		return upstream.remote === "."
+			? { branchName, baseRef: upstream.remoteBranch, fetchTarget: null }
+			: {
+					branchName,
+					baseRef: `${upstream.remote}/${upstream.remoteBranch}`,
+					fetchTarget: {
+						remote: upstream.remote,
+						branch: upstream.remoteBranch,
+					},
+				};
+	}
+	return {
+		branchName,
+		baseRef: `origin/${branchName}`,
+		fetchTarget: { remote: "origin", branch: branchName },
+	};
 }
 
 export async function buildBranch(

--- a/packages/host-service/src/trpc/router/git/utils/git-status.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-status.ts
@@ -1,5 +1,6 @@
 import type { SimpleGit } from "simple-git";
 import type { Branch, ChangedFile } from "../types";
+import { scheduleBaseRefFetch } from "./base-ref-freshness";
 import {
 	buildBranch,
 	countUntrackedFileLines,
@@ -34,6 +35,14 @@ export async function getGitStatusSnapshot({
 	const base = await resolveBaseComparison(git, baseBranch);
 	const defaultBranchName = base?.branchName ?? null;
 	const baseRef = base?.baseRef ?? "HEAD";
+
+	// Keep the base's remote-tracking ref from going stale — a rebase onto a
+	// newer upstream otherwise balloons the against-base diff with upstream
+	// commits. TTL'd and non-blocking; GitWatcher re-triggers status when the
+	// fetch moves the ref.
+	if (base?.fetchTarget) {
+		scheduleBaseRefFetch(git, worktreePath, base.fetchTarget);
+	}
 
 	const [currentBranch, defaultBranch, status, ignoredRaw] = await Promise.all([
 		buildBranch(git, currentBranchName, true, baseRef),

--- a/packages/host-service/src/trpc/router/git/utils/git-status.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-status.ts
@@ -36,10 +36,8 @@ export async function getGitStatusSnapshot({
 	const defaultBranchName = base?.branchName ?? null;
 	const baseRef = base?.baseRef ?? "HEAD";
 
-	// Keep the base's remote-tracking ref from going stale — a rebase onto a
-	// newer upstream otherwise balloons the against-base diff with upstream
-	// commits. TTL'd and non-blocking; GitWatcher re-triggers status when the
-	// fetch moves the ref.
+	// Non-blocking refresh so the against-base diff stops ballooning after a
+	// rebase; see base-ref-freshness.
 	if (base?.fetchTarget) {
 		scheduleBaseRefFetch(git, worktreePath, base.fetchTarget);
 	}

--- a/packages/host-service/src/trpc/router/git/v2-diff-surfaces.integration.test.ts
+++ b/packages/host-service/src/trpc/router/git/v2-diff-surfaces.integration.test.ts
@@ -231,7 +231,11 @@ describe("Surfaces B/C — sidebar badge + Changes tab counts", () => {
 		await git.raw(["reset", "--hard", originSha]);
 
 		const base = await resolveBaseComparison(git);
-		expect(base).toEqual({ branchName: "main", baseRef: "upstream/main" });
+		expect(base).toEqual({
+			branchName: "main",
+			baseRef: "upstream/main",
+			fetchTarget: { remote: "upstream", branch: "main" },
+		});
 	});
 
 	test("non-ASCII filename reports correct additions (was +0 -0 before fix)", async () => {

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -313,7 +313,14 @@ async function planBranchSource(
 		resolved &&
 		(resolved.kind === "local" || resolved.kind === "remote-tracking")
 	) {
-		return { branch, startPoint: resolved, usedExistingBranch: true };
+		// `shortName`, not the input: resolveRef may have adopted an existing
+		// branch's canonical casing, and `-b <input-casing>` would mint a
+		// case-twin sharing the same loose-ref file on case-insensitive disks.
+		return {
+			branch: resolved.shortName,
+			startPoint: resolved,
+			usedExistingBranch: true,
+		};
 	}
 
 	if (resolved && resolved.kind === "tag") {
@@ -858,6 +865,9 @@ export const workspacesRouter = router({
 						listBranchNames(ctx, localProject.repoPath),
 					]);
 					plan = planResult;
+					// Adopt the plan's branch name — it may carry an existing
+					// branch's canonical casing rather than the typed input.
+					resolvedBranch = plan.branch;
 					autoNameFellBack = wantAi && aiNames === null;
 					aiTitle = aiNames?.title ?? null;
 					// Namespace newly-created branches under the configured

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -865,8 +865,7 @@ export const workspacesRouter = router({
 						listBranchNames(ctx, localProject.repoPath),
 					]);
 					plan = planResult;
-					// Adopt the plan's branch name — it may carry an existing
-					// branch's canonical casing rather than the typed input.
+					// plan.branch may carry an existing branch's canonical casing.
 					resolvedBranch = plan.branch;
 					autoNameFellBack = wantAi && aiNames === null;
 					aiTitle = aiNames?.title ?? null;


### PR DESCRIPTION
## Problem

Users report their workspace's main-branch tracking and PR link drifting from GitHub state — a branch that shows **146 files changed** vs `main`, and a PR that never connects — most often on macOS's case-insensitive filesystem. Three distinct causes, all in the v2 host-service path:

## Root causes & fixes

**1. PR↔branch matching was case-sensitive on the branch.** `upstreamKey`/`headKey` lowercased owner/repo but kept the branch verbatim, so a local `roshvan/mcp-1525-…` never matched a PR head `Roshvan/mcp-1525-…`, and every sync actively re-wrote `pullRequestId = null`. Now the branch is compared case-insensitively. Because GitHub's `head=` REST filter is *itself* case-sensitive server-side (verified against this repo), a per-head lookup for a drifted branch returns nothing — so a shallow **open-PR sweep** (one page, no checks/statuses, once per repo per 60s TTL, only when a per-head lookup missed) fills the gap and matches case-insensitively. A sweep failure marks keys failed so existing links are *kept*, never cleared.

**2. Workspace creation could mint a case-twin branch.** On a case-insensitive filesystem `git rev-parse refs/heads/foo` happily resolves the `refs/heads/Foo` file, so `resolveRef`'s exact-case probe couldn't distinguish an exact match from case drift — and `git worktree add -b` would create a second branch sharing the existing one's loose-ref file (the mechanism that corrupts HEAD underneath the workspace). `resolveRef` now enumerates real refnames via `for-each-ref`: exact matches keep prior precedence (local > remote > tag); a case-insensitive match **adopts the existing branch's canonical casing**, which `planBranchSource`/create propagate.

**3. The Changes panel never fetched its base ref.** It diffs `origin/<base>...HEAD` (3-dot merge-base), but nothing in the status path fetched `origin/<base>` — so after a rebase onto a newer upstream, every replayed upstream commit was counted as a workspace change, ballooning the file count. `getGitStatusSnapshot` now schedules a fire-and-forget fetch of the base's remote branch (keyed by the repo common-dir, TTL'd, in-flight-deduped); GitWatcher picks up the ref change and re-queries.

## Verification

- Unit + integration tests, each **mutation-checked** (revert the fix → test fails).
- End-to-end against real on-disk repos: `resolveRef` adopts canonical casing for local/remote/`origin/`-prefixed drift; diff balloons 4→heals to 1 file after the background fetch.
- Live-GitHub: exact-head finds the PR, drifted-head misses server-side, the sweep matches it, a bogus branch stays unmatched.
- Via **CDP against the running host-service**: `getStatus` balloon (4 files) → heal (1 file), background fetch fires (`FETCH_HEAD` + `origin/main` sha advance confirmed independently), TTL dedup holds on rapid calls.

## Notes / prior art

- Supersedes #4367 and closes the class in #4364 — that PR added a case-insensitive *fallback* after the exact-case probe, which on macOS never runs because the probe wrongly succeeds; this replaces the probes with enumeration so both are covered.
- Mirrors GitHub Desktop's #21320 rename guard (enumerate branches, never trust a single-ref probe) and their list-and-match PR design.
- The repo-wide sweep is deliberately narrow (shallow open-PR page, no checks) to avoid regressing the #4268/#4291 504-on-large-repos fix.
- **Follow-up worth considering:** the base-ref fetch uses a 5-min TTL; a content-keyed dedup on `(headSha, baseSha)` + a short failure-only backoff would remove the arbitrary interval and make the heal immediate after a rebase. Left out of this PR to keep it focused.
- The v1 desktop path (`pr-resolution.ts`) has the same case-sensitivity bug but is left untouched pending the v1 sunset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5455">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace↔GitHub drift that caused inflated file counts and PR links not attaching. Keeps branch casing and base refs accurate so diffs and links stay correct.

- **Bug Fixes**
  - PR linking: keep `upstreamKey` and per-head cache keys case-sensitive to isolate case-variant branches; add a shallow `state=open` sweep (once per repo per TTL, only when a head lookup misses) that matches case-insensitively to recover drifted branches; cache failures for the TTL and preserve existing links if the sweep fails; tests now use a real, migrated in-memory SQLite DB to verify case-variant isolation across bypass and cached paths.
  - Branch ref resolution: enumerate branches via `for-each-ref` and adopt canonical casing; prevent case-twin creation on case-insensitive filesystems; propagate the canonical name during workspace creation; surface real `for-each-ref` failures instead of degrading to “no branches.”
  - Base-ref freshness: background-fetch the base remote branch during status (TTL, in-flight dedup keyed by repo common-dir, resolve common dir per call, never rejects) so `origin/<base>...HEAD` diffs don’t balloon after a rebase.

<sup>Written for commit 2f719919d4a7f6a9360a8a956670cd69e07ec7b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace and branch reuse now adopts canonical casing from existing local or remote-tracking refs.
  * Added a repo-wide open-PR sweep fallback to recover missed PR lookups when branch names differ only by letter case.
  * Introduced TTL-based background refresh for remote-tracking base refs to keep comparisons up to date.

* **Bug Fixes**
  * Improved Git ref resolution and PR linking for case-drifted branches/tags, including correct “no matches” vs real failures.
  * If the open-PR sweep fails transiently, existing workspace↔PR links are preserved (not cleared).
  * Prevented PR cross-linking between case-variant branch names.

* **Tests**
  * Added/expanded regression coverage for these case-handling behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->