### PR TITLE
ci: build Vercel apps on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,84 @@ jobs:
           RELAY_URL: ${{ secrets.RELAY_URL }}
         run: bun turbo run build --filter=@superset/desktop
 
+  build-vercel-apps:
+    name: Build Vercel apps (${{ matrix.app }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: api
+            package: "@superset/api"
+          - app: web
+            package: "@superset/web"
+          - app: marketing
+            package: "@superset/marketing"
+          - app: admin
+            package: "@superset/admin"
+          - app: docs
+            package: "@superset/docs"
+    env:
+      # Build-only validation: skip runtime env-var validation so the build
+      # exercises the compiler/bundler, not deploy-time configuration.
+      SKIP_ENV_VALIDATION: "1"
+      NEXT_TELEMETRY_DISABLED: "1"
+      TURBO_TELEMETRY_DISABLED: "1"
+      DATABASE_URL: "postgres://superset:superset@localhost:5432/superset"
+      DATABASE_URL_UNPOOLED: "postgres://superset:superset@localhost:5432/superset"
+      BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_ci_placeholder"
+      BETTER_AUTH_SECRET: "ci-placeholder-secret"
+      NEXT_PUBLIC_API_URL: "https://api-ci.superset.local"
+      NEXT_PUBLIC_WEB_URL: "https://app-ci.superset.local"
+      NEXT_PUBLIC_MARKETING_URL: "https://marketing-ci.superset.local"
+      NEXT_PUBLIC_ADMIN_URL: "https://admin-ci.superset.local"
+      NEXT_PUBLIC_DOCS_URL: "https://docs-ci.superset.local"
+      NEXT_PUBLIC_ELECTRIC_URL: "https://electric-ci.superset.local"
+      NEXT_PUBLIC_RELAY_URL: "https://relay-ci.superset.local"
+      RELAY_URL: "https://relay-ci.superset.local"
+      NEXT_PUBLIC_COOKIE_DOMAIN: ".superset.local"
+      NEXT_PUBLIC_POSTHOG_KEY: "phc_ci_placeholder"
+      NEXT_PUBLIC_POSTHOG_HOST: "https://us.i.posthog.com"
+      NEXT_PUBLIC_SENTRY_ENVIRONMENT: "development"
+      NEXT_PUBLIC_SENTRY_DSN_API: ""
+      NEXT_PUBLIC_SENTRY_DSN_WEB: ""
+      SENTRY_AUTH_TOKEN: ""
+      KV_REST_API_URL: "https://kv-ci.superset.local"
+      KV_REST_API_TOKEN: "kv_ci_placeholder"
+      KV_URL: "redis://localhost:6379"
+      RESEND_API_KEY: "re_ci_placeholder"
+      STRIPE_SECRET_KEY: "sk_test_ci_placeholder"
+      STRIPE_WEBHOOK_SECRET: "whsec_ci_placeholder"
+      STRIPE_PRO_MONTHLY_PRICE_ID: "price_ci_monthly"
+      STRIPE_PRO_YEARLY_PRICE_ID: "price_ci_yearly"
+      STRIPE_ENTERPRISE_YEARLY_PRICE_ID: "price_ci_enterprise"
+      SECRETS_ENCRYPTION_KEY: "00000000000000000000000000000000"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        id: setup-bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Cache dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-revision }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen --ignore-scripts
+
+      - name: Build ${{ matrix.app }}
+        run: bun turbo run build --filter="${{ matrix.package }}"
+
   build-cli:
     name: Build CLI
     uses: ./.github/workflows/build-cli.yml


### PR DESCRIPTION
## Summary

This PR adds a CI build matrix for the Vercel-deployed apps: API, web, marketing, admin, and docs.

## Why this matters

The current CI workflow validates lint, tests, typecheck, the desktop build, and CLI build, but it does not build the Next/Fumadocs apps that production and preview deploy workflows ship to Vercel. That leaves production build failures to be discovered late during deploy-preview or deploy-production runs instead of during normal pull-request CI.

This is high-priority because these apps are user-facing deployment surfaces, and catching their build failures before deployment reduces broken previews, failed production deploys, and maintainer firefighting.

## Changes

- Adds a `build-vercel-apps` CI job.
- Builds `@superset/api`, `@superset/web`, `@superset/marketing`, `@superset/admin`, and `@superset/docs` in a fail-fast-disabled matrix.
- Uses synthetic CI-safe environment values so the job can run without deployment secrets and never deploys anything.
- Keeps the existing desktop and CLI build jobs unchanged.

## Validation

Commands run:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'` — passed
- `git diff --check` — passed

Commands not run:

- The new GitHub Actions matrix itself — not run locally because it requires CI runners and full Next/Fumadocs app builds.

Failures:

- `bunx @biomejs/biome@2.4.2 check .github/workflows/ci.yml` — not applicable
  - Related to this PR: no
  - Evidence: Biome reports workflow YAML is ignored by the repository Biome config.

## Risk

Risk level: medium

Compatibility impact: no runtime code changes. CI becomes stricter and may surface existing build failures in deployable apps.
Rollback simplicity: remove the added workflow job.
Remaining edge cases: placeholder env values are intended only for build-time validation; deployment workflows continue to use real secrets/vars.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

This intentionally does not call Vercel or create Neon branches. It validates local production builds for the app packages without deployment side effects.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5474">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds Vercel apps in PR CI to catch production build errors early and avoid broken previews. Adds a non-deploying matrix build with CI‑safe env values.

- **New Features**
  - Adds `build-vercel-apps` job to build `@superset/api`, `@superset/web`, `@superset/marketing`, `@superset/admin`, `@superset/docs` in a fail-fast-disabled matrix.
  - Uses Bun with dependency caching and frozen, no-script installs; runs `bun turbo run build --filter` per package.
  - Supplies synthetic env vars (e.g., `SKIP_ENV_VALIDATION=1`, telemetry off, placeholder URLs/keys for DB, Sentry, PostHog, Stripe, KV) so builds succeed without secrets and never deploy.

<sup>Written for commit 5d23ef71e0233b072308065828035d69c9ea15da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CI workflow job that builds multiple apps in parallel.
  * CI now runs build checks for the API, web, marketing, admin, and docs as separate matrix targets.
  * Updated the CI build pipeline to use Bun, cache dependencies, and install with frozen settings for consistent, build-only execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->