### PR TITLE
feat(desktop): animate update pill countdown border and pixel-dissolve exit

### DIFF
--- a/apps/desktop/src/renderer/components/UpdatesPill/CountdownBorder.tsx
+++ b/apps/desktop/src/renderer/components/UpdatesPill/CountdownBorder.tsx
@@ -52,7 +52,7 @@ export function CountdownBorder({
 					strokeLinecap="round"
 					pathLength={100}
 					strokeDasharray={100}
-					className="stroke-emerald-500/60"
+					className="stroke-emerald-500/35"
 					style={{
 						x: STROKE_WIDTH / 2,
 						y: STROKE_WIDTH / 2,

--- a/apps/desktop/src/renderer/components/UpdatesPill/CountdownBorder.tsx
+++ b/apps/desktop/src/renderer/components/UpdatesPill/CountdownBorder.tsx
@@ -1,0 +1,67 @@
+import { cn } from "@superset/ui/utils";
+import { useLayoutEffect, useRef, useState } from "react";
+
+const STROKE_WIDTH = 1.5;
+
+interface CountdownBorderProps {
+	/** How long the line takes to wrap all the way around, in ms */
+	durationMs: number;
+	/**
+	 * Corner radius matching the host element. "pill" measures the host and
+	 * uses half its height — SVG clamps rx against width and ry against
+	 * height separately, so an oversized rx would go elliptical instead of
+	 * matching a rounded-full border.
+	 */
+	radius: number | "pill";
+	className?: string;
+}
+
+/**
+ * A line that progressively traces the host element's border, signalling
+ * how long until the element goes away. Host must be `position: relative`.
+ */
+export function CountdownBorder({
+	durationMs,
+	radius,
+	className,
+}: CountdownBorderProps) {
+	const svgRef = useRef<SVGSVGElement>(null);
+	const [measuredRadius, setMeasuredRadius] = useState<number | null>(null);
+
+	useLayoutEffect(() => {
+		if (radius !== "pill" || !svgRef.current) return;
+		setMeasuredRadius((svgRef.current.clientHeight - STROKE_WIDTH) / 2);
+	}, [radius]);
+
+	const cornerRadius = radius === "pill" ? measuredRadius : radius;
+
+	return (
+		<svg
+			ref={svgRef}
+			aria-hidden="true"
+			className={cn(
+				"pointer-events-none absolute inset-0 size-full",
+				className,
+			)}
+		>
+			{cornerRadius !== null && (
+				<rect
+					rx={cornerRadius}
+					fill="none"
+					strokeWidth={STROKE_WIDTH}
+					strokeLinecap="round"
+					pathLength={100}
+					strokeDasharray={100}
+					className="stroke-emerald-500/60"
+					style={{
+						x: STROKE_WIDTH / 2,
+						y: STROKE_WIDTH / 2,
+						width: `calc(100% - ${STROKE_WIDTH}px)`,
+						height: `calc(100% - ${STROKE_WIDTH}px)`,
+						animation: `countdown-border-trace ${durationMs}ms linear both`,
+					}}
+				/>
+			)}
+		</svg>
+	);
+}

--- a/apps/desktop/src/renderer/components/UpdatesPill/UpdatesPill.tsx
+++ b/apps/desktop/src/renderer/components/UpdatesPill/UpdatesPill.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { LuCircleArrowUp, LuCircleCheck } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { AUTO_UPDATE_STATUS } from "shared/auto-update";
+import { CountdownBorder } from "./CountdownBorder";
 import { DownloadRing } from "./DownloadRing";
 import { useAutoUpdateStatus } from "./useAutoUpdateStatus";
 
@@ -14,6 +15,8 @@ const BAR_WINDOW = 2;
 const FRAME_INTERVAL_MS = 80;
 /** How long the post-update "✓ vX.Y.Z" confirmation shows before hiding */
 const CONFIRM_MS = 5000;
+/** Duration of the pixel-dissolve exit once the confirmation expires */
+const EXIT_MS = 450;
 
 function useAsciiFrame(active: boolean): number {
 	const [frame, setFrame] = useState(0);
@@ -63,6 +66,7 @@ export function UpdatesPill({ isCollapsed = false }: UpdatesPillProps) {
 	const event = useAutoUpdateStatus();
 	const [isInstalling, setIsInstalling] = useState(false);
 	const [confirmationDone, setConfirmationDone] = useState(false);
+	const [isLeaving, setIsLeaving] = useState(false);
 	const installMutation = electronTrpc.autoUpdate.install.useMutation();
 	const checkMutation = electronTrpc.autoUpdate.check.useMutation();
 	const frame = useAsciiFrame(isInstalling);
@@ -80,16 +84,27 @@ export function UpdatesPill({ isCollapsed = false }: UpdatesPillProps) {
 	}, [status, installMutation.isError]);
 
 	// The post-update confirmation ("✓ vX.Y.Z" after relaunching on a new
-	// version) hides itself after a beat, even if the status lingers.
+	// version) hides itself after a beat, even if the status lingers: a line
+	// traces the border while the clock runs, then the pill pixel-dissolves.
 	useEffect(() => {
 		if (status === AUTO_UPDATE_STATUS.UPDATED) {
+			setIsLeaving(false);
 			setConfirmationDone(false);
-			const timeout = setTimeout(() => setConfirmationDone(true), CONFIRM_MS);
-			return () => clearTimeout(timeout);
+			const leaveTimeout = setTimeout(() => setIsLeaving(true), CONFIRM_MS);
+			const doneTimeout = setTimeout(
+				() => setConfirmationDone(true),
+				CONFIRM_MS + EXIT_MS,
+			);
+			return () => {
+				clearTimeout(leaveTimeout);
+				clearTimeout(doneTimeout);
+			};
 		}
+		setIsLeaving(false);
 	}, [status]);
 
 	const isUpdated = status === AUTO_UPDATE_STATUS.UPDATED && !confirmationDone;
+	const isDissolving = isUpdated && isLeaving;
 
 	if (
 		status !== AUTO_UPDATE_STATUS.DOWNLOADING &&
@@ -137,13 +152,21 @@ export function UpdatesPill({ isCollapsed = false }: UpdatesPillProps) {
 						aria-disabled={isBusy}
 						aria-label={tooltip}
 						className={cn(
-							"flex size-8 items-center justify-center rounded-md",
+							"relative flex size-8 items-center justify-center rounded-md",
 							"animate-in fade-in duration-300",
 							isBusy
 								? "cursor-default text-muted-foreground"
 								: "hover:bg-accent/50",
 						)}
+						style={
+							isDissolving
+								? { animation: `pill-pixel-out ${EXIT_MS}ms steps(3) both` }
+								: undefined
+						}
 					>
+						{isUpdated && (
+							<CountdownBorder durationMs={CONFIRM_MS} radius={5} />
+						)}
 						{isDownloading ? (
 							<DownloadRing percent={percent} className="size-3.5" />
 						) : isInstalling ? (
@@ -181,7 +204,7 @@ export function UpdatesPill({ isCollapsed = false }: UpdatesPillProps) {
 					onClick={handleClick}
 					aria-disabled={isBusy}
 					className={cn(
-						"inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1",
+						"relative inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1",
 						"font-mono text-[10px] tabular-nums leading-none",
 						"ring-1 ring-inset animate-in fade-in slide-in-from-bottom-1 duration-300",
 						isBusy && "cursor-default",
@@ -195,7 +218,15 @@ export function UpdatesPill({ isCollapsed = false }: UpdatesPillProps) {
 						isError &&
 							"bg-destructive/10 ring-destructive/25 text-destructive hover:bg-destructive/20",
 					)}
+					style={
+						isDissolving
+							? { animation: `pill-pixel-out ${EXIT_MS}ms steps(3) both` }
+							: undefined
+					}
 				>
+					{isUpdated && (
+						<CountdownBorder durationMs={CONFIRM_MS} radius="pill" />
+					)}
 					{isInstalling ? (
 						<>
 							<span className="w-3 text-center text-xs leading-none">

--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -308,6 +308,47 @@
 		}
 	}
 
+	/* UpdatesPill: countdown line tracing the border while the confirmation runs out */
+	@keyframes countdown-border-trace {
+		from {
+			stroke-dashoffset: 100;
+		}
+		to {
+			stroke-dashoffset: 0;
+		}
+	}
+
+	/* UpdatesPill: retro pixel-dissolve when the confirmation expires — a
+	   checkerboard mask flips on and coarsens in discrete steps (mask-image
+	   animates discretely, swapping at segment midpoints) until the pill
+	   crumbles away */
+	@keyframes pill-pixel-out {
+		0% {
+			opacity: 1;
+			mask-image: none;
+		}
+		30% {
+			opacity: 1;
+			mask-image: repeating-conic-gradient(#000 0% 25%, transparent 0% 50%);
+			mask-size: 3px 3px;
+		}
+		55% {
+			opacity: 0.9;
+			mask-image: repeating-conic-gradient(transparent 0% 25%, #000 0% 50%);
+			mask-size: 5px 5px;
+		}
+		80% {
+			opacity: 0.75;
+			mask-image: repeating-conic-gradient(#000 0% 25%, transparent 0% 50%);
+			mask-size: 8px 8px;
+		}
+		100% {
+			opacity: 0;
+			mask-image: repeating-conic-gradient(#000 0% 25%, transparent 0% 50%);
+			mask-size: 12px 12px;
+		}
+	}
+
 	/* Tiptap chat input placeholder */
 	.tiptap-chat-input p.is-editor-empty:first-child::before {
 		content: attr(data-placeholder);


### PR DESCRIPTION
## Summary
- The post-update "✓ vX.Y.Z" confirmation pill now signals that it's about to hide: a soft emerald line traces around the pill's border over the 5s confirmation window, then the pill exits with a retro pixel-dissolve instead of vanishing abruptly.
- Applies to both the expanded sidebar-footer pill and the collapsed icon-button variant.

## Why / Context
The confirmation pill unmounted with no exit transition and no hint of how long it would stick around — it just blinked out after 5 seconds. Follow-up to #5629.

## How It Works
- **`CountdownBorder.tsx`** (new, next to `DownloadRing.tsx`): an absolutely-positioned SVG rect whose stroke draws itself around the host's border over `durationMs`, using `pathLength={100}` normalization and a `stroke-dashoffset` animation (same technique as the existing `check-draw` checkmark). For the rounded-full pill it accepts `radius="pill"` and measures its own height to derive the true corner radius — SVG clamps `rx` against width and `ry` against height independently, so a hardcoded oversized `rx` would render elliptical corners that don't follow the border.
- **`pill-pixel-out`** keyframes in `globals.css`: a checkerboard `mask-image` (`repeating-conic-gradient` trick) flips on and coarsens through discrete 3px → 5px → 8px → 12px stages while opacity steps down, so the pill crumbles away over 450ms. `mask-image` animates discretely (swaps at segment midpoints), which is what produces the pixelated feel.
- `UpdatesPill` now has an `isLeaving` state: at `CONFIRM_MS` the dissolve starts, and unmount is deferred to `CONFIRM_MS + EXIT_MS` so the animation completes. The leaving state resets whenever the status moves off `UPDATED`.

## Manual QA Checklist
- [ ] After an update relaunch, the "✓ vX.Y.Z" pill shows a border line wrapping fully around over ~5s, hugging the rounded corners
- [ ] At the 5s mark the pill pixel-dissolves (~450ms) instead of blinking out
- [ ] Collapsed sidebar: the check icon-button shows the same countdown border (rounded-md corners) and dissolve
- [ ] Download → ready → install states unchanged
- [ ] No console errors in renderer DevTools

## Testing
- `bun run lint` (clean)
- `bunx tsc --noEmit` — no errors in the touched files (pre-existing `routeTree.gen` errors in this worktree are unrelated)
- Not yet eyeballed in a live post-update relaunch; the dissolve tuning (`mask-size` stops, `EXIT_MS`) may want a taste pass

## Known Limitations
- `CountdownBorder` measures once on mount; the pill's height is fixed by design so no resize handling is needed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5640">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a visual countdown and a pixel-dissolve exit to the post-update confirmation pill so users see when it will hide. Applies to both the expanded pill and the collapsed icon button.

- **New Features**
  - New countdown border that traces around the pill over 5s (supports true pill corners via measured radius).
  - Pixel-dissolve exit (450ms) with deferred unmount; added leaving state to time the transition.
  - Download/ready/install behaviors unchanged.

<sup>Written for commit 88c12334d803387c76f7897d0c1254d60f7871e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a countdown border animation to the update confirmation pill.
  * Added a pixel-dissolve animation when the confirmation pill disappears.
  * Animations are supported in both collapsed and expanded pill views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->