### PR TITLE
fix(discord-triage): edit-precondition must use Linear-normalized description

### DIFF
--- a/apps/discord-triage/src/index.ts
+++ b/apps/discord-triage/src/index.ts
@@ -75,7 +75,9 @@ async function fileIssue(opts: {
 		id: issue.id,
 		identifier: issue.identifier,
 		url: issue.url,
-		description,
+		// Linear normalizes markdown on write; the edited-since-filing check must
+		// compare against the stored form, not the submitted string.
+		description: issue.description ?? description,
 	};
 }
 


### PR DESCRIPTION
## Summary
- The edited-since-filing guard added in #5638 compared the stored description against the *submitted* markdown string. Linear normalizes markdown on write (wraps URLs in `<...>`, reformats tables), so the guard always tripped and every enhancement was skipped in prod (`skipping enhance ... description edited since filing`, caught during post-deploy e2e on SUPER-1478).
- Baseline the check on the stored description returned by `createIssue` instead.

## Testing
- `bun run typecheck`, `bun run lint`
- Manual: prod e2e re-run after deploy (forum post in #bugs → enhanced ticket) — will confirm on this PR

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the edited-since-filing check in `discord-triage` by comparing against Linear’s stored, normalized description. Prevents false positives that were skipping enhancements in production (seen on SUPER-1478).

- **Bug Fixes**
  - Use `issue.description` from `createIssue` (fallback to submitted `description`) so the precondition matches Linear-normalized markdown (URL angle-bracketing, table formatting).

<sup>Written for commit 69d7f1e1fbd5d18c8ed89929db0735e57f8e60dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue update handling by preserving the normalized description returned after filing.
  * Prevented inaccurate comparisons when determining whether an issue’s description was edited after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->