### PR TITLE
feat(mobile): drop workspace list virtualization for stable per-row context menus

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/WorkspacesScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/WorkspacesScreen.tsx
@@ -1,11 +1,15 @@
-import { LegendList } from "@legendapp/list/react-native";
 import type { SelectGithubPullRequest } from "@superset/db/schema";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueryClient } from "@tanstack/react-query";
 import { compareDesc, isAfter } from "date-fns";
 import { Stack, useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useMemo, useState } from "react";
-import { RefreshControl, useWindowDimensions, View } from "react-native";
+import {
+	RefreshControl,
+	ScrollView,
+	useWindowDimensions,
+	View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/ui/text";
 import {
@@ -21,15 +25,8 @@ import { NewChatWidget } from "./components/NewChatWidget";
 import { OrganizationHeaderButton } from "./components/OrganizationHeaderButton";
 import { OrganizationSwitcherSheet } from "./components/OrganizationSwitcherSheet";
 import { prStateFor, WorkspaceRow } from "./components/WorkspaceRow";
-import { useVisibleDiffStats } from "./hooks/useVisibleDiffStats";
+import { useWorkspaceDiffStats } from "./hooks/useWorkspaceDiffStats";
 import { useWorkspacesFilterStore } from "./stores/workspacesFilterStore";
-
-const VIEWABILITY_CONFIG = {
-	itemVisiblePercentThreshold: 50,
-	minimumViewTime: 250,
-};
-
-const MAX_VISIBLE_DIFF_STATS = 20;
 
 const NAVIGATION_BAR_HEIGHT = 44;
 
@@ -41,7 +38,6 @@ export function WorkspacesScreen() {
 	);
 	const sort = useWorkspacesFilterStore((store) => store.sort);
 	const [searchQuery, setSearchQuery] = useState("");
-	const [visibleIds, setVisibleIds] = useState<string[]>([]);
 	const [refreshing, setRefreshing] = useState(false);
 	const { width, height: windowHeight } = useWindowDimensions();
 	const insets = useSafeAreaInsets();
@@ -105,11 +101,6 @@ export function WorkspacesScreen() {
 		projectNamesById,
 	]);
 
-	const workspacesById = useMemo(
-		() => new Map(workspaces.map((workspace) => [workspace.id, workspace])),
-		[workspaces],
-	);
-
 	const pullRequestsByRepoBranch = useMemo(() => {
 		const rank = { closed: 3, draft: 1, merged: 2, open: 0 } as const;
 		const byRepoBranch = new Map<string, SelectGithubPullRequest>();
@@ -131,27 +122,10 @@ export function WorkspacesScreen() {
 		return byRepoBranch;
 	}, [pullRequests]);
 
-	const diffStats = useVisibleDiffStats({
-		visibleIds,
-		workspacesById,
+	const diffStats = useWorkspaceDiffStats({
+		workspaces: visibleWorkspaces,
 		resolveHostUrl: cache.resolveHostUrl,
 	});
-
-	const onViewableItemsChanged = useCallback(
-		({
-			viewableItems,
-		}: {
-			viewableItems: Array<{ item: HostWorkspaceItem; isViewable: boolean }>;
-		}) => {
-			setVisibleIds(
-				viewableItems
-					.filter((viewable) => viewable.isViewable)
-					.slice(0, MAX_VISIBLE_DIFF_STATS)
-					.map((viewable) => viewable.item.id),
-			);
-		},
-		[],
-	);
 
 	const refreshHostData = useCallback(() => {
 		void queryClient.invalidateQueries({
@@ -182,24 +156,22 @@ export function WorkspacesScreen() {
 		[projects],
 	);
 
-	const renderItem = useCallback(
-		({ item }: { item: HostWorkspaceItem }) => {
-			const repositoryId = repositoryIdsByProject.get(item.projectId);
-			return (
-				<WorkspaceRow
-					workspace={item}
-					pullRequest={
-						repositoryId
-							? pullRequestsByRepoBranch.get(`${repositoryId}::${item.branch}`)
-							: undefined
-					}
-					diffStats={diffStats.get(item.id) ?? null}
-					cache={cache}
-				/>
-			);
-		},
-		[pullRequestsByRepoBranch, repositoryIdsByProject, diffStats, cache],
-	);
+	const renderRow = (item: HostWorkspaceItem) => {
+		const repositoryId = repositoryIdsByProject.get(item.projectId);
+		return (
+			<WorkspaceRow
+				key={item.id}
+				workspace={item}
+				pullRequest={
+					repositoryId
+						? pullRequestsByRepoBranch.get(`${repositoryId}::${item.branch}`)
+						: undefined
+				}
+				diffStats={diffStats.get(item.id) ?? null}
+				cache={cache}
+			/>
+		);
+	};
 
 	const handleSwitchOrganization = (organizationId: string) => {
 		setSheetOpen(false);
@@ -241,7 +213,7 @@ export function WorkspacesScreen() {
 					<HostOfflineView hostName={selectedHost.name} />
 				</View>
 			) : (
-				<LegendList
+				<ScrollView
 					className="flex-1 bg-background"
 					contentInsetAdjustmentBehavior="automatic"
 					contentContainerStyle={{
@@ -250,27 +222,21 @@ export function WorkspacesScreen() {
 						paddingBottom: 112,
 						paddingTop: 8,
 					}}
-					data={visibleWorkspaces}
-					extraData={renderItem}
-					keyExtractor={(item: HostWorkspaceItem) => item.id}
-					renderItem={renderItem}
-					viewabilityConfig={VIEWABILITY_CONFIG}
-					onViewableItemsChanged={onViewableItemsChanged}
 					refreshControl={
 						<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
 					}
-					ListEmptyComponent={
-						isReady ? (
-							<View className="items-center justify-center py-20">
-								<Text className="text-center text-muted-foreground">
-									{searchQuery.trim()
-										? "No workspaces match your search"
-										: "No workspaces in this project yet"}
-								</Text>
-							</View>
-						) : null
-					}
-				/>
+				>
+					{visibleWorkspaces.map(renderRow)}
+					{visibleWorkspaces.length === 0 && isReady ? (
+						<View className="items-center justify-center py-20">
+							<Text className="text-center text-muted-foreground">
+								{searchQuery.trim()
+									? "No workspaces match your search"
+									: "No workspaces in this project yet"}
+							</Text>
+						</View>
+					) : null}
+				</ScrollView>
 			)}
 			<NewChatWidget workspaces={workspaces} />
 			<OrganizationSwitcherSheet

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/components/WorkspaceRow/WorkspaceRow.tsx
@@ -20,7 +20,7 @@ import type {
 	HostWorkspacesCacheOps,
 } from "@/hooks/useHostWorkspaces";
 import { useTheme } from "@/hooks/useTheme";
-import type { DiffStats } from "../../hooks/useVisibleDiffStats";
+import type { DiffStats } from "../../hooks/useWorkspaceDiffStats";
 import { WorkspaceRowMenu } from "./components/WorkspaceRowMenu";
 
 const PR_BADGE_CONFIG = {

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/hooks/useVisibleDiffStats/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/hooks/useVisibleDiffStats/index.ts
@@ -1,1 +1,0 @@
-export { type DiffStats, useVisibleDiffStats } from "./useVisibleDiffStats";

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/hooks/useWorkspaceDiffStats/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/hooks/useWorkspaceDiffStats/index.ts
@@ -1,0 +1,4 @@
+export {
+	type DiffStats,
+	useWorkspaceDiffStats,
+} from "./useWorkspaceDiffStats";

--- a/apps/mobile/screens/(authenticated)/(home)/workspaces/hooks/useWorkspaceDiffStats/useWorkspaceDiffStats.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/workspaces/hooks/useWorkspaceDiffStats/useWorkspaceDiffStats.ts
@@ -32,39 +32,34 @@ function aggregateDiffStats(status: GitStatusSnapshot): DiffStats {
 	return { additions, deletions };
 }
 
+const MAX_DIFF_STAT_ROWS = 30;
+
 /**
- * Live working-tree diff stats. Fetching is viewport-bounded (only settled
- * visible rows subscribe — one screenful, not the whole project), but the
- * returned map is built from the whole query cache so rows scrolling back
- * into view render their last-known stats instead of flickering in.
+ * Live working-tree diff stats for the top rows of the sorted list (they're
+ * what's on or near screen with recency sorting). The returned map is built
+ * from the whole query cache so rows keep their last-known stats.
  */
-export function useVisibleDiffStats({
-	visibleIds,
-	workspacesById,
+export function useWorkspaceDiffStats({
+	workspaces,
 	resolveHostUrl,
 }: {
-	visibleIds: string[];
-	workspacesById: Map<string, HostWorkspaceItem>;
+	/** Sorted rows currently rendered by the list. */
+	workspaces: HostWorkspaceItem[];
 	resolveHostUrl: (hostId: string) => string | null;
 }): Map<string, DiffStats> {
 	const queryClient = useQueryClient();
 
 	const eligible = useMemo(() => {
 		const result: Array<{ workspaceId: string; hostUrl: string }> = [];
-		for (const workspaceId of visibleIds) {
-			const workspace = workspacesById.get(workspaceId);
-			if (
-				!workspace ||
-				!workspace.hostReachable ||
-				workspace.worktreeExists === false
-			) {
+		for (const workspace of workspaces.slice(0, MAX_DIFF_STAT_ROWS)) {
+			if (!workspace.hostReachable || workspace.worktreeExists === false) {
 				continue;
 			}
 			const hostUrl = resolveHostUrl(workspace.hostId);
-			if (hostUrl) result.push({ workspaceId, hostUrl });
+			if (hostUrl) result.push({ workspaceId: workspace.id, hostUrl });
 		}
 		return result;
-	}, [visibleIds, workspacesById, resolveHostUrl]);
+	}, [workspaces, resolveHostUrl]);
 
 	const _queries = useQueries({
 		queries: eligible.map(({ workspaceId, hostUrl }) => ({


### PR DESCRIPTION
## Why

In the prod TestFlight build, workspace list rows were janky: some taps were dead, and long-press would navigate AND open the context menu on the next screen. Root cause: each row mounts a native `Link.Menu` (`UIContextMenuInteraction`), and LegendList's virtualization churns those native views on scroll, leaving stale/rebinding gesture recognizers.

## What

- Replace LegendList with a plain `ScrollView` + `map` in `WorkspacesScreen`. The list is bounded (single host, single project — at most low hundreds of rows), so virtualization buys nothing and costs gesture stability. Every row keeps a stable native view for its context-menu interaction.
- Rework `useVisibleDiffStats` → `useWorkspaceDiffStats`: diff stats now fetch for the top 30 sorted rows (no viewport tracking, which required the virtualized list's viewability callbacks). Same query keys/caching, so rows never flicker.
- Keep pull-to-refresh, content insets, and the empty state; delete the viewability plumbing.
- `@legendapp/list` stays — the chat AI elements still use it.

## Verification

- `tsc --noEmit` and biome clean.
- On-device verification pending (taps/long-press across many rows).

Follow-up to #5534.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Workspace lists now use smoother scrolling and more reliable pull-to-refresh behavior.
  * Workspace change statistics are calculated consistently for displayed workspaces.
  * Empty workspace states continue to display directly within the list.
  * Diff statistics now prioritize the first 30 eligible workspaces for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->