### PR TITLE
fix(host-service): use native structured output for workspace naming

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { z } from "zod";
+
+const model = { id: "small-model" };
+const rawGeneratedNames = {
+	title: "Project Overview!!! ",
+	branchName: " Project Overview?! ",
+};
+const sanitizedNames = {
+	title: "Project Overview",
+	branchName: "project-overview",
+};
+
+interface GenerateOptions {
+	structuredOutput: {
+		schema: z.ZodType;
+		jsonPromptInjection?: boolean;
+	};
+}
+
+interface AgentOptions {
+	instructions: string;
+}
+
+const generateMock = mock(
+	async (_prompt: string, _options: GenerateOptions) => ({
+		object: rawGeneratedNames,
+	}),
+);
+const agentConstructorMock = mock((_options: AgentOptions) => ({
+	generate: generateMock,
+}));
+const getSmallModelMock = mock(async () => model);
+
+mock.module("@mastra/core/agent", () => ({
+	Agent: agentConstructorMock,
+}));
+
+mock.module("@superset/chat/server/shared", () => ({
+	getSmallModel: getSmallModelMock,
+}));
+
+const { generateWorkspaceNamesFromPrompt } = await import(
+	"./ai-workspace-names"
+);
+
+describe("generateWorkspaceNamesFromPrompt", () => {
+	beforeEach(() => {
+		agentConstructorMock.mockClear();
+		generateMock.mockClear();
+		getSmallModelMock.mockClear();
+	});
+
+	test("uses native structured output and tells the model to name vague tasks", async () => {
+		await expect(
+			generateWorkspaceNamesFromPrompt("whats this projec about"),
+		).resolves.toEqual(sanitizedNames);
+
+		expect(agentConstructorMock).toHaveBeenCalledTimes(1);
+		const agentCall = agentConstructorMock.mock.calls[0];
+		if (!agentCall) throw new Error("Agent constructor was not called");
+		const [agentOptions] = agentCall;
+		expect(agentOptions.instructions).toContain(
+			"do not answer the prompt, ask questions, or request more context",
+		);
+
+		expect(generateMock).toHaveBeenCalledTimes(1);
+		const generateCall = generateMock.mock.calls[0];
+		if (!generateCall) throw new Error("Agent generate was not called");
+		const [, generateOptions] = generateCall;
+		const { schema } = generateOptions.structuredOutput;
+		expect(schema).toBeDefined();
+		expect(generateOptions.structuredOutput).not.toHaveProperty(
+			"jsonPromptInjection",
+		);
+		expect(z.toJSONSchema(schema)).toMatchObject({
+			type: "object",
+			properties: {
+				title: { type: "string" },
+				branchName: { type: "string" },
+			},
+		});
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
@@ -32,30 +32,36 @@ function trimTitle(raw: string): string {
 		.slice(0, WORKSPACE_TITLE_MAX);
 }
 
-// Forgiving transforms: coerce anything the model sends into shape
-// rather than failing the whole rename. The small model has been
-// reliable with `.describe()` guidance so hard bounds aren't needed.
-// Empty fields fall through to the caller, which skips the respective
-// rename step.
-const workspaceNamesSchema = z.object({
+const workspaceNamesOutputSchema = z.object({
 	title: z
 		.string()
-		.transform(trimTitle)
 		.describe(
 			`Short human-readable workspace title. Up to ${WORKSPACE_TITLE_MAX} characters. No trailing punctuation. Prefer whole words; never truncate mid-word.`,
 		),
 	branchName: z
 		.string()
-		.transform(sanitizeBranchCandidate)
 		.describe(
 			`Git branch name in kebab-case (lowercase, dashes). 2-4 words, up to ${BRANCH_NAME_MAX} characters. Only [a-z0-9-]. No leading/trailing dashes. No prefixes.`,
 		),
 });
 
+// Keep transforms out of the provider-facing schema: transformed Zod fields
+// lose their JSON Schema type in the current converter, which Anthropic's
+// native structured-output endpoint rejects. Coerce the validated response
+// locally instead. Empty fields still fall through to the caller, which skips
+// the respective rename step.
+const workspaceNamesSchema = workspaceNamesOutputSchema.transform(
+	({ title, branchName }) => ({
+		title: trimTitle(title),
+		branchName: sanitizeBranchCandidate(branchName),
+	}),
+);
+
 export type GeneratedWorkspaceNames = z.infer<typeof workspaceNamesSchema>;
 
 const INSTRUCTIONS = [
 	"You name new code workspaces from the user's initial prompt.",
+	"The prompt describes work to do in an existing repository. Name that work; do not answer the prompt, ask questions, or request more context. Always infer useful names, even when the prompt is vague.",
 	"Return a structured object with two fields:",
 	`- title: a short human-readable label (<= ${WORKSPACE_TITLE_MAX} chars). Full words only; never cut mid-word. No trailing punctuation.`,
 	`- branchName: a kebab-case git branch name (<= ${BRANCH_NAME_MAX} chars, 2-4 words). Only a-z 0-9 and dashes. No prefixes.`,
@@ -87,8 +93,7 @@ export async function generateWorkspaceNamesFromPrompt(
 		const { object } = await Promise.race([
 			agent.generate(cleaned, {
 				structuredOutput: {
-					schema: workspaceNamesSchema,
-					jsonPromptInjection: true,
+					schema: workspaceNamesOutputSchema,
 				},
 			}),
 			new Promise<never>((_, reject) =>
@@ -98,7 +103,7 @@ export async function generateWorkspaceNamesFromPrompt(
 				),
 			),
 		]);
-		return object;
+		return workspaceNamesSchema.parse(object);
 	} catch (error) {
 		console.warn(
 			"[generateWorkspaceNamesFromPrompt] generation failed:",


### PR DESCRIPTION
## TL;DR

Workspace naming opted into Mastra's JSON prompt fallback. That disabled native structured output, so Claude could return no object and Superset used a random name even though auth worked.

The bug was one flag. The fix removes it, sends the provider a plain schema, and runs our sanitizers after generation.

## Before

```ts
const { object } = await agent.generate(cleaned, {
	structuredOutput: {
		schema: workspaceNamesSchema,
		jsonPromptInjection: true,
	},
});
return object;
```

`jsonPromptInjection` turned off the provider's structured-output contract. The supplied schema also contained Zod transforms, which do not convert cleanly to provider JSON Schema.

## Now

```ts
const { object } = await agent.generate(cleaned, {
	structuredOutput: {
		schema: workspaceNamesOutputSchema,
	},
});
return workspaceNamesSchema.parse(object);
```

The provider receives a plain `{ title: string, branchName: string }` schema. Title trimming and branch sanitization run locally afterward.

## Tested

- original failing prompt: `whats this projec about`
- live Claude Haiku 4.5 OAuth: 5/5 naming calls passed; original prompt passed twice
- real `workspaces.create` E2E: no warning, persisted name/branch matched the actual Git branch
- focused test, host-service typecheck, repo lint, and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI-generated workspace names by trimming titles and sanitizing branch names.
  * Enhanced structured response handling for more reliable workspace name generation.

* **Tests**
  * Added coverage verifying workspace names are cleaned correctly and generated responses follow the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->