### PR TITLE
feat(desktop): default new users to v2 instead of v1

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -73,11 +73,11 @@ export const POSTHOG_COOKIE_NAME = "superset";
 export const V2_ONLY_USER_CUTOFF = "2026-05-15T14:00:00.000Z";
 // 2026-06-08 06:59 UTC = Sun 23:59 PDT (11:59pm Pacific).
 export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-08T06:59:00.000Z";
-// Rollout boundary: accounts created at/after this default to v2. Anchored to the
-// end of the 2026-07-09 desktop release day (start of 2026-07-10 UTC) so every
-// signup during the release stays on v1 regardless of when the build reaches
-// them — no existing v1 user flips. Bump this if the release slips.
-export const V2_NEW_USER_V2_DEFAULT_START = "2026-07-10T00:00:00.000Z";
+// Rollout boundary: accounts created at/after this default to v2. Set to the
+// 2026-07-09 release cutover, 10:00 AM Pacific (PDT, UTC-7) = 17:00 UTC. Everyone
+// who signed up before the cutover stays on v1, so no existing v1 user flips.
+// Bump this if the release slips.
+export const V2_NEW_USER_V2_DEFAULT_START = "2026-07-09T17:00:00.000Z";
 
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -73,10 +73,11 @@ export const POSTHOG_COOKIE_NAME = "superset";
 export const V2_ONLY_USER_CUTOFF = "2026-05-15T14:00:00.000Z";
 // 2026-06-08 06:59 UTC = Sun 23:59 PDT (11:59pm Pacific).
 export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-08T06:59:00.000Z";
-// Rollout boundary: accounts created at/after this default to v2. Set ahead of
-// all current signups so no existing v1-experiment user is affected. Bump this
-// if the desktop release carrying the change ships later. 2026-07-09 00:00 UTC.
-export const V2_NEW_USER_V2_DEFAULT_START = "2026-07-09T00:00:00.000Z";
+// Rollout boundary: accounts created at/after this default to v2. Anchored to the
+// end of the 2026-07-09 desktop release day (start of 2026-07-10 UTC) so every
+// signup during the release stays on v1 regardless of when the build reaches
+// them — no existing v1 user flips. Bump this if the release slips.
+export const V2_NEW_USER_V2_DEFAULT_START = "2026-07-10T00:00:00.000Z";
 
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -59,12 +59,24 @@ export const TEARDOWN_TIMEOUT_MS = 60_000;
 // PostHog
 export const POSTHOG_COOKIE_NAME = "superset";
 
-// Users whose account was created at or after V2_ONLY_USER_CUTOFF are v2-only:
-// the v1↔v2 surface switch is hidden and v2 cloud is forced on. Pre-cutoff users
-// keep the existing opt-in toggle. Stored as an ISO string so the value is
-// identical on server, desktop renderer, web, and admin.
+// v2-only users have the v1↔v2 surface switch hidden and v2 cloud forced on.
+// Two windows of account-creation time qualify (stored as ISO strings so the
+// values are identical on server, desktop renderer, web, and admin):
+//   [V2_ONLY_USER_CUTOFF, V2_NEW_USER_V1_EXPERIMENT_START) — the original v2-only
+//     cohort.
+//   [V2_NEW_USER_V2_DEFAULT_START, ∞) — new users now default to v2.
+// The gap [V2_NEW_USER_V1_EXPERIMENT_START, V2_NEW_USER_V2_DEFAULT_START) is the
+// new-users-v1 experiment cohort; they started in v1 and stay there — flipping
+// the default must never pull existing v1 users into v2. Pre-cutoff users keep
+// the existing opt-in toggle.
 // 2026-05-15 14:00 UTC = Fri 07:00 PDT / 10:00 EDT.
 export const V2_ONLY_USER_CUTOFF = "2026-05-15T14:00:00.000Z";
+// 2026-06-08 06:59 UTC = Sun 23:59 PDT (11:59pm Pacific).
+export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-08T06:59:00.000Z";
+// Rollout boundary: accounts created at/after this default to v2. Set ahead of
+// all current signups so no existing v1-experiment user is affected. Bump this
+// if the desktop release carrying the change ships later. 2026-07-09 00:00 UTC.
+export const V2_NEW_USER_V2_DEFAULT_START = "2026-07-09T00:00:00.000Z";
 
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -59,17 +59,12 @@ export const TEARDOWN_TIMEOUT_MS = 60_000;
 // PostHog
 export const POSTHOG_COOKIE_NAME = "superset";
 
-// Users whose account was created within the window
-// [V2_ONLY_USER_CUTOFF, V2_NEW_USER_V1_EXPERIMENT_START) are v2-only: the v1↔v2
-// surface switch is hidden and v2 cloud is forced on. Pre-cutoff users keep the
-// existing opt-in toggle. Accounts created at or after the experiment start are
-// sent to v1 (the new-users-v1 experiment) and are never forced into v2. Stored
-// as ISO strings so the values are identical on server, desktop renderer, web,
-// and admin.
+// Users whose account was created at or after V2_ONLY_USER_CUTOFF are v2-only:
+// the v1↔v2 surface switch is hidden and v2 cloud is forced on. Pre-cutoff users
+// keep the existing opt-in toggle. Stored as an ISO string so the value is
+// identical on server, desktop renderer, web, and admin.
 // 2026-05-15 14:00 UTC = Fri 07:00 PDT / 10:00 EDT.
 export const V2_ONLY_USER_CUTOFF = "2026-05-15T14:00:00.000Z";
-// 2026-06-08 06:59 UTC = Sun 23:59 PDT (11:59pm Pacific).
-export const V2_NEW_USER_V1_EXPERIMENT_START = "2026-06-08T06:59:00.000Z";
 
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */

--- a/packages/shared/src/v2-only-user.ts
+++ b/packages/shared/src/v2-only-user.ts
@@ -1,7 +1,4 @@
-import {
-	V2_NEW_USER_V1_EXPERIMENT_START,
-	V2_ONLY_USER_CUTOFF,
-} from "./constants";
+import { V2_ONLY_USER_CUTOFF } from "./constants";
 
 export function isV2OnlyUser(
 	createdAt: Date | string | number | null | undefined,
@@ -12,8 +9,5 @@ export function isV2OnlyUser(
 			? createdAt.getTime()
 			: new Date(createdAt).getTime();
 	if (Number.isNaN(created)) return false;
-	return (
-		created >= new Date(V2_ONLY_USER_CUTOFF).getTime() &&
-		created < new Date(V2_NEW_USER_V1_EXPERIMENT_START).getTime()
-	);
+	return created >= new Date(V2_ONLY_USER_CUTOFF).getTime();
 }

--- a/packages/shared/src/v2-only-user.ts
+++ b/packages/shared/src/v2-only-user.ts
@@ -1,4 +1,8 @@
-import { V2_ONLY_USER_CUTOFF } from "./constants";
+import {
+	V2_NEW_USER_V1_EXPERIMENT_START,
+	V2_NEW_USER_V2_DEFAULT_START,
+	V2_ONLY_USER_CUTOFF,
+} from "./constants";
 
 export function isV2OnlyUser(
 	createdAt: Date | string | number | null | undefined,
@@ -9,5 +13,11 @@ export function isV2OnlyUser(
 			? createdAt.getTime()
 			: new Date(createdAt).getTime();
 	if (Number.isNaN(created)) return false;
-	return created >= new Date(V2_ONLY_USER_CUTOFF).getTime();
+	// Original v2-only cohort, OR new users on/after the v2-default rollout. The
+	// gap between them is the new-users-v1 experiment cohort, who stay on v1.
+	return (
+		(created >= new Date(V2_ONLY_USER_CUTOFF).getTime() &&
+			created < new Date(V2_NEW_USER_V1_EXPERIMENT_START).getTime()) ||
+		created >= new Date(V2_NEW_USER_V2_DEFAULT_START).getTime()
+	);
 }


### PR DESCRIPTION
## Summary

New signups default to the **v2** experience instead of v1, **without flipping any existing user**. The v1↔v2 decision is computed client-side in the desktop renderer from the account's `createdAt`, so this is a small change in `packages/shared`.

`isV2OnlyUser()` returns `true` for two account-creation windows:
- `[V2_ONLY_USER_CUTOFF, V2_NEW_USER_V1_EXPERIMENT_START)` — the original v2-only cohort (unchanged).
- `[V2_NEW_USER_V2_DEFAULT_START, ∞)` — new users going forward.

The gap between them — the **new-users-v1 experiment cohort** (created 2026-06-08 → rollout) — deliberately stays on **v1**.

### Rollout boundary
`V2_NEW_USER_V2_DEFAULT_START` = `2026-07-09T17:00:00.000Z` (**2026-07-09, 10:00 AM Pacific / PDT**). Everyone who signed up before the cutover stays on v1, so no existing v1 user flips. Bump this if the release slips.

### Behavior
| Account created | Experience |
| --- | --- |
| before 2026-05-15 | opt-in toggle (unchanged) |
| 2026-05-15 → 2026-06-08 | v2-only (unchanged) |
| 2026-06-08 → 2026-07-09 10am PT | **v1 — protected, unchanged** |
| on/after 2026-07-09 10am PT | **v2 (new default)** |

Explicit per-device opt-out still wins (`optInV2 ?? (v2Only || dev)`).

## Test Plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` passes all packages
- [ ] Verify an account created on/after the cutover lands on v2
- [ ] Verify a new-users-v1 experiment account (created 2026-06-08 → now) still lands on v1
- [ ] Verify a pre-cutoff account still sees the opt-in toggle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated V2-only user detection to include both legacy v2-only users and users created on/after the new v2 default rollout boundary.
  * Removed an unintended time-window restriction so cohort-based status checks behave consistently across cohorts.
* **Documentation**
  * Clarified the v1↔v2 account-creation timeline, including the intermediate v1 experiment window and the new start date where new users default to v2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->