### PR TITLE
fix(host-service): refresh minted JWTs after source token rotation

### DIFF
--- a/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.test.ts
+++ b/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.test.ts
@@ -376,3 +376,37 @@ describe("JwtApiAuthProvider with config-backed host auth", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });
+
+describe("JwtApiAuthProvider source-token rotation", () => {
+	test("does not reuse a minted JWT after the source API key rotates", async () => {
+		let apiKey = "sk_live_old";
+		const seenApiKeys: string[] = [];
+		const fetchMock = mockFetch(async (input, init) => {
+			const request =
+				input instanceof Request ? input : new Request(input.toString(), init);
+			seenApiKeys.push(request.headers.get("x-api-key") ?? "");
+			return Response.json({
+				token:
+					request.headers.get("x-api-key") === "sk_live_new"
+						? "minted.new.jwt"
+						: "minted.old.jwt",
+			});
+		});
+		const authProvider = new JwtApiAuthProvider({
+			getSessionToken: async () => apiKey,
+			apiUrl: API_URL,
+		});
+
+		await expect(authProvider.getHeaders()).resolves.toEqual({
+			Authorization: "Bearer minted.old.jwt",
+		});
+
+		apiKey = "sk_live_new";
+
+		await expect(authProvider.getHeaders()).resolves.toEqual({
+			Authorization: "Bearer minted.new.jwt",
+		});
+		expect(seenApiKeys).toEqual(["sk_live_old", "sk_live_new"]);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts
+++ b/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts
@@ -24,6 +24,7 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 	private readonly onInvalidateCache?: () => void;
 	private readonly apiUrl: string;
 	private cachedJwt: string | null = null;
+	private cachedJwtSourceToken: string | null = null;
 	private cachedJwtExpiresAt = 0;
 
 	constructor(options: JwtApiAuthProviderOptions) {
@@ -39,18 +40,12 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 
 	invalidateCache(): void {
 		this.cachedJwt = null;
+		this.cachedJwtSourceToken = null;
 		this.cachedJwtExpiresAt = 0;
 		this.onInvalidateCache?.();
 	}
 
 	async getJwt(): Promise<string> {
-		if (
-			this.cachedJwt &&
-			Date.now() < this.cachedJwtExpiresAt - JWT_REFRESH_BUFFER_MS
-		) {
-			return this.cachedJwt;
-		}
-
 		const sessionToken = await this.getSessionToken();
 
 		// CLI OAuth code+PKCE login stores the OAuth access token directly,
@@ -61,6 +56,14 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 		// anyway, only sessions and api keys).
 		if (looksLikeJwt(sessionToken)) {
 			return sessionToken;
+		}
+
+		if (
+			this.cachedJwt &&
+			this.cachedJwtSourceToken === sessionToken &&
+			Date.now() < this.cachedJwtExpiresAt - JWT_REFRESH_BUFFER_MS
+		) {
+			return this.cachedJwt;
 		}
 
 		// better-auth's apiKey plugin reads `sk_live_…` from x-api-key, not
@@ -76,6 +79,7 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 		}
 		const data = (await response.json()) as { token: string };
 		this.cachedJwt = data.token;
+		this.cachedJwtSourceToken = sessionToken;
 		this.cachedJwtExpiresAt = Date.now() + JWT_CACHE_DURATION_MS;
 		return data.token;
 	}


### PR DESCRIPTION
## Summary

This PR fixes host-service JWT cache reuse after the underlying API key or session token rotates.

## Why this matters

`JwtApiAuthProvider` cached exchanged JWTs only by time. For non-JWT credentials (API keys or session tokens), that meant a host could continue sending a JWT minted from the previous source credential until the 55-minute cache window expired, even after the credential source started returning a new token.

That is production-relevant for login refreshes, API key rotation, and revoked/replaced credentials because host→cloud calls can keep authenticating with stale credential-derived JWTs longer than intended.

## Changes

- Reads the current source token before deciding whether an exchanged JWT cache entry is reusable.
- Tracks which source token produced the cached JWT.
- Reuses a cached exchanged JWT only when it is still fresh **and** was minted from the same current source token.
- Clears the cached source-token binding on invalidation.
- Adds regression coverage for API key rotation without explicit invalidation.

## Validation

Commands run:

- `bun --cwd packages/host-service test src/providers/auth/JwtAuthProvider/JwtAuthProvider.test.ts` — passed
- `bunx @biomejs/biome@2.4.2 check packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.test.ts` — passed
- `git diff --check` — passed

Failures:

- `bun --cwd packages/host-service typecheck` — failed
  - Related to this PR: no
  - Evidence: existing failure in `src/trpc/router/git/get-check-job-logs.test.ts(52,42)` where a plain `string` is passed to a TRPC error-code matcher expecting the TRPC error-code union.
  - Follow-up: should be handled separately because this PR only touches auth-provider cache behavior.

## Risk

Risk level: low

Compatibility impact: no public API changes. Stable source tokens still reuse cached exchanged JWTs. Direct OAuth JWT source tokens still pass through without exchange.
Rollback simplicity: revert the provider cache-binding change and the regression test.
Remaining edge cases: this intentionally does not remove JWT caching; it only prevents reuse across source credential rotations.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

The fix preserves the existing invalidation path and cache window. It only adds source-token identity as a cache key for exchanged JWTs.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind cached exchanged JWTs in `packages/host-service` to the current source token so hosts refresh immediately after API key or session token rotation. This prevents stale host→cloud auth while keeping direct OAuth JWT passthrough unchanged.

- **Bug Fixes**
  - Reuse a cached exchanged JWT only if it was minted from the current source token and is still fresh.
  - Read the latest source token before reuse; invalidate clears both the JWT and its source-token binding.
  - Added a test verifying a new JWT is minted after API key rotation.

<sup>Written for commit 82a09768f018d2b2400a6941d3018f059d671f67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JWT reuse after API key rotation. The app now refreshes the cached JWT when the underlying source key changes, preventing stale authentication headers.
  * Added coverage to verify the old token is replaced with a newly minted one after rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->