### PR TITLE
feat(host-service): add manual version-matched remote updates

### DIFF
--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -17,8 +17,8 @@ desktop-specific details (build output, signing, auto-update, troubleshooting).
 The flow will:
 1. Show current version and prompt for new version (patch/minor/major/custom)
 2. Set desktop, `host-service`, and `cli` all to the new version (unified) and refresh `bun.lock`
-3. Create and push a `desktop-v<version>` tag
-4. Monitor the GitHub Actions build
+3. Create and push `desktop-v<version>` and `cli-v<version>` tags
+4. Monitor both GitHub Actions builds
 5. Create a **draft release** for review
 
 > Desktop, `host-service`, and `cli` share one version, enforced by CI
@@ -76,10 +76,14 @@ If you prefer not to use the script:
 
 ```bash
 git tag desktop-v1.0.0
+git tag cli-v1.0.0
 git push origin desktop-v1.0.0
+git push origin cli-v1.0.0
 ```
 
-This creates a draft release. Publish it manually at GitHub Releases.
+The CLI tag publishes the exact standalone version that remote hosts can
+install. The desktop workflow creates a draft release; publish it manually at
+GitHub Releases.
 
 ## Auto-update
 

--- a/apps/desktop/src/renderer/hooks/host-service/useHostInfo/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useHostInfo/index.ts
@@ -1,0 +1,7 @@
+export {
+	EXPECTED_HOST_SERVICE_VERSION,
+	getHostVersionState,
+	type HostVersionState,
+	hostInfoQueryKey,
+	useHostInfo,
+} from "./useHostInfo";

--- a/apps/desktop/src/renderer/hooks/host-service/useHostInfo/useHostInfo.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useHostInfo/useHostInfo.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { getHostVersionState, hostInfoQueryKey } from "./useHostInfo";
+
+describe("getHostVersionState", () => {
+	it("matches equal release and prerelease versions", () => {
+		expect(getHostVersionState("1.14.0", "1.14.0")).toBe("match");
+		expect(getHostVersionState("1.14.0-2", "1.14.0-2")).toBe("match");
+	});
+
+	it("treats an earlier prerelease as outdated", () => {
+		expect(getHostVersionState("1.14.0-1", "1.14.0-2")).toBe("outdated");
+	});
+
+	it("treats numeric interim releases as newer than their stable baseline", () => {
+		expect(getHostVersionState("1.14.0", "1.14.0-2")).toBe("outdated");
+		expect(getHostVersionState("1.14.0-2", "1.14.0")).toBe("newer");
+	});
+
+	it("detects newer versions without offering downgrade semantics", () => {
+		expect(getHostVersionState("1.15.0", "1.14.0")).toBe("newer");
+	});
+
+	it("rejects invalid running or expected versions", () => {
+		expect(getHostVersionState("dev", "1.14.0")).toBe("invalid");
+		expect(getHostVersionState("01.14.0", "1.14.0")).toBe("invalid");
+		expect(getHostVersionState("1.14.0", "latest")).toBe("invalid");
+	});
+});
+
+describe("hostInfoQueryKey", () => {
+	it("retains the existing remote host info cache key", () => {
+		expect(hostInfoQueryKey("org-1", "machine-1")).toEqual([
+			"remoteHostInfo",
+			"org-1",
+			"machine-1",
+		]);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/host-service/useHostInfo/useHostInfo.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useHostInfo/useHostInfo.ts
@@ -1,0 +1,60 @@
+import hostServicePackageJson from "@superset/host-service/package.json" with {
+	type: "json",
+};
+import { compareHostVersions } from "@superset/shared/host-version";
+import { useQuery } from "@tanstack/react-query";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+
+export const EXPECTED_HOST_SERVICE_VERSION: string =
+	hostServicePackageJson.version;
+
+export type HostVersionState = "match" | "outdated" | "newer" | "invalid";
+
+export function getHostVersionState(
+	runningVersion: string,
+	expectedVersion: string,
+): HostVersionState {
+	const order = compareHostVersions(runningVersion, expectedVersion);
+	if (order === null) return "invalid";
+	if (order === 0) return "match";
+	return order < 0 ? "outdated" : "newer";
+}
+
+export function hostInfoQueryKey(organizationId: string, machineId: string) {
+	return ["remoteHostInfo", organizationId, machineId] as const;
+}
+
+interface UseHostInfoOptions {
+	enabled?: boolean;
+	refetchInterval?: number | false;
+}
+
+interface UseHostInfoInput {
+	hostUrl: string | null;
+	organizationId: string;
+	machineId: string;
+}
+
+export function useHostInfo(
+	{ hostUrl, organizationId, machineId }: UseHostInfoInput,
+	options?: UseHostInfoOptions,
+) {
+	return useQuery({
+		queryKey: hostInfoQueryKey(organizationId, machineId),
+		enabled:
+			Boolean(hostUrl && organizationId && machineId) &&
+			(options?.enabled ?? true),
+		queryFn: ({ signal }) => {
+			if (!hostUrl) throw new Error("Host unavailable");
+			return getHostServiceClientByUrl(hostUrl).host.info.query(undefined, {
+				signal,
+			});
+		},
+		staleTime: 30_000,
+		refetchInterval: options?.refetchInterval ?? false,
+		refetchIntervalInBackground:
+			options?.refetchInterval !== undefined &&
+			options.refetchInterval !== false,
+		retry: false,
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/WorkspaceHostIncompatibleState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/WorkspaceHostIncompatibleState.tsx
@@ -3,12 +3,14 @@ import { Link } from "@tanstack/react-router";
 import { ArrowRight, ArrowUpCircle, Monitor } from "lucide-react";
 
 interface WorkspaceHostIncompatibleStateProps {
+	hostId: string;
 	hostName: string;
 	hostVersion: string;
 	minVersion: string;
 }
 
 export function WorkspaceHostIncompatibleState({
+	hostId,
 	hostName,
 	hostVersion,
 	minVersion,
@@ -82,8 +84,8 @@ export function WorkspaceHostIncompatibleState({
 					variant="ghost"
 					className="-ml-2 h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
 				>
-					<Link to="/v2-workspaces">
-						Browse workspaces
+					<Link to="/settings/hosts/$hostId" params={{ hostId }}>
+						Open host settings
 						<ArrowRight
 							className="size-3.5"
 							strokeWidth={2}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useRemoteHostStatus/useRemoteHostStatus.ts
@@ -1,14 +1,15 @@
 import type { SelectV2Workspace } from "@superset/db/schema";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import { MIN_HOST_SERVICE_VERSION } from "@superset/shared/host-version";
+import {
+	isHostVersionAtLeast,
+	MIN_HOST_SERVICE_VERSION,
+} from "@superset/shared/host-version";
 import { and, eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useQuery } from "@tanstack/react-query";
+import { useHostInfo } from "renderer/hooks/host-service/useHostInfo";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
-import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import semver from "semver";
 
 export type RemoteHostStatus =
 	| { status: "skip" }
@@ -20,8 +21,6 @@ export type RemoteHostStatus =
 			minVersion: string;
 	  }
 	| { status: "ready" };
-
-const HOST_INFO_STALE_MS = 30_000;
 
 export function useRemoteHostStatus(
 	workspace: SelectV2Workspace | null,
@@ -57,20 +56,17 @@ export function useRemoteHostStatus(
 		hostId,
 	)}`;
 
-	const infoQuery = useQuery({
-		queryKey: ["remoteHostInfo", organizationId, hostId],
-		queryFn: () => getHostServiceClientByUrl(hostUrl).host.info.query(),
-		enabled: workspace != null && !isLocal,
-		staleTime: HOST_INFO_STALE_MS,
-		retry: false,
-	});
+	const infoQuery = useHostInfo(
+		{ hostUrl, organizationId, machineId: hostId },
+		{ enabled: workspace != null && !isLocal },
+	);
 
 	if (!workspace) return { status: "loading" };
 	if (isLocal) return { status: "skip" };
 
 	if (infoQuery.isSuccess) {
 		const hostVersion = infoQuery.data.version;
-		if (!semver.satisfies(hostVersion, `>=${MIN_HOST_SERVICE_VERSION}`)) {
+		if (!isHostVersionAtLeast(hostVersion, MIN_HOST_SERVICE_VERSION)) {
 			return {
 				status: "incompatible",
 				hostName: hostRow?.name ?? "Unknown host",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -88,6 +88,7 @@ function V2WorkspaceLayout() {
 	if (hostStatus.status === "incompatible") {
 		return (
 			<WorkspaceHostIncompatibleState
+				hostId={workspace.hostId}
 				hostName={hostStatus.hostName}
 				hostVersion={hostStatus.hostVersion}
 				minVersion={hostStatus.minVersion}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
@@ -13,6 +13,7 @@ import { useLocalHostService } from "renderer/routes/_authenticated/providers/Lo
 import type { CandidateRow } from "./components/AddMemberDropdown";
 import { AddMemberDropdown } from "./components/AddMemberDropdown";
 import { HostHeader } from "./components/HostHeader";
+import { HostVersionSection } from "./components/HostVersionSection";
 import type { MemberRowData } from "./components/MembersTable";
 import { MembersTable } from "./components/MembersTable";
 import { WorktreeLocationSection } from "./components/WorktreeLocationSection";
@@ -170,6 +171,16 @@ export function HostSettings({ hostId }: HostSettingsProps) {
 			/>
 
 			<div className="space-y-10">
+				<HostVersionSection
+					key={host.machineId}
+					hostUrl={hostUrl}
+					organizationId={host.organizationId}
+					machineId={host.machineId}
+					isRemoteTarget={isRemoteTarget}
+					isOnline={host.isOnline}
+					canUpdate={isOwner}
+				/>
+
 				<WorktreeLocationSection
 					hostUrl={hostUrl}
 					hostName={host.name}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostVersionSection/HostVersionSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostVersionSection/HostVersionSection.tsx
@@ -1,0 +1,424 @@
+import { alert } from "@superset/ui/atoms/Alert";
+import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { cn } from "@superset/ui/utils";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowUpCircle, LoaderCircle } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import {
+	EXPECTED_HOST_SERVICE_VERSION,
+	getHostVersionState,
+	useHostInfo,
+} from "renderer/hooks/host-service/useHostInfo";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import {
+	canOfferHostUpdate,
+	getHostUpdateLifecycleDecision,
+	type TerminalVerificationState,
+} from "./host-version-lifecycle";
+
+const UPDATE_POLL_INTERVAL_MS = 2_000;
+const UPDATE_TIMEOUT_MS = 2 * 60_000;
+
+interface HostVersionSectionProps {
+	hostUrl: string | null;
+	organizationId: string;
+	machineId: string;
+	isRemoteTarget: boolean;
+	isOnline: boolean;
+	canUpdate: boolean;
+}
+
+interface CompatibleHostInfo {
+	version: string;
+	supportsRemoteUpdate?: boolean;
+}
+
+function hostUpdateStatusQueryKey(organizationId: string, machineId: string) {
+	return ["remoteHostUpdateStatus", organizationId, machineId] as const;
+}
+
+export function HostVersionSection({
+	hostUrl,
+	organizationId,
+	machineId,
+	isRemoteTarget,
+	isOnline,
+	canUpdate,
+}: HostVersionSectionProps) {
+	const queryClient = useQueryClient();
+	const [awaitingTarget, setAwaitingTarget] = useState<string | null>(null);
+	const [terminalVerification, setTerminalVerification] =
+		useState<TerminalVerificationState>("not-needed");
+	const mountedRef = useRef(true);
+	const updateToastIdRef = useRef<string | number | null>(null);
+	const verifiedTerminalResultRef = useRef<string | null>(null);
+	const timedOutTargetRef = useRef<string | null>(null);
+	const shouldPoll = awaitingTarget !== null;
+
+	const infoQuery = useHostInfo(
+		{ hostUrl, organizationId, machineId },
+		{
+			enabled: isRemoteTarget && (isOnline || shouldPoll),
+			refetchInterval: shouldPoll ? UPDATE_POLL_INTERVAL_MS : false,
+		},
+	);
+
+	const updateStatusQuery = useQuery({
+		queryKey: hostUpdateStatusQueryKey(organizationId, machineId),
+		enabled: Boolean(hostUrl && isRemoteTarget),
+		queryFn: ({ signal }) => {
+			if (!hostUrl) throw new Error("Host unavailable");
+			return getHostServiceClientByUrl(hostUrl).host.update.status.query(
+				undefined,
+				{ signal },
+			);
+		},
+		refetchInterval: shouldPoll ? UPDATE_POLL_INTERVAL_MS : false,
+		refetchIntervalInBackground: shouldPoll,
+		retry: false,
+	});
+
+	const requestUpdate = useMutation({
+		mutationFn: () =>
+			apiTrpcClient.host.update.mutate({
+				organizationId,
+				machineId,
+				targetVersion: EXPECTED_HOST_SERVICE_VERSION,
+			}),
+		onMutate: () => {
+			setAwaitingTarget(null);
+			setTerminalVerification("not-needed");
+			verifiedTerminalResultRef.current = null;
+			timedOutTargetRef.current = null;
+			queryClient.setQueryData(
+				hostUpdateStatusQueryKey(organizationId, machineId),
+				{ status: "idle" },
+			);
+			if (updateToastIdRef.current !== null) {
+				toast.dismiss(updateToastIdRef.current);
+			}
+			updateToastIdRef.current = toast.loading("Sending host update...");
+		},
+		onSuccess: (result) => {
+			if (!mountedRef.current) return;
+			setAwaitingTarget(EXPECTED_HOST_SERVICE_VERSION);
+			toast.loading(
+				result.outcome === "satisfied"
+					? "Verifying host version..."
+					: "Updating host...",
+				{
+					id: updateToastIdRef.current ?? undefined,
+					description: `Installing ${EXPECTED_HOST_SERVICE_VERSION}. The host may disconnect briefly.`,
+				},
+			);
+			void infoQuery.refetch();
+			void updateStatusQuery.refetch();
+		},
+		onError: (error) => {
+			if (!mountedRef.current) return;
+			setAwaitingTarget(null);
+			toast.error("Failed to request host update", {
+				id: updateToastIdRef.current ?? undefined,
+				description: error.message,
+			});
+			updateToastIdRef.current = null;
+			void updateStatusQuery.refetch();
+		},
+	});
+
+	const hostInfo = infoQuery.data as CompatibleHostInfo | undefined;
+	const runningVersion = hostInfo?.version ?? null;
+	const versionState = runningVersion
+		? getHostVersionState(runningVersion, EXPECTED_HOST_SERVICE_VERSION)
+		: null;
+	const supportsRemoteUpdate = hostInfo?.supportsRemoteUpdate ?? false;
+	const updateStatus = updateStatusQuery.data;
+	const hasFreshUpdateStatus =
+		updateStatusQuery.isFetchedAfterMount && updateStatusQuery.isSuccess;
+	const lifecycle = getHostUpdateLifecycleDecision({
+		status: updateStatus,
+		isFetchedAfterMount: hasFreshUpdateStatus,
+		runningVersion,
+		expectedVersion: EXPECTED_HOST_SERVICE_VERSION,
+		now: Date.now(),
+		recentCompletionWindowMs: UPDATE_TIMEOUT_MS,
+	});
+	const lifecycleResumableTarget =
+		lifecycle.kind === "resume" ? lifecycle.targetVersion : null;
+	const resumableTarget =
+		lifecycleResumableTarget === timedOutTargetRef.current
+			? null
+			: lifecycleResumableTarget;
+	const hasTimedOutActiveUpdate =
+		lifecycleResumableTarget !== null &&
+		lifecycleResumableTarget === timedOutTargetRef.current;
+	const terminalVerificationKey =
+		lifecycle.kind === "verify" ? lifecycle.resultKey : null;
+
+	useEffect(() => {
+		if (!resumableTarget || awaitingTarget === resumableTarget) return;
+
+		if (updateToastIdRef.current === null) {
+			updateToastIdRef.current = toast.loading("Updating host...", {
+				description: `Waiting for ${resumableTarget} to finish installing.`,
+			});
+		}
+		setAwaitingTarget(resumableTarget);
+	}, [awaitingTarget, resumableTarget]);
+
+	useEffect(() => {
+		if (lifecycle.kind === "settled") timedOutTargetRef.current = null;
+	}, [lifecycle.kind]);
+
+	useEffect(() => {
+		if (!terminalVerificationKey || awaitingTarget) {
+			setTerminalVerification((current) =>
+				current === "not-needed" ? current : "not-needed",
+			);
+			return;
+		}
+		if (verifiedTerminalResultRef.current === terminalVerificationKey) return;
+
+		verifiedTerminalResultRef.current = terminalVerificationKey;
+		setTerminalVerification("pending");
+		let cancelled = false;
+		void infoQuery.refetch().then((result) => {
+			if (cancelled || !mountedRef.current) return;
+			setTerminalVerification(result.isSuccess ? "complete" : "failed");
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [awaitingTarget, infoQuery.refetch, terminalVerificationKey]);
+
+	useEffect(() => {
+		if (!awaitingTarget) return;
+
+		if (runningVersion === awaitingTarget) {
+			setAwaitingTarget(null);
+			toast.success("Host updated", {
+				id: updateToastIdRef.current ?? undefined,
+				description: `Now running ${awaitingTarget}.`,
+			});
+			updateToastIdRef.current = null;
+			return;
+		}
+
+		if (
+			hasFreshUpdateStatus &&
+			updateStatus?.status === "failed" &&
+			updateStatus.targetVersion === awaitingTarget
+		) {
+			setAwaitingTarget(null);
+			toast.error("Host update failed", {
+				id: updateToastIdRef.current ?? undefined,
+				description:
+					updateStatus.error ?? "The host could not apply the update.",
+			});
+			updateToastIdRef.current = null;
+		}
+	}, [awaitingTarget, hasFreshUpdateStatus, runningVersion, updateStatus]);
+
+	useEffect(() => {
+		if (!awaitingTarget) return;
+
+		const timeout = setTimeout(() => {
+			if (!mountedRef.current) return;
+			timedOutTargetRef.current = awaitingTarget;
+			setAwaitingTarget(null);
+			toast.error("Host update timed out", {
+				id: updateToastIdRef.current ?? undefined,
+				description:
+					"The update was sent, but the host did not return with the expected version.",
+			});
+			updateToastIdRef.current = null;
+		}, UPDATE_TIMEOUT_MS);
+
+		return () => clearTimeout(timeout);
+	}, [awaitingTarget]);
+
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+			if (updateToastIdRef.current !== null) {
+				toast.dismiss(updateToastIdRef.current);
+				updateToastIdRef.current = null;
+			}
+		};
+	}, []);
+
+	if (!isRemoteTarget) return null;
+
+	const isUpdating =
+		requestUpdate.isPending || shouldPoll || resumableTarget !== null;
+	const showUpdateButton =
+		versionState === "outdated" &&
+		canUpdate &&
+		isOnline &&
+		supportsRemoteUpdate;
+	const canRequestUpdate = canOfferHostUpdate({
+		versionState,
+		canUpdate,
+		isOnline,
+		supportsRemoteUpdate,
+		isRequestPending: requestUpdate.isPending,
+		isAwaitingTarget: shouldPoll,
+		lifecycle,
+		terminalVerification,
+	});
+	const isUpdateActionBusy =
+		isUpdating ||
+		terminalVerification === "pending" ||
+		lifecycle.kind === "checking";
+	const confirmUpdate = () => {
+		alert({
+			title: "Update this host?",
+			description: `Update this host from ${runningVersion ?? "its current version"} to ${EXPECTED_HOST_SERVICE_VERSION}? The host will restart and briefly disconnect active clients.`,
+			actions: [
+				{ label: "Cancel", variant: "outline", onClick: () => {} },
+				{
+					label: "Update host",
+					variant: "default",
+					onClick: () => requestUpdate.mutate(),
+				},
+			],
+		});
+	};
+
+	const statusLabel = (() => {
+		if (isUpdating) {
+			if (requestUpdate.isPending) return "Sending update request";
+			if (updateStatus?.status === "succeeded") return "Restarting host";
+			if (!infoQuery.isSuccess) return "Reconnecting";
+			return "Installing update";
+		}
+		if (terminalVerification === "pending") return "Verifying host version";
+		if (terminalVerification === "failed") {
+			return "Version verification unavailable";
+		}
+		if (hasTimedOutActiveUpdate) return "Update status timed out";
+		if (lifecycle.kind === "checking" && supportsRemoteUpdate) {
+			return "Checking update status";
+		}
+		if (versionState === "match") return "Up to date";
+		if (versionState === "outdated") return "Update available";
+		if (versionState === "newer") return "Host is newer";
+		if (versionState === "invalid") return "Unknown version";
+		if (!isOnline) return "Host offline";
+		if (infoQuery.isError) return "Version unavailable";
+		return "Checking version";
+	})();
+
+	const supportCopy = (() => {
+		if (isUpdating) {
+			return "The host will reconnect automatically after the update is installed.";
+		}
+		if (terminalVerification === "pending") {
+			return "Confirming the version currently running on the host.";
+		}
+		if (terminalVerification === "failed") {
+			return "The previous update completed, but the host version could not be verified. Reconnect the host and try again.";
+		}
+		if (hasTimedOutActiveUpdate) {
+			return "The host still reports an update in progress, but it did not finish within two minutes.";
+		}
+		if (!runningVersion) {
+			return isOnline
+				? "The host version could not be read."
+				: "Reconnect this host to check its installed version.";
+		}
+		if (versionState === "match") {
+			return "This host matches the version bundled with this client.";
+		}
+		if (versionState === "newer") {
+			return "This host is newer than this client. Update this app to use the same host version.";
+		}
+		if (versionState === "invalid") {
+			return "The host reported an unrecognized version. Update Superset directly on that device.";
+		}
+		if (!isOnline) return "Reconnect this host before requesting an update.";
+		if (!supportsRemoteUpdate) {
+			return `Remote updates are unavailable for this host. Update Superset directly on that device to ${EXPECTED_HOST_SERVICE_VERSION}.`;
+		}
+		if (!canUpdate) return "Only host owners can send remote updates.";
+		if (lifecycle.kind === "checking") {
+			return "Checking whether another host update is already in progress.";
+		}
+		return "Install the matching host version. The host may disconnect briefly while restarting.";
+	})();
+
+	return (
+		<section className="space-y-3" aria-live="polite">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h3 className="text-sm font-medium">Host version</h3>
+					<p className="mt-0.5 text-sm text-muted-foreground">
+						Version of the Superset service running on this host.
+					</p>
+				</div>
+				{showUpdateButton ? (
+					<Button
+						type="button"
+						size="sm"
+						onClick={confirmUpdate}
+						disabled={!canRequestUpdate}
+						className="shrink-0 gap-1.5"
+					>
+						{isUpdateActionBusy ? (
+							<LoaderCircle
+								className="size-3.5 animate-spin"
+								aria-hidden="true"
+							/>
+						) : (
+							<ArrowUpCircle className="size-3.5" aria-hidden="true" />
+						)}
+						{isUpdating
+							? "Updating..."
+							: terminalVerification === "pending"
+								? "Verifying..."
+								: lifecycle.kind === "checking"
+									? "Checking..."
+									: "Update host"}
+					</Button>
+				) : null}
+			</div>
+
+			<div className="w-full max-w-lg border-y border-border/60 text-sm">
+				<div className="flex items-center justify-between gap-4 py-2.5">
+					<span className="text-muted-foreground">Running</span>
+					<code className="font-mono text-xs tabular-nums">
+						{runningVersion ?? "Unknown"}
+					</code>
+				</div>
+				<div className="flex items-center justify-between gap-4 border-t border-border/60 py-2.5">
+					<span className="text-muted-foreground">Expected</span>
+					<code className="font-mono text-xs tabular-nums">
+						{EXPECTED_HOST_SERVICE_VERSION}
+					</code>
+				</div>
+			</div>
+
+			<div className="flex max-w-lg items-start gap-2 text-xs text-muted-foreground">
+				<span
+					aria-hidden="true"
+					className={cn(
+						"mt-1 size-1.5 shrink-0 rounded-full",
+						versionState === "match" && "bg-emerald-500",
+						versionState === "outdated" && "bg-amber-500",
+						versionState === "invalid" && "bg-destructive",
+						(versionState === "newer" || versionState === null) &&
+							"bg-muted-foreground/60",
+					)}
+				/>
+				<p>
+					<span className="font-medium text-foreground">{statusLabel}.</span>{" "}
+					{supportCopy}
+				</p>
+			</div>
+		</section>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostVersionSection/host-version-lifecycle.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostVersionSection/host-version-lifecycle.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "bun:test";
+import {
+	canOfferHostUpdate,
+	getHostUpdateLifecycleDecision,
+	type HostUpdateLifecycleDecision,
+	type TerminalVerificationState,
+} from "./host-version-lifecycle";
+
+const EXPECTED_VERSION = "1.14.0-2";
+const NOW = 1_000_000;
+const RECENT_WINDOW_MS = 120_000;
+
+describe("getHostUpdateLifecycleDecision", () => {
+	it("does not trust a cached updating status before the mount fetch", () => {
+		expect(
+			getHostUpdateLifecycleDecision({
+				status: { status: "updating", targetVersion: EXPECTED_VERSION },
+				isFetchedAfterMount: false,
+				runningVersion: "1.14.0-1",
+				expectedVersion: EXPECTED_VERSION,
+				now: NOW,
+				recentCompletionWindowMs: RECENT_WINDOW_MS,
+			}),
+		).toEqual({ kind: "checking" });
+	});
+
+	it("resumes a freshly observed update", () => {
+		expect(
+			getHostUpdateLifecycleDecision({
+				status: { status: "updating", targetVersion: EXPECTED_VERSION },
+				isFetchedAfterMount: true,
+				runningVersion: "1.14.0-1",
+				expectedVersion: EXPECTED_VERSION,
+				now: NOW,
+				recentCompletionWindowMs: RECENT_WINDOW_MS,
+			}),
+		).toEqual({ kind: "resume", targetVersion: EXPECTED_VERSION });
+	});
+
+	it("does not resume when host info already proves the target is running", () => {
+		expect(
+			getHostUpdateLifecycleDecision({
+				status: { status: "updating", targetVersion: EXPECTED_VERSION },
+				isFetchedAfterMount: true,
+				runningVersion: EXPECTED_VERSION,
+				expectedVersion: EXPECTED_VERSION,
+				now: NOW,
+				recentCompletionWindowMs: RECENT_WINDOW_MS,
+			}),
+		).toEqual({ kind: "settled" });
+	});
+
+	it("resumes exact verification for a recently completed update", () => {
+		expect(
+			getHostUpdateLifecycleDecision({
+				status: {
+					status: "succeeded",
+					targetVersion: EXPECTED_VERSION,
+					completedAt: NOW - 1_000,
+				},
+				isFetchedAfterMount: true,
+				runningVersion: "1.14.0-1",
+				expectedVersion: EXPECTED_VERSION,
+				now: NOW,
+				recentCompletionWindowMs: RECENT_WINDOW_MS,
+			}),
+		).toEqual({ kind: "resume", targetVersion: EXPECTED_VERSION });
+	});
+
+	it("verifies an historical successful result once when host info differs", () => {
+		expect(
+			getHostUpdateLifecycleDecision({
+				status: {
+					status: "succeeded",
+					targetVersion: EXPECTED_VERSION,
+					completedAt: 123,
+				},
+				isFetchedAfterMount: true,
+				runningVersion: "1.14.0-1",
+				expectedVersion: EXPECTED_VERSION,
+				now: NOW,
+				recentCompletionWindowMs: RECENT_WINDOW_MS,
+			}),
+		).toEqual({
+			kind: "verify",
+			targetVersion: EXPECTED_VERSION,
+			resultKey: `${EXPECTED_VERSION}:123`,
+		});
+	});
+
+	it("settles completed and failed history without repeated lifecycle work", () => {
+		expect(
+			getHostUpdateLifecycleDecision({
+				status: {
+					status: "succeeded",
+					targetVersion: EXPECTED_VERSION,
+					completedAt: 123,
+				},
+				isFetchedAfterMount: true,
+				runningVersion: EXPECTED_VERSION,
+				expectedVersion: EXPECTED_VERSION,
+				now: NOW,
+				recentCompletionWindowMs: RECENT_WINDOW_MS,
+			}),
+		).toEqual({ kind: "settled" });
+		expect(
+			getHostUpdateLifecycleDecision({
+				status: {
+					status: "failed",
+					targetVersion: EXPECTED_VERSION,
+					completedAt: 123,
+				},
+				isFetchedAfterMount: true,
+				runningVersion: "1.14.0-1",
+				expectedVersion: EXPECTED_VERSION,
+				now: NOW,
+				recentCompletionWindowMs: RECENT_WINDOW_MS,
+			}),
+		).toEqual({ kind: "settled" });
+	});
+});
+
+describe("canOfferHostUpdate", () => {
+	function canOffer(
+		lifecycle: HostUpdateLifecycleDecision,
+		terminalVerification: TerminalVerificationState = "not-needed",
+	) {
+		return canOfferHostUpdate({
+			versionState: "outdated",
+			canUpdate: true,
+			isOnline: true,
+			supportsRemoteUpdate: true,
+			isRequestPending: false,
+			isAwaitingTarget: false,
+			lifecycle,
+			terminalVerification,
+		});
+	}
+
+	it("blocks while status is untrusted or an update is active", () => {
+		expect(canOffer({ kind: "checking" })).toBe(false);
+		expect(canOffer({ kind: "resume", targetVersion: EXPECTED_VERSION })).toBe(
+			false,
+		);
+	});
+
+	it("blocks historical success until a fresh host-info verification", () => {
+		const lifecycle: HostUpdateLifecycleDecision = {
+			kind: "verify",
+			targetVersion: EXPECTED_VERSION,
+			resultKey: `${EXPECTED_VERSION}:123`,
+		};
+		expect(canOffer(lifecycle, "pending")).toBe(false);
+		expect(canOffer(lifecycle, "failed")).toBe(false);
+		expect(canOffer(lifecycle, "complete")).toBe(true);
+	});
+
+	it("offers an update only after the lifecycle is settled", () => {
+		expect(canOffer({ kind: "settled" })).toBe(true);
+		expect(
+			canOfferHostUpdate({
+				versionState: "newer",
+				canUpdate: true,
+				isOnline: true,
+				supportsRemoteUpdate: true,
+				isRequestPending: false,
+				isAwaitingTarget: false,
+				lifecycle: { kind: "settled" },
+				terminalVerification: "not-needed",
+			}),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostVersionSection/host-version-lifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostVersionSection/host-version-lifecycle.ts
@@ -1,0 +1,108 @@
+export type HostUpdateLifecycleDecision =
+	| { kind: "checking" }
+	| { kind: "resume"; targetVersion: string }
+	| { kind: "verify"; targetVersion: string; resultKey: string }
+	| { kind: "settled" };
+
+export interface HostUpdateStatusSnapshot {
+	status: "idle" | "updating" | "succeeded" | "failed";
+	targetVersion?: string;
+	completedAt?: number;
+}
+
+interface GetHostUpdateLifecycleDecisionInput {
+	status: HostUpdateStatusSnapshot | undefined;
+	isFetchedAfterMount: boolean;
+	runningVersion: string | null;
+	expectedVersion: string;
+	now: number;
+	recentCompletionWindowMs: number;
+}
+
+export function getHostUpdateLifecycleDecision({
+	status,
+	isFetchedAfterMount,
+	runningVersion,
+	expectedVersion,
+	now,
+	recentCompletionWindowMs,
+}: GetHostUpdateLifecycleDecisionInput): HostUpdateLifecycleDecision {
+	if (!isFetchedAfterMount || !status) return { kind: "checking" };
+
+	if (status.status === "updating" && status.targetVersion) {
+		if (runningVersion === status.targetVersion) return { kind: "settled" };
+		return { kind: "resume", targetVersion: status.targetVersion };
+	}
+
+	if (
+		status.status === "succeeded" &&
+		status.targetVersion === expectedVersion &&
+		runningVersion !== expectedVersion
+	) {
+		const completionAge =
+			typeof status.completedAt === "number"
+				? now - status.completedAt
+				: Number.POSITIVE_INFINITY;
+		if (completionAge >= 0 && completionAge <= recentCompletionWindowMs) {
+			return { kind: "resume", targetVersion: status.targetVersion };
+		}
+		return {
+			kind: "verify",
+			targetVersion: status.targetVersion,
+			resultKey: `${status.targetVersion}:${status.completedAt ?? "unknown"}`,
+		};
+	}
+
+	return { kind: "settled" };
+}
+
+export type TerminalVerificationState =
+	| "not-needed"
+	| "pending"
+	| "complete"
+	| "failed";
+
+interface CanOfferHostUpdateInput {
+	versionState: "match" | "outdated" | "newer" | "invalid" | null;
+	canUpdate: boolean;
+	isOnline: boolean;
+	supportsRemoteUpdate: boolean;
+	isRequestPending: boolean;
+	isAwaitingTarget: boolean;
+	lifecycle: HostUpdateLifecycleDecision;
+	terminalVerification: TerminalVerificationState;
+}
+
+export function canOfferHostUpdate({
+	versionState,
+	canUpdate,
+	isOnline,
+	supportsRemoteUpdate,
+	isRequestPending,
+	isAwaitingTarget,
+	lifecycle,
+	terminalVerification,
+}: CanOfferHostUpdateInput): boolean {
+	if (
+		versionState !== "outdated" ||
+		!canUpdate ||
+		!isOnline ||
+		!supportsRemoteUpdate ||
+		isRequestPending ||
+		isAwaitingTarget
+	) {
+		return false;
+	}
+
+	if (lifecycle.kind === "checking" || lifecycle.kind === "resume") {
+		return false;
+	}
+
+	if (lifecycle.kind === "verify") {
+		return terminalVerification === "complete";
+	}
+
+	return (
+		terminalVerification !== "pending" && terminalVerification !== "failed"
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostVersionSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/components/HostVersionSection/index.ts
@@ -1,0 +1,1 @@
+export { HostVersionSection } from "./HostVersionSection";

--- a/apps/relay/src/auth.ts
+++ b/apps/relay/src/auth.ts
@@ -4,6 +4,8 @@ export interface AuthContext {
 	sub: string;
 	email: string;
 	organizationIds: string[];
+	scope?: string;
+	runId?: string;
 }
 
 let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
@@ -28,12 +30,14 @@ export async function verifyJWT(
 		const sub = payload.sub;
 		const email = payload.email as string | undefined;
 		const organizationIds = payload.organizationIds as string[] | undefined;
+		const scope = typeof payload.scope === "string" ? payload.scope : undefined;
+		const runId = typeof payload.runId === "string" ? payload.runId : undefined;
 
 		if (!sub || !organizationIds) {
 			return null;
 		}
 
-		return { sub, email: email ?? "", organizationIds };
+		return { sub, email: email ?? "", organizationIds, scope, runId };
 	} catch (error) {
 		// Don't log expected hourly-rotation expiries, and log only the terse
 		// message otherwise: the full error dumped a stack trace + decoded

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -8,6 +8,7 @@ import { checkHostAccess } from "./access";
 import { type AuthContext, verifyJWT } from "./auth";
 import * as directory from "./directory";
 import { env } from "./env";
+import { canProxyHostTrpcPath } from "./procedure-access";
 import { createProxyBridge, internalProxyUrl, PROXY_HOP_PARAM } from "./proxy";
 import { captureSentryException, initSentry } from "./sentry";
 import { startSyntheticCheck } from "./synthetic";
@@ -319,6 +320,13 @@ app.all("/hosts/:hostId/trpc/*", async (c) => {
 	const prefix = `/hosts/${hostId}`;
 	const url = new URL(c.req.url);
 	const path = `${url.pathname.slice(prefix.length) || "/"}${url.search}`;
+	if (!canProxyHostTrpcPath(c.get("auth"), hostId, path)) {
+		return trpcErrorResponse(
+			c,
+			"FORBIDDEN",
+			"Host updates require owner-authorized dispatch",
+		);
+	}
 	const body = (await c.req.text().catch(() => "")) || undefined;
 
 	const headers: Record<string, string> = {};

--- a/apps/relay/src/procedure-access.test.ts
+++ b/apps/relay/src/procedure-access.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthContext } from "./auth";
+import { canProxyHostTrpcPath } from "./procedure-access";
+
+const memberAuth: AuthContext = {
+	sub: "user-1",
+	email: "member@example.com",
+	organizationIds: ["org-1"],
+};
+const hostId = "org-1:host-1";
+
+describe("canProxyHostTrpcPath", () => {
+	it("allows normal host procedures for ordinary host members", () => {
+		expect(canProxyHostTrpcPath(memberAuth, hostId, "/trpc/host.info")).toBe(
+			true,
+		);
+		expect(
+			canProxyHostTrpcPath(memberAuth, hostId, "/trpc/workspaces.list?batch=1"),
+		).toBe(true);
+	});
+
+	it.each([
+		"/trpc/host.update.start",
+		"/trpc/host.update.start?batch=1",
+		"/trpc/host.info,host.update.start?batch=1",
+		"/trpc/host.info%2Chost.update.start?batch=1",
+		"/trpc/host.info%252Chost.update.start?batch=1",
+		"/trpc/host%252Eupdate%252Estart",
+	])("rejects unscoped update path %s", (path) => {
+		expect(canProxyHostTrpcPath(memberAuth, hostId, path)).toBe(false);
+	});
+
+	it("allows the server-minted host-update scope", () => {
+		expect(
+			canProxyHostTrpcPath(
+				{
+					...memberAuth,
+					scope: "host-update",
+					runId: `host-update:${hostId}`,
+				},
+				hostId,
+				"/trpc/host.update.start",
+			),
+		).toBe(true);
+	});
+
+	it("does not accept unrelated server scopes", () => {
+		expect(
+			canProxyHostTrpcPath(
+				{
+					...memberAuth,
+					scope: "automation-run",
+					runId: `host-update:${hostId}`,
+				},
+				hostId,
+				"/trpc/host.update.start",
+			),
+		).toBe(false);
+	});
+
+	it("does not allow a host-update token on another host", () => {
+		expect(
+			canProxyHostTrpcPath(
+				{
+					...memberAuth,
+					scope: "host-update",
+					runId: `host-update:${hostId}`,
+				},
+				"org-1:host-2",
+				"/trpc/host.update.start",
+			),
+		).toBe(false);
+	});
+});

--- a/apps/relay/src/procedure-access.ts
+++ b/apps/relay/src/procedure-access.ts
@@ -1,0 +1,37 @@
+import type { AuthContext } from "./auth";
+
+const HOST_UPDATE_SCOPE = "host-update";
+const HOST_UPDATE_PROCEDURE = "host.update.start";
+
+function trpcProcedures(path: string): string[] {
+	const pathname = path.split("?", 1)[0] ?? "";
+	const encodedProcedures = pathname.startsWith("/trpc/")
+		? pathname.slice("/trpc/".length)
+		: "";
+	let decodedProcedures = encodedProcedures;
+	while (decodedProcedures.includes("%")) {
+		try {
+			const next = decodeURIComponent(decodedProcedures);
+			if (next === decodedProcedures) break;
+			decodedProcedures = next;
+		} catch {
+			break;
+		}
+	}
+	return decodedProcedures.split(",").filter(Boolean);
+}
+
+export function canProxyHostTrpcPath(
+	auth: AuthContext,
+	hostId: string,
+	path: string,
+): boolean {
+	const requestsHostUpdate = trpcProcedures(path).includes(
+		HOST_UPDATE_PROCEDURE,
+	);
+	return (
+		!requestsHostUpdate ||
+		(auth.scope === HOST_UPDATE_SCOPE &&
+			auth.runId === `${HOST_UPDATE_SCOPE}:${hostId}`)
+	);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -972,11 +972,13 @@
         "@date-fns/tz": "1.4.1",
         "friendly-words": "1.3.1",
         "rrule": "2.8.1",
+        "semver": "7.7.4",
         "zod": "4.3.6",
       },
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "@types/friendly-words": "1.2.2",
+        "@types/semver": "7.7.1",
         "bun-types": "1.3.14",
         "typescript": "6.0.3",
       },

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -4,8 +4,10 @@
  * Bundle layout (extracts into ~/superset/):
  *   bin/superset                 — Bun-compiled CLI binary
  *   bin/superset-host            — Shell wrapper to run the host-service
+ *   bin/superset-host-supervisor — Shell wrapper for the update supervisor
  *   lib/node                     — Standalone Node.js runtime
  *   lib/host-service.js          — Bundled host-service entry
+ *   lib/host-supervisor.js       — One-shot remote update supervisor
  *   lib/node_modules/            — Full native addon packages (JS wrappers + bindings)
  *     better-sqlite3/
  *     node-pty/
@@ -403,6 +405,22 @@ async function buildCli(target: Target, outputPath: string): Promise<void> {
 	);
 }
 
+async function buildHostSupervisor(outputPath: string): Promise<void> {
+	const cliDir = resolve(import.meta.dir, "..");
+	await exec(
+		"bun",
+		[
+			"build",
+			"--target=node",
+			"--format=esm",
+			"--outfile",
+			outputPath,
+			"src/supervisor/main.ts",
+		],
+		cliDir,
+	);
+}
+
 async function buildHostService(): Promise<string> {
 	const hostServiceDir = resolve(import.meta.dir, "../../host-service");
 	await exec("bun", ["run", "build:host"], hostServiceDir);
@@ -426,6 +444,16 @@ exec "$SCRIPT_DIR/../lib/node" "$SCRIPT_DIR/../lib/host-service.js" "$@"
 	chmodSync(wrapperPath, 0o755);
 }
 
+function writeHostSupervisorWrapper(binDir: string): void {
+	const wrapper = `#!/bin/sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../lib/node" "$SCRIPT_DIR/../lib/host-supervisor.js" "$@"
+`;
+	const wrapperPath = join(binDir, "superset-host-supervisor");
+	writeFileSync(wrapperPath, wrapper, { mode: 0o755 });
+	chmodSync(wrapperPath, 0o755);
+}
+
 async function main(): Promise<void> {
 	const { target } = parseArgs();
 	const cliDir = resolve(import.meta.dir, "..");
@@ -441,6 +469,9 @@ async function main(): Promise<void> {
 
 	console.log("[build-dist] building CLI binary");
 	await buildCli(target, join(stagingRoot, "bin", "superset"));
+
+	console.log("[build-dist] building host update supervisor");
+	await buildHostSupervisor(join(stagingRoot, "lib", "host-supervisor.js"));
 
 	console.log("[build-dist] building host-service bundle");
 	const hostServiceBundle = await buildHostService();
@@ -471,6 +502,7 @@ async function main(): Promise<void> {
 
 	console.log("[build-dist] writing host wrapper");
 	writeHostWrapper(join(stagingRoot, "bin"));
+	writeHostSupervisorWrapper(join(stagingRoot, "bin"));
 
 	const tarball = join(cliDir, "dist", `superset-${target}.tar.gz`);
 	console.log(`[build-dist] creating ${tarball}`);

--- a/packages/cli/src/commands/start/command.ts
+++ b/packages/cli/src/commands/start/command.ts
@@ -33,7 +33,7 @@ export default command({
 				organizationId: organization.id,
 				sessionToken: ctx.bearer,
 				authConfigPath:
-					ctx.authSource === "oauth" ? SUPERSET_CONFIG_PATH : undefined,
+					ctx.authSource === "override" ? undefined : SUPERSET_CONFIG_PATH,
 				api: ctx.api,
 				port: options.port,
 				daemon: options.daemon ?? false,

--- a/packages/cli/src/commands/update/command.test.ts
+++ b/packages/cli/src/commands/update/command.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { atomicReplace } from "./command";
+
+function withInstallRoots(
+	run: (paths: { installRoot: string; newRoot: string }) => void,
+): void {
+	const directory = mkdtempSync(join(tmpdir(), "superset-update-replace-"));
+	const installRoot = join(directory, "install");
+	const newRoot = join(directory, "new");
+	mkdirSync(installRoot);
+	mkdirSync(newRoot);
+	writeFileSync(join(installRoot, "version"), "old");
+	writeFileSync(join(newRoot, "version"), "new");
+	try {
+		run({ installRoot, newRoot });
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
+}
+
+describe("atomicReplace", () => {
+	it("removes the backup during a normal update", () => {
+		withInstallRoots(({ installRoot, newRoot }) => {
+			atomicReplace(installRoot, newRoot);
+			expect(readFileSync(join(installRoot, "version"), "utf8")).toBe("new");
+			expect(existsSync(`${installRoot}.bak`)).toBe(false);
+		});
+	});
+
+	it("retains the old install for supervised verification", () => {
+		withInstallRoots(({ installRoot, newRoot }) => {
+			atomicReplace(installRoot, newRoot, { keepBackup: true });
+			expect(readFileSync(join(installRoot, "version"), "utf8")).toBe("new");
+			expect(readFileSync(join(`${installRoot}.bak`, "version"), "utf8")).toBe(
+				"old",
+			);
+		});
+	});
+});

--- a/packages/cli/src/commands/update/command.ts
+++ b/packages/cli/src/commands/update/command.ts
@@ -99,7 +99,11 @@ function findExtractedRoot(extractDir: string): string {
 	return extractDir;
 }
 
-function atomicReplace(installRoot: string, newRoot: string): void {
+export function atomicReplace(
+	installRoot: string,
+	newRoot: string,
+	options: { keepBackup?: boolean } = {},
+): void {
 	const backupRoot = `${installRoot}.bak`;
 	if (existsSync(backupRoot)) {
 		rmSync(backupRoot, { recursive: true, force: true });
@@ -115,7 +119,9 @@ function atomicReplace(installRoot: string, newRoot: string): void {
 		}
 		throw error;
 	}
-	rmSync(backupRoot, { recursive: true, force: true });
+	if (!options.keepBackup) {
+		rmSync(backupRoot, { recursive: true, force: true });
+	}
 }
 
 function resolveInstallRoot(): string {
@@ -185,6 +191,7 @@ export default command({
 		}
 
 		const installRoot = resolveInstallRoot();
+		const keepBackup = process.env.SUPERSET_UPDATE_KEEP_BACKUP === "1";
 		// Stage as a sibling of the install root so the final renameSync()
 		// is an intra-filesystem move. tmpdir() is frequently a separate
 		// mount (tmpfs on Linux) — renaming across it fails with EXDEV.
@@ -203,7 +210,7 @@ export default command({
 			const newHostBin = join(newRoot, "bin", "superset-host");
 			if (existsSync(newHostBin)) chmodSync(newHostBin, 0o755);
 
-			atomicReplace(installRoot, newRoot);
+			atomicReplace(installRoot, newRoot, { keepBackup });
 
 			return {
 				data: {
@@ -211,6 +218,7 @@ export default command({
 					target: targetVersion,
 					updated: true,
 					installRoot,
+					...(keepBackup ? { backupRoot: `${installRoot}.bak` } : {}),
 				},
 				message: pinnedVersion
 					? `Installed ${targetVersion} (${installRoot})`

--- a/packages/cli/src/lib/host/manifest.ts
+++ b/packages/cli/src/lib/host/manifest.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { SUPERSET_HOME_DIR } from "../config";
+import { isProcessAlive } from "../process-state";
 
 /**
  * Manifest format matches the desktop app's HostServiceManifest
@@ -20,6 +21,7 @@ export interface HostServiceManifest {
 	authToken: string;
 	startedAt: number;
 	organizationId: string;
+	version?: string;
 }
 
 function manifestDir(organizationId: string): string {
@@ -62,15 +64,7 @@ export function removeManifest(organizationId: string): void {
 	if (existsSync(path)) rmSync(path);
 }
 
-export function isProcessAlive(pid: number): boolean {
-	if (!pid) return false;
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch {
-		return false;
-	}
-}
+export { isProcessAlive };
 
 export function hostDbPath(organizationId: string): string {
 	return join(manifestDir(organizationId), "host.db");

--- a/packages/cli/src/lib/host/spawn.test.ts
+++ b/packages/cli/src/lib/host/spawn.test.ts
@@ -42,6 +42,7 @@ mock.module("node:child_process", () => ({
 }));
 
 const { SUPERSET_CONFIG_PATH } = await import("../config");
+const { readManifest } = await import("./manifest");
 const { spawnHostService } = await import("./spawn");
 
 function createApi(): ApiClient {
@@ -94,5 +95,47 @@ describe("spawnHostService", () => {
 			SUPERSET_CONFIG_PATH,
 		);
 		expect(spawnCalls[0]?.options.env?.AUTH_TOKEN).toBe("session-token");
+		expect(spawnCalls[0]?.options.env?.SUPERSET_HOST_LIFECYCLE_MODE).toBe(
+			"daemon",
+		);
+	});
+
+	test("marks an attached host as foreground-managed", async () => {
+		globalThis.fetch = mock(
+			async () => new Response("ok", { status: 200 }),
+		) as unknown as typeof fetch;
+
+		await spawnHostService({
+			organizationId: "00000000-0000-0000-0000-000000000002",
+			sessionToken: "session-token",
+			authConfigPath: SUPERSET_CONFIG_PATH,
+			api: createApi(),
+			port: 54881,
+			daemon: false,
+		});
+
+		expect(spawnCalls[0]?.options.env?.SUPERSET_HOST_LIFECYCLE_MODE).toBe(
+			"foreground",
+		);
+	});
+
+	test("includes the running bundle version in the child and manifest", async () => {
+		globalThis.fetch = mock(
+			async () => new Response("ok", { status: 200 }),
+		) as unknown as typeof fetch;
+
+		await spawnHostService({
+			organizationId: "00000000-0000-0000-0000-000000000001",
+			sessionToken: "session-token",
+			authConfigPath: SUPERSET_CONFIG_PATH,
+			api: createApi(),
+			port: 54880,
+			daemon: true,
+		});
+
+		expect(spawnCalls[0]?.options.env?.SUPERSET_VERSION).not.toBeEmpty();
+		expect(readManifest("00000000-0000-0000-0000-000000000001")?.version).toBe(
+			spawnCalls[0]?.options.env?.SUPERSET_VERSION,
+		);
 	});
 });

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -111,6 +111,7 @@ export async function spawnHostService(
 			...process.env,
 			ORGANIZATION_ID: options.organizationId,
 			AUTH_TOKEN: options.sessionToken,
+			SUPERSET_HOST_LIFECYCLE_MODE: options.daemon ? "daemon" : "foreground",
 			...(options.authConfigPath
 				? { SUPERSET_AUTH_CONFIG_PATH: options.authConfigPath }
 				: {}),
@@ -121,6 +122,7 @@ export async function spawnHostService(
 			HOST_SERVICE_SECRET: secret,
 			HOST_DB_PATH: hostDbPath(options.organizationId),
 			HOST_MIGRATIONS_FOLDER: migrationsFolder,
+			SUPERSET_VERSION: env.VERSION,
 		},
 	});
 
@@ -142,6 +144,7 @@ export async function spawnHostService(
 		authToken: secret,
 		startedAt: Date.now(),
 		organizationId: options.organizationId,
+		version: env.VERSION,
 	};
 	writeManifest(manifest);
 

--- a/packages/cli/src/lib/process-state.ts
+++ b/packages/cli/src/lib/process-state.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+
+export function isLinuxZombieStat(stat: string): boolean {
+	const commandEnd = stat.lastIndexOf(")");
+	return commandEnd >= 0 && stat.slice(commandEnd + 2, commandEnd + 3) === "Z";
+}
+
+export function isProcessAlive(pid: number): boolean {
+	if (!Number.isSafeInteger(pid) || pid <= 1) return false;
+	try {
+		process.kill(pid, 0);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EPERM") return false;
+	}
+
+	if (process.platform === "linux") {
+		try {
+			if (isLinuxZombieStat(readFileSync(`/proc/${pid}/stat`, "utf8"))) {
+				return false;
+			}
+		} catch {}
+	}
+	return true;
+}

--- a/packages/cli/src/supervisor/main.integration.test.ts
+++ b/packages/cli/src/supervisor/main.integration.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+	acquireUpdateLock,
+	readUpdateLock,
+	readUpdateResult,
+} from "@superset/host-service/update-protocol";
+
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000000321";
+const PREVIOUS_VERSION = "1.14.0";
+const TARGET_VERSION = "1.15.0";
+const processes = new Set<number>();
+const directories = new Set<string>();
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitFor(
+	condition: () => boolean,
+	timeoutMs = 5_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (condition()) return;
+		await Bun.sleep(25);
+	}
+	throw new Error("Timed out waiting for supervisor fixture state");
+}
+
+async function createFixture() {
+	const root = mkdtempSync(join(tmpdir(), "host-supervisor-e2e-"));
+	directories.add(root);
+	const homeDir = join(root, ".superset");
+	const organizationDir = join(homeDir, "host", ORGANIZATION_ID);
+	const installRoot = join(root, "install");
+	const binDir = join(installRoot, "bin");
+	mkdirSync(organizationDir, { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	writeFileSync(
+		join(homeDir, "config.json"),
+		JSON.stringify({
+			apiKey: "sk_live_test",
+			organizationId: ORGANIZATION_ID,
+		}),
+	);
+	writeFileSync(join(installRoot, "version"), PREVIOUS_VERSION);
+
+	const fakeHostPath = join(root, "fake-host.ts");
+	writeFileSync(
+		fakeHostPath,
+		`import { writeFileSync } from "node:fs";
+const [manifestPath, organizationId, version] = process.argv.slice(2);
+const authToken = "fixture-secret";
+const server = Bun.serve({
+  port: 0,
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/trpc/host.info") {
+	  if (request.headers.get("authorization") !== "Bearer " + authToken) {
+	    return new Response("unauthorized", { status: 401 });
+	  }
+	  if (url.searchParams.get("input") !== JSON.stringify({ json: null })) {
+	    return new Response("missing tRPC input", { status: 400 });
+	  }
+      return Response.json({ result: { data: { json: { version } } } });
+    }
+    return new Response("not found", { status: 404 });
+  },
+});
+writeFileSync(manifestPath, JSON.stringify({
+  pid: process.pid,
+  endpoint: \`http://127.0.0.1:\${server.port}\`,
+  authToken,
+  startedAt: Date.now(),
+  organizationId,
+  version,
+}));
+process.on("SIGTERM", () => process.exit(0));
+await new Promise(() => {});
+`,
+	);
+
+	const cliPath = join(binDir, "superset");
+	writeFileSync(
+		cliPath,
+		`#!/bin/sh
+set -eu
+ROOT="${installRoot}"
+ORG_DIR="${organizationDir}"
+case "$1" in
+  update)
+    TARGET="$3"
+    if [ "$TARGET" = "9.9.9" ]; then
+      exit 23
+    fi
+    rm -rf "$ROOT.bak"
+    cp -R "$ROOT" "$ROOT.bak"
+    printf '%s' "$TARGET" > "$ROOT/version"
+    ;;
+  start)
+    VERSION="$(cat "$ROOT/version")"
+    rm -f "$ORG_DIR/manifest.json"
+    "${process.execPath}" "${fakeHostPath}" "$ORG_DIR/manifest.json" "${ORGANIZATION_ID}" "$VERSION" >/dev/null 2>&1 &
+    for _ in $(seq 1 100); do
+      [ -f "$ORG_DIR/manifest.json" ] && exit 0
+      sleep 0.02
+    done
+    exit 24
+    ;;
+  *) exit 25 ;;
+esac
+`,
+	);
+	chmodSync(cliPath, 0o755);
+
+	const oldHost = Bun.spawn(
+		[
+			process.execPath,
+			fakeHostPath,
+			join(organizationDir, "manifest.json"),
+			ORGANIZATION_ID,
+			PREVIOUS_VERSION,
+		],
+		{ stdout: "ignore", stderr: "ignore" },
+	);
+	if (!oldHost.pid) throw new Error("Failed to start old host fixture");
+	processes.add(oldHost.pid);
+	await waitFor(() => existsSync(join(organizationDir, "manifest.json")));
+
+	return { root, homeDir, organizationDir, installRoot, oldHost };
+}
+
+async function runSupervisor(
+	fixture: Awaited<ReturnType<typeof createFixture>>,
+	target: string,
+) {
+	const supervisorPath = resolve(import.meta.dir, "main.ts");
+	const child = Bun.spawn([process.execPath, supervisorPath], {
+		env: {
+			...process.env,
+			SUPERSET_AUTH_CONFIG_PATH: join(fixture.homeDir, "config.json"),
+			SUPERSET_HOME_DIR: fixture.homeDir,
+			SUPERSET_INSTALL_ROOT: fixture.installRoot,
+			SUPERSET_UPDATE_OLD_PID: String(fixture.oldHost.pid),
+			SUPERSET_UPDATE_ORG_ID: ORGANIZATION_ID,
+			SUPERSET_UPDATE_TARGET_VERSION: target,
+		},
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	if (!child.pid) throw new Error("Failed to start supervisor fixture");
+	processes.add(child.pid);
+
+	const lock = acquireUpdateLock({
+		organizationId: ORGANIZATION_ID,
+		ownerPid: child.pid,
+		targetVersion: target,
+		previousVersion: PREVIOUS_VERSION,
+		homeDir: fixture.homeDir,
+	});
+	if (!lock.acquired)
+		throw new Error("Failed to hand fixture lock to supervisor");
+
+	const exitCode = await child.exited;
+	processes.delete(child.pid);
+	return exitCode;
+}
+
+afterEach(() => {
+	for (const pid of processes) {
+		try {
+			process.kill(pid, "SIGKILL");
+		} catch {}
+	}
+	processes.clear();
+	for (const directory of directories) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+	directories.clear();
+});
+
+describe("host update supervisor", () => {
+	it("updates, restarts, verifies, and releases its lock", async () => {
+		const fixture = await createFixture();
+		await expect(runSupervisor(fixture, TARGET_VERSION)).resolves.toBe(0);
+
+		expect(isAlive(fixture.oldHost.pid)).toBe(false);
+		expect(readUpdateLock(ORGANIZATION_ID, fixture.homeDir)).toBeNull();
+		expect(readUpdateResult(ORGANIZATION_ID, fixture.homeDir)).toMatchObject({
+			status: "succeeded",
+			targetVersion: TARGET_VERSION,
+			previousVersion: PREVIOUS_VERSION,
+			finalVersion: TARGET_VERSION,
+		});
+		expect(existsSync(`${fixture.installRoot}.bak`)).toBe(false);
+
+		await waitFor(() =>
+			existsSync(join(fixture.organizationDir, "manifest.json")),
+		);
+		const manifest = JSON.parse(
+			readFileSync(join(fixture.organizationDir, "manifest.json"), "utf8"),
+		) as { pid: number; version: string };
+		processes.add(manifest.pid);
+		expect(manifest.version).toBe(TARGET_VERSION);
+		expect(isAlive(manifest.pid)).toBe(true);
+	});
+
+	it("leaves the old host running when installation fails", async () => {
+		const fixture = await createFixture();
+		await expect(runSupervisor(fixture, "9.9.9")).resolves.toBe(1);
+
+		expect(isAlive(fixture.oldHost.pid)).toBe(true);
+		expect(readUpdateLock(ORGANIZATION_ID, fixture.homeDir)).toBeNull();
+		expect(readUpdateResult(ORGANIZATION_ID, fixture.homeDir)).toMatchObject({
+			status: "failed",
+			targetVersion: "9.9.9",
+			previousVersion: PREVIOUS_VERSION,
+		});
+		expect(readFileSync(join(fixture.installRoot, "version"), "utf8")).toBe(
+			PREVIOUS_VERSION,
+		);
+	});
+});

--- a/packages/cli/src/supervisor/main.test.ts
+++ b/packages/cli/src/supervisor/main.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { isLinuxZombieStat } from "../lib/process-state";
+import {
+	extractHostInfoVersion,
+	type HostManifest,
+	isMainModule,
+	isUnchangedHostManifest,
+	removeStaleHostManifest,
+	rollbackInstall,
+	runCommand,
+	signalDetachedProcessGroup,
+	verifyAuthenticatedHost,
+} from "./main";
+
+const HOST_MANIFEST: HostManifest = {
+	pid: 1234,
+	endpoint: "http://127.0.0.1:4879",
+	authToken: "secret",
+	startedAt: 1000,
+	organizationId: "00000000-0000-4000-8000-000000000123",
+	version: "1.14.0",
+};
+
+describe("Node entrypoint detection", () => {
+	it("matches the executed JavaScript path without Bun import.meta.main", () => {
+		expect(
+			isMainModule(
+				"file:///tmp/superset-supervisor.js",
+				"/tmp/superset-supervisor.js",
+			),
+		).toBe(true);
+		expect(
+			isMainModule("file:///tmp/superset-supervisor.js", "/tmp/other.js"),
+		).toBe(false);
+		expect(isMainModule("file:///tmp/superset-supervisor.js", undefined)).toBe(
+			false,
+		);
+	});
+});
+
+describe("Linux process state", () => {
+	it("treats zombie processes as exited", () => {
+		expect(isLinuxZombieStat("1550 (node <defunct>) Z 1 1550 1550")).toBe(true);
+		expect(isLinuxZombieStat("1829 (node) S 1 1829 1829")).toBe(false);
+	});
+});
+
+describe("extractHostInfoVersion", () => {
+	it("reads the non-batched superjson tRPC envelope", () => {
+		expect(
+			extractHostInfoVersion({
+				result: { data: { json: { version: "1.14.2" } } },
+			}),
+		).toBe("1.14.2");
+	});
+
+	it.each([
+		null,
+		{},
+		{ result: {} },
+		{ result: { data: { json: {} } } },
+		{ result: { data: { json: { version: 1142 } } } },
+	])("rejects malformed payload %#", (payload) => {
+		expect(extractHostInfoVersion(payload)).toBeNull();
+	});
+});
+
+describe("rollbackInstall", () => {
+	it("atomically restores the retained backup", () => {
+		const directory = mkdtempSync(join(tmpdir(), "host-supervisor-rollback-"));
+		const installRoot = join(directory, "install");
+		const backupRoot = `${installRoot}.bak`;
+		mkdirSync(installRoot);
+		mkdirSync(backupRoot);
+		writeFileSync(join(installRoot, "version"), "new");
+		writeFileSync(join(backupRoot, "version"), "old");
+
+		try {
+			rollbackInstall(installRoot);
+			expect(readFileSync(join(installRoot, "version"), "utf8")).toBe("old");
+			expect(existsSync(backupRoot)).toBe(false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("does not disturb the current install when no backup exists", () => {
+		const directory = mkdtempSync(join(tmpdir(), "host-supervisor-rollback-"));
+		const installRoot = join(directory, "install");
+		mkdirSync(installRoot);
+		writeFileSync(join(installRoot, "version"), "current");
+
+		try {
+			expect(() => rollbackInstall(installRoot)).toThrow(
+				/Previous install backup is missing/,
+			);
+			expect(readFileSync(join(installRoot, "version"), "utf8")).toBe(
+				"current",
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("recovery manifest", () => {
+	it("removes a stale manifest before asking the CLI to restart", () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "host-supervisor-manifest-"));
+		const manifest = join(
+			homeDir,
+			"host",
+			HOST_MANIFEST.organizationId,
+			"manifest.json",
+		);
+		mkdirSync(dirname(manifest), { recursive: true });
+		writeFileSync(manifest, JSON.stringify(HOST_MANIFEST));
+
+		try {
+			removeStaleHostManifest(HOST_MANIFEST.organizationId, homeDir);
+			expect(existsSync(manifest)).toBe(false);
+		} finally {
+			rmSync(homeDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("authenticated host identity", () => {
+	it("requires every manifest identity field to remain unchanged", () => {
+		expect(isUnchangedHostManifest(HOST_MANIFEST, { ...HOST_MANIFEST })).toBe(
+			true,
+		);
+		expect(
+			isUnchangedHostManifest(HOST_MANIFEST, {
+				...HOST_MANIFEST,
+				pid: HOST_MANIFEST.pid + 1,
+			}),
+		).toBe(false);
+		expect(
+			isUnchangedHostManifest(HOST_MANIFEST, {
+				...HOST_MANIFEST,
+				authToken: "replacement-secret",
+			}),
+		).toBe(false);
+	});
+
+	it("authenticates the unchanged host before it can be signaled", async () => {
+		const queryVersion = mock(async () => "1.14.0");
+		await expect(
+			verifyAuthenticatedHost({
+				expectedManifest: HOST_MANIFEST,
+				expectedVersion: "1.14.0",
+				readCurrentManifest: () => ({ ...HOST_MANIFEST }),
+				queryVersion,
+			}),
+		).resolves.toEqual(HOST_MANIFEST);
+		expect(queryVersion).toHaveBeenCalledTimes(1);
+	});
+
+	it("refuses changed, unreachable, or wrong-version hosts", async () => {
+		const queryVersion = mock(async () => "1.14.0");
+		await expect(
+			verifyAuthenticatedHost({
+				expectedManifest: HOST_MANIFEST,
+				expectedVersion: "1.14.0",
+				readCurrentManifest: () => ({ ...HOST_MANIFEST, pid: 9999 }),
+				queryVersion,
+			}),
+		).rejects.toThrow(/manifest changed/);
+		expect(queryVersion).not.toHaveBeenCalled();
+
+		await expect(
+			verifyAuthenticatedHost({
+				expectedManifest: HOST_MANIFEST,
+				expectedVersion: "1.14.0",
+				readCurrentManifest: () => ({ ...HOST_MANIFEST }),
+				queryVersion: async () => null,
+			}),
+		).rejects.toThrow(/reported unreachable/);
+		await expect(
+			verifyAuthenticatedHost({
+				expectedManifest: HOST_MANIFEST,
+				expectedVersion: "1.14.0",
+				readCurrentManifest: () => ({ ...HOST_MANIFEST }),
+				queryVersion: async () => "1.15.0",
+			}),
+		).rejects.toThrow(/reported 1.15.0/);
+	});
+});
+
+describe("bounded supervisor commands", () => {
+	it("signals the detached process group instead of one child pid", () => {
+		const signalProcess = mock(() => true as const);
+		signalDetachedProcessGroup(4321, "SIGTERM", signalProcess);
+		expect(signalProcess).toHaveBeenCalledWith(-4321, "SIGTERM");
+	});
+
+	it("times out and terminates the whole detached command group", async () => {
+		const child = new EventEmitter() as EventEmitter & {
+			pid: number;
+			stdout?: undefined;
+			stderr?: undefined;
+			unref: () => void;
+		};
+		const unref = mock(() => undefined);
+		child.pid = 4321;
+		child.unref = unref;
+		const spawnProcess = mock(() => child) as unknown as typeof spawn;
+		const signalProcessGroup = mock(() => undefined);
+		const log = mock(() => undefined);
+
+		await expect(
+			runCommand("fake-command", ["--flag"], {
+				log,
+				timeoutMs: 5,
+				terminationGraceMs: 5,
+				spawnProcess,
+				signalProcessGroup,
+			}),
+		).rejects.toThrow(/timed out after 5ms/);
+
+		expect(signalProcessGroup).toHaveBeenNthCalledWith(1, 4321, "SIGTERM");
+		expect(signalProcessGroup).toHaveBeenNthCalledWith(2, 4321, "SIGKILL");
+		const spawnOptions = (
+			spawnProcess as unknown as { mock: { calls: unknown[][] } }
+		).mock.calls[0]?.[2] as { detached?: boolean } | undefined;
+		expect(spawnOptions?.detached).toBe(true);
+		expect(unref).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/cli/src/supervisor/main.ts
+++ b/packages/cli/src/supervisor/main.ts
@@ -1,0 +1,619 @@
+/**
+ * One-shot supervisor for a remotely requested standalone host update.
+ * It remains outside the host-service process so it can replace the install,
+ * restart the host, and verify the exact version that came back online.
+ */
+import { spawn } from "node:child_process";
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	readUpdateLock,
+	releaseUpdateLock,
+	updateLogPath,
+	writeUpdateResult,
+} from "@superset/host-service/update-protocol";
+import { isProcessAlive } from "../lib/process-state";
+
+const POLL_INTERVAL_MS = 500;
+const OLD_HOST_EXIT_TIMEOUT_MS = 15_000;
+const NEW_HOST_TIMEOUT_MS = 60_000;
+const LOCK_HANDOFF_TIMEOUT_MS = 5_000;
+const UPDATE_COMMAND_TIMEOUT_MS = 5 * 60_000;
+const START_COMMAND_TIMEOUT_MS = 30_000;
+const COMMAND_TERMINATION_GRACE_MS = 2_000;
+const MAX_RESULT_ERROR_LENGTH = 1_000;
+
+function delay(milliseconds: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export function isMainModule(
+	moduleUrl: string,
+	entryPath: string | undefined = process.argv[1],
+): boolean {
+	if (!entryPath) return false;
+	try {
+		return resolve(fileURLToPath(moduleUrl)) === resolve(entryPath);
+	} catch {
+		return false;
+	}
+}
+
+export interface HostManifest {
+	pid: number;
+	endpoint: string;
+	authToken: string;
+	startedAt: number;
+	organizationId: string;
+	version?: string;
+}
+
+function requiredEnv(name: string): string {
+	const value = process.env[name];
+	if (!value) throw new Error(`Missing required environment variable ${name}`);
+	return value;
+}
+
+function parsePid(value: string, name: string): number {
+	const pid = Number(value);
+	if (!Number.isSafeInteger(pid) || pid <= 1 || pid === process.pid) {
+		throw new Error(`Invalid ${name}: ${value}`);
+	}
+	return pid;
+}
+
+function supersetHomeDir(): string {
+	return process.env.SUPERSET_HOME_DIR || join(homedir(), ".superset");
+}
+
+function organizationDir(
+	organizationId: string,
+	homeDir = supersetHomeDir(),
+): string {
+	return join(homeDir, "host", organizationId);
+}
+
+function manifestPath(
+	organizationId: string,
+	homeDir = supersetHomeDir(),
+): string {
+	return join(organizationDir(organizationId, homeDir), "manifest.json");
+}
+
+export function removeStaleHostManifest(
+	organizationId: string,
+	homeDir = supersetHomeDir(),
+): void {
+	rmSync(manifestPath(organizationId, homeDir), { force: true });
+}
+
+function createLogger(organizationId: string): (message: string) => void {
+	const directory = organizationDir(organizationId);
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	const path = updateLogPath(organizationId, supersetHomeDir());
+	return (message) => {
+		try {
+			appendFileSync(path, `[${new Date().toISOString()}] ${message}\n`, {
+				mode: 0o600,
+			});
+		} catch {
+			// Logging is best-effort; the result file remains authoritative.
+		}
+	};
+}
+
+function readManifest(organizationId: string): HostManifest | null {
+	try {
+		const parsed = JSON.parse(
+			readFileSync(manifestPath(organizationId), "utf8"),
+		) as Partial<HostManifest>;
+		if (
+			typeof parsed.pid !== "number" ||
+			typeof parsed.endpoint !== "string" ||
+			typeof parsed.authToken !== "string" ||
+			typeof parsed.startedAt !== "number" ||
+			parsed.organizationId !== organizationId
+		) {
+			return null;
+		}
+		return parsed as HostManifest;
+	} catch {
+		return null;
+	}
+}
+
+async function waitForProcessExit(
+	pid: number,
+	timeoutMs: number,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) return;
+		await delay(POLL_INTERVAL_MS);
+	}
+}
+
+function resolveInstallRoot(): string {
+	const installRoot = process.env.SUPERSET_INSTALL_ROOT;
+	if (!installRoot) {
+		throw new Error("Missing SUPERSET_INSTALL_ROOT");
+	}
+	return installRoot;
+}
+
+function resolveSupersetBinary(): string {
+	return join(resolveInstallRoot(), "bin", "superset");
+}
+
+function installBackupRoot(installRoot = resolveInstallRoot()): string {
+	return `${installRoot}.bak`;
+}
+
+async function waitForLockOwnership(organizationId: string) {
+	const deadline = Date.now() + LOCK_HANDOFF_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		const lock = readUpdateLock(organizationId, supersetHomeDir());
+		if (lock?.pid === process.pid) return lock;
+		await delay(50);
+	}
+	throw new Error("Host did not transfer the update lock to the supervisor");
+}
+
+function discardInstallBackup(log: (message: string) => void): void {
+	const backupRoot = installBackupRoot();
+	try {
+		rmSync(backupRoot, { recursive: true, force: true });
+		log("removed verified previous install backup");
+	} catch (error) {
+		log(
+			`could not remove previous install backup: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+export function rollbackInstall(installRoot = resolveInstallRoot()): void {
+	const backupRoot = installBackupRoot(installRoot);
+	if (!existsSync(backupRoot)) {
+		throw new Error(`Previous install backup is missing at ${backupRoot}`);
+	}
+
+	const failedRoot = `${installRoot}.failed-${process.pid}`;
+	rmSync(failedRoot, { recursive: true, force: true });
+	if (existsSync(installRoot)) renameSync(installRoot, failedRoot);
+	try {
+		renameSync(backupRoot, installRoot);
+	} catch (error) {
+		if (existsSync(failedRoot) && !existsSync(installRoot)) {
+			renameSync(failedRoot, installRoot);
+		}
+		throw error;
+	}
+	rmSync(failedRoot, { recursive: true, force: true });
+}
+
+function assertRestartOrganization(organizationId: string): void {
+	const configPath =
+		process.env.SUPERSET_AUTH_CONFIG_PATH ??
+		join(supersetHomeDir(), "config.json");
+	let configuredOrganizationId: unknown;
+	try {
+		const config = JSON.parse(readFileSync(configPath, "utf8")) as {
+			organizationId?: unknown;
+		};
+		configuredOrganizationId = config.organizationId;
+	} catch (error) {
+		throw new Error(
+			`Cannot read persisted Superset auth config at ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (configuredOrganizationId !== organizationId) {
+		throw new Error(
+			`Refusing to restart organization ${organizationId}; persisted CLI organization is ${String(configuredOrganizationId ?? "unset")}`,
+		);
+	}
+}
+
+export function signalDetachedProcessGroup(
+	pid: number,
+	signal: NodeJS.Signals,
+	signalProcess: typeof process.kill = process.kill,
+): void {
+	if (!Number.isSafeInteger(pid) || pid <= 1) {
+		throw new Error(`Refusing to signal invalid process group ${pid}`);
+	}
+	try {
+		signalProcess(-pid, signal);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+	}
+}
+
+interface RunCommandOptions {
+	log: (message: string) => void;
+	timeoutMs: number;
+	environmentOverrides?: NodeJS.ProcessEnv;
+	terminationGraceMs?: number;
+	spawnProcess?: typeof spawn;
+	signalProcessGroup?: (pid: number, signal: NodeJS.Signals) => void;
+}
+
+export async function runCommand(
+	command: string,
+	args: string[],
+	options: RunCommandOptions,
+): Promise<void> {
+	options.log(`running ${command} ${args.join(" ")}`);
+	await new Promise<void>((resolve, reject) => {
+		const spawnProcess = options.spawnProcess ?? spawn;
+		const child = spawnProcess(command, args, {
+			detached: true,
+			env: { ...process.env, ...options.environmentOverrides },
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const terminationGraceMs =
+			options.terminationGraceMs ?? COMMAND_TERMINATION_GRACE_MS;
+		const signalProcessGroup =
+			options.signalProcessGroup ?? signalDetachedProcessGroup;
+		const timeoutError = new Error(
+			`${command} ${args.join(" ")} timed out after ${options.timeoutMs}ms`,
+		);
+		let settled = false;
+		let timedOut = false;
+		let killTimer: ReturnType<typeof setTimeout> | null = null;
+		let hardDeadline: ReturnType<typeof setTimeout> | null = null;
+
+		const finish = (error?: Error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			if (killTimer) clearTimeout(killTimer);
+			if (hardDeadline) clearTimeout(hardDeadline);
+			if (timedOut) {
+				child.stdout?.destroy();
+				child.stderr?.destroy();
+				child.unref();
+			}
+			if (error) reject(error);
+			else resolve();
+		};
+
+		const terminate = (signal: NodeJS.Signals) => {
+			if (!child.pid) return;
+			try {
+				signalProcessGroup(child.pid, signal);
+			} catch (error) {
+				options.log(
+					`failed to signal command process group ${child.pid}: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		};
+
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			options.log(
+				`command timed out after ${options.timeoutMs}ms; terminating process group`,
+			);
+			terminate("SIGTERM");
+			killTimer = setTimeout(() => terminate("SIGKILL"), terminationGraceMs);
+			hardDeadline = setTimeout(
+				() => finish(timeoutError),
+				terminationGraceMs * 2,
+			);
+		}, options.timeoutMs);
+
+		child.stdout?.on("data", (chunk: Buffer | string) => {
+			for (const line of String(chunk).trimEnd().split("\n")) {
+				if (line) options.log(`stdout: ${line}`);
+			}
+		});
+		child.stderr?.on("data", (chunk: Buffer | string) => {
+			for (const line of String(chunk).trimEnd().split("\n")) {
+				if (line) options.log(`stderr: ${line}`);
+			}
+		});
+		child.once("error", (error) => finish(error));
+		child.once("close", (code, signal) => {
+			if (timedOut) {
+				finish(timeoutError);
+				return;
+			}
+			if (code === 0) {
+				finish();
+				return;
+			}
+			finish(
+				new Error(
+					`${command} ${args.join(" ")} exited ${code ?? `on ${signal ?? "unknown signal"}`}`,
+				),
+			);
+		});
+	});
+}
+
+export function extractHostInfoVersion(payload: unknown): string | null {
+	if (!payload || typeof payload !== "object") return null;
+	const result = (payload as { result?: unknown }).result;
+	if (!result || typeof result !== "object") return null;
+	const data = (result as { data?: unknown }).data;
+	if (!data || typeof data !== "object") return null;
+	const json = (data as { json?: unknown }).json;
+	if (!json || typeof json !== "object") return null;
+	const version = (json as { version?: unknown }).version;
+	return typeof version === "string" ? version : null;
+}
+
+async function queryHostVersion(
+	manifest: HostManifest,
+): Promise<string | null> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 2_000);
+	try {
+		const url = new URL("/trpc/host.info", manifest.endpoint);
+		url.searchParams.set("input", JSON.stringify({ json: null }));
+		const response = await fetch(url, {
+			headers: { Authorization: `Bearer ${manifest.authToken}` },
+			signal: controller.signal,
+		});
+		if (!response.ok) return null;
+		return extractHostInfoVersion(await response.json());
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+export function isUnchangedHostManifest(
+	expected: HostManifest,
+	actual: HostManifest | null,
+): actual is HostManifest {
+	return (
+		actual !== null &&
+		actual.pid === expected.pid &&
+		actual.endpoint === expected.endpoint &&
+		actual.authToken === expected.authToken &&
+		actual.startedAt === expected.startedAt &&
+		actual.organizationId === expected.organizationId &&
+		actual.version === expected.version
+	);
+}
+
+export async function verifyAuthenticatedHost(options: {
+	expectedManifest: HostManifest;
+	expectedVersion: string;
+	readCurrentManifest?: (organizationId: string) => HostManifest | null;
+	queryVersion?: (manifest: HostManifest) => Promise<string | null>;
+}): Promise<HostManifest> {
+	const readCurrentManifest = options.readCurrentManifest ?? readManifest;
+	const queryVersion = options.queryVersion ?? queryHostVersion;
+	const current = readCurrentManifest(options.expectedManifest.organizationId);
+	if (!isUnchangedHostManifest(options.expectedManifest, current)) {
+		throw new Error(
+			"Host manifest changed during update; refusing to signal it",
+		);
+	}
+
+	const reportedVersion = await queryVersion(current);
+	if (reportedVersion !== options.expectedVersion) {
+		throw new Error(
+			`Host identity check failed before signal (expected ${options.expectedVersion}, reported ${reportedVersion ?? "unreachable"})`,
+		);
+	}
+	return current;
+}
+
+async function stopVerifiedHost(
+	manifest: HostManifest,
+	expectedVersion: string,
+	log: (message: string) => void,
+): Promise<void> {
+	const verified = await verifyAuthenticatedHost({
+		expectedManifest: manifest,
+		expectedVersion,
+	});
+	try {
+		process.kill(verified.pid, "SIGTERM");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+	}
+	await waitForProcessExit(verified.pid, OLD_HOST_EXIT_TIMEOUT_MS);
+	if (isProcessAlive(verified.pid)) {
+		// PID reuse or a rewritten manifest must never turn the fallback into a
+		// SIGKILL of an unrelated process. Authenticate the host again first.
+		await verifyAuthenticatedHost({
+			expectedManifest: manifest,
+			expectedVersion,
+		});
+		log(`verified host pid=${verified.pid} did not exit; sending SIGKILL`);
+		process.kill(verified.pid, "SIGKILL");
+		await waitForProcessExit(verified.pid, 5_000);
+	}
+	if (isProcessAlive(verified.pid)) {
+		throw new Error(`Verified host pid=${verified.pid} did not exit`);
+	}
+}
+
+async function waitForTargetHost(
+	organizationId: string,
+	previousStartedAt: number,
+	targetVersion: string,
+	log: (message: string) => void,
+): Promise<void> {
+	const deadline = Date.now() + NEW_HOST_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		const manifest = readManifest(organizationId);
+		if (
+			manifest &&
+			manifest.startedAt > previousStartedAt &&
+			isProcessAlive(manifest.pid)
+		) {
+			const reportedVersion = await queryHostVersion(manifest);
+			if (reportedVersion === targetVersion) {
+				log(`verified host pid=${manifest.pid} version=${reportedVersion}`);
+				return;
+			}
+			if (reportedVersion) {
+				log(`host reported ${reportedVersion}; waiting for ${targetVersion}`);
+			}
+		}
+		await delay(POLL_INTERVAL_MS);
+	}
+	throw new Error(
+		`Host did not return on version ${targetVersion} within ${NEW_HOST_TIMEOUT_MS / 1_000}s`,
+	);
+}
+
+function releaseOwnedLock(organizationId: string): void {
+	releaseUpdateLock({
+		organizationId,
+		ownerPid: process.pid,
+		homeDir: supersetHomeDir(),
+	});
+}
+
+async function main(): Promise<void> {
+	const organizationId = requiredEnv("SUPERSET_UPDATE_ORG_ID");
+	const oldPid = parsePid(
+		requiredEnv("SUPERSET_UPDATE_OLD_PID"),
+		"SUPERSET_UPDATE_OLD_PID",
+	);
+	const targetVersion = requiredEnv("SUPERSET_UPDATE_TARGET_VERSION");
+	let previousVersion =
+		process.env.SUPERSET_UPDATE_PREVIOUS_VERSION || "unknown";
+	const log = createLogger(organizationId);
+	const previousManifest = readManifest(organizationId);
+	let installSucceeded = false;
+
+	log(
+		`supervisor pid=${process.pid} hostPid=${oldPid} target=${targetVersion}`,
+	);
+
+	try {
+		const ownedLock = await waitForLockOwnership(organizationId);
+		if (previousVersion === "unknown") {
+			previousVersion = ownedLock.previousVersion;
+		}
+		assertRestartOrganization(organizationId);
+		if (!previousManifest || previousManifest.pid !== oldPid) {
+			throw new Error(
+				"Running host manifest does not match the update request",
+			);
+		}
+		const supersetBinary = resolveSupersetBinary();
+		if (!existsSync(supersetBinary)) {
+			throw new Error(`Superset CLI not found at ${supersetBinary}`);
+		}
+
+		// Download and atomically replace the install while the old host remains
+		// available. A failed download therefore never strands the remote host.
+		await runCommand(supersetBinary, ["update", "--version", targetVersion], {
+			log,
+			timeoutMs: UPDATE_COMMAND_TIMEOUT_MS,
+			environmentOverrides: { SUPERSET_UPDATE_KEEP_BACKUP: "1" },
+		});
+		installSucceeded = true;
+
+		log(`authenticating old host pid=${oldPid} before restart`);
+		await stopVerifiedHost(previousManifest, previousVersion, log);
+
+		await runCommand(supersetBinary, ["start", "--daemon"], {
+			log,
+			timeoutMs: START_COMMAND_TIMEOUT_MS,
+		});
+		await waitForTargetHost(
+			organizationId,
+			previousManifest?.startedAt ?? 0,
+			targetVersion,
+			log,
+		);
+
+		writeUpdateResult(
+			organizationId,
+			{
+				status: "succeeded",
+				targetVersion,
+				previousVersion,
+				finalVersion: targetVersion,
+				completedAt: Date.now(),
+			},
+			supersetHomeDir(),
+		);
+		discardInstallBackup(log);
+		log(`update completed on ${targetVersion}`);
+	} catch (error) {
+		let message = error instanceof Error ? error.message : String(error);
+
+		// If installation completed but the new host failed verification, stop
+		// that process, restore the retained atomic backup, and restart the old
+		// bundle. The result remains failed even when recovery succeeds.
+		if (installSucceeded) {
+			try {
+				const currentManifest = readManifest(organizationId);
+				const currentVersion = currentManifest
+					? await queryHostVersion(currentManifest)
+					: null;
+				const currentIsOriginal = previousManifest
+					? isUnchangedHostManifest(previousManifest, currentManifest)
+					: false;
+				if (currentManifest && currentVersion && !currentIsOriginal) {
+					log(
+						`stopping authenticated replacement host pid=${currentManifest.pid}`,
+					);
+					await stopVerifiedHost(currentManifest, currentVersion, log);
+				}
+				rollbackInstall();
+				log("restored previous install backup");
+
+				const rollbackManifest = readManifest(organizationId);
+				const rollbackVersion = rollbackManifest
+					? await queryHostVersion(rollbackManifest)
+					: null;
+				if (rollbackVersion !== previousVersion) {
+					removeStaleHostManifest(organizationId);
+					log("removed stale host manifest before recovery restart");
+					await runCommand(resolveSupersetBinary(), ["start", "--daemon"], {
+						log,
+						timeoutMs: START_COMMAND_TIMEOUT_MS,
+					});
+				} else {
+					log(
+						`previous host remains authenticated on ${previousVersion}; restart not needed`,
+					);
+				}
+			} catch (recoveryError) {
+				message += `; rollback recovery failed: ${
+					recoveryError instanceof Error
+						? recoveryError.message
+						: String(recoveryError)
+				}`;
+			}
+		}
+
+		writeUpdateResult(
+			organizationId,
+			{
+				status: "failed",
+				targetVersion,
+				previousVersion,
+				error: message.slice(0, MAX_RESULT_ERROR_LENGTH),
+				completedAt: Date.now(),
+			},
+			supersetHomeDir(),
+		);
+		log(`update failed: ${message}`);
+		process.exitCode = 1;
+	} finally {
+		releaseOwnedLock(organizationId);
+	}
+}
+
+if (isMainModule(import.meta.url)) void main();

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -40,6 +40,10 @@
 			"types": "./src/trpc/router/attachments/index.ts",
 			"default": "./src/trpc/router/attachments/index.ts"
 		},
+		"./update-protocol": {
+			"types": "./src/runtime/update/protocol.ts",
+			"default": "./src/runtime/update/protocol.ts"
+		},
 		"./router": {
 			"types": "./dist-types/trpc/router/router.d.ts"
 		},

--- a/packages/host-service/src/runtime/update/capability.test.ts
+++ b/packages/host-service/src/runtime/update/capability.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { supportsRemoteUpdate } from "./capability";
+
+describe("remote update capability", () => {
+	test("supports a standalone Unix host with the supervisor installed", () => {
+		expect(
+			supportsRemoteUpdate({
+				environment: {
+					SUPERSET_INSTALL_ROOT: "/opt/superset",
+					SUPERSET_AUTH_CONFIG_PATH: "/home/me/.superset/config.json",
+					SUPERSET_HOST_LIFECYCLE_MODE: "daemon",
+				},
+				platform: "linux",
+				pathExists: (path) =>
+					path === "/opt/superset/bin/superset-host-supervisor",
+			}),
+		).toBe(true);
+	});
+
+	test("rejects Electron-managed hosts even if a supervisor path exists", () => {
+		expect(
+			supportsRemoteUpdate({
+				environment: {
+					HOST_PARENT_PID: "123",
+					SUPERSET_AUTH_CONFIG_PATH: "/tmp/config.json",
+					SUPERSET_HOST_SUPERVISOR_BIN: "/tmp/supervisor",
+					SUPERSET_HOST_LIFECYCLE_MODE: "daemon",
+				},
+				platform: "darwin",
+				pathExists: () => true,
+			}),
+		).toBe(false);
+	});
+
+	test("rejects missing supervisors, transient auth, and Windows installs", () => {
+		expect(
+			supportsRemoteUpdate({
+				environment: {
+					SUPERSET_AUTH_CONFIG_PATH: "/tmp/config.json",
+					SUPERSET_HOST_LIFECYCLE_MODE: "daemon",
+				},
+				platform: "linux",
+				pathExists: () => false,
+			}),
+		).toBe(false);
+		expect(
+			supportsRemoteUpdate({
+				environment: {
+					SUPERSET_HOST_SUPERVISOR_BIN: "/tmp/supervisor",
+					SUPERSET_HOST_LIFECYCLE_MODE: "daemon",
+				},
+				platform: "linux",
+				pathExists: () => true,
+			}),
+		).toBe(false);
+		expect(
+			supportsRemoteUpdate({
+				environment: {
+					SUPERSET_AUTH_CONFIG_PATH: "C:\\config.json",
+					SUPERSET_HOST_SUPERVISOR_BIN: "C:\\supervisor.exe",
+					SUPERSET_HOST_LIFECYCLE_MODE: "daemon",
+				},
+				platform: "win32",
+				pathExists: () => true,
+			}),
+		).toBe(false);
+	});
+
+	test("rejects foreground standalone hosts", () => {
+		expect(
+			supportsRemoteUpdate({
+				environment: {
+					SUPERSET_AUTH_CONFIG_PATH: "/tmp/config.json",
+					SUPERSET_HOST_LIFECYCLE_MODE: "foreground",
+					SUPERSET_HOST_SUPERVISOR_BIN: "/tmp/supervisor",
+				},
+				platform: "linux",
+				pathExists: () => true,
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/host-service/src/runtime/update/capability.ts
+++ b/packages/host-service/src/runtime/update/capability.ts
@@ -1,0 +1,26 @@
+import { existsSync } from "node:fs";
+import { resolveUpdateSupervisorBinary } from "./paths";
+
+export function supportsRemoteUpdate(options?: {
+	environment?: NodeJS.ProcessEnv;
+	execPath?: string;
+	platform?: NodeJS.Platform;
+	pathExists?: (path: string) => boolean;
+}): boolean {
+	const environment = options?.environment ?? process.env;
+	const platform = options?.platform ?? process.platform;
+	const pathExists = options?.pathExists ?? existsSync;
+
+	// Desktop owns and restarts its host child. Replacing the standalone CLI
+	// install from that child would update the wrong runtime.
+	if (environment.HOST_PARENT_PID) return false;
+	if (platform === "win32") return false;
+	if (environment.SUPERSET_HOST_LIFECYCLE_MODE !== "daemon") return false;
+	// The supervisor restarts through the CLI after replacing the install. A
+	// transient --api-key override is unavailable to that new process.
+	if (!environment.SUPERSET_AUTH_CONFIG_PATH) return false;
+
+	return pathExists(
+		resolveUpdateSupervisorBinary(environment, options?.execPath),
+	);
+}

--- a/packages/host-service/src/runtime/update/index.ts
+++ b/packages/host-service/src/runtime/update/index.ts
@@ -1,0 +1,11 @@
+export { supportsRemoteUpdate } from "./capability";
+export * from "./protocol";
+export {
+	spawnUpdateSupervisor,
+	terminateUpdateSupervisor,
+} from "./spawn-supervisor";
+export {
+	classifyUpdateTarget,
+	HOST_SERVICE_VERSION,
+	isInstallableUpdateVersion,
+} from "./version";

--- a/packages/host-service/src/runtime/update/lock.ts
+++ b/packages/host-service/src/runtime/update/lock.ts
@@ -1,0 +1,142 @@
+import {
+	closeSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+	writeSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { updateLockPath } from "./paths";
+
+export interface UpdateLockRecord {
+	pid: number;
+	targetVersion: string;
+	previousVersion: string;
+	startedAt: number;
+}
+
+function isPidAlive(pid: number): boolean {
+	if (!Number.isInteger(pid) || pid <= 1) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+export function readUpdateLock(
+	organizationId: string,
+	homeDir?: string,
+): UpdateLockRecord | null {
+	try {
+		const parsed = JSON.parse(
+			readFileSync(updateLockPath(organizationId, homeDir), "utf8"),
+		) as Partial<UpdateLockRecord>;
+		if (
+			typeof parsed.pid !== "number" ||
+			typeof parsed.targetVersion !== "string" ||
+			typeof parsed.previousVersion !== "string" ||
+			typeof parsed.startedAt !== "number"
+		) {
+			return null;
+		}
+		return {
+			pid: parsed.pid,
+			targetVersion: parsed.targetVersion,
+			previousVersion: parsed.previousVersion,
+			startedAt: parsed.startedAt,
+		};
+	} catch {
+		return null;
+	}
+}
+
+export function acquireUpdateLock(options: {
+	organizationId: string;
+	ownerPid: number;
+	targetVersion: string;
+	previousVersion: string;
+	homeDir?: string;
+	now?: number;
+	isOwnerAlive?: (pid: number) => boolean;
+}):
+	| { acquired: true; lock: UpdateLockRecord }
+	| { acquired: false; lock: UpdateLockRecord | null } {
+	const path = updateLockPath(options.organizationId, options.homeDir);
+	const ownerAlive = options.isOwnerAlive ?? isPidAlive;
+	const existing = readUpdateLock(options.organizationId, options.homeDir);
+	if (existing && ownerAlive(existing.pid)) {
+		return { acquired: false, lock: existing };
+	}
+	if (existing) rmSync(path, { force: true });
+
+	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+	const lock: UpdateLockRecord = {
+		pid: options.ownerPid,
+		targetVersion: options.targetVersion,
+		previousVersion: options.previousVersion,
+		startedAt: options.now ?? Date.now(),
+	};
+
+	let descriptor: number;
+	try {
+		descriptor = openSync(path, "wx", 0o600);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+			return {
+				acquired: false,
+				lock: readUpdateLock(options.organizationId, options.homeDir),
+			};
+		}
+		throw error;
+	}
+	try {
+		writeSync(descriptor, JSON.stringify(lock));
+	} finally {
+		closeSync(descriptor);
+	}
+	return { acquired: true, lock };
+}
+
+export function transferUpdateLock(options: {
+	organizationId: string;
+	fromPid: number;
+	toPid: number;
+	homeDir?: string;
+}): UpdateLockRecord {
+	const path = updateLockPath(options.organizationId, options.homeDir);
+	const current = readUpdateLock(options.organizationId, options.homeDir);
+	if (!current || current.pid !== options.fromPid) {
+		throw new Error("Update lock ownership changed before supervisor handoff");
+	}
+
+	const next = { ...current, pid: options.toPid };
+	const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+	writeFileSync(temporaryPath, JSON.stringify(next), { mode: 0o600 });
+	try {
+		renameSync(temporaryPath, path);
+	} catch (error) {
+		rmSync(temporaryPath, { force: true });
+		throw error;
+	}
+	return next;
+}
+
+export function releaseUpdateLock(options: {
+	organizationId: string;
+	ownerPid?: number;
+	homeDir?: string;
+}): boolean {
+	const current = readUpdateLock(options.organizationId, options.homeDir);
+	if (options.ownerPid !== undefined && current?.pid !== options.ownerPid) {
+		return false;
+	}
+	rmSync(updateLockPath(options.organizationId, options.homeDir), {
+		force: true,
+	});
+	return true;
+}

--- a/packages/host-service/src/runtime/update/paths.ts
+++ b/packages/host-service/src/runtime/update/paths.ts
@@ -1,0 +1,59 @@
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const UPDATE_SUPERVISOR_BINARY_NAME = "superset-host-supervisor";
+
+export function resolveSupersetHomeDir(
+	environment: NodeJS.ProcessEnv = process.env,
+): string {
+	return environment.SUPERSET_HOME_DIR || join(homedir(), ".superset");
+}
+
+export function resolveUpdateInstallRoot(
+	environment: NodeJS.ProcessEnv = process.env,
+	execPath = process.execPath,
+): string {
+	return environment.SUPERSET_INSTALL_ROOT || dirname(dirname(execPath));
+}
+
+export function resolveUpdateSupervisorBinary(
+	environment: NodeJS.ProcessEnv = process.env,
+	execPath = process.execPath,
+): string {
+	return (
+		environment.SUPERSET_HOST_SUPERVISOR_BIN ||
+		join(
+			resolveUpdateInstallRoot(environment, execPath),
+			"bin",
+			UPDATE_SUPERVISOR_BINARY_NAME,
+		)
+	);
+}
+
+export function hostUpdateDirectory(
+	organizationId: string,
+	homeDir = resolveSupersetHomeDir(),
+): string {
+	return join(homeDir, "host", organizationId);
+}
+
+export function updateLockPath(
+	organizationId: string,
+	homeDir = resolveSupersetHomeDir(),
+): string {
+	return join(hostUpdateDirectory(organizationId, homeDir), "update.lock");
+}
+
+export function updateResultPath(
+	organizationId: string,
+	homeDir = resolveSupersetHomeDir(),
+): string {
+	return join(hostUpdateDirectory(organizationId, homeDir), "last-update.json");
+}
+
+export function updateLogPath(
+	organizationId: string,
+	homeDir = resolveSupersetHomeDir(),
+): string {
+	return join(hostUpdateDirectory(organizationId, homeDir), "update.log");
+}

--- a/packages/host-service/src/runtime/update/protocol.test.ts
+++ b/packages/host-service/src/runtime/update/protocol.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	acquireUpdateLock,
+	readUpdateLock,
+	releaseUpdateLock,
+	transferUpdateLock,
+} from "./lock";
+import { updateLockPath } from "./paths";
+import {
+	clearUpdateResult,
+	getHostUpdateStatus,
+	readUpdateResult,
+	writeUpdateResult,
+} from "./status";
+
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000000123";
+
+function withTempHome(run: (homeDir: string) => void): void {
+	const homeDir = mkdtempSync(join(tmpdir(), "host-update-protocol-"));
+	try {
+		run(homeDir);
+	} finally {
+		rmSync(homeDir, { recursive: true, force: true });
+	}
+}
+
+describe("host update protocol", () => {
+	test("hands exclusive lock ownership to the supervisor", () => {
+		withTempHome((homeDir) => {
+			const acquired = acquireUpdateLock({
+				organizationId: ORGANIZATION_ID,
+				ownerPid: 100,
+				targetVersion: "1.15.0",
+				previousVersion: "1.14.0",
+				homeDir,
+				now: 1234,
+				isOwnerAlive: () => false,
+			});
+			expect(acquired.acquired).toBe(true);
+
+			const blocked = acquireUpdateLock({
+				organizationId: ORGANIZATION_ID,
+				ownerPid: 101,
+				targetVersion: "1.16.0",
+				previousVersion: "1.14.0",
+				homeDir,
+				isOwnerAlive: () => true,
+			});
+			expect(blocked.acquired).toBe(false);
+
+			transferUpdateLock({
+				organizationId: ORGANIZATION_ID,
+				fromPid: 100,
+				toPid: 200,
+				homeDir,
+			});
+			expect(readUpdateLock(ORGANIZATION_ID, homeDir)).toEqual({
+				pid: 200,
+				targetVersion: "1.15.0",
+				previousVersion: "1.14.0",
+				startedAt: 1234,
+			});
+			expect(
+				releaseUpdateLock({
+					organizationId: ORGANIZATION_ID,
+					ownerPid: 100,
+					homeDir,
+				}),
+			).toBe(false);
+			expect(
+				releaseUpdateLock({
+					organizationId: ORGANIZATION_ID,
+					ownerPid: 200,
+					homeDir,
+				}),
+			).toBe(true);
+			expect(readUpdateLock(ORGANIZATION_ID, homeDir)).toBeNull();
+		});
+	});
+
+	test("reports live and unexpectedly-dead supervisor states", () => {
+		withTempHome((homeDir) => {
+			acquireUpdateLock({
+				organizationId: ORGANIZATION_ID,
+				ownerPid: 200,
+				targetVersion: "1.15.0",
+				previousVersion: "1.14.0",
+				homeDir,
+				now: 1234,
+				isOwnerAlive: () => false,
+			});
+
+			expect(
+				getHostUpdateStatus({
+					organizationId: ORGANIZATION_ID,
+					homeDir,
+					isOwnerAlive: () => true,
+				}),
+			).toEqual({
+				status: "updating",
+				targetVersion: "1.15.0",
+				previousVersion: "1.14.0",
+				startedAt: 1234,
+			});
+
+			const failed = getHostUpdateStatus({
+				organizationId: ORGANIZATION_ID,
+				homeDir,
+				isOwnerAlive: () => false,
+				now: 5678,
+			});
+			expect(failed).toEqual({
+				status: "failed",
+				targetVersion: "1.15.0",
+				previousVersion: "1.14.0",
+				error: "Update supervisor exited before reporting a result",
+				completedAt: 5678,
+			});
+			expect(readUpdateLock(ORGANIZATION_ID, homeDir)).toBeNull();
+		});
+	});
+
+	test("persists bounded result data and clears it", () => {
+		withTempHome((homeDir) => {
+			writeUpdateResult(
+				ORGANIZATION_ID,
+				{
+					status: "failed",
+					targetVersion: "1.15.0",
+					previousVersion: "1.14.0",
+					error: "x".repeat(2_000),
+					completedAt: 5678,
+				},
+				homeDir,
+			);
+			const result = readUpdateResult(ORGANIZATION_ID, homeDir);
+			expect(result?.error).toHaveLength(1_000);
+			clearUpdateResult(ORGANIZATION_ID, homeDir);
+			expect(readUpdateResult(ORGANIZATION_ID, homeDir)).toBeNull();
+			expect(updateLockPath(ORGANIZATION_ID, homeDir)).toContain(
+				join("host", ORGANIZATION_ID, "update.lock"),
+			);
+		});
+	});
+});

--- a/packages/host-service/src/runtime/update/protocol.ts
+++ b/packages/host-service/src/runtime/update/protocol.ts
@@ -1,0 +1,22 @@
+export {
+	acquireUpdateLock,
+	readUpdateLock,
+	releaseUpdateLock,
+	transferUpdateLock,
+	type UpdateLockRecord,
+} from "./lock";
+export {
+	hostUpdateDirectory,
+	resolveSupersetHomeDir,
+	updateLockPath,
+	updateLogPath,
+	updateResultPath,
+} from "./paths";
+export {
+	clearUpdateResult,
+	getHostUpdateStatus,
+	type HostUpdateStatus,
+	readUpdateResult,
+	type UpdateResult,
+	writeUpdateResult,
+} from "./status";

--- a/packages/host-service/src/runtime/update/spawn-supervisor.test.ts
+++ b/packages/host-service/src/runtime/update/spawn-supervisor.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SpawnOptions, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { spawnUpdateSupervisor } from "./spawn-supervisor";
+
+describe("spawnUpdateSupervisor", () => {
+	test("detaches with the versioned update protocol and persisted auth path", () => {
+		const unref = mock(() => undefined);
+		const child = Object.assign(new EventEmitter(), { pid: 321, unref });
+		let capturedOptions: SpawnOptions | undefined;
+		const spawnMock = mock(
+			(_command: string, _args: readonly string[], options: SpawnOptions) => {
+				capturedOptions = options;
+				return child;
+			},
+		);
+		const spawnProcess = spawnMock as unknown as typeof spawn;
+
+		const result = spawnUpdateSupervisor({
+			organizationId: "00000000-0000-4000-8000-000000000123",
+			oldPid: 123,
+			targetVersion: "1.15.0",
+			execPath: "/opt/superset/lib/node",
+			environment: {
+				HOME: "/home/me",
+				PATH: "/usr/bin",
+				SUPERSET_AUTH_CONFIG_PATH: "/home/me/.superset/config.json",
+				SUPERSET_HOME_DIR: "/home/me/.superset",
+			},
+			spawnProcess,
+		});
+
+		expect(result).toEqual({
+			supervisorPid: 321,
+			supervisorBinary: "/opt/superset/bin/superset-host-supervisor",
+		});
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(capturedOptions?.detached).toBe(true);
+		expect(capturedOptions?.stdio).toBe("ignore");
+		expect(capturedOptions?.env).toMatchObject({
+			SUPERSET_AUTH_CONFIG_PATH: "/home/me/.superset/config.json",
+			SUPERSET_HOME_DIR: "/home/me/.superset",
+			SUPERSET_INSTALL_ROOT: "/opt/superset",
+			SUPERSET_UPDATE_OLD_PID: "123",
+			SUPERSET_UPDATE_ORG_ID: "00000000-0000-4000-8000-000000000123",
+			SUPERSET_UPDATE_TARGET_VERSION: "1.15.0",
+		});
+		expect(unref).toHaveBeenCalledTimes(1);
+	});
+
+	test("handles an asynchronous spawn error without throwing it", () => {
+		const child = Object.assign(new EventEmitter(), {
+			pid: 321,
+			unref: mock(() => undefined),
+		});
+		const spawnProcess = mock(() => child) as unknown as typeof spawn;
+		const onSpawnError = mock((_error: Error) => undefined);
+
+		spawnUpdateSupervisor({
+			organizationId: "00000000-0000-4000-8000-000000000123",
+			oldPid: 123,
+			targetVersion: "1.15.0",
+			execPath: "/opt/superset/lib/node",
+			environment: {
+				HOME: "/home/me",
+				PATH: "/usr/bin",
+				SUPERSET_AUTH_CONFIG_PATH: "/home/me/.superset/config.json",
+			},
+			spawnProcess,
+			onSpawnError,
+		});
+
+		expect(() => child.emit("error", new Error("EACCES"))).not.toThrow();
+		expect(onSpawnError).toHaveBeenCalledTimes(1);
+		expect(onSpawnError.mock.calls[0]?.[0]?.message).toBe("EACCES");
+	});
+
+	test("attaches the error listener before rejecting a missing child pid", () => {
+		const child = Object.assign(new EventEmitter(), {
+			pid: undefined,
+			unref: mock(() => undefined),
+		});
+		const spawnProcess = mock(() => child) as unknown as typeof spawn;
+		const onSpawnError = mock((_error: Error) => undefined);
+
+		expect(() =>
+			spawnUpdateSupervisor({
+				organizationId: "00000000-0000-4000-8000-000000000123",
+				oldPid: 123,
+				targetVersion: "1.15.0",
+				execPath: "/opt/superset/lib/node",
+				environment: {
+					HOME: "/home/me",
+					PATH: "/usr/bin",
+					SUPERSET_AUTH_CONFIG_PATH: "/home/me/.superset/config.json",
+				},
+				spawnProcess,
+				onSpawnError,
+			}),
+		).toThrow("Failed to spawn update supervisor");
+		expect(() => child.emit("error", new Error("ENOENT"))).not.toThrow();
+		expect(onSpawnError.mock.calls[0]?.[0]?.message).toBe("ENOENT");
+	});
+});

--- a/packages/host-service/src/runtime/update/spawn-supervisor.ts
+++ b/packages/host-service/src/runtime/update/spawn-supervisor.ts
@@ -1,0 +1,77 @@
+import { spawn } from "node:child_process";
+import {
+	resolveSupersetHomeDir,
+	resolveUpdateInstallRoot,
+	resolveUpdateSupervisorBinary,
+} from "./paths";
+
+export interface SpawnUpdateSupervisorOptions {
+	organizationId: string;
+	oldPid: number;
+	targetVersion: string;
+	environment?: NodeJS.ProcessEnv;
+	execPath?: string;
+	spawnProcess?: typeof spawn;
+	onSpawnError?: (error: Error) => void;
+}
+
+export interface SpawnUpdateSupervisorResult {
+	supervisorPid: number;
+	supervisorBinary: string;
+}
+
+export function spawnUpdateSupervisor(
+	options: SpawnUpdateSupervisorOptions,
+): SpawnUpdateSupervisorResult {
+	const environment = options.environment ?? process.env;
+	const supervisorBinary = resolveUpdateSupervisorBinary(
+		environment,
+		options.execPath,
+	);
+	const spawnProcess = options.spawnProcess ?? spawn;
+	const child = spawnProcess(supervisorBinary, [], {
+		detached: true,
+		stdio: "ignore",
+		env: {
+			PATH: environment.PATH ?? "",
+			HOME: environment.HOME ?? "",
+			SUPERSET_HOME_DIR: resolveSupersetHomeDir(environment),
+			...(environment.SUPERSET_AUTH_CONFIG_PATH
+				? {
+						SUPERSET_AUTH_CONFIG_PATH: environment.SUPERSET_AUTH_CONFIG_PATH,
+					}
+				: {}),
+			SUPERSET_INSTALL_ROOT: resolveUpdateInstallRoot(
+				environment,
+				options.execPath,
+			),
+			SUPERSET_UPDATE_ORG_ID: options.organizationId,
+			SUPERSET_UPDATE_OLD_PID: String(options.oldPid),
+			SUPERSET_UPDATE_TARGET_VERSION: options.targetVersion,
+		},
+	});
+
+	child.once("error", (error) => {
+		if (options.onSpawnError) {
+			options.onSpawnError(error);
+			return;
+		}
+		console.error("[host-update] update supervisor process failed:", error);
+	});
+	if (!child.pid) {
+		throw new Error("Failed to spawn update supervisor");
+	}
+	child.unref();
+	return { supervisorPid: child.pid, supervisorBinary };
+}
+
+export function terminateUpdateSupervisor(
+	supervisorPid: number,
+	signal: NodeJS.Signals = "SIGTERM",
+): void {
+	try {
+		process.kill(supervisorPid, signal);
+	} catch {
+		// The supervisor may already have exited.
+	}
+}

--- a/packages/host-service/src/runtime/update/status.ts
+++ b/packages/host-service/src/runtime/update/status.ts
@@ -1,0 +1,148 @@
+import {
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { readUpdateLock, releaseUpdateLock } from "./lock";
+import { updateResultPath } from "./paths";
+
+const MAX_UPDATE_ERROR_LENGTH = 1_000;
+
+export interface UpdateResult {
+	status: "succeeded" | "failed";
+	targetVersion: string;
+	previousVersion: string;
+	finalVersion?: string;
+	error?: string;
+	completedAt: number;
+}
+
+export type HostUpdateStatus =
+	| { status: "idle" }
+	| {
+			status: "updating";
+			targetVersion: string;
+			previousVersion: string;
+			startedAt: number;
+	  }
+	| UpdateResult;
+
+function isPidAlive(pid: number): boolean {
+	if (!Number.isInteger(pid) || pid <= 1) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+export function clearUpdateResult(
+	organizationId: string,
+	homeDir?: string,
+): void {
+	rmSync(updateResultPath(organizationId, homeDir), { force: true });
+}
+
+export function writeUpdateResult(
+	organizationId: string,
+	result: UpdateResult,
+	homeDir?: string,
+): void {
+	const path = updateResultPath(organizationId, homeDir);
+	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+	const normalized: UpdateResult = {
+		...result,
+		...(result.error
+			? { error: result.error.slice(0, MAX_UPDATE_ERROR_LENGTH) }
+			: {}),
+	};
+	const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+	writeFileSync(temporaryPath, JSON.stringify(normalized), { mode: 0o600 });
+	try {
+		renameSync(temporaryPath, path);
+	} catch (error) {
+		rmSync(temporaryPath, { force: true });
+		throw error;
+	}
+}
+
+export function readUpdateResult(
+	organizationId: string,
+	homeDir?: string,
+): UpdateResult | null {
+	try {
+		const parsed = JSON.parse(
+			readFileSync(updateResultPath(organizationId, homeDir), "utf8"),
+		) as Partial<UpdateResult>;
+		if (
+			(parsed.status !== "succeeded" && parsed.status !== "failed") ||
+			typeof parsed.targetVersion !== "string" ||
+			typeof parsed.previousVersion !== "string" ||
+			typeof parsed.completedAt !== "number" ||
+			(parsed.finalVersion !== undefined &&
+				typeof parsed.finalVersion !== "string") ||
+			(parsed.error !== undefined && typeof parsed.error !== "string")
+		) {
+			return null;
+		}
+		return {
+			status: parsed.status,
+			targetVersion: parsed.targetVersion,
+			previousVersion: parsed.previousVersion,
+			...(parsed.finalVersion ? { finalVersion: parsed.finalVersion } : {}),
+			...(parsed.error ? { error: parsed.error } : {}),
+			completedAt: parsed.completedAt,
+		};
+	} catch {
+		return null;
+	}
+}
+
+export function getHostUpdateStatus(options: {
+	organizationId: string;
+	homeDir?: string;
+	now?: number;
+	isOwnerAlive?: (pid: number) => boolean;
+}): HostUpdateStatus {
+	const lock = readUpdateLock(options.organizationId, options.homeDir);
+	if (lock) {
+		const ownerAlive = options.isOwnerAlive ?? isPidAlive;
+		if (ownerAlive(lock.pid)) {
+			return {
+				status: "updating",
+				targetVersion: lock.targetVersion,
+				previousVersion: lock.previousVersion,
+				startedAt: lock.startedAt,
+			};
+		}
+
+		releaseUpdateLock({
+			organizationId: options.organizationId,
+			ownerPid: lock.pid,
+			homeDir: options.homeDir,
+		});
+		if (!readUpdateResult(options.organizationId, options.homeDir)) {
+			writeUpdateResult(
+				options.organizationId,
+				{
+					status: "failed",
+					targetVersion: lock.targetVersion,
+					previousVersion: lock.previousVersion,
+					error: "Update supervisor exited before reporting a result",
+					completedAt: options.now ?? Date.now(),
+				},
+				options.homeDir,
+			);
+		}
+	}
+
+	return (
+		readUpdateResult(options.organizationId, options.homeDir) ?? {
+			status: "idle",
+		}
+	);
+}

--- a/packages/host-service/src/runtime/update/version.test.ts
+++ b/packages/host-service/src/runtime/update/version.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { classifyUpdateTarget } from "./version";
+
+describe("host update versions", () => {
+	test("classifies targets with shared publication ordering", () => {
+		expect(classifyUpdateTarget("1.14.0-1", "1.14.0-1")).toBe("satisfied");
+		expect(classifyUpdateTarget("1.14.0", "1.14.0-1")).toBe("upgrade");
+		expect(classifyUpdateTarget("1.14.0-1", "1.14.0")).toBe("downgrade");
+		expect(classifyUpdateTarget("1.14.0-2", "1.14.0-1")).toBe("downgrade");
+	});
+});

--- a/packages/host-service/src/runtime/update/version.ts
+++ b/packages/host-service/src/runtime/update/version.ts
@@ -1,0 +1,18 @@
+import hostServicePackageJson from "@superset/host-service/package.json" with {
+	type: "json",
+};
+import { compareHostVersions } from "@superset/shared/host-version";
+
+export { isInstallableHostVersion as isInstallableUpdateVersion } from "@superset/shared/host-version";
+
+export const HOST_SERVICE_VERSION: string = hostServicePackageJson.version;
+
+export function classifyUpdateTarget(
+	currentVersion: string,
+	targetVersion: string,
+): "satisfied" | "upgrade" | "downgrade" {
+	const order = compareHostVersions(targetVersion, currentVersion);
+	if (order === null) return "downgrade";
+	if (order === 0) return "satisfied";
+	return order < 0 ? "downgrade" : "upgrade";
+}

--- a/packages/host-service/src/trpc/router/host/host.ts
+++ b/packages/host-service/src/trpc/router/host/host.ts
@@ -1,15 +1,13 @@
 import os from "node:os";
-import hostServicePackageJson from "@superset/host-service/package.json" with {
-	type: "json",
-};
 import { getHostId, getHostName } from "@superset/shared/host-info";
 import { TRPCError } from "@trpc/server";
+import {
+	HOST_SERVICE_VERSION,
+	supportsRemoteUpdate,
+} from "../../../runtime/update";
 import type { ApiClient } from "../../../types";
 import { protectedProcedure, router } from "../../index";
-
-// Auto-derived from this package's package.json so callers can report exactly
-// which bundled host-service build is currently serving requests.
-const HOST_SERVICE_VERSION: string = hostServicePackageJson.version;
+import { hostUpdateRouter } from "./update";
 
 const ORGANIZATION_CACHE_TTL_MS = 60 * 60 * 1000;
 
@@ -52,9 +50,11 @@ export const hostRouter = router({
 			hostId: getHostId(),
 			hostName: getHostName(),
 			version: HOST_SERVICE_VERSION,
+			supportsRemoteUpdate: supportsRemoteUpdate(),
 			organization,
 			platform: os.platform(),
 			uptime: process.uptime(),
 		};
 	}),
+	update: hostUpdateRouter,
 });

--- a/packages/host-service/src/trpc/router/host/update.ts
+++ b/packages/host-service/src/trpc/router/host/update.ts
@@ -1,0 +1,140 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+	acquireUpdateLock,
+	classifyUpdateTarget,
+	clearUpdateResult,
+	getHostUpdateStatus,
+	HOST_SERVICE_VERSION,
+	isInstallableUpdateVersion,
+	releaseUpdateLock,
+	spawnUpdateSupervisor,
+	supportsRemoteUpdate,
+	terminateUpdateSupervisor,
+	transferUpdateLock,
+	writeUpdateResult,
+} from "../../../runtime/update";
+import { protectedProcedure, router } from "../../index";
+
+const targetVersionSchema = z.string().refine(isInstallableUpdateVersion, {
+	message:
+		"Expected MAJOR.MINOR.PATCH with an optional prerelease suffix and no build metadata",
+});
+
+export const hostUpdateRouter = router({
+	start: protectedProcedure
+		.input(z.object({ targetVersion: targetVersionSchema }))
+		.mutation(({ ctx, input }) => {
+			if (!supportsRemoteUpdate()) {
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message: "Remote update is not supported by this host install",
+				});
+			}
+
+			const disposition = classifyUpdateTarget(
+				HOST_SERVICE_VERSION,
+				input.targetVersion,
+			);
+			if (disposition === "downgrade") {
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message: `Refusing to downgrade host from ${HOST_SERVICE_VERSION} to ${input.targetVersion}`,
+				});
+			}
+
+			const currentStatus = getHostUpdateStatus({
+				organizationId: ctx.organizationId,
+			});
+			if (currentStatus.status === "updating") {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message: `Update to ${currentStatus.targetVersion} is already in progress`,
+				});
+			}
+
+			if (disposition === "satisfied") {
+				clearUpdateResult(ctx.organizationId);
+				writeUpdateResult(ctx.organizationId, {
+					status: "succeeded",
+					targetVersion: input.targetVersion,
+					previousVersion: HOST_SERVICE_VERSION,
+					finalVersion: HOST_SERVICE_VERSION,
+					completedAt: Date.now(),
+				});
+				return {
+					outcome: "satisfied" as const,
+					previousVersion: HOST_SERVICE_VERSION,
+					newVersion: HOST_SERVICE_VERSION,
+					targetVersion: input.targetVersion,
+					supervisorPid: null,
+				};
+			}
+
+			const acquired = acquireUpdateLock({
+				organizationId: ctx.organizationId,
+				ownerPid: process.pid,
+				targetVersion: input.targetVersion,
+				previousVersion: HOST_SERVICE_VERSION,
+			});
+			if (!acquired.acquired) {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message: acquired.lock
+						? `Update to ${acquired.lock.targetVersion} is already in progress`
+						: "Another update is already in progress",
+				});
+			}
+
+			clearUpdateResult(ctx.organizationId);
+			let supervisorPid: number | null = null;
+			try {
+				const supervisor = spawnUpdateSupervisor({
+					organizationId: ctx.organizationId,
+					oldPid: process.pid,
+					targetVersion: input.targetVersion,
+				});
+				supervisorPid = supervisor.supervisorPid;
+				transferUpdateLock({
+					organizationId: ctx.organizationId,
+					fromPid: process.pid,
+					toPid: supervisor.supervisorPid,
+				});
+			} catch (error) {
+				if (supervisorPid !== null) {
+					terminateUpdateSupervisor(supervisorPid);
+				}
+				releaseUpdateLock({
+					organizationId: ctx.organizationId,
+					ownerPid: process.pid,
+				});
+				writeUpdateResult(ctx.organizationId, {
+					status: "failed",
+					targetVersion: input.targetVersion,
+					previousVersion: HOST_SERVICE_VERSION,
+					error:
+						error instanceof Error
+							? error.message
+							: "Failed to start update supervisor",
+					completedAt: Date.now(),
+				});
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to start update supervisor",
+					cause: error,
+				});
+			}
+
+			return {
+				outcome: "dispatched" as const,
+				previousVersion: HOST_SERVICE_VERSION,
+				newVersion: null,
+				targetVersion: input.targetVersion,
+				supervisorPid,
+			};
+		}),
+
+	status: protectedProcedure.query(({ ctx }) =>
+		getHostUpdateStatus({ organizationId: ctx.organizationId }),
+	),
+});

--- a/packages/host-service/test/integration/smoke.integration.test.ts
+++ b/packages/host-service/test/integration/smoke.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { TRPCClientError } from "@trpc/client";
+import { HOST_SERVICE_VERSION } from "../../src/runtime/update";
 import { createTestHost, type TestHost } from "../helpers/createTestHost";
 
 describe("host-service smoke", () => {
@@ -49,6 +50,8 @@ describe("host-service smoke", () => {
 		});
 		expect(info.platform).toEqual(process.platform);
 		expect(typeof info.uptime).toBe("number");
+		expect(info.version).toBe(HOST_SERVICE_VERSION);
+		expect(info.supportsRemoteUpdate).toBe(false);
 		expect(host.apiCalls.map((c) => c.path)).toContain(
 			"organization.getByIdFromJwt.query",
 		);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -150,11 +150,13 @@
 		"@date-fns/tz": "1.4.1",
 		"friendly-words": "1.3.1",
 		"rrule": "2.8.1",
+		"semver": "7.7.4",
 		"zod": "4.3.6"
 	},
 	"devDependencies": {
 		"@superset/typescript": "workspace:*",
 		"@types/friendly-words": "1.2.2",
+		"@types/semver": "7.7.1",
 		"bun-types": "1.3.14",
 		"typescript": "6.0.3"
 	}

--- a/packages/shared/src/host-version.test.ts
+++ b/packages/shared/src/host-version.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+	compareHostVersions,
+	isHostVersionAtLeast,
+	isInstallableHostVersion,
+} from "./host-version";
+
+describe("isInstallableHostVersion", () => {
+	test.each([
+		"1.14.0",
+		"1.14.0-2",
+		"1.14.0-canary.3",
+	])("accepts %s", (version) => {
+		expect(isInstallableHostVersion(version)).toBe(true);
+	});
+
+	test("caps versions at 64 characters", () => {
+		expect(isInstallableHostVersion(`1.2.3-${"a".repeat(58)}`)).toBe(true);
+		expect(isInstallableHostVersion(`1.2.3-${"a".repeat(59)}`)).toBe(false);
+	});
+
+	test.each([
+		"cli-v1.14.0",
+		"01.14.0",
+		"1.014.0",
+		"1.14.00",
+		"1.14.0-02",
+		"1.14.0-rc..1",
+		"1.14.0-rc-1",
+		"1.14.0+build.1",
+		" 1.14.0",
+	])("rejects %s", (version) => {
+		expect(isInstallableHostVersion(version)).toBe(false);
+	});
+});
+
+describe("compareHostVersions", () => {
+	test("orders numeric hotfixes after their stable core", () => {
+		expect(compareHostVersions("1.14.0", "1.14.0-0")).toBe(-1);
+		expect(compareHostVersions("1.14.0-2", "1.14.0-1")).toBe(1);
+		expect(compareHostVersions("1.14.0-10", "1.14.0-9")).toBe(1);
+	});
+
+	test("orders release cores before applying hotfix semantics", () => {
+		expect(compareHostVersions("1.15.0", "1.14.0-999")).toBe(1);
+		expect(compareHostVersions("2.0.0", "1.999.999-999")).toBe(1);
+		expect(compareHostVersions("1.13.999-999", "1.14.0")).toBe(-1);
+	});
+
+	test("retains SemVer ordering for non-hotfix prereleases", () => {
+		expect(compareHostVersions("1.14.0-rc.2", "1.14.0-rc.1")).toBe(1);
+		expect(compareHostVersions("1.14.0-rc.1", "1.14.0")).toBe(-1);
+	});
+
+	test("returns null for non-installable versions", () => {
+		expect(compareHostVersions("dev", "1.14.0")).toBeNull();
+		expect(compareHostVersions("1.14.0", "1.14.0+build.1")).toBeNull();
+	});
+});
+
+describe("isHostVersionAtLeast", () => {
+	test("uses publication ordering and rejects invalid versions", () => {
+		expect(isHostVersionAtLeast("1.14.0-1", "1.14.0")).toBe(true);
+		expect(isHostVersionAtLeast("1.14.0", "1.14.0-1")).toBe(false);
+		expect(isHostVersionAtLeast("dev", "1.14.0")).toBe(false);
+	});
+});

--- a/packages/shared/src/host-version.ts
+++ b/packages/shared/src/host-version.ts
@@ -1,3 +1,5 @@
+import semver from "semver";
+
 /**
  * Minimum host-service version a v2 workspace UI can work with against a
  * **remote** host whose binary we don't control (gates renderer mounting
@@ -23,3 +25,100 @@
  * WebSocket route is attach-only by `terminalId`.
  */
 export const MIN_HOST_SERVICE_VERSION = "0.8.0";
+
+/**
+ * Versions accepted by `superset update --version`. Build metadata and
+ * hyphens within prerelease identifiers are intentionally unsupported by the
+ * CLI download naming scheme.
+ */
+export const INSTALLABLE_HOST_VERSION_RE =
+	/^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.]+)?$/;
+export const MAX_INSTALLABLE_HOST_VERSION_LENGTH = 64;
+
+export type HostVersionOrder = -1 | 0 | 1;
+
+function normalizeOrder(order: number): HostVersionOrder {
+	if (order === 0) return 0;
+	return order < 0 ? -1 : 1;
+}
+
+function parseInstallableHostVersion(version: string) {
+	if (version.length > MAX_INSTALLABLE_HOST_VERSION_LENGTH) return null;
+	if (!INSTALLABLE_HOST_VERSION_RE.test(version)) return null;
+	return semver.parse(version);
+}
+
+export function isInstallableHostVersion(version: string): boolean {
+	return parseInstallableHostVersion(version) !== null;
+}
+
+type PublicationRelease =
+	| { type: "stable" }
+	| { type: "numeric-hotfix"; sequence: string };
+
+function getPublicationRelease(
+	version: string,
+	core: string,
+): PublicationRelease | null {
+	if (version === core) return { type: "stable" };
+
+	const suffix = version.slice(core.length + 1);
+	if (/^(?:0|[1-9][0-9]*)$/.test(suffix)) {
+		return { type: "numeric-hotfix", sequence: suffix };
+	}
+	return null;
+}
+
+function compareNumericStrings(left: string, right: string): HostVersionOrder {
+	if (left.length !== right.length) {
+		return left.length < right.length ? -1 : 1;
+	}
+	if (left === right) return 0;
+	return left < right ? -1 : 1;
+}
+
+/**
+ * Orders installable host releases by publication sequence. Numeric `-N`
+ * releases are CLI/host hotfixes published after the stable version with the
+ * same core. Different cores always retain normal SemVer ordering.
+ *
+ * Returns `null` when either value is not installable by the CLI.
+ */
+export function compareHostVersions(
+	leftVersion: string,
+	rightVersion: string,
+): HostVersionOrder | null {
+	const left = parseInstallableHostVersion(leftVersion);
+	const right = parseInstallableHostVersion(rightVersion);
+	if (!left || !right) return null;
+
+	for (const key of ["major", "minor", "patch"] as const) {
+		if (left[key] !== right[key]) {
+			return left[key] < right[key] ? -1 : 1;
+		}
+	}
+
+	const core = `${left.major}.${left.minor}.${left.patch}`;
+	const leftPublication = getPublicationRelease(leftVersion, core);
+	const rightPublication = getPublicationRelease(rightVersion, core);
+	if (leftPublication && rightPublication) {
+		if (leftPublication.type === "stable") {
+			return rightPublication.type === "stable" ? 0 : -1;
+		}
+		if (rightPublication.type === "stable") return 1;
+		return compareNumericStrings(
+			leftPublication.sequence,
+			rightPublication.sequence,
+		);
+	}
+
+	return normalizeOrder(semver.compare(left, right));
+}
+
+export function isHostVersionAtLeast(
+	version: string,
+	minimumVersion: string,
+): boolean {
+	const order = compareHostVersions(version, minimumVersion);
+	return order !== null && order >= 0;
+}

--- a/packages/trpc/src/router/host/host.ts
+++ b/packages/trpc/src/router/host/host.ts
@@ -16,6 +16,7 @@ import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { jwtProcedure, protectedProcedure } from "../../trpc";
+import { hostUpdateProcedure } from "./update";
 
 export const hostRouter = {
 	list: jwtProcedure
@@ -300,4 +301,6 @@ export const hostRouter = {
 				);
 			return { success: true };
 		}),
+
+	update: hostUpdateProcedure,
 } satisfies TRPCRouterRecord;

--- a/packages/trpc/src/router/host/update-handler.test.ts
+++ b/packages/trpc/src/router/host/update-handler.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, mock } from "bun:test";
+import { RelayDispatchError } from "../automation/relay-client";
+import {
+	executeHostUpdate,
+	type HostUpdateContext,
+	type HostUpdateDependencies,
+	type HostUpdateResult,
+	hostUpdateInputSchema,
+} from "./update-handler";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const ORGANIZATION_ID = "22222222-2222-4222-8222-222222222222";
+const MACHINE_ID = "host-machine-id";
+const TARGET_VERSION = "1.14.2-rc.1";
+
+const context: HostUpdateContext = {
+	userId: USER_ID,
+	email: "owner@example.com",
+	organizationIds: [ORGANIZATION_ID],
+};
+
+const input = {
+	organizationId: ORGANIZATION_ID,
+	machineId: MACHINE_ID,
+	targetVersion: TARGET_VERSION,
+};
+
+const result: HostUpdateResult = {
+	outcome: "dispatched",
+	previousVersion: "1.14.1",
+	newVersion: null,
+	supervisorPid: 4321,
+};
+
+function createDependencies(
+	overrides: Partial<HostUpdateDependencies> = {},
+): HostUpdateDependencies {
+	return {
+		relayUrl: "https://relay.example.com",
+		findHostRole: mock(async () => "owner" as const),
+		mintJwt: mock(async () => "signed-user-jwt"),
+		dispatch: mock(async () => result),
+		...overrides,
+	};
+}
+
+describe("hostUpdateInputSchema", () => {
+	it.each([
+		"1.14.2",
+		"1.14.2-1",
+		"1.14.2-rc.1",
+	])("accepts updater version %s", (targetVersion) => {
+		expect(
+			hostUpdateInputSchema.safeParse({ ...input, targetVersion }).success,
+		).toBe(true);
+	});
+
+	it.each([
+		"v1.14.2",
+		"1.14",
+		"01.14.2",
+		"1.014.2",
+		"1.14.02",
+		"1.14.2-01",
+		"1.14.2-rc..1",
+		"1.14.2+build.1",
+		"1.14.2-rc-1",
+		" 1.14.2",
+		`1.14.2-${"a".repeat(64)}`,
+	])("rejects updater-incompatible version %s", (targetVersion) => {
+		expect(
+			hostUpdateInputSchema.safeParse({ ...input, targetVersion }).success,
+		).toBe(false);
+	});
+});
+
+describe("executeHostUpdate", () => {
+	it("requires organization membership before querying host access", async () => {
+		const dependencies = createDependencies();
+
+		await expect(
+			executeHostUpdate(
+				{ ...context, organizationIds: [] },
+				input,
+				dependencies,
+			),
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "Not a member of this organization",
+		});
+		expect(dependencies.findHostRole).not.toHaveBeenCalled();
+		expect(dependencies.mintJwt).not.toHaveBeenCalled();
+		expect(dependencies.dispatch).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		null,
+		"member" as const,
+	])("requires the v2 host owner role when role is %s", async (role) => {
+		const dependencies = createDependencies({
+			findHostRole: mock(async () => role),
+		});
+
+		await expect(
+			executeHostUpdate(context, input, dependencies),
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "Only the host owner can update it",
+		});
+		expect(dependencies.mintJwt).not.toHaveBeenCalled();
+		expect(dependencies.dispatch).not.toHaveBeenCalled();
+	});
+
+	it("mints a scoped JWT and relays the exact target version", async () => {
+		const dependencies = createDependencies();
+
+		await expect(
+			executeHostUpdate(context, input, dependencies),
+		).resolves.toEqual(result);
+		expect(dependencies.findHostRole).toHaveBeenCalledWith({
+			organizationId: ORGANIZATION_ID,
+			userId: USER_ID,
+			machineId: MACHINE_ID,
+		});
+		expect(dependencies.mintJwt).toHaveBeenCalledWith({
+			userId: USER_ID,
+			email: "owner@example.com",
+			organizationIds: [ORGANIZATION_ID],
+			scope: "host-update",
+			runId: `host-update:${ORGANIZATION_ID}:${MACHINE_ID}`,
+			ttlSeconds: 300,
+		});
+		expect(dependencies.dispatch).toHaveBeenCalledWith({
+			relayUrl: "https://relay.example.com",
+			hostId: `${ORGANIZATION_ID}:${MACHINE_ID}`,
+			jwt: "signed-user-jwt",
+			targetVersion: TARGET_VERSION,
+		});
+	});
+
+	it("maps relay dispatch failures to BAD_GATEWAY", async () => {
+		const dependencies = createDependencies({
+			dispatch: mock(async () => {
+				throw new RelayDispatchError(
+					"relay 502: unavailable",
+					502,
+					"unavailable",
+				);
+			}),
+		});
+
+		await expect(
+			executeHostUpdate(context, input, dependencies),
+		).rejects.toMatchObject({
+			code: "BAD_GATEWAY",
+			message: "Failed to dispatch host update: relay 502: unavailable",
+		});
+	});
+});

--- a/packages/trpc/src/router/host/update-handler.ts
+++ b/packages/trpc/src/router/host/update-handler.ts
@@ -1,0 +1,116 @@
+import { buildHostRoutingKey } from "@superset/shared/host-routing";
+import {
+	isInstallableHostVersion,
+	MAX_INSTALLABLE_HOST_VERSION_LENGTH,
+} from "@superset/shared/host-version";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { RelayDispatchError } from "../automation/relay-client";
+
+export const hostUpdateInputSchema = z.object({
+	organizationId: z.string().uuid(),
+	machineId: z.string().min(1),
+	targetVersion: z
+		.string()
+		.max(MAX_INSTALLABLE_HOST_VERSION_LENGTH)
+		.refine(isInstallableHostVersion, {
+			message: "Invalid Superset version",
+		}),
+});
+
+export type HostUpdateInput = z.infer<typeof hostUpdateInputSchema>;
+
+export interface HostUpdateResult {
+	outcome: "dispatched" | "satisfied";
+	previousVersion: string;
+	newVersion: string | null;
+	supervisorPid: number | null;
+}
+
+export interface HostUpdateContext {
+	userId: string;
+	email: string;
+	organizationIds: string[];
+}
+
+interface HostAccessInput {
+	organizationId: string;
+	userId: string;
+	machineId: string;
+}
+
+interface MintJwtInput {
+	userId: string;
+	email?: string;
+	organizationIds: string[];
+	scope: string;
+	runId: string;
+	ttlSeconds: number;
+}
+
+interface RelayHostUpdateInput {
+	relayUrl: string;
+	hostId: string;
+	jwt: string;
+	targetVersion: string;
+}
+
+export interface HostUpdateDependencies {
+	relayUrl: string;
+	findHostRole: (input: HostAccessInput) => Promise<"owner" | "member" | null>;
+	mintJwt: (input: MintJwtInput) => Promise<string>;
+	dispatch: (input: RelayHostUpdateInput) => Promise<HostUpdateResult>;
+}
+
+export async function executeHostUpdate(
+	ctx: HostUpdateContext,
+	input: HostUpdateInput,
+	dependencies: HostUpdateDependencies,
+): Promise<HostUpdateResult> {
+	if (!ctx.organizationIds.includes(input.organizationId)) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Not a member of this organization",
+		});
+	}
+
+	const role = await dependencies.findHostRole({
+		organizationId: input.organizationId,
+		userId: ctx.userId,
+		machineId: input.machineId,
+	});
+	if (role !== "owner") {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Only the host owner can update it",
+		});
+	}
+
+	const hostId = buildHostRoutingKey(input.organizationId, input.machineId);
+	const jwt = await dependencies.mintJwt({
+		userId: ctx.userId,
+		email: ctx.email || undefined,
+		organizationIds: [input.organizationId],
+		scope: "host-update",
+		runId: `host-update:${hostId}`,
+		ttlSeconds: 300,
+	});
+
+	try {
+		return await dependencies.dispatch({
+			relayUrl: dependencies.relayUrl,
+			hostId,
+			jwt,
+			targetVersion: input.targetVersion,
+		});
+	} catch (error) {
+		if (error instanceof RelayDispatchError) {
+			throw new TRPCError({
+				code: "BAD_GATEWAY",
+				message: `Failed to dispatch host update: ${error.message}`,
+				cause: error,
+			});
+		}
+		throw error;
+	}
+}

--- a/packages/trpc/src/router/host/update.ts
+++ b/packages/trpc/src/router/host/update.ts
@@ -1,0 +1,41 @@
+import { mintUserJwt } from "@superset/auth/server";
+import { db } from "@superset/db/client";
+import { v2UsersHosts } from "@superset/db/schema";
+import { and, eq } from "drizzle-orm";
+import { env } from "../../env";
+import { jwtProcedure } from "../../trpc";
+import { relayMutation } from "../automation/relay-client";
+import {
+	executeHostUpdate,
+	type HostUpdateDependencies,
+	type HostUpdateResult,
+	hostUpdateInputSchema,
+} from "./update-handler";
+
+const hostUpdateDependencies: HostUpdateDependencies = {
+	relayUrl: env.RELAY_URL,
+	findHostRole: async ({ organizationId, userId, machineId }) => {
+		const access = await db.query.v2UsersHosts.findFirst({
+			where: and(
+				eq(v2UsersHosts.organizationId, organizationId),
+				eq(v2UsersHosts.userId, userId),
+				eq(v2UsersHosts.hostId, machineId),
+			),
+			columns: { role: true },
+		});
+		return access?.role ?? null;
+	},
+	mintJwt: mintUserJwt,
+	dispatch: ({ relayUrl, hostId, jwt, targetVersion }) =>
+		relayMutation<{ targetVersion: string }, HostUpdateResult>(
+			{ relayUrl, hostId, jwt },
+			"host.update.start",
+			{ targetVersion },
+		),
+};
+
+export const hostUpdateProcedure = jwtProcedure
+	.input(hostUpdateInputSchema)
+	.mutation(({ ctx, input }) =>
+		executeHostUpdate(ctx, input, hostUpdateDependencies),
+	);

--- a/plans/20260709-unified-version-bumping.md
+++ b/plans/20260709-unified-version-bumping.md
@@ -43,6 +43,9 @@ Every desktop bump now sets **desktop + host-service + cli** to the same new
 version (was: desktop + host-service patch-bump). Both the normal and
 commit/worktree paths refresh `bun.lock` and commit all three package.jsons.
 
+The flow pushes both `desktop-vX` and `cli-vX`; the latter publishes the exact
+standalone bundle used by explicit remote host update requests.
+
 Commit: `chore(desktop): bump version to X (host-service a -> X, cli b -> X)`.
 
 ## Interim CLI release (`scripts/release/cli.ts`, `bun run release cli`)

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -17,7 +17,7 @@ step). One entry point: **`bun run release`**. Design/rationale lives in
 | Command | When |
 | --- | --- |
 | `bun run release` | Interactive menu (TTY only). |
-| `bun run release desktop [version]` | New app release. Moves desktop + host-service + cli together. Draft by default. |
+| `bun run release desktop [version]` | New app release. Moves desktop + host-service + cli together and publishes the matching standalone CLI bundle. Draft by default. |
 | `bun run release cli [suffix]` | CLI-only hotfix **between** desktop releases → `<desktop>-N`. |
 | `… --daemon` | Also ship a pty-daemon fix (patch-bumps it on `0.x`). |
 | `bun run release check` | Verify versions are unified (exit 1 on drift). |
@@ -62,6 +62,10 @@ bun run release desktop 1.15.0 --publish [--merge] # auto-publish (+ merge the P
 
 Once published (non-draft), it becomes `/releases/latest`, which the desktop
 auto-updater reads.
+
+The desktop flow also pushes `cli-v<version>` and waits for `release-cli.yml`.
+That exact standalone bundle is what an owner-triggered remote host update
+installs; publishing it does not automatically update any host.
 
 ## When the daemon guard blocks
 

--- a/scripts/release/desktop.ts
+++ b/scripts/release/desktop.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 
 // Desktop app release: bumps desktop + host-service + cli to one unified version
-// (and, with --daemon, patch-bumps pty-daemon), tags desktop-v<version> to
-// trigger release-desktop.yml, monitors the build, and leaves a draft (or
-// publishes with --publish). See plans/20260709-unified-version-bumping.md and
+// (and, with --daemon, patch-bumps pty-daemon), tags desktop-v<version> and
+// cli-v<version> so both bundled and standalone hosts have the exact release,
+// monitors the builds, and leaves a desktop draft (or publishes with
+// --publish). See plans/20260709-unified-version-bumping.md and
 // apps/desktop/RELEASE.md.
 //
 // Usage: [version] [commit] [--publish] [--merge] [--daemon]
@@ -102,16 +103,19 @@ export async function runDesktop(argv: string[]): Promise<void> {
 	}
 
 	const tag = `desktop-v${version}`;
+	const cliTag = `cli-v${version}`;
 	info(`Starting release process for version ${version}`);
 	console.log("");
 
 	await handleExistingTag(tag, republish);
+	await handleExistingTag(cliTag, republish);
 
 	let prNumber = "";
 	if (commitInput) {
-		await releaseFromCommit(version, commitInput, tag, withDaemon);
+		await releaseFromCommit(version, commitInput, [tag, cliTag], withDaemon);
 	} else {
-		prNumber = (await releaseFromHead(root, version, tag, withDaemon)).prNumber;
+		prNumber = (await releaseFromHead(root, version, [tag, cliTag], withDaemon))
+			.prNumber;
 	}
 
 	await monitorAndPublish(root, tag, { autoPublish, autoMerge, prNumber });
@@ -227,7 +231,7 @@ async function bumpUnified(
 async function releaseFromHead(
 	root: string,
 	version: string,
-	tag: string,
+	tags: string[],
 	withDaemon: boolean,
 ): Promise<{ prNumber: string; branch: string }> {
 	const current = readVersion(root, DESKTOP_DIR);
@@ -276,17 +280,19 @@ async function releaseFromHead(
 		}
 	}
 
-	info(`Creating tag ${tag}...`);
-	await $`git tag ${tag}`;
-	await $`git push origin ${tag}`;
-	success("Tag pushed to remote");
+	for (const tag of tags) {
+		info(`Creating tag ${tag}...`);
+		await $`git tag ${tag}`;
+		await $`git push origin ${tag}`;
+		success(`Tag ${tag} pushed to remote`);
+	}
 	return { prNumber, branch };
 }
 
 async function releaseFromCommit(
 	version: string,
 	commitInput: string,
-	tag: string,
+	tags: string[],
 	withDaemon: boolean,
 ): Promise<void> {
 	const fullSha = (
@@ -327,9 +333,11 @@ async function releaseFromCommit(
 		}
 
 		await $`git push origin ${`HEAD:refs/heads/${tempBranch}`}`.cwd(worktree);
-		await $`git tag ${tag}`.cwd(worktree);
-		await $`git push origin ${tag}`.cwd(worktree);
-		success(`Tag ${tag} pushed from temp branch`);
+		for (const tag of tags) {
+			await $`git tag ${tag}`.cwd(worktree);
+			await $`git push origin ${tag}`.cwd(worktree);
+			success(`Tag ${tag} pushed from temp branch`);
+		}
 	} finally {
 		await $`git worktree remove --force ${worktree}`.nothrow().quiet();
 		rmSync(worktree, { recursive: true, force: true });
@@ -346,12 +354,15 @@ async function monitorAndPublish(
 	success("Release process initiated!");
 
 	const sha = (await $`git rev-list -n 1 ${tag}`.text()).trim();
-	info("Monitoring GitHub Actions workflow...");
-	const runId = await findWorkflowRun(root, "release-desktop.yml", sha);
-	if (!runId) {
-		warn("Could not find workflow run automatically.");
-		console.log(`  https://github.com/${repo}/actions`);
-	} else {
+	for (const workflow of ["release-desktop.yml", "release-cli.yml"]) {
+		info(`Monitoring ${workflow}...`);
+		const runId = await findWorkflowRun(root, workflow, sha);
+		if (!runId) {
+			warn(`Could not find ${workflow} run automatically.`);
+			console.log(`  https://github.com/${repo}/actions`);
+			continue;
+		}
+
 		console.log(`  https://github.com/${repo}/actions/runs/${runId}`);
 		await $`gh run watch ${runId}`.nothrow();
 		const conclusion = (
@@ -359,10 +370,13 @@ async function monitorAndPublish(
 				.nothrow()
 				.text()
 		).trim();
-		if (conclusion === "success") success("Workflow completed successfully!");
+		if (conclusion === "success")
+			success(`${workflow} completed successfully!`);
 		else if (conclusion === "failure")
-			fail(`Workflow failed: https://github.com/${repo}/actions/runs/${runId}`);
-		else warn(`Workflow ended with status: ${conclusion}`);
+			fail(
+				`${workflow} failed: https://github.com/${repo}/actions/runs/${runId}`,
+			);
+		else warn(`${workflow} ended with status: ${conclusion}`);
 	}
 
 	info("Waiting for draft release...");

--- a/scripts/release/lib.test.ts
+++ b/scripts/release/lib.test.ts
@@ -59,12 +59,21 @@ describe("latestReleaseTag", () => {
 		];
 		expect(latestReleaseTag(tags, "desktop")).toBe("desktop-v1.14.0");
 	});
-	test("cli prerelease ordering (release > prerelease)", () => {
+	test("orders CLI tags by their publication sequence", () => {
 		expect(latestReleaseTag(["cli-v1.14.0-1", "cli-v0.2.24"], "cli")).toBe(
 			"cli-v1.14.0-1",
 		);
 		expect(latestReleaseTag(["cli-v1.14.0-1", "cli-v1.14.0-2"], "cli")).toBe(
 			"cli-v1.14.0-2",
+		);
+		expect(
+			latestReleaseTag(
+				["cli-v1.14.0", "cli-v1.14.0-1", "cli-v1.14.0-2"],
+				"cli",
+			),
+		).toBe("cli-v1.14.0-2");
+		expect(latestReleaseTag(["cli-v1.14.0-9", "cli-v1.15.0"], "cli")).toBe(
+			"cli-v1.15.0",
 		);
 	});
 	test("no matching tags -> undefined", () => {

--- a/scripts/release/lib.ts
+++ b/scripts/release/lib.ts
@@ -92,8 +92,8 @@ export function unifiedErrors(
 	return errors;
 }
 
-/** Newest well-formed tag for a stream, filtering malformed historical tags
- * (e.g. desktop-vdesktop-v0.0.14). Uses semver ordering (prerelease < release). */
+/** Newest well-formed tag for a stream, filtering malformed historical tags.
+ * Numeric CLI `-N` hotfixes are chronological successors to their stable base. */
 export function latestReleaseTag(
 	tags: string[],
 	stream: Stream,
@@ -105,8 +105,30 @@ export function latestReleaseTag(
 			: /^cli-v\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$/;
 	const versions = tags
 		.filter((t) => re.test(t))
-		.map((t) => t.slice(prefix.length))
-		.sort(semver.rcompare);
+		.map((t) => t.slice(prefix.length));
+	versions.sort((left, right) => {
+		if (stream === "desktop") return semver.rcompare(left, right);
+		const leftParsed = semver.parse(left);
+		const rightParsed = semver.parse(right);
+		if (!leftParsed || !rightParsed) return 0;
+		for (const key of ["major", "minor", "patch"] as const) {
+			const difference = rightParsed[key] - leftParsed[key];
+			if (difference !== 0) return difference;
+		}
+		const sequence = (version: semver.SemVer) => {
+			if (version.prerelease.length === 0) return 0;
+			return version.prerelease.length === 1 &&
+				typeof version.prerelease[0] === "number"
+				? version.prerelease[0]
+				: null;
+		};
+		const leftSequence = sequence(leftParsed);
+		const rightSequence = sequence(rightParsed);
+		if (leftSequence !== null && rightSequence !== null) {
+			return rightSequence - leftSequence;
+		}
+		return semver.rcompare(left, right);
+	});
 	return versions[0] ? `${prefix}${versions[0]}` : undefined;
 }
 


### PR DESCRIPTION
## Summary

- surface remote host version mismatches in host settings without triggering automatic updates
- allow host owners to confirm and request an exact version-matched update through a scoped cloud/relay command
- add a standalone CLI supervisor that installs, restarts, verifies, and rolls back remote host updates
- publish matching CLI artifacts alongside desktop releases so the requested host version exists

## Why

Desktop and standalone remote hosts can drift from the host-service version bundled with the current client. Previously the UI could only report generic incompatibility and owners had no safe in-app path to bring a standalone host back to the same version.

Updates remain fully manual: displaying a mismatch does not send a command, and the owner must click **Update host** and confirm the exact source and target versions.

## Safety

- cloud mutation requires the v2 host owner role
- relay only permits `host.update.start` with a server-minted, host-scoped token
- hosts reject downgrades, unsupported installs, and concurrent updates
- the detached supervisor retains the previous install until the replacement reports the exact target version
- failed installs or verification restore and restart the previous version
- Linux zombie processes are treated as exited during daemon restart checks

## Validation

- 117 focused tests passed across 15 files
- affected typechecks passed for shared, host-service, CLI, tRPC, relay, desktop, and release scripts
- root lint passed across 5,001 files
- version consistency, host-service bundle, supervisor bundle, and Node syntax checks passed
- CDP + disposable Vercel Sandbox E2E verified:
  - viewing a mismatch and canceling confirmation sent no update
  - confirmed update moved a Linux host from `1.14.0-1` to exact `1.14.0-2`
  - the supervisor cleared its lock and backup after verification
  - the UI finished at **Up to date** with no update button


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5585">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds manual, version-matched remote updates for standalone hosts. The app now surfaces version mismatches and lets owners trigger a scoped, supervised update to the exact client-matched `host-service` version.

- **New Features**
  - Host Settings shows the running vs expected `host-service` version and offers an explicit “Update host” action; the v2 workspace “incompatible” view links directly to these settings.
  - Update flow is owner-confirmed and manual: calls `host.update.start` via relay with a host-scoped token; no automatic updates.
  - `host-service` exposes version, remote-update capability, and a status/lock protocol; it rejects downgrades and concurrent installs.
  - A detached CLI supervisor installs, restarts, verifies the exact target, and rolls back on failure; zombie PIDs on Linux are treated as exited.
  - CLI bundles and publishes a `superset-host-supervisor` and matching artifacts; `superset update` gains safe, atomic replace with optional backup.
  - Version handling moved to shared utilities (validation and comparison using `semver`), enabling exact version matching in UI and API.
  - Release flow now also tags `cli-v<version>` with desktop releases to publish the exact standalone bundle remote hosts install.

- **Migration**
  - Supported targets: standalone Unix hosts started via the CLI with persisted auth (`daemon` lifecycle). Electron-managed and Windows hosts are not supported for remote updates.
  - Owners initiate updates from Host Settings. Ensure desktop releases continue pushing the matching `cli-v<version>` tag (handled by the updated scripts).

<sup>Written for commit 0f6fb8f7c1becdd65f21cd215736b4b6a1be611f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

