### PR TITLE
feat(shared): add GPT-5.6 models to Codex picker

### DIFF
--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -98,6 +98,12 @@ describe("buildAgentModelArgs", () => {
 			["--model", "anthropic/claude-fable-5"],
 		);
 	});
+
+	it("includes every GPT-5.6 Codex model", () => {
+		for (const model of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+			expect(buildAgentModelArgs("codex", model)).toEqual(["--model", model]);
+		}
+	});
 });
 
 describe("AGENT_EFFORT_SUPPORT", () => {

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -69,6 +69,9 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "codex",
 		modelFlag: "--model",
 		models: [
+			{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+			{ id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
+			{ id: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
 			{ id: "gpt-5.5", label: "GPT-5.5" },
 			{ id: "gpt-5.4", label: "GPT-5.4" },
 			{ id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },


### PR DESCRIPTION
Adds GPT-5.6 Sol, Terra, and Luna to the Codex new-session model picker.

Tested each ID with `codex exec --model <id> "what model are you?"` (exit 0), plus unit tests, lint, and typecheck.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5558">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added GPT-5.6 Sol, Terra, and Luna to the Codex new-session model picker so users can choose the latest variants. Added tests to verify each model ID is accepted.

<sup>Written for commit ceaa5b1b75b0c15cf8298bd05ae000665981e7c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting GPT-5.6 Codex models: Sol, Terra, and Luna.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->