### PR TITLE
fix(desktop): open terminal links to files outside the workspace root

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
@@ -1,8 +1,75 @@
-import { toErrorMessage } from "@superset/workspace-fs/host";
+import path from "node:path";
+import {
+	type FsReadResult,
+	isPathWithinRoot,
+	normalizeAbsolutePath,
+	readFileAtPath,
+	toErrorMessage,
+	WorkspaceFsPathError,
+} from "@superset/workspace-fs/host";
 import { observable } from "@trpc/server/observable";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
-import { getServiceForWorkspace } from "../workspace-fs-service";
+import {
+	getServiceForRootPath,
+	getServiceForWorkspace,
+	resolveWorkspaceRootPath,
+} from "../workspace-fs-service";
+
+/**
+ * Reads a file for a workspace, transparently handling paths that resolve
+ * OUTSIDE the workspace root.
+ *
+ * Terminal file links (and other explicit "open this path" affordances) can
+ * point at files outside the worktree — e.g. `~/tmp/commit_1234.txt`. The link
+ * detector validates those with an UNJAILED stat, so they render as clickable
+ * links; if the viewer then read them through the jailed workspace service
+ * they'd throw "outside workspace root" and surface as "File not found" even
+ * though the file exists (and `vim` opens it fine). Falling back to an unjailed
+ * read for out-of-root paths keeps the in-app viewer consistent with what the
+ * detector already validated.
+ *
+ * In-root reads keep going through the jailed service unchanged. The lexical
+ * within-root pre-check routes normal files to the jailed path; the
+ * WorkspaceFsPathError catch additionally covers workspaces whose root is
+ * itself reached through a symlink (path is lexically in-root but its realpath
+ * escapes the non-realpath'd root).
+ */
+async function readWorkspaceFile(
+	workspaceId: string,
+	args: {
+		absolutePath: string;
+		offset?: number;
+		maxBytes?: number;
+		encoding?: string;
+	},
+): Promise<FsReadResult> {
+	const rootPath = resolveWorkspaceRootPath(workspaceId);
+
+	// Only an explicit absolute path that lands outside the root counts as an
+	// intentional out-of-root open (a terminal link to ~/tmp/foo). Everything
+	// else stays on the jailed service exactly as before.
+	const isAbsolute = path.isAbsolute(args.absolutePath);
+	const outsideRoot = isAbsolute && !isPathWithinRoot(rootPath, args.absolutePath);
+
+	if (!outsideRoot) {
+		try {
+			return await getServiceForRootPath(rootPath).readFile(args);
+		} catch (error) {
+			// Symlinked workspace root: an in-root path whose realpath escapes the
+			// (non-realpath'd) root. Fall through to an unjailed read; re-throw
+			// anything else (missing file, EISDIR, …) unchanged.
+			if (!(error instanceof WorkspaceFsPathError) || !isAbsolute) {
+				throw error;
+			}
+		}
+	}
+
+	return await readFileAtPath({
+		...args,
+		absolutePath: normalizeAbsolutePath(args.absolutePath),
+	});
+}
 
 function isClosedStreamError(error: unknown): boolean {
 	return (
@@ -55,8 +122,7 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.query(async ({ input }) => {
-				const service = getServiceForWorkspace(input.workspaceId);
-				const result = await service.readFile({
+				const result = await readWorkspaceFile(input.workspaceId, {
 					absolutePath: input.absolutePath,
 					offset: input.offset,
 					maxBytes: input.maxBytes,

--- a/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
@@ -5,7 +5,6 @@ import {
 	normalizeAbsolutePath,
 	readFileAtPath,
 	toErrorMessage,
-	WorkspaceFsPathError,
 } from "@superset/workspace-fs/host";
 import { observable } from "@trpc/server/observable";
 import { z } from "zod";
@@ -17,23 +16,19 @@ import {
 } from "../workspace-fs-service";
 
 /**
- * Reads a file for a workspace, transparently handling paths that resolve
- * OUTSIDE the workspace root.
+ * Reads a file for a workspace. Reads are jailed to the workspace root.
  *
- * Terminal file links (and other explicit "open this path" affordances) can
- * point at files outside the worktree — e.g. `~/tmp/commit_1234.txt`. The link
- * detector validates those with an UNJAILED stat, so they render as clickable
- * links; if the viewer then read them through the jailed workspace service
- * they'd throw "outside workspace root" and surface as "File not found" even
- * though the file exists (and `vim` opens it fine). Falling back to an unjailed
- * read for out-of-root paths keeps the in-app viewer consistent with what the
- * detector already validated.
+ * `allowOutsideRoot` lets a caller opt into reading an explicit absolute path
+ * that resolves OUTSIDE the root. This exists only for the file viewer opening
+ * a path the user explicitly pointed at — e.g. a terminal link to
+ * `~/tmp/commit_1234.txt`, which the link detector already validated with an
+ * unjailed stat, and which would otherwise surface as "File not found" even
+ * though the file exists (and `vim` opens it fine). Every other caller omits
+ * the flag and stays jailed, so this never becomes a general arbitrary-read
+ * primitive.
  *
- * In-root reads keep going through the jailed service unchanged. The lexical
- * within-root pre-check routes normal files to the jailed path; the
- * WorkspaceFsPathError catch additionally covers workspaces whose root is
- * itself reached through a symlink (path is lexically in-root but its realpath
- * escapes the non-realpath'd root).
+ * In-root paths always go through the jailed service, keeping its
+ * symlink-escape protection intact.
  */
 async function readWorkspaceFile(
 	workspaceId: string,
@@ -43,32 +38,22 @@ async function readWorkspaceFile(
 		maxBytes?: number;
 		encoding?: string;
 	},
+	allowOutsideRoot: boolean,
 ): Promise<FsReadResult> {
 	const rootPath = resolveWorkspaceRootPath(workspaceId);
 
-	// Only an explicit absolute path that lands outside the root counts as an
-	// intentional out-of-root open (a terminal link to ~/tmp/foo). Everything
-	// else stays on the jailed service exactly as before.
-	const isAbsolute = path.isAbsolute(args.absolutePath);
-	const outsideRoot = isAbsolute && !isPathWithinRoot(rootPath, args.absolutePath);
-
-	if (!outsideRoot) {
-		try {
-			return await getServiceForRootPath(rootPath).readFile(args);
-		} catch (error) {
-			// Symlinked workspace root: an in-root path whose realpath escapes the
-			// (non-realpath'd) root. Fall through to an unjailed read; re-throw
-			// anything else (missing file, EISDIR, …) unchanged.
-			if (!(error instanceof WorkspaceFsPathError) || !isAbsolute) {
-				throw error;
-			}
-		}
+	if (
+		allowOutsideRoot &&
+		path.isAbsolute(args.absolutePath) &&
+		!isPathWithinRoot(rootPath, args.absolutePath)
+	) {
+		return await readFileAtPath({
+			...args,
+			absolutePath: normalizeAbsolutePath(args.absolutePath),
+		});
 	}
 
-	return await readFileAtPath({
-		...args,
-		absolutePath: normalizeAbsolutePath(args.absolutePath),
-	});
+	return await getServiceForRootPath(rootPath).readFile(args);
 }
 
 function isClosedStreamError(error: unknown): boolean {
@@ -119,15 +104,23 @@ export const createFilesystemRouter = () => {
 					offset: z.number().optional(),
 					maxBytes: z.number().optional(),
 					encoding: z.string().optional(),
+					// Opt-in for the file viewer to open a user-pointed path outside
+					// the workspace root (e.g. a terminal link). Defaults off so every
+					// other caller stays jailed.
+					allowOutsideRoot: z.boolean().optional(),
 				}),
 			)
 			.query(async ({ input }) => {
-				const result = await readWorkspaceFile(input.workspaceId, {
-					absolutePath: input.absolutePath,
-					offset: input.offset,
-					maxBytes: input.maxBytes,
-					encoding: input.encoding,
-				});
+				const result = await readWorkspaceFile(
+					input.workspaceId,
+					{
+						absolutePath: input.absolutePath,
+						offset: input.offset,
+						maxBytes: input.maxBytes,
+						encoding: input.encoding,
+					},
+					input.allowOutsideRoot ?? false,
+				);
 
 				if (result.kind === "bytes") {
 					return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
@@ -64,6 +64,9 @@ export function useFileContent({
 			absolutePath: filePath,
 			encoding: "utf-8",
 			maxBytes: MAX_FILE_SIZE,
+			// The viewer opens paths the user points at (e.g. terminal links),
+			// which may live outside the workspace root.
+			allowOutsideRoot: true,
 		},
 		{
 			enabled: rawReadEnabled,
@@ -110,6 +113,7 @@ export function useFileContent({
 			workspaceId: workspaceId ?? "",
 			absolutePath: filePath,
 			maxBytes: MAX_IMAGE_SIZE,
+			allowOutsideRoot: true,
 		},
 		{ enabled: imageReadEnabled, retry: false },
 	);

--- a/packages/workspace-fs/src/fs.test.ts
+++ b/packages/workspace-fs/src/fs.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { createDirectory, readFile, writeFile } from "./fs";
+import { createDirectory, readFile, readFileAtPath, writeFile } from "./fs";
 
 const tempRoots: string[] = [];
 
@@ -113,6 +113,45 @@ describe("readFile", () => {
 		expect(result.exceededLimit).toEqual(false);
 		if (result.kind === "bytes") {
 			expect(Buffer.from(result.content).toString("utf-8")).toEqual("hello");
+		}
+	});
+});
+
+describe("readFileAtPath", () => {
+	it("reads a file at an absolute path without a root jail", async () => {
+		const rootPath = await createTempRoot();
+		const absolutePath = path.join(rootPath, "notes.txt");
+		await fs.writeFile(absolutePath, "hello");
+
+		const result = await readFileAtPath({ absolutePath, encoding: "utf-8" });
+
+		expect(result.kind).toEqual("text");
+		if (result.kind === "text") {
+			expect(result.content).toEqual("hello");
+		}
+	});
+
+	it("reads a path that a jailed readFile rejects as outside the root", async () => {
+		// Mirrors the terminal-link case: the file lives outside the workspace
+		// root (like ~/tmp/commit_1234.txt), so a jailed read fails while the
+		// unjailed primitive the router falls back to succeeds.
+		const rootPath = await createTempRoot();
+		const outsideRoot = await createTempRoot();
+		const outsidePath = path.join(outsideRoot, "commit_1234.txt");
+		await fs.writeFile(outsidePath, "outside the workspace");
+
+		await expect(
+			readFile({ rootPath, absolutePath: outsidePath, encoding: "utf-8" }),
+		).rejects.toThrow();
+
+		const result = await readFileAtPath({
+			absolutePath: outsidePath,
+			encoding: "utf-8",
+		});
+
+		expect(result.kind).toEqual("text");
+		if (result.kind === "text") {
+			expect(result.content).toEqual("outside the workspace");
 		}
 	});
 });

--- a/packages/workspace-fs/src/fs.ts
+++ b/packages/workspace-fs/src/fs.ts
@@ -425,7 +425,31 @@ export async function readFile({
 	const targetPath = ensureWithinRoot({ rootPath, absolutePath });
 	await assertRealpathWithinRoot(rootPath, targetPath);
 
-	const fileHandle = await fs.open(targetPath, "r");
+	return await readFileAtPath({ absolutePath: targetPath, offset, maxBytes, encoding });
+}
+
+/**
+ * Reads a file at an explicit absolute path WITHOUT the workspace-root jail.
+ *
+ * `readFile` layers the root/symlink-escape checks on top of this. Callers
+ * that reach for this directly are responsible for authorizing the path out of
+ * band — it exists for host-side flows that have already validated the target
+ * (e.g. opening a terminal link the user explicitly clicked, whose existence
+ * was confirmed by an unjailed stat and which may legitimately live outside the
+ * workspace root).
+ */
+export async function readFileAtPath({
+	absolutePath,
+	offset,
+	maxBytes,
+	encoding,
+}: {
+	absolutePath: string;
+	offset?: number;
+	maxBytes?: number;
+	encoding?: string;
+}): Promise<FsReadResult> {
+	const fileHandle = await fs.open(absolutePath, "r");
 	try {
 		const stats = await fileHandle.stat();
 		const revision = toRevision(stats);


### PR DESCRIPTION
Closes #5510

Ctrl+clicking a terminal path to a file outside the worktree root opened the viewer as "File not found": detection validated it with an unjailed stat, but the viewer read through the workspace-fs jail.

`filesystem.readFile` now reads out-of-root absolute paths through an unjailed `readFileAtPath` (extracted from the jailed `readFile`), matching what detection already validated. In-root reads are unchanged.

Editing/saving an out-of-root file still goes through the jailed write and errors — left out of scope (viewing only).

Test: `readFileAtPath` reads a path the jailed `readFile` rejects (`packages/workspace-fs/src/fs.test.ts`).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5511">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes opening terminal links to files outside the workspace root. The viewer can now opt in to unjailed reads for explicit absolute paths, so out-of-root files open instead of "File not found"; all other reads stay jailed.

- **Bug Fixes**
  - Gate out-of-root reads behind `allowOutsideRoot` on the desktop `filesystem.readFile`; only the viewer sets it. In-root reads remain jailed and symlink escapes from within the root still error.
  - Added `readFileAtPath` in `@superset/workspace-fs` and `readWorkspaceFile` to route absolute out-of-root paths to an unjailed read; added tests. Writes remain jailed.

<sup>Written for commit 9ec9f60163d4fbbf92fb682402bf673779960945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional support to read files from absolute paths outside the workspace root (opt-in).
  * File viewer content can now open referenced locations that fall outside the configured workspace root.
* **Bug Fixes**
  * Improved reliability when reading files affected by root-jail and symlink/path validation edge cases.
  * Reads now correctly succeed for valid absolute paths while preserving existing workspace-scoped safeguards by default.
* **Tests**
  * Expanded coverage for absolute-path reads and outside-root fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->