### PR TITLE
fix(relay): allow free plans to use the relay

### DIFF
--- a/apps/relay/src/access.ts
+++ b/apps/relay/src/access.ts
@@ -37,7 +37,7 @@ export async function checkHostAccess(
 	try {
 		const client = createApiClient(token);
 		const result = await client.host.checkAccess.query({ hostId });
-		const ok = result.allowed && result.paidPlan;
+		const ok = result.allowed;
 		if (ok) {
 			allowedCache.set(key, true);
 		} else {


### PR DESCRIPTION
## Summary

Relay access no longer requires a paid subscription. The relay gate (`checkHostAccess`) now grants access based solely on `result.allowed` from `host.checkAccess`, dropping the `&& result.paidPlan` requirement. Free-plan users whose host is authorized in their org can now use the relay HTTP proxy and `/tunnel` WebSocket instead of getting `403 Forbidden` / a closed socket.

Scope is limited to the relay server enforcement — the only place that actually blocked free users. The desktop paywall UI is intentionally left untouched. The `paidPlan` field returned by `host.checkAccess` is now unused by any consumer but kept in place to minimize the diff.

## Test Plan

- [ ] Free-plan user's authorized host connects via relay (no 403 / tunnel close)
- [ ] Non-authorized host (wrong org) still denied
- [ ] Paid-plan behavior unchanged

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5571">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow free-plan users with an authorized host to use the relay HTTP proxy and `/tunnel` WebSocket. Access now relies only on `host.checkAccess` returning `allowed`, removing the paid plan check.

<sup>Written for commit de920be726597e3c71fc07810db672bcc7dd791d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host access is now granted whenever access is approved, including for eligible plans that were previously blocked by an unnecessary plan-status check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->