### PR TITLE
fix(relay): proxy terminal/events WebSockets to the owning instance over 6PN

### DIFF
--- a/apps/relay/src/env.ts
+++ b/apps/relay/src/env.ts
@@ -9,6 +9,9 @@ export const env = createEnv({
 		KV_REST_API_TOKEN: z.string().min(1),
 		FLY_REGION: z.string().default("local"),
 		FLY_MACHINE_ID: z.string().default("local"),
+		// Fly sets this automatically; used to build `<machine>.vm.<app>.internal`
+		// addresses for relay-to-relay WebSocket proxying across instances.
+		FLY_APP_NAME: z.string().default("local"),
 		RELAY_SENTRY_DSN: z.string().url().optional(),
 		RELAY_SYNTHETIC_JWT: z.string().min(1).optional(),
 		RELAY_PUBLIC_URL: z.url().default("https://relay.superset.sh"),

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -8,6 +8,7 @@ import { checkHostAccess } from "./access";
 import { type AuthContext, verifyJWT } from "./auth";
 import * as directory from "./directory";
 import { env } from "./env";
+import { createProxyBridge, internalProxyUrl, PROXY_HOP_PARAM } from "./proxy";
 import { captureSentryException, initSentry } from "./sentry";
 import { startSyntheticCheck } from "./synthetic";
 import { isTrpcPath, trpcErrorResponse } from "./trpc-error";
@@ -145,33 +146,6 @@ async function maybeReplay(hostId: string): Promise<{
 		header: { "fly-replay": `region=${owner.region}` },
 		kind: "region",
 	};
-}
-
-// Query marker on a relay-to-relay proxy hop. Guards against an infinite
-// bridge loop when the directory is briefly stale: a hop that lands on a node
-// which doesn't own the tunnel is failed rather than re-proxied.
-const PROXY_HOP_PARAM = "_rlp";
-
-// Build the private-network URL for the relay instance that owns the tunnel.
-// Fly resolves `<machine-id>.vm.<app>.internal` to that specific machine over
-// the encrypted 6PN network, so plain `ws://` on the internal port is fine.
-function internalProxyUrl(
-	owner: { machineId: string },
-	hostId: string,
-	pathAfterHost: string,
-	search: string,
-): string {
-	const base = `ws://${owner.machineId}.vm.${env.FLY_APP_NAME}.internal:${env.RELAY_PORT}`;
-	const sep = search ? "&" : "?";
-	return `${base}/hosts/${hostId}${pathAfterHost}${search}${sep}${PROXY_HOP_PARAM}=1`;
-}
-
-// Only 1000 and the 3000-4999 app range may be sent on a WS close frame;
-// anything else (1005/1006/1015, protocol codes) throws. Fall back to 1000.
-function safeCloseCode(code: number | undefined): number {
-	return code === 1000 || (code != null && code >= 3000 && code <= 4999)
-		? code
-		: 1000;
 }
 
 function pathAfterHost(c: Context<AppContext>): string {
@@ -384,68 +358,11 @@ app.get(
 		// both ways. The owning node runs the normal access check + channel path.
 		const proxyOwner = c.get("proxyOwner");
 		if (proxyOwner) {
-			const target = internalProxyUrl(proxyOwner, hostId, path, url.search);
-			let upstream: WebSocket | null = null;
-			let clientClosed = false;
-			// Client→host frames ride the tunnel as strings (see the owning
-			// node's `String(event.data)` below), and terminal input is always
-			// JSON text — so forward this direction as text to preserve framing.
-			const pending: string[] = [];
-			const MAX_PENDING_FRAMES = 512;
-
-			return {
-				onOpen: (_event, ws) => {
-					try {
-						upstream = new WebSocket(target);
-					} catch {
-						ws.close(1011, "Upstream connect failed");
-						return;
-					}
-					upstream.binaryType = "arraybuffer";
-					upstream.addEventListener("open", () => {
-						for (const frame of pending) upstream?.send(frame);
-						pending.length = 0;
-					});
-					upstream.addEventListener("message", (event) => {
-						if (ws.readyState !== 1) return;
-						ws.send(event.data as string | ArrayBuffer);
-					});
-					upstream.addEventListener("close", (event) => {
-						if (!clientClosed && ws.readyState === 1) {
-							ws.close(safeCloseCode(event.code), "Upstream closed");
-						}
-					});
-					upstream.addEventListener("error", () => {
-						if (!clientClosed && ws.readyState === 1) {
-							ws.close(1011, "Upstream error");
-						}
-					});
-				},
-				onMessage: (event) => {
-					const frame = String(event.data);
-					if (upstream?.readyState === 1) {
-						upstream.send(frame);
-					} else if (pending.length < MAX_PENDING_FRAMES) {
-						pending.push(frame);
-					}
-				},
-				onClose: () => {
-					clientClosed = true;
-					try {
-						upstream?.close();
-					} catch {
-						// already closed
-					}
-				},
-				onError: () => {
-					clientClosed = true;
-					try {
-						upstream?.close();
-					} catch {
-						// already closed
-					}
-				},
-			};
+			const target = internalProxyUrl(proxyOwner, hostId, path, url.search, {
+				appName: env.FLY_APP_NAME,
+				port: env.RELAY_PORT,
+			});
+			return createProxyBridge(target);
 		}
 
 		let channelId: string | null = null;

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -41,6 +41,11 @@ type AppContext = {
 		auth: AuthContext;
 		token: string;
 		hostId: string;
+		// Set by the auth middleware when a WS upgrade targets a tunnel owned by
+		// another relay instance: the WS handler bridges to that instance over
+		// Fly's private network instead of fly-replaying (which can't route a
+		// WS upgrade).
+		proxyOwner: { region: string; machineId: string };
 	};
 };
 
@@ -142,6 +147,33 @@ async function maybeReplay(hostId: string): Promise<{
 	};
 }
 
+// Query marker on a relay-to-relay proxy hop. Guards against an infinite
+// bridge loop when the directory is briefly stale: a hop that lands on a node
+// which doesn't own the tunnel is failed rather than re-proxied.
+const PROXY_HOP_PARAM = "_rlp";
+
+// Build the private-network URL for the relay instance that owns the tunnel.
+// Fly resolves `<machine-id>.vm.<app>.internal` to that specific machine over
+// the encrypted 6PN network, so plain `ws://` on the internal port is fine.
+function internalProxyUrl(
+	owner: { machineId: string },
+	hostId: string,
+	pathAfterHost: string,
+	search: string,
+): string {
+	const base = `ws://${owner.machineId}.vm.${env.FLY_APP_NAME}.internal:${env.RELAY_PORT}`;
+	const sep = search ? "&" : "?";
+	return `${base}/hosts/${hostId}${pathAfterHost}${search}${sep}${PROXY_HOP_PARAM}=1`;
+}
+
+// Only 1000 and the 3000-4999 app range may be sent on a WS close frame;
+// anything else (1005/1006/1015, protocol codes) throws. Fall back to 1000.
+function safeCloseCode(code: number | undefined): number {
+	return code === 1000 || (code != null && code >= 3000 && code <= 4999)
+		? code
+		: 1000;
+}
+
 function pathAfterHost(c: Context<AppContext>): string {
 	const hostId = c.req.param("hostId") ?? "";
 	const path = new URL(c.req.url).pathname;
@@ -170,6 +202,40 @@ const authMiddleware: MiddlewareHandler<AppContext> = async (c, next) => {
 	// tunnel, the destination machine will authorize the request — no need
 	// to double-bill the API for checkHostAccess on every cross-machine hop.
 	if (!tunnelManager.hasTunnel(hostId)) {
+		const isWsUpgrade = c.req.header("upgrade")?.toLowerCase() === "websocket";
+
+		// fly-replay can't route a WS upgrade — the replay header rides on a
+		// response that only arrives after the handshake, so the browser sees a
+		// non-101 status and fails with 1006/502. So WS upgrades never fly-replay:
+		// when another instance owns the tunnel, hand the WS handler the owner so
+		// it bridges over Fly's private network instead. A `_rlp=1` hop that
+		// reached us means the directory is stale (we were told we own it but
+		// don't) — fail so the upstream relay closes and the client reconnects,
+		// rather than re-proxying into a loop.
+		if (isWsUpgrade) {
+			const isProxyHop = c.req.query(PROXY_HOP_PARAM) === "1";
+			if (!isProxyHop) {
+				const owner = await directory.lookup(hostId).catch((err) => {
+					captureSentryException(err, { op: "directory.lookup", hostId });
+					return null;
+				});
+				const ownedElsewhere =
+					owner != null &&
+					!(
+						owner.region === env.FLY_REGION &&
+						owner.machineId === env.FLY_MACHINE_ID
+					);
+				if (ownedElsewhere) {
+					c.set("auth", auth);
+					c.set("token", token);
+					c.set("hostId", hostId);
+					c.set("proxyOwner", owner);
+					return next();
+				}
+			}
+			return c.json({ error: "Host not connected" }, 503);
+		}
+
 		const replay = await maybeReplay(hostId);
 		if (replay) return c.body(null, 200, replay.header);
 		return wantsTrpc
@@ -312,6 +378,76 @@ app.get(
 		const prefix = `/hosts/${hostId}`;
 		const path = url.pathname.slice(prefix.length) || "/";
 		const query = url.search.slice(1) || undefined;
+
+		// Cross-instance bridge: this node doesn't own the tunnel, so relay the
+		// WS to the owning instance over Fly's private network and pipe frames
+		// both ways. The owning node runs the normal access check + channel path.
+		const proxyOwner = c.get("proxyOwner");
+		if (proxyOwner) {
+			const target = internalProxyUrl(proxyOwner, hostId, path, url.search);
+			let upstream: WebSocket | null = null;
+			let clientClosed = false;
+			// Client→host frames ride the tunnel as strings (see the owning
+			// node's `String(event.data)` below), and terminal input is always
+			// JSON text — so forward this direction as text to preserve framing.
+			const pending: string[] = [];
+			const MAX_PENDING_FRAMES = 512;
+
+			return {
+				onOpen: (_event, ws) => {
+					try {
+						upstream = new WebSocket(target);
+					} catch {
+						ws.close(1011, "Upstream connect failed");
+						return;
+					}
+					upstream.binaryType = "arraybuffer";
+					upstream.addEventListener("open", () => {
+						for (const frame of pending) upstream?.send(frame);
+						pending.length = 0;
+					});
+					upstream.addEventListener("message", (event) => {
+						if (ws.readyState !== 1) return;
+						ws.send(event.data as string | ArrayBuffer);
+					});
+					upstream.addEventListener("close", (event) => {
+						if (!clientClosed && ws.readyState === 1) {
+							ws.close(safeCloseCode(event.code), "Upstream closed");
+						}
+					});
+					upstream.addEventListener("error", () => {
+						if (!clientClosed && ws.readyState === 1) {
+							ws.close(1011, "Upstream error");
+						}
+					});
+				},
+				onMessage: (event) => {
+					const frame = String(event.data);
+					if (upstream?.readyState === 1) {
+						upstream.send(frame);
+					} else if (pending.length < MAX_PENDING_FRAMES) {
+						pending.push(frame);
+					}
+				},
+				onClose: () => {
+					clientClosed = true;
+					try {
+						upstream?.close();
+					} catch {
+						// already closed
+					}
+				},
+				onError: () => {
+					clientClosed = true;
+					try {
+						upstream?.close();
+					} catch {
+						// already closed
+					}
+				},
+			};
+		}
+
 		let channelId: string | null = null;
 
 		return {
@@ -375,11 +511,18 @@ try {
 	console.error("[relay] startup cleanup failed", err);
 }
 
-server = serve({ fetch: app.fetch, port: env.RELAY_PORT }, (info) => {
-	console.log(
-		`[relay] listening on http://localhost:${info.port} (region=${env.FLY_REGION} machine=${env.FLY_MACHINE_ID})`,
-	);
-});
+// Bind dual-stack (`::`) rather than the default `0.0.0.0`. Fly's private
+// 6PN network (`<machine>.vm.<app>.internal`) is IPv6-only, and relay-to-relay
+// WS proxying dials peers over it; `::` accepts both the public IPv4 proxy
+// traffic (IPv4-mapped, V6ONLY=0 on Linux) and 6PN IPv6 peer connections.
+server = serve(
+	{ fetch: app.fetch, port: env.RELAY_PORT, hostname: "::" },
+	(info) => {
+		console.log(
+			`[relay] listening on [::]:${info.port} (region=${env.FLY_REGION} machine=${env.FLY_MACHINE_ID})`,
+		);
+	},
+);
 injectWebSocket(server);
 
 // Disable Nagle's algorithm on every incoming connection. Both the client's

--- a/apps/relay/src/proxy.test.ts
+++ b/apps/relay/src/proxy.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "bun:test";
+import { createProxyBridge, internalProxyUrl, safeCloseCode } from "./proxy";
+
+function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const started = Date.now();
+		const tick = () => {
+			if (cond()) return resolve();
+			if (Date.now() - started > timeoutMs)
+				return reject(new Error("waitFor timed out"));
+			setTimeout(tick, 10);
+		};
+		tick();
+	});
+}
+
+type FakeClient = {
+	readyState: number;
+	send: (d: string | ArrayBuffer) => void;
+	close: (code?: number, reason?: string) => void;
+};
+
+test("internalProxyUrl targets the owner machine over 6PN with the loop guard", () => {
+	const url = internalProxyUrl(
+		{ machineId: "abc123" },
+		"org:host",
+		"/terminal/t1",
+		"?token=x&workspaceId=w",
+		{ appName: "superset-relay", port: 8080 },
+	);
+	expect(url).toBe(
+		"ws://abc123.vm.superset-relay.internal:8080/hosts/org:host/terminal/t1?token=x&workspaceId=w&_rlp=1",
+	);
+	// No prior query → the guard opens with `?`.
+	expect(
+		internalProxyUrl({ machineId: "m" }, "h", "/events", "", {
+			appName: "app",
+			port: 80,
+		}),
+	).toBe("ws://m.vm.app.internal:80/hosts/h/events?_rlp=1");
+});
+
+test("safeCloseCode only lets 1000 / 3000-4999 through", () => {
+	expect(safeCloseCode(1000)).toBe(1000);
+	expect(safeCloseCode(4001)).toBe(4001);
+	expect(safeCloseCode(1006)).toBe(1000);
+	expect(safeCloseCode(1011)).toBe(1000);
+	expect(safeCloseCode(undefined)).toBe(1000);
+});
+
+test("bridge pipes client→upstream text and upstream→client binary (framing preserved)", async () => {
+	const receivedByUpstream: string[] = [];
+	const server = Bun.serve({
+		port: 0,
+		fetch(req, s) {
+			if (s.upgrade(req)) return undefined;
+			return new Response("expected ws", { status: 400 });
+		},
+		websocket: {
+			message(ws, msg) {
+				receivedByUpstream.push(String(msg));
+				// Echo back binary PTY-style bytes to exercise the binary path.
+				ws.send(new Uint8Array([1, 2, 3, 4]));
+			},
+		},
+	});
+
+	const clientSent: (string | ArrayBuffer)[] = [];
+	const client: FakeClient = {
+		readyState: 1,
+		send: (d) => clientSent.push(d),
+		close: () => {},
+	};
+
+	const bridge = createProxyBridge(`ws://localhost:${server.port}/`);
+	bridge.onOpen(null, client as never);
+	// Sent before the upstream is open → must be buffered then flushed on open.
+	bridge.onMessage({ data: "echo probe-ok\r" });
+
+	await waitFor(() => receivedByUpstream.length > 0);
+	expect(receivedByUpstream).toContain("echo probe-ok\r");
+
+	await waitFor(() => clientSent.some((d) => d instanceof ArrayBuffer));
+	const binary = clientSent.find(
+		(d) => d instanceof ArrayBuffer,
+	) as ArrayBuffer;
+	expect(Array.from(new Uint8Array(binary))).toEqual([1, 2, 3, 4]);
+
+	server.stop(true);
+});
+
+test("bridge propagates an upstream close to the client with a safe code", async () => {
+	const server = Bun.serve({
+		port: 0,
+		fetch(req, s) {
+			if (s.upgrade(req)) return undefined;
+			return new Response("expected ws", { status: 400 });
+		},
+		websocket: {
+			open(ws) {
+				ws.close(4001, "drain");
+			},
+			message() {},
+		},
+	});
+
+	let closedCode: number | undefined;
+	const client: FakeClient = {
+		readyState: 1,
+		send: () => {},
+		close: (code) => {
+			closedCode = code;
+		},
+	};
+
+	const bridge = createProxyBridge(`ws://localhost:${server.port}/`);
+	bridge.onOpen(null, client as never);
+
+	await waitFor(() => closedCode !== undefined);
+	expect(closedCode).toBe(4001);
+
+	server.stop(true);
+});

--- a/apps/relay/src/proxy.ts
+++ b/apps/relay/src/proxy.ts
@@ -1,0 +1,113 @@
+import type { WSContext } from "hono/ws";
+
+// Query marker on a relay-to-relay proxy hop. Guards against an infinite
+// bridge loop when the directory is briefly stale: a hop that lands on a node
+// which doesn't own the tunnel is failed rather than re-proxied.
+export const PROXY_HOP_PARAM = "_rlp";
+
+// Build the private-network URL for the relay instance that owns the tunnel.
+// Fly resolves `<machine-id>.vm.<app>.internal` to that specific machine over
+// the encrypted 6PN network, so plain `ws://` on the internal port is fine.
+export function internalProxyUrl(
+	owner: { machineId: string },
+	hostId: string,
+	pathAfterHost: string,
+	search: string,
+	opts: { appName: string; port: number },
+): string {
+	const base = `ws://${owner.machineId}.vm.${opts.appName}.internal:${opts.port}`;
+	const sep = search ? "&" : "?";
+	return `${base}/hosts/${hostId}${pathAfterHost}${search}${sep}${PROXY_HOP_PARAM}=1`;
+}
+
+// Only 1000 and the 3000-4999 app range may be sent on a WS close frame;
+// anything else (1005/1006/1015, protocol codes) throws. Fall back to 1000.
+export function safeCloseCode(code: number | undefined): number {
+	return code === 1000 || (code != null && code >= 3000 && code <= 4999)
+		? code
+		: 1000;
+}
+
+// Buffer cap for client frames that arrive before the upstream WS is open.
+const MAX_PENDING_FRAMES = 512;
+
+type WsEventHandlers = {
+	onOpen: (evt: unknown, ws: WSContext) => void;
+	onMessage: (evt: { data: unknown }) => void;
+	onClose: () => void;
+	onError: () => void;
+};
+
+/**
+ * Bridge a client terminal/events WebSocket to the relay instance that owns the
+ * host tunnel, over Fly's private network. Frames are piped both ways with
+ * framing preserved: client→host rides as text (the tunnel carries client
+ * frames as strings and terminal input is JSON), host→client preserves binary
+ * (PTY bytes) vs text (JSON control). The owning node runs the normal access
+ * check + channel path on the far end.
+ *
+ * `connect` defaults to the global WebSocket; injectable so tests can point at
+ * a local upstream without Fly 6PN.
+ */
+export function createProxyBridge(
+	target: string,
+	connect: (url: string) => WebSocket = (url) => new WebSocket(url),
+): WsEventHandlers {
+	let upstream: WebSocket | null = null;
+	let clientClosed = false;
+	const pending: string[] = [];
+
+	return {
+		onOpen: (_evt, ws) => {
+			try {
+				upstream = connect(target);
+			} catch {
+				ws.close(1011, "Upstream connect failed");
+				return;
+			}
+			upstream.binaryType = "arraybuffer";
+			upstream.addEventListener("open", () => {
+				for (const frame of pending) upstream?.send(frame);
+				pending.length = 0;
+			});
+			upstream.addEventListener("message", (event) => {
+				if (ws.readyState !== 1) return;
+				ws.send(event.data as string | ArrayBuffer);
+			});
+			upstream.addEventListener("close", (event) => {
+				if (!clientClosed && ws.readyState === 1) {
+					ws.close(safeCloseCode(event.code), "Upstream closed");
+				}
+			});
+			upstream.addEventListener("error", () => {
+				if (!clientClosed && ws.readyState === 1) {
+					ws.close(1011, "Upstream error");
+				}
+			});
+		},
+		onMessage: (event) => {
+			const frame = String(event.data);
+			if (upstream?.readyState === 1) {
+				upstream.send(frame);
+			} else if (pending.length < MAX_PENDING_FRAMES) {
+				pending.push(frame);
+			}
+		},
+		onClose: () => {
+			clientClosed = true;
+			try {
+				upstream?.close();
+			} catch {
+				// already closed
+			}
+		},
+		onError: () => {
+			clientClosed = true;
+			try {
+				upstream?.close();
+			} catch {
+				// already closed
+			}
+		},
+	};
+}


### PR DESCRIPTION
## Problem

Terminal panes on a remote host show a permanent **"disconnected"** whenever the host runs in a **different Fly region than the client** — e.g. a **Vercel Sandbox** host (us-east / `iad`) with a desktop in the west (`sjc`). The relay fleet is one machine per region (sjc, iad, fra, nrt, sin, gru), so cross-region is the normal case.

Diagnosis (reproduced against a live Vercel-sandbox host):
- `_whoowns` → `{ok:true, region:"iad"}`, `terminal.createSession` (HTTP) → **200**, a terminal is really created on the host.
- The terminal/events **WebSocket** upgrade → **502** from Fly (`fly-request-id …-sjc`).

Root cause: the relay routes cross-node traffic with **Fly-Replay**, which is transparent for HTTP but **cannot route a WebSocket upgrade** — the replay header rides on a response that only arrives *after* the handshake, so the client sees a non-101 and fails (1006/502). The `_whoowns` affinity preflight sets no real Fly stickiness cookie, so the WS lands on the wrong region and 502s. The CLI works because it talks to the daemon over the local socket, bypassing the relay.

## Fix

When a WS upgrade lands on a relay node that doesn't own the host's tunnel, **bridge it to the owning node over Fly's private 6PN network** (`<machine>.vm.<app>.internal`) instead of fly-replaying:

- `auth` middleware: WS upgrades never fly-replay; if another instance owns the tunnel it hands the WS handler the owner (JWT is verified here; the **owning** node still runs `checkHostAccess`).
- WS handler: opens a `ws://…​.internal` connection to the owner and pipes frames both ways, preserving text (client→host JSON) vs binary (host→client PTY bytes) framing.
- `_rlp=1` loop guard: a proxy hop that lands on a non-owner (stale directory) fails instead of re-proxying.
- Bind the server **dual-stack (`::`)** so peers are reachable over IPv6 6PN; add `FLY_APP_NAME` for the internal address.

Same-instance connections (the common same-region case) are unchanged — the proxy only engages when `hasTunnel` is false.

## Verification

- Typecheck + biome clean.
- **Not yet runtime-verified** — needs a deploy to the multi-region fleet. Best test bed: the Vercel-sandbox host in `iad` + desktop in `sjc` that currently reproduces the 502. Plan to confirm the terminal WS returns **101** and the pane connects post-deploy.

## Risk / rollout notes

- The `::` bind is the one change to watch: Fly health checks + public traffic must stay green (dual-stack accepts IPv4-mapped on Linux, V6ONLY=0). Recommend deploying one machine and watching `/health` before fleet rollout.
- No client/desktop change required; the `_whoowns` preflight becomes redundant but harmless.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5542">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-region terminal disconnects by proxying terminal/events WebSockets to the owning relay instance over Fly’s 6PN network. This restores proper 101 upgrades and stable terminals when host and client run in different regions.

- **Bug Fixes**
  - Route WS upgrades to the owning relay over 6PN using `ws://<machine>.vm.<app>.internal` instead of replaying.
  - Bridge frames both ways, preserving text/binary framing and using safe close codes.
  - Add `_rlp=1` hop guard to prevent loops when ownership is stale.
  - Bind server to `::` for IPv6/6PN and add `FLY_APP_NAME` to build internal addresses.

- **Refactors**
  - Extracted WS proxy bridge into `proxy.ts` with local integration tests in `proxy.test.ts` covering framing, pending-buffer flush, and close-code propagation.

<sup>Written for commit 64517972cd0c0da33b2798c78be50355d89b9795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-instance WebSocket bridging for tunnel hosts owned by other relay instances.
  * Introduced a new environment setting to identify the relay app name for internal routing.

* **Bug Fixes**
  * Improved WebSocket upgrade handling by using directory-based ownership to route requests to the correct relay instance.
  * Prevented failed upgrades by returning a clear “Host not connected” response when no eligible proxy path exists.

* **Tests**
  * Added coverage for proxy URL construction, safe close-code handling, and bidirectional WebSocket bridging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->