### PR TITLE
fix(security): update axios override to patched release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -789,7 +789,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",
@@ -1130,7 +1130,7 @@
     "workerd",
   ],
   "overrides": {
-    "axios": "1.14.0",
+    "axios": "1.18.1",
     "hono": "4.12.25",
     "kysely": "0.28.17",
     "shell-quote": "1.8.4",
@@ -3512,7 +3512,7 @@
 
     "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
-    "axios": ["axios@1.14.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ=="],
+    "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
 
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
 
@@ -7142,6 +7142,10 @@
 
     "ava/pretty-ms": ["pretty-ms@8.0.0", "", { "dependencies": { "parse-ms": "^3.0.0" } }, "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q=="],
 
+    "axios/follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "babel-preset-expo/@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.28.6", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA=="],
@@ -8291,6 +8295,8 @@
     "ava/figures/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "ava/pretty-ms/parse-ms": ["parse-ms@3.0.0", "", {}, "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="],
+
+    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "babel-preset-expo/@babel/plugin-transform-modules-commonjs/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"tooling/*"
 	],
 	"overrides": {
-		"axios": "1.14.0",
+		"axios": "1.18.1",
 		"hono": "4.12.25",
 		"kysely": "0.28.17",
 		"shell-quote": "1.8.4"


### PR DESCRIPTION
## Summary

This PR updates the repository-level Axios override from `1.14.0` to `1.18.1` and refreshes `bun.lock` so all transitive Axios consumers resolve to the patched release.

## Why this matters

The root override forced all Axios consumers to `1.14.0`. `bun audit` reports 23 Axios advisories for that version, including high-severity proxy/SSRF, credential leak, and prototype-pollution gadget issues. The API uses Axios transitively through integrations such as Slack and Tavily/Mastra, so the override affects production server-side dependency resolution.

External references checked before the change:

- npm lists `axios@1.18.1` as the current latest release: https://www.npmjs.com/package/axios?activeTab=versions
- Axios GitHub releases note `1.18.0`/`1.18.1` hardening and fixes: https://github.com/axios/axios/releases
- Axios GitHub security advisories published on 2026-07-06 list `>=1.18.0` as patched for the newest Axios 1.x advisories, including FormData recursion, auth subfield prototype-pollution, `0.0.0.0` `NO_PROXY` bypass, and request-construction prototype-pollution gadgets: https://github.com/axios/axios/security/advisories

## Changes

- Updates the root `overrides.axios` pin from `1.14.0` to `1.18.1`.
- Refreshes `bun.lock` to resolve Axios to `1.18.1` and its updated dependency set.
- Preserves the repository-wide override so all transitive consumers share one patched Axios floor.

## Validation

Commands run:

- `bun info axios version` — passed; returned `1.18.1`
- `bun install --lockfile-only --ignore-scripts` — passed
- `bun install --frozen --ignore-scripts` — passed
- `bun audit --json` before/after — ran; Axios advisories dropped from 23 to 0
- `bun pm why axios` — passed; showed Axios resolved to `1.18.1` through Slack/Tavily/Mastra paths
- `cd apps/api && bun test src` — passed (16 tests)
- `bunx @biomejs/biome@2.4.2 check package.json` — passed
- `git diff --check` — passed

Failures:

- `bun audit --json` still exits non-zero after the change due to unrelated non-Axios advisories already present in the dependency graph.

## Risk

Risk level: medium

Compatibility impact: Axios is upgraded across all transitive consumers from `1.14.0` to `1.18.1`. This is a patch/minor-range security update on the existing Axios 1.x line.
Rollback simplicity: revert `package.json` and `bun.lock`.
Remaining edge cases: transitive consumers may rely on Axios internals, but `@slack/web-api` and `@tavily/core` both declare Axios ranges that accept `1.18.1`.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

`bun install` also refreshed stale workspace version metadata in `bun.lock` for packages whose package.json versions already changed on `main`; no package source files were modified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the repo-wide `axios` override to `1.18.1` to remove known security advisories and ensure all transitive consumers use the patched version.

- **Dependencies**
  - Set `overrides.axios` to `1.18.1` in `package.json` and `bun.lock`.
  - Regenerated lockfile so Slack/Tavily/Mastra paths resolve to `axios@1.18.1` (adds `https-proxy-agent`, updates `follow-redirects`).
  - `bun audit`: Axios findings drop from 23 to 0.

<sup>Written for commit d1a790f66c6959a06801e0d25a31a50f6ce05c81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

