### PR TITLE
fix(host-service): don't roll a cancelled PR check up to a green "success"

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
 	coercePullRequestState,
+	computeChecksStatus,
 	mapPullRequestState,
+	type PullRequestCheck,
 } from "./pull-request-mappers";
+
+const check = (status: PullRequestCheck["status"]): PullRequestCheck => ({
+	name: `check-${status}`,
+	status,
+	url: null,
+});
 
 describe("mapPullRequestState", () => {
 	test("maps merged and closed states regardless of other flags", () => {
@@ -32,5 +40,52 @@ describe("coercePullRequestState", () => {
 	test("falls back to open for unknown values", () => {
 		expect(coercePullRequestState("nonsense")).toBe("open");
 		expect(coercePullRequestState(null)).toBe("open");
+	});
+});
+
+describe("computeChecksStatus", () => {
+	test("returns 'none' when there are no checks", () => {
+		expect(computeChecksStatus([])).toBe("none");
+	});
+
+	test("returns 'success' when all checks succeed", () => {
+		expect(computeChecksStatus([check("success"), check("success")])).toBe(
+			"success",
+		);
+	});
+
+	test("returns 'failure' when any check failed", () => {
+		expect(computeChecksStatus([check("success"), check("failure")])).toBe(
+			"failure",
+		);
+	});
+
+	test("returns 'pending' when a check is still running and none failed", () => {
+		expect(computeChecksStatus([check("success"), check("pending")])).toBe(
+			"pending",
+		);
+	});
+
+	// Regression: a cancelled run is terminal and did not pass, so it must not
+	// roll up to a green 'success'.
+	test("treats a cancelled check as a non-passing status, not success", () => {
+		expect(computeChecksStatus([check("cancelled")])).toBe("failure");
+		expect(computeChecksStatus([check("success"), check("cancelled")])).toBe(
+			"failure",
+		);
+	});
+
+	test("cancelled/failure outrank a concurrent pending check", () => {
+		expect(computeChecksStatus([check("pending"), check("cancelled")])).toBe(
+			"failure",
+		);
+	});
+
+	// `skipped` (GitHub SKIPPED/NEUTRAL) is intentionally non-blocking.
+	test("keeps skipped checks non-blocking (folds into success)", () => {
+		expect(computeChecksStatus([check("success"), check("skipped")])).toBe(
+			"success",
+		);
+		expect(computeChecksStatus([check("skipped")])).toBe("success");
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
@@ -90,7 +90,18 @@ export function parseCheckContexts(
 
 export function computeChecksStatus(checks: PullRequestCheck[]): ChecksStatus {
 	if (checks.length === 0) return "none";
-	if (checks.some((check) => check.status === "failure")) return "failure";
+	// A `cancelled` run is terminal and did not pass, so it must roll up as a
+	// non-passing status rather than falling through to `success` — otherwise a
+	// PR whose CI was cancelled (superseded commit, concurrency-group cancel,
+	// manual cancel) shows a green checks indicator. `skipped`/`neutral` remain
+	// non-blocking and fold into `success` below.
+	if (
+		checks.some(
+			(check) => check.status === "failure" || check.status === "cancelled",
+		)
+	) {
+		return "failure";
+	}
 	if (checks.some((check) => check.status === "pending")) return "pending";
 	return "success";
 }


### PR DESCRIPTION
## Description

The PR checks indicator could show green (`success`) for a pull request whose CI was **cancelled**.

`computeChecksStatus` only short-circuits on `failure` and `pending`, so any other per-check status falls through to `success`. `mapCheckRunStatus` deliberately maps a `CANCELLED` check-run conclusion to its own `"cancelled"` status — which is neither `failure` nor `pending`, so the rollup reported `success`.

### The fix

Treat `cancelled` as a non-passing status in the rollup (it's terminal and did not pass). `skipped`/`neutral` stay non-blocking and continue to fold into `success`, which matches GitHub's own semantics.

```ts
if (checks.some((c) => c.status === "failure" || c.status === "cancelled")) {
  return "failure";
}
```

## Related Issues

Closes #5667

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- Added a `computeChecksStatus` suite to `pull-request-mappers.test.ts` (the file had no coverage for it): empty→`none`, all-success→`success`, any-failure→`failure`, pending→`pending`, **cancelled→`failure`** (regression), cancelled/failure outranking a concurrent pending, and `skipped` staying non-blocking.
- `bun test pull-request-mappers.test.ts` → **13 pass** (5 existing + 8 new), 0 fail.
- `bun run --filter=@superset/host-service typecheck` → clean.

## Additional Notes

Adjacent (out of scope here, happy to follow up): `mapCheckRunStatus` maps a **COMPLETED** run whose conclusion is `STALE` or `STARTUP_FAILURE` to `"pending"` via the `default` branch, so such a run reads as pending indefinitely. Left untouched to keep this PR focused on the cancelled→green regression.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes green PR check status when CI was cancelled by rolling `cancelled` into `failure` in `computeChecksStatus`. Prevents false greens and risky merges.

- **Bug Fixes**
  - Treat `cancelled` as non-passing in the rollup; return `failure` if any check is `failure` or `cancelled`. `skipped`/`neutral` still fold into `success`.
  - Add tests for `computeChecksStatus` covering empty, all-success, any-failure, pending, cancelled precedence, and skipped non-blocking.

<sup>Written for commit 51937f8e749d782b3766571258b737ad4d99bf9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request check summaries now correctly report cancelled checks as failures.
  * Check status prioritization is improved when cancelled, failed, pending, successful, or skipped checks appear together.
  * Added coverage for check rollup behavior, including empty, successful, pending, and skipped checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->