### PR TITLE
fix(desktop): copy/save markdown preview tables as GFM instead of [table]

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -16,7 +16,10 @@ import { ListItem } from "@tiptap/extension-list-item";
 import { OrderedList } from "@tiptap/extension-ordered-list";
 import { Paragraph } from "@tiptap/extension-paragraph";
 import { Strike } from "@tiptap/extension-strike";
-import { TableKit } from "@tiptap/extension-table";
+import { Table } from "@tiptap/extension-table";
+import { TableCell } from "@tiptap/extension-table-cell";
+import { TableHeader } from "@tiptap/extension-table-header";
+import { TableRow } from "@tiptap/extension-table-row";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { Text } from "@tiptap/extension-text";
@@ -28,6 +31,10 @@ import { Markdown } from "tiptap-markdown";
 import { EditableCodeBlockView } from "./components/EditableCodeBlockView";
 import { ReadOnlyCodeBlockView } from "./components/ReadOnlyCodeBlockView";
 import { ReadOnlySafeImageView } from "./components/ReadOnlySafeImageView";
+import {
+	serializeMarkdownTable,
+	serializeTableChild,
+} from "./serializeMarkdownTable";
 
 const lowlight = createLowlight(common);
 const ENABLE_RAW_MARKDOWN_HTML = false;
@@ -155,23 +162,56 @@ export function createMarkdownExtensions({
 			},
 		}),
 		SafeImage,
-		TableKit.configure({
-			table: {
-				resizable: false,
-				cellMinWidth: 192,
-				HTMLAttributes: {
-					class: "markdown-table my-4 min-w-full border-collapse",
-				},
+		// Individually-extended table nodes (instead of TableKit) so we can attach
+		// a GFM markdown serializer to the `table` node's `storage.markdown`. This
+		// overrides tiptap-markdown's built-in serializer, which otherwise writes
+		// the literal `[table]` when copying a headerless/partial cell selection.
+		// The CellSelection editing plugins live on the `Table` node, so behavior
+		// (rendering, parsing, selection) is unchanged.
+		Table.extend({
+			addStorage() {
+				return {
+					...this.parent?.(),
+					markdown: { serialize: serializeMarkdownTable },
+				};
 			},
-			tableHeader: {
-				HTMLAttributes: {
-					class: "bg-muted px-4 py-2 text-left text-sm font-semibold align-top",
-				},
+		}).configure({
+			resizable: false,
+			cellMinWidth: 192,
+			HTMLAttributes: {
+				class: "markdown-table my-4 min-w-full border-collapse",
 			},
-			tableCell: {
-				HTMLAttributes: {
-					class: "border-t border-border px-4 py-2 text-sm align-top",
-				},
+		}),
+		TableRow.extend({
+			addStorage() {
+				return {
+					...this.parent?.(),
+					markdown: { serialize: serializeTableChild },
+				};
+			},
+		}),
+		TableHeader.extend({
+			addStorage() {
+				return {
+					...this.parent?.(),
+					markdown: { serialize: serializeTableChild },
+				};
+			},
+		}).configure({
+			HTMLAttributes: {
+				class: "bg-muted px-4 py-2 text-left text-sm font-semibold align-top",
+			},
+		}),
+		TableCell.extend({
+			addStorage() {
+				return {
+					...this.parent?.(),
+					markdown: { serialize: serializeTableChild },
+				};
+			},
+		}).configure({
+			HTMLAttributes: {
+				class: "border-t border-border px-4 py-2 text-sm align-top",
 			},
 		}),
 		Markdown.configure({

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/serializeMarkdownTable.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/serializeMarkdownTable.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+import { getSchema } from "@tiptap/core";
+import { Bold } from "@tiptap/extension-bold";
+import { Document } from "@tiptap/extension-document";
+import { Paragraph } from "@tiptap/extension-paragraph";
+import { Table } from "@tiptap/extension-table";
+import { TableCell } from "@tiptap/extension-table-cell";
+import { TableHeader } from "@tiptap/extension-table-header";
+import { TableRow } from "@tiptap/extension-table-row";
+import { Text } from "@tiptap/extension-text";
+import {
+	defaultMarkdownSerializer,
+	MarkdownSerializer,
+} from "@tiptap/pm/markdown";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { serializeMarkdownTable } from "./serializeMarkdownTable";
+
+// Build the real schema so node names match production exactly
+// (table / tableRow / tableHeader / tableCell). getSchema does not touch the DOM.
+const schema = getSchema([
+	Document,
+	Text,
+	Paragraph,
+	Bold,
+	Table,
+	TableRow,
+	TableHeader,
+	TableCell,
+]);
+
+// serializeMarkdownTable renders descendants itself, so the nodes map only needs
+// `table` plus `text` (inline leaves are dispatched through the nodes map). In
+// the real app tiptap-markdown supplies the full map. `bold` maps to
+// prosemirror-markdown's `strong` serializer, the same one used for the Bold mark.
+const serializer = new MarkdownSerializer(
+	{
+		table: serializeMarkdownTable,
+		text: defaultMarkdownSerializer.nodes.text,
+	},
+	{ bold: defaultMarkdownSerializer.marks.strong },
+);
+
+const paragraph = (content?: ProseMirrorNode) =>
+	schema.nodes.paragraph.create(null, content);
+const th = (text?: string) =>
+	schema.nodes.tableHeader.create(
+		null,
+		paragraph(text ? schema.text(text) : undefined),
+	);
+const cell = (text?: string) =>
+	schema.nodes.tableCell.create(
+		null,
+		paragraph(text ? schema.text(text) : undefined),
+	);
+const row = (cells: ProseMirrorNode[]) =>
+	schema.nodes.tableRow.create(null, cells);
+const toMarkdown = (table: ProseMirrorNode) =>
+	serializer.serialize(schema.nodes.doc.create(null, table));
+
+describe("serializeMarkdownTable", () => {
+	it("serializes a header + body table to GFM (never [table])", () => {
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [
+				row([th("a"), th("b")]),
+				row([cell("c"), cell("d")]),
+			]),
+		);
+
+		expect(md).toBe("| a | b |\n| --- | --- |\n| c | d |");
+		expect(md).not.toContain("[table]");
+	});
+
+	it("synthesizes an empty header for a headerless / partial cell selection", () => {
+		// This is the reported bug: a CellSelection copy of body cells has no
+		// header row, which made tiptap-markdown fall back to `[table]`.
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [row([cell("c"), cell("d")])]),
+		);
+
+		expect(md).toBe("|  |  |\n| --- | --- |\n| c | d |");
+		expect(md).not.toContain("[table]");
+	});
+
+	it("escapes pipes and renders empty cells", () => {
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [
+				row([th("a"), th("b")]),
+				row([cell("x|y"), cell()]),
+			]),
+		);
+
+		expect(md).toContain("| x\\|y |  |");
+		expect(md).not.toContain("[table]");
+	});
+
+	it("pads ragged rows to the widest row", () => {
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [
+				row([th("a"), th("b"), th("c")]),
+				row([cell("c")]),
+			]),
+		);
+
+		expect(md).toContain("| c |  |  |");
+	});
+
+	it("keeps inline marks inside cells", () => {
+		const boldCell = schema.nodes.tableCell.create(
+			null,
+			paragraph(schema.text("bold", [schema.marks.bold.create()])),
+		);
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [row([th("h")]), row([boldCell])]),
+		);
+
+		expect(md).toContain("**bold**");
+		expect(md).not.toContain("[table]");
+	});
+});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/serializeMarkdownTable.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/serializeMarkdownTable.ts
@@ -1,0 +1,160 @@
+import type { MarkdownSerializerState } from "@tiptap/pm/markdown";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+
+/**
+ * GFM markdown serializer for TipTap table nodes.
+ *
+ * `tiptap-markdown@0.9.0` ships its own `table` serializer, but it bails to the
+ * raw-HTML fallback (which, with `html: false`, writes the literal `[table]`)
+ * whenever the table isn't a "clean" header+body GFM table — specifically when
+ * the first row isn't entirely `tableHeader` cells, or a cell holds more than
+ * one child node. That is exactly what a ProseMirror `CellSelection` copy of
+ * *body* cells produces, so copying content inside a rendered table put
+ * `[table]` on the clipboard.
+ *
+ * We register these serializers via each table node extension's
+ * `storage.markdown.serialize`. `tiptap-markdown` merges an extension's own
+ * markdown spec over its built-in one, so these override the strict defaults for
+ * both clipboard copy (`transformCopiedText`) and `getMarkdown()` (save).
+ */
+
+/**
+ * prosemirror-markdown's serializer state exposes `out`/`closed` at runtime (its
+ * own serializers and `serialize()` read them) but does not declare them on the
+ * public type. We snapshot and restore them so a single cell's inline content
+ * can be rendered into an isolated buffer without leaking into the outer output.
+ */
+interface SerializerStateInternals {
+	out: string;
+	closed: ProseMirrorNode | null;
+}
+
+/**
+ * Render one table cell's content to a single-line markdown string.
+ *
+ * GFM cells must stay on one physical line, so hard breaks / newlines are
+ * collapsed to spaces and `|` is escaped so cell content can't split the row.
+ */
+export function renderTableCellContent(
+	state: MarkdownSerializerState,
+	cell: ProseMirrorNode,
+): string {
+	const internals = state as unknown as SerializerStateInternals;
+	const previousOut = internals.out;
+	const previousClosed = internals.closed;
+	// Render into a clean buffer and don't let the outer pending block-close flush
+	// into the cell; both are restored before the table's own output is written.
+	internals.out = "";
+	internals.closed = null;
+
+	cell.forEach((block, _offset, index) => {
+		// A cell is `block+`; the common case is a single paragraph. Join multiple
+		// blocks with a space to keep the cell on one line.
+		if (index > 0) {
+			internals.out += " ";
+		}
+		if (block.isTextblock) {
+			state.renderInline(block);
+		} else {
+			state.render(block, cell, index);
+		}
+	});
+
+	const rendered = internals.out;
+	internals.out = previousOut;
+	internals.closed = previousClosed;
+
+	return rendered
+		.replace(/\\\r?\n/g, " ") // prosemirror hard break ("\\\n") -> space
+		.replace(/\r?\n/g, " ") // any remaining newline -> space
+		.replace(/\|/g, "\\|") // escape pipes so they don't split the cell
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/**
+ * Serialize a `table` node to a GitHub-flavored markdown table. Called by
+ * `tiptap-markdown` as `(state, node) => void` via `storage.markdown.serialize`.
+ */
+export function serializeMarkdownTable(
+	state: MarkdownSerializerState,
+	node: ProseMirrorNode,
+): void {
+	const rows: Array<{ cells: string[]; isHeader: boolean }> = [];
+
+	node.forEach((rowNode) => {
+		const cells: string[] = [];
+		let isHeader = false;
+		rowNode.forEach((cellNode) => {
+			if (cellNode.type.name === "tableHeader") {
+				isHeader = true;
+			}
+			cells.push(renderTableCellContent(state, cellNode));
+		});
+		rows.push({ cells, isHeader });
+	});
+
+	if (rows.length === 0) {
+		state.closeBlock(node);
+		return;
+	}
+
+	const columnCount = rows.reduce(
+		(max, row) => Math.max(max, row.cells.length),
+		0,
+	);
+
+	const formatRow = (cells: string[]): string => {
+		const padded = cells.slice();
+		while (padded.length < columnCount) {
+			padded.push("");
+		}
+		return `| ${padded.join(" | ")} |`;
+	};
+
+	const lines: string[] = [];
+	let bodyStart = 0;
+
+	if (rows[0]?.isHeader) {
+		lines.push(formatRow(rows[0].cells));
+		bodyStart = 1;
+	} else {
+		// GFM requires a header + delimiter row. When the (possibly partial)
+		// selection has no header row, emit an empty header and keep every row as
+		// a body row — no data is lost.
+		lines.push(formatRow([]));
+	}
+
+	lines.push(
+		`| ${Array.from({ length: columnCount }, () => "---").join(" | ")} |`,
+	);
+
+	for (let i = bodyStart; i < rows.length; i += 1) {
+		const row = rows[i];
+		if (row) {
+			lines.push(formatRow(row.cells));
+		}
+	}
+
+	lines.forEach((line, index) => {
+		if (index > 0) {
+			state.ensureNewLine();
+		}
+		state.write(line);
+	});
+
+	state.closeBlock(node);
+}
+
+/**
+ * Defense-in-depth serializer for `tableRow`/`tableHeader`/`tableCell`. These are
+ * never reached in the normal document or CellSelection path (serializeMarkdownTable
+ * renders all descendants itself), but registering them guarantees a stray render
+ * can never emit `[tableRow]` / `[tableCell]`.
+ */
+export function serializeTableChild(
+	state: MarkdownSerializerState,
+	node: ProseMirrorNode,
+): void {
+	state.renderContent(node);
+}


### PR DESCRIPTION
## Summary

Fixes markdown-table content being copied as the literal string `[table]` in the desktop `.md` preview. Selecting cells inside a previewed table and pressing Cmd/Ctrl+C now yields a proper GitHub-flavored markdown table.

## Root Cause

The `.md` preview renders through `TipTapMarkdownRenderer`, which configures `tiptap-markdown` with `transformCopiedText: true`. That installs a ProseMirror `clipboardTextSerializer` that re-serializes the copied slice back to markdown.

`tiptap-markdown@0.9.0` *does* ship a `table` serializer, but it bails to the raw-HTML fallback — which, because `html: false`, writes the literal `[<nodeName>]`, i.e. `[table]` — whenever the table isn't a "clean" header+body GFM table. Its guard rejects a table when the first row isn't entirely `tableHeader` cells, or a cell holds more than one child, or a cell spans. A ProseMirror `CellSelection` copy of *body* cells produces exactly a headerless partial table, so "copying content inside the table" hit the fallback.

The same serializer backs `getEditorMarkdown()` (save / `onChange`), so editing + saving a table-containing `.md` in the preview's editable mode corrupted it to `[table]` as well. Right-click → Copy was unaffected because `SelectionContextMenu` reads `window.getSelection().toString()`.

## Implementation

- **New `serializeMarkdownTable.ts`** (co-located with the renderer): a GFM table serializer plus an inline cell renderer driving prosemirror-markdown's serializer state. It emits `| a | b |` / `| --- | --- |` / `| c | d |`, escapes `|`, collapses newlines to keep each cell on one line, pads ragged rows, and **synthesizes an empty header** when the (possibly partial) selection has no header row — so no data is lost. A trivial `serializeTableChild` is attached to the row/header/cell nodes as defense-in-depth against any stray `[tableRow]`/`[tableCell]`.
- **`createMarkdownExtensions.ts`**: replaced the `TableKit` bundle with the individual `Table`/`TableRow`/`TableHeader`/`TableCell` extensions (already declared deps) so the serializer can be attached via `addStorage().markdown.serialize`. `tiptap-markdown` merges an extension's own markdown spec over its built-in one, so this overrides the strict default for both copy and save. Existing config/classes are preserved, and the CellSelection editing plugins live on the `Table` node, so rendering, parsing, and selection are unchanged. `Markdown.configure(...)` is untouched — "copy preserves markdown" still holds for all other content.

## Testing

- [x] `bun test serializeMarkdownTable.test.ts` — 5 cases: header+body → GFM (never `[table]`), headerless/partial CellSelection → synthesized header, pipe escaping + empty cells, ragged-row padding, inline marks (`**bold**`)
- [x] `bun run typecheck` (desktop) clean; the changed files pass `biome check` clean
- [ ] Manual (dev app): preview a `.md` with a table → select body cells → Cmd/Ctrl+C → clipboard holds a real GFM table; non-table copy still yields markdown

## Known Limitations / Follow-up

The shared editable `MarkdownEditor` (tasks, automations, new-workspace prompt, editable file viewer) uses the same `TableKit` + `transformCopiedText` combination and has the identical latent bug. It's out of scope here; a follow-up can promote this serializer to a shared location and reuse it there.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5654">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copying or saving tables in the desktop Markdown preview now produces real GFM tables instead of `[table]`. Fixes clipboard and save corruption when selecting cells in a previewed table.

- **Bug Fixes**
  - Added a GFM table serializer and registered it via `storage.markdown.serialize` to override `tiptap-markdown`’s strict default; escapes `|`, collapses newlines, keeps inline marks, and pads rows.
  - Synthesizes an empty header for headerless/partial selections so copied/saved content isn’t lost.
  - Replaced `TableKit` with `Table`/`TableRow`/`TableHeader`/`TableCell` to attach the serializer; rendering, parsing, and selection behavior remain unchanged.
  - Added unit tests for header/body tables, partial selections, escaping, padding, and marks.

<sup>Written for commit e575652e592692df5279ca5460339be4579594b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown table rendering so tables consistently display as GitHub-Flavored Markdown instead of placeholder text.
  * Improved handling of headerless, partial, and uneven tables by adding required headers and padding missing cells.
  * Preserved cell formatting, escaped pipe characters, and handled multiline content correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->