### PR TITLE
fix(host-service): isolate dev pty daemons

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -11,6 +11,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as childProcess from "node:child_process";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as net from "node:net";
 import * as os from "node:os";
@@ -1037,3 +1038,70 @@ function isProcessAliveForTest(pid: number): boolean {
 		return (err as NodeJS.ErrnoException).code === "EPERM";
 	}
 }
+
+describe("ptyDaemonSocketPath", () => {
+	const ORG = "org-socket-path";
+	const legacyPath = () => {
+		const shortId = createHash("sha256").update(ORG).digest("hex").slice(0, 12);
+		return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
+	};
+
+	test("every production home keeps the legacy org-only path", () => {
+		expect(ptyDaemonSocketPath(ORG, { NODE_ENV: "production" })).toBe(
+			legacyPath(),
+		);
+		expect(
+			ptyDaemonSocketPath(ORG, {
+				NODE_ENV: "production",
+				SUPERSET_HOME_DIR: path.join(os.homedir(), ".superset"),
+			}),
+		).toBe(legacyPath());
+		expect(
+			ptyDaemonSocketPath(ORG, {
+				NODE_ENV: "production",
+				SUPERSET_HOME_DIR: "/tmp/custom-production-home",
+			}),
+		).toBe(legacyPath());
+	});
+
+	test("non-default development homes get their own stable daemon socket", () => {
+		const a = ptyDaemonSocketPath(ORG, {
+			NODE_ENV: "development",
+			SUPERSET_HOME_DIR: "/tmp/home-a",
+		});
+		const b = ptyDaemonSocketPath(ORG, {
+			NODE_ENV: "development",
+			SUPERSET_HOME_DIR: "/tmp/home-b",
+		});
+		expect(a).not.toBe(legacyPath());
+		expect(b).not.toBe(legacyPath());
+		expect(a).not.toBe(b);
+		expect(
+			ptyDaemonSocketPath(ORG, {
+				NODE_ENV: "development",
+				SUPERSET_HOME_DIR: "/tmp/home-a",
+			}),
+		).toBe(a);
+	});
+
+	test("development with a default home keeps the legacy org-only path", () => {
+		expect(ptyDaemonSocketPath(ORG, { NODE_ENV: "development" })).toBe(
+			legacyPath(),
+		);
+		expect(
+			ptyDaemonSocketPath(ORG, {
+				NODE_ENV: "development",
+				SUPERSET_HOME_DIR: `${path.join(os.homedir(), ".superset")}/../.superset/`,
+			}),
+		).toBe(legacyPath());
+	});
+
+	test("stays under Darwin's 104-byte sun_path limit for long worktree homes", () => {
+		const socket = ptyDaemonSocketPath("a1b2c3d4-e5f6-7890-abcd-ef1234567890", {
+			NODE_ENV: "development",
+			SUPERSET_HOME_DIR:
+				"/Users/someone/.superset/worktrees/0123456789abcdef-0123/very-long-branch-name-for-a-feature/superset-dev-data",
+		});
+		expect(Buffer.byteLength(socket)).toBeLessThan(104);
+	});
+});

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -98,19 +98,32 @@ export function shouldKillStaleDaemonForDev(
 }
 
 /**
- * Per-organization socket path. **Must stay short** — Darwin's `sun_path`
+ * Per-instance socket path. **Must stay short** — Darwin's `sun_path`
  * is 104 bytes, and `$SUPERSET_HOME_DIR/host/{orgId}/pty-daemon.sock` blows
- * past that in dev (worktree-relative SUPERSET_HOME_DIR + 36-char UUID).
- *
- * We put the socket in `os.tmpdir()` with a hash of the org id. Owner-only
+ * past that in dev (worktree-relative SUPERSET_HOME_DIR + 36-char UUID), so
+ * the socket lives in `os.tmpdir()` under a fixed-length hash. Owner-only
  * file mode (0600, set by the daemon's Server.listen) is the auth boundary;
  * the directory permissions don't matter.
+ *
+ * Development manifests are per-home, so a home-agnostic socket lets a dev
+ * instance adopt the packaged app's daemon through the manifest-missing
+ * socket-probe fallback. Namespace only development worktrees with a
+ * non-default `SUPERSET_HOME_DIR`; all production paths deliberately keep the
+ * legacy org-only socket so existing packaged daemons remain adoptable.
  */
-export function ptyDaemonSocketPath(organizationId: string): string {
-	const shortId = createHash("sha256")
-		.update(organizationId)
-		.digest("hex")
-		.slice(0, 12);
+export function ptyDaemonSocketPath(
+	organizationId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	const home = env.SUPERSET_HOME_DIR;
+	const defaultHome = path.join(os.homedir(), ".superset");
+	const isDefaultHome =
+		!home || path.resolve(home) === path.resolve(defaultHome);
+	const key =
+		env.NODE_ENV === "development" && !isDefaultHome
+			? `${organizationId}:${home}`
+			: organizationId;
+	const shortId = createHash("sha256").update(key).digest("hex").slice(0, 12);
 	return path.join(os.tmpdir(), `superset-ptyd-${shortId}.sock`);
 }
 


### PR DESCRIPTION
## Context

The packaged app and every development checkout keep their local state under different homes.

In this description, `<repo>` means **the root directory of the exact Git checkout that launched the development app**. It can be either:

- the main checkout path, such as `/path/to/superset`
- a Git worktree path, such as `/path/to/worktrees/my-branch`

It is not a literal directory named `repo`.

## Data layout

```text
Packaged production
~/.superset/
├── tanstack-db.sqlite
└── host/<organizationId>/
    ├── host.db
    ├── manifest.json
    ├── pty-daemon-manifest.json
    ├── host-service.log
    └── pty-daemon.log

Development checkout
<repo>/superset-dev-data/
├── tanstack-db.sqlite
└── host/<organizationId>/
    ├── host.db
    ├── manifest.json
    ├── pty-daemon-manifest.json
    ├── host-service.log
    └── pty-daemon.log
```

Therefore production and development do **not** share their SQLite databases, manifests, or logs, even when both contain the same `organizationId`. Each development worktree also has its own `<repo>/superset-dev-data` tree.

The inspected development `tanstack-db.sqlite` contained a stale cached row for the production organization. That cache-scoping problem is separate from this PR, but it explains why development started a host service for the same organization ID. The two environments still wrote separate manifests and databases.

The missing isolation boundary was the Unix socket. It lived outside both state trees and both environments used:

```text
/tmp/superset-ptyd-sha256(organizationId).sock
```

When the development host had no local manifest, it probed that shared socket, adopted the packaged app daemon, and wrote the production PID into the development manifest. On a later development reload, stale-daemon cleanup SIGTERM'd that recorded PID—killing the packaged app's PTY daemon and disconnecting every terminal.

## Change

Only a development process with a non-default `SUPERSET_HOME_DIR` now keys its socket as:

```text
sha256(organizationId + ":" + SUPERSET_HOME_DIR)
```

Because local setup sets `SUPERSET_HOME_DIR=<repo>/superset-dev-data`, the main checkout and every worktree receive distinct socket names.

Every non-development path keeps the existing `sha256(organizationId)` socket key, including packaged production with either the default or a custom home. No database path, manifest format, protocol, production socket, or production lifecycle behavior changes.

## Rollout safety

Existing packaged daemons retain their exact socket name, so upgrades can continue to find and adopt them; there is no production socket migration or one-time restart requirement. A development checkout simply starts using its own new socket and can no longer reach or record a packaged daemon PID.

This PR prevents the destructive cross-environment daemon adoption. It intentionally does not change or migrate the separately persisted renderer cache.

## Validation

- Unit coverage locks the legacy production key for default and custom homes, distinct keys only for non-default development homes, and the Darwin Unix-socket path limit.
- Focused tests, lint, and host-service typecheck pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-mode daemon socket handling for custom home directories.
  * Prevented socket-path conflicts when working across multiple custom development environments.
  * Preserved existing socket-path behavior in production and default home-directory configurations.
  * Ensured generated socket paths remain within macOS system limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
