### PR TITLE
fix(host-service): resolve teardown from config.json on v2 delete; only skip teardown on explicit retry

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts
@@ -14,6 +14,8 @@ import {
 export interface DestroyWorkspaceInput {
 	deleteBranch?: boolean;
 	force?: boolean;
+	/** Skip the teardown script — retry-after-teardown-failure only. */
+	skipTeardown?: boolean;
 }
 
 export interface DestroyWorkspaceSuccess {
@@ -21,6 +23,7 @@ export interface DestroyWorkspaceSuccess {
 	worktreeRemoved: boolean;
 	branchDeleted: boolean;
 	cloudDeleted: boolean;
+	teardownStatus: "ok" | "skipped" | "failed" | "not-run";
 	warnings: string[];
 }
 
@@ -95,6 +98,7 @@ export function useDestroyWorkspace(workspaceId: string): UseDestroyWorkspace {
 					workspaceId,
 					deleteBranch: input.deleteBranch ?? false,
 					force: input.force ?? false,
+					skipTeardown: input.skipTeardown ?? false,
 				});
 			} catch (err) {
 				throw normalizeError(err);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx
@@ -48,7 +48,7 @@ export function DashboardSidebarDeleteDialog({
 				open={open}
 				onOpenChange={handleOpenChange}
 				cause={error.cause}
-				onForceDelete={() => run(true)}
+				onForceDelete={() => run({ force: true, skipTeardown: true })}
 			/>
 		);
 	}
@@ -67,7 +67,7 @@ export function DashboardSidebarDeleteDialog({
 			hasUnpushedCommits={hasUnpushedCommits}
 			canConfirm={canConfirm}
 			blockingReason={blockingReason}
-			onConfirm={() => run(hasWarnings)}
+			onConfirm={() => run({ force: hasWarnings })}
 			confirmLabel={confirmLabel}
 		/>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -96,7 +96,13 @@ export function useDestroyDialogState({
 	);
 
 	const run = useCallback(
-		async (force: boolean) => {
+		async ({
+			force,
+			skipTeardown = false,
+		}: {
+			force: boolean;
+			skipTeardown?: boolean;
+		}) => {
 			if (inFlight.current) return;
 			inFlight.current = true;
 			let keepDeleting = false;
@@ -112,17 +118,18 @@ export function useDestroyDialogState({
 			try {
 				let result: DestroyWorkspaceSuccess;
 				try {
-					result = await destroy({ deleteBranch, force });
+					result = await destroy({ deleteBranch, force, skipTeardown });
 				} catch (firstErr) {
 					const e = firstErr as DestroyWorkspaceError;
 					// Silent force-retry on the dirty-worktree race: preflight said
 					// clean but the worktree was dirty by destroy time. The user
 					// already confirmed once — don't bounce them back through a
-					// second warning. Do NOT extend this to `in-progress` (that's
-					// a different CONFLICT cause; retrying just races the same
-					// guard).
+					// second warning. Teardown still runs on the retry (the dirty
+					// conflict fires before teardown does). Do NOT extend this to
+					// `in-progress` (that's a different CONFLICT cause; retrying
+					// just races the same guard).
 					if (e.kind === "conflict" && !force) {
-						result = await destroy({ deleteBranch, force: true });
+						result = await destroy({ deleteBranch, force: true, skipTeardown });
 					} else {
 						throw firstErr;
 					}

--- a/packages/host-service/src/runtime/setup/config.ts
+++ b/packages/host-service/src/runtime/setup/config.ts
@@ -231,3 +231,9 @@ export function hasConfiguredScripts(config: SetupConfig | null): boolean {
 export function getResolvedSetupCommands(config: SetupConfig | null): string[] {
 	return nonEmptyStrings(config?.setup);
 }
+
+export function getResolvedTeardownCommands(
+	config: SetupConfig | null,
+): string[] {
+	return nonEmptyStrings(config?.teardown);
+}

--- a/packages/host-service/src/runtime/teardown/teardown.test.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.test.ts
@@ -9,7 +9,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildTeardownInitialCommand } from "./teardown";
+import {
+	buildTeardownCommandString,
+	buildTeardownInitialCommand,
+	resolveTeardownCommand,
+} from "./teardown";
 
 function isFishAvailable(): boolean {
 	const result = spawnSync("fish", ["-c", "exit 0"], { stdio: "ignore" });
@@ -46,6 +50,106 @@ describe("teardown initial command", () => {
 			]);
 
 			expect(result.status).toBe(7);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("single-quotes config command strings for exec bash -c", () => {
+		expect(buildTeardownCommandString("echo 'hi' && exit")).toBe(
+			`exec bash -c 'echo '\\''hi'\\'' && exit'`,
+		);
+	});
+});
+
+describe("resolveTeardownCommand", () => {
+	// Fresh dirs per call; homeDir points at an empty dir so real user
+	// overrides in ~/.superset can't leak into the resolution.
+	function setup() {
+		const root = mkdtempSync(join(tmpdir(), "host-service-teardown-resolve-"));
+		const repoPath = join(root, "repo");
+		const worktreePath = join(root, "worktree");
+		const homeDir = join(root, "home");
+		for (const dir of [repoPath, worktreePath, homeDir]) {
+			mkdirSync(join(dir, ".superset"), { recursive: true });
+		}
+		return {
+			root,
+			args: { repoPath, worktreePath, projectId: "proj-1", homeDir },
+		};
+	}
+
+	function writeScript(dir: string) {
+		writeFileSync(join(dir, ".superset", "teardown.sh"), "exit 0\n", {
+			mode: 0o755,
+		});
+	}
+
+	test("config commands win over an existing worktree teardown.sh", () => {
+		const { root, args } = setup();
+		try {
+			writeScript(args.worktreePath);
+			writeFileSync(
+				join(args.repoPath, ".superset", "config.json"),
+				JSON.stringify({ teardown: ["./scripts/teardown.sh", "echo done"] }),
+			);
+
+			expect(resolveTeardownCommand(args)).toBe(
+				"exec bash -c './scripts/teardown.sh && echo done'",
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("falls back to the worktree teardown.sh when config has no teardown", () => {
+		const { root, args } = setup();
+		try {
+			writeScript(args.worktreePath);
+			writeFileSync(
+				join(args.repoPath, ".superset", "config.json"),
+				JSON.stringify({ setup: ["bun install"] }),
+			);
+
+			expect(resolveTeardownCommand(args)).toBe(
+				`exec bash '${join(args.worktreePath, ".superset", "teardown.sh")}'`,
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("falls back to the main repo teardown.sh when the worktree copy is gitignored", () => {
+		const { root, args } = setup();
+		try {
+			writeScript(args.repoPath);
+
+			expect(resolveTeardownCommand(args)).toBe(
+				`exec bash '${join(args.repoPath, ".superset", "teardown.sh")}'`,
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns null when nothing is configured", () => {
+		const { root, args } = setup();
+		try {
+			expect(resolveTeardownCommand(args)).toBeNull();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("treats whitespace-only config commands as unconfigured", () => {
+		const { root, args } = setup();
+		try {
+			writeFileSync(
+				join(args.repoPath, ".superset", "config.json"),
+				JSON.stringify({ teardown: ["  ", ""] }),
+			);
+
+			expect(resolveTeardownCommand(args)).toBeNull();
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/host-service/src/runtime/teardown/teardown.test.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.test.ts
@@ -55,10 +55,25 @@ describe("teardown initial command", () => {
 		}
 	});
 
-	test("single-quotes config command strings for exec bash -c", () => {
-		expect(buildTeardownCommandString("echo 'hi' && exit")).toBe(
-			`exec bash -c 'echo '\\''hi'\\'' && exit'`,
-		);
+	test("joins config commands for the user's shell like setup does", () => {
+		const command = buildTeardownCommandString([
+			"./scripts/down.sh",
+			"echo done",
+		]);
+
+		expect(command).toBe("./scripts/down.sh && echo done; exit");
+		expect(command).not.toContain("$?");
+	});
+
+	test("config command exit propagates the last status under fish", () => {
+		if (!isFishAvailable()) return;
+
+		const result = spawnSync("fish", [
+			"-c",
+			buildTeardownCommandString(["sh -c 'exit 7'"]),
+		]);
+
+		expect(result.status).toBe(7);
 	});
 });
 
@@ -95,7 +110,7 @@ describe("resolveTeardownCommand", () => {
 			);
 
 			expect(resolveTeardownCommand(args)).toBe(
-				"exec bash -c './scripts/teardown.sh && echo done'",
+				"./scripts/teardown.sh && echo done; exit",
 			);
 		} finally {
 			rmSync(root, { recursive: true, force: true });

--- a/packages/host-service/src/runtime/teardown/teardown.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.ts
@@ -60,7 +60,7 @@ export function resolveTeardownCommand(args: {
 	const config = loadSetupConfig(args);
 	const commands = getResolvedTeardownCommands(config);
 	if (commands.length > 0) {
-		return buildTeardownCommandString(commands.join(" && "));
+		return buildTeardownCommandString(commands);
 	}
 
 	for (const root of [args.worktreePath, args.repoPath]) {
@@ -195,9 +195,15 @@ export function buildTeardownInitialCommand(scriptPath: string): string {
 	return `exec bash ${singleQuote(scriptPath)}`;
 }
 
-/** Same `exec bash` trick as above, for config-declared command strings. */
-export function buildTeardownCommandString(command: string): string {
-	return `exec bash -c ${singleQuote(command)}`;
+/**
+ * Config commands run in the user's login shell — the same contract as setup
+ * (`resolveInitialCommand` joins with ` && ` and types into the terminal), so
+ * shell-specific commands that worked at create don't break at delete. The
+ * trailing `exit` closes the hidden PTY; with no argument it propagates the
+ * last command's status in bash, zsh, and fish alike (no `$?` needed).
+ */
+export function buildTeardownCommandString(commands: string[]): string {
+	return `${commands.join(" && ")}; exit`;
 }
 
 /** POSIX single-quote escape: safe for any byte sequence in a path. */

--- a/packages/host-service/src/runtime/teardown/teardown.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.ts
@@ -7,6 +7,7 @@ import {
 	createTerminalSessionInternal,
 	disposeSession,
 } from "../../terminal/terminal";
+import { getResolvedTeardownCommands, loadSetupConfig } from "../setup/config";
 
 export { TEARDOWN_TIMEOUT_MS };
 
@@ -31,7 +32,45 @@ interface RunTeardownOptions {
 	db: HostDb;
 	workspaceId: string;
 	worktreePath: string;
+	repoPath: string;
+	projectId: string;
 	timeoutMs?: number;
+	/** Override $HOME for tests (forwarded to `loadSetupConfig`). */
+	homeDir?: string;
+}
+
+/**
+ * Resolve what teardown should execute, mirroring setup's source order
+ * (`resolveInitialCommand` in workspace-creation/shared/setup-terminal.ts):
+ *
+ *   1. `teardown` commands from `.superset/config.json` (+ user override and
+ *      `config.local.json` overlay) — joined with ` && `.
+ *   2. `<worktreePath>/.superset/teardown.sh`
+ *   3. `<repoPath>/.superset/teardown.sh` — the main repo is authoritative;
+ *      worktrees skip gitignored files.
+ *
+ * Returns null when nothing is configured.
+ */
+export function resolveTeardownCommand(args: {
+	repoPath: string;
+	worktreePath: string;
+	projectId: string;
+	homeDir?: string;
+}): string | null {
+	const config = loadSetupConfig(args);
+	const commands = getResolvedTeardownCommands(config);
+	if (commands.length > 0) {
+		return buildTeardownCommandString(commands.join(" && "));
+	}
+
+	for (const root of [args.worktreePath, args.repoPath]) {
+		const scriptPath = join(root, TEARDOWN_SCRIPT_REL_PATH);
+		if (existsSync(scriptPath)) {
+			return buildTeardownInitialCommand(scriptPath);
+		}
+	}
+
+	return null;
 }
 
 /**
@@ -47,13 +86,25 @@ export async function runTeardown({
 	db,
 	workspaceId,
 	worktreePath,
+	repoPath,
+	projectId,
 	timeoutMs = TEARDOWN_TIMEOUT_MS,
+	homeDir,
 }: RunTeardownOptions): Promise<TeardownResult> {
-	const scriptPath = join(worktreePath, TEARDOWN_SCRIPT_REL_PATH);
-	if (!existsSync(scriptPath)) return { status: "skipped" };
+	const initialCommand = resolveTeardownCommand({
+		repoPath,
+		worktreePath,
+		projectId,
+		homeDir,
+	});
+	if (!initialCommand) {
+		console.log(
+			`[teardown] Nothing to run for workspace ${workspaceId}: no teardown commands in config and no ${TEARDOWN_SCRIPT_REL_PATH} in ${worktreePath} or ${repoPath}`,
+		);
+		return { status: "skipped" };
+	}
 
 	const terminalId = randomUUID();
-	const initialCommand = buildTeardownInitialCommand(scriptPath);
 
 	const session = await createTerminalSessionInternal({
 		terminalId,
@@ -142,6 +193,11 @@ export function buildTeardownInitialCommand(scriptPath: string): string {
 	// avoids shell-specific exit-status syntax like `$?`, which breaks in fish
 	// and leaves the hidden teardown terminal open until timeout.
 	return `exec bash ${singleQuote(scriptPath)}`;
+}
+
+/** Same `exec bash` trick as above, for config-declared command strings. */
+export function buildTeardownCommandString(command: string): string {
+	return `exec bash -c ${singleQuote(command)}`;
 }
 
 /** POSIX single-quote escape: safe for any byte sequence in a path. */

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -37,6 +37,8 @@ export interface DestroyWorkspaceInput {
 	workspaceId: string;
 	deleteBranch: boolean;
 	force: boolean;
+	/** Skip the teardown script (retry-after-teardown-failure only). */
+	skipTeardown?: boolean;
 }
 
 /**
@@ -142,13 +144,18 @@ export const workspaceCleanupRouter = router({
 	 * while the path still exists, the cloud row remains so the workspace is
 	 * still visible and delete can be retried instead of orphaning disk state.
 	 *
-	 * Force semantics:
+	 * Force semantics ("delete despite dirty files" — NOT "skip teardown"):
 	 *   - skips preflight (step 0)
-	 *   - skips teardown  (step 1)
+	 *   - teardown (step 1) still runs; a failure becomes a warning
+	 *     instead of blocking
 	 *   - step 2b always uses `--force --force`
 	 *   - step 4 always uses `-D` regardless: the `deleteBranch`
 	 *     checkbox is the user's consent, so refusing unmerged branches
 	 *     would just silently drop the opt-in.
+	 *
+	 * Skip-teardown semantics: `skipTeardown` bypasses step 1 entirely.
+	 * Reserved for the retry after a teardown failure, where re-running
+	 * the script would just fail (or time out) again.
 	 *
 	 * Typed errors for the renderer:
 	 *   - CONFLICT             → dirty worktree; prompt force-retry.
@@ -168,6 +175,7 @@ export const workspaceCleanupRouter = router({
 				workspaceId: z.string(),
 				deleteBranch: z.boolean().default(false),
 				force: z.boolean().default(false),
+				skipTeardown: z.boolean().default(false),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => destroyWorkspace(ctx, input)),
@@ -237,29 +245,44 @@ async function runDestroy(
 
 	// ─── Step 1: Teardown ──────────────────────────────────────────
 	// Script is the user's last chance to stop services / flush state
-	// before the workspace goes away. Failure here is recoverable
-	// via force-retry, which skips this step.
-	if (!input.force && local && project) {
+	// before the workspace goes away. Failure here is recoverable via
+	// retry with `skipTeardown` (the TeardownFailedPane's "Delete
+	// anyway"), which is the only thing that skips this step. `force`
+	// still runs teardown — it means "delete despite dirty files", so a
+	// failure is downgraded to a warning instead of blocking.
+	let teardownStatus: "ok" | "skipped" | "failed" | "not-run" = "not-run";
+	if (!input.skipTeardown && local && project) {
 		const teardown: TeardownResult = await runTeardown({
 			db: ctx.db,
 			workspaceId: input.workspaceId,
 			worktreePath: local.worktreePath,
+			repoPath: project.repoPath,
+			projectId: project.id,
 		});
+		teardownStatus = teardown.status;
 		if (teardown.status === "failed") {
-			const cause: TeardownFailureCause = {
-				kind: "TEARDOWN_FAILED",
-				exitCode: teardown.exitCode,
-				signal: teardown.signal,
-				timedOut: teardown.timedOut,
-				outputTail: teardown.outputTail,
-			};
-			throw new TRPCError({
-				code: "INTERNAL_SERVER_ERROR",
-				message: "Teardown script failed",
-				cause,
-			});
+			if (!input.force) {
+				const cause: TeardownFailureCause = {
+					kind: "TEARDOWN_FAILED",
+					exitCode: teardown.exitCode,
+					signal: teardown.signal,
+					timedOut: teardown.timedOut,
+					outputTail: teardown.outputTail,
+				};
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Teardown script failed",
+					cause,
+				});
+			}
+			warnings.push(
+				`Teardown script failed (exit ${teardown.exitCode ?? "?"}); continued because force was set`,
+			);
 		}
 	}
+	console.log(
+		`[workspaceCleanup.destroy] teardown ${teardownStatus} for ${input.workspaceId} (force=${input.force}, skipTeardown=${input.skipTeardown ?? false})`,
+	);
 
 	// ─── Step 2: Local cleanup ─────────────────────────────────────
 	// 2a. PTYs
@@ -413,6 +436,7 @@ async function runDestroy(
 		cloudDeleted: true,
 		worktreeRemoved,
 		branchDeleted,
+		teardownStatus,
 		warnings,
 	};
 }

--- a/packages/host-service/test/integration/teardown.integration.test.ts
+++ b/packages/host-service/test/integration/teardown.integration.test.ts
@@ -82,7 +82,10 @@ describe("runTeardown integration", () => {
 			db: scenario.host.db,
 			workspaceId: scenario.workspaceId,
 			worktreePath: scenario.repo.repoPath,
+			repoPath: scenario.repo.repoPath,
+			projectId: scenario.projectId,
 			timeoutMs: 3_000,
+			homeDir: tmp,
 		});
 
 		expect(Date.now() - startedAt).toBeLessThan(3_000);

--- a/plans/done/20260707-1351-v2-delete-teardown-resolution.md
+++ b/plans/done/20260707-1351-v2-delete-teardown-resolution.md
@@ -1,0 +1,231 @@
+# Run project teardown scripts on the v2 workspace delete path
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Reference: This plan follows conventions from AGENTS.md and the ExecPlan template in `.agents/skills/create-plan/`.
+
+## Purpose / Big Picture
+
+When a user deletes ("closes") a workspace in the Superset desktop app, the project's teardown script is supposed to run first — stopping dev servers, removing docker containers, freeing ports, deleting scratch state. Today, on the current (v2, host-service-backed) delete path, teardown is silently skipped in the two most common configurations:
+
+1. Projects that declare teardown as a **command array in `.superset/config.json`** (which is exactly what the project-settings "Scripts" editor writes) never have it run, because the v2 destroy path only looks for a literal file at `<worktree>/.superset/teardown.sh` and never reads config.json.
+2. Any delete that ends up with `force: true` — which includes every "Delete anyway" confirmation on a workspace with uncommitted changes or unpushed commits, and **every delete issued through the legacy external surface (CLI/SDK/MCP)** — skips teardown entirely, because `force` currently conflates "delete despite dirty files" with "skip the teardown script".
+
+After this change, deleting a workspace runs the project's configured teardown (config.json commands first, `teardown.sh` file as fallback) in both the clean and the dirty-worktree ("Delete anyway") flows, and only the explicit retry-after-teardown-failure path skips it. A user can verify this by giving their project a teardown command that writes a marker file, deleting a workspace, and seeing the marker appear.
+
+Real-world reproduction that motivated this plan: the project at `~/Developer/K3` has `.superset/config.json` containing `"teardown": ["./scripts/worktree/teardown.sh"]`. The script exists and works when run by hand inside the worktree. Deleting a freshly created, completely clean workspace (e.g. the worktree at `~/.superset/worktrees/<project-uuid>/polite-wildcat`) via the desktop app never executes it, with no log output anywhere.
+
+## Assumptions
+
+- The fix targets only the v2 delete path (host-service `workspaceCleanup.destroy`). The legacy v1 electron-main delete (`apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts`) already resolves teardown from config.json via its own `runTeardown` in `apps/desktop/src/lib/trpc/routers/workspaces/utils/teardown.ts` and is not modified.
+- Teardown commands run with the worktree as the working directory (matching v1 behavior and the K3 config, which uses worktree-relative paths like `./scripts/worktree/teardown.sh`).
+- The 60-second teardown timeout (`TEARDOWN_TIMEOUT_MS` in `packages/shared/src/constants.ts:57`) stays as-is.
+- Backwards compatibility of the `destroy` input is required: existing callers pass only `{ workspaceId, deleteBranch, force }`, so the new `skipTeardown` field must default to `false`.
+
+## Open Questions
+
+- Should the legacy external `workspace.delete` procedure (CLI/SDK/MCP surface, `packages/host-service/src/trpc/router/workspace/workspace.ts:71-81`, which hard-codes `force: true`) now run teardown best-effort? This plan says yes (see Decision Log D3) — it makes SDK deletes take up to 60s longer if a teardown hangs, but skipping lifecycle scripts silently is the exact bug being fixed. If the product decision is "no", pass `skipTeardown: true` there instead and note it in the Decision Log. Impacts: Plan of Work step 4, Validation.
+- Should a teardown *failure* during a forced delete surface as a toast warning only (this plan's choice, D4), or block? Impacts: Plan of Work step 3.
+
+## Progress
+
+- [x] (2026-07-07 05:00Z) Milestone 1: config-aware teardown resolution in host-service (`resolveTeardownCommand` + `runTeardown` changes + unit tests).
+- [x] (2026-07-07 05:10Z) Milestone 2: decouple `force` from teardown skipping in the destroy saga (`skipTeardown` input, best-effort semantics under force, `teardownStatus` result field, skip logging).
+- [x] (2026-07-07 05:15Z) Milestone 3: renderer wiring (`useDestroyWorkspace`, `useDestroyDialogState`, `DashboardSidebarDeleteDialog`) so only the retry-after-teardown-failure path skips teardown.
+- [x] (2026-07-07 05:30Z) Validation: `bun run typecheck` (28/28), `bun run lint` (clean), host-service unit + integration suites (teardown, workspace-cleanup, workspace-create-delete) all pass.
+- [ ] Manual marker-file scenario (requires the running desktop app; see Validation and Acceptance) — not yet run.
+
+## Surprises & Discoveries
+
+(From the investigation that produced this plan; add more as implementation proceeds.)
+
+- Observation: setup and teardown resolve their scripts completely differently on the v2 path.
+  Evidence: setup (`packages/host-service/src/trpc/router/workspace-creation/shared/setup-terminal.ts:89-107`) reads config.json commands first, then falls back to `<mainRepoPath>/.superset/setup.sh` — deliberately the main repo, "NOT the worktree — worktrees skip gitignored files". Teardown (`packages/host-service/src/runtime/teardown/teardown.ts:52-53`) checks only `existsSync(join(worktreePath, ".superset/teardown.sh"))` and never opens config.json.
+- Observation: every delete with warnings sends `force: true`, and `force` skips teardown.
+  Evidence: `DashboardSidebarDeleteDialog.tsx:70` does `onConfirm={() => run(hasWarnings)}`; `workspace-cleanup.ts:242` guards teardown with `if (!input.force && local && project)`.
+- Observation: the legacy external delete surface always forces, so CLI/SDK/MCP deletes never run teardown either.
+  Evidence: `packages/host-service/src/trpc/router/workspace/workspace.ts:74-80` calls `destroyWorkspace(ctx, { workspaceId, deleteBranch: false, force: true })`.
+- Observation: all skip paths are silent — `runTeardown` returns `{ status: "skipped" }` with no logging, and the saga logs nothing when the force guard bypasses step 1. This is why the bug was hard for users to diagnose.
+- Observation: the superset repo itself masks the config.json gap in dogfooding, because its `.superset/teardown.sh` is a git-tracked file that exists in every worktree; K3-style projects (config commands only, or gitignored `.superset/`) are the ones that break.
+- Observation: the config.json `teardown` array is a documented regression, not a missing feature. PR #178 (2025-11-28) added exactly this to the original delete path (`apps/desktop/src/lib/trpc/routers/workspaces/utils/teardown.ts`, still present); PR #3443 (2026-04-14) moved deletes to the v2 host-service saga whose rewritten `runTeardown` dropped config support. The public docs (`apps/docs/content/docs/setup-teardown-scripts.mdx`, linked from the app's settings UI) still promise "Delete workspace → teardown commands run" with `"teardown": ["docker-compose down"]`-style examples — treat that page as the behavioral spec this plan restores.
+
+## Decision Log
+
+- Decision (D1): Teardown resolution order is (1) `teardown` command array from `loadSetupConfig` (config.json + `~/.superset/projects/<projectId>/config.json` override + `config.local.json` overlay), joined with `&&`; (2) `<worktreePath>/.superset/teardown.sh`; (3) `<repoPath>/.superset/teardown.sh`.
+  Rationale: exact parity with how setup resolves (`resolveInitialCommand` in setup-terminal.ts), plus keeping the worktree-file check first among the file fallbacks to preserve current behavior for repos that commit a worktree-local script. The main-repo fallback covers gitignored `.superset/` directories, the case setup already handles.
+  Date/Author: 2026-07-07 / investigation session (ivan.van + Claude).
+- Decision (D2): Introduce a separate `skipTeardown: boolean` (default `false`) on the destroy input instead of overloading `force`.
+  Rationale: `force` legitimately means "ignore dirty preflight"; only the retry after a *teardown failure* should mean "don't run teardown again" (re-running a script that just timed out would add another 60s wait to the user's "Delete anyway" click).
+  Date/Author: 2026-07-07.
+- Decision (D3): The legacy `workspace.delete` procedure keeps `force: true` but does not set `skipTeardown`, so external deletes now run teardown best-effort.
+  Rationale: the silent skip is the bug; external deletes deleting live dev servers without teardown is worse than a bounded 60s delay. Revisit if SDK latency becomes a complaint (see Open Questions).
+  Date/Author: 2026-07-07.
+- Decision (D4): Under `force: true`, a teardown failure is downgraded to a warning in the result's `warnings` array and the delete proceeds; under `force: false`, the existing typed `TEARDOWN_FAILED` error (which drives the TeardownFailedPane retry UI) is preserved unchanged.
+  Rationale: force means "proceed regardless"; throwing would strand the user in a loop. The non-force contract must not change because `useDestroyDialogState` and `TeardownFailedPane` depend on it.
+  Date/Author: 2026-07-07.
+- Decision (D5): Command-array teardown runs as `exec bash -c '<cmd1 && cmd2>'` inside the PTY, reusing the existing single-quote escaping.
+  Rationale: the existing `exec bash <script>` pattern exists to avoid shell-specific exit-status syntax (`$?` breaks under fish — see the fish test in `teardown.test.ts`); `exec bash -c` extends the same trick to arbitrary command strings.
+  Date/Author: 2026-07-07.
+
+## Outcomes & Retrospective
+
+Implemented as planned across all three milestones, on branch `fix/v2-delete-teardown-resolution` (fork flow: `ivanvan93/superset` → `superset-sh/superset`). Deviations from the plan: none of substance. Notes:
+
+- The existing `teardown.integration.test.ts` needed the new `repoPath`/`projectId`/`homeDir` args; `BasicScenario` already exposed `projectId`, so no helper changes were required.
+- The integration run visibly exercised the new semantics: `[workspaceCleanup.destroy] teardown skipped for <id> (force=true, skipTeardown=false)` — force deletes now go through teardown resolution instead of bypassing it.
+- The manual desktop-app marker-file scenario remains outstanding (needs a signed-in dev session); automated coverage exercises the same saga end-to-end with real git worktrees and a fake PTY.
+
+## Context and Orientation
+
+Superset is a Bun + Turborepo monorepo. The desktop app (`apps/desktop`, Electron) talks to a per-organization background process called the **host service** (`packages/host-service`) over tRPC (a typed RPC framework; procedures live under `packages/host-service/src/trpc/router/`). A **workspace** is an isolated git worktree of a project's repository, created under `~/.superset/worktrees/<project-uuid>/<workspace-name>`; the project's canonical clone (the "main repo") lives wherever the user keeps it, e.g. `~/Developer/K3`.
+
+Projects configure lifecycle scripts in `.superset/config.json` at the main repo root, with the shape `{ "setup": string[], "teardown": string[], "run": string[] }`. Two overlay files can modify it: a per-machine override at `~/.superset/projects/<projectId>/config.json` and a repo-local overlay at `.superset/config.local.json`. All of that resolution is already implemented in `loadSetupConfig` in `packages/host-service/src/runtime/setup/config.ts` — read that file first; this plan extends it minimally.
+
+The delete flow, end to end:
+
+- UI: `apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx` renders the confirm dialog. Its state hook `hooks/useDestroyDialogState/useDestroyDialogState.ts` calls `destroy({ deleteBranch, force })` from `apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts`, which invokes the host-service procedure `workspaceCleanup.destroy`.
+- Saga: `packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts`, function `runDestroy`, runs five phases: (0) dirty-worktree preflight, (1) teardown, (2) PTY + worktree cleanup, (3) cloud delete, (4) optional local branch delete, (5) local sqlite cleanup. Phase 1 currently calls `runTeardown` from `packages/host-service/src/runtime/teardown/teardown.ts`, guarded by `if (!input.force && local && project)`.
+- `runTeardown` spawns a hidden PTY session (via `createTerminalSessionInternal` in `packages/host-service/src/terminal/terminal.ts`, with `listed: false`) whose working directory defaults to the worktree path, types an initial command into the user's login shell, captures the last 4KB of output, and reports `ok` / `skipped` / `failed`. Today its initial command is always `exec bash '<worktree>/.superset/teardown.sh'` and it returns `skipped` when that file does not exist.
+- Failure UX: a `failed` result makes the saga throw `INTERNAL_SERVER_ERROR` with a `TEARDOWN_FAILED` cause; the renderer shows `TeardownFailedPane` (same dialog) with the output tail, and its "Delete anyway" button calls `run(true)` (`DashboardSidebarDeleteDialog.tsx:51`).
+- Legacy external surface: `packages/host-service/src/trpc/router/workspace/workspace.ts` `delete` procedure (used by CLI/SDK/MCP) calls `destroyWorkspace(ctx, { workspaceId, deleteBranch: false, force: true })`.
+
+Affected areas: `packages/host-service` (runtime/teardown, runtime/setup, trpc/router/workspace-cleanup, trpc/router/workspace) and `apps/desktop` renderer (the destroy hook and delete dialog). No database schema changes. No electron main-process changes.
+
+## Plan of Work
+
+### Milestone 1: config-aware teardown resolution in host-service
+
+First, in `packages/host-service/src/runtime/setup/config.ts`, add a sibling of `getResolvedSetupCommands`:
+
+    export function getResolvedTeardownCommands(
+    	config: SetupConfig | null,
+    ): string[] {
+    	return nonEmptyStrings(config?.teardown);
+    }
+
+Next, rework `packages/host-service/src/runtime/teardown/teardown.ts`. Extend `RunTeardownOptions` with the fields needed for config resolution: `repoPath: string` and `projectId: string` (plus an optional `homeDir?: string` passthrough for tests, forwarded to `loadSetupConfig`). Add an exported pure resolver so the decision logic is unit-testable without a PTY:
+
+    export function resolveTeardownCommand(args: {
+    	repoPath: string;
+    	worktreePath: string;
+    	projectId: string;
+    	homeDir?: string;
+    }): string | null
+
+Implement it per Decision D1: call `loadSetupConfig({ repoPath, projectId, homeDir })` and `getResolvedTeardownCommands`; if non-empty, return `buildTeardownCommandString(commands.join(" && "))`; else if `<worktreePath>/.superset/teardown.sh` exists, return the existing `buildTeardownInitialCommand(scriptPath)`; else if `<repoPath>/.superset/teardown.sh` exists, return `buildTeardownInitialCommand` of that path; else return `null`. Add the new command builder next to the existing one, reusing the `singleQuote` helper (Decision D5):
+
+    export function buildTeardownCommandString(command: string): string {
+    	return `exec bash -c ${singleQuote(command)}`;
+    }
+
+Then change `runTeardown` to call `resolveTeardownCommand` at the top; on `null`, `console.log` a skip line naming the workspace id and the three locations it checked (this addresses the "no logs anywhere" complaint) and return `{ status: "skipped" }`. The rest of the function (PTY session, output tail, timeout, kill-grace) is unchanged except that `initialCommand` is now the resolved command. Note the PTY already runs with the worktree as cwd and the terminal env builder injects `SUPERSET_ROOT_PATH` (`packages/host-service/src/terminal/env.ts:193`), so config commands that need the main repo can use that variable — same contract as setup.
+
+Update the caller in `workspace-cleanup.ts` (phase 1) to pass `repoPath: project.repoPath` and `projectId: project.id` (both already available from `isMainWorkspace`'s returned `project` row — confirm the row's field names by reading `is-main-workspace.ts` before wiring).
+
+Extend `packages/host-service/src/runtime/teardown/teardown.test.ts` (bun:test, uses `mkdtempSync` temp dirs — follow the existing style) with resolver cases: config commands win over an existing worktree `teardown.sh`; worktree `teardown.sh` used when config has no teardown; main-repo `teardown.sh` used when the worktree copy is absent; `null` when nothing is configured; command strings with single quotes escape correctly; empty/whitespace command arrays are treated as unconfigured. Use the `homeDir` override pointed at an empty temp dir so real user overrides in `~/.superset` can't leak into tests.
+
+At the end of this milestone, deleting a clean K3-style workspace runs the config-declared teardown. Verify with the unit tests before proceeding.
+
+### Milestone 2: decouple force from teardown in the destroy saga
+
+In `packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts`:
+
+- Add `skipTeardown: z.boolean().default(false)` to the `destroy` input schema and `skipTeardown: boolean` to `DestroyWorkspaceInput`.
+- Change the phase-1 guard from `if (!input.force && local && project)` to `if (!input.skipTeardown && local && project)`.
+- Inside phase 1, when the result is `failed`: if `input.force` is false, throw the existing `TEARDOWN_FAILED` error exactly as today (do not touch the error shape — `TeardownFailedPane` and `useDestroyWorkspace` parse it); if `input.force` is true, push a warning such as `` `Teardown script failed (exit ${exitCode ?? "?"}); continued because force was set` `` onto `warnings` and continue (Decision D4).
+- Add a `teardownStatus: "ok" | "skipped" | "failed" | "not-run"` field to the returned object (`not-run` when the guard didn't fire — skipTeardown set, or missing local/project rows) so callers and future UI can observe what happened, and `console.log` one line per outcome.
+- Update the doc comment block above `destroy` (the "Force semantics" list currently documents "skips teardown (step 1)") to describe the new semantics.
+
+Leave `packages/host-service/src/trpc/router/workspace/workspace.ts` `delete` as `{ deleteBranch: false, force: true }` — with the new guard it now runs teardown best-effort (Decision D3). Check other `destroyWorkspace`/`workspaceCleanup.destroy` callers compile unchanged (the added input field is optional-with-default): grep for `destroyWorkspace(` and `workspaceCleanup.destroy` across `packages/` and `apps/`; known ones are the workspace router above and `packages/mcp-v2/src/tools/workspaces/delete.ts` (which goes through the workspace router).
+
+### Milestone 3: renderer wiring
+
+In `apps/desktop/src/renderer/hooks/host-service/useDestroyWorkspace/useDestroyWorkspace.ts`, extend the `destroy` call's input type with `skipTeardown?: boolean` and pass it through to the tRPC mutation.
+
+In `useDestroyDialogState.ts`, change `run(force: boolean)` to `run(opts: { force: boolean; skipTeardown?: boolean })` (or two parameters — match local style) and forward both to `destroy`. The silent conflict retry inside `run` (currently `destroy({ deleteBranch, force: true })` after a `conflict` error) must pass `skipTeardown: false` semantics, i.e. just `force: true` — teardown has not run yet at that point because the dirty-worktree conflict is thrown in phase 0, before phase 1.
+
+In `DashboardSidebarDeleteDialog.tsx`: the main confirm (`onConfirm={() => run(hasWarnings)}`) becomes `run({ force: hasWarnings })` — dirty workspaces still run teardown now; and the `TeardownFailedPane` retry (`onForceDelete={() => run(true)}`) becomes `run({ force: true, skipTeardown: true })` — the one place where skipping is the point, because the script just failed and the user chose to proceed anyway.
+
+Search for any other `useDestroyWorkspace`/`useDestroyDialogState` consumers (e.g. other delete dialogs under `apps/desktop/src/renderer`) and apply the same mapping. The v1 delete surfaces (`useDeleteWorkspace`, `deleteWithToast` in `TeardownLogsDialog`) are out of scope.
+
+## Concrete Steps
+
+All commands run from the repo root unless noted.
+
+    # after Milestone 1
+    cd packages/host-service && bun test src/runtime/teardown
+    # Expected: all tests pass, including the new resolver cases
+
+    # after Milestones 2-3, from repo root
+    bun run typecheck        # Expected: exits 0, no errors
+    bun run lint             # Expected: exits 0 — CI fails on warnings too (AGENTS.md rule 7)
+    bun test                 # Expected: all suites pass
+
+Note: `bun run lint:fix` after edits, then confirm `bun run lint` is clean before pushing (repo rule — warnings are treated as errors).
+
+## Validation and Acceptance
+
+Manual end-to-end check, using any project whose teardown is declared in config.json (K3 is ideal). Make the teardown observable, e.g. append to the project's teardown script (or temporarily set in the main repo's `.superset/config.local.json`):
+
+    { "teardown": { "after": ["date >> /tmp/superset-teardown-ran.log"] } }
+
+Then with the desktop app running against the modified host-service (`bun dev`):
+
+1. Clean delete: create a workspace, make no changes, delete it via the sidebar delete dialog. Expect `/tmp/superset-teardown-ran.log` to gain a line, and the host-service log (the `bun dev` terminal, `[host-service:<org>]`-prefixed lines) to show the teardown-ran log line.
+2. Dirty delete: create a workspace, `touch scratch.txt` inside it, delete it — the dialog shows the uncommitted-changes warning and the button reads "Delete anyway". Confirm. Expect teardown to run (marker line appears). This is the case that was silently broken.
+3. Teardown-failure retry: point teardown at a failing command (`config.local.json` teardown `["exit 1"]`), delete a workspace, see the TeardownFailedPane with output. Click "Delete anyway". Expect the delete to complete *without* re-running teardown (no new marker line after the failure attempt).
+4. External surface: delete a workspace via the SDK/MCP `workspace.delete`. Expect teardown to run and the delete to succeed even if teardown fails.
+
+Acceptance is behavioral: cases 1, 2 and 4 write the marker; case 3 completes without a second run; `typecheck`, `lint`, `test` are all clean.
+
+## Idempotence and Recovery
+
+All edits are additive or in-place; re-running the validation steps is safe. `destroy` remains idempotent from the caller's perspective (the in-flight guard and the existing saga ordering are untouched). If Milestone 2 or 3 goes wrong, Milestone 1 alone is still shippable and fixes the K3-class projects for clean deletes; the renderer changes are inert until the input field is used. Remember to remove any `config.local.json` used during manual validation (it is gitignored, but it changes local behavior).
+
+## Artifacts and Notes
+
+The two guards that cause the bug, verbatim from the current tree:
+
+    // packages/host-service/src/runtime/teardown/teardown.ts:52
+    const scriptPath = join(worktreePath, TEARDOWN_SCRIPT_REL_PATH);
+    if (!existsSync(scriptPath)) return { status: "skipped" };
+
+    // packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts:242
+    if (!input.force && local && project) { ...runTeardown... }
+
+    // apps/desktop/.../DashboardSidebarDeleteDialog.tsx:70
+    onConfirm={() => run(hasWarnings)}   // hasWarnings ⇒ force ⇒ teardown skipped
+
+K3's config, the shape that must work after this change:
+
+    { "setup": ["./scripts/worktree/setup.sh"],
+      "teardown": ["./scripts/worktree/teardown.sh"],
+      "run": ["./scripts/worktree/run.sh"] }
+
+## Interfaces and Dependencies
+
+No new dependencies. End state signatures:
+
+    // packages/host-service/src/runtime/setup/config.ts
+    export function getResolvedTeardownCommands(config: SetupConfig | null): string[]
+
+    // packages/host-service/src/runtime/teardown/teardown.ts
+    export function resolveTeardownCommand(args: {
+    	repoPath: string; worktreePath: string; projectId: string; homeDir?: string;
+    }): string | null
+    export function buildTeardownCommandString(command: string): string
+    // runTeardown options gain: repoPath: string; projectId: string; homeDir?: string
+
+    // packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+    export interface DestroyWorkspaceInput {
+    	workspaceId: string; deleteBranch: boolean; force: boolean; skipTeardown: boolean;
+    }
+    // destroy result gains: teardownStatus: "ok" | "skipped" | "failed" | "not-run"
+
+    // apps/desktop renderer
+    // useDestroyWorkspace destroy input gains skipTeardown?: boolean
+    // useDestroyDialogState run(opts: { force: boolean; skipTeardown?: boolean })
+
+---
+
+Revision note (2026-07-07): added a Surprises & Discoveries entry establishing via git history (PR #178 → PR #3443) that config-array teardown is a regression of a shipped, documented behavior, and pointing the implementer at `apps/docs/content/docs/setup-teardown-scripts.mdx` as the behavioral spec. No scope change.


### PR DESCRIPTION
## Problem

Deleting a workspace on the v2 delete path silently skips the project's teardown scripts in the two most common configurations:

1. **`teardown` command arrays in `.superset/config.json` are never executed.** The v2 destroy path only looks for a literal file at `<worktree>/.superset/teardown.sh` and never reads config.json — even though the v2 project-settings Scripts editor writes config.json arrays, and the docs (`setup-teardown-scripts.mdx`: "Delete workspace → **teardown** commands run") promise they run. This is a regression: #178 added config-array teardown to the original delete path; the v2 unification in #3443 dropped it, and #4090 upgraded only *setup* to read config while shipping the editor that writes teardown arrays nothing executes.
2. **Any delete with `force: true` skipped teardown entirely** — every "Delete anyway" on a workspace with uncommitted/unpushed changes (`run(hasWarnings)`), and every CLI/SDK/MCP delete (`workspace.delete` hard-codes `force: true`). `force` conflated "delete despite dirty files" with "skip the teardown script".

Both skips were silent: no log line, no warning, no result field.

Repro: a project with `"teardown": ["./scripts/worktree/teardown.sh"]` in `.superset/config.json` (no `.superset/teardown.sh` file). Create a workspace, keep it clean, delete it → teardown never runs. Setup runs fine on creation.

## Fix

**Teardown now resolves exactly like setup** (`resolveInitialCommand` in `setup-terminal.ts`):

1. `teardown` commands from `.superset/config.json` (+ `~/.superset/projects/<id>/config.json` override + `config.local.json` overlay), joined with ` && `, run as `exec bash -c '…'` (same fish-safe `exec` trick as the existing script path)
2. `<worktree>/.superset/teardown.sh` (unchanged behavior)
3. `<mainRepo>/.superset/teardown.sh` — main repo is authoritative; worktrees skip gitignored files (parity with setup)

**`force` no longer skips teardown.** A new `skipTeardown` destroy input (default `false`) is the only bypass, and the renderer sets it only on the TeardownFailedPane "Delete anyway" retry — where re-running the script that just failed/timed out would only stall the user again. Under `force`, a teardown failure downgrades to a `warnings` entry instead of blocking; the non-force `TEARDOWN_FAILED` typed-error contract is unchanged.

**Observability:** skips are logged (`[teardown] Nothing to run …`, `[workspaceCleanup.destroy] teardown <status> …`) and the destroy result gains `teardownStatus: "ok" | "skipped" | "failed" | "not-run"`.

The legacy external `workspace.delete` surface keeps `force: true` and therefore now runs teardown best-effort (failures don't block SDK/CLI deletes).

## Testing

- New unit tests for `resolveTeardownCommand` (config wins over worktree script; worktree → main-repo fallback; null when unconfigured; whitespace-only commands ignored; quoting) — `bun test src/runtime/teardown`: 8 pass
- Existing integration suites (`teardown`, `workspace-cleanup`, `workspace-create-delete`): 27 pass; the create-delete run now visibly logs `teardown skipped … (force=true, skipTeardown=false)`, showing forced deletes go through resolution
- `bun run typecheck` (28/28 packages), `bun run lint` clean

ExecPlan with the full investigation and decision log: `plans/done/20260707-1351-v2-delete-teardown-resolution.md`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5485">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure v2 workspace deletes run project teardown and only skip it on an explicit retry after a teardown failure. Teardown now resolves from `.superset/config.json` and runs in the user's shell (like setup), with clear logs and a `teardownStatus` in the result.

- **Bug Fixes**
  - Teardown resolution mirrors setup: read `teardown` from `.superset/config.json` (incl. user overrides), else `<worktree>/.superset/teardown.sh`, else `<repo>/.superset/teardown.sh`.
  - Config teardown commands run in the user's shell with `&&` and a trailing `exit` for parity and correct exit codes across bash/zsh/fish.
  - `force` no longer skips teardown; new `skipTeardown` input controls bypass and is only set on the TeardownFailedPane "Delete anyway" retry.
  - On `force`, teardown failures become warnings; non-force still throws the `TEARDOWN_FAILED` error.
  - Added logs for skips and outcomes; `workspaceCleanup.destroy` returns `teardownStatus: "ok" | "skipped" | "failed" | "not-run"`.

- **Migration**
  - No action required. CLI/SDK deletes (which set `force: true`) now run teardown best-effort and may take up to the timeout if teardown hangs.

<sup>Written for commit de1edcdcc9f6823baca4e72438923408b5a1e8d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace deletion now supports an independent option to skip teardown during specific retry flows.
  * Teardown commands are now resolved from configuration first, with automatic fallback to workspace/repository teardown scripts when not configured.

* **Bug Fixes**
  * Workspace deletion now reports teardown outcomes more precisely (ok, skipped, failed, or not run).
  * Retry and force-delete behavior now preserves teardown unless teardown is explicitly skipped, improving consistency across dirty and conflict cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->