### PR TITLE
fix(host-service): accept empty agent model/effort in workspaces.create

### DIFF
--- a/packages/host-service/src/trpc/router/git/get-check-job-logs.test.ts
+++ b/packages/host-service/src/trpc/router/git/get-check-job-logs.test.ts
@@ -43,7 +43,10 @@ function createCaller(opts: {
 	return { caller: gitRouter.createCaller(ctx), downloadCalls };
 }
 
-async function expectTrpcError(promise: Promise<unknown>, code: string) {
+async function expectTrpcError(
+	promise: Promise<unknown>,
+	code: TRPCError["code"],
+) {
 	try {
 		await promise;
 		throw new Error("expected the call to reject");

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -61,8 +61,8 @@ const agentLaunchSchema = z
 		agent: z.string().min(1),
 		prompt: z.string(),
 		attachmentIds: z.array(z.string().uuid()).optional(),
-		model: z.string().min(1).optional(),
-		effort: z.string().min(1).optional(),
+		model: z.string().optional(),
+		effort: z.string().optional(),
 	})
 	.refine(
 		(value) =>


### PR DESCRIPTION
## Problem

Creating a workspace with an agent failed with a Zod validation error:

```json
[{ "code": "too_small", "minimum": 1, "path": ["agents", 0, "model"],
   "message": "Too small: expected string to have >=1 characters" }]
```

The `workspaces.create` `agentLaunchSchema` declared `model`/`effort` as `z.string().min(1).optional()`. That accepts `undefined` but **rejects an empty string** — so any caller sending `model: ""` (e.g. a blank model picker) is blocked at input validation.

## Fix

Drop `.min(1)` from `model` and `effort`:

```ts
model: z.string().optional(),
effort: z.string().optional(),
```

Empty is semantically "no override", and everything downstream already treats it that way:
- `buildAgentModelArgs(presetId, "")` short-circuits on `!model → []` (no flag)
- the chat path gates on `input.model ?` (falsy `""` → no metadata)

So `""` and `undefined` behave identically after validation; the only change is that the schema no longer rejects `""`.

## Also: unblock typecheck on `main`

`main` was red before this branch — PR #5257 landed `get-check-job-logs.test.ts` with `expectTrpcError(promise, code: string)`, where `.toBe((error as TRPCError).code)` infers its expected arg as the TRPC error-code enum, so `string` isn't assignable (TS2769). Since CI typechecks the branch merged with `main`, this failure surfaced here. Narrowed the param to `TRPCError["code"]`.

## Verification

- `@superset/host-service` typecheck passes locally.
- Parsed the exact failing input against the schema: `model: ""` now parses instead of throwing; real ids pass through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed validation for agent launch settings so `model` and `effort` no longer require non-empty strings when included, preventing unnecessary rejections.
* **Tests**
  * Improved test helper typing for TRPC error code assertions to better align with the actual TRPC error shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->