### PR TITLE
feat(relay): add syd (Sydney) region to relay fleet

### DIFF
--- a/apps/relay/fly.toml
+++ b/apps/relay/fly.toml
@@ -1,7 +1,7 @@
 # Region topology is NOT in this file — fly.toml has no per-region count syntax.
 # The fleet shape is asserted by `apps/relay/scripts/deploy.sh`, which runs
-# `fly scale count` after `fly deploy`. Current target: 6 machines, 1 per region:
-#   sjc (primary), iad, fra, nrt, sin, gru.
+# `fly scale count` after `fly deploy`. Current target: 7 machines, 1 per region:
+#   sjc (primary), iad, fra, nrt, sin, syd, gru.
 # Update the REGIONS array in scripts/deploy.sh to change the topology.
 
 app = "superset-relay"

--- a/apps/relay/scripts/deploy.sh
+++ b/apps/relay/scripts/deploy.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 APP=superset-relay
-REGIONS=(sjc iad fra nrt sin gru)
+REGIONS=(sjc iad fra nrt sin syd gru)
 COUNT=${#REGIONS[@]}
 REGION_LIST=$(IFS=, ; echo "${REGIONS[*]}")
 


### PR DESCRIPTION
## What

Adds Fly's Sydney region (`syd`) to the relay fleet, bringing it to **7 machines, 1 per region**: `sjc` (primary), `iad`, `fra`, `nrt`, `sin`, `syd`, `gru`.

## Why

The relay fleet is driven entirely by the `REGIONS` array in `apps/relay/scripts/deploy.sh` — the relay reads `FLY_REGION` dynamically and fly-replay routes by region string, so there's no client-side allowlist to touch.

Australian users previously had no closer relay than `sin`/`nrt`. When their remote host lands in a Sydney-adjacent Fly region, the region mismatch surfaces as a relay 502 on WebSocket upgrades (fly-replay isn't transparent for WS upgrades). A `syd` machine gives AU traffic a local relay and closes that gap.

## Changes

- `apps/relay/scripts/deploy.sh` — add `syd` to `REGIONS` (6 → 7)
- `apps/relay/fly.toml` — update topology comment

## Rollout

Run `apps/relay/scripts/deploy.sh`: the `fly scale count "app=7" --region ... --max-per-region 1` step provisions the Sydney machine, followed by the rolling deploy and smoke test (which now covers `syd`).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `syd` (Sydney) to the relay fleet, bringing it to 7 regions with 1 machine each. This gives AU users a local relay and reduces WebSocket 502s caused by region mismatches.

- **Migration**
  - Run `apps/relay/scripts/deploy.sh`; it scales to 7 regions (adds `syd`), deploys, and runs smoke tests.

<sup>Written for commit 8ab79f2d2b3240953d0bf2c6a580231d0402966b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded deployment coverage to an additional region.
  * Updated scaling settings so the service now starts with one more machine, improving regional availability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->