### PR TITLE
fix(api): keep proxied Linear images out of shared caches

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
 		"clean": "git clean -xdf .cache .next .turbo node_modules",
 		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${API_PORT:-3001}'",
 		"start": "next start --port 3001",
+		"test": "bun test",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/apps/api/src/app/api/proxy/linear-image/route-core.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route-core.ts
@@ -1,0 +1,175 @@
+const LINEAR_IMAGE_HOST = "uploads.linear.app";
+const LINEAR_IMAGE_FETCH_TIMEOUT_MS = 15_000;
+const NO_STORE_HEADERS = {
+	"Cache-Control": "no-store",
+	Pragma: "no-cache",
+	"X-Content-Type-Options": "nosniff",
+} as const;
+const ALLOWED_IMAGE_CONTENT_TYPES = new Set([
+	"image/avif",
+	"image/gif",
+	"image/jpeg",
+	"image/png",
+	"image/webp",
+]);
+
+type LinearImageSession = {
+	user?: unknown;
+	session?: {
+		activeOrganizationId?: string | null;
+	};
+} | null;
+
+type LinearImageConnection =
+	| {
+			accessToken: string;
+	  }
+	| null
+	| undefined;
+
+type LinearImageProxyDependencies = {
+	fetch: typeof fetch;
+	findLinearConnection: (
+		organizationId: string,
+	) => Promise<LinearImageConnection>;
+	getSession: (headers: Headers) => Promise<LinearImageSession>;
+};
+
+function noStoreResponse(
+	body: BodyInit | null,
+	init: ResponseInit = {},
+): Response {
+	const headers = new Headers(init.headers);
+	for (const [header, value] of Object.entries(NO_STORE_HEADERS)) {
+		headers.set(header, value);
+	}
+
+	return new Response(body, {
+		...init,
+		headers,
+	});
+}
+
+function getAllowedImageContentType(response: Response): string | null {
+	const contentType = response.headers
+		.get("content-type")
+		?.split(";")[0]
+		?.trim()
+		.toLowerCase();
+
+	return contentType && ALLOWED_IMAGE_CONTENT_TYPES.has(contentType)
+		? contentType
+		: null;
+}
+
+export async function handleLinearImageProxy(
+	request: Request,
+	dependencies: LinearImageProxyDependencies,
+): Promise<Response> {
+	try {
+		return await handleLinearImageProxyRequest(request, dependencies);
+	} catch (error) {
+		console.error("[proxy/linear-image] Linear proxy failed:", {
+			errorName: error instanceof Error ? error.name : typeof error,
+		});
+		return noStoreResponse("Failed to proxy Linear image", { status: 500 });
+	}
+}
+
+async function handleLinearImageProxyRequest(
+	request: Request,
+	dependencies: LinearImageProxyDependencies,
+): Promise<Response> {
+	const sessionData = await dependencies.getSession(request.headers);
+
+	if (!sessionData?.user) {
+		return noStoreResponse("Unauthorized", { status: 401 });
+	}
+
+	const organizationId = sessionData.session?.activeOrganizationId;
+	if (!organizationId) {
+		return noStoreResponse("No active organization", { status: 400 });
+	}
+
+	const url = new URL(request.url);
+	const linearUrl = url.searchParams.get("url");
+
+	if (!linearUrl) {
+		return noStoreResponse("Missing url parameter", { status: 400 });
+	}
+
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(linearUrl);
+	} catch {
+		return noStoreResponse("Invalid URL", { status: 400 });
+	}
+
+	if (parsedUrl.protocol !== "https:" || parsedUrl.host !== LINEAR_IMAGE_HOST) {
+		return noStoreResponse(
+			`Only https://${LINEAR_IMAGE_HOST} URLs are allowed`,
+			{
+				status: 400,
+			},
+		);
+	}
+
+	if (parsedUrl.username || parsedUrl.password) {
+		return noStoreResponse("Linear image URLs cannot include credentials", {
+			status: 400,
+		});
+	}
+
+	const connection = await dependencies.findLinearConnection(organizationId);
+
+	if (!connection) {
+		return noStoreResponse("Linear integration not connected", { status: 400 });
+	}
+
+	try {
+		const linearResponse = await dependencies.fetch(parsedUrl.toString(), {
+			headers: {
+				Authorization: `Bearer ${connection.accessToken}`,
+			},
+			redirect: "error",
+			signal: AbortSignal.timeout(LINEAR_IMAGE_FETCH_TIMEOUT_MS),
+		});
+
+		if (!linearResponse.ok) {
+			console.error("[proxy/linear-image] Linear fetch failed:", {
+				host: parsedUrl.host,
+				hasQuery: parsedUrl.search.length > 0,
+				pathLength: parsedUrl.pathname.length,
+				status: linearResponse.status,
+				statusText: linearResponse.statusText,
+			});
+			return noStoreResponse("Failed to fetch image from Linear", {
+				status: linearResponse.status,
+			});
+		}
+
+		const contentType = getAllowedImageContentType(linearResponse);
+		if (!contentType) {
+			return noStoreResponse("Unsupported Linear image content type", {
+				status: 415,
+			});
+		}
+
+		return noStoreResponse(linearResponse.body, {
+			status: 200,
+			headers: {
+				"Content-Type": contentType,
+			},
+		});
+	} catch (error) {
+		console.error("[proxy/linear-image] Linear fetch threw:", {
+			errorName: error instanceof Error ? error.name : typeof error,
+			host: parsedUrl.host,
+			hasQuery: parsedUrl.search.length > 0,
+			pathLength: parsedUrl.pathname.length,
+		});
+		return noStoreResponse("Failed to fetch image from Linear", {
+			status: 502,
+		});
+	}
+}

--- a/apps/api/src/app/api/proxy/linear-image/route-core.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route-core.ts
@@ -1,5 +1,6 @@
 const LINEAR_IMAGE_HOST = "uploads.linear.app";
 const LINEAR_IMAGE_FETCH_TIMEOUT_MS = 15_000;
+const CLIENT_CLOSED_REQUEST_STATUS = 499;
 const NO_STORE_HEADERS = {
 	"Cache-Control": "no-store",
 	Pragma: "no-cache",
@@ -62,6 +63,36 @@ function getAllowedImageContentType(response: Response): string | null {
 		: null;
 }
 
+function getErrorName(error: unknown): string {
+	return error instanceof Error ? error.name : typeof error;
+}
+
+function getLinearImageFetchSignal(requestSignal: AbortSignal): AbortSignal {
+	return AbortSignal.any([
+		requestSignal,
+		AbortSignal.timeout(LINEAR_IMAGE_FETCH_TIMEOUT_MS),
+	]);
+}
+
+function isClientClosedRequest(
+	requestSignal: AbortSignal,
+	error: unknown,
+): boolean {
+	return requestSignal.aborted && getErrorName(error) === "AbortError";
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+	if (!response.body) {
+		return;
+	}
+
+	try {
+		await response.body.cancel();
+	} catch {
+		// Best effort only: the proxy is already returning a local error response.
+	}
+}
+
 export async function handleLinearImageProxy(
 	request: Request,
 	dependencies: LinearImageProxyDependencies,
@@ -70,7 +101,7 @@ export async function handleLinearImageProxy(
 		return await handleLinearImageProxyRequest(request, dependencies);
 	} catch (error) {
 		console.error("[proxy/linear-image] Linear proxy failed:", {
-			errorName: error instanceof Error ? error.name : typeof error,
+			errorName: getErrorName(error),
 		});
 		return noStoreResponse("Failed to proxy Linear image", { status: 500 });
 	}
@@ -132,10 +163,11 @@ async function handleLinearImageProxyRequest(
 				Authorization: `Bearer ${connection.accessToken}`,
 			},
 			redirect: "error",
-			signal: AbortSignal.timeout(LINEAR_IMAGE_FETCH_TIMEOUT_MS),
+			signal: getLinearImageFetchSignal(request.signal),
 		});
 
 		if (!linearResponse.ok) {
+			await cancelResponseBody(linearResponse);
 			console.error("[proxy/linear-image] Linear fetch failed:", {
 				host: parsedUrl.host,
 				hasQuery: parsedUrl.search.length > 0,
@@ -150,6 +182,7 @@ async function handleLinearImageProxyRequest(
 
 		const contentType = getAllowedImageContentType(linearResponse);
 		if (!contentType) {
+			await cancelResponseBody(linearResponse);
 			return noStoreResponse("Unsupported Linear image content type", {
 				status: 415,
 			});
@@ -162,8 +195,15 @@ async function handleLinearImageProxyRequest(
 			},
 		});
 	} catch (error) {
+		if (isClientClosedRequest(request.signal, error)) {
+			return noStoreResponse("Client closed request", {
+				status: CLIENT_CLOSED_REQUEST_STATUS,
+				statusText: "Client Closed Request",
+			});
+		}
+
 		console.error("[proxy/linear-image] Linear fetch threw:", {
-			errorName: error instanceof Error ? error.name : typeof error,
+			errorName: getErrorName(error),
 			host: parsedUrl.host,
 			hasQuery: parsedUrl.search.length > 0,
 			pathLength: parsedUrl.pathname.length,

--- a/apps/api/src/app/api/proxy/linear-image/route.test.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route.test.ts
@@ -17,10 +17,10 @@ const fetchLinearImage = mock(
 const originalConsoleError = console.error;
 const consoleError = mock(() => undefined);
 
-function linearImageRequest(linearUrl: string): Request {
+function linearImageRequest(linearUrl: string, init?: RequestInit): Request {
 	const url = new URL("http://localhost/api/proxy/linear-image");
 	url.searchParams.set("url", linearUrl);
-	return new Request(url);
+	return new Request(url, init);
 }
 
 function proxy(request: Request) {
@@ -29,6 +29,23 @@ function proxy(request: Request) {
 		findLinearConnection,
 		getSession,
 	});
+}
+
+function streamWithCancel(): {
+	body: ReadableStream<Uint8Array>;
+	cancel: ReturnType<typeof mock>;
+} {
+	const cancel = mock(() => undefined);
+
+	return {
+		body: new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode("denied"));
+			},
+			cancel,
+		}),
+		cancel,
+	};
 }
 
 function expectNoStoreHeaders(response: Response) {
@@ -85,6 +102,31 @@ describe("linear image proxy", () => {
 		expect(fetchOptions?.signal instanceof AbortSignal).toBe(true);
 	});
 
+	test("propagates client aborts to the upstream Linear image fetch", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		fetchLinearImage.mockImplementationOnce(async () => {
+			throw new DOMException("The operation was aborted.", "AbortError");
+		});
+
+		const response = await proxy(
+			linearImageRequest("https://uploads.linear.app/private-image.jpg", {
+				signal: controller.signal,
+			}),
+		);
+
+		expect(response.status).toBe(499);
+		expect(response.statusText).toBe("Client Closed Request");
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe("Client closed request");
+		const fetchOptions = fetchLinearImage.mock.calls[0]?.[1] as
+			| RequestInit
+			| undefined;
+		expect(fetchOptions?.signal instanceof AbortSignal).toBe(true);
+		expect(fetchOptions?.signal?.aborted).toBe(true);
+		expect(consoleError).not.toHaveBeenCalled();
+	});
+
 	test("rejects non-Linear image hosts before fetching", async () => {
 		const response = await proxy(
 			linearImageRequest("https://example.com/private-image.jpg"),
@@ -130,8 +172,9 @@ describe("linear image proxy", () => {
 	});
 
 	test("keeps upstream failures out of caches without logging raw URLs", async () => {
+		const upstreamBody = streamWithCancel();
 		fetchLinearImage.mockResolvedValueOnce(
-			new Response("denied", {
+			new Response(upstreamBody.body, {
 				status: 403,
 				statusText: "Forbidden",
 			}),
@@ -153,11 +196,13 @@ describe("linear image proxy", () => {
 			status: 403,
 			statusText: "Forbidden",
 		});
+		expect(upstreamBody.cancel).toHaveBeenCalled();
 	});
 
 	test("rejects active image content types from Linear", async () => {
+		const upstreamBody = streamWithCancel();
 		fetchLinearImage.mockResolvedValueOnce(
-			new Response("<svg><script>alert(1)</script></svg>", {
+			new Response(upstreamBody.body, {
 				headers: { "content-type": "image/svg+xml" },
 			}),
 		);
@@ -169,6 +214,7 @@ describe("linear image proxy", () => {
 		expect(response.status).toBe(415);
 		expectNoStoreHeaders(response);
 		expect(await response.text()).toBe("Unsupported Linear image content type");
+		expect(upstreamBody.cancel).toHaveBeenCalled();
 	});
 
 	test("returns a no-store bad gateway when hardened fetch throws", async () => {

--- a/apps/api/src/app/api/proxy/linear-image/route.test.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getSession = mock(async () => ({
+	user: { id: "user-1" },
+	session: { activeOrganizationId: "org-1" },
+}));
+const findLinearConnection = mock(async () => ({
+	accessToken: "linear-token",
+}));
+
+mock.module("@superset/auth/server", () => ({
+	auth: {
+		api: {
+			getSession,
+		},
+	},
+}));
+
+mock.module("@superset/db/client", () => ({
+	db: {
+		query: {
+			integrationConnections: {
+				findFirst: findLinearConnection,
+			},
+		},
+	},
+}));
+
+mock.module("@superset/db/schema", () => ({
+	integrationConnections: {
+		organizationId: "organizationId",
+		provider: "provider",
+	},
+}));
+
+mock.module("drizzle-orm", () => ({
+	and: (...conditions: unknown[]) => ({ conditions, type: "and" }),
+	eq: (field: unknown, value: unknown) => ({ field, type: "eq", value }),
+}));
+
+const originalFetch = globalThis.fetch;
+const { GET } = await import("./route");
+
+function linearImageRequest(linearUrl: string): Request {
+	const url = new URL("http://localhost/api/proxy/linear-image");
+	url.searchParams.set("url", linearUrl);
+	return new Request(url);
+}
+
+describe("linear image proxy", () => {
+	beforeEach(() => {
+		getSession.mockClear();
+		findLinearConnection.mockClear();
+		getSession.mockResolvedValue({
+			user: { id: "user-1" },
+			session: { activeOrganizationId: "org-1" },
+		});
+		findLinearConnection.mockResolvedValue({ accessToken: "linear-token" });
+		globalThis.fetch = originalFetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	test("keeps authenticated Linear images out of shared caches", async () => {
+		const fetchLinearImage = mock(
+			async () =>
+				new Response(new Uint8Array([1, 2, 3]), {
+					headers: { "content-type": "image/jpeg" },
+				}),
+		);
+		globalThis.fetch = fetchLinearImage as unknown as typeof fetch;
+
+		const response = await GET(
+			linearImageRequest("https://uploads.linear.app/private-image.jpg"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toBe("image/jpeg");
+		expect(response.headers.get("cache-control")).toBe(
+			"private, no-store, max-age=0",
+		);
+		expect(response.headers.get("pragma")).toBe("no-cache");
+		expect(response.headers.get("vary")).toBe("Cookie, Authorization");
+		expect(fetchLinearImage.mock.calls[0]?.[0]).toBe(
+			"https://uploads.linear.app/private-image.jpg",
+		);
+		expect(fetchLinearImage.mock.calls[0]?.[1]).toEqual({
+			headers: { Authorization: "Bearer linear-token" },
+		});
+	});
+
+	test("rejects non-Linear image hosts before fetching", async () => {
+		const fetchLinearImage = mock(async () => new Response("unexpected"));
+		globalThis.fetch = fetchLinearImage as unknown as typeof fetch;
+
+		const response = await GET(
+			linearImageRequest("https://example.com/private-image.jpg"),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toBe(
+			"Only uploads.linear.app URLs are allowed",
+		);
+		expect(fetchLinearImage).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/app/api/proxy/linear-image/route.test.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route.test.ts
@@ -1,5 +1,50 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { integrationConnections } from "@superset/db/schema";
 import { handleLinearImageProxy } from "./route-core";
+
+const findFirstIntegrationConnection = mock(async () => ({
+	accessToken: "linear-token",
+}));
+const getRouteSession = mock(async () => ({
+	user: { id: "user-1" },
+	session: { activeOrganizationId: "org-1" },
+}));
+const andClause = mock((...clauses: unknown[]) => ({ clauses, type: "and" }));
+const eqClause = mock((left: unknown, right: unknown) => ({
+	left,
+	right,
+	type: "eq",
+}));
+const isNullClause = mock((column: unknown) => ({
+	column,
+	type: "isNull",
+}));
+
+mock.module("@superset/auth/server", () => ({
+	auth: {
+		api: {
+			getSession: getRouteSession,
+		},
+	},
+}));
+
+mock.module("@superset/db/client", () => ({
+	db: {
+		query: {
+			integrationConnections: {
+				findFirst: findFirstIntegrationConnection,
+			},
+		},
+	},
+}));
+
+mock.module("drizzle-orm", () => ({
+	and: andClause,
+	eq: eqClause,
+	isNull: isNullClause,
+}));
+
+const { GET } = await import("./route");
 
 const getSession = mock(async () => ({
 	user: { id: "user-1" },
@@ -16,6 +61,14 @@ const fetchLinearImage = mock(
 );
 const originalConsoleError = console.error;
 const consoleError = mock(() => undefined);
+
+const originalFetch = globalThis.fetch;
+const routeFetch = mock(
+	async () =>
+		new Response(new Uint8Array([4, 5, 6]), {
+			headers: { "content-type": "image/png" },
+		}),
+);
 
 function linearImageRequest(linearUrl: string, init?: RequestInit): Request {
 	const url = new URL("http://localhost/api/proxy/linear-image");
@@ -59,12 +112,31 @@ describe("linear image proxy", () => {
 		getSession.mockClear();
 		findLinearConnection.mockClear();
 		fetchLinearImage.mockClear();
+		findFirstIntegrationConnection.mockClear();
+		getRouteSession.mockClear();
+		andClause.mockClear();
+		eqClause.mockClear();
+		isNullClause.mockClear();
+		routeFetch.mockClear();
 		consoleError.mockClear();
 		getSession.mockResolvedValue({
 			user: { id: "user-1" },
 			session: { activeOrganizationId: "org-1" },
 		});
 		findLinearConnection.mockResolvedValue({ accessToken: "linear-token" });
+		findFirstIntegrationConnection.mockResolvedValue({
+			accessToken: "linear-token",
+		});
+		getRouteSession.mockResolvedValue({
+			user: { id: "user-1" },
+			session: { activeOrganizationId: "org-1" },
+		});
+		routeFetch.mockResolvedValue(
+			new Response(new Uint8Array([4, 5, 6]), {
+				headers: { "content-type": "image/png" },
+			}),
+		);
+		globalThis.fetch = routeFetch as unknown as typeof fetch;
 		fetchLinearImage.mockResolvedValue(
 			new Response(new Uint8Array([1, 2, 3]), {
 				headers: { "content-type": "image/jpeg" },
@@ -75,6 +147,7 @@ describe("linear image proxy", () => {
 
 	afterEach(() => {
 		console.error = originalConsoleError;
+		globalThis.fetch = originalFetch;
 	});
 
 	test("keeps authenticated Linear images out of shared caches", async () => {
@@ -100,6 +173,71 @@ describe("linear image proxy", () => {
 		});
 		expect(fetchOptions?.redirect).toBe("error");
 		expect(fetchOptions?.signal instanceof AbortSignal).toBe(true);
+	});
+
+	test("GET queries only active Linear integrations for the session organization", async () => {
+		const response = await GET(
+			linearImageRequest("https://uploads.linear.app/private-image.png"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(findFirstIntegrationConnection).toHaveBeenCalledTimes(1);
+		expect(getRouteSession.mock.calls[0]?.[0]).toEqual({
+			headers: expect.any(Headers),
+		});
+		expect(eqClause.mock.calls).toEqual([
+			[integrationConnections.organizationId, "org-1"],
+			[integrationConnections.provider, "linear"],
+		]);
+		expect(isNullClause.mock.calls).toEqual([
+			[integrationConnections.disconnectedAt],
+		]);
+		expect(andClause.mock.calls[0]).toEqual([
+			{
+				left: integrationConnections.organizationId,
+				right: "org-1",
+				type: "eq",
+			},
+			{
+				left: integrationConnections.provider,
+				right: "linear",
+				type: "eq",
+			},
+			{ column: integrationConnections.disconnectedAt, type: "isNull" },
+		]);
+		expect(routeFetch.mock.calls[0]?.[1]).toMatchObject({
+			headers: { Authorization: "Bearer linear-token" },
+			redirect: "error",
+		});
+	});
+
+	test("applies a timeout signal to upstream Linear image fetches", async () => {
+		const originalTimeout = AbortSignal.timeout;
+		const timeoutSignal = new AbortController().signal;
+		const timeout = mock(() => timeoutSignal);
+
+		Object.defineProperty(AbortSignal, "timeout", {
+			configurable: true,
+			value: timeout,
+		});
+
+		try {
+			const response = await proxy(
+				linearImageRequest("https://uploads.linear.app/private-image.jpg"),
+			);
+
+			expect(response.status).toBe(200);
+			expect(timeout).toHaveBeenCalledWith(15_000);
+			const fetchOptions = fetchLinearImage.mock.calls[0]?.[1] as
+				| RequestInit
+				| undefined;
+			expect(fetchOptions?.signal instanceof AbortSignal).toBe(true);
+		} finally {
+			Object.defineProperty(AbortSignal, "timeout", {
+				configurable: true,
+				value: originalTimeout,
+			});
+		}
 	});
 
 	test("propagates client aborts to the upstream Linear image fetch", async () => {

--- a/apps/api/src/app/api/proxy/linear-image/route.test.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { handleLinearImageProxy } from "./route-core";
 
 const getSession = mock(async () => ({
 	user: { id: "user-1" },
@@ -7,44 +8,14 @@ const getSession = mock(async () => ({
 const findLinearConnection = mock(async () => ({
 	accessToken: "linear-token",
 }));
-
-mock.module("@superset/auth/server", () => ({
-	auth: {
-		api: {
-			getSession,
-		},
-	},
-}));
-
-mock.module("@superset/db/client", () => ({
-	db: {
-		query: {
-			integrationConnections: {
-				findFirst: findLinearConnection,
-			},
-		},
-	},
-}));
-
-mock.module("@superset/db/schema", () => ({
-	integrationConnections: {
-		organizationId: "organizationId",
-		provider: "provider",
-	},
-	usersSlackUsers: {
-		id: "id",
-		slackUserId: "slackUserId",
-		teamId: "teamId",
-	},
-}));
-
-mock.module("drizzle-orm", () => ({
-	and: (...conditions: unknown[]) => ({ conditions, type: "and" }),
-	eq: (field: unknown, value: unknown) => ({ field, type: "eq", value }),
-}));
-
-const originalFetch = globalThis.fetch;
-const { GET } = await import("./route");
+const fetchLinearImage = mock(
+	async () =>
+		new Response(new Uint8Array([1, 2, 3]), {
+			headers: { "content-type": "image/jpeg" },
+		}),
+);
+const originalConsoleError = console.error;
+const consoleError = mock(() => undefined);
 
 function linearImageRequest(linearUrl: string): Request {
 	const url = new URL("http://localhost/api/proxy/linear-image");
@@ -52,62 +23,224 @@ function linearImageRequest(linearUrl: string): Request {
 	return new Request(url);
 }
 
+function proxy(request: Request) {
+	return handleLinearImageProxy(request, {
+		fetch: fetchLinearImage as unknown as typeof fetch,
+		findLinearConnection,
+		getSession,
+	});
+}
+
+function expectNoStoreHeaders(response: Response) {
+	expect(response.headers.get("cache-control")).toBe("no-store");
+	expect(response.headers.get("pragma")).toBe("no-cache");
+	expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+}
+
 describe("linear image proxy", () => {
 	beforeEach(() => {
 		getSession.mockClear();
 		findLinearConnection.mockClear();
+		fetchLinearImage.mockClear();
+		consoleError.mockClear();
 		getSession.mockResolvedValue({
 			user: { id: "user-1" },
 			session: { activeOrganizationId: "org-1" },
 		});
 		findLinearConnection.mockResolvedValue({ accessToken: "linear-token" });
-		globalThis.fetch = originalFetch;
+		fetchLinearImage.mockResolvedValue(
+			new Response(new Uint8Array([1, 2, 3]), {
+				headers: { "content-type": "image/jpeg" },
+			}),
+		);
+		console.error = consoleError;
 	});
 
 	afterEach(() => {
-		globalThis.fetch = originalFetch;
+		console.error = originalConsoleError;
 	});
 
 	test("keeps authenticated Linear images out of shared caches", async () => {
-		const fetchLinearImage = mock(
-			async () =>
-				new Response(new Uint8Array([1, 2, 3]), {
-					headers: { "content-type": "image/jpeg" },
-				}),
-		);
-		globalThis.fetch = fetchLinearImage as unknown as typeof fetch;
-
-		const response = await GET(
+		const response = await proxy(
 			linearImageRequest("https://uploads.linear.app/private-image.jpg"),
 		);
 
 		expect(response.status).toBe(200);
 		expect(response.headers.get("content-type")).toBe("image/jpeg");
-		expect(response.headers.get("cache-control")).toBe(
-			"private, no-store, max-age=0",
-		);
-		expect(response.headers.get("pragma")).toBe("no-cache");
-		expect(response.headers.get("vary")).toBe("Cookie, Authorization");
+		expectNoStoreHeaders(response);
+		expect(response.headers.has("vary")).toBe(false);
+		expect([...new Uint8Array(await response.arrayBuffer())]).toEqual([
+			1, 2, 3,
+		]);
 		expect(fetchLinearImage.mock.calls[0]?.[0]).toBe(
 			"https://uploads.linear.app/private-image.jpg",
 		);
-		expect(fetchLinearImage.mock.calls[0]?.[1]).toEqual({
-			headers: { Authorization: "Bearer linear-token" },
+		const fetchOptions = fetchLinearImage.mock.calls[0]?.[1] as
+			| RequestInit
+			| undefined;
+		expect(fetchOptions?.headers).toEqual({
+			Authorization: "Bearer linear-token",
 		});
+		expect(fetchOptions?.redirect).toBe("error");
+		expect(fetchOptions?.signal instanceof AbortSignal).toBe(true);
 	});
 
 	test("rejects non-Linear image hosts before fetching", async () => {
-		const fetchLinearImage = mock(async () => new Response("unexpected"));
-		globalThis.fetch = fetchLinearImage as unknown as typeof fetch;
-
-		const response = await GET(
+		const response = await proxy(
 			linearImageRequest("https://example.com/private-image.jpg"),
 		);
 
 		expect(response.status).toBe(400);
+		expectNoStoreHeaders(response);
 		expect(await response.text()).toBe(
-			"Only uploads.linear.app URLs are allowed",
+			"Only https://uploads.linear.app URLs are allowed",
 		);
+		expect(findLinearConnection).not.toHaveBeenCalled();
 		expect(fetchLinearImage).not.toHaveBeenCalled();
+	});
+
+	test("rejects non-HTTPS Linear image URLs before attaching auth", async () => {
+		const response = await proxy(
+			linearImageRequest("http://uploads.linear.app/private-image.jpg"),
+		);
+
+		expect(response.status).toBe(400);
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe(
+			"Only https://uploads.linear.app URLs are allowed",
+		);
+		expect(findLinearConnection).not.toHaveBeenCalled();
+		expect(fetchLinearImage).not.toHaveBeenCalled();
+	});
+
+	test("rejects credentialed Linear image URLs before attaching auth", async () => {
+		const response = await proxy(
+			linearImageRequest(
+				"https://user:pass@uploads.linear.app/private-image.jpg",
+			),
+		);
+
+		expect(response.status).toBe(400);
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe(
+			"Linear image URLs cannot include credentials",
+		);
+		expect(findLinearConnection).not.toHaveBeenCalled();
+		expect(fetchLinearImage).not.toHaveBeenCalled();
+	});
+
+	test("keeps upstream failures out of caches without logging raw URLs", async () => {
+		fetchLinearImage.mockResolvedValueOnce(
+			new Response("denied", {
+				status: 403,
+				statusText: "Forbidden",
+			}),
+		);
+
+		const response = await proxy(
+			linearImageRequest(
+				"https://uploads.linear.app/private-image.jpg?sig=secret",
+			),
+		);
+
+		expect(response.status).toBe(403);
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe("Failed to fetch image from Linear");
+		expect(consoleError.mock.calls[0]?.[1]).toEqual({
+			hasQuery: true,
+			host: "uploads.linear.app",
+			pathLength: "/private-image.jpg".length,
+			status: 403,
+			statusText: "Forbidden",
+		});
+	});
+
+	test("rejects active image content types from Linear", async () => {
+		fetchLinearImage.mockResolvedValueOnce(
+			new Response("<svg><script>alert(1)</script></svg>", {
+				headers: { "content-type": "image/svg+xml" },
+			}),
+		);
+
+		const response = await proxy(
+			linearImageRequest("https://uploads.linear.app/private-image.svg"),
+		);
+
+		expect(response.status).toBe(415);
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe("Unsupported Linear image content type");
+	});
+
+	test("returns a no-store bad gateway when hardened fetch throws", async () => {
+		fetchLinearImage.mockImplementationOnce(async () => {
+			throw new TypeError("fetch aborted");
+		});
+
+		const response = await proxy(
+			linearImageRequest("https://uploads.linear.app/private-image.jpg"),
+		);
+
+		expect(response.status).toBe(502);
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe("Failed to fetch image from Linear");
+		const fetchOptions = fetchLinearImage.mock.calls[0]?.[1] as
+			| RequestInit
+			| undefined;
+		expect(fetchOptions?.headers).toEqual({
+			Authorization: "Bearer linear-token",
+		});
+		expect(fetchOptions?.redirect).toBe("error");
+		expect(fetchOptions?.signal instanceof AbortSignal).toBe(true);
+		expect(consoleError.mock.calls[0]?.[1]).toEqual({
+			errorName: "TypeError",
+			hasQuery: false,
+			host: "uploads.linear.app",
+			pathLength: "/private-image.jpg".length,
+		});
+	});
+
+	test("keeps missing Linear integrations out of caches", async () => {
+		findLinearConnection.mockResolvedValueOnce(null);
+
+		const response = await proxy(
+			linearImageRequest("https://uploads.linear.app/private-image.jpg"),
+		);
+
+		expect(response.status).toBe(400);
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe("Linear integration not connected");
+		expect(fetchLinearImage).not.toHaveBeenCalled();
+	});
+
+	test("keeps auth backend exceptions out of caches", async () => {
+		getSession.mockImplementationOnce(async () => {
+			throw new Error("session backend down");
+		});
+
+		const response = await proxy(
+			linearImageRequest("https://uploads.linear.app/private-image.jpg"),
+		);
+
+		expect(response.status).toBe(500);
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe("Failed to proxy Linear image");
+		expect(fetchLinearImage).not.toHaveBeenCalled();
+		expect(consoleError.mock.calls[0]?.[1]).toEqual({ errorName: "Error" });
+	});
+
+	test("keeps database exceptions out of caches", async () => {
+		findLinearConnection.mockImplementationOnce(async () => {
+			throw new Error("database down");
+		});
+
+		const response = await proxy(
+			linearImageRequest("https://uploads.linear.app/private-image.jpg"),
+		);
+
+		expect(response.status).toBe(500);
+		expectNoStoreHeaders(response);
+		expect(await response.text()).toBe("Failed to proxy Linear image");
+		expect(fetchLinearImage).not.toHaveBeenCalled();
+		expect(consoleError.mock.calls[0]?.[1]).toEqual({ errorName: "Error" });
 	});
 });

--- a/apps/api/src/app/api/proxy/linear-image/route.test.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route.test.ts
@@ -31,6 +31,11 @@ mock.module("@superset/db/schema", () => ({
 		organizationId: "organizationId",
 		provider: "provider",
 	},
+	usersSlackUsers: {
+		id: "id",
+		slackUserId: "slackUserId",
+		teamId: "teamId",
+	},
 }));
 
 mock.module("drizzle-orm", () => ({

--- a/apps/api/src/app/api/proxy/linear-image/route.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route.ts
@@ -1,84 +1,23 @@
 import { auth } from "@superset/auth/server";
 import { db } from "@superset/db/client";
 import { integrationConnections } from "@superset/db/schema";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
+import { handleLinearImageProxy } from "./route-core";
 
-const LINEAR_IMAGE_HOST = "uploads.linear.app";
 export async function GET(request: Request): Promise<Response> {
-	const sessionData = await auth.api.getSession({
-		headers: request.headers,
-	});
-
-	if (!sessionData?.user) {
-		return new Response("Unauthorized", { status: 401 });
-	}
-
-	const organizationId = sessionData.session.activeOrganizationId;
-	if (!organizationId) {
-		return new Response("No active organization", { status: 400 });
-	}
-
-	const url = new URL(request.url);
-	const linearUrl = url.searchParams.get("url");
-
-	if (!linearUrl) {
-		return new Response("Missing url parameter", { status: 400 });
-	}
-
-	// Validate the URL is from Linear's uploads domain (security)
-	let parsedUrl: URL;
-	try {
-		parsedUrl = new URL(linearUrl);
-	} catch {
-		return new Response("Invalid URL", { status: 400 });
-	}
-
-	if (parsedUrl.host !== LINEAR_IMAGE_HOST) {
-		return new Response(`Only ${LINEAR_IMAGE_HOST} URLs are allowed`, {
-			status: 400,
-		});
-	}
-
-	// Get the org's Linear access token
-	const connection = await db.query.integrationConnections.findFirst({
-		where: and(
-			eq(integrationConnections.organizationId, organizationId),
-			eq(integrationConnections.provider, "linear"),
-		),
-	});
-
-	if (!connection) {
-		return new Response("Linear integration not connected", { status: 400 });
-	}
-
-	// Fetch the image from Linear with auth
-	const linearResponse = await fetch(linearUrl, {
-		headers: {
-			Authorization: `Bearer ${connection.accessToken}`,
-		},
-	});
-
-	if (!linearResponse.ok) {
-		console.error("[proxy/linear-image] Linear fetch failed:", {
-			status: linearResponse.status,
-			statusText: linearResponse.statusText,
-			url: linearUrl,
-		});
-		return new Response("Failed to fetch image from Linear", {
-			status: linearResponse.status,
-		});
-	}
-
-	const contentType = linearResponse.headers.get("content-type") ?? "image/png";
-	const imageData = await linearResponse.arrayBuffer();
-
-	return new Response(imageData, {
-		status: 200,
-		headers: {
-			"Content-Type": contentType,
-			"Cache-Control": "private, no-store, max-age=0",
-			Pragma: "no-cache",
-			Vary: "Cookie, Authorization",
-		},
+	return handleLinearImageProxy(request, {
+		fetch,
+		findLinearConnection: (organizationId) =>
+			db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.organizationId, organizationId),
+					eq(integrationConnections.provider, "linear"),
+					isNull(integrationConnections.disconnectedAt),
+				),
+			}),
+		getSession: (headers) =>
+			auth.api.getSession({
+				headers,
+			}),
 	});
 }

--- a/apps/api/src/app/api/proxy/linear-image/route.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route.ts
@@ -4,8 +4,6 @@ import { integrationConnections } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
 
 const LINEAR_IMAGE_HOST = "uploads.linear.app";
-const CACHE_MAX_AGE = 31536000; // 1 year (Linear URLs are content-addressed)
-
 export async function GET(request: Request): Promise<Response> {
 	const sessionData = await auth.api.getSession({
 		headers: request.headers,
@@ -78,7 +76,9 @@ export async function GET(request: Request): Promise<Response> {
 		status: 200,
 		headers: {
 			"Content-Type": contentType,
-			"Cache-Control": `public, max-age=${CACHE_MAX_AGE}, immutable`,
+			"Cache-Control": "private, no-store, max-age=0",
+			Pragma: "no-cache",
+			Vary: "Cookie, Authorization",
 		},
 	});
 }


### PR DESCRIPTION
## Description

This PR hardens the authenticated Linear image proxy so org-scoped Linear uploads are never returned as public immutable cache entries. The route still fetches validated `uploads.linear.app` image URLs with the organization-scoped Linear token, but it now:

- applies `Cache-Control: no-store`, `Pragma: no-cache`, and `X-Content-Type-Options: nosniff` consistently
- rejects non-HTTPS, non-Linear, credentialed, redirected, disconnected-integration, and active-content responses before proxying bytes to the client
- combines client disconnects with the upstream fetch timeout, returns a no-store `499 Client Closed Request` for client-aborted fetches, and cancels rejected upstream response bodies
- avoids raw Linear URL/query logging on upstream failures
- streams allowed raster image bodies instead of buffering them in memory
- tests the proxy through an injected core handler, with adapter coverage for the active Linear integration predicate and timeout guard
- wires `@superset/api` tests into the normal Turbo `test` task so these API route regressions run in CI

## Related Issues

No existing issue. This was discovered during repository analysis.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other: API test/CI coverage wiring

## Testing

Commands run:

- `bun test apps/api/src/app/api/proxy/linear-image/route.test.ts` — passed (13 tests, 93 assertions)
- `bun turbo test --filter=@superset/api` — passed (29 tests, 126 assertions)
- `bun turbo test --filter=@superset/api --dry=json` — confirmed `@superset/api#test` now resolves to `bun test`
- `bun turbo typecheck --filter=@superset/api` — passed
- `bunx @biomejs/biome@2.4.2 check apps/api/package.json apps/api/src/app/api/proxy/linear-image/route.ts apps/api/src/app/api/proxy/linear-image/route-core.ts apps/api/src/app/api/proxy/linear-image/route.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- `bun run lint` — passed after temporarily moving local ignored/private runtime directories (`.codex-notes/` and `.omx/`) out of the workspace and restoring them; no tracked files were changed

Commands with known unrelated failures:

- `bun run typecheck` — failed in `@superset/host-service` at `packages/host-service/src/trpc/router/git/get-check-job-logs.test.ts:52`; this file/package is outside this PR diff, while `bun turbo typecheck --filter=@superset/api` passed for the touched API package.

Commands not run:

- Full monorepo test suite — not run; this PR is scoped to the API Linear image proxy and the package-level API suite above now runs through Turbo and passed.

## Screenshots (if applicable)

N/A.

## Additional Notes

Risk level: low to medium. This intentionally trades public immutable caching for privacy and bounded proxy behavior at an authenticated API boundary. The final proxy allows only safe raster image content types (`avif`, `gif`, `jpeg`, `png`, `webp`), blocks redirects while using the Linear bearer token, treats client-closed fetches separately from upstream failures with a route-local `499 Client Closed Request`, and keeps successful responses streaming with local response headers rather than upstream cache headers.

The `@superset/api` package now has a `test` script so its existing and new Bun tests are exercised by the root Turbo test pipeline. That is intentionally included here because otherwise the Linear proxy regression tests could pass locally but be skipped by CI.

This does not change the existing org-scoped Linear authorization model: the route still uses the caller session's active organization to select that organization's active Linear integration token, and Linear remains the upstream authority for resource-level access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hardened proxy flow for Linear-uploaded images with authenticated access and strict allowlisting of `uploads.linear.app` URLs.

* **Bug Fixes**
  * Improved security and consistency of proxy responses, including secure `no-store/no-cache` and `nosniff` headers, validation against credentialed/invalid URLs, and safer handling of unsupported image content types and upstream failures.

* **Tests**
  * Added a Bun test suite covering successful proxying, timeout/abort propagation, correct status handling (400/415/499/502/500), and structured error logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->