### PR TITLE
refactor(workspace-client,web): standardize reconnecting WS clients on partysocket

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
 	"devDependencies": {
 		"@superset/typescript": "workspace:*",
 		"@tailwindcss/postcss": "4.2.2",
+		"@types/bun": "1.3.14",
 		"@types/node": "24.12.0",
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
 		"@superset/shared": "workspace:*",
 		"@superset/trpc": "workspace:*",
 		"@superset/ui": "workspace:*",
+		"@superset/workspace-client": "workspace:*",
 		"@t3-oss/env-nextjs": "0.13.11",
 		"@tanstack/react-query": "5.101.1",
 		"@tanstack/react-query-devtools": "5.101.1",

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.test.ts
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	TerminalConnection,
+	type TerminalConnectionState,
+	type TerminalControlMessage,
+} from "./TerminalConnection";
+
+// Stands in for the relay + host-service PTY endpoint. Serves /_whoowns (200)
+// and records every terminal WS dial's URL; `push`/`pushBinary` emit frames.
+function makeRelayServer() {
+	const dials: string[] = [];
+	const clients = new Set<Bun.ServerWebSocket<unknown>>();
+	const server = Bun.serve({
+		port: 0,
+		fetch(req, srv) {
+			const url = new URL(req.url);
+			if (url.pathname.endsWith("/_whoowns")) {
+				return new Response(JSON.stringify({ ok: true }), { status: 200 });
+			}
+			dials.push(
+				`${url.pathname}?${url.searchParams.toString()}`.replace(
+					/token=[^&]*/,
+					(m) => m, // keep token visible for assertions
+				),
+			);
+			if (srv.upgrade(req)) return;
+			return new Response("no", { status: 400 });
+		},
+		websocket: {
+			open(ws) {
+				clients.add(ws);
+			},
+			close(ws) {
+				clients.delete(ws);
+			},
+			message() {},
+		},
+	});
+	return {
+		server,
+		dials,
+		relayUrl: `http://localhost:${server.port}`,
+		push(payload: object) {
+			for (const ws of clients) ws.send(JSON.stringify(payload));
+		},
+		pushBinary(bytes: Uint8Array) {
+			for (const ws of clients) ws.send(bytes);
+		},
+		dropClients() {
+			for (const ws of clients) ws.close();
+		},
+		clientCount: () => clients.size,
+	};
+}
+
+function waitFor(cond: () => boolean, timeoutMs = 6_000): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const start = Date.now();
+		const t = setInterval(() => {
+			if (cond()) {
+				clearInterval(t);
+				resolve();
+			} else if (Date.now() - start > timeoutMs) {
+				clearInterval(t);
+				reject(new Error("waitFor timeout"));
+			}
+		}, 20);
+	});
+}
+
+const TARGET = {
+	workspaceId: "ws-1",
+	terminalId: "term-1",
+	routingKey: "org-1:machine-1",
+};
+
+let connection: TerminalConnection | null = null;
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	connection?.dispose();
+	connection = null;
+	for (const fn of cleanups.splice(0)) fn();
+});
+
+function startConnection(relay: ReturnType<typeof makeRelayServer>) {
+	const binaries: Uint8Array[] = [];
+	const controls: TerminalControlMessage[] = [];
+	const states: TerminalConnectionState[] = [];
+	let tokenVersion = 0;
+	connection = new TerminalConnection(
+		TARGET,
+		{
+			onBinary: (b) => binaries.push(b),
+			onControl: (m) => controls.push(m),
+			onStateChange: (s) => states.push(s),
+		},
+		{
+			getToken: async () => `tok-${++tokenVersion}`,
+			relayUrl: () => relay.relayUrl,
+		},
+	);
+	connection.start();
+	return { binaries, controls, states };
+}
+
+describe("TerminalConnection", () => {
+	it("dials the terminal path with workspace params and a token", async () => {
+		const relay = makeRelayServer();
+		cleanups.push(() => relay.server.stop(true));
+		startConnection(relay);
+		await waitFor(() => relay.dials.length === 1);
+		const dial = relay.dials[0] ?? "";
+		expect(dial).toContain("/hosts/org-1:machine-1/terminal/term-1");
+		expect(dial).toContain("workspaceId=ws-1");
+		expect(dial).toContain("token=tok-1");
+		expect(dial).not.toContain("replay=0"); // first attach wants replay
+	});
+
+	it("delivers binary PTY bytes and control messages", async () => {
+		const relay = makeRelayServer();
+		cleanups.push(() => relay.server.stop(true));
+		const { binaries, controls } = startConnection(relay);
+		await waitFor(() => relay.clientCount() === 1);
+		relay.push({ type: "attached", terminalId: "term-1" });
+		relay.pushBinary(new Uint8Array([104, 105]));
+		await waitFor(() => controls.length === 1 && binaries.length === 1);
+		expect(controls[0]).toEqual({ type: "attached", terminalId: "term-1" });
+		expect([...(binaries[0] ?? [])]).toEqual([104, 105]);
+	});
+
+	it("reconnects after a drop with a FRESH token and replay=0 once bytes were seen", async () => {
+		const relay = makeRelayServer();
+		cleanups.push(() => relay.server.stop(true));
+		const { states } = startConnection(relay);
+		await waitFor(() => relay.clientCount() === 1);
+		relay.push({ type: "attached", terminalId: "term-1" });
+		relay.pushBinary(new Uint8Array([104]));
+		await waitFor(() => relay.dials.length === 1);
+
+		relay.dropClients();
+		await waitFor(() => relay.dials.length === 2);
+		const redial = relay.dials[1] ?? "";
+		expect(redial).toContain("token=tok-2"); // not the URL from attempt 1
+		expect(redial).toContain("replay=0");
+		expect(states).toContain("reconnecting");
+	});
+
+	it("stops permanently after a PTY exit", async () => {
+		const relay = makeRelayServer();
+		cleanups.push(() => relay.server.stop(true));
+		const { controls } = startConnection(relay);
+		await waitFor(() => relay.clientCount() === 1);
+		relay.push({ type: "exit", exitCode: 0, signal: 0 });
+		await waitFor(() => controls.length === 1);
+		await waitFor(() => relay.clientCount() === 0);
+		// No redial: the session is done.
+		await Bun.sleep(1_200);
+		expect(relay.dials.length).toBe(1);
+	});
+});

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
@@ -2,8 +2,6 @@ import {
 	createRelaySocket,
 	type RelaySocket,
 } from "@superset/workspace-client/relay-socket";
-import { getAuthToken } from "../../../../../trpc/auth-token";
-import { getRelayUrl } from "../../../../../trpc/relay-url";
 
 export type TerminalConnectionState = "connecting" | "reconnecting" | "error";
 
@@ -31,6 +29,13 @@ interface TerminalConnectionHandlers {
 	onStateChange: (state: TerminalConnectionState) => void;
 }
 
+// Environment wiring injected by the caller so this class stays free of
+// env/posthog module-scope imports (and unit-testable).
+interface TerminalConnectionDeps {
+	getToken: () => Promise<string>;
+	relayUrl: () => string;
+}
+
 const BASE_RECONNECT_DELAY_MS = 500;
 const MAX_RECONNECT_DELAY_MS = 10_000;
 const MAX_RECONNECT_ATTEMPTS = 12;
@@ -45,6 +50,7 @@ const MAX_RECONNECT_ATTEMPTS = 12;
 export class TerminalConnection {
 	private readonly target: TerminalConnectionTarget;
 	private readonly handlers: TerminalConnectionHandlers;
+	private readonly deps: TerminalConnectionDeps;
 	private socket: RelaySocket | null = null;
 	private state: TerminalConnectionState = "connecting";
 	private failedAttempts = 0;
@@ -56,9 +62,11 @@ export class TerminalConnection {
 	constructor(
 		target: TerminalConnectionTarget,
 		handlers: TerminalConnectionHandlers,
+		deps: TerminalConnectionDeps,
 	) {
 		this.target = target;
 		this.handlers = handlers;
+		this.deps = deps;
 	}
 
 	start() {
@@ -73,7 +81,7 @@ export class TerminalConnection {
 
 		const socket = createRelaySocket({
 			buildUrl: () => this.buildUrl(),
-			getToken: () => getAuthToken(),
+			getToken: () => this.deps.getToken(),
 			// Definitive access denial: retrying can't change the answer.
 			onAccessDenied: () => {
 				this.terminated = true;
@@ -145,7 +153,7 @@ export class TerminalConnection {
 	}
 
 	private async buildUrl(): Promise<string> {
-		const base = getRelayUrl().replace(/\/$/, "");
+		const base = this.deps.relayUrl().replace(/\/$/, "");
 		const url = new URL(
 			`${base}/hosts/${this.target.routingKey}/terminal/${encodeURIComponent(
 				this.target.terminalId,

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
@@ -122,10 +122,6 @@ export class TerminalConnection {
 			}
 			this.emitState(this.everAttached ? "reconnecting" : "connecting");
 		});
-
-		socket.addEventListener("error", () => {
-			// close fires after error; partysocket owns the retry loop.
-		});
 	}
 
 	dispose() {
@@ -149,7 +145,7 @@ export class TerminalConnection {
 	}
 
 	private async buildUrl(): Promise<string> {
-		const base = getRelayUrl().replace(/^http/, "ws").replace(/\/$/, "");
+		const base = getRelayUrl().replace(/\/$/, "");
 		const url = new URL(
 			`${base}/hosts/${this.target.routingKey}/terminal/${encodeURIComponent(
 				this.target.terminalId,

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
@@ -1,3 +1,7 @@
+import {
+	createRelaySocket,
+	type RelaySocket,
+} from "@superset/workspace-client/relay-socket";
 import { getAuthToken } from "../../../../../trpc/auth-token";
 import { getRelayUrl } from "../../../../../trpc/relay-url";
 
@@ -31,20 +35,19 @@ const BASE_RECONNECT_DELAY_MS = 500;
 const MAX_RECONNECT_DELAY_MS = 10_000;
 const MAX_RECONNECT_ATTEMPTS = 12;
 
-// Owns the terminal WebSocket lifecycle: exponential-backoff reconnect on an
-// unexpected close, plus page-visibility recovery. Mobile browsers freeze
-// backgrounded tabs and drop the socket; the visibility, pageshow, resume and
-// online listeners reconnect the moment the page comes back. The server keys
-// sessions by terminalId and adopts/respawns the PTY on reattach, so reopening
-// the same URL resumes the session.
+// Owns the terminal WebSocket lifecycle on top of createRelaySocket, which
+// re-signs the URL with a fresh token and runs the relay preflight before
+// every attempt. Mobile browsers freeze backgrounded tabs and drop the
+// socket; the visibility, pageshow, resume and online listeners reconnect
+// the moment the page comes back. The server keys sessions by terminalId and
+// adopts/respawns the PTY on reattach, so reopening the same URL resumes the
+// session.
 export class TerminalConnection {
 	private readonly target: TerminalConnectionTarget;
 	private readonly handlers: TerminalConnectionHandlers;
-	private socket: WebSocket | null = null;
+	private socket: RelaySocket | null = null;
 	private state: TerminalConnectionState = "connecting";
-	private generation = 0;
-	private reconnectAttempt = 0;
-	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private failedAttempts = 0;
 	private hasReceivedBytes = false;
 	private everAttached = false;
 	private terminated = false;
@@ -67,80 +70,23 @@ export class TerminalConnection {
 			window.addEventListener("pageshow", this.handleResume);
 			window.addEventListener("online", this.handleResume);
 		}
-		void this.connect();
-	}
 
-	dispose() {
-		this.disposed = true;
-		this.cancelReconnect();
-		if (typeof document !== "undefined") {
-			document.removeEventListener("visibilitychange", this.handleResume);
-			document.removeEventListener("resume", this.handleResume);
-		}
-		if (typeof window !== "undefined") {
-			window.removeEventListener("pageshow", this.handleResume);
-			window.removeEventListener("online", this.handleResume);
-		}
-		this.teardownSocket();
-	}
-
-	send(message: TerminalClientMessage) {
-		const socket = this.socket;
-		if (!socket || socket.readyState !== WebSocket.OPEN) return;
-		socket.send(JSON.stringify(message));
-	}
-
-	private connect = async () => {
-		if (this.disposed || this.terminated) return;
-		this.cancelReconnect();
-		this.teardownSocket();
-		const generation = ++this.generation;
-		this.emitState(this.everAttached ? "reconnecting" : "connecting");
-
-		let url: string;
-		try {
-			url = await this.buildUrl();
-		} catch {
-			if (generation !== this.generation || this.disposed) return;
-			this.scheduleReconnect();
-			return;
-		}
-		if (generation !== this.generation || this.disposed || this.terminated) {
-			return;
-		}
-
-		let socket: WebSocket;
-		try {
-			socket = new WebSocket(url);
-		} catch {
-			this.scheduleReconnect();
-			return;
-		}
+		const socket = createRelaySocket({
+			buildUrl: () => this.buildUrl(),
+			getToken: () => getAuthToken(),
+			// Definitive access denial: retrying can't change the answer.
+			onAccessDenied: () => {
+				this.terminated = true;
+				this.emitState("error");
+			},
+			minReconnectionDelay: BASE_RECONNECT_DELAY_MS,
+			maxReconnectionDelay: MAX_RECONNECT_DELAY_MS,
+			maxEnqueuedMessages: 0,
+		});
 		socket.binaryType = "arraybuffer";
 		this.socket = socket;
-		this.attachListeners(socket);
-	};
 
-	private async buildUrl(): Promise<string> {
-		const token = await getAuthToken();
-		const base = getRelayUrl().replace(/^http/, "ws").replace(/\/$/, "");
-		const url = new URL(
-			`${base}/hosts/${this.target.routingKey}/terminal/${encodeURIComponent(
-				this.target.terminalId,
-			)}`,
-		);
-		url.searchParams.set("workspaceId", this.target.workspaceId);
-		url.searchParams.set("themeType", "dark");
-		url.searchParams.set("token", token);
-		// Once xterm holds scrollback, skip the daemon ring-buffer re-dump on
-		// reattach; the in-memory buffer still replays output missed offline.
-		if (this.hasReceivedBytes) url.searchParams.set("replay", "0");
-		return url.toString();
-	}
-
-	private attachListeners(socket: WebSocket) {
-		socket.onmessage = (event) => {
-			if (this.socket !== socket) return;
+		socket.addEventListener("message", (event) => {
 			if (event.data instanceof ArrayBuffer) {
 				this.hasReceivedBytes = true;
 				this.handlers.onBinary(new Uint8Array(event.data));
@@ -153,80 +99,86 @@ export class TerminalConnection {
 				return;
 			}
 			if (message.type === "attached") {
-				this.reconnectAttempt = 0;
+				this.failedAttempts = 0;
 				this.everAttached = true;
 			} else if (message.type === "exit" || message.type === "error") {
+				// Server closes after these; reconnecting would just repeat them.
 				this.terminated = true;
-				this.cancelReconnect();
+				socket.close();
 			}
 			this.handlers.onControl(message);
-		};
+		});
 
-		socket.onclose = () => {
-			if (this.socket !== socket) return;
-			this.socket = null;
+		socket.addEventListener("close", () => {
 			if (this.terminated || this.disposed) return;
-			this.scheduleReconnect();
-		};
+			// Frozen tabs don't count against the attempt budget; the visibility
+			// listener resets and reconnects on resume.
+			if (typeof document !== "undefined" && document.hidden) return;
+			this.failedAttempts += 1;
+			if (this.failedAttempts >= MAX_RECONNECT_ATTEMPTS) {
+				this.emitState("error");
+				socket.close();
+				return;
+			}
+			this.emitState(this.everAttached ? "reconnecting" : "connecting");
+		});
+
+		socket.addEventListener("error", () => {
+			// close fires after error; partysocket owns the retry loop.
+		});
 	}
 
-	private teardownSocket() {
-		const socket = this.socket;
+	dispose() {
+		this.disposed = true;
+		if (typeof document !== "undefined") {
+			document.removeEventListener("visibilitychange", this.handleResume);
+			document.removeEventListener("resume", this.handleResume);
+		}
+		if (typeof window !== "undefined") {
+			window.removeEventListener("pageshow", this.handleResume);
+			window.removeEventListener("online", this.handleResume);
+		}
+		this.socket?.close();
 		this.socket = null;
-		if (!socket) return;
-		socket.onmessage = null;
-		socket.onclose = null;
-		try {
-			socket.close();
-		} catch {
-			// best-effort
-		}
 	}
 
-	private scheduleReconnect() {
-		if (this.reconnectTimer !== null) return;
-		if (this.terminated || this.disposed) return;
-		if (this.reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
-			this.emitState("error");
-			return;
-		}
-		this.emitState("reconnecting");
-		// Frozen tabs don't run timers; the visibility listener reconnects on
-		// resume instead of burning the attempt budget on a timer that won't fire.
-		if (typeof document !== "undefined" && document.hidden) return;
+	send(message: TerminalClientMessage) {
+		const socket = this.socket;
+		if (!socket || socket.readyState !== WebSocket.OPEN) return;
+		socket.send(JSON.stringify(message));
+	}
 
-		const delay = Math.min(
-			BASE_RECONNECT_DELAY_MS * 2 ** this.reconnectAttempt,
-			MAX_RECONNECT_DELAY_MS,
+	private async buildUrl(): Promise<string> {
+		const base = getRelayUrl().replace(/^http/, "ws").replace(/\/$/, "");
+		const url = new URL(
+			`${base}/hosts/${this.target.routingKey}/terminal/${encodeURIComponent(
+				this.target.terminalId,
+			)}`,
 		);
-		this.reconnectAttempt += 1;
-		this.reconnectTimer = setTimeout(() => {
-			this.reconnectTimer = null;
-			void this.connect();
-		}, delay);
-	}
-
-	private cancelReconnect() {
-		if (this.reconnectTimer !== null) {
-			clearTimeout(this.reconnectTimer);
-			this.reconnectTimer = null;
-		}
+		url.searchParams.set("workspaceId", this.target.workspaceId);
+		url.searchParams.set("themeType", "dark");
+		// Once xterm holds scrollback, skip the daemon ring-buffer re-dump on
+		// reattach; the in-memory buffer still replays output missed offline.
+		if (this.hasReceivedBytes) url.searchParams.set("replay", "0");
+		return url.toString();
 	}
 
 	private handleResume = () => {
 		if (this.disposed || this.terminated) return;
 		if (typeof document !== "undefined" && document.hidden) return;
-		this.reconnectAttempt = 0;
+		this.failedAttempts = 0;
 		const socket = this.socket;
+		if (!socket) return;
 		if (
-			socket &&
-			(socket.readyState === WebSocket.OPEN ||
-				socket.readyState === WebSocket.CONNECTING)
+			socket.readyState === WebSocket.OPEN ||
+			socket.readyState === WebSocket.CONNECTING
 		) {
 			return;
 		}
-		this.cancelReconnect();
-		void this.connect();
+		this.emitState(this.everAttached ? "reconnecting" : "connecting");
+		// Resets partysocket's retry counter and dials immediately — also the
+		// recovery path after the attempt budget closed the socket.
+		socket.reconnect();
 	};
 
 	private emitState(state: TerminalConnectionState) {

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx
@@ -6,6 +6,8 @@ import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MobileTerminalInput } from "../../../../../components/MobileTerminalInput";
+import { getAuthToken } from "../../../../../trpc/auth-token";
+import { getRelayUrl } from "../../../../../trpc/relay-url";
 import { TerminalConnection } from "./TerminalConnection";
 
 const TERMINAL_THEME: ITheme = {
@@ -143,6 +145,7 @@ export function WebTerminal({
 				},
 				onStateChange: (next) => setState(next),
 			},
+			{ getToken: getAuthToken, relayUrl: getRelayUrl },
 		);
 		connectionRef.current = connection;
 		connection.start();

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,7 +3,8 @@
 	"compilerOptions": {
 		"paths": {
 			"@/*": ["./src/*"]
-		}
+		},
+		"types": ["node", "bun"]
 	},
 	"include": ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
 	"exclude": ["node_modules"]

--- a/bun.lock
+++ b/bun.lock
@@ -639,6 +639,7 @@
         "@superset/shared": "workspace:*",
         "@superset/trpc": "workspace:*",
         "@superset/ui": "workspace:*",
+        "@superset/workspace-client": "workspace:*",
         "@t3-oss/env-nextjs": "0.13.11",
         "@tanstack/react-query": "5.101.1",
         "@tanstack/react-query-devtools": "5.101.1",
@@ -1159,6 +1160,7 @@
         "@tanstack/react-query": "5.101.1",
         "@trpc/client": "11.16.0",
         "@trpc/react-query": "11.16.0",
+        "partysocket": "1.3.0",
         "superjson": "2.2.6",
       },
       "devDependencies": {
@@ -4316,6 +4318,8 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "event-target-polyfill": ["event-target-polyfill@0.0.4", "", {}, "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
@@ -5449,6 +5453,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "partysocket": ["partysocket@1.3.0", "", { "dependencies": { "event-target-polyfill": "^0.0.4" }, "peerDependencies": { "react": ">=17" }, "optionalPeers": ["react"] }, "sha512-1zToNyolZFK/7nuAw/K2bZrNzFqaZyRoCEkS+9vG6WSC5ikrN6qWRe96q6ImU51uptz2r+dAwSkwhJVdQi4LiA=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -670,6 +670,7 @@
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "@tailwindcss/postcss": "4.2.2",
+        "@types/bun": "1.3.14",
         "@types/node": "24.12.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",

--- a/packages/workspace-client/package.json
+++ b/packages/workspace-client/package.json
@@ -7,6 +7,10 @@
 		".": {
 			"types": "./src/index.ts",
 			"default": "./src/index.ts"
+		},
+		"./relay-socket": {
+			"types": "./src/lib/relaySocket/index.ts",
+			"default": "./src/lib/relaySocket/index.ts"
 		}
 	},
 	"scripts": {
@@ -20,6 +24,7 @@
 		"@tanstack/react-query": "5.101.1",
 		"@trpc/client": "11.16.0",
 		"@trpc/react-query": "11.16.0",
+		"partysocket": "1.3.0",
 		"superjson": "2.2.6"
 	},
 	"devDependencies": {

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -16,6 +16,11 @@ export {
 	type RelayAffinityProbe,
 } from "./lib/primeRelayAffinity";
 export {
+	createRelaySocket,
+	type RelaySocket,
+	type RelaySocketOptions,
+} from "./lib/relaySocket";
+export {
 	useWorkspaceClient,
 	useWorkspaceHostUrl,
 	useWorkspaceWsUrl,

--- a/packages/workspace-client/src/lib/eventBus.test.ts
+++ b/packages/workspace-client/src/lib/eventBus.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getEventBus } from "./eventBus";
+
+// Real WS server standing in for a host-service event bus. Records upgrades
+// and client commands; `push` broadcasts a server event to connected clients.
+function makeHostServer() {
+	const upgrades: string[] = [];
+	const commands: Array<Record<string, unknown>> = [];
+	const clients = new Set<Bun.ServerWebSocket<unknown>>();
+	const server = Bun.serve({
+		port: 0,
+		fetch(req, srv) {
+			upgrades.push(new URL(req.url).pathname);
+			if (srv.upgrade(req)) return;
+			return new Response("no", { status: 400 });
+		},
+		websocket: {
+			open(ws) {
+				clients.add(ws);
+			},
+			close(ws) {
+				clients.delete(ws);
+			},
+			message(_ws, data) {
+				commands.push(JSON.parse(String(data)));
+			},
+		},
+	});
+	return {
+		server,
+		upgrades,
+		commands,
+		hostUrl: `http://localhost:${server.port}`,
+		push(payload: object) {
+			for (const ws of clients) ws.send(JSON.stringify(payload));
+		},
+		dropClients() {
+			for (const ws of clients) ws.close();
+		},
+		clientCount: () => clients.size,
+	};
+}
+
+function waitFor(cond: () => boolean, timeoutMs = 4_000): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const start = Date.now();
+		const t = setInterval(() => {
+			if (cond()) {
+				clearInterval(t);
+				resolve();
+			} else if (Date.now() - start > timeoutMs) {
+				clearInterval(t);
+				reject(new Error("waitFor timeout"));
+			}
+		}, 20);
+	});
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	for (const fn of cleanups.splice(0)) fn();
+});
+
+describe("eventBus", () => {
+	it("routes events to listeners by type and workspaceId (exact and wildcard)", async () => {
+		const host = makeHostServer();
+		const bus = getEventBus(host.hostUrl, () => "tok");
+		const exact: string[] = [];
+		const wildcard: string[] = [];
+		const other: string[] = [];
+		cleanups.push(bus.on("git:changed", "ws-1", (id) => exact.push(id)));
+		cleanups.push(bus.on("git:changed", "*", (id) => wildcard.push(id)));
+		cleanups.push(bus.on("git:changed", "ws-2", (id) => other.push(id)));
+		cleanups.push(() => host.server.stop(true));
+
+		await waitFor(() => host.clientCount() === 1);
+		host.push({ type: "git:changed", workspaceId: "ws-1", paths: ["a.ts"] });
+		await waitFor(() => exact.length === 1 && wildcard.length === 1);
+		expect(other.length).toBe(0);
+	});
+
+	it("shares one connection per hostUrl across handles", async () => {
+		const host = makeHostServer();
+		const busA = getEventBus(host.hostUrl, () => "tok");
+		const busB = getEventBus(host.hostUrl, () => "tok");
+		cleanups.push(busA.on("git:changed", "*", () => {}));
+		cleanups.push(busB.on("port:changed", "*", () => {}));
+		cleanups.push(() => host.server.stop(true));
+
+		await waitFor(() => host.clientCount() === 1);
+		// Give a second dial a chance to appear if sharing were broken.
+		await Bun.sleep(150);
+		expect(host.upgrades.length).toBe(1);
+	});
+
+	it("refcounts fs:watch and only unwatches at zero", async () => {
+		const host = makeHostServer();
+		const bus = getEventBus(host.hostUrl, () => "tok");
+		cleanups.push(bus.on("fs:events", "*", () => {}));
+		cleanups.push(() => host.server.stop(true));
+		await waitFor(() => host.clientCount() === 1);
+
+		bus.watchFs("ws-1");
+		bus.watchFs("ws-1"); // second watcher: no duplicate command
+		await waitFor(() => host.commands.length >= 1);
+		await Bun.sleep(100);
+		expect(host.commands).toEqual([{ type: "fs:watch", workspaceId: "ws-1" }]);
+
+		bus.unwatchFs("ws-1"); // still one watcher left: no unwatch yet
+		await Bun.sleep(100);
+		expect(host.commands.length).toBe(1);
+
+		bus.unwatchFs("ws-1");
+		await waitFor(() => host.commands.length === 2);
+		expect(host.commands[1]).toEqual({
+			type: "fs:unwatch",
+			workspaceId: "ws-1",
+		});
+	});
+
+	it("re-sends active fs:watch commands after a reconnect", async () => {
+		const host = makeHostServer();
+		const bus = getEventBus(host.hostUrl, () => "tok");
+		cleanups.push(bus.on("fs:events", "*", () => {}));
+		cleanups.push(() => host.server.stop(true));
+		await waitFor(() => host.clientCount() === 1);
+
+		bus.watchFs("ws-1");
+		await waitFor(() => host.commands.length === 1);
+
+		host.dropClients();
+		// The wrapper reconnects (1s base delay) and the open handler replays
+		// every active watch from state.
+		await waitFor(() => host.commands.length === 2, 8_000);
+		expect(host.commands[1]).toEqual({ type: "fs:watch", workspaceId: "ws-1" });
+	});
+
+	it("closes the connection when the last listener unsubscribes", async () => {
+		const host = makeHostServer();
+		const bus = getEventBus(host.hostUrl, () => "tok");
+		const off = bus.on("git:changed", "*", () => {});
+		cleanups.push(() => host.server.stop(true));
+		await waitFor(() => host.clientCount() === 1);
+
+		off();
+		await waitFor(() => host.clientCount() === 0);
+		// And no zombie reconnect afterwards.
+		await Bun.sleep(1_500);
+		expect(host.clientCount()).toBe(0);
+	});
+});

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -5,7 +5,7 @@ import type {
 } from "@superset/host-service/events";
 import type { AgentIdentity } from "@superset/shared/agent-identity";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
-import { primeRelayAffinity } from "./primeRelayAffinity";
+import { createRelaySocket, type RelaySocket } from "./relaySocket";
 
 export type { AgentIdentity };
 
@@ -98,26 +98,22 @@ const RECONNECT_MAX_MS = 30_000;
 const ACCESS_DENIED_RETRY_MS = 5 * 60_000;
 
 interface ConnectionState {
-	socket: WebSocket | null;
+	socket: RelaySocket;
 	refCount: number;
 	listeners: Set<ListenerEntry>;
 	fsWatchedWorkspaces: Map<string, number>;
-	reconnectAttempts: number;
-	reconnectTimer: ReturnType<typeof setTimeout> | null;
-	disposed: boolean;
 }
 
 const connections = new Map<string, ConnectionState>();
 
-function buildEventBusUrl(hostUrl: string, wsToken: string | null): string {
+function buildEventBusUrl(hostUrl: string): string {
 	const base = hostUrl.replace(/\/$/, "");
 	const wsBase = base.replace(/^http/, "ws");
-	const params = wsToken ? `?token=${encodeURIComponent(wsToken)}` : "";
-	return `${wsBase}/events${params}`;
+	return `${wsBase}/events`;
 }
 
 function sendCommand(state: ConnectionState, message: ClientMessage): void {
-	if (state.socket?.readyState === WebSocket.OPEN) {
+	if (state.socket.readyState === WebSocket.OPEN) {
 		state.socket.send(JSON.stringify(message));
 	}
 }
@@ -207,82 +203,6 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 	}
 }
 
-function connect(
-	state: ConnectionState,
-	hostUrl: string,
-	getWsToken: () => string | null,
-): void {
-	if (state.disposed) return;
-
-	const wsUrl = buildEventBusUrl(hostUrl, getWsToken());
-	// Pre-flight an HTTP request to lock fly's edge affinity to the owning
-	// machine before the WS upgrade. fly-replay isn't transparent to all WS
-	// clients on the upgrade itself, but is on plain HTTP, so a quick GET
-	// avoids the connect → 1006 close → reconnect flicker.
-	void primeRelayAffinity(wsUrl).then((probe) => {
-		if (state.disposed || state.socket) return;
-		if (probe?.status === 403) {
-			scheduleReconnect(state, hostUrl, getWsToken, ACCESS_DENIED_RETRY_MS);
-			return;
-		}
-		let socket: WebSocket;
-		try {
-			socket = new WebSocket(wsUrl);
-		} catch {
-			scheduleReconnect(state, hostUrl, getWsToken);
-			return;
-		}
-		state.socket = socket;
-
-		socket.onopen = () => {
-			state.reconnectAttempts = 0;
-
-			// Re-send all active fs:watch commands
-			for (const workspaceId of state.fsWatchedWorkspaces.keys()) {
-				sendCommand(state, { type: "fs:watch", workspaceId });
-			}
-		};
-
-		socket.onmessage = (event) => {
-			handleMessage(state, event.data);
-		};
-
-		socket.onclose = () => {
-			if (state.disposed) return;
-			state.socket = null;
-			scheduleReconnect(state, hostUrl, getWsToken);
-		};
-
-		socket.onerror = () => {
-			// onclose will fire after onerror
-		};
-	});
-}
-
-function scheduleReconnect(
-	state: ConnectionState,
-	hostUrl: string,
-	getWsToken: () => string | null,
-	fixedDelayMs?: number,
-): void {
-	if (state.disposed || state.reconnectTimer) return;
-
-	const delay =
-		fixedDelayMs ??
-		Math.min(
-			RECONNECT_BASE_MS * 2 ** state.reconnectAttempts,
-			RECONNECT_MAX_MS,
-		);
-	state.reconnectAttempts++;
-
-	state.reconnectTimer = setTimeout(() => {
-		state.reconnectTimer = null;
-		if (!state.disposed) {
-			connect(state, hostUrl, getWsToken);
-		}
-	}, delay);
-}
-
 function getOrCreateConnection(
 	hostUrl: string,
 	getWsToken: () => string | null,
@@ -291,17 +211,41 @@ function getOrCreateConnection(
 	const existing = connections.get(key);
 	if (existing) return existing;
 
+	// createRelaySocket runs the fly-affinity preflight and re-signs the URL
+	// with a fresh token before every attempt; backoff and reconnection live
+	// inside partysocket. Buffering is disabled so command semantics stay
+	// "send only while open" — watches are replayed from state on each open.
+	const socket = createRelaySocket({
+		buildUrl: () => buildEventBusUrl(hostUrl),
+		getToken: getWsToken,
+		accessDeniedRetryMs: ACCESS_DENIED_RETRY_MS,
+		minReconnectionDelay: RECONNECT_BASE_MS,
+		maxReconnectionDelay: RECONNECT_MAX_MS,
+		maxEnqueuedMessages: 0,
+	});
+
 	const state: ConnectionState = {
-		socket: null,
+		socket,
 		refCount: 0,
 		listeners: new Set(),
 		fsWatchedWorkspaces: new Map(),
-		reconnectAttempts: 0,
-		reconnectTimer: null,
-		disposed: false,
 	};
+
+	socket.addEventListener("open", () => {
+		// Re-send all active fs:watch commands
+		for (const workspaceId of state.fsWatchedWorkspaces.keys()) {
+			sendCommand(state, { type: "fs:watch", workspaceId });
+		}
+	});
+	socket.addEventListener("message", (event) => {
+		handleMessage(state, event.data);
+	});
+	socket.addEventListener("error", () => {
+		// partysocket reconnects on its own; suppress the default unhandled-
+		// error console noise when a host bounces offline.
+	});
+
 	connections.set(key, state);
-	connect(state, hostUrl, getWsToken);
 	return state;
 }
 
@@ -312,17 +256,7 @@ function maybeCleanupConnection(hostUrl: string): void {
 
 	if (state.refCount > 0 || state.listeners.size > 0) return;
 
-	state.disposed = true;
-	if (state.reconnectTimer) {
-		clearTimeout(state.reconnectTimer);
-		state.reconnectTimer = null;
-	}
-	if (
-		state.socket?.readyState === WebSocket.CONNECTING ||
-		state.socket?.readyState === WebSocket.OPEN
-	) {
-		state.socket.close(1000, "No more subscribers");
-	}
+	state.socket.close(1000, "No more subscribers");
 	connections.delete(key);
 }
 

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -106,12 +106,6 @@ interface ConnectionState {
 
 const connections = new Map<string, ConnectionState>();
 
-function buildEventBusUrl(hostUrl: string): string {
-	const base = hostUrl.replace(/\/$/, "");
-	const wsBase = base.replace(/^http/, "ws");
-	return `${wsBase}/events`;
-}
-
 function sendCommand(state: ConnectionState, message: ClientMessage): void {
 	if (state.socket.readyState === WebSocket.OPEN) {
 		state.socket.send(JSON.stringify(message));
@@ -216,7 +210,7 @@ function getOrCreateConnection(
 	// inside partysocket. Buffering is disabled so command semantics stay
 	// "send only while open" — watches are replayed from state on each open.
 	const socket = createRelaySocket({
-		buildUrl: () => buildEventBusUrl(hostUrl),
+		buildUrl: () => `${hostUrl.replace(/\/$/, "")}/events`,
 		getToken: getWsToken,
 		accessDeniedRetryMs: ACCESS_DENIED_RETRY_MS,
 		minReconnectionDelay: RECONNECT_BASE_MS,
@@ -239,10 +233,6 @@ function getOrCreateConnection(
 	});
 	socket.addEventListener("message", (event) => {
 		handleMessage(state, event.data);
-	});
-	socket.addEventListener("error", () => {
-		// partysocket reconnects on its own; suppress the default unhandled-
-		// error console noise when a host bounces offline.
 	});
 
 	connections.set(key, state);

--- a/packages/workspace-client/src/lib/relaySocket/index.ts
+++ b/packages/workspace-client/src/lib/relaySocket/index.ts
@@ -1,0 +1,5 @@
+export {
+	createRelaySocket,
+	type RelaySocket,
+	type RelaySocketOptions,
+} from "./relaySocket";

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.test.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createRelaySocket, type RelaySocket } from "./relaySocket";
+
+// Local WS server whose /hosts/:id/_whoowns preflight status is scriptable.
+function makeServer(getWhoownsStatus: () => number) {
+	const tokensSeen: string[] = [];
+	const server = Bun.serve({
+		port: 0,
+		fetch(req, srv) {
+			const url = new URL(req.url);
+			if (url.pathname.endsWith("/_whoowns")) {
+				return new Response(
+					getWhoownsStatus() === 200 ? JSON.stringify({ ok: true }) : "{}",
+					{ status: getWhoownsStatus() },
+				);
+			}
+			tokensSeen.push(url.searchParams.get("token") ?? "");
+			if (srv.upgrade(req)) return;
+			return new Response("no", { status: 400 });
+		},
+		websocket: {
+			open(ws) {
+				ws.send("hello");
+			},
+			message() {},
+		},
+	});
+	return { server, tokensSeen, port: server.port };
+}
+
+const HOST_PATH = "/hosts/org-1:machine-1/events";
+let socket: RelaySocket | null = null;
+
+afterEach(() => {
+	socket?.close();
+	socket = null;
+});
+
+function waitFor(cond: () => boolean, timeoutMs = 3_000): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const start = Date.now();
+		const t = setInterval(() => {
+			if (cond()) {
+				clearInterval(t);
+				resolve();
+			} else if (Date.now() - start > timeoutMs) {
+				clearInterval(t);
+				reject(new Error("waitFor timeout"));
+			}
+		}, 20);
+	});
+}
+
+describe("createRelaySocket", () => {
+	it("signs every attempt with a fresh token", async () => {
+		const { server, tokensSeen, port } = makeServer(() => 200);
+		let tokenVersion = 0;
+		socket = createRelaySocket({
+			buildUrl: () => `ws://localhost:${port}${HOST_PATH}`,
+			getToken: () => `tok-${++tokenVersion}`,
+			minReconnectionDelay: 20,
+			maxReconnectionDelay: 40,
+		});
+		await waitFor(() => tokensSeen.length >= 1);
+		// Force a reconnect; the next dial must carry a NEW token.
+		socket.reconnect();
+		await waitFor(() => tokensSeen.length >= 2);
+		expect(tokensSeen[0]).toBe("tok-1");
+		expect(tokensSeen[1]).not.toBe(tokensSeen[0]);
+		server.stop(true);
+	});
+
+	it("closes permanently and reports on preflight 403", async () => {
+		const { server, tokensSeen, port } = makeServer(() => 403);
+		let denied = 0;
+		socket = createRelaySocket({
+			buildUrl: () => `ws://localhost:${port}${HOST_PATH}`,
+			getToken: () => "tok",
+			onAccessDenied: () => denied++,
+			minReconnectionDelay: 20,
+			maxReconnectionDelay: 40,
+		});
+		await waitFor(() => denied === 1);
+		await Bun.sleep(200);
+		expect(denied).toBe(1); // no retry loop after fatal close
+		expect(tokensSeen.length).toBe(0); // never dialed the WS
+		expect(socket.readyState).toBe(3); // CLOSED
+		server.stop(true);
+	});
+
+	it("keeps re-probing at accessDeniedRetryMs and recovers when access is granted", async () => {
+		let status = 403;
+		const { server, tokensSeen, port } = makeServer(() => status);
+		let denied = 0;
+		socket = createRelaySocket({
+			buildUrl: () => `ws://localhost:${port}${HOST_PATH}`,
+			getToken: () => "tok",
+			onAccessDenied: () => denied++,
+			accessDeniedRetryMs: 50,
+			minReconnectionDelay: 10,
+			maxReconnectionDelay: 20,
+		});
+		await waitFor(() => denied >= 2); // still polling, not closed
+		status = 200; // access granted
+		await waitFor(() => tokensSeen.length >= 1);
+		expect(socket.readyState).toBeLessThanOrEqual(1); // CONNECTING or OPEN
+		server.stop(true);
+	});
+
+	it("dials local (non-/hosts) URLs without a preflight", async () => {
+		const { server, tokensSeen, port } = makeServer(() => 503);
+		socket = createRelaySocket({
+			buildUrl: () => `ws://localhost:${port}/events`,
+			getToken: () => "psk-1",
+			minReconnectionDelay: 20,
+			maxReconnectionDelay: 40,
+		});
+		await waitFor(() => tokensSeen.length >= 1);
+		expect(tokensSeen[0]).toBe("psk-1");
+		server.stop(true);
+	});
+});

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.test.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.test.ts
@@ -107,10 +107,10 @@ describe("createRelaySocket", () => {
 		server.stop(true);
 	});
 
-	it("dials local (non-/hosts) URLs without a preflight", async () => {
+	it("dials local (non-/hosts) URLs without a preflight, converting http to ws", async () => {
 		const { server, tokensSeen, port } = makeServer(() => 503);
 		socket = createRelaySocket({
-			buildUrl: () => `ws://localhost:${port}/events`,
+			buildUrl: () => `http://localhost:${port}/events`,
 			getToken: () => "psk-1",
 			minReconnectionDelay: 20,
 			maxReconnectionDelay: 40,

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
@@ -20,6 +20,8 @@ export interface RelaySocketOptions {
 	maxReconnectionDelay?: number;
 	maxRetries?: number;
 	connectionTimeout?: number;
+	/** Defaults to 0: send() is a no-op unless the socket is open. Opt into
+	 * partysocket's buffer-and-replay only when stale sends are safe. */
 	maxEnqueuedMessages?: number;
 }
 
@@ -70,7 +72,7 @@ export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 		maxReconnectionDelay: opts.maxReconnectionDelay,
 		maxRetries: opts.maxRetries,
 		connectionTimeout: opts.connectionTimeout,
-		maxEnqueuedMessages: opts.maxEnqueuedMessages,
+		maxEnqueuedMessages: opts.maxEnqueuedMessages ?? 0,
 	});
 	return socket;
 }

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
@@ -1,0 +1,73 @@
+import { WebSocket as ReconnectingWebSocket } from "partysocket";
+import { primeRelayAffinity } from "../primeRelayAffinity";
+
+export interface RelaySocketOptions {
+	/** URL for this attempt, WITHOUT the auth token — the wrapper signs it. */
+	buildUrl: () => string | Promise<string>;
+	/** Fresh token per attempt (user JWT for relay hosts, PSK for local). */
+	getToken: () => string | null | Promise<string | null>;
+	/**
+	 * Definitive access denial: the `_whoowns` preflight returned 403 (the
+	 * relay only 403s a verified-valid token, so retrying with a fresher one
+	 * can't change the answer; expired tokens surface as 401 and self-heal via
+	 * `getToken`). Without `accessDeniedRetryMs` the socket closes permanently
+	 * — call `reconnect()` to try again after access changes.
+	 */
+	onAccessDenied?: () => void;
+	/** Keep re-probing at this cadence after a 403 instead of closing. */
+	accessDeniedRetryMs?: number;
+	minReconnectionDelay?: number;
+	maxReconnectionDelay?: number;
+	maxRetries?: number;
+	connectionTimeout?: number;
+	maxEnqueuedMessages?: number;
+}
+
+export type RelaySocket = ReconnectingWebSocket;
+
+function signUrl(url: string, token: string | null): string {
+	if (!token) return url;
+	const u = new URL(url);
+	u.searchParams.set("token", token);
+	return u.toString();
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Reconnecting WebSocket for host-service endpoints (direct or relay-fronted).
+ * partysocket evaluates the async URL provider before EVERY attempt, so each
+ * dial carries a fresh token — the class of bug where a reconnect loop reuses
+ * a URL signed with an hourly-rotated JWT (PR #5628) can't recur here. The
+ * provider also runs the `_whoowns` preflight (fly edge affinity + the only
+ * place a browser client can observe the upgrade's real HTTP status).
+ */
+export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
+	let socket: ReconnectingWebSocket | null = null;
+
+	const provider = async (): Promise<string> => {
+		const url = signUrl(await opts.buildUrl(), await opts.getToken());
+		const probe = await primeRelayAffinity(url);
+		if (probe?.status === 403) {
+			opts.onAccessDenied?.();
+			if (opts.accessDeniedRetryMs == null) {
+				socket?.close(1000, "relay access denied");
+			} else {
+				await sleep(opts.accessDeniedRetryMs);
+			}
+			// Rejecting aborts this attempt; partysocket surfaces it as an error
+			// event and re-enters its backoff loop (no-op once close() was called).
+			throw new Error("relay access denied");
+		}
+		return url;
+	};
+
+	socket = new ReconnectingWebSocket(provider, [], {
+		minReconnectionDelay: opts.minReconnectionDelay,
+		maxReconnectionDelay: opts.maxReconnectionDelay,
+		maxRetries: opts.maxRetries,
+		connectionTimeout: opts.connectionTimeout,
+		maxEnqueuedMessages: opts.maxEnqueuedMessages,
+	});
+	return socket;
+}

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
@@ -25,10 +25,13 @@ export interface RelaySocketOptions {
 
 export type RelaySocket = ReconnectingWebSocket;
 
+// Accepts http(s) host URLs and converts to ws(s), so consumers can pass
+// their host URL straight through without scheme juggling.
 function signUrl(url: string, token: string | null): string {
-	if (!token) return url;
 	const u = new URL(url);
-	u.searchParams.set("token", token);
+	if (u.protocol === "http:") u.protocol = "ws:";
+	if (u.protocol === "https:") u.protocol = "wss:";
+	if (token) u.searchParams.set("token", token);
 	return u.toString();
 }
 

--- a/plans/done/20260712-partysocket-ws-consolidation.md
+++ b/plans/done/20260712-partysocket-ws-consolidation.md
@@ -43,8 +43,29 @@ One `createRelaySocket(opts)` (~150 lines) wrapping partysocket's generic export
 
 ## Outcome (2026-07-12)
 
-Phases 1–3 shipped in one PR (SUPER-1469). Spike result: a rejecting async url
-provider surfaces as an error event and re-enters partysocket's backoff loop —
-verified against source (`ws.js` `_connect` catch) and empirically. Phase 4
-(desktop terminal transport) deferred as designed; revisit when that transport
-needs touching anyway.
+Phases 1–3 shipped in PR #5637 (SUPER-1469). Spike result: a rejecting async
+url provider surfaces as an error event and re-enters partysocket's backoff
+loop — verified against source (`ws.js` `_connect` catch) and empirically.
+Phase 4 (desktop terminal transport) deferred as designed; revisit when that
+transport needs touching anyway.
+
+### Verification record (details in PR #5637 comments)
+
+- **Tests**: 17 across wrapper / eventBus (first-ever suite) / web
+  TerminalConnection (DI'd `getToken`/`relayUrl` for testability). The
+  fresh-token-redial test fails if #5628's stale-URL bug is reintroduced
+  (mutation-verified).
+- **Perf bench**: partysocket's per-message clone+dispatch costs ~0.56µs/frame
+  (574k → 434k frames/sec on 512B binary frames) — noise at real terminal
+  rates; desktop hot path unmigrated.
+- **Live E2E (CDP)**: desktop eventBus connects; web terminal attached over a
+  local relay + tunnel, echoed output, and survived a mid-session relay
+  restart — preflight probed 5× (503, no WS dials) then 200 → reattach with
+  scrollback, ~15s, zero user action.
+- **Stress, branch vs revert** (150 conns, 15k-event flood, 3× flap): parity
+  on throughput/delivery/herd-size/cleanup. Deltas: +0.35ms per connect,
+  ~+5KB heap per connection, and backoff escalates under sub-5s flapping
+  (resets after 5s uptime — verified) — deliberate relay protection.
+- **Net behavior gains**: web terminals get fly-affinity preflight (blind
+  dials were the SUPER-1157 symptom surface), definitive 403s cost zero WS
+  dials (was 12 blind attempts), hung connects recover in 4s (was unbounded).

--- a/plans/done/20260712-partysocket-ws-consolidation.md
+++ b/plans/done/20260712-partysocket-ws-consolidation.md
@@ -40,3 +40,11 @@ One `createRelaySocket(opts)` (~150 lines) wrapping partysocket's generic export
 - React Native: cloudflare/partykit#401 (Hermes lacks `MessageEvent`) — check before any apps/mobile use.
 - Relay semantics (post-#5628): 401 = expired/invalid JWT (retry with fresh token), 403 = definitive access denial (stop/slow-poll). The wrapper must never treat 401 as fatal.
 - New WS consumers should use the wrapper from day one.
+
+## Outcome (2026-07-12)
+
+Phases 1–3 shipped in one PR (SUPER-1469). Spike result: a rejecting async url
+provider surfaces as an error event and re-enters partysocket's backoff loop —
+verified against source (`ws.js` `_connect` catch) and empirically. Phase 4
+(desktop terminal transport) deferred as designed; revisit when that transport
+needs touching anyway.


### PR DESCRIPTION
**Links**
- Ticket: SUPER-1469
- Design doc: `plans/done/20260712-partysocket-ws-consolidation.md` (moved to done in this PR)
- Motivating incident: #5628

## Summary
- Adds `createRelaySocket` in `@superset/workspace-client`: a ~75-line wrapper over partysocket's generic reconnecting WebSocket. It re-signs the URL with a fresh token and runs the `_whoowns` preflight before **every** attempt, treats a preflight 403 as a definitive denial (permanent close + `onAccessDenied`, or slow-poll via `accessDeniedRetryMs`), and disables buffering so send semantics stay "only while open".
- Migrates the two simplest hand-rolled reconnect loops onto it with **zero consumer changes**: the eventBus (desktop host events) and web's `WebTerminal/TerminalConnection`.
- The desktop terminal transport is deferred by design (its sleep/wake watchdog, coalescer, and socket-identity logic don't map onto partysocket's silent socket swapping) — rationale in the design doc.

## Why / Context
The stale-token reconnect-loop bug (#5628, ~25 users/day) existed because three transports each hand-roll backoff + token freshness and drift independently. partysocket's async URL provider — evaluated before every dial — makes that bug class structurally impossible for anything built on the wrapper. Research/selection rationale in the design doc; partysocket is the maintained reconnecting-websocket fork (Cloudflare/PartyKit, 1.3.0 June 2026).

## How It Works
- The preflight lives inside partysocket's async `url` provider. **Spike result** (was the design doc's blocking question): a rejecting provider surfaces as an `error` event and re-enters partysocket's backoff loop — verified in partysocket's source (`_connect`'s catch → `_handleError` → `_connect`) and empirically against a live server.
- eventBus: `connect`/`scheduleReconnect`/`disposed` machinery deleted; partysocket owns reconnection. fs:watch replay still happens on each `open`. 403 → 5-min slow poll (unchanged semantics from #5628).
- Web terminal: keeps the 12-attempt budget (own counter → "error" state, since partysocket's maxRetries exhausts silently), visibility/pageshow/online resume via `reconnect()` (also the recovery path after budget exhaustion), `replay=0` suppression, and fatal exit/error handling. New behavior: web terminals now also get the fly-affinity preflight and fatal-403 handling.
- Web imports via a new `@superset/workspace-client/relay-socket` subpath export so the React/tRPC barrel stays out of web's graph.

## Manual QA / Verification done
- Wrapper unit tests (real WS server + scriptable `_whoowns`): fresh token per attempt, fatal 403 (no dial, single denial callback, CLOSED), 403 slow-poll then recovery when access granted, local URLs skip preflight. Fatal-close test mutation-verified.
- Live dev desktop (CDP): signed in, sidebar/workspaces load, local `/events` socket **opens through the wrapper** (Network.webSocketCreated handshake confirmed), and unreachable relay hosts retry with backoff without console errors (the two React setState warnings present trace to `DockBadgeController` — pre-existing, unrelated).
- Not tested live: a real relay-fronted eventBus 403 (needs a second-user setup; covered by the wrapper unit tests and by #5628's relay-side E2E), and web terminal against production relay (typecheck + identical control-flow mapping; worth a spot check on preview).

## Testing
- `bun test packages/workspace-client apps/web` (17 pass): wrapper behavior (fresh token per attempt, fatal 403, 403 slow-poll recovery, http→ws conversion), eventBus's first-ever regression suite (listener routing, per-host connection sharing, fs:watch refcounting, watch replay after reconnect, last-listener cleanup), and TerminalConnection (dial shape, binary/control delivery, fresh-token + replay=0 redial, permanent stop on exit). The fresh-token redial test fails if #5628's stale-URL bug is reintroduced (mutation-verified).
- TerminalConnection now takes `getToken`/`relayUrl` as constructor deps (WebTerminal injects the real ones) so it's unit-testable without web's env/posthog module graph.
- `bun run lint`, `bunx turbo typecheck --filter=@superset/desktop --filter=@superset/web --filter=@superset/workspace-client`
- Desktop renderer lib suite: only the 10 pre-existing font-test failures (identical on clean main)

## Known Limitations
- Desktop terminal transport still hand-rolled (deferred; see design doc phase 4).
- partysocket's `connectionTimeout` (4s default) now applies to both migrated transports — previously unbounded browser default; strictly tighter.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5637">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized reconnecting WebSocket clients on `partysocket` via `createRelaySocket` that refreshes tokens, preflights on every attempt, converts http→ws, and handles 403s. Migrated the event bus and web terminal; added regression tests, addressing SUPER-1469.

- **Refactors**
  - Added `createRelaySocket` in `@superset/workspace-client`: fresh token per dial, `_whoowns` preflight on each attempt, 403 → permanent close or slow‑poll via `accessDeniedRetryMs`, http(s)→ws(s) conversion, and unbuffered sends by default (`maxEnqueuedMessages=0`).
  - Moved event bus and `WebTerminal/TerminalConnection` to the wrapper: event bus replays `fs:watch` on open and closes when the last listener unsubscribes; terminal injects `getToken`/`relayUrl`, keeps the 12‑attempt budget and resumes via `reconnect()`, sets `replay=0` after first bytes, and stops on `exit`/`error`.
  - Recorded the verification outcome in `plans/done/20260712-partysocket-ws-consolidation.md`.

- **Dependencies**
  - Added `partysocket@1.3.0`; new export `@superset/workspace-client/relay-socket`; `apps/web` adds `@superset/workspace-client` and dev `@types/bun` (tsconfig includes `bun`).

<sup>Written for commit 7005f11c5c87f0b84729ec7c5b1fd38028c99bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reconnecting relay-socket transport with refreshed authentication for terminal streaming and workspace event delivery.
  * Added public exports for relay-socket creation and related types in the workspace-client package (including a new `./relay-socket` entry).
* **Bug Fixes**
  * Improved reconnect handling across tab visibility and ensured permanent stop on definitive access denial; prevented retry loops after terminal exit.
* **Tests**
  * Added Bun coverage for relay probing/reconnect, terminal reconnect/exit behavior, and event-bus routing + fs watch refcounting.
* **Chores**
  * Updated workspace-client dependencies/exports and improved web TypeScript environment typings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
