### PR TITLE
Add Elixir syntax highlighting

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -167,6 +167,7 @@
 		"bindings": "1.5.0",
 		"bufferutil": "4.1.0",
 		"clsx": "2.1.1",
+		"codemirror-lang-elixir": "^4.0.1",
 		"culori": "4.0.2",
 		"date-fns": "4.1.0",
 		"default-shell": "2.2.0",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/loadLanguageSupport/loadLanguageSupport.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/loadLanguageSupport/loadLanguageSupport.ts
@@ -84,6 +84,10 @@ export async function loadLanguageSupport(
 			const { go } = await import("@codemirror/lang-go");
 			return go();
 		}
+		case "elixir": {
+			const { elixir } = await import("codemirror-lang-elixir");
+			return elixir();
+		}
 		case "shell":
 			return loadLegacyLanguage(
 				() => import("@codemirror/legacy-modes/mode/shell"),

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/loadLanguageSupport.ts
@@ -84,6 +84,10 @@ export async function loadLanguageSupport(
 			const { go } = await import("@codemirror/lang-go");
 			return go();
 		}
+		case "elixir": {
+			const { elixir } = await import("codemirror-lang-elixir");
+			return elixir();
+		}
 		case "shell":
 			return loadLegacyLanguage(
 				() => import("@codemirror/legacy-modes/mode/shell"),

--- a/apps/desktop/src/shared/detect-language.ts
+++ b/apps/desktop/src/shared/detect-language.ts
@@ -47,6 +47,8 @@ export function detectLanguage(filePath: string): string {
 		java: "java",
 		kt: "kotlin",
 		swift: "swift",
+		ex: "elixir",
+		exs: "elixir",
 		c: "c",
 		cpp: "cpp",
 		h: "c",

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -243,6 +243,7 @@
         "bindings": "1.5.0",
         "bufferutil": "4.1.0",
         "clsx": "2.1.1",
+        "codemirror-lang-elixir": "^4.0.1",
         "culori": "4.0.2",
         "date-fns": "4.1.0",
         "default-shell": "2.2.0",
@@ -789,7 +790,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",
@@ -3736,6 +3737,8 @@
 
     "code-inspector-plugin": ["code-inspector-plugin@1.4.5", "", { "dependencies": { "@code-inspector/core": "1.4.5", "@code-inspector/esbuild": "1.4.5", "@code-inspector/mako": "1.4.5", "@code-inspector/turbopack": "1.4.5", "@code-inspector/vite": "1.4.5", "@code-inspector/webpack": "1.4.5", "chalk": "4.1.1" } }, "sha512-yp3zHd5AZhtVoBNOzKQuJVo1wZe7AIO2vAiVhF8WIAK02IwM9+gY+Pr9deajx+XyJLbzMW+3CgdfLIh+xxW2Hg=="],
 
+    "codemirror-lang-elixir": ["codemirror-lang-elixir@4.0.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "lezer-elixir": "^1.0.0" } }, "sha512-z6W/XB4b7TZrp9EZYBGVq93vQfvKbff+1iM8YZaVErL0dguBAeLmVRlEv1NuDZHOP1qjJ3NwyibkUkNWn7q9VQ=="],
+
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
     "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
@@ -4789,6 +4792,8 @@
     "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "lezer-elixir": ["lezer-elixir@1.1.3", "", { "dependencies": { "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.3.0" } }, "sha512-Ymc58/WhxdZS9yEOlnKbF3rdeBdFcPm4OEm26KMqA1Za9vztXi7I5qwGw1KxYmm3Nv0iDHq//EQyBwSEzKG9Mg=="],
 
     "libsql": ["libsql@0.5.22", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.22", "@libsql/darwin-x64": "0.5.22", "@libsql/linux-arm-gnueabihf": "0.5.22", "@libsql/linux-arm-musleabihf": "0.5.22", "@libsql/linux-arm64-gnu": "0.5.22", "@libsql/linux-arm64-musl": "0.5.22", "@libsql/linux-x64-gnu": "0.5.22", "@libsql/linux-x64-musl": "0.5.22", "@libsql/win32-x64-msvc": "0.5.22" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA=="],
 


### PR DESCRIPTION
## What

Opening a `.ex` / `.exs` file in the code viewer rendered as plaintext — Elixir was missing from both the extension→language map and the CodeMirror language loader.

## Changes

- **`detect-language.ts`** — map `ex` / `exs` → `"elixir"`
- **`loadLanguageSupport.ts`** (both the `v2-workspace` and `screens/main` copies) — add an `"elixir"` case that lazy-loads the grammar, matching the existing `lang-*` pattern
- **`package.json`** — add `codemirror-lang-elixir` (lezer-based CM6 grammar, `@codemirror/language` peer already present)

`bun.lock` also picks up a pre-existing version-drift correction (`apps/desktop` 1.13.0→1.13.1, `host-service` 0.8.23→0.8.24) that `bun install` synced from the already-updated `package.json` — not introduced by this change.

## Testing

Verified the grammar in a standalone CodeMirror harness using the exact `elixir()` call `loadLanguageSupport` makes — keywords, atoms, module aliases, sigils, comments, strings, and numbers all highlight distinctly; no console errors.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Elixir syntax highlighting to the code editor so `.ex` and `.exs` files render with proper colors by loading the Elixir CM6 grammar.

- **Dependencies**
  - Added `codemirror-lang-elixir`.
  - Updated `bun.lock` to include the new package; other version syncs reflect existing `package.json` changes.

<sup>Written for commit d27ab81b46e1ad75746139d3a4f7c30e198490b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Elixir syntax support in the code editor.
  * Elixir files with `.ex` and `.exs` extensions are now detected automatically.
  * Improved editor experience for Elixir code with proper language highlighting and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->