### PR TITLE
fix(host-service): reject "." and ".." as empty/template project directory names

### DIFF
--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.test.ts
@@ -20,6 +20,8 @@ import { join } from "node:path";
 import simpleGit, { type SimpleGit } from "simple-git";
 import {
 	cloneRepoInto,
+	cloneTemplateInto,
+	initEmptyRepo,
 	initLocalRepoInPlace,
 	resolveLocalRepo,
 } from "./resolve-repo";
@@ -460,5 +462,59 @@ describe("cloneRepoInto", () => {
 
 		expect(resolved.parsed).toBeNull();
 		expect(resolved.remoteName).toBeNull();
+	});
+});
+
+// ── directory-name guard (initEmptyRepo / cloneTemplateInto) ───────
+//
+// The guard runs before any filesystem/git work, so these assert the
+// rejection without a real repo. A project name that slugs down to "." or
+// ".." (via `dirNameForEmpty`) would otherwise reach `join(parentDir, "..")`
+// and escape the projects directory — the same reserved segments
+// `deriveCloneDirectoryName` already rejects for the clone-from-URL path.
+
+describe("initEmptyRepo directory-name guard", () => {
+	test("rejects '.' as a directory name", async () => {
+		await expect(initEmptyRepo(workRoot, ".")).rejects.toThrow(
+			/Invalid directory name/,
+		);
+	});
+
+	test("rejects '..' as a directory name", async () => {
+		await expect(initEmptyRepo(workRoot, "..")).rejects.toThrow(
+			/Invalid directory name/,
+		);
+	});
+
+	test("still rejects embedded path separators", async () => {
+		await expect(initEmptyRepo(workRoot, "a/b")).rejects.toThrow(
+			/Invalid directory name/,
+		);
+		await expect(initEmptyRepo(workRoot, "a\\b")).rejects.toThrow(
+			/Invalid directory name/,
+		);
+	});
+
+	test("still rejects empty / whitespace-only names", async () => {
+		await expect(initEmptyRepo(workRoot, "   ")).rejects.toThrow(
+			/Invalid directory name/,
+		);
+	});
+});
+
+describe("cloneTemplateInto directory-name guard", () => {
+	// The guard is the first statement, so no template is ever fetched.
+	const templateUrl = "https://example.invalid/template.git";
+
+	test("rejects '.' as a directory name", async () => {
+		await expect(
+			cloneTemplateInto(templateUrl, workRoot, "."),
+		).rejects.toThrow(/Invalid directory name/);
+	});
+
+	test("rejects '..' as a directory name", async () => {
+		await expect(
+			cloneTemplateInto(templateUrl, workRoot, ".."),
+		).rejects.toThrow(/Invalid directory name/);
 	});
 });

--- a/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
+++ b/packages/host-service/src/trpc/router/project/utils/resolve-repo.ts
@@ -256,6 +256,25 @@ export async function resolveMatchingSlug(
 }
 
 /**
+ * Guard a user-derived directory name before it is joined onto a parent dir.
+ * Rejects empty/whitespace names, embedded path separators, and the `.`/`..`
+ * path references. Without the `.`/`..` check, a project named "." or ".."
+ * flows through `dirNameForEmpty` unchanged and `join(parentDir, "..")`
+ * resolves *outside* the intended `<parentDir>/<name>` location (to the
+ * parent dir itself, or its parent). Mirrors the reserved-segment rejection
+ * already done in `deriveCloneDirectoryName`, so all creation paths agree.
+ */
+function assertUsableDirName(dirName: string): void {
+	const trimmed = dirName.trim();
+	if (!trimmed || /[/\\]/.test(dirName) || trimmed === "." || trimmed === "..") {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Invalid directory name: "${dirName}"`,
+		});
+	}
+}
+
+/**
  * Empty git repo at `<parentDir>/<dirName>`: atomic mkdir (fails on EEXIST,
  * so we never blow away someone else's directory), `git init`, initial
  * empty commit. Cleans up the dir on any post-mkdir failure.
@@ -268,12 +287,7 @@ export async function initEmptyRepo(
 	parentDir: string,
 	dirName: string,
 ): Promise<ResolvedRepo> {
-	if (!dirName.trim() || /[/\\]/.test(dirName)) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: `Invalid directory name: "${dirName}"`,
-		});
-	}
+	assertUsableDirName(dirName);
 
 	const resolvedParentDir = resolvePath(parentDir);
 	ensureParentDirectory(resolvedParentDir);
@@ -311,12 +325,7 @@ export async function cloneTemplateInto(
 	dirName: string,
 	credentials?: GitCredentialProvider,
 ): Promise<ResolvedRepo> {
-	if (!dirName.trim() || /[/\\]/.test(dirName)) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: `Invalid directory name: "${dirName}"`,
-		});
-	}
+	assertUsableDirName(dirName);
 
 	const resolvedParentDir = resolvePath(parentDir);
 	ensureParentDirectory(resolvedParentDir);


### PR DESCRIPTION
## Description

`initEmptyRepo` and `cloneTemplateInto` guard the target directory name against empty strings and embedded path separators before joining it onto the parent projects dir — but not against the `.` / `..` path references. A project named `.` or `..` flows through `dirNameForEmpty` unchanged, so `join(parentDir, "..")` resolves **outside** the intended `<parentDir>/<name>` location (the parent dir itself, or its parent).

The clone-from-URL path already rejects these reserved segments in `deriveCloneDirectoryName` (with tests for `.` and `..`). This brings the empty/template creation paths in line, so all three agree.

### What changed
- Extracted a shared `assertUsableDirName` guard in `resolve-repo.ts` that rejects empty/whitespace names, embedded path separators, and the `.` / `..` references.
- Applied it in both `initEmptyRepo` and `cloneTemplateInto`, replacing the duplicated inline guard.

No behavior change for valid names; only `.` / `..` (previously accepted) are now rejected with the existing `Invalid directory name` error.

## Related Issues

Closes #5664

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- Added directory-name-guard tests for `initEmptyRepo` and `cloneTemplateInto` in `resolve-repo.test.ts` (reject `.`, `..`, path separators, and whitespace-only names), mirroring the existing `deriveCloneDirectoryName` reserved-segment tests. The guard is the first statement in each function, so the tests exercise it without a real repo or network.
- `bun test resolve-repo.test.ts` → **36 pass** (30 existing + 6 new), 0 fail.
- `bun run --filter=@superset/host-service typecheck` → clean.

## Additional Notes

Happy to also tighten `dirNameForEmpty` in `project/handlers.ts` to reject `.` / `..` earlier (for a clearer user-facing message) if maintainers prefer surfacing it there in addition to the boundary guard.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5665">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects "." and ".." as project directory names when creating empty or template repos to prevent escaping the projects directory. Aligns validation with the clone-from-URL path; closes #5664.

- **Bug Fixes**
  - Added `assertUsableDirName` in `resolve-repo.ts` to reject empty/whitespace, path separators, and "."/"..".
  - Applied the guard in `initEmptyRepo` and `cloneTemplateInto`; valid names unchanged; same “Invalid directory name” error.
  - Added tests for both paths, mirroring existing `deriveCloneDirectoryName` checks.

<sup>Written for commit ff8bab925428dc20aa47308f84724394760913f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project creation and template cloning validation.
  * Prevented invalid directory names—including path separators, empty names, and reserved `.` or `..` references—from creating projects outside the intended location.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->