### PR TITLE
fix(desktop): keep v2 workspace creating state until create fully resolves

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -1,7 +1,7 @@
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
@@ -135,9 +135,6 @@ export function useDashboardSidebarData() {
 	const workspaceTransactionsById = useWorkspaceTransactionsStore(
 		(state) => state.byWorkspaceId,
 	);
-	const clearWorkspaceTransaction = useWorkspaceTransactionsStore(
-		(state) => state.clear,
-	);
 
 	const { data: hosts = [] } = useLiveQuery(
 		(q) =>
@@ -248,8 +245,6 @@ export function useDashboardSidebarData() {
 						taskId: workspace.taskId,
 						createdAt: workspace.createdAt,
 						updatedAt: workspace.updatedAt,
-						// Host-served rows are confirmed (replaces Electric $synced).
-						isSynced: workspace.source === "host",
 						tabOrder: localState.tabOrder,
 						sectionId: localState.sectionId,
 						isHidden: localState.isHidden,
@@ -292,8 +287,6 @@ export function useDashboardSidebarData() {
 					taskId: workspace.taskId,
 					createdAt: workspace.createdAt,
 					updatedAt: workspace.updatedAt,
-					// Host-served rows are confirmed (replaces Electric $synced).
-					isSynced: workspace.source === "host",
 					tabOrder: MAIN_WORKSPACE_TAB_ORDER,
 					sectionId: null as string | null,
 				})),
@@ -308,23 +301,6 @@ export function useDashboardSidebarData() {
 			})),
 		[hostsByMachineId, rawLocalMainWorkspaces, workspaceTransactionsById],
 	);
-
-	useEffect(() => {
-		for (const workspace of [
-			...rawSidebarWorkspaces,
-			...rawLocalMainWorkspaces,
-		]) {
-			const transaction = workspaceTransactionsById[workspace.id];
-			if (workspace.isSynced && transaction?.type === "insert") {
-				clearWorkspaceTransaction(workspace.id);
-			}
-		}
-	}, [
-		clearWorkspaceTransaction,
-		rawLocalMainWorkspaces,
-		rawSidebarWorkspaces,
-		workspaceTransactionsById,
-	]);
 
 	const visibleSidebarWorkspaces = useMemo(() => {
 		const sidebarProjectIds = new Set(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -31,9 +31,9 @@ function V2WorkspaceLayout() {
 	const pendingTransaction = useWorkspaceTransactionsStore((state) =>
 		workspaceId ? (state.byWorkspaceId[workspaceId] ?? null) : null,
 	);
-	const clearWorkspaceTransaction = useWorkspaceTransactionsStore(
-		(state) => state.clear,
-	);
+	// The create transaction clears when the workspaces.create mutation
+	// settles — not when the host-served row first arrives, which happens
+	// mid-create before agent/terminal panes are seeded.
 	const isCreatePending = pendingTransaction?.type === "insert";
 
 	const { workspaces: hostWorkspaces, isReady } = useHostWorkspaces();
@@ -53,13 +53,6 @@ function V2WorkspaceLayout() {
 		[collections, workspaceId],
 	);
 	const failedEntry = failedEntries?.[0] ?? null;
-
-	useEffect(() => {
-		// A host-served row is the create confirmation (replaces Electric $synced).
-		if (workspace?.source === "host" && pendingTransaction?.type === "insert") {
-			clearWorkspaceTransaction(workspace.id);
-		}
-	}, [clearWorkspaceTransaction, pendingTransaction, workspace]);
 
 	const lastEnsuredWorkspaceIdRef = useRef<string | null>(null);
 	useEffect(() => {

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -120,13 +120,6 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 				hostUrl,
 			).workspaces.create.mutate(args.snapshot);
 
-			trackWorkspaceTransaction(workspaceId, {
-				id: workspaceId,
-				state: "persisting",
-				createdAt: now,
-				mutations: [{ type: "insert" }],
-				isPersisted: { promise: createPromise },
-			});
 			writeWorkspacePaneLayout(
 				collections,
 				{ id: workspaceId, projectId: args.snapshot.projectId },
@@ -160,6 +153,19 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 					recordFailure(message);
 					return { ok: false, error: message };
 				});
+
+			// Track against `completed` (not the raw mutation promise) so the
+			// pending-create UI holds until the resolved pane layout — agent and
+			// terminal panes — has been written. The host broadcasts the workspace
+			// row mid-create, before agents/terminals launch, so clearing any
+			// earlier would drop the user into a briefly-empty workspace.
+			trackWorkspaceTransaction(workspaceId, {
+				id: workspaceId,
+				state: "persisting",
+				createdAt: now,
+				mutations: [{ type: "insert" }],
+				isPersisted: { promise: completed },
+			});
 
 			return { workspaceId, completed };
 		},


### PR DESCRIPTION
## Summary

Creating a v2 workspace dropped you into an empty workspace with no loading indication for a second or two before the agent/terminal panes appeared.

The host broadcasts the new workspace row mid-create — after worktree registration but before agents/terminals launch — and both the v2 workspace layout and the sidebar treated that row as the create confirmation, clearing the pending transaction early (an Electric-$synced-era leftover).

- Track the create transaction against the `completed` chain in `useWorkspaceCreates.submit()`, which settles only after `writeWorkspacePaneLayout` has folded the launched agent/terminal panes into the local pane layout (or a failure was recorded).
- Remove the clear-on-host-row effects in `v2-workspace/layout.tsx` and `useDashboardSidebarData`, plus the now-dead `isSynced` plumbing.

`WorkspaceCreatingState` and the sidebar spinner now hold until the workspace is actually ready; you land directly in a workspace with its panes present. No-agent/no-setup creates still transition to the normal empty state, and failed creates still show `WorkspaceCreateErrorState`. If a create response is lost in transit (rare relay drop), the creating screen's existing 30s "Reload window" hatch covers it.

## Test Plan

- [ ] Create a workspace with an agent prompt — creating screen persists until the chat pane exists; no empty-workspace flash
- [ ] Create a workspace with no agent/setup commands — transitions to the normal empty state
- [ ] Failing create (e.g. duplicate branch conflict) still shows the create error state with retry
- [x] `bun run lint`, desktop `tsc --noEmit`, sidebar + workspace-creates tests pass

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5545">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the empty flash when creating a v2 workspace by keeping the creating state until the create flow fully resolves and panes are seeded. Users now land directly in a ready workspace, and the sidebar spinner matches the actual state.

- **Bug Fixes**
  - Track the create transaction against the post-layout `completed` promise so it clears only after `writeWorkspacePaneLayout` writes agent/terminal panes.
  - Remove early clear-on-host-row logic in `v2-workspace/layout.tsx` and `useDashboardSidebarData`; drop the unused `isSynced`.
  - No-agent creates still transition to the normal empty state; failures still show the create error state.

<sup>Written for commit c917916e542b2a8d762d927d5a4388f4a41d1cf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace creation state handling so pending workspaces stay visible until setup is fully complete.
  * Prevented workspaces from appearing as synced too early, reducing cases where sidebar or dashboard state could clear before layout is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->