### PR TITLE
fix(desktop): augment PATH for host-service so git status resolves with a truncated login-shell PATH

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
@@ -192,6 +192,9 @@ export async function getProcessEnvWithShellPath(
 		}
 	}
 
+	// A truncated login-shell PATH still needs homebrew/common dirs so git resolves; matches terminal behavior.
+	augmentPathForMacOS(env);
+
 	return env;
 }
 


### PR DESCRIPTION
## Problem
Support report: the Changes panel shows **"Unable to load git status"** in every workspace (incl. main), even though `git status --porcelain` works fine when run manually in the same worktrees. Survives app-state wipe + full reinstall. The workspace **terminal works fine** in the same app.

## Root cause
Two different PATH resolution paths:
- **Terminal** always calls `augmentPathForMacOS` → finds git even with a broken login-shell PATH.
- **host-service** is spawned via `getProcessEnvWithShellPath`, which trusted the login shell's PATH **verbatim on success** and only augmented on the failure/timeout fallback (`shell-env.ts`).

host-service runs `git.status()` by spawning the bare `git` binary off `PATH`. If the user's login shell reports a **truncated PATH** (e.g. the reporter's `.zshenv` that ran `grep` before setting PATH), git isn't found → every workspace fails, while the terminal keeps working.

## Fix
Call `augmentPathForMacOS(env)` on the success path of `getProcessEnvWithShellPath` too, matching the terminal. Darwin-only, idempotent, only prepends well-known dirs it's missing — no behavior change when the shell PATH is already complete.

## Notes
- Users already running a host-service spawned with the bad PATH still need to restart it (PATH is resolved once at spawn); this prevents the state going forward.
- Not addressed here (intentionally): the renderer swallows the real error into the generic "Unable to load git status" — separate follow-up.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5574">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Changes panel showing "Unable to load git status" by augmenting PATH for the host-service on macOS even when the login shell returns a truncated PATH. Aligns host-service PATH handling with the terminal so `git` resolves reliably.

- **Bug Fixes**
  - Always call `augmentPathForMacOS(env)` after `getProcessEnvWithShellPath` succeeds (macOS only).
  - Prevents failures caused by incomplete PATH from `.zshenv` or similar.

- **Migration**
  - Restart the app (or host-service) to pick up the corrected PATH.

<sup>Written for commit 1feb6d3d1da2b26bbec67a77472dbfc67960f210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution on macOS by ensuring common Homebrew and standard tool directories remain available in the system `PATH`, even when the login-shell environment is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->