### PR TITLE
feat(discord-triage): auto-ingest Discord support channels into Linear Triage

### DIFF
--- a/apps/discord-triage/Dockerfile
+++ b/apps/discord-triage/Dockerfile
@@ -1,0 +1,28 @@
+FROM oven/bun:1.3.14 AS base
+WORKDIR /app
+
+# Stage 1: Prune monorepo to discord-triage's dependency graph
+FROM base AS prune
+COPY . .
+RUN bunx turbo@2.8.7 prune @superset/discord-triage --docker
+
+# Stage 2: Install deps + copy full source
+FROM base AS builder
+COPY --from=prune /app/out/json/ ./
+RUN bun install --frozen-lockfile --ignore-scripts
+COPY --from=prune /app/out/full/ ./
+
+# Stage 3: Runtime
+FROM base AS runner
+ENV NODE_ENV=production
+
+RUN groupadd --system --gid 1001 bot && \
+    useradd --system --uid 1001 --gid bot bot
+
+COPY --from=builder --chown=bot:bot /app /app
+
+USER bot
+WORKDIR /app/apps/discord-triage
+
+EXPOSE 8080
+CMD ["bun", "run", "src/index.ts"]

--- a/apps/discord-triage/README.md
+++ b/apps/discord-triage/README.md
@@ -10,7 +10,8 @@ Gateway bot that auto-ingests Discord support messages into Linear Triage. Every
 | `DISCORD_CHANNEL_IDS` | Comma-separated channel IDs to watch |
 | `LINEAR_API_KEY` | Linear personal API key |
 | `LINEAR_TEAM_KEY` | Team key, default `SUPER` |
-| `LINEAR_SOURCE_LABEL` | Label name, default `Discord` |
+| `LINEAR_SOURCE_LABEL` | Label name, default `Discord`; must exist on the team (boot fails otherwise) |
+| `LINEAR_WEBHOOK_SECRET` | Signing secret of the Linear webhook; `/linear-webhook` (issue close → archive Discord thread) stays disabled when unset |
 
 ## One-time setup
 

--- a/apps/discord-triage/README.md
+++ b/apps/discord-triage/README.md
@@ -1,0 +1,31 @@
+# discord-triage
+
+Gateway bot that auto-ingests Discord support messages into Linear Triage. Every new top-level message in a watched text channel (and every new post in a watched forum channel) becomes a Linear issue labeled `Source: Discord`; the bot opens a thread on the message with a link to the issue. Thread replies are not synced (future work).
+
+## Env
+
+| Var | Value |
+|---|---|
+| `DISCORD_BOT_TOKEN` | Bot token from the Discord developer portal |
+| `DISCORD_CHANNEL_IDS` | Comma-separated channel IDs to watch |
+| `LINEAR_API_KEY` | Linear personal API key |
+| `LINEAR_TEAM_KEY` | Team key, default `SUPER` |
+| `LINEAR_SOURCE_LABEL` | Label name, default `Discord` |
+
+## One-time setup
+
+1. [discord.com/developers/applications](https://discord.com/developers/applications) → New Application → Bot:
+   - enable **Message Content Intent** (privileged)
+   - copy the bot token
+2. Invite it: OAuth2 → URL Generator → scope `bot`, permissions: View Channels, Send Messages, Send Messages in Threads, Create Public Threads, Read Message History. Open the generated URL, add to the server.
+3. Right-click the support channel → Copy Channel ID (enable Developer Mode in Discord settings if missing).
+4. Linear personal API key: Linear → Settings → API.
+5. Deploy:
+   ```bash
+   fly apps create superset-discord-triage
+   fly secrets set -a superset-discord-triage DISCORD_BOT_TOKEN=... LINEAR_API_KEY=...
+   bun run deploy   # from apps/discord-triage; builds from repo root, forces --ha=false
+   ```
+   The bot MUST run as a single machine (`--ha=false`) — two machines file every issue twice. Watched channel IDs live in `fly.toml` `[env]`, not secrets.
+
+Issues land in Triage because API-created issues default to the Triage state — the bot never sets a state explicitly.

--- a/apps/discord-triage/fly.toml
+++ b/apps/discord-triage/fly.toml
@@ -1,0 +1,32 @@
+app = "superset-discord-triage"
+primary_region = "sjc"
+kill_signal = "SIGINT"
+kill_timeout = "10s"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+  # 1456374121494478869 = #bugs (forum), 1466502145825050759 = #feature-request (text)
+  DISCORD_CHANNEL_IDS = "1456374121494478869,1466502145825050759"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # Gateway bot must stay connected; never scale to zero.
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[http_service.checks]]
+  interval = "15s"
+  timeout = "2s"
+  grace_period = "30s"
+  method = "GET"
+  path = "/health"
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/apps/discord-triage/package.json
+++ b/apps/discord-triage/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@superset/discord-triage",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "bun run --env-file=../../.env --hot src/index.ts",
+		"start": "bun run src/index.ts",
+		"deploy": "./scripts/deploy.sh",
+		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
+	},
+	"dependencies": {
+		"@linear/sdk": "68.1.1",
+		"@t3-oss/env-core": "0.13.11",
+		"discord.js": "14.26.4",
+		"zod": "4.3.6"
+	},
+	"devDependencies": {
+		"@superset/typescript": "workspace:*",
+		"@types/node": "24.12.0",
+		"bun-types": "1.3.14",
+		"typescript": "6.0.3"
+	}
+}

--- a/apps/discord-triage/scripts/deploy.sh
+++ b/apps/discord-triage/scripts/deploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP=superset-discord-triage
+
+cd "$(git rev-parse --show-toplevel)"
+
+# --ha=false: gateway bot must be a single machine or every message files duplicate issues
+echo "==> fly deploy"
+fly deploy \
+  --config apps/discord-triage/fly.toml \
+  --dockerfile apps/discord-triage/Dockerfile \
+  --app "$APP" \
+  --ha=false \
+  --strategy immediate \
+  .
+
+echo "==> Status"
+fly status --app "$APP"

--- a/apps/discord-triage/src/env.ts
+++ b/apps/discord-triage/src/env.ts
@@ -1,0 +1,27 @@
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+export const env = createEnv({
+	server: {
+		DISCORD_BOT_TOKEN: z.string().min(1),
+		/** Comma-separated channel IDs to watch (text and/or forum channels). */
+		DISCORD_CHANNEL_IDS: z
+			.string()
+			.min(1)
+			.transform((v) =>
+				v
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean),
+			),
+		LINEAR_API_KEY: z.string().min(1),
+		LINEAR_TEAM_KEY: z.string().min(1).default("SUPER"),
+		/** Label applied to every ingested issue. Must exist on the team. */
+		LINEAR_SOURCE_LABEL: z.string().min(1).default("Discord"),
+		/** Signing secret for the Linear webhook; endpoint is disabled when unset. */
+		LINEAR_WEBHOOK_SECRET: z.string().min(1).optional(),
+		PORT: z.coerce.number().default(8080),
+	},
+	runtimeEnv: process.env,
+	emptyStringAsUndefined: true,
+});

--- a/apps/discord-triage/src/index.ts
+++ b/apps/discord-triage/src/index.ts
@@ -1,0 +1,250 @@
+import { timingSafeEqual } from "node:crypto";
+import { LinearClient } from "@linear/sdk";
+import {
+	ChannelType,
+	Client,
+	Events,
+	GatewayIntentBits,
+	type Message,
+	type ThreadChannel,
+} from "discord.js";
+import { env } from "./env";
+
+const linear = new LinearClient({ apiKey: env.LINEAR_API_KEY });
+
+let teamId: string;
+let sourceLabelId: string | undefined;
+
+async function resolveLinearIds() {
+	const teams = await linear.teams({
+		filter: { key: { eq: env.LINEAR_TEAM_KEY } },
+	});
+	const team = teams.nodes[0];
+	if (!team) throw new Error(`Linear team ${env.LINEAR_TEAM_KEY} not found`);
+	teamId = team.id;
+
+	const labels = await team.labels({
+		filter: { name: { eq: env.LINEAR_SOURCE_LABEL } },
+	});
+	sourceLabelId = labels.nodes[0]?.id;
+	if (!sourceLabelId) {
+		console.warn(
+			`Label "${env.LINEAR_SOURCE_LABEL}" not found on team; issues will be unlabeled`,
+		);
+	}
+}
+
+function issueTitle(content: string, fallback: string): string {
+	const firstLine =
+		content
+			.split("\n")
+			.find((l) => l.trim().length > 0)
+			?.trim() ?? "";
+	if (!firstLine) return fallback;
+	return firstLine.length > 80 ? `${firstLine.slice(0, 77)}...` : firstLine;
+}
+
+async function fileIssue(opts: {
+	title: string;
+	content: string;
+	authorTag: string;
+	messageUrl: string;
+}): Promise<{ identifier: string; url: string } | undefined> {
+	// No stateId: API-created issues default into Triage.
+	const payload = await linear.createIssue({
+		teamId,
+		title: opts.title,
+		description: `${opts.content}\n\n---\nReported by **${opts.authorTag}** in Discord: ${opts.messageUrl}`,
+		labelIds: sourceLabelId ? [sourceLabelId] : undefined,
+	});
+	const issue = await payload.issue;
+	if (!issue) return undefined;
+	return { identifier: issue.identifier, url: issue.url };
+}
+
+const discord = new Client({
+	intents: [
+		GatewayIntentBits.Guilds,
+		GatewayIntentBits.GuildMessages,
+		GatewayIntentBits.MessageContent,
+	],
+});
+
+async function handleChannelMessage(message: Message) {
+	const issue = await fileIssue({
+		title: issueTitle(
+			message.content,
+			`Discord report from ${message.author.tag}`,
+		),
+		content: message.content,
+		authorTag: message.author.tag,
+		messageUrl: message.url,
+	});
+	if (!issue) return;
+	const thread = await message.startThread({ name: issue.identifier });
+	await thread.send(
+		`Filed to Linear Triage as [${issue.identifier}](${issue.url})`,
+	);
+}
+
+// Forum posts arrive as new threads; the starter message may lag thread creation.
+async function handleForumPost(thread: ThreadChannel) {
+	const starter = await thread.fetchStarterMessage().catch(() => null);
+	const content = starter?.content ?? "";
+	const issue = await fileIssue({
+		title: thread.name || issueTitle(content, "Discord forum post"),
+		content,
+		authorTag: starter?.author.tag ?? "unknown",
+		messageUrl: starter?.url ?? thread.url,
+	});
+	if (!issue) return;
+	await thread.send(
+		`Filed to Linear Triage as [${issue.identifier}](${issue.url})`,
+	);
+}
+
+discord.on(Events.MessageCreate, (message) => {
+	if (message.author.bot) return;
+	if (!env.DISCORD_CHANNEL_IDS.includes(message.channelId)) return;
+	if (message.channel.type !== ChannelType.GuildText) return;
+	// Replies are follow-up discussion, not new reports.
+	if (message.reference) return;
+	handleChannelMessage(message).catch((err) =>
+		console.error("failed to file issue", err),
+	);
+});
+
+discord.on(Events.ThreadCreate, (thread) => {
+	if (thread.parent?.type !== ChannelType.GuildForum) return;
+	if (!thread.parentId || !env.DISCORD_CHANNEL_IDS.includes(thread.parentId))
+		return;
+	handleForumPost(thread).catch((err) =>
+		console.error("failed to file forum issue", err),
+	);
+});
+
+discord.once(Events.ClientReady, (client) => {
+	console.log(
+		`discord-triage ready as ${client.user.tag}, watching ${env.DISCORD_CHANNEL_IDS.join(", ")}`,
+	);
+});
+
+const GUILD_ID = "1446776342577283114";
+const THREAD_LINK = new RegExp(
+	`https://discord\\.com/channels/${GUILD_ID}/(\\d+)`,
+	"g",
+);
+const CLOSED_STATE_TYPES = new Set(["completed", "canceled", "duplicate"]);
+
+async function discordRest(
+	path: string,
+	init?: RequestInit,
+): Promise<Response> {
+	return fetch(`https://discord.com/api/v10${path}`, {
+		...init,
+		headers: {
+			Authorization: `Bot ${env.DISCORD_BOT_TOKEN}`,
+			"Content-Type": "application/json",
+			...init?.headers,
+		},
+	});
+}
+
+type LinearWebhookPayload = {
+	type?: string;
+	action?: string;
+	webhookTimestamp: number;
+	updatedFrom?: Record<string, unknown>;
+	data?: {
+		identifier?: string;
+		description?: string;
+		state?: { type?: string; name?: string };
+	};
+};
+
+// On issue close (Done/Canceled/Duplicate), reply in + archive the linked Discord threads.
+async function handleIssueClosed(payload: LinearWebhookPayload) {
+	const issue = payload.data;
+	if (!issue) return;
+	const threadIds = [
+		...new Set(
+			[...String(issue.description ?? "").matchAll(THREAD_LINK)].map(
+				(m) => m[1],
+			),
+		),
+	];
+	if (threadIds.length === 0) return;
+	const done = issue.state?.type === "completed";
+	const message = done
+		? `✅ Fixed — closed in Linear as **${issue.identifier}** (${issue.state?.name}).`
+		: `Closed in Linear as **${issue.identifier}** (${issue.state?.name}).`;
+	for (const threadId of threadIds) {
+		const t = await discordRest(`/channels/${threadId}`);
+		if (!t.ok) continue;
+		const thread = (await t.json()) as {
+			guild_id?: string;
+			thread_metadata?: { archived?: boolean };
+		};
+		if (thread.guild_id !== GUILD_ID) continue;
+		if (thread.thread_metadata?.archived) continue;
+		await discordRest(`/channels/${threadId}/messages`, {
+			method: "POST",
+			body: JSON.stringify({ content: message }),
+		});
+		await discordRest(`/channels/${threadId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ archived: true }),
+		});
+		console.log(`archived thread ${threadId} for ${issue.identifier}`);
+	}
+}
+
+async function handleLinearWebhook(req: Request): Promise<Response> {
+	if (!env.LINEAR_WEBHOOK_SECRET) {
+		return new Response("webhook not configured", { status: 503 });
+	}
+	const raw = await req.text();
+	const hasher = new Bun.CryptoHasher("sha256", env.LINEAR_WEBHOOK_SECRET);
+	const expected = hasher.update(raw).digest("hex");
+	const sig = req.headers.get("linear-signature") ?? "";
+	if (
+		sig.length !== expected.length ||
+		!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
+	) {
+		return new Response("bad signature", { status: 401 });
+	}
+	const payload = JSON.parse(raw);
+	if (Math.abs(Date.now() - payload.webhookTimestamp) > 60_000) {
+		return new Response("stale", { status: 400 });
+	}
+	const stateChanged =
+		payload.type === "Issue" &&
+		payload.action === "update" &&
+		payload.updatedFrom &&
+		"stateId" in payload.updatedFrom;
+	if (stateChanged && CLOSED_STATE_TYPES.has(payload.data?.state?.type)) {
+		handleIssueClosed(payload).catch((err) =>
+			console.error("webhook handling failed", err),
+		);
+	}
+	return new Response("ok");
+}
+
+Bun.serve({
+	port: env.PORT,
+	fetch(req) {
+		const path = new URL(req.url).pathname;
+		if (path === "/health") {
+			return new Response(discord.isReady() ? "ok" : "starting", {
+				status: discord.isReady() ? 200 : 503,
+			});
+		}
+		if (path === "/linear-webhook" && req.method === "POST") {
+			return handleLinearWebhook(req);
+		}
+		return new Response("not found", { status: 404 });
+	},
+});
+
+await resolveLinearIds();
+await discord.login(env.DISCORD_BOT_TOKEN);

--- a/apps/discord-triage/src/index.ts
+++ b/apps/discord-triage/src/index.ts
@@ -28,8 +28,8 @@ async function resolveLinearIds() {
 	});
 	sourceLabelId = labels.nodes[0]?.id;
 	if (!sourceLabelId) {
-		console.warn(
-			`Label "${env.LINEAR_SOURCE_LABEL}" not found on team; issues will be unlabeled`,
+		throw new Error(
+			`Label "${env.LINEAR_SOURCE_LABEL}" not found on team ${env.LINEAR_TEAM_KEY}`,
 		);
 	}
 }
@@ -131,10 +131,11 @@ discord.once(Events.ClientReady, (client) => {
 
 const GUILD_ID = "1446776342577283114";
 const THREAD_LINK = new RegExp(
-	`https://discord\\.com/channels/${GUILD_ID}/(\\d+)`,
+	`https://discord\\.com/channels/${GUILD_ID}/(\\d+)(?:/(\\d+))?`,
 	"g",
 );
 const CLOSED_STATE_TYPES = new Set(["completed", "canceled", "duplicate"]);
+const THREAD_CHANNEL_TYPES = new Set([10, 11, 12]);
 
 async function discordRest(
 	path: string,
@@ -166,35 +167,44 @@ type LinearWebhookPayload = {
 async function handleIssueClosed(payload: LinearWebhookPayload) {
 	const issue = payload.data;
 	if (!issue) return;
-	const threadIds = [
-		...new Set(
-			[...String(issue.description ?? "").matchAll(THREAD_LINK)].map(
-				(m) => m[1],
-			),
-		),
-	];
-	if (threadIds.length === 0) return;
+	// Message links are /channels/<guild>/<channel>/<message>. For forum posts the
+	// channel segment IS the thread; for text channels the thread shares the
+	// message's ID. Try both segments and let the type check below disambiguate.
+	const candidateIds = new Set<string>();
+	for (const m of String(issue.description ?? "").matchAll(THREAD_LINK)) {
+		if (m[1]) candidateIds.add(m[1]);
+		if (m[2]) candidateIds.add(m[2]);
+	}
+	if (candidateIds.size === 0) return;
 	const done = issue.state?.type === "completed";
 	const message = done
 		? `✅ Fixed — closed in Linear as **${issue.identifier}** (${issue.state?.name}).`
 		: `Closed in Linear as **${issue.identifier}** (${issue.state?.name}).`;
-	for (const threadId of threadIds) {
+	for (const threadId of candidateIds) {
 		const t = await discordRest(`/channels/${threadId}`);
 		if (!t.ok) continue;
 		const thread = (await t.json()) as {
+			type?: number;
 			guild_id?: string;
 			thread_metadata?: { archived?: boolean };
 		};
+		if (!THREAD_CHANNEL_TYPES.has(thread.type ?? -1)) continue;
 		if (thread.guild_id !== GUILD_ID) continue;
 		if (thread.thread_metadata?.archived) continue;
-		await discordRest(`/channels/${threadId}/messages`, {
+		const post = await discordRest(`/channels/${threadId}/messages`, {
 			method: "POST",
 			body: JSON.stringify({ content: message }),
 		});
-		await discordRest(`/channels/${threadId}`, {
+		if (!post.ok) {
+			throw new Error(`post to thread ${threadId} failed: ${post.status}`);
+		}
+		const patch = await discordRest(`/channels/${threadId}`, {
 			method: "PATCH",
 			body: JSON.stringify({ archived: true }),
 		});
+		if (!patch.ok) {
+			throw new Error(`archive thread ${threadId} failed: ${patch.status}`);
+		}
 		console.log(`archived thread ${threadId} for ${issue.identifier}`);
 	}
 }
@@ -223,9 +233,14 @@ async function handleLinearWebhook(req: Request): Promise<Response> {
 		payload.updatedFrom &&
 		"stateId" in payload.updatedFrom;
 	if (stateChanged && CLOSED_STATE_TYPES.has(payload.data?.state?.type)) {
-		handleIssueClosed(payload).catch((err) =>
-			console.error("webhook handling failed", err),
-		);
+		// Await so failures return 5xx and Linear retries; archived threads are
+		// skipped above, which keeps retries idempotent.
+		try {
+			await handleIssueClosed(payload);
+		} catch (err) {
+			console.error("webhook handling failed", err);
+			return new Response("handling failed", { status: 500 });
+		}
 	}
 	return new Response("ok");
 }

--- a/apps/discord-triage/src/index.ts
+++ b/apps/discord-triage/src/index.ts
@@ -213,15 +213,20 @@ async function handleLinearWebhook(req: Request): Promise<Response> {
 	if (!env.LINEAR_WEBHOOK_SECRET) {
 		return new Response("webhook not configured", { status: 503 });
 	}
-	const raw = await req.text();
-	const hasher = new Bun.CryptoHasher("sha256", env.LINEAR_WEBHOOK_SECRET);
-	const expected = hasher.update(raw).digest("hex");
+	// Verify over the exact received bytes; string round-trips can break HMAC.
+	const rawBytes = new Uint8Array(await req.arrayBuffer());
+	const raw = new TextDecoder().decode(rawBytes);
 	const sig = req.headers.get("linear-signature") ?? "";
+	const expected = new Bun.CryptoHasher("sha256", env.LINEAR_WEBHOOK_SECRET)
+		.update(rawBytes)
+		.digest("hex");
 	if (
 		sig.length !== expected.length ||
 		!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
 	) {
-		console.warn(`webhook rejected: bad signature (sig len ${sig.length})`);
+		console.warn(
+			`webhook rejected: bad signature (len ${rawBytes.length}, enc ${req.headers.get("content-encoding")}, type ${req.headers.get("content-type")})`,
+		);
 		return new Response("bad signature", { status: 401 });
 	}
 	const payload = JSON.parse(raw);

--- a/apps/discord-triage/src/index.ts
+++ b/apps/discord-triage/src/index.ts
@@ -221,12 +221,17 @@ async function handleLinearWebhook(req: Request): Promise<Response> {
 		sig.length !== expected.length ||
 		!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
 	) {
+		console.warn(`webhook rejected: bad signature (sig len ${sig.length})`);
 		return new Response("bad signature", { status: 401 });
 	}
 	const payload = JSON.parse(raw);
 	if (Math.abs(Date.now() - payload.webhookTimestamp) > 60_000) {
+		console.warn("webhook rejected: stale timestamp");
 		return new Response("stale", { status: 400 });
 	}
+	console.log(
+		`webhook: ${payload.type}/${payload.action} ${payload.data?.identifier ?? ""} -> ${payload.data?.state?.name ?? ""}`,
+	);
 	const stateChanged =
 		payload.type === "Issue" &&
 		payload.action === "update" &&

--- a/apps/discord-triage/tsconfig.json
+++ b/apps/discord-triage/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@superset/typescript/base.json",
+	"compilerOptions": {
+		"types": ["bun-types"]
+	},
+	"include": ["src"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -356,6 +356,22 @@
         "vite-tsconfig-paths": "5.1.4",
       },
     },
+    "apps/discord-triage": {
+      "name": "@superset/discord-triage",
+      "version": "0.1.0",
+      "dependencies": {
+        "@linear/sdk": "68.1.1",
+        "@t3-oss/env-core": "0.13.11",
+        "discord.js": "14.26.4",
+        "zod": "4.3.6",
+      },
+      "devDependencies": {
+        "@superset/typescript": "workspace:*",
+        "@types/node": "24.12.0",
+        "bun-types": "1.3.14",
+        "typescript": "6.0.3",
+      },
+    },
     "apps/docs": {
       "name": "@superset/docs",
       "version": "0.0.0",
@@ -1606,6 +1622,18 @@
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
+    "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
+
+    "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
+
+    "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
+
+    "@discordjs/rest": ["@discordjs/rest@2.6.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.40", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg=="],
+
+    "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
+
+    "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
+
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 
     "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
@@ -2688,6 +2716,12 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w=="],
 
+    "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
+
+    "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
+
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
     "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
@@ -2847,6 +2881,8 @@
     "@superset/db": ["@superset/db@workspace:packages/db"],
 
     "@superset/desktop": ["@superset/desktop@workspace:apps/desktop"],
+
+    "@superset/discord-triage": ["@superset/discord-triage@workspace:apps/discord-triage"],
 
     "@superset/docs": ["@superset/docs@workspace:apps/docs"],
 
@@ -3401,6 +3437,8 @@
     "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.31", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.31", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ=="],
 
@@ -4099,6 +4137,10 @@
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
     "direction": ["direction@2.0.1", "", { "bin": { "direction": "cli.js" } }, "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="],
+
+    "discord-api-types": ["discord-api-types@0.38.49", "", {}, "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="],
+
+    "discord.js": ["discord.js@14.26.4", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA=="],
 
     "dmg-builder": ["dmg-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "fs-extra": "^10.1.0", "iconv-lite": "^0.6.2", "js-yaml": "^4.1.0" }, "optionalDependencies": { "dmg-license": "^1.0.11" } }, "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg=="],
 
@@ -4946,6 +4988,8 @@
 
     "lodash.samplesize": ["lodash.samplesize@4.2.0", "", {}, "sha512-1ZhKV7/nuISuaQdxfCqrs4HHxXIYN+0Z4f7NMQn2PHkxFZJGavJQ1j/paxyJnLJmN2ZamNN6SMepneV+dCgQTA=="],
 
+    "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
+
     "lodash.throttle": ["lodash.throttle@4.1.1", "", {}, "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="],
 
     "lodash.zip": ["lodash.zip@4.2.0", "", {}, "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg=="],
@@ -4981,6 +5025,8 @@
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "maath": ["maath@0.10.8", "", { "peerDependencies": { "@types/three": ">=0.134.0", "three": ">=0.134.0" } }, "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g=="],
+
+    "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -6270,6 +6316,8 @@
 
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
+    "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
+
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
@@ -6823,6 +6871,12 @@
     "@develar/schema-utils/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "@develar/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
+
+    "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
+
+    "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 


### PR DESCRIPTION
## Description

New always-on service `apps/discord-triage` (Bun gateway bot on Fly, modeled on `apps/relay`) that wires the community Discord into Linear Triage:

- Watches **#bugs** (forum) and **#feature-request** (text), configured via `DISCORD_CHANNEL_IDS` in `fly.toml`. Every new forum post / top-level message becomes a Linear issue labeled `Source: Discord` (no state set → lands in Triage), and the bot opens a thread on the message with the issue link. Reply messages are skipped so discussion doesn't spam Triage.
- **Linear → Discord autoclose**: `/linear-webhook` receives Linear issue webhooks (HMAC-SHA256 verified via `LINEAR_WEBHOOK_SECRET`, timestamp-checked). When an issue moves to Done/Canceled/Duplicate, the bot posts the resolution into every Discord thread linked in the issue description and archives the thread. Already-archived threads are skipped so webhook retries can't unarchive them.
- `/health` endpoint backs the Fly HTTP check.

## Deployment notes

- Already deployed and verified live as `superset-discord-triage` (intake + autoclose both round-trip tested).
- `scripts/deploy.sh` builds from the repo root (turbo prune needs the monorepo as Docker context) and forces `--ha=false`: **the gateway bot must run as exactly one machine or every message files duplicate issues.**
- Secrets: `DISCORD_BOT_TOKEN`, `LINEAR_API_KEY` (scoped: Read + Create issues, Superset team only), `LINEAR_WEBHOOK_SECRET`.
- `@linear/sdk` pinned to 68.1.1 to match apps/api and packages/trpc (sherif-clean).

## Type of Change

- [x] New feature

## Testing

- `turbo typecheck --filter=@superset/discord-triage` and Biome clean; the four custom lint scripts pass. (Repo-root `bun run lint` fails locally only on untracked `.conductor/*` worktrees with nested biome configs — pre-existing, not in CI.)
- Live E2E: forum post → Triage issue with label + thread link-back in seconds; issue → Done → thread got the ✅ reply and was archived.

## Additional Notes

Bot permissions in Discord: View Channels, Send Messages (+in Threads), Create Public Threads, Read Message History, Manage Threads (needed to archive other users' forum posts). Message Content intent enabled.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an always-on Discord triage bot that turns support posts into Linear Triage issues and auto-archives Discord threads when the linked Linear issue is closed. Improves webhook handling to resolve threads from both forum posts and text messages and to retry safely.

- **New Features**
  - New service `apps/discord-triage` (Fly app) using `discord.js` and `@linear/sdk`.
  - Watches `DISCORD_CHANNEL_IDS`: each new top-level message or forum post files a Linear issue, labels it (`LINEAR_SOURCE_LABEL`, default "Discord"), and opens a thread link-back. Replies are ignored.
  - `/linear-webhook` verifies HMAC-SHA256 over the raw request body via `LINEAR_WEBHOOK_SECRET`; logs arrivals and signature/timestamp rejections; on Done/Canceled/Duplicate, posts the resolution and archives linked threads. Thread IDs are resolved from both forum starter links and text message links, and Discord API failures return 5xx so Linear retries (archived-thread skip keeps it idempotent).
  - `/health` endpoint for Fly checks.

- **Migration**
  - Run as a single machine only (`--ha=false`) to avoid duplicate issues.
  - Set secrets: `DISCORD_BOT_TOKEN`, `LINEAR_API_KEY`, `LINEAR_WEBHOOK_SECRET`. Set env: `DISCORD_CHANNEL_IDS`, optional `LINEAR_TEAM_KEY`, `LINEAR_SOURCE_LABEL` (label must exist). Configure Linear to POST to `/linear-webhook`.

<sup>Written for commit f692844915661c10adec9c323761a6db6eba2118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Launched a Discord-to-Linear triage gateway that watches configured text and forum channels, creates labeled Linear issues, and posts links back into Discord threads (without syncing thread replies).
  - Handles Linear issue state changes (completed, canceled, duplicate) by posting closure notes and archiving matching Discord threads.
  - Added `GET /health` and a signed `POST /linear-webhook` endpoint with strict payload/signature verification.
- **Deployment**
  - Added Fly.io configuration, multi-stage Docker setup, and an automated deploy script.
- **Documentation**
  - Added setup/deployment README with required environment variables and operational notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->