### PR TITLE
fix(desktop): workspaces table rows not filling the pane (phantom colSpan column)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -10,7 +10,7 @@ import {
 import { Table, TableBody, TableHead, TableRow } from "@superset/ui/table";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
 	LuChevronDown,
 	LuChevronRight,
@@ -34,7 +34,10 @@ import {
 import { useV2ProjectLocalMetaStore } from "renderer/stores/v2-project-local-meta";
 import { V2WorkspaceProjectIcon } from "../V2WorkspaceProjectIcon";
 import { V2WorkspaceRow } from "./components/V2WorkspaceRow";
-import { V2_WORKSPACES_COLUMN_COUNT } from "./constants";
+import {
+	useWorkspaceColumns,
+	type WorkspaceColumnVisibility,
+} from "./hooks/useWorkspaceColumns";
 import type { SortDirection, SortField } from "./types";
 
 interface V2WorkspacesListProps {
@@ -148,6 +151,9 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 	const [sortField, setSortField] = useState<SortField>("host");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
+	const containerRef = useRef<HTMLDivElement>(null);
+	const { columns, columnCount } = useWorkspaceColumns(containerRef);
+
 	const handleSort = (field: SortField) => {
 		if (sortField === field) {
 			setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
@@ -194,39 +200,39 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 						onSort={handleSort}
 					/>
 				</TableHead>
-				<TableHead
-					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-48 @lg:table-cell")}
-				>
-					<SortableHeader
-						field="host"
-						label="Host"
-						sortField={sortField}
-						sortDirection={sortDirection}
-						onSort={handleSort}
-					/>
-				</TableHead>
-				<TableHead
-					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-56 @3xl:table-cell")}
-				>
-					<SortableHeader
-						field="branch"
-						label="Branch"
-						sortField={sortField}
-						sortDirection={sortDirection}
-						onSort={handleSort}
-					/>
-				</TableHead>
-				<TableHead
-					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-44 @5xl:table-cell")}
-				>
-					<SortableHeader
-						field="created"
-						label="Created"
-						sortField={sortField}
-						sortDirection={sortDirection}
-						onSort={handleSort}
-					/>
-				</TableHead>
+				{columns.host ? (
+					<TableHead className={cn(DATA_TABLE_HEAD_CELL, "w-48")}>
+						<SortableHeader
+							field="host"
+							label="Host"
+							sortField={sortField}
+							sortDirection={sortDirection}
+							onSort={handleSort}
+						/>
+					</TableHead>
+				) : null}
+				{columns.branch ? (
+					<TableHead className={cn(DATA_TABLE_HEAD_CELL, "w-56")}>
+						<SortableHeader
+							field="branch"
+							label="Branch"
+							sortField={sortField}
+							sortDirection={sortDirection}
+							onSort={handleSort}
+						/>
+					</TableHead>
+				) : null}
+				{columns.created ? (
+					<TableHead className={cn(DATA_TABLE_HEAD_CELL, "w-44")}>
+						<SortableHeader
+							field="created"
+							label="Created"
+							sortField={sortField}
+							sortDirection={sortDirection}
+							onSort={handleSort}
+						/>
+					</TableHead>
+				) : null}
 				<TableHead className={cn(DATA_TABLE_HEAD_CELL, "w-14 pr-6")} />
 			</TableRow>
 		</DataTableHeader>
@@ -234,7 +240,7 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 
 	if (totalCount === 0) {
 		return (
-			<div className="@container flex min-h-0 flex-1 flex-col">
+			<div ref={containerRef} className="flex min-h-0 flex-1 flex-col">
 				<Table className="table-fixed">{columnHeader}</Table>
 				<Empty className="flex-1 border-0">
 					<EmptyHeader>
@@ -272,7 +278,7 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 	}
 
 	return (
-		<div className="@container min-h-0 flex-1">
+		<div ref={containerRef} className="min-h-0 flex-1">
 			<Table
 				containerClassName="h-full overflow-y-auto"
 				className="table-fixed"
@@ -283,6 +289,8 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 						key={project.projectId}
 						project={project}
 						currentWorkspaceId={currentWorkspaceId}
+						columns={columns}
+						columnCount={columnCount}
 					/>
 				))}
 			</Table>
@@ -293,9 +301,16 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 interface ProjectSectionProps {
 	project: ProjectGroup;
 	currentWorkspaceId: string | null;
+	columns: WorkspaceColumnVisibility;
+	columnCount: number;
 }
 
-function ProjectSection({ project, currentWorkspaceId }: ProjectSectionProps) {
+function ProjectSection({
+	project,
+	currentWorkspaceId,
+	columns,
+	columnCount,
+}: ProjectSectionProps) {
 	const persistedCollapsed = useV2ProjectLocalMetaStore(
 		(state) => state.projects[project.projectId]?.isCollapsed ?? false,
 	);
@@ -311,7 +326,7 @@ function ProjectSection({ project, currentWorkspaceId }: ProjectSectionProps) {
 	return (
 		<TableBody id={`v2-workspaces-project-${project.projectId}`}>
 			<TableRow className="sticky top-8 z-[5] border-border/60 hover:bg-transparent">
-				<td colSpan={V2_WORKSPACES_COLUMN_COUNT} className="p-0">
+				<td colSpan={columnCount} className="p-0">
 					<button
 						type="button"
 						onClick={() => toggleCollapsed(project.projectId)}
@@ -344,6 +359,7 @@ function ProjectSection({ project, currentWorkspaceId }: ProjectSectionProps) {
 							key={workspace.id}
 							workspace={workspace}
 							isCurrentRoute={workspace.id === currentWorkspaceId}
+							columns={columns}
 						/>
 					))}
 		</TableBody>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -195,7 +195,7 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 					/>
 				</TableHead>
 				<TableHead
-					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-48 md:table-cell")}
+					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-48 @lg:table-cell")}
 				>
 					<SortableHeader
 						field="host"
@@ -206,7 +206,7 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 					/>
 				</TableHead>
 				<TableHead
-					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-56 lg:table-cell")}
+					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-56 @3xl:table-cell")}
 				>
 					<SortableHeader
 						field="branch"
@@ -217,7 +217,7 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 					/>
 				</TableHead>
 				<TableHead
-					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-44 xl:table-cell")}
+					className={cn(DATA_TABLE_HEAD_CELL, "hidden w-44 @5xl:table-cell")}
 				>
 					<SortableHeader
 						field="created"
@@ -234,7 +234,7 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 
 	if (totalCount === 0) {
 		return (
-			<div className="flex min-h-0 flex-1 flex-col">
+			<div className="@container flex min-h-0 flex-1 flex-col">
 				<Table className="table-fixed">{columnHeader}</Table>
 				<Empty className="flex-1 border-0">
 					<EmptyHeader>
@@ -272,7 +272,7 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 	}
 
 	return (
-		<div className="min-h-0 flex-1">
+		<div className="@container min-h-0 flex-1">
 			<Table
 				containerClassName="h-full overflow-y-auto"
 				className="table-fixed"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -43,10 +43,12 @@ import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/u
 import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 import { PRIcon } from "renderer/screens/main/components/PRIcon/PRIcon";
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
+import type { WorkspaceColumnVisibility } from "../../hooks/useWorkspaceColumns";
 
 interface V2WorkspaceRowProps {
 	workspace: AccessibleV2Workspace;
 	isCurrentRoute: boolean;
+	columns: WorkspaceColumnVisibility;
 }
 
 function hostIconFor(hostType: V2WorkspaceHostType) {
@@ -56,6 +58,7 @@ function hostIconFor(hostType: V2WorkspaceHostType) {
 export function V2WorkspaceRow({
 	workspace,
 	isCurrentRoute,
+	columns,
 }: V2WorkspaceRowProps) {
 	const navigate = useNavigate();
 	const { gateFeature } = usePaywall();
@@ -277,35 +280,41 @@ export function V2WorkspaceRow({
 							</span>
 						</TableCell>
 
-						<TableCell className="hidden py-1.5 @lg:table-cell">
-							{treatAsOffline ? (
-								<Tooltip delayDuration={300}>
-									<TooltipTrigger asChild>{hostCell}</TooltipTrigger>
-									<TooltipContent side="top">Host is offline</TooltipContent>
-								</Tooltip>
-							) : (
-								hostCell
-							)}
-						</TableCell>
+						{columns.host ? (
+							<TableCell className="py-1.5">
+								{treatAsOffline ? (
+									<Tooltip delayDuration={300}>
+										<TooltipTrigger asChild>{hostCell}</TooltipTrigger>
+										<TooltipContent side="top">Host is offline</TooltipContent>
+									</Tooltip>
+								) : (
+									hostCell
+								)}
+							</TableCell>
+						) : null}
 
-						<TableCell className="hidden py-1.5 @3xl:table-cell">
-							<span
-								className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
-								title={workspace.branch}
-							>
-								<LuGitBranch className="size-3 shrink-0" />
-								<span className="min-w-0 truncate font-mono text-[11px]">
-									{workspace.branch}
+						{columns.branch ? (
+							<TableCell className="py-1.5">
+								<span
+									className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
+									title={workspace.branch}
+								>
+									<LuGitBranch className="size-3 shrink-0" />
+									<span className="min-w-0 truncate font-mono text-[11px]">
+										{workspace.branch}
+									</span>
 								</span>
-							</span>
-						</TableCell>
+							</TableCell>
+						) : null}
 
-						<TableCell
-							className="hidden truncate py-1.5 text-xs tabular-nums text-muted-foreground @5xl:table-cell"
-							title={`Created ${workspace.createdAt.toLocaleString()} by ${creatorLabel}`}
-						>
-							{timeLabel} · {creatorLabel}
-						</TableCell>
+						{columns.created ? (
+							<TableCell
+								className="truncate py-1.5 text-xs tabular-nums text-muted-foreground"
+								title={`Created ${workspace.createdAt.toLocaleString()} by ${creatorLabel}`}
+							>
+								{timeLabel} · {creatorLabel}
+							</TableCell>
+						) : null}
 
 						<TableCell className="py-1.5 pr-6">
 							<div className="flex items-center justify-center">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -277,7 +277,7 @@ export function V2WorkspaceRow({
 							</span>
 						</TableCell>
 
-						<TableCell className="hidden py-1.5 md:table-cell">
+						<TableCell className="hidden py-1.5 @lg:table-cell">
 							{treatAsOffline ? (
 								<Tooltip delayDuration={300}>
 									<TooltipTrigger asChild>{hostCell}</TooltipTrigger>
@@ -288,7 +288,7 @@ export function V2WorkspaceRow({
 							)}
 						</TableCell>
 
-						<TableCell className="hidden py-1.5 lg:table-cell">
+						<TableCell className="hidden py-1.5 @3xl:table-cell">
 							<span
 								className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
 								title={workspace.branch}
@@ -301,7 +301,7 @@ export function V2WorkspaceRow({
 						</TableCell>
 
 						<TableCell
-							className="hidden truncate py-1.5 text-xs tabular-nums text-muted-foreground xl:table-cell"
+							className="hidden truncate py-1.5 text-xs tabular-nums text-muted-foreground @5xl:table-cell"
 							title={`Created ${workspace.createdAt.toLocaleString()} by ${creatorLabel}`}
 						>
 							{timeLabel} · {creatorLabel}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts
@@ -1,2 +1,0 @@
-// Feeds the project-group row's colSpan so it spans the full table width.
-export const V2_WORKSPACES_COLUMN_COUNT = 6;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/hooks/useWorkspaceColumns/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/hooks/useWorkspaceColumns/index.ts
@@ -1,0 +1,5 @@
+export {
+	useWorkspaceColumns,
+	type WorkspaceColumns,
+	type WorkspaceColumnVisibility,
+} from "./useWorkspaceColumns";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/hooks/useWorkspaceColumns/useWorkspaceColumns.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/hooks/useWorkspaceColumns/useWorkspaceColumns.ts
@@ -1,0 +1,62 @@
+import { type RefObject, useLayoutEffect, useState } from "react";
+
+export interface WorkspaceColumnVisibility {
+	host: boolean;
+	branch: boolean;
+	created: boolean;
+}
+
+export interface WorkspaceColumns {
+	columns: WorkspaceColumnVisibility;
+	/** Total rendered columns — feeds the project-group row's colSpan. */
+	columnCount: number;
+}
+
+// Pin, name, and actions always render.
+const BASE_COLUMN_COUNT = 3;
+
+// Optional columns appear once the list container itself (not the window —
+// the resizable sidebar makes viewport breakpoints lie) is wide enough.
+const HOST_MIN_WIDTH = 512;
+const BRANCH_MIN_WIDTH = 768;
+const CREATED_MIN_WIDTH = 1024;
+
+/**
+ * Decides which optional table columns fit the list container. Rendering
+ * (not CSS-hiding) columns from one measured width keeps the project-group
+ * row's colSpan in sync with the real column count — a colSpan larger than
+ * the rendered columns makes `table-fixed` mint a phantom empty column that
+ * steals half the Name column's flexible width.
+ */
+export function useWorkspaceColumns(
+	containerRef: RefObject<HTMLElement | null>,
+): WorkspaceColumns {
+	const [width, setWidth] = useState<number | null>(null);
+
+	useLayoutEffect(() => {
+		const element = containerRef.current;
+		if (!element) return;
+		setWidth(element.clientWidth);
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (entry) setWidth(entry.contentRect.width);
+		});
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, [containerRef]);
+
+	// Until the first measurement, assume wide so the common case doesn't flash.
+	const measured = width ?? Number.POSITIVE_INFINITY;
+	const columns: WorkspaceColumnVisibility = {
+		host: measured >= HOST_MIN_WIDTH,
+		branch: measured >= BRANCH_MIN_WIDTH,
+		created: measured >= CREATED_MIN_WIDTH,
+	};
+	const columnCount =
+		BASE_COLUMN_COUNT +
+		Number(columns.host) +
+		Number(columns.branch) +
+		Number(columns.created);
+
+	return { columns, columnCount };
+}


### PR DESCRIPTION
## Summary
- Fixes the v2 Workspaces list rows getting crushed/cut off at smaller window sizes: the Name column collapsed to a few characters while a dead empty strip sat to the right of the actions column.
- Column responsiveness is now driven by the list pane's measured width (ResizeObserver) instead of viewport breakpoints, and the project-group row's `colSpan` always matches the real rendered column count.

## Why / Context
Two compounding bugs from the recent table rework (#5454):

1. **Phantom column.** The project-group header row hardcoded `colSpan={6}`, but the Host/Branch/Created columns were CSS-hidden (`md:`/`lg:`/`xl:table-cell`) at narrower widths, leaving only 3–5 real columns. A `colSpan` larger than the rendered column count makes the browser mint an extra empty column, and with `table-fixed` that phantom column split the flexible width ~50/50 with the Name column — Name got truncated to nothing and rows looked like they stopped filling the container.
2. **Wrong breakpoint reference.** The `md`/`lg`/`xl` breakpoints measure the window, but the list sits next to a resizable sidebar, so the columns showed/hid based on a width the pane doesn't actually have.

CSS can't keep a DOM attribute (`colSpan`) in sync with CSS-hidden cells, so both signals now come from one measured source of truth.

## How It Works
- New `useWorkspaceColumns` hook puts a `ResizeObserver` on the list container and returns which optional columns fit (Host ≥ 512px, Branch ≥ 768px, Created ≥ 1024px of pane width) plus the total column count.
- Header cells and row cells are conditionally rendered from that visibility (no more `hidden md:table-cell`), and the project-group row uses the same count for its `colSpan` — the two can never disagree again.
- First paint is flash-free: the hook measures `clientWidth` in `useLayoutEffect` (before paint) and assumes wide until measured.
- `constants.ts` (`V2_WORKSPACES_COLUMN_COUNT`) is deleted — the count is now derived.

## Manual QA Checklist
- [ ] Rows fill the full pane width at every window size (hover highlight reaches the right edge, no dead strip after the trash icon)
- [ ] Name column takes the leftover space and truncates gracefully
- [ ] Host / Branch / Created columns appear/disappear as the window **or the sidebar** is resized
- [ ] Project group header ("Superset · N") still spans the full row width and stays sticky
- [ ] Empty state (filters with no matches) renders the header without layout breaks
- [ ] Sorting, pin/unpin, delete, and row context menu still work

## Testing
- `bun run lint` — clean
- `tsc --noEmit` on `apps/desktop` — no errors in the touched files (a few pre-existing, unrelated route-typing errors exist in this worktree, likely a stale generated route tree)
- Not yet verified in the running app — the bug was reproduced from a screenshot and the fix is structural; please run through the QA checklist above.

## Design Decisions
- **Why JS measurement instead of Tailwind container queries**: container queries were the first attempt, but they can only toggle CSS — the group row's `colSpan` is a DOM attribute, so any CSS-only approach leaves a window where the colSpan exceeds the visible columns and `table-fixed` creates the phantom column. Rendering columns from one measured width is the only way to keep them atomically in sync.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 Workspaces rows getting cut off by a phantom column and makes columns respond to the pane width so the Name column no longer gets crushed.

- **Bug Fixes**
  - Added `useWorkspaceColumns` with a `ResizeObserver` on the list pane to decide Host/Branch/Created at 512/768/1024px.
  - Columns are conditionally rendered instead of using `md/lg/xl` CSS classes.
  - Project-group header `colSpan` now uses the computed column count; removed `V2_WORKSPACES_COLUMN_COUNT`.
  - Prevents first-paint flash by measuring in `useLayoutEffect` with a wide default.

<sup>Written for commit a7c1e4086a791ca40e51eca7d3e54f279d32dfea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace lists now adapt their visible columns to the available window width.
  * Additional workspace details such as host, branch, and created date appear only when there is enough space.
  * Table layout and empty states now stay aligned as columns appear or disappear.

* **Bug Fixes**
  * Improved row and header alignment in the workspaces list.
  * Reduced layout flicker during initial loading and resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->