### PR TITLE
ci(relay): add Deploy Relay workflow (Fly)

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # The deploy script only reads the working tree; no git auth needed.
+          persist-credentials: false
 
       - name: Install flyctl
         run: |

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,0 +1,40 @@
+name: Deploy Relay
+
+# The relay ships to Fly (not Vercel), so it's not part of deploy-production.yml.
+# Auto-deploys only when relay-relevant code changes — a 7-region rolling Fly
+# deploy is too heavy to run on every unrelated push to main. Use the manual
+# "Run workflow" button (workflow_dispatch) to force a deploy, e.g. to ship a
+# relay change that merged before this workflow existed.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/relay/**"
+      - "packages/shared/**"
+      - ".github/workflows/deploy-relay.yml"
+  workflow_dispatch:
+
+# Never let two relay deploys overlap — rolling deploys mutate the live fleet.
+concurrency:
+  group: deploy-relay
+  cancel-in-progress: false
+
+jobs:
+  deploy-relay:
+    name: Deploy Relay to Fly
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install flyctl
+        run: |
+          curl -L https://fly.io/install.sh | sh
+          echo "$HOME/.fly/bin" >> "$GITHUB_PATH"
+
+      - name: Deploy relay (scale + rolling deploy + smoke test)
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: apps/relay/scripts/deploy.sh


### PR DESCRIPTION
## Summary

The relay ships to **Fly**, not Vercel, and was never wired into CI. `deploy-production.yml` (on push to `main`) deploys only DB / API / Web / Marketing / Admin — all Vercel. So **relay changes silently never deployed**: a merged relay fix stays dark until someone remembers to run the manual Fly deploy. This is exactly what happened with the descriptive-`Forbidden` relay fix in #5573.

This adds a dedicated `Deploy Relay` workflow that reuses the canonical `apps/relay/scripts/deploy.sh` (the same `fly scale` + rolling deploy + smoke-test a human would run — single source of truth, no duplicated deploy logic).

## Design choices
- **Dedicated workflow, not a job in `deploy-production.yml`.** A 7-region rolling Fly deploy mutates the live fleet and is too heavy to run on every unrelated push to `main`. So it's **path-filtered** to `apps/relay/**` + `packages/shared/**` (the runtime code the relay bundles) + the workflow file.
- **`workflow_dispatch`** included so it can be force-run — notably to ship the relay fix from #5573, which merged *before* this workflow existed and so won't be picked up by the path filter retroactively.
- **`concurrency: deploy-relay` (no cancel)** so two rolling deploys never overlap.
- Reuses the existing pinned `actions/checkout` SHA; installs `flyctl` via the official installer (mirrors how the Vercel jobs install their CLI).

## Required before this works
- [ ] Add a **`FLY_API_TOKEN`** secret to the **production** environment (repo Settings → Environments → production). Without it the deploy step fails fast.

## Test plan
- [x] Workflow YAML parses; triggers = `push` (path-filtered) + `workflow_dispatch`.
- [ ] After merge + secret: **Run workflow** manually once to ship #5573's relay change, and confirm the smoke test passes for all 7 regions.

## Follow-up (optional)
- Consider pinning `flyctl` install to a SHA-pinned `superfly/flyctl-actions/setup-flyctl` to match the repo's action-pinning discipline.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated GitHub Actions workflow to deploy the relay to Fly on relevant changes, using the canonical `apps/relay/scripts/deploy.sh`, preventing overlapping deploys, and hardening checkout by not persisting credentials.

- **New Features**
  - New workflow: `.github/workflows/deploy-relay.yml`.
  - Triggers on `push` to `main` (path-filtered) and `workflow_dispatch` for manual runs.
  - Uses `concurrency: deploy-relay` (no cancel) to avoid overlapping rolling deploys.
  - Installs `flyctl` and runs `apps/relay/scripts/deploy.sh` (scale, rolling deploy, smoke test) in the `production` environment.
  - Hardened checkout with `persist-credentials: false` since the deploy reads only the working tree.

- **Migration**
  - Add `FLY_API_TOKEN` secret to the `production` environment before running.
  - After adding the secret, run the workflow once to deploy any previously merged relay changes.

<sup>Written for commit 1598d7307f171e6b1266041c31a6ce51ff63e8b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated deployment workflow for the relay service to Fly.io on merges to the main branch when relevant files change.
  * Added the ability to manually trigger relay deployments.
  * Prevented overlapping relay deployment runs via deployment concurrency settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->