### PR TITLE
fix(workspace-client): add bun-types so the package typechecks its bun:test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1100,6 +1100,7 @@
         "@superset/typescript": "workspace:*",
         "@types/node": "24.12.0",
         "@types/react": "19.2.14",
+        "bun-types": "1.3.11",
         "react": "19.2.3",
         "typescript": "6.0.3",
       },

--- a/packages/workspace-client/package.json
+++ b/packages/workspace-client/package.json
@@ -26,6 +26,7 @@
 		"@superset/typescript": "workspace:*",
 		"@types/node": "24.12.0",
 		"@types/react": "19.2.14",
+		"bun-types": "1.3.11",
 		"react": "19.2.3",
 		"typescript": "6.0.3"
 	},

--- a/packages/workspace-client/src/lib/primeRelayAffinity.test.ts
+++ b/packages/workspace-client/src/lib/primeRelayAffinity.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 test("returns null (no probe) for non-/hosts URLs without fetching", async () => {
 	globalThis.fetch = (() => {
 		throw new Error("should not fetch");
-	}) as typeof fetch;
+	}) as unknown as typeof fetch;
 	expect(await primeRelayAffinity("wss://relay.superset.sh/ws")).toBeNull();
 });
 
@@ -20,7 +20,7 @@ test("probes /_whoowns keeping the token, and parses status + region", async () 
 		return new Response(JSON.stringify({ ok: true, region: "iad" }), {
 			status: 200,
 		});
-	}) as typeof fetch;
+	}) as unknown as typeof fetch;
 
 	const probe = await primeRelayAffinity(
 		"wss://relay.superset.sh/hosts/org:host/terminal/t1?token=abc",
@@ -36,7 +36,7 @@ test("surfaces a 503 as host-offline signal (status 503, no region)", async () =
 	globalThis.fetch = (async () =>
 		new Response(JSON.stringify({ error: "Host not connected" }), {
 			status: 503,
-		})) as typeof fetch;
+		})) as unknown as typeof fetch;
 	expect(
 		await primeRelayAffinity("wss://relay.superset.sh/hosts/h/events?token=x"),
 	).toEqual({ status: 503, region: null });
@@ -45,7 +45,7 @@ test("surfaces a 503 as host-offline signal (status 503, no region)", async () =
 test("returns null when the relay is unreachable", async () => {
 	globalThis.fetch = (async () => {
 		throw new Error("network down");
-	}) as typeof fetch;
+	}) as unknown as typeof fetch;
 	expect(
 		await primeRelayAffinity(
 			"wss://relay.superset.sh/hosts/h/terminal/t?token=x",

--- a/packages/workspace-client/tsconfig.json
+++ b/packages/workspace-client/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "@superset/typescript/base.json",
 	"compilerOptions": {
-		"jsx": "react-jsx"
+		"jsx": "react-jsx",
+		"types": ["bun-types"]
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
## Why (main is currently red)

#5546 added `packages/workspace-client/src/lib/primeRelayAffinity.test.ts` — the **first** `bun:test` file in this package — but its `tsconfig.json` had no `bun-types`. So `tsc --noEmit` fails with `TS2307: Cannot find module 'bun:test'`, turning main's **Typecheck** job red. (It slipped through because I ran `bunx tsc` for this package *before* adding the test file, then only re-ran the desktop typecheck.)

## Fix
- Add `"types": ["bun-types"]` to `packages/workspace-client/tsconfig.json` and `bun-types@1.3.11` to devDeps — matching `apps/relay`, which already has `bun:test` tests.
- Cast the test's `fetch` mocks through `unknown` (`as unknown as typeof fetch`) — Bun's stricter `fetch` type rejects the direct cast.

## Verified
Full monorepo `bun run typecheck` → **28/28 successful** (was failing on `@superset/workspace-client#typecheck`). workspace-client tests + biome clean.

Follow-up to #5546 — that PR was admin-merged over this flaky-looking Typecheck failure that turned out to be real. Merging this restores green main.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5553">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TypeScript typecheck failure in `@superset/workspace-client` by adding `bun-types` for `bun:test` and adjusting test `fetch` mocks. Restores green Typecheck on main.

- **Bug Fixes**
  - Add `"types": ["bun-types"]` to `tsconfig.json` and `bun-types@1.3.11` to devDeps (aligned with `apps/relay`).
  - Cast test `fetch` mocks via `unknown` to satisfy Bun’s stricter `fetch` type.

<sup>Written for commit 735468d7cbb3cd3efd1a5ca03a1e397d8b31b99a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for Bun type definitions in the workspace client setup.

* **Tests**
  * Updated test mocks to match the current fetch typing approach, with no changes to test behavior or expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->