### PR TITLE
chore(seo): sitemap and redirect housekeeping (marketing + docs)

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -37,6 +37,41 @@ const config = {
 				destination: "/overview",
 				permanent: false,
 			},
+			// Legacy /docs-prefixed URLs (e.g. /docs/automations) now live at root.
+			{
+				source: "/docs/:path*",
+				destination: "/:path*",
+				permanent: true,
+			},
+			// Old top-level entry points from the previous docs structure (were 404ing).
+			{
+				source: "/getting-started",
+				destination: "/overview",
+				permanent: true,
+			},
+			{
+				source: "/installation",
+				destination: "/overview",
+				permanent: true,
+			},
+			{
+				source: "/quick-start",
+				destination: "/first-workspace",
+				permanent: true,
+			},
+		];
+	},
+	async headers() {
+		// Keep raw markdown surfaces out of the index (they duplicate rendered pages).
+		return [
+			{
+				source: "/:path*.mdx",
+				headers: [{ key: "X-Robots-Tag", value: "noindex" }],
+			},
+			{
+				source: "/llms-full.txt",
+				headers: [{ key: "X-Robots-Tag", value: "noindex" }],
+			},
 		];
 	},
 	async rewrites() {

--- a/apps/marketing/content/compare/best-agentic-ide.mdx
+++ b/apps/marketing/content/compare/best-agentic-ide.mdx
@@ -1,0 +1,176 @@
+---
+title: "Best Agentic IDE in 2026: Multi-Agent Coding Tools Compared"
+description: "Compare the best agentic IDEs of 2026, including Superset, Cursor, Zed, Devin Desktop, VS Code + Copilot, JetBrains Junie, Conductor, and Orca."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "roundup"
+competitors:
+  - cursor
+  - zed
+  - devin-desktop
+  - github-copilot
+  - jetbrains-junie
+  - conductor
+  - orca
+keywords:
+  - agentic ide
+  - best agentic ide 2026
+  - multi agent ide
+  - ai code editor
+  - ai agent editor
+  - ai ide
+  - agentic coding ide
+---
+
+The term "agentic IDE" now covers two different things, and choosing well depends on which one you actually need.
+
+Some tools are AI editors that grew an agent: you write code in a familiar editor, and an agent mode can plan tasks, edit across files, and run commands for you. Others are agent workspaces: the agent is the primary unit, and the product is built around running many of them in parallel, isolating each task, and reviewing the results.
+
+Both are legitimately "agentic." But if your bottleneck is running several coding agents on the same repository without collisions, the deciding factor is isolation and orchestration, not autocomplete quality. That is where an agent-agnostic, worktree-per-task workspace like Superset stands apart.
+
+---
+
+## The Short Version
+
+| Tool | Best for | Agent model | Parallel work isolation | Main tradeoff |
+|---|---|---|---|---|
+| **Superset** | Running many agents in parallel on one repo | Bring your own (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Git worktree per task, local plus remote/cloud | Not a single-editor autocomplete experience |
+| **Cursor** | AI-first editing with parallel agents | Built-in models plus Composer; agent mode | Local git worktrees (up to 8) and cloud VMs | Editor-centric; less agent-agnostic |
+| **Zed** | Fast editor that hosts external agents | Hosts Claude Code, Codex, Gemini via ACP | Working copy with diff review; no per-task worktrees | Not built around parallel isolated runs |
+| **Devin Desktop** | Managing local and cloud agents on a board | Devin Local plus ACP agents | Cloud isolated; local mechanism unspecified | Newer rebrand of Windsurf; in transition |
+| **VS Code + Copilot** | Broadest ecosystem and cloud coding agent | Copilot plus delegation to Claude/Codex | Cloud branch-to-PR; in-editor edits working copy | In-editor parallelism is limited |
+| **JetBrains + Junie** | Agentic coding inside JetBrains IDEs | Junie plus ACP agents | Cloud sandbox (in testing); no local worktrees | Tied to the JetBrains ecosystem |
+| **Conductor** | Focused Mac app for a few agents | Claude Code, Codex, Cursor | Git worktree per task | macOS only; narrow agent set |
+| **Orca** | Free desktop workspace for parallel agents | Agent-agnostic (25+) | Git worktree per task | Fewer remote/automation surfaces |
+
+## Two Kinds of Agentic IDE
+
+### 1. AI editors with agent modes
+
+These start as editors and add autonomous agents. You get familiar editing plus an agent that can plan, edit across files, run the terminal, and iterate on errors. Cursor, Zed, VS Code with Copilot, JetBrains with Junie, and Devin Desktop (the product formerly known as Windsurf) all fit here.
+
+An important 2026 update: several of these now isolate parallel work too. Cursor 2.0 can run multiple agents in local Git worktrees, and Cursor, Copilot, and Devin all offer cloud agents that work on a separate branch and hand back a pull request. So "editors just edit one working copy" is no longer universally true. The nuance is where and how isolation happens.
+
+### 2. Agent workspaces
+
+These treat the agent as the primary unit. The product is built around launching many agents, isolating each task in its own Git worktree, and reviewing and merging results. Superset, Conductor, Orca, and Crystal (now Nimbalyst) fit here. They are less about typing code yourself and more about directing a fleet of agents and reviewing what they produce.
+
+Many developers end up using one of each: an editor for hands-on work and an agent workspace for larger parallel runs.
+
+## Tool-by-Tool Breakdown
+
+### Superset
+
+Superset is an agent-agnostic workspace built around running coding agents in parallel. Every task gets its own Git worktree, branch, and persistent terminal, so agents never collide on the same repository. Around that core it adds a built-in diff and file editor, an in-app browser for docs and dev servers, port management, MCP tooling, and remote and cloud workspaces that run across your own network devices. It runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom agents, and hands off to VS Code, Cursor, JetBrains, or Xcode when you want a full editor.
+
+Best for:
+
+- Running many agents at once on the same codebase
+- Bring-your-own-agent flexibility across vendors
+- Local-first work with optional remote and cloud hosts
+
+### Cursor
+
+Cursor is an AI-first fork of VS Code with a strong agent mode that reads the codebase, edits across files, and runs commands. Cursor 2.0 added a multi-agent interface that can run up to eight agents in parallel, each in its own local Git worktree, plus background agents that run in cloud VMs and hand back a branch. It is one of the most capable editors here, though it is centered on its own models and workflow rather than being agent-agnostic. Pricing starts at a free tier with Pro at $20/month.
+
+For the direct comparison, see [Superset vs Cursor](/compare/superset-vs-cursor).
+
+### Zed
+
+Zed is a fast, GPU-accelerated, open-source editor whose signature strength is hosting external agents. It co-developed the Agent Client Protocol (ACP) and can run Claude Code, Codex, Gemini, and OpenCode inside its agent panel, presenting an editable diff you accept before committing. Zed edits in the working copy with review gating rather than isolating each task in a worktree, so it is excellent for agent-assisted editing but not built around parallel isolated runs. It has a free personal tier (unlimited with your own keys or external agents), Pro at $10/month, and Business at $30/seat.
+
+### Devin Desktop (formerly Windsurf)
+
+Windsurf is now Devin Desktop, following Cognition's acquisition; the original Cascade agent has been retired in favor of Devin Local, a rewritten in-editor agent with subagents. Devin Desktop makes an "Agent Command Center" the default surface, a board to manage local and cloud agents, and it supports ACP so agents like Codex, Claude, and OpenCode can run alongside Devin. Its autonomous cloud agents run remotely; the local parallel-isolation mechanism is less clearly documented. Pricing starts free, with Pro at $20/month and Max at $200/month.
+
+For the direct comparison, see [Superset vs Windsurf](/compare/superset-vs-windsurf).
+
+### VS Code + GitHub Copilot
+
+VS Code with Copilot has the broadest ecosystem of any option. Copilot agent mode plans multi-step tasks, edits across files, and runs the terminal in your local working copy, while the separate Copilot coding agent runs in GitHub's cloud on a branch and opens a pull request. MCP is supported on every plan, and higher tiers can delegate to third-party agents like Claude and Codex. In-editor parallelism is limited, but the cloud coding agent lets you dispatch multiple issues. Plans run from free to Pro at $10, Pro+ at $39, and Max at $100.
+
+For the direct comparison, see [Superset vs GitHub Copilot](/compare/superset-vs-github-copilot).
+
+### JetBrains + Junie
+
+Junie is JetBrains' first-party coding agent, built into AI Chat across IntelliJ, PyCharm, WebStorm, and the rest. It plans multi-step tasks, edits across files, runs tests, and iterates, with a "Brave Mode" that runs actions without prompting. JetBrains co-developed ACP and supports external agents in its IDEs, and it is testing cloud execution in isolated sandboxes. There is no documented local worktree-per-agent model. AI pricing runs from a free tier to Pro at $10, Ultimate at $30, and Enterprise at $60.
+
+### Conductor
+
+Conductor is a native macOS app for running Claude Code, Codex, and Cursor agents in parallel, each in an isolated workspace backed by a Git worktree, with a clean review-and-merge and pull-request flow. It is focused and polished for that agent set, but it is Mac only and narrower than an agent-agnostic workspace. The app is free with a bring-your-own-subscription model.
+
+For the direct comparison, see [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Orca
+
+Orca is a free, open-source desktop "agent development environment" that runs many agents in parallel, each with its own Git worktree and browser tab, and a unified UI for diffs, pull requests, and CI. It is agent-agnostic with 25+ supported agents and runs on macOS, Windows, and Linux with mobile companions. It shares Superset's worktree model, with fewer remote and automation surfaces.
+
+For the direct comparison, see [Superset vs Orca](/compare/superset-vs-orca).
+
+## How To Choose
+
+Pick based on your primary bottleneck:
+
+- If your bottleneck is hands-on editing with an agent assist, use Cursor, Zed, VS Code + Copilot, or JetBrains + Junie.
+- If your bottleneck is hosting external CLI agents inside an editor, Zed, JetBrains, and Devin Desktop lead on ACP support.
+- If your bottleneck is running many agents on one repository without collisions, use an agent workspace: Superset, Conductor, or Orca.
+
+The more agent-heavy your workflow, the more the winning criterion shifts from editing experience to isolation, review, and orchestration.
+
+## Best Picks by Use Case
+
+### Best agentic IDE for parallel agents: Superset
+
+Superset wins when you need multiple agents working at once on the same repository, with worktree isolation, review, and remote hosting built in.
+
+### Best AI editor with parallel agents: Cursor
+
+Cursor is the strongest single-editor experience that also runs multiple agents in local worktrees.
+
+### Best editor for hosting external agents: Zed
+
+Zed's ACP support makes it the cleanest way to run Claude Code, Codex, or Gemini inside a fast editor.
+
+### Best for the broadest ecosystem: VS Code + Copilot
+
+Copilot covers the most surfaces, from in-editor agent mode to a cloud coding agent that opens pull requests.
+
+### Best focused Mac app: Conductor
+
+Conductor is a polished, narrow choice if Claude Code, Codex, and Cursor are your agents and you are on macOS.
+
+## Verdict
+
+There is no single "best agentic IDE" in the abstract. There is a best tool for your workflow:
+
+- Cursor if you want an AI-first editor that also runs parallel agents
+- Zed if you want a fast editor that hosts external CLI agents
+- VS Code + Copilot if you want the broadest ecosystem
+- JetBrains + Junie if you live in JetBrains IDEs
+- Superset if you want to orchestrate many agents in parallel on one repo, with isolation and review as the core
+
+As soon as you are running more than one agent on the same codebase, worktree isolation and review matter more than editor polish. If that is your world, Superset is the agentic IDE to optimize around.
+
+For a broader tool comparison, see [Best AI Coding Tools and Agents (2026)](/compare/best-ai-coding-agents-2026). To understand the category itself, see [What Is an Agentic IDE?](/compare/what-is-an-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is an agentic IDE?
+
+An agentic IDE is a development environment where AI agents can autonomously plan and execute multi-step coding tasks -- editing files, running commands, and iterating -- rather than only autocompleting code. Some are editors with an agent mode; others are workspaces built around running many agents in parallel.
+
+### What is a multi-agent IDE?
+
+A multi-agent IDE runs several coding agents at once. The safest versions give each agent its own isolated Git worktree so parallel work does not collide. Superset, Orca, and Conductor are built around this; Cursor 2.0 also runs multiple agents in local worktrees.
+
+### Which agentic IDE is best for running Claude Code?
+
+If you run one Claude Code session at a time, any strong editor works. If you want several Claude Code sessions in parallel on one repository, a worktree-based workspace like Superset is the better fit. See [Best IDE for Claude Code](/compare/best-ide-for-claude-code).
+
+### Do agentic IDEs isolate parallel work?
+
+It varies. Superset, Orca, Conductor, and Cursor 2.0 use local Git worktrees. Copilot, Devin, and JetBrains push isolation to the cloud (a branch and a pull request). Zed and in-editor agent modes typically edit the working copy with diff review.
+
+### Is Superset an IDE or an orchestrator?
+
+Both, depending on how you use it. It is a workspace where agents are first-class: you orchestrate many of them in isolated worktrees, then review and merge, or hand off to a full editor like VS Code or JetBrains.

--- a/apps/marketing/content/compare/best-ide-for-claude-code.mdx
+++ b/apps/marketing/content/compare/best-ide-for-claude-code.mdx
@@ -1,0 +1,127 @@
+---
+title: "Best IDE for Claude Code in 2026: Where to Run It"
+description: "The best places to run Claude Code in 2026, from the terminal and VS Code to JetBrains, Zed, Conductor, and Superset for parallel worktree sessions."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "roundup"
+competitors:
+  - vs-code
+  - jetbrains
+  - zed
+  - cursor
+  - conductor
+  - cmux
+keywords:
+  - best ide for claude code
+  - where to run claude code
+  - claude code ide
+  - run claude code in vscode
+  - claude code editor
+  - claude code parallel
+---
+
+Claude Code runs almost anywhere: a terminal, an editor extension, a desktop app, the web, and even your phone. So "the best IDE for Claude Code" is really two questions. If you run one session at a time, pick the surface that fits your editor. If you want several Claude Code sessions in parallel on the same repository, the answer changes: you need Git worktree isolation more than another editor pane.
+
+This guide covers both, from the simplest terminal setup to a full parallel-agent workspace.
+
+---
+
+## The Short Version
+
+| Where you run Claude Code | Best for | Parallel sessions on one repo? | Main tradeoff |
+|---|---|---|---|
+| **Superset** | Running many Claude Code sessions at once | Yes -- one Git worktree per task | Not a single-file editor experience |
+| **Terminal (CLI)** | The most complete, scriptable Claude Code | Manual (tmux + worktrees yourself) | You manage isolation and review |
+| **VS Code extension** | Editing alongside Claude Code | Limited without extra tooling | In-editor, single working copy |
+| **JetBrains extension** | JetBrains users | Limited | Tied to JetBrains IDEs |
+| **Zed (ACP)** | A fast editor hosting Claude Code | Working-copy edits with review | No per-task worktrees |
+| **Conductor** | A focused Mac app for a few agents | Yes -- worktrees | macOS only |
+| **cmux** | A native macOS agent terminal | Organizes sessions; no auto isolation | macOS only; isolation is manual |
+
+## Where You Can Run Claude Code
+
+Claude Code is Anthropic's coding agent, and the same engine runs across several official surfaces: the CLI (the most complete), a desktop app, VS Code and JetBrains extensions, the web, and mobile. Beyond Anthropic's own surfaces, Claude Code also runs inside third-party editors and workspaces that host it as an agent. The right choice depends on whether you want a place to edit or a place to orchestrate.
+
+## The Options
+
+### Terminal (Claude Code CLI)
+
+The CLI is the reference surface: it is the most complete, supports scripting and the Agent SDK, and works in any terminal. For a single deep task, it is hard to beat. The catch is parallelism: running several sessions on one repository means managing tmux panes and Git worktrees yourself, then reviewing each diff by hand. Great for one task; more work for many.
+
+### VS Code extension
+
+The VS Code extension puts Claude Code beside your code, so you can edit while it works. It is the natural home if VS Code is your editor. Like most in-editor setups, it operates in a single working copy, so running several isolated sessions at once needs extra tooling.
+
+### JetBrains extension
+
+Claude Code has a JetBrains extension for IntelliJ, PyCharm, WebStorm, and the rest, bringing it into those IDEs with the same shared configuration and MCP support. Ideal if you already live in JetBrains, with the same single-working-copy limitation for parallel work.
+
+### Zed (via ACP)
+
+Zed hosts Claude Code natively through the Agent Client Protocol, running it inside Zed's agent panel and presenting an editable diff you accept before committing. It is one of the cleanest ways to run Claude Code inside a fast, modern editor. Zed edits in the working copy with review gating rather than isolating each task in a worktree.
+
+### Conductor
+
+Conductor is a macOS app that runs Claude Code (and Codex and Cursor) in parallel, each in an isolated Git worktree, with a review-and-merge and pull-request flow. It is a focused, polished way to run a few agents in parallel on a Mac. It is macOS only.
+
+For the direct comparison, see [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### cmux
+
+cmux is a native macOS terminal built for agents. It keeps many Claude Code sessions visible in tabs and split panes with notifications, but it does not isolate what each session changes -- that is left to you. It is a great terminal for agents, not an orchestrator.
+
+For the direct comparison, see [Superset vs cmux](/compare/superset-vs-cmux).
+
+### Superset
+
+Superset runs Claude Code as a first-class agent, giving every session its own Git worktree, branch, and persistent terminal, so multiple Claude Code sessions can work the same repository at once without collisions. Around that it adds a built-in diff and file editor, an in-app browser, MCP tooling, and remote and cloud workspaces. You can review inside Superset or hand off to VS Code, Cursor, JetBrains, or Xcode. It is the strongest fit when your goal is many Claude Code sessions in parallel, not another editor pane.
+
+For the direct comparison, see [Superset vs Claude Code](/compare/superset-vs-claude-code).
+
+## How To Choose
+
+- For one deep task, run the Claude Code CLI in your terminal, or use the VS Code or JetBrains extension if you want to edit alongside it.
+- To host Claude Code inside a fast editor, use Zed's ACP support.
+- To run many Claude Code sessions in parallel on one repository, use a worktree-based workspace like Superset or Conductor.
+
+## Best Picks by Use Case
+
+### Best for a single deep task: Claude Code CLI
+
+The terminal remains the most complete and scriptable way to run Claude Code.
+
+### Best for editing alongside Claude Code: VS Code or JetBrains
+
+The official extensions are the natural home if you want to keep editing in your IDE.
+
+### Best editor host for Claude Code: Zed
+
+Zed's ACP support runs Claude Code cleanly inside a fast, modern editor.
+
+### Best for parallel Claude Code sessions: Superset
+
+Superset gives every session its own worktree, so many can run at once without collisions, with review and orchestration built in.
+
+## Verdict
+
+If you run Claude Code one task at a time, the best IDE is whichever editor you already use: the CLI for depth, VS Code or JetBrains to edit alongside, or Zed to host it inside a fast editor. The moment you want several Claude Code sessions in parallel on the same repository, the deciding factor becomes worktree isolation and review, and a workspace like Superset is the better answer.
+
+For the workflow details, see [How to Run Multiple Claude Code Agents in Parallel](/compare/multiple-claude-code-agents-parallel). For the broader category, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best IDE for Claude Code?
+
+For a single task, the Claude Code CLI or the VS Code and JetBrains extensions are excellent. For running several sessions in parallel on one repository, a worktree-based workspace like Superset is the better fit.
+
+### Can I run Claude Code in VS Code?
+
+Yes. Claude Code has an official VS Code extension that runs it beside your code. For isolated parallel sessions, pair it with a worktree workflow or use a workspace like Superset.
+
+### How do I run multiple Claude Code sessions at once?
+
+Give each session its own Git worktree so they do not share a working directory. You can do this manually with tmux and worktrees, or automatically with a workspace like Superset or Conductor. See [How to Run Multiple Claude Code Agents in Parallel](/compare/multiple-claude-code-agents-parallel).
+
+### Does Claude Code have its own IDE?
+
+Claude Code ships as a CLI, a desktop app, VS Code and JetBrains extensions, a web experience, and mobile apps. For orchestrating many sessions in parallel, developers often add a worktree-based workspace on top.

--- a/apps/marketing/content/compare/best-ide-for-codex.mdx
+++ b/apps/marketing/content/compare/best-ide-for-codex.mdx
@@ -1,0 +1,123 @@
+---
+title: "Best IDE for OpenAI Codex in 2026: Where to Run It"
+description: "The best places to run OpenAI Codex in 2026, from the CLI and IDE extension to the Codex cloud app, Conductor, and Superset for parallel worktree sessions."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "roundup"
+competitors:
+  - vs-code
+  - cursor
+  - codex-app
+  - conductor
+keywords:
+  - best ide for codex
+  - where to run codex
+  - codex worktree
+  - codex ssh
+  - openai codex ide
+  - codex parallel agents
+---
+
+OpenAI's Codex is one product with many faces: a terminal CLI, an editor extension, a desktop app, a web experience, and a cloud service that runs tasks in parallel sandboxes. So the best "IDE for Codex" depends on where you want the work to happen. Do you want Codex on your machine, in your editor, or running in the cloud? And do you want to run several Codex tasks at once on the same repository?
+
+This guide covers each option, including how to get parallel Codex runs with Git worktrees.
+
+---
+
+## The Short Version
+
+| Where you run Codex | Best for | Parallel tasks on one repo? | Main tradeoff |
+|---|---|---|---|
+| **Superset** | Running many local Codex tasks at once | Yes -- one Git worktree per task | Not a single-file editor experience |
+| **Codex CLI** | The scriptable, local Codex | Manual (worktrees yourself) | You manage isolation and review |
+| **Codex IDE extension** | Editing alongside Codex | Limited | In-editor, single working copy |
+| **Codex cloud / app** | Fire-and-forget parallel tasks | Yes -- isolated cloud sandboxes | Runs in OpenAI's cloud, tied to a plan |
+| **Cursor** | AI editor that can run Codex-style agents | Local worktrees (its own agents) | Centered on Cursor's own models |
+| **Conductor** | A focused Mac app for a few agents | Yes -- worktrees | macOS only |
+
+## Where You Can Run Codex
+
+Codex shares one account, configuration, and usage limits across its surfaces. The CLI runs locally in your terminal. The IDE extension brings it into your editor. The desktop and web apps add a graphical experience, and the cloud service clones your repo into isolated environments and runs tasks in the background. The key decision is local versus cloud, and single versus parallel.
+
+## The Options
+
+### Codex CLI
+
+The CLI is the local, scriptable Codex: it reads your codebase, runs commands, and edits files on your machine. It is the best surface for a single task and for anyone who wants Codex in scripts or over SSH on a remote box. For parallel tasks on one repository, you manage Git worktrees and review yourself.
+
+For the direct comparison, see [Superset vs Codex CLI](/compare/superset-vs-codex).
+
+### Codex IDE extension
+
+The editor extension puts Codex beside your code so you can review and edit as it works. It is the natural choice if you want Codex inside your existing editor, with the usual single-working-copy limitation for parallel runs.
+
+### Codex cloud and desktop app
+
+The Codex cloud experience is the distinctive one: describe a task, and Codex clones your repo into an isolated cloud environment, works in the background without using your machine, and returns a diff and logs to review. You can start several tasks in parallel this way. It is convenient for fire-and-forget work, and it runs in OpenAI's cloud tied to your ChatGPT plan rather than on your local machine.
+
+For the direct comparison, see [Superset vs Codex App](/compare/superset-vs-codex-app).
+
+### Cursor
+
+Cursor is an AI editor that runs its own parallel agents in local Git worktrees. It is not a dedicated Codex host, but if you want an editor-centric experience with multi-agent runs, it is a strong option alongside running Codex directly.
+
+For the direct comparison, see [Superset vs Cursor](/compare/superset-vs-cursor).
+
+### Conductor
+
+Conductor is a macOS app that runs Codex (along with Claude Code and Cursor) in parallel, each in an isolated Git worktree, with a review-and-merge flow. It is a focused way to run a few agents in parallel on a Mac. It is macOS only.
+
+For the direct comparison, see [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Superset
+
+Superset runs the Codex CLI as a first-class agent, giving every task its own Git worktree, branch, and persistent terminal, so multiple Codex tasks can run on the same repository at once without collisions -- locally, or on your own remote hosts. Around that it adds a built-in diff and file editor, an in-app browser, port management, and MCP tooling. If your goal is parallel local Codex runs with real worktree isolation rather than cloud sandboxes, this is the fit.
+
+## How To Choose
+
+- For one task or a scriptable/SSH setup, use the Codex CLI.
+- To edit alongside Codex, use the IDE extension.
+- For fire-and-forget parallel tasks in the cloud, use Codex cloud.
+- For parallel local Codex runs with worktree isolation, use a workspace like Superset or Conductor.
+
+## Best Picks by Use Case
+
+### Best for a single or scripted task: Codex CLI
+
+The terminal is the most flexible, scriptable way to run Codex, including over SSH.
+
+### Best for cloud parallelism: Codex cloud
+
+OpenAI's cloud sandboxes run multiple tasks in parallel without using your machine.
+
+### Best for parallel local runs: Superset
+
+Superset gives every Codex task its own worktree on your own machine, with review and orchestration built in.
+
+### Best focused Mac app: Conductor
+
+Conductor is a polished choice if Codex, Claude Code, and Cursor are your agents and you are on macOS.
+
+## Verdict
+
+The best IDE for Codex depends on where you want work to run. Use the CLI for a single or scripted task, the IDE extension to edit alongside it, and Codex cloud for fire-and-forget parallel tasks in OpenAI's environments. If you want parallel Codex runs on your own machine, each isolated in a Git worktree, a workspace like Superset is the better answer.
+
+For the broader category, see [Best Agentic IDE in 2026](/compare/best-agentic-ide) and [Best AI Coding Tools and Agents (2026)](/compare/best-ai-coding-agents-2026).
+
+## Frequently Asked Questions
+
+### What is the best IDE for Codex?
+
+For a single or scripted task, the Codex CLI. For editing alongside it, the IDE extension. For parallel tasks, either Codex cloud (OpenAI's sandboxes) or a local worktree workspace like Superset.
+
+### How do I run Codex with Git worktrees?
+
+Give each Codex task its own worktree so tasks do not share a working directory. You can set this up manually, or use a workspace like Superset or Conductor that creates a worktree per task automatically.
+
+### Can I run Codex over SSH?
+
+Yes. The Codex CLI runs in any terminal, including a remote machine over SSH. Superset can also run agents on your own remote hosts through remote workspaces.
+
+### Does Codex run tasks in parallel?
+
+Codex cloud runs multiple tasks in parallel in isolated cloud environments. For parallel runs on your own machine with Git worktrees, use a local workspace like Superset.

--- a/apps/marketing/content/compare/superset-vs-claude-code-app.mdx
+++ b/apps/marketing/content/compare/superset-vs-claude-code-app.mdx
@@ -1,0 +1,109 @@
+---
+title: "Superset vs Claude Code App (2026): Orchestrator vs Multi-Surface Agent"
+description: "Compare Superset and the Claude Code app across desktop, web, and mobile. See how worktree-based agent orchestration differs from a single multi-surface coding agent."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - claude-code-app
+keywords:
+  - superset vs claude code app
+  - claude code app alternative
+  - claude code app
+  - claude code desktop
+  - claude code web
+  - run claude code in parallel
+---
+
+Claude Code is Anthropic's coding agent, and the same engine now runs across six surfaces: a terminal CLI, a desktop app, VS Code, JetBrains, the web, and mobile. When people say "the Claude Code app," they usually mean the desktop app (a graphical interface over the local engine) or Claude Code on the web. Superset is not another Claude Code surface -- it is an orchestration workspace that runs Claude Code, and other agents, in parallel with Git worktree isolation. This page compares the two.
+
+For the general agent comparison, see [Superset vs Claude Code](/compare/superset-vs-claude-code).
+
+---
+
+## At a Glance
+
+| | **Superset** | **Claude Code App** |
+|---|---|---|
+| **Category** | Agent orchestration workspace | Anthropic's coding agent, multiple surfaces |
+| **Surfaces** | Desktop app, CLI, MCP server | CLI, desktop app, VS Code, JetBrains, web, mobile |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Claude Code (Anthropic models) |
+| **Parallelism** | Many agents on separate branches, one worktree each | Parallel sessions (desktop); cloud sessions (web) |
+| **Isolation** | Automatic Git worktree per task | No native per-task worktree isolation |
+| **Review tooling** | Built-in diff/file editor, staging, commit | Desktop diff viewer and app preview |
+| **Pricing** | Free tier + Pro $20/seat/mo | Claude Pro / Max plans; API pricing |
+| **License** | Source-available (ELv2) | Proprietary |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is the Claude Code App?
+
+Claude Code is Anthropic's AI coding agent, running the same underlying engine across six surfaces, each tuned for a different workflow. The CLI is the most complete surface. The desktop app wraps the local engine in a graphical interface with a diff viewer, app preview, and parallel sessions. VS Code and JetBrains extensions bring it into those editors. Claude Code on the web runs in Anthropic's cloud and keeps working after you disconnect. The mobile apps act as a thin client to start and monitor sessions. Configuration, project memory, and MCP servers are shared across the local surfaces. Claude Code is available on Claude Pro and Max plans and via the API.
+
+## Key Differences
+
+### One Agent, Many Surfaces vs Many Agents, One Workspace
+
+The Claude Code app is about running one excellent agent wherever you work -- terminal, editor, desktop, web, or phone. Superset is about running many agents in one place. It can run Claude Code as one of several agents, each in its own worktree, alongside Codex, OpenCode, Cursor, Gemini, and custom terminal agents. If Claude Code is your only agent, its app coverage is broad; if you run several agents or want to compare them on the same task, Superset is built for that.
+
+### Isolation Model
+
+The Claude Code desktop app supports parallel sessions, and the web surface runs in the cloud, but Claude Code does not natively give each parallel task its own Git worktree. Superset makes a worktree per task the default, so multiple agents can work on the same repository at once without sharing a working directory or stepping on each other's branch. If your reason for wanting parallelism is running several tasks on one repo safely, that isolation is the key difference.
+
+### Review and Orchestration in One Place
+
+Superset centralizes launching, isolating, reviewing, and merging across all your agents in a single workspace, with an in-app browser and one-click handoff to your editor. The Claude Code app gives you Claude's own desktop diff viewer and app preview per session. If you want a single orchestration and review layer that spans more than one agent, that is Superset's role.
+
+### They Work Together
+
+This is not strictly either/or. Many developers run Claude Code as their primary agent inside Superset, using the Claude Code app on its own for quick single-task work and Superset when several agents need isolated worktrees on the same repo. Superset wraps Claude Code rather than replacing it.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month, and you bring your own agent providers. Claude Code is available through Claude Pro and Max plans and via Anthropic's API. You pay Anthropic for Claude Code usage whether you run it directly or inside Superset.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want to run multiple agents, or Claude Code alongside others, in one workspace
+- Need automatic Git worktree isolation for parallel work on one repo
+- Want unified review and orchestration across agents
+- Prefer local-first work with your own remote/cloud hosts
+
+**Choose the Claude Code App if you:**
+
+- Use Claude Code as your single agent and want it on every surface
+- Want Anthropic's own desktop, web, and mobile experiences
+- Like starting a task on the web and monitoring it from your phone
+- Do not need multi-agent orchestration or per-task worktrees
+
+**Verdict:** The Claude Code app is excellent if Claude Code is your one agent and you want it everywhere. Superset is the better fit if you run several agents, want automatic worktree isolation for parallel work on the same repository, and want one workspace to orchestrate and review them all -- with Claude Code as a first-class agent inside it.
+
+---
+
+## Frequently Asked Questions
+
+### What does "Claude Code app" mean?
+
+It is ambiguous. It usually refers to the Claude Code desktop app (a GUI over the local engine), but can also mean Claude Code on the web or the mobile apps. Superset is a separate workspace that can run Claude Code as one of many agents.
+
+### Does the Claude Code app use Git worktrees?
+
+Not natively. The desktop app supports parallel sessions and the web runs in the cloud, but Claude Code does not automatically give each task its own worktree. Superset does.
+
+### Can I use Claude Code inside Superset?
+
+Yes. Superset runs Claude Code as a first-class agent, each session in its own worktree, alongside other agents. You still pay Anthropic for Claude Code usage.
+
+### Which should I use for running several tasks on one repo?
+
+If you want several agents working the same repository at once without collisions, Superset's worktree-per-task model is the safer answer. The Claude Code app is better for single-agent work across many surfaces.

--- a/apps/marketing/content/compare/superset-vs-claude-squad.mdx
+++ b/apps/marketing/content/compare/superset-vs-claude-squad.mdx
@@ -1,0 +1,104 @@
+---
+title: "Superset vs Claude Squad (2026): Desktop Workspace vs Terminal Multiplexer"
+description: "Compare Superset and Claude Squad for running multiple coding agents in Git worktrees. See how a desktop agent workspace differs from a terminal TUI."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - claude-squad
+keywords:
+  - superset vs claude squad
+  - claude squad alternative
+  - claude squad
+  - manage multiple claude code agents
+  - parallel claude code
+  - git worktree agents
+---
+
+Superset and Claude Squad both run multiple coding agents in parallel, each in its own Git worktree. Claude Squad does it as a terminal app: a TUI that manages agent sessions with Git worktrees and tmux. Superset does it as a desktop workspace, layering diff review, an in-app browser, MCP, and remote and cloud workspaces on the same worktree model. If you love the terminal, Claude Squad is lean and effective; if you want a graphical workspace around the same idea, Superset covers more.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Claude Squad** |
+|---|---|---|
+| **Category** | Desktop agent orchestration workspace | Terminal TUI for managing agents |
+| **What it does** | Runs 100+ agents in parallel with worktree isolation, review, and browser | Runs multiple agent sessions in isolated worktrees via tmux |
+| **Isolation** | Automatic Git worktree per task | Git worktree per agent + tmux sessions |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Agent-agnostic (Claude Code, Codex, Gemini, Aider, OpenCode, Amp, custom) |
+| **Interface** | Graphical desktop app with panes and diff review | Terminal TUI |
+| **Review tooling** | Built-in diff/file editor, staging, commit | Terminal-native; review in the agent or your editor |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | CLI (macOS, Linux) |
+| **License** | Source-available (ELv2) | Open source (AGPL-3.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Claude Squad?
+
+Claude Squad is an open-source terminal app that manages multiple AI coding agents in separate isolated workspaces so you can run several tasks at once. It combines Git worktrees for per-branch code isolation with tmux for per-agent terminal sessions, driven from a single TUI (`cs`). It is agent-agnostic -- Claude Code, Codex, Gemini, Aider, OpenCode, Amp, and any local agent via custom configuration -- and is AGPL-3.0 licensed, installable via Homebrew or a curl script on macOS and Linux.
+
+## Key Differences
+
+### Terminal TUI vs Desktop Workspace
+
+Claude Squad lives entirely in the terminal. It is fast, keyboard-driven, and pairs worktrees with tmux to keep sessions isolated. Superset is a graphical desktop workspace: the same worktree-per-task isolation, but with panes, a built-in diff and file editor, an in-app browser for docs and dev servers, and one-click handoff into your IDE. Which you prefer comes down to whether you want a lean terminal tool or a full workspace UI.
+
+### Review and Extras
+
+Because Claude Squad is terminal-native, review happens in the agent itself or in whatever editor you open. Superset adds review, browser preview, port management, and MCP tooling in one app. If you want those surfaces built in rather than assembled yourself, that is Superset's advantage.
+
+### Reach Beyond One Machine
+
+Superset extends past the local desktop with remote and cloud workspaces on your own network devices, plus a CLI and MCP server. Claude Squad runs locally. If moving work across machines or scripting the orchestration matters, Superset offers more.
+
+### Shared Foundation
+
+Both are agent-agnostic and both make a Git worktree per agent the unit of isolation, so the core workflow -- many agents, separate branches, review before merge -- is the same. The difference is the surface: a TUI versus a desktop workspace with more built in.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Claude Squad is free and open source (AGPL-3.0). In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want a graphical workspace with built-in review and browser
+- Need remote, cloud, CLI, or MCP surfaces
+- Prefer a full workspace over assembling terminal tooling yourself
+- Work on more than macOS and Linux, or plan to
+
+**Choose Claude Squad if you:**
+
+- Live in the terminal and want a lean, keyboard-driven TUI
+- Are comfortable with tmux and reviewing in your own editor
+- Want a free, open-source tool with minimal footprint
+- Only need local, single-machine orchestration
+
+**Verdict:** Claude Squad is a great fit if you want a lightweight terminal multiplexer for parallel agents and are happy managing review yourself. Superset is the better fit if you want the same worktree model wrapped in a desktop workspace with review, browser, remote hosting, and MCP built in.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and Claude Squad both use Git worktrees?
+
+Yes. Both isolate each agent in its own Git worktree and branch. Claude Squad adds tmux for terminal sessions; Superset adds a desktop UI, review, and browser around the same model.
+
+### Is Claude Squad only for Claude Code?
+
+No. Despite the name, Claude Squad is agent-agnostic and runs Claude Code, Codex, Gemini, Aider, OpenCode, Amp, and custom agents. Superset is likewise agent-agnostic.
+
+### Which one has a graphical interface?
+
+Superset is a graphical desktop app. Claude Squad is a terminal TUI. If you want built-in visual diff review and a browser, Superset provides them; if you prefer the terminal, Claude Squad is lighter.

--- a/apps/marketing/content/compare/superset-vs-cmux.mdx
+++ b/apps/marketing/content/compare/superset-vs-cmux.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs cmux (2026): Agent Terminal vs Agent Orchestrator"
+description: "Compare Superset and cmux for running AI coding agents. See how a native terminal for agents differs from a Git worktree orchestration workspace."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - cmux
+keywords:
+  - superset vs cmux
+  - cmux alternative
+  - cmux claude code
+  - terminal for ai agents
+  - agent terminal
+  - ai coding terminal
+---
+
+Superset and cmux both help you run many AI coding agents at once, but they sit in different categories. cmux is a native terminal built for agents: it makes concurrent sessions visible and controllable in one polished macOS app. Superset is an orchestration workspace: it gives every task its own Git worktree and layers review, browser, and automation around the agents. One organizes your agent sessions; the other isolates and manages the work each agent does.
+
+---
+
+## At a Glance
+
+| | **Superset** | **cmux** |
+|---|---|---|
+| **Category** | Agent orchestration workspace | Native terminal for AI agents |
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Runs agent sessions in vertical tabs and split panes with notifications and an embedded browser |
+| **Isolation** | Automatic Git worktree per task | None built in -- isolation is left to the agent or to you |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Any terminal agent (Claude Code, Codex, OpenCode, Gemini, Aider, Goose, and more) |
+| **Review tooling** | Built-in diff/file editor, staging, and commit | Terminal-native; review happens in the agent or your editor |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | macOS only |
+| **License** | Source-available (ELv2) | Open source (GPL-3.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is cmux?
+
+cmux is a native macOS terminal built specifically for running AI coding agents. Built on a GPU-accelerated core, it adds vertical tabs, split panes, notification "rings" around a pane when a process needs attention, an embedded scriptable browser, and a programmable socket API. Its goal is to make many concurrent agent sessions visible and controllable in one native app, including surfacing an agent's subagents as their own panes. cmux runs any terminal-launchable agent and is free and open source under GPL-3.0, on macOS only.
+
+> Note: two actively maintained tools share the name "cmux." This page is about the native macOS agent terminal from manaflow. A separate, smaller project (craigsc/cmux) is a Claude-Code-only bash CLI that does use Git worktrees per agent; if that is the tool you mean, its model is closer to Superset's but far narrower in scope.
+
+## Key Differences
+
+### Organizing Sessions vs Isolating Work
+
+This is the core distinction. cmux is a terminal: it makes your agent sessions easy to see, split, and switch between, but it does not isolate what each agent changes. If two agents work on the same repository, they share one working directory unless you set up isolation yourself. Superset makes a Git worktree per task the default, so every agent gets its own branch and directory automatically. cmux answers "how do I see all my agents?"; Superset answers "how do I run agents on the same repo without collisions?"
+
+### Review and Merge Flow
+
+Because cmux is terminal-native, reviewing and merging happens in the agent itself or in whatever editor you open afterward. Superset includes a built-in diff and file editor where you can review, stage, and commit each task's changes, then jump into VS Code, Cursor, JetBrains, or Xcode if you prefer. If you want the review layer inside the same app that runs the agents, that is a Superset feature rather than a cmux one.
+
+### Beyond the Terminal
+
+Superset extends past a single machine with remote and cloud workspaces, scheduled automations with a TypeScript SDK, and CLI and MCP server surfaces. cmux is focused on being an excellent native terminal on macOS, with an embedded browser and scripting API for driving sessions. They can even be complementary: some developers will keep cmux as their daily agent terminal and reach for a worktree orchestrator when multiple agents need to touch the same repo.
+
+### Platform
+
+cmux is macOS only today. Superset ships on macOS now, with Windows and Linux planned, and also runs as a CLI and MCP server. If you need anything beyond macOS, that is a practical difference.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. cmux is free and open source, with an optional paid edition for early access to upcoming features. In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want automatic Git worktree isolation so agents can share one repo safely
+- Want built-in diff review and merge inside the same app
+- Need remote, cloud, CLI, or MCP surfaces
+- Work on more than just macOS, or plan to
+
+**Choose cmux if you:**
+
+- Want a fast, native macOS terminal purpose-built for agent sessions
+- Mostly run one agent (or manage isolation yourself) and value terminal polish
+- Like an embedded browser and a scriptable API in your terminal
+- Prefer a fully open-source GPL tool
+
+**Verdict:** These tools are not really substitutes. cmux is the best fit if your goal is a beautiful native terminal that keeps many agent sessions organized. Superset is the better fit if your goal is running multiple agents on the same repository without collisions, with review and orchestration built in. Many developers will end up using a terminal like cmux alongside an orchestrator like Superset.
+
+---
+
+## Frequently Asked Questions
+
+### Does cmux use Git worktrees?
+
+The native macOS cmux terminal does not isolate tasks in Git worktrees itself -- that is left to the agent or to you. (A separate, smaller project that shares the name, craigsc/cmux, does use worktrees but only for Claude Code.) Superset makes a worktree per task automatic.
+
+### Is cmux only for macOS?
+
+Yes. The cmux agent terminal is macOS only today. Superset ships on macOS now with Windows and Linux planned, plus CLI and MCP surfaces.
+
+### Can I use cmux and Superset together?
+
+Yes. They solve different problems. You can keep cmux as your native agent terminal and use Superset when multiple agents need isolated worktrees on the same repository, with review and orchestration in one place.
+
+### What is the best terminal for AI coding agents?
+
+If you want a polished native terminal for agent sessions on macOS, cmux is a strong choice. If your bottleneck is coordinating several agents on one repository, the deciding factor becomes worktree isolation and review, which is what Superset is built around. See our roundup of the [best terminal for AI coding agents](/compare/best-terminal-for-ai-coding).

--- a/apps/marketing/content/compare/superset-vs-codex-app.mdx
+++ b/apps/marketing/content/compare/superset-vs-codex-app.mdx
@@ -1,0 +1,103 @@
+---
+title: "Superset vs Codex App (2026): Local Worktrees vs Cloud Coding Agents"
+description: "Compare Superset and the OpenAI Codex app for parallel AI coding. See how local Git worktree orchestration differs from Codex's cloud task environments."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - codex-app
+keywords:
+  - superset vs codex app
+  - codex app alternative
+  - codex app
+  - openai codex app
+  - codex cloud agents
+  - conductor vs codex app
+---
+
+Codex is OpenAI's coding agent, offered as one product across a terminal CLI, an editor extension, a cloud service, a desktop app, and a web experience that all share one account and usage limits. When people say "the Codex app," they usually mean the desktop and cloud experience that runs coding tasks in parallel cloud environments. Superset takes a different approach: it runs agents in parallel on your own machine, each in an isolated Git worktree. This page compares those two models.
+
+For the terminal-focused comparison, see [Superset vs Codex CLI](/compare/superset-vs-codex).
+
+---
+
+## At a Glance
+
+| | **Superset** | **Codex App** |
+|---|---|---|
+| **Category** | Local-first agent orchestration workspace | OpenAI's Codex coding suite (app + cloud) |
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Runs Codex coding tasks across CLI, editor, desktop, web, and cloud |
+| **Parallelism** | Many agents on separate branches on your machine | Multiple tasks in parallel cloud environments |
+| **Isolation** | Automatic local Git worktree per task | Isolated cloud environments per task |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | OpenAI Codex |
+| **Where code runs** | Your local machine (and your own remote/cloud hosts) | OpenAI-managed cloud sandboxes (plus local CLI/editor) |
+| **Pricing** | Free tier + Pro $20/seat/mo | Included with ChatGPT plans; usage scales by tier |
+| **License** | Source-available (ELv2) | Proprietary (Codex CLI is open source) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is the Codex App?
+
+Codex is OpenAI's agentic coding system, delivered as one product across several surfaces that share a single account, configuration, and usage limits: a terminal CLI, an editor extension, a cloud agent, a desktop app, and a web experience, plus ChatGPT integration. The cloud experience is the distinctive part: you describe a task, Codex clones your repo into an isolated cloud environment, works in the background without using your local machine, and returns a diff and logs to review before you merge. You can start multiple tasks in parallel this way. Codex is included with ChatGPT plans, and usage scales with the plan tier.
+
+## Key Differences
+
+### Where the Work Runs
+
+This is the core difference. The Codex app's flagship parallelism is cloud-hosted: your repository is cloned into OpenAI-managed environments, and tasks run remotely so your machine can be off. Superset runs agents locally, each in a Git worktree on your own disk, using your real environment, dependencies, and services. Cloud execution is convenient for fire-and-forget tasks; local execution keeps everything on your machine and works without a round-trip to a hosted sandbox. Superset also lets you run on your own remote hosts when you want that, but the default is local and under your control.
+
+### One Vendor's Suite vs Agent-Agnostic
+
+Codex runs OpenAI's Codex agent. Superset is agent-agnostic: it can run Codex itself as one of many agents, alongside Claude Code, OpenCode, Cursor, Gemini, and others, all in the same workspace. If you want to standardize on OpenAI's suite, the Codex app is cohesive. If you want to mix agents or avoid tying your workflow to one vendor, Superset is built for that.
+
+### Review and Environment
+
+With the Codex app's cloud tasks, you configure the environment once (dependencies, variables), then review the returned diff and logs. With Superset, each agent runs in your existing checkout as a worktree, so the environment is whatever your machine already has, and you review in the built-in diff editor or jump straight into your own IDE. Teams with complex local setups, private services, or offline constraints often prefer keeping the loop local.
+
+### Pricing Model
+
+The Codex app is included with ChatGPT plans, and usage scales with your tier. Superset offers a free tier and Pro at $20/seat/month, and you bring your own agent providers -- including OpenAI -- so spend on models stays with those providers.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want agents to run locally in isolated Git worktrees on your own machine
+- Run more than one agent, or want to avoid locking into a single vendor
+- Need your real local environment, private services, or offline work
+- Want review and orchestration in one workspace across many agents
+
+**Choose the Codex App if you:**
+
+- Are standardized on OpenAI and want a cohesive Codex suite
+- Like fire-and-forget cloud tasks that run while your machine is off
+- Already pay for a ChatGPT plan and want Codex bundled in
+- Prefer OpenAI-managed environments over local setup
+
+**Verdict:** The Codex app is a strong choice if you live in OpenAI's ecosystem and like cloud tasks that run in the background. Superset is the better fit if you want local, worktree-isolated agents on your own machine, the freedom to run Codex alongside other agents, and a single workspace to orchestrate and review them all.
+
+---
+
+## Frequently Asked Questions
+
+### Is the Codex app the same as Codex CLI?
+
+They are surfaces of the same product. Codex CLI runs in your terminal; the app and cloud experience add a desktop app, a web experience, and parallel cloud task environments. For the CLI-specific comparison, see [Superset vs Codex CLI](/compare/superset-vs-codex).
+
+### Does the Codex app use Git worktrees?
+
+The Codex app's parallel tasks run in isolated cloud environments, not local Git worktrees. Superset makes a local worktree per task the default so agents run on your own machine.
+
+### Can Superset run Codex?
+
+Yes. Superset is agent-agnostic and can run the Codex CLI as one of many agents, each in its own worktree, alongside Claude Code, OpenCode, Cursor, Gemini, and others.
+
+### Which is cheaper?
+
+It depends on usage. The Codex app is bundled with ChatGPT plans and scales with your tier. Superset has a free tier and Pro at $20/seat/month, and you pay OpenAI directly for model usage.

--- a/apps/marketing/content/compare/superset-vs-conductor.mdx
+++ b/apps/marketing/content/compare/superset-vs-conductor.mdx
@@ -2,7 +2,7 @@
 title: "Superset vs Conductor (2026): Comparing AI Agent Orchestration Platforms"
 description: "Compare Superset and Conductor for managing AI coding agents. See how these orchestration tools differ in agent support, workflow, and developer experience."
 date: 2026-02-02
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - conductor
@@ -14,7 +14,7 @@ keywords:
   - conductor vs superset
 ---
 
-Superset and Conductor both run multiple coding agents in parallel with Git worktrees. The difference is scope: Conductor is tightly focused on Claude Code and Codex on macOS, while Superset has grown into a broader local-first workspace for many agents, with chat, browser, and review surfaces around the orchestration core.
+Superset and Conductor both run multiple coding agents in parallel with Git worktrees. The difference is scope: Conductor is a focused macOS app for Claude Code, Codex, and Cursor, while Superset has grown into a broader local-first workspace for many agents, with chat, browser, and review surfaces around the orchestration core.
 
 ---
 
@@ -22,11 +22,11 @@ Superset and Conductor both run multiple coding agents in parallel with Git work
 
 | | **Superset** | **Conductor** |
 |---|---|---|
-| **What it does** | Runs 10+ AI agents in parallel with Git worktree isolation | Runs Claude Code / Codex agents in parallel with Git worktree isolation |
-| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Aider, etc.) | Claude Code and Codex |
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation | Runs Claude Code / Codex / Cursor agents in parallel with Git worktree isolation |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, etc.) | Claude Code, Codex, and Cursor |
 | **Repo model** | Uses your existing local repo and creates isolated worktrees per task | Clones your repo and creates isolated workspaces on your Mac |
 | **Editor handoff** | VS Code, Cursor, JetBrains, Xcode | Cursor and VS Code handoff documented directly |
-| **Workflow style** | Agent-agnostic workspace orchestration | Mac app centered on Claude Code / Codex task flow |
+| **Workflow style** | Agent-agnostic workspace orchestration | Mac app centered on Claude Code / Codex / Cursor task flow |
 | **Platform** | Local-first desktop app | macOS app |
 
 ---
@@ -39,7 +39,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is Conductor?
 
-Conductor is a macOS app from Melty Labs for running Claude Code and Codex in parallel. Its homepage positions it as a Mac app that clones your repo, creates isolated workspaces, and lets you review and merge changes from multiple agents. The docs emphasize workflow guides like issue-to-PR setup, provider configuration, Codex support, and opening workspaces in Cursor or VS Code.
+Conductor is a macOS app from Melty Labs for running Claude Code, Codex, and Cursor agents in parallel. Its homepage positions it as a Mac app that runs those agents in isolated workspaces, then lets you review and merge changes and open pull requests. The docs emphasize workflow guides like issue-to-PR setup, provider configuration, and opening workspaces in Cursor or VS Code.
 
 ---
 
@@ -47,7 +47,7 @@ Conductor is a macOS app from Melty Labs for running Claude Code and Codex in pa
 
 ### Agent Flexibility
 
-Superset is deliberately broad -- any process that runs in a shell can fit into its workflow, and the current product also layers chat, browser preview, and review tooling around those agents. Conductor currently supports Claude Code and Codex. If those are your two primary agents, that focus can be a feature. If you want to mix in OpenCode, Aider, custom scripts, or whatever launches next month, Superset gives you more room to adapt.
+Superset is deliberately broad -- any process that runs in a shell can fit into its workflow, and the current product also layers chat, browser preview, and review tooling around those agents. Conductor supports Claude Code, Codex, and Cursor. If those are your primary agents, that focus can be a feature. If you want to mix in OpenCode, Gemini, custom scripts, or whatever launches next month, Superset gives you more room to adapt.
 
 ### Mac App Workflow vs Agent-Agnostic Terminal
 
@@ -80,11 +80,11 @@ Superset offers a free tier and Pro at $20/seat/month. Conductor's current websi
 
 **Choose Conductor if you:**
 
-- Primarily use Claude Code and Codex and want a focused Mac app for them
-- Want a polished issue-to-PR style workflow around those two agents
+- Primarily use Claude Code, Codex, and Cursor and want a focused Mac app for them
+- Want a polished issue-to-PR style workflow around those agents
 - Prefer Conductor's workspace dashboard and documented Cursor/VS Code handoff
 
-**Verdict:** Conductor is strongest if your world already revolves around Claude Code and Codex on macOS. Superset is the better fit if you expect your agent mix to change, want the orchestration layer to stay editor-independent, or care more about breadth than a tightly scoped app workflow.
+**Verdict:** Conductor is strongest if your world already revolves around Claude Code, Codex, and Cursor on macOS. Superset is the better fit if you expect your agent mix to change, want the orchestration layer to stay editor-independent, or care more about breadth than a tightly scoped app workflow.
 
 ---
 
@@ -96,7 +96,7 @@ Conductor currently markets itself as a Mac app. Its homepage language and downl
 
 ### Can Conductor run agents other than Claude Code?
 
-Conductor's current public positioning is Claude Code and Codex. If you want OpenCode, Aider, or custom CLI tools in the same orchestrator, Superset is the more flexible choice.
+Conductor supports Claude Code, Codex, and Cursor. If you want OpenCode, Gemini, or custom CLI tools in the same orchestrator, Superset is the more flexible choice.
 
 ### Do both tools use Git worktrees?
 

--- a/apps/marketing/content/compare/superset-vs-crystal.mdx
+++ b/apps/marketing/content/compare/superset-vs-crystal.mdx
@@ -1,0 +1,104 @@
+---
+title: "Superset vs Crystal (2026): Comparing Parallel Claude Code Workspaces"
+description: "Compare Superset and Crystal (now Nimbalyst) for running Claude Code and Codex in parallel Git worktrees. See how agent breadth, remote workflows, and scope differ."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - crystal
+keywords:
+  - superset vs crystal
+  - crystal alternative
+  - nimbalyst alternative
+  - parallel claude code
+  - claude code worktrees
+  - agentic ide
+---
+
+Superset and Crystal both run multiple Claude Code and Codex sessions in parallel Git worktrees inside one desktop app, with per-session diff review and integrated Git operations. The difference is scope and direction: Crystal is a focused, open-source app for Claude Code and Codex, now continuing under the name Nimbalyst, while Superset is a broader, agent-agnostic workspace that adds more agents, an in-app browser, remote and cloud workspaces, and automation.
+
+Note: Crystal has been renamed and is being succeeded by [Nimbalyst](https://nimbalyst.com/) as of early 2026. If you are evaluating "Crystal" today, you are effectively evaluating Nimbalyst.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Crystal (now Nimbalyst)** |
+|---|---|---|
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, browser, and automation | Runs Claude Code and Codex sessions in parallel Git worktrees with review and Git ops |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, Mistral Vibe, and more) | Claude Code and Codex |
+| **Isolation** | Automatic Git worktree per task | Git worktree per session |
+| **Review tooling** | Built-in diff/file editor, staging, commit | In-app diff review, per-iteration commits, rebase/squash/merge |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local desktop |
+| **Automation** | Automations: scheduled sessions, TypeScript SDK, Slack bot | Focused on interactive sessions |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Windows, Linux) |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces and can schedule agent sessions as automations. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Crystal?
+
+Crystal is an open-source Electron desktop app for running multiple Claude Code and Codex sessions in parallel Git worktrees. Each session gets its own worktree, with per-iteration commits, in-app diff review, and integrated Git operations like rebase, squash, and merge without leaving the app. It is MIT licensed and runs on macOS, Windows, and Linux. Its maintainers have renamed the project and now direct active development to Nimbalyst, so treat "Crystal" as the legacy name for what is now Nimbalyst.
+
+## Key Differences
+
+### Agent Breadth
+
+Crystal is built around Claude Code and Codex. If those are your two agents, its focus is a feature. Superset is deliberately agent-agnostic: it runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents you define. If you want to mix agents or adopt new ones as they launch, Superset gives you more room.
+
+### Same Worktree Core, Wider Surface
+
+Both apps make a Git worktree per session the unit of work and both include strong in-app review and Git operations. Around that, Superset adds an in-app browser for docs and dev servers, port management, an MCP server, and one-click handoff into more editors. Crystal keeps a tighter footprint focused on the review-and-merge loop for Claude Code and Codex.
+
+### Reach and Automation
+
+Superset extends past the local desktop with remote and cloud workspaces on your own network devices, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. Crystal is a local, interactive desktop app. If you want unattended or scheduled runs, or work that moves across machines, Superset covers more of it.
+
+### Project Status
+
+Crystal is stable and open source, but its maintainers have moved active development to Nimbalyst. Superset is actively developed under its current name. If long-term maintenance direction matters to you, factor in the Nimbalyst transition when evaluating Crystal.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Crystal is free and open source (MIT). In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Use more than Claude Code and Codex, or want to adopt new agents freely
+- Want remote, cloud, CLI, or MCP surfaces around the same worktree model
+- Need scheduled or unattended runs through automations
+- Prefer an actively developed product under one name
+
+**Choose Crystal (Nimbalyst) if you:**
+
+- Primarily use Claude Code and Codex and want a focused desktop app
+- Want a free, MIT-licensed tool with strong in-app Git operations
+- Work on one machine and value a tight review-and-merge loop
+
+**Verdict:** Crystal is a clean, open-source choice if Claude Code and Codex are your world and you want a focused parallel-worktree app -- just note its transition to Nimbalyst. Superset is the better fit if you want the same worktree model with broader agent support, an in-app browser, remote and cloud workspaces, and automation.
+
+---
+
+## Frequently Asked Questions
+
+### Is Crystal still maintained?
+
+Crystal has been renamed and its maintainers now direct active development to Nimbalyst. It still works, but new development happens under the Nimbalyst name.
+
+### Do both use Git worktrees?
+
+Yes. Both give each session its own Git worktree, branch, and working directory. The isolation model is the same; the products differ in agent breadth and surrounding features.
+
+### Can Crystal run agents other than Claude Code and Codex?
+
+Crystal is built specifically for Claude Code and Codex. If you want OpenCode, Cursor, Gemini, or custom agents in the same workspace, Superset is the more flexible choice.

--- a/apps/marketing/content/compare/superset-vs-orca.mdx
+++ b/apps/marketing/content/compare/superset-vs-orca.mdx
@@ -1,0 +1,107 @@
+---
+title: "Superset vs Orca (2026): Comparing Worktree-Based Agent Workspaces"
+description: "Compare Superset and Orca for running AI coding agents in parallel Git worktrees. See how these agent development environments differ in remote workflows, automation, and scope."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - orca
+keywords:
+  - superset vs orca
+  - orca alternative
+  - orca ade alternative
+  - agentic ide
+  - ai agent orchestration
+  - worktree agent workspace
+---
+
+Superset and Orca are unusually close in design. Both are desktop workspaces that run many AI coding agents in parallel, give each task its own Git worktree, and add diff review and an in-app browser around the orchestration core. The differences are not about the core idea -- they are about scope, remote and cloud workflows, automation, and how far each product extends beyond a single machine.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Orca** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Runs multiple AI agents in parallel with Git worktree isolation and per-task browser tabs |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Local agent development environment (ADE) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Agent-agnostic (25+ CLI agents, including Claude Code, Codex, OpenCode, Cursor CLI, Gemini) |
+| **Isolation** | Automatic Git worktree per task | Automatic Git worktree per task |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local desktop, plus iOS and Android companion apps |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Focused on interactive parallel runs |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Windows, Linux) + mobile companions |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Orca?
+
+Orca is a free, open-source desktop "agent development environment" from Stably. It runs multiple coding agents in parallel, giving every task its own Git worktree, its own agent terminal, and its own browser tab, with a unified UI for diffs, pull request and CI inspection, file browsing, and agent-status tracking. Its pitch is to fan one prompt across several agents, compare the results, and merge the winner. Orca is agent-agnostic, supports 25+ CLI agents, ships on macOS, Windows, and Linux, and offers iOS and Android companion apps. It is MIT licensed.
+
+## Key Differences
+
+### Same Worktree Model, Different Reach
+
+Both products make one Git worktree per task the default primitive, so this is not where they diverge. The difference is reach. Superset extends past the local desktop into remote and cloud workspaces that run on your own network devices, so you can start a task on one machine and pick it up from another. Orca is a local desktop environment with mobile companion apps for monitoring and control. If your work stays on one machine, both feel similar. If you want to move work across machines or run agents on a remote host, Superset covers more of that surface.
+
+### Automation and Scheduling
+
+Superset includes Automations: you can schedule agent sessions like cron jobs, drive them with a TypeScript SDK, and trigger or receive them through a Slack bot. That makes it suited to recurring or unattended work such as nightly dependency bumps, scheduled test runs, or triage. Orca is centered on interactive parallel runs where you launch, compare, and merge in the moment. If you want agents to run on a schedule or as part of a larger pipeline, Superset has more built in.
+
+### Breadth of Surfaces
+
+Beyond the desktop app, Superset is also available as a command-line interface and an MCP server, so the same orchestration can be scripted or embedded into other tools. Orca focuses on its desktop ADE plus mobile companions. Both are agent-agnostic and both give each task a browser, so day to day they overlap heavily; Superset simply exposes more entry points around the same core.
+
+### Licensing
+
+Orca is MIT licensed, which is maximally permissive. Superset is source-available under the Elastic License 2.0. For most individual developers and teams the practical experience is the same, but if a fully permissive open-source license is a hard requirement, that is a real distinction worth noting.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Orca is free and open source, with a bring-your-own-subscription model. In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want remote and cloud workspaces, not just a single local desktop
+- Need scheduled or unattended agent runs through automations and an SDK
+- Want CLI and MCP server surfaces around the same orchestration
+- Care about enterprise features like SOC 2 and team workflows
+
+**Choose Orca if you:**
+
+- Want a free, MIT-licensed desktop ADE for parallel agents
+- Mostly work on one machine and value the fan-out-and-compare workflow
+- Want mobile companion apps to monitor runs
+- Prefer a fully permissive open-source license
+
+**Verdict:** Orca and Superset share the same foundation, so you will not go wrong with either for local parallel agent work. Orca is a clean, free, open-source choice if your work lives on one machine. Superset is the better fit if you want the orchestration to extend across remote and cloud hosts, run on a schedule, and expose CLI and MCP surfaces for larger workflows.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and Orca both use Git worktrees?
+
+Yes. Both create an isolated Git worktree for each task, giving every agent its own branch and working directory. The isolation mechanism is the same; the products differ in reach, automation, and surfaces.
+
+### Is Orca open source?
+
+Yes. Orca is MIT licensed and free to use. Superset is source-available under the Elastic License 2.0 and offers a free tier plus paid Pro.
+
+### Can both run agents other than Claude Code?
+
+Yes. Both are agent-agnostic. Orca lists 25+ supported CLI agents, and Superset runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents.
+
+### Which one works across multiple machines?
+
+Superset adds remote and cloud workspaces that run across your own network devices, so a task can move between machines. Orca is a local desktop environment with iOS and Android companion apps for monitoring and control.

--- a/apps/marketing/content/compare/superset-vs-sculptor.mdx
+++ b/apps/marketing/content/compare/superset-vs-sculptor.mdx
@@ -1,0 +1,102 @@
+---
+title: "Superset vs Sculptor (2026): Comparing Parallel Coding Agent Desktops"
+description: "Compare Superset and Imbue's Sculptor for running coding agents in parallel. See how agent-agnostic worktree orchestration differs from a container-and-pairing model."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - sculptor
+keywords:
+  - superset vs sculptor
+  - sculptor alternative
+  - sculptor imbue
+  - parallel coding agents
+  - agentic ide
+  - claude code parallel
+---
+
+Superset and Sculptor are both desktop apps for running coding agents in parallel with isolated workspaces and built-in review. Sculptor, from the AI lab Imbue, centers on Claude Code and Imbue's own Pi harness, with an isolated environment per agent and a "Pairing Mode" that syncs an agent's work back into your local repo. Superset is broader and agent-agnostic, making a Git worktree per task the default across many agents, with an in-app browser, MCP, and remote and cloud workspaces around it.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Sculptor** |
+|---|---|---|
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Runs coding agents in parallel isolated environments with pairing back to your repo |
+| **Isolation** | Automatic Git worktree per task | Isolated worktrees per workspace, plus optional containers |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Claude Code and Imbue's Pi; can manage other terminal agents |
+| **Signature feature** | Broad agent-agnostic orchestration + remote/cloud hosts | Pairing Mode syncs an agent's work into your local repo/IDE |
+| **Review tooling** | Built-in diff/file editor, staging, commit | In-app review with pairing to local checkout |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS Apple Silicon, Linux; Intel Mac and Windows planned) |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Sculptor?
+
+Sculptor is a desktop app from Imbue for running coding agents in parallel. You connect a repository, create isolated workspaces, and prompt agents that each run in their own environment; a "Pairing Mode" syncs an agent's work back into your local repo and IDE. It isolates work with worktrees per workspace, plus an experimental container backend for remote or containerized execution. Sculptor ships with Claude Code and Imbue's Pi harness and can manage other terminal-based agents. It is MIT licensed, free in beta (bring your own Anthropic API key or Claude Pro/Max), and runs on Apple Silicon macOS and Linux, with Intel Mac and Windows planned.
+
+## Key Differences
+
+### Agent Breadth
+
+Sculptor centers on Claude Code and Imbue's Pi harness, though it can manage other terminal agents. Superset is agent-agnostic from the ground up, running Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom agents in the same workspace. If your work spans several agents or you want to swap them freely, Superset gives you more room; if you mainly use Claude Code and Pi, Sculptor is tailored to that.
+
+### Pairing vs Worktree-First Orchestration
+
+Sculptor's signature is Pairing Mode: an agent works in an isolated environment, and its changes sync back into your local checkout and IDE. Superset keeps the worktree itself as the unit you work in, with in-app review and one-click handoff to your editor. Both isolate agents; they differ in how the isolated work rejoins your main checkout.
+
+### Containers and Reach
+
+Sculptor offers an experimental container backend alongside worktrees. Superset's default is a local Git worktree per task, and it extends across your own network devices with remote and cloud workspaces, plus CLI and MCP surfaces. If you want containerized isolation specifically, Sculptor leans that way; if you want worktree-first orchestration that spans machines, Superset does.
+
+### Maturity and Platform
+
+Both are actively evolving. Superset ships on macOS today with Windows and Linux planned, plus CLI and MCP. Sculptor runs on Apple Silicon macOS and Linux, with Intel Mac and Windows on the way, and is in free beta. Match the platform support to your fleet.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Sculptor is open source and free in beta, using your own Anthropic API key or Claude plan. In both cases, you still pay the underlying providers for model usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Run several agents, or want to swap agents freely
+- Want worktree-first orchestration that spans local, remote, and cloud hosts
+- Want an in-app browser, MCP, and CLI surfaces built in
+- Need a workspace to rely on across a mixed platform fleet
+
+**Choose Sculptor if you:**
+
+- Mainly use Claude Code and Imbue's Pi harness
+- Like the Pairing Mode workflow that syncs agent work into your local IDE
+- Want an experimental container backend for isolation
+- Are comfortable with a free beta on macOS or Linux
+
+**Verdict:** Sculptor is a strong pick if Claude Code and Pi are your focus and you like its pairing and container model. Superset is the better fit if you want agent-agnostic, worktree-first orchestration across many agents, with review, browser, MCP, and remote and cloud workspaces in one place.
+
+---
+
+## Frequently Asked Questions
+
+### Does Sculptor use Git worktrees or containers?
+
+Both. Sculptor isolates workspaces with worktrees and also offers an experimental container backend. Superset's default is a local Git worktree per task, with remote and cloud hosts available when you want them.
+
+### Is Sculptor only for Claude Code?
+
+Sculptor ships with Claude Code and Imbue's Pi harness and can manage other terminal agents, but it is centered on that pair. Superset is agent-agnostic across many agents.
+
+### What is Pairing Mode?
+
+Pairing Mode is a Sculptor feature that syncs an agent's work from its isolated environment back into your local repository and IDE. Superset instead keeps the worktree as the place you review and hand off from.

--- a/apps/marketing/content/compare/superset-vs-t3-code.mdx
+++ b/apps/marketing/content/compare/superset-vs-t3-code.mdx
@@ -1,0 +1,109 @@
+---
+title: "Superset vs T3 Code (2026): Comparing Coding Agent Control Planes"
+description: "Compare Superset and T3 Code for orchestrating AI coding agents in Git worktrees. See how a mature agent workspace differs from an early open-source control plane."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - t3-code
+keywords:
+  - superset vs t3 code
+  - t3 code alternative
+  - t3 code
+  - coding agent control plane
+  - agentic ide
+  - worktree agent workspace
+---
+
+Superset and T3 Code aim at the same idea: a single GUI that orchestrates multiple AI coding agents, each writing to its own branch in an isolated Git worktree. The main difference today is maturity and scope. T3 Code is a new, openly experimental control plane from the T3 team. Superset is a further-along workspace that wraps the same worktree model in review, browser, remote hosting, and automation surfaces.
+
+Note that T3 Code is a distinct product from T3 Chat, the AI chat app. For that comparison, see [Superset vs T3 Chat](/compare/superset-vs-t3-chat).
+
+---
+
+## At a Glance
+
+| | **Superset** | **T3 Code** |
+|---|---|---|
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, browser, and automation | A control plane that runs coding agents, each thread on its own branch/worktree |
+| **Isolation** | Automatic Git worktree per task | Git worktree per agent thread (worktree/local toggle) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, Mistral Vibe, and more) | Claude Code, Codex, OpenCode, Cursor (more planned) |
+| **Maturity** | Established, with SOC 2 and remote/cloud workspaces | Very early alpha (expect rapid change) |
+| **Review tooling** | Built-in diff/file editor, staging, commit | Inline diff review, one-button commit/push/PR |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local desktop and CLI launcher |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Windows, Linux) plus `npx` launcher |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces and can schedule agent sessions as automations. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is T3 Code?
+
+T3 Code is an open-source desktop and web GUI from Theo Browne's T3 team, described as a control plane for coding agents. It orchestrates multiple agents from one workspace, and every agent thread writes to its own branch, with a per-thread toggle between an isolated worktree and the local checkout. It wraps agents like Claude Code, Codex, OpenCode, and Cursor on a bring-your-own-subscription basis, adds inline diff review and one-button commit, push, and PR creation, and runs on macOS, Windows, and Linux (or via an `npx` launcher). It is MIT licensed and, by its maintainers' own description, very early alpha software.
+
+## Key Differences
+
+### Maturity and Scope
+
+The honest headline difference is maturity. T3 Code is new and openly labeled as early alpha, so features and stability are moving fast. Superset covers the same worktree-per-task idea but has grown a larger surface around it: remote and cloud workspaces, scheduled automations with a TypeScript SDK and Slack bot, an MCP server, and enterprise groundwork like a passed SOC 2 audit. If you want to experiment on the leading edge, T3 Code is appealing. If you want a workspace to rely on for daily multi-agent work, Superset is further along.
+
+### Same Isolation Idea, Different Surface Area
+
+Both make a per-task branch and worktree the unit of work, and both offer inline diff review with quick commit and PR flows. Around that shared core, Superset adds an in-app browser for docs and dev servers, port management, and one-click handoff into VS Code, Cursor, JetBrains, or Xcode. T3 Code keeps a tighter footprint as a front-end over your chosen agents. So the deciding question is less "does it use worktrees" -- both do -- and more how much surrounding workflow you want built in.
+
+### Agent Breadth
+
+T3 Code currently wraps Claude Code, Codex, OpenCode, and Cursor, with more planned. Superset runs those plus Copilot, Gemini, Mistral Vibe, and custom terminal agents you define with your own launch command. If your agent mix is broad or changes often, Superset gives you more room today; if you use the common four, T3 Code covers them.
+
+### Reach Beyond One Machine
+
+Superset extends past the local desktop with remote and cloud workspaces that run on your own network devices, plus CLI and MCP surfaces. T3 Code is a local desktop GUI with an `npx` launcher. If moving work across machines or scripting the orchestration matters, Superset has more of that built in.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. T3 Code is free and open source with a bring-your-own-subscription model -- no resold tokens and no quota caps. In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want a mature workspace with review, browser, and automation built in
+- Need remote, cloud, CLI, or MCP surfaces
+- Run a broad or changing set of agents
+- Care about enterprise readiness like SOC 2
+
+**Choose T3 Code if you:**
+
+- Want a free, MIT-licensed, openly experimental control plane
+- Use Claude Code, Codex, OpenCode, or Cursor and like the T3 approach
+- Are comfortable with early alpha software that changes quickly
+- Prefer the smallest possible front-end over your own agents
+
+**Verdict:** T3 Code and Superset share a philosophy: worktree-per-thread orchestration with bring-your-own agents. T3 Code is the choice if you want to ride an early, open, fast-moving project. Superset is the choice if you want the same model with more built-in workflow and the stability to depend on it day to day.
+
+---
+
+## Frequently Asked Questions
+
+### Is T3 Code the same as T3 Chat?
+
+No. T3 Chat is the AI chat app; T3 Code is a separate control plane for coding agents. For the chat comparison, see [Superset vs T3 Chat](/compare/superset-vs-t3-chat).
+
+### Do both use Git worktrees?
+
+Yes. Both give each agent thread its own branch and worktree (T3 Code offers a per-thread worktree-or-local toggle). The isolation model is shared; the products differ in maturity and surrounding features.
+
+### Is T3 Code production ready?
+
+Its maintainers describe it as very early alpha, so expect rapid change. Superset is further along and adds remote/cloud workspaces, automations, and a passed SOC 2 audit.
+
+### Can both run agents other than Claude Code?
+
+Yes. T3 Code supports Claude Code, Codex, OpenCode, and Cursor today. Superset runs those plus Copilot, Gemini, Mistral Vibe, and custom terminal agents.

--- a/apps/marketing/content/compare/superset-vs-vibe-kanban.mdx
+++ b/apps/marketing/content/compare/superset-vs-vibe-kanban.mdx
@@ -1,0 +1,106 @@
+---
+title: "Superset vs Vibe Kanban (2026): A Vibe Kanban Alternative for Parallel Agents"
+description: "Compare Superset and Vibe Kanban for orchestrating AI coding agents in Git worktrees. See why Superset is a natural home as Vibe Kanban sunsets."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - vibe-kanban
+keywords:
+  - superset vs vibe kanban
+  - vibe kanban alternative
+  - vibe kanban
+  - parallel coding agents
+  - agent orchestration board
+  - worktree agent workspace
+---
+
+Vibe Kanban put a Kanban board over AI coding agents: plan work as cards, then spin up workspaces where agents execute in parallel, each in its own Git worktree. It became one of the most popular tools in this category. Bloop has since announced that Vibe Kanban is sunsetting, with the project continuing as community open source, which makes "what do I move to?" a live question. Superset covers the same worktree-based parallel-agent model in an actively developed workspace, so it is a natural place to land.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Vibe Kanban** |
+|---|---|---|
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Kanban board that runs coding agents in parallel workspaces |
+| **Interface** | Agent workspace with panes, diff review, and browser | Kanban board of tasks mapped to agent runs |
+| **Isolation** | Automatic Git worktree per task | Git worktree per workspace/task |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Agent-agnostic (10+, including Claude Code, Codex, Gemini, Copilot, Amp, Cursor, OpenCode) |
+| **Project status** | Actively developed | Sunsetting; continues as community open source |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Cross-platform (Node + Rust) |
+| **License** | Source-available (ELv2) | Open source (Apache-2.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces and can schedule agent sessions as automations. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Vibe Kanban?
+
+Vibe Kanban is an open-source app from Bloop that puts a Kanban board over AI coding agents. You plan work as issues, then spin up workspaces where agents execute in parallel or in sequence, with centralized configuration and review. It is agent-agnostic, switching between 10+ coding agents including Claude Code, Codex, Gemini CLI, Copilot, Amp, Cursor, and OpenCode, and it uses Git worktrees per workspace. It is Apache-2.0 licensed and became the most-starred tool in this category. Bloop has announced that Vibe Kanban is sunsetting; the project continues as community open source, so evaluate its current maintenance state before adopting it.
+
+## Key Differences
+
+### Actively Developed vs Sunsetting
+
+The most practical difference today is direction. Vibe Kanban is sunsetting as a maintained product, even though the open-source code remains. Superset is actively developed, with ongoing work on remote and cloud workspaces, automations, and its review and browser surfaces. If you are choosing where to invest your workflow now, ongoing maintenance matters.
+
+### Board Metaphor vs Agent Workspace
+
+Vibe Kanban organizes work as a Kanban board, mapping cards to agent runs. Superset organizes work as a workspace of live agent sessions, each in its own pane and worktree, with review and an in-app browser alongside. Both run agents in parallel Git worktrees underneath. If you like planning work as a board, Vibe Kanban's metaphor is appealing; if you prefer a live workspace you drive directly, Superset fits better.
+
+### Reach and Surfaces
+
+Superset extends past the local desktop with remote and cloud workspaces on your own network devices, plus CLI and MCP server surfaces and scheduled automations. Vibe Kanban runs locally as a cross-platform app. If you want the orchestration to move across machines or be scripted, Superset offers more of that.
+
+### Shared Foundation
+
+Both are agent-agnostic and both make a Git worktree per task the unit of work, so migrating mental models is easy: your agents, your branches, your review flow. The move from Vibe Kanban to Superset is mostly about trading a board view for a live workspace, and gaining active development plus remote and automation surfaces.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Vibe Kanban is free and open source (Apache-2.0). In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want an actively developed home for parallel agent work
+- Prefer a live agent workspace with built-in review and browser
+- Need remote, cloud, CLI, or MCP surfaces
+- Want scheduled or unattended runs through automations
+
+**Choose Vibe Kanban if you:**
+
+- Specifically want a Kanban-board metaphor over your agents
+- Are comfortable running a sunsetting project as community open source
+- Want a fully permissive Apache-2.0 tool and will self-maintain
+
+**Verdict:** Vibe Kanban popularized the board-over-agents approach, but its sunset makes long-term reliance a question. Superset offers the same worktree-based, agent-agnostic parallel model in an actively developed workspace, with review, browser, remote hosting, and automation built in -- a natural place to move as Vibe Kanban winds down.
+
+---
+
+## Frequently Asked Questions
+
+### Is Vibe Kanban still maintained?
+
+Bloop has announced that Vibe Kanban is sunsetting. The open-source code continues as a community project, but it is no longer positioned as an actively maintained product. Check its current state before adopting it.
+
+### Is Superset a good Vibe Kanban alternative?
+
+Yes. Superset uses the same worktree-per-task, agent-agnostic model, and adds a live agent workspace with review, an in-app browser, remote and cloud workspaces, and automations, under active development.
+
+### Do both use Git worktrees?
+
+Yes. Both give each task its own Git worktree and branch. The isolation model is shared; the interfaces and project direction differ.
+
+### Can Superset run the same agents Vibe Kanban did?
+
+Largely yes. Superset runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents, covering the common agents Vibe Kanban supported.

--- a/apps/marketing/content/compare/superset-vs-windsurf.mdx
+++ b/apps/marketing/content/compare/superset-vs-windsurf.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Superset vs Windsurf (2026): Parallel Agent Orchestration vs AI IDE"
-description: "Compare Superset and Windsurf for AI-assisted development. See how parallel agent orchestration differs from an AI-powered integrated development environment."
+description: "Compare Superset and Windsurf, now Devin Desktop, for AI-assisted development. See how parallel worktree orchestration differs from an AI-powered IDE."
 date: 2026-02-18
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - windsurf
@@ -10,103 +10,105 @@ keywords:
   - superset vs windsurf
   - windsurf alternative
   - windsurf vs superset
+  - devin desktop alternative
   - ai ide comparison
   - ai coding tool comparison
 ---
 
-Windsurf is an AI-powered IDE that embeds AI into every part of the editing experience. Superset is a local-first workspace that runs many AI coding agents in parallel, each in its own Git worktree. They solve fundamentally different problems: Windsurf replaces your editor with an AI-native one, while Superset scales autonomous agent work alongside any editor.
+Windsurf is an AI-powered IDE, now rebranded as Devin Desktop after Cognition's acquisition. Superset is a local-first workspace that runs many AI coding agents in parallel, each in its own Git worktree. They solve different problems: Windsurf, as Devin Desktop, is an AI-native editor with a command center for local and cloud agents, while Superset scales autonomous agent work across isolated worktrees alongside any editor.
+
+Note: as of mid-2026, Windsurf is now Devin Desktop, and the original Cascade agent has been retired in favor of Devin Local. This page uses both names. For Cognition's autonomous cloud engineer, see [Superset vs Devin](/compare/superset-vs-devin).
 
 ---
 
 ## At a Glance
 
-| | **Superset** | **Windsurf** |
+| | **Superset** | **Windsurf (Devin Desktop)** |
 |---|---|---|
-| **Category** | Agent orchestration workspace | AI-powered IDE (VS Code fork) |
-| **AI approach** | Agent-agnostic — works with Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Built-in AI models proxied through Windsurf servers |
-| **Parallelism** | Core feature — 10+ agents across isolated worktrees | Sequential by default; Windsurf Flows handles multi-step tasks |
-| **Editor** | Works alongside any editor (VS Code, Cursor, JetBrains, Xcode) | You must use the Windsurf IDE |
-| **Pricing** | Free tier + Pro $20/seat/mo | Free tier (limited), Pro $15/mo, Ultra $60/mo, Teams $35/seat/mo |
-| **Privacy** | Local Git worktrees; you control agent and provider choices | Code sent to Windsurf servers and third-party AI providers |
+| **Category** | Agent orchestration workspace | AI-powered IDE with an agent command center |
+| **AI approach** | Agent-agnostic -- Claude Code, Codex, OpenCode, Cursor, Gemini, or any CLI agent | Devin Local plus ACP agents (Codex, Claude, OpenCode) |
+| **Parallelism** | Core feature -- 100+ agents across isolated worktrees | Manages local and cloud agents from a Kanban command center |
+| **Isolation** | Automatic Git worktree per task | Cloud isolated; local mechanism not clearly documented |
+| **Editor** | Works alongside any editor (VS Code, Cursor, JetBrains, Xcode) | You use the Devin Desktop IDE |
+| **Pricing** | Free tier + Pro $20/seat/mo | Free tier, Pro $20/mo, Max $200/mo |
 | **License** | Source-available (ELv2) | Closed source |
 
 ---
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Aider, Copilot, Cursor Agent, Gemini CLI, Superset Chat, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
 
 ---
 
-## What Is Windsurf?
+## What Is Windsurf (Devin Desktop)?
 
-Windsurf (from Codeium) is a VS Code fork with AI integrated throughout the editing experience. Its core feature is Cascade, an agentic workflow engine that can read files, write code, run terminal commands, and search your codebase in multi-step flows. It also offers Tab completions, inline chat, and a Memories system that learns your project's patterns over time. Windsurf routes requests through its servers to provide access to multiple AI models.
+Windsurf began as a VS Code fork with AI integrated throughout the editing experience, built around Cascade, an agentic flow engine. After Cognition acquired Windsurf, it was rebranded as Devin Desktop, delivered as an over-the-air update and backwards-compatible with Windsurf. The original Cascade agent has been retired in favor of Devin Local, a from-scratch rewrite in Rust with subagent support. Devin Desktop makes an "Agent Command Center" the default surface -- a Kanban view to manage local and cloud agents, pull requests, and context -- and supports the Agent Client Protocol (ACP), so agents like Codex, Claude, and OpenCode can run inside it alongside Devin.
 
 ---
 
 ## Key Differences
 
-### Single Agent vs Many Agents
+### One IDE vs an Agent-Agnostic Workspace
 
-Windsurf's Cascade is a single agentic flow — it tackles one task at a time through multiple steps (reading code, writing changes, running commands). Superset runs many agents simultaneously in isolated worktrees: one writing tests, another refactoring a service, a third updating docs. Windsurf improves single-task depth; Superset adds multi-task breadth.
+Devin Desktop is an editor: you work inside its IDE, with Devin Local and a command center for managing agents. Superset is a workspace that sits around any editor. It runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom agents, each in its own worktree, and hands off to VS Code, Cursor, JetBrains, or Xcode. If you want one AI-native IDE, Devin Desktop is that; if you want an editor-independent orchestration layer, Superset is built for it.
 
-### Editor Lock-In vs Editor Freedom
+### Isolation Model
 
-Using Windsurf means adopting the Windsurf IDE. If you use JetBrains, Xcode, Neovim, or even Cursor, you have to switch. Superset runs alongside any editor. It now has its own chat, diff/file review, and browser surfaces, but it still treats your editor as interchangeable rather than something it needs to own.
+Superset makes a local Git worktree per task the default, so many agents can work the same repository at once without collisions. Devin Desktop manages multiple agents from its command center and runs autonomous work in the cloud (isolated remotely), but its local per-agent isolation mechanism is not clearly documented. If local worktree isolation is the point, that is Superset's core.
 
-### Model Lock-In vs Model Freedom
+### Hosting External Agents
 
-Windsurf routes all AI requests through its servers and credit system. You get access to multiple models (GPT-4, Claude, etc.) but Windsurf controls the routing and pricing. Superset runs whatever CLI agents you install — or Superset Chat when you want a built-in surface — with your own provider choices. When a new agent ships, you can use it immediately.
+Both can run external CLI agents now. Devin Desktop added ACP support, so ACP-compatible agents run inside it. Superset runs any terminal agent directly in a worktree. The difference is framing: Superset treats agent orchestration as the product, while Devin Desktop treats it as a capability inside an IDE.
 
-### Privacy
+### Reach and Automation
 
-Superset runs agents locally in Git worktrees, and the full source is on GitHub under Elastic License 2.0 (ELv2). Windsurf sends code to its servers and third-party AI providers. Windsurf is closed source, so you cannot audit what data is collected or how it's processed.
+Superset extends past the local desktop with remote and cloud workspaces on your own network devices, plus CLI and MCP surfaces and scheduled automations. Devin Desktop pairs its local IDE with Cognition's cloud agents. Both cross the local/cloud boundary; they differ in whether the center of gravity is a worktree workspace or an IDE.
 
-### Session Persistence
+### Privacy and Licensing
 
-Windsurf's Cascade sessions live within the IDE. Superset adds a stronger workspace layer around autonomous runs: persistent sessions, task-level worktrees, in-app diff/file review, and browser previews for local apps. Long-running tasks are easier to manage when they are attached to explicit worktrees instead of a single editor thread.
+Superset runs agents locally in Git worktrees and is source-available on GitHub under Elastic License 2.0 (ELv2). Windsurf/Devin Desktop is closed source. If auditability and local-first control matter, that is a real distinction.
 
 ---
 
 ## Pricing
 
-Superset offers a free tier and Pro at $20/seat/month. You also pay your agents' API providers directly — no markup, no credit system. Windsurf offers a free tier, Pro at $15/month, Ultra at $60/month, and Teams at $35/seat/month, all using a credit-based system for AI requests.
+Superset offers a free tier and Pro at $20/seat/month, and you pay your agents' providers directly with no markup. Devin Desktop offers a free tier, Pro at $20/month, and Max at $200/month, with team plans available; usage is governed by quotas.
 
 ---
 
 ## Which Should You Choose?
 
-**Choose Windsurf if you:**
-- Want AI deeply embedded in your editing experience (completions, inline chat, multi-step flows)
-- Primarily use VS Code and are comfortable switching to a fork
-- Prefer a single integrated tool that handles editing and AI in one app
-- Don't need to run multiple agents in parallel
+**Choose Windsurf (Devin Desktop) if you:**
+- Want an AI-native IDE with a command center for local and cloud agents
+- Like managing agents and pull requests from a Kanban board
+- Are comfortable adopting Cognition's editor and cloud agents
+- Want ACP agents hosted inside one IDE
 
 **Choose Superset if you:**
-- Run CLI-based coding agents and want to parallelize across 10+ tasks
-- Use JetBrains, Xcode, Neovim, or any non-VS Code editor
-- Need local worktrees and direct control over providers
-- Want agent and model flexibility with no vendor lock-in
-- Need sessions that survive crashes and app restarts
+- Run CLI-based agents and want to parallelize across many isolated worktrees
+- Use JetBrains, Xcode, Neovim, or any editor, and want orchestration to stay independent
+- Need local worktrees plus your own remote and cloud hosts
+- Want agent and model flexibility with no editor lock-in
 
-Both tools can coexist. Use Windsurf as your editor for inline AI assistance, and Superset alongside it to dispatch parallel agents for larger tasks like test generation, refactors, and migrations.
+Both can coexist. Use Devin Desktop as your AI IDE, and Superset alongside it to dispatch parallel agents for larger tasks like test generation, refactors, and migrations.
 
 ---
 
 ## Frequently Asked Questions
 
-### Is Superset a Windsurf replacement?
+### Is Windsurf still called Windsurf?
 
-No. Superset is not an AI IDE with inline completions. It does provide in-app chat, diff/file editing, browser previews, and worktree orchestration, but it is still not trying to replace Windsurf as your full editor. The two products can be used together.
+Windsurf is now Devin Desktop, following Cognition's acquisition. It shipped as a backwards-compatible update, and the original Cascade agent has been replaced by Devin Local. Many people still search for "Windsurf," which is why this comparison keeps the name.
 
-### Does Windsurf support parallel agents?
+### Does Windsurf (Devin Desktop) support parallel agents?
 
-Windsurf's Cascade handles multi-step tasks sequentially within a single flow. It does not run multiple independent agents in parallel across isolated environments. Superset's worktree-based isolation is specifically designed for parallel agent execution.
+Devin Desktop manages multiple local and cloud agents from its command center, and its cloud agents run in isolation. It does not clearly document a local worktree-per-agent model. Superset's worktree isolation is built specifically for parallel agent execution on one repository.
 
 ### Is Superset open source?
 
-No. Superset is source-available on GitHub under Elastic License 2.0 (ELv2). Windsurf is closed source from Codeium.
+Superset is source-available on GitHub under Elastic License 2.0 (ELv2). Windsurf/Devin Desktop is closed source.
 
-### Can I use Windsurf as my editor with Superset?
+### What is the difference between Windsurf and Devin?
 
-Yes. Superset integrates with any editor. You can open Superset worktrees in Windsurf to review agent changes in the full IDE context.
+Windsurf, now Devin Desktop, is the IDE. Devin is Cognition's autonomous cloud software engineer. They are related surfaces from the same company. See [Superset vs Devin](/compare/superset-vs-devin).

--- a/apps/marketing/content/compare/what-is-an-agentic-ide.mdx
+++ b/apps/marketing/content/compare/what-is-an-agentic-ide.mdx
@@ -1,0 +1,106 @@
+---
+title: "What Is an Agentic IDE? A 2026 Guide"
+description: "An agentic IDE lets AI agents plan and execute coding tasks, not just autocomplete. Learn what defines the category, how it differs from AI editors, and where to run agents."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "tutorial"
+competitors:
+  - cursor
+  - zed
+  - conductor
+keywords:
+  - what is an agentic ide
+  - agentic ide meaning
+  - agentic ide
+  - multi agent ide
+  - ai agent editor
+  - agentic coding
+---
+
+An agentic IDE is a development environment where AI agents can autonomously plan and carry out multi-step coding tasks -- reading the codebase, editing multiple files, running commands and tests, and iterating on the results -- rather than only suggesting the next line of code. The shift is from autocomplete to delegation: you describe an outcome, and the agent does the work while you review.
+
+The term is new and a little overloaded, so this guide defines it clearly, separates the two things people mean by it, and explains how to choose.
+
+---
+
+## Autocomplete vs Agent
+
+The first generation of AI coding tools completed code as you typed. You stayed in control of every keystroke; the AI predicted the next few.
+
+An agentic IDE inverts that. You give the agent a task -- "add pagination to the users endpoint and update the tests" -- and it plans the steps, edits the files, runs the test suite, reads the failures, and tries again. You move from writing code to directing and reviewing it. The editor is still there, but it is no longer the center of gravity.
+
+## What Makes an IDE "Agentic"
+
+A tool is meaningfully agentic when it can do most of the following without hand-holding:
+
+- **Plan** a multi-step task from a natural-language goal
+- **Edit across files**, not just the open buffer
+- **Run the terminal** -- build, test, lint, and read the output
+- **Iterate** on errors until the task is done or it asks for help
+- **Use tools** through protocols like MCP to reach docs, databases, and services
+
+Autocomplete and single-file chat do not clear this bar. Planning, multi-file edits, command execution, and iteration are what separate an agentic IDE from an AI-assisted editor.
+
+## The Two Kinds of Agentic IDE
+
+In practice, "agentic IDE" refers to two different product shapes.
+
+### 1. AI editors with an agent mode
+
+These start as editors and add an autonomous agent. You still open files and type, but an agent mode can take over a task end to end. [Cursor](/compare/superset-vs-cursor), Zed, VS Code with GitHub Copilot, and JetBrains with Junie fit here. They are excellent for hands-on work with agent assistance, and several now run multiple agents at once.
+
+### 2. Agent workspaces
+
+These treat the agent as the primary unit. The product is built around launching many agents, isolating each task, and reviewing and merging what they produce. [Superset](/compare/superset-vs-cursor), [Conductor](/compare/superset-vs-conductor), and [Orca](/compare/superset-vs-orca) fit here. You spend less time typing code and more time directing a fleet of agents.
+
+Both are legitimately agentic. The difference is whether the editor or the agent is the center of the product.
+
+## The Multi-Agent Problem
+
+The moment you run more than one agent on the same repository, a new problem appears: collisions. Two agents editing the same working directory will overwrite each other's changes and tangle their branches.
+
+The clean solution is a **Git worktree per task**. A worktree gives each agent its own directory and branch that share the same repository history, so agents can work in parallel without stepping on each other. You review each worktree's diff independently and merge the ones you want.
+
+This is why the strongest multi-agent IDEs are built around worktrees. It is also the dividing line in the category: some tools isolate parallel work in local worktrees ([Superset](/compare/superset-vs-orca), Orca, Conductor, and Cursor 2.0), some push isolation to the cloud as a branch and a pull request (Copilot, Devin, JetBrains), and some edit the working copy with review gating (Zed and most in-editor agent modes).
+
+## Where the Agents Actually Run
+
+An agentic IDE has to run agents somewhere:
+
+- **Locally**, in worktrees on your own machine, using your real environment and services
+- **On a remote host** you own, over the network
+- **In the cloud**, in a managed sandbox that clones your repo and runs tasks in the background
+
+Local execution keeps everything on your machine and works offline; cloud execution is convenient for fire-and-forget tasks. Some tools do one; a few, like Superset, do both.
+
+## How To Choose an Agentic IDE
+
+Start from your bottleneck:
+
+- If you mostly write code with agent assistance, an AI editor like Cursor, Zed, VS Code + Copilot, or JetBrains + Junie is the right home.
+- If you want to host external CLI agents inside an editor, look at Zed, JetBrains, and Devin Desktop, which support the Agent Client Protocol.
+- If your bottleneck is running many agents on one repository without collisions, use an agent workspace built around worktrees, like Superset, Conductor, or Orca.
+
+For a full head-to-head, see [Best Agentic IDE in 2026](/compare/best-agentic-ide). For agent-specific guides, see [Best IDE for Claude Code](/compare/best-ide-for-claude-code) and [Best IDE for OpenAI Codex](/compare/best-ide-for-codex).
+
+## Verdict
+
+An agentic IDE is not just an editor with a smarter autocomplete. It is an environment where agents plan, edit, run, and iterate, and where the hard problems become isolation, review, and orchestration. If you only need agent-assisted editing, an AI editor is enough. If you are running many agents at once, the worktree-per-task workspaces are what the category is really about -- and that is where [Superset](/compare/superset-vs-cursor) is built to live.
+
+## Frequently Asked Questions
+
+### What is an agentic IDE in simple terms?
+
+It is a coding environment where you give an AI agent a task and it plans and executes the steps -- editing files, running commands, and iterating -- instead of only autocompleting code. You direct and review rather than type every line.
+
+### What is the difference between an agentic IDE and an AI editor?
+
+An AI editor centers on you writing code with AI assistance. An agentic IDE centers on agents doing tasks autonomously. Many products blur the line: an AI editor with a strong agent mode is agentic, and an agent workspace can still hand off to an editor.
+
+### What is a multi-agent IDE?
+
+A multi-agent IDE runs several coding agents at once. The safest versions give each agent its own isolated Git worktree so parallel work does not collide. See [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+### Do I need an agentic IDE?
+
+If you only occasionally use AI to complete code, a standard editor is fine. If you delegate whole tasks to agents -- especially several at a time -- an agentic IDE built around worktree isolation and review will save you from collisions and lost work.

--- a/apps/marketing/src/app/sitemap.ts
+++ b/apps/marketing/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import type { MetadataRoute } from "next";
 import { getBlogPosts } from "@/lib/blog";
 import { getChangelogEntries } from "@/lib/changelog";
 import { getComparisonPages } from "@/lib/compare";
+import { getAllLegalSlugs, getLegalPage } from "@/lib/legal";
 import { getAllPeople } from "@/lib/people";
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -76,16 +77,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			priority: 0.3,
 		},
 		{
-			url: `${baseUrl}/privacy`,
-			lastModified: new Date("2025-01-15"),
-			changeFrequency: "yearly",
-			priority: 0.3,
+			url: `${baseUrl}/enterprise`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.8,
 		},
 		{
-			url: `${baseUrl}/terms`,
-			lastModified: new Date("2025-01-15"),
-			changeFrequency: "yearly",
-			priority: 0.3,
+			url: `${baseUrl}/roadmap`,
+			lastModified: new Date(),
+			changeFrequency: "weekly",
+			priority: 0.7,
+		},
+		{
+			url: `${baseUrl}/contact`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.6,
 		},
 	];
 
@@ -124,11 +131,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		}),
 	);
 
+	const legalPages: MetadataRoute.Sitemap = getAllLegalSlugs().map((slug) => {
+		const page = getLegalPage(slug);
+		return {
+			url: `${baseUrl}/${slug}`,
+			lastModified: page?.lastUpdated ? new Date(page.lastUpdated) : new Date(),
+			changeFrequency: "yearly" as const,
+			priority: 0.3,
+		};
+	});
+
 	return [
 		...staticPages,
 		...blogPages,
 		...changelogPages,
 		...teamPages,
 		...comparisonPages,
+		...legalPages,
 	];
 }


### PR DESCRIPTION
Minor sitemap and redirect housekeeping across the marketing and docs sites. Adds a few existing routes to the sitemap and tidies up some legacy redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the marketing sitemap to include legal pages and added new static routes.
  * Added multiple new “Best … IDE” roundup and comparison pages, plus a new tutorial: “What Is an Agentic IDE? (2026)”.
* **Bug Fixes**
  * Improved legacy documentation handling with additional redirects to current destinations.
  * Added search-exclusion rules to prevent indexing of raw content surfaces and `llms-full.txt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->