### PR TITLE
fix(mobile): center project avatar initial + add press feedback to picker chips

### DIFF
--- a/apps/mobile/components/PickerTrigger/PickerTrigger.tsx
+++ b/apps/mobile/components/PickerTrigger/PickerTrigger.tsx
@@ -1,0 +1,16 @@
+import { Button, type ButtonProps } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function PickerTrigger({ className, ...props }: ButtonProps) {
+	return (
+		<Button
+			className={cn(
+				"h-auto flex-row items-center gap-1 rounded-full px-2 py-1",
+				className,
+			)}
+			size="sm"
+			variant="ghost"
+			{...props}
+		/>
+	);
+}

--- a/apps/mobile/components/PickerTrigger/index.ts
+++ b/apps/mobile/components/PickerTrigger/index.ts
@@ -1,0 +1,1 @@
+export { PickerTrigger } from "./PickerTrigger";

--- a/apps/mobile/screens/(authenticated)/(home)/filter/components/ProjectAvatar/ProjectAvatar.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/filter/components/ProjectAvatar/ProjectAvatar.tsx
@@ -37,7 +37,11 @@ export function ProjectAvatar({
 		>
 			<Text
 				className="font-bold"
-				style={{ fontSize: size * 0.45, color: theme.mutedForeground }}
+				style={{
+					fontSize: size * 0.45,
+					lineHeight: size * 0.55,
+					color: theme.mutedForeground,
+				}}
 			>
 				{initial}
 			</Text>

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/NewChatWidget/NewChatWidget.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/NewChatWidget/NewChatWidget.tsx
@@ -3,13 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { ChevronDownIcon, PlusIcon } from "lucide-react-native";
 import { useState } from "react";
-import {
-	Alert,
-	KeyboardAvoidingView,
-	Pressable,
-	StyleSheet,
-	View,
-} from "react-native";
+import { Alert, KeyboardAvoidingView, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
 	PromptInput,
@@ -25,6 +19,7 @@ import {
 	PromptInputTools,
 	usePromptInputController,
 } from "@/components/ai-elements/prompt-input";
+import { PickerTrigger } from "@/components/PickerTrigger";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
@@ -132,9 +127,10 @@ function NewChatWidgetInner({
 				>
 					<PromptInput className="bg-card/95" onSubmit={handleSubmit}>
 						{expanded ? (
-							<PromptInputHeader className="gap-3">
-								<Pressable
-									className="flex-row items-center gap-1.5"
+							<PromptInputHeader className="px-1 pt-2">
+								<PickerTrigger
+									accessibilityLabel="Select a project"
+									className="gap-1.5"
 									disabled={targets.length === 0}
 									onPress={() =>
 										router.push("/(authenticated)/(home)/new-chat/project")
@@ -148,9 +144,9 @@ function NewChatWidgetInner({
 									<Text className="text-foreground text-sm font-medium">
 										{selectedTarget?.projectName ?? "No project"}
 									</Text>
-								</Pressable>
-								<Pressable
-									className="flex-row items-center gap-1"
+								</PickerTrigger>
+								<PickerTrigger
+									accessibilityLabel="Select a branch"
 									disabled={!selectedTarget}
 									onPress={() =>
 										router.push("/(authenticated)/(home)/new-chat/branch")
@@ -166,7 +162,7 @@ function NewChatWidgetInner({
 										as={ChevronDownIcon}
 										className="size-3.5 text-muted-foreground"
 									/>
-								</Pressable>
+								</PickerTrigger>
 							</PromptInputHeader>
 						) : null}
 						<PromptInputAttachments />
@@ -186,9 +182,8 @@ function NewChatWidgetInner({
 									>
 										<Icon as={PlusIcon} className="size-4" />
 									</PromptInputButton>
-									<Pressable
+									<PickerTrigger
 										accessibilityLabel="Select a model"
-										className="flex-row items-center gap-1 rounded-lg px-2 py-1.5"
 										onPress={() =>
 											router.push("/(authenticated)/(home)/new-chat/model")
 										}
@@ -200,7 +195,7 @@ function NewChatWidgetInner({
 											as={ChevronDownIcon}
 											className="size-3.5 text-muted-foreground"
 										/>
-									</Pressable>
+									</PickerTrigger>
 								</PromptInputTools>
 								<PromptInputSubmit
 									status={createChatWorkspace.isPending ? "submitted" : "ready"}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/chat/[sessionId]/components/ChatComposer/components/ModelPicker/ModelPicker.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/chat/[sessionId]/components/ChatComposer/components/ModelPicker/ModelPicker.tsx
@@ -8,7 +8,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 import { ChevronsUpDownIcon } from "lucide-react-native";
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, useWindowDimensions, View } from "react-native";
-import { Button } from "@/components/ui/button";
+import { PickerTrigger } from "@/components/PickerTrigger";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import { useTheme } from "@/hooks/useTheme";
@@ -69,20 +69,17 @@ export function ModelPicker({
 
 	return (
 		<>
-			<Button
+			<PickerTrigger
 				accessibilityLabel="Select a model"
-				className="h-auto flex-row items-center gap-1 rounded-full border-0 bg-transparent px-2 py-1"
 				disabled={disabled}
 				onPress={() => setIsPresented(true)}
-				size="sm"
-				variant="ghost"
 			>
 				<Text className="text-muted-foreground text-xs">{label}</Text>
 				<Icon
 					as={ChevronsUpDownIcon}
 					className="size-3.5 text-muted-foreground"
 				/>
-			</Button>
+			</PickerTrigger>
 
 			<Host style={{ position: "absolute", width }}>
 				<BottomSheet


### PR DESCRIPTION
## Summary
- Fix the off-center fallback initial in `ProjectAvatar` (the "P" in the new-chat widget's "No project" state).
- Add pressed-state feedback to the new-chat project/branch/model picker triggers, which were raw `Pressable`s with no visual response to taps.
- Extract a shared `PickerTrigger` chip component so all composer picker triggers share one look and press behavior.

## Why / Context
The avatar initial inherited `text-base` (24px line height) from the shared `Text` component while only `fontSize` was overridden (~8px at size 18), so the glyph sat in a line box taller than the 18px container and rendered off-center.

The design system already has a standard press affordance — the ghost `Button` variant's `active:bg-accent` highlight (the iOS-style highlight fill), used by the composer's "+" button and the workspace-chat model picker chip. The three `NewChatWidget` triggers just weren't using it.

## How It Works
- `ProjectAvatar` gives the initial an explicit `lineHeight: size * 0.55` to match the scaled font size.
- New `apps/mobile/components/PickerTrigger/` wraps the ui `Button` (ghost, `rounded-full px-2 py-1`) — accent highlight on press, 50% dim when disabled.
- `NewChatWidget` project/branch/model triggers and `ChatComposer`'s `ModelPicker` chip now use it. `PromptInputHeader` padding trimmed to `px-1 pt-2` so the chips' own padding keeps content optically aligned where it was.

## Manual QA Checklist
- [ ] "No project" avatar initial is vertically centered at 18px
- [ ] Project/branch/model chips in the new-chat widget show a highlight while pressed
- [ ] Disabled chips (no targets / no selected target) render dimmed
- [ ] Workspace-chat model picker chip looks unchanged and still opens the sheet
- [ ] Header content alignment in the expanded composer unchanged

## Testing
- `bun run lint` (exit 0)
- `bunx tsc --noEmit` in `apps/mobile`: 44 pre-existing errors on this branch (`HostWorkspaceItem` typing in `WorkspacesScreen`/`useNewChatTargets`), same count with these changes stashed; none in touched files
- Not yet verified in the simulator — the 0.55 line-height factor may need a small nudge if font metrics don't center perfectly at 18px

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5559">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the fallback initial in `ProjectAvatar` and adds consistent press feedback to project/branch/model picker chips via a shared `PickerTrigger` pill component. This improves tap affordance in the new-chat widget and matches the workspace-chat behavior.

- Bug Fixes
  - Centered the avatar initial by setting lineHeight relative to size (18px avatar now aligned).

- Refactors
  - Added `PickerTrigger` (ghost `Button`, rounded pill, press highlight; dims when disabled).
  - Replaced raw `Pressable`s in `NewChatWidget` project/branch/model and `ChatComposer` `ModelPicker`; trimmed `PromptInputHeader` padding to keep alignment.

<sup>Written for commit 72292bdc1f50c2632f3e20f5b7bc0ef57d82b629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared picker trigger for mobile selections, giving project, branch, and model pickers a more consistent look and feel.
* **UI Improvements**
  * Updated picker controls in the chat and workspace screens to use the new trigger style.
  * Refined avatar initial-letter alignment for better visual consistency.
* **Bug Fixes**
  * Improved button spacing and layout behavior across picker-related controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->