### PR TITLE
ci: skip preview deployments for forked pull requests

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   deploy-database:
     name: Deploy Database (Neon)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: preview
 
@@ -79,6 +80,7 @@ jobs:
 
   deploy-api:
     name: Deploy API
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: preview
     needs: deploy-database
@@ -242,6 +244,7 @@ jobs:
 
   deploy-web:
     name: Deploy Web
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment:
       name: preview
@@ -363,6 +366,7 @@ jobs:
 
   deploy-marketing:
     name: Deploy Marketing
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: preview
     needs: deploy-database
@@ -477,6 +481,7 @@ jobs:
 
   deploy-admin:
     name: Deploy Admin
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: preview
     needs: deploy-database
@@ -595,6 +600,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Docs
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: preview
     needs: deploy-database
@@ -679,7 +685,7 @@ jobs:
   post-final-comment:
     name: Post Deployment Comment
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
     needs: [deploy-database, deploy-api, deploy-web, deploy-marketing, deploy-admin, deploy-docs]
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

This PR prevents the preview deployment workflow from attempting Neon/Vercel preview deployments for forked pull requests.

## Why this matters

`deploy-preview.yml` is triggered by `pull_request` and uses preview infrastructure plus deployment secrets for Neon branches, Vercel builds, aliases, and the final PR comment. Forked pull-request runs do not receive those secrets, so the workflow can fail in deployment jobs that are impossible to complete for untrusted fork code.

This is both a CI reliability issue and a security-boundary issue: deployment workflows should not run secret-dependent infrastructure steps for forked PR code.

## Changes

- Adds a same-repository guard to every preview deployment job.
- Preserves preview deployments for trusted PR branches in `superset-sh/superset`.
- Keeps the final deployment comment running only for trusted same-repository PRs, while still using `always()` there so it can summarize failed deploy jobs.

## Validation

Commands run:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-preview.yml")'` — passed
- `git diff --check` — passed

Commands not run:

- GitHub Actions fork/same-repository event execution — not run locally.

## Risk

Risk level: low

Compatibility impact: forked PRs skip preview deployments instead of failing secret-dependent deployment jobs. Same-repository PR preview deployments remain enabled.
Rollback simplicity: remove the added job-level guards.
Remaining edge cases: forked contributors still get the normal CI workflow; they just do not get deployment previews from this secret-backed workflow.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

I intentionally did not switch this workflow to `pull_request_target`, because that would broaden the security boundary for running untrusted fork code with repository privileges/secrets.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5476">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip preview deployments for forked pull requests to prevent failing secret-dependent Neon/Vercel steps and maintain the security boundary. Same-repo PRs keep normal previews and the final deployment comment.

- **Bug Fixes**
  - Added a same-repository guard to all preview deployment jobs.
  - Restricted the final deployment comment with always() and the same-repo check.

<sup>Written for commit ae7a7f8fec2cef5cd410571dc1080be1854a65dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted preview deployments and deployment-status comments to pull requests originating from the same repository.
  * Prevented preview deployment workflows from running for pull requests submitted from external repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->