### PR TITLE
chore(desktop): bump version to 1.14.3 (desktop + host-service + cli)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.14.1",
+	"version": "1.14.3",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.14.1",
+      "version": "1.14.3",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.36",
@@ -720,7 +720,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.14.1",
+      "version": "1.14.3",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -801,7 +801,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.14.1",
+      "version": "1.14.3",
       "dependencies": {
         "@hono/node-server": "1.19.13",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.14.1",
+	"version": "1.14.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.14.1",
+	"version": "1.14.3",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Unified version bump to **1.14.3** for the `desktop-v1.14.3` release, cut from main `5708d1ac6` (includes the #5573 headless fixes). Brings `main`'s package.json in line with the release tag: desktop = host-service = cli = 1.14.3.

Supersedes the two stale 1.14.2 bump PRs:
- #5578 (`release-cli-1.14.2`) — cli-v1.14.2 already shipped; 1.14.3 supersedes it.
- #5568 (`run-release`) — this morning's 1.14.2 desktop attempt.

**Note:** merge is currently blocked by `main`'s pre-existing red `Typecheck` (`packages/db/src/task-list-query.test.ts`, from #2895), which blocks every PR. That needs fixing first.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5579">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps versions to 1.14.3 for `@superset/desktop`, `@superset/host-service`, and `@superset/cli` to align packages for the desktop v1.14.3 release. Updates `bun.lock` accordingly.

<sup>Written for commit c848dfa2efdd884ae7808663e84491bfd10a2c92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app, command-line interface, and host service to version **1.14.3**.
  * This aligns the release version across the available product components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->