### PR TITLE
feat(workspace-client,desktop): relay WS outage telemetry + version-stamped desktop events

### DIFF
--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -1,3 +1,4 @@
+import { setRelaySocketTelemetry } from "@superset/workspace-client";
 import posthogFull from "posthog-js/dist/module.full.no-external";
 import type { PostHog } from "posthog-js/react";
 import { env } from "../env.renderer";
@@ -23,8 +24,26 @@ export function initPostHog() {
 		loaded: (ph) => {
 			ph.register({
 				app_name: "desktop",
+				// Event-level version (person-profile desktop_version reflects the
+				// current install, not the build that emitted a given event).
+				app_version: window.App.appVersion,
 				platform: window.navigator.platform,
 			});
 		},
+	});
+
+	// Relay socket health (event bus / workspace "disconnected" surface). At
+	// most one event per outage episode plus one on recovery.
+	setRelaySocketTelemetry((event) => {
+		posthogFull.capture(`relay_ws_${event.kind}`, {
+			socket_name: event.socketName,
+			endpoint: event.endpoint,
+			preflight_status: event.preflightStatus,
+			tunnel_region: event.tunnelRegion,
+			close_code: event.closeCode,
+			close_reason: event.closeReason,
+			reconnect_attempts: event.failedAttempts,
+			outage_ms: event.outageMs,
+		});
 	});
 }

--- a/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
+++ b/apps/web/src/app/workspaces/[workspaceId]/components/WebTerminal/TerminalConnection.ts
@@ -80,6 +80,7 @@ export class TerminalConnection {
 		}
 
 		const socket = createRelaySocket({
+			name: "web-terminal",
 			buildUrl: () => this.buildUrl(),
 			getToken: () => this.deps.getToken(),
 			// Definitive access denial: retrying can't change the answer.

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -19,6 +19,8 @@ export {
 	createRelaySocket,
 	type RelaySocket,
 	type RelaySocketOptions,
+	type RelaySocketTelemetryEvent,
+	setRelaySocketTelemetry,
 } from "./lib/relaySocket";
 export {
 	useWorkspaceClient,

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -210,6 +210,7 @@ function getOrCreateConnection(
 	// inside partysocket. Buffering is disabled so command semantics stay
 	// "send only while open" — watches are replayed from state on each open.
 	const socket = createRelaySocket({
+		name: "event-bus",
 		buildUrl: () => `${hostUrl.replace(/\/$/, "")}/events`,
 		getToken: getWsToken,
 		accessDeniedRetryMs: ACCESS_DENIED_RETRY_MS,

--- a/packages/workspace-client/src/lib/relaySocket/index.ts
+++ b/packages/workspace-client/src/lib/relaySocket/index.ts
@@ -1,4 +1,8 @@
 export {
+	type RelaySocketTelemetryEvent,
+	setRelaySocketTelemetry,
+} from "./outageReporter";
+export {
 	createRelaySocket,
 	type RelaySocket,
 	type RelaySocketOptions,

--- a/packages/workspace-client/src/lib/relaySocket/outageReporter.test.ts
+++ b/packages/workspace-client/src/lib/relaySocket/outageReporter.test.ts
@@ -43,6 +43,44 @@ describe("createOutageReporter", () => {
 		expect(telemetry[1]?.outageMs).not.toBeNull();
 	});
 
+	it("attaches the outage's last observed close info when the threshold-crossing call has none", () => {
+		collect();
+		const reporter = createOutageReporter("bus");
+		reporter.attempt("ws://relay/hosts/h/events", null);
+		// Dial failures surface as close (with code) and error (without) pairs;
+		// the error side can be the one that crosses the threshold.
+		reporter.failed(4, { code: 1006, reason: "abnormal" });
+		reporter.failed(5);
+		expect(telemetry).toHaveLength(1);
+		expect(telemetry[0]).toMatchObject({
+			kind: "degraded",
+			closeCode: 1006,
+			closeReason: "abnormal",
+		});
+
+		// The stashed close info doesn't leak into the next outage.
+		reporter.opened(6);
+		for (let i = 1; i <= 6; i++) {
+			reporter.failed(i);
+		}
+		const second = telemetry.filter((e) => e.kind === "degraded")[1];
+		expect(second?.closeCode).toBeNull();
+	});
+
+	it("never lets a throwing sink escape into the caller", () => {
+		setRelaySocketTelemetry(() => {
+			throw new Error("analytics exploded");
+		});
+		const reporter = createOutageReporter("bus");
+		reporter.attempt("ws://relay/hosts/h/events", {
+			status: 403,
+			region: null,
+		});
+		expect(() => reporter.accessDenied(1)).not.toThrow();
+		expect(() => reporter.failed(6)).not.toThrow();
+		expect(() => reporter.opened(7)).not.toThrow();
+	});
+
 	it("stays silent for short blips and clean opens", () => {
 		collect();
 		const reporter = createOutageReporter("bus");

--- a/packages/workspace-client/src/lib/relaySocket/outageReporter.test.ts
+++ b/packages/workspace-client/src/lib/relaySocket/outageReporter.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	createOutageReporter,
+	type RelaySocketTelemetryEvent,
+	setRelaySocketTelemetry,
+} from "./outageReporter";
+
+let telemetry: RelaySocketTelemetryEvent[] = [];
+
+function collect(): void {
+	telemetry = [];
+	setRelaySocketTelemetry((e) => telemetry.push(e));
+}
+
+afterEach(() => {
+	setRelaySocketTelemetry(null);
+	telemetry = [];
+});
+
+describe("createOutageReporter", () => {
+	it("reports degraded once at the attempt threshold, then recovered", () => {
+		collect();
+		const reporter = createOutageReporter("bus");
+		reporter.attempt("ws://relay/hosts/h/events?token=secret", {
+			status: 200,
+			region: "iad",
+		});
+		for (let i = 1; i <= 8; i++) {
+			reporter.failed(i, { code: 1006, reason: "" });
+		}
+		expect(telemetry.map((e) => e.kind)).toEqual(["degraded"]);
+		expect(telemetry[0]).toMatchObject({
+			socketName: "bus",
+			endpoint: "ws://relay/hosts/h/events",
+			preflightStatus: 200,
+			tunnelRegion: "iad",
+			closeCode: 1006,
+			failedAttempts: 5,
+		});
+
+		reporter.opened(9);
+		expect(telemetry.map((e) => e.kind)).toEqual(["degraded", "recovered"]);
+		expect(telemetry[1]?.outageMs).not.toBeNull();
+	});
+
+	it("stays silent for short blips and clean opens", () => {
+		collect();
+		const reporter = createOutageReporter("bus");
+		reporter.attempt("ws://relay/hosts/h/events", null);
+		reporter.failed(1);
+		reporter.failed(2);
+		reporter.opened(3);
+		expect(telemetry).toEqual([]);
+	});
+
+	it("reports access_denied once per episode and suppresses degraded", () => {
+		collect();
+		const reporter = createOutageReporter("bus");
+		reporter.attempt("ws://relay/hosts/h/events?token=secret", {
+			status: 403,
+			region: null,
+		});
+		for (let i = 1; i <= 10; i++) {
+			reporter.accessDenied(i);
+			reporter.failed(i); // partysocket error event after provider rejection
+		}
+		expect(telemetry.map((e) => e.kind)).toEqual(["access_denied"]);
+		expect(telemetry[0]?.preflightStatus).toBe(403);
+		expect(telemetry[0]?.endpoint).not.toContain("secret");
+
+		// Regrant: a successful open ends the episode, next denial reports again.
+		reporter.opened(11);
+		reporter.accessDenied(1);
+		expect(telemetry.map((e) => e.kind)).toEqual([
+			"access_denied",
+			"recovered",
+			"access_denied",
+		]);
+	});
+});

--- a/packages/workspace-client/src/lib/relaySocket/outageReporter.ts
+++ b/packages/workspace-client/src/lib/relaySocket/outageReporter.ts
@@ -50,28 +50,36 @@ export function createOutageReporter(socketName: string) {
 	let probe: RelayAffinityProbe | null = null;
 	let endpoint: string | null = null;
 	let outageStartedAt: number | null = null;
+	// Failed dials surface as error and close events in either order, and only
+	// the close carries a code — keep the outage's last observed one so the
+	// threshold-crossing call doesn't have to be the one that saw it.
+	let lastClose: CloseInfo | null = null;
 	// One telemetry event per outage episode; cleared on the next open.
 	let reported = false;
 
 	const emit = (
 		kind: RelaySocketTelemetryEvent["kind"],
 		failedAttempts: number,
-		close?: CloseInfo,
+		close: CloseInfo | null,
 	): void => {
-		telemetrySink?.({
-			kind,
-			socketName,
-			endpoint,
-			preflightStatus: probe?.status ?? null,
-			tunnelRegion: probe?.region ?? null,
-			closeCode: close?.code ?? null,
-			closeReason: close?.reason || null,
-			failedAttempts,
-			outageMs:
-				kind === "recovered" && outageStartedAt !== null
-					? Date.now() - outageStartedAt
-					: null,
-		});
+		try {
+			telemetrySink?.({
+				kind,
+				socketName,
+				endpoint,
+				preflightStatus: probe?.status ?? null,
+				tunnelRegion: probe?.region ?? null,
+				closeCode: close?.code ?? null,
+				closeReason: close?.reason || null,
+				failedAttempts,
+				outageMs:
+					kind === "recovered" && outageStartedAt !== null
+						? Date.now() - outageStartedAt
+						: null,
+			});
+		} catch {
+			// A throwing sink must never break the socket lifecycle.
+		}
 	};
 
 	return {
@@ -86,21 +94,23 @@ export function createOutageReporter(socketName: string) {
 			outageStartedAt ??= Date.now();
 			if (reported) return;
 			reported = true;
-			emit("access_denied", failedAttempts);
+			emit("access_denied", failedAttempts, null);
 		},
 
 		/** A dial failed or an established connection dropped. */
 		failed(failedAttempts: number, close?: CloseInfo): void {
 			outageStartedAt ??= Date.now();
+			if (close) lastClose = close;
 			if (reported || failedAttempts < DEGRADED_AFTER_ATTEMPTS) return;
 			reported = true;
-			emit("degraded", failedAttempts, close);
+			emit("degraded", failedAttempts, lastClose);
 		},
 
 		/** The socket (re)connected; closes out a reported episode. */
 		opened(failedAttempts: number): void {
-			if (reported) emit("recovered", failedAttempts);
+			if (reported) emit("recovered", failedAttempts, null);
 			outageStartedAt = null;
+			lastClose = null;
 			reported = false;
 		},
 	};

--- a/packages/workspace-client/src/lib/relaySocket/outageReporter.ts
+++ b/packages/workspace-client/src/lib/relaySocket/outageReporter.ts
@@ -1,0 +1,107 @@
+import type { RelayAffinityProbe } from "../primeRelayAffinity";
+
+export interface RelaySocketTelemetryEvent {
+	kind: "access_denied" | "degraded" | "recovered";
+	socketName: string;
+	/** Attempt URL without its query string — the token never leaves this module. */
+	endpoint: string | null;
+	/** `_whoowns` preflight status; null when the probe failed (relay unreachable). */
+	preflightStatus: number | null;
+	tunnelRegion: string | null;
+	closeCode: number | null;
+	closeReason: string | null;
+	/** Dial attempts in the current outage at emit time. */
+	failedAttempts: number;
+	/** Outage duration; only on `recovered`. */
+	outageMs: number | null;
+}
+
+type RelaySocketTelemetrySink = (event: RelaySocketTelemetryEvent) => void;
+
+let telemetrySink: RelaySocketTelemetrySink | null = null;
+
+/**
+ * Install a process-wide sink for socket-health events. Analytics wiring lives
+ * in the consuming app so this package stays analytics-vendor-free. At most one
+ * event per outage episode (plus one on recovery), so the sink can forward
+ * without sampling.
+ */
+export function setRelaySocketTelemetry(
+	sink: RelaySocketTelemetrySink | null,
+): void {
+	telemetrySink = sink;
+}
+
+// Below this many consecutive failed dials an outage is assumed transient
+// (host restart, network blip) and not worth an event.
+const DEGRADED_AFTER_ATTEMPTS = 5;
+
+export interface CloseInfo {
+	code: number;
+	reason: string;
+}
+
+/**
+ * Collapses a socket's connection churn into outage episodes: one
+ * `access_denied` or `degraded` event when an episode is worth reporting, one
+ * `recovered` when it ends. Pure policy — callers feed it dial outcomes.
+ */
+export function createOutageReporter(socketName: string) {
+	let probe: RelayAffinityProbe | null = null;
+	let endpoint: string | null = null;
+	let outageStartedAt: number | null = null;
+	// One telemetry event per outage episode; cleared on the next open.
+	let reported = false;
+
+	const emit = (
+		kind: RelaySocketTelemetryEvent["kind"],
+		failedAttempts: number,
+		close?: CloseInfo,
+	): void => {
+		telemetrySink?.({
+			kind,
+			socketName,
+			endpoint,
+			preflightStatus: probe?.status ?? null,
+			tunnelRegion: probe?.region ?? null,
+			closeCode: close?.code ?? null,
+			closeReason: close?.reason || null,
+			failedAttempts,
+			outageMs:
+				kind === "recovered" && outageStartedAt !== null
+					? Date.now() - outageStartedAt
+					: null,
+		});
+	};
+
+	return {
+		/** A dial is starting: remember its target and preflight result. */
+		attempt(signedUrl: string, attemptProbe: RelayAffinityProbe | null): void {
+			endpoint = signedUrl.split("?")[0] ?? null;
+			probe = attemptProbe;
+		},
+
+		/** The preflight returned a definitive 403. */
+		accessDenied(failedAttempts: number): void {
+			outageStartedAt ??= Date.now();
+			if (reported) return;
+			reported = true;
+			emit("access_denied", failedAttempts);
+		},
+
+		/** A dial failed or an established connection dropped. */
+		failed(failedAttempts: number, close?: CloseInfo): void {
+			outageStartedAt ??= Date.now();
+			if (reported || failedAttempts < DEGRADED_AFTER_ATTEMPTS) return;
+			reported = true;
+			emit("degraded", failedAttempts, close);
+		},
+
+		/** The socket (re)connected; closes out a reported episode. */
+		opened(failedAttempts: number): void {
+			if (reported) emit("recovered", failedAttempts);
+			outageStartedAt = null;
+			reported = false;
+		},
+	};
+}

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.test.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import {
+	type RelaySocketTelemetryEvent,
+	setRelaySocketTelemetry,
+} from "./outageReporter";
 import { createRelaySocket, type RelaySocket } from "./relaySocket";
 
 // Local WS server whose /hosts/:id/_whoowns preflight status is scriptable.
@@ -34,6 +38,7 @@ let socket: RelaySocket | null = null;
 afterEach(() => {
 	socket?.close();
 	socket = null;
+	setRelaySocketTelemetry(null);
 });
 
 function waitFor(cond: () => boolean, timeoutMs = 3_000): Promise<void> {
@@ -106,6 +111,68 @@ describe("createRelaySocket", () => {
 		expect(socket.readyState).toBeLessThanOrEqual(1); // CONNECTING or OPEN
 		server.stop(true);
 	});
+
+	it("emits degraded once per outage, then recovered with outage stats", async () => {
+		const { server, port } = makeServer(() => 200);
+		server.stop(true); // outage: every dial is refused
+		const telemetry: RelaySocketTelemetryEvent[] = [];
+		setRelaySocketTelemetry((e) => telemetry.push(e));
+		socket = createRelaySocket({
+			name: "test-bus",
+			buildUrl: () => `ws://localhost:${port}${HOST_PATH}`,
+			getToken: () => "secret-token",
+			minReconnectionDelay: 10,
+			maxReconnectionDelay: 20,
+		});
+		await waitFor(() => telemetry.some((e) => e.kind === "degraded"), 8_000);
+		// Keep failing: still one degraded per outage.
+		await Bun.sleep(150);
+		expect(telemetry.filter((e) => e.kind === "degraded").length).toBe(1);
+		const degraded = telemetry.find((e) => e.kind === "degraded");
+		expect(degraded?.socketName).toBe("test-bus");
+		expect(degraded?.endpoint).not.toContain("secret-token");
+
+		const revived = Bun.serve({
+			port,
+			fetch(req, srv) {
+				const url = new URL(req.url);
+				if (url.pathname.endsWith("/_whoowns")) {
+					return new Response(JSON.stringify({ ok: true }), { status: 200 });
+				}
+				if (srv.upgrade(req)) return;
+				return new Response("no", { status: 400 });
+			},
+			websocket: { open() {}, message() {} },
+		});
+		await waitFor(() => telemetry.some((e) => e.kind === "recovered"), 8_000);
+		const recovered = telemetry.find((e) => e.kind === "recovered");
+		expect(recovered?.failedAttempts).toBeGreaterThanOrEqual(5);
+		expect(recovered?.outageMs).not.toBeNull();
+		revived.stop(true);
+	}, 20_000);
+
+	it("emits access_denied once per denial episode and recovered on regrant", async () => {
+		let status = 403;
+		const { server, port } = makeServer(() => status);
+		const telemetry: RelaySocketTelemetryEvent[] = [];
+		setRelaySocketTelemetry((e) => telemetry.push(e));
+		let denied = 0;
+		socket = createRelaySocket({
+			buildUrl: () => `ws://localhost:${port}${HOST_PATH}`,
+			getToken: () => "tok",
+			onAccessDenied: () => denied++,
+			accessDeniedRetryMs: 30,
+			minReconnectionDelay: 10,
+			maxReconnectionDelay: 20,
+		});
+		await waitFor(() => denied >= 3);
+		expect(telemetry.filter((e) => e.kind === "access_denied").length).toBe(1);
+		expect(telemetry.filter((e) => e.kind === "degraded").length).toBe(0);
+		expect(telemetry[0]?.preflightStatus).toBe(403);
+		status = 200;
+		await waitFor(() => telemetry.some((e) => e.kind === "recovered"), 8_000);
+		server.stop(true);
+	}, 20_000);
 
 	it("dials local (non-/hosts) URLs without a preflight, converting http to ws", async () => {
 		const { server, tokensSeen, port } = makeServer(() => 503);

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
@@ -1,7 +1,10 @@
 import { WebSocket as ReconnectingWebSocket } from "partysocket";
 import { primeRelayAffinity } from "../primeRelayAffinity";
+import { createOutageReporter } from "./outageReporter";
 
 export interface RelaySocketOptions {
+	/** Label attached to telemetry events so consumers are distinguishable. */
+	name?: string;
 	/** URL for this attempt, WITHOUT the auth token — the wrapper signs it. */
 	buildUrl: () => string | Promise<string>;
 	/** Fresh token per attempt (user JWT for relay hosts, PSK for local). */
@@ -49,11 +52,17 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
  */
 export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 	let socket: ReconnectingWebSocket | null = null;
+	const reporter = createOutageReporter(opts.name ?? "relay");
+	// retryCount only resets after minUptime of stable connection, so it counts
+	// consecutive failed dials across the whole outage.
+	const attempts = () => socket?.retryCount ?? 0;
 
 	const provider = async (): Promise<string> => {
 		const url = signUrl(await opts.buildUrl(), await opts.getToken());
 		const probe = await primeRelayAffinity(url);
+		reporter.attempt(url, probe);
 		if (probe?.status === 403) {
+			reporter.accessDenied(attempts());
 			opts.onAccessDenied?.();
 			if (opts.accessDeniedRetryMs == null) {
 				socket?.close(1000, "relay access denied");
@@ -74,5 +83,15 @@ export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 		connectionTimeout: opts.connectionTimeout,
 		maxEnqueuedMessages: opts.maxEnqueuedMessages ?? 0,
 	});
+
+	socket.addEventListener("close", (event) => {
+		// 1000 = deliberate close (cleanup, access-denied shutdown), not a failure.
+		if (event.code !== 1000) {
+			reporter.failed(attempts(), { code: event.code, reason: event.reason });
+		}
+	});
+	socket.addEventListener("error", () => reporter.failed(attempts()));
+	socket.addEventListener("open", () => reporter.opened(attempts()));
+
 	return socket;
 }

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
@@ -53,16 +53,18 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 	let socket: ReconnectingWebSocket | null = null;
 	const reporter = createOutageReporter(opts.name ?? "relay");
-	// retryCount only resets after minUptime of stable connection, so it counts
-	// consecutive failed dials across the whole outage.
-	const attempts = () => socket?.retryCount ?? 0;
+	// retryCount is the 0-based ordinal of the current dial and only resets
+	// after minUptime of stable connection. When reporting a failure the dial
+	// counts itself, hence +1; at open time it already equals the failures
+	// that preceded the successful dial.
+	const failuresSoFar = () => (socket?.retryCount ?? 0) + 1;
 
 	const provider = async (): Promise<string> => {
 		const url = signUrl(await opts.buildUrl(), await opts.getToken());
 		const probe = await primeRelayAffinity(url);
 		reporter.attempt(url, probe);
 		if (probe?.status === 403) {
-			reporter.accessDenied(attempts());
+			reporter.accessDenied(failuresSoFar());
 			opts.onAccessDenied?.();
 			if (opts.accessDeniedRetryMs == null) {
 				socket?.close(1000, "relay access denied");
@@ -85,13 +87,22 @@ export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 	});
 
 	socket.addEventListener("close", (event) => {
+		// Only count real server closes. partysocket also dispatches synthetic
+		// close events (deliberate close(), and echoes of dial errors that the
+		// error listener already counts); its browser cloneEvent mangles those —
+		// code becomes the string "close" — which is how we can tell them apart.
+		if (typeof event.code !== "number") return;
 		// 1000 = deliberate close (cleanup, access-denied shutdown), not a failure.
-		if (event.code !== 1000) {
-			reporter.failed(attempts(), { code: event.code, reason: event.reason });
-		}
+		if (event.code === 1000) return;
+		reporter.failed(failuresSoFar(), {
+			code: event.code,
+			reason: typeof event.reason === "string" ? event.reason : "",
+		});
 	});
-	socket.addEventListener("error", () => reporter.failed(attempts()));
-	socket.addEventListener("open", () => reporter.opened(attempts()));
+	socket.addEventListener("error", () => reporter.failed(failuresSoFar()));
+	socket.addEventListener("open", () =>
+		reporter.opened(socket?.retryCount ?? 0),
+	);
 
 	return socket;
 }


### PR DESCRIPTION
## Summary
- Add outage-episode telemetry to `createRelaySocket` (the eventBus / workspace "disconnected" surface, previously silent): `relay_ws_access_denied`, `relay_ws_degraded`, and `relay_ws_recovered` PostHog events, at most one per outage plus one on recovery.
- Register `app_version` as a PostHog super property in the desktop renderer so every event (including the existing `terminal_connect_failed`) is attributable to the build that emitted it.

## Why / Context
Investigating the remote-workspace disconnect reports (relay 401 redial loop, fixed by #5628/#5637 but not yet released) hit two observability gaps:

1. `terminal_connect_failed` events carry no app version — once 1.14.4 ships there's no way to segment pre/post-fix builds and confirm the 401 curve dies. The person-profile `desktop_version` reflects the *current* install, not the build at event time.
2. The eventBus relay socket that drives workspace "disconnected" state emits no telemetry at all, so access-denial episodes (the v2Hosts/v2UsersHosts class of failure) and outage durations are invisible in production.

## How It Works
- `outageReporter.ts` (co-located in `relaySocket/`) is a pure state machine: callers feed it dial outcomes (`attempt`, `accessDenied`, `failed`, `opened`) and it collapses connection churn into episodes — one `access_denied` (preflight 403) or `degraded` (≥5 consecutive failed dials) event per episode, one `recovered` with `outage_ms` and attempt count when the socket reconnects. partysocket's `retryCount` only resets after 5s of stable uptime, so flapping accumulates into one episode instead of spamming pairs.
- The sink is process-wide (`setRelaySocketTelemetry`), keeping `@superset/workspace-client` analytics-vendor-free; the desktop renderer wires it to PostHog in `initPostHog`. Web consumers are unaffected (sink defaults to null).
- Sockets carry a `name` label (`event-bus`, `web-terminal`) so consumers are distinguishable in queries. The reported endpoint is the attempt URL minus its query string — the token never leaves the module.

## Manual QA Checklist
- [x] Desktop dev app: events carry `app_version` (CDP-verified: super property registered, `1.14.1` in dev)
- [x] Outage cycle CDP-verified end-to-end: dead endpoint → one `relay_ws_degraded` after 5 failed dials → healed endpoint → one `relay_ws_recovered` with sane `outage_ms`; access-denied and terminal give-up paths verified too (see verification comment)

## Testing
- `bun run typecheck` (workspace-client, desktop, web)
- `bun run lint` (exits 0)
- `bun test` in `packages/workspace-client` — 18 pass: new pure unit tests for the reporter policy (threshold boundary, once-per-episode dedup, silent short blips, episode reset on regrant, token stripping) plus WS integration tests proving the socket wiring end-to-end against a scriptable local relay
- Mutation-verified: removing the `degraded` emission and breaking the access-denied dedup each made exactly the expected test fail

## Design Decisions
- **Module-level sink instead of threading a callback through `RelaySocketOptions`**: every `getEventBus` call site would need plumbing for no gain; a process-wide analytics hook is the same shape posthog itself uses.
- **Once-per-episode emission instead of per-attempt**: the eventBus 403 path re-probes every 5 minutes indefinitely — per-attempt events would flood; episode + recovery events preserve the debugging signal (cause, duration, attempt count) at bounded volume.

## Known Limitations
- `terminal_connect_failed` in the desktop terminal transport keeps its own capture path; it now gains `app_version` via the super property but doesn't use the outage reporter (it has its own max-attempts/give-up semantics). Unifying them is possible follow-up.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5653">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds relay WebSocket outage telemetry and version-stamped desktop analytics to improve visibility into remote workspace disconnects. Emits `relay_ws_*` events once per outage and records `app_version` on every desktop event; fixes attempt counting and filters synthetic closes for accurate stats.

- **New Features**
  - `@superset/workspace-client`: added outage reporter and process-wide telemetry sink (`setRelaySocketTelemetry`, `RelaySocketTelemetryEvent`). `createRelaySocket` now reports `access_denied`, `degraded` (≥5 failed dials), and `recovered` with `outage_ms` and attempt count; tokens are stripped from endpoints. Hardened reporting: correct attempt ordinals, ignore partysocket synthetic closes, include last close info when errors cross the threshold, and guard the sink with try/catch.
  - Socket labeling: new `name` option on `createRelaySocket`; event bus uses `event-bus`, web terminal uses `web-terminal`.
  - Desktop: PostHog sink forwards `relay_ws_${kind}` events with endpoint, region, close info, and attempt counts. Registers `app_version` as a super property so all desktop events are attributed to the emitting build.

<sup>Written for commit fc1911c1f106aa9425a715c9a403b7595741b629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relay connection health telemetry for outages, access-denied episodes, and recovery, including endpoint context and outage duration.
  * Desktop analytics now forward relay socket outage/recovery signals to PostHog and include the application version.
  * Web terminal and event-bus relay connections now include identifiable connection labels for clearer attribution.
* **Bug Fixes**
  * Improved reliability of relay outage telemetry emission, ensuring telemetry failures don’t affect socket behavior.
* **Tests**
  * Expanded telemetry and outage episode coverage, including threshold crossing, recovery, access-denied semantics, and data privacy (no token leakage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
