### PR TITLE
feat(desktop): terminal connection status indicator with diagnosis popover

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -26,6 +26,7 @@ import {
 	type TerminalLogEntry,
 	type TerminalTransport,
 } from "./terminal-ws-transport";
+import type { TerminalFailureClassification } from "./terminalConnectionDiagnostics";
 
 interface RegistryEntry {
 	terminalId: string;
@@ -200,6 +201,19 @@ class TerminalRuntimeRegistryImpl {
 		if (entry.transport.connectionState === "disconnected") return;
 		if (entry.transport.currentUrl === wsUrl) return;
 		connect(entry.transport, entry.runtime.terminal, wsUrl);
+	}
+
+	/**
+	 * Manually re-dial the last URL after the transport stopped trying (gave
+	 * up on max attempts, access denied, fatal server error). connect() clears
+	 * the terminated flag, so this restarts a dead loop.
+	 */
+	retryConnect(terminalId: string, instanceId = terminalId) {
+		const entry = this.getEntry(terminalId, instanceId);
+		if (!entry?.runtime) return;
+		const url = entry.transport.currentUrl;
+		if (!url) return;
+		connect(entry.transport, entry.runtime.terminal, url);
 	}
 
 	/**
@@ -384,6 +398,21 @@ class TerminalRuntimeRegistryImpl {
 		return this.getEntry(terminalId, instanceId)?.transport.logs ?? EMPTY_LOGS;
 	}
 
+	/**
+	 * Why the connection is down, once the transport has stopped retrying.
+	 * Null while healthy or still auto-reconnecting. Changes are announced
+	 * through the state and log listeners (diagnosis flips always accompany a
+	 * state change or a log push).
+	 */
+	getConnectionDiagnosis(
+		terminalId: string,
+		instanceId?: string,
+	): TerminalFailureClassification | null {
+		return (
+			this.getEntry(terminalId, instanceId)?.transport.lastDiagnosis ?? null
+		);
+	}
+
 	clearLogs(terminalId: string, instanceId?: string): void {
 		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry) return;
@@ -448,6 +477,7 @@ if (import.meta.hot) {
 export type {
 	ConnectionState,
 	LinkHoverInfo,
+	TerminalFailureClassification,
 	TerminalLinkHandlers,
 	TerminalLogEntry,
 };

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -213,6 +213,9 @@ class TerminalRuntimeRegistryImpl {
 		if (!entry?.runtime) return;
 		const url = entry.transport.currentUrl;
 		if (!url) return;
+		// Manual retry gets a full backoff budget, like reconnectNow(); the
+		// exhausted counter would otherwise block scheduling any follow-up.
+		entry.transport._reconnectAttempt = 0;
 		connect(entry.transport, entry.runtime.terminal, url);
 	}
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -5,7 +5,10 @@ import {
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { ensureFreshJwt } from "renderer/lib/auth-client";
 import { posthog } from "renderer/lib/posthog";
-import { classifyTerminalFailure } from "./terminalConnectionDiagnostics";
+import {
+	classifyTerminalFailure,
+	type TerminalFailureClassification,
+} from "./terminalConnectionDiagnostics";
 import { createWriteCoalescer, type WriteCoalescer } from "./write-coalescer";
 
 export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
@@ -79,6 +82,12 @@ export interface TerminalTransport {
 	_writeCoalescer: WriteCoalescer | null;
 	/** Internal: last `_whoowns` probe, used to explain a failed connection. */
 	_lastProbe: RelayAffinityProbe | null;
+	/**
+	 * Why the connection is down, once the transport has stopped trying (gave
+	 * up, access denied, fatal server error, PTY exit). Null while healthy or
+	 * still auto-reconnecting. Drives the pane header status indicator.
+	 */
+	lastDiagnosis: TerminalFailureClassification | null;
 	/** Internal: bumped per connect() so async preflight callbacks from a
 	 * superseded attempt (reconnectNow re-entering the same URL) can't open a
 	 * duplicate socket or fatally terminate the newer attempt. */
@@ -184,6 +193,7 @@ export function createTransport(): TerminalTransport {
 		_resumeListener: null,
 		_writeCoalescer: null,
 		_lastProbe: null,
+		lastDiagnosis: null,
 		_connectEpoch: 0,
 	};
 }
@@ -377,6 +387,7 @@ export function connect(
 		terminal.write(data),
 	);
 	transport._terminated = false;
+	transport.lastDiagnosis = null;
 	setupLiveness(transport);
 	setConnectionState(transport, "connecting");
 	const actualUrl = transport._hasReceivedBytes
@@ -444,6 +455,7 @@ export function connect(
 						return;
 					}
 					const diagnosis = classifyTerminalFailure(probe, true);
+					transport.lastDiagnosis = diagnosis;
 					pushLog(
 						transport,
 						"error",
@@ -511,12 +523,17 @@ function attachSocketListeners(
 		}
 
 		if (message.type === "attached") {
+			transport.lastDiagnosis = null;
 			setConnectionState(transport, "open");
 			sendResize(transport, terminal.cols, terminal.rows);
 			return;
 		}
 
 		if (message.type === "error") {
+			transport.lastDiagnosis = {
+				category: "unknown",
+				message: message.message,
+			};
 			pushLog(transport, "error", message.message);
 			// Server closes after this; reconnecting would just hit the same error.
 			transport._terminated = true;
@@ -527,6 +544,10 @@ function attachSocketListeners(
 		if (message.type === "exit") {
 			transport._writeCoalescer?.flushSync();
 			transport._terminated = true;
+			transport.lastDiagnosis = {
+				category: "unknown",
+				message: `The terminal session ended (exit code ${message.exitCode}).`,
+			};
 			cancelReconnect(transport);
 			terminal.writeln(
 				`\r\n[terminal] exited with code ${message.exitCode} (signal ${message.signal})`,
@@ -551,7 +572,7 @@ function attachSocketListeners(
 				pushLog(
 					transport,
 					"warn",
-					`WebSocket closed while connected to ${endpoint} (${formatCloseDetails(event)}). Reconnecting...`,
+					`WebSocket closed while connected to ${endpoint} (${formatCloseDetails(event)}). Reconnecting (attempt ${transport._reconnectAttempt + 1}/${MAX_RECONNECT_ATTEMPTS})...`,
 				);
 			} else {
 				// Gave up. Classify why from the preflight probe and record it so
@@ -560,6 +581,7 @@ function attachSocketListeners(
 					transport._lastProbe,
 					isRelayHostUrl(transport.currentUrl),
 				);
+				transport.lastDiagnosis = diagnosis;
 				pushLog(
 					transport,
 					"error",
@@ -609,6 +631,7 @@ export function disconnect(transport: TerminalTransport) {
 	transport.currentUrl = null;
 	transport._terminal = null;
 	transport._reconnectAttempt = 0;
+	transport.lastDiagnosis = null;
 	setTerminalTitle(transport, undefined);
 	setConnectionState(transport, "disconnected");
 	transport.onDataDisposable?.dispose();
@@ -651,6 +674,7 @@ export function disposeTransport(transport: TerminalTransport) {
 	transport.currentUrl = null;
 	transport._terminal = null;
 	transport._reconnectAttempt = 0;
+	transport.lastDiagnosis = null;
 	setTerminalTitle(transport, undefined);
 	transport.onDataDisposable?.dispose();
 	transport.onDataDisposable = null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -465,11 +465,6 @@ export function TerminalPane({
 					isDropActive ? "opacity-75" : "opacity-0",
 				)}
 			/>
-			{connectionState === "closed" && (
-				<div className="flex items-center gap-2 border-t border-border px-3 py-1.5 text-xs text-muted-foreground">
-					<span>Disconnected</span>
-				</div>
-			)}
 			<LinkHoverHint
 				hoverLabel={resolveHoverLabel(hoveredLink, filePolicy, urlPolicy)}
 				hoverPosition={hoveredLink}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/TerminalPaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/TerminalPaneHeaderExtras.tsx
@@ -6,13 +6,23 @@ import {
 	terminalRichInputOpenStore,
 	useTerminalRichInputOpen,
 } from "../../richInputOpenStore";
+import { TerminalConnectionIndicator } from "./components/TerminalConnectionIndicator";
+
+interface TerminalPaneHeaderExtrasProps {
+	terminalId: string;
+	terminalInstanceId: string;
+}
 
 /**
  * Header affordance that opens the rich-input overlay, so the ⌘I composer is
  * discoverable without knowing the shortcut. Toggles the same shared open-state
  * the hotkey drives; the tooltip carries the shortcut as the teach path.
+ * Also hosts the connection status indicator for the pane's WebSocket.
  */
-export function TerminalPaneHeaderExtras() {
+export function TerminalPaneHeaderExtras({
+	terminalId,
+	terminalInstanceId,
+}: TerminalPaneHeaderExtrasProps) {
 	const isOpen = useTerminalRichInputOpen();
 	const hotkeyText = useHotkeyDisplay("TOGGLE_TERMINAL_RICH_INPUT").text;
 	const label =
@@ -20,6 +30,10 @@ export function TerminalPaneHeaderExtras() {
 
 	return (
 		<div className="flex items-center">
+			<TerminalConnectionIndicator
+				terminalId={terminalId}
+				terminalInstanceId={terminalInstanceId}
+			/>
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<button

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
@@ -126,7 +126,11 @@ export function TerminalConnectionIndicator({
 							<button
 								type="button"
 								onClick={() =>
-									navigator.clipboard.writeText(formatLogsForClipboard(logs))
+									navigator.clipboard
+										.writeText(formatLogsForClipboard(logs))
+										.catch((error) =>
+											console.error("[terminal] copy log failed:", error),
+										)
 								}
 								className="text-muted-foreground transition-colors hover:text-foreground"
 							>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
@@ -1,0 +1,168 @@
+import { Button } from "@superset/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { cn } from "@superset/ui/utils";
+import { useCallback, useSyncExternalStore } from "react";
+import {
+	type TerminalLogEntry,
+	terminalRuntimeRegistry,
+} from "renderer/lib/terminal/terminal-runtime-registry";
+
+interface TerminalConnectionIndicatorProps {
+	terminalId: string;
+	terminalInstanceId: string;
+}
+
+function formatTime(timestamp: number): string {
+	const d = new Date(timestamp);
+	const hh = String(d.getHours()).padStart(2, "0");
+	const mm = String(d.getMinutes()).padStart(2, "0");
+	const ss = String(d.getSeconds()).padStart(2, "0");
+	return `${hh}:${mm}:${ss}`;
+}
+
+function formatLogsForClipboard(logs: readonly TerminalLogEntry[]): string {
+	return logs
+		.map(
+			(entry) =>
+				`${new Date(entry.timestamp).toISOString()} [${entry.level}] ${entry.message}`,
+		)
+		.join("\n");
+}
+
+/**
+ * Pane-header connection status for the terminal WebSocket. Hidden while the
+ * connection is healthy; shows an amber "Reconnecting" dot while the
+ * auto-reconnect loop runs and a red "Disconnected" dot once the transport
+ * stops trying. The popover carries the human diagnosis, a manual reconnect,
+ * and the raw transport log for bug reports.
+ */
+export function TerminalConnectionIndicator({
+	terminalId,
+	terminalInstanceId,
+}: TerminalConnectionIndicatorProps) {
+	const subscribe = useCallback(
+		(callback: () => void) => {
+			const unsubState = terminalRuntimeRegistry.onStateChange(
+				terminalId,
+				callback,
+				terminalInstanceId,
+			);
+			const unsubLogs = terminalRuntimeRegistry.onLogsChange(
+				terminalId,
+				callback,
+				terminalInstanceId,
+			);
+			return () => {
+				unsubState();
+				unsubLogs();
+			};
+		},
+		[terminalId, terminalInstanceId],
+	);
+	const connectionState = useSyncExternalStore(subscribe, () =>
+		terminalRuntimeRegistry.getConnectionState(terminalId, terminalInstanceId),
+	);
+	const logs = useSyncExternalStore(subscribe, () =>
+		terminalRuntimeRegistry.getLogs(terminalId, terminalInstanceId),
+	);
+	const diagnosis = useSyncExternalStore(subscribe, () =>
+		terminalRuntimeRegistry.getConnectionDiagnosis(
+			terminalId,
+			terminalInstanceId,
+		),
+	);
+
+	if (connectionState === "open" || connectionState === "disconnected") {
+		return null;
+	}
+	// First connect hasn't had trouble yet — don't flash a status.
+	if (connectionState === "connecting" && logs.length === 0 && !diagnosis) {
+		return null;
+	}
+
+	// Red only once the transport has stopped trying; amber covers both the
+	// in-flight dial and the backoff pause between attempts.
+	const gaveUp = diagnosis !== null && connectionState === "closed";
+	const label = gaveUp ? "Disconnected" : "Reconnecting…";
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					aria-label={`Terminal connection: ${label}`}
+					className="flex h-5 items-center gap-1.5 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+				>
+					<span
+						className={cn(
+							"size-1.5 rounded-full",
+							gaveUp ? "bg-destructive" : "animate-pulse bg-yellow-500",
+						)}
+					/>
+					<span>{label}</span>
+				</button>
+			</PopoverTrigger>
+			<PopoverContent align="end" className="w-80 p-3 text-xs">
+				<div className="flex flex-col gap-2">
+					<p className="cursor-text select-text text-muted-foreground">
+						{diagnosis?.message ??
+							"The terminal connection dropped. Retrying automatically…"}
+					</p>
+					<div className="flex items-center gap-2">
+						<Button
+							size="sm"
+							variant="outline"
+							className="h-6 px-2 text-xs"
+							onClick={() =>
+								terminalRuntimeRegistry.retryConnect(
+									terminalId,
+									terminalInstanceId,
+								)
+							}
+						>
+							Reconnect
+						</Button>
+						{logs.length > 0 && (
+							<button
+								type="button"
+								onClick={() =>
+									navigator.clipboard.writeText(formatLogsForClipboard(logs))
+								}
+								className="text-muted-foreground transition-colors hover:text-foreground"
+							>
+								Copy log · {logs.length}
+							</button>
+						)}
+					</div>
+					{logs.length > 0 && (
+						/* column-reverse pins the scroll to the newest entry; the list
+						   is reversed so reading order stays chronological. */
+						<div className="flex max-h-48 flex-col-reverse overflow-y-auto rounded border border-border bg-muted/30 p-2 font-mono">
+							{logs
+								.slice()
+								.reverse()
+								.map((entry) => (
+									<div
+										key={entry.id}
+										className="flex cursor-text select-text gap-2 py-0.5"
+									>
+										<span className="shrink-0 tabular-nums opacity-60">
+											{formatTime(entry.timestamp)}
+										</span>
+										<span
+											className={cn(
+												"break-all",
+												entry.level === "error" && "text-destructive",
+											)}
+										>
+											{entry.message}
+										</span>
+									</div>
+								))}
+						</div>
+					)}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/index.ts
@@ -1,0 +1,1 @@
+export { TerminalConnectionIndicator } from "./TerminalConnectionIndicator";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -344,7 +344,15 @@ export function usePaneRegistry({
 						/>
 					</div>
 				),
-				renderHeaderExtras: () => <TerminalPaneHeaderExtras />,
+				renderHeaderExtras: (ctx: RendererContext<PaneViewerData>) => {
+					const { terminalId } = ctx.pane.data as TerminalPaneData;
+					return (
+						<TerminalPaneHeaderExtras
+							terminalId={terminalId}
+							terminalInstanceId={ctx.pane.id}
+						/>
+					);
+				},
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalPane
 						ctx={ctx}


### PR DESCRIPTION
## Summary

Makes the terminal pane's remote-disconnect state self-explanatory. Previously a dead terminal WebSocket showed only a bare `Disconnected` footer; diagnosing it meant devtools or PostHog. The transport already captured close codes, retry attempts, and preflight diagnoses into an in-memory log buffer that no UI consumed.

**New pattern (severity escalation, pane header):**
- While the auto-reconnect loop runs: small amber pulsing dot + "Reconnecting…" next to the Terminal dropdown. No pane chrome, terminal canvas untouched.
- Once the transport stops trying (max attempts, preflight 403, fatal server error, PTY exit): red dot + "Disconnected".
- Clicking the indicator opens a popover: human-readable diagnosis (from `classifyTerminalFailure`, e.g. "This host is offline (not connected to the relay)."), a **Reconnect** button, **Copy log · n** (ISO-timestamped, bug-report ready), and the raw transport log in a contained scroll area (newest pinned, selectable per the error-text rule).

## Implementation

- `terminal-ws-transport.ts`: structured `lastDiagnosis` on the transport, set at the four terminal-failure sites and cleared on fresh connect + successful attach. Red vs amber in the UI is driven by it: diagnosis present = stopped trying. Reconnect log lines now carry the attempt counter (`attempt 3/10`).
- `terminal-runtime-registry.ts`: `getConnectionDiagnosis()` accessor and `retryConnect()`, which re-dials `transport.currentUrl` so the header doesn't rebuild the signed WS URL (relay URLs get re-signed with a fresh JWT inside `connect()`). `connect()` clears the terminated flag, so this revives a dead loop — previously the only recovery after give-up was window refocus or pane remount.
- `TerminalConnectionIndicator` renders in `TerminalPaneHeaderExtras` (now receives `terminalId`/`instanceId` from the pane registry). Hidden while healthy and during a clean first connect.
- Removed the old `Disconnected` footer from `TerminalPane`.

## Verification

- `tsc --noEmit` and `bun run lint` both exit 0.
- Verified live over CDP against the dev app: pointed a connected pane's transport at a dead endpoint with 2 attempts left → amber "Reconnecting…" through the backoff loop → red "Disconnected" with the give-up diagnosis after max attempts → popover shows the full timestamped sequence (error + close code 1006 + attempt counters) → one click on Reconnect restored the session (`open`, indicator gone).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a terminal connection status indicator in the pane header with a diagnosis popover, replacing the old footer. This makes disconnects clear and lets users reconnect or copy logs for bug reports.

- **New Features**
  - Header indicator: amber pulsing “Reconnecting…” during auto-retry; red “Disconnected” when retries stop.
  - Popover shows a plain-English diagnosis, a Reconnect button, and copyable, timestamped transport logs; copy action handles clipboard permission errors.
  - Hidden while healthy and during the first clean connect; reconnect log lines now include attempt counters.

- **Refactors**
  - Transport tracks `lastDiagnosis` (give-up, preflight 403, fatal server error, PTY exit); cleared on new connect and successful attach.
  - Registry adds `getConnectionDiagnosis()` and `retryConnect()` to re-dial `transport.currentUrl`; manual retry resets the reconnect budget (JWT re-signed within `connect()`).
  - `TerminalPaneHeaderExtras` now receives `terminalId`/`instanceId` and renders the indicator; removed the “Disconnected” footer in `TerminalPane`.

<sup>Written for commit d580fe290b1473f0aa08199fb9112ca35ee18ebf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a terminal connection indicator that shows reconnecting and disconnected states.
  * Introduced connection “diagnosis” details and a transport log view with timestamps.
  * Added a manual **Reconnect** action and an option to copy connection logs.
  * Enhanced connection failure reporting for relay preflight, server errors, and WebSocket close/exit events.
* **UI Updates**
  * Removed the standalone “Disconnected” banner from terminal panes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->