### PR TITLE
fix(chat): bound gcTime on chat display queries to cap renderer heap growth

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts
@@ -11,6 +11,11 @@ interface UseChatDisplayOptions {
 	fps?: number;
 }
 
+// Retention window for an inactive session's cached snapshot (full message
+// history). Overrides the global 30-min gcTime so visited sessions' snapshots
+// are freed shortly after their pane unmounts instead of accumulating on the heap.
+const CHAT_QUERY_GC_TIME_MS = 60_000;
+
 function toRefetchIntervalMs(fps: number): number {
 	if (!Number.isFinite(fps) || fps <= 0) return Math.floor(1000 / 60);
 	return Math.max(16, Math.floor(1000 / fps));
@@ -123,6 +128,7 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 		refetchInterval: refetchIntervalMs,
 		refetchIntervalInBackground: true,
 		refetchOnWindowFocus: false,
+		gcTime: CHAT_QUERY_GC_TIME_MS,
 	} as const;
 
 	const snapshotQuery = workspaceTrpc.chat.getSnapshot.useQuery(

--- a/packages/chat/src/client/hooks/use-chat-display/use-chat-display.ts
+++ b/packages/chat/src/client/hooks/use-chat-display/use-chat-display.ts
@@ -25,6 +25,11 @@ export interface UseChatDisplayOptions {
 	fps?: number;
 }
 
+// Retention window for an inactive session's cached messages/display state.
+// Overrides the global 30-min gcTime so visited sessions' data is freed shortly
+// after their pane unmounts instead of accumulating on the heap.
+const CHAT_QUERY_GC_TIME_MS = 60_000;
+
 function toRefetchIntervalMs(fps: number): number {
 	if (!Number.isFinite(fps) || fps <= 0) return Math.floor(1000 / 60);
 	return Math.max(16, Math.floor(1000 / fps));
@@ -147,6 +152,7 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 		refetchInterval: refetchIntervalMs,
 		refetchIntervalInBackground: true,
 		refetchOnWindowFocus: false,
+		gcTime: CHAT_QUERY_GC_TIME_MS,
 	} as const;
 
 	const displayQuery = chatRuntimeServiceTrpc.session.getDisplayState.useQuery(


### PR DESCRIPTION
## Problem

The chat display hooks poll on a **per-session query key** but set no `gcTime`, so they inherit the global `QueryClient` default of **30 minutes** (`workspace-client` `GC_TIME_MS`):

- `apps/desktop/.../useWorkspaceChatDisplay.ts` → `chat.getSnapshot`
- `packages/chat/.../use-chat-display.ts` → `session.getDisplayState` + `session.listMessages`

React Query retains a query's data for the full `gcTime` **after it loses its last observer**. So every session you visit leaves its snapshot — the full message history, including image/file payloads — sitting in the cache for 30 minutes after its pane unmounts. Across many sessions/panes over a long working session, these orphaned snapshots accumulate and grow the renderer heap.

## Fix

Override `gcTime` to **60s** on these polling queries so inactive sessions' cached data is released shortly after their pane unmounts.

- Mounted panes are unaffected — `gcTime` only starts counting once a query has no observers.
- 60s still lets a quick re-open hit the cache without a refetch.
- Scoped to the chat display queries (not the global default), so filesystem/git queries keep their existing behavior.

## Context

This is the **retained-heap** complement to the polling-rate reduction (default `fps` 60 → 4) already on `main`. It carries forward the one still-relevant lever from the now-closed #3170, re-based cleanly onto main's current `getSnapshot` architecture.

### Not included (possible follow-up)
Idle polling still runs at the flat `refetchInterval` with `refetchIntervalInBackground: true`. That's allocation *churn* (a GC-pressure/CPU concern), not retained heap, and was largely addressed by the fps reduction — left out here to keep this change scoped to the heap-growth cause.

## Verification
- `bun run typecheck` for `@superset/desktop` + `@superset/chat`: **pass**
- `bun run lint`: **exit 0**

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5459">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents renderer heap growth by releasing inactive chat snapshots shortly after panes close.

- **Bug Fixes**
  - Set `gcTime: 60_000` on per-session chat polling queries (`chat.getSnapshot`, `session.getDisplayState`, `session.listMessages`) in `apps/desktop` and `packages/chat`.
  - Keeps data while observed; drops it ~60s after unmount to avoid accumulation, while allowing quick reopen to hit cache.

<sup>Written for commit e7be9a10f0d82be555268a304864ab513a7a7e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat session handling so inactive chat data is cleared sooner after a pane closes.
  * Reduced the chance of outdated chat snapshots or messages lingering in the interface when switching sessions.
  * Kept chat-related data cached briefly for smoother return visits, while avoiding unnecessary long-term retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->