### PR TITLE
feat(discord-triage): mirror Discord artifacts and enhance tickets with Claude Sonnet

### DIFF
--- a/apps/discord-triage/README.md
+++ b/apps/discord-triage/README.md
@@ -2,10 +2,13 @@
 
 Gateway bot that auto-ingests Discord support messages into Linear Triage. Every new top-level message in a watched text channel (and every new post in a watched forum channel) becomes a Linear issue labeled `Source: Discord`; the bot opens a thread on the message with a link to the issue. Thread replies are not synced (future work).
 
+After filing, an async enhancement pass mirrors message attachments to Linear uploads (Discord CDN URLs expire) and — when `ANTHROPIC_API_KEY` is set — has Claude Sonnet rewrite the ticket into the standard format (improved title, Context, Artifacts, References, original report preserved as a quote). Screenshots are passed to the model as vision input. Enhancement failures leave the raw issue untouched.
+
 ## Env
 
 | Var | Value |
 |---|---|
+| `ANTHROPIC_API_KEY` | Enables Claude Sonnet ticket summarization/enhancement; skipped when unset |
 | `DISCORD_BOT_TOKEN` | Bot token from the Discord developer portal |
 | `DISCORD_CHANNEL_IDS` | Comma-separated channel IDs to watch |
 | `LINEAR_API_KEY` | Linear personal API key |

--- a/apps/discord-triage/package.json
+++ b/apps/discord-triage/package.json
@@ -10,6 +10,7 @@
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {
+		"@anthropic-ai/sdk": "0.78.0",
 		"@linear/sdk": "68.1.1",
 		"@t3-oss/env-core": "0.13.11",
 		"discord.js": "14.26.4",

--- a/apps/discord-triage/src/enhance.ts
+++ b/apps/discord-triage/src/enhance.ts
@@ -26,9 +26,15 @@ type Artifact = {
 	contentType: string;
 	url: string;
 	isImage: boolean;
+	mirrored: boolean;
 	visionData?: string;
 	textContent?: string;
 };
+
+// Filenames are user-controlled; escape markdown link-label characters.
+export function mdEscape(name: string): string {
+	return name.replace(/[\\[\]]/g, "\\$&");
+}
 
 function isVisionType(
 	contentType: string,
@@ -64,10 +70,13 @@ async function mirrorAttachment(
 		contentType,
 		url: attachment.url,
 		isImage: isVisionType(contentType),
+		mirrored: false,
 	};
 	if (attachment.size > MAX_UPLOAD_BYTES) return artifact;
 	try {
-		const res = await fetch(attachment.url);
+		const res = await fetch(attachment.url, {
+			signal: AbortSignal.timeout(15_000),
+		});
 		if (!res.ok) return artifact;
 		const bytes = Buffer.from(await res.arrayBuffer());
 		if (artifact.isImage && bytes.byteLength <= MAX_VISION_BYTES) {
@@ -88,8 +97,12 @@ async function mirrorAttachment(
 			method: "PUT",
 			headers,
 			body: bytes,
+			signal: AbortSignal.timeout(30_000),
 		});
-		if (put.ok) artifact.url = upload.assetUrl;
+		if (put.ok) {
+			artifact.url = upload.assetUrl;
+			artifact.mirrored = true;
+		}
 	} catch (err) {
 		console.error(`failed to mirror attachment ${attachment.name}`, err);
 	}
@@ -120,8 +133,16 @@ async function summarize(
 	artifacts: Artifact[],
 ): Promise<Summary | undefined> {
 	if (!anthropic) return undefined;
+	// Aggregate cap: the API rejects requests over ~32MB; stop adding images
+	// once the combined base64 payload gets large.
+	let visionBudget = 20 * 1024 * 1024;
 	const images = artifacts.filter(
-		(a): a is Artifact & { visionData: string } => a.visionData !== undefined,
+		(a): a is Artifact & { visionData: string } => {
+			if (a.visionData === undefined || a.visionData.length > visionBudget)
+				return false;
+			visionBudget -= a.visionData.length;
+			return true;
+		},
 	);
 	const textFiles = artifacts.filter(
 		(a): a is Artifact & { textContent: string } => a.textContent !== undefined,
@@ -170,7 +191,12 @@ async function summarize(
 	});
 	const text = response.content.find((b) => b.type === "text")?.text;
 	if (!text) return undefined;
-	return JSON.parse(text) as Summary;
+	const parsed = JSON.parse(text) as Summary;
+	// Schema can't enforce string length; clamp so a runaway title can't degrade the ticket.
+	return {
+		title: parsed.title.replace(/\s+/g, " ").trim().slice(0, 120),
+		context: parsed.context,
+	};
 }
 
 export type EnhanceOptions = {
@@ -181,6 +207,8 @@ export type EnhanceOptions = {
 	authorTag: string;
 	messageUrl: string;
 	attachments: Attachment[];
+	/** Description written at filing time; skip the rewrite if a human edited since. */
+	initialDescription: string;
 };
 
 // Post-filing pass: mirror Discord attachments into the ticket and rewrite
@@ -196,15 +224,17 @@ export async function enhanceIssue(
 		console.error(`summarization failed for issue ${opts.issueId}`, err);
 		return undefined;
 	});
-	if (!summary && artifacts.length === 0) return;
+	// Nothing improved (no summary, no re-hosted file) — leave the raw issue alone.
+	if (!summary && !artifacts.some((a) => a.mirrored)) return;
 
 	const sections = [`## Context\n${summary?.context ?? opts.content}`.trim()];
 	if (artifacts.length > 0) {
 		sections.push(
 			`## Artifacts\n${artifacts
-				.map((a) =>
-					a.isImage ? `![${a.name}](${a.url})` : `[${a.name}](${a.url})`,
-				)
+				.map((a) => {
+					const label = mdEscape(a.name);
+					return a.isImage ? `![${label}](${a.url})` : `[${label}](${a.url})`;
+				})
 				.join("\n")}`,
 		);
 	}
@@ -221,6 +251,14 @@ export async function enhanceIssue(
 		sections.push(
 			`## Original report\n> ${opts.content.split("\n").join("\n> ")}`,
 		);
+	}
+	// Don't clobber edits made while mirroring/summarizing was in flight.
+	const current = await linear.issue(opts.issueId);
+	if ((current.description ?? "") !== opts.initialDescription) {
+		console.log(
+			`skipping enhance for ${opts.issueId}: description edited since filing`,
+		);
+		return;
 	}
 	await linear.updateIssue(opts.issueId, {
 		...(summary ? { title: summary.title } : {}),

--- a/apps/discord-triage/src/enhance.ts
+++ b/apps/discord-triage/src/enhance.ts
@@ -1,0 +1,232 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { LinearClient } from "@linear/sdk";
+import type { Attachment } from "discord.js";
+import { env } from "./env";
+
+const anthropic = env.ANTHROPIC_API_KEY
+	? new Anthropic({ apiKey: env.ANTHROPIC_API_KEY })
+	: undefined;
+
+const ENHANCE_MODEL = "claude-sonnet-5";
+
+const VISION_TYPES = new Set<Anthropic.Base64ImageSource["media_type"]>([
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+]);
+// Claude image blocks cap at ~5MB; Linear uploads at 50MB.
+const MAX_VISION_BYTES = 5 * 1024 * 1024;
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+// Cap per-file text fed to the model (logs/code); the full file is still linked.
+const MAX_TEXT_CHARS = 20_000;
+
+type Artifact = {
+	name: string;
+	contentType: string;
+	url: string;
+	isImage: boolean;
+	visionData?: string;
+	textContent?: string;
+};
+
+function isVisionType(
+	contentType: string,
+): contentType is Anthropic.Base64ImageSource["media_type"] {
+	return VISION_TYPES.has(
+		contentType as Anthropic.Base64ImageSource["media_type"],
+	);
+}
+
+// Code/log/config attachments — including the message.txt Discord auto-attaches
+// for long posts — whose content should be read into the summarization.
+function isTextType(contentType: string, name: string): boolean {
+	const base = contentType.split(";")[0]?.trim() ?? "";
+	if (base.startsWith("text/")) return true;
+	if (
+		["application/json", "application/xml", "application/x-yaml"].includes(base)
+	)
+		return true;
+	return /\.(log|txt|json|ya?ml|toml|md|ts|tsx|js|jsx|py|sh|sql|css|html|patch|diff)$/i.test(
+		name,
+	);
+}
+
+// Discord CDN URLs expire, so re-host each attachment as a Linear upload.
+// Falls back to the (expiring) Discord URL when mirroring fails.
+async function mirrorAttachment(
+	linear: LinearClient,
+	attachment: Attachment,
+): Promise<Artifact> {
+	const contentType = attachment.contentType ?? "application/octet-stream";
+	const artifact: Artifact = {
+		name: attachment.name,
+		contentType,
+		url: attachment.url,
+		isImage: isVisionType(contentType),
+	};
+	if (attachment.size > MAX_UPLOAD_BYTES) return artifact;
+	try {
+		const res = await fetch(attachment.url);
+		if (!res.ok) return artifact;
+		const bytes = Buffer.from(await res.arrayBuffer());
+		if (artifact.isImage && bytes.byteLength <= MAX_VISION_BYTES) {
+			artifact.visionData = bytes.toString("base64");
+		} else if (isTextType(contentType, attachment.name)) {
+			artifact.textContent = bytes.toString("utf-8").slice(0, MAX_TEXT_CHARS);
+		}
+		const payload = await linear.fileUpload(
+			contentType,
+			attachment.name,
+			bytes.byteLength,
+		);
+		const upload = payload.uploadFile;
+		if (!upload) return artifact;
+		const headers = new Headers({ "Content-Type": contentType });
+		for (const h of upload.headers ?? []) headers.set(h.key, h.value);
+		const put = await fetch(upload.uploadUrl, {
+			method: "PUT",
+			headers,
+			body: bytes,
+		});
+		if (put.ok) artifact.url = upload.assetUrl;
+	} catch (err) {
+		console.error(`failed to mirror attachment ${attachment.name}`, err);
+	}
+	return artifact;
+}
+
+type Summary = { title: string; context: string };
+
+const SUMMARY_SCHEMA = {
+	type: "object",
+	properties: {
+		title: {
+			type: "string",
+			description: "Ticket title: specific and concrete, max 80 characters",
+		},
+		context: {
+			type: "string",
+			description:
+				"2-4 sentences: what's broken or wanted and why. Outcome-focused, not solution-focused. Markdown allowed.",
+		},
+	},
+	required: ["title", "context"],
+	additionalProperties: false,
+};
+
+async function summarize(
+	report: EnhanceOptions,
+	artifacts: Artifact[],
+): Promise<Summary | undefined> {
+	if (!anthropic) return undefined;
+	const images = artifacts.filter(
+		(a): a is Artifact & { visionData: string } => a.visionData !== undefined,
+	);
+	const textFiles = artifacts.filter(
+		(a): a is Artifact & { textContent: string } => a.textContent !== undefined,
+	);
+	const content: Anthropic.ContentBlockParam[] = [
+		{
+			type: "text",
+			text: [
+				`A user posted this report in the Superset Discord #${report.channelName} channel:`,
+				"",
+				`Title: ${report.title}`,
+				`Report: ${report.content || "(no text — see attached files)"}`,
+				...textFiles.flatMap((a) => [
+					"",
+					`Attached file \`${a.name}\`${a.textContent.length >= MAX_TEXT_CHARS ? " (truncated)" : ""}:`,
+					"```",
+					a.textContent,
+					"```",
+				]),
+				"",
+				`Write an improved ticket title and Context section for the Linear ticket. Use only details present in the report${images.length > 0 || textFiles.length > 0 ? " and the attached files/screenshots" : ""}; never invent repro steps, versions, or behavior that isn't shown.`,
+			].join("\n"),
+		},
+		...images.map(
+			(a): Anthropic.ImageBlockParam => ({
+				type: "image",
+				source: {
+					type: "base64",
+					media_type:
+						a.contentType as Anthropic.Base64ImageSource["media_type"],
+					data: a.visionData,
+				},
+			}),
+		),
+	];
+	const response = await anthropic.messages.create({
+		model: ENHANCE_MODEL,
+		// Adaptive thinking shares this budget; leave headroom so JSON never truncates.
+		max_tokens: 4096,
+		system:
+			"You groom raw Discord support reports into clear, well-scoped Linear tickets for the Superset desktop/web app team. Stay faithful to the report.",
+		messages: [{ role: "user", content }],
+		output_config: {
+			format: { type: "json_schema", schema: SUMMARY_SCHEMA },
+		},
+	});
+	const text = response.content.find((b) => b.type === "text")?.text;
+	if (!text) return undefined;
+	return JSON.parse(text) as Summary;
+}
+
+export type EnhanceOptions = {
+	issueId: string;
+	channelName: string;
+	title: string;
+	content: string;
+	authorTag: string;
+	messageUrl: string;
+	attachments: Attachment[];
+};
+
+// Post-filing pass: mirror Discord attachments into the ticket and rewrite
+// title/description with Claude. Failures leave the raw issue untouched.
+export async function enhanceIssue(
+	linear: LinearClient,
+	opts: EnhanceOptions,
+): Promise<void> {
+	const artifacts = await Promise.all(
+		opts.attachments.map((a) => mirrorAttachment(linear, a)),
+	);
+	const summary = await summarize(opts, artifacts).catch((err) => {
+		console.error(`summarization failed for issue ${opts.issueId}`, err);
+		return undefined;
+	});
+	if (!summary && artifacts.length === 0) return;
+
+	const sections = [`## Context\n${summary?.context ?? opts.content}`.trim()];
+	if (artifacts.length > 0) {
+		sections.push(
+			`## Artifacts\n${artifacts
+				.map((a) =>
+					a.isImage ? `![${a.name}](${a.url})` : `[${a.name}](${a.url})`,
+				)
+				.join("\n")}`,
+		);
+	}
+	const date = new Date().toISOString().slice(0, 10);
+	sections.push(
+		[
+			"## References",
+			"| Source | Who | Link | Date |",
+			"|--------|-----|------|------|",
+			`| Discord #${opts.channelName} | ${opts.authorTag} | [message](${opts.messageUrl}) | ${date} |`,
+		].join("\n"),
+	);
+	if (summary && opts.content) {
+		sections.push(
+			`## Original report\n> ${opts.content.split("\n").join("\n> ")}`,
+		);
+	}
+	await linear.updateIssue(opts.issueId, {
+		...(summary ? { title: summary.title } : {}),
+		description: sections.join("\n\n"),
+	});
+	console.log(
+		`enhanced issue ${opts.issueId} (${artifacts.length} artifact(s), summarized: ${Boolean(summary)})`,
+	);
+}

--- a/apps/discord-triage/src/env.ts
+++ b/apps/discord-triage/src/env.ts
@@ -14,6 +14,8 @@ export const env = createEnv({
 					.map((s) => s.trim())
 					.filter(Boolean),
 			),
+		/** Enables Claude summarization/enhancement of tickets; skipped when unset. */
+		ANTHROPIC_API_KEY: z.string().min(1).optional(),
 		LINEAR_API_KEY: z.string().min(1),
 		LINEAR_TEAM_KEY: z.string().min(1).default("SUPER"),
 		/** Label applied to every ingested issue. Must exist on the team. */

--- a/apps/discord-triage/src/index.ts
+++ b/apps/discord-triage/src/index.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 import { LinearClient } from "@linear/sdk";
 import {
+	type Attachment,
 	ChannelType,
 	Client,
 	Events,
@@ -8,6 +9,7 @@ import {
 	type Message,
 	type ThreadChannel,
 } from "discord.js";
+import { enhanceIssue } from "./enhance";
 import { env } from "./env";
 
 const linear = new LinearClient({ apiKey: env.LINEAR_API_KEY });
@@ -49,17 +51,23 @@ async function fileIssue(opts: {
 	content: string;
 	authorTag: string;
 	messageUrl: string;
-}): Promise<{ identifier: string; url: string } | undefined> {
+	attachments: Attachment[];
+}): Promise<{ id: string; identifier: string; url: string } | undefined> {
+	// Discord URLs expire; the enhancement pass re-hosts these on Linear.
+	const attachmentList =
+		opts.attachments.length > 0
+			? `\n\nAttachments:\n${opts.attachments.map((a) => `- [${a.name}](${a.url})`).join("\n")}`
+			: "";
 	// No stateId: API-created issues default into Triage.
 	const payload = await linear.createIssue({
 		teamId,
 		title: opts.title,
-		description: `${opts.content}\n\n---\nReported by **${opts.authorTag}** in Discord: ${opts.messageUrl}`,
+		description: `${opts.content}${attachmentList}\n\n---\nReported by **${opts.authorTag}** in Discord: ${opts.messageUrl}`,
 		labelIds: sourceLabelId ? [sourceLabelId] : undefined,
 	});
 	const issue = await payload.issue;
 	if (!issue) return undefined;
-	return { identifier: issue.identifier, url: issue.url };
+	return { id: issue.id, identifier: issue.identifier, url: issue.url };
 }
 
 const discord = new Client({
@@ -71,19 +79,36 @@ const discord = new Client({
 });
 
 async function handleChannelMessage(message: Message) {
+	const attachments = [...message.attachments.values()];
+	const title = issueTitle(
+		message.content,
+		`Discord report from ${message.author.tag}`,
+	);
 	const issue = await fileIssue({
-		title: issueTitle(
-			message.content,
-			`Discord report from ${message.author.tag}`,
-		),
+		title,
 		content: message.content,
 		authorTag: message.author.tag,
 		messageUrl: message.url,
+		attachments,
 	});
 	if (!issue) return;
 	const thread = await message.startThread({ name: issue.identifier });
 	await thread.send(
 		`Filed to Linear Triage as [${issue.identifier}](${issue.url})`,
+	);
+	enhanceIssue(linear, {
+		issueId: issue.id,
+		channelName:
+			"name" in message.channel && message.channel.name
+				? message.channel.name
+				: "support",
+		title,
+		content: message.content,
+		authorTag: message.author.tag,
+		messageUrl: message.url,
+		attachments,
+	}).catch((err) =>
+		console.error(`enhance failed for ${issue.identifier}`, err),
 	);
 }
 
@@ -91,15 +116,31 @@ async function handleChannelMessage(message: Message) {
 async function handleForumPost(thread: ThreadChannel) {
 	const starter = await thread.fetchStarterMessage().catch(() => null);
 	const content = starter?.content ?? "";
+	const attachments = starter ? [...starter.attachments.values()] : [];
+	const title = thread.name || issueTitle(content, "Discord forum post");
+	const authorTag = starter?.author.tag ?? "unknown";
+	const messageUrl = starter?.url ?? thread.url;
 	const issue = await fileIssue({
-		title: thread.name || issueTitle(content, "Discord forum post"),
+		title,
 		content,
-		authorTag: starter?.author.tag ?? "unknown",
-		messageUrl: starter?.url ?? thread.url,
+		authorTag,
+		messageUrl,
+		attachments,
 	});
 	if (!issue) return;
 	await thread.send(
 		`Filed to Linear Triage as [${issue.identifier}](${issue.url})`,
+	);
+	enhanceIssue(linear, {
+		issueId: issue.id,
+		channelName: thread.parent?.name ?? "forum",
+		title,
+		content,
+		authorTag,
+		messageUrl,
+		attachments,
+	}).catch((err) =>
+		console.error(`enhance failed for ${issue.identifier}`, err),
 	);
 }
 

--- a/apps/discord-triage/src/index.ts
+++ b/apps/discord-triage/src/index.ts
@@ -9,7 +9,7 @@ import {
 	type Message,
 	type ThreadChannel,
 } from "discord.js";
-import { enhanceIssue } from "./enhance";
+import { enhanceIssue, mdEscape } from "./enhance";
 import { env } from "./env";
 
 const linear = new LinearClient({ apiKey: env.LINEAR_API_KEY });
@@ -52,22 +52,31 @@ async function fileIssue(opts: {
 	authorTag: string;
 	messageUrl: string;
 	attachments: Attachment[];
-}): Promise<{ id: string; identifier: string; url: string } | undefined> {
+}): Promise<
+	| { id: string; identifier: string; url: string; description: string }
+	| undefined
+> {
 	// Discord URLs expire; the enhancement pass re-hosts these on Linear.
 	const attachmentList =
 		opts.attachments.length > 0
-			? `\n\nAttachments:\n${opts.attachments.map((a) => `- [${a.name}](${a.url})`).join("\n")}`
+			? `\n\nAttachments:\n${opts.attachments.map((a) => `- [${mdEscape(a.name)}](${a.url})`).join("\n")}`
 			: "";
+	const description = `${opts.content}${attachmentList}\n\n---\nReported by **${opts.authorTag}** in Discord: ${opts.messageUrl}`;
 	// No stateId: API-created issues default into Triage.
 	const payload = await linear.createIssue({
 		teamId,
 		title: opts.title,
-		description: `${opts.content}${attachmentList}\n\n---\nReported by **${opts.authorTag}** in Discord: ${opts.messageUrl}`,
+		description,
 		labelIds: sourceLabelId ? [sourceLabelId] : undefined,
 	});
 	const issue = await payload.issue;
 	if (!issue) return undefined;
-	return { id: issue.id, identifier: issue.identifier, url: issue.url };
+	return {
+		id: issue.id,
+		identifier: issue.identifier,
+		url: issue.url,
+		description,
+	};
 }
 
 const discord = new Client({
@@ -107,6 +116,7 @@ async function handleChannelMessage(message: Message) {
 		authorTag: message.author.tag,
 		messageUrl: message.url,
 		attachments,
+		initialDescription: issue.description,
 	}).catch((err) =>
 		console.error(`enhance failed for ${issue.identifier}`, err),
 	);
@@ -114,7 +124,11 @@ async function handleChannelMessage(message: Message) {
 
 // Forum posts arrive as new threads; the starter message may lag thread creation.
 async function handleForumPost(thread: ThreadChannel) {
-	const starter = await thread.fetchStarterMessage().catch(() => null);
+	let starter = await thread.fetchStarterMessage().catch(() => null);
+	for (let i = 0; !starter && i < 3; i++) {
+		await new Promise((r) => setTimeout(r, 2000));
+		starter = await thread.fetchStarterMessage().catch(() => null);
+	}
 	const content = starter?.content ?? "";
 	const attachments = starter ? [...starter.attachments.values()] : [];
 	const title = thread.name || issueTitle(content, "Discord forum post");
@@ -139,6 +153,7 @@ async function handleForumPost(thread: ThreadChannel) {
 		authorTag,
 		messageUrl,
 		attachments,
+		initialDescription: issue.description,
 	}).catch((err) =>
 		console.error(`enhance failed for ${issue.identifier}`, err),
 	);

--- a/bun.lock
+++ b/bun.lock
@@ -360,6 +360,7 @@
       "name": "@superset/discord-triage",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "0.78.0",
         "@linear/sdk": "68.1.1",
         "@t3-oss/env-core": "0.13.11",
         "discord.js": "14.26.4",


### PR DESCRIPTION
## Summary
- Discord reports now carry their artifacts into Linear: message attachments are re-hosted as Linear uploads (Discord CDN URLs expire after ~24h), with images embedded inline and other files linked.
- A `claude-sonnet-5` pass rewrites each filed ticket into the repo's standard format (improved title + `Context` / `Artifacts` / `References` / `Original report`), reading screenshots as vision input and log/code attachments (incl. Discord's auto `message.txt` for long posts) as text.
- Filing stays fast and safe: enhancement runs async after the thread reply, and any failure (download, upload, API error) leaves the raw issue untouched.

## Why / Context
Tickets ingested from Discord were raw message text only — screenshots and log files never made it into Linear, and titles/descriptions were unstructured. This made Triage grooming manual and lossy (Discord attachment links also expire).

## How It Works
- `src/enhance.ts` — post-filing pass called from both the text-channel and forum-post handlers:
  1. `mirrorAttachment`: downloads each attachment, re-uploads via Linear `fileUpload` (falls back to the Discord URL on failure); captures base64 for images ≤5MB and text content (≤20k chars) for log/code files.
  2. `summarize`: `claude-sonnet-5` with structured output (`output_config` json_schema → `{title, context}`); prompt forbids inventing details. Skipped when `ANTHROPIC_API_KEY` is unset.
  3. `updateIssue`: rewrites title + description; original report preserved as a quote; the Discord message link stays in the References table so the existing issue-close → archive-thread webhook keeps working.
- Initial `fileIssue` description now lists attachment links immediately, so nothing is lost if enhancement fails.

## Manual QA (live e2e in Discord #dev, SUPER-1476)
- [x] Ran the bot locally against `#🦾dev` (prod ignores unwatched channels — no double-filing) and posted a real report with a screenshot + `host-service-error.log`
- [x] Issue filed into Triage with `Discord` label; thread reply posted
- [x] Enhanced description written with Context/Artifacts/References structure; screenshot renders inline in Linear
- [x] Issue canceled → prod webhook posted resolution in the thread and archived it (new description format is autoclose-compatible)
- [x] Both credential failures below degraded gracefully (raw issue intact, bot kept running)
- [x] Claude summarization verified live (SUPER-1477): `claude-sonnet-5` synthesized title + Context from the log attachment and screenshot; both artifacts mirrored to `uploads.linear.app` with the new full-scope Linear key

## Testing
- `bun run typecheck` (apps/discord-triage)
- `bun run lint`

## Deploy prerequisites — done
- ✅ Full-write-scope `LINEAR_API_KEY` (`discord-triage-bot-full`) set on Fly — `fileUpload` verified working (the original key 403'd on it)
- ✅ Valid `ANTHROPIC_API_KEY` set on Fly
- Ship by running `bun run deploy` from `apps/discord-triage` after merge

## Rollback
- Enhancement is additive and fail-safe; to disable summarization only, unset `ANTHROPIC_API_KEY`. Full rollback = redeploy previous image.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5638">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirrors Discord attachments to Linear and auto-structures new tickets with `claude-sonnet-5` to improve triage and avoid expired links. Runs async and fails safe with new timeouts and edit-detection; addresses SUPER-1476.

- **New Features**
  - Re-hosts message attachments as Linear uploads; images embed inline, other files are linked.
  - Reads screenshots and log/code into `claude-sonnet-5` to rewrite title and description into Context / Artifacts / References, preserving the original report.
  - Skips summarization when `ANTHROPIC_API_KEY` is unset; any download/upload/API error leaves the raw issue unchanged.
  - Hardened enhancement: timeouts on downloads/uploads, capped vision payload, no-op when nothing changed or the issue was edited, forum-starter fetch retry, clamped model titles, and markdown-escaped filenames.

- **Migration**
  - Use a `LINEAR_API_KEY` with write scope to enable `fileUpload`; without it, artifact mirroring falls back to Discord URLs.
  - Set `ANTHROPIC_API_KEY` to enable summarization; unset to disable.

<sup>Written for commit 5780f885f8e71a6c1e158f7296fdda659bc02e15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord tickets now include attached files and images in the created Linear issue.
  * Attachments are mirrored to improve reliability of access, and supported content is included for better ticket context.
  * When enabled, ticket enhancement can rewrite issues into a clearer format with structured Context, Artifacts, References, and an optional Original report section.
  * If enhancement isn’t available or can’t produce results, the ticket is left unchanged.
* **Documentation**
  * Updated setup docs to describe configuring the Claude enhancement toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
