### PR TITLE
docs(changelog): rework launch tweet instructions to single-tweet format

### DIFF
--- a/.github/prompts/generate-changelog.md
+++ b/.github/prompts/generate-changelog.md
@@ -161,60 +161,75 @@ Only set it when you have a genuinely strong hero; a mediocre or awkwardly-tilte
 worse than none, so leave it out and the card renders text-only rather than force a bad
 image. Inline media still carries the visuals.
 
-## Launch tweet / thread
+## Launch tweet
 
-Alongside the changelog `.mdx`, always draft a short "what we shipped" thread for X and
-write it to a **sibling file** `apps/marketing/content/changelog/YYYY-MM-DD-tweet.md` (a `.md`, not
+Alongside the changelog `.mdx`, always draft the "what we shipped" launch tweet and write
+it to a **sibling file** `apps/marketing/content/changelog/YYYY-MM-DD-tweet.md` (a `.md`, not
 `.mdx` — the changelog loader only reads `.mdx`, so this companion file is ignored by the
 site and won't render as an entry). Give it light frontmatter (`title`, `date`,
-`type: tweet`) and the thread body.
+`type: tweet`) and the body.
 
-Lead with the 2-4 biggest features and give each the **why**, not just the **what**.
+It is **one single tweet** (one long X post), not a thread. It goes out together with the
+changelog link, so the tweet carries the highlights and the changelog carries the detail.
 
-Style — match this shape and voice:
+Shape:
 
-- Open with `What we shipped <this week | the last N weeks> @ Superset 🛳️`.
-- Number the top features; put a trailing emoji on each title.
-- Flagship feature (#1): 1-2 short paragraphs framing the **bet / vision** behind it —
-  where the product is going — not just the mechanics. Remaining features: one tight
-  paragraph each on what it does + how to turn it on (e.g. "Enable it in Settings → …").
-- First-person plural, opinionated, casual. No corporate hedging or feature-list dryness.
-- If a feature was itself used to produce the changelog (e.g. an automation drafted it),
-  call it out ("This changelog draft was created by an automation").
-- Close with: `As always, tons of bug fixes and improvements, thanks to all our users in
-  open beta for V2 helping us make the product better everyday <3`
+- Open with `What we shipped this week @superset_sh 🛳️` (or `the last N weeks`).
+- Number the top 2-4 features; trailing emoji on each title.
+- Flagship feature (#1): 1-2 short paragraphs. Lead with the pain or the bet behind it,
+  then what it does. Remaining features: one tight paragraph each on what it does + how
+  to turn it on (e.g. "Enable it in Settings → …").
+- Fold everything smaller into one `Also this week: …` sentence.
+- If an automation drafted the changelog, say so ("This changelog draft was created by an
+  automation").
+- Close with: `Plus a bunch of bug fixes. Thanks to everyone in the v2 open beta for the
+  reports, please keep them coming!`
+- End with the changelog link: `Full changelog: https://superset.sh/changelog/<slug>`.
+
+Voice — the source of truth is the Notion page **"Kiet's Email voice"**. Before writing
+the tweet, fetch it with the Notion MCP (`notion-search` for "Kiet's Email voice", then
+`notion-fetch` the result) and follow it; the same rules apply to tweets. If the Notion
+MCP isn't available in the environment (e.g. the headless CI run), fall back to this
+summary:
+
+- First-person plural, casual, opinionated. Write like a person typing fast, then cut half.
+- **No em dashes.** Periods or commas.
+- No performative or salesy lines ("genuinely excited", "we really appreciate you",
+  vision taglines bolted onto feature blurbs).
+- No AI tells: no noun-pile compression (use normal verbs and articles), no "not just X,
+  but Y", no rule-of-three stacking, no signposting ("Here's the thing"), and none of:
+  delve, leverage, robust, seamless, crucial, comprehensive, streamline.
 
 Reference example (the voice + shape to emulate):
 
 ```text
-What we shipped the last 2 weeks @ Superset 🛳️
+What we shipped this week @superset_sh 🛳️
 
-1. Automations ⚡
+1. Rich input for the terminal ⌨️
+Writing a real prompt in a raw TTY line is painful. No multiline editing, no mentions,
+and pasting can execute line by line. So we brought the workspace chat composer into the
+terminal. Press ⌘I over any terminal pane and you get a real editor: Shift+Enter
+newlines, @-file mentions, drafts that survive tab switches. Your prompt lands in the
+TUI as one clean block.
 
-One of the most important features in Superset for the future. If the software
-development lifecycle becomes more like a factory, human inputs should be to tune
-automation, not generate the code.
+2. Terminal scrolling at Ghostty speed 🖱️
+Claude Code transcripts used to scroll at a third of native speed in Superset. Agent
+TUIs tune themselves to the terminal they think they're in, so we fixed the identity we
+advertise. Scrolling now matches Ghostty.
 
-Automations is our first experiment towards that, scheduling agents to create workspaces
-and PRs on events and triggers. Simply create a prompt and run any agents on it.
+3. Mistral Vibe 🤝
+Mistral's Vibe CLI is now a first-class Superset agent, contributed by the Mistral team
+themselves. Its own icon in the pickers, a model selector, a completion chime. We also
+added GPT-5.6 Sol, Terra, and Luna to the Codex picker.
 
-We will add more capabilities such as auto-triage GitHub issues, Linear tasks, etc. This
-changelog draft was created by an automation.
+Also this week: wake offline hosts with a configurable wake command, remote hosts on
+every plan (relay no longer needs a paid subscription), a Sydney relay region, and
+Linear project/cycle filters for Tasks.
 
-2. CLI 🎹
+Plus a bunch of bug fixes. Thanks to everyone in the v2 open beta for the reports,
+please keep them coming!
 
-Superset can now be driven through the CLI by agents. Let Claude Code, Codex, etc. create
-workspaces, spin up other agents, and even create automations, all through the command
-line. Packaged directly into the Superset terminal, no installation necessary.
-
-3. Slack bot 🤖
-
-Create Superset workspaces and tasks directly from your threads, it can read contexts
-from your conversations, create issues, and spin up workspace + agents on your machine to
-solve it. Enable it through Settings -> Integrations.
-
-As always, tons of bug fixes and improvements, thanks to all our users in open beta for V2
-helping us make the product better everyday <3
+Full changelog: https://superset.sh/changelog/2026-07-12-terminal-rich-input
 ```
 
 ## Reference Examples
@@ -235,7 +250,7 @@ Otherwise, produce and commit the full set:
    - the changelog entry `apps/marketing/content/changelog/YYYY-MM-DD-<slug>.mdx`
    - its media assets in `apps/marketing/public/changelog/` (screenshots/recordings, when
      the environment allows — see above; otherwise placeholders + TODOs)
-   - the companion launch thread `apps/marketing/content/changelog/YYYY-MM-DD-tweet.md`
+   - the companion launch tweet `apps/marketing/content/changelog/YYYY-MM-DD-tweet.md`
 2. **Format:** run `bun run lint:fix`, then verify `bun run lint` exits 0 before committing.
 3. **Branch:** create `changelog/YYYY-MM-DD`.
 4. **Commit** the `.mdx`, its media assets, and the `-tweet.md` file together with message

--- a/.github/prompts/generate-changelog.md
+++ b/.github/prompts/generate-changelog.md
@@ -175,7 +175,8 @@ changelog link, so the tweet carries the highlights and the changelog carries th
 Shape:
 
 - Open with `What we shipped this week @superset_sh 🛳️` (or `the last N weeks`).
-- Number the top 2-4 features; trailing emoji on each title.
+- Number the top features, up to 4; trailing emoji on each title. One numbered feature
+  is fine on a slow week. Never pad or invent to hit a count.
 - Flagship feature (#1): 1-2 short paragraphs. Lead with the pain or the bet behind it,
   then what it does. Remaining features: one tight paragraph each on what it does + how
   to turn it on (e.g. "Enable it in Settings → …").
@@ -196,9 +197,11 @@ summary:
 - **No em dashes.** Periods or commas.
 - No performative or salesy lines ("genuinely excited", "we really appreciate you",
   vision taglines bolted onto feature blurbs).
-- No AI tells: no noun-pile compression (use normal verbs and articles), no "not just X,
-  but Y", no rule-of-three stacking, no signposting ("Here's the thing"), and none of:
-  delve, leverage, robust, seamless, crucial, comprehensive, streamline.
+- No AI tells in the prose: no noun-pile compression (use normal verbs and articles), no
+  "not just X, but Y", no stacking parallel clauses for rhythm, no signposting ("Here's
+  the thing"), and none of: delve, leverage, robust, seamless, crucial, comprehensive,
+  streamline. A plain comma list of shipped capabilities (as in the example below) is
+  fine; the ban is on rhetorical stacking, not lists of real things.
 
 Reference example (the voice + shape to emulate):
 


### PR DESCRIPTION
## Summary
- Rewrite the "Launch tweet / thread" section of `.github/prompts/generate-changelog.md`: the weekly changelog automation now drafts **one single tweet** (posted with the changelog link) instead of a thread.
- Bake in Kiet's voice rules, with the Notion page "Kiet's Email voice" as the source of truth: the automation fetches it via the Notion MCP before writing (falls back to an inline summary in headless CI). Key bans: no em dashes, no performative/salesy lines, no AI tells (noun-piles, "not just X but Y", rule-of-three, signposting, words like seamless/leverage/robust).
- Replace the old close ("As always, tons of bug fixes ... <3") with the current one ("Plus a bunch of bug fixes. Thanks to everyone in the v2 open beta for the reports, please keep them coming!") and require a trailing `Full changelog: <url>` line.
- Swap the reference example for the 2026-07-12 tweet (rich terminal input / Ghostty-speed scrolling / Mistral Vibe), and fix the handle to `@superset_sh`.

## Why / Context
This week's tweet was hand-reworked into Kiet's voice and shipped as a single post alongside the changelog. The prompt still described the old thread format and voice, so next Monday's automated run would regress to it.

## Testing
- Docs-only (prompt file); reviewed rendered markdown. Biome doesn't process `.md`, no lint impact.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the changelog launch tweet docs to generate a single tweet (not a thread) that publishes alongside the changelog link and is saved as a sibling `.md` file.
Clarified shape and voice: up to 4 numbered features with trailing emoji (one is fine on slow weeks), fold smaller items into “Also this week,” call out when automation drafted the changelog, open with `@superset_sh`, close with the new copy and a required “Full changelog: <url>” line; tone pulled from Kiet’s Notion voice via MCP with CI fallback; refreshed the 2026‑07‑12 example and updated all “thread” references to “tweet.”

<sup>Written for commit c13c72d025e8a6aaed5be2e96ed4f38845f41622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated weekly changelog guidance to generate a single launch tweet instead of a thread.
  * Refined tweet structure, tone, feature numbering, and handling of smaller updates (“Also this week”).
  * Strengthened requirements for automation attribution and a closing line that ends with the full changelog URL.
  * Updated output workflow to use the launch tweet artifact format (`YYYY-MM-DD-tweet.md`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->