### PR TITLE
feat(desktop): make terminal rich input a global toggle for all panes

### DIFF
--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/TiptapPromptEditor/TiptapPromptEditor.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/TiptapPromptEditor/TiptapPromptEditor.tsx
@@ -28,6 +28,7 @@ const mentionSuggestionKey = new PluginKey("fileMentionSuggestion");
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useDebouncedValue } from "renderer/hooks/useDebouncedValue";
+import { resolveHotkeyFromEvent } from "renderer/hotkeys";
 import { FileIcon } from "renderer/lib/fileIcons";
 import {
 	getCommandMatchRank,
@@ -554,10 +555,13 @@ export function TiptapPromptEditor({
 					return false;
 				},
 				keydown: (_view, event) => {
-					// Stop modifier+arrow propagation so pane-navigation hotkeys don't fire
+					// Keep bare Cmd/Ctrl+Arrow line-nav inside the editor, but let chords
+					// that resolve to a real hotkey (e.g. ⌘⌥←/→ = prev/next tab) bubble to
+					// react-hotkeys-hook instead of the editor swallowing them.
 					if (
 						(event.key === "ArrowLeft" || event.key === "ArrowRight") &&
-						(event.metaKey || event.ctrlKey)
+						(event.metaKey || event.ctrlKey) &&
+						resolveHotkeyFromEvent(event) === null
 					) {
 						event.stopPropagation();
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -77,7 +77,7 @@ export function TerminalPane({
 	// button and the ⌘I hotkey toggle the same overlay, and the state survives
 	// the mounted pane being re-pointed across terminals (tab switch, session
 	// dropdown).
-	const isRichInputOpen = useTerminalRichInputOpen(terminalId);
+	const isRichInputOpen = useTerminalRichInputOpen();
 
 	const appearance = useTerminalAppearance();
 	const appearanceRef = useRef(appearance);
@@ -357,12 +357,12 @@ export function TerminalPane({
 
 	useHotkey(
 		"TOGGLE_TERMINAL_RICH_INPUT",
-		() => terminalRichInputOpenStore.toggle(terminalId),
+		() => terminalRichInputOpenStore.toggle(),
 		{ enabled: ctx.isActive, preventDefault: true },
 	);
 
 	const closeRichInput = useCallback(() => {
-		terminalRichInputOpenStore.close(terminalId);
+		terminalRichInputOpenStore.close();
 		terminalRuntimeRegistry
 			.getTerminal(terminalId, terminalInstanceId)
 			?.focus();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/TerminalPaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/TerminalPaneHeaderExtras.tsx
@@ -1,31 +1,19 @@
-import type { RendererContext } from "@superset/panes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { SquarePen } from "lucide-react";
 import { useHotkeyDisplay } from "renderer/hotkeys";
-import type {
-	PaneViewerData,
-	TerminalPaneData,
-} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import {
 	terminalRichInputOpenStore,
 	useTerminalRichInputOpen,
 } from "../../richInputOpenStore";
-
-interface TerminalPaneHeaderExtrasProps {
-	context: RendererContext<PaneViewerData>;
-}
 
 /**
  * Header affordance that opens the rich-input overlay, so the ⌘I composer is
  * discoverable without knowing the shortcut. Toggles the same shared open-state
  * the hotkey drives; the tooltip carries the shortcut as the teach path.
  */
-export function TerminalPaneHeaderExtras({
-	context,
-}: TerminalPaneHeaderExtrasProps) {
-	const { terminalId } = context.pane.data as TerminalPaneData;
-	const isOpen = useTerminalRichInputOpen(terminalId);
+export function TerminalPaneHeaderExtras() {
+	const isOpen = useTerminalRichInputOpen();
 	const hotkeyText = useHotkeyDisplay("TOGGLE_TERMINAL_RICH_INPUT").text;
 	const label =
 		hotkeyText === "Unassigned" ? "Rich input" : `Rich input (${hotkeyText})`;
@@ -36,7 +24,7 @@ export function TerminalPaneHeaderExtras({
 				<TooltipTrigger asChild>
 					<button
 						type="button"
-						onClick={() => terminalRichInputOpenStore.toggle(terminalId)}
+						onClick={() => terminalRichInputOpenStore.toggle()}
 						aria-label={label}
 						aria-pressed={isOpen}
 						className={cn(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/richInputOpenStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/richInputOpenStore.ts
@@ -1,33 +1,42 @@
 import { useSyncExternalStore } from "react";
 
 /**
- * Which terminals currently have the rich-input overlay open, keyed by
- * terminalId and module-scoped like the draft map (see TerminalRichInput) so
- * open/closed survives the mounted pane being re-pointed at another terminal
- * (tab switch, session dropdown). Shared here rather than held as pane-local
- * state so the header button and the ⌘I hotkey toggle the same thing.
+ * Whether the rich-input overlay is open. Global (universal on/off for every
+ * terminal pane) rather than per-terminal, so the header button and the ⌘I
+ * hotkey flip one shared switch that all panes reflect. Persisted to
+ * localStorage so the preference survives reloads.
  */
-const openTerminalIds = new Set<string>();
+const STORAGE_KEY = "superset.terminalRichInputOpen";
+
+let isOpen = readPersisted();
 const listeners = new Set<() => void>();
 
-function emit() {
+function readPersisted(): boolean {
+	try {
+		return localStorage.getItem(STORAGE_KEY) === "true";
+	} catch {
+		return false;
+	}
+}
+
+function set(next: boolean) {
+	if (isOpen === next) return;
+	isOpen = next;
+	try {
+		localStorage.setItem(STORAGE_KEY, next ? "true" : "false");
+	} catch {}
 	for (const listener of listeners) listener();
 }
 
 export const terminalRichInputOpenStore = {
-	open(terminalId: string) {
-		if (openTerminalIds.has(terminalId)) return;
-		openTerminalIds.add(terminalId);
-		emit();
+	open() {
+		set(true);
 	},
-	close(terminalId: string) {
-		if (!openTerminalIds.delete(terminalId)) return;
-		emit();
+	close() {
+		set(false);
 	},
-	toggle(terminalId: string) {
-		if (openTerminalIds.has(terminalId)) openTerminalIds.delete(terminalId);
-		else openTerminalIds.add(terminalId);
-		emit();
+	toggle() {
+		set(!isOpen);
 	},
 	subscribe(listener: () => void) {
 		listeners.add(listener);
@@ -37,8 +46,9 @@ export const terminalRichInputOpenStore = {
 	},
 };
 
-export function useTerminalRichInputOpen(terminalId: string): boolean {
-	return useSyncExternalStore(terminalRichInputOpenStore.subscribe, () =>
-		openTerminalIds.has(terminalId),
+export function useTerminalRichInputOpen(): boolean {
+	return useSyncExternalStore(
+		terminalRichInputOpenStore.subscribe,
+		() => isOpen,
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -344,9 +344,7 @@ export function usePaneRegistry({
 						/>
 					</div>
 				),
-				renderHeaderExtras: (ctx: RendererContext<PaneViewerData>) => (
-					<TerminalPaneHeaderExtras context={ctx} />
-				),
+				renderHeaderExtras: () => <TerminalPaneHeaderExtras />,
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalPane
 						ctx={ctx}


### PR DESCRIPTION
## Summary

Converts the terminal rich-input overlay toggle from **per-terminal** to a **single global on/off** that governs every terminal pane.

- Previously the open/closed state lived in a module-scoped `Set<string>` keyed by `terminalId` — each terminal tracked its own state, and it reset on every app reload.
- Now it's one global `boolean` persisted to `localStorage` (`superset.terminalRichInputOpen`). Toggling from any pane (header button or `⌘I` hotkey) flips the switch for all panes, and the preference survives reloads.
- `terminalRichInputOpenStore` methods and `useTerminalRichInputOpen()` no longer take a `terminalId`; the now-unused `context` plumbing was removed from `TerminalPaneHeaderExtras` and `usePaneRegistry`.

## Test Plan

- [ ] Open two terminal panes; toggle rich input on one → it turns on for both.
- [ ] Toggle via `⌘I` and via the header button — both flip the shared state.
- [ ] Reload the app → the last on/off state is restored.
- [ ] Esc closes the overlay for all panes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5522">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the terminal rich-input overlay a single global on/off toggle for all panes. Also fixes prompt editor hotkeys so tab navigation chords (e.g., ⌘⌥←/→) work as expected.

- **New Features**
  - One global boolean persisted in localStorage (`superset.terminalRichInputOpen`).
  - Toggling from any pane (header button or ⌘I) updates all panes.
  - Esc closes the overlay everywhere.

- **Bug Fixes**
  - Prompt editor no longer swallows Cmd/Ctrl+Arrow chords; defined hotkeys (e.g., ⌘⌥←/→) bubble to `react-hotkeys-hook`.

<sup>Written for commit e32de89b7d4ce6519216495cb64325fb19948fa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the terminal rich-input overlay so the header button and the ⌘I/keyboard shortcut control the same overlay state consistently, even when switching terminal panes.
  * The overlay’s open/closed preference now persists between sessions.
  * Updated prompt editor hotkey handling so modifier+arrow chords only block propagation when they don’t map to an actual hotkey, improving global hotkey behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->