### PR TITLE
fix(desktop): keep agent hook debug logs off the PTY so they can't corrupt TUIs

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -19,10 +19,33 @@ describe("getNotifyScriptContent", () => {
 			'PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$SUPERSET_AGENT_ID")\\",\\"sessionId\\":\\"$(json_escape "$SESSION_ID")\\"}}}"',
 		);
 		expect(script).toContain(
-			"event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID",
+			'debug_log "event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID"',
 		);
 		expect(script).toContain('V1_EVENT_TYPE="$EVENT_TYPE"');
 		expect(script).toContain('V1_EVENT_TYPE="Stop"');
+	});
+
+	it("never writes to stdout/stderr — hook stdio is the agent TUI's PTY", () => {
+		// Anything a hook prints lands at the TUI's cursor position and corrupts
+		// its diff-rendered screen (only debug_log's file redirection is allowed).
+		for (const template of [
+			"notify-hook.template.sh",
+			"cursor-hook.template.sh",
+			"copilot-hook.template.sh",
+		]) {
+			const script = readFileSync(
+				path.join(import.meta.dir, "templates", template),
+				"utf-8",
+			);
+			expect(script).not.toContain(">&2");
+		}
+		// gemini-hook must print exactly one JSON object to stdout (protocol
+		// requirement), but nothing to stderr.
+		const gemini = readFileSync(
+			path.join(import.meta.dir, "templates", "gemini-hook.template.sh"),
+			"utf-8",
+		);
+		expect(gemini).not.toContain(">&2");
 	});
 
 	it("gives the v2 host-service hook enough time to deliver", () => {

--- a/apps/desktop/src/main/lib/agent-setup/templates/gemini-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/gemini-hook.template.sh
@@ -42,7 +42,9 @@ if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -n "$SUPERSET_TERMINAL_ID" ]; the
 
   case "$STATUS_CODE" in
     2*) exit 0 ;;
-    *) echo "[gemini-hook] host-service dispatch failed status=$STATUS_CODE; falling back to v1" >&2 ;;
+    # Log to file, never stderr: hook stdio is inherited from the agent's PTY,
+    # so stray output corrupts the TUI's diff-rendered screen.
+    *) printf '%s [gemini-hook] host-service dispatch failed status=%s; falling back to v1\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" "$STATUS_CODE" >> "${SUPERSET_HOOK_DEBUG_LOG:-/tmp/superset-agent-hooks.log}" 2>/dev/null || true ;;
   esac
 fi
 

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -48,16 +48,17 @@ elif [ "$SUPERSET_ENV" = "development" ] || [ "$NODE_ENV" = "development" ]; the
   DEBUG_HOOKS_ENABLED="1"
 fi
 
-if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
-  echo "[notify-hook] event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID" >&2
-fi
-
+# Diagnostics must NEVER go to stdout/stderr: hooks run as children of TUI
+# agents with stdio inherited from the PTY, so anything printed lands at the
+# cursor position and corrupts the agent's diff-rendered screen. Debug output
+# goes to the log file only — tail it with:
+#   tail -f /tmp/superset-agent-hooks.log
 debug_log() {
   [ "$DEBUG_HOOKS_ENABLED" = "1" ] || return 0
   printf '%s [notify-hook] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" "$*" >> "${SUPERSET_HOOK_DEBUG_LOG:-/tmp/superset-agent-hooks.log}" 2>/dev/null || true
 }
 
-debug_log "event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID tabId=$SUPERSET_TAB_ID"
+debug_log "event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID"
 
 V1_EVENT_TYPE="$EVENT_TYPE"
 case "$V1_EVENT_TYPE" in
@@ -82,9 +83,6 @@ if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -n "$SUPERSET_TERMINAL_ID" ]; the
     -d "$PAYLOAD" \
     -o /dev/null -w "%{http_code}" 2>/dev/null)
 
-  if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
-    echo "[notify-hook] host-service dispatched status=$STATUS_CODE" >&2
-  fi
   debug_log "host-service status=$STATUS_CODE url=$SUPERSET_HOST_AGENT_HOOK_URL"
 
   case "$STATUS_CODE" in
@@ -95,37 +93,19 @@ fi
 # v1 fallback: Electron localhost hook server. Kept while v1 terminals exist.
 [ -z "$SUPERSET_TAB_ID" ] && [ -z "$SESSION_ID" ] && [ -z "$SUPERSET_TERMINAL_ID" ] && exit 0
 
-if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
-  STATUS_CODE=$(curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
-    --connect-timeout 1 --max-time 2 \
-    --data-urlencode "paneId=$SUPERSET_PANE_ID" \
-    --data-urlencode "tabId=$SUPERSET_TAB_ID" \
-    --data-urlencode "workspaceId=$SUPERSET_WORKSPACE_ID" \
-    --data-urlencode "terminalId=$SUPERSET_TERMINAL_ID" \
-    --data-urlencode "sessionId=$SESSION_ID" \
-    --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
-    --data-urlencode "resourceId=$RESOURCE_ID" \
-    --data-urlencode "eventType=$V1_EVENT_TYPE" \
-    --data-urlencode "env=$SUPERSET_ENV" \
-    --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
-    -o /dev/null -w "%{http_code}" 2>/dev/null)
-  echo "[notify-hook] v1 dispatched status=$STATUS_CODE" >&2
-  debug_log "v1 status=$STATUS_CODE port=${SUPERSET_PORT:-{{DEFAULT_PORT}}}"
-else
-  debug_log "v1 dispatch port=${SUPERSET_PORT:-{{DEFAULT_PORT}}}"
-  curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
-    --connect-timeout 1 --max-time 2 \
-    --data-urlencode "paneId=$SUPERSET_PANE_ID" \
-    --data-urlencode "tabId=$SUPERSET_TAB_ID" \
-    --data-urlencode "workspaceId=$SUPERSET_WORKSPACE_ID" \
-    --data-urlencode "terminalId=$SUPERSET_TERMINAL_ID" \
-    --data-urlencode "sessionId=$SESSION_ID" \
-    --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
-    --data-urlencode "resourceId=$RESOURCE_ID" \
-    --data-urlencode "eventType=$V1_EVENT_TYPE" \
-    --data-urlencode "env=$SUPERSET_ENV" \
-    --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
-    > /dev/null 2>&1
-fi
+STATUS_CODE=$(curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
+  --connect-timeout 1 --max-time 2 \
+  --data-urlencode "paneId=$SUPERSET_PANE_ID" \
+  --data-urlencode "tabId=$SUPERSET_TAB_ID" \
+  --data-urlencode "workspaceId=$SUPERSET_WORKSPACE_ID" \
+  --data-urlencode "terminalId=$SUPERSET_TERMINAL_ID" \
+  --data-urlencode "sessionId=$SESSION_ID" \
+  --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
+  --data-urlencode "resourceId=$RESOURCE_ID" \
+  --data-urlencode "eventType=$V1_EVENT_TYPE" \
+  --data-urlencode "env=$SUPERSET_ENV" \
+  --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
+  -o /dev/null -w "%{http_code}" 2>/dev/null)
+debug_log "v1 status=$STATUS_CODE port=${SUPERSET_PORT:-{{DEFAULT_PORT}}}"
 
 exit 0


### PR DESCRIPTION
## Summary
- Agent lifecycle hooks (notify-hook, gemini-hook) were writing debug/diagnostic lines to stderr. Hooks run as children of TUI agents (OpenCode, Claude, Gemini) with stdio inherited from the PTY, so those lines printed at the cursor position and corrupted the TUI's diff-rendered screen — interleaved `[notify-hook]` lines and orphaned text fragments overlaying the UI.
- All diagnostics now go exclusively to the existing `debug_log` file channel (`/tmp/superset-agent-hooks.log`, overridable via `SUPERSET_HOOK_DEBUG_LOG`). No hook template writes to stdout/stderr anymore (gemini-hook still prints its protocol-required `{}` JSON to stdout).

## Why / Context
`notify-hook.template.sh` auto-enables debug output when `SUPERSET_ENV=development`, and its stderr echoes were exact duplicates of the `debug_log` file writes next to them. In dev builds, every agent lifecycle event (Start/Stop/PermissionRequest) sprayed log lines into the agent's TUI. Diff-rendering TUIs never recover from foreign writes: they repaint only cells they believe changed, so hook text persists as garbage and bottom-row writes desync their screen model by one line. `gemini-hook.template.sh` additionally had an **ungated** stderr echo on its v2→v1 fallback path that fired even in production.

## How It Works
- `notify-hook.template.sh`: dropped the three stderr echoes; the event-received `debug_log` line now carries the full field set the echo had (adds `paneId`, `workspaceId`). The v1 dispatch was duplicated into debug/non-debug branches solely so debug mode could echo the status code — collapsed to a single branch that always captures the status and `debug_log`s it.
- `gemini-hook.template.sh`: the fallback echo now appends to the same log file (unconditional, since it's a rare failure-path signal).
- New regression test asserts no hook template contains `>&2`.

Debugging workflow is unchanged in capability: `tail -f /tmp/superset-agent-hooks.log` instead of reading interleaved (and mangled) lines inside the TUI.

## Manual QA
- Rendered the template (`{{MARKER}}`/`{{DEFAULT_PORT}}` substituted) and executed it with a fake Stop payload:
  - with `SUPERSET_DEBUG_HOOKS=1`: stdout+stderr empty, log file receives the event line (full field set) and dispatch status line
  - without debug: stdout+stderr empty
- `bash -n` on both modified templates.
- Rollout is automatic: `createNotifyScript()` rewrites the installed `notify.sh` on next app launch via content comparison (no marker bump needed — hook semantics unchanged, wire payloads identical).

## Testing
- `bun test src/main/lib/agent-setup` (73 pass, includes new no-stderr regression test)
- `bun run lint`
- `bun run typecheck` (desktop)

## Known Limitations
- OpenCode's payload fields (`hookSessionId`/`resourceId`) parse as empty in the notify hook — pre-existing and unrelated to the logging channel; the Stop event still dispatches. Worth a separate ticket.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5634">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep agent hook debug output off the PTY to stop corrupting diff-rendered TUIs. All diagnostics now go to the hook debug log file instead of stdout/stderr.

- **Bug Fixes**
  - Removed all stderr echoes from `notify-hook.template.sh` and `gemini-hook.template.sh`; diagnostics append to `${SUPERSET_HOOK_DEBUG_LOG:-/tmp/superset-agent-hooks.log}`. Gemini still prints only the required JSON to stdout.
  - Simplified `notify-hook` v1 dispatch into a single path and logged status with more context fields (`paneId`, `workspaceId`, etc.).
  - Added a regression test to ensure no hook template writes to stderr (`>&2`) and updated expectations for the notify script content.

<sup>Written for commit 819d9438fc922eb64a748c2a91a3543f2b3b74e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented agent hook diagnostics from appearing unexpectedly in terminal output or interfering with command-line protocols.
  * Improved logging for host-service dispatch failures, including response status details and event context.
  * Preserved fallback behavior when host-service delivery is unavailable, while recording failures in the debug log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->