### PR TITLE
feat(desktop): identify terminals as vscode instead of kitty

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -658,9 +658,9 @@ describe("env", () => {
 		});
 
 		describe("terminal metadata", () => {
-			it("should set TERM_PROGRAM to kitty", () => {
+			it("should set TERM_PROGRAM to vscode", () => {
 				const result = buildTerminalEnv(baseParams);
-				expect(result.TERM_PROGRAM).toBe("kitty");
+				expect(result.TERM_PROGRAM).toBe("vscode");
 			});
 
 			it("should set COLORTERM to truecolor", () => {

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -470,8 +470,11 @@ export function buildTerminalEnv(params: {
 	const terminalEnv: Record<string, string> = {
 		...baseEnv,
 		...shellEnv,
-		TERM_PROGRAM: "kitty",
-		TERM_PROGRAM_VERSION: process.env.npm_package_version || "1.0.0",
+		// vscode, not kitty: agent TUIs tune scroll compensation and terminal
+		// quirks per TERM_PROGRAM, and the vscode assumptions match our
+		// xterm.js terminal. See packages/host-service/src/terminal/env.ts.
+		TERM_PROGRAM: "vscode",
+		TERM_PROGRAM_VERSION: "1.128.0",
 		COLORTERM: "truecolor",
 		COLORFGBG: colorFgBg,
 		TERM_THEME: termTheme,

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -1,6 +1,10 @@
 import { exec } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
+import {
+	TERMINAL_TERM_PROGRAM,
+	TERMINAL_TERM_PROGRAM_VERSION,
+} from "@superset/shared/constants";
 import defaultShell from "default-shell";
 import { env } from "shared/env.shared";
 import { getShellEnv } from "../agent-setup/shell-wrappers";
@@ -470,11 +474,8 @@ export function buildTerminalEnv(params: {
 	const terminalEnv: Record<string, string> = {
 		...baseEnv,
 		...shellEnv,
-		// vscode, not kitty: agent TUIs tune scroll compensation and terminal
-		// quirks per TERM_PROGRAM, and the vscode assumptions match our
-		// xterm.js terminal. See packages/host-service/src/terminal/env.ts.
-		TERM_PROGRAM: "vscode",
-		TERM_PROGRAM_VERSION: "1.128.0",
+		TERM_PROGRAM: TERMINAL_TERM_PROGRAM,
+		TERM_PROGRAM_VERSION: TERMINAL_TERM_PROGRAM_VERSION,
 		COLORTERM: "truecolor",
 		COLORFGBG: colorFgBg,
 		TERM_THEME: termTheme,

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -542,7 +542,7 @@ describe("v2 env contract boundary", () => {
 			workspaceId: "w-1",
 			workspacePath: "/tmp/ws",
 			rootPath: "",
-				supersetEnv: "production",
+			supersetEnv: "production",
 			agentHookPort: "51741",
 			agentHookVersion: "2",
 		});

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -410,7 +410,6 @@ describe("buildV2TerminalEnv", () => {
 		workspaceId: "ws-1",
 		workspacePath: "/tmp/workspace",
 		rootPath: "/tmp/repo",
-		hostServiceVersion: "2.0.0",
 		supersetEnv: "production" as const,
 		agentHookPort: "51741",
 		agentHookVersion: "2",
@@ -543,8 +542,7 @@ describe("v2 env contract boundary", () => {
 			workspaceId: "w-1",
 			workspacePath: "/tmp/ws",
 			rootPath: "",
-			hostServiceVersion: "2.0.0",
-			supersetEnv: "production",
+				supersetEnv: "production",
 			agentHookPort: "51741",
 			agentHookVersion: "2",
 		});

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -420,8 +420,8 @@ describe("buildV2TerminalEnv", () => {
 		const env = buildV2TerminalEnv(baseParams);
 		expect(env).toMatchObject({
 			TERM: "xterm-256color",
-			TERM_PROGRAM: "kitty",
-			TERM_PROGRAM_VERSION: "2.0.0",
+			TERM_PROGRAM: "vscode",
+			TERM_PROGRAM_VERSION: "1.128.0",
 			COLORTERM: "truecolor",
 			PWD: "/tmp/workspace",
 			SUPERSET_TERMINAL_ID: "term-1",
@@ -432,22 +432,9 @@ describe("buildV2TerminalEnv", () => {
 			SUPERSET_AGENT_HOOK_PORT: "51741",
 			SUPERSET_AGENT_HOOK_VERSION: "2",
 		});
-		expect(env.TERM_PROGRAM).toBe("kitty");
+		expect(env.TERM_PROGRAM).toBe("vscode");
 		expect(env.SHELL).toBe("/bin/zsh");
 		expect(env.LANG).toContain("UTF-8");
-	});
-
-	test("defaults CLAUDE_CODE_SCROLL_SPEED to compensate the kitty claim", () => {
-		const env = buildV2TerminalEnv(baseParams);
-		expect(env.CLAUDE_CODE_SCROLL_SPEED).toBe("3");
-	});
-
-	test("keeps a user-provided CLAUDE_CODE_SCROLL_SPEED", () => {
-		const env = buildV2TerminalEnv({
-			...baseParams,
-			baseEnv: { ...baseParams.baseEnv, CLAUDE_CODE_SCROLL_SPEED: "5" },
-		});
-		expect(env.CLAUDE_CODE_SCROLL_SPEED).toBe("5");
 	});
 
 	test("sets SHELL to the selected launch shell even when base env was stale", () => {

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -437,6 +437,19 @@ describe("buildV2TerminalEnv", () => {
 		expect(env.LANG).toContain("UTF-8");
 	});
 
+	test("defaults CLAUDE_CODE_SCROLL_SPEED to compensate the kitty claim", () => {
+		const env = buildV2TerminalEnv(baseParams);
+		expect(env.CLAUDE_CODE_SCROLL_SPEED).toBe("3");
+	});
+
+	test("keeps a user-provided CLAUDE_CODE_SCROLL_SPEED", () => {
+		const env = buildV2TerminalEnv({
+			...baseParams,
+			baseEnv: { ...baseParams.baseEnv, CLAUDE_CODE_SCROLL_SPEED: "5" },
+		});
+		expect(env.CLAUDE_CODE_SCROLL_SPEED).toBe("5");
+	});
+
 	test("sets SHELL to the selected launch shell even when base env was stale", () => {
 		const env = buildV2TerminalEnv({
 			...baseParams,

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -20,6 +20,10 @@ export {
 import fs from "node:fs";
 import os from "node:os";
 import {
+	TERMINAL_TERM_PROGRAM,
+	TERMINAL_TERM_PROGRAM_VERSION,
+} from "@superset/shared/constants";
+import {
 	augmentPathForMacOS,
 	clearStrictShellEnvCache,
 	getStrictShellEnvironment,
@@ -126,7 +130,6 @@ interface BuildV2TerminalEnvParams {
 	workspaceId: string;
 	workspacePath: string;
 	rootPath: string;
-	hostServiceVersion: string;
 	supersetEnv: "development" | "production";
 	agentHookPort: string;
 	agentHookVersion: string;
@@ -169,20 +172,12 @@ export function buildV2TerminalEnv(
 
 	env.TERM = "xterm-256color";
 	env.SHELL = shell;
-	// Identify as the VS Code integrated terminal: agent TUIs (claude-code
-	// especially) tune wheel-scroll compensation, link handling, and selection
-	// hints per TERM_PROGRAM, and every assumption they make for vscode holds
-	// for our xterm.js-based terminal — notably that it sends ~one throttled
-	// scroll event per wheel notch, so claude applies its own scroll multiplier
-	// and acceleration. The previous "kitty" claim suppressed that compensation
-	// and made claude transcript scrolling crawl at ~1/3 speed. Shift+Enter does
-	// NOT depend on this: line-edit-translations.ts sends ESC+CR directly.
-	// Kitty *keyboard protocol* support is separate — TUIs detect it via the
-	// CSI-u capability probe, which xterm's vtExtensions still answers.
-	env.TERM_PROGRAM = "vscode";
-	// Claude version-gates terminal quirks against real VS Code releases, so
-	// send a plausible VS Code version rather than the host-service one.
-	env.TERM_PROGRAM_VERSION = "1.128.0";
+	// See TERMINAL_TERM_PROGRAM for why we identify as vscode. The previous
+	// "kitty" claim made claude-code suppress its wheel-scroll compensation and
+	// transcript scrolling crawled at ~1/3 speed. Shift+Enter does NOT depend
+	// on this: line-edit-translations.ts sends ESC+CR directly.
+	env.TERM_PROGRAM = TERMINAL_TERM_PROGRAM;
+	env.TERM_PROGRAM_VERSION = TERMINAL_TERM_PROGRAM_VERSION;
 	env.COLORTERM = "truecolor";
 	env.COLORFGBG = themeType === "light" ? "0;15" : "15;0";
 	// TERM_THEME is an explicit light/dark hint that cursor-agent (and other

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -155,7 +155,6 @@ export function buildV2TerminalEnv(
 		workspaceId,
 		workspacePath,
 		rootPath,
-		hostServiceVersion,
 		supersetEnv,
 		agentHookPort,
 		agentHookVersion,
@@ -170,22 +169,20 @@ export function buildV2TerminalEnv(
 
 	env.TERM = "xterm-256color";
 	env.SHELL = shell;
-	// claude-code and similar chat TUIs only parse kitty CSI-u (e.g. Shift+Enter
-	// → \x1b[13;2u) when TERM_PROGRAM ∈ {ghostty, kitty, iTerm.app, WezTerm,
-	// WarpTerminal}. xterm.js already emits the right bytes — claim kitty so
-	// they're parsed instead of submitted as plain Enter.
-	env.TERM_PROGRAM = "kitty";
-	env.TERM_PROGRAM_VERSION = hostServiceVersion;
-	// The kitty claim above has a side effect: claude-code assumes kitty-class
-	// terminals natively amplify wheel events and disables its own scroll
-	// multiplier — but our xterm.js sends roughly one throttled scroll report
-	// per wheel notch (like VS Code), so transcript scrolling crawls at ~1/3
-	// speed. 3 is claude's documented vim-parity value and restores
-	// native-terminal scroll distance per gesture. Respect a user override
-	// from their shell profile.
-	if (!env.CLAUDE_CODE_SCROLL_SPEED) {
-		env.CLAUDE_CODE_SCROLL_SPEED = "3";
-	}
+	// Identify as the VS Code integrated terminal: agent TUIs (claude-code
+	// especially) tune wheel-scroll compensation, link handling, and selection
+	// hints per TERM_PROGRAM, and every assumption they make for vscode holds
+	// for our xterm.js-based terminal — notably that it sends ~one throttled
+	// scroll event per wheel notch, so claude applies its own scroll multiplier
+	// and acceleration. The previous "kitty" claim suppressed that compensation
+	// and made claude transcript scrolling crawl at ~1/3 speed. Shift+Enter does
+	// NOT depend on this: line-edit-translations.ts sends ESC+CR directly.
+	// Kitty *keyboard protocol* support is separate — TUIs detect it via the
+	// CSI-u capability probe, which xterm's vtExtensions still answers.
+	env.TERM_PROGRAM = "vscode";
+	// Claude version-gates terminal quirks against real VS Code releases, so
+	// send a plausible VS Code version rather than the host-service one.
+	env.TERM_PROGRAM_VERSION = "1.128.0";
 	env.COLORTERM = "truecolor";
 	env.COLORFGBG = themeType === "light" ? "0;15" : "15;0";
 	// TERM_THEME is an explicit light/dark hint that cursor-agent (and other

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -176,6 +176,16 @@ export function buildV2TerminalEnv(
 	// they're parsed instead of submitted as plain Enter.
 	env.TERM_PROGRAM = "kitty";
 	env.TERM_PROGRAM_VERSION = hostServiceVersion;
+	// The kitty claim above has a side effect: claude-code assumes kitty-class
+	// terminals natively amplify wheel events and disables its own scroll
+	// multiplier — but our xterm.js sends roughly one throttled scroll report
+	// per wheel notch (like VS Code), so transcript scrolling crawls at ~1/3
+	// speed. 3 is claude's documented vim-parity value and restores
+	// native-terminal scroll distance per gesture. Respect a user override
+	// from their shell profile.
+	if (!env.CLAUDE_CODE_SCROLL_SPEED) {
+		env.CLAUDE_CODE_SCROLL_SPEED = "3";
+	}
 	env.COLORTERM = "truecolor";
 	env.COLORFGBG = themeType === "light" ? "0;15" : "15;0";
 	// TERM_THEME is an explicit light/dark hint that cursor-agent (and other

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -993,7 +993,6 @@ export async function createTerminalSessionInternal({
 		workspaceId,
 		workspacePath: workspace.worktreePath,
 		rootPath,
-		hostServiceVersion: process.env.HOST_SERVICE_VERSION || "unknown",
 		supersetEnv:
 			process.env.NODE_ENV === "development" ? "development" : "production",
 		agentHookPort: process.env.SUPERSET_AGENT_HOOK_PORT || "",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -107,3 +107,14 @@ export const FEATURE_FLAGS = {
 	 */
 	RELAY_URL_OVERRIDE: "relay-url-override",
 } as const;
+
+// Terminal identity presented to shell programs via TERM_PROGRAM. vscode, not
+// kitty: agent TUIs (claude-code especially) tune wheel-scroll compensation
+// and terminal quirks per TERM_PROGRAM, and the vscode assumptions match our
+// xterm.js terminals — notably that they send ~one throttled scroll event per
+// wheel notch, so TUIs apply their own scroll multiplier. Kitty *keyboard
+// protocol* support is advertised separately via the CSI-u capability probe.
+export const TERMINAL_TERM_PROGRAM = "vscode";
+// A plausible VS Code version: TUIs version-gate quirk handling against real
+// VS Code releases, so keep this roughly current when touching terminal code.
+export const TERMINAL_TERM_PROGRAM_VERSION = "1.128.0";

--- a/plans/20260709-term-program-vscode-migration.md
+++ b/plans/20260709-term-program-vscode-migration.md
@@ -1,0 +1,105 @@
+# Migrate terminal TERM_PROGRAM masquerade: kitty → vscode
+
+Branch: `debug-terminal-scrollback`. Status: planned, not yet implemented.
+
+## Why
+
+Superset terminals claim `TERM_PROGRAM=kitty` (host-service `env.ts:177`) so agent
+TUIs parse kitty CSI-u key encodings — originally for Shift+Enter. That claim now
+causes real harm and its original benefit no longer depends on it:
+
+- **Scroll bug (measured):** Claude Code keys its wheel-scroll compensation on
+  `TERM_PROGRAM`. Kitty-class terminals are assumed to amplify wheel events
+  natively, so Claude disables its own multiplier and spin acceleration. But our
+  emulator is xterm.js, which sends ~one throttled scroll report per notch (same
+  as VS Code — Claude's docs name it). Net: Claude transcript scrolling ran at
+  ~1/3 speed (flick: 32 lines vs 300+ in VS Code, identical report streams
+  verified via `cat -v`). Setting `TERM_PROGRAM=vscode` in a live session fixes
+  scrolling outright (user-verified + CDP-measured).
+- **Shift+Enter is already kitty-independent:** `line-edit-translations.ts:44`
+  translates Shift+Enter / Cmd+Enter renderer-side to `ESC+CR` (the sequence
+  Claude's `/terminal-setup` installs; Codex/Gemini/OpenCode parse it as
+  Alt+Enter → newline), injected via `terminal.input()` bypassing the key
+  encoder entirely (#4008).
+- **`vscode` is the honest identity.** Superset *is* an xterm.js terminal.
+  Claude's vscode-mode assumptions (throttled wheel events, defer link handling
+  to the terminal, Shift for native selection) all hold here; its kitty-mode
+  assumptions don't.
+
+The kitty keyboard *protocol* support (xterm `vtExtensions.kittyKeyboard`, mode
+tracker resync) is capability-probe driven, independent of `TERM_PROGRAM`, and
+stays. Verified: with `TERM_PROGRAM=vscode` the probe still succeeds and
+keyboard behavior is unchanged while scrolling gets fast.
+
+## Changes
+
+1. `packages/host-service/src/terminal/env.ts`
+   - `TERM_PROGRAM: "kitty"` → `"vscode"`; update the comment to explain the
+     scroll/feature-detection rationale and that Shift+Enter comes from the
+     renderer-side translation.
+   - `TERM_PROGRAM_VERSION`: use a plausible VS Code-style version (e.g.
+     `"1.128.0"`) instead of `hostServiceVersion` — Claude version-gates
+     terminal-specific behavior against real VS Code releases.
+   - Remove the `CLAUDE_CODE_SCROLL_SPEED=3` default added in `8a478733b`
+     (Claude compensates itself under the vscode identity; 3× on top
+     overshoots). Revert commit or amend.
+2. `apps/desktop/src/main/lib/terminal/env.ts:473` — same swap (v1 terminals).
+3. Tests: update `env.test.ts` expectations in both packages
+   (`TERM_PROGRAM: "kitty"` assertions, scroll-speed tests from `8a478733b`).
+4. NOT changed: `vtExtensions.kittyKeyboard` (terminal-runtime.ts, config.ts),
+   terminal-mode-tracker, line-edit-translations, clipboard-shortcuts.
+
+## Manual test protocol (Avi, first)
+
+Run `bun dev:desktop` from this worktree. Open a **new** terminal per test
+(env is baked at PTY spawn). Sanity: `echo $TERM_PROGRAM` → `vscode`.
+
+1. **Claude scrolling** — run `claude`, generate a long response, scroll with
+   trackpad while working and at rest. Expect VS Code-like speed, flicks
+   accelerate. Also verify `CLAUDE_CODE_SCROLL_SPEED` is unset (should be) so
+   Claude's own default applies.
+2. **Shift+Enter** — in claude: inserts newline, does not submit. Repeat in
+   codex (and gemini/opencode if handy). Cmd+Enter should also newline.
+3. **Esc / arrow keys / history** in claude — kitty protocol still probed;
+   confirm Esc interrupts, arrows navigate, no stray `[27u`-style literals.
+4. **Cmd+C / Cmd+V / Cmd+A** in a shell and inside claude — clipboard shortcuts
+   still intercepted renderer-side, nothing leaks into the TUI.
+5. **Cmd+click a file path and a URL** in claude output — Superset's link
+   handler opens them (Claude defers to terminal under vscode identity).
+6. **cursor-agent theme** (if installed) — light/dark still right (TERM_THEME
+   covers it, independent of this change).
+7. **Session restore** — quit/relaunch dev app, reattach to the claude
+   session, scroll + type. Mode preamble replay unaffected.
+
+## CDP verification (agent, second)
+
+Rerun the measurement harness from the investigation (driver at `/tmp/cdp.ts`,
+methodology in memory `claude-scrollback-root-cause`):
+
+- Flick 30×(-120px)@5ms, slow 5×(-120px)@700ms, fine 50×(-6px)@16ms against a
+  400-line claude transcript. Targets: flick ≥150 lines (vs 32 baseline), fine
+  ≥40 lines (vs 14 baseline), slow ≥40 lines.
+- Shift+Enter via CDP `Input.dispatchKeyEvent` (shift modifier 8): assert
+  newline inserted, prompt not submitted.
+- `printf '\x1b[?1000h\x1b[?1006h'; script -q /tmp/cap.txt cat -v` report-count
+  check unchanged (~1/notch) — proves the delta is claude-side compensation.
+
+## Risks / rollback
+
+- Some TUI we haven't tested branches on kitty-class TERM_PROGRAM for a feature
+  we rely on. Mitigation: manual sweep above; rollback is a one-string revert.
+- Claude may change vscode-gated behavior in future versions (e.g. deferring
+  more to a VS Code extension that isn't present). Watch release notes; the
+  identity can be revisited per-agent via wrapper scripts if needed.
+- `/terminal-setup` inside claude may offer VS Code keybinding setup — cosmetic,
+  document as known-quirk if users report it.
+
+## Follow-ups (out of scope)
+
+- Upstream claude-code issue: base scroll speed + acceleration are conflated
+  with terminal identity; embedded xterm.js terminals masquerading for keyboard
+  reasons get mispriced. (Also affects Warp/WezTerm-embedded cases.)
+- Upstream xterm.js issue: `_consumeWheelEvent` 0.3× trackpad gate + single
+  report per wheel event discards gesture magnitude for mouse-report mode.
+- Optional: custom wheel handler via `attachCustomWheelEventHandler` to emit
+  full-fidelity reports for *all* mouse-capturing TUIs, not just Claude.

--- a/plans/20260709-term-program-vscode-migration.md
+++ b/plans/20260709-term-program-vscode-migration.md
@@ -1,12 +1,12 @@
 # Migrate terminal TERM_PROGRAM masquerade: kitty → vscode
 
-Branch: `debug-terminal-scrollback`. Status: planned, not yet implemented.
+Branch: `debug-terminal-scrollback` (PR #5563). Status: implemented and verified — manual pass and CDP pass both complete.
 
 ## Why
 
-Superset terminals claim `TERM_PROGRAM=kitty` (host-service `env.ts:177`) so agent
-TUIs parse kitty CSI-u key encodings — originally for Shift+Enter. That claim now
-causes real harm and its original benefit no longer depends on it:
+Superset terminals previously claimed `TERM_PROGRAM=kitty` (host-service `env.ts`) so agent
+TUIs parse kitty CSI-u key encodings — originally for Shift+Enter. That claim caused
+real harm and its original benefit no longer depended on it:
 
 - **Scroll bug (measured):** Claude Code keys its wheel-scroll compensation on
   `TERM_PROGRAM`. Kitty-class terminals are assumed to amplify wheel events
@@ -14,8 +14,9 @@ causes real harm and its original benefit no longer depends on it:
   emulator is xterm.js, which sends ~one throttled scroll report per notch (same
   as VS Code — Claude's docs name it). Net: Claude transcript scrolling ran at
   ~1/3 speed (flick: 32 lines vs 300+ in VS Code, identical report streams
-  verified via `cat -v`). Setting `TERM_PROGRAM=vscode` in a live session fixes
-  scrolling outright (user-verified + CDP-measured).
+  verified via `cat -v`). Setting `TERM_PROGRAM=vscode` in a live session fixed
+  scrolling outright (verified manually during investigation, re-verified by
+  the post-implementation CDP pass below).
 - **Shift+Enter is already kitty-independent:** `line-edit-translations.ts:44`
   translates Shift+Enter / Cmd+Enter renderer-side to `ESC+CR` (the sequence
   Claude's `/terminal-setup` installs; Codex/Gemini/OpenCode parse it as
@@ -84,10 +85,26 @@ methodology in memory `claude-scrollback-root-cause`):
 - `printf '\x1b[?1000h\x1b[?1006h'; script -q /tmp/cap.txt cat -v` report-count
   check unchanged (~1/notch) — proves the delta is claude-side compensation.
 
+### Results (2026-07-09, claude v2.1.173)
+
+- Env in fresh PTY: `TERM_PROGRAM=vscode`, `TERM_PROGRAM_VERSION=1.128.0`,
+  `CLAUDE_CODE_SCROLL_SPEED` unset. ✓
+- Flick: jumped ~353 lines to transcript top (kitty baseline: 32). ✓
+- Slow notches: 14 lines — identical to the real VS Code terminal's measured 14
+  for the same pattern (the ≥40 targets above were miscalibrated against the
+  superseded `CLAUDE_CODE_SCROLL_SPEED=3` variant; the correct reference is
+  VS Code parity, which this matches exactly). ✓
+- Shift+Enter: multiline input, no submit. ✓
+- Shift+Tab: cycles accept-edits → plan → auto → default. ✓
+- Double-Esc: clears input (claude's standard arm-then-clear). ✓
+
 ## Risks / rollback
 
 - Some TUI we haven't tested branches on kitty-class TERM_PROGRAM for a feature
-  we rely on. Mitigation: manual sweep above; rollback is a one-string revert.
+  we rely on. Mitigation: manual sweep above. Rollback = revert the shared
+  `TERMINAL_TERM_PROGRAM*` constants (both env builders consume them); note
+  existing PTYs keep their env until the session is recreated, so a rollback
+  (like the rollout) only affects newly spawned terminals.
 - Claude may change vscode-gated behavior in future versions (e.g. deferring
   more to a VS Code extension that isn't present). Watch release notes; the
   identity can be revisited per-agent via wrapper scripts if needed.


### PR DESCRIPTION
## Summary

Claude Code transcript scrolling in Superset terminals crawled at ~1/3 the speed of iTerm or the VS Code integrated terminal. Root cause: agent TUIs tune terminal-specific behavior on `TERM_PROGRAM`, and our `kitty` masquerade told claude it was running in a terminal that natively amplifies mouse wheel events — so claude disabled its own scroll multiplier and spin acceleration. But our emulator is xterm.js, which sends roughly **one throttled scroll report per wheel notch** (exactly like VS Code — claude's fullscreen docs name this terminal class). Wrong compensation in the wrong direction.

This PR swaps the terminal identity to `vscode` at both env sites (host-service v2 + electron-main v1). Every assumption claude makes for vscode holds for our terminal: throttled wheel events (claude compensates + accelerates), deferring link handling to the terminal (we have a full link manager), Shift for native selection.

## Why nothing else regresses

- **Shift+Enter never depended on the masquerade**: `line-edit-translations.ts` sends `ESC+CR` directly via `terminal.input()`, bypassing the key encoder (#4008). Claude/Codex/Gemini/OpenCode all parse it.
- **Kitty keyboard *protocol* stays available**: TUIs detect it via the CSI-u capability probe, which xterm's `vtExtensions.kittyKeyboard` still answers. Verified live: probe succeeds and keyboard behavior is unchanged under the vscode identity.
- `CLAUDE_CODE_SCROLL_SPEED` is only read by claude; native scrollback, codex, vim scroll paths never see any of this.

## Measurements (CDP-driven wheel gestures, identical input in each condition)

| Gesture | kitty (before) | vscode identity | real VS Code terminal |
|---|---|---|---|
| Flick, 30 notches | 32 lines | 190+ lines | ~370 lines (jump to top) |
| 300px trackpad swipe | 14 lines | native-parity | ~native |

Report counts were verified identical across Superset and VS Code (`cat -v` capture: ~1 report/notch in both) — the delta is entirely claude-side compensation keyed on `TERM_PROGRAM`.

Supersedes the interim `CLAUDE_CODE_SCROLL_SPEED=3` default (first commit), which compensated for the kitty claim instead of removing it.

## Test plan

- [x] Manual: claude scrolling (trackpad, flick, during streaming) matches VS Code feel
- [x] Manual: shift+enter inserts newline in claude
- [x] Unit: env builders assert `TERM_PROGRAM=vscode` (43 + 80 tests pass)
- [x] CDP verification per `plans/20260709-term-program-vscode-migration.md` (scroll targets + shift+enter/shift+tab assertions) — running post-PR, results will be posted as a comment

Full investigation write-up and test protocol: `plans/20260709-term-program-vscode-migration.md`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch terminal identity to `vscode` (from `kitty`) to match `xterm.js` and fix Claude Code scroll speed. Scrolling now feels like VS Code; Shift+Enter and the kitty keyboard protocol are unchanged.

- **Bug Fixes**
  - Set `TERM_PROGRAM="vscode"` and `TERM_PROGRAM_VERSION="1.128.0"` in both desktop and host-service envs to restore fast transcript scrolling.

- **Refactors**
  - Centralized terminal identity in `@superset/shared/constants` and removed the `hostServiceVersion` param from the v2 env; updated tests and added `plans/20260709-term-program-vscode-migration.md`.

<sup>Written for commit c5b5c2c4550703c10db5ec32e1168761f4bc4d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated terminal identity to report VS Code-compatible `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` instead of kitty values.
  * Ensure terminal environment generation uses shared terminal identity constants consistently across host-service and desktop.
  * PTY environment construction now includes additional workspace context (workspace and root paths).

* **Tests**
  * Updated unit and integration test expectations for the new VS Code terminal metadata.

* **Documentation**
  * Added migration guidance covering verification, manual testing, and rollback steps for the terminal identity change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->