### PR TITLE
chore(cli): bump pty-daemon 0.2.4 -> 0.2.5 and cascade host-service/cli versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.13.1",
+      "version": "1.14.0",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -709,7 +709,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -790,7 +790,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "0.8.24",
+      "version": "0.8.26",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",
@@ -931,7 +931,7 @@
     },
     "packages/pty-daemon": {
       "name": "@superset/pty-daemon",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "bin": {
         "pty-daemon": "./src/main.ts",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "0.8.25",
+	"version": "0.8.26",
 	"private": true,
 	"type": "module",
 	"exports": {

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/pty-daemon",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
## What

Bump the CLI-bundled pty-daemon and cascade the version bump through the packages that ship it.

| Package | From | To |
|---|---|---|
| \`@superset/pty-daemon\` (cli daemon) | 0.2.4 | **0.2.5** |
| \`@superset/host-service\` | 0.8.25 | **0.8.26** |
| \`@superset/cli\` | 0.2.23 | **0.2.24** |

## Why

The daemon version's single source of truth is \`pty-daemon/package.json#version\` — \`DAEMON_VERSION\`, \`EXPECTED_DAEMON_VERSION\`, and \`SUPERSET_PTY_DAEMON_VERSION\` all derive from it, so bumping it there is sufficient (no hardcoded strings). Since 0.2.4 the daemon has one unreleased fix — raise RLIMIT_NOFILE / surface real spawn errno (#5067) — so this cuts 0.2.5.

host-service and cli both bundle the daemon, so they bump alongside. **Desktop is intentionally not bumped** in this PR.

\`bun.lock\` resynced.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5541">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the versions of the CLI, host service, and PTY daemon packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->