### PR TITLE
feat(desktop,web): native-fidelity terminal wheel scrolling — take 2 (custom xterm handler + kitty identity)

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -658,9 +658,9 @@ describe("env", () => {
 		});
 
 		describe("terminal metadata", () => {
-			it("should set TERM_PROGRAM to vscode", () => {
+			it("should set TERM_PROGRAM to kitty", () => {
 				const result = buildTerminalEnv(baseParams);
-				expect(result.TERM_PROGRAM).toBe("vscode");
+				expect(result.TERM_PROGRAM).toBe("kitty");
 			});
 
 			it("should set COLORTERM to truecolor", () => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -1,3 +1,4 @@
+import { installTerminalWheelEventHandler } from "@superset/shared/terminal-wheel-handler";
 import { FitAddon } from "@xterm/addon-fit";
 import type { ProgressAddon } from "@xterm/addon-progress";
 import type { SearchAddon } from "@xterm/addon-search";
@@ -233,6 +234,7 @@ export function createRuntime(
 	terminal.open(wrapper);
 
 	installTerminalKeyEventHandler(terminal);
+	installTerminalWheelEventHandler(terminal);
 
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -1,3 +1,7 @@
+import {
+	getCellDimensions,
+	installTerminalWheelEventHandler,
+} from "@superset/shared/terminal-wheel-handler";
 import { toast } from "@superset/ui/sonner";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
@@ -159,6 +163,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	});
 
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
+	const uninstallWheelHandler = installTerminalWheelEventHandler(xterm);
 
 	const linkManager = new TerminalLinkManager(xterm);
 	linkManager.setHandlers({
@@ -224,6 +229,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 			disposed = true;
 			cancelAnimationFrame(rafId);
 			cleanupQuerySuppression();
+			uninstallWheelHandler();
 			linkManager.dispose();
 			try {
 				webglAddon?.dispose();
@@ -311,28 +317,15 @@ function getTerminalCoordsFromEvent(
 	const x = event.clientX - rect.left;
 	const y = event.clientY - rect.top;
 
-	// Note: xterm.js does not expose a public API for mouse-to-coords conversion,
-	// so we must access internal _core._renderService.dimensions. This is fragile
-	// and may break in future xterm.js versions.
-	const dimensions = (
-		xterm as unknown as {
-			_core?: {
-				_renderService?: {
-					dimensions?: { css: { cell: { width: number; height: number } } };
-				};
-			};
-		}
-	)._core?._renderService?.dimensions;
-	if (!dimensions?.css?.cell) return null;
-
-	const cellWidth = dimensions.css.cell.width;
-	const cellHeight = dimensions.css.cell.height;
-
-	if (cellWidth <= 0 || cellHeight <= 0) return null;
+	const cell = getCellDimensions(xterm);
+	if (!cell) return null;
 
 	// Clamp to valid terminal grid range to prevent excessive delta calculations
-	const col = Math.max(0, Math.min(xterm.cols - 1, Math.floor(x / cellWidth)));
-	const row = Math.max(0, Math.min(xterm.rows - 1, Math.floor(y / cellHeight)));
+	const col = Math.max(0, Math.min(xterm.cols - 1, Math.floor(x / cell.width)));
+	const row = Math.max(
+		0,
+		Math.min(xterm.rows - 1, Math.floor(y / cell.height)),
+	);
 
 	return { col, row };
 }

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/WebTerminal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { installTerminalWheelEventHandler } from "@superset/shared/terminal-wheel-handler";
 import { FitAddon } from "@xterm/addon-fit";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal } from "@xterm/xterm";
@@ -81,6 +82,10 @@ export function WebTerminal({
 		const fitAddon = new FitAddon();
 		terminal.loadAddon(fitAddon);
 		terminal.open(container);
+		// PTYs identify as TERM_PROGRAM=kitty (host-service env), which tells
+		// TUIs to expect a native-fidelity wheel report stream — this handler
+		// provides it. See @superset/shared/terminal-wheel-handler.
+		installTerminalWheelEventHandler(terminal);
 		if (window.matchMedia("(pointer: coarse)").matches) {
 			const xtermInput = terminal.textarea;
 			if (xtermInput) {

--- a/bun.lock
+++ b/bun.lock
@@ -1039,6 +1039,7 @@
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "@types/friendly-words": "1.2.2",
+        "@xterm/xterm": "6.1.0-beta.220",
         "bun-types": "1.3.14",
         "typescript": "6.0.3",
       },

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -419,8 +419,8 @@ describe("buildV2TerminalEnv", () => {
 		const env = buildV2TerminalEnv(baseParams);
 		expect(env).toMatchObject({
 			TERM: "xterm-256color",
-			TERM_PROGRAM: "vscode",
-			TERM_PROGRAM_VERSION: "1.128.0",
+			TERM_PROGRAM: "kitty",
+			TERM_PROGRAM_VERSION: "0.42.0",
 			COLORTERM: "truecolor",
 			PWD: "/tmp/workspace",
 			SUPERSET_TERMINAL_ID: "term-1",
@@ -431,7 +431,7 @@ describe("buildV2TerminalEnv", () => {
 			SUPERSET_AGENT_HOOK_PORT: "51741",
 			SUPERSET_AGENT_HOOK_VERSION: "2",
 		});
-		expect(env.TERM_PROGRAM).toBe("vscode");
+		expect(env.TERM_PROGRAM).toBe("kitty");
 		expect(env.SHELL).toBe("/bin/zsh");
 		expect(env.LANG).toContain("UTF-8");
 	});

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -172,10 +172,11 @@ export function buildV2TerminalEnv(
 
 	env.TERM = "xterm-256color";
 	env.SHELL = shell;
-	// See TERMINAL_TERM_PROGRAM for why we identify as vscode. The previous
-	// "kitty" claim made claude-code suppress its wheel-scroll compensation and
-	// transcript scrolling crawled at ~1/3 speed. Shift+Enter does NOT depend
-	// on this: line-edit-translations.ts sends ESC+CR directly.
+	// See TERMINAL_TERM_PROGRAM for why we identify as kitty: the client's
+	// full-fidelity wheel handler produces a native-grade report stream that
+	// TUIs must trust as-is, not amplify with vscode-style compensation.
+	// Shift+Enter does NOT depend on this: line-edit-translations.ts sends
+	// ESC+CR directly.
 	env.TERM_PROGRAM = TERMINAL_TERM_PROGRAM;
 	env.TERM_PROGRAM_VERSION = TERMINAL_TERM_PROGRAM_VERSION;
 	env.COLORTERM = "truecolor";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,10 @@
 			"types": "./src/constants.ts",
 			"default": "./src/constants.ts"
 		},
+		"./terminal-wheel-handler": {
+			"types": "./src/terminal-wheel-handler/index.ts",
+			"default": "./src/terminal-wheel-handler/index.ts"
+		},
 		"./dev-credentials": {
 			"types": "./src/dev-credentials.ts",
 			"default": "./src/dev-credentials.ts"
@@ -155,6 +159,7 @@
 	"devDependencies": {
 		"@superset/typescript": "workspace:*",
 		"@types/friendly-words": "1.2.2",
+		"@xterm/xterm": "6.1.0-beta.220",
 		"bun-types": "1.3.14",
 		"typescript": "6.0.3"
 	}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -108,13 +108,18 @@ export const FEATURE_FLAGS = {
 	RELAY_URL_OVERRIDE: "relay-url-override",
 } as const;
 
-// Terminal identity presented to shell programs via TERM_PROGRAM. vscode, not
-// kitty: agent TUIs (claude-code especially) tune wheel-scroll compensation
-// and terminal quirks per TERM_PROGRAM, and the vscode assumptions match our
-// xterm.js terminals — notably that they send ~one throttled scroll event per
-// wheel notch, so TUIs apply their own scroll multiplier. Kitty *keyboard
-// protocol* support is advertised separately via the CSI-u capability probe.
-export const TERMINAL_TERM_PROGRAM = "vscode";
-// A plausible VS Code version: TUIs version-gate quirk handling against real
-// VS Code releases, so keep this roughly current when touching terminal code.
-export const TERMINAL_TERM_PROGRAM_VERSION = "1.128.0";
+// Terminal identity presented to shell programs via TERM_PROGRAM. kitty:
+// agent TUIs (claude-code especially) tune wheel-scroll compensation per
+// TERM_PROGRAM, and our terminals install the full-fidelity wheel handler
+// (@superset/shared/terminal-wheel-handler) that produces a native
+// kitty/iTerm-grade report stream. Under kitty-class identities TUIs trust
+// that stream as-is; a vscode identity would make claude-code amplify each
+// report (its compensation for xterm.js's damped stock stream) and
+// over-scroll ~3x. The identity and the wheel handler must ship together —
+// reverting one without the other reintroduces slow or runaway scrolling.
+// Kitty *keyboard protocol* support is advertised separately via the CSI-u
+// capability probe.
+export const TERMINAL_TERM_PROGRAM = "kitty";
+// A plausible kitty version: TUIs may version-gate quirk handling against
+// real kitty releases, so keep this roughly current when touching terminal code.
+export const TERMINAL_TERM_PROGRAM_VERSION = "0.42.0";

--- a/packages/shared/src/terminal-wheel-handler/cell-dimensions.ts
+++ b/packages/shared/src/terminal-wheel-handler/cell-dimensions.ts
@@ -1,0 +1,32 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+export interface CellDimensions {
+	width: number;
+	height: number;
+}
+
+/**
+ * Read the rendered cell size in CSS pixels.
+ *
+ * xterm.js does not expose a public API for cell dimensions, so this reads
+ * internal _core._renderService.dimensions. Returns null when the renderer
+ * has not measured yet (terminal not opened / hidden) or if the internal
+ * shape changes in a future xterm.js version.
+ */
+export function getCellDimensions(xterm: XTerm): CellDimensions | null {
+	const dimensions = (
+		xterm as unknown as {
+			_core?: {
+				_renderService?: {
+					dimensions?: { css: { cell: { width: number; height: number } } };
+				};
+			};
+		}
+	)._core?._renderService?.dimensions;
+	if (!dimensions?.css?.cell) return null;
+
+	const { width, height } = dimensions.css.cell;
+	if (width <= 0 || height <= 0) return null;
+
+	return { width, height };
+}

--- a/packages/shared/src/terminal-wheel-handler/index.ts
+++ b/packages/shared/src/terminal-wheel-handler/index.ts
@@ -1,0 +1,13 @@
+export { type CellDimensions, getCellDimensions } from "./cell-dimensions";
+export {
+	buildArrowSequence,
+	buildSgrWheelReport,
+	consumeWheelLines,
+	createSgrMouseModeTracker,
+	createTerminalWheelEventHandler,
+	createWheelLineState,
+	installTerminalWheelEventHandler,
+	type WheelLineContext,
+	type WheelLineInput,
+	type WheelLineState,
+} from "./terminal-wheel-handler";

--- a/packages/shared/src/terminal-wheel-handler/terminal-identity-coupling.test.ts
+++ b/packages/shared/src/terminal-wheel-handler/terminal-identity-coupling.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { TERMINAL_TERM_PROGRAM } from "../constants";
+
+// Identities claude-code (and other agent TUIs) treat as "the terminal
+// delivers full-fidelity wheel reports natively — trust the stream as-is,
+// do not amplify". This is claude's kitty-class detection set.
+const KITTY_CLASS_IDENTITIES = [
+	"kitty",
+	"ghostty",
+	"iTerm.app",
+	"WezTerm",
+	"WarpTerminal",
+];
+
+describe("terminal identity ↔ wheel handler coupling", () => {
+	// This test is deliberately colocated with the wheel handler: the two
+	// halves must never diverge, and each fails differently when they do.
+	//
+	// - TERM_PROGRAM reverted to "vscode" while this handler ships → TUIs
+	//   amplify an already full-rate report stream → ~3x over-scroll.
+	// - Handler removed while TERM_PROGRAM stays kitty-class → TUIs trust a
+	//   damped stock stream → scrolling crawls at ~30% (the pre-#5563 bug).
+	//
+	// If you are changing TERMINAL_TERM_PROGRAM: either keep it kitty-class,
+	// or remove/adjust the wheel handler in the same PR and delete this test
+	// with a written rationale. Context: PRs #5563, #5639, #5641 and
+	// plans/20260709-term-program-vscode-migration.md.
+	it("TERM_PROGRAM claims a kitty-class terminal while the full-fidelity wheel handler ships", () => {
+		expect(KITTY_CLASS_IDENTITIES).toContain(TERMINAL_TERM_PROGRAM);
+	});
+});

--- a/packages/shared/src/terminal-wheel-handler/terminal-wheel-handler.test.ts
+++ b/packages/shared/src/terminal-wheel-handler/terminal-wheel-handler.test.ts
@@ -1,0 +1,306 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import {
+	buildArrowSequence,
+	buildSgrWheelReport,
+	consumeWheelLines,
+	createTerminalWheelEventHandler,
+	createWheelLineState,
+	type WheelLineContext,
+} from "./terminal-wheel-handler";
+
+const DOM_DELTA_PIXEL = 0;
+const DOM_DELTA_LINE = 1;
+const DOM_DELTA_PAGE = 2;
+
+function makeContext(
+	overrides: Partial<WheelLineContext> = {},
+): WheelLineContext {
+	return {
+		cellHeight: 17,
+		rows: 40,
+		scrollSensitivity: 1,
+		fastScrollSensitivity: 5,
+		contextKey: "alternate:any:false",
+		...overrides,
+	};
+}
+
+function pixelEvent(deltaY: number) {
+	return { deltaY, deltaMode: DOM_DELTA_PIXEL, altKey: false, ctrlKey: false };
+}
+
+describe("consumeWheelLines", () => {
+	it("maps one cell height of pixels to one line without damping", () => {
+		const state = createWheelLineState();
+		expect(consumeWheelLines(state, pixelEvent(17), makeContext())).toBe(1);
+	});
+
+	it("accumulates fractional deltas across events instead of dropping them", () => {
+		// Three trackpad ticks of 6px against a 17px cell: stock xterm (with its
+		// 0.3x damping) would need ~10 ticks per line; we need three.
+		const state = createWheelLineState();
+		const context = makeContext();
+		expect(consumeWheelLines(state, pixelEvent(6), context)).toBe(0);
+		expect(consumeWheelLines(state, pixelEvent(6), context)).toBe(0);
+		expect(consumeWheelLines(state, pixelEvent(6), context)).toBe(1);
+	});
+
+	it("preserves the remainder after emitting whole lines", () => {
+		const state = createWheelLineState();
+		const context = makeContext();
+		expect(consumeWheelLines(state, pixelEvent(25), context)).toBe(1);
+		// 25/17 = 1.47 → remainder 0.47; another 9px (0.53) crosses the line.
+		expect(consumeWheelLines(state, pixelEvent(9), context)).toBe(1);
+	});
+
+	it("emits multiple lines for a single large event (flick momentum)", () => {
+		const state = createWheelLineState();
+		expect(consumeWheelLines(state, pixelEvent(170), makeContext())).toBe(10);
+	});
+
+	it("handles scrolling up with negative deltas", () => {
+		const state = createWheelLineState();
+		const context = makeContext();
+		expect(consumeWheelLines(state, pixelEvent(-34), context)).toBe(-2);
+	});
+
+	it("lets opposite-direction residue cancel naturally", () => {
+		const state = createWheelLineState();
+		const context = makeContext();
+		consumeWheelLines(state, pixelEvent(9), context); // +0.53 pending
+		expect(consumeWheelLines(state, pixelEvent(-9), context)).toBe(0);
+		expect(state.partialLines).toBeCloseTo(0);
+	});
+
+	it("resets the accumulator when the context changes", () => {
+		const state = createWheelLineState();
+		consumeWheelLines(state, pixelEvent(16), makeContext()); // 0.94 pending
+		const lines = consumeWheelLines(
+			state,
+			pixelEvent(2),
+			makeContext({ contextKey: "alternate:none:false" }),
+		);
+		// Without the reset the stale 0.94 would fire a phantom line.
+		expect(lines).toBe(0);
+	});
+
+	it("treats DOM_DELTA_LINE deltas as lines directly", () => {
+		const state = createWheelLineState();
+		expect(
+			consumeWheelLines(
+				state,
+				{ deltaY: 3, deltaMode: DOM_DELTA_LINE, altKey: false, ctrlKey: false },
+				makeContext(),
+			),
+		).toBe(3);
+	});
+
+	it("treats DOM_DELTA_PAGE deltas as pages of rows", () => {
+		const state = createWheelLineState();
+		expect(
+			consumeWheelLines(
+				state,
+				{ deltaY: 1, deltaMode: DOM_DELTA_PAGE, altKey: false, ctrlKey: false },
+				makeContext({ rows: 24 }),
+			),
+		).toBe(24);
+	});
+
+	it("applies fast-scroll sensitivity when alt or ctrl is held", () => {
+		const state = createWheelLineState();
+		expect(
+			consumeWheelLines(
+				state,
+				{
+					deltaY: 17,
+					deltaMode: DOM_DELTA_PIXEL,
+					altKey: true,
+					ctrlKey: false,
+				},
+				makeContext(),
+			),
+		).toBe(5);
+	});
+
+	it("caps a single event at one page of lines", () => {
+		const state = createWheelLineState();
+		expect(
+			consumeWheelLines(state, pixelEvent(100_000), makeContext({ rows: 40 })),
+		).toBe(40);
+		expect(state.partialLines).toBe(0);
+	});
+});
+
+describe("sequence builders", () => {
+	it("builds SGR wheel reports with direction and modifiers", () => {
+		const noMods = { altKey: false, ctrlKey: false };
+		expect(buildSgrWheelReport(-10, 5, 7, noMods)).toBe("\x1b[<64;5;7M");
+		expect(buildSgrWheelReport(10, 5, 7, noMods)).toBe("\x1b[<65;5;7M");
+		expect(buildSgrWheelReport(10, 1, 1, { altKey: true, ctrlKey: true })).toBe(
+			"\x1b[<89;1;1M",
+		);
+	});
+
+	it("builds cursor sequences honoring application cursor keys mode", () => {
+		expect(buildArrowSequence(-1, false)).toBe("\x1b[A");
+		expect(buildArrowSequence(1, false)).toBe("\x1b[B");
+		expect(buildArrowSequence(-1, true)).toBe("\x1bOA");
+		expect(buildArrowSequence(1, true)).toBe("\x1bOB");
+	});
+});
+
+interface FakeTerminalOptions {
+	bufferType?: "normal" | "alternate";
+	mouseTrackingMode?: "none" | "x10" | "vt200" | "drag" | "any";
+	applicationCursorKeysMode?: boolean;
+	cellHeight?: number;
+}
+
+function makeFakeTerminal(options: FakeTerminalOptions = {}) {
+	const input = mock((_data: string, _userInput?: boolean) => {});
+	const terminal = {
+		input,
+		cols: 80,
+		rows: 40,
+		options: { scrollSensitivity: 1, fastScrollSensitivity: 5 },
+		buffer: { active: { type: options.bufferType ?? "alternate" } },
+		modes: {
+			mouseTrackingMode: options.mouseTrackingMode ?? "none",
+			applicationCursorKeysMode: options.applicationCursorKeysMode ?? false,
+		},
+		element: null,
+		_core: {
+			_renderService: {
+				dimensions: {
+					css: { cell: { width: 8, height: options.cellHeight ?? 17 } },
+				},
+			},
+		},
+	};
+	return { terminal: terminal as unknown as XTerm, input };
+}
+
+function wheelEvent(
+	deltaY: number,
+	overrides: Partial<WheelEvent> = {},
+): WheelEvent & { defaultPrevented: boolean } {
+	const event = {
+		deltaY,
+		deltaMode: DOM_DELTA_PIXEL,
+		altKey: false,
+		ctrlKey: false,
+		shiftKey: false,
+		clientX: 0,
+		clientY: 0,
+		defaultPrevented: false,
+		preventDefault() {
+			this.defaultPrevented = true;
+		},
+		stopPropagation() {},
+		...overrides,
+	};
+	return event as unknown as WheelEvent & { defaultPrevented: boolean };
+}
+
+describe("createTerminalWheelEventHandler", () => {
+	let sgrActive: boolean;
+	const isSgrActive = () => sgrActive;
+
+	beforeEach(() => {
+		sgrActive = false;
+	});
+
+	it("defers to stock xterm in the normal buffer without mouse tracking (scrollback)", () => {
+		const { terminal, input } = makeFakeTerminal({ bufferType: "normal" });
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(40))).toBe(true);
+		expect(input).not.toHaveBeenCalled();
+	});
+
+	it("sends SGR reports for normal-buffer mouse tracking (Claude Code)", () => {
+		sgrActive = true;
+		const { terminal, input } = makeFakeTerminal({
+			bufferType: "normal",
+			mouseTrackingMode: "any",
+		});
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(34))).toBe(false);
+		expect(input).toHaveBeenCalledWith("\x1b[<65;1;1M\x1b[<65;1;1M", true);
+	});
+
+	it("defers to viewport scrollback for x10 tracking in the normal buffer", () => {
+		const { terminal, input } = makeFakeTerminal({
+			bufferType: "normal",
+			mouseTrackingMode: "x10",
+		});
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(40))).toBe(true);
+		expect(input).not.toHaveBeenCalled();
+	});
+
+	it("defers to stock xterm when shift is held (selection bypass)", () => {
+		const { terminal } = makeFakeTerminal();
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(40, { shiftKey: true }))).toBe(true);
+	});
+
+	it("sends one arrow per line in the alt buffer without mouse tracking", () => {
+		const { terminal, input } = makeFakeTerminal();
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		const event = wheelEvent(51); // 3 lines at 17px cells
+		expect(handler(event)).toBe(false);
+		expect(input).toHaveBeenCalledWith("\x1b[B\x1b[B\x1b[B", true);
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it("uses application cursor sequences when DECCKM is set", () => {
+		const { terminal, input } = makeFakeTerminal({
+			applicationCursorKeysMode: true,
+		});
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		handler(wheelEvent(-17));
+		expect(input).toHaveBeenCalledWith("\x1bOA", true);
+	});
+
+	it("consumes sub-line deltas without emitting, then fires on accumulation", () => {
+		const { terminal, input } = makeFakeTerminal();
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(6))).toBe(false);
+		expect(handler(wheelEvent(6))).toBe(false);
+		expect(input).not.toHaveBeenCalled();
+		expect(handler(wheelEvent(6))).toBe(false);
+		expect(input).toHaveBeenCalledWith("\x1b[B", true);
+	});
+
+	it("sends SGR wheel reports when mouse tracking + SGR encoding are active", () => {
+		sgrActive = true;
+		const { terminal, input } = makeFakeTerminal({ mouseTrackingMode: "any" });
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(34))).toBe(false);
+		expect(input).toHaveBeenCalledWith("\x1b[<65;1;1M\x1b[<65;1;1M", true);
+	});
+
+	it("defers to stock xterm when mouse tracking is active without SGR encoding", () => {
+		const { terminal, input } = makeFakeTerminal({
+			mouseTrackingMode: "vt200",
+		});
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(40))).toBe(true);
+		expect(input).not.toHaveBeenCalled();
+	});
+
+	it("falls back to arrows for x10 tracking, which never reports wheel", () => {
+		const { terminal, input } = makeFakeTerminal({ mouseTrackingMode: "x10" });
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(17))).toBe(false);
+		expect(input).toHaveBeenCalledWith("\x1b[B", true);
+	});
+
+	it("defers to stock xterm when cell dimensions are unavailable", () => {
+		const { terminal } = makeFakeTerminal();
+		(terminal as unknown as { _core: unknown })._core = undefined;
+		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+		expect(handler(wheelEvent(40))).toBe(true);
+	});
+});

--- a/packages/shared/src/terminal-wheel-handler/terminal-wheel-handler.test.ts
+++ b/packages/shared/src/terminal-wheel-handler/terminal-wheel-handler.test.ts
@@ -303,4 +303,27 @@ describe("createTerminalWheelEventHandler", () => {
 		const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
 		expect(handler(wheelEvent(40))).toBe(true);
 	});
+
+	it("honors the stock-wheel escape hatch per event, without reinstall", () => {
+		const globals = globalThis as { localStorage?: Pick<Storage, "getItem"> };
+		const original = globals.localStorage;
+		try {
+			globals.localStorage = {
+				getItem: (key) =>
+					key === "SUPERSET_TERMINAL_STOCK_WHEEL" ? "1" : null,
+			};
+			const { terminal, input } = makeFakeTerminal();
+			const handler = createTerminalWheelEventHandler(terminal, isSgrActive);
+			expect(handler(wheelEvent(51))).toBe(true);
+			expect(input).not.toHaveBeenCalled();
+
+			// Clearing the flag re-enables the handler on the very next event —
+			// parked/reused terminal instances must not need a window reload.
+			globals.localStorage = { getItem: () => null };
+			expect(handler(wheelEvent(51))).toBe(false);
+			expect(input).toHaveBeenCalled();
+		} finally {
+			globals.localStorage = original;
+		}
+	});
 });

--- a/packages/shared/src/terminal-wheel-handler/terminal-wheel-handler.ts
+++ b/packages/shared/src/terminal-wheel-handler/terminal-wheel-handler.ts
@@ -1,0 +1,283 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { getCellDimensions } from "./cell-dimensions";
+
+// Escape hatch: revert to stock xterm wheel handling without a rebuild.
+// Run in DevTools console: localStorage.setItem('SUPERSET_TERMINAL_STOCK_WHEEL', '1')
+function isStockWheelForced(): boolean {
+	try {
+		return localStorage.getItem("SUPERSET_TERMINAL_STOCK_WHEEL") === "1";
+	} catch {
+		return false;
+	}
+}
+
+// WheelEvent.DOM_DELTA_* — inlined so pure helpers are testable without a DOM.
+const DOM_DELTA_LINE = 1;
+const DOM_DELTA_PAGE = 2;
+
+export interface WheelLineState {
+	/** Fractional lines carried over between events (signed). */
+	partialLines: number;
+	/** Buffer/mode fingerprint; a change resets the accumulator. */
+	contextKey: string;
+}
+
+export function createWheelLineState(): WheelLineState {
+	return { partialLines: 0, contextKey: "" };
+}
+
+export interface WheelLineInput {
+	deltaY: number;
+	deltaMode: number;
+	altKey: boolean;
+	ctrlKey: boolean;
+}
+
+export interface WheelLineContext {
+	cellHeight: number;
+	rows: number;
+	scrollSensitivity: number;
+	fastScrollSensitivity: number;
+	contextKey: string;
+}
+
+/**
+ * Convert a wheel event into a whole number of terminal lines, carrying the
+ * fractional remainder across events.
+ *
+ * This mirrors xterm's MouseService._consumeWheelEvent with two deliberate
+ * differences (the reason this module exists — xterm.js PR #5391 regression):
+ * - no 0.3x trackpad damping, so pixels map 1:1 onto cell heights
+ * - callers emit one sequence per line instead of capping at one per event
+ */
+export function consumeWheelLines(
+	state: WheelLineState,
+	input: WheelLineInput,
+	context: WheelLineContext,
+): number {
+	if (state.contextKey !== context.contextKey) {
+		state.partialLines = 0;
+		state.contextKey = context.contextKey;
+	}
+
+	// Parity with xterm's _applyScrollModifier fast-scroll behavior.
+	const sensitivity =
+		input.altKey || input.ctrlKey
+			? context.fastScrollSensitivity * context.scrollSensitivity
+			: context.scrollSensitivity;
+
+	let lines = input.deltaY * sensitivity;
+	if (input.deltaMode === DOM_DELTA_LINE) {
+		// already in lines
+	} else if (input.deltaMode === DOM_DELTA_PAGE) {
+		lines *= context.rows;
+	} else {
+		lines /= context.cellHeight;
+	}
+
+	state.partialLines += lines;
+	let whole = Math.trunc(state.partialLines);
+	state.partialLines -= whole;
+
+	// Guard against pathological single-event floods (e.g. a synthetic event
+	// with a huge delta): cap one event at a full page of lines.
+	const cap = Math.max(1, context.rows);
+	if (Math.abs(whole) > cap) {
+		whole = Math.sign(whole) * cap;
+		state.partialLines = 0;
+	}
+
+	return whole;
+}
+
+/**
+ * Track whether the application enabled SGR mouse encoding (DECSET 1006).
+ *
+ * xterm does not expose the active mouse encoding publicly, and synthesizing
+ * SGR-format reports while the app expects legacy X10 encoding would corrupt
+ * its input, so we observe the DECSET/DECRST traffic ourselves. The handlers
+ * return false so xterm's own processing still runs.
+ */
+export function createSgrMouseModeTracker(xterm: XTerm): {
+	isActive: () => boolean;
+	dispose: () => void;
+} {
+	let active = false;
+
+	const hasSgrParam = (params: (number | number[])[]): boolean =>
+		params.flat().includes(1006);
+
+	const setHandler = xterm.parser.registerCsiHandler(
+		{ prefix: "?", final: "h" },
+		(params) => {
+			if (hasSgrParam(params)) active = true;
+			return false;
+		},
+	);
+	const resetHandler = xterm.parser.registerCsiHandler(
+		{ prefix: "?", final: "l" },
+		(params) => {
+			if (hasSgrParam(params)) active = false;
+			return false;
+		},
+	);
+
+	return {
+		isActive: () => active,
+		dispose: () => {
+			setHandler.dispose();
+			resetHandler.dispose();
+		},
+	};
+}
+
+const WHEEL_UP_BUTTON = 64;
+const WHEEL_DOWN_BUTTON = 65;
+const MODIFIER_ALT = 8;
+const MODIFIER_CTRL = 16;
+
+export function buildSgrWheelReport(
+	deltaY: number,
+	col: number,
+	row: number,
+	modifiers: { altKey: boolean; ctrlKey: boolean },
+): string {
+	let button = deltaY < 0 ? WHEEL_UP_BUTTON : WHEEL_DOWN_BUTTON;
+	if (modifiers.altKey) button |= MODIFIER_ALT;
+	if (modifiers.ctrlKey) button |= MODIFIER_CTRL;
+	return `\x1b[<${button};${col};${row}M`;
+}
+
+export function buildArrowSequence(
+	deltaY: number,
+	applicationCursorKeys: boolean,
+): string {
+	return `\x1b${applicationCursorKeys ? "O" : "["}${deltaY < 0 ? "A" : "B"}`;
+}
+
+function getReportCoords(
+	xterm: XTerm,
+	event: WheelEvent,
+	cellWidth: number,
+	cellHeight: number,
+): { col: number; row: number } {
+	// Position matters for TUIs that route wheel by pane (vim splits, tmux).
+	// The screen element excludes the terminal's padding; fall back to the
+	// root element if it isn't rendered yet.
+	const element =
+		xterm.element?.querySelector(".xterm-screen") ?? xterm.element;
+	if (!element) return { col: 1, row: 1 };
+
+	const rect = element.getBoundingClientRect();
+	const col = Math.floor((event.clientX - rect.left) / cellWidth) + 1;
+	const row = Math.floor((event.clientY - rect.top) / cellHeight) + 1;
+	return {
+		col: Math.max(1, Math.min(xterm.cols, col)),
+		row: Math.max(1, Math.min(xterm.rows, row)),
+	};
+}
+
+/**
+ * Custom wheel handler restoring full-fidelity scrolling for TUIs that
+ * capture the wheel: mouse-tracking apps in any buffer (Claude Code, vim
+ * with mouse=a, htop, tmux) and alt-buffer apps without tracking (less).
+ *
+ * Stock xterm.js damps trackpad wheel deltas to 30% and emits at most one
+ * report/arrow per DOM wheel event ("scrolling samples every third tick").
+ * This handler converts pixels to lines at full fidelity and emits one
+ * sequence per line — the report stream a native terminal (kitty, iTerm,
+ * Ghostty) produces.
+ *
+ * Coupled to terminal identity: TERM_PROGRAM must claim a kitty-class
+ * terminal (see TERMINAL_TERM_PROGRAM in @superset/shared/constants).
+ * Under a vscode identity Claude Code amplifies each report to compensate
+ * for xterm's damped stream, so full-fidelity reports would over-scroll ~3x.
+ */
+export function createTerminalWheelEventHandler(
+	xterm: XTerm,
+	isSgrMouseModeActive: () => boolean,
+): (event: WheelEvent) => boolean {
+	const state = createWheelLineState();
+
+	return (event: WheelEvent): boolean => {
+		// Shift is xterm's mouse-capture bypass (selection); keep stock behavior.
+		if (event.deltaY === 0 || event.shiftKey) return true;
+
+		const bufferType = xterm.buffer.active.type;
+		const tracking = xterm.modes.mouseTrackingMode;
+		// x10 tracking never reports wheel; in the alt buffer it falls through
+		// to arrows below, in the normal buffer to viewport scrollback.
+		const wantsMouseReports =
+			tracking === "vt200" || tracking === "drag" || tracking === "any";
+
+		if (wantsMouseReports) {
+			// Without SGR encoding we cannot safely synthesize reports — legacy
+			// X10 byte encoding breaks past column 223. Let stock xterm handle it.
+			if (!isSgrMouseModeActive()) return true;
+		} else if (bufferType !== "alternate") {
+			// Normal buffer without mouse tracking: viewport scrollback.
+			return true;
+		}
+
+		const cell = getCellDimensions(xterm);
+		if (!cell) return true;
+
+		const applicationCursorKeys = xterm.modes.applicationCursorKeysMode;
+		const lines = consumeWheelLines(
+			state,
+			{
+				deltaY: event.deltaY,
+				deltaMode: event.deltaMode,
+				altKey: event.altKey,
+				ctrlKey: event.ctrlKey,
+			},
+			{
+				cellHeight: cell.height,
+				rows: xterm.rows,
+				scrollSensitivity: xterm.options.scrollSensitivity ?? 1,
+				fastScrollSensitivity: xterm.options.fastScrollSensitivity ?? 5,
+				contextKey: `${bufferType}:${tracking}:${applicationCursorKeys}`,
+			},
+		);
+
+		if (lines !== 0) {
+			let sequence: string;
+			if (wantsMouseReports) {
+				const { col, row } = getReportCoords(
+					xterm,
+					event,
+					cell.width,
+					cell.height,
+				);
+				sequence = buildSgrWheelReport(event.deltaY, col, row, event);
+			} else {
+				sequence = buildArrowSequence(event.deltaY, applicationCursorKeys);
+			}
+			xterm.input(sequence.repeat(Math.abs(lines)), true);
+		}
+
+		// Consumed (possibly into the fractional accumulator): stop the event so
+		// nothing else scrolls, mirroring stock behavior in mouse-report mode.
+		event.preventDefault();
+		event.stopPropagation();
+		return false;
+	};
+}
+
+/**
+ * Install the full-fidelity wheel handler on a terminal. Returns an
+ * uninstaller; xterm.dispose() also cleans everything up implicitly.
+ */
+export function installTerminalWheelEventHandler(xterm: XTerm): () => void {
+	if (isStockWheelForced()) return () => {};
+
+	const sgrTracker = createSgrMouseModeTracker(xterm);
+	xterm.attachCustomWheelEventHandler(
+		createTerminalWheelEventHandler(xterm, sgrTracker.isActive),
+	);
+
+	return () => {
+		sgrTracker.dispose();
+		xterm.attachCustomWheelEventHandler(() => true);
+	};
+}

--- a/packages/shared/src/terminal-wheel-handler/terminal-wheel-handler.ts
+++ b/packages/shared/src/terminal-wheel-handler/terminal-wheel-handler.ts
@@ -3,7 +3,11 @@ import { getCellDimensions } from "./cell-dimensions";
 
 // Escape hatch: revert to stock xterm wheel handling without a rebuild.
 // Run in DevTools console: localStorage.setItem('SUPERSET_TERMINAL_STOCK_WHEEL', '1')
-function isStockWheelForced(): boolean {
+// Checked per wheel event (localStorage reads are sub-microsecond in
+// Chromium) because terminal instances are parked and reused across React
+// mounts — an install-time check would require a full window reload to
+// take effect.
+export function isStockWheelForced(): boolean {
 	try {
 		return localStorage.getItem("SUPERSET_TERMINAL_STOCK_WHEEL") === "1";
 	} catch {
@@ -200,6 +204,8 @@ export function createTerminalWheelEventHandler(
 	const state = createWheelLineState();
 
 	return (event: WheelEvent): boolean => {
+		if (isStockWheelForced()) return true;
+
 		// Shift is xterm's mouse-capture bypass (selection); keep stock behavior.
 		if (event.deltaY === 0 || event.shiftKey) return true;
 
@@ -269,8 +275,6 @@ export function createTerminalWheelEventHandler(
  * uninstaller; xterm.dispose() also cleans everything up implicitly.
  */
 export function installTerminalWheelEventHandler(xterm: XTerm): () => void {
-	if (isStockWheelForced()) return () => {};
-
 	const sgrTracker = createSgrMouseModeTracker(xterm);
 	xterm.attachCustomWheelEventHandler(
 		createTerminalWheelEventHandler(xterm, sgrTracker.isActive),

--- a/plans/20260709-term-program-vscode-migration.md
+++ b/plans/20260709-term-program-vscode-migration.md
@@ -2,6 +2,19 @@
 
 Branch: `debug-terminal-scrollback` (PR #5563). Status: implemented and verified — manual pass and CDP pass both complete.
 
+> **SUPERSEDED (2026-07-11).** The vscode identity fixed scroll *distance* but
+> not *cadence*: xterm.js still emitted ~one damped report per third wheel
+> event, and Claude compensated with multi-line jumps per report (chunky
+> "every third tick" feel). The deeper fix ships a custom wheel handler
+> (`@superset/shared/terminal-wheel-handler`, installed in the desktop
+> renderer's v1/v2 terminals and the web `WebTerminal`) that produces a
+> native-fidelity report stream (no 0.3x trackpad damping, one SGR
+> report/arrow per line), and reverts `TERMINAL_TERM_PROGRAM` to `kitty` so
+> Claude trusts that stream without amplification — the iTerm/Ghostty
+> combination. The identity and the handler are coupled: reverting one
+> without the other reintroduces slow (kitty + damped stream) or runaway
+> (vscode + full stream) scrolling.
+
 ## Why
 
 Superset terminals previously claimed `TERM_PROGRAM=kitty` (host-service `env.ts`) so agent


### PR DESCRIPTION
**Links**
- Re-lands #5639 (reverted in #5641 — merged before scroll-feel QA was done)
- Review findings addressed from the post-merge review of #5639
- Upstream root cause: xterm.js PR [#5391](https://github.com/xtermjs/xterm.js/pull/5391)

## Summary
- Re-applies #5639 verbatim (revert-of-revert, commit `fbd73bb99`): custom full-fidelity xterm wheel handler in `@superset/shared/terminal-wheel-handler` installed in desktop v1/v2 + web terminals, and `TERMINAL_TERM_PROGRAM` `vscode` → `kitty`.
- New on top (commit `f2deef4d5`), addressing the review findings:
  - **Coupling test**: `terminal-identity-coupling.test.ts` colocated with the handler asserts `TERMINAL_TERM_PROGRAM` is kitty-class, so a one-sided revert of either half fails CI instead of silently shipping ~3x over-scroll or damped scrolling.
  - **Escape hatch is live per-event**: `SUPERSET_TERMINAL_STOCK_WHEEL` is now checked on each wheel event (sub-µs localStorage read at ≤120Hz) instead of at install time — terminals are parked/reused across React mounts, so the old check effectively required a full window reload. Covered by a test proving the flag toggles both ways without reinstall.

## Why draft
#5639's Manual QA (real scroll-feel validation in a dev build) never happened before it merged — that's why it was reverted. **This PR stays draft until that QA is done.** Checklist below is the gate.

## Manual QA gate (before marking ready)
- [x] Fresh Claude Code session (new PTY — old ones keep the previous TERM_PROGRAM): transcript scrolling tracks the trackpad smoothly, no every-third-tick chunkiness, flicks travel proportionally
- [x] Claude does NOT over-scroll (~3x) — this is the kitty-vs-vscode identity check
- [x] `vim` (`mouse=a`) and `less` in the alt buffer scroll at finger speed
- [x] Normal shell scrollback feel unchanged; shift+wheel still selects/bypasses
- [x] Shift+Enter in Claude still inserts a newline
- [ ] tmux or vim splits: wheel scrolls the pane under the cursor
- [x] Escape hatch: set `SUPERSET_TERMINAL_STOCK_WHEEL=1` in DevTools → scrolling reverts on the next wheel event without reload; clear it → handler resumes
- [ ] Web WebTerminal smoke check

## Testing
- `bun test packages/shared/src/terminal-wheel-handler` (26 tests incl. new coupling + escape-hatch tests)
- Desktop terminal suites, host-service/desktop env suites, typecheck (desktop/web/shared/host-service), `bun run lint`, sherif — all green on the original change; re-run on this branch for the delta

## Notes
- Full design rationale, decision table, and risk/rollback are in #5639's description — unchanged here.
- Claude's lines-per-report under the specific `kitty` name is the one open question the QA gate answers; if it feels off, tuning is a one-line constant change (`ghostty` / `iTerm.app`).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5642">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores native-feel terminal wheel scrolling in desktop and web by adding a custom xterm handler and identifying terminals as `kitty`. Fixes chunky/under/over-scrolling in Claude Code and other TUIs.

- **New Features**
  - Added `@superset/shared/terminal-wheel-handler` that emits one SGR wheel report or arrow per line (no damping); installed in desktop v1/v2 terminals and `WebTerminal`.
  - Switched `TERM_PROGRAM` to `kitty` (with version) so TUIs trust the full-fidelity stream; a coupling test enforces handler ↔ identity alignment.
  - Live escape hatch: set `localStorage.SUPERSET_TERMINAL_STOCK_WHEEL=1` to defer to stock xterm per event, no reload needed.

<sup>Written for commit f2deef4d539e747f4be1ba83f810960f0443bf6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal scrolling for interactive applications across desktop and web.
  * Added more accurate mouse-wheel reporting for smooth scrolling, including support for fractional and large scroll movements.
  * Added an option to restore standard terminal scrolling behavior when needed.

* **Bug Fixes**
  * Improved scrolling consistency in terminal-based applications and different terminal interaction modes.
  * Prevented excessive scroll movement at terminal boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->