### PR TITLE
chore(desktop): bump version to 1.15.0 (host-service 1.14.1 -> 1.15.0, cli 1.14.1 -> 1.15.0)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.14.1",
+	"version": "1.15.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@ai-sdk/anthropic": "3.0.64",
@@ -746,7 +746,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -841,7 +841,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@agentclientprotocol/sdk": "1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.14.1",
+	"version": "1.15.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.14.1",
+	"version": "1.15.0",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Version-bump commit from the desktop-v1.15.0 release cut (tag desktop-v1.15.0, cut from 3c9288eb4). Desktop, host-service, and CLI move to 1.15.0 in lockstep; cli-v1.15.0 shipped via the lockstep workflow.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5655">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns versions to 1.15.0 across `@superset/desktop`, `@superset/host-service`, and `@superset/cli` for the desktop v1.15.0 release. Updates package.json and `bun.lock` only; no behavior changes.

<sup>Written for commit 3135112e192c65504ad1d076f1dd924918b7fead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application, command-line tool, and host service to version 1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->