### PR TITLE
fix(desktop): render sign-in last-used badge inline with shared Badge component

### DIFF
--- a/apps/desktop/src/renderer/routes/sign-in/page.tsx
+++ b/apps/desktop/src/renderer/routes/sign-in/page.tsx
@@ -4,6 +4,7 @@ import {
 	DEV_NAME,
 	DEV_PASSWORD,
 } from "@superset/shared/dev-credentials";
+import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, Navigate, useNavigate } from "@tanstack/react-router";
@@ -133,11 +134,7 @@ function SignInPage() {
 		}
 	};
 
-	const lastUsedBadge = (
-		<span className="absolute right-3 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-			Last used
-		</span>
-	);
+	const lastUsedBadge = <Badge variant="secondary">Last used</Badge>;
 
 	return (
 		<div className="flex flex-col h-full w-full bg-background">
@@ -166,7 +163,7 @@ function SignInPage() {
 								variant="outline"
 								size="lg"
 								onClick={signInAsDev}
-								className="relative w-full gap-3"
+								className="w-full gap-3"
 								disabled={isLoadingDev}
 							>
 								{isLoadingDev
@@ -184,7 +181,7 @@ function SignInPage() {
 							variant="outline"
 							size="lg"
 							onClick={() => signIn("github")}
-							className="relative w-full gap-3"
+							className="w-full gap-3"
 							disabled={signInMutation.isPending}
 						>
 							<FaGithub className="size-5" />
@@ -196,7 +193,7 @@ function SignInPage() {
 							variant="outline"
 							size="lg"
 							onClick={() => signIn("google")}
-							className="relative w-full gap-3"
+							className="w-full gap-3"
 							disabled={signInMutation.isPending}
 						>
 							<FcGoogle className="size-5" />


### PR DESCRIPTION
## Summary
The "Last used" badge on the desktop sign-in page was a hand-rolled span absolutely positioned at the right edge of the auth buttons, so it overlapped the centered button label and didn't match the design system.

- Replace the custom span with the shared `Badge` component from `@superset/ui/badge` (`secondary` variant)
- Render it inline after the button label instead of absolutely positioned, so it can no longer cover the text
- Drop the now-unneeded `relative` class from the sign-in buttons

## Test plan
- `bun run typecheck` (apps/desktop) and `biome check` pass
- Sign in via any provider, relaunch signed out: badge sits inline next to the label of the last-used method without overlapping it

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5535">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the custom absolutely positioned "Last used" badge on the desktop sign-in buttons with the shared `Badge` from `@superset/ui/badge`, rendered inline after the label. This prevents text overlap and aligns the UI with the design system.

<sup>Written for commit 9b01ac8cc510b6b1762f151d4782d1a43118ea28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sign-in page’s “Last used” label to use a badge-style appearance.
  * Simplified the layout of the sign-in buttons for a cleaner, more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->