### PR TITLE
fix(relay): preserve upstream WS close codes + time out a stalled bridge dial

### DIFF
--- a/apps/relay/src/proxy.test.ts
+++ b/apps/relay/src/proxy.test.ts
@@ -20,6 +20,32 @@ type FakeClient = {
 	close: (code?: number, reason?: string) => void;
 };
 
+test("closes the client with 1011 when the upstream never finishes opening", async () => {
+	// Accepts the connect but never fires "open" (dead-but-in-DNS peer).
+	const stalledUpstream = {
+		binaryType: "",
+		readyState: 0,
+		addEventListener: () => {},
+		send: () => {},
+		close: () => {},
+	} as unknown as WebSocket;
+
+	let closedCode: number | undefined;
+	const client: FakeClient = {
+		readyState: 1,
+		send: () => {},
+		close: (code) => {
+			closedCode = code;
+		},
+	};
+
+	const bridge = createProxyBridge("ws://unused/", () => stalledUpstream, 20);
+	bridge.onOpen(null, client as never);
+
+	await waitFor(() => closedCode !== undefined);
+	expect(closedCode).toBe(1011);
+});
+
 test("internalProxyUrl targets the owner machine over 6PN with the loop guard", () => {
 	const url = internalProxyUrl(
 		{ machineId: "abc123" },
@@ -40,12 +66,16 @@ test("internalProxyUrl targets the owner machine over 6PN with the loop guard", 
 	).toBe("ws://m.vm.app.internal:80/hosts/h/events?_rlp=1");
 });
 
-test("safeCloseCode only lets 1000 / 3000-4999 through", () => {
+test("safeCloseCode preserves sendable codes and only remaps unsendable ones", () => {
 	expect(safeCloseCode(1000)).toBe(1000);
+	expect(safeCloseCode(1001)).toBe(1001);
+	expect(safeCloseCode(1011)).toBe(1011);
 	expect(safeCloseCode(4001)).toBe(4001);
-	expect(safeCloseCode(1006)).toBe(1000);
-	expect(safeCloseCode(1011)).toBe(1000);
-	expect(safeCloseCode(undefined)).toBe(1000);
+	// Unsendable / missing codes collapse to 1011, never 1000.
+	expect(safeCloseCode(1006)).toBe(1011);
+	expect(safeCloseCode(1005)).toBe(1011);
+	expect(safeCloseCode(1015)).toBe(1011);
+	expect(safeCloseCode(undefined)).toBe(1011);
 });
 
 test("bridge pipes client→upstream text and upstream→client binary (framing preserved)", async () => {

--- a/apps/relay/src/proxy.ts
+++ b/apps/relay/src/proxy.ts
@@ -1,13 +1,9 @@
 import type { WSContext } from "hono/ws";
 
-// Query marker on a relay-to-relay proxy hop. Guards against an infinite
-// bridge loop when the directory is briefly stale: a hop that lands on a node
-// which doesn't own the tunnel is failed rather than re-proxied.
+// Loop guard: a hop marked with this on a non-owning node is failed, not re-proxied.
 export const PROXY_HOP_PARAM = "_rlp";
 
-// Build the private-network URL for the relay instance that owns the tunnel.
-// Fly resolves `<machine-id>.vm.<app>.internal` to that specific machine over
-// the encrypted 6PN network, so plain `ws://` on the internal port is fine.
+// Owning instance's 6PN address; plain ws:// is fine on Fly's encrypted network.
 export function internalProxyUrl(
 	owner: { machineId: string },
 	hostId: string,
@@ -20,16 +16,27 @@ export function internalProxyUrl(
 	return `${base}/hosts/${hostId}${pathAfterHost}${search}${sep}${PROXY_HOP_PARAM}=1`;
 }
 
-// Only 1000 and the 3000-4999 app range may be sent on a WS close frame;
-// anything else (1005/1006/1015, protocol codes) throws. Fall back to 1000.
+// Remap only unsendable codes to 1011; never to 1000, which the client reads as
+// a clean exit and stops reconnecting.
+const NON_SENDABLE_CLOSE_CODES = new Set([1004, 1005, 1006, 1015]);
+
 export function safeCloseCode(code: number | undefined): number {
-	return code === 1000 || (code != null && code >= 3000 && code <= 4999)
-		? code
-		: 1000;
+	if (code == null || NON_SENDABLE_CLOSE_CODES.has(code)) return 1011;
+	if (
+		code === 1000 ||
+		(code >= 1001 && code <= 1014) ||
+		(code >= 3000 && code <= 4999)
+	) {
+		return code;
+	}
+	return 1011;
 }
 
 // Buffer cap for client frames that arrive before the upstream WS is open.
 const MAX_PENDING_FRAMES = 512;
+
+// Tear the bridge down if the upstream never opens (dead peer still in DNS).
+const UPSTREAM_OPEN_TIMEOUT_MS = 10_000;
 
 type WsEventHandlers = {
 	onOpen: (evt: unknown, ws: WSContext) => void;
@@ -38,24 +45,25 @@ type WsEventHandlers = {
 	onError: () => void;
 };
 
-/**
- * Bridge a client terminal/events WebSocket to the relay instance that owns the
- * host tunnel, over Fly's private network. Frames are piped both ways with
- * framing preserved: client→host rides as text (the tunnel carries client
- * frames as strings and terminal input is JSON), host→client preserves binary
- * (PTY bytes) vs text (JSON control). The owning node runs the normal access
- * check + channel path on the far end.
- *
- * `connect` defaults to the global WebSocket; injectable so tests can point at
- * a local upstream without Fly 6PN.
- */
+// Bridge a client WS to the owning relay instance over 6PN, preserving framing
+// (client→host text, host→client binary/text). `connect`/`openTimeoutMs` are
+// injectable for tests.
 export function createProxyBridge(
 	target: string,
 	connect: (url: string) => WebSocket = (url) => new WebSocket(url),
+	openTimeoutMs: number = UPSTREAM_OPEN_TIMEOUT_MS,
 ): WsEventHandlers {
 	let upstream: WebSocket | null = null;
 	let clientClosed = false;
+	let openTimer: ReturnType<typeof setTimeout> | null = null;
 	const pending: string[] = [];
+
+	const clearOpenTimer = () => {
+		if (openTimer != null) {
+			clearTimeout(openTimer);
+			openTimer = null;
+		}
+	};
 
 	return {
 		onOpen: (_evt, ws) => {
@@ -66,7 +74,18 @@ export function createProxyBridge(
 				return;
 			}
 			upstream.binaryType = "arraybuffer";
+			openTimer = setTimeout(() => {
+				openTimer = null;
+				if (clientClosed) return;
+				try {
+					upstream?.close();
+				} catch {
+					// already closed
+				}
+				if (ws.readyState === 1) ws.close(1011, "Upstream connect timeout");
+			}, openTimeoutMs);
 			upstream.addEventListener("open", () => {
+				clearOpenTimer();
 				for (const frame of pending) upstream?.send(frame);
 				pending.length = 0;
 			});
@@ -75,11 +94,13 @@ export function createProxyBridge(
 				ws.send(event.data as string | ArrayBuffer);
 			});
 			upstream.addEventListener("close", (event) => {
+				clearOpenTimer();
 				if (!clientClosed && ws.readyState === 1) {
 					ws.close(safeCloseCode(event.code), "Upstream closed");
 				}
 			});
 			upstream.addEventListener("error", () => {
+				clearOpenTimer();
 				if (!clientClosed && ws.readyState === 1) {
 					ws.close(1011, "Upstream error");
 				}
@@ -95,6 +116,7 @@ export function createProxyBridge(
 		},
 		onClose: () => {
 			clientClosed = true;
+			clearOpenTimer();
 			try {
 				upstream?.close();
 			} catch {
@@ -103,6 +125,7 @@ export function createProxyBridge(
 		},
 		onError: () => {
 			clientClosed = true;
+			clearOpenTimer();
 			try {
 				upstream?.close();
 			} catch {


### PR DESCRIPTION
Review follow-ups to the cross-region WS bridge (#5542), flagged by CodeRabbit + cubic.

## 1. `safeCloseCode` masked errors as clean closes
It collapsed every code except 1000/3000-4999 down to **1000**. But the desktop terminal transport treats `event.code === 1000` as a *clean exit* — it won't reconnect and won't log. So on the cross-region proxy path, an upstream **1001** (host-service going away / deploy) or **1011** (error) became "clean exit" and the client silently stopped reconnecting — worse than the same-region path, which preserves the code.

Now: preserve all sendable codes, and only remap the reserved/unsendable set (`1004/1005/1006/1015`) and a missing code to **1011**, so a failure still reads as a failure and the client reconnects consistently.

## 2. No connect timeout on the relay-to-relay dial
A peer that's dying but still resolvable in Fly DNS can accept the TCP connect yet never finish the WS handshake. Without a timeout the client hangs in "connecting" indefinitely (frames buffering into `pending`). Added a 10s open-timeout that tears the bridge down so the client reconnects.

## Not addressed (with reason)
- **"Forward the Authorization header on the internal dial"** — N/A. Terminal/events WebSockets are browser-originated and always use the `?token=` query param (browsers can't set WS headers), which `internalProxyUrl` already forwards. No header-auth WS client exists on this path.

## Tests
`safeCloseCode` assertions updated (1001/1011 preserved, 1006/1005/1015/undefined → 1011) and a new stalled-dial timeout test (injectable `openTimeoutMs`, matching the existing injectable `connect` seam). Both **mutation-checked**. Typecheck + biome clean.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5548">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves upstream WebSocket close codes and adds a 10s open-timeout for the cross‑region relay bridge so clients reconnect instead of stalling. Aligns cross‑region behavior with the same‑region path.

- **Bug Fixes**
  - Preserve sendable close codes (1000, 1001–1014, 3000–4999); remap unsendable/missing/out‑of‑range (1004/1005/1006/1015/undefined) to 1011, never 1000.
  - Add an upstream open-timeout (default 10s) in `createProxyBridge`; on timeout, close the client with 1011 and clear the timer on open/close/error.
  - Tests: updated `safeCloseCode` cases and added a stalled‑dial timeout test with injectable `openTimeoutMs`.

<sup>Written for commit 80d43ee3ea4af08fd9b6ddb5a1a38a3d7fe988c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy behavior when the upstream WebSocket stalls before reaching `open`, now closing the client more reliably with close code `1011` after a configurable timeout (default: 10s).
  * Updated close-code forwarding to preserve valid, sendable WebSocket close codes and remap undefined/reserved/non-sendable values to `1011`.
* **Tests**
  * Added coverage for the “dead-but-in-DNS” upstream scenario and revised assertions for the updated close-code handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->