### PR TITLE
fix(workspace-fs): restrict watchPath to the workspace root, drop no-op recursive flag

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
@@ -246,7 +246,6 @@ export const createFilesystemRouter = () => {
 				z.object({
 					workspaceId: z.string(),
 					absolutePath: z.string(),
-					recursive: z.boolean().optional(),
 				}),
 			)
 			.subscription(({ input }) => {
@@ -255,7 +254,6 @@ export const createFilesystemRouter = () => {
 					let isDisposed = false;
 					const stream = service.watchPath({
 						absolutePath: input.absolutePath,
-						recursive: input.recursive,
 					});
 					const iterator = stream[Symbol.asyncIterator]();
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useWorkspaceFileEvents/useWorkspaceFileEvents.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useWorkspaceFileEvents/useWorkspaceFileEvents.ts
@@ -107,7 +107,6 @@ export function useWorkspaceFileEventBridge(
 		{
 			workspaceId,
 			absolutePath: worktreePath ?? "",
-			recursive: true,
 		},
 		{
 			enabled:

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -255,7 +255,6 @@ export class EventBus {
 			const service = this.filesystem.getServiceForWorkspace(workspaceId);
 			const stream = service.watchPath({
 				absolutePath: rootPath,
-				recursive: true,
 			});
 			iterator = stream[Symbol.asyncIterator]();
 		} catch (error) {

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -336,7 +336,6 @@ export class GitWatcher {
 			const service = this.filesystem.getServiceForWorkspace(workspaceId);
 			const stream = service.watchPath({
 				absolutePath: worktreePath,
-				recursive: true,
 			});
 			iterator = stream[Symbol.asyncIterator]();
 		} catch (error) {

--- a/packages/workspace-fs/src/cache-and-paths-memory.bench.ts
+++ b/packages/workspace-fs/src/cache-and-paths-memory.bench.ts
@@ -136,7 +136,7 @@ describe("BENCH: pathTypes heap delta vs unique paths", () => {
 		const manager = new FsWatcherManager({ debounceMs: 50 });
 		let createCount = 0;
 		const unsubscribe = await manager.subscribe(
-			{ absolutePath: rootPath, recursive: true },
+			{ absolutePath: rootPath },
 			(batch) => {
 				for (const event of batch.events) {
 					if (event.kind === "create") createCount++;

--- a/packages/workspace-fs/src/client/client.test.ts
+++ b/packages/workspace-fs/src/client/client.test.ts
@@ -62,7 +62,7 @@ describe("createFsClient", () => {
 		expect(metadata).toBeNull();
 
 		const iterator = client
-			.watchPath({ absolutePath: "/tmp/workspace", recursive: true })
+			.watchPath({ absolutePath: "/tmp/workspace" })
 			[Symbol.asyncIterator]();
 		const next = await iterator.next();
 		expect(next).toEqual({
@@ -95,7 +95,7 @@ describe("createFsClient", () => {
 			},
 			{
 				method: "watchPath",
-				input: { absolutePath: "/tmp/workspace", recursive: true },
+				input: { absolutePath: "/tmp/workspace" },
 			},
 		]);
 	});

--- a/packages/workspace-fs/src/core/service.ts
+++ b/packages/workspace-fs/src/core/service.ts
@@ -69,7 +69,6 @@ export interface FsService {
 
 	watchPath(input: {
 		absolutePath: string;
-		recursive?: boolean;
 	}): AsyncIterable<{ events: FsWatchEvent[] }>;
 }
 
@@ -147,7 +146,7 @@ export interface FsRequestMap {
 
 export interface FsSubscriptionMap {
 	watchPath: {
-		input: { absolutePath: string; recursive?: boolean };
+		input: { absolutePath: string };
 		event: { events: FsWatchEvent[] };
 	};
 }

--- a/packages/workspace-fs/src/host/service.test.ts
+++ b/packages/workspace-fs/src/host/service.test.ts
@@ -73,7 +73,6 @@ describe("createFsHostService", () => {
 		const iterator = service
 			.watchPath({
 				absolutePath: "/tmp/workspace",
-				recursive: true,
 			})
 			[Symbol.asyncIterator]();
 
@@ -106,5 +105,34 @@ describe("createFsHostService", () => {
 
 		await iterator.return?.();
 		expect(unsubscribed).toEqual(true);
+	});
+
+	it("rejects watchPath targets other than the workspace root", async () => {
+		const service = createFsHostService({
+			rootPath: "/tmp/workspace",
+			watcherManager: {
+				async subscribe() {
+					throw new Error("subscribe must not be reached");
+				},
+				async close() {},
+			},
+		});
+
+		for (const absolutePath of [
+			"/tmp/workspace/node_modules",
+			"/tmp/workspace/node_modules/pkg",
+			"/tmp/workspace/src",
+			"/tmp/other",
+			"/tmp",
+		]) {
+			expect(() => service.watchPath({ absolutePath })).toThrow(
+				"watchPath only supports the workspace root",
+			);
+		}
+
+		// Trailing-slash spelling of the root is still the root.
+		expect(() =>
+			service.watchPath({ absolutePath: "/tmp/workspace/" }),
+		).not.toThrow();
 	});
 });

--- a/packages/workspace-fs/src/host/service.ts
+++ b/packages/workspace-fs/src/host/service.ts
@@ -9,6 +9,7 @@ import {
 	readFile,
 	writeFile,
 } from "../fs";
+import { normalizeAbsolutePath } from "../paths";
 import type { SearchContentOptions } from "../search";
 import { searchContent, searchFiles } from "../search";
 import type { FsWatchEvent } from "../types";
@@ -237,11 +238,18 @@ export function createFsHostService(
 				throw new Error("watchPath requires a watcher manager");
 			}
 
-			return createAsyncQueue<{ events: FsWatchEvent[] }>(async (push) => {
-				return await watcherManager.subscribe(
-					{ absolutePath: input.absolutePath, recursive: input.recursive },
-					push,
+			// Only the workspace root may be watched. A watch root at/inside an
+			// ignored dir (node_modules) or behind a symlink defeats the ignore
+			// globs, which match relative to the watch root.
+			const absolutePath = normalizeAbsolutePath(input.absolutePath);
+			if (absolutePath !== normalizeAbsolutePath(rootPath)) {
+				throw new Error(
+					`watchPath only supports the workspace root: ${rootPath}`,
 				);
+			}
+
+			return createAsyncQueue<{ events: FsWatchEvent[] }>(async (push) => {
+				return await watcherManager.subscribe({ absolutePath }, push);
 			});
 		},
 

--- a/packages/workspace-fs/src/watch-pathtypes-growth.test.ts
+++ b/packages/workspace-fs/src/watch-pathtypes-growth.test.ts
@@ -102,16 +102,13 @@ describe("FsWatcherManager.pathTypes — monotonic growth", () => {
 
 		const manager = createManager({ debounceMs: 50 });
 		const events: string[] = [];
-		await manager.subscribe(
-			{ absolutePath: rootPath, recursive: true },
-			(batch) => {
-				for (const event of batch.events) {
-					if (event.kind !== "overflow") {
-						events.push(`${event.kind}:${event.absolutePath}`);
-					}
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				if (event.kind !== "overflow") {
+					events.push(`${event.kind}:${event.absolutePath}`);
 				}
-			},
-		);
+			}
+		});
 
 		const fileCount = 12;
 		for (let i = 0; i < fileCount; i++) {
@@ -135,14 +132,11 @@ describe("FsWatcherManager.pathTypes — monotonic growth", () => {
 
 		const manager = createManager({ debounceMs: 50 });
 		const events: string[] = [];
-		await manager.subscribe(
-			{ absolutePath: rootPath, recursive: true },
-			(batch) => {
-				for (const event of batch.events) {
-					if (event.kind !== "overflow") events.push(event.kind);
-				}
-			},
-		);
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				if (event.kind !== "overflow") events.push(event.kind);
+			}
+		});
 
 		// Create one file, wait for it to be tracked.
 		const filePath = path.join(rootPath, "stable.txt");
@@ -169,16 +163,13 @@ describe("FsWatcherManager.pathTypes — monotonic growth", () => {
 
 		const manager = createManager({ debounceMs: 50 });
 		const events: string[] = [];
-		await manager.subscribe(
-			{ absolutePath: rootPath, recursive: true },
-			(batch) => {
-				for (const event of batch.events) {
-					if (event.kind !== "overflow") {
-						events.push(`${event.kind}:${event.absolutePath}`);
-					}
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				if (event.kind !== "overflow") {
+					events.push(`${event.kind}:${event.absolutePath}`);
 				}
-			},
-		);
+			}
+		});
 
 		// Phase 1: create 5 files.
 		for (let i = 0; i < 5; i++) {
@@ -230,10 +221,7 @@ describe("FsWatcherManager.pathTypes — monotonic growth", () => {
 			debounceMs: 50,
 			filePathsMax: FILE_PATHS_MAX,
 		});
-		await manager.subscribe(
-			{ absolutePath: rootPath, recursive: true },
-			() => {},
-		);
+		await manager.subscribe({ absolutePath: rootPath }, () => {});
 
 		const total = FILE_PATHS_MAX + 20;
 
@@ -276,14 +264,11 @@ describe("FsWatcherManager.pathTypes — monotonic growth", () => {
 
 		const manager = createManager({ debounceMs: 50 });
 		let createCount = 0;
-		await manager.subscribe(
-			{ absolutePath: rootPath, recursive: true },
-			(batch) => {
-				for (const event of batch.events) {
-					if (event.kind === "create") createCount++;
-				}
-			},
-		);
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				if (event.kind === "create") createCount++;
+			}
+		});
 
 		// Burst: create 30 unique paths before any delete fires. Without
 		// a cap, pathTypes holds all 30 simultaneously.

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -32,9 +32,9 @@ const MAX_WORK_CHUNK_SIZE = 500;
 const THROTTLE_DELAY_MS = 200;
 const MAX_BUFFERED_EVENTS = 30_000;
 
+// Watches are always recursive — @parcel/watcher offers no shallow mode.
 export interface WatchPathOptions {
 	absolutePath: string;
-	recursive?: boolean;
 }
 
 export interface InternalWatchEvent {


### PR DESCRIPTION
## Context

An audit of our file watchers (checking whether anything can end up watching `node_modules`) found that the shipped behavior is safe only by caller convention, not by construction. Verified live over CDP by driving `filesystem.watchPath` subscriptions in the dev app:

- `watchPath` accepted **any absolute path** on the machine with any valid `workspaceId` — no containment validation.
- A watch root **at or inside `node_modules`** silently defeats `DEFAULT_IGNORE_PATTERNS`: @parcel/watcher matches ignore globs relative to the watch root, so `**/node_modules/**` never matches. Confirmed end-to-end: watching `<repo>/node_modules` delivered every event, unfiltered.
- A **symlinked watch root** disables ignores entirely (native prefix check bails); production is protected only by the `realpath()` in `watch.ts`.
- The `recursive` option was **declared and threaded through every layer but never read** — every watch is recursive regardless.

## Changes

1. **`watchPath` now rejects any target that isn't exactly the service's workspace root** (after `normalizeAbsolutePath`). All three production callers (host-service `event-bus`, `git-watcher`, desktop renderer bridge) already pass the identical string the service root was built from, so nothing legitimate changes. This makes the node_modules-root, inside-node_modules, and arbitrary-path bypasses unreachable through the API. The guard throws synchronously at subscription setup, so a bad path surfaces as a real error instead of being converted to a synthetic `overflow` event.

2. **Removed the no-op `recursive` flag** from `WatchPathOptions`, the `FsService` interface, the WS subscription contract, the desktop tRPC schema, and all call sites. A future caller hoping for a shallow watch now gets a compile error instead of a silently recursive watcher. (`createDirectory`'s `recursive` and git-watcher's `node:fs.watch(gitDir, { recursive: true })` are real options and untouched.)

Strict equality (vs. within-root containment) is deliberate: no feature watches subpaths today, relaxing later is backward-compatible while tightening isn't, and per-subpath watches would each spawn their own native watcher (the manager dedupes by exact path). If subpath watching becomes a requirement, the safe recipe is `isPathWithinRoot` + a JS-side re-filter with `defaultIgnoreMatchers` (VS Code's parcelWatcher does exactly this double-filtering).

## Testing

- New test rejects `node_modules`, subpaths, siblings, and parents; accepts trailing-slash root spelling. Mutation-checked (guard removed → test fails).
- Live CDP verification of the bypasses that motivated the guard (pre-fix).
- Monorepo typecheck 35/35; `workspace-fs` 45/45; `host-service` events 17/17; desktop 2113/2113; lint clean.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts `watchPath` to the exact workspace root and removes the unused `recursive` option. Blocks `node_modules`/arbitrary-path watches that bypass `@parcel/watcher` ignores; no behavior change for current callers.

- **Bug Fixes**
  - Validate the target equals the service’s workspace root (normalized). Invalid paths throw at subscription setup; roots at/inside `node_modules` or behind symlinks can’t bypass ignore globs.

- **Refactors**
  - Removed `recursive` from `WatchPathOptions`, `FsService`, desktop tRPC schema, WS subscription, and callers; watches are always recursive with `@parcel/watcher`.

<sup>Written for commit 150103c4496e0cfdab43b749c2428ab2b3ea6d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File watching is now consistently recursive by default.
  * Restricted file-watch requests to the configured workspace root, improving reliability and security.
  * Improved handling of paths with trailing slashes and rejected paths outside the workspace.
* **Refactor**
  * Removed the configurable recursive-watch option from the file-watching interface for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->