### PR TITLE
feat(chat): add MiniMax models to the model picker

### DIFF
--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ModelPicker/utils/providerToLogo/index.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ModelPicker/utils/providerToLogo/index.ts
@@ -1,5 +1,6 @@
 export {
 	ANTHROPIC_LOGO_PROVIDER,
+	MINIMAX_LOGO_PROVIDER,
 	OPENAI_LOGO_PROVIDER,
 	providerToLogo,
 } from "./providerToLogo";

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ModelPicker/utils/providerToLogo/providerToLogo.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ModelPicker/utils/providerToLogo/providerToLogo.ts
@@ -1,10 +1,12 @@
 export const ANTHROPIC_LOGO_PROVIDER = "anthropic";
 export const OPENAI_LOGO_PROVIDER = "openai";
+export const MINIMAX_LOGO_PROVIDER = "minimax";
 
 /** Derive a logo provider slug from the provider name */
 export function providerToLogo(provider: string): string {
 	const lower = provider.toLowerCase();
 	const isO3Model = lower === "o3" || lower.startsWith("o3-");
+	if (lower.includes("minimax")) return MINIMAX_LOGO_PROVIDER;
 	if (lower.includes("anthropic") || lower.includes("claude")) {
 		return ANTHROPIC_LOGO_PROVIDER;
 	}

--- a/apps/desktop/src/renderer/lib/dev-chat.ts
+++ b/apps/desktop/src/renderer/lib/dev-chat.ts
@@ -6,7 +6,22 @@ export const DEV_CHAT_MODELS: ModelOption[] = [
 	{
 		id: "minimax/MiniMax-M3",
 		name: "MiniMax-M3",
-		provider: "MiniMax",
+		provider: "MiniMax (minimax.io)",
+	},
+	{
+		id: "minimax/MiniMax-M2.7",
+		name: "MiniMax-M2.7",
+		provider: "MiniMax (minimax.io)",
+	},
+	{
+		id: "minimax-cn/MiniMax-M3",
+		name: "MiniMax-M3",
+		provider: "MiniMax (minimaxi.com)",
+	},
+	{
+		id: "minimax-cn/MiniMax-M2.7",
+		name: "MiniMax-M2.7",
+		provider: "MiniMax (minimaxi.com)",
 	},
 	{
 		id: "anthropic/claude-opus-4-8",

--- a/apps/desktop/src/renderer/lib/dev-chat.ts
+++ b/apps/desktop/src/renderer/lib/dev-chat.ts
@@ -4,6 +4,11 @@ import { MOCK_ORG_ID } from "shared/constants";
 
 export const DEV_CHAT_MODELS: ModelOption[] = [
 	{
+		id: "minimax/MiniMax-M3",
+		name: "MiniMax-M3",
+		provider: "MiniMax",
+	},
+	{
 		id: "anthropic/claude-opus-4-8",
 		name: "Opus 4.8",
 		provider: "Anthropic",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ModelPicker/utils/providerToLogo/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ModelPicker/utils/providerToLogo/index.ts
@@ -1,5 +1,6 @@
 export {
 	ANTHROPIC_LOGO_PROVIDER,
+	MINIMAX_LOGO_PROVIDER,
 	OPENAI_LOGO_PROVIDER,
 	providerToLogo,
 } from "./providerToLogo";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ModelPicker/utils/providerToLogo/providerToLogo.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ModelPicker/utils/providerToLogo/providerToLogo.ts
@@ -1,10 +1,12 @@
 export const ANTHROPIC_LOGO_PROVIDER = "anthropic";
 export const OPENAI_LOGO_PROVIDER = "openai";
+export const MINIMAX_LOGO_PROVIDER = "minimax";
 
 /** Derive a logo provider slug from the provider name */
 export function providerToLogo(provider: string): string {
 	const lower = provider.toLowerCase();
 	const isO3Model = lower === "o3" || lower.startsWith("o3-");
+	if (lower.includes("minimax")) return MINIMAX_LOGO_PROVIDER;
 	if (lower.includes("anthropic") || lower.includes("claude")) {
 		return ANTHROPIC_LOGO_PROVIDER;
 	}

--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -38,6 +38,60 @@ For Anthropic-compatible providers (OpenRouter, Vercel AI Gateway), set `ANTHROP
 
 ---
 
+## MiniMax
+
+Superset Chat supports `MiniMax-M3` and `MiniMax-M2.7` in both API regions.
+Open the provider settings from the model picker and add your API key:
+
+```bash
+MINIMAX_API_KEY=your-minimax-api-key
+```
+
+Select **MiniMax (minimax.io)** for the global endpoint or
+**MiniMax (minimaxi.com)** for the China endpoint. Superset Chat uses the
+Anthropic-compatible adapter for both regions.
+
+Terminal agents that accept custom provider environment variables can use
+either supported protocol. Choose the Base URL for your region.
+
+### Anthropic-Compatible
+
+Global:
+
+```bash
+ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+ANTHROPIC_AUTH_TOKEN=your-minimax-api-key
+ANTHROPIC_API_KEY=
+```
+
+China:
+
+```bash
+ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
+ANTHROPIC_AUTH_TOKEN=your-minimax-api-key
+ANTHROPIC_API_KEY=
+```
+
+### OpenAI-Compatible
+
+Global:
+
+```bash
+OPENAI_BASE_URL=https://api.minimax.io/v1
+OPENAI_API_KEY=your-minimax-api-key
+```
+
+China:
+
+```bash
+OPENAI_BASE_URL=https://api.minimaxi.com/v1
+OPENAI_API_KEY=your-minimax-api-key
+```
+
+Use `MiniMax-M3` or `MiniMax-M2.7` as the model ID with either protocol.
+
+---
+
 ## Vercel AI Gateway
 
 Route requests through the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway).

--- a/packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.test.ts
+++ b/packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { CloudModelProvider } from "./CloudModelProvider";
+
+const originalMiniMaxApiKey = process.env.MINIMAX_API_KEY;
+
+afterEach(() => {
+	if (originalMiniMaxApiKey === undefined) {
+		delete process.env.MINIMAX_API_KEY;
+		return;
+	}
+	process.env.MINIMAX_API_KEY = originalMiniMaxApiKey;
+});
+
+describe("CloudModelProvider", () => {
+	it("forwards MiniMax API keys as usable cloud credentials", async () => {
+		const provider = new CloudModelProvider({
+			envResolver: async () => ({ MINIMAX_API_KEY: "test-minimax-key" }),
+		});
+
+		expect(await provider.hasUsableRuntimeEnv()).toBe(true);
+		await provider.prepareRuntimeEnv();
+		expect(process.env.MINIMAX_API_KEY).toBe("test-minimax-key");
+	});
+});

--- a/packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.ts
+++ b/packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.ts
@@ -10,6 +10,7 @@ const CLOUD_PROVIDER_ENV_KEYS = [
 	"OPENAI_API_KEY",
 	"OPENAI_AUTH_TOKEN",
 	"OPENAI_BASE_URL",
+	"MINIMAX_API_KEY",
 	"CLAUDE_CODE_USE_BEDROCK",
 	"AWS_REGION",
 	"AWS_DEFAULT_REGION",
@@ -74,7 +75,8 @@ export class CloudModelProvider implements ModelProviderRuntimeResolver {
 				env.ANTHROPIC_API_KEY ||
 					env.ANTHROPIC_AUTH_TOKEN ||
 					env.OPENAI_API_KEY ||
-					env.OPENAI_AUTH_TOKEN,
+					env.OPENAI_AUTH_TOKEN ||
+					env.MINIMAX_API_KEY,
 			),
 		};
 	}

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -6,6 +6,7 @@ import {
 	buildAgentModelArgs,
 	getAgentEffortSupport,
 	getAgentModelSupport,
+	SUPERSET_CHAT_MODELS,
 } from "./agent-models";
 import { BUILTIN_TERMINAL_AGENT_TYPES } from "./builtin-terminal-agents";
 
@@ -35,11 +36,38 @@ describe("AGENT_MODEL_SUPPORT", () => {
 			expect(entry.models.length).toBeGreaterThan(0);
 		}
 	});
-	it("includes MiniMax-M3 for the superset chat model picker", () => {
-		expect(getAgentModelSupport("superset")?.models).toContainEqual({
-			id: "minimax/MiniMax-M3",
-			label: "MiniMax-M3",
-		});
+
+	it("includes MiniMax-M3 and MiniMax-M2.7 for both API regions", () => {
+		const expectedModels = [
+			{
+				id: "minimax/MiniMax-M3",
+				label: "MiniMax-M3",
+				provider: "MiniMax (minimax.io)",
+			},
+			{
+				id: "minimax/MiniMax-M2.7",
+				label: "MiniMax-M2.7",
+				provider: "MiniMax (minimax.io)",
+			},
+			{
+				id: "minimax-cn/MiniMax-M3",
+				label: "MiniMax-M3",
+				provider: "MiniMax (minimaxi.com)",
+			},
+			{
+				id: "minimax-cn/MiniMax-M2.7",
+				label: "MiniMax-M2.7",
+				provider: "MiniMax (minimaxi.com)",
+			},
+		];
+
+		for (const model of expectedModels) {
+			expect(SUPERSET_CHAT_MODELS).toContainEqual(model);
+			expect(getAgentModelSupport("superset")?.models).toContainEqual({
+				id: model.id,
+				label: model.label,
+			});
+		}
 	});
 });
 

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -35,6 +35,12 @@ describe("AGENT_MODEL_SUPPORT", () => {
 			expect(entry.models.length).toBeGreaterThan(0);
 		}
 	});
+	it("includes MiniMax-M3 for the superset chat model picker", () => {
+		expect(getAgentModelSupport("superset")?.models).toContainEqual({
+			id: "minimax/MiniMax-M3",
+			label: "MiniMax-M3",
+		});
+	});
 });
 
 describe("getAgentModelSupport", () => {

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -36,7 +36,26 @@ export interface SupersetChatModel extends AgentModelOption {
  * model edits here so the two never drift.
  */
 export const SUPERSET_CHAT_MODELS: readonly SupersetChatModel[] = [
-	{ id: "minimax/MiniMax-M3", label: "MiniMax-M3", provider: "MiniMax" },
+	{
+		id: "minimax/MiniMax-M3",
+		label: "MiniMax-M3",
+		provider: "MiniMax (minimax.io)",
+	},
+	{
+		id: "minimax/MiniMax-M2.7",
+		label: "MiniMax-M2.7",
+		provider: "MiniMax (minimax.io)",
+	},
+	{
+		id: "minimax-cn/MiniMax-M3",
+		label: "MiniMax-M3",
+		provider: "MiniMax (minimaxi.com)",
+	},
+	{
+		id: "minimax-cn/MiniMax-M2.7",
+		label: "MiniMax-M2.7",
+		provider: "MiniMax (minimaxi.com)",
+	},
 	{ id: "anthropic/claude-opus-4-8", label: "Opus 4.8", provider: "Anthropic" },
 	{ id: "anthropic/claude-opus-4-7", label: "Opus 4.7", provider: "Anthropic" },
 	{ id: "anthropic/claude-fable-5", label: "Fable 5", provider: "Anthropic" },

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -36,6 +36,7 @@ export interface SupersetChatModel extends AgentModelOption {
  * model edits here so the two never drift.
  */
 export const SUPERSET_CHAT_MODELS: readonly SupersetChatModel[] = [
+	{ id: "minimax/MiniMax-M3", label: "MiniMax-M3", provider: "MiniMax" },
 	{ id: "anthropic/claude-opus-4-8", label: "Opus 4.8", provider: "Anthropic" },
 	{ id: "anthropic/claude-opus-4-7", label: "Opus 4.7", provider: "Anthropic" },
 	{ id: "anthropic/claude-fable-5", label: "Fable 5", provider: "Anthropic" },


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax-M3 and MiniMax-M2.7 to the global and China Superset chat catalogs.
- Forward the MiniMax API key through the cloud host runtime and keep both regional provider labels on the MiniMax logo slug.
- Document both API regions and the Anthropic-compatible and OpenAI-compatible endpoints.

## Test plan
- `bunx @biomejs/biome@2.4.2 check packages/shared/src/agent-models.ts packages/shared/src/agent-models.test.ts apps/desktop/src/renderer/lib/dev-chat.ts packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.ts packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.test.ts`
- `bun test packages/shared/src/agent-models.test.ts packages/host-service/src/providers/model-providers/CloudModelProvider/CloudModelProvider.test.ts apps/desktop/src/renderer/lib/dev-chat.test.ts`
- Captured the generated request URLs with mocked fetch for both protocols in both API regions.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
