### PR TITLE
feat(cli): add `workspaces get` to look up a workspace by id

### DIFF
--- a/packages/cli/src/commands/workspaces/get/command.test.ts
+++ b/packages/cli/src/commands/workspaces/get/command.test.ts
@@ -121,6 +121,13 @@ describe("workspaces get", () => {
 		).rejects.toThrow(/Unknown field: bogus/);
 	});
 
+	test("--field rejects inherited Object.prototype keys", async () => {
+		findResult = { workspace: { ...WORKSPACE }, warnings: [] };
+		await expect(
+			invoke({ id: WORKSPACE.id }, { field: "toString" }),
+		).rejects.toThrow(/Unknown field: toString/);
+	});
+
 	test("errors when no reachable host knows the id", async () => {
 		findResult = { workspace: undefined, warnings: [] };
 		await expect(invoke({ id: WORKSPACE.id })).rejects.toThrow(/not found/);

--- a/packages/cli/src/commands/workspaces/get/command.test.ts
+++ b/packages/cli/src/commands/workspaces/get/command.test.ts
@@ -77,7 +77,6 @@ describe("workspaces get", () => {
 		expect(result.data.projectName).toBe("Superset");
 		expect(result.data.hostName).toBe("Town-Hall");
 		expect(result.data.worktreePath).toBe(WORKSPACE.worktreePath);
-		// Human view is an aligned key/value block.
 		expect(result.message).toContain("name");
 		expect(result.message).toContain("ludicrous-candytuft");
 	});

--- a/packages/cli/src/commands/workspaces/get/command.test.ts
+++ b/packages/cli/src/commands/workspaces/get/command.test.ts
@@ -90,7 +90,7 @@ describe("workspaces get", () => {
 	});
 
 	test("errors when no id is passed and the env var is unset", async () => {
-		expect(invoke({})).rejects.toThrow(/No workspace id/);
+		await expect(invoke({})).rejects.toThrow(/No workspace id/);
 	});
 
 	test("--field prints the raw value as the message, data stays full", async () => {
@@ -116,14 +116,14 @@ describe("workspaces get", () => {
 
 	test("--field rejects an unknown field name", async () => {
 		findResult = { workspace: { ...WORKSPACE }, warnings: [] };
-		expect(invoke({ id: WORKSPACE.id }, { field: "bogus" })).rejects.toThrow(
-			/Unknown field: bogus/,
-		);
+		await expect(
+			invoke({ id: WORKSPACE.id }, { field: "bogus" }),
+		).rejects.toThrow(/Unknown field: bogus/);
 	});
 
 	test("errors when no reachable host knows the id", async () => {
 		findResult = { workspace: undefined, warnings: [] };
-		expect(invoke({ id: WORKSPACE.id })).rejects.toThrow(/not found/);
+		await expect(invoke({ id: WORKSPACE.id })).rejects.toThrow(/not found/);
 	});
 
 	test("falls back to ids when cloud project/host lookups fail", async () => {

--- a/packages/cli/src/commands/workspaces/get/command.test.ts
+++ b/packages/cli/src/commands/workspaces/get/command.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// Control what `findHostWorkspace` resolves per test. The command imports it
+// from the lib barrel, so mock that module before importing the SUT.
+type FindResult = {
+	workspace: Record<string, unknown> | undefined;
+	warnings: string[];
+};
+let findResult: FindResult = { workspace: undefined, warnings: [] };
+mock.module("../../../lib/host-workspaces", () => ({
+	findHostWorkspace: async () => findResult,
+}));
+
+const { default: getCommand } = await import("./command");
+
+const WORKSPACE = {
+	id: "b502bf30-8693-4815-be65-795035e0ce5f",
+	organizationId: "org-1",
+	projectId: "proj-1",
+	hostId: "host-1",
+	name: "ludicrous-candytuft",
+	branch: "setup",
+	type: "worktree" as const,
+	createdByUserId: "user-1",
+	taskId: null,
+	createdAt: new Date("2026-04-24T22:00:41.950Z"),
+	updatedAt: new Date("2026-04-24T22:00:41.950Z"),
+	worktreePath: "/home/me/.superset/worktrees/proj-1/setup",
+	worktreeExists: true,
+};
+
+function makeCtx(
+	overrides: {
+		organizationId?: string | undefined;
+		projects?: Array<{ id: string; name: string }>;
+		hosts?: Array<{ id: string; name: string }>;
+	} = {},
+) {
+	const {
+		organizationId = "org-1",
+		projects = [{ id: "proj-1", name: "Superset" }],
+		hosts = [{ id: "host-1", name: "Town-Hall" }],
+	} = overrides;
+	return {
+		api: {
+			v2Project: { list: { query: async () => projects } },
+			host: { list: { query: async () => hosts } },
+		},
+		config: { organizationId },
+		bearer: "bearer",
+		authSource: "oauth",
+	} as never;
+}
+
+function invoke(args: { id?: string }, options: { field?: string } = {}) {
+	return getCommand.run({
+		ctx: makeCtx(),
+		args: args as never,
+		options: options as never,
+		signal: new AbortController().signal,
+	});
+}
+
+afterEach(() => {
+	findResult = { workspace: undefined, warnings: [] };
+	delete process.env.SUPERSET_WORKSPACE_ID;
+});
+
+describe("workspaces get", () => {
+	test("resolves by explicit id and enriches project/host names", async () => {
+		findResult = { workspace: { ...WORKSPACE }, warnings: [] };
+		const result = (await invoke({ id: WORKSPACE.id })) as {
+			data: Record<string, unknown>;
+			message: string;
+		};
+		expect(result.data.name).toBe("ludicrous-candytuft");
+		expect(result.data.projectName).toBe("Superset");
+		expect(result.data.hostName).toBe("Town-Hall");
+		expect(result.data.worktreePath).toBe(WORKSPACE.worktreePath);
+		// Human view is an aligned key/value block.
+		expect(result.message).toContain("name");
+		expect(result.message).toContain("ludicrous-candytuft");
+	});
+
+	test("defaults the id to $SUPERSET_WORKSPACE_ID when no arg is given", async () => {
+		process.env.SUPERSET_WORKSPACE_ID = WORKSPACE.id;
+		findResult = { workspace: { ...WORKSPACE }, warnings: [] };
+		const result = (await invoke({})) as { data: Record<string, unknown> };
+		expect(result.data.id).toBe(WORKSPACE.id);
+	});
+
+	test("errors when no id is passed and the env var is unset", async () => {
+		expect(invoke({})).rejects.toThrow(/No workspace id/);
+	});
+
+	test("--field prints the raw value as the message, data stays full", async () => {
+		findResult = { workspace: { ...WORKSPACE }, warnings: [] };
+		const result = (await invoke({ id: WORKSPACE.id }, { field: "name" })) as {
+			data: Record<string, unknown>;
+			message: string;
+		};
+		expect(result.message).toBe("ludicrous-candytuft");
+		expect(result.data.branch).toBe("setup");
+	});
+
+	test("--field with a null value yields an empty message", async () => {
+		findResult = { workspace: { ...WORKSPACE }, warnings: [] };
+		const result = (await invoke(
+			{ id: WORKSPACE.id },
+			{ field: "taskId" },
+		)) as {
+			message: string;
+		};
+		expect(result.message).toBe("");
+	});
+
+	test("--field rejects an unknown field name", async () => {
+		findResult = { workspace: { ...WORKSPACE }, warnings: [] };
+		expect(invoke({ id: WORKSPACE.id }, { field: "bogus" })).rejects.toThrow(
+			/Unknown field: bogus/,
+		);
+	});
+
+	test("errors when no reachable host knows the id", async () => {
+		findResult = { workspace: undefined, warnings: [] };
+		expect(invoke({ id: WORKSPACE.id })).rejects.toThrow(/not found/);
+	});
+
+	test("falls back to ids when cloud project/host lookups fail", async () => {
+		findResult = { workspace: { ...WORKSPACE }, warnings: [] };
+		const result = (await getCommand.run({
+			ctx: {
+				api: {
+					v2Project: {
+						list: {
+							query: async () => {
+								throw new Error("cloud down");
+							},
+						},
+					},
+					host: {
+						list: {
+							query: async () => {
+								throw new Error("cloud down");
+							},
+						},
+					},
+				},
+				config: { organizationId: "org-1" },
+				bearer: "bearer",
+				authSource: "oauth",
+			} as never,
+			args: { id: WORKSPACE.id } as never,
+			options: {} as never,
+			signal: new AbortController().signal,
+		})) as { data: Record<string, unknown> };
+		expect(result.data.projectName).toBe("proj-1");
+		expect(result.data.hostName).toBe("host-1");
+	});
+});

--- a/packages/cli/src/commands/workspaces/get/command.ts
+++ b/packages/cli/src/commands/workspaces/get/command.ts
@@ -1,0 +1,102 @@
+import { CLIError, positional, string } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { findHostWorkspace } from "../../../lib/host-workspaces";
+
+export default command({
+	description: "Show details for a single workspace by id",
+	args: [
+		positional("id").desc("Workspace ID (defaults to $SUPERSET_WORKSPACE_ID)"),
+	],
+	options: {
+		field: string()
+			.alias("f")
+			.desc(
+				"Print a single field's raw value (e.g. name, branch, worktreePath)",
+			),
+	},
+	run: async ({ ctx, args, options }) => {
+		const id =
+			(args.id as string | undefined) ?? process.env.SUPERSET_WORKSPACE_ID;
+		if (!id) {
+			throw new CLIError(
+				"No workspace id",
+				"Pass an id or run inside a workspace where $SUPERSET_WORKSPACE_ID is set",
+			);
+		}
+
+		const organizationId = ctx.config.organizationId;
+		if (!organizationId) {
+			throw new CLIError("No active organization", "Run: superset auth login");
+		}
+
+		// Workspace records are host-owned: resolve the id across the org's
+		// reachable hosts, then enrich project/host ids with cloud names.
+		const [{ workspace, warnings }, projects, hosts] = await Promise.all([
+			findHostWorkspace(
+				{ api: ctx.api, organizationId, userJwt: ctx.bearer },
+				id,
+			),
+			ctx.api.v2Project.list
+				.query({ organizationId })
+				.catch(() => [] as Array<{ id: string; name: string }>),
+			ctx.api.host.list
+				.query({ organizationId })
+				.catch(() => [] as Array<{ id: string; name: string }>),
+		]);
+		for (const warning of warnings) {
+			process.stderr.write(`Warning: ${warning}\n`);
+		}
+		if (!workspace) {
+			throw new CLIError(
+				`Workspace not found on any reachable host: ${id}`,
+				"List workspaces with: superset workspaces list",
+			);
+		}
+
+		const projectName =
+			projects.find((project) => project.id === workspace.projectId)?.name ??
+			workspace.projectId;
+		const hostName =
+			hosts.find((host) => host.id === workspace.hostId)?.name ??
+			workspace.hostId;
+
+		const detail = {
+			id: workspace.id,
+			name: workspace.name,
+			branch: workspace.branch,
+			type: workspace.type,
+			projectId: workspace.projectId,
+			projectName,
+			hostId: workspace.hostId,
+			hostName,
+			taskId: workspace.taskId,
+			worktreePath: workspace.worktreePath,
+			worktreeExists: workspace.worktreeExists,
+			createdAt: workspace.createdAt,
+		};
+
+		if (options.field) {
+			if (!(options.field in detail)) {
+				throw new CLIError(
+					`Unknown field: ${options.field}`,
+					`Available fields: ${Object.keys(detail).join(", ")}`,
+				);
+			}
+			const value = detail[options.field as keyof typeof detail];
+			return {
+				data: detail,
+				message: value === null || value === undefined ? "" : String(value),
+			};
+		}
+
+		const width = Math.max(...Object.keys(detail).map((key) => key.length));
+		const message = Object.entries(detail)
+			.map(([key, value]) => {
+				const shown = value === null || value === undefined ? "—" : value;
+				return `${key.padEnd(width)}  ${shown}`;
+			})
+			.join("\n");
+
+		return { data: detail, message };
+	},
+});

--- a/packages/cli/src/commands/workspaces/get/command.ts
+++ b/packages/cli/src/commands/workspaces/get/command.ts
@@ -76,7 +76,7 @@ export default command({
 		};
 
 		if (options.field) {
-			if (!(options.field in detail)) {
+			if (!Object.hasOwn(detail, options.field)) {
 				throw new CLIError(
 					`Unknown field: ${options.field}`,
 					`Available fields: ${Object.keys(detail).join(", ")}`,


### PR DESCRIPTION
## What

Adds `superset workspaces get [id]` (alias `superset ws get`) to look up a single workspace by id and print its details.

Closes #5539.

## Why

`$SUPERSET_WORKSPACE_NAME` was intentionally stripped from the setup-script environment (the name can race/change) — only `$SUPERSET_WORKSPACE_ID` and `$SUPERSET_WORKSPACE_PATH` are injected now. As suggested in #5539, this exposes fetching workspace name/info **by id** so setup scripts can resolve the current name on demand instead of relying on a stale env var.

## Behavior

- **`id` defaults to `$SUPERSET_WORKSPACE_ID`** when omitted, so a setup script can just run `superset ws get` with no args.
- **`--field <name>` / `-f`** prints a single field's raw value with no `jq` needed — the direct replacement for the removed `$SUPERSET_WORKSPACE_NAME`:
  ```sh
  name="$(superset ws get -f name)"
  cd "$(superset ws get -f worktreePath)"
  ```
- **`--json`** (global, auto-on under agent/CI) returns the full object for structured consumers.
- Default human output is an aligned key/value detail view.

Returns: `id, name, branch, type, projectId, projectName, hostId, hostName, taskId, worktreePath, worktreeExists, createdAt`. Resolves the id across the org's reachable hosts via the existing `findHostWorkspace` helper (same path as `open`/`update`), and enriches project/host ids with cloud names (degrading to ids when the cloud is unreachable).

## Naming

`get` matches the CLI's existing convention for single-resource lookups (`tasks get`, `automations get`); there is no `info`/`show`/`describe` anywhere in the command tree.

## Tests

New `command.test.ts` (first command-level test in the CLI package) drives `run()` with a mocked `ctx` and stubbed `findHostWorkspace`, covering id-from-arg, id-from-env default, missing-id error, `--field` value/empty/unknown, not-found, and the project/host name fallback. Each assertion was mutation-verified to fail when its branch is broken. Also manually exercised end-to-end against production.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5549">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `superset workspaces get [id]` (alias `superset ws get`) to fetch a workspace by id and print its details. Enables setup scripts to resolve the current name/path from `$SUPERSET_WORKSPACE_ID` after removing `$SUPERSET_WORKSPACE_NAME` (closes #5539).

- **New Features**
  - Defaults `id` to `$SUPERSET_WORKSPACE_ID` when omitted.
  - `-f, --field <name>` prints a single raw value (e.g., `name`, `worktreePath`) for easy scripting.
  - Supports `--json` for structured output; human output is aligned key/value.
  - Enriches `projectName` and `hostName` via cloud lookups; falls back to ids if unavailable.
  - Resolves the workspace across reachable hosts via `findHostWorkspace`.
  - Outputs include `id`, `name`, `branch`, `type`, `projectId`/`projectName`, `hostId`/`hostName`, `taskId`, `worktreePath`/`worktreeExists`, `createdAt`.

- **Bug Fixes**
  - Guarded `--field` against prototype-chain keys; stabilized error-path tests by awaiting rejected assertions.

<sup>Written for commit 92100150107d58f64bfb1e57f6b48b7891e60337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `workspaces get` command to display details for a single workspace by ID.
  * Supports selecting the workspace ID via argument or `SUPERSET_WORKSPACE_ID`.
  * Added a `--field` option to return a single value for a specific workspace field.

* **Bug Fixes**
  * Improved error handling for missing workspace IDs, unreachable hosts, and invalid `--field` values.
  * More reliable project/host name enrichment with fallback to raw IDs when lookups fail.

* **Tests**
  * Added a Bun test suite covering success, fallback behavior, and error cases for `workspaces get`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->