### PR TITLE
feat(desktop): default file/diff opening to new tab instead of split pane

### DIFF
--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.test.ts
@@ -67,6 +67,19 @@ describe("changes sidebar file policy", () => {
 		).toBe("external");
 	});
 
+	it("maps shift-click to the diff when the settings action is pane", () => {
+		expect(
+			resolveChangesSidebarFileIntent(
+				{ ...map, shift: "pane" },
+				{
+					metaKey: false,
+					ctrlKey: false,
+					shiftKey: true,
+				},
+			),
+		).toBe("diff");
+	});
+
 	it("returns null for unbound tiers", () => {
 		expect(
 			resolveChangesSidebarFileIntent(

--- a/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/policies/changesSidebarFilePolicy.ts
@@ -22,7 +22,7 @@ function intentFor(
 	if (action === null) return null;
 	if (action === "external") return "external";
 	if (action === "newTab") return "diffNewTab";
-	return tier === "plain" ? "diff" : "file";
+	return tier === "plain" || tier === "shift" ? "diff" : "file";
 }
 
 function shortIntentLabel(intent: ChangesSidebarFileIntent): string {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/AgentCommentComposer/hooks/useDiffCommentTarget/useDiffCommentTarget.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/AgentCommentComposer/hooks/useDiffCommentTarget/useDiffCommentTarget.ts
@@ -19,7 +19,7 @@ export const NEW_PREFIX = "new:";
 const LAST_NEW_AGENT_CONFIG_ID_KEY = "lastSelectedDiffCommentNewAgentConfigId";
 const LAST_TERMINAL_ID_KEY = "lastSelectedDiffCommentTerminalId";
 const LAST_PLACEMENT_KEY = "lastSelectedDiffCommentPlacement";
-const DEFAULT_PLACEMENT: AgentSessionPlacement = "split-pane";
+const DEFAULT_PLACEMENT: AgentSessionPlacement = "new-tab";
 
 function readStorage(key: string): string | null {
 	if (typeof window === "undefined") return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -85,6 +85,21 @@ describe("healV2UserPreferences", () => {
 			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
 		);
 	});
+
+	it("migrates the previous split-pane default to the current new-tab default", () => {
+		const healed = healV2UserPreferences({
+			sidebarFileLinks: {
+				plain: "pane",
+				shift: "newTab",
+				meta: "pane",
+				metaShift: "external",
+			},
+		});
+
+		expect(healed.sidebarFileLinks).toEqual(
+			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
+		);
+	});
 });
 
 describe("healWorkspaceLocalState", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -201,16 +201,26 @@ const DEFAULT_LINK_TIER_MAP: LinkTierMap = {
 	metaShift: "external",
 };
 
-const LEGACY_SIDEBAR_FILE_LINKS: LinkTierMap = {
-	plain: "pane",
-	shift: "newTab",
-	meta: "external",
-	metaShift: "external",
-};
+// Previously shipped default maps. A stored row matching any of these is
+// treated as un-customized and upgraded to the current default on read.
+const LEGACY_SIDEBAR_FILE_LINKS: LinkTierMap[] = [
+	{
+		plain: "pane",
+		shift: "newTab",
+		meta: "external",
+		metaShift: "external",
+	},
+	{
+		plain: "pane",
+		shift: "newTab",
+		meta: "pane",
+		metaShift: "external",
+	},
+];
 
 const DEFAULT_SIDEBAR_FILE_LINKS: LinkTierMap = {
-	plain: "pane",
-	shift: "newTab",
+	plain: "newTab",
+	shift: "pane",
 	meta: "pane",
 	metaShift: "external",
 };
@@ -319,10 +329,13 @@ export function healV2UserPreferences(raw: unknown): V2UserPreferencesRow {
 				...r.sidebarFileLinks,
 			}
 		: DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks;
+	const storedSidebarFileLinks = r.sidebarFileLinks;
 	const shouldMigrateLegacySidebarFileLinks =
-		r.sidebarFileLinks &&
-		isCompleteLinkTierMap(r.sidebarFileLinks) &&
-		isSameLinkTierMap(r.sidebarFileLinks, LEGACY_SIDEBAR_FILE_LINKS);
+		storedSidebarFileLinks &&
+		isCompleteLinkTierMap(storedSidebarFileLinks) &&
+		LEGACY_SIDEBAR_FILE_LINKS.some((legacy) =>
+			isSameLinkTierMap(storedSidebarFileLinks, legacy),
+		);
 	return {
 		...DEFAULT_V2_USER_PREFERENCES,
 		...r,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -9,6 +9,7 @@ import {
 } from "@superset/ui/select";
 import { Switch } from "@superset/ui/switch";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { DEFAULT_FILE_OPEN_MODE } from "shared/constants";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -163,7 +164,7 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 							</p>
 						</div>
 						<Select
-							value={fileOpenMode ?? "split-pane"}
+							value={fileOpenMode ?? DEFAULT_FILE_OPEN_MODE}
 							onValueChange={(value) =>
 								setFileOpenMode.mutate({ mode: value as FileOpenMode })
 							}

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -44,7 +44,7 @@ export const DEFAULT_TERMINAL_SCROLLBACK = 5000;
 // Default user preference values
 export const DEFAULT_CONFIRM_ON_QUIT = true;
 export const DEFAULT_TERMINAL_LINK_BEHAVIOR = "file-viewer" as const;
-export const DEFAULT_FILE_OPEN_MODE = "split-pane" as const;
+export const DEFAULT_FILE_OPEN_MODE = "new-tab" as const;
 export const DEFAULT_AUTO_APPLY_DEFAULT_PRESET = true;
 export const DEFAULT_SHOW_PRESETS_BAR = true;
 export const DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON = true;


### PR DESCRIPTION
## What

Change the desktop app's default open behavior from **split pane** to **new tab** everywhere it applied.

- **`DEFAULT_FILE_OPEN_MODE`** `split-pane` → `new-tab` — controls how files open from the file tree, terminal links, and chat file references when no preview pane exists. Drives the store, the `useFileOpenMode` hook, and the tRPC settings router. The Behavior settings dropdown fallback now references the constant instead of a hardcoded `"split-pane"`.
- **Diff-comment agent session placement** default `split-pane` → `new-tab` — where a new agent session opens when commenting on a diff.
- **Changes sidebar click policy** — plain click now opens the diff in a **new tab** (was: current tab / split); **shift+click** opens the diff in the **current tab** (the old default, now behind a modifier). `cmd/ctrl+click` (open raw file) and `cmd/ctrl+shift+click` (open in editor) are unchanged.

## Changes-sidebar click map (after)

| Click | Action |
| --- | --- |
| Plain | Diff in a new tab *(new default)* |
| Shift | Diff in the current tab *(old split behavior)* |
| Cmd/Ctrl | Open the raw file in the current tab *(unchanged)* |
| Cmd/Ctrl+Shift | Open in external editor *(unchanged)* |

To keep the split-diff behavior reachable on shift, `intentFor` now resolves a `"pane"` action to the diff for both the `plain` and `shift` tiers (previously only `plain`).

## Migration & existing users

- The Changes-sidebar read-time migration (`LEGACY_SIDEBAR_FILE_LINKS`) is now a list. The previous shipped default (`plain: pane, shift: newTab, meta: pane, metaShift: external`) is included, so users still on that un-customized default are upgraded to the new-tab default automatically.
- Users who **explicitly** customized their mapping / file-open mode keep their choice.
- ExecutionMode (terminal/agent presets) already defaulted to new-tab — untouched.

## Tests

- `changesSidebarFilePolicy.test.ts` — added `shift + pane → "diff"`.
- `schema.test.ts` — added previous-default → current-default migration case.
- Full typecheck, lint, and affected tests pass.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the desktop app’s default open behavior from split pane to new tab. Updates click behavior in the Changes sidebar and diff comment placement, with safe migration for existing users.

- **New Features**
  - App-wide default `DEFAULT_FILE_OPEN_MODE` is `new-tab` (file tree, terminal links, chat references).
  - Diff-comment agent session placement default is `new-tab`.
  - Changes sidebar: click opens diff in a new tab; Shift+click opens in the current tab; Cmd/Ctrl and Cmd/Ctrl+Shift remain unchanged.
  - Behavior settings fallback now uses `DEFAULT_FILE_OPEN_MODE`.

- **Migration**
  - Users on the previous uncustomized mapping are auto-migrated to the new-tab default.
  - Users with explicit preferences keep their settings.

<sup>Written for commit 0b3bd91051a1ab56396973de5cc8593b0770a282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Shift-click in the changes sidebar now opens the diff view.
  - New items may open in a new tab by default in more places.

- **Bug Fixes**
  - Updated sidebar link preference handling so older saved settings migrate correctly.
  - Fixed the default file open mode shown in settings when no preference is set.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->