### PR TITLE
test(electric-proxy): lock tenant filters and upstream auth stripping

### DIFF
--- a/apps/electric-proxy/package.json
+++ b/apps/electric-proxy/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"test": "bun test src",
 		"dev": "dotenv -e ../../.env -- sh -c 'exec wrangler dev --port ${WRANGLER_PORT:-8787}'",
 		"deploy": "wrangler deploy",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
@@ -17,6 +18,7 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "4.20260329.1",
 		"@superset/typescript": "workspace:*",
+		"bun-types": "1.3.11",
 		"typescript": "6.0.3",
 		"wrangler": "4.78.0"
 	}

--- a/apps/electric-proxy/src/electric.test.ts
+++ b/apps/electric-proxy/src/electric.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { buildUpstreamUrl } from "./electric";
+import type { Env } from "./types";
+
+const env = {
+	AUTH_URL: "https://app.example",
+	ELECTRIC_SECRET: "server-secret",
+	ELECTRIC_SHAPE_URL: "https://electric.example/v1/shape",
+} satisfies Env;
+
+describe("buildUpstreamUrl", () => {
+	test("forwards only Electric protocol parameters from the client URL", () => {
+		const clientUrl = new URL(
+			"https://proxy.example/shape?table=tasks&organizationId=org-1&handle=client-handle&offset=123&where=malicious&secret=client-secret&columns=*",
+		);
+		const upstream = buildUpstreamUrl(
+			clientUrl,
+			"tasks",
+			{ fragment: '"organization_id" = $1', params: ["org-1"] },
+			env,
+		);
+
+		expect(upstream.origin).toBe("https://electric.example");
+		expect(upstream.searchParams.get("table")).toBe("tasks");
+		expect(upstream.searchParams.get("where")).toBe('"organization_id" = $1');
+		expect(upstream.searchParams.get("params[1]")).toBe("org-1");
+		expect(upstream.searchParams.get("secret")).toBe("server-secret");
+		expect(upstream.searchParams.get("handle")).toBe("client-handle");
+		expect(upstream.searchParams.get("offset")).toBe("123");
+		expect(upstream.searchParams.getAll("columns")).toEqual([]);
+	});
+
+	test("restricts sensitive columns for API keys", () => {
+		const upstream = buildUpstreamUrl(
+			new URL("https://proxy.example/shape"),
+			"auth.apikeys",
+			{ fragment: '"organization_id" = $1', params: ["org-1"] },
+			env,
+		);
+
+		expect(upstream.searchParams.get("columns")).toBe(
+			"id,name,start,created_at,last_request",
+		);
+	});
+
+	test("uses Electric source credentials when both source values are configured", () => {
+		const upstream = buildUpstreamUrl(
+			new URL("https://proxy.example/shape"),
+			"tasks",
+			{ fragment: '"organization_id" = $1', params: ["org-1"] },
+			{
+				AUTH_URL: "https://app.example",
+				ELECTRIC_SECRET: "fallback-secret",
+				ELECTRIC_SHAPE_URL: "https://electric.example/v1/shape",
+				ELECTRIC_SOURCE_ID: "source-id",
+				ELECTRIC_SOURCE_SECRET: "source-secret",
+			},
+		);
+
+		expect(upstream.searchParams.get("source_id")).toBe("source-id");
+		expect(upstream.searchParams.get("secret")).toBe("source-secret");
+	});
+});

--- a/apps/electric-proxy/src/index.test.ts
+++ b/apps/electric-proxy/src/index.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Env } from "./types";
+
+const verifyJWT = mock(async () => ({
+	email: "user@example.com",
+	organizationIds: ["org-1", "org-2"],
+	sub: "user-1",
+}));
+
+mock.module("./auth", () => ({ verifyJWT }));
+
+const worker = (await import("./index")).default;
+const originalFetch = globalThis.fetch;
+
+const env = {
+	AUTH_URL: "https://app.example",
+	ELECTRIC_SECRET: "server-secret",
+	ELECTRIC_SHAPE_URL: "https://electric.example/v1/shape",
+} satisfies Env;
+
+function request(path: string, init?: RequestInit): Request {
+	return new Request(`https://proxy.example${path}`, init);
+}
+
+describe("electric proxy worker", () => {
+	beforeEach(() => {
+		verifyJWT.mockClear();
+		verifyJWT.mockResolvedValue({
+			email: "user@example.com",
+			organizationIds: ["org-1", "org-2"],
+			sub: "user-1",
+		});
+		globalThis.fetch = originalFetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	test("requires a bearer token", async () => {
+		const response = await worker.fetch(request("/shape?table=tasks"), env);
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe(
+			"Missing or invalid Authorization header",
+		);
+	});
+
+	test("requires organizationId for organization-scoped tables", async () => {
+		const response = await worker.fetch(
+			request("/shape?table=tasks", {
+				headers: { Authorization: "Bearer token" },
+			}),
+			env,
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toBe("Missing organizationId parameter");
+	});
+
+	test("rejects organizations outside the JWT memberships", async () => {
+		const response = await worker.fetch(
+			request("/shape?table=tasks&organizationId=org-3", {
+				headers: { Authorization: "Bearer token" },
+			}),
+			env,
+		);
+
+		expect(response.status).toBe(403);
+		expect(await response.text()).toBe("Not a member of this organization");
+	});
+
+	test("strips auth-bearing headers before forwarding upstream", async () => {
+		const fetchUpstream = mock(
+			async () =>
+				new Response("shape", {
+					headers: {
+						"content-encoding": "br",
+						"content-length": "999",
+						"electric-handle": "handle-1",
+					},
+				}),
+		);
+		globalThis.fetch = fetchUpstream as unknown as typeof fetch;
+
+		const response = await worker.fetch(
+			request("/shape?table=tasks&organizationId=org-1&handle=h1", {
+				headers: {
+					Authorization: "Bearer token",
+					Cookie: "session=secret",
+					"X-Client-Header": "keep-me",
+				},
+			}),
+			env,
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("shape");
+		expect(response.headers.get("access-control-allow-origin")).toBe("*");
+		expect(response.headers.get("content-encoding")).toBeNull();
+		expect(response.headers.get("content-length")).toBeNull();
+		expect(response.headers.get("vary")).toBe("Authorization");
+
+		const [forwardedInput, forwardedInit] = fetchUpstream.mock
+			.calls[0] as unknown as [RequestInfo | URL, RequestInit | undefined];
+		const forwardedUrl = new URL(String(forwardedInput));
+		expect(forwardedUrl.searchParams.get("table")).toBe("tasks");
+		expect(forwardedUrl.searchParams.get("where")).toBe(
+			'"organization_id" = $1',
+		);
+		expect(forwardedUrl.searchParams.get("params[1]")).toBe("org-1");
+		const forwardedHeaders = new Headers(forwardedInit?.headers);
+		expect(forwardedHeaders.get("Authorization")).toBeNull();
+		expect(forwardedHeaders.get("Cookie")).toBeNull();
+		expect(forwardedHeaders.get("X-Client-Header")).toBe("keep-me");
+	});
+
+	test("allows auth.organizations without an organizationId parameter", async () => {
+		const fetchUpstream = mock(async () => new Response("organizations"));
+		globalThis.fetch = fetchUpstream as unknown as typeof fetch;
+
+		// JWT claims arrive UNSORTED here; the proxy sorts them (index.ts:74) so
+		// Electric receives a stable shape handle regardless of claim ordering.
+		verifyJWT.mockResolvedValue({
+			email: "user@example.com",
+			organizationIds: ["org-2", "org-1"],
+			sub: "user-1",
+		});
+
+		const response = await worker.fetch(
+			request("/shape?table=auth.organizations", {
+				headers: { Authorization: "Bearer token" },
+			}),
+			env,
+		);
+
+		expect(response.status).toBe(200);
+		const [forwardedInput] = fetchUpstream.mock.calls[0] as unknown as [
+			RequestInfo | URL,
+			RequestInit | undefined,
+		];
+		const forwardedUrl = new URL(String(forwardedInput));
+		expect(forwardedUrl.searchParams.get("where")).toBe('"id" in ($1, $2)');
+		expect(forwardedUrl.searchParams.get("params[1]")).toBe("org-1");
+		expect(forwardedUrl.searchParams.get("params[2]")).toBe("org-2");
+	});
+
+	test("rejects unknown tables at the HTTP layer", async () => {
+		const response = await worker.fetch(
+			request("/shape?table=unknown_table&organizationId=org-1", {
+				headers: { Authorization: "Bearer token" },
+			}),
+			env,
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toBe("Unknown table: unknown_table");
+	});
+});

--- a/apps/electric-proxy/src/where.test.ts
+++ b/apps/electric-proxy/src/where.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { buildWhereClause } from "./where";
+
+describe("buildWhereClause", () => {
+	test("scopes organization-owned tables to the requested organization", () => {
+		const clause = buildWhereClause("tasks", "org-1", ["org-1"]);
+
+		expect(clause).not.toBeNull();
+		expect(clause?.fragment).toContain('"organization_id" = $1');
+		expect(clause?.params).toEqual(["org-1"]);
+	});
+
+	test("limits auth.organizations to JWT organization memberships", () => {
+		const clause = buildWhereClause("auth.organizations", "", [
+			"org-1",
+			"org-2",
+		]);
+
+		expect(clause).not.toBeNull();
+		expect(clause?.fragment).toContain('"id" in ($1, $2)');
+		expect(clause?.params).toEqual(["org-1", "org-2"]);
+	});
+
+	test("denies auth.organizations when the JWT has no organizations", () => {
+		expect(buildWhereClause("auth.organizations", "", [])).toEqual({
+			fragment: "1 = 0",
+			params: [],
+		});
+	});
+
+	test("uses the restricted API key organization column", () => {
+		const clause = buildWhereClause("auth.apikeys", "org-1", ["org-1"]);
+
+		expect(clause).toEqual({
+			fragment: '"organization_id" = $1',
+			params: ["org-1"],
+		});
+	});
+
+	test("rejects unknown table names", () => {
+		expect(buildWhereClause("unknown_table", "org-1", ["org-1"])).toBeNull();
+	});
+});

--- a/apps/electric-proxy/tsconfig.json
+++ b/apps/electric-proxy/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "@superset/typescript/base.json",
 	"compilerOptions": {
-		"types": ["@cloudflare/workers-types"],
+		"types": ["@cloudflare/workers-types", "bun-types"],
 		"lib": ["ES2022", "ES2021.String"],
 		"moduleResolution": "Bundler",
 		"module": "ESNext",

--- a/bun.lock
+++ b/bun.lock
@@ -424,6 +424,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "4.20260329.1",
         "@superset/typescript": "workspace:*",
+        "bun-types": "1.3.11",
         "typescript": "6.0.3",
         "wrangler": "4.78.0",
       },


### PR DESCRIPTION
## Description

This PR adds executable security regression coverage for the Electric proxy. The new tests lock down the tenant-scoping and upstream-forwarding contracts that protect Electric shape requests:

- organization-owned tables include the requested organization filter
- `auth.organizations` is limited to JWT organization memberships
- `auth.apikeys` uses the restricted organization column and sensitive column projection
- unknown tables are rejected
- client-provided `where`, `secret`, and `columns` params are not forwarded as trusted upstream params
- bearer/cookie headers are stripped before forwarding to Electric
- invalid/missing auth and unauthorized organizations are rejected at the worker boundary

The PR also adds the missing `test` script and Bun test types for this workspace so the tests are discoverable through Turbo.

## Related Issues

No existing issue. This was discovered during repository analysis.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (please describe): security regression tests / test infrastructure

## Testing

Commands run:

- `bun --cwd apps/electric-proxy test` — passed
- `bun run test --filter=electric-proxy` — passed
- `bun --cwd apps/electric-proxy typecheck` — passed
- `bunx @biomejs/biome@2.4.2 check apps/electric-proxy/package.json apps/electric-proxy/tsconfig.json apps/electric-proxy/src/where.test.ts apps/electric-proxy/src/electric.test.ts apps/electric-proxy/src/index.test.ts bun.lock` — passed
- `git diff --check` — passed

## Screenshots (if applicable)

N/A.

## Additional Notes

Risk level: low. This PR does not change production Electric proxy behavior; it adds regression coverage and a workspace test script for security-critical tenant filtering and auth-header stripping.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5470">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds executable security regression tests for the Electric proxy to lock tenant scoping, upstream auth stripping, and response header sanitization for shape requests, including source credential handling and sensitive column restrictions. Also locks stable handles by sorting JWT organization IDs and allows `auth.organizations` without an organizationId; adds a workspace `test` script and `bun-types` so tests run under Turbo.

<sup>Written for commit 3ceb62963e40581c5427552be4cb8450b01a6673. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy request handling for organization-scoped access, authorization checks, and upstream forwarding behavior.
  * Tightened handling of query parameters and headers to make forwarded requests more consistent and secure.

* **Chores**
  * Added automated test coverage for core proxy behaviors.
  * Updated project setup to support Bun-based testing and typings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->