### PR TITLE
feat(desktop): add cmd+f search to the v2 changes pane

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -391,6 +391,16 @@ export const HOTKEYS_REGISTRY = {
 		category: "Terminal",
 		description: "Search text in the active chat",
 	},
+	FIND_IN_CHANGES: {
+		key: {
+			mac: L("meta+f"),
+			windows: L("ctrl+shift+f"),
+			linux: L("ctrl+shift+f"),
+		},
+		label: "Find in Changes",
+		category: "Terminal",
+		description: "Search text in the changes diff",
+	},
 	NEW_GROUP: {
 		key: {
 			mac: L("meta+t"),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -8,6 +8,7 @@ import type { RendererContext } from "@superset/panes";
 import { Button } from "@superset/ui/button";
 import { useCallback, useMemo, useRef } from "react";
 import { LuFileCode } from "react-icons/lu";
+import { MarkdownSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/MarkdownSearch";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import {
 	type ChangesetFile,
@@ -31,6 +32,7 @@ import { useDiffCodeViewItems } from "./hooks/useDiffCodeViewItems";
 import { useDiffCodeViewScroll } from "./hooks/useDiffCodeViewScroll";
 import { useDiffCodeViewTheme } from "./hooks/useDiffCodeViewTheme";
 import { useDiffCommentComposer } from "./hooks/useDiffCommentComposer";
+import { useDiffPaneSearch } from "./hooks/useDiffPaneSearch";
 
 interface CreateNewAgentSessionInput {
 	configId: string;
@@ -55,6 +57,7 @@ export function DiffPane({
 }: DiffPaneProps) {
 	const data = context.pane.data as DiffPaneData;
 	const codeViewRef = useRef<CodeViewHandle<DiffAnnotationMetadata>>(null);
+	const searchContainerRef = useRef<HTMLDivElement>(null);
 
 	const ref = useSidebarDiffRef(workspaceId);
 	const { files, isLoading } = useChangeset({ workspaceId, ref });
@@ -116,6 +119,17 @@ export function DiffPane({
 			extraAnnotationsByItemId: composerAnnotationsByItemId,
 		});
 	fileByItemIdRef.current = fileByItemId;
+
+	const search = useDiffPaneSearch({
+		containerRef: searchContainerRef,
+		codeViewRef,
+		items,
+		fileByItemId,
+		collapsedSet,
+		setCollapsed,
+		isActive: context.isActive,
+		paneId: context.pane.id,
+	});
 
 	const { targetItemId } = useDiffCodeViewScroll({
 		codeViewRef,
@@ -281,17 +295,31 @@ export function DiffPane({
 					count={currentSection.count}
 				/>
 			) : null}
-			<CodeView<DiffAnnotationMetadata>
-				ref={codeViewRef}
-				className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
-				style={style}
-				items={items}
-				options={codeViewOptions}
-				onScroll={onScroll}
-				renderHeaderPrefix={renderHeaderPrefix}
-				renderHeaderMetadata={renderHeaderMetadata}
-				renderAnnotation={renderAnnotation}
-			/>
+			<div ref={searchContainerRef} className="relative min-h-0 w-full flex-1">
+				<MarkdownSearch
+					isOpen={search.isSearchOpen}
+					query={search.query}
+					caseSensitive={search.caseSensitive}
+					matchCount={search.matchCount}
+					activeMatchIndex={search.activeMatchIndex}
+					onQueryChange={search.setQuery}
+					onCaseSensitiveChange={search.setCaseSensitive}
+					onFindNext={search.findNext}
+					onFindPrevious={search.findPrevious}
+					onClose={search.closeSearch}
+				/>
+				<CodeView<DiffAnnotationMetadata>
+					ref={codeViewRef}
+					className="h-full w-full overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
+					style={style}
+					items={items}
+					options={codeViewOptions}
+					onScroll={onScroll}
+					renderHeaderPrefix={renderHeaderPrefix}
+					renderHeaderMetadata={renderHeaderMetadata}
+					renderAnnotation={renderAnnotation}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/index.ts
@@ -1,0 +1,1 @@
+export { useDiffPaneSearch } from "./useDiffPaneSearch";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/useDiffPaneSearch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/useDiffPaneSearch.ts
@@ -71,6 +71,21 @@ function resolveRowSide(row: HTMLElement): SelectionSide {
 		: "additions";
 }
 
+function getRowForRangeBoundary(node: Node): Element | null {
+	const element = node instanceof Element ? node : node.parentElement;
+	return element?.closest("[data-line]") ?? null;
+}
+
+/** The DOM scan concatenates row text with no separator, so a query can match
+ *  across two adjacent rows. The data-driven match list is strictly per-line,
+ *  so painting such a range would show a highlight the counter never counts. */
+function isWithinSingleRow(range: Range): boolean {
+	return (
+		getRowForRangeBoundary(range.startContainer) ===
+		getRowForRangeBoundary(range.endContainer)
+	);
+}
+
 /** Locate the rendered row for a match, if the virtualizer currently has it
  *  mounted. Returns null while the row is scrolled out of the render window. */
 function findMatchRowElement(
@@ -302,6 +317,7 @@ export function useDiffPaneSearch({
 			});
 			const allHighlight = new Highlight();
 			for (const range of ranges) {
+				if (!isWithinSingleRow(range)) continue;
 				allHighlight.add(range);
 			}
 			CSS.highlights.set(highlightKeys.matches, allHighlight);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/useDiffPaneSearch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/useDiffPaneSearch.ts
@@ -1,0 +1,424 @@
+import {
+	type CodeViewItem,
+	DIFFS_TAG_NAME,
+	type SelectionSide,
+} from "@pierre/diffs";
+import type { CodeViewHandle } from "@pierre/diffs/react";
+import type { RefObject } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useHotkey } from "renderer/hotkeys";
+import { getDiffSearchRoots } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/utils/diffRendererRoots";
+import type { UseTextSearchReturn } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks";
+import {
+	findTextRanges,
+	type HighlightStyleElementMap,
+	type SearchRootIndexCache,
+	syncHighlightStyles,
+} from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useTextSearch/utils/textSearchDom";
+import { useSettings } from "renderer/stores/settings";
+import {
+	type ChangesetFile,
+	getChangesetFileKey,
+} from "../../../../../useChangeset";
+import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
+import {
+	collectDiffSearchMatches,
+	type DiffSearchMatch,
+} from "./utils/collectDiffSearchMatches";
+
+const SEARCH_DEBOUNCE_MS = 150;
+let nextHighlightInstanceId = 0;
+
+interface UseDiffPaneSearchOptions {
+	containerRef: RefObject<HTMLDivElement | null>;
+	codeViewRef: RefObject<CodeViewHandle<DiffAnnotationMetadata> | null>;
+	items: CodeViewItem<DiffAnnotationMetadata>[];
+	fileByItemId: ReadonlyMap<string, ChangesetFile>;
+	collapsedSet: ReadonlySet<string>;
+	setCollapsed: (changeKey: string, value: boolean) => void;
+	isActive: boolean;
+	paneId: string;
+}
+
+function supportsCustomHighlights(): boolean {
+	return (
+		typeof CSS !== "undefined" &&
+		typeof Highlight !== "undefined" &&
+		Boolean(CSS.highlights)
+	);
+}
+
+function getShadowRootsWithin(element: HTMLElement): ShadowRoot[] {
+	const roots: ShadowRoot[] = [];
+	if (element.matches(DIFFS_TAG_NAME) && element.shadowRoot) {
+		roots.push(element.shadowRoot);
+	}
+	for (const host of element.querySelectorAll<HTMLElement>(DIFFS_TAG_NAME)) {
+		if (host.shadowRoot) {
+			roots.push(host.shadowRoot);
+		}
+	}
+	return roots;
+}
+
+function resolveRowSide(row: HTMLElement): SelectionSide {
+	const lineType = row.dataset.lineType;
+	if (lineType === "change-deletion") return "deletions";
+	if (lineType === "change-addition") return "additions";
+	const column = row.closest("[data-code]");
+	return column instanceof HTMLElement && "deletions" in column.dataset
+		? "deletions"
+		: "additions";
+}
+
+/** Locate the rendered row for a match, if the virtualizer currently has it
+ *  mounted. Returns null while the row is scrolled out of the render window. */
+function findMatchRowElement(
+	codeViewHandle: CodeViewHandle<DiffAnnotationMetadata> | null,
+	match: DiffSearchMatch,
+): HTMLElement | null {
+	const instance = codeViewHandle?.getInstance();
+	if (!instance) return null;
+	const rendered = instance
+		.getRenderedItems()
+		.find((item) => item.id === match.itemId);
+	if (!rendered) return null;
+
+	for (const shadowRoot of getShadowRootsWithin(rendered.element)) {
+		const rows = shadowRoot.querySelectorAll<HTMLElement>(
+			`[data-line="${match.lineNumber}"]`,
+		);
+		for (const row of rows) {
+			if (resolveRowSide(row) === match.side) return row;
+		}
+	}
+	return null;
+}
+
+/**
+ * Cmd+F search for the Changes pane. Matches are computed from the parsed
+ * diff data (the CodeView virtualizes rows, so the DOM only ever holds the
+ * viewport); highlights are painted onto whatever rows are mounted and
+ * repainted as the virtualizer swaps rows in and out.
+ */
+export function useDiffPaneSearch({
+	containerRef,
+	codeViewRef,
+	items,
+	fileByItemId,
+	collapsedSet,
+	setCollapsed,
+	isActive,
+	paneId,
+}: UseDiffPaneSearchOptions): UseTextSearchReturn {
+	const expandUnchanged = useSettings((s) => s.expandUnchanged);
+
+	const [isSearchOpen, setIsSearchOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const [debouncedQuery, setDebouncedQuery] = useState("");
+	const [caseSensitive, setCaseSensitive] = useState(false);
+	const [activeMatchIndex, setActiveMatchIndex] = useState(0);
+
+	const searchEntries = useMemo(() => {
+		return items.flatMap((item) => {
+			if (item.type !== "diff") return [];
+			const file = fileByItemId.get(item.id);
+			if (!file) return [];
+			return [
+				{
+					itemId: item.id,
+					changeKey: getChangesetFileKey(file),
+					fileDiff: item.fileDiff,
+				},
+			];
+		});
+	}, [items, fileByItemId]);
+
+	const matches = useMemo(() => {
+		if (!isSearchOpen || !debouncedQuery) return [];
+		return collectDiffSearchMatches(searchEntries, {
+			query: debouncedQuery,
+			caseSensitive,
+			expandUnchanged,
+		});
+	}, [
+		isSearchOpen,
+		debouncedQuery,
+		caseSensitive,
+		searchEntries,
+		expandUnchanged,
+	]);
+
+	const matchesRef = useRef(matches);
+	matchesRef.current = matches;
+	const activeMatchIndexRef = useRef(activeMatchIndex);
+	activeMatchIndexRef.current = activeMatchIndex;
+	const pendingScrollIndexRef = useRef<number | null>(null);
+
+	const highlightInstanceIdRef = useRef<number | null>(null);
+	if (highlightInstanceIdRef.current === null) {
+		highlightInstanceIdRef.current = nextHighlightInstanceId;
+		nextHighlightInstanceId += 1;
+	}
+	const highlightKeys = useMemo(() => {
+		const id = highlightInstanceIdRef.current;
+		return {
+			matches: `changes-search-matches-${id}`,
+			active: `changes-search-active-${id}`,
+		};
+	}, []);
+	const highlightStyles = useMemo(
+		() => `
+::highlight(${highlightKeys.matches}) {
+	background-color: var(--highlight-match);
+}
+::highlight(${highlightKeys.active}) {
+	background-color: var(--highlight-active);
+}
+`,
+		[highlightKeys.active, highlightKeys.matches],
+	);
+	const highlightStyleElementsRef = useRef<HighlightStyleElementMap>(new Map());
+	const searchIndexCacheRef = useRef<SearchRootIndexCache>(new WeakMap());
+
+	const scrollToMatch = useCallback(
+		(match: DiffSearchMatch) => {
+			codeViewRef.current?.scrollTo({
+				type: "line",
+				id: match.itemId,
+				lineNumber: match.lineNumber,
+				side: match.side,
+				align: "center",
+				behavior: "instant",
+			});
+		},
+		[codeViewRef],
+	);
+
+	const goToMatch = useCallback(
+		(index: number) => {
+			const match = matchesRef.current[index];
+			if (!match) return;
+			setActiveMatchIndex(index);
+			if (collapsedSet.has(match.changeKey)) {
+				pendingScrollIndexRef.current = index;
+				setCollapsed(match.changeKey, false);
+				return;
+			}
+			pendingScrollIndexRef.current = null;
+			scrollToMatch(match);
+		},
+		[collapsedSet, setCollapsed, scrollToMatch],
+	);
+
+	// Finish a navigation that had to expand a collapsed file first: scroll
+	// once the file's rows are part of the layout again.
+	useEffect(() => {
+		const index = pendingScrollIndexRef.current;
+		if (index === null) return;
+		const match = matches[index];
+		if (!match) {
+			pendingScrollIndexRef.current = null;
+			return;
+		}
+		if (collapsedSet.has(match.changeKey)) return;
+		pendingScrollIndexRef.current = null;
+		scrollToMatch(match);
+	}, [collapsedSet, matches, scrollToMatch]);
+
+	const findNext = useCallback(() => {
+		const total = matchesRef.current.length;
+		if (total === 0) return;
+		goToMatch((activeMatchIndexRef.current + 1) % total);
+	}, [goToMatch]);
+
+	const findPrevious = useCallback(() => {
+		const total = matchesRef.current.length;
+		if (total === 0) return;
+		goToMatch((activeMatchIndexRef.current - 1 + total) % total);
+	}, [goToMatch]);
+
+	const closeSearch = useCallback(() => {
+		setIsSearchOpen(false);
+		setQuery("");
+		setDebouncedQuery("");
+		setActiveMatchIndex(0);
+		pendingScrollIndexRef.current = null;
+	}, []);
+
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setDebouncedQuery(query);
+		}, SEARCH_DEBOUNCE_MS);
+		return () => clearTimeout(timer);
+	}, [query]);
+
+	// Jump to the first match whenever the effective query changes. Later
+	// match-list updates (diffs streaming in, files collapsing) must not yank
+	// the viewport, so this keys off the query alone.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: jump only when the query changes
+	useEffect(() => {
+		setActiveMatchIndex(0);
+		activeMatchIndexRef.current = 0;
+		if (!debouncedQuery) return;
+		const first = matchesRef.current[0];
+		if (first) goToMatch(0);
+	}, [debouncedQuery, caseSensitive]);
+
+	// Keep the active index valid when the match list shrinks under it.
+	useEffect(() => {
+		if (matches.length > 0 && activeMatchIndex >= matches.length) {
+			setActiveMatchIndex(0);
+		}
+	}, [matches, activeMatchIndex]);
+
+	// Paint highlights over the mounted rows, and repaint as the virtualizer
+	// mounts/unmounts rows while scrolling.
+	useEffect(() => {
+		if (!isSearchOpen || !debouncedQuery || !supportsCustomHighlights()) {
+			return;
+		}
+		const container = containerRef.current;
+		if (!container) return;
+
+		const paint = () => {
+			const searchRoots = getDiffSearchRoots(container);
+			CSS.highlights.delete(highlightKeys.matches);
+			CSS.highlights.delete(highlightKeys.active);
+			if (searchRoots.length === 0) return;
+
+			syncHighlightStyles(
+				searchRoots,
+				document,
+				highlightStyleElementsRef.current,
+				highlightStyles,
+			);
+
+			const ranges = findTextRanges({
+				indexCache: searchIndexCacheRef.current,
+				searchRoots,
+				searchQuery: debouncedQuery,
+				caseSensitive,
+			});
+			const allHighlight = new Highlight();
+			for (const range of ranges) {
+				allHighlight.add(range);
+			}
+			CSS.highlights.set(highlightKeys.matches, allHighlight);
+
+			const active = matches[activeMatchIndex];
+			if (!active) return;
+			const row = findMatchRowElement(codeViewRef.current, active);
+			if (!row) return;
+			const codeElement = row.querySelector("[data-code]") ?? row;
+			const rowRanges = findTextRanges({
+				indexCache: new WeakMap(),
+				searchRoots: [codeElement],
+				searchQuery: debouncedQuery,
+				caseSensitive,
+			});
+			const activeRange = rowRanges[active.occurrence];
+			if (activeRange) {
+				CSS.highlights.set(highlightKeys.active, new Highlight(activeRange));
+			}
+		};
+
+		paint();
+
+		let frameId = 0;
+		const observedTargets = new Set<Node>();
+		const observer = new MutationObserver(() => {
+			cancelAnimationFrame(frameId);
+			frameId = requestAnimationFrame(() => {
+				searchIndexCacheRef.current = new WeakMap();
+				observeTargets();
+				paint();
+			});
+		});
+		const observeTargets = () => {
+			const targets = new Set<Node>([container]);
+			for (const searchRoot of getDiffSearchRoots(container)) {
+				const rootNode = searchRoot.getRootNode();
+				targets.add(rootNode instanceof ShadowRoot ? rootNode : searchRoot);
+			}
+			for (const target of targets) {
+				if (observedTargets.has(target)) continue;
+				observer.observe(target, {
+					characterData: true,
+					childList: true,
+					subtree: true,
+				});
+				observedTargets.add(target);
+			}
+		};
+		observeTargets();
+
+		return () => {
+			cancelAnimationFrame(frameId);
+			observer.disconnect();
+			CSS.highlights.delete(highlightKeys.matches);
+			CSS.highlights.delete(highlightKeys.active);
+		};
+	}, [
+		isSearchOpen,
+		debouncedQuery,
+		caseSensitive,
+		matches,
+		activeMatchIndex,
+		containerRef,
+		codeViewRef,
+		highlightKeys,
+		highlightStyles,
+	]);
+
+	// Remove injected ::highlight style elements when the pane unmounts.
+	useEffect(() => {
+		return () => {
+			for (const styleElement of highlightStyleElementsRef.current.values()) {
+				styleElement.remove();
+			}
+			highlightStyleElementsRef.current.clear();
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!isActive && isSearchOpen) {
+			closeSearch();
+		}
+	}, [isActive, isSearchOpen, closeSearch]);
+
+	// Same-kind panes share one React instance across tab switches, so search
+	// state must be discarded when the rendered pane identity changes.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset on pane change only
+	useEffect(() => {
+		if (isSearchOpen) {
+			closeSearch();
+		}
+	}, [paneId]);
+
+	useHotkey(
+		"FIND_IN_CHANGES",
+		() => {
+			if (isSearchOpen) {
+				closeSearch();
+				return;
+			}
+			setIsSearchOpen(true);
+		},
+		{ enabled: isActive, preventDefault: true },
+	);
+
+	return {
+		isSearchOpen,
+		setIsSearchOpen,
+		query,
+		caseSensitive,
+		matchCount: matches.length,
+		activeMatchIndex,
+		setQuery,
+		setCaseSensitive,
+		findNext,
+		findPrevious,
+		closeSearch,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/utils/collectDiffSearchMatches/collectDiffSearchMatches.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/utils/collectDiffSearchMatches/collectDiffSearchMatches.test.ts
@@ -136,6 +136,35 @@ describe("collectDiffSearchMatches", () => {
 		]);
 	});
 
+	test("fills the gaps between and after hunks exactly once when expandUnchanged is set", () => {
+		// Two changes far enough apart to produce two hunks, with needles in the
+		// unchanged gap between them (line 10) and in the tail after the last
+		// hunk (line 28). Exercises the expandedLine handoff across hunks.
+		const gap = `${"pad\n".repeat(8)}needle mid\n${"pad\n".repeat(8)}`;
+		const tail = `${"pad\n".repeat(8)}needle end\n`;
+		const entry = makeEntry(
+			`old start\n${gap}old middle\n${tail}`,
+			`new start\n${gap}new middle\n${tail}`,
+		);
+		expect(entry.fileDiff.hunks).toHaveLength(2);
+
+		const collapsed = collectDiffSearchMatches([entry], {
+			...defaultOptions,
+			query: "needle",
+		});
+		expect(collapsed).toEqual([]);
+
+		const expanded = collectDiffSearchMatches([entry], {
+			caseSensitive: false,
+			expandUnchanged: true,
+			query: "needle",
+		});
+		expect(expanded.map((match) => [match.side, match.lineNumber])).toEqual([
+			["additions", 10],
+			["additions", 28],
+		]);
+	});
+
 	test("orders matches by file, then rendered position", () => {
 		const first = makeEntry("", "needle a\n", "diff:a.ts");
 		const second = makeEntry("needle removed\n", "needle added\n", "diff:b.ts");

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/utils/collectDiffSearchMatches/collectDiffSearchMatches.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/utils/collectDiffSearchMatches/collectDiffSearchMatches.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { parseDiffFromFile } from "@pierre/diffs";
+import {
+	collectDiffSearchMatches,
+	type DiffSearchEntry,
+} from "./collectDiffSearchMatches";
+
+function makeEntry(
+	original: string,
+	modified: string,
+	itemId = "diff:file.ts",
+): DiffSearchEntry {
+	return {
+		itemId,
+		changeKey: itemId.replace(/^diff:/, ""),
+		fileDiff: parseDiffFromFile(
+			{ name: "file.ts", contents: original },
+			{ name: "file.ts", contents: modified },
+		),
+	};
+}
+
+const defaultOptions = {
+	caseSensitive: false,
+	expandUnchanged: false,
+};
+
+describe("collectDiffSearchMatches", () => {
+	test("returns no matches for an empty query", () => {
+		const entry = makeEntry("alpha\n", "alpha\nbeta\n");
+		expect(
+			collectDiffSearchMatches([entry], { ...defaultOptions, query: "" }),
+		).toEqual([]);
+	});
+
+	test("finds matches on added lines with addition-side numbering", () => {
+		const entry = makeEntry("alpha\n", "alpha\nneedle beta\n");
+		const matches = collectDiffSearchMatches([entry], {
+			...defaultOptions,
+			query: "needle",
+		});
+		expect(matches).toEqual([
+			{
+				itemId: entry.itemId,
+				changeKey: entry.changeKey,
+				side: "additions",
+				lineNumber: 2,
+				occurrence: 0,
+			},
+		]);
+	});
+
+	test("finds matches on deleted lines with deletion-side numbering", () => {
+		const entry = makeEntry("alpha\nneedle gone\nomega\n", "alpha\nomega\n");
+		const matches = collectDiffSearchMatches([entry], {
+			...defaultOptions,
+			query: "needle",
+		});
+		expect(matches).toEqual([
+			{
+				itemId: entry.itemId,
+				changeKey: entry.changeKey,
+				side: "deletions",
+				lineNumber: 2,
+				occurrence: 0,
+			},
+		]);
+	});
+
+	test("finds matches on unchanged context lines inside hunks", () => {
+		const entry = makeEntry("context needle\nold\n", "context needle\nnew\n");
+		const matches = collectDiffSearchMatches([entry], {
+			...defaultOptions,
+			query: "needle",
+		});
+		expect(matches).toContainEqual({
+			itemId: entry.itemId,
+			changeKey: entry.changeKey,
+			side: "additions",
+			lineNumber: 1,
+			occurrence: 0,
+		});
+	});
+
+	test("counts multiple occurrences on one line separately", () => {
+		const entry = makeEntry("", "foo foo foo\n");
+		const matches = collectDiffSearchMatches([entry], {
+			...defaultOptions,
+			query: "foo",
+		});
+		expect(matches.map((match) => match.occurrence)).toEqual([0, 1, 2]);
+		expect(new Set(matches.map((match) => match.lineNumber)).size).toBe(1);
+	});
+
+	test("respects case sensitivity", () => {
+		const entry = makeEntry("", "Needle\nneedle\n");
+		const insensitive = collectDiffSearchMatches([entry], {
+			...defaultOptions,
+			query: "needle",
+		});
+		expect(insensitive).toHaveLength(2);
+
+		const sensitive = collectDiffSearchMatches([entry], {
+			caseSensitive: true,
+			expandUnchanged: false,
+			query: "needle",
+		});
+		expect(sensitive).toHaveLength(1);
+		expect(sensitive[0]?.lineNumber).toBe(2);
+	});
+
+	test("skips unchanged lines outside hunks unless expandUnchanged is set", () => {
+		const farApartOriginal = `needle top\n${"pad\n".repeat(20)}old\n`;
+		const farApartModified = `needle top\n${"pad\n".repeat(20)}new\n`;
+
+		const entry = makeEntry(farApartOriginal, farApartModified);
+		const collapsed = collectDiffSearchMatches([entry], {
+			...defaultOptions,
+			query: "needle",
+		});
+		expect(collapsed).toEqual([]);
+
+		const expanded = collectDiffSearchMatches([entry], {
+			caseSensitive: false,
+			expandUnchanged: true,
+			query: "needle",
+		});
+		expect(expanded).toEqual([
+			{
+				itemId: entry.itemId,
+				changeKey: entry.changeKey,
+				side: "additions",
+				lineNumber: 1,
+				occurrence: 0,
+			},
+		]);
+	});
+
+	test("orders matches by file, then rendered position", () => {
+		const first = makeEntry("", "needle a\n", "diff:a.ts");
+		const second = makeEntry("needle removed\n", "needle added\n", "diff:b.ts");
+		const matches = collectDiffSearchMatches([first, second], {
+			...defaultOptions,
+			query: "needle",
+		});
+		expect(
+			matches.map((match) => [match.itemId, match.side, match.lineNumber]),
+		).toEqual([
+			["diff:a.ts", "additions", 1],
+			["diff:b.ts", "deletions", 1],
+			["diff:b.ts", "additions", 1],
+		]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/utils/collectDiffSearchMatches/collectDiffSearchMatches.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/utils/collectDiffSearchMatches/collectDiffSearchMatches.ts
@@ -1,0 +1,134 @@
+import type { FileDiffMetadata, SelectionSide } from "@pierre/diffs";
+
+export interface DiffSearchEntry {
+	itemId: string;
+	changeKey: string;
+	fileDiff: FileDiffMetadata;
+}
+
+export interface DiffSearchMatch {
+	itemId: string;
+	changeKey: string;
+	side: SelectionSide;
+	lineNumber: number;
+	/** Zero-based occurrence of the query within this line's text, counted the
+	 *  same way the DOM highlighter walks a rendered row (overlaps allowed). */
+	occurrence: number;
+}
+
+interface CollectDiffSearchMatchesOptions {
+	query: string;
+	caseSensitive: boolean;
+	/** Mirrors the CodeView `expandUnchanged` option: when set, whole files are
+	 *  rendered, so unchanged lines outside hunks are searchable too. */
+	expandUnchanged: boolean;
+}
+
+/**
+ * Compute every match of `query` across the diff data itself, in the order the
+ * lines appear in the rendered changeset. The CodeView virtualizes its rows,
+ * so DOM-based searching only ever sees the mounted viewport — this walks the
+ * parsed hunks instead and stays stable while scrolling.
+ */
+export function collectDiffSearchMatches(
+	entries: readonly DiffSearchEntry[],
+	options: CollectDiffSearchMatchesOptions,
+): DiffSearchMatch[] {
+	if (!options.query) return [];
+
+	const needle = options.caseSensitive
+		? options.query
+		: options.query.toLowerCase();
+	const matches: DiffSearchMatch[] = [];
+
+	for (const entry of entries) {
+		const { fileDiff } = entry;
+		const emitLine = (
+			text: string,
+			side: SelectionSide,
+			lineNumber: number,
+		) => {
+			const haystack = options.caseSensitive ? text : text.toLowerCase();
+			let fromIndex = 0;
+			let occurrence = 0;
+			while (true) {
+				const at = haystack.indexOf(needle, fromIndex);
+				if (at === -1) break;
+				matches.push({
+					itemId: entry.itemId,
+					changeKey: entry.changeKey,
+					side,
+					lineNumber,
+					occurrence,
+				});
+				occurrence += 1;
+				fromIndex = at + 1;
+			}
+		};
+
+		const includeUnchanged = options.expandUnchanged && !fileDiff.isPartial;
+		// Next addition-side line to emit when unchanged regions are rendered.
+		let expandedLine = 1;
+
+		for (const hunk of fileDiff.hunks) {
+			if (includeUnchanged) {
+				for (; expandedLine < hunk.additionStart; expandedLine += 1) {
+					emitLine(
+						fileDiff.additionLines[expandedLine - 1] ?? "",
+						"additions",
+						expandedLine,
+					);
+				}
+			}
+
+			let additionLine = hunk.additionStart;
+			let deletionLine = hunk.deletionStart;
+
+			for (const block of hunk.hunkContent) {
+				if (block.type === "context") {
+					for (let index = 0; index < block.lines; index += 1) {
+						emitLine(
+							fileDiff.additionLines[block.additionLineIndex + index] ?? "",
+							"additions",
+							additionLine + index,
+						);
+					}
+					additionLine += block.lines;
+					deletionLine += block.lines;
+					continue;
+				}
+
+				for (let index = 0; index < block.deletions; index += 1) {
+					emitLine(
+						fileDiff.deletionLines[block.deletionLineIndex + index] ?? "",
+						"deletions",
+						deletionLine + index,
+					);
+				}
+				for (let index = 0; index < block.additions; index += 1) {
+					emitLine(
+						fileDiff.additionLines[block.additionLineIndex + index] ?? "",
+						"additions",
+						additionLine + index,
+					);
+				}
+				deletionLine += block.deletions;
+				additionLine += block.additions;
+			}
+
+			expandedLine = additionLine;
+		}
+
+		if (includeUnchanged) {
+			for (; expandedLine <= fileDiff.additionLines.length; expandedLine += 1) {
+				emitLine(
+					fileDiff.additionLines[expandedLine - 1] ?? "",
+					"additions",
+					expandedLine,
+				);
+			}
+		}
+	}
+
+	return matches;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/utils/collectDiffSearchMatches/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffPaneSearch/utils/collectDiffSearchMatches/index.ts
@@ -1,0 +1,5 @@
+export type {
+	DiffSearchEntry,
+	DiffSearchMatch,
+} from "./collectDiffSearchMatches";
+export { collectDiffSearchMatches } from "./collectDiffSearchMatches";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useTextSearch/useTextSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useTextSearch/useTextSearch.ts
@@ -2,8 +2,8 @@ import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	findTextRanges,
-	getHighlightStyleContainers,
 	type SearchRootIndexCache,
+	syncHighlightStyles,
 } from "./utils/textSearchDom";
 
 const SEARCH_DEBOUNCE_MS = 150;
@@ -101,32 +101,12 @@ export function useTextSearch({
 		(searchRoots: Array<Node & ParentNode>) => {
 			if (typeof document === "undefined") return;
 
-			const styleContainers = new Set(
-				getHighlightStyleContainers(searchRoots, document),
+			syncHighlightStyles(
+				searchRoots,
+				document,
+				highlightStyleElementsRef.current,
+				highlightStyles,
 			);
-
-			for (const [
-				styleContainer,
-				styleElement,
-			] of highlightStyleElementsRef.current) {
-				if (styleContainers.has(styleContainer)) {
-					continue;
-				}
-
-				styleElement.remove();
-				highlightStyleElementsRef.current.delete(styleContainer);
-			}
-
-			for (const styleContainer of styleContainers) {
-				if (highlightStyleElementsRef.current.has(styleContainer)) {
-					continue;
-				}
-
-				const styleElement = document.createElement("style");
-				styleElement.textContent = highlightStyles;
-				styleContainer.appendChild(styleElement);
-				highlightStyleElementsRef.current.set(styleContainer, styleElement);
-			}
 		},
 		[highlightStyles],
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useTextSearch/utils/textSearchDom/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useTextSearch/utils/textSearchDom/index.ts
@@ -1,2 +1,10 @@
-export type { SearchRootIndex, SearchRootIndexCache } from "./textSearchDom";
-export { findTextRanges, getHighlightStyleContainers } from "./textSearchDom";
+export type {
+	HighlightStyleElementMap,
+	SearchRootIndex,
+	SearchRootIndexCache,
+} from "./textSearchDom";
+export {
+	findTextRanges,
+	getHighlightStyleContainers,
+	syncHighlightStyles,
+} from "./textSearchDom";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useTextSearch/utils/textSearchDom/textSearchDom.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/hooks/useTextSearch/utils/textSearchDom/textSearchDom.ts
@@ -154,3 +154,44 @@ export function getHighlightStyleContainers(
 
 	return Array.from(styleContainers);
 }
+
+export type HighlightStyleElementMap = Map<
+	HTMLHeadElement | ShadowRoot,
+	HTMLStyleElement
+>;
+
+/**
+ * Keep a `::highlight()` style element mounted in every style container that
+ * hosts a search root (document head or shadow root), removing elements whose
+ * container no longer holds any search root.
+ */
+export function syncHighlightStyles(
+	searchRoots: Array<Node & ParentNode>,
+	ownerDocument: Document,
+	styleElements: HighlightStyleElementMap,
+	styles: string,
+): void {
+	const styleContainers = new Set(
+		getHighlightStyleContainers(searchRoots, ownerDocument),
+	);
+
+	for (const [styleContainer, styleElement] of styleElements) {
+		if (styleContainers.has(styleContainer)) {
+			continue;
+		}
+
+		styleElement.remove();
+		styleElements.delete(styleContainer);
+	}
+
+	for (const styleContainer of styleContainers) {
+		if (styleElements.has(styleContainer)) {
+			continue;
+		}
+
+		const styleElement = ownerDocument.createElement("style");
+		styleElement.textContent = styles;
+		styleContainer.appendChild(styleElement);
+		styleElements.set(styleContainer, styleElement);
+	}
+}


### PR DESCRIPTION
## Summary

Adds find-in-pane (⌘F / Ctrl+Shift+F) to the v2 workspace Changes pane (`DiffPane`).

Because the pane's `CodeView` (`@pierre/diffs`) virtualizes rows, a DOM-based text search would only ever see the mounted viewport. Search is therefore split into two layers:

- **Data-driven matches** — a new `collectDiffSearchMatches` util walks each file's parsed hunks (context/deletion/addition lines with per-side line numbers) to build the complete, scroll-stable match list across the whole changeset, honoring the `expandUnchanged` setting.
- **DOM painting** — CSS Custom Highlights are painted over whatever rows are currently mounted and repainted (via MutationObserver) as the virtualizer swaps rows in and out; painting never mutates the match list.

Details:

- New `FIND_IN_CHANGES` hotkey in the registry, gated on pane focus like the terminal/file-viewer/chat find hotkeys that share the binding.
- Next/previous navigation uses the virtualizer's `scrollTo({type: "line", …})`, so it reaches unmounted rows; matches in collapsed files auto-expand the file before scrolling.
- Search state resets when the pane identity changes (same-kind v2 panes reuse one React instance across tabs) and closes when the pane loses focus.
- Reuses the existing `MarkdownSearch` find-bar UI and `findTextRanges` DOM walker; extracted the `::highlight()` style injection from `useTextSearch` into a shared `syncHighlightStyles` helper used by both hooks.

Scope notes: matches cover diff code lines only (comment threads and file headers are slotted light DOM, excluded from both counting and painting); lines revealed via manual context expansion are highlighted visually but not counted.

## Test Plan

- [x] `bun test collectDiffSearchMatches.test.ts` — 8 cases covering addition/deletion/context numbering, occurrence counting, case sensitivity, `expandUnchanged`, and match ordering against real `parseDiffFromFile` output
- [x] `bun run lint` clean; `tsc` clean for all touched files
- [ ] Manual: ⌘F in Changes pane — match count stays stable while scrolling; Enter/Shift+Enter cycle across files, expand collapsed files, and jump to off-screen matches

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5648">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cmd+F (or Ctrl+Shift+F) search to the v2 Changes pane with full diff coverage and inline highlights. Highlights no longer span across rows, keeping the match counter accurate during scroll and navigation.

- **New Features**
  - `FIND_IN_CHANGES` hotkey opens a `MarkdownSearch` find bar in the Changes pane.
  - Searches across the whole diff using `@pierre/diffs` hunks; respects `expandUnchanged`.
  - Uses CSS Custom Highlights over virtualized rows; match count stays stable.
  - Next/previous jumps to off-screen lines and auto-expands collapsed files; closes on blur and resets on pane change.

- **Refactors**
  - Extracted `syncHighlightStyles` for shared `::highlight()` CSS injection and updated `useTextSearch` to use it.
  - Added `collectDiffSearchMatches` with tests for numbering, occurrences, case sensitivity, ordering, `expandUnchanged`, and a two-hunk gap-fill case.

<sup>Written for commit 69434b5b46c6795932d153fe9bd851332b897060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Find in Changes” search within diff views, including match counting, next/previous navigation, repeated matches, and optional expansion of unchanged content.
  * Introduced a platform-specific hotkey to toggle the diff search, and improved search highlighting across virtualized rows and shadow-root content.
  * Enhanced text search highlight rendering by synchronizing highlight style elements with the active DOM/roots.
* **Tests**
  * Added Bun tests covering diff match extraction, ordering, line references, case sensitivity, and unchanged-context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->