### PR TITLE
feat(dev): run a real redis behind an HTTP shim so the relay works locally

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -132,11 +132,16 @@ STRIPE_PRO_YEARLY_PRICE_ID=price_fake_pro_yearly
 STRIPE_ENTERPRISE_YEARLY_PRICE_ID=price_fake_enterprise_yearly
 
 # -----------------------------------------------------------------------------
-# Upstash Redis & QStash (fake for local dev)
+# Upstash Redis (local: real redis behind the SRH HTTP shim) & QStash (fake)
+#
+# The relay stores its host directory here, so these must point at something
+# real or `bun run dev:relay` cannot register a host. setup.local.sh overwrites
+# these with per-workspace allocated ports; the defaults below match
+# docker-compose.yml for anyone running compose directly.
 # -----------------------------------------------------------------------------
-KV_REST_API_URL=https://fake-kv.example.com
-KV_REST_API_TOKEN=fake-kv-token
-KV_URL=rediss://default:fake-kv-token@fake-kv.example.com:6379
+KV_REST_API_URL=http://localhost:8079
+KV_REST_API_TOKEN=local_dev_token
+KV_URL=redis://localhost:6379
 QSTASH_TOKEN=fake-qstash-token
 QSTASH_URL=https://fake-qstash.example.com
 QSTASH_CURRENT_SIGNING_KEY=sig_fake_current

--- a/.superset/setup.local.sh
+++ b/.superset/setup.local.sh
@@ -2,8 +2,9 @@
 # Local-development setup. Provisions a fully self-contained, PER-WORKSPACE
 # Superset stack backed by a local Postgres container + fake credentials — no
 # Neon account, no real third-party keys. Mirrors setup.sh, but replaces the
-# Neon branch with a docker-compose bundle (Postgres + neon-proxy + Electric)
-# on per-workspace allocated ports so multiple worktrees never collide.
+# Neon branch with a docker-compose bundle (Postgres + neon-proxy + Electric +
+# Redis/SRH) on per-workspace allocated ports so multiple worktrees never
+# collide.
 set -uo pipefail
 
 SUPERSET_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,12 +18,16 @@ source "$SUPERSET_SCRIPT_DIR/lib/setup/steps.sh" # reuse allocate_port_base + he
 cd "$ROOT_DIR" || exit 1
 
 ELECTRIC_SECRET_VALUE="local_electric_dev_secret"
+# Must match SRH_TOKEN in docker-compose.yml.
+LOCAL_KV_TOKEN_VALUE="local_dev_token"
 
 # Set by local_allocate_ports; consumed by docker compose + .env writing.
 LOCAL_DB_PROJECT=""
 LOCAL_PG_PORT=""
 LOCAL_NEON_PROXY_PORT=""
 LOCAL_ELECTRIC_PORT=""
+LOCAL_REDIS_PORT=""
+LOCAL_SRH_PORT=""
 
 sanitize_name() {
   echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-48
@@ -71,13 +76,16 @@ local_allocate_ports() {
   LOCAL_PG_PORT=$((base + 14))
   LOCAL_NEON_PROXY_PORT=$((base + 15))
   LOCAL_ELECTRIC_PORT=$((base + 9))
+  LOCAL_REDIS_PORT=$((base + 16))
+  LOCAL_SRH_PORT=$((base + 17))
   export LOCAL_PG_PORT LOCAL_NEON_PROXY_PORT LOCAL_ELECTRIC_PORT
+  export LOCAL_REDIS_PORT LOCAL_SRH_PORT
   # Export so migrate/seed (child bun processes) use these — an inherited env
   # var beats the .env file, so this overrides any stale DATABASE_URL.
   export DATABASE_URL="postgres://postgres:postgres@db.localtest.me:$LOCAL_NEON_PROXY_PORT/main"
   export DATABASE_URL_UNPOOLED="postgres://postgres:postgres@localhost:$LOCAL_PG_PORT/main"
   LOCAL_DB_PROJECT="superset-$(sanitize_name "${SUPERSET_WORKSPACE_NAME:-$(basename "$PWD")}")"
-  success "Base $base → pg=$LOCAL_PG_PORT proxy=$LOCAL_NEON_PROXY_PORT electric=$LOCAL_ELECTRIC_PORT (project $LOCAL_DB_PROJECT)"
+  success "Base $base → pg=$LOCAL_PG_PORT proxy=$LOCAL_NEON_PROXY_PORT electric=$LOCAL_ELECTRIC_PORT redis=$LOCAL_REDIS_PORT srh=$LOCAL_SRH_PORT (project $LOCAL_DB_PROJECT)"
   return 0
 }
 
@@ -127,7 +135,27 @@ local_db_up() {
     return 1
   fi
 
-  success "DB stack ready (pg :$LOCAL_PG_PORT, proxy :$LOCAL_NEON_PROXY_PORT, electric :$LOCAL_ELECTRIC_PORT)"
+  # Same story for SRH: redis being healthy doesn't mean the HTTP shim is
+  # serving yet. Probe a real command. The Content-Type header is required —
+  # SRH rejects the request without it.
+  echo "  Waiting for serverless-redis-http to serve commands on :$LOCAL_SRH_PORT..."
+  local k srh_ready=0
+  for k in $(seq 1 30); do
+    if curl -s --max-time 3 -X POST "http://localhost:$LOCAL_SRH_PORT/" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $LOCAL_KV_TOKEN_VALUE" \
+        -d '["PING"]' 2>/dev/null | grep -q 'PONG'; then
+      srh_ready=1
+      break
+    fi
+    sleep 1
+  done
+  if [ "$srh_ready" -ne 1 ]; then
+    error "serverless-redis-http did not become ready within 30s"
+    return 1
+  fi
+
+  success "DB stack ready (pg :$LOCAL_PG_PORT, proxy :$LOCAL_NEON_PROXY_PORT, electric :$LOCAL_ELECTRIC_PORT, redis :$LOCAL_REDIS_PORT, srh :$LOCAL_SRH_PORT)"
   return 0
 }
 
@@ -184,8 +212,15 @@ local_write_env() {
     write_env_var "LOCAL_PG_PORT" "$LOCAL_PG_PORT"
     write_env_var "LOCAL_NEON_PROXY_PORT" "$LOCAL_NEON_PROXY_PORT"
     write_env_var "LOCAL_ELECTRIC_PORT" "$LOCAL_ELECTRIC_PORT"
+    write_env_var "LOCAL_REDIS_PORT" "$LOCAL_REDIS_PORT"
+    write_env_var "LOCAL_SRH_PORT" "$LOCAL_SRH_PORT"
     write_env_var "DATABASE_URL" "$DATABASE_URL"
     write_env_var "DATABASE_URL_UNPOOLED" "$DATABASE_URL_UNPOOLED"
+    echo ""
+    echo "# Relay host directory: real redis behind the SRH HTTP shim"
+    write_env_var "KV_REST_API_URL" "http://localhost:$LOCAL_SRH_PORT"
+    write_env_var "KV_REST_API_TOKEN" "$LOCAL_KV_TOKEN_VALUE"
+    write_env_var "KV_URL" "redis://localhost:$LOCAL_REDIS_PORT"
     echo ""
     echo "# Workspace ports"
     write_env_var "WEB_PORT" "$WEB_PORT"
@@ -267,7 +302,9 @@ DEVVARS
     { "port": $CADDY_ELECTRIC_PORT, "label": "Caddy Electric" },
     { "port": $WRANGLER_PORT, "label": "Electric Proxy (Wrangler)" },
     { "port": $LOCAL_PG_PORT, "label": "Postgres" },
-    { "port": $LOCAL_NEON_PROXY_PORT, "label": "Neon Proxy" }
+    { "port": $LOCAL_NEON_PROXY_PORT, "label": "Neon Proxy" },
+    { "port": $LOCAL_REDIS_PORT, "label": "Redis" },
+    { "port": $LOCAL_SRH_PORT, "label": "Redis HTTP (SRH)" }
   ]
 }
 PORTSJSON

--- a/.superset/teardown.local.sh
+++ b/.superset/teardown.local.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Local-development teardown. Removes this workspace's DB bundle (Postgres +
-# neon-proxy + Electric) and its volume. App servers (web/api/desktop/etc.)
-# are stopped by Ctrl+C on `bun dev`; this only tears down the docker stack.
+# neon-proxy + Electric + Redis/SRH) and its volume. App servers
+# (web/api/desktop/etc.) are stopped by Ctrl+C on `bun dev`; this only tears
+# down the docker stack.
 set -uo pipefail
 
 SUPERSET_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ That's it. **You do not need a Neon account, Stripe keys, or any other third-par
 
 1. Copies `.env.local.example` → `.env`
 2. Allocates a per-workspace port range so multiple worktrees don't collide
-3. Brings up Postgres + neon-proxy + Electric via `docker compose` (project-scoped to this worktree)
+3. Brings up Postgres + neon-proxy + Electric + Redis (behind an HTTP shim, for the relay) via `docker compose` (project-scoped to this worktree)
 4. Runs `bun install` and `bun run db:migrate`
 5. Seeds a `Local Admin` dev account via `bun run db:seed-dev`
 6. Writes a gitignored `.superset/config.local.json` overlay so subsequent worktrees automatically use this setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,5 +44,32 @@ services:
       postgres:
         condition: service_healthy
 
+  # Backs the relay's host directory (apps/relay/src/directory.ts). No volume:
+  # the directory is TTL-scoped presence data and is meant to be lost on restart.
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${LOCAL_REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # @upstash/redis speaks Upstash's HTTP REST protocol, not the Redis wire
+  # protocol, so a plain redis-server cannot answer it. SRH is the HTTP shim in
+  # front — the same role neon-proxy plays for Postgres above. Local dev only.
+  serverless-redis-http:
+    image: hiett/serverless-redis-http:latest
+    environment:
+      SRH_MODE: env
+      SRH_TOKEN: local_dev_token
+      SRH_CONNECTION_STRING: "redis://redis:6379"
+    ports:
+      - "${LOCAL_SRH_PORT:-8079}:80"
+    depends_on:
+      redis:
+        condition: service_healthy
+
 volumes:
   superset_db_data:

--- a/plans/local-redis-srh-for-relay.md
+++ b/plans/local-redis-srh-for-relay.md
@@ -1,0 +1,158 @@
+# Run the relay locally against a real Redis
+
+## Problem
+
+`apps/relay` cannot run locally today. It hard-requires `KV_REST_API_URL` + `KV_REST_API_TOKEN` (`apps/relay/src/env.ts:8-9`) and reaches Redis through `@upstash/redis` (`apps/relay/src/directory.ts:1-13`), but `.env.local.example:129-131` ships placeholders that can never answer a request:
+
+```
+# Upstash Redis & QStash (fake for local dev)
+KV_REST_API_URL=https://fake-kv.example.com
+KV_REST_API_TOKEN=fake-kv-token
+KV_URL=rediss://default:fake-kv-token@fake-kv.example.com:6379
+```
+
+The file contradicts itself twenty lines later — `RELAY_URL=http://localhost:4734` assumes you *are* running the relay locally. Anyone who tries hits a dead KV and reaches for a workaround (an in-memory directory branch keyed on `FLY_MACHINE_ID === "local"` was written and then reverted for exactly this reason). The fix belongs in the local stack, not in relay's production code path.
+
+## Why not just run `redis-server`
+
+`@upstash/redis` speaks Upstash's **HTTP REST** protocol, not the Redis wire protocol. A plain `redis:7` on `:6379` will not answer it. You need an HTTP shim in front.
+
+## Solution: SRH
+
+[`hiett/serverless-redis-http`](https://github.com/hiett/serverless-redis-http) (SRH) is an HTTP→Redis proxy that is wire-compatible with Upstash's REST API. Upstash [documents it in their own SDK docs](https://upstash.com/docs/redis/sdks/ts/developing) for local development and testing: *"We are working with Scott together to keep SRH up to date with the latest Upstash features."*
+
+Due diligence, as of 2026-07-08:
+
+| | |
+|:--|:--|
+| License | MIT |
+| Stars | 247 |
+| Last commit | 2026-01-06 |
+| Last tagged release | `0.0.10`, May 2024 — so `:latest` is doing real work |
+| Maintainers | effectively one (Scott Hiett), with Upstash collaboration |
+
+Small, single-maintainer, and stale on tags. Acceptable for a **local-dev-only** container; it must never appear in a production path. It is also directly analogous to something we already depend on: `neon-proxy` (`ghcr.io/timowilhelm/local-neon-http-proxy`) is an HTTP shim in front of real Postgres, in this same compose file, for this same reason.
+
+### Verified, not assumed
+
+Ran the relay's **actual** `apps/relay/src/directory.ts` against SRH (not a toy `PING`). Every function, including the Lua `EVAL` scripts:
+
+```
+after register:  { region: "iad", machineId: "m1" }
+after heartbeat: { region: "iad", machineId: "m1" }
+sweepStale:      0
+cleared:         1
+after clear:     null
+```
+
+`register` / `lookup` / `heartbeat` / `sweepStale` / `clearStaleEntriesForMachine` all behave correctly. No relay code change is needed.
+
+## Changes
+
+Four files. Ports are allocated per-worktree, matching how `postgres` / `neon-proxy` / `electric` already work, so two worktrees can run relays at once without colliding on `:6379` / `:8079`.
+
+### 1. `docker-compose.yml`
+
+Add two services beside the existing three. No volume — the tunnel directory is ephemeral (TTL-scoped) and `teardown.local.sh` runs `down -v` anyway.
+
+```yaml
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${LOCAL_REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  serverless-redis-http:
+    # HTTP shim so @upstash/redis can talk to the local Redis: the SDK speaks
+    # Upstash's REST protocol, not the Redis wire protocol. Same role neon-proxy
+    # plays for Postgres. Local dev only.
+    image: hiett/serverless-redis-http:latest
+    environment:
+      SRH_MODE: env
+      SRH_TOKEN: local_dev_token
+      SRH_CONNECTION_STRING: "redis://redis:6379"
+    ports:
+      - "${LOCAL_SRH_PORT:-8079}:80"
+    depends_on:
+      redis:
+        condition: service_healthy
+```
+
+### 2. `.superset/setup.local.sh`
+
+The `+16` / `+17` slots are free (apps use `+0..+13`, pg `+14`, neon-proxy `+15`, electric reuses `+9`; the window is 20 wide).
+
+- Declare `LOCAL_REDIS_PORT` / `LOCAL_SRH_PORT` beside the existing `LOCAL_*_PORT` vars (~line 23-25).
+- In `local_allocate_ports` (~line 71): `LOCAL_REDIS_PORT=$((base + 16))`, `LOCAL_SRH_PORT=$((base + 17))`, add both to the `export` line and the `success` message.
+- Add an SRH readiness wait mirroring the existing neon-proxy `curl` loop (~line 113):
+  ```bash
+  curl -s --max-time 3 -X POST "http://localhost:$LOCAL_SRH_PORT/" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer local_dev_token" \
+    -d '["PING"]' | grep -q PONG
+  ```
+  Note the `Content-Type: application/json` header — SRH returns `{"error":"Invalid content type..."}` without it.
+- In `local_write_env` (~line 184): write `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `KV_URL`. These are **not** written today; they only come from the `.env.local.example` copy, which is why the port must be written here to stay consistent per worktree.
+
+### 2b. `EXPO_PUBLIC_RELAY_URL` is never provisioned — separate, and more urgent
+
+Independent of Redis. `apps/mobile/lib/env.ts:9` now requires `EXPO_PUBLIC_RELAY_URL` (`z.url()`, so a missing value throws at module load), and `host-client.ts:28` builds `${EXPO_PUBLIC_RELAY_URL}/hosts/<key>/trpc` from it. **Nothing anywhere sets it.** Greppable proof: the only hits in the whole repo are those two mobile files.
+
+`apps/mobile/app.config.ts:7` loads the **root `.env`**, and `apps/mobile/eas.json` declares no `env` block. So both paths are broken:
+
+- **Local** — `.superset/lib/setup/steps.sh` already allocates `RELAY_PORT=$((BASE + 13))` (`:507`) and writes `RELAY_URL` (`:537`) and `NEXT_PUBLIC_RELAY_URL` (`:534`, and again at `:538` — a harmless duplicate worth deleting). It writes `EXPO_PUBLIC_API_URL` (`:536`) but not the relay equivalent. Add beside it:
+  ```bash
+  write_env_var "EXPO_PUBLIC_RELAY_URL" "http://localhost:$RELAY_PORT"
+  ```
+  Same one-liner in `.superset/setup.local.sh` (`RELAY_PORT` at `:174`, writes at `:214-215`).
+- **Production** — no repo file supplies it, so it has to be an EAS-hosted env var. Until it exists, a production/preview build of the mobile app **crashes at startup** on the `z.url()` parse. This must land before the mobile app ships with a required relay URL.
+
+So `steps.sh` *does* need touching — for `EXPO_PUBLIC_RELAY_URL`, not for Redis. It never starts compose and never writes `KV_REST_API_*`, so the Redis changes stay confined to `setup.local.sh`.
+
+### 3. `.env.local.example`
+
+Replace the fake block (lines 128-131). Defaults match the compose defaults for anyone running compose directly without `setup.local.sh`:
+
+```
+# -----------------------------------------------------------------------------
+# Upstash Redis (local: real redis behind the SRH HTTP shim) & QStash (fake)
+# -----------------------------------------------------------------------------
+KV_REST_API_URL=http://localhost:8079
+KV_REST_API_TOKEN=local_dev_token
+KV_URL=redis://localhost:6379
+```
+
+`QSTASH_*` stays fake — nothing local exercises it.
+
+### 4. `DEVELOPMENT.md`
+
+Item 3 of "What `setup.local.sh` does" currently reads:
+
+> 3. Brings up Postgres + neon-proxy + Electric via `docker compose` (project-scoped to this worktree)
+
+Add Redis + SRH. `## Prerequisites` needs no change (Docker is already listed).
+
+## Not changing
+
+- **`turbo.jsonc`** — `KV_REST_API_URL` / `KV_REST_API_TOKEN` are already in `globalEnv` (lines 19-20). Note `EXPO_PUBLIC_RELAY_URL` is *not* there; check whether Expo vars are expected in `globalEnv` before adding (no `EXPO_PUBLIC_*` currently is).
+- **`apps/relay/src/index.ts`** — already serves `app.all("/hosts/:hostId/trpc/*")` (`:277`) behind `authMiddleware` (`:275`), which is exactly the route mobile calls. The deployed relay needs no change for mobile chat.
+- **Root `package.json`** — relay is deliberately not in the default `dev` script (only `dev:relay` / `dev:all`). Starting Redis in compose does not imply starting the relay.
+- **`AGENTS.md` / `CONTRIBUTING.md` / `README.md`** — none document local services or env vars; all defer to `DEVELOPMENT.md`.
+- **`apps/docs/content/docs/setup-teardown-scripts.mdx`** — describes *user-configurable* per-workspace setup scripts, not our compose stack. Its `docker-compose down` lines are example JSON config.
+- **`apps/relay/src/directory.ts`** — no code change. This whole plan exists so the code stays honest about its one storage backend.
+
+## Verification
+
+1. `./.superset/teardown.local.sh && ./.superset/setup.local.sh` — stack comes up, SRH readiness wait passes.
+2. `.env` contains `KV_REST_API_URL=http://localhost:<base+17>`.
+3. `bun run dev:relay` boots without env-validation failure.
+4. Register a host and confirm `lookup` returns it — the mobile chat E2E over the relay is the end-to-end check.
+5. Two worktrees can run `setup.local.sh` and `dev:relay` concurrently without port collision.
+
+## Risk
+
+SRH's `:latest` tag is unpinned and the project is small. If it breaks, pin a digest. Nothing in production depends on it: `FLY_MACHINE_ID` and the real Upstash KV govern deployed relays, and this touches neither.


### PR DESCRIPTION
## Problem

`apps/relay` cannot run locally. It reaches Redis through `@upstash/redis` (`apps/relay/src/directory.ts`) and hard-requires `KV_REST_API_URL` + `KV_REST_API_TOKEN` (`apps/relay/src/env.ts:8-9`), but `.env.local.example` shipped placeholders that can never answer a request:

```
KV_REST_API_URL=https://fake-kv.example.com
KV_REST_API_TOKEN=fake-kv-token
```

That hostname does not resolve (`curl` exits 6). The file also contradicts itself twenty lines later — `RELAY_URL=http://localhost:4734` assumes you *are* running the relay locally.

**The user-visible symptom is that hosts are permanently offline.** `v2_hosts.is_online` is written by exactly one place: the relay, at `apps/relay/src/tunnel.ts:303`, when a host tunnel connects. With a dead KV, `register()` throws, the tunnel never completes, `setOnline()` never fires, and the column stays `false` — so desktop/mobile render the host as offline forever. It reads like a sync or auth bug and is really a dead Redis.

## Why not just run `redis-server`

`@upstash/redis` speaks Upstash's **HTTP REST** protocol, not the Redis wire protocol. A plain `redis:7` on `:6379` cannot answer it; you need an HTTP shim in front.

## Approach

Add [`hiett/serverless-redis-http`](https://github.com/hiett/serverless-redis-http) (SRH), an HTTP→Redis proxy wire-compatible with Upstash's REST API. Upstash [documents it in their own SDK docs](https://upstash.com/docs/redis/sdks/ts/developing) for local development: *"We are working with Scott together to keep SRH up to date with the latest Upstash features."*

This is directly analogous to something the repo already depends on: `neon-proxy` (`ghcr.io/timowilhelm/local-neon-http-proxy`) is an HTTP shim in front of real Postgres, in this same compose file, for this same reason.

Due diligence: MIT, ~247 stars, last commit 2026-01-06, not archived. Last *tagged* release is `0.0.10` (May 2024), effectively one maintainer — acceptable for a **local-dev-only** container, and it never appears in a production path.

## Verified, not assumed

Ran the relay's **actual** `directory.ts` against SRH — not a toy `PING`. Every function, including the Lua `EVAL` scripts:

```
after register:  { region: "iad", machineId: "m1" }
after heartbeat: { region: "iad", machineId: "m1" }
sweepStale:      0
cleared:         1
after clear:     null
```

`register` / `lookup` / `heartbeat` / `sweepStale` / `clearStaleEntriesForMachine` all behave correctly. **No relay code change is needed.**

Also brought the two new services up from this exact compose file under an isolated project and confirmed `{"result":"PONG"}`, then tore it down.

## Changes

- **`docker-compose.yml`** — add `redis` (healthchecked) + `serverless-redis-http` (`depends_on: service_healthy`). No volume: the directory is TTL-scoped presence data, meant to be lost on restart.
- **`.superset/setup.local.sh`** — allocate `LOCAL_REDIS_PORT=base+16` / `LOCAL_SRH_PORT=base+17` (the `+16`/`+17` slots were free in the 20-port window), add an SRH readiness probe mirroring the existing neon-proxy `curl` loop, write `KV_REST_API_URL` / `KV_REST_API_TOKEN` / `KV_URL` into `.env`, and list both ports in `ports.json`.
- **`.env.local.example`** — replace the fake block with working local values matching the compose defaults.
- **`.superset/teardown.local.sh`** — comment only; `down -v` on the project already removes the new services.
- **`DEVELOPMENT.md`** — mention Redis in the service list.
- **`plans/local-redis-srh-for-relay.md`** — the write-up, incl. a separate finding (below).

Ports are per-worktree like the rest of the stack, so two worktrees can run relays concurrently without colliding on `:6379`/`:8079`.

## Not changed

- `turbo.jsonc` already lists `KV_REST_API_URL` / `KV_REST_API_TOKEN` in `globalEnv`.
- Root `package.json` — the relay is deliberately not in the default `dev` script (`dev:relay` / `dev:all` only). Starting Redis does not imply starting the relay.
- `.superset/lib/setup/steps.sh` — despite a near-duplicate `RELAY_PORT` block, it never starts compose and never writes `KV_REST_API_*`.
- `apps/relay/**` — no production code touched.

## Separate finding (not fixed here)

`EXPO_PUBLIC_RELAY_URL` is read by `apps/mobile` but **provisioned by nothing in this repo** — no setup script, no `.env*.example`, and `apps/mobile/eas.json` declares no `env` block (`app.config.ts` loads the root `.env`). Anything that makes it a required var will crash mobile at startup. Documented in the plan file; belongs in a mobile-side PR.

## Test plan

- [x] `bash -n .superset/setup.local.sh`
- [x] `docker compose config` resolves both new services, with and without allocated ports
- [x] `redis` + `serverless-redis-http` come up from this compose file and answer `PING`
- [x] Relay's real `directory.ts` exercised against SRH (all Lua scripts pass)
- [x] `bun run lint` exits 0
- [ ] Full `./.superset/teardown.local.sh && ./.superset/setup.local.sh` on a clean worktree
- [ ] `bun run dev:relay` boots, a host tunnel registers, and `v2_hosts.is_online` flips to `t`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5543">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs a real Redis behind `serverless-redis-http` so `apps/relay` works locally and hosts no longer appear permanently offline due to a dead KV.

- New Features
  - Add `redis` and `serverless-redis-http` services to `docker-compose.yml` (Upstash REST-compatible, health-checked).
  - Update `.superset/setup.local.sh` to allocate per-worktree ports (+16/+17), wait for SRH readiness, and write `KV_REST_API_URL`, `KV_REST_API_TOKEN`, and `KV_URL` into `.env` and `ports.json`.
  - Replace fake KV values in `.env.local.example` with working local defaults.
  - Note Redis/SRH in `DEVELOPMENT.md`. Local-dev only; no production code changes.

- Migration
  - Run `./.superset/teardown.local.sh && ./.superset/setup.local.sh`.
  - Start the relay (`bun run dev:relay`) and verify a host registers.

<sup>Written for commit ba7e0e3b1b8ba2760648fb8af3cb56ee165a00a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local development now includes Redis with an HTTP-compatible shim, so the app can use a real local KV backend instead of fake placeholders.
  * Per-worktree port allocation now covers the new Redis services to support multiple local checkouts.

* **Bug Fixes**
  * Updated local environment defaults and startup checks so the KV connection settings are ready to use after setup.

* **Documentation**
  * Clarified setup and teardown notes to reflect the expanded local stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->