### PR TITLE
feat(release): 1.14.1 + plain-version CLI/desktop lockstep

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.14.0",
+	"version": "1.14.1",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -720,7 +720,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.14.0-2",
+      "version": "1.14.1",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -801,7 +801,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.14.0-2",
+      "version": "1.14.1",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.14.0-2",
+	"version": "1.14.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.14.0-2",
+	"version": "1.14.1",
 	"private": true,
 	"type": "module",
 	"exports": {

--- a/plans/20260709-unified-version-bumping.md
+++ b/plans/20260709-unified-version-bumping.md
@@ -11,7 +11,7 @@ The toolchain is TypeScript (run by Bun, no build step) under `scripts/release/`
 
 - `bun run release` — interactive menu (Desktop / CLI hotfix), TTY only
 - `bun run release desktop [version] [commit] [--publish] [--merge] [--daemon] [--republish]`
-- `bun run release cli [suffix] [--daemon] [--no-tag]`
+- `bun run release cli [version] [--daemon] [--no-tag]`
 - `bun run release check` — verify versions are unified (exit 1 on drift)
 
 All flows and the CI guard read **one** source of truth, `scripts/release/lib.ts`
@@ -48,10 +48,11 @@ min-version floor (`semver.satisfies` excludes prereleases —
 ## Desktop release (`scripts/release/desktop.ts`)
 
 Sets **desktop + host-service + cli** to the new version, commits, tags
-`desktop-v<version>`, builds, and leaves a **draft**. **On publish** (`--publish`,
-or the manual `--draft=false`) it also cuts a matching plain **`cli-v<version>`**
-so the standalone CLI ships with desktop. Draft mode ships nothing until you
-publish (it prints the `cli-v` command to run then).
+`desktop-v<version>`, builds, and leaves a **draft**. **With `--publish`** it also
+cuts a matching plain **`cli-v<version>`** so the standalone CLI ships with
+desktop. Draft mode ships nothing until you publish, and cutting the tag is *not*
+automatic on a manual `gh release edit --draft=false` — the script has already
+exited, so it prints the `cli-v` command for you to run then.
 
 ## CLI hotfix (`scripts/release/cli.ts`, `bun run release cli`)
 

--- a/plans/20260709-unified-version-bumping.md
+++ b/plans/20260709-unified-version-bumping.md
@@ -24,13 +24,21 @@ flags. Prompts only fire on a TTY; without one (e.g. an agent), the flow fails
 with guidance (pass a version, `--republish`) instead of hanging. Flows also
 export `runDesktop` / `runCli` for programmatic use.
 
-## Rules
+## Rules — everything plain, CLI leads by a patch
 
-- **Desktop is the ceiling.** It is always a plain `MAJOR.MINOR.PATCH` release.
-- `host-service` and `cli` **base** (strip any `-N` suffix) must equal desktop.
-- `host-service` **must equal** `cli` (they ship as one bundle).
-- Interim CLI releases add a prerelease suffix: `1.14.0-1`, `1.14.0-2`, … These
-  sort **below** `1.14.0` in semver, so the CLI never ships above desktop.
+**No prerelease suffixes anywhere.** A suffix (`1.14.1-N`) sorts *below* the
+release, so `superset update` won't deliver it, **and** it fails the host-service
+min-version floor (`semver.satisfies` excludes prereleases —
+`satisfies("1.14.1-1", ">=0.8.0") === false`). So:
+
+- **Desktop** is always a plain `MAJOR.MINOR.PATCH` release.
+- A desktop release sets `cli == host-service == desktop` **and** publishes a
+  matching plain `cli-v<version>` — the standalone CLI ships in lockstep.
+- **CLI hotfixes** between desktop releases bump a plain **patch** above the
+  current CLI (`1.14.1 → 1.14.2 → 1.14.3`), so the CLI *leads* desktop by a patch
+  within the same minor line until the next desktop release catches up.
+- `check:versions` enforces: `cli == host-service`, both plain, `cli >= desktop`,
+  same major.minor as desktop.
 
 ## One-time snap
 
@@ -39,25 +47,23 @@ export `runDesktop` / `runCli` for programmatic use.
 
 ## Desktop release (`scripts/release/desktop.ts`)
 
-Every desktop bump now sets **desktop + host-service + cli** to the same new
-version (was: desktop + host-service patch-bump). Both the normal and
-commit/worktree paths refresh `bun.lock` and commit all three package.jsons.
+Sets **desktop + host-service + cli** to the new version, commits, tags
+`desktop-v<version>`, builds, and leaves a **draft**. **On publish** (`--publish`,
+or the manual `--draft=false`) it also cuts a matching plain **`cli-v<version>`**
+so the standalone CLI ships with desktop. Draft mode ships nothing until you
+publish (it prints the `cli-v` command to run then).
 
-Commit: `chore(desktop): bump version to X (host-service a -> X, cli b -> X)`.
+## CLI hotfix (`scripts/release/cli.ts`, `bun run release cli`)
 
-## Interim CLI release (`scripts/release/cli.ts`, `bun run release cli`)
+Ship a CLI-side fix between desktop releases:
 
-Between desktop releases, ship a CLI-side fix without a desktop release:
+- Current CLI = highest of `packages/cli` version, latest `cli-v` tag, and desktop.
+- New version = plain patch above that (`1.14.2`), or an explicit `bun run release
+  cli <version>` (must be plain, `> current`, same minor as desktop).
+- Sets `cli` + `host-service` to it, refreshes lock, commits, tags `cli-v<version>`.
+- `--daemon` also patch-bumps `pty-daemon` on its own `0.x` track.
 
-- Base = current desktop version `D`.
-- Suffix auto-increments: if cli is `D-N` → `D-(N+1)`, else `D-1`.
-- Sets `cli` + `host-service` to `D-N`, refreshes lock, commits.
-- `--daemon` also **patch-bumps `pty-daemon`** on its own track (e.g. `0.2.5 →
-  0.2.6`) so the release can carry a daemon fix. The daemon never takes the
-  `D-N` version (see below).
-- Tags `cli-v D-N` → triggers `release-cli.yml` (bundles host-service).
-
-`bun run release cli [suffix] [--daemon] [--no-tag]`.
+`bun run release cli [version] [--daemon] [--no-tag]`.
 
 ## Why the daemon stays separate
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -6,19 +6,24 @@ step). One entry point: **`bun run release`**. Design/rationale lives in
 
 ## Model
 
-- **desktop == host-service == cli** — one unified version, enforced by
-  `bun run check:versions` (a CI-gated check).
+- **desktop == host-service == cli** at each desktop release — one unified plain
+  version, enforced by `bun run check:versions` (CI-gated). A desktop release also
+  publishes a matching plain `cli-v<version>`, so the standalone CLI ships in lockstep.
+- **CLI hotfixes lead by a patch.** Between desktop releases, a CLI-only fix bumps
+  a plain patch above the current CLI (`1.14.1 → 1.14.2`), within desktop's minor
+  line, until the next desktop release catches up.
+- **No prerelease suffixes.** A suffix sorts *below* the release (so `superset
+  update` won't deliver it) and fails the host-service min-version floor
+  (`semver.satisfies` excludes prereleases). Everything stays plain.
 - **pty-daemon** is on its own `0.x` track, bumped only with `--daemon`.
-- Interim CLI hotfixes ride a `<desktop>-N` prerelease (e.g. `1.14.0-1`), which
-  sorts **below** the desktop version, so the CLI never ships above desktop.
 
 ## Commands
 
 | Command | When |
 | --- | --- |
 | `bun run release` | Interactive menu (TTY only). |
-| `bun run release desktop [version]` | New app release. Moves desktop + host-service + cli together. Draft by default. |
-| `bun run release cli [suffix]` | CLI-only hotfix **between** desktop releases → `<desktop>-N`. |
+| `bun run release desktop [version]` | New app release. Moves desktop + host-service + cli together + publishes matching `cli-v`. Draft by default. |
+| `bun run release cli [version]` | CLI-only hotfix **between** desktop releases → plain patch above the current CLI. |
 | `… --daemon` | Also ship a pty-daemon fix (patch-bumps it on `0.x`). |
 | `bun run release check` | Verify versions are unified (exit 1 on drift). |
 

--- a/scripts/release/cli.ts
+++ b/scripts/release/cli.ts
@@ -21,6 +21,7 @@ import {
 	bumpDaemonPatch,
 	DESKTOP_PACKAGE,
 	fail,
+	fetchTags,
 	findWorkflowRun,
 	green,
 	guardDaemonBump,
@@ -68,7 +69,9 @@ export async function runCli(argv: string[]): Promise<void> {
 	}
 
 	// The current CLI is the highest of package.json, the latest cli-v tag, and
-	// desktop — so a hotfix never lands below what's already published.
+	// desktop — so a hotfix never lands below what's already published. Fetch
+	// tags first so the tag check uses published state, not stale local tags.
+	await fetchTags(root);
 	const cliPkg = readVersion(root, "packages/cli");
 	const latestTag = await previousReleaseTag(root, "cli");
 	const latestTagVer = latestTag ? latestTag.replace(/^cli-v/, "") : "0.0.0";

--- a/scripts/release/cli.ts
+++ b/scripts/release/cli.ts
@@ -1,17 +1,22 @@
 #!/usr/bin/env bun
 
-// Interim CLI release: bumps the CLI bundle (cli + host-service) to a prerelease
-// under the current desktop version — e.g. 1.14.0-1, 1.14.0-2, ... These sort
-// BELOW the desktop release, so the CLI never ships above desktop. Tags
-// cli-v<version> to trigger release-cli.yml (which bundles host-service).
+// Interim CLI hotfix: ships a CLI-side fix BETWEEN desktop releases by bumping
+// the CLI bundle (cli + host-service) a plain patch above the current CLI — e.g.
+// desktop 1.14.1 → cli 1.14.2, 1.14.3. The CLI leads desktop by a patch until the
+// next desktop release catches up. Tags cli-v<version> to trigger release-cli.yml
+// (which bundles host-service).
 //
-// pty-daemon stays on its OWN 0.x track and is only bumped with --daemon (a
-// prerelease daemon would sort below desktop's bundled one and churn on the
-// shared org socket). See plans/20260709-unified-version-bumping.md.
+// Plain versions (no prerelease suffix) on purpose: a suffix would sort BELOW the
+// release (so `superset update` wouldn't deliver it) AND fail the host-service
+// min-version floor (semver.satisfies excludes prereleases). See
+// plans/20260709-unified-version-bumping.md.
 //
-// Prefer `bun run release cli`. Usage: [suffix] [--daemon] [--no-tag]
+// pty-daemon stays on its OWN 0.x track and is only bumped with --daemon.
+//
+// Prefer `bun run release cli`. Usage: [version] [--daemon] [--no-tag]
 
 import { $ } from "bun";
+import semver from "semver";
 import {
 	bumpDaemonPatch,
 	DESKTOP_PACKAGE,
@@ -21,7 +26,9 @@ import {
 	guardDaemonBump,
 	info,
 	isPlainRelease,
-	nextInterimVersion,
+	maxVersion,
+	nextCliHotfix,
+	previousReleaseTag,
 	readVersion,
 	refreshLockfile,
 	releaseDiffReport,
@@ -34,7 +41,7 @@ import {
 } from "./lib.ts";
 
 export async function runCli(argv: string[]): Promise<void> {
-	let forceSuffix: number | undefined;
+	let explicitVersion: string | undefined;
 	let noTag = false;
 	let withDaemon = false;
 	for (const arg of argv) {
@@ -42,10 +49,10 @@ export async function runCli(argv: string[]): Promise<void> {
 		else if (arg === "--daemon") withDaemon = true;
 		else if (arg.startsWith("-"))
 			fail(
-				`Unknown option: ${arg}\nUsage: release cli [suffix] [--daemon] [--no-tag]`,
+				`Unknown option: ${arg}\nUsage: release cli [version] [--daemon] [--no-tag]`,
 			);
-		else if (/^\d+$/.test(arg)) forceSuffix = Number(arg);
-		else fail(`Suffix must be a positive integer, got: ${arg}`);
+		else if (isPlainRelease(arg)) explicitVersion = arg;
+		else fail(`Version must be a plain MAJOR.MINOR.PATCH, got: ${arg}`);
 	}
 
 	if (!Bun.which("gh")) fail("GitHub CLI (gh) is required but not installed.");
@@ -56,21 +63,41 @@ export async function runCli(argv: string[]): Promise<void> {
 	const desktop = readVersion(root, DESKTOP_PACKAGE);
 	if (!isPlainRelease(desktop)) {
 		fail(
-			`Desktop version '${desktop}' is not a plain MAJOR.MINOR.PATCH release; cannot base a CLI prerelease on it.`,
+			`Desktop version '${desktop}' is not a plain MAJOR.MINOR.PATCH release.`,
 		);
 	}
-	const cliCur = readVersion(root, "packages/cli");
-	const newVersion = nextInterimVersion(desktop, cliCur, forceSuffix);
+
+	// The current CLI is the highest of package.json, the latest cli-v tag, and
+	// desktop — so a hotfix never lands below what's already published.
+	const cliPkg = readVersion(root, "packages/cli");
+	const latestTag = await previousReleaseTag(root, "cli");
+	const latestTagVer = latestTag ? latestTag.replace(/^cli-v/, "") : "0.0.0";
+	const current = maxVersion([cliPkg, latestTagVer, desktop]);
+
+	const newVersion = explicitVersion ?? nextCliHotfix(current);
+	if (!semver.gt(newVersion, current)) {
+		fail(
+			`Version ${newVersion} must be greater than the current CLI ${current}.`,
+		);
+	}
+	if (
+		semver.major(newVersion) !== semver.major(desktop) ||
+		semver.minor(newVersion) !== semver.minor(desktop)
+	) {
+		fail(
+			`Version ${newVersion} must stay in desktop '${desktop}' minor line (a hotfix leads by patch). For a new minor/major, cut a desktop release.`,
+		);
+	}
 	const tag = `cli-v${newVersion}`;
 
-	info(`Desktop version (ceiling): ${desktop}`);
-	info(`Current CLI version:       ${cliCur}`);
-	info(`New CLI bundle version:    ${green(newVersion)}`);
+	info(`Desktop version:        ${desktop}`);
+	info(`Current CLI (published): ${current}`);
+	info(`New CLI hotfix version:  ${green(newVersion)}`);
 	console.log("");
 
 	if ((await $`git rev-parse ${tag}`.nothrow().quiet()).exitCode === 0) {
 		fail(
-			`Tag ${tag} already exists. Pass a higher suffix or delete the tag first.`,
+			`Tag ${tag} already exists. Pass a higher version or delete the tag first.`,
 		);
 	}
 
@@ -95,9 +122,9 @@ export async function runCli(argv: string[]): Promise<void> {
 
 	const addPkgs = UNIFIED_PACKAGES.map((p) => `${p}/package.json`);
 	await $`git add ${addPkgs} ${daemonAdd} bun.lock`;
-	const msg = `chore(cli): release ${newVersion} (cli + host-service ${cliCur} -> ${newVersion}${daemonMsg})`;
+	const msg = `chore(cli): release ${newVersion} (cli + host-service ${current} -> ${newVersion}${daemonMsg})`;
 	await $`git commit -m ${msg}`;
-	success(`Committed ${cliCur} -> ${newVersion}${daemonMsg}`);
+	success(`Committed ${current} -> ${newVersion}${daemonMsg}`);
 
 	if (noTag) {
 		warn(
@@ -117,7 +144,7 @@ export async function runCli(argv: string[]): Promise<void> {
 				.text()
 		).trim();
 		if (!existing) {
-			const body = `Interim CLI release ${newVersion} (cli + host-service). Under desktop ${desktop}.\n\nCreated by scripts/release/cli.ts.`;
+			const body = `Interim CLI hotfix ${newVersion} (cli + host-service), a patch above desktop ${desktop}.\n\nCreated by scripts/release/cli.ts.`;
 			const r =
 				await $`gh pr create --title ${`chore(cli): release ${newVersion}`} --body ${body} --base main --head ${branch}`
 					.nothrow()

--- a/scripts/release/desktop.ts
+++ b/scripts/release/desktop.ts
@@ -410,12 +410,20 @@ async function publishMatchingCli(
 	desktopTag: string,
 ): Promise<void> {
 	const cliTag = `cli-v${version}`;
-	if ((await exitCode($`git rev-parse ${cliTag}`)) === 0) {
-		warn(`${cliTag} already exists; skipping standalone CLI publish.`);
+	// Check origin, not a possibly-stale local tag: a leftover local cli-v tag
+	// would otherwise skip a publish that origin never received.
+	const remote = (
+		await $`git ls-remote --tags origin ${`refs/tags/${cliTag}`}`
+			.nothrow()
+			.text()
+	).trim();
+	if (remote) {
+		warn(`${cliTag} already on origin; skipping standalone CLI publish.`);
 		return;
 	}
 	info(`Publishing matching standalone CLI ${cliTag}...`);
-	await $`git tag ${cliTag} ${desktopTag}`;
+	// -f force-updates any stale local tag onto the desktop release commit.
+	await $`git tag -f ${cliTag} ${desktopTag}`;
 	await $`git push origin ${cliTag}`;
 	success(
 		`Tag ${cliTag} pushed — release-cli.yml will publish the standalone CLI ${version}`,

--- a/scripts/release/desktop.ts
+++ b/scripts/release/desktop.ts
@@ -380,9 +380,11 @@ async function monitorAndPublish(
 		return;
 	}
 
+	const version = tag.replace(/^desktop-v/, "");
 	if (opts.autoPublish) {
 		await $`gh release edit ${tag} --draft=false`;
 		success("Release published!");
+		await publishMatchingCli(version, tag);
 		if (opts.autoMerge && opts.prNumber) {
 			const r =
 				await $`gh pr merge ${opts.prNumber} --squash --delete-branch`.nothrow();
@@ -394,7 +396,30 @@ async function monitorAndPublish(
 		success("Draft release created!");
 		console.log(`\nReview: ${url}`);
 		console.log(`Publish with: gh release edit ${tag} --draft=false`);
+		console.log(
+			`Then ship the matching standalone CLI ${version}:\n  git tag cli-v${version} ${tag} && git push origin cli-v${version}`,
+		);
 	}
+}
+
+/** After the desktop release is published, cut the matching plain cli-v<version>
+ * (same commit) so the standalone CLI ships in lockstep with desktop. Skipped in
+ * draft mode — nothing ships until the desktop release is live. */
+async function publishMatchingCli(
+	version: string,
+	desktopTag: string,
+): Promise<void> {
+	const cliTag = `cli-v${version}`;
+	if ((await exitCode($`git rev-parse ${cliTag}`)) === 0) {
+		warn(`${cliTag} already exists; skipping standalone CLI publish.`);
+		return;
+	}
+	info(`Publishing matching standalone CLI ${cliTag}...`);
+	await $`git tag ${cliTag} ${desktopTag}`;
+	await $`git push origin ${cliTag}`;
+	success(
+		`Tag ${cliTag} pushed — release-cli.yml will publish the standalone CLI ${version}`,
+	);
 }
 
 if (import.meta.main) await runDesktop(process.argv.slice(2));

--- a/scripts/release/lib.test.ts
+++ b/scripts/release/lib.test.ts
@@ -3,49 +3,57 @@ import {
 	incrementPatch,
 	isPlainRelease,
 	latestReleaseTag,
-	nextInterimVersion,
+	maxVersion,
+	nextCliHotfix,
 	unifiedErrors,
 } from "./lib.ts";
 
-describe("nextInterimVersion", () => {
-	test("plain desktop -> -1", () => {
-		expect(nextInterimVersion("1.14.0", "1.14.0")).toBe("1.14.0-1");
+describe("nextCliHotfix", () => {
+	test("plain patch above the current CLI", () => {
+		expect(nextCliHotfix("1.14.1")).toBe("1.14.2");
+		expect(nextCliHotfix("1.14.2")).toBe("1.14.3");
+		expect(nextCliHotfix("1.14.9")).toBe("1.14.10");
 	});
-	test("continues the suffix", () => {
-		expect(nextInterimVersion("1.14.0", "1.14.0-2")).toBe("1.14.0-3");
-		expect(nextInterimVersion("1.14.0", "1.14.0-9")).toBe("1.14.0-10");
+});
+
+describe("maxVersion", () => {
+	test("picks the highest by semver", () => {
+		expect(maxVersion(["1.14.1", "1.14.0-2", "1.14.1"])).toBe("1.14.1");
+		expect(maxVersion(["1.14.2", "1.14.1"])).toBe("1.14.2");
 	});
-	test("resets to -1 when base is stale (new ceiling)", () => {
-		expect(nextInterimVersion("1.15.0", "1.14.0-3")).toBe("1.15.0-1");
-	});
-	test("legacy independent version -> -1", () => {
-		expect(nextInterimVersion("1.14.0", "0.2.24")).toBe("1.14.0-1");
-	});
-	test("forceSuffix overrides", () => {
-		expect(nextInterimVersion("1.14.0", "1.14.0-2", 7)).toBe("1.14.0-7");
+	test("a plain release beats a prerelease of the same tuple", () => {
+		expect(maxVersion(["1.14.0-2", "1.14.1"])).toBe("1.14.1");
+		expect(maxVersion(["1.14.1-1", "1.14.1"])).toBe("1.14.1");
 	});
 });
 
 describe("unifiedErrors", () => {
-	const ok = (d: string, vs: string[]) =>
+	const check = (d: string, vs: string[]) =>
 		unifiedErrors(
 			d,
 			vs.map((v, i) => ({ name: `p${i}`, version: v })),
 		);
-	test("all equal to desktop -> no errors", () => {
-		expect(ok("1.14.0", ["1.14.0", "1.14.0"])).toEqual([]);
+	test("release state: cli == host == desktop", () => {
+		expect(check("1.14.1", ["1.14.1", "1.14.1"])).toEqual([]);
 	});
-	test("interim prerelease shared base -> no errors", () => {
-		expect(ok("1.14.0", ["1.14.0-1", "1.14.0-1"])).toEqual([]);
+	test("hotfix leads desktop by a plain patch", () => {
+		expect(check("1.14.1", ["1.14.2", "1.14.2"])).toEqual([]);
+		expect(check("1.14.1", ["1.14.5", "1.14.5"])).toEqual([]);
 	});
-	test("base mismatch flagged", () => {
-		expect(ok("1.14.0", ["1.15.0-1", "1.14.0"]).length).toBeGreaterThan(0);
+	test("rejects a prerelease suffix (fails the host floor)", () => {
+		expect(check("1.14.1", ["1.14.2-1", "1.14.2-1"]).length).toBeGreaterThan(0);
 	});
-	test("packages disagree -> flagged", () => {
-		expect(ok("1.14.0", ["1.14.0-1", "1.14.0-2"]).length).toBeGreaterThan(0);
+	test("rejects cli below desktop", () => {
+		expect(check("1.14.1", ["1.14.0", "1.14.0"]).length).toBeGreaterThan(0);
+	});
+	test("rejects a different minor line", () => {
+		expect(check("1.14.1", ["1.15.0", "1.15.0"]).length).toBeGreaterThan(0);
+	});
+	test("rejects packages that disagree", () => {
+		expect(check("1.14.1", ["1.14.2", "1.14.3"]).length).toBeGreaterThan(0);
 	});
 	test("desktop must be a plain release", () => {
-		expect(ok("1.14.0-1", ["1.14.0-1"]).length).toBeGreaterThan(0);
+		expect(check("1.14.1-1", ["1.14.1-1"]).length).toBeGreaterThan(0);
 	});
 });
 
@@ -59,12 +67,9 @@ describe("latestReleaseTag", () => {
 		];
 		expect(latestReleaseTag(tags, "desktop")).toBe("desktop-v1.14.0");
 	});
-	test("cli prerelease ordering (release > prerelease)", () => {
-		expect(latestReleaseTag(["cli-v1.14.0-1", "cli-v0.2.24"], "cli")).toBe(
-			"cli-v1.14.0-1",
-		);
-		expect(latestReleaseTag(["cli-v1.14.0-1", "cli-v1.14.0-2"], "cli")).toBe(
-			"cli-v1.14.0-2",
+	test("cli picks the highest (release > prerelease)", () => {
+		expect(latestReleaseTag(["cli-v1.14.0-2", "cli-v1.14.1"], "cli")).toBe(
+			"cli-v1.14.1",
 		);
 	});
 	test("no matching tags -> undefined", () => {

--- a/scripts/release/lib.ts
+++ b/scripts/release/lib.ts
@@ -51,21 +51,25 @@ export function isPlainRelease(v: string): boolean {
 	return PLAIN_SEMVER.test(v);
 }
 
-/** Next interim CLI version: `<desktop>-N`. Continues from N+1 if cli is already
- * `<desktop>-N`, else starts at 1. `forceSuffix` overrides. */
-export function nextInterimVersion(
-	desktop: string,
-	cliCurrent: string,
-	forceSuffix?: number,
-): string {
-	if (forceSuffix != null) return `${desktop}-${forceSuffix}`;
-	const m = cliCurrent.match(/^(.*)-(\d+)$/);
-	if (m && m[1] === desktop) return `${desktop}-${Number(m[2]) + 1}`;
-	return `${desktop}-1`;
+/** Highest of the given versions by semver precedence. */
+export function maxVersion(versions: string[]): string {
+	return versions.reduce((a, b) => (semver.gte(a, b) ? a : b));
 }
 
-/** Errors if UNIFIED entries don't share the desktop base or don't match each
- * other. Empty array = unified. */
+/** Next interim CLI hotfix: a plain patch above the current CLI. Between desktop
+ * releases the CLI leads desktop by patches (desktop 1.14.1 → cli 1.14.2, 1.14.3);
+ * the next desktop release catches up. PLAIN — no prerelease suffix — because a
+ * suffix would (a) sort BELOW the release so `superset update` won't deliver it
+ * and (b) fail the host-service min-version floor (semver.satisfies excludes
+ * prereleases). See plans/20260709-unified-version-bumping.md. */
+export function nextCliHotfix(current: string): string {
+	return incrementPatch(current);
+}
+
+/** Errors if the unified packages aren't plain, don't match each other, or drift
+ * from desktop. A desktop release sets cli == host == desktop; CLI hotfixes lead
+ * by plain patches within desktop's minor line (never a different minor, never
+ * below desktop). Empty array = valid. */
 export function unifiedErrors(
 	desktop: string,
 	entries: { name: string; version: string }[],
@@ -78,14 +82,27 @@ export function unifiedErrors(
 	}
 	let first: string | undefined;
 	for (const { name, version } of entries) {
-		const base = version.split("-")[0];
-		if (base !== desktop) {
-			errors.push(`${name} '${version}' base != desktop '${desktop}'`);
+		if (!isPlainRelease(version)) {
+			errors.push(
+				`${name} '${version}' must be plain MAJOR.MINOR.PATCH (no prerelease suffix — suffixes fail the host-service min-version floor)`,
+			);
 		}
 		if (first === undefined) first = version;
 		else if (version !== first) {
 			errors.push(
 				`${name} '${version}' != '${first}' (unified packages must match)`,
+			);
+		}
+	}
+	if (first && isPlainRelease(first) && isPlainRelease(desktop)) {
+		if (semver.lt(first, desktop)) {
+			errors.push(`cli/host '${first}' is below desktop '${desktop}'`);
+		} else if (
+			semver.major(first) !== semver.major(desktop) ||
+			semver.minor(first) !== semver.minor(desktop)
+		) {
+			errors.push(
+				`cli/host '${first}' must stay in desktop '${desktop}' minor line (patch-ahead only)`,
 			);
 		}
 	}

--- a/scripts/release/lib.ts
+++ b/scripts/release/lib.ts
@@ -183,6 +183,14 @@ export async function refreshLockfile(root: string): Promise<void> {
 	await $`bun install --lockfile-only`.cwd(root).quiet().nothrow();
 }
 
+/** Sync local tags with origin so tag-derived version checks reflect published
+ * state, not stale/local tags. Prune so deleted remote tags don't linger. */
+export async function fetchTags(root: string): Promise<void> {
+	await $`git -C ${root} fetch --tags --force --prune-tags origin`
+		.nothrow()
+		.quiet();
+}
+
 async function tagList(root: string, pattern: string): Promise<string[]> {
 	const out = await $`git -C ${root} tag -l ${pattern}`.nothrow().text();
 	return out


### PR DESCRIPTION
Version bump for the desktop **1.14.1** release (draft), cut from main `ddf3bdd03` via `bun run release desktop 1.14.1 ddf3bdd03`.

- desktop `1.14.0 → 1.14.1`
- host-service `1.14.0-2 → 1.14.1`
- cli `1.14.0-2 → 1.14.1`

Tag `desktop-v1.14.1` is building via release-desktop.yml. Merging this lands the unified version bump on main.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5562">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the desktop 1.14.1 release by aligning versions across the monorepo and moving to plain-version CLI/desktop lockstep. Desktop auto-publishes a matching `cli-v<version>` on `--publish`, CLI hotfixes bump a plain patch within the same minor, and tag checks now use published state to avoid reused versions.

- **Dependencies**
  - `@superset/desktop`: 1.14.0 → 1.14.1
  - `@superset/host-service`: 1.14.0-2 → 1.14.1
  - `@superset/cli`: 1.14.0-2 → 1.14.1

<sup>Written for commit 22f8f1656f7103fa9f20798f8a414f054dad24ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated desktop application, CLI, and host service to **v1.14.1**.
  * Standardized unified versioning so desktop, host-service, and CLI ship plain **MAJOR.MINOR.PATCH** versions (no prerelease suffixes).
* **Documentation**
  * Revised release/versioning docs for the new unified strategy and CLI hotfix workflow (including `cli-v<version>` tagging and `[version]` CLI-only release input).
* **Refactor**
  * Updated release automation to compute interim CLI hotfix versions as patch bumps above the current baseline while enforcing desktop line alignment.
* **Tests**
  * Updated release helper tests to match the new versioning rules and tag-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->