### PR TITLE
fix(desktop): dismiss stuck tooltips and forward tab-switch hotkeys in in-workspace browser

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -160,6 +160,15 @@ export const createBrowserRouter = () => {
 				});
 			}),
 
+		// Renderer-registered canonical chords the main process should suppress in
+		// the focused guest and forward for replay (override/layout-aware).
+		setForwardableChords: publicProcedure
+			.input(z.object({ chords: z.array(z.string()) }))
+			.mutation(({ input }) => {
+				browserManager.setForwardableChords(input.chords);
+				return { success: true };
+			}),
+
 		// Keystrokes intercepted from the focused guest webview, replayed by the
 		// renderer into its hotkey system (guest focus hides them from the host).
 		onKeyForward: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -1,6 +1,9 @@
 import { observable } from "@trpc/server/observable";
 import { session } from "electron";
-import { browserManager } from "main/lib/browser/browser-manager";
+import {
+	browserManager,
+	type ForwardedKey,
+} from "main/lib/browser/browser-manager";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 
@@ -153,6 +156,22 @@ export const createBrowserRouter = () => {
 					browserManager.on(`reload-pane:${input.paneId}`, handler);
 					return () => {
 						browserManager.off(`reload-pane:${input.paneId}`, handler);
+					};
+				});
+			}),
+
+		// Keystrokes intercepted from the focused guest webview, replayed by the
+		// renderer into its hotkey system (guest focus hides them from the host).
+		onKeyForward: publicProcedure
+			.input(z.object({ paneId: z.string() }))
+			.subscription(({ input }) => {
+				return observable<ForwardedKey>((emit) => {
+					const handler = (key: ForwardedKey) => {
+						emit.next(key);
+					};
+					browserManager.on(`key-forward:${input.paneId}`, handler);
+					return () => {
+						browserManager.off(`key-forward:${input.paneId}`, handler);
 					};
 				});
 			}),

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -8,6 +8,15 @@ interface ConsoleEntry {
 	timestamp: number;
 }
 
+export interface ForwardedKey {
+	key: string;
+	code: string;
+	meta: boolean;
+	control: boolean;
+	alt: boolean;
+	shift: boolean;
+}
+
 const MAX_CONSOLE_ENTRIES = 500;
 
 function sanitizeUrl(url: string): string {
@@ -242,25 +251,38 @@ class BrowserManager extends EventEmitter {
 	// accelerator closes the whole window. `before-input-event` fires in the
 	// main process before both, and `preventDefault()` suppresses both.
 	//
-	// keyDown guard prevents a second fire on keyUp. Shift guard preserves
-	// Cmd+Shift+W (CLOSE_TAB) and Cmd+Shift+R (forceReload).
+	// CmdOrCtrl+W/R are intercepted here (menu accelerators fire even when the
+	// guest holds focus). Every other chord is forwarded to the host renderer,
+	// which replays it into its hotkey system so shortcuts like tab switching
+	// keep working while the browser is focused. keyDown guard prevents a
+	// second fire on keyUp.
 	private setupBeforeInput(paneId: string, wc: Electron.WebContents): void {
 		const handler = (event: Electron.Event, input: Electron.Input): void => {
 			if (input.type !== "keyDown") return;
-			if (input.shift || input.alt) return;
 			if (!(input.meta || input.control)) return;
 
-			const key = input.key.toLowerCase();
-			if (key === "w") {
-				event.preventDefault();
-				this.emit(`close-pane:${paneId}`);
-				return;
+			if (!input.shift && !input.alt) {
+				const key = input.key.toLowerCase();
+				if (key === "w") {
+					event.preventDefault();
+					this.emit(`close-pane:${paneId}`);
+					return;
+				}
+				if (key === "r") {
+					event.preventDefault();
+					this.emit(`reload-pane:${paneId}`);
+					return;
+				}
 			}
-			if (key === "r") {
-				event.preventDefault();
-				this.emit(`reload-pane:${paneId}`);
-				return;
-			}
+
+			this.emit(`key-forward:${paneId}`, {
+				key: input.key,
+				code: input.code,
+				meta: input.meta,
+				control: input.control,
+				alt: input.alt,
+				shift: input.shift,
+			} satisfies ForwardedKey);
 		};
 
 		wc.on("before-input-event", handler);

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { clipboard, Menu, webContents } from "electron";
 import { safeOpenExternal } from "main/lib/safe-url";
+import { chordFromInput } from "shared/hotkey-chord";
 
 interface ConsoleEntry {
 	level: "log" | "warn" | "error" | "info" | "debug";
@@ -38,6 +39,13 @@ class BrowserManager extends EventEmitter {
 	private consoleListeners = new Map<string, () => void>();
 	private contextMenuListeners = new Map<string, () => void>();
 	private beforeInputListeners = new Map<string, () => void>();
+	// Canonical chords the renderer wants replayed into its hotkey system when
+	// the guest webview has focus. Kept override/layout-aware by the renderer.
+	private forwardableChords = new Set<string>();
+
+	setForwardableChords(chords: string[]): void {
+		this.forwardableChords = new Set(chords);
+	}
 
 	register(paneId: string, webContentsId: number): void {
 		// Clean even when prevId === webContentsId so BrowserManager owns
@@ -252,16 +260,17 @@ class BrowserManager extends EventEmitter {
 	// main process before both, and `preventDefault()` suppresses both.
 	//
 	// CmdOrCtrl+W/R are intercepted here (menu accelerators fire even when the
-	// guest holds focus). Every other chord is forwarded to the host renderer,
-	// which replays it into its hotkey system so shortcuts like tab switching
-	// keep working while the browser is focused. keyDown guard prevents a
+	// guest holds focus). Chords the renderer registered as forwardable (tab
+	// switching, …) are preventDefault'd and forwarded so the host can replay
+	// them; suppressing the guest event stops the page from also acting on the
+	// same keystroke. Every other key falls through untouched, so in-page
+	// shortcuts (copy/paste/find/…) keep working. keyDown guard prevents a
 	// second fire on keyUp.
 	private setupBeforeInput(paneId: string, wc: Electron.WebContents): void {
 		const handler = (event: Electron.Event, input: Electron.Input): void => {
 			if (input.type !== "keyDown") return;
-			if (!(input.meta || input.control)) return;
 
-			if (!input.shift && !input.alt) {
+			if ((input.meta || input.control) && !input.shift && !input.alt) {
 				const key = input.key.toLowerCase();
 				if (key === "w") {
 					event.preventDefault();
@@ -275,6 +284,9 @@ class BrowserManager extends EventEmitter {
 				}
 			}
 
+			const chord = chordFromInput(input);
+			if (!chord || !this.forwardableChords.has(chord)) return;
+			event.preventDefault();
 			this.emit(`key-forward:${paneId}`, {
 				key: input.key,
 				code: input.code,

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -39,8 +39,8 @@ class BrowserManager extends EventEmitter {
 	private consoleListeners = new Map<string, () => void>();
 	private contextMenuListeners = new Map<string, () => void>();
 	private beforeInputListeners = new Map<string, () => void>();
-	// Canonical chords the renderer wants replayed into its hotkey system when
-	// the guest webview has focus. Kept override/layout-aware by the renderer.
+	// Canonical chords to suppress in the focused guest and forward for the
+	// renderer to replay. Kept override/layout-aware by the renderer.
 	private forwardableChords = new Set<string>();
 
 	setForwardableChords(chords: string[]): void {
@@ -257,15 +257,9 @@ class BrowserManager extends EventEmitter {
 	// When a webview has focus, keystrokes route to the guest renderer — host
 	// `react-hotkeys-hook` listeners never see them and the menu's CmdOrCtrl+W
 	// accelerator closes the whole window. `before-input-event` fires in the
-	// main process before both, and `preventDefault()` suppresses both.
-	//
-	// CmdOrCtrl+W/R are intercepted here (menu accelerators fire even when the
-	// guest holds focus). Chords the renderer registered as forwardable (tab
-	// switching, …) are preventDefault'd and forwarded so the host can replay
-	// them; suppressing the guest event stops the page from also acting on the
-	// same keystroke. Every other key falls through untouched, so in-page
-	// shortcuts (copy/paste/find/…) keep working. keyDown guard prevents a
-	// second fire on keyUp.
+	// main process before both, so we intercept CmdOrCtrl+W/R and any
+	// renderer-registered forwardable chord here. Everything else falls through
+	// untouched, keeping in-page shortcuts (copy/paste/find/…) working.
 	private setupBeforeInput(paneId: string, wc: Electron.WebContents): void {
 		const handler = (event: Electron.Event, input: Electron.Input): void => {
 			if (input.type !== "keyDown") return;

--- a/apps/desktop/src/renderer/hotkeys/components/HotkeyTooltip/HotkeyTooltip.tsx
+++ b/apps/desktop/src/renderer/hotkeys/components/HotkeyTooltip/HotkeyTooltip.tsx
@@ -19,8 +19,11 @@ export function HotkeyTooltip({
 }) {
 	const { text } = useHotkeyDisplay(id ?? ("" as HotkeyId));
 	if (!id || text === "Unassigned") return <>{children}</>;
+	// The chip is never interactive, and the hoverable-content grace period
+	// leaves the tooltip stuck open when the pointer crosses onto a native
+	// webview (the host document stops receiving pointer events).
 	return (
-		<Tooltip delayDuration={1000}>
+		<Tooltip delayDuration={1000} disableHoverableContent>
 			<TooltipTrigger asChild>{children}</TooltipTrigger>
 			<TooltipContent side={side}>{text}</TooltipContent>
 		</Tooltip>

--- a/apps/desktop/src/renderer/hotkeys/utils/binding.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/binding.ts
@@ -1,5 +1,5 @@
+import { canonicalizeChord, normalizeToken } from "shared/hotkey-chord";
 import type { ParsedBinding, ShortcutBinding } from "../types";
-import { canonicalizeChord, normalizeToken } from "./resolveHotkeyFromEvent";
 
 /**
  * Keys whose `event.code` is stable across keyboard layouts (Enter, arrows,

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -1,3 +1,4 @@
+import { canonicalizeChord, eventToChord } from "shared/hotkey-chord";
 import { HOTKEYS, type HotkeyId } from "../registry";
 import { useHotkeyOverridesStore } from "../stores/hotkeyOverridesStore";
 import { useKeyboardLayoutStore } from "../stores/keyboardLayoutStore";
@@ -7,6 +8,18 @@ import {
 } from "../stores/keyboardPreferencesStore";
 import type { ShortcutBinding } from "../types";
 import { bindingToDispatchChord } from "./binding";
+
+// Pure chord helpers live in `shared/hotkey-chord` (main + renderer). Re-export
+// the ones consumed elsewhere in the hotkey module so their import paths are
+// unchanged.
+export {
+	canonicalizeChord,
+	eventToChord,
+	isIgnorableKey,
+	MODIFIERS,
+	matchesChord,
+	normalizeToken,
+} from "shared/hotkey-chord";
 
 /**
  * KeyboardEvent → registered {@link HotkeyId}, or `null` if unbound. Uses the
@@ -19,89 +32,6 @@ export function resolveHotkeyFromEvent(event: KeyboardEvent): HotkeyId | null {
 	const chord = eventToChord(event);
 	if (!chord) return null;
 	return registeredAppChords.get(chord) ?? null;
-}
-
-// Mirrors react-hotkeys-hook's alias table (react-hotkeys-hook/dist/index.js:3-19)
-const CODE_ALIASES: Record<string, string> = {
-	esc: "escape",
-	return: "enter",
-	left: "arrowleft",
-	right: "arrowright",
-	up: "arrowup",
-	down: "arrowdown",
-	MetaLeft: "meta",
-	MetaRight: "meta",
-	ShiftLeft: "shift",
-	ShiftRight: "shift",
-	AltLeft: "alt",
-	AltRight: "alt",
-	OSLeft: "meta",
-	OSRight: "meta",
-	ControlLeft: "ctrl",
-	ControlRight: "ctrl",
-};
-
-export const MODIFIERS = new Set(["meta", "ctrl", "control", "alt", "shift"]);
-
-// Lock keys must never commit a binding on their own.
-const LOCK_KEYS = new Set(["capslock", "numlock", "scrolllock"]);
-
-export function normalizeToken(token: string): string {
-	const aliased = CODE_ALIASES[token.trim()] ?? token.trim();
-	return aliased.toLowerCase().replace(/key|digit|numpad/, "");
-}
-
-export function isIgnorableKey(normalized: string): boolean {
-	return !normalized || MODIFIERS.has(normalized) || LOCK_KEYS.has(normalized);
-}
-
-/**
- * Stable form for comparing chord strings. Tolerates modifier order and
- * aliases: `meta+alt+up` ≡ `alt+meta+arrowup` ≡ `control+alt+arrowup`.
- */
-export function canonicalizeChord(chord: string): string {
-	const parts = chord.toLowerCase().split("+").map(normalizeToken);
-	const mods: string[] = [];
-	const keys: string[] = [];
-	for (const part of parts) {
-		if (MODIFIERS.has(part)) {
-			mods.push(part === "control" ? "ctrl" : part);
-		} else {
-			keys.push(part);
-		}
-	}
-	mods.sort();
-	return [...mods, ...keys].join("+");
-}
-
-/** KeyboardEvent → canonical chord (comparable to {@link canonicalizeChord} output), or null for pure modifier / synthetic presses. */
-export function eventToChord(event: KeyboardEvent): string | null {
-	if (event.code === undefined) return null;
-	// IME composition: keydown during CJK / dead-key composition must not
-	// trigger hotkeys. Safari reports keyCode 229 instead of isComposing.
-	if (event.isComposing || event.keyCode === 229) return null;
-	const key = normalizeToken(event.code);
-	if (isIgnorableKey(key)) return null;
-	// AltGr is reported by Chromium as ctrlKey+altKey on Windows/Linux.
-	// Treating that combination as Ctrl+Alt would let printable keystrokes on
-	// non-US layouts (e.g. AltGr+E = € on German) accidentally trigger
-	// ctrl+alt+e bindings. Suppress both when AltGr is held; no binding opts
-	// into AltGr explicitly.
-	const altGraph = event.getModifierState?.("AltGraph") === true;
-	const mods: string[] = [];
-	if (event.metaKey) mods.push("meta");
-	if (event.ctrlKey && !altGraph) mods.push("ctrl");
-	if (event.altKey && !altGraph) mods.push("alt");
-	if (event.shiftKey) mods.push("shift");
-	mods.sort();
-	return [...mods, key].join("+");
-}
-
-/** True if `event` produces `chord` (tolerating modifier order / aliases). */
-export function matchesChord(event: KeyboardEvent, chord: string): boolean {
-	const eventChord = eventToChord(event);
-	if (!eventChord) return false;
-	return eventChord === canonicalizeChord(chord);
 }
 
 /** Sent straight to the PTY. Canonicalized at build time so lookups via `eventToChord` / `canonicalizeChord` match directly. */

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -9,9 +9,8 @@ import {
 import type { ShortcutBinding } from "../types";
 import { bindingToDispatchChord } from "./binding";
 
-// Pure chord helpers live in `shared/hotkey-chord` (main + renderer). Re-export
-// the ones consumed elsewhere in the hotkey module so their import paths are
-// unchanged.
+// Re-export the chord helpers (now in `shared/hotkey-chord`) so existing
+// hotkey-module import paths stay unchanged.
 export {
 	canonicalizeChord,
 	eventToChord,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -233,7 +233,7 @@ export function V2PresetsBar({
 			style={{ scrollbarWidth: "none" }}
 		>
 			<DropdownMenu>
-				<Tooltip delayDuration={1000}>
+				<Tooltip delayDuration={1000} disableHoverableContent>
 					<TooltipTrigger asChild>
 						<DropdownMenuTrigger asChild>
 							<Button

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -125,7 +125,7 @@ export function BrowserPaneToolbar({ ctx }: BrowserPaneToolbarProps) {
 			/>
 			<div className="flex shrink-0 items-center pr-1">
 				<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
-				<Tooltip>
+				<Tooltip disableHoverableContent>
 					<TooltipTrigger asChild>
 						<button
 							type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -1,7 +1,7 @@
 import type { RendererContext, Tab } from "@superset/panes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { GlobeIcon } from "lucide-react";
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import { TbDeviceDesktop } from "react-icons/tb";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { BrowserPaneData, PaneViewerData } from "../../../../types";
@@ -22,12 +22,29 @@ function getSingleBrowserPane(
 	return { id: pane.id, data: pane.data as BrowserPaneData };
 }
 
+function BrowserTabFavicon({ src }: { src: string | null }) {
+	const [failed, setFailed] = useState(false);
+	// Chromium guesses /favicon.ico for pages that declare none, so the URL can
+	// 404 — fall back to a globe instead of a broken image.
+	if (!src || failed) {
+		return <GlobeIcon className="size-3.5 shrink-0 text-muted-foreground" />;
+	}
+	return (
+		<img
+			src={src}
+			alt=""
+			className="size-3.5 shrink-0"
+			onError={() => setFailed(true)}
+		/>
+	);
+}
+
 export function renderBrowserTabIcon(tab: Tab<PaneViewerData>) {
 	const browser = getSingleBrowserPane(tab);
-	if (!browser?.data.faviconUrl) return null;
-	return (
-		<img src={browser.data.faviconUrl} alt="" className="size-3.5 shrink-0" />
-	);
+	if (!browser) return null;
+	const faviconUrl = browser.data.faviconUrl ?? null;
+	// Keyed by URL so a failed favicon retries when the pane navigates.
+	return <BrowserTabFavicon key={faviconUrl ?? "none"} src={faviconUrl} />;
 }
 
 interface BrowserPaneProps {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -1,7 +1,7 @@
 import type { RendererContext, Tab } from "@superset/panes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { GlobeIcon } from "lucide-react";
-import { useCallback, useState, useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { TbDeviceDesktop } from "react-icons/tb";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { BrowserPaneData, PaneViewerData } from "../../../../types";
@@ -9,6 +9,7 @@ import type { BrowserPaneData, PaneViewerData } from "../../../../types";
 import { browserRuntimeRegistry } from "./browserRuntimeRegistry";
 import { BrowserErrorOverlay } from "./components/BrowserErrorOverlay";
 import { BrowserOverflowMenu } from "./components/BrowserOverflowMenu";
+import { BrowserTabFavicon } from "./components/BrowserTabFavicon";
 import { BrowserToolbar } from "./components/BrowserToolbar";
 import { usePersistentWebview } from "./hooks/usePersistentWebview";
 
@@ -22,29 +23,18 @@ function getSingleBrowserPane(
 	return { id: pane.id, data: pane.data as BrowserPaneData };
 }
 
-function BrowserTabFavicon({ src }: { src: string | null }) {
-	const [failed, setFailed] = useState(false);
-	// Chromium guesses /favicon.ico for pages that declare none, so the URL can
-	// 404 — fall back to a globe instead of a broken image.
-	if (!src || failed) {
-		return <GlobeIcon className="size-3.5 shrink-0 text-muted-foreground" />;
-	}
-	return (
-		<img
-			src={src}
-			alt=""
-			className="size-3.5 shrink-0"
-			onError={() => setFailed(true)}
-		/>
-	);
-}
-
 export function renderBrowserTabIcon(tab: Tab<PaneViewerData>) {
 	const browser = getSingleBrowserPane(tab);
 	if (!browser) return null;
 	const faviconUrl = browser.data.faviconUrl ?? null;
-	// Keyed by URL so a failed favicon retries when the pane navigates.
-	return <BrowserTabFavicon key={faviconUrl ?? "none"} src={faviconUrl} />;
+	// Keyed by page + favicon URL so a failed favicon retries on navigation
+	// even when the favicon URL itself is unchanged.
+	return (
+		<BrowserTabFavicon
+			key={`${browser.data.url}|${faviconUrl ?? "none"}`}
+			src={faviconUrl}
+		/>
+	);
 }
 
 interface BrowserPaneProps {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabFavicon/BrowserTabFavicon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabFavicon/BrowserTabFavicon.tsx
@@ -1,0 +1,19 @@
+import { GlobeIcon } from "lucide-react";
+import { useState } from "react";
+
+export function BrowserTabFavicon({ src }: { src: string | null }) {
+	const [failed, setFailed] = useState(false);
+	// Chromium guesses /favicon.ico for pages that declare none, so the URL can
+	// 404 — fall back to a globe instead of a broken image.
+	if (!src || failed) {
+		return <GlobeIcon className="size-3.5 shrink-0 text-muted-foreground" />;
+	}
+	return (
+		<img
+			src={src}
+			alt=""
+			className="size-3.5 shrink-0"
+			onError={() => setFailed(true)}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabFavicon/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserTabFavicon/index.ts
@@ -1,0 +1,1 @@
+export { BrowserTabFavicon } from "./BrowserTabFavicon";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,17 +1,27 @@
 import type { RendererContext } from "@superset/panes";
 import { useCallback, useEffect, useRef } from "react";
-import { type HotkeyId, resolveHotkeyFromEvent } from "renderer/hotkeys";
+import {
+	getDispatchChord,
+	type HotkeyId,
+	resolveHotkeyFromEvent,
+	useHotkeyOverridesStore,
+	useKeyboardPreferencesStore,
+} from "renderer/hotkeys";
+import { useKeyboardLayoutStore } from "renderer/hotkeys/stores/keyboardLayoutStore";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type {
 	BrowserPaneData,
 	PaneViewerData,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { canonicalizeChord } from "shared/hotkey-chord";
 import { browserRuntimeRegistry } from "../../browserRuntimeRegistry";
 import { DEFAULT_BROWSER_URL } from "../../constants";
 
 // Hotkeys the browser pane replays onto the host document when the guest
 // webview forwards a keystroke. Scoped to tab switching: these have no menu
-// accelerator (so replaying can't double-fire) and aren't page shortcuts.
+// accelerator (so replaying can't double-fire) and aren't page shortcuts. The
+// main process is told these chords (override/layout-aware) so it suppresses +
+// forwards only them — see the forwardable-chord sync below.
 const FORWARDABLE_HOTKEYS = new Set<HotkeyId>([
 	"PREV_TAB",
 	"NEXT_TAB",
@@ -152,6 +162,31 @@ export function usePersistentWebview({
 			keyForwardSub.unsubscribe();
 		};
 	}, [paneId]);
+
+	// Keep the main process's forwardable-chord set in sync with the current
+	// (override/layout-aware) bindings so it suppresses + forwards exactly the
+	// tab-switch chords the renderer will replay. Recomputes on remap / layout
+	// change — the same triggers `resolveHotkeyFromEvent`'s index rebuilds on.
+	useEffect(() => {
+		const push = () => {
+			const chords = [...FORWARDABLE_HOTKEYS]
+				.map((id) => getDispatchChord(id))
+				.filter((chord): chord is string => chord !== null)
+				.map(canonicalizeChord);
+			electronTrpcClient.browser.setForwardableChords
+				.mutate({ chords })
+				.catch(() => {});
+		};
+		push();
+		const unsubs = [
+			useHotkeyOverridesStore.subscribe(push),
+			useKeyboardLayoutStore.subscribe(push),
+			useKeyboardPreferencesStore.subscribe(push),
+		];
+		return () => {
+			for (const unsub of unsubs) unsub();
+		};
+	}, []);
 
 	const goBack = useCallback(() => {
 		browserRuntimeRegistry.goBack(paneId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,5 +1,6 @@
 import type { RendererContext } from "@superset/panes";
 import { useCallback, useEffect, useRef } from "react";
+import { type HotkeyId, resolveHotkeyFromEvent } from "renderer/hotkeys";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type {
 	BrowserPaneData,
@@ -7,6 +8,25 @@ import type {
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { browserRuntimeRegistry } from "../../browserRuntimeRegistry";
 import { DEFAULT_BROWSER_URL } from "../../constants";
+
+// Hotkeys the browser pane replays onto the host document when the guest
+// webview forwards a keystroke. Scoped to tab switching: these have no menu
+// accelerator (so replaying can't double-fire) and aren't page shortcuts.
+const FORWARDABLE_HOTKEYS = new Set<HotkeyId>([
+	"PREV_TAB",
+	"NEXT_TAB",
+	"PREV_TAB_ALT",
+	"NEXT_TAB_ALT",
+	"JUMP_TO_TAB_1",
+	"JUMP_TO_TAB_2",
+	"JUMP_TO_TAB_3",
+	"JUMP_TO_TAB_4",
+	"JUMP_TO_TAB_5",
+	"JUMP_TO_TAB_6",
+	"JUMP_TO_TAB_7",
+	"JUMP_TO_TAB_8",
+	"JUMP_TO_TAB_9",
+]);
 
 interface UsePersistentWebviewOptions {
 	paneId: string;
@@ -98,11 +118,38 @@ export function usePersistentWebview({
 				},
 			},
 		);
+		// The guest webview swallows keystrokes, so host hotkeys never fire while
+		// the browser is focused. Replay forwarded chords onto the host document
+		// so react-hotkeys-hook picks them up — gated to tab-switch hotkeys.
+		const keyForwardSub = electronTrpcClient.browser.onKeyForward.subscribe(
+			{ paneId },
+			{
+				onData: (key) => {
+					const init: KeyboardEventInit = {
+						key: key.key,
+						code: key.code,
+						metaKey: key.meta,
+						ctrlKey: key.control,
+						altKey: key.alt,
+						shiftKey: key.shift,
+						bubbles: true,
+						cancelable: true,
+					};
+					const id = resolveHotkeyFromEvent(new KeyboardEvent("keydown", init));
+					if (!id || !FORWARDABLE_HOTKEYS.has(id)) return;
+					document.dispatchEvent(new KeyboardEvent("keydown", init));
+					// Balance react-hotkeys-hook's global pressed-key set — a keydown
+					// without a keyup would leave the key stuck as "pressed".
+					document.dispatchEvent(new KeyboardEvent("keyup", init));
+				},
+			},
+		);
 		return () => {
 			newWindowSub.unsubscribe();
 			contextMenuSub.unsubscribe();
 			closePaneSub.unsubscribe();
 			reloadPaneSub.unsubscribe();
+			keyForwardSub.unsubscribe();
 		};
 	}, [paneId]);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -17,11 +17,10 @@ import { canonicalizeChord } from "shared/hotkey-chord";
 import { browserRuntimeRegistry } from "../../browserRuntimeRegistry";
 import { DEFAULT_BROWSER_URL } from "../../constants";
 
-// Hotkeys the browser pane replays onto the host document when the guest
-// webview forwards a keystroke. Scoped to tab switching: these have no menu
-// accelerator (so replaying can't double-fire) and aren't page shortcuts. The
-// main process is told these chords (override/layout-aware) so it suppresses +
-// forwards only them — see the forwardable-chord sync below.
+// Hotkeys the pane replays onto the host document when the guest forwards a
+// keystroke. Scoped to tab switching: no menu accelerator (so replaying can't
+// double-fire) and not page shortcuts. The main process is synced these chords
+// so it suppresses + forwards only them — see the forwardable-chord sync below.
 const FORWARDABLE_HOTKEYS = new Set<HotkeyId>([
 	"PREV_TAB",
 	"NEXT_TAB",
@@ -128,9 +127,8 @@ export function usePersistentWebview({
 				},
 			},
 		);
-		// The guest webview swallows keystrokes, so host hotkeys never fire while
-		// the browser is focused. Replay forwarded chords onto the host document
-		// so react-hotkeys-hook picks them up — gated to tab-switch hotkeys.
+		// Replay forwarded chords onto the host document so react-hotkeys-hook
+		// picks them up. Re-gated to tab-switch hotkeys in case the main set lags.
 		const keyForwardSub = electronTrpcClient.browser.onKeyForward.subscribe(
 			{ paneId },
 			{
@@ -148,8 +146,8 @@ export function usePersistentWebview({
 					const id = resolveHotkeyFromEvent(new KeyboardEvent("keydown", init));
 					if (!id || !FORWARDABLE_HOTKEYS.has(id)) return;
 					document.dispatchEvent(new KeyboardEvent("keydown", init));
-					// Balance react-hotkeys-hook's global pressed-key set — a keydown
-					// without a keyup would leave the key stuck as "pressed".
+					// keyup balances react-hotkeys-hook's pressed-key set; without it
+					// the key stays stuck as "pressed".
 					document.dispatchEvent(new KeyboardEvent("keyup", init));
 				},
 			},
@@ -163,10 +161,9 @@ export function usePersistentWebview({
 		};
 	}, [paneId]);
 
-	// Keep the main process's forwardable-chord set in sync with the current
-	// (override/layout-aware) bindings so it suppresses + forwards exactly the
-	// tab-switch chords the renderer will replay. Recomputes on remap / layout
-	// change — the same triggers `resolveHotkeyFromEvent`'s index rebuilds on.
+	// Sync the main process's forwardable-chord set with the current bindings,
+	// recomputing on the same remap / layout / preference changes that rebuild
+	// `resolveHotkeyFromEvent`'s index.
 	useEffect(() => {
 		const push = () => {
 			const chords = [...FORWARDABLE_HOTKEYS]

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -51,7 +51,13 @@ export function usePersistentWebview({
 	ctxRef.current = ctx;
 
 	const paneData = ctx.pane.data as BrowserPaneData;
-	const initialUrlRef = useRef(paneData.url || DEFAULT_BROWSER_URL);
+	// Read through a ref so attach keys on paneId alone: navigation echoes
+	// updating pane data must not re-attach, but a replacePane (new paneId on
+	// the same component instance — e.g. opening a link into an existing
+	// browser pane) must attach with the new pane's URL, not the URL captured
+	// at first mount.
+	const attachUrlRef = useRef(paneData.url || DEFAULT_BROWSER_URL);
+	attachUrlRef.current = paneData.url || DEFAULT_BROWSER_URL;
 
 	useEffect(() => {
 		const placeholder = placeholderRef.current;
@@ -60,7 +66,7 @@ export function usePersistentWebview({
 		browserRuntimeRegistry.attach(
 			paneId,
 			placeholder,
-			initialUrlRef.current,
+			attachUrlRef.current,
 			({ url, pageTitle, faviconUrl }) => {
 				const current = ctxRef.current.pane.data as BrowserPaneData;
 				if (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -178,7 +178,11 @@ export function usePersistentWebview({
 				.map(canonicalizeChord);
 			electronTrpcClient.browser.setForwardableChords
 				.mutate({ chords })
-				.catch(() => {});
+				.catch((error) => {
+					// Stale main-process suppression means webview tab-switch hotkeys
+					// silently stop working — leave a trace.
+					console.warn("[browser] failed to sync forwardable chords", error);
+				});
 		};
 		push();
 		const unsubs = [

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -90,6 +90,32 @@ describe("healV2UserPreferences", () => {
 			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
 		);
 	});
+
+	it("migrates the legacy url link default to the current default", () => {
+		const healed = healV2UserPreferences({
+			urlLinks: {
+				plain: null,
+				shift: null,
+				meta: "pane",
+				metaShift: "external",
+			},
+		});
+
+		expect(healed.urlLinks).toEqual(DEFAULT_V2_USER_PREFERENCES.urlLinks);
+		expect(healed.urlLinks.shift).toBe("newTab");
+	});
+
+	it("keeps a customized url link map untouched", () => {
+		const customized = {
+			plain: "external",
+			shift: null,
+			meta: "pane",
+			metaShift: "external",
+		} as const;
+		const healed = healV2UserPreferences({ urlLinks: customized });
+
+		expect(healed.urlLinks).toEqual(customized);
+	});
 });
 
 describe("healWorkspaceLocalState", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -448,11 +448,19 @@ export function healV2UserPreferences(raw: unknown): V2UserPreferencesRow {
 		r.sidebarFileLinks &&
 		isCompleteLinkTierMap(r.sidebarFileLinks) &&
 		isSameLinkTierMap(r.sidebarFileLinks, LEGACY_SIDEBAR_FILE_LINKS);
+	// A stored map identical to the retired default was never customized —
+	// swap it for the current default (shift gained "newTab").
+	const shouldMigrateLegacyUrlLinks =
+		r.urlLinks &&
+		isCompleteLinkTierMap(r.urlLinks) &&
+		isSameLinkTierMap(r.urlLinks, DEFAULT_LINK_TIER_MAP);
 	return {
 		...DEFAULT_V2_USER_PREFERENCES,
 		...r,
 		fileLinks: { ...DEFAULT_V2_USER_PREFERENCES.fileLinks, ...r.fileLinks },
-		urlLinks: { ...DEFAULT_V2_USER_PREFERENCES.urlLinks, ...r.urlLinks },
+		urlLinks: shouldMigrateLegacyUrlLinks
+			? DEFAULT_V2_USER_PREFERENCES.urlLinks
+			: { ...DEFAULT_V2_USER_PREFERENCES.urlLinks, ...r.urlLinks },
 		sidebarFileLinks: shouldMigrateLegacySidebarFileLinks
 			? DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks
 			: sidebarFileLinks,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -301,6 +301,13 @@ const DEFAULT_LINK_TIER_MAP: LinkTierMap = {
 	metaShift: "external",
 };
 
+const DEFAULT_URL_LINKS: LinkTierMap = {
+	plain: null,
+	shift: "newTab",
+	meta: "pane",
+	metaShift: "external",
+};
+
 const LEGACY_SIDEBAR_FILE_LINKS: LinkTierMap = {
 	plain: "pane",
 	shift: "newTab",
@@ -343,7 +350,7 @@ function isCompleteLinkTierMap(
 export const v2UserPreferencesSchema = z.object({
 	id: z.literal("preferences"),
 	fileLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
-	urlLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
+	urlLinks: linkTierMapSchema.default(DEFAULT_URL_LINKS),
 	sidebarFileLinks: linkTierMapSchema.default(DEFAULT_SIDEBAR_FILE_LINKS),
 	portOpenAction: linkActionSchema.default(DEFAULT_PORT_OPEN_ACTION),
 	terminalPresetsInitialized: z.boolean().default(false),
@@ -371,7 +378,7 @@ export const V2_USER_PREFERENCES_ID = "preferences" as const;
 export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	id: V2_USER_PREFERENCES_ID,
 	fileLinks: DEFAULT_LINK_TIER_MAP,
-	urlLinks: DEFAULT_LINK_TIER_MAP,
+	urlLinks: DEFAULT_URL_LINKS,
 	sidebarFileLinks: DEFAULT_SIDEBAR_FILE_LINKS,
 	portOpenAction: DEFAULT_PORT_OPEN_ACTION,
 	terminalPresetsInitialized: false,

--- a/apps/desktop/src/shared/hotkey-chord.test.ts
+++ b/apps/desktop/src/shared/hotkey-chord.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import {
+	canonicalizeChord,
+	chordFromInput,
+	eventToChord,
+	type KeyChordInput,
+} from "./hotkey-chord";
+
+// Plain-object stub cast to KeyboardEvent — Bun's test runtime has no DOM
+// KeyboardEvent constructor (mirrors resolveHotkeyFromEvent.test.ts).
+function ev(init: {
+	code: string;
+	metaKey?: boolean;
+	ctrlKey?: boolean;
+	altKey?: boolean;
+	shiftKey?: boolean;
+	altGraph?: boolean;
+}): KeyboardEvent {
+	return {
+		type: "keydown",
+		code: init.code,
+		key: "",
+		metaKey: !!init.metaKey,
+		ctrlKey: !!init.ctrlKey,
+		altKey: !!init.altKey,
+		shiftKey: !!init.shiftKey,
+		isComposing: false,
+		keyCode: 0,
+		getModifierState: (mod: string) =>
+			mod === "AltGraph" ? !!init.altGraph : false,
+	} as unknown as KeyboardEvent;
+}
+
+function input(
+	partial: Partial<KeyChordInput> & { code: string },
+): KeyChordInput {
+	return {
+		meta: false,
+		control: false,
+		alt: false,
+		shift: false,
+		...partial,
+	};
+}
+
+describe("chordFromInput", () => {
+	it("canonicalizes modifiers regardless of press order", () => {
+		expect(chordFromInput(input({ code: "BracketLeft", control: true }))).toBe(
+			"ctrl+bracketleft",
+		);
+		expect(
+			chordFromInput(input({ code: "Digit1", meta: true, shift: true })),
+		).toBe("meta+shift+1");
+	});
+
+	it("returns null for pure modifier / lock keys", () => {
+		expect(
+			chordFromInput(input({ code: "ControlLeft", control: true })),
+		).toBeNull();
+		expect(chordFromInput(input({ code: "CapsLock" }))).toBeNull();
+		expect(chordFromInput(input({ code: "" }))).toBeNull();
+	});
+
+	it("matches a chord the renderer registers via canonicalizeChord", () => {
+		// The renderer registers code-based dispatch chords, then canonicalizes.
+		expect(chordFromInput(input({ code: "BracketRight", meta: true }))).toBe(
+			canonicalizeChord("meta+BracketRight"),
+		);
+	});
+});
+
+// The renderer registers forwardable chords from DOM events (eventToChord) and
+// the main process matches guest keystrokes against them (chordFromInput). If
+// the two canonicalize the same physical key differently, forwarding silently
+// misses — so pin that they agree for the shared (guard-free) input space.
+describe("eventToChord ≡ chordFromInput", () => {
+	const cases: Array<{
+		code: string;
+		meta?: boolean;
+		ctrl?: boolean;
+		alt?: boolean;
+		shift?: boolean;
+	}> = [
+		{ code: "BracketLeft", ctrl: true },
+		{ code: "BracketRight", meta: true },
+		{ code: "Digit1", meta: true },
+		{ code: "Digit9", ctrl: true, shift: true },
+		{ code: "KeyE", ctrl: true, alt: true },
+		{ code: "Tab", ctrl: true },
+		{ code: "ControlLeft", ctrl: true },
+		{ code: "CapsLock" },
+	];
+
+	for (const c of cases) {
+		it(`agrees for ${JSON.stringify(c)}`, () => {
+			const domChord = eventToChord(
+				ev({
+					code: c.code,
+					metaKey: c.meta,
+					ctrlKey: c.ctrl,
+					altKey: c.alt,
+					shiftKey: c.shift,
+				}),
+			);
+			const mainChord = chordFromInput(
+				input({
+					code: c.code,
+					meta: c.meta ?? false,
+					control: c.ctrl ?? false,
+					alt: c.alt ?? false,
+					shift: c.shift ?? false,
+				}),
+			);
+			expect(mainChord).toBe(domChord);
+		});
+	}
+});

--- a/apps/desktop/src/shared/hotkey-chord.test.ts
+++ b/apps/desktop/src/shared/hotkey-chord.test.ts
@@ -43,6 +43,18 @@ function input(
 	};
 }
 
+describe("canonicalizeChord", () => {
+	it("resolves physical modifier codes regardless of case", () => {
+		expect(canonicalizeChord("MetaLeft+KeyK")).toBe("meta+k");
+		expect(canonicalizeChord("metaleft+k")).toBe("meta+k");
+	});
+
+	it("resolves word aliases regardless of case", () => {
+		expect(canonicalizeChord("ctrl+Return")).toBe("ctrl+enter");
+		expect(canonicalizeChord("CTRL+ESC")).toBe("ctrl+escape");
+	});
+});
+
 describe("chordFromInput", () => {
 	it("canonicalizes modifiers regardless of press order", () => {
 		expect(chordFromInput(input({ code: "BracketLeft", control: true }))).toBe(

--- a/apps/desktop/src/shared/hotkey-chord.ts
+++ b/apps/desktop/src/shared/hotkey-chord.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure keyboard-chord normalization shared by the renderer hotkey system and
+ * the main-process webview key-forwarder. Kept free of store/DOM dependencies
+ * so both processes canonicalize chords identically (single source of truth).
+ */
+
+// Mirrors react-hotkeys-hook's alias table (react-hotkeys-hook/dist/index.js:3-19)
+const CODE_ALIASES: Record<string, string> = {
+	esc: "escape",
+	return: "enter",
+	left: "arrowleft",
+	right: "arrowright",
+	up: "arrowup",
+	down: "arrowdown",
+	MetaLeft: "meta",
+	MetaRight: "meta",
+	ShiftLeft: "shift",
+	ShiftRight: "shift",
+	AltLeft: "alt",
+	AltRight: "alt",
+	OSLeft: "meta",
+	OSRight: "meta",
+	ControlLeft: "ctrl",
+	ControlRight: "ctrl",
+};
+
+export const MODIFIERS = new Set(["meta", "ctrl", "control", "alt", "shift"]);
+
+// Lock keys must never commit a binding on their own.
+const LOCK_KEYS = new Set(["capslock", "numlock", "scrolllock"]);
+
+export function normalizeToken(token: string): string {
+	const aliased = CODE_ALIASES[token.trim()] ?? token.trim();
+	return aliased.toLowerCase().replace(/key|digit|numpad/, "");
+}
+
+export function isIgnorableKey(normalized: string): boolean {
+	return !normalized || MODIFIERS.has(normalized) || LOCK_KEYS.has(normalized);
+}
+
+/**
+ * Stable form for comparing chord strings. Tolerates modifier order and
+ * aliases: `meta+alt+up` ≡ `alt+meta+arrowup` ≡ `control+alt+arrowup`.
+ */
+export function canonicalizeChord(chord: string): string {
+	const parts = chord.toLowerCase().split("+").map(normalizeToken);
+	const mods: string[] = [];
+	const keys: string[] = [];
+	for (const part of parts) {
+		if (MODIFIERS.has(part)) {
+			mods.push(part === "control" ? "ctrl" : part);
+		} else {
+			keys.push(part);
+		}
+	}
+	mods.sort();
+	return [...mods, ...keys].join("+");
+}
+
+/** KeyboardEvent → canonical chord (comparable to {@link canonicalizeChord} output), or null for pure modifier / synthetic presses. */
+export function eventToChord(event: KeyboardEvent): string | null {
+	if (event.code === undefined) return null;
+	// IME composition: keydown during CJK / dead-key composition must not
+	// trigger hotkeys. Safari reports keyCode 229 instead of isComposing.
+	if (event.isComposing || event.keyCode === 229) return null;
+	const key = normalizeToken(event.code);
+	if (isIgnorableKey(key)) return null;
+	// AltGr is reported by Chromium as ctrlKey+altKey on Windows/Linux.
+	// Treating that combination as Ctrl+Alt would let printable keystrokes on
+	// non-US layouts (e.g. AltGr+E = € on German) accidentally trigger
+	// ctrl+alt+e bindings. Suppress both when AltGr is held; no binding opts
+	// into AltGr explicitly.
+	const altGraph = event.getModifierState?.("AltGraph") === true;
+	const mods: string[] = [];
+	if (event.metaKey) mods.push("meta");
+	if (event.ctrlKey && !altGraph) mods.push("ctrl");
+	if (event.altKey && !altGraph) mods.push("alt");
+	if (event.shiftKey) mods.push("shift");
+	mods.sort();
+	return [...mods, key].join("+");
+}
+
+/** True if `event` produces `chord` (tolerating modifier order / aliases). */
+export function matchesChord(event: KeyboardEvent, chord: string): boolean {
+	const eventChord = eventToChord(event);
+	if (!eventChord) return false;
+	return eventChord === canonicalizeChord(chord);
+}
+
+/** Electron `before-input-event` input shape, used by the main process. */
+export interface KeyChordInput {
+	code: string;
+	meta: boolean;
+	control: boolean;
+	alt: boolean;
+	shift: boolean;
+}
+
+/**
+ * Electron key input → canonical chord, matching {@link eventToChord} so the
+ * main process can compare guest keystrokes against the renderer-registered
+ * forwardable chords. Returns null for pure modifier presses.
+ */
+export function chordFromInput(input: KeyChordInput): string | null {
+	if (!input.code) return null;
+	const key = normalizeToken(input.code);
+	if (isIgnorableKey(key)) return null;
+	const mods: string[] = [];
+	if (input.meta) mods.push("meta");
+	if (input.control) mods.push("ctrl");
+	if (input.alt) mods.push("alt");
+	if (input.shift) mods.push("shift");
+	mods.sort();
+	return [...mods, key].join("+");
+}

--- a/apps/desktop/src/shared/hotkey-chord.ts
+++ b/apps/desktop/src/shared/hotkey-chord.ts
@@ -57,27 +57,45 @@ export function canonicalizeChord(chord: string): string {
 	return [...mods, ...keys].join("+");
 }
 
+interface ChordModifiers {
+	meta: boolean;
+	ctrl: boolean;
+	alt: boolean;
+	shift: boolean;
+}
+
+/**
+ * Key code + already-resolved modifiers → canonical chord, or null when the key
+ * can't form one on its own (modifier / lock key). The sole place modifier
+ * ordering lives, so every code→chord path canonicalizes identically — callers
+ * differ only in how they detect the code and resolve modifiers.
+ */
+function assembleChord(code: string, mods: ChordModifiers): string | null {
+	const key = normalizeToken(code);
+	if (isIgnorableKey(key)) return null;
+	const parts: string[] = [];
+	if (mods.meta) parts.push("meta");
+	if (mods.ctrl) parts.push("ctrl");
+	if (mods.alt) parts.push("alt");
+	if (mods.shift) parts.push("shift");
+	parts.sort();
+	return [...parts, key].join("+");
+}
+
 /** KeyboardEvent → canonical chord (comparable to {@link canonicalizeChord} output), or null for pure modifier / synthetic presses. */
 export function eventToChord(event: KeyboardEvent): string | null {
 	if (event.code === undefined) return null;
-	// IME composition: keydown during CJK / dead-key composition must not
-	// trigger hotkeys. Safari reports keyCode 229 instead of isComposing.
+	// Ignore CJK / dead-key composition. Safari reports keyCode 229 here.
 	if (event.isComposing || event.keyCode === 229) return null;
-	const key = normalizeToken(event.code);
-	if (isIgnorableKey(key)) return null;
-	// AltGr is reported by Chromium as ctrlKey+altKey on Windows/Linux.
-	// Treating that combination as Ctrl+Alt would let printable keystrokes on
-	// non-US layouts (e.g. AltGr+E = € on German) accidentally trigger
-	// ctrl+alt+e bindings. Suppress both when AltGr is held; no binding opts
-	// into AltGr explicitly.
+	// AltGr surfaces as ctrlKey+altKey in Chromium; drop both so printable
+	// non-US keystrokes (AltGr+E = € on German) don't trigger ctrl+alt+e.
 	const altGraph = event.getModifierState?.("AltGraph") === true;
-	const mods: string[] = [];
-	if (event.metaKey) mods.push("meta");
-	if (event.ctrlKey && !altGraph) mods.push("ctrl");
-	if (event.altKey && !altGraph) mods.push("alt");
-	if (event.shiftKey) mods.push("shift");
-	mods.sort();
-	return [...mods, key].join("+");
+	return assembleChord(event.code, {
+		meta: event.metaKey,
+		ctrl: event.ctrlKey && !altGraph,
+		alt: event.altKey && !altGraph,
+		shift: event.shiftKey,
+	});
 }
 
 /** True if `event` produces `chord` (tolerating modifier order / aliases). */
@@ -97,19 +115,17 @@ export interface KeyChordInput {
 }
 
 /**
- * Electron key input → canonical chord, matching {@link eventToChord} so the
- * main process can compare guest keystrokes against the renderer-registered
- * forwardable chords. Returns null for pure modifier presses.
+ * Electron key input → canonical chord for the main process. Shares
+ * {@link assembleChord} with {@link eventToChord}, so a given key produces the
+ * same chord in both processes. The DOM-only AltGr/IME guards are absent here
+ * because Electron's `Input` doesn't surface them.
  */
 export function chordFromInput(input: KeyChordInput): string | null {
 	if (!input.code) return null;
-	const key = normalizeToken(input.code);
-	if (isIgnorableKey(key)) return null;
-	const mods: string[] = [];
-	if (input.meta) mods.push("meta");
-	if (input.control) mods.push("ctrl");
-	if (input.alt) mods.push("alt");
-	if (input.shift) mods.push("shift");
-	mods.sort();
-	return [...mods, key].join("+");
+	return assembleChord(input.code, {
+		meta: input.meta,
+		ctrl: input.control,
+		alt: input.alt,
+		shift: input.shift,
+	});
 }

--- a/apps/desktop/src/shared/hotkey-chord.ts
+++ b/apps/desktop/src/shared/hotkey-chord.ts
@@ -29,8 +29,18 @@ export const MODIFIERS = new Set(["meta", "ctrl", "control", "alt", "shift"]);
 // Lock keys must never commit a binding on their own.
 const LOCK_KEYS = new Set(["capslock", "numlock", "scrolllock"]);
 
+const CODE_ALIASES_LOWER: Record<string, string> = Object.fromEntries(
+	Object.entries(CODE_ALIASES).map(([key, value]) => [
+		key.toLowerCase(),
+		value,
+	]),
+);
+
 export function normalizeToken(token: string): string {
-	const aliased = CODE_ALIASES[token.trim()] ?? token.trim();
+	const trimmed = token.trim();
+	// Case-insensitive alias lookup: chord strings arrive both as raw
+	// event.code (`MetaLeft`) and as pre-lowercased tokens (`metaleft`).
+	const aliased = CODE_ALIASES_LOWER[trimmed.toLowerCase()] ?? trimmed;
 	return aliased.toLowerCase().replace(/key|digit|numpad/, "");
 }
 
@@ -43,7 +53,9 @@ export function isIgnorableKey(normalized: string): boolean {
  * aliases: `meta+alt+up` ≡ `alt+meta+arrowup` ≡ `control+alt+arrowup`.
  */
 export function canonicalizeChord(chord: string): string {
-	const parts = chord.toLowerCase().split("+").map(normalizeToken);
+	// normalizeToken lowercases after its alias lookup; lowercasing here first
+	// would break case-sensitive physical-code aliases like `MetaLeft` → meta.
+	const parts = chord.split("+").map(normalizeToken);
 	const mods: string[] = [];
 	const keys: string[] = [];
 	for (const part of parts) {


### PR DESCRIPTION
Fixes five UI bugs in the in-workspace browser (plus a favicon fallback picked up during verification). Most stem from the browser being a native Electron `<webview>` composited on top of the host page, so it captures pointer/keyboard events the host renderer never sees.

## 1. Popover/tooltip stays stuck over the URL bar
Radix keeps a tooltip open during its "hoverable content" grace period, waiting for more pointer events — but once the cursor crosses onto the native webview the host document stops receiving pointer events, so the close logic never runs and the tooltip hangs over the URL bar.

**Fix:** `disableHoverableContent` on the webview-adjacent tooltips. Since #5870 restyled the preset tooltips into `HotkeyTooltip`, the flag now lives there (its content is always a non-interactive hotkey chip, so there is no downside anywhere it's used), plus the Manage Presets and DevTools tooltips.

## 2. Tab-switch keyboard shortcuts don't work when the browser is focused
With the guest webview focused, keystrokes route to the guest renderer, so host `react-hotkeys-hook` never sees them. `browser-manager.ts` already intercepts via `before-input-event` but only forwarded `Cmd/Ctrl+W` and `+R`.

**Fix:** the renderer computes the (override/layout-aware) chords for the tab-switch hotkeys (`PREV/NEXT_TAB`, `_ALT` variants, `JUMP_TO_TAB_1..9`) and syncs them to the main process via `browser.setForwardableChords`. `before-input-event` suppresses exactly those chords in the guest and forwards them over a `browser.onKeyForward` subscription; `usePersistentWebview` rebuilds the `KeyboardEvent`, re-resolves it through `resolveHotkeyFromEvent`, and replays it on `document` only if it resolves to an allowlisted tab-switch hotkey. Chord canonicalization is shared between main and renderer (`shared/hotkey-chord.ts`, single `assembleChord` helper) and pinned by a parity unit test.

## 3. Browser tab favicon fallback
Chromium guesses `/favicon.ico` for pages that declare no favicon, so `faviconUrl` can point at a 404 and the tab shows a broken image (and pages with no favicon showed no icon at all). Tabs now fall back to a globe icon when the favicon is missing or fails to load, keyed by page + favicon URL so navigation retries.

## 4. Opening a link into an existing browser pane never navigates
Clicking a link (e.g. a URL in a terminal) opens the in-workspace browser — but once a browser pane exists, every subsequent link click replaced the pane in the store without the page ever loading the new URL. Root cause: `usePersistentWebview` captured the pane URL in a ref at first mount; when `openPane` -> `replacePane` swaps in a new pane id on the same component instance, the attach effect re-ran with the stale first-mount URL, so the fresh webview loaded the old page (and the persist echo then reverted the pane data too).

**Fix:** keep the attach-URL ref current on every render. Attach still keys on `paneId` alone, so tab switches and navigation echoes don't re-attach; only a pane replacement picks up the new URL. Verified live: alternating cmd+clicks between two terminal URLs navigate the pane correctly every time (previously only the first-ever link worked).

## 5. Shift+click opens links in a new browser tab
The default URL-link tier map now assigns `shift` -> "Open in new tab" (previously unbound): shift+clicking a URL in a terminal opens it in a new in-app browser tab instead of doing nothing. Existing profiles are migrated on read when their stored map deep-equals the retired default (same pattern as the sidebar file-link migration) — anyone who customized any tier keeps their configuration.

## Review-comment cleanups
- `setForwardableChords` sync failures now log a warning instead of being swallowed (stale suppression is otherwise undiagnosable).
- `BrowserTabFavicon` extracted to its own component module per repo structure guidelines; its key now includes the page URL so a failed favicon retries on navigation even when the favicon URL is unchanged.
- `normalizeToken`'s alias lookup is case-insensitive, so `canonicalizeChord("MetaLeft+KeyK")` === `eventToChord` output (`meta+k`); pinned by tests.
- The two bot P1s (missing `preventDefault` on the forward path, alt-only chords dropped) were against the first commit only — the current code preventDefaults every forwarded chord (verified live: the guest page receives nothing) and has no meta/ctrl early-return.

## Regression safety
- Existing `Cmd/Ctrl+W`/`+R` interception is untouched (re-verified live).
- Non-registered keys fall through: plain typing and in-page shortcuts in the guest are unchanged (verified live).
- A balancing `keyup` is dispatched so react-hotkeys-hook's pressed-key set never gets a stuck key.

## Verification (live E2E on the dev app via CDP + OS-level keystrokes)
- **Forwarding chain end-to-end:** with the guest webview holding OS focus, a real `ctrl+Tab` was intercepted in main (guest page received nothing), forwarded, replayed on the host document (observed as an untrusted keydown), and the workspace switched tabs. `⌘W` with guest focus closed just the pane.
- **Tooltip A/B:** with main's `HotkeyTooltip`, hover a preset button → move toward the webview → tooltip sticks open indefinitely (bug reproduced); with this branch it closes as the pointer leaves the trigger.
- **Link navigation:** real cmd+clicks on URLs rendered in a terminal, alternating between two links — every click navigates the browser pane (previously only the first).
- **Favicon:** about:blank → globe; example.com (404 favicon) → globe; github.com → real favicon.
- **Chord parity:** `bun test src/shared/hotkey-chord.test.ts` pins `eventToChord ≡ chordFromInput` for all forwarded chords plus alias-case canonicalization.
- Lint clean; the 5 local typecheck errors are pre-existing and reproduce identically on `origin/main` in the same environment (CI Typecheck green).
