### PR TITLE
fix(desktop): apply custom agent icons to terminal presets

### DIFF
--- a/apps/desktop/src/renderer/lib/preset-icon-key.test.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon-key.test.ts
@@ -31,6 +31,32 @@ describe("resolveV2PresetIconKey", () => {
 		).toBe("claude");
 	});
 
+	it("prefers linked host-agent icon overrides", () => {
+		expect(
+			resolveV2PresetIconKey({ agentId: "custom-config" }, [
+				createAgent({
+					id: "custom-config",
+					presetId: "custom",
+					iconId: "codex",
+				}),
+			]),
+		).toBe("codex");
+	});
+
+	it("resolves linked host-agent uploaded image icons", () => {
+		const dataUri = "data:image/png;base64,abc123";
+
+		expect(
+			resolveV2PresetIconKey({ agentId: "custom-config" }, [
+				createAgent({
+					id: "custom-config",
+					presetId: "custom",
+					iconId: dataUri,
+				}),
+			]),
+		).toBe(dataUri);
+	});
+
 	it("keeps supporting legacy rows whose agentId is already a preset id", () => {
 		expect(resolveV2PresetIconKey({ agentId: "codex" }, [])).toBe("codex");
 	});
@@ -56,6 +82,24 @@ describe("resolveV2PresetIconKey", () => {
 				[],
 			),
 		).toBe("cursor-agent");
+	});
+
+	it("prefers matching agent icon overrides when inferring from commands", () => {
+		expect(
+			resolveV2PresetIconKey(
+				{
+					commands: ["custom-agent"],
+				},
+				[
+					createAgent({
+						id: "custom-config",
+						presetId: "custom",
+						iconId: "claude",
+						command: "custom-agent",
+					}),
+				],
+			),
+		).toBe("claude");
 	});
 
 	it("does not infer from editable preset names", () => {

--- a/apps/desktop/src/renderer/lib/preset-icon-key.test.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon-key.test.ts
@@ -61,6 +61,18 @@ describe("resolveV2PresetIconKey", () => {
 		expect(resolveV2PresetIconKey({ agentId: "codex" }, [])).toBe("codex");
 	});
 
+	it("does not apply icon overrides to legacy rows whose agentId is already a preset id", () => {
+		expect(
+			resolveV2PresetIconKey({ agentId: "codex" }, [
+				createAgent({
+					id: "custom-codex-config",
+					presetId: "codex",
+					iconId: "claude",
+				}),
+			]),
+		).toBe("codex");
+	});
+
 	it("infers the icon from stored commands when the agent link is stale", () => {
 		expect(
 			resolveV2PresetIconKey(
@@ -100,6 +112,30 @@ describe("resolveV2PresetIconKey", () => {
 				],
 			),
 		).toBe("claude");
+	});
+
+	it("falls back to a shared preset id when command matches have different icon overrides", () => {
+		expect(
+			resolveV2PresetIconKey(
+				{
+					commands: ["codex"],
+				},
+				[
+					createAgent({
+						id: "codex-config-a",
+						presetId: "codex",
+						iconId: "claude",
+						command: "codex",
+					}),
+					createAgent({
+						id: "codex-config-b",
+						presetId: "codex",
+						iconId: "opencode",
+						command: "codex",
+					}),
+				],
+			),
+		).toBe("codex");
 	});
 
 	it("does not infer from editable preset names", () => {

--- a/apps/desktop/src/renderer/lib/preset-icon-key.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon-key.ts
@@ -25,10 +25,10 @@ function getExecutableName(command: string): string | undefined {
 	return segments.at(-1)?.toLowerCase();
 }
 
-function singlePresetId(ids: Iterable<string | undefined>): string | undefined {
+function singleValue(values: Iterable<string | undefined>): string | undefined {
 	const uniqueIds = new Set<string>();
-	for (const id of ids) {
-		const trimmed = id?.trim();
+	for (const value of values) {
+		const trimmed = value?.trim();
 		if (trimmed) uniqueIds.add(trimmed);
 	}
 	return uniqueIds.size === 1 ? uniqueIds.values().next().value : undefined;
@@ -41,9 +41,7 @@ function getLinkedIconKey(
 	const agentId = preset.agentId?.trim();
 	if (!agentId) return undefined;
 
-	const linkedAgent =
-		agents?.find((agent) => agent.id === agentId) ??
-		agents?.find((agent) => agent.presetId === agentId);
+	const linkedAgent = agents?.find((agent) => agent.id === agentId);
 	if (linkedAgent) return linkedAgent.iconId ?? linkedAgent.presetId;
 
 	const normalizedAgentId = agentId.toLowerCase();
@@ -52,41 +50,47 @@ function getLinkedIconKey(
 		: undefined;
 }
 
-function getPresetIdFromExecutable(
+function getIconKeyFromExecutable(
 	executable: string,
 	agents: HostAgentConfig[] | undefined,
 ): string | undefined {
-	const agentIconKey = singlePresetId(
-		(agents ?? [])
-			.filter((agent) => getExecutableName(agent.command) === executable)
-			.map((agent) => agent.iconId ?? agent.presetId),
+	const matchingAgents = (agents ?? []).filter(
+		(agent) => getExecutableName(agent.command) === executable,
+	);
+	const agentIconKey = singleValue(
+		matchingAgents.map((agent) => agent.iconId ?? agent.presetId),
 	);
 	if (agentIconKey) return agentIconKey;
 
-	return singlePresetId(
+	const agentPresetId = singleValue(
+		matchingAgents.map((agent) => agent.presetId),
+	);
+	if (agentPresetId) return agentPresetId;
+
+	return singleValue(
 		HOST_AGENT_PRESETS.filter(
 			(preset) => getExecutableName(preset.command) === executable,
 		).map((preset) => preset.presetId),
 	);
 }
 
-function getCommandPresetId(
+function getCommandIconKey(
 	preset: PresetIconSource,
 	agents: HostAgentConfig[] | undefined,
 ): string | undefined {
-	const presetIds = new Set<string>();
+	const iconKeys = new Set<string>();
 	for (const command of preset.commands ?? []) {
 		const executable = getExecutableName(command);
 		if (!executable) continue;
-		const presetId = getPresetIdFromExecutable(executable, agents);
-		if (presetId) presetIds.add(presetId);
+		const iconKey = getIconKeyFromExecutable(executable, agents);
+		if (iconKey) iconKeys.add(iconKey);
 	}
-	return presetIds.size === 1 ? presetIds.values().next().value : undefined;
+	return iconKeys.size === 1 ? iconKeys.values().next().value : undefined;
 }
 
 export function resolveV2PresetIconKey(
 	preset: PresetIconSource,
 	agents: HostAgentConfig[] | undefined,
 ): string | undefined {
-	return getLinkedIconKey(preset, agents) ?? getCommandPresetId(preset, agents);
+	return getLinkedIconKey(preset, agents) ?? getCommandIconKey(preset, agents);
 }

--- a/apps/desktop/src/renderer/lib/preset-icon-key.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon-key.ts
@@ -34,17 +34,17 @@ function singlePresetId(ids: Iterable<string | undefined>): string | undefined {
 	return uniqueIds.size === 1 ? uniqueIds.values().next().value : undefined;
 }
 
-function getLinkedPresetId(
+function getLinkedIconKey(
 	preset: PresetIconSource,
 	agents: HostAgentConfig[] | undefined,
 ): string | undefined {
 	const agentId = preset.agentId?.trim();
 	if (!agentId) return undefined;
 
-	const linkedAgentPresetId =
-		agents?.find((agent) => agent.id === agentId)?.presetId ??
-		agents?.find((agent) => agent.presetId === agentId)?.presetId;
-	if (linkedAgentPresetId) return linkedAgentPresetId;
+	const linkedAgent =
+		agents?.find((agent) => agent.id === agentId) ??
+		agents?.find((agent) => agent.presetId === agentId);
+	if (linkedAgent) return linkedAgent.iconId ?? linkedAgent.presetId;
 
 	const normalizedAgentId = agentId.toLowerCase();
 	return BUILTIN_PRESET_IDS.has(normalizedAgentId)
@@ -56,12 +56,12 @@ function getPresetIdFromExecutable(
 	executable: string,
 	agents: HostAgentConfig[] | undefined,
 ): string | undefined {
-	const agentPresetId = singlePresetId(
+	const agentIconKey = singlePresetId(
 		(agents ?? [])
 			.filter((agent) => getExecutableName(agent.command) === executable)
-			.map((agent) => agent.presetId),
+			.map((agent) => agent.iconId ?? agent.presetId),
 	);
-	if (agentPresetId) return agentPresetId;
+	if (agentIconKey) return agentIconKey;
 
 	return singlePresetId(
 		HOST_AGENT_PRESETS.filter(
@@ -88,7 +88,5 @@ export function resolveV2PresetIconKey(
 	preset: PresetIconSource,
 	agents: HostAgentConfig[] | undefined,
 ): string | undefined {
-	return (
-		getLinkedPresetId(preset, agents) ?? getCommandPresetId(preset, agents)
-	);
+	return getLinkedIconKey(preset, agents) ?? getCommandPresetId(preset, agents);
 }

--- a/apps/desktop/src/renderer/lib/preset-icon.ts
+++ b/apps/desktop/src/renderer/lib/preset-icon.ts
@@ -9,10 +9,11 @@ import {
  * Resolves the preset-icon key for a v2 terminal preset.
  *
  * v2 preset rows store the linked host-agent config id in `agentId` (a UUID),
- * not the icon key. The icon key lives on the agent as `presetId`
- * (e.g. `"cursor-agent"`), so the canonical resolution is
- * `agentId → agent → agent.presetId → icon`. Falls back to `agentId` itself
- * for legacy v2 rows whose `agentId` still holds a presetId.
+ * not the icon key. The icon key lives on the agent as `iconId` when the user
+ * picked a custom override, otherwise the agent falls back to `presetId`
+ * (e.g. `"cursor-agent"`). The canonical resolution is
+ * `agentId → agent → agent.iconId ?? agent.presetId → icon`. Falls back to
+ * `agentId` itself for legacy v2 rows whose `agentId` still holds a presetId.
  *
  * If the link is missing or stale, falls back to the stored command's
  * executable for display only. Launch still uses the linked agent when present

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
@@ -29,7 +29,7 @@ interface PresetRowProps {
 	projectOptionsById: ReadonlyMap<string, PresetProjectOption>;
 	/**
 	 * v2 host-agent configs. When the preset's `agentId` matches a config,
-	 * its `presetId` (e.g. `"cursor-agent"`) is used to resolve the icon.
+	 * its `iconId` override or fallback `presetId` is used to resolve the icon.
 	 * Older v2 rows that still store `presetId` in `agentId` resolve via the
 	 * `presetId` fallback. Omitted by v1 callers — no v1 row has `agentId`.
 	 */

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
@@ -197,7 +197,7 @@ export function V2PresetsSection({
 			}
 			pills.push({
 				agentId: agent.id,
-				iconId: agent.presetId,
+				iconId: agent.iconId ?? agent.presetId,
 				label: agent.label,
 				description: DESCRIPTION_BY_PRESET_ID.get(agent.presetId) ?? "",
 				commands: [getAgentCommandText(agent)],


### PR DESCRIPTION
## Summary
- Resolve v2 terminal preset icons from the linked host agent icon override before falling back to the built-in preset ID.
- Show custom agent icon overrides in the terminal preset quick-add/import menu.
- Add regression coverage for custom icon overrides, uploaded data URI icons, command fallback, and existing built-in behavior.

## Root Cause
V2 terminal presets store the linked host agent config ID in `agentId`, but icon resolution only mapped that linked agent back to `presetId`. Built-in agents worked because their icon is implied by `presetId`; custom agents store their selected icon on `iconId`, which was ignored.

## Validation
- `bun test apps/desktop/src/renderer/lib/preset-icon-key.test.ts apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts`
- `bun run lint`
- `git diff --check`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 terminal preset icons to respect the linked agent’s `iconId` override, with fallbacks to `presetId` or stable command inference. Quick-add/import now shows custom agent icons.

- **Bug Fixes**
  - Resolve via `agentId → agent.iconId ?? agent.presetId`; support legacy rows where `agentId` stores a preset id (no overrides applied).
  - When inferring by command, use an agent’s `iconId` if matches agree; if they conflict, fall back to the shared `presetId`.
  - Preserve uploaded image icons (data URIs). Tests cover overrides, legacy behavior, conflicts, and command fallback.

<sup>Written for commit b4f7b33ec57ff63919c140c0d80a24b511751ca9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved v2 preset-icon resolution so linked host-agent `iconId` overrides the preset/default icon (including data-URI icons).
  * Ensured icon overrides are not applied to legacy v2 rows where a preset id is already set.
  * Refined command-based icon inference to prefer the matching host-agent override.
* **New Features**
  * Quick Add agent pills now prefer `iconId` when available (fallbacks to `presetId`).
* **Documentation**
  * Updated inline comments/help to reflect the current v2 icon-resolution logic.
* **Tests**
  * Expanded coverage for icon precedence and inference edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->