### PR TITLE
feat(sdk): expose host agent launch options

### DIFF
--- a/packages/sdk/src/resources/agents.ts
+++ b/packages/sdk/src/resources/agents.ts
@@ -55,6 +55,8 @@ export class Agents extends APIResource {
 			agent: params.agent,
 			prompt: params.prompt,
 			attachmentIds: params.attachmentIds,
+			model: params.model,
+			effort: params.effort,
 		});
 	}
 
@@ -74,6 +76,8 @@ export type PromptTransport = "argv" | "stdin";
 export interface HostAgentConfig {
 	id: string;
 	presetId: string;
+	/** Built-in icon key to render, or null to fall back to `presetId`. Absent on older host-service versions. */
+	iconId?: string | null;
 	label: string;
 	command: string;
 	args: string[];
@@ -99,6 +103,10 @@ export interface AgentCreateParams {
 	prompt: string;
 	/** Host-scoped attachment ids; host resolves to absolute paths in the prompt. */
 	attachmentIds?: string[];
+	/** Optional model id to pass to the selected agent, when the preset supports model selection. */
+	model?: string;
+	/** Optional reasoning-effort id to pass to the selected agent, when the preset supports effort selection. */
+	effort?: string;
 }
 
 export type AgentCreateResult =

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -186,6 +186,10 @@ export interface WorkspaceAgentLaunch {
 	prompt: string;
 	/** Host-scoped attachment ids; host resolves to absolute paths in the prompt. */
 	attachmentIds?: string[];
+	/** Optional model id to pass to the selected agent, when the preset supports model selection. */
+	model?: string;
+	/** Optional reasoning-effort id to pass to the selected agent, when the preset supports effort selection. */
+	effort?: string;
 }
 
 export type WorkspaceCreateAgentResult =


### PR DESCRIPTION
## Summary

This PR exposes the host agent launch `model` and `effort` options through the TypeScript SDK and forwards them from `agents.create` to the host-service `agents.run` route.

## Why this matters

The host service already accepts `model` and `effort` for both direct agent launches and workspace-create agent sugar, but SDK consumers could not express those fields through `AgentCreateParams` and the direct SDK launch path dropped them before crossing the relay.

That creates a real contract drift between the public SDK and the app/host behavior: SDK-launched agents could not select the same runtime model or reasoning-effort options that the host router supports.

## Changes

- Adds `model` and `effort` to `AgentCreateParams` and forwards them to `agents.run`.
- Adds `model` and `effort` to `WorkspaceAgentLaunch` so workspace-create agent sugar is typed consistently with the host route.
- Adds `iconId` to `HostAgentConfig` to match the host-service `settings.agentConfigs.list` response shape.

## Validation

Commands run:

- `bun --cwd packages/sdk typecheck` — passed
- `git diff --check` — passed

Commands not run:

- `bunx @biomejs/biome@2.4.2 check packages/sdk/src/resources/agents.ts packages/sdk/src/resources/workspaces.ts` — not applicable because the SDK source tree is ignored by the current Biome config; Biome reported “No files were processed”.

Failures:

- `bun --cwd packages/sdk build` — failed
  - Related to this PR: no
  - Evidence: the build reaches declaration emit and fails with TypeScript 6 `TS5011` because `tsconfig.json` lacks an explicit `rootDir`. This is the existing SDK build issue addressed separately in #5471.
  - Follow-up: #5471 adds the SDK `rootDir` fix.

## Risk

Risk level: low

Compatibility impact: additive SDK type fields and pass-through forwarding only.
Rollback simplicity: revert the two SDK resource file changes.
Remaining edge cases: unsupported model/effort ids continue to be handled by the host-service preset validation/fallback behavior.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

This intentionally does not duplicate model catalog validation in the SDK. The host service already owns preset-specific support and launch argument generation.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5472">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose host agent launch options `model` and `effort` in the SDK and pass them through to host `agents.run` and workspace-create. This lets API consumers pick runtime model and reasoning effort like in the app.

- **New Features**
  - Added `model` and `effort` to `AgentCreateParams`; forwarded to host `agents.run`.
  - Added `model` and `effort` to `WorkspaceAgentLaunch` for workspace-create launches.
  - Added optional `iconId` to `HostAgentConfig` to match host `settings.agentConfigs.list`.

<sup>Written for commit d86f446b98dcf8f435b21f932777b7b6e142a49c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent launch and creation flows now support optional model and reasoning-effort selections when the chosen preset allows it.
  * Agent configurations can now include an icon key, with fallback handling for built-in icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->