### PR TITLE
feat(desktop): enable inline workspace ports and agents row by default

### DIFF
--- a/apps/desktop/src/renderer/stores/inline-workspace-ports.ts
+++ b/apps/desktop/src/renderer/stores/inline-workspace-ports.ts
@@ -33,7 +33,7 @@ export const useInlineWorkspacePortsStore = create<InlineWorkspacePortsState>()(
 	devtools(
 		persist(
 			(set) => ({
-				enabled: false,
+				enabled: true,
 				setEnabled: (enabled) => set({ enabled }),
 			}),
 			{ name: "inline-workspace-ports" },

--- a/apps/desktop/src/renderer/stores/workspace-agents-row.ts
+++ b/apps/desktop/src/renderer/stores/workspace-agents-row.ts
@@ -4,7 +4,7 @@ import { devtools, persist } from "zustand/middleware";
 /**
  * EXPERIMENT: show running agents inline under each workspace in the sidebar.
  *
- * Off by default. Single source of truth for the experiment — read it
+ * On by default. Single source of truth for the experiment — read it
  * everywhere via {@link useWorkspaceAgentsRowEnabled}.
  *
  * To conclude the experiment, pick an outcome and remove the other side:
@@ -25,7 +25,7 @@ export const useWorkspaceAgentsRowStore = create<WorkspaceAgentsRowState>()(
 	devtools(
 		persist(
 			(set) => ({
-				enabled: false,
+				enabled: true,
 				setEnabled: (enabled) => set({ enabled }),
 			}),
 			{ name: "workspace-agents-row" },


### PR DESCRIPTION
## Summary

Flips both experimental sidebar flags on by default:

- **Inline workspace ports** (`inline-workspace-ports` store) — ports render inline under each workspace item instead of the bottom panel.
- **Workspace agents row** (`workspace-agents-row` store) — running agents render inline under each workspace item.

Both remain toggleable in Experimental Settings. Since the stores use zustand `persist`, users who never toggled pick up the new `true` default; anyone who explicitly set a value keeps their choice.

## Test Plan

- [ ] Fresh install / cleared localStorage: both experiments show as enabled and render inline in the sidebar.
- [ ] Experimental Settings toggles still flip each flag off/on.
- [ ] A user who previously toggled a flag off keeps that setting.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5483">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turn on inline workspace ports and the workspace agents row by default so ports and running agents show directly under each workspace in the sidebar. Both experiments remain toggleable in Experimental Settings; defaults only apply to users who never changed them, thanks to `zustand` `persist`.

<sup>Written for commit 9a37f1ad72c9327874f8a0f78f81d7e26b79e098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled inline workspace ports by default for new sessions.
  * Enabled inline display of running workspace agents by default when no saved preference exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->