### PR TITLE
fix(release): enforce CLI lockstep on desktop publish and guard cli-latest rollback

### DIFF
--- a/.github/workflows/release-cli-lockstep.yml
+++ b/.github/workflows/release-cli-lockstep.yml
@@ -1,0 +1,52 @@
+name: Release CLI Lockstep
+
+# When a desktop-v* release is published (draft -> published or --publish),
+# tag the matching plain cli-v<version> at the same commit so the standalone
+# CLI always ships in lockstep with desktop — regardless of how the desktop
+# release was published. Skips when the tag already exists (e.g. a CLI hotfix
+# already claimed the version, or a republish).
+#
+# The tag is created via the API with GITHUB_TOKEN, which does NOT emit a push
+# event that could trigger release-cli.yml — so that workflow is dispatched
+# explicitly on the new tag ref (its jobs gate on the ref, which a tag-ref
+# dispatch satisfies).
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  tag-matching-cli:
+    name: Tag matching cli-v release
+    if: startsWith(github.event.release.tag_name, 'desktop-v')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      DESKTOP_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Tag cli-v<version> and dispatch release-cli.yml
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$DESKTOP_TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Unexpected desktop tag format: $DESKTOP_TAG"
+            exit 1
+          fi
+          VERSION="${DESKTOP_TAG#desktop-v}"
+          CLI_TAG="cli-v${VERSION}"
+
+          if gh api "repos/${GH_REPO}/git/ref/tags/${CLI_TAG}" >/dev/null 2>&1; then
+            echo "${CLI_TAG} already exists — lockstep satisfied."
+            exit 0
+          fi
+
+          SHA=$(gh api "repos/${GH_REPO}/commits/${DESKTOP_TAG}" --jq .sha)
+          gh api "repos/${GH_REPO}/git/refs" -f ref="refs/tags/${CLI_TAG}" -f sha="${SHA}"
+          echo "Created ${CLI_TAG} at ${SHA}"
+
+          gh workflow run release-cli.yml --ref "${CLI_TAG}"
+          echo "Dispatched release-cli.yml on ${CLI_TAG}"

--- a/.github/workflows/release-cli-lockstep.yml
+++ b/.github/workflows/release-cli-lockstep.yml
@@ -48,5 +48,10 @@ jobs:
           gh api "repos/${GH_REPO}/git/refs" -f ref="refs/tags/${CLI_TAG}" -f sha="${SHA}"
           echo "Created ${CLI_TAG} at ${SHA}"
 
-          gh workflow run release-cli.yml --ref "${CLI_TAG}"
+          # A rerun of this workflow can't recover a failed dispatch (the
+          # tag-exists check above exits early), so name the manual command.
+          if ! gh workflow run release-cli.yml --ref "${CLI_TAG}"; then
+            echo "::error::${CLI_TAG} was created but the dispatch failed. Recover with: gh workflow run release-cli.yml --ref ${CLI_TAG}"
+            exit 1
+          fi
           echo "Dispatched release-cli.yml on ${CLI_TAG}"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -79,8 +79,18 @@ jobs:
           # version must not roll users or Homebrew back).
           set -euo pipefail
           NEW="${VERSION_TAG#cli-v}"
-          CURRENT=$(curl -fsSL "https://github.com/${{ github.repository }}/releases/download/cli-latest/version.txt" || true)
-          CURRENT=$(printf '%s' "$CURRENT" | tr -d '[:space:]')
+          # Fail CLOSED: only a genuinely absent pointer/manifest may skip the
+          # comparison. A transient fetch error aborts the job rather than
+          # letting an old re-cut move the pointer backward unverified.
+          CURRENT=""
+          if ASSETS=$(gh release view cli-latest --json assets --jq '.assets[].name' 2>&1); then
+            if printf '%s\n' "$ASSETS" | grep -qx 'version.txt'; then
+              CURRENT=$(gh release download cli-latest --pattern version.txt --output - | tr -d '[:space:]')
+            fi
+          elif ! printf '%s' "$ASSETS" | grep -qi 'release not found'; then
+            echo "::error::Could not verify cli-latest pointer: $ASSETS"
+            exit 1
+          fi
           if [ -n "$CURRENT" ] && [ "$(printf '%s\n%s\n' "$NEW" "$CURRENT" | sort -V | tail -n1)" != "$NEW" ]; then
             echo "is_newest=false" >> "$GITHUB_OUTPUT"
             echo "cli-latest already serves $CURRENT (newer than $NEW); leaving the pointer and Homebrew untouched."

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,10 +1,11 @@
 name: Release CLI
 
-# Fires on cli-v* tag push. Builds the full 3-target matrix, publishes a
-# prerelease GitHub Release plus a rolling cli-latest pointer, then bumps the
-# Homebrew formula. workflow_dispatch is the manual escape hatch for testing
-# the full pipeline without cutting a tag (the release job is gated to tag
-# pushes only).
+# Fires on cli-v* tag push, or dispatched on a cli-v* tag ref by
+# release-cli-lockstep.yml (an API-created tag emits no push event). Builds the
+# full 3-target matrix, publishes a prerelease GitHub Release plus a rolling
+# cli-latest pointer, then bumps the Homebrew formula. A bare workflow_dispatch
+# (branch ref) is the manual escape hatch for testing the build without
+# cutting a tag (the release job is gated to cli-v* tag refs).
 
 on:
   push:
@@ -25,6 +26,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/cli-v')
     permissions:
       contents: write
+    outputs:
+      is_newest: ${{ steps.pointer.outputs.is_newest }}
 
     steps:
       - name: Checkout code
@@ -61,6 +64,7 @@ jobs:
           echo "${VERSION_TAG#cli-v}" > release-artifacts/version.txt
 
       - name: Update rolling cli-latest release
+        id: pointer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION_TAG: ${{ github.ref_name }}
@@ -70,8 +74,19 @@ jobs:
           # from `/releases/download/cli-latest/` so it never has to filter
           # the repo's release list (where desktop releases would otherwise
           # shadow the latest CLI release on the global /releases/latest
-          # endpoint). Recreate it on every CLI release.
+          # endpoint). Recreate it on every CLI release — unless this tag is
+          # OLDER than what cli-latest already serves (a re-cut of an old
+          # version must not roll users or Homebrew back).
           set -euo pipefail
+          NEW="${VERSION_TAG#cli-v}"
+          CURRENT=$(curl -fsSL "https://github.com/${{ github.repository }}/releases/download/cli-latest/version.txt" || true)
+          CURRENT=$(printf '%s' "$CURRENT" | tr -d '[:space:]')
+          if [ -n "$CURRENT" ] && [ "$(printf '%s\n%s\n' "$NEW" "$CURRENT" | sort -V | tail -n1)" != "$NEW" ]; then
+            echo "is_newest=false" >> "$GITHUB_OUTPUT"
+            echo "cli-latest already serves $CURRENT (newer than $NEW); leaving the pointer and Homebrew untouched."
+            exit 0
+          fi
+          echo "is_newest=true" >> "$GITHUB_OUTPUT"
           gh release delete cli-latest --yes --cleanup-tag || true
           gh release create cli-latest \
             release-artifacts/*.tar.gz \
@@ -88,7 +103,9 @@ jobs:
     # never runs. needs: release guarantees the tarballs are published first.
     name: Bump Homebrew Formula
     needs: release
-    if: startsWith(github.ref, 'refs/tags/cli-v')
+    # is_newest gate: skip the formula bump when the pointer update was skipped
+    # (re-cut of an older tag) so Homebrew never downgrades either.
+    if: startsWith(github.ref, 'refs/tags/cli-v') && needs.release.outputs.is_newest == 'true'
     uses: ./.github/workflows/bump-homebrew.yml
     with:
       tag: ${{ github.ref_name }}

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -7,8 +7,9 @@ step). One entry point: **`bun run release`**. Design/rationale lives in
 ## Model
 
 - **desktop == host-service == cli** at each desktop release — one unified plain
-  version, enforced by `bun run check:versions` (CI-gated). A desktop release also
-  publishes a matching plain `cli-v<version>`, so the standalone CLI ships in lockstep.
+  version, enforced by `bun run check:versions` (CI-gated). Publishing a desktop
+  release fires `release-cli-lockstep.yml`, which tags the matching plain
+  `cli-v<version>` so the standalone CLI ships in lockstep automatically.
 - **CLI hotfixes lead by a patch.** Between desktop releases, a CLI-only fix bumps
   a plain patch above the current CLI (`1.14.1 → 1.14.2`), within desktop's minor
   line, until the next desktop release catches up.
@@ -66,7 +67,9 @@ bun run release desktop 1.15.0 --publish [--merge] # auto-publish (+ merge the P
 ```
 
 Once published (non-draft), it becomes `/releases/latest`, which the desktop
-auto-updater reads.
+auto-updater reads. Publishing (either way) also triggers
+`release-cli-lockstep.yml`, which tags `cli-v<version>` and ships the matching
+standalone CLI — no manual CLI step.
 
 ## When the daemon guard blocks
 
@@ -86,6 +89,9 @@ gh release delete cli-v1.14.0-2 --yes --cleanup-tag   # delete release + remote 
 git tag -d cli-v1.14.0-2                               # delete local tag
 # then re-run the release, or pass --republish (desktop) to recreate the same version
 ```
+
+Re-cutting an **older** `cli-v` tag is safe: `release-cli.yml` only moves the
+rolling `cli-latest` pointer (and Homebrew) forward, never backward.
 
 ## Agent / non-interactive
 

--- a/scripts/release/check-versions.ts
+++ b/scripts/release/check-versions.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
 
-// Enforces unified versioning: desktop is the ceiling (a plain MAJOR.MINOR.PATCH
-// release), and every UNIFIED_PACKAGES entry must share that base and equal each
-// other. Interim CLI releases add a -N suffix (e.g. 1.14.0-1) which sorts BELOW
-// the release, so the CLI never ships above desktop. pty-daemon is excluded.
+// Enforces unified versioning: every version is a plain MAJOR.MINOR.PATCH (no
+// prerelease suffixes), UNIFIED_PACKAGES entries must equal each other and sit
+// at or above desktop within its minor line — CLI hotfixes lead desktop by
+// patches until the next desktop release catches up. pty-daemon is excluded.
 
 import {
 	assertUnified,
@@ -23,7 +23,7 @@ export async function runCheck(): Promise<boolean> {
 			`\nVersion drift detected. Unified rule: ${DESKTOP_PACKAGE} == ${UNIFIED_PACKAGES.join(" == ")}`,
 		);
 		console.error(
-			`(interim CLI releases may add a -N suffix, e.g. ${desktop}-1).`,
+			"(CLI hotfixes may lead desktop by plain patches within its minor line).",
 		);
 		return false;
 	}

--- a/scripts/release/desktop.ts
+++ b/scripts/release/desktop.ts
@@ -384,7 +384,9 @@ async function monitorAndPublish(
 	if (opts.autoPublish) {
 		await $`gh release edit ${tag} --draft=false`;
 		success("Release published!");
-		await publishMatchingCli(version, tag);
+		info(
+			`release-cli-lockstep.yml will tag cli-v${version} and ship the matching standalone CLI.`,
+		);
 		if (opts.autoMerge && opts.prNumber) {
 			const r =
 				await $`gh pr merge ${opts.prNumber} --squash --delete-branch`.nothrow();
@@ -397,37 +399,9 @@ async function monitorAndPublish(
 		console.log(`\nReview: ${url}`);
 		console.log(`Publish with: gh release edit ${tag} --draft=false`);
 		console.log(
-			`Then ship the matching standalone CLI ${version}:\n  git tag cli-v${version} ${tag} && git push origin cli-v${version}`,
+			`Publishing auto-tags cli-v${version} and ships the standalone CLI (release-cli-lockstep.yml).`,
 		);
 	}
-}
-
-/** After the desktop release is published, cut the matching plain cli-v<version>
- * (same commit) so the standalone CLI ships in lockstep with desktop. Skipped in
- * draft mode — nothing ships until the desktop release is live. */
-async function publishMatchingCli(
-	version: string,
-	desktopTag: string,
-): Promise<void> {
-	const cliTag = `cli-v${version}`;
-	// Check origin, not a possibly-stale local tag: a leftover local cli-v tag
-	// would otherwise skip a publish that origin never received.
-	const remote = (
-		await $`git ls-remote --tags origin ${`refs/tags/${cliTag}`}`
-			.nothrow()
-			.text()
-	).trim();
-	if (remote) {
-		warn(`${cliTag} already on origin; skipping standalone CLI publish.`);
-		return;
-	}
-	info(`Publishing matching standalone CLI ${cliTag}...`);
-	// -f force-updates any stale local tag onto the desktop release commit.
-	await $`git tag -f ${cliTag} ${desktopTag}`;
-	await $`git push origin ${cliTag}`;
-	success(
-		`Tag ${cliTag} pushed — release-cli.yml will publish the standalone CLI ${version}`,
-	);
 }
 
 if (import.meta.main) await runDesktop(process.argv.slice(2));


### PR DESCRIPTION
## Problem

The desktop/CLI unified-version model is enforced in-repo (`check:versions`) but not at **publish** time:

1. **Manual desktop publish left the CLI behind.** `publishMatchingCli` only ran on the `--publish` path of `scripts/release/desktop.ts`. In the default draft flow, the README told you to publish with `gh release edit desktop-vX --draft=false` — and the matching `cli-v<version>` tag was just a printed manual instruction. A published desktop with no published CLI was one forgotten command away. (1.14.1/1.14.3 happened to be tagged correctly, but only by operator discipline.)
2. **`cli-latest` could roll backward.** `release-cli.yml` recreated the rolling `cli-latest` release (and bumped Homebrew) on *every* `cli-v*` tag push with no version comparison — re-cutting an older tag (a documented flow) would downgrade `superset update` and `brew` users.
3. **Stale guidance.** `check-versions.ts` comments and error hints still described the abandoned `-N` prerelease-suffix scheme, which `unifiedErrors` itself now rejects.

## Changes

- **New `release-cli-lockstep.yml`**: fires on `release: published` for `desktop-v*`, tags the matching `cli-v<version>` at the same commit (skips if it already exists, e.g. a hotfix claimed it), and explicitly dispatches `release-cli.yml` on the tag ref (an API-created tag with `GITHUB_TOKEN` emits no push event). Works for both `--publish` and manual `gh release edit` publishes.
- **`desktop.ts`**: removed `publishMatchingCli` — the workflow is now the single tagging path (also removes the script/workflow race) — and updated operator messaging.
- **`release-cli.yml`**: the `cli-latest` update step compares the pushed version against the pointer's `version.txt` (`sort -V`) and skips pointer + Homebrew updates when the tag is older. Equal versions still update (same-version re-cut).
- **`check-versions.ts`** + **README**: guidance now matches the actual model (plain patch-ahead hotfixes, no suffixes; lockstep automated on publish; re-cuts can't roll back).

## Verification

- `bun test scripts/release/` — 15 pass; `bun run release check` ✓; Biome clean.
- Guard logic table-tested: older→skip, equal→update, newer→update, missing version.txt→update, legacy `-N` suffix current→update.
- Published state audited: desktop `1.14.3` == `cli-v1.14.3` == `cli-latest` == Homebrew formula, so no catch-up bump was needed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5589">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce desktop/CLI lockstep at publish time and prevent `cli-latest` rollbacks so users and Homebrew never downgrade. Manual desktop publishes now auto-ship the matching CLI, pointer verification fails closed, and failed dispatches include a recovery command.

- **Bug Fixes**
  - Added `release-cli-lockstep.yml` to tag `cli-v<version>` on desktop `release: published` and dispatch `release-cli.yml`; skips if the tag exists and prints a manual recovery command when dispatch fails.
  - Updated `release-cli.yml` to compare against `cli-latest/version.txt` and only advance the pointer; equal versions still update. Fails closed if `cli-latest` cannot be verified, and gates the Homebrew bump on `is_newest`.

- **Refactors**
  - Removed `publishMatchingCli` from `scripts/release/desktop.ts`; the workflow is the single path and operator messaging was updated.
  - Updated `scripts/release/README.md` and `check-versions.ts` to reflect the plain patch-ahead model and clarify that re-cutting older tags won’t roll back.

<sup>Written for commit cab615d7e7a792db64fac6c39b4112a7318c05ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Desktop releases now automatically create/tag the matching standalone CLI release in lockstep.
  - Release automation now updates the `cli-latest` pointer and dispatches CLI release handling based on the published tag.

- **Bug Fixes**
  - Prevents `cli-latest`/Homebrew pointer downgrades by skipping updates when an older CLI tag is processed.

- **Documentation**
  - Updated release guides and publish messaging to reflect automatic CLI tagging/shipping and safer re-cuts.
  - Refined version-drift error messaging to clarify allowed PATCH hotfix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->