### PR TITLE
feat(desktop): status-grouped workspace sidebar behind a feature flag

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/index.ts
@@ -1,4 +1,6 @@
 export {
+	fetchTerminalAgentBindings,
+	getTerminalAgentBindingsQueryKey,
 	type TerminalAgentBinding,
 	useTerminalAgentBinding,
 	useTerminalAgentBindings,

--- a/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/useTerminalAgentBindings.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/useTerminalAgentBindings.ts
@@ -13,6 +13,29 @@ type TerminalAgentBindings = Awaited<
 export type TerminalAgentBinding = TerminalAgentBindings[number];
 
 /**
+ * React Query key for a workspace's terminal-agent bindings. Exported so the
+ * bulk status source (`useV2WorkspaceStatuses`) reads/writes the exact same
+ * cache entries as the per-row hook — rows and status buckets can never show
+ * contradictory agent states.
+ */
+export function getTerminalAgentBindingsQueryKey(
+	hostUrl: string | null,
+	workspaceId: string,
+) {
+	return ["terminal-agent-bindings", hostUrl, workspaceId] as const;
+}
+
+/** Fetch a workspace's terminal-agent bindings from its host. */
+export function fetchTerminalAgentBindings(
+	hostUrl: string,
+	workspaceId: string,
+): Promise<TerminalAgentBindings> {
+	return getHostServiceClientByUrl(
+		hostUrl,
+	).terminalAgents.listByWorkspace.query({ workspaceId });
+}
+
+/**
  * Map of `terminalId → agent binding` for a workspace, read from the host
  * store and invalidated on `agent:lifecycle` / `terminal:lifecycle` events.
  */
@@ -23,7 +46,7 @@ export function useTerminalAgentBindings(
 	const hostUrl = useWorkspaceHostUrl(workspaceId);
 	const queryClient = useQueryClient();
 	const queryKey = useMemo(
-		() => ["terminal-agent-bindings", hostUrl, workspaceId] as const,
+		() => getTerminalAgentBindingsQueryKey(hostUrl, workspaceId),
 		[hostUrl, workspaceId],
 	);
 
@@ -35,9 +58,7 @@ export function useTerminalAgentBindings(
 		enabled,
 		queryFn: () => {
 			if (!hostUrl) return [] as TerminalAgentBindings;
-			return getHostServiceClientByUrl(
-				hostUrl,
-			).terminalAgents.listByWorkspace.query({ workspaceId });
+			return fetchTerminalAgentBindings(hostUrl, workspaceId);
 		},
 		// Lifecycle events invalidate for instant updates; the finite
 		// staleTime lets focus/remount refetches self-heal any staleness

--- a/apps/desktop/src/renderer/hooks/host-service/useV2WorkspaceStatuses/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2WorkspaceStatuses/index.ts
@@ -1,0 +1,4 @@
+export {
+	useV2WorkspaceStatuses,
+	type WorkspaceStatusMap,
+} from "./useV2WorkspaceStatuses";

--- a/apps/desktop/src/renderer/hooks/host-service/useV2WorkspaceStatuses/useV2WorkspaceStatuses.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2WorkspaceStatuses/useV2WorkspaceStatuses.ts
@@ -1,0 +1,193 @@
+import { useQueries } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { useV2NotificationStore } from "renderer/stores/v2-notifications";
+import {
+	type ActivePaneStatus,
+	getHighestPriorityStatus,
+	type PaneStatus,
+} from "shared/tabs-types";
+import {
+	fetchTerminalAgentBindings,
+	getTerminalAgentBindingsQueryKey,
+	type TerminalAgentBinding,
+} from "../useTerminalAgentBindings";
+import { deriveTerminalAgentStatus } from "../useTerminalAgentStatuses/deriveTerminalAgentStatus";
+
+/**
+ * Poll interval for the bulk source. Mounted sidebar rows still invalidate
+ * their (shared-key) binding query instantly on `agent:lifecycle` events, and
+ * this hook observes the same cache entries — so visible workspaces update
+ * immediately. This interval only bounds staleness for workspaces whose row is
+ * unmounted (e.g. inside a collapsed status bucket), which the per-row event
+ * subscription never covers. A dedicated bulk lifecycle subscription (for
+ * instant updates on unmounted rows too) is a follow-up; see the plan step 2.
+ */
+const BULK_STATUS_REFETCH_INTERVAL_MS = 5_000;
+
+/**
+ * A finished agent stays in the Waiting bucket while it's recent, then ages into
+ * Idle once it's been quiet this long. This is the only path a stopped agent
+ * takes to Idle: clicking a row never demotes it (not seen-gated), only elapsed
+ * time with no new agent activity does. Keyed off the agent's own last-event
+ * time, so it's unaffected by mere viewing. ~a day ≈ "still my move today,
+ * parked after that"; tune here.
+ */
+const WAITING_TO_IDLE_AFTER_MS = 24 * 60 * 60 * 1_000;
+
+export type WorkspaceStatusMap = Map<string, ActivePaneStatus | null>;
+
+function getStatusMapFingerprint(map: WorkspaceStatusMap): string {
+	return JSON.stringify(
+		[...map.entries()].sort(([a], [b]) => a.localeCompare(b)),
+	);
+}
+
+/**
+ * Bulk `workspaceId → ActivePaneStatus | null` for status-grouped sidebar
+ * buckets. Independent of what rows are rendered: it mounts the binding query
+ * for every requested id itself (reusing the exact per-row query key/fetcher so
+ * both share React Query cache and can never disagree), so a workspace inside a
+ * collapsed bucket is still classified correctly instead of being stuck as Idle.
+ *
+ * `null` means "no active agent" (idle, or status not yet resolved) — callers
+ * fall through to PR lifecycle for such workspaces; only `working`/`permission`
+ * pull a workspace into the Working bucket, so an unresolved status never
+ * wrongly reads as Working.
+ *
+ * Unlike the per-row indicator, this is deliberately **not seen-gated**: a
+ * finished agent resolves to `review` whether or not you've clicked/seen the
+ * row. Bucketing reflects the *state of the work* ("agent finished — your
+ * move"), not an unread badge, so opening a workspace clears its green dot (a
+ * per-row concern) without dropping it out of the Waiting bucket into Idle.
+ *
+ * A stopped agent still reaches Idle, but by **time, not viewing**: once it's
+ * been quiet longer than `WAITING_TO_IDLE_AFTER_MS` it ages out of Waiting. So
+ * Idle means "no agent activity, or the agent finished long enough ago that
+ * you've clearly moved on" (and no PR).
+ */
+export function useV2WorkspaceStatuses(
+	workspaceIds: string[],
+	options?: { enabled?: boolean },
+): WorkspaceStatusMap {
+	const enabled = options?.enabled ?? true;
+	const { workspaces, cache } = useHostWorkspaces();
+	const { resolveHostUrl } = cache;
+	const manualUnread = useV2NotificationStore((state) => state.manualUnread);
+
+	const workspacesById = useMemo(
+		() => new Map(workspaces.map((workspace) => [workspace.id, workspace])),
+		[workspaces],
+	);
+
+	// Resolve (workspaceId, hostUrl) targets. Workspaces on an unreachable host
+	// (null url) or not present in the collection are skipped — they still get
+	// their manual-unread mark applied below.
+	const targets = useMemo(
+		() =>
+			workspaceIds.flatMap((workspaceId) => {
+				const workspace = workspacesById.get(workspaceId);
+				if (!workspace) return [];
+				const hostUrl = resolveHostUrl(workspace.hostId);
+				if (!hostUrl) return [];
+				return [{ workspaceId, hostUrl }];
+			}),
+		[workspaceIds, workspacesById, resolveHostUrl],
+	);
+
+	const results = useQueries({
+		queries: targets.map((target) => ({
+			queryKey: getTerminalAgentBindingsQueryKey(
+				target.hostUrl,
+				target.workspaceId,
+			),
+			enabled,
+			refetchInterval: BULK_STATUS_REFETCH_INTERVAL_MS,
+			staleTime: 30_000,
+			queryFn: () =>
+				fetchTerminalAgentBindings(target.hostUrl, target.workspaceId),
+		})),
+	});
+
+	const bindingsByWorkspaceId = useMemo(() => {
+		const map = new Map<string, TerminalAgentBinding[]>();
+		targets.forEach((target, index) => {
+			const data = results[index]?.data;
+			if (data) map.set(target.workspaceId, data);
+		});
+		return map;
+		// results is a fresh array each render; the fingerprint layer below
+		// stabilizes the final output so groups only rebuild on real changes.
+	}, [targets, results]);
+
+	// Waiting→Idle is a time boundary, not a data change. `Date.now()` only
+	// advances this on re-render, and a poll that returns identical bindings
+	// won't re-render — so a quiet Waiting workspace could linger past its window
+	// until some unrelated update. Drive the cutoff off a clock we bump with an
+	// explicit timer at the next expiry instead. `nextExpiryAt` is a primitive,
+	// so the timer only reschedules when the earliest expiry actually changes
+	// (`bindingsByWorkspaceId` is a fresh reference every render). Initialised to
+	// mount time, so anything already past its window ages immediately.
+	const [now, setNow] = useState(() => Date.now());
+	const nextExpiryAt = useMemo(() => {
+		let next = Number.POSITIVE_INFINITY;
+		for (const bindings of bindingsByWorkspaceId.values()) {
+			for (const binding of bindings) {
+				const expiry = binding.lastEventAt + WAITING_TO_IDLE_AFTER_MS;
+				if (expiry > now && expiry < next) next = expiry;
+			}
+		}
+		return Number.isFinite(next) ? next : null;
+	}, [bindingsByWorkspaceId, now]);
+	useEffect(() => {
+		if (nextExpiryAt == null) return;
+		const timer = setTimeout(
+			() => setNow(Date.now()),
+			Math.max(0, nextExpiryAt - Date.now()),
+		);
+		return () => clearTimeout(timer);
+	}, [nextExpiryAt]);
+
+	const previousRef = useRef<{
+		fingerprint: string;
+		map: WorkspaceStatusMap;
+	} | null>(null);
+
+	return useMemo(() => {
+		const map: WorkspaceStatusMap = new Map();
+		// Anything the agent last touched before this cutoff has aged out of
+		// Waiting into Idle. Keyed off `now`, which the expiry timer above bumps,
+		// so the transition fires deterministically at the window boundary.
+		const agingCutoff = now - WAITING_TO_IDLE_AFTER_MS;
+		for (const workspaceId of workspaceIds) {
+			const statuses: (PaneStatus | undefined)[] = [
+				manualUnread[workspaceId] ? "review" : undefined,
+			];
+			for (const binding of bindingsByWorkspaceId.get(workspaceId) ?? []) {
+				const status = deriveTerminalAgentStatus({
+					lastEventType: binding.lastEventType,
+					lastEventAt: binding.lastEventAt,
+					// Not seen-gated: clicking a row must not demote it. The per-row
+					// seen-gated variant lives in useTerminalAgentStatuses.
+					lastSeenAt: undefined,
+				});
+				// A finished (review) agent stays Waiting only while recent; once it's
+				// been quiet past the window it ages to idle. This is the sole path a
+				// stopped agent takes to Idle.
+				statuses.push(
+					status === "review" && binding.lastEventAt < agingCutoff
+						? "idle"
+						: status,
+				);
+			}
+			map.set(workspaceId, getHighestPriorityStatus(statuses));
+		}
+
+		const fingerprint = getStatusMapFingerprint(map);
+		if (previousRef.current?.fingerprint === fingerprint) {
+			return previousRef.current.map;
+		}
+		previousRef.current = { fingerprint, map };
+		return map;
+	}, [workspaceIds, bindingsByWorkspaceId, manualUnread, now]);
+}

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/index.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/index.ts
@@ -1,2 +1,6 @@
-export type { V2UserPreferencesApi } from "./useV2UserPreferences";
+export type {
+	RightSidebarTab,
+	SidebarGroupMode,
+	V2UserPreferencesApi,
+} from "./useV2UserPreferences";
 export { useV2UserPreferences } from "./useV2UserPreferences";

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -6,11 +6,13 @@ import {
 	DEFAULT_V2_USER_PREFERENCES,
 	type LinkAction,
 	type LinkTierMap,
+	type SidebarGroupMode,
 	V2_USER_PREFERENCES_ID,
 	type V2UserPreferencesRow,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 
 export type RightSidebarTab = V2UserPreferencesRow["rightSidebarTab"];
+export type { SidebarGroupMode };
 
 export interface V2UserPreferencesApi {
 	preferences: V2UserPreferencesRow;
@@ -24,6 +26,7 @@ export interface V2UserPreferencesApi {
 	setDeleteLocalBranch: (next: boolean) => void;
 	setShowPresetsBar: (next: boolean | ((prev: boolean) => boolean)) => void;
 	toggleShowPresetsBar: () => void;
+	setSidebarGroupMode: (next: SidebarGroupMode) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -200,6 +203,25 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setShowPresetsBar((prev) => !prev);
 	}, [setShowPresetsBar]);
 
+	const setSidebarGroupMode = useCallback(
+		(next: SidebarGroupMode) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					sidebarGroupMode: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.sidebarGroupMode = next;
+			});
+		},
+		[collections],
+	);
+
 	return {
 		preferences,
 		setFileLinks,
@@ -212,5 +234,6 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setDeleteLocalBranch,
 		setShowPresetsBar,
 		toggleShowPresetsBar,
+		setSidebarGroupMode,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -35,6 +35,7 @@ import { DashboardSidebarHoverCardOverlay } from "./components/DashboardSidebarH
 import { DashboardSidebarPortsList } from "./components/DashboardSidebarPortsList";
 import { DashboardSidebarProjectSection } from "./components/DashboardSidebarProjectSection";
 import { DashboardSidebarSectionRenameProvider } from "./components/DashboardSidebarSectionRenameContext";
+import { DashboardSidebarStatusSection } from "./components/DashboardSidebarStatusSection";
 import { V2SetupScriptCard } from "./components/V2SetupScriptCard";
 import { useDashboardSidebarData } from "./hooks/useDashboardSidebarData";
 import { useDashboardSidebarShortcuts } from "./hooks/useDashboardSidebarShortcuts";
@@ -98,8 +99,14 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 export function DashboardSidebar({
 	isCollapsed = false,
 }: DashboardSidebarProps) {
-	const { groups, refreshWorkspacePullRequest, toggleProjectCollapsed } =
-		useDashboardSidebarData();
+	const {
+		groups,
+		groupMode,
+		sidebarProjects,
+		refreshWorkspacePullRequest,
+		toggleProjectCollapsed,
+	} = useDashboardSidebarData();
+	const isStatusMode = groupMode === "status";
 	const { reorderProjects } = useDashboardSidebarState();
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -140,7 +147,9 @@ export function DashboardSidebar({
 
 	const workspaceShortcutLabels = useDashboardSidebarShortcuts(orderedGroups);
 
-	const activeV2Project = useMemo(() => {
+	// Resolve the active workspace's REAL project id from its row (never a
+	// group id — in status mode the group is a synthetic `status:*` bucket).
+	const activeWorkspaceProjectId = useMemo(() => {
 		if (!activeV2WorkspaceId) return null;
 		for (const project of groups) {
 			for (const child of project.children) {
@@ -148,17 +157,25 @@ export function DashboardSidebar({
 					child.type === "workspace" &&
 					child.workspace.id === activeV2WorkspaceId
 				) {
-					return project;
+					return child.workspace.projectId;
 				}
 				if (child.type === "section") {
 					for (const ws of child.section.workspaces) {
-						if (ws.id === activeV2WorkspaceId) return project;
+						if (ws.id === activeV2WorkspaceId) return ws.projectId;
 					}
 				}
 			}
 		}
 		return null;
 	}, [groups, activeV2WorkspaceId]);
+
+	const activeV2Project = useMemo(() => {
+		if (!activeWorkspaceProjectId) return null;
+		const project = sidebarProjects.find(
+			(candidate) => candidate.id === activeWorkspaceProjectId,
+		);
+		return project ? { id: project.id, name: project.name } : null;
+	}, [activeWorkspaceProjectId, sidebarProjects]);
 
 	const handleDragEnd = useCallback(
 		({ active, over }: DragEndEvent) => {
@@ -185,54 +202,71 @@ export function DashboardSidebar({
 							<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
 							<div className="flex-1 overflow-y-auto hide-scrollbar">
-								<DndContext
-									sensors={sensors}
-									collisionDetection={closestCenter}
-									measuring={{
-										droppable: { strategy: MeasuringStrategy.Always },
-									}}
-									onDragStart={({ active }) => {
-										const project = groups.find((p) => p.id === active.id);
-										setActiveProject(project ?? null);
-									}}
-									onDragEnd={handleDragEnd}
-									onDragCancel={() => setActiveProject(null)}
-								>
-									<SortableContext
-										items={projectOrder}
-										strategy={verticalListSortingStrategy}
+								{isStatusMode ? (
+									// Status buckets carry their own canonical order from the
+									// builder and aren't drag-reorderable, so render `groups`
+									// directly — `orderedGroups` lags a render behind on the
+									// `projectOrder` effect and would briefly drop the new
+									// `status:*` ids, blanking the rail on a mode/bucket change.
+									groups.map((group) => (
+										<DashboardSidebarStatusSection
+											key={group.id}
+											project={group}
+											isSidebarCollapsed={isCollapsed}
+											workspaceShortcutLabels={workspaceShortcutLabels}
+											onWorkspaceHover={refreshWorkspacePullRequest}
+										/>
+									))
+								) : (
+									<DndContext
+										sensors={sensors}
+										collisionDetection={closestCenter}
+										measuring={{
+											droppable: { strategy: MeasuringStrategy.Always },
+										}}
+										onDragStart={({ active }) => {
+											const project = groups.find((p) => p.id === active.id);
+											setActiveProject(project ?? null);
+										}}
+										onDragEnd={handleDragEnd}
+										onDragCancel={() => setActiveProject(null)}
 									>
-										{orderedGroups.map((project) => (
-											<SortableProjectWrapper
-												key={project.id}
-												project={project}
-												isCollapsed={isCollapsed}
-												isDraggingProject={activeProject != null}
-												workspaceShortcutLabels={workspaceShortcutLabels}
-												onWorkspaceHover={refreshWorkspacePullRequest}
-												onToggleCollapse={toggleProjectCollapsed}
-											/>
-										))}
-									</SortableContext>
+										<SortableContext
+											items={projectOrder}
+											strategy={verticalListSortingStrategy}
+										>
+											{orderedGroups.map((project) => (
+												<SortableProjectWrapper
+													key={project.id}
+													project={project}
+													isCollapsed={isCollapsed}
+													isDraggingProject={activeProject != null}
+													workspaceShortcutLabels={workspaceShortcutLabels}
+													onWorkspaceHover={refreshWorkspacePullRequest}
+													onToggleCollapse={toggleProjectCollapsed}
+												/>
+											))}
+										</SortableContext>
 
-									{createPortal(
-										<DragOverlay dropAnimation={null}>
-											{activeProject && (
-												<div className="bg-background shadow-lg border-b border-border">
-													<DashboardSidebarProjectSection
-														project={activeProject}
-														isSidebarCollapsed={isCollapsed}
-														isDraggingProject
-														workspaceShortcutLabels={workspaceShortcutLabels}
-														onWorkspaceHover={() => {}}
-														onToggleCollapse={() => {}}
-													/>
-												</div>
-											)}
-										</DragOverlay>,
-										document.body,
-									)}
-								</DndContext>
+										{createPortal(
+											<DragOverlay dropAnimation={null}>
+												{activeProject && (
+													<div className="bg-background shadow-lg border-b border-border">
+														<DashboardSidebarProjectSection
+															project={activeProject}
+															isSidebarCollapsed={isCollapsed}
+															isDraggingProject
+															workspaceShortcutLabels={workspaceShortcutLabels}
+															onWorkspaceHover={() => {}}
+															onToggleCollapse={() => {}}
+														/>
+													</div>
+												)}
+											</DragOverlay>,
+											document.body,
+										)}
+									</DndContext>
+								)}
 							</div>
 							{!isCollapsed && !inlineWorkspacePortsEnabled && (
 								<DashboardSidebarPortsList />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -37,6 +37,7 @@ import {
 	useOpenTemplateGalleryModal,
 } from "renderer/stores/add-repository-modal";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { SidebarGroupingToggle } from "./components/SidebarGroupingToggle";
 
 interface DashboardSidebarHeaderProps {
 	isCollapsed?: boolean;
@@ -256,7 +257,11 @@ export function DashboardSidebarHeader({
 					<SidebarToggle />
 					<NavigationControls />
 				</ZoomStable>
-				<ZoomStable enabled={isMac} className="ml-auto">
+				<ZoomStable
+					enabled={isMac}
+					className="ml-auto flex items-center gap-0.5"
+				>
+					<SidebarGroupingToggle />
 					<ResourceConsumption surface="v2" />
 				</ZoomStable>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/components/SidebarGroupingToggle/SidebarGroupingToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/components/SidebarGroupingToggle/SidebarGroupingToggle.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuLabel,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { LuLayoutList } from "react-icons/lu";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
+import { useStatusGroupedSidebarEnabled } from "renderer/stores/status-grouped-sidebar";
+
+/**
+ * Inline control in the sidebar header (beside the resources badge) that opens
+ * a menu to group the rail by status or by project. Renders nothing unless the
+ * status-grouped-sidebar feature flag is enabled. Mirrors the neighboring
+ * ResourceConsumption trigger (ghost icon-xs) and carries `no-drag` so clicks
+ * land instead of being swallowed by the window drag region.
+ */
+export function SidebarGroupingToggle() {
+	const enabled = useStatusGroupedSidebarEnabled();
+	const { preferences, setSidebarGroupMode } = useV2UserPreferences();
+
+	if (!enabled) return null;
+
+	const groupMode = preferences.sidebarGroupMode;
+
+	return (
+		<DropdownMenu>
+			<Tooltip delayDuration={150}>
+				<TooltipTrigger asChild>
+					<DropdownMenuTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon-xs"
+							aria-label="Group workspaces"
+							className="no-drag text-muted-foreground hover:text-foreground"
+						>
+							<LuLayoutList className="size-3.5" />
+						</Button>
+					</DropdownMenuTrigger>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" sideOffset={6} showArrow={false}>
+					Group workspaces
+				</TooltipContent>
+			</Tooltip>
+			<DropdownMenuContent
+				align="end"
+				className="w-40"
+				onCloseAutoFocus={(event) => event.preventDefault()}
+			>
+				<DropdownMenuLabel>Group by</DropdownMenuLabel>
+				<DropdownMenuRadioGroup
+					value={groupMode}
+					onValueChange={(value) =>
+						setSidebarGroupMode(value === "status" ? "status" : "project")
+					}
+				>
+					<DropdownMenuRadioItem value="status">Status</DropdownMenuRadioItem>
+					<DropdownMenuRadioItem value="project">Project</DropdownMenuRadioItem>
+				</DropdownMenuRadioGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/components/SidebarGroupingToggle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/components/SidebarGroupingToggle/index.ts
@@ -1,0 +1,1 @@
+export { SidebarGroupingToggle } from "./SidebarGroupingToggle";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarStatusSection/DashboardSidebarStatusSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarStatusSection/DashboardSidebarStatusSection.tsx
@@ -1,0 +1,118 @@
+import { cn } from "@superset/ui/utils";
+import { AnimatePresence, motion } from "framer-motion";
+import { useMemo, useState } from "react";
+import { HiChevronRight } from "react-icons/hi2";
+import type { DashboardSidebarProject, SidebarStatusBucket } from "../../types";
+import { getProjectChildrenWorkspaces } from "../../utils/projectChildren";
+import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
+import { STATUS_BUCKET_META } from "./statusBucketMeta";
+
+interface DashboardSidebarStatusSectionProps {
+	project: DashboardSidebarProject;
+	isSidebarCollapsed?: boolean;
+	workspaceShortcutLabels: Map<string, string>;
+	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
+}
+
+/**
+ * Renders one synthetic status bucket (Working / Open PR / Done / Idle).
+ *
+ * Deliberately NOT `DashboardSidebarProjectSection`: a status bucket has no real
+ * project, so it has no context menu / rename / section actions, no DnD, and
+ * owns its own collapse state (the `status:*` id isn't a real project the
+ * persisted-collapse mutations understand). Workspace rows are reused verbatim
+ * so an individual row looks and behaves identically to project mode.
+ */
+export function DashboardSidebarStatusSection({
+	project,
+	isSidebarCollapsed = false,
+	workspaceShortcutLabels,
+	onWorkspaceHover,
+}: DashboardSidebarStatusSectionProps) {
+	const bucket: SidebarStatusBucket = project.statusBucket ?? "idle";
+	const meta = STATUS_BUCKET_META[bucket];
+	const workspaces = useMemo(
+		() => getProjectChildrenWorkspaces(project.children),
+		[project.children],
+	);
+	const [isCollapsed, setIsCollapsed] = useState(false);
+
+	if (workspaces.length === 0) return null;
+
+	if (isSidebarCollapsed) {
+		return (
+			<div className="flex flex-col items-center gap-1 border-b border-border py-1 last:border-b-0">
+				<div
+					className={cn("size-2 rounded-full", meta.dotClassName)}
+					title={`${meta.label} (${workspaces.length})`}
+				/>
+				{workspaces.map((workspace) => (
+					<DashboardSidebarWorkspaceItem
+						key={workspace.id}
+						workspace={workspace}
+						isCollapsed
+						onHoverCardOpen={() => onWorkspaceHover(workspace.id)}
+						shortcutLabel={workspaceShortcutLabels.get(workspace.id)}
+					/>
+				))}
+			</div>
+		);
+	}
+
+	return (
+		<div className="border-b border-border last:border-b-0">
+			<button
+				type="button"
+				onClick={() => setIsCollapsed((value) => !value)}
+				className="flex w-full items-center gap-2 px-2 py-1.5 text-left transition-colors hover:bg-accent/40"
+				aria-expanded={!isCollapsed}
+			>
+				<HiChevronRight
+					className={cn(
+						"size-3.5 shrink-0 text-muted-foreground transition-transform",
+						!isCollapsed && "rotate-90",
+					)}
+				/>
+				<span
+					className={cn("size-2 shrink-0 rounded-full", meta.dotClassName)}
+				/>
+				<span className="text-sm font-medium text-foreground">
+					{meta.label}
+				</span>
+				<span className="text-xs tabular-nums text-muted-foreground">
+					{workspaces.length}
+				</span>
+				<span className="ml-auto truncate text-[10px] uppercase tracking-wide text-muted-foreground/60">
+					{meta.sublabel}
+				</span>
+			</button>
+
+			<AnimatePresence initial={false}>
+				{!isCollapsed && (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: 0.15, ease: "easeOut" }}
+						className="overflow-hidden"
+					>
+						<div className="pb-1">
+							{workspaces.map((workspace) => (
+								<div
+									key={workspace.id}
+									style={{ borderLeft: `2px solid ${meta.accentColor}` }}
+								>
+									<DashboardSidebarWorkspaceItem
+										workspace={workspace}
+										onHoverCardOpen={() => onWorkspaceHover(workspace.id)}
+										shortcutLabel={workspaceShortcutLabels.get(workspace.id)}
+									/>
+								</div>
+							))}
+						</div>
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarStatusSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarStatusSection/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarStatusSection } from "./DashboardSidebarStatusSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarStatusSection/statusBucketMeta.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarStatusSection/statusBucketMeta.ts
@@ -1,0 +1,51 @@
+import type { SidebarStatusBucket } from "../../types";
+
+export interface StatusBucketMeta {
+	label: string;
+	sublabel: string;
+	/** Tailwind background class for the header dot / accent. */
+	dotClassName: string;
+	/** CSS color for the row's left accent border. */
+	accentColor: string;
+}
+
+/**
+ * Per-bucket display metadata. Colors echo the canonical agent glyphs from
+ * `shared/tabs-types` (working = amber, agent-finished/`review` = green) so a
+ * bucket header matches the row indicators grouped under it. `waiting` takes
+ * the green — it holds the agent-finished (`review`) workspaces — so Open PR
+ * moves to blue to keep the two apart.
+ */
+export const STATUS_BUCKET_META: Record<SidebarStatusBucket, StatusBucketMeta> =
+	{
+		working: {
+			label: "Working",
+			sublabel: "agent running",
+			dotClassName: "bg-amber-500",
+			accentColor: "var(--color-amber-500)",
+		},
+		waiting: {
+			label: "Waiting",
+			sublabel: "needs response",
+			dotClassName: "bg-emerald-500",
+			accentColor: "var(--color-emerald-500)",
+		},
+		open_pr: {
+			label: "Open PR",
+			sublabel: "open pull request",
+			dotClassName: "bg-blue-500",
+			accentColor: "var(--color-blue-500)",
+		},
+		done: {
+			label: "Done",
+			sublabel: "merged",
+			dotClassName: "bg-violet-500",
+			accentColor: "var(--color-violet-500)",
+		},
+		idle: {
+			label: "Idle",
+			sublabel: "no activity",
+			dotClassName: "bg-muted-foreground/50",
+			accentColor: "var(--color-muted-foreground)",
+		},
+	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -30,6 +30,19 @@ const PR_STATE_LABEL: Record<
 	queued: "Queued",
 };
 
+/**
+ * Deterministic dot color for the status-mode repo chip. Derived from the
+ * project id so a repo keeps the same hue across rows and sessions.
+ */
+function repoChipDotColor(seed: string): string {
+	let hash = 0;
+	for (let i = 0; i < seed.length; i++) {
+		hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+	}
+	const hue = Math.abs(hash) % 360;
+	return `hsl(${hue} 55% 55%)`;
+}
+
 interface DashboardSidebarExpandedWorkspaceRowProps
 	extends ComponentPropsWithoutRef<"div"> {
 	workspace: DashboardSidebarWorkspace;
@@ -84,7 +97,12 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			branch,
 			pullRequest,
 			pendingTransaction,
+			repoLabel,
+			projectId,
 		} = workspace;
+		// `repoLabel` is only populated when building status-grouped rows, so its
+		// presence alone means "we're in status mode and should show the repo."
+		const showRepoChip = !!repoLabel;
 		const isPending = pendingTransaction?.type === "insert";
 		const showsStandaloneActiveStripe = accentColor == null;
 		const localRef = useRef<HTMLDivElement>(null);
@@ -244,14 +262,30 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 								)}
 							/>
 						) : (
-							<span
-								className={cn(
-									"truncate text-[13px] leading-tight transition-colors",
-									isActive ? "text-foreground" : "text-foreground/80",
+							<div className="flex min-w-0 items-center gap-1.5">
+								<span
+									className={cn(
+										"truncate text-[13px] leading-tight transition-colors",
+										isActive ? "text-foreground" : "text-foreground/80",
+									)}
+								>
+									{name || branch}
+								</span>
+								{showRepoChip && (
+									<span
+										className="flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5"
+										title={repoLabel ?? undefined}
+									>
+										<span
+											className="size-1.5 shrink-0 rounded-full"
+											style={{ backgroundColor: repoChipDotColor(projectId) }}
+										/>
+										<span className="max-w-[84px] truncate text-[10px] leading-none text-muted-foreground">
+											{repoLabel}
+										</span>
+									</span>
 								)}
-							>
-								{name || branch}
-							</span>
+							</div>
 						)}
 
 						<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center justify-items-end [&>*]:col-start-1 [&>*]:row-start-1">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarStatusGroups.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarStatusGroups.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "bun:test";
+import type { ActivePaneStatus } from "shared/tabs-types";
+import type { DashboardSidebarWorkspacePullRequest } from "../../types";
+import type {
+	SidebarProjectInput,
+	SidebarWorkspaceInput,
+} from "./buildDashboardSidebarProjects";
+import { buildDashboardSidebarStatusGroups } from "./buildDashboardSidebarStatusGroups";
+
+const MACHINE_ID = "machine-1";
+const DATE = new Date("2026-01-01T00:00:00.000Z");
+
+function makeProject(
+	overrides: Partial<SidebarProjectInput> = {},
+): SidebarProjectInput {
+	return {
+		id: "project-1",
+		name: "Project One",
+		slug: "project-one",
+		githubRepositoryId: null,
+		githubOwner: null,
+		githubRepoName: null,
+		iconUrl: null,
+		createdAt: DATE,
+		updatedAt: DATE,
+		isCollapsed: false,
+		...overrides,
+	};
+}
+
+function makeWorkspace(
+	overrides: Partial<SidebarWorkspaceInput> = {},
+): SidebarWorkspaceInput {
+	return {
+		id: "workspace-1",
+		projectId: "project-1",
+		hostId: MACHINE_ID,
+		type: "worktree",
+		hostIsOnline: true,
+		name: "Workspace",
+		branch: "feature",
+		taskId: null,
+		createdAt: DATE,
+		updatedAt: DATE,
+		tabOrder: 1,
+		sectionId: null,
+		pendingTransaction: null,
+		...overrides,
+	};
+}
+
+function pr(
+	state: DashboardSidebarWorkspacePullRequest["state"],
+): DashboardSidebarWorkspacePullRequest {
+	return {
+		url: "https://github.com/owner/repo/pull/1",
+		number: 1,
+		title: "PR",
+		state,
+		reviewDecision: null,
+		checksStatus: "none",
+		checks: [],
+	};
+}
+
+function build(args: {
+	projects: SidebarProjectInput[];
+	workspaces: SidebarWorkspaceInput[];
+	prs?: Record<string, DashboardSidebarWorkspacePullRequest>;
+	statuses?: Record<string, ActivePaneStatus | null>;
+}) {
+	return buildDashboardSidebarStatusGroups({
+		sidebarProjects: args.projects,
+		visibleSidebarWorkspaces: args.workspaces,
+		machineId: MACHINE_ID,
+		pullRequestsByWorkspaceId: new Map(Object.entries(args.prs ?? {})),
+		statusByWorkspaceId: new Map(Object.entries(args.statuses ?? {})),
+	});
+}
+
+describe("buildDashboardSidebarStatusGroups", () => {
+	it("buckets workspaces by derived status and omits empty buckets", () => {
+		const groups = build({
+			projects: [makeProject()],
+			workspaces: [
+				makeWorkspace({ id: "w-working", tabOrder: 1 }),
+				makeWorkspace({ id: "w-waiting", tabOrder: 2 }),
+				makeWorkspace({ id: "w-openpr", tabOrder: 3 }),
+				makeWorkspace({ id: "w-done", tabOrder: 4 }),
+				makeWorkspace({ id: "w-idle", tabOrder: 5 }),
+			],
+			prs: { "w-openpr": pr("open"), "w-done": pr("merged") },
+			statuses: { "w-working": "working", "w-waiting": "review" },
+		});
+
+		expect(groups.map((g) => g.slug)).toEqual([
+			"working",
+			"waiting",
+			"open_pr",
+			"done",
+			"idle",
+		]);
+		expect(groups.map((g) => g.id)).toEqual([
+			"status:working",
+			"status:waiting",
+			"status:open_pr",
+			"status:done",
+			"status:idle",
+		]);
+		const idByBucket = (slug: string) =>
+			groups
+				.find((g) => g.slug === slug)
+				?.children.map((c) =>
+					c.type === "workspace" ? c.workspace.id : "section",
+				);
+		expect(idByBucket("working")).toEqual(["w-working"]);
+		expect(idByBucket("waiting")).toEqual(["w-waiting"]);
+		expect(idByBucket("open_pr")).toEqual(["w-openpr"]);
+		expect(idByBucket("done")).toEqual(["w-done"]);
+		expect(idByBucket("idle")).toEqual(["w-idle"]);
+	});
+
+	it("omits a bucket entirely when it has no workspaces", () => {
+		const groups = build({
+			projects: [makeProject()],
+			workspaces: [makeWorkspace({ id: "w-idle" })],
+		});
+		expect(groups.map((g) => g.slug)).toEqual(["idle"]);
+	});
+
+	it("emits only workspace children (never sections) and marks groups as status kind", () => {
+		const groups = build({
+			projects: [makeProject()],
+			workspaces: [makeWorkspace({ id: "w-1" })],
+		});
+		for (const group of groups) {
+			expect(group.kind).toBe("status");
+			expect(group.children.every((c) => c.type === "workspace")).toBe(true);
+		}
+	});
+
+	it("preserves each workspace's REAL projectId (never the synthetic status:* id)", () => {
+		const groups = build({
+			projects: [makeProject({ id: "project-1" })],
+			workspaces: [makeWorkspace({ id: "w-1", projectId: "project-1" })],
+		});
+		const child = groups[0]?.children[0];
+		expect(child?.type).toBe("workspace");
+		if (child?.type === "workspace") {
+			expect(child.workspace.projectId).toBe("project-1");
+		}
+	});
+
+	it("populates repoLabel from the GitHub repo name, falling back to project name", () => {
+		const groups = build({
+			projects: [
+				makeProject({ id: "p-gh", githubRepoName: "my-repo", name: "Fancy" }),
+				makeProject({ id: "p-norepo", githubRepoName: null, name: "Plain" }),
+			],
+			workspaces: [
+				makeWorkspace({ id: "w-gh", projectId: "p-gh" }),
+				makeWorkspace({ id: "w-norepo", projectId: "p-norepo" }),
+			],
+		});
+		const labels = new Map(
+			groups
+				.flatMap((g) => g.children)
+				.flatMap((c) =>
+					c.type === "workspace"
+						? [[c.workspace.id, c.workspace.repoLabel] as const]
+						: [],
+				),
+		);
+		expect(labels.get("w-gh")).toBe("my-repo");
+		expect(labels.get("w-norepo")).toBe("Plain");
+	});
+
+	it("sorts permission-blocked agents first within the Working bucket", () => {
+		const groups = build({
+			projects: [makeProject()],
+			workspaces: [
+				makeWorkspace({ id: "w-working", tabOrder: 1 }),
+				makeWorkspace({ id: "w-blocked", tabOrder: 2 }),
+			],
+			statuses: { "w-working": "working", "w-blocked": "permission" },
+		});
+		const working = groups.find((g) => g.slug === "working");
+		expect(
+			working?.children.map((c) =>
+				c.type === "workspace" ? c.workspace.id : "section",
+			),
+		).toEqual(["w-blocked", "w-working"]);
+	});
+
+	it("drops workspaces whose project isn't in the sidebar (parity with project mode)", () => {
+		const groups = build({
+			projects: [makeProject({ id: "project-1" })],
+			workspaces: [makeWorkspace({ id: "w-orphan", projectId: "missing" })],
+		});
+		expect(groups).toEqual([]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarStatusGroups.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarStatusGroups.ts
@@ -1,0 +1,167 @@
+import { getV2WorkspaceDisplayName } from "renderer/utils/getV2WorkspaceDisplayName";
+import type { ActivePaneStatus } from "shared/tabs-types";
+import type {
+	DashboardSidebarProject,
+	DashboardSidebarProjectChild,
+	DashboardSidebarWorkspace,
+	SidebarStatusBucket,
+} from "../../types";
+import type {
+	SidebarProjectInput,
+	SidebarWorkspaceInput,
+} from "./buildDashboardSidebarProjects";
+import {
+	deriveSidebarStatusBucket,
+	SIDEBAR_STATUS_BUCKET_ORDER,
+} from "./deriveSidebarStatusBucket";
+
+type SidebarPullRequest = DashboardSidebarWorkspace["pullRequest"];
+
+const BUCKET_LABEL: Record<SidebarStatusBucket, string> = {
+	working: "Working",
+	waiting: "Waiting",
+	open_pr: "Open PR",
+	done: "Done",
+	idle: "Idle",
+};
+
+// Synthetic bucket "projects" have no real created/updated timestamps; a stable
+// epoch keeps fingerprints/sorting deterministic.
+const EPOCH = new Date(0);
+
+export interface BuildDashboardSidebarStatusGroupsParams {
+	sidebarProjects: SidebarProjectInput[];
+	visibleSidebarWorkspaces: SidebarWorkspaceInput[];
+	machineId: string;
+	pullRequestsByWorkspaceId: Map<string, SidebarPullRequest>;
+	statusByWorkspaceId: Map<string, ActivePaneStatus | null>;
+}
+
+interface BucketEntry {
+	tabOrder: number;
+	isLocalMain: boolean;
+	paneStatus: ActivePaneStatus | null;
+	workspace: DashboardSidebarWorkspace;
+}
+
+/**
+ * Builds status-grouped sidebar "projects" (Working / Open PR / Done / Idle).
+ * Returns the same `DashboardSidebarProject[]` shape as
+ * `buildDashboardSidebarProjects` so workspace rows render unchanged, but each
+ * group is a synthetic status bucket (`kind: "status"`, `id: status:<bucket>`)
+ * with no real project chrome. Sections are intentionally ignored (they are a
+ * project-scoped concept); every child is a `{ type: "workspace" }`.
+ *
+ * The per-workspace object construction mirrors `buildDashboardSidebarProjects`
+ * so a row looks identical in either grouping mode — keep them in sync.
+ */
+export function buildDashboardSidebarStatusGroups({
+	sidebarProjects,
+	visibleSidebarWorkspaces,
+	machineId,
+	pullRequestsByWorkspaceId,
+	statusByWorkspaceId,
+}: BuildDashboardSidebarStatusGroupsParams): DashboardSidebarProject[] {
+	const projectsById = new Map(
+		sidebarProjects.map((project) => [project.id, project]),
+	);
+
+	const entriesByBucket = new Map<SidebarStatusBucket, BucketEntry[]>();
+	for (const bucket of SIDEBAR_STATUS_BUCKET_ORDER) {
+		entriesByBucket.set(bucket, []);
+	}
+
+	for (const workspace of visibleSidebarWorkspaces) {
+		// Match project-mode visibility: a workspace whose project isn't in the
+		// sidebar is not shown in either mode.
+		const project = projectsById.get(workspace.projectId);
+		if (!project) continue;
+
+		const hostType: DashboardSidebarWorkspace["hostType"] =
+			workspace.hostId === machineId ? "local-device" : "remote-device";
+		const pullRequest = pullRequestsByWorkspaceId.get(workspace.id) ?? null;
+		const paneStatus = statusByWorkspaceId.get(workspace.id) ?? null;
+
+		const sidebarWorkspace: DashboardSidebarWorkspace = {
+			id: workspace.id,
+			projectId: workspace.projectId,
+			hostId: workspace.hostId,
+			hostType,
+			type: workspace.type,
+			hostIsOnline:
+				hostType === "remote-device" ? workspace.hostIsOnline : null,
+			accentColor: null,
+			name: getV2WorkspaceDisplayName(workspace),
+			branch: workspace.branch,
+			pullRequest,
+			repoUrl:
+				project.githubOwner && project.githubRepoName
+					? `https://github.com/${project.githubOwner}/${project.githubRepoName}`
+					: null,
+			branchExistsOnRemote:
+				project.githubOwner !== null && project.githubRepoName !== null,
+			previewUrl: null,
+			needsRebase: null,
+			behindCount: null,
+			createdAt: workspace.createdAt,
+			updatedAt: workspace.updatedAt,
+			taskId: workspace.taskId,
+			pendingTransaction: workspace.pendingTransaction,
+			// Prefer the GitHub repo name; fall back to the project name so the
+			// chip is never empty. null only if the project itself has no name.
+			repoLabel: project.githubRepoName ?? project.name ?? null,
+		};
+
+		const bucket = deriveSidebarStatusBucket(paneStatus, pullRequest);
+		entriesByBucket.get(bucket)?.push({
+			tabOrder: workspace.tabOrder,
+			isLocalMain: workspace.type === "main" && hostType === "local-device",
+			paneStatus,
+			workspace: sidebarWorkspace,
+		});
+	}
+
+	const groups: DashboardSidebarProject[] = [];
+	for (const bucket of SIDEBAR_STATUS_BUCKET_ORDER) {
+		const entries = entriesByBucket.get(bucket) ?? [];
+		if (entries.length === 0) continue;
+
+		entries.sort((left, right) => {
+			// Within Working, surface permission-blocked agents first — the most
+			// urgent state (D1).
+			if (bucket === "working") {
+				const leftBlocked = left.paneStatus === "permission";
+				const rightBlocked = right.paneStatus === "permission";
+				if (leftBlocked !== rightBlocked) return leftBlocked ? -1 : 1;
+			}
+			// Then local main workspaces first, then by persisted tab order —
+			// matches project-mode ordering.
+			if (left.isLocalMain !== right.isLocalMain) {
+				return left.isLocalMain ? -1 : 1;
+			}
+			return left.tabOrder - right.tabOrder;
+		});
+
+		const children: DashboardSidebarProjectChild[] = entries.map(
+			({ workspace }) => ({ type: "workspace", workspace }),
+		);
+
+		groups.push({
+			id: `status:${bucket}`,
+			name: BUCKET_LABEL[bucket],
+			slug: bucket,
+			kind: "status",
+			statusBucket: bucket,
+			githubRepositoryId: null,
+			githubOwner: null,
+			githubRepoName: null,
+			iconUrl: null,
+			createdAt: EPOCH,
+			updatedAt: EPOCH,
+			isCollapsed: false,
+			children,
+		});
+	}
+
+	return groups;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/deriveSidebarStatusBucket.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/deriveSidebarStatusBucket.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import type { DashboardSidebarWorkspacePullRequest } from "../../types";
+import { deriveSidebarStatusBucket } from "./deriveSidebarStatusBucket";
+
+function pr(
+	state: DashboardSidebarWorkspacePullRequest["state"],
+): DashboardSidebarWorkspacePullRequest {
+	return {
+		url: "https://github.com/owner/repo/pull/1",
+		number: 1,
+		title: "Example",
+		state,
+		reviewDecision: null,
+		checksStatus: "none",
+		checks: [],
+	};
+}
+
+describe("deriveSidebarStatusBucket", () => {
+	it("active work wins over any PR state (D3)", () => {
+		expect(deriveSidebarStatusBucket("working", pr("open"))).toBe("working");
+		expect(deriveSidebarStatusBucket("working", pr("merged"))).toBe("working");
+		expect(deriveSidebarStatusBucket("permission", pr("merged"))).toBe(
+			"working",
+		);
+		expect(deriveSidebarStatusBucket("working", null)).toBe("working");
+		expect(deriveSidebarStatusBucket("permission", null)).toBe("working");
+	});
+
+	it("`review` → waiting only when there's no PR (a PR outranks agent-finished)", () => {
+		// Agent-finished/unread (green dot) with no PR is distinct from truly idle.
+		expect(deriveSidebarStatusBucket("review", null)).toBe("waiting");
+		// ...but an open/merged PR is the more meaningful state and wins: an agent
+		// that ends by opening a PR belongs in Open PR / Done, not Waiting.
+		expect(deriveSidebarStatusBucket("review", pr("open"))).toBe("open_pr");
+		expect(deriveSidebarStatusBucket("review", pr("merged"))).toBe("done");
+		// ...and a *closed* (unmerged) PR means the agent didn't hand back without
+		// one — it's idle, not waiting.
+		expect(deriveSidebarStatusBucket("review", pr("closed"))).toBe("idle");
+	});
+
+	it("merged PR → done when no active work", () => {
+		expect(deriveSidebarStatusBucket(null, pr("merged"))).toBe("done");
+	});
+
+	it("open / draft / queued PR → open_pr when no active work (D2: drafts are Open PR)", () => {
+		expect(deriveSidebarStatusBucket(null, pr("open"))).toBe("open_pr");
+		expect(deriveSidebarStatusBucket(null, pr("draft"))).toBe("open_pr");
+		expect(deriveSidebarStatusBucket(null, pr("queued"))).toBe("open_pr");
+	});
+
+	it("closed-not-merged, no PR, or unresolved status → idle", () => {
+		expect(deriveSidebarStatusBucket(null, pr("closed"))).toBe("idle");
+		expect(deriveSidebarStatusBucket(null, null)).toBe("idle");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/deriveSidebarStatusBucket.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/deriveSidebarStatusBucket.ts
@@ -1,0 +1,52 @@
+import type { ActivePaneStatus } from "shared/tabs-types";
+import type {
+	DashboardSidebarWorkspacePullRequest,
+	SidebarStatusBucket,
+} from "../../types";
+
+export type { SidebarStatusBucket };
+
+/** Fixed display order for the status buckets (top → bottom of the rail). */
+export const SIDEBAR_STATUS_BUCKET_ORDER: readonly SidebarStatusBucket[] = [
+	"working",
+	"waiting",
+	"open_pr",
+	"done",
+	"idle",
+] as const;
+
+/**
+ * Maps a workspace's live pane status + PR state to a single sidebar bucket.
+ *
+ * Only a *live* agent outranks the PR: a running/blocked workspace is "working"
+ * no matter what. Otherwise the PR is the more meaningful state — a merged or
+ * open PR wins over the transient "agent just finished" signal (an agent that
+ * ends by opening a PR belongs in Open PR, not Waiting). "Waiting" is reserved
+ * for a finished agent with *no* PR — it handed back to you without one.
+ * Precedence, top to bottom:
+ *
+ * - `working`/`permission` (agent processing or blocked) → **working**
+ * - merged PR → **done**
+ * - open/draft/queued PR → **open_pr**
+ * - `review` (agent finished, and no PR) → **waiting**
+ *   (awaiting the user — distinct from truly idle, per user feedback)
+ * - everything else (closed-not-merged PR, no PR, seen/idle/unknown) → **idle**
+ */
+export function deriveSidebarStatusBucket(
+	paneStatus: ActivePaneStatus | null,
+	pr: DashboardSidebarWorkspacePullRequest | null,
+): SidebarStatusBucket {
+	if (paneStatus === "working" || paneStatus === "permission") return "working";
+	if (pr?.state === "merged") return "done";
+	if (
+		pr &&
+		(pr.state === "open" || pr.state === "draft" || pr.state === "queued")
+	) {
+		return "open_pr";
+	}
+	// Waiting is reserved for a finished agent that handed back with *no* PR. A
+	// closed (unmerged) PR is not open/draft/queued/merged, so it falls through
+	// here — such a workspace is idle, not waiting.
+	if (paneStatus === "review" && !pr) return "waiting";
+	return "idle";
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -2,7 +2,9 @@ import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef } from "react";
+import { useV2WorkspaceStatuses } from "renderer/hooks/host-service/useV2WorkspaceStatuses";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -12,12 +14,14 @@ import {
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useStatusGroupedSidebarEnabled } from "renderer/stores/status-grouped-sidebar";
 import { useWorkspaceTransactionsStore } from "renderer/stores/workspace-creates";
 import type {
 	DashboardSidebarProject,
 	DashboardSidebarWorkspace,
 } from "../../types";
 import { buildDashboardSidebarProjects } from "./buildDashboardSidebarProjects";
+import { buildDashboardSidebarStatusGroups } from "./buildDashboardSidebarStatusGroups";
 import {
 	derivePullRequestQueryTargets,
 	getDashboardSidebarPullRequestQueryKey,
@@ -388,20 +392,53 @@ export function useDashboardSidebarData() {
 	const pullRequestsByWorkspaceId =
 		useStablePullRequestsByWorkspaceId(pullRequestRows);
 
+	const { preferences } = useV2UserPreferences();
+	// Status grouping is an opt-in experiment. When it's off, force project mode
+	// regardless of the persisted preference so a stale "status" never leaks the
+	// feature to users who haven't enabled it.
+	const statusGroupingEnabled = useStatusGroupedSidebarEnabled();
+	const groupMode = statusGroupingEnabled
+		? preferences.sidebarGroupMode
+		: "project";
+	const isStatusMode = groupMode === "status";
+
+	// Only mount the bulk agent-status queries when status grouping is active;
+	// project mode has no need for them.
+	const statusWorkspaceIds = useMemo(
+		() =>
+			isStatusMode
+				? visibleSidebarWorkspaces.map((workspace) => workspace.id)
+				: [],
+		[isStatusMode, visibleSidebarWorkspaces],
+	);
+	const statusByWorkspaceId = useV2WorkspaceStatuses(statusWorkspaceIds, {
+		enabled: isStatusMode,
+	});
+
 	const computedGroups = useMemo<DashboardSidebarProject[]>(
 		() =>
-			buildDashboardSidebarProjects({
-				sidebarProjects,
-				sidebarSections,
-				visibleSidebarWorkspaces,
-				machineId,
-				pullRequestsByWorkspaceId,
-			}),
+			isStatusMode
+				? buildDashboardSidebarStatusGroups({
+						sidebarProjects,
+						visibleSidebarWorkspaces,
+						machineId,
+						pullRequestsByWorkspaceId,
+						statusByWorkspaceId,
+					})
+				: buildDashboardSidebarProjects({
+						sidebarProjects,
+						sidebarSections,
+						visibleSidebarWorkspaces,
+						machineId,
+						pullRequestsByWorkspaceId,
+					}),
 		[
+			isStatusMode,
 			machineId,
 			pullRequestsByWorkspaceId,
 			sidebarProjects,
 			sidebarSections,
+			statusByWorkspaceId,
 			visibleSidebarWorkspaces,
 		],
 	);
@@ -409,6 +446,8 @@ export function useDashboardSidebarData() {
 
 	return {
 		groups,
+		groupMode,
+		sidebarProjects,
 		refreshWorkspacePullRequest,
 		toggleProjectCollapsed,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -7,6 +7,18 @@ export type DashboardSidebarWorkspaceHostType =
 
 export type DashboardSidebarWorkspaceType = "main" | "worktree";
 
+/**
+ * Derived per-workspace status bucket for the status-grouped sidebar. Kept here
+ * (rather than in the builder) so both the builder and the shape types can
+ * reference it without an import cycle.
+ */
+export type SidebarStatusBucket =
+	| "working"
+	| "waiting"
+	| "open_pr"
+	| "done"
+	| "idle";
+
 export interface DashboardSidebarWorkspacePullRequestCheck {
 	name: string;
 	status: "success" | "failure" | "pending" | "skipped" | "cancelled";
@@ -44,6 +56,13 @@ export interface DashboardSidebarWorkspace {
 	updatedAt: Date;
 	taskId: string | null;
 	pendingTransaction: WorkspaceTransactionSnapshot | null;
+	/**
+	 * Repo name for the per-row chip in status mode (where rows from different
+	 * repos mix under one bucket). Populated by the status builder as the GitHub
+	 * repo name, falling back to the project name so the chip is never empty;
+	 * null only if the project has neither. Only *rendered* in status mode.
+	 */
+	repoLabel?: string | null;
 }
 
 export interface DashboardSidebarSection {
@@ -79,4 +98,13 @@ export interface DashboardSidebarProject {
 	updatedAt: Date;
 	isCollapsed: boolean;
 	children: DashboardSidebarProjectChild[];
+	/**
+	 * "project" (default/omitted) = a real repo group. "status" = a synthetic
+	 * bucket produced by `buildDashboardSidebarStatusGroups` whose `id` is
+	 * `status:<bucket>`; the render layer forks on this to skip all real-project
+	 * chrome (context menu, DnD, section actions).
+	 */
+	kind?: "project" | "status";
+	/** Set only when `kind === "status"`. */
+	statusBucket?: SidebarStatusBucket;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -319,9 +319,15 @@ export const v2UserPreferencesSchema = z.object({
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
 	showPresetsBar: z.boolean().default(true),
+	// Left workspace rail grouping. "project" groups by repo → workspace (the
+	// default, unchanged behavior); "status" groups by derived per-workspace
+	// status (Working / Open PR / Done / Idle). Local, per-device, per-org —
+	// same expectation as the Theme setting; no DB/Electric/migration.
+	sidebarGroupMode: z.enum(["project", "status"]).default("project"),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
+export type SidebarGroupMode = V2UserPreferencesRow["sidebarGroupMode"];
 
 export const V2_USER_PREFERENCES_ID = "preferences" as const;
 
@@ -337,6 +343,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	rightSidebarWidth: 340,
 	deleteLocalBranch: false,
 	showPresetsBar: true,
+	sidebarGroupMode: "project",
 };
 
 /**

--- a/apps/desktop/src/renderer/stores/status-grouped-sidebar.ts
+++ b/apps/desktop/src/renderer/stores/status-grouped-sidebar.ts
@@ -1,0 +1,18 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { env } from "renderer/env.renderer";
+
+/**
+ * Enablement for the status-grouped workspace sidebar (Working / Waiting /
+ * Open PR / Done / Idle grouping). Production rollout is gated by the
+ * `status-grouped-sidebar-access` PostHog flag (default off / server-driven).
+ * Dev builds are always on so the feature is visible locally without adding
+ * yourself to the flag — mirrors the v2 rollout in `useIsV2CloudEnabled`.
+ * Read it everywhere via this hook.
+ */
+export function useStatusGroupedSidebarEnabled(): boolean {
+	const flagEnabled = useFeatureFlagEnabled(
+		FEATURE_FLAGS.STATUS_GROUPED_SIDEBAR,
+	);
+	return !!flagEnabled || env.NODE_ENV === "development";
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -88,6 +88,8 @@ export const FEATURE_FLAGS = {
 	GITHUB_INTEGRATION_ACCESS: "github-integration-access",
 	/** Gates access to Cloud features (environment variables, sandboxes). */
 	CLOUD_ACCESS: "cloud-access",
+	/** Gates the status-grouped workspace sidebar (Working / Open PR / Done / Idle). */
+	STATUS_GROUPED_SIDEBAR: "status-grouped-sidebar-access",
 	/** When enabled, blocks remote agent execution on the desktop (e.g., for enterprise orgs). */
 	DISABLE_REMOTE_AGENT: "disable-remote-agent",
 	/**


### PR DESCRIPTION
## What

Adds an opt-in **"group by status"** mode to the desktop workspace rail, alongside the existing project grouping. Workspaces are bucketed by their derived status so you can see what needs attention at a glance:

| Bucket | Meaning |
|---|---|
| **Working** | agent running, or blocked on a permission prompt |
| **Waiting** | agent finished, needs a response (and no PR yet) |
| **Open PR** | has an open / draft / queued pull request |
| **Done** | PR merged |
| **Idle** | no activity (Waiting ages here after 24h) |

Precedence (`deriveSidebarStatusBucket`): a live/blocked agent (**Working**) outranks a PR; PR state (**Open PR** / **Done**) outranks a finished agent (**Waiting**); **Waiting** ages to **Idle** after 24h of no agent activity. Buckets render with per-bucket counts and colored headers, and empty buckets are hidden.

## How it's gated

Production rollout is behind the **`status-grouped-sidebar-access` PostHog feature flag (default off)**, mirroring the existing `CLOUD_ACCESS` pattern (`useFeatureFlagEnabled`) — so it can be rolled out to a cohort / percentage and killed remotely without a new desktop build. **Dev builds are always on** (same shape as `useIsV2CloudEnabled`) so contributors see it locally without adding themselves to the flag. When enabled, a compact **layout-list control** in the sidebar header opens a menu to switch the rail between **Status** and **Project** grouping, persisted as a user preference (`sidebarGroupMode`).

> The `status-grouped-sidebar-access` flag still needs to be created in the PostHog dashboard (default off) before production rollout — nothing in-repo creates it.

## Also included

Hardens host-service cold start with a bounded **auto-retry (5× / 3s)** in `LocalHostServiceProvider`, recovering from the 10s start-timeout race that could otherwise leave the host-service dead until a manual reload.

## Testing

- `bun run --filter '@superset/desktop' typecheck` — pass
- `bun run --filter '@superset/shared' typecheck` — pass
- `bun run lint` (biome, warnings treated as errors) — clean
- `bunx sherif` — clean
- Unit tests for `deriveSidebarStatusBucket` and `buildDashboardSidebarStatusGroups` — 12 pass

## Notes

- The Status vs Project mode is a pure projection of the same live workspace list used by project grouping, so the two views stay consistent (a workspace present/absent in one is present/absent in the other).

https://claude.ai/code/session_01JPzkGzFZyYxGDgcy5vi2ni


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5677">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional “group by status” mode in the desktop workspace sidebar, with Working/Waiting/Open PR/Done/Idle buckets and a compact header toggle, to highlight what needs attention. Status is sourced from a shared bulk feed (5s polling) so off‑screen rows stay fresh; rollout is gated by `status-grouped-sidebar-access` (dev builds always on).

- **New Features**
  - Sidebar can group by Status or Project. Buckets: Working, Waiting, Open PR, Done, Idle (empty buckets are hidden). Precedence: live/permission → Working; merged → Done; open/draft/queued → Open PR; finished/no PR → Waiting; else → Idle. Waiting auto-ages to Idle after 24h.
  - New header menu to switch grouping; choice is saved in `sidebarGroupMode`. Rows in status mode show a small repo chip (GitHub repo name or project) with a consistent color; Working surfaces permission prompts first.
  - Shared React Query cache keys between the bulk status source and per-row hooks; bulk polling every 5s keeps unmounted rows accurate so rows and buckets never disagree. Prod is behind `status-grouped-sidebar-access` (default off); ensure the flag exists before rollout.

- **Bug Fixes**
  - Active workspace’s real project is resolved correctly in status mode (fixes header context/actions).
  - Host-service cold start now auto-retries up to 5 times (3s delay) to recover from the 10s bootstrap race.

<sup>Written for commit 6a627d5dded4d748952ebf963b087b42470adbf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in status-grouped workspace sidebar view that clusters workspaces by live activity, pull request state, and completion bucket.
  * Introduced a sidebar grouping toggle (Project vs Status) gated by a new feature flag, plus persisted `sidebarGroupMode` preference.
  * Added a dedicated status section UI with bucket-specific styling and animated workspace lists.
  * Added deterministic repo chip coloring and repo labels on status-mode rows.
* **Bug Fixes**
  * Improved active workspace project resolution and sidebar status bucketing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->