### PR TITLE
feat(desktop): pin the local workspace name to "local" and block renaming it

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/core/ContextProvider.tsx
+++ b/apps/desktop/src/renderer/commandPalette/core/ContextProvider.tsx
@@ -17,6 +17,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { getV2WorkspaceDisplayName } from "renderer/utils/getV2WorkspaceDisplayName";
 import type { CommandContext } from "./types";
 
 const Context = createContext<CommandContext | null>(null);
@@ -51,7 +52,7 @@ export function CommandContextProvider({ children }: { children: ReactNode }) {
 		if (!workspace) return null;
 		return {
 			id: workspace.id,
-			name: workspace.name,
+			name: getV2WorkspaceDisplayName(workspace),
 			projectId: workspace.projectId,
 			type: workspace.type,
 			hostId: workspace.hostId,

--- a/apps/desktop/src/renderer/commandPalette/ui/WorkspaceList/WorkspaceListFrame.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/WorkspaceList/WorkspaceListFrame.tsx
@@ -16,6 +16,7 @@ import {
 	navigateToWorkspace,
 } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useAccessibleV2Workspaces } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { getV2WorkspaceDisplayName } from "renderer/utils/getV2WorkspaceDisplayName";
 import { useFrameStackStore } from "../../core/frames";
 import { useCommandPaletteQuery } from "../CommandPalette/CommandPalette";
 
@@ -177,7 +178,7 @@ function V2WorkspaceList({ query }: { query: string }) {
 					{group.workspaces.map((workspace) => {
 						const HostIcon =
 							workspace.hostType === "local-device" ? LuLaptop : LuMonitor;
-						const displayName = workspace.name || workspace.branch;
+						const displayName = getV2WorkspaceDisplayName(workspace);
 						return (
 							<CommandItem
 								key={workspace.id}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -167,7 +167,7 @@ export function DashboardSidebarWorkspaceItem({
 							onCopyPath={handleCopyPath}
 							onCopyBranchName={handleCopyBranchName}
 							onRemoveFromSidebar={handleRemoveFromSidebar}
-							onRename={startRename}
+							onRename={isMainWorkspace ? undefined : startRename}
 							onDelete={
 								isMainWorkspace ? undefined : () => setIsDeleteDialogOpen(true)
 							}
@@ -223,7 +223,7 @@ export function DashboardSidebarWorkspaceItem({
 				workspaceStatus={workspaceStatus}
 				isInSection={isInSection}
 				onClick={handleClick}
-				onDoubleClick={isPending ? undefined : startRename}
+				onDoubleClick={isPending || isMainWorkspace ? undefined : startRename}
 				onRemoveFromSidebarClick={handleRemoveFromSidebar}
 				onCloseWorkspaceClick={() => setIsDeleteDialogOpen(true)}
 				onRenameValueChange={setRenameValue}
@@ -263,7 +263,7 @@ export function DashboardSidebarWorkspaceItem({
 						onCopyPath={handleCopyPath}
 						onCopyBranchName={handleCopyBranchName}
 						onRemoveFromSidebar={handleRemoveFromSidebar}
-						onRename={startRename}
+						onRename={isMainWorkspace ? undefined : startRename}
 						onDelete={
 							isMainWorkspace ? undefined : () => setIsDeleteDialogOpen(true)
 						}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -43,7 +43,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 	onCopyPath: () => void;
 	onCopyBranchName: () => void;
 	onRemoveFromSidebar: () => void;
-	onRename: () => void;
+	onRename?: () => void;
 	onDelete?: () => void;
 	onToggleUnread: () => void;
 	onClearStatus: () => void;
@@ -95,13 +95,15 @@ export function DashboardSidebarWorkspaceContextMenu({
 		<ContextMenu onOpenChange={setContextMenuOpen}>
 			<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
 			<ContextMenuContent onCloseAutoFocus={(event) => event.preventDefault()}>
-				<ContextMenuItem onSelect={onRename}>
-					<LuPencil className="size-4 mr-2" />
-					Rename
-				</ContextMenuItem>
+				{onRename && (
+					<ContextMenuItem onSelect={onRename}>
+						<LuPencil className="size-4 mr-2" />
+						Rename
+					</ContextMenuItem>
+				)}
 				{isLocalWorkspace && (
 					<>
-						<ContextMenuSeparator />
+						{onRename && <ContextMenuSeparator />}
 						<ContextMenuItem onSelect={onOpenInFinder}>
 							<LuFolderOpen className="size-4 mr-2" />
 							Open in Finder
@@ -112,7 +114,7 @@ export function DashboardSidebarWorkspaceContextMenu({
 						</ContextMenuItem>
 					</>
 				)}
-				{!isLocalWorkspace && <ContextMenuSeparator />}
+				{!isLocalWorkspace && onRename && <ContextMenuSeparator />}
 				<ContextMenuItem onSelect={onCopyBranchName}>
 					<LuGitBranch className="size-4 mr-2" />
 					Copy Branch Name

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceTransactionSnapshot } from "renderer/stores/workspace-creates";
+import { getV2WorkspaceDisplayName } from "renderer/utils/getV2WorkspaceDisplayName";
 import type {
 	DashboardSidebarProject,
 	DashboardSidebarProjectChild,
@@ -123,7 +124,7 @@ export function buildDashboardSidebarProjects({
 			hostIsOnline:
 				hostType === "remote-device" ? workspace.hostIsOnline : null,
 			accentColor: null,
-			name: workspace.name,
+			name: getV2WorkspaceDisplayName(workspace),
 			branch: workspace.branch,
 			pullRequest: pullRequestsByWorkspaceId.get(workspace.id) ?? null,
 			repoUrl:

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceTitle/V2WorkspaceTitle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceTitle/V2WorkspaceTitle.tsx
@@ -1,6 +1,7 @@
 import { OverflowFadeText } from "@superset/ui/overflow-fade-text";
 import { ChevronRight, GitBranch } from "lucide-react";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { getV2WorkspaceDisplayName } from "renderer/utils/getV2WorkspaceDisplayName";
 
 interface V2WorkspaceTitleProps {
 	workspaceId: string;
@@ -9,8 +10,11 @@ interface V2WorkspaceTitleProps {
 export function V2WorkspaceTitle({ workspaceId }: V2WorkspaceTitleProps) {
 	const { workspaces } = useHostWorkspaces();
 	const workspace = workspaces.find((w) => w.id === workspaceId) ?? null;
-	const name = workspace?.name ?? null;
-	const branch = workspace?.branch ?? null;
+	const name = workspace ? getV2WorkspaceDisplayName(workspace) || null : null;
+	const rawBranch = workspace?.branch ?? null;
+	// The display name falls back to the branch for unnamed worktrees; don't
+	// render the same text twice.
+	const branch = rawBranch === name ? null : rawBranch;
 
 	if (!name && !branch) {
 		return null;

--- a/apps/desktop/src/renderer/utils/getV2WorkspaceDisplayName/getV2WorkspaceDisplayName.test.ts
+++ b/apps/desktop/src/renderer/utils/getV2WorkspaceDisplayName/getV2WorkspaceDisplayName.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { getV2WorkspaceDisplayName } from "./getV2WorkspaceDisplayName";
+
+describe("getV2WorkspaceDisplayName", () => {
+	it("always displays main workspaces as 'local'", () => {
+		expect(
+			getV2WorkspaceDisplayName({
+				type: "main",
+				name: "some custom name",
+				branch: "main",
+			}),
+		).toBe("local");
+	});
+
+	it("uses the worktree workspace name when set", () => {
+		expect(
+			getV2WorkspaceDisplayName({
+				type: "worktree",
+				name: "Fix login bug",
+				branch: "fix-login-bug",
+			}),
+		).toBe("Fix login bug");
+	});
+
+	it("falls back to the branch for unnamed worktree workspaces", () => {
+		expect(
+			getV2WorkspaceDisplayName({
+				type: "worktree",
+				name: "",
+				branch: "fix-login-bug",
+			}),
+		).toBe("fix-login-bug");
+	});
+});

--- a/apps/desktop/src/renderer/utils/getV2WorkspaceDisplayName/getV2WorkspaceDisplayName.ts
+++ b/apps/desktop/src/renderer/utils/getV2WorkspaceDisplayName/getV2WorkspaceDisplayName.ts
@@ -1,0 +1,17 @@
+interface V2WorkspaceNameSource {
+	type: "main" | "worktree";
+	name: string;
+	branch: string;
+}
+
+/**
+ * Main workspaces are the repo checkout itself — their stored name tracks the
+ * checked-out branch rather than a user-chosen label, so they always display
+ * as "local".
+ */
+export function getV2WorkspaceDisplayName(
+	workspace: V2WorkspaceNameSource,
+): string {
+	if (workspace.type === "main") return "local";
+	return workspace.name || workspace.branch;
+}

--- a/apps/desktop/src/renderer/utils/getV2WorkspaceDisplayName/index.ts
+++ b/apps/desktop/src/renderer/utils/getV2WorkspaceDisplayName/index.ts
@@ -1,0 +1,1 @@
+export { getV2WorkspaceDisplayName } from "./getV2WorkspaceDisplayName";

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -62,21 +62,28 @@ export const workspaceRouter = router({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			const current = ctx.db.query.workspaces
+				.findFirst({ where: eq(workspaces.id, input.id) })
+				.sync();
+			if (!current) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace not found",
+				});
+			}
+			if (input.name !== undefined && current.type === "main") {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message:
+						'The local workspace cannot be renamed — it always displays as "local".',
+				});
+			}
 			const patch: { name?: string; branch?: string; taskId?: string | null } =
 				{};
 			if (input.name !== undefined) patch.name = input.name;
 			if (input.branch !== undefined) patch.branch = input.branch;
 			if (input.taskId !== undefined) patch.taskId = input.taskId;
 			if (Object.keys(patch).length === 0) {
-				const current = ctx.db.query.workspaces
-					.findFirst({ where: eq(workspaces.id, input.id) })
-					.sync();
-				if (!current) {
-					throw new TRPCError({
-						code: "NOT_FOUND",
-						message: "Workspace not found",
-					});
-				}
 				return toCloudShape(current, ctx.organizationId);
 			}
 			const updated = updateLocalWorkspace(


### PR DESCRIPTION
## Summary
- The v2 dashboard UI now always displays the main (non-worktree) workspace as **"local"** — in the sidebar, top-bar title, and command palette — instead of its stored name (which just tracks the checked-out branch, e.g. "main").
- Rename affordances (double-click, context-menu "Rename") are removed for the main workspace, and the host-service `workspace.update` mutation rejects `name` changes for it, so no client path (including the CLI) can rename it.

## Why / Context
The v1 sidebar already hardcoded the branch workspace to "local" and hid rename, but the v2 dashboard UI showed the main workspace's raw name and let users rename it. The main workspace is the repo checkout itself — its name isn't a user-chosen label, so it should read as a fixed "local" everywhere.

## How It Works
- New shared helper `getV2WorkspaceDisplayName` (`apps/desktop/src/renderer/utils/getV2WorkspaceDisplayName/`): returns `"local"` for `type === "main"`, otherwise `name || branch`.
- The sidebar normalizes the name once at the data layer (`buildDashboardSidebarProjects`), so every sidebar surface (row, hover card, drag overlay, remove-from-sidebar dialog) shows "local" without per-site special-casing.
- `DashboardSidebarWorkspaceItem` passes `onRename` as `undefined` for main workspaces; `DashboardSidebarWorkspaceContextMenu` now takes an optional `onRename` and hides the item (and its separator) when absent. Double-click rename is likewise disabled.
- `V2WorkspaceTitle` (top bar) shows "local › <branch>" for the main workspace, and no longer renders the branch twice for unnamed worktrees.
- Host-service `workspace.update` throws `BAD_REQUEST` when a `name` patch targets a `type === "main"` row. Branch re-points and task linking on the main workspace still work; internal name-follows-branch sync (`ensure-main-workspace`) uses `updateLocalWorkspace` directly and is unaffected.

## Manual QA Checklist

### Sidebar
- [ ] Main workspace row shows "local" (regardless of stored name / checked-out branch)
- [ ] Double-click on the main workspace row does not enter rename mode
- [ ] Context menu on the main workspace has no "Rename" item and no stray leading separator
- [ ] Worktree workspaces still rename via double-click and context menu
- [ ] Hover card for the main workspace shows "local" heading + branch; "Rename branch" (git branch) still works

### Other surfaces
- [ ] Top bar shows "local › <branch>" on the main workspace route
- [ ] Command palette workspace switcher lists the main workspace as "local"

### Backend guard
- [ ] `superset workspaces update <main-id> --name x` (or direct `workspace.update` call) fails with a clear error; `--branch`/task updates still succeed

## Testing
- `bun run typecheck` (desktop + host-service via turbo)
- `bun run lint` (exits 0)
- `bun test` for the new `getV2WorkspaceDisplayName` helper and existing `buildDashboardSidebarProjects` suite (7 pass)
- Not manually QA'd in the running app — UI checklist above is for review

## Design Decisions
- **Normalize at the sidebar data layer instead of each component**: one spot covers row, hover card, dialogs, and drag overlay; rename is disabled for main so the normalized name never feeds a write.
- **Guard host-service rather than the cloud mutations**: the desktop/CLI rename path goes through the host's `workspace.update`. The cloud `updateNameFromHost` path is left alone because the host legitimately pushes name-follows-branch updates for main workspaces; the cloud-stored name is no longer user-visible.

## Known Limitations
- The stored name of a main workspace still tracks the checked-out branch in the DB (by design); only the display is pinned to "local". The web app's workspace list (`apps/web`) still shows the raw name — it has no rename UI and wasn't touched.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5586">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the main (local) workspace display name to "local" across the v2 dashboard and command palette, and blocks renaming it via UI and API. This keeps the local workspace consistent and prevents accidental renames.

- **New Features**
  - Added `getV2WorkspaceDisplayName` to show `"local"` for `type === "main"`; otherwise falls back to `name || branch`.
  - Sidebar, top-bar title, and command palette now use this helper; double‑click and context‑menu rename are disabled for the main workspace.
  - Host-service `workspace.update` rejects `name` patches for main workspaces with a clear error; branch/task updates still work.

<sup>Written for commit 72eb7eb9e7e5ff224c67736c5780df4ded8c798b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace names now display consistently across the sidebar, command palette, workspace lists, and top bar.
  * Unnamed workspaces fall back to their branch name, while main workspaces display as “local.”
* **Bug Fixes**
  * Prevented duplicate workspace and branch labels in the top bar.
  * Disabled renaming for main workspaces and rejected unsupported rename attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->