### PR TITLE
feat(desktop): surface why a terminal can't connect + emit failure telemetry

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -76,8 +76,7 @@ export interface TerminalTransport {
 	 * a parse/render cycle each and overwhelm the renderer (#2241, #2244).
 	 */
 	_writeCoalescer: WriteCoalescer | null;
-	/** Internal: most recent relay `_whoowns` preflight result, used to explain
-	 * a failed connection (see `classifyTerminalFailure`). */
+	/** Internal: last `_whoowns` probe, used to explain a failed connection. */
 	_lastProbe: RelayAffinityProbe | null;
 }
 
@@ -317,9 +316,7 @@ function formatWsEndpoint(wsUrl: string | null): string {
 	}
 }
 
-// Relay-routed terminals live under `/hosts/<id>/...`; local/same-machine
-// terminals don't. Only the former go through the relay preflight and can be
-// classified with a probe status.
+// Relay-routed terminals live under `/hosts/<id>/...`; local ones don't.
 function isRelayHostUrl(wsUrl: string | null): boolean {
 	if (!wsUrl) return false;
 	try {
@@ -411,14 +408,9 @@ export function connect(
 		attachSocketListeners(transport, terminal, socket);
 	};
 
-	// Pre-flight an HTTP request to lock fly's edge affinity to the owning
-	// machine before the WS upgrade. fly-replay isn't transparent on the
-	// upgrade itself (browser sees 200 → 1006 close), but is on plain HTTP,
-	// so a quick GET avoids the connect → 1006 → reconnect flicker. Skip
-	// for non-/hosts URLs (tests, local dev) so connect stays synchronous.
-	// The probe result is also kept to explain a later failure (see close
-	// handler). Probe `wsUrl`, not `actualUrl`: the `_whoowns` endpoint has no
-	// use for the WS-only `replay` hint that `actualUrl` may carry.
+	// Pre-flight `_whoowns` to pin fly edge affinity before the WS upgrade (see
+	// primeRelayAffinity); skip for non-/hosts URLs. Probe `wsUrl`, not the
+	// `replay`-carrying `actualUrl`, and keep the result to explain a failure.
 	if (isRelayHostUrl(wsUrl)) {
 		transport._lastProbe = null;
 		void primeRelayAffinity(wsUrl).then((probe) => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,5 +1,10 @@
-import { primeRelayAffinity } from "@superset/workspace-client";
+import {
+	primeRelayAffinity,
+	type RelayAffinityProbe,
+} from "@superset/workspace-client";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { posthog } from "renderer/lib/posthog";
+import { classifyTerminalFailure } from "./terminalConnectionDiagnostics";
 import { createWriteCoalescer, type WriteCoalescer } from "./write-coalescer";
 
 export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
@@ -71,6 +76,13 @@ export interface TerminalTransport {
 	 * a parse/render cycle each and overwhelm the renderer (#2241, #2244).
 	 */
 	_writeCoalescer: WriteCoalescer | null;
+	/**
+	 * Internal: result of the most recent relay `_whoowns` preflight. The
+	 * WebSocket API hides the upgrade's HTTP status (a 502/503 surfaces only as
+	 * close code 1006), so this is the one client-visible signal for *why* a
+	 * failed connection failed. Used to classify the give-up message + telemetry.
+	 */
+	_lastProbe: RelayAffinityProbe | null;
 }
 
 const MAX_LOG_ENTRIES = 200;
@@ -171,6 +183,7 @@ export function createTransport(): TerminalTransport {
 		_lastLivenessTick: 0,
 		_resumeListener: null,
 		_writeCoalescer: null,
+		_lastProbe: null,
 	};
 }
 
@@ -308,6 +321,18 @@ function formatWsEndpoint(wsUrl: string | null): string {
 	}
 }
 
+// Relay-routed terminals live under `/hosts/<id>/...`; local/same-machine
+// terminals don't. Only the former go through the relay preflight and can be
+// classified with a probe status.
+function isRelayHostUrl(wsUrl: string | null): boolean {
+	if (!wsUrl) return false;
+	try {
+		return new URL(wsUrl).pathname.startsWith("/hosts/");
+	} catch {
+		return false;
+	}
+}
+
 function formatCloseDetails(event: CloseEvent): string {
 	const code = event.code || "unknown";
 	const reason = event.reason ? `, reason: ${event.reason}` : "";
@@ -395,14 +420,14 @@ export function connect(
 	// upgrade itself (browser sees 200 → 1006 close), but is on plain HTTP,
 	// so a quick GET avoids the connect → 1006 → reconnect flicker. Skip
 	// for non-/hosts URLs (tests, local dev) so connect stays synchronous.
-	let needsPreFlight = false;
-	try {
-		needsPreFlight = new URL(actualUrl).pathname.startsWith("/hosts/");
-	} catch {
-		needsPreFlight = false;
-	}
-	if (needsPreFlight) {
-		void primeRelayAffinity(actualUrl).then(openSocket);
+	// The probe result is also kept to explain a later failure (see close
+	// handler) since the WS API hides the upgrade's HTTP status.
+	if (isRelayHostUrl(actualUrl)) {
+		transport._lastProbe = null;
+		void primeRelayAffinity(actualUrl).then((probe) => {
+			transport._lastProbe = probe;
+			openSocket();
+		});
 	} else {
 		openSocket();
 	}
@@ -486,11 +511,36 @@ function attachSocketListeners(
 				!transport._reconnectTimer &&
 				Boolean(transport.currentUrl && transport._terminal) &&
 				transport._reconnectAttempt < MAX_RECONNECT_ATTEMPTS;
-			pushLog(
-				transport,
-				willReconnect ? "warn" : "error",
-				`WebSocket closed while connected to ${formatWsEndpoint(transport.currentUrl)} (${formatCloseDetails(event)}). ${willReconnect ? "Reconnecting..." : "Max reconnect attempts reached."}`,
-			);
+			const endpoint = formatWsEndpoint(transport.currentUrl);
+			if (willReconnect) {
+				pushLog(
+					transport,
+					"warn",
+					`WebSocket closed while connected to ${endpoint} (${formatCloseDetails(event)}). Reconnecting...`,
+				);
+			} else {
+				// Gave up. Classify *why* from the preflight probe (the WS close
+				// code alone can't tell host-offline from a relay routing failure)
+				// and record it so this failure mode is queryable, not silent.
+				const diagnosis = classifyTerminalFailure(
+					transport._lastProbe,
+					isRelayHostUrl(transport.currentUrl),
+				);
+				pushLog(
+					transport,
+					"error",
+					`WebSocket closed while connected to ${endpoint} (${formatCloseDetails(event)}). Max reconnect attempts reached. ${diagnosis.message}`,
+				);
+				posthog.capture("terminal_connect_failed", {
+					endpoint,
+					close_code: event.code,
+					close_reason: event.reason || undefined,
+					preflight_status: transport._lastProbe?.status ?? null,
+					tunnel_region: transport._lastProbe?.region ?? null,
+					reconnect_attempts: transport._reconnectAttempt,
+					category: diagnosis.category,
+				});
+			}
 		}
 		// Auto-reconnect on unexpected close (host-service restart, network blip)
 		scheduleReconnect(transport);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -76,12 +76,8 @@ export interface TerminalTransport {
 	 * a parse/render cycle each and overwhelm the renderer (#2241, #2244).
 	 */
 	_writeCoalescer: WriteCoalescer | null;
-	/**
-	 * Internal: result of the most recent relay `_whoowns` preflight. The
-	 * WebSocket API hides the upgrade's HTTP status (a 502/503 surfaces only as
-	 * close code 1006), so this is the one client-visible signal for *why* a
-	 * failed connection failed. Used to classify the give-up message + telemetry.
-	 */
+	/** Internal: most recent relay `_whoowns` preflight result, used to explain
+	 * a failed connection (see `classifyTerminalFailure`). */
 	_lastProbe: RelayAffinityProbe | null;
 }
 
@@ -420,8 +416,7 @@ export function connect(
 	// upgrade itself (browser sees 200 → 1006 close), but is on plain HTTP,
 	// so a quick GET avoids the connect → 1006 → reconnect flicker. Skip
 	// for non-/hosts URLs (tests, local dev) so connect stays synchronous.
-	// The probe result is also kept to explain a later failure (see close
-	// handler) since the WS API hides the upgrade's HTTP status.
+	// The probe result is also kept to explain a later failure (see close handler).
 	if (isRelayHostUrl(actualUrl)) {
 		transport._lastProbe = null;
 		void primeRelayAffinity(actualUrl).then((probe) => {
@@ -519,9 +514,8 @@ function attachSocketListeners(
 					`WebSocket closed while connected to ${endpoint} (${formatCloseDetails(event)}). Reconnecting...`,
 				);
 			} else {
-				// Gave up. Classify *why* from the preflight probe (the WS close
-				// code alone can't tell host-offline from a relay routing failure)
-				// and record it so this failure mode is queryable, not silent.
+				// Gave up. Classify why from the preflight probe and record it so
+				// this failure mode is queryable, not silent.
 				const diagnosis = classifyTerminalFailure(
 					transport._lastProbe,
 					isRelayHostUrl(transport.currentUrl),

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -416,10 +416,12 @@ export function connect(
 	// upgrade itself (browser sees 200 → 1006 close), but is on plain HTTP,
 	// so a quick GET avoids the connect → 1006 → reconnect flicker. Skip
 	// for non-/hosts URLs (tests, local dev) so connect stays synchronous.
-	// The probe result is also kept to explain a later failure (see close handler).
-	if (isRelayHostUrl(actualUrl)) {
+	// The probe result is also kept to explain a later failure (see close
+	// handler). Probe `wsUrl`, not `actualUrl`: the `_whoowns` endpoint has no
+	// use for the WS-only `replay` hint that `actualUrl` may carry.
+	if (isRelayHostUrl(wsUrl)) {
 		transport._lastProbe = null;
-		void primeRelayAffinity(actualUrl).then((probe) => {
+		void primeRelayAffinity(wsUrl).then((probe) => {
 			transport._lastProbe = probe;
 			openSocket();
 		});

--- a/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.test.ts
@@ -39,6 +39,14 @@ describe("classifyTerminalFailure", () => {
 		expect(result.message).toContain("iad");
 	});
 
+	it("treats a 502/504 gateway status as a temporary relay failure, not host-offline", () => {
+		for (const status of [502, 504]) {
+			const result = classifyTerminalFailure({ status, region: null }, true);
+			expect(result.category).toBe("stream-blocked");
+			expect(result.message).toContain("temporary");
+		}
+	});
+
 	it("falls back to unknown for unexpected statuses", () => {
 		expect(
 			classifyTerminalFailure({ status: 500, region: null }, true),

--- a/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { classifyTerminalFailure } from "./terminalConnectionDiagnostics";
+
+describe("classifyTerminalFailure", () => {
+	it("does not guess a cause for local (non-host) terminals", () => {
+		expect(
+			classifyTerminalFailure({ status: 200, region: "iad" }, false),
+		).toMatchObject({ category: "unknown" });
+	});
+
+	it("reports relay-unreachable when the preflight itself failed", () => {
+		expect(classifyTerminalFailure(null, true)).toMatchObject({
+			category: "relay-unreachable",
+		});
+	});
+
+	it("reports host-offline on 503", () => {
+		expect(
+			classifyTerminalFailure({ status: 503, region: null }, true),
+		).toMatchObject({ category: "host-offline" });
+	});
+
+	it("reports unauthorized on 401/403", () => {
+		expect(
+			classifyTerminalFailure({ status: 401, region: null }, true),
+		).toMatchObject({ category: "unauthorized" });
+		expect(
+			classifyTerminalFailure({ status: 403, region: null }, true),
+		).toMatchObject({ category: "unauthorized" });
+	});
+
+	it("reports stream-blocked when the host is present (200) but the WS still drops", () => {
+		const result = classifyTerminalFailure(
+			{ status: 200, region: "iad" },
+			true,
+		);
+		expect(result.category).toBe("stream-blocked");
+		// The region is surfaced so cross-region routing is obvious.
+		expect(result.message).toContain("iad");
+	});
+
+	it("falls back to unknown for unexpected statuses", () => {
+		expect(
+			classifyTerminalFailure({ status: 500, region: null }, true),
+		).toMatchObject({ category: "unknown" });
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.ts
@@ -14,14 +14,10 @@ export interface TerminalFailureClassification {
 }
 
 /**
- * Turn the `_whoowns` preflight result into a cause for a failed terminal WS.
- *
- * The browser WebSocket API never exposes the upgrade's HTTP status — a
- * relay 502/503 just surfaces as close code 1006 — so the preflight probe is
- * the only client-side signal for *why* the stream won't connect. The key
- * case is `stream-blocked`: the host tunnel is present (probe 200) yet the WS
- * still drops, which is the fingerprint of a relay routing problem (e.g. the
- * cross-region 6PN path) rather than an offline host.
+ * Turn the `_whoowns` preflight result (see `primeRelayAffinity`) into a cause
+ * for a failed terminal WS. The key case is `stream-blocked`: the host tunnel
+ * is present (probe 200) yet the WS still drops — the fingerprint of a relay
+ * routing problem (e.g. the cross-region 6PN path), not an offline host.
  */
 export function classifyTerminalFailure(
 	probe: RelayAffinityProbe | null,

--- a/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.ts
@@ -49,6 +49,15 @@ export function classifyTerminalFailure(
 			message: "You don't have access to this host.",
 		};
 	}
+	// Bad/absent gateway response: the relay couldn't reach the host right now.
+	// Usually transient (edge/routing), so don't assert the host is offline.
+	if (probe.status === 502 || probe.status === 504) {
+		return {
+			category: "stream-blocked",
+			message:
+				"The relay couldn't reach this host right now. This is usually temporary.",
+		};
+	}
 	if (probe.status === 200) {
 		const where = probe.region ? ` (region ${probe.region})` : "";
 		return {

--- a/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.ts
@@ -1,0 +1,67 @@
+import type { RelayAffinityProbe } from "@superset/workspace-client";
+
+export type TerminalFailureCategory =
+	| "relay-unreachable"
+	| "host-offline"
+	| "unauthorized"
+	| "stream-blocked"
+	| "unknown";
+
+export interface TerminalFailureClassification {
+	category: TerminalFailureCategory;
+	/** Short, user-facing reason for the terminal not connecting. */
+	message: string;
+}
+
+/**
+ * Turn the `_whoowns` preflight result into a cause for a failed terminal WS.
+ *
+ * The browser WebSocket API never exposes the upgrade's HTTP status — a
+ * relay 502/503 just surfaces as close code 1006 — so the preflight probe is
+ * the only client-side signal for *why* the stream won't connect. The key
+ * case is `stream-blocked`: the host tunnel is present (probe 200) yet the WS
+ * still drops, which is the fingerprint of a relay routing problem (e.g. the
+ * cross-region 6PN path) rather than an offline host.
+ */
+export function classifyTerminalFailure(
+	probe: RelayAffinityProbe | null,
+	isHostUrl: boolean,
+): TerminalFailureClassification {
+	// Local / same-machine terminals never hit the relay; don't guess a cause.
+	if (!isHostUrl) {
+		return {
+			category: "unknown",
+			message: "The terminal connection was lost.",
+		};
+	}
+	if (!probe) {
+		return {
+			category: "relay-unreachable",
+			message:
+				"Couldn't reach the relay service. Check your network connection.",
+		};
+	}
+	if (probe.status === 503) {
+		return {
+			category: "host-offline",
+			message: "This host is offline (not connected to the relay).",
+		};
+	}
+	if (probe.status === 401 || probe.status === 403) {
+		return {
+			category: "unauthorized",
+			message: "You don't have access to this host.",
+		};
+	}
+	if (probe.status === 200) {
+		const where = probe.region ? ` (region ${probe.region})` : "";
+		return {
+			category: "stream-blocked",
+			message: `The host is online${where} but the terminal stream couldn't connect. This is usually a relay routing issue, not the host.`,
+		};
+	}
+	return {
+		category: "unknown",
+		message: `The terminal connection failed (relay status ${probe.status}).`,
+	};
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalConnectionDiagnostics.ts
@@ -14,16 +14,14 @@ export interface TerminalFailureClassification {
 }
 
 /**
- * Turn the `_whoowns` preflight result (see `primeRelayAffinity`) into a cause
- * for a failed terminal WS. The key case is `stream-blocked`: the host tunnel
- * is present (probe 200) yet the WS still drops — the fingerprint of a relay
- * routing problem (e.g. the cross-region 6PN path), not an offline host.
+ * Cause of a failed terminal WS from the `_whoowns` probe. `stream-blocked`
+ * (host present but WS drops) is the relay-routing fingerprint, e.g. cross-region.
  */
 export function classifyTerminalFailure(
 	probe: RelayAffinityProbe | null,
 	isHostUrl: boolean,
 ): TerminalFailureClassification {
-	// Local / same-machine terminals never hit the relay; don't guess a cause.
+	// Local terminals never hit the relay; don't guess a cause.
 	if (!isHostUrl) {
 		return {
 			category: "unknown",
@@ -49,8 +47,7 @@ export function classifyTerminalFailure(
 			message: "You don't have access to this host.",
 		};
 	}
-	// Bad/absent gateway response: the relay couldn't reach the host right now.
-	// Usually transient (edge/routing), so don't assert the host is offline.
+	// Bad gateway: relay couldn't reach the host now, usually transient.
 	if (probe.status === 502 || probe.status === 504) {
 		return {
 			category: "stream-blocked",

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -11,7 +11,10 @@ export {
 	type WorkspaceChangedPayload,
 	type WorkspaceSnapshotPayload,
 } from "./lib/eventBus";
-export { primeRelayAffinity } from "./lib/primeRelayAffinity";
+export {
+	primeRelayAffinity,
+	type RelayAffinityProbe,
+} from "./lib/primeRelayAffinity";
 export {
 	useWorkspaceClient,
 	useWorkspaceHostUrl,

--- a/packages/workspace-client/src/lib/primeRelayAffinity.test.ts
+++ b/packages/workspace-client/src/lib/primeRelayAffinity.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, expect, test } from "bun:test";
+import { primeRelayAffinity } from "./primeRelayAffinity";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+test("returns null (no probe) for non-/hosts URLs without fetching", async () => {
+	globalThis.fetch = (() => {
+		throw new Error("should not fetch");
+	}) as typeof fetch;
+	expect(await primeRelayAffinity("wss://relay.superset.sh/ws")).toBeNull();
+});
+
+test("probes /_whoowns keeping the token, and parses status + region", async () => {
+	let calledUrl = "";
+	globalThis.fetch = (async (input: string | URL | Request) => {
+		calledUrl = String(input);
+		return new Response(JSON.stringify({ ok: true, region: "iad" }), {
+			status: 200,
+		});
+	}) as typeof fetch;
+
+	const probe = await primeRelayAffinity(
+		"wss://relay.superset.sh/hosts/org:host/terminal/t1?token=abc",
+	);
+
+	expect(probe).toEqual({ status: 200, region: "iad" });
+	expect(calledUrl).toContain("/hosts/org:host/_whoowns");
+	expect(calledUrl).toContain("token=abc"); // auth query preserved
+	expect(calledUrl.startsWith("https://")).toBe(true); // wss -> https
+});
+
+test("surfaces a 503 as host-offline signal (status 503, no region)", async () => {
+	globalThis.fetch = (async () =>
+		new Response(JSON.stringify({ error: "Host not connected" }), {
+			status: 503,
+		})) as typeof fetch;
+	expect(
+		await primeRelayAffinity("wss://relay.superset.sh/hosts/h/events?token=x"),
+	).toEqual({ status: 503, region: null });
+});
+
+test("returns null when the relay is unreachable", async () => {
+	globalThis.fetch = (async () => {
+		throw new Error("network down");
+	}) as typeof fetch;
+	expect(
+		await primeRelayAffinity(
+			"wss://relay.superset.sh/hosts/h/terminal/t?token=x",
+		),
+	).toBeNull();
+});

--- a/packages/workspace-client/src/lib/primeRelayAffinity.ts
+++ b/packages/workspace-client/src/lib/primeRelayAffinity.ts
@@ -1,21 +1,9 @@
 /**
- * Many WebSocket clients (browsers especially) don't transparently follow
- * fly-replay headers on the WS upgrade response — they see a non-101
- * status and fail the handshake with code 1006. To avoid that flicker, we
- * pre-flight a plain HTTP GET to the same /hosts/<id>/_whoowns endpoint
- * first. fly-replay is fully transparent for HTTP, and the GET locks fly's
- * edge affinity to the owning machine for subsequent requests, so the
- * follow-up WS upgrade lands on the right instance and gets a clean 101.
- *
- * The response also doubles as a cheap health probe: because the WS API
- * hides the upgrade's HTTP status (a 502/503 just surfaces as close code
- * 1006), the returned status is the only client-visible signal for *why* a
- * terminal/events stream can't connect. Callers use it to distinguish
- * host-offline (503) from a routing failure (200 but the WS still drops)
- * from an auth problem (401/403).
- *
- * Best-effort: if the probe fails or times out, we return null and still
- * try the WS — it just may briefly flicker during the implicit retry.
+ * Pre-flight GET to /hosts/<id>/_whoowns before the WS upgrade: browsers don't
+ * follow fly-replay on a WS upgrade (fails 1006) but do on HTTP, so this pins
+ * fly edge affinity to the owning machine. The status is also the only signal
+ * for *why* a stream fails (the WS API hides the upgrade status): 503 offline,
+ * 401/403 unauthorized, 200-but-drops routing. Best-effort; null on failure.
  */
 
 const PROBE_TIMEOUT_MS = 3_000;

--- a/packages/workspace-client/src/lib/primeRelayAffinity.ts
+++ b/packages/workspace-client/src/lib/primeRelayAffinity.ts
@@ -7,33 +7,63 @@
  * edge affinity to the owning machine for subsequent requests, so the
  * follow-up WS upgrade lands on the right instance and gets a clean 101.
  *
- * Best-effort: if the probe fails or times out, we still try the WS — it
- * just may briefly flicker during the implicit retry.
+ * The response also doubles as a cheap health probe: because the WS API
+ * hides the upgrade's HTTP status (a 502/503 just surfaces as close code
+ * 1006), the returned status is the only client-visible signal for *why* a
+ * terminal/events stream can't connect. Callers use it to distinguish
+ * host-offline (503) from a routing failure (200 but the WS still drops)
+ * from an auth problem (401/403).
+ *
+ * Best-effort: if the probe fails or times out, we return null and still
+ * try the WS — it just may briefly flicker during the implicit retry.
  */
 
 const PROBE_TIMEOUT_MS = 3_000;
 
-export async function primeRelayAffinity(wsUrl: string): Promise<void> {
-	try {
-		const url = new URL(wsUrl);
-		const match = url.pathname.match(/^(\/hosts\/[^/]+)/);
-		if (!match) return; // not a /hosts/<id>/* URL — nothing to prime
-		url.pathname = `${match[1]}/_whoowns`;
-		url.protocol = url.protocol === "wss:" ? "https:" : "http:";
-		// Keep search (token query param) so the relay can authenticate.
+export interface RelayAffinityProbe {
+	/** HTTP status of the `_whoowns` preflight: 200 (host tunnel present),
+	 * 503 (host not connected), 401/403 (unauthorized). */
+	status: number;
+	/** Relay region that owns the host tunnel, when the endpoint reports it. */
+	region: string | null;
+}
 
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
-		try {
-			await fetch(url.toString(), {
-				method: "GET",
-				signal: controller.signal,
-				cache: "no-store",
-			});
-		} finally {
-			clearTimeout(timer);
-		}
+export async function primeRelayAffinity(
+	wsUrl: string,
+): Promise<RelayAffinityProbe | null> {
+	let url: URL;
+	try {
+		url = new URL(wsUrl);
 	} catch {
-		// Best-effort.
+		return null;
+	}
+	const match = url.pathname.match(/^(\/hosts\/[^/]+)/);
+	if (!match) return null; // not a /hosts/<id>/* URL — nothing to prime
+
+	url.pathname = `${match[1]}/_whoowns`;
+	url.protocol = url.protocol === "wss:" ? "https:" : "http:";
+	// Keep search (token query param) so the relay can authenticate.
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+	try {
+		const res = await fetch(url.toString(), {
+			method: "GET",
+			signal: controller.signal,
+			cache: "no-store",
+		});
+		let region: string | null = null;
+		try {
+			const body = (await res.json()) as { region?: unknown };
+			if (typeof body?.region === "string") region = body.region;
+		} catch {
+			// Error statuses may carry an empty / non-JSON body.
+		}
+		return { status: res.status, region };
+	} catch {
+		// Network error / timeout — the relay itself is unreachable.
+		return null;
+	} finally {
+		clearTimeout(timer);
 	}
 }


### PR DESCRIPTION
## Why

When a terminal pane can't connect, it just shows **"disconnected"** with no cause — which is exactly what made the recent cross-region relay bug hard to spot (control plane worked, only the terminal WS 502'd). The root difficulty: the **browser WebSocket API hides the upgrade's HTTP status** — a relay 502/503 only surfaces as close code `1006`, so the client can't see *why*.

## What

Both changes lean on the `_whoowns` preflight the client **already fires** before every terminal WS (its response status was thrown away until now).

**1. Classify the failure (surface the *why*).** On give-up, the pane log now says the cause instead of a generic close:
- preflight **503** → "This host is offline (not connected to the relay)."
- preflight **401/403** → "You don't have access to this host."
- preflight **200 but the WS still drops** → "The host is online (region X) but the terminal stream couldn't connect — usually a relay routing issue." ← the fingerprint of the cross-region bug
- preflight **unreachable** → "Couldn't reach the relay service."

**2. Emit `terminal_connect_failed` telemetry** on give-up (PostHog), so this failure mode is queryable/alertable instead of silent:
`{ endpoint, close_code, close_reason, preflight_status, tunnel_region, reconnect_attempts, category }` (endpoint has the token stripped).

## Notes
- `primeRelayAffinity` now returns `{ status, region } | null` (was `void`); both existing callers ignore the value, so it's backward-compatible.
- Fires **once per give-up** (max reconnect attempts reached), not on every transient blip.
- Pure classifier + probe-parsing are unit-tested and mutation-checked. Desktop typecheck + biome clean.

Follow-on ideas from the same discussion (not in this PR): a bounded error state with Retry/Copy-diagnostics buttons, and a **cross-region** synthetic check in the relay (today's `synthetic.ts` only exercises same-region).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5546">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface why a terminal can’t connect and emit telemetry on final failure. We classify errors using the relay `_whoowns` preflight (now probed with the `wsUrl`), show a clear message in the pane, and send a PostHog event for alerting.

- **New Features**
  - Show a specific reason on give-up: 503 host offline, 401/403 no access, 200-but-WS-drops = relay routing issue (with region), 502/504 = temporary relay failure, or relay unreachable.
  - Emit `terminal_connect_failed` on give-up with endpoint, close_code, close_reason, preflight_status, tunnel_region, reconnect_attempts, category.
  - Only applies to relay-host terminals (`/hosts/...`); local terminals unchanged.

- **Refactors**
  - `@superset/workspace-client` `primeRelayAffinity` now returns `{ status, region } | null` (and exports `RelayAffinityProbe`) and is used to classify failures; added unit tests for probe parsing and classification.
  - Probe `_whoowns` with the original `wsUrl` (not `actualUrl`); deduplicated diagnostics comments and centralized rationale in `primeRelayAffinity`.

<sup>Written for commit 17770b99c9d71124e119b7595d2179d91baa0f0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal connections now run a relay-aware precheck for relay-routed hosts and generate more specific user-facing failure diagnoses.
* **Bug Fixes**
  * Improved “max reconnect attempts reached” reporting with expanded diagnostic context (failure category, preflight status, tunnel region when available) and more detailed failure analytics.
* **Tests**
  * Added/expanded automated coverage for relay affinity probing and terminal failure classification to ensure consistent categorization across common HTTP and stream-drop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->