### PR TITLE
feat(host-service): honor SUPERSET_WORKTREES_ROOT env for worktree location

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
@@ -45,6 +45,18 @@ describe("defaultWorktreesRoot", () => {
 			join(homedir(), ".superset", "worktrees"),
 		);
 	});
+
+	it("expands a leading ~ against the home directory", () => {
+		process.env[ENV_KEY] = "~/worktrees";
+		expect(defaultWorktreesRoot()).toBe(join(homedir(), "worktrees"));
+	});
+
+	it("rejects a relative env var instead of silently resolving against cwd", () => {
+		process.env[ENV_KEY] = "relative/worktrees";
+		expect(() => defaultWorktreesRoot()).toThrow(
+			"Worktree location must be an absolute path or start with ~",
+		);
+	});
 });
 
 describe("worktreeBaseDir precedence over SUPERSET_WORKTREES_ROOT", () => {
@@ -75,6 +87,12 @@ describe("worktreeBaseDir precedence over SUPERSET_WORKTREES_ROOT", () => {
 	it("uses the env var as the default when no worktreeBaseDir is given", () => {
 		expect(projectWorktreesRoot(PROJECT_ID)).toBe(
 			join("/Volumes/samsung/worktrees", PROJECT_ID),
+		);
+	});
+
+	it("falls through to the env var default in safeResolveWorktreePath", () => {
+		expect(safeResolveWorktreePath(PROJECT_ID, "feature")).toBe(
+			join("/Volumes/samsung/worktrees", PROJECT_ID, "feature"),
 		);
 	});
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+	defaultWorktreesRoot,
+	projectWorktreesRoot,
+	safeResolveWorktreePath,
+} from "./worktree-paths";
+
+const ENV_KEY = "SUPERSET_WORKTREES_ROOT";
+const PROJECT_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("defaultWorktreesRoot", () => {
+	let previous: string | undefined;
+
+	beforeEach(() => {
+		previous = process.env[ENV_KEY];
+		delete process.env[ENV_KEY];
+	});
+
+	afterEach(() => {
+		if (previous === undefined) delete process.env[ENV_KEY];
+		else process.env[ENV_KEY] = previous;
+	});
+
+	it("falls back to the homedir default when the env var is unset", () => {
+		expect(defaultWorktreesRoot()).toBe(
+			join(homedir(), ".superset", "worktrees"),
+		);
+	});
+
+	it("uses SUPERSET_WORKTREES_ROOT when it is set", () => {
+		process.env[ENV_KEY] = "/Volumes/samsung/worktrees";
+		expect(defaultWorktreesRoot()).toBe("/Volumes/samsung/worktrees");
+	});
+
+	it("trims and absolute-resolves the env var value", () => {
+		process.env[ENV_KEY] = "  /Volumes/samsung/./worktrees/../worktrees  ";
+		expect(defaultWorktreesRoot()).toBe(resolve("/Volumes/samsung/worktrees"));
+	});
+
+	it("ignores a whitespace-only env var and uses the homedir default", () => {
+		process.env[ENV_KEY] = "   ";
+		expect(defaultWorktreesRoot()).toBe(
+			join(homedir(), ".superset", "worktrees"),
+		);
+	});
+});
+
+describe("worktreeBaseDir precedence over SUPERSET_WORKTREES_ROOT", () => {
+	let previous: string | undefined;
+
+	beforeEach(() => {
+		previous = process.env[ENV_KEY];
+		process.env[ENV_KEY] = "/Volumes/samsung/worktrees";
+	});
+
+	afterEach(() => {
+		if (previous === undefined) delete process.env[ENV_KEY];
+		else process.env[ENV_KEY] = previous;
+	});
+
+	it("lets an explicit worktreeBaseDir win in projectWorktreesRoot", () => {
+		expect(projectWorktreesRoot(PROJECT_ID, "/custom/base")).toBe(
+			join("/custom/base", PROJECT_ID),
+		);
+	});
+
+	it("lets an explicit worktreeBaseDir win in safeResolveWorktreePath", () => {
+		expect(safeResolveWorktreePath(PROJECT_ID, "feature", "/custom/base")).toBe(
+			join("/custom/base", PROJECT_ID, "feature"),
+		);
+	});
+
+	it("uses the env var as the default when no worktreeBaseDir is given", () => {
+		expect(projectWorktreesRoot(PROJECT_ID)).toBe(
+			join("/Volumes/samsung/worktrees", PROJECT_ID),
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
@@ -4,7 +4,14 @@ import { TRPCError } from "@trpc/server";
 
 // Kept outside the primary checkout so editors, file watchers, and
 // ignore rules treat worktrees as separate trees, not nested ones.
+//
+// SUPERSET_WORKTREES_ROOT overrides the location so worktrees can live on the
+// same volume as the repo they clone from — the APFS clonefile in
+// .superset/setup.sh only works within a single volume, so a homedir-rooted
+// default forces a slow full install when the repo lives on an external disk.
 export function defaultWorktreesRoot(): string {
+	const override = process.env.SUPERSET_WORKTREES_ROOT?.trim();
+	if (override) return resolve(override);
 	return join(homedir(), ".superset", "worktrees");
 }
 

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
@@ -9,9 +9,14 @@ import { TRPCError } from "@trpc/server";
 // same volume as the repo they clone from — the APFS clonefile in
 // .superset/setup.sh only works within a single volume, so a homedir-rooted
 // default forces a slow full install when the repo lives on an external disk.
+// The value is normalized exactly like the user-facing worktreeBaseDir setting
+// (~ expansion, absolute-path requirement) so both configuration paths behave
+// identically instead of silently resolving a relative value against cwd.
 export function defaultWorktreesRoot(): string {
-	const override = process.env.SUPERSET_WORKTREES_ROOT?.trim();
-	if (override) return resolve(override);
+	const override = normalizeWorktreeBaseDir(
+		process.env.SUPERSET_WORKTREES_ROOT,
+	);
+	if (override) return override;
 	return join(homedir(), ".superset", "worktrees");
 }
 


### PR DESCRIPTION
## What

`defaultWorktreesRoot()` now honors a new `SUPERSET_WORKTREES_ROOT` environment variable that overrides where Superset creates git worktrees. When the env var is set, its value is trimmed and absolute-resolved (`resolve()`) and used as the default worktrees root; when unset (or whitespace-only) it falls back to the existing `join(homedir(), ".superset", "worktrees")`.

## Why

**External-volume APFS clonefile.** Worktrees were always rooted under the OS home directory. Users whose repos live on an external disk (e.g. `/Volumes/samsung`) need their worktrees on the **same volume**, because the APFS clonefile used by `.superset/setup.sh` only works within a single volume. When the worktree lands on a different volume than the repo, the clonefile fails and setup falls back to a slow full install. `SUPERSET_WORKTREES_ROOT` lets those users relocate worktrees onto the repo's volume. The v0.2.12 CLI hardcodes this path and honored no env var for it — this closes that gap.

**`homedir()` vs `supersetHomeDir()` inconsistency.** `defaultWorktreesRoot()` reached for the raw OS `homedir()` directly, which is inconsistent with `supersetHomeDir()` elsewhere in host-service (`packages/host-service/src/daemon/manifest.ts`), which already honors an env override (`SUPERSET_HOME_DIR`) before falling back to `homedir()`. This change brings worktree-root resolution in line with that established pattern of an env override in front of a homedir default.

## Precedence (unchanged)

The env var only changes the **default** that `worktreeBaseDir` falls back to. The existing per-project / host `worktreeBaseDir` override in `projectWorktreesRoot()` / `safeResolveWorktreePath()` still wins, because it is passed explicitly and only falls through to `defaultWorktreesRoot()` when nullish (`worktreeBaseDir ?? defaultWorktreesRoot()`).

Resulting order (highest to lowest):
1. Explicit `worktreeBaseDir` (per-project or host setting)
2. `SUPERSET_WORKTREES_ROOT` env var (new)
3. `join(homedir(), ".superset", "worktrees")` default

## Tests

Adds co-located unit tests in `worktree-paths.test.ts` covering:
- env var set → used (and trimmed + absolute-resolved)
- env var unset / whitespace-only → homedir default
- explicit `worktreeBaseDir` still wins over the env var (both `projectWorktreesRoot` and `safeResolveWorktreePath`)

`bun test` (host-service shared suite), `bun run lint`, and full-repo `bun run typecheck` all pass clean.

https://claude.ai/code/session_01QwC8JuezD3GVej8KyUMkEp

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5681">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the SUPERSET_WORKTREES_ROOT env var to control where git worktrees are created, with trimming, ~ expansion, and an absolute-path requirement. Keeps worktrees on the same volume as the repo so APFS clonefile works and installs stay fast.

- **New Features**
  - `defaultWorktreesRoot()` uses SUPERSET_WORKTREES_ROOT when set, normalized like `worktreeBaseDir` (trim, expand `~`, require absolute; reject relative paths).
  - Precedence unchanged: explicit `worktreeBaseDir` > env var > homedir default.

<sup>Written for commit 48812bd47b664ca1081b28cad53ef9126dda81ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the default worktrees directory through the `SUPERSET_WORKTREES_ROOT` environment variable.
  * Configured paths are trimmed and resolved to absolute paths, with a fallback to the standard home-directory location.
  * Explicit worktree base directories continue to take precedence over the environment setting.

* **Tests**
  * Added coverage for environment-based configuration, fallback behavior, whitespace handling, and path precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->