### PR TITLE
chore: route customer-facing contact emails to support@superset.sh

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHelpMenu/DashboardSidebarHelpMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHelpMenu/DashboardSidebarHelpMenu.tsx
@@ -115,7 +115,7 @@ export function DashboardSidebarHelpMenu({
 							</DropdownMenuItem>
 							<DropdownMenuItem onClick={() => openExternal(COMPANY.MAIL_TO)}>
 								<HiOutlineEnvelope className="h-4 w-4" />
-								Email Founders
+								Email Support
 							</DropdownMenuItem>
 						</DropdownMenuSubContent>
 					</DropdownMenuSub>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -138,7 +138,7 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 					<p className="text-sm text-muted-foreground mt-1">
 						For questions about billing,{" "}
 						<a
-							href="mailto:founders@superset.sh"
+							href="mailto:support@superset.sh"
 							className="text-primary hover:underline"
 						>
 							contact us

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -268,7 +268,7 @@ function PlansPage() {
 
 		if (action === "contact") {
 			track("enterprise_trial_requested", { source: "billing_plans" });
-			openUrl.mutate("mailto:founders@superset.sh");
+			openUrl.mutate("mailto:support@superset.sh");
 			return;
 		}
 
@@ -380,7 +380,7 @@ function PlansPage() {
 								track("billing_support_contacted", {
 									source: "billing_plans_inline",
 								});
-								openUrl.mutate("mailto:founders@superset.sh");
+								openUrl.mutate("mailto:support@superset.sh");
 							}}
 							className="inline-flex items-center gap-1 text-primary hover:underline"
 						>

--- a/apps/marketing/src/app/contact/actions.ts
+++ b/apps/marketing/src/app/contact/actions.ts
@@ -60,7 +60,7 @@ export async function submitContactInquiry(data: unknown) {
 
 		const { error } = await resend.emails.send({
 			from: "Superset <noreply@superset.sh>",
-			to: "founders@superset.sh",
+			to: "support@superset.sh",
 			replyTo: sanitizedEmail,
 			subject: `Contact message from ${sanitizedName}: ${sanitizedTopic}`,
 			react: ContactInquiryEmail({

--- a/apps/marketing/src/app/enterprise/actions.ts
+++ b/apps/marketing/src/app/enterprise/actions.ts
@@ -71,7 +71,7 @@ export async function submitEnterpriseInquiry(data: unknown) {
 
 		const { error } = await resend.emails.send({
 			from: "Superset <noreply@superset.sh>",
-			to: "founders@superset.sh",
+			to: "support@superset.sh",
 			replyTo: sanitizedEmail,
 			subject: `Enterprise inquiry from ${sanitizedName} (${sanitizedCompany})`,
 			react: EnterpriseInquiryEmail({

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -885,7 +885,7 @@ export const auth = betterAuth({
 				) => {
 					if (plan.name === "enterprise") {
 						throw new Error(
-							"Enterprise subscriptions are managed by admins. Contact founders@superset.sh.",
+							"Enterprise subscriptions are managed by admins. Contact support@superset.sh.",
 						);
 					}
 

--- a/packages/email/scripts/notify-disconnected-integrations.ts
+++ b/packages/email/scripts/notify-disconnected-integrations.ts
@@ -33,7 +33,7 @@ import { aliasedTable, and, eq, isNull } from "drizzle-orm";
 import { Resend } from "resend";
 
 const FROM = "Superset <noreply@superset.sh>";
-const REPLY_TO = "founders@superset.sh";
+const REPLY_TO = "support@superset.sh";
 
 function parseArgs() {
 	const args = process.argv.slice(2);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -28,7 +28,7 @@ export const COMPANY = {
 	X_URL: "https://x.com/superset_sh",
 	LINKEDIN_URL: "https://www.linkedin.com/company/superset-sh",
 	YOUTUBE_URL: "https://www.youtube.com/@superset-sh",
-	MAIL_TO: "mailto:founders@superset.sh",
+	MAIL_TO: "mailto:support@superset.sh",
 	REPORT_ISSUE_URL: "https://github.com/superset-sh/superset/issues/new",
 	DISCORD_URL: "https://discord.gg/cZeD9WYcV7",
 	STATUS_URL: "https://status.superset.sh",


### PR DESCRIPTION
## Summary
- Switch customer-facing contact addresses from `founders@superset.sh` (manually-checked inbox) to `support@superset.sh` (triaged queue) across marketing, desktop, and shared packages — 8 files.
- Rename the desktop sidebar help-menu item from "Email Founders" to "Email Support" since it opens the shared `COMPANY.MAIL_TO` constant.

## Why / Context
support@ has a triage pipeline while founders@ is checked manually, so anything a customer sends expecting a timely response (billing questions, contact/enterprise forms, error-message contacts) should route to support@. Enterprise leads route to support@ too — triage guarantees they're seen and can escalate to founders.

Intentionally kept on founders@: the blog post's founder-voice "compare notes" invitation (`apps/marketing/content/blog/roadmap-to-100-agents.mdx`) and `CODE_OF_CONDUCT.md` reports (confidential, shouldn't flow through a shared triage queue).

## Testing
- `bun run typecheck` — passes
- `biome check` — clean
- String-only changes; no behavior or type changes.

## Follow-ups
- Configure support triage to escalate enterprise leads (enterprise-form subject from `apps/marketing/src/app/enterprise/actions.ts`, plans-page mailtos tracked as `enterprise_trial_requested`) to founders instead of auto-replying.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5587">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all customer-facing contact emails from `founders@superset.sh` to `support@superset.sh` to provide triaged responses.
Updates billing mailto links in the desktop app, marketing contact/enterprise form recipients, auth error copy, integration notification reply-to, and sets `COMPANY.MAIL_TO`; the sidebar item now reads “Email Support”.

<sup>Written for commit 0803d0444d28a51fa186d4e43dbaef29e9e42e12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Replaced references to the founders’ email address with the support email address throughout help menus, billing pages, contact forms, enterprise inquiries, and support notifications.
  * Updated enterprise checkout messaging to direct customers to support.
  * Renamed the sidebar option from “Email Founders” to “Email Support.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->