### PR TITLE
docs(readme): advertise recent features, CLI/SDK/MCP surfaces, and Mistral Vibe

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Superset works with any CLI-based coding agent, including:
 
 If it runs in a terminal, it runs on Superset
 
+Agents get more than a terminal:
+
+- **Model picker**: choose a model and reasoning effort when you launch an agent
+- **Per-agent settings**: tune launch commands, prompt templates, and model overrides in Settings → Agents
+- **Custom agents**: add any terminal agent with its own icon and it works like a built-in
+- **Status and notifications**: working indicators, completion chimes, and dock badges when an agent needs you
+- **Built-in chat**: talk to models in a chat pane, with inline tool approvals and plan review
+
 ## More Than a Desktop App
 
 Every surface talks to the same workspaces, so you can start a task in the app and check on it from anywhere.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Wait less, ship more.
 | **Built-in Diff Viewer** | Inspect, comment on, and edit agent changes without leaving the app |
 | **Command Palette** | Jump to any workspace, action, or setting from one search box |
 | **In-App Browser & Ports** | Preview running dev servers, with ports detected per workspace |
-| **Remote Workspaces** | Connect another machine and reach its workspaces from anywhere, on every plan |
+| **Remote Workspaces** | Connect another machine and reach its workspaces from anywhere |
 | **Automations** | Run agent sessions on a schedule |
 | **Custom Agents** | Add your own terminal agents with custom icons |
 | **Workspace Presets** | Automate env setup, dependency installation, and more |
@@ -62,18 +62,18 @@ Superset works with any CLI-based coding agent, including:
 
 | Agent | Status |
 |:------|:-------|
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Fully supported |
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Fully supported |
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Fully supported |
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Fully supported |
-| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Fully supported |
+| <img height="16" align="top" alt="Amp Code" src="packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Fully supported |
+| <img height="16" align="top" alt="Claude Code" src="packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Fully supported |
+| <img height="16" align="top" alt="Cursor Agent" src="packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Fully supported |
+| <img height="16" align="top" alt="Gemini CLI" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Fully supported |
+| <img height="16" align="top" alt="Mistral Vibe" src="packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Fully supported |
 | Any other CLI agent | Works without configuration |
 
 If it runs in a terminal, it runs on Superset
@@ -94,7 +94,7 @@ Every surface talks to the same workspaces, so you can start a task in the app a
 |:--------|:-------------|
 | [**Desktop App**](https://github.com/superset-sh/superset/releases/latest) | The full IDE: terminals, diff viewer, in-app browser, automations |
 | [**CLI**](https://docs.superset.sh/cli/getting-started) | A single `superset` binary to manage workspaces, agents, terminals, and hosts from any shell |
-| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Drive Superset programmatically with [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) from Node, Bun, or the browser |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Drive Superset programmatically with [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) from Node, Bun, or Deno |
 | [**MCP Server**](https://docs.superset.sh/mcp) | Let Claude Code, Codex, Cursor, and other agents create and manage workspaces themselves |
 
 The CLI comes bundled with the desktop app, or install it standalone:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Superset orchestrates CLI-based coding agents across isolated git worktrees, wit
 - **Monitor all your agents** from one place and get notified when they need attention
 - **Review and edit changes quickly** with the built-in diff viewer and editor
 - **Open any workspace where you need it** with one-click handoff to your editor or terminal
+- **Reach your workspaces from anywhere** via remote hosts, the CLI, the SDK, or MCP
 
 Wait less, ship more.
 
@@ -42,11 +43,17 @@ Wait less, ship more.
 |:--------|:------------|
 | **Parallel Execution** | Run 10+ coding agents simultaneously on your machine |
 | **Worktree Isolation** | Each task gets its own branch and working directory |
-| **Agent Monitoring** | Track agent status and get notified when changes are ready |
-| **Built-in Diff Viewer** | Inspect and edit agent changes without leaving the app |
+| **Agent Monitoring** | Track every agent from the sidebar, with dock badges when one needs attention |
+| **Built-in Terminal** | Tabs, splits, presets, persistent sessions, and an optional rich prompt editor |
+| **Built-in Diff Viewer** | Inspect, comment on, and edit agent changes without leaving the app |
+| **Command Palette** | Jump to any workspace, action, or setting from one search box |
+| **In-App Browser & Ports** | Preview running dev servers, with ports detected per workspace |
+| **Remote Workspaces** | Connect another machine and reach its workspaces from anywhere, on every plan |
+| **Automations** | Run agent sessions on a schedule |
+| **Custom Agents** | Add your own terminal agents with custom icons |
 | **Workspace Presets** | Automate env setup, dependency installation, and more |
+| **Slack & Linear** | Spin up workspaces from Slack messages or Linear issues |
 | **Universal Compatibility** | Works with any CLI agent that runs in a terminal |
-| **Quick Context Switching** | Jump between tasks as they need your attention |
 | **IDE Integration** | Open any workspace in your favorite editor with one click |
 
 ## Supported Agents
@@ -63,12 +70,34 @@ Superset works with any CLI-based coding agent, including:
 | <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Fully supported |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Fully supported |
+| <img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Fully supported |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Fully supported |
 | <picture><source media="(prefers-color-scheme: dark)" srcset="packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" src="packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Fully supported |
 | Any other CLI agent | Works without configuration |
 
 If it runs in a terminal, it runs on Superset
+
+## More Than a Desktop App
+
+Every surface talks to the same workspaces, so you can start a task in the app and check on it from anywhere.
+
+| Surface | What you get |
+|:--------|:-------------|
+| [**Desktop App**](https://github.com/superset-sh/superset/releases/latest) | The full IDE: terminals, diff viewer, in-app browser, automations |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | A single `superset` binary to manage workspaces, agents, terminals, and hosts from any shell |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Drive Superset programmatically with [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) from Node, Bun, or the browser |
+| [**MCP Server**](https://docs.superset.sh/mcp) | Let Claude Code, Codex, Cursor, and other agents create and manage workspaces themselves |
+
+The CLI comes bundled with the desktop app, or install it standalone:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+An iOS app is coming soon so you can check on your agents from your phone.
 
 ## Requirements
 
@@ -141,12 +170,13 @@ All shortcuts are customizable via **Settings > Keyboard Shortcuts** (`⌘/`). S
 
 ## Configuration
 
-Configure workspace setup and teardown in `.superset/config.json`. See [full documentation](https://docs.superset.sh/setup-teardown-scripts).
+Configure workspace setup, teardown, and run scripts in `.superset/config.json`. See [full documentation](https://docs.superset.sh/setup-teardown-scripts).
 
 ```json
 {
   "setup": ["./.superset/setup.sh"],
-  "teardown": ["./.superset/teardown.sh"]
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
 }
 ```
 
@@ -154,6 +184,7 @@ Configure workspace setup and teardown in `.superset/config.json`. See [full doc
 |:-------|:-----|:------------|
 | `setup` | `string[]` | Commands to run when creating a workspace |
 | `teardown` | `string[]` | Commands to run when deleting a workspace |
+| `run` | `string[]` | Restartable dev-server commands, triggered by the Run button |
 
 ### Example setup script
 
@@ -173,6 +204,7 @@ echo "Workspace ready!"
 
 Scripts have access to environment variables:
 - `SUPERSET_WORKSPACE_NAME`: name of the workspace
+- `SUPERSET_WORKSPACE_PATH`: path to the workspace worktree
 - `SUPERSET_ROOT_PATH`: path to the main repository
 
 ## Mastra Dependencies


### PR DESCRIPTION
## Summary
- Expand the features table from 8 to 14 rows to cover what shipped since spring: built-in terminal (splits, presets, rich prompt editor), command palette, in-app browser and ports, remote workspaces, automations, custom agents, and the Slack/Linear integrations.
- Add a "More Than a Desktop App" section covering the four surfaces (desktop app, CLI, TypeScript SDK, MCP server) with docs links and CLI install commands, plus an iOS coming-soon note.
- Add Mistral Vibe to the supported agents table and the missing `run` script option + `SUPERSET_WORKSPACE_PATH` env var to the configuration section.

## Why / Context
The README still advertised the March feature set. A lot has shipped since (rich terminal input, remote hosts on every plan, automations, custom agents, the CLI/SDK/MCP surfaces, Mistral Vibe) and none of it was visible to someone landing on the repo.

Feature names and descriptions are pulled from the changelog, docs site, and pricing page so the README matches what we say elsewhere. Copy follows the house voice: no em dashes, no padding, swept with the usual grep.

## Notes
- "Remote workspaces on every plan" comes from the 2026-07-12 changelog (#5571). The docs page still flags remote workspaces as Pro; if the docs are right and the changelog is wrong, that phrase should come out.
- Mistral Vibe links to mistral.ai since the repo has no more specific product URL for it.

## Testing
- Docs-only. Verified all docs.superset.sh slugs against `apps/docs/content/docs/` file names, the CLI install commands against `cli/getting-started.mdx`, and the `run`/env-var additions against `setup-teardown-scripts.mdx`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5676">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the README to showcase recent features, surfaces (desktop, CLI, TypeScript SDK, MCP), and Mistral Vibe. Adds CLI install steps plus config docs for `run` scripts and `SUPERSET_WORKSPACE_PATH`.

- **New Features**
  - Expanded features table: built-in terminal, command palette, in-app browser & ports, remote workspaces, automations, custom agents, Slack/Linear, presets.
  - Supported agents: added Mistral Vibe and agent-level features (model picker, per-agent settings, status/notifications, built-in chat).
  - Surfaces: desktop app, CLI, TypeScript SDK (`@superset_sh/sdk`), MCP server, with install commands and an iOS note.
  - Configuration: documented `run` scripts and `SUPERSET_WORKSPACE_PATH`.

- **Bug Fixes**
  - Removed plan-specific claim for remote workspaces.
  - Added alt text to agent icons.
  - Clarified SDK runtimes (Node, Bun, Deno).

<sup>Written for commit e59e3edd630192c134938e5c3f22e0a8fa322086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README marketing and features overview, including “Reach your workspaces from anywhere,” built-in terminal and diff viewer, in-app browser with ports, command palette, remote workspaces, automations, custom agents, and workspace presets.
  - Updated the supported agents list to include Mistral Vibe.
  - Expanded “More Than a Desktop App” with details for the Desktop App, CLI, TypeScript SDK, and MCP server (including CLI guidance and an iOS note).
  - Enhanced `.superset/config.json` with workspace setup/teardown/run script support via a new `run` array and documented `SUPERSET_WORKSPACE_PATH`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->