### PR TITLE
fix(desktop): shorten canary version in post-update confirmation pill

### DIFF
--- a/apps/desktop/src/renderer/components/UpdatesPill/UpdatesPill.tsx
+++ b/apps/desktop/src/renderer/components/UpdatesPill/UpdatesPill.tsx
@@ -30,6 +30,16 @@ function useAsciiFrame(active: boolean): number {
 	return frame;
 }
 
+/**
+ * Compact version for the inline pill — canary builds carry a timestamp
+ * suffix ("1.14.1-canary.20260711221936") that would overflow the sidebar
+ * footer, so shorten to "1.14.1-ca". The tooltip keeps the full version.
+ */
+function displayVersion(version: string): string {
+	const [base, prereleaseTag] = version.split("-", 2);
+	return prereleaseTag ? `${base}-${prereleaseTag.slice(0, 2)}` : base;
+}
+
 /** Marquee-style terminal progress bar, e.g. `[·##···]` */
 function asciiBar(frame: number): string {
 	const cells = Array.from({ length: BAR_CELLS }, (_, i) =>
@@ -219,7 +229,9 @@ export function UpdatesPill({ isCollapsed = false }: UpdatesPillProps) {
 									}}
 								/>
 							</svg>
-							<span>{version ? `v${version}` : "downloaded"}</span>
+							<span>
+								{version ? `v${displayVersion(version)}` : "downloaded"}
+							</span>
 						</>
 					) : isReady ? (
 						<>


### PR DESCRIPTION
## Summary
- The post-update "✓ vX.Y.Z" confirmation pill now shows a compact version: canary's timestamp suffix (`1.14.1-canary.20260711221936`) is trimmed to `1.14.1-ca`; stable versions are unchanged.

## Why / Context
Canary versions embed a 14-digit build timestamp, making the pill text 31 characters (~210px at its 10px mono font). The pill is `shrink-0` and sits in the sidebar footer next to the Settings and help buttons — the sidebar's minimum width is 220px (default 280px), so on canary builds the confirmation crushed the Settings button or overflowed the row for the 5 seconds it was visible.

## How It Works
A `displayVersion` helper in `UpdatesPill.tsx` splits the semver at the first `-` and keeps the base version plus the first two letters of any prerelease tag (`1.14.1-canary.20260711221936` → `1.14.1-ca`). Only the inline pill text uses it; the hover tooltip still shows the full version. The other pill states (downloading %, "↑ update", "↻ retry") never rendered the version inline, so they're unaffected.

## Manual QA Checklist
- [ ] After an update on a canary build, the pill reads `✓ v1.14.1-ca` and the sidebar footer row doesn't overflow at min width (220px)
- [ ] Tooltip on the confirmation still shows the full version including timestamp
- [ ] Stable versions display unchanged (`✓ v1.14.3`)

## Testing
- `bun run typecheck` (desktop)
- `bun run lint`
- Not manually exercised: the UPDATED state requires an actual canary relaunch; the trim logic is a pure string transform verified by inspection.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5629">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened the post-update confirmation pill’s canary version to prevent the sidebar footer from overflowing. Canary builds like `1.14.1-canary.20260711221936` now show as `1.14.1-ca`; stable versions are unchanged and the tooltip still shows the full version.

<sup>Written for commit 69efd8c1f94f28a37c2a0eb00ec7fca9b6265eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sidebar version pill to display prerelease and canary versions in a shorter, more readable format.
  * The full version remains available in the tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->