### PR TITLE
ci: serialize production deployments

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,6 +8,10 @@ on:
 env:
   VERCEL_CLI_VERSION: 50.22.1
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy-database:
     name: Deploy Database Migrations


### PR DESCRIPTION
## Summary

This PR adds a workflow-level concurrency guard to the production deployment workflow.

## Why this matters

`deploy-production.yml` runs database migrations and then deploys multiple Vercel surfaces. Without a concurrency group, a push-triggered production deploy and a manually dispatched production deploy can overlap. That creates avoidable release risk around database migration ordering, Vercel deployment aliases, and partial multi-surface rollout state.

## Changes

- Adds a `deploy-production` concurrency group to the production deployment workflow.
- Sets `cancel-in-progress: false` so newer production deploys queue behind the active deploy instead of canceling it mid-flight.

## Validation

Commands run:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-production.yml")'` — passed
- `git diff --check` — passed

Commands not run:

- GitHub Actions concurrency scheduling — not run locally.

## Risk

Risk level: low

Compatibility impact: production deployments still run on `main` pushes and manual dispatch; overlapping runs are serialized.
Rollback simplicity: remove the added `concurrency` block.
Remaining edge cases: this queues concurrent production deploys; it intentionally does not cancel an in-progress production deployment.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

I used `cancel-in-progress: false` because this workflow includes database migrations and multiple deployment targets. Canceling a live production deploy could leave a partial rollout.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5477">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize production deploys by adding a workflow-level `concurrency` group to `deploy-production.yml` (`group: deploy-production`, `cancel-in-progress: false`). New runs queue behind the active deploy to avoid overlapping migrations and Vercel alias races.

<sup>Written for commit ef3a9144147423d3b393db65ca27307c086201a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment scheduling to allow an in-progress deployment to finish before subsequent runs proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->