### PR TITLE
feat(desktop): tab-drag merge preview, plus settings & sidebar UX polish and nested dropdown corners

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -249,7 +249,7 @@ export function DashboardSidebar({
 									"border-t border-border",
 									isCollapsed
 										? "flex flex-col items-center gap-1 py-1"
-										: "flex items-center gap-1 px-2 py-1",
+										: "flex items-center gap-1 p-3",
 								)}
 							>
 								{isCollapsed ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -228,12 +228,12 @@ export function DashboardSidebarHeader({
 
 	return (
 		<div
-			className="flex flex-col gap-1 border-b border-border px-2 pt-2 pb-2"
+			className="flex flex-col gap-1 border-b border-border px-3 pt-2 pb-2"
 			// Pin the top inset so the traffic-light row stays a constant physical
 			// distance from the window top under page zoom (see the row below).
 			style={isMac ? { paddingTop: `${8 / zoomFactor}px` } : undefined}
 		>
-			{/* -mx-2 cancels the parent's px-2 so this row owns the 80px traffic-light
+			{/* -mx-3 cancels the parent's px-3 so this row owns the 80px traffic-light
 			    inset; inset and height are counter-scaled to a constant physical size
 			    so the fixed macOS traffic lights stay aligned under page zoom. On Mac
 			    the control clusters below use ZoomStable so the collapse/nav icons and
@@ -242,7 +242,7 @@ export function DashboardSidebarHeader({
 			    pinned row height it matches is Mac-only; elsewhere the row height (h-8)
 			    scales with zoom, so the controls should scale with it. */}
 			<div
-				className="drag -mx-2 flex h-8 items-center gap-1.5 pr-2"
+				className="drag -mx-3 flex h-8 items-center gap-1.5 pr-3"
 				style={
 					isMac
 						? {
@@ -304,7 +304,7 @@ export function DashboardSidebarHeader({
 				<span className="flex-1 text-left">Tasks & PRs</span>
 			</button>
 
-			<div className="flex items-center gap-0">
+			<div className="flex items-center gap-1">
 				<button
 					type="button"
 					onClick={() => openModal()}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/AgentCommentComposer/components/AgentPlacementToggle/AgentPlacementToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/AgentCommentComposer/components/AgentPlacementToggle/AgentPlacementToggle.tsx
@@ -23,7 +23,7 @@ export function AgentPlacementToggle({
 				value="split-pane"
 				aria-label="Open in split pane"
 				title="Split pane"
-				className="h-6 gap-1 rounded-[4px] px-1.5 text-[11px] text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
+				className="h-6 gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
 			>
 				<LuColumns2 className="size-3" />
 				<span>Split</span>
@@ -32,7 +32,7 @@ export function AgentPlacementToggle({
 				value="new-tab"
 				aria-label="Open in new tab"
 				title="New tab"
-				className="h-6 gap-1 rounded-[4px] px-1.5 text-[11px] text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
+				className="h-6 gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
 			>
 				<LuPanelTopOpen className="size-3" />
 				<span>New tab</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FileViewToggle/FileViewToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FileViewToggle/FileViewToggle.tsx
@@ -25,7 +25,7 @@ export function FileViewToggle({
 						type="button"
 						title={label}
 						className={cn(
-							"flex h-4 min-w-0 max-w-20 items-center rounded px-1.5 text-[10px] leading-none transition-colors",
+							"flex h-4 min-w-0 max-w-20 items-center rounded-sm px-1.5 text-[10px] leading-none transition-colors",
 							view.id === activeViewId
 								? "bg-background text-foreground shadow-sm"
 								: "text-muted-foreground hover:text-foreground",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -16,6 +16,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { getHostServiceUnavailableMessage } from "renderer/lib/host-service-unavailable";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useScrollReset } from "renderer/routes/_authenticated/settings/hooks/useScrollReset";
 import { AgentDetail } from "./components/AgentDetail";
 import { AgentsSettingsSidebar } from "./components/AgentsSettingsSidebar";
 import {
@@ -200,6 +201,9 @@ export function V2AgentsSettings({
 
 	const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
 	const [isCreating, setIsCreating] = useState(false);
+	const detailRef = useScrollReset<HTMLDivElement>(
+		isCreating ? "new" : selectedAgentId,
+	);
 	const consumedInitialPresetIdRef = useRef(false);
 
 	// Auto-select first agent when none selected, and clear selection when the
@@ -261,7 +265,7 @@ export function V2AgentsSettings({
 					isResetting={resetMutation.isPending}
 				/>
 			)}
-			<div className="flex-1 overflow-y-auto">
+			<div ref={detailRef} className="flex-1 overflow-y-auto">
 				{isCreating ? (
 					<NewCustomAgentDetail
 						onCreate={(input) => addCustomMutation.mutate(input)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
@@ -26,7 +26,7 @@ export function SettingsSidebar() {
 		: null;
 
 	return (
-		<div className="w-56 flex flex-col p-3 overflow-hidden">
+		<div className="w-56 flex flex-col py-3 overflow-hidden bg-sidebar">
 			{/* Back button */}
 			<Link
 				to={originRoute}
@@ -40,8 +40,8 @@ export function SettingsSidebar() {
 			<h1 className="text-lg font-semibold px-3 mb-4">Settings</h1>
 
 			{/* Search input */}
-			<div className="relative px-1 mb-4">
-				<HiMagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+			<div className="relative px-3 mb-4">
+				<HiMagnifyingGlass className="absolute left-6 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
 				<input
 					type="text"
 					placeholder="Search settings..."
@@ -53,23 +53,23 @@ export function SettingsSidebar() {
 					<button
 						type="button"
 						onClick={() => setSearchQuery("")}
-						className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+						className="absolute right-6 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
 					>
 						<HiXMark className="h-4 w-4" />
 					</button>
 				)}
 			</div>
 
-			<div className="flex-1 overflow-y-auto min-h-0">
+			<div className="flex-1 overflow-y-auto min-h-0 border-t border-border pt-4 pb-4 px-3">
 				<GeneralSettings matchCounts={matchCounts} />
 			</div>
 
-			<div className="pt-3 mt-3 border-t border-border">
+			<div className="pt-3 border-t border-border px-3">
 				<a
 					href={COMPANY.DOCS_URL}
 					target="_blank"
 					rel="noopener noreferrer"
-					className="flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+					className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground transition-colors"
 				>
 					<HiArrowTopRightOnSquare className="h-4 w-4" />
 					<span>Documentation</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hooks/useScrollReset/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hooks/useScrollReset/index.ts
@@ -1,0 +1,1 @@
+export { useScrollReset } from "./useScrollReset";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hooks/useScrollReset/useScrollReset.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hooks/useScrollReset/useScrollReset.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from "react";
+
+/** Scrolls the referenced container back to the top whenever `trigger` changes. */
+export function useScrollReset<T extends HTMLElement>(trigger: unknown) {
+	const ref = useRef<T>(null);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: trigger is the reset signal, not read in the body
+	useEffect(() => {
+		ref.current?.scrollTo({ top: 0 });
+	}, [trigger]);
+	return ref;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/layout.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Outlet, useParams } from "@tanstack/react-router";
+import { useScrollReset } from "../hooks/useScrollReset";
 import { HostsSettingsSidebar } from "./components/HostsSettingsSidebar";
 
 export const Route = createFileRoute("/_authenticated/settings/hosts")({
@@ -7,10 +8,11 @@ export const Route = createFileRoute("/_authenticated/settings/hosts")({
 
 function HostsSettingsLayout() {
 	const params = useParams({ strict: false }) as { hostId?: string };
+	const contentRef = useScrollReset<HTMLDivElement>(params.hostId);
 	return (
 		<div className="flex h-full w-full">
 			<HostsSettingsSidebar selectedHostId={params.hostId ?? null} />
-			<div className="flex-1 overflow-y-auto">
+			<div ref={contentRef} className="flex-1 overflow-y-auto">
 				<Outlet />
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -4,7 +4,7 @@ import {
 	useLocation,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
@@ -113,11 +113,18 @@ function SettingsLayout() {
 	const originRoute = useSettingsOriginRoute();
 	const location = useLocation();
 	const navigate = useNavigate();
+	const contentRef = useRef<HTMLDivElement>(null);
 	const normalizedSearchQuery = searchQuery.trim();
 	const isSearchActive = normalizedSearchQuery.length > 0;
 	const totalMatches = isSearchActive
 		? searchSettings(normalizedSearchQuery).length
 		: 0;
+
+	// Reset scroll to top when navigating to a different settings page.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger, not read in the body
+	useEffect(() => {
+		contentRef.current?.scrollTo({ top: 0 });
+	}, [location.pathname]);
 
 	useEffect(() => {
 		if (!isSearchActive) return;
@@ -175,9 +182,9 @@ function SettingsLayout() {
 				<NavigationControls />
 			</div>
 
-			<div className="flex flex-1 overflow-hidden">
+			<div className="flex flex-1 overflow-hidden bg-background">
 				<SettingsSidebar />
-				<div className="flex-1 m-3 bg-background rounded overflow-auto">
+				<div ref={contentRef} className="flex-1 overflow-auto">
 					{isSearchActive && (
 						<SearchResultsBanner
 							query={normalizedSearchQuery}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -4,7 +4,7 @@ import {
 	useLocation,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
@@ -16,6 +16,7 @@ import {
 import { NavigationControls } from "../_dashboard/components/NavigationControls";
 import { SearchResultsBanner } from "./components/SearchResultsBanner";
 import { SettingsSidebar } from "./components/SettingsSidebar";
+import { useScrollReset } from "./hooks/useScrollReset";
 import {
 	getMatchCountBySection,
 	searchSettings,
@@ -113,18 +114,13 @@ function SettingsLayout() {
 	const originRoute = useSettingsOriginRoute();
 	const location = useLocation();
 	const navigate = useNavigate();
-	const contentRef = useRef<HTMLDivElement>(null);
+	// Reset scroll to top when navigating to a different settings page.
+	const contentRef = useScrollReset<HTMLDivElement>(location.pathname);
 	const normalizedSearchQuery = searchQuery.trim();
 	const isSearchActive = normalizedSearchQuery.length > 0;
 	const totalMatches = isSearchActive
 		? searchSettings(normalizedSearchQuery).length
 		: 0;
-
-	// Reset scroll to top when navigating to a different settings page.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger, not read in the body
-	useEffect(() => {
-		contentRef.current?.scrollTo({ top: 0 });
-	}, [location.pathname]);
 
 	useEffect(() => {
 		if (!isSearchActive) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/projects/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/projects/layout.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Outlet, useParams } from "@tanstack/react-router";
+import { useScrollReset } from "../hooks/useScrollReset";
 import { ProjectsSettingsSidebar } from "./components/ProjectsSettingsSidebar";
 
 export const Route = createFileRoute("/_authenticated/settings/projects")({
@@ -7,10 +8,11 @@ export const Route = createFileRoute("/_authenticated/settings/projects")({
 
 function ProjectsSettingsLayout() {
 	const params = useParams({ strict: false }) as { projectId?: string };
+	const contentRef = useScrollReset<HTMLDivElement>(params.projectId);
 	return (
 		<div className="flex h-full w-full">
 			<ProjectsSettingsSidebar selectedProjectId={params.projectId ?? null} />
-			<div className="flex-1 overflow-y-auto">
+			<div ref={contentRef} className="flex-1 overflow-y-auto">
 				<Outlet />
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -107,7 +107,7 @@ export function WorkspaceSidebarHeader({
 	}
 
 	return (
-		<div className="flex flex-col gap-1 border-b border-border px-2 pt-2 pb-2">
+		<div className="flex flex-col border-b border-border px-2 pt-2 pb-2">
 			<button
 				type="button"
 				onClick={handleWorkspacesClick}

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -1,10 +1,12 @@
 import { cn } from "@superset/ui/utils";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { useDragLayer } from "react-dnd";
 import { useStore } from "zustand";
 import type { Pane } from "../../../types";
 import type { WorkspaceProps } from "../../types";
 import { Tab } from "./components/Tab";
 import { TabBar } from "./components/TabBar";
+import { TAB_DRAG_TYPE } from "./components/TabBar/components/TabItem";
 import { useWorkspaceInteractionState } from "./hooks/useWorkspaceInteractionState";
 
 export function Workspace<TData>({
@@ -29,6 +31,27 @@ export function Workspace<TData>({
 	const { onSplitResizeDragging } = useWorkspaceInteractionState({
 		onInteractionStateChange,
 	});
+
+	// The tab id currently being dragged in the tab bar, if any.
+	const draggedTabId = useDragLayer((monitor) => {
+		if (!monitor.isDragging() || monitor.getItemType() !== TAB_DRAG_TYPE) {
+			return null;
+		}
+		const item = monitor.getItem() as { tabId?: string } | null;
+		return item?.tabId ?? null;
+	});
+
+	// While dragging the active tab, render the tab before it in order instead.
+	// Dropping a tab onto its own view is a no-op (you'd merge it into itself),
+	// so showing the preceding tab lets you see — and drop onto — the actual
+	// merge target.
+	const displayedTab = useMemo(() => {
+		if (draggedTabId && draggedTabId === activeTabId) {
+			const index = tabs.findIndex((t) => t.id === draggedTabId);
+			if (index > 0) return tabs[index - 1];
+		}
+		return activeTab;
+	}, [draggedTabId, activeTabId, tabs, activeTab]);
 
 	const previousPanesRef = useRef<Map<string, Pane<TData>>>(new Map());
 	useEffect(() => {
@@ -101,10 +124,10 @@ export function Workspace<TData>({
 				renderTabAccessory={renderTabAccessory}
 			/>
 			{renderBelowTabBar?.()}
-			{activeTab ? (
+			{displayedTab ? (
 				<Tab
 					store={store}
-					tab={activeTab}
+					tab={displayedTab}
 					registry={registry}
 					paneActions={paneActions}
 					contextMenuActions={contextMenuActions}

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -41,14 +41,15 @@ export function Workspace<TData>({
 		return item?.tabId ?? null;
 	});
 
-	// While dragging the active tab, render the tab before it in order instead.
-	// Dropping a tab onto its own view is a no-op (you'd merge it into itself),
-	// so showing the preceding tab lets you see — and drop onto — the actual
-	// merge target.
+	// While dragging the active tab, render its neighbor (preceding tab, or the
+	// next one when dragging the first tab) instead. Dropping a tab onto its own
+	// view is a no-op (you'd merge it into itself), so showing a sibling lets
+	// you see — and drop onto — an actual merge target.
 	const displayedTab = useMemo(() => {
 		if (draggedTabId && draggedTabId === activeTabId) {
 			const index = tabs.findIndex((t) => t.id === draggedTabId);
 			if (index > 0) return tabs[index - 1];
+			if (index === 0 && tabs.length > 1) return tabs[1];
 		}
 		return activeTab;
 	}, [draggedTabId, activeTabId, tabs, activeTab]);

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -85,7 +85,7 @@ function ContextMenuSubContent({
 		<ContextMenuPrimitive.SubContent
 			data-slot="context-menu-sub-content"
 			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border p-1 shadow-lg",
 				className,
 			)}
 			{...props}
@@ -142,7 +142,7 @@ function ContextMenuContent({
 				ref={setRef}
 				data-slot="context-menu-content"
 				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border p-1 shadow-md",
 					className,
 				)}
 				{...props}

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -49,7 +49,7 @@ function DropdownMenuContent({
 				data-slot="dropdown-menu-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border p-1 shadow-md",
 					className,
 				)}
 				{...props}
@@ -237,7 +237,7 @@ function DropdownMenuSubContent({
 		<DropdownMenuPrimitive.SubContent
 			data-slot="dropdown-menu-sub-content"
 			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg border p-1 shadow-lg",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/menubar.tsx
+++ b/packages/ui/src/components/ui/menubar.tsx
@@ -79,7 +79,7 @@ function MenubarContent({
 				alignOffset={alignOffset}
 				sideOffset={sideOffset}
 				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-lg border p-1 shadow-md",
 					className,
 				)}
 				{...props}
@@ -121,7 +121,7 @@ function MenubarCheckboxItem({
 		<MenubarPrimitive.CheckboxItem
 			data-slot="menubar-checkbox-item"
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			checked={checked}
@@ -146,7 +146,7 @@ function MenubarRadioItem({
 		<MenubarPrimitive.RadioItem
 			data-slot="menubar-radio-item"
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}
@@ -248,7 +248,7 @@ function MenubarSubContent({
 		<MenubarPrimitive.SubContent
 			data-slot="menubar-sub-content"
 			className={cn(
-				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-lg border p-1 shadow-lg",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -62,7 +62,7 @@ function SelectContent({
 			<SelectPrimitive.Content
 				data-slot="select-content"
 				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border shadow-md",
 					position === "popper" &&
 						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
 					className,

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ function TabsTrigger({
 		<TabsPrimitive.Trigger
 			data-slot="tabs-trigger"
 			className={cn(
-				"data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-[7px] border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## What

A pass of desktop UX polish — the settings screen, the dashboard sidebar alignment, and the shared dropdown/toggle corner radii — plus a small tab-drag affordance.

## Settings screen

- **Nav fills its panel on a single keyline.** The search box, every nav row, and the Documentation link now share the same 12px left/right keyline, with item icons sitting directly under the search magnifier. Row hover/active backgrounds go edge-to-edge within that keyline instead of stopping short on the right.
- **Distinct sidebar surface.** The sidebar now uses `bg-sidebar`, separated from the `bg-background` content area (background lifted onto the shared row).
- **Divider + spacing.** Added a divider below the search bar (mirrors the Documentation divider) and even top/bottom spacers around the nav list.
- **Padding lives on the pages.** Removed the content container's outer margin — the pages already carry their own `p-6`, so standard pages keep their spacing and the inner-sidebar sections (projects/hosts/agents) now sit flush.
- **Scroll to top on navigation.** Selecting a different settings page resets the content scroll to the top.

## Dashboard sidebar

- **One 12px keyline, top to bottom.** Header and footer are unified so nav items align with the Settings button (left) and the Add-repository button aligns with the Help button (right).
- **Settings button margin** matches the Documentation button (12px all around).
- **Gutter** added between the New Workspace button and the Add-repository button, matching the footer's Settings ↔ Help gutter.
- Header nav items sit flush (removed the inter-item gap) to match the settings nav rhythm.

## Shared UI (`packages/ui`)

- **Clean nested dropdown corners.** Dropdown, Select, Context menu, and Menubar containers bumped to `rounded-lg` so their `rounded-sm` items nest concentrically inside the 4px inset — applies to every dropdown app-wide. Menubar checkbox/radio items brought up from `rounded-xs` to `rounded-sm` to match.
- **Radius token cleanup** on the tab trigger and the split/file-view toggles (arbitrary values → tokens / consistent radii).

## Tab dragging (`packages/panes`)

- **Merge-target preview when dragging a tab.** While dragging the active tab in the workspace tab bar (terminal, file, or diff tabs), the view renders the *preceding* tab instead — dropping a tab onto its own view is a no-op, so this surfaces the real merge target you're dropping onto.

## Notes

- The dropdown radius change is in shared `packages/ui`, so web/marketing/admin inherit the same nested-corner treatment.
- Pure styling/layout aside from the settings scroll-to-top and the tab-drag preview; no data or API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refined sidebar spacing, padding, backgrounds, and documentation link styling.
  * Updated menu, tab, toggle, and select corner rounding for a more consistent appearance.
  * Improved workspace and settings layout spacing.

* **Bug Fixes**
  * Settings, host, project, and agent pages now reset scroll position when navigating between items.
  * Improved tab drag-and-drop behavior by keeping a visible drop target when moving the active tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->