### PR TITLE
fix(desktop): heal malformed persisted pane layouts instead of crashing

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "bun:test";
+import type { WorkspaceState } from "@superset/panes";
 import {
 	DEFAULT_V2_USER_PREFERENCES,
 	healV2UserPreferences,
 	healWorkspaceLocalState,
+	sanitizePaneLayout,
 } from "./schema";
+
+type PaneLayout = WorkspaceState<unknown>;
 
 describe("healV2UserPreferences", () => {
 	it("returns full defaults for empty/non-object input", () => {
@@ -88,10 +92,26 @@ describe("healV2UserPreferences", () => {
 });
 
 describe("healWorkspaceLocalState", () => {
+	const validPaneLayout: PaneLayout = {
+		version: 1,
+		tabs: [
+			{
+				id: "tab-1",
+				createdAt: 0,
+				activePaneId: "pane-1",
+				layout: { type: "pane", paneId: "pane-1" },
+				panes: {
+					"pane-1": { id: "pane-1", kind: "terminal", data: {} },
+				},
+			},
+		],
+		activeTabId: "tab-1",
+	};
+
 	const baseStored = {
 		workspaceId: "11111111-1111-1111-1111-111111111111",
 		createdAt: new Date("2026-01-01T00:00:00.000Z"),
-		paneLayout: { panes: [], focusedPaneId: null },
+		paneLayout: validPaneLayout,
 		sidebarState: {
 			projectId: "22222222-2222-2222-2222-222222222222",
 			tabOrder: 3,
@@ -108,11 +128,9 @@ describe("healWorkspaceLocalState", () => {
 		const healed = healWorkspaceLocalState(baseStored);
 		expect(healed.workspaceId).toBe(baseStored.workspaceId);
 		expect(healed.createdAt).toBe(baseStored.createdAt);
-		// Reference equality — bun's strict toBe types reject the narrow stub,
-		// so compare via Object.is on a widened lhs and assert the boolean.
-		expect(Object.is(healed.paneLayout as unknown, baseStored.paneLayout)).toBe(
-			true,
-		);
+		// A valid layout survives the read-time heal structurally intact (heal
+		// rebuilds the object, so this is structural, not reference, equality).
+		expect(healed.paneLayout).toEqual(validPaneLayout);
 		expect(healed.sidebarState.projectId).toBe(
 			baseStored.sidebarState.projectId,
 		);
@@ -158,5 +176,106 @@ describe("healWorkspaceLocalState", () => {
 		expect(() => healWorkspaceLocalState(undefined)).not.toThrow();
 		expect(() => healWorkspaceLocalState("garbage")).not.toThrow();
 		expect(() => healWorkspaceLocalState(42)).not.toThrow();
+	});
+
+	it("heals a legacy-shaped persisted layout to an empty layout", () => {
+		// The pre-binary-tree shape `{ panes, focusedPaneId }` has no `tabs`;
+		// left as-is it fed an undefined node to the renderer and white-screened.
+		const healed = healWorkspaceLocalState({
+			...baseStored,
+			paneLayout: { panes: [], focusedPaneId: null },
+		});
+		expect(healed.paneLayout).toEqual({
+			version: 1,
+			tabs: [],
+			activeTabId: null,
+		});
+	});
+});
+
+describe("sanitizePaneLayout", () => {
+	const validTab: PaneLayout["tabs"][number] = {
+		id: "tab-1",
+		createdAt: 0,
+		activePaneId: "pane-1",
+		layout: { type: "pane", paneId: "pane-1" },
+		panes: { "pane-1": { id: "pane-1", kind: "terminal", data: {} } },
+	};
+
+	const EMPTY: PaneLayout = { version: 1, tabs: [], activeTabId: null };
+
+	it("resets non-object / legacy / versionless input to empty", () => {
+		expect(sanitizePaneLayout(null)).toEqual(EMPTY);
+		expect(sanitizePaneLayout("garbage")).toEqual(EMPTY);
+		expect(sanitizePaneLayout({ panes: [], focusedPaneId: null })).toEqual(
+			EMPTY,
+		);
+		expect(sanitizePaneLayout({ version: 1 })).toEqual(EMPTY);
+	});
+
+	it("keeps a valid layout intact", () => {
+		const layout: PaneLayout = {
+			version: 1,
+			tabs: [validTab],
+			activeTabId: "tab-1",
+		};
+		expect(sanitizePaneLayout(layout)).toEqual(layout);
+	});
+
+	it("keeps a valid split layout intact", () => {
+		const layout: PaneLayout = {
+			version: 1,
+			tabs: [
+				{
+					...validTab,
+					layout: {
+						type: "split",
+						direction: "horizontal",
+						first: { type: "pane", paneId: "pane-1" },
+						second: { type: "pane", paneId: "pane-2" },
+					},
+					panes: {
+						"pane-1": { id: "pane-1", kind: "terminal", data: {} },
+						"pane-2": { id: "pane-2", kind: "chat", data: {} },
+					},
+				},
+			],
+			activeTabId: "tab-1",
+		};
+		expect(sanitizePaneLayout(layout)).toEqual(layout);
+	});
+
+	it("drops a corrupt tab (split missing a child) but keeps valid tabs", () => {
+		const corruptTab = {
+			id: "tab-bad",
+			createdAt: 0,
+			activePaneId: null,
+			// split with `second` missing — the exact shape that crashed the
+			// renderer by feeding an undefined node to LayoutNodeView.
+			layout: {
+				type: "split",
+				direction: "horizontal",
+				first: { type: "pane", paneId: "x" },
+			},
+			panes: {},
+		};
+		const result = sanitizePaneLayout({
+			version: 1,
+			tabs: [corruptTab, validTab],
+			activeTabId: "tab-bad",
+		});
+		expect(result.tabs).toHaveLength(1);
+		expect(result.tabs[0]?.id).toBe("tab-1");
+		// activeTabId pointed at the dropped tab → repaired to a survivor.
+		expect(result.activeTabId).toBe("tab-1");
+	});
+
+	it("repairs activeTabId when it points at a dropped/absent tab", () => {
+		const result = sanitizePaneLayout({
+			version: 1,
+			tabs: [validTab],
+			activeTabId: "does-not-exist",
+		});
+		expect(result.activeTabId).toBe("tab-1");
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -1,5 +1,5 @@
 import type { AppRouter } from "@superset/host-service";
-import type { WorkspaceState } from "@superset/panes";
+import type { LayoutNode, Tab, WorkspaceState } from "@superset/panes";
 import type { inferRouterInputs } from "@trpc/server";
 import { z } from "zod";
 
@@ -16,6 +16,73 @@ export const dashboardSidebarProjectSchema = z.object({
 });
 
 const paneWorkspaceStateSchema = z.custom<WorkspaceState<unknown>>();
+
+// Structural validators for the persisted pane layout. `paneWorkspaceStateSchema`
+// above is a permissive passthrough for writes (the store always produces a
+// valid shape); these run on READ via `sanitizePaneLayout` so a malformed or
+// legacy-shaped layout (e.g. the pre-binary-tree `{ panes, focusedPaneId }`
+// shape) is healed instead of feeding an undefined node to the renderer.
+const layoutNodeSchema: z.ZodType<LayoutNode> = z.lazy(() =>
+	z.discriminatedUnion("type", [
+		z.object({ type: z.literal("pane"), paneId: z.string() }),
+		z.object({
+			type: z.literal("split"),
+			direction: z.enum(["horizontal", "vertical"]),
+			first: layoutNodeSchema,
+			second: layoutNodeSchema,
+			splitPercentage: z.number().optional(),
+		}),
+	]),
+);
+
+const paneNodeSchema = z.object({
+	id: z.string(),
+	kind: z.string(),
+	titleOverride: z.string().optional(),
+	pinned: z.boolean().optional(),
+	data: z.unknown(),
+});
+
+const tabNodeSchema = z.object({
+	id: z.string(),
+	titleOverride: z.string().optional(),
+	createdAt: z.number(),
+	activePaneId: z.string().nullable(),
+	layout: layoutNodeSchema,
+	panes: z.record(z.string(), paneNodeSchema),
+});
+
+const EMPTY_PANE_LAYOUT: WorkspaceState<unknown> = {
+	version: 1,
+	tabs: [],
+	activeTabId: null,
+};
+
+/**
+ * Read-time heal for a persisted pane layout. An unparseable top-level shape
+ * (missing `version`/`tabs`, or the legacy `{ panes, focusedPaneId }` layout)
+ * resets to empty; individually-corrupt tabs (e.g. a split node missing a
+ * child) are dropped while valid tabs are kept, and `activeTabId` is repaired
+ * to point at a surviving tab. Prevents the renderer from rendering an
+ * undefined layout node.
+ */
+export function sanitizePaneLayout(raw: unknown): WorkspaceState<unknown> {
+	if (!raw || typeof raw !== "object") return EMPTY_PANE_LAYOUT;
+	const value = raw as Record<string, unknown>;
+	if (value.version !== 1 || !Array.isArray(value.tabs)) {
+		return EMPTY_PANE_LAYOUT;
+	}
+	const tabs = value.tabs.flatMap((tab): Tab<unknown>[] => {
+		const parsed = tabNodeSchema.safeParse(tab);
+		return parsed.success ? [parsed.data as Tab<unknown>] : [];
+	});
+	const activeTabId =
+		typeof value.activeTabId === "string" &&
+		tabs.some((tab) => tab.id === value.activeTabId)
+			? value.activeTabId
+			: (tabs[0]?.id ?? null);
+	return { version: 1, tabs, activeTabId };
+}
 
 const changesFilterSchema = z.discriminatedUnion("kind", [
 	z.object({ kind: z.literal("all") }),
@@ -287,6 +354,10 @@ export function healWorkspaceLocalState(raw: unknown): WorkspaceLocalStateRow {
 	) as Partial<WorkspaceLocalStateRow["sidebarState"]>;
 	return {
 		...r,
+		// Heal a malformed/legacy persisted layout so consumers never render an
+		// undefined node. Passed through untouched before, which white-screened
+		// the workspace view on a corrupt layout.
+		paneLayout: sanitizePaneLayout(r.paneLayout),
 		viewedFiles:
 			r.viewedFiles ?? WORKSPACE_LOCAL_STATE_OPTIONAL_DEFAULTS.viewedFiles,
 		recentlyViewedFiles:

--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -144,6 +144,13 @@ function LayoutNodeView<TData>({
 	onSplitResizeDragging?: TabProps<TData>["onSplitResizeDragging"];
 	parentDirection?: "horizontal" | "vertical" | null;
 }) {
+	// A persisted layout can be malformed — a split node with a missing
+	// child, or a corrupt node shape from an older schema. Render nothing
+	// rather than crashing the whole renderer on `node.type` of undefined.
+	if (!node || (node.type !== "pane" && node.type !== "split")) {
+		return null;
+	}
+
 	if (node.type === "pane") {
 		const pane = tab.panes[node.paneId];
 		if (!pane) return null;


### PR DESCRIPTION
## Problem

Opening a workspace whose persisted `paneLayout` is malformed white-screens the entire renderer:

```
TypeError: Cannot read properties of undefined (reading 'type')
    at LayoutNodeView (…/Tab.tsx)
```

`LayoutNodeView` reads `node.type` unconditionally, so an undefined layout node — a split node missing a child, or the pre-binary-tree `{ panes, focusedPaneId }` layout shape — takes down the whole workspace view.

**Root cause:** the pane layout is persisted through `paneLayout: z.custom<WorkspaceState>()` (no validation) and passed through the read-time heal (`healWorkspaceLocalState`) untouched, so a malformed/legacy layout reaches the renderer intact.

Pre-existing since the #3088 layout redesign; surfaced by opening an older workspace.

## Fix

- **`sanitizePaneLayout`** — read-time heal wired into `healWorkspaceLocalState`: an unparseable top-level (missing `version`/`tabs`, or the legacy shape) resets to an empty layout; individually-corrupt tabs are dropped while valid ones are kept; `activeTabId` is repaired to a surviving tab.
- **`LayoutNodeView` guard** — an undefined/unknown node renders nothing instead of dereferencing it (belt-and-suspenders for any layout that slips through).

## Tests

New coverage for the legacy `{ panes, focusedPaneId }` shape → empty, corrupt-tab dropping, valid split preservation, and `activeTabId` repair. Verified failing without the heal (4 fail), passing with it (16 pass). `bun run typecheck` + `lint` clean.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5512">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a white-screen crash when opening workspaces with malformed or legacy pane layouts. We now heal the layout on read and guard the renderer, so older workspaces load safely.

- **Bug Fixes**
  - Added `sanitizePaneLayout` in `healWorkspaceLocalState` to reset invalid/legacy layouts to empty, drop corrupt tabs, and repair `activeTabId`.
  - Added a guard in `LayoutNodeView` to render nothing for unknown/undefined nodes, preventing `node.type` errors.

<sup>Written for commit d051990119dbffb1bf2c4833aeef85c5882f1dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from older or corrupted saved workspace layouts.
  * Invalid or missing pane data is now repaired or safely ignored, helping prevent blank or broken workspace views.
  * Legacy pane layouts are automatically converted to the current layout format, while preserving valid tabs and active tab selection when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->