### PR TITLE
feat(marketing): expand agentic IDE compare pages + competitor-vs pages + freshness pass

### DIFF
--- a/apps/marketing/content/compare/best-agentic-ide.mdx
+++ b/apps/marketing/content/compare/best-agentic-ide.mdx
@@ -1,0 +1,176 @@
+---
+title: "Best Agentic IDE in 2026: Multi-Agent Coding Tools Compared"
+description: "Compare the best agentic IDEs of 2026, including Superset, Cursor, Zed, Devin Desktop, VS Code + Copilot, JetBrains Junie, Conductor, and Orca."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "roundup"
+competitors:
+  - cursor
+  - zed
+  - devin-desktop
+  - github-copilot
+  - jetbrains-junie
+  - conductor
+  - orca
+keywords:
+  - agentic ide
+  - best agentic ide 2026
+  - multi agent ide
+  - ai code editor
+  - ai agent editor
+  - ai ide
+  - agentic coding ide
+---
+
+The term "agentic IDE" now covers two different things, and choosing well depends on which one you actually need.
+
+Some tools are AI editors that grew an agent: you write code in a familiar editor, and an agent mode can plan tasks, edit across files, and run commands for you. Others are agent workspaces: the agent is the primary unit, and the product is built around running many of them in parallel, isolating each task, and reviewing the results.
+
+Both are legitimately "agentic." But if your bottleneck is running several coding agents on the same repository without collisions, the deciding factor is isolation and orchestration, not autocomplete quality. That is where an agent-agnostic, worktree-per-task workspace like Superset stands apart.
+
+---
+
+## The Short Version
+
+| Tool | Best for | Agent model | Parallel work isolation | Main tradeoff |
+|---|---|---|---|---|
+| **Superset** | Running many agents in parallel on one repo | Bring your own (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Git worktree per task, local plus remote/cloud | Not a single-editor autocomplete experience |
+| **Cursor** | AI-first editing with parallel agents | Built-in models plus Composer; agent mode | Local git worktrees (up to 8) and cloud VMs | Editor-centric; less agent-agnostic |
+| **Zed** | Fast editor that hosts external agents | Hosts Claude Code, Codex, Gemini via ACP | Working copy with diff review; no per-task worktrees | Not built around parallel isolated runs |
+| **Devin Desktop** | Managing local and cloud agents on a board | Devin Local plus ACP agents | Cloud isolated; local mechanism unspecified | Newer rebrand of Windsurf; in transition |
+| **VS Code + Copilot** | Broadest ecosystem and cloud coding agent | Copilot plus delegation to Claude/Codex | Cloud branch-to-PR; in-editor edits working copy | In-editor parallelism is limited |
+| **JetBrains + Junie** | Agentic coding inside JetBrains IDEs | Junie plus ACP agents | Cloud sandbox (in testing); no local worktrees | Tied to the JetBrains ecosystem |
+| **Conductor** | Focused Mac app for a few agents | Claude Code, Codex, Cursor | Git worktree per task | macOS only; narrow agent set |
+| **Orca** | Free desktop workspace for parallel agents | Agent-agnostic (25+) | Git worktree per task | Fewer remote/automation surfaces |
+
+## Two Kinds of Agentic IDE
+
+### 1. AI editors with agent modes
+
+These start as editors and add autonomous agents. You get familiar editing plus an agent that can plan, edit across files, run the terminal, and iterate on errors. Cursor, Zed, VS Code with Copilot, JetBrains with Junie, and Devin Desktop (the product formerly known as Windsurf) all fit here.
+
+An important 2026 update: several of these now isolate parallel work too. Cursor 2.0 can run multiple agents in local Git worktrees, and Cursor, Copilot, and Devin all offer cloud agents that work on a separate branch and hand back a pull request. So "editors just edit one working copy" is no longer universally true. The nuance is where and how isolation happens.
+
+### 2. Agent workspaces
+
+These treat the agent as the primary unit. The product is built around launching many agents, isolating each task in its own Git worktree, and reviewing and merging results. Superset, Conductor, Orca, and Crystal (now Nimbalyst) fit here. They are less about typing code yourself and more about directing a fleet of agents and reviewing what they produce.
+
+Many developers end up using one of each: an editor for hands-on work and an agent workspace for larger parallel runs.
+
+## Tool-by-Tool Breakdown
+
+### Superset
+
+Superset is an agent-agnostic workspace built around running coding agents in parallel. Every task gets its own Git worktree, branch, and persistent terminal, so agents never collide on the same repository. Around that core it adds a built-in diff and file editor, an in-app browser for docs and dev servers, port management, MCP tooling, and remote and cloud workspaces that run across your own network devices. It runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom agents, and hands off to VS Code, Cursor, JetBrains, or Xcode when you want a full editor.
+
+Best for:
+
+- Running many agents at once on the same codebase
+- Bring-your-own-agent flexibility across vendors
+- Local-first work with optional remote and cloud hosts
+
+### Cursor
+
+Cursor is an AI-first fork of VS Code with a strong agent mode that reads the codebase, edits across files, and runs commands. Cursor 2.0 added a multi-agent interface that can run up to eight agents in parallel, each in its own local Git worktree, plus background agents that run in cloud VMs and hand back a branch. It is one of the most capable editors here, though it is centered on its own models and workflow rather than being agent-agnostic. Pricing starts at a free tier with Pro at $20/month.
+
+For the direct comparison, see [Superset vs Cursor](/compare/superset-vs-cursor).
+
+### Zed
+
+Zed is a fast, GPU-accelerated, open-source editor whose signature strength is hosting external agents. It co-developed the Agent Client Protocol (ACP) and can run Claude Code, Codex, Gemini, and OpenCode inside its agent panel, presenting an editable diff you accept before committing. Zed edits in the working copy with review gating rather than isolating each task in a worktree, so it is excellent for agent-assisted editing but not built around parallel isolated runs. It has a free personal tier (unlimited with your own keys or external agents), Pro at $10/month, and Business at $30/seat.
+
+### Devin Desktop (formerly Windsurf)
+
+Windsurf is now Devin Desktop, following Cognition's acquisition; the original Cascade agent has been retired in favor of Devin Local, a rewritten in-editor agent with subagents. Devin Desktop makes an "Agent Command Center" the default surface, a board to manage local and cloud agents, and it supports ACP so agents like Codex, Claude, and OpenCode can run alongside Devin. Its autonomous cloud agents run remotely; the local parallel-isolation mechanism is less clearly documented. Pricing starts free, with Pro at $20/month and Max at $200/month.
+
+For the direct comparison, see [Superset vs Windsurf](/compare/superset-vs-windsurf).
+
+### VS Code + GitHub Copilot
+
+VS Code with Copilot has the broadest ecosystem of any option. Copilot agent mode plans multi-step tasks, edits across files, and runs the terminal in your local working copy, while the separate Copilot coding agent runs in GitHub's cloud on a branch and opens a pull request. MCP is supported on every plan, and higher tiers can delegate to third-party agents like Claude and Codex. In-editor parallelism is limited, but the cloud coding agent lets you dispatch multiple issues. Plans run from free to Pro at $10, Pro+ at $39, and Max at $100.
+
+For the direct comparison, see [Superset vs GitHub Copilot](/compare/superset-vs-github-copilot).
+
+### JetBrains + Junie
+
+Junie is JetBrains' first-party coding agent, built into AI Chat across IntelliJ, PyCharm, WebStorm, and the rest. It plans multi-step tasks, edits across files, runs tests, and iterates, with a "Brave Mode" that runs actions without prompting. JetBrains co-developed ACP and supports external agents in its IDEs, and it is testing cloud execution in isolated sandboxes. There is no documented local worktree-per-agent model. AI pricing runs from a free tier to Pro at $10, Ultimate at $30, and Enterprise at $60.
+
+### Conductor
+
+Conductor is a native macOS app for running Claude Code, Codex, and Cursor agents in parallel, each in an isolated workspace backed by a Git worktree, with a clean review-and-merge and pull-request flow. It is focused and polished for that agent set, but it is Mac only and narrower than an agent-agnostic workspace. The app is free with a bring-your-own-subscription model.
+
+For the direct comparison, see [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Orca
+
+Orca is a free, open-source desktop "agent development environment" that runs many agents in parallel, each with its own Git worktree and browser tab, and a unified UI for diffs, pull requests, and CI. It is agent-agnostic with 25+ supported agents and runs on macOS, Windows, and Linux with mobile companions. It shares Superset's worktree model, with fewer remote and automation surfaces.
+
+For the direct comparison, see [Superset vs Orca](/compare/superset-vs-orca).
+
+## How To Choose
+
+Pick based on your primary bottleneck:
+
+- If your bottleneck is hands-on editing with an agent assist, use Cursor, Zed, VS Code + Copilot, or JetBrains + Junie.
+- If your bottleneck is hosting external CLI agents inside an editor, Zed, JetBrains, and Devin Desktop lead on ACP support.
+- If your bottleneck is running many agents on one repository without collisions, use an agent workspace: Superset, Conductor, or Orca.
+
+The more agent-heavy your workflow, the more the winning criterion shifts from editing experience to isolation, review, and orchestration.
+
+## Best Picks by Use Case
+
+### Best agentic IDE for parallel agents: Superset
+
+Superset wins when you need multiple agents working at once on the same repository, with worktree isolation, review, and remote hosting built in.
+
+### Best AI editor with parallel agents: Cursor
+
+Cursor is the strongest single-editor experience that also runs multiple agents in local worktrees.
+
+### Best editor for hosting external agents: Zed
+
+Zed's ACP support makes it the cleanest way to run Claude Code, Codex, or Gemini inside a fast editor.
+
+### Best for the broadest ecosystem: VS Code + Copilot
+
+Copilot covers the most surfaces, from in-editor agent mode to a cloud coding agent that opens pull requests.
+
+### Best focused Mac app: Conductor
+
+Conductor is a polished, narrow choice if Claude Code, Codex, and Cursor are your agents and you are on macOS.
+
+## Verdict
+
+There is no single "best agentic IDE" in the abstract. There is a best tool for your workflow:
+
+- Cursor if you want an AI-first editor that also runs parallel agents
+- Zed if you want a fast editor that hosts external CLI agents
+- VS Code + Copilot if you want the broadest ecosystem
+- JetBrains + Junie if you live in JetBrains IDEs
+- Superset if you want to orchestrate many agents in parallel on one repo, with isolation and review as the core
+
+As soon as you are running more than one agent on the same codebase, worktree isolation and review matter more than editor polish. If that is your world, Superset is the agentic IDE to optimize around.
+
+For a broader tool comparison, see [Best AI Coding Tools and Agents (2026)](/compare/best-ai-coding-agents-2026). To understand the category itself, see [What Is an Agentic IDE?](/compare/what-is-an-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is an agentic IDE?
+
+An agentic IDE is a development environment where AI agents can autonomously plan and execute multi-step coding tasks -- editing files, running commands, and iterating -- rather than only autocompleting code. Some are editors with an agent mode; others are workspaces built around running many agents in parallel.
+
+### What is a multi-agent IDE?
+
+A multi-agent IDE runs several coding agents at once. The safest versions give each agent its own isolated Git worktree so parallel work does not collide. Superset, Orca, and Conductor are built around this; Cursor 2.0 also runs multiple agents in local worktrees.
+
+### Which agentic IDE is best for running Claude Code?
+
+If you run one Claude Code session at a time, any strong editor works. If you want several Claude Code sessions in parallel on one repository, a worktree-based workspace like Superset is the better fit. See [Best IDE for Claude Code](/compare/best-ide-for-claude-code).
+
+### Do agentic IDEs isolate parallel work?
+
+It varies. Superset, Orca, Conductor, and Cursor 2.0 use local Git worktrees. Copilot, Devin, and JetBrains push isolation to the cloud (a branch and a pull request). Zed and in-editor agent modes typically edit the working copy with diff review.
+
+### Is Superset an IDE or an orchestrator?
+
+Both, depending on how you use it. It is a workspace where agents are first-class: you orchestrate many of them in isolated worktrees, then review and merge, or hand off to a full editor like VS Code or JetBrains.

--- a/apps/marketing/content/compare/best-ide-for-claude-code.mdx
+++ b/apps/marketing/content/compare/best-ide-for-claude-code.mdx
@@ -1,0 +1,127 @@
+---
+title: "Best IDE for Claude Code in 2026: Where to Run It"
+description: "The best places to run Claude Code in 2026, from the terminal and VS Code to JetBrains, Zed, Conductor, and Superset for parallel worktree sessions."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "roundup"
+competitors:
+  - vs-code
+  - jetbrains
+  - zed
+  - cursor
+  - conductor
+  - cmux
+keywords:
+  - best ide for claude code
+  - where to run claude code
+  - claude code ide
+  - run claude code in vscode
+  - claude code editor
+  - claude code parallel
+---
+
+Claude Code runs almost anywhere: a terminal, an editor extension, a desktop app, the web, and even your phone. So "the best IDE for Claude Code" is really two questions. If you run one session at a time, pick the surface that fits your editor. If you want several Claude Code sessions in parallel on the same repository, the answer changes: you need Git worktree isolation more than another editor pane.
+
+This guide covers both, from the simplest terminal setup to a full parallel-agent workspace.
+
+---
+
+## The Short Version
+
+| Where you run Claude Code | Best for | Parallel sessions on one repo? | Main tradeoff |
+|---|---|---|---|
+| **Superset** | Running many Claude Code sessions at once | Yes -- one Git worktree per task | Not a single-file editor experience |
+| **Terminal (CLI)** | The most complete, scriptable Claude Code | Manual (tmux + worktrees yourself) | You manage isolation and review |
+| **VS Code extension** | Editing alongside Claude Code | Limited without extra tooling | In-editor, single working copy |
+| **JetBrains extension** | JetBrains users | Limited | Tied to JetBrains IDEs |
+| **Zed (ACP)** | A fast editor hosting Claude Code | Working-copy edits with review | No per-task worktrees |
+| **Conductor** | A focused Mac app for a few agents | Yes -- worktrees | macOS only |
+| **cmux** | A native macOS agent terminal | Organizes sessions; no auto isolation | macOS only; isolation is manual |
+
+## Where You Can Run Claude Code
+
+Claude Code is Anthropic's coding agent, and the same engine runs across several official surfaces: the CLI (the most complete), a desktop app, VS Code and JetBrains extensions, the web, and mobile. Beyond Anthropic's own surfaces, Claude Code also runs inside third-party editors and workspaces that host it as an agent. The right choice depends on whether you want a place to edit or a place to orchestrate.
+
+## The Options
+
+### Terminal (Claude Code CLI)
+
+The CLI is the reference surface: it is the most complete, supports scripting and the Agent SDK, and works in any terminal. For a single deep task, it is hard to beat. The catch is parallelism: running several sessions on one repository means managing tmux panes and Git worktrees yourself, then reviewing each diff by hand. Great for one task; more work for many.
+
+### VS Code extension
+
+The VS Code extension puts Claude Code beside your code, so you can edit while it works. It is the natural home if VS Code is your editor. Like most in-editor setups, it operates in a single working copy, so running several isolated sessions at once needs extra tooling.
+
+### JetBrains extension
+
+Claude Code has a JetBrains extension for IntelliJ, PyCharm, WebStorm, and the rest, bringing it into those IDEs with the same shared configuration and MCP support. Ideal if you already live in JetBrains, with the same single-working-copy limitation for parallel work.
+
+### Zed (via ACP)
+
+Zed hosts Claude Code natively through the Agent Client Protocol, running it inside Zed's agent panel and presenting an editable diff you accept before committing. It is one of the cleanest ways to run Claude Code inside a fast, modern editor. Zed edits in the working copy with review gating rather than isolating each task in a worktree.
+
+### Conductor
+
+Conductor is a macOS app that runs Claude Code (and Codex and Cursor) in parallel, each in an isolated Git worktree, with a review-and-merge and pull-request flow. It is a focused, polished way to run a few agents in parallel on a Mac. It is macOS only.
+
+For the direct comparison, see [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### cmux
+
+cmux is a native macOS terminal built for agents. It keeps many Claude Code sessions visible in tabs and split panes with notifications, but it does not isolate what each session changes -- that is left to you. It is a great terminal for agents, not an orchestrator.
+
+For the direct comparison, see [Superset vs cmux](/compare/superset-vs-cmux).
+
+### Superset
+
+Superset runs Claude Code as a first-class agent, giving every session its own Git worktree, branch, and persistent terminal, so multiple Claude Code sessions can work the same repository at once without collisions. Around that it adds a built-in diff and file editor, an in-app browser, MCP tooling, and remote and cloud workspaces. You can review inside Superset or hand off to VS Code, Cursor, JetBrains, or Xcode. It is the strongest fit when your goal is many Claude Code sessions in parallel, not another editor pane.
+
+For the direct comparison, see [Superset vs Claude Code](/compare/superset-vs-claude-code).
+
+## How To Choose
+
+- For one deep task, run the Claude Code CLI in your terminal, or use the VS Code or JetBrains extension if you want to edit alongside it.
+- To host Claude Code inside a fast editor, use Zed's ACP support.
+- To run many Claude Code sessions in parallel on one repository, use a worktree-based workspace like Superset or Conductor.
+
+## Best Picks by Use Case
+
+### Best for a single deep task: Claude Code CLI
+
+The terminal remains the most complete and scriptable way to run Claude Code.
+
+### Best for editing alongside Claude Code: VS Code or JetBrains
+
+The official extensions are the natural home if you want to keep editing in your IDE.
+
+### Best editor host for Claude Code: Zed
+
+Zed's ACP support runs Claude Code cleanly inside a fast, modern editor.
+
+### Best for parallel Claude Code sessions: Superset
+
+Superset gives every session its own worktree, so many can run at once without collisions, with review and orchestration built in.
+
+## Verdict
+
+If you run Claude Code one task at a time, the best IDE is whichever editor you already use: the CLI for depth, VS Code or JetBrains to edit alongside, or Zed to host it inside a fast editor. The moment you want several Claude Code sessions in parallel on the same repository, the deciding factor becomes worktree isolation and review, and a workspace like Superset is the better answer.
+
+For the workflow details, see [How to Run Multiple Claude Code Agents in Parallel](/compare/multiple-claude-code-agents-parallel). For the broader category, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best IDE for Claude Code?
+
+For a single task, the Claude Code CLI or the VS Code and JetBrains extensions are excellent. For running several sessions in parallel on one repository, a worktree-based workspace like Superset is the better fit.
+
+### Can I run Claude Code in VS Code?
+
+Yes. Claude Code has an official VS Code extension that runs it beside your code. For isolated parallel sessions, pair it with a worktree workflow or use a workspace like Superset.
+
+### How do I run multiple Claude Code sessions at once?
+
+Give each session its own Git worktree so they do not share a working directory. You can do this manually with tmux and worktrees, or automatically with a workspace like Superset or Conductor. See [How to Run Multiple Claude Code Agents in Parallel](/compare/multiple-claude-code-agents-parallel).
+
+### Does Claude Code have its own IDE?
+
+Claude Code ships as a CLI, a desktop app, VS Code and JetBrains extensions, a web experience, and mobile apps. For orchestrating many sessions in parallel, developers often add a worktree-based workspace on top.

--- a/apps/marketing/content/compare/best-ide-for-codex.mdx
+++ b/apps/marketing/content/compare/best-ide-for-codex.mdx
@@ -1,0 +1,123 @@
+---
+title: "Best IDE for OpenAI Codex in 2026: Where to Run It"
+description: "The best places to run OpenAI Codex in 2026, from the CLI and IDE extension to the Codex cloud app, Conductor, and Superset for parallel worktree sessions."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "roundup"
+competitors:
+  - vs-code
+  - cursor
+  - codex-app
+  - conductor
+keywords:
+  - best ide for codex
+  - where to run codex
+  - codex worktree
+  - codex ssh
+  - openai codex ide
+  - codex parallel agents
+---
+
+OpenAI's Codex is one product with many faces: a terminal CLI, an editor extension, a desktop app, a web experience, and a cloud service that runs tasks in parallel sandboxes. So the best "IDE for Codex" depends on where you want the work to happen. Do you want Codex on your machine, in your editor, or running in the cloud? And do you want to run several Codex tasks at once on the same repository?
+
+This guide covers each option, including how to get parallel Codex runs with Git worktrees.
+
+---
+
+## The Short Version
+
+| Where you run Codex | Best for | Parallel tasks on one repo? | Main tradeoff |
+|---|---|---|---|
+| **Superset** | Running many local Codex tasks at once | Yes -- one Git worktree per task | Not a single-file editor experience |
+| **Codex CLI** | The scriptable, local Codex | Manual (worktrees yourself) | You manage isolation and review |
+| **Codex IDE extension** | Editing alongside Codex | Limited | In-editor, single working copy |
+| **Codex cloud / app** | Fire-and-forget parallel tasks | Yes -- isolated cloud sandboxes | Runs in OpenAI's cloud, tied to a plan |
+| **Cursor** | AI editor that can run Codex-style agents | Local worktrees (its own agents) | Centered on Cursor's own models |
+| **Conductor** | A focused Mac app for a few agents | Yes -- worktrees | macOS only |
+
+## Where You Can Run Codex
+
+Codex shares one account, configuration, and usage limits across its surfaces. The CLI runs locally in your terminal. The IDE extension brings it into your editor. The desktop and web apps add a graphical experience, and the cloud service clones your repo into isolated environments and runs tasks in the background. The key decision is local versus cloud, and single versus parallel.
+
+## The Options
+
+### Codex CLI
+
+The CLI is the local, scriptable Codex: it reads your codebase, runs commands, and edits files on your machine. It is the best surface for a single task and for anyone who wants Codex in scripts or over SSH on a remote box. For parallel tasks on one repository, you manage Git worktrees and review yourself.
+
+For the direct comparison, see [Superset vs Codex CLI](/compare/superset-vs-codex).
+
+### Codex IDE extension
+
+The editor extension puts Codex beside your code so you can review and edit as it works. It is the natural choice if you want Codex inside your existing editor, with the usual single-working-copy limitation for parallel runs.
+
+### Codex cloud and desktop app
+
+The Codex cloud experience is the distinctive one: describe a task, and Codex clones your repo into an isolated cloud environment, works in the background without using your machine, and returns a diff and logs to review. You can start several tasks in parallel this way. It is convenient for fire-and-forget work, and it runs in OpenAI's cloud tied to your ChatGPT plan rather than on your local machine.
+
+For the direct comparison, see [Superset vs Codex App](/compare/superset-vs-codex-app).
+
+### Cursor
+
+Cursor is an AI editor that runs its own parallel agents in local Git worktrees. It is not a dedicated Codex host, but if you want an editor-centric experience with multi-agent runs, it is a strong option alongside running Codex directly.
+
+For the direct comparison, see [Superset vs Cursor](/compare/superset-vs-cursor).
+
+### Conductor
+
+Conductor is a macOS app that runs Codex (along with Claude Code and Cursor) in parallel, each in an isolated Git worktree, with a review-and-merge flow. It is a focused way to run a few agents in parallel on a Mac. It is macOS only.
+
+For the direct comparison, see [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Superset
+
+Superset runs the Codex CLI as a first-class agent, giving every task its own Git worktree, branch, and persistent terminal, so multiple Codex tasks can run on the same repository at once without collisions -- locally, or on your own remote hosts. Around that it adds a built-in diff and file editor, an in-app browser, port management, and MCP tooling. If your goal is parallel local Codex runs with real worktree isolation rather than cloud sandboxes, this is the fit.
+
+## How To Choose
+
+- For one task or a scriptable/SSH setup, use the Codex CLI.
+- To edit alongside Codex, use the IDE extension.
+- For fire-and-forget parallel tasks in the cloud, use Codex cloud.
+- For parallel local Codex runs with worktree isolation, use a workspace like Superset or Conductor.
+
+## Best Picks by Use Case
+
+### Best for a single or scripted task: Codex CLI
+
+The terminal is the most flexible, scriptable way to run Codex, including over SSH.
+
+### Best for cloud parallelism: Codex cloud
+
+OpenAI's cloud sandboxes run multiple tasks in parallel without using your machine.
+
+### Best for parallel local runs: Superset
+
+Superset gives every Codex task its own worktree on your own machine, with review and orchestration built in.
+
+### Best focused Mac app: Conductor
+
+Conductor is a polished choice if Codex, Claude Code, and Cursor are your agents and you are on macOS.
+
+## Verdict
+
+The best IDE for Codex depends on where you want work to run. Use the CLI for a single or scripted task, the IDE extension to edit alongside it, and Codex cloud for fire-and-forget parallel tasks in OpenAI's environments. If you want parallel Codex runs on your own machine, each isolated in a Git worktree, a workspace like Superset is the better answer.
+
+For the broader category, see [Best Agentic IDE in 2026](/compare/best-agentic-ide) and [Best AI Coding Tools and Agents (2026)](/compare/best-ai-coding-agents-2026).
+
+## Frequently Asked Questions
+
+### What is the best IDE for Codex?
+
+For a single or scripted task, the Codex CLI. For editing alongside it, the IDE extension. For parallel tasks, either Codex cloud (OpenAI's sandboxes) or a local worktree workspace like Superset.
+
+### How do I run Codex with Git worktrees?
+
+Give each Codex task its own worktree so tasks do not share a working directory. You can set this up manually, or use a workspace like Superset or Conductor that creates a worktree per task automatically.
+
+### Can I run Codex over SSH?
+
+Yes. The Codex CLI runs in any terminal, including a remote machine over SSH. Superset can also run agents on your own remote hosts through remote workspaces.
+
+### Does Codex run tasks in parallel?
+
+Codex cloud runs multiple tasks in parallel in isolated cloud environments. For parallel runs on your own machine with Git worktrees, use a local workspace like Superset.

--- a/apps/marketing/content/compare/claude-code-vs-codex.mdx
+++ b/apps/marketing/content/compare/claude-code-vs-codex.mdx
@@ -1,0 +1,94 @@
+---
+title: "Claude Code vs Codex (2026): Comparing the Top Coding Agents"
+description: "Compare Claude Code and OpenAI Codex for AI coding in 2026, across surfaces, parallelism, and pricing, plus how to run either or both in parallel with Superset."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - claude-code
+  - codex
+keywords:
+  - claude code vs codex
+  - codex vs claude code
+  - claude code or codex
+  - best coding agent 2026
+  - codex pro vs claude max
+  - ai coding agent comparison
+---
+
+Claude Code and Codex are the two most widely used AI coding agents of 2026. Claude Code is Anthropic's agent; Codex is OpenAI's. Both plan multi-step tasks, edit across files, run commands, and iterate, and both run across many surfaces. The differences are in where parallel work runs, the surfaces each emphasizes, and pricing. And because both are excellent, many developers run them side by side, which is where an orchestrator like [Superset](/compare/superset-vs-claude-code) comes in.
+
+This page compares the two agents, then shows how to run either or both in parallel.
+
+---
+
+## At a Glance
+
+| | **Claude Code** | **Codex** |
+|---|---|---|
+| **Vendor** | Anthropic | OpenAI |
+| **Surfaces** | CLI, desktop, VS Code, JetBrains, web, mobile | CLI, editor, desktop, web, cloud |
+| **Parallelism** | Parallel sessions (desktop); cloud sessions (web) | Isolated cloud environments |
+| **Local worktree isolation** | Not native | Not native (cloud sandboxes instead) |
+| **Pricing** | Claude Pro and Max plans; API | Included with ChatGPT plans; API |
+| **Best known for** | Deep, reliable single-task work | Cloud-parallel task delegation |
+
+---
+
+## What Is Claude Code?
+
+Claude Code is Anthropic's coding agent, running the same engine across six surfaces: a terminal CLI (the most complete), a desktop app with a diff viewer and parallel sessions, VS Code and JetBrains extensions, a cloud web experience that keeps running after you disconnect, and mobile apps. It shares configuration, project memory, and MCP servers across local surfaces. It is available on Claude Pro and Max plans and via the API.
+
+## What Is Codex?
+
+Codex is OpenAI's coding agent, delivered as a CLI, an editor extension, a desktop app, a web experience, and a cloud service that runs tasks in isolated cloud environments. Its distinctive strength is cloud parallelism: describe a task, and Codex clones your repo into a managed environment, runs it in the background, and returns a diff. It is included with ChatGPT plans, with usage scaling by tier.
+
+## Claude Code vs Codex: Key Differences
+
+### Surfaces
+
+Claude Code spreads across six surfaces including mobile, emphasizing a consistent engine everywhere. Codex spans CLI, editor, desktop, web, and a cloud service, emphasizing background cloud tasks. Both have strong CLIs; they differ in which secondary surfaces they lean on.
+
+### Parallelism Model
+
+Neither agent natively gives each parallel task its own local Git worktree. Claude Code offers parallel sessions on the desktop and cloud sessions on the web. Codex leans on isolated cloud environments for parallel tasks. If you want local worktree isolation for parallel work, that comes from a workspace layered on top, not from either agent itself.
+
+### Pricing
+
+Claude Code is bundled with Claude Pro and Max plans and available via the API. Codex is bundled with ChatGPT plans and available via the API. The right value depends on which subscription you already have and your usage; many teams keep both.
+
+### Which Is Better?
+
+There is no universal winner. Claude Code is prized for deep, reliable single-task work; Codex for cloud-parallel delegation and OpenAI integration. The most common answer among heavy users is to run both and pick per task, which is exactly why an agent-agnostic orchestrator is useful.
+
+## Running Claude Code and Codex in Parallel
+
+If you use both agents, or run several sessions of either, the bottleneck becomes isolation and review. Superset runs Claude Code and Codex (and OpenCode, Cursor, Gemini, and more) as first-class agents, each in its own Git worktree, so multiple sessions work the same repository without collisions. It adds built-in diff review, an in-app browser, MCP, and remote and cloud workspaces, and hands off to your editor. See [Superset vs Claude Code](/compare/superset-vs-claude-code), [Superset vs Codex](/compare/superset-vs-codex), and the guide to running [multiple agents in parallel](/compare/multiple-claude-code-agents-parallel).
+
+## Which Should You Choose?
+
+- **Choose Claude Code** if you want deep, reliable single-task coding across the broadest set of surfaces, including mobile.
+- **Choose Codex** if you are in the OpenAI ecosystem and want cloud-parallel task delegation.
+- **Run both, orchestrated by Superset**, if you want to compare agents on the same task and run many sessions in parallel with worktree isolation.
+
+**Verdict:** Claude Code and Codex are both excellent and increasingly comparable. Rather than pick one forever, many developers run both and let an agent-agnostic workspace like Superset handle isolation, review, and parallelism across them.
+
+---
+
+## Frequently Asked Questions
+
+### Is Claude Code or Codex better?
+
+Both are top-tier. Claude Code is known for deep single-task reliability across many surfaces; Codex for cloud-parallel delegation and OpenAI integration. The best choice depends on your ecosystem, and many teams use both.
+
+### Can I use Claude Code and Codex together?
+
+Yes. They are separate products, and you can run both. A workspace like Superset runs each as a first-class agent in its own Git worktree, so you can compare them on the same task.
+
+### Do Claude Code or Codex use Git worktrees?
+
+Neither natively isolates parallel tasks in local Git worktrees. Claude Code uses parallel and cloud sessions; Codex uses cloud sandboxes. For local worktree isolation, run them inside a workspace like Superset.
+
+### What is the difference between Codex Pro and Claude Max?
+
+They are different vendors' plans: Codex usage comes with ChatGPT plans, while Claude Code comes with Claude Pro and Max plans. Compare based on which subscription you already have and your expected usage; pricing and limits change, so check each provider's current plans.

--- a/apps/marketing/content/compare/conductor-alternative.mdx
+++ b/apps/marketing/content/compare/conductor-alternative.mdx
@@ -1,0 +1,107 @@
+---
+title: "Best Conductor Alternatives in 2026"
+description: "The best alternatives to Conductor for running AI coding agents in parallel Git worktrees, including Superset, Orca, Crystal, Claude Squad, and Vibe Kanban."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "roundup"
+competitors:
+  - orca
+  - crystal
+  - cmux
+  - claude-squad
+  - vibe-kanban
+keywords:
+  - conductor alternative
+  - conductor alternatives
+  - conductor competitors
+  - conductor vs superset
+  - parallel ai coding agents
+  - agentic ide
+---
+
+Conductor is a popular macOS app for running Claude Code, Codex, and Cursor agents in parallel Git worktrees. It is polished and focused, but it is Mac only, proprietary, and limited to a few agents, so plenty of developers look for an alternative that is cross-platform, agent-agnostic, open source, or extends beyond a single machine. Here are the best Conductor alternatives in 2026.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Platform | License |
+|---|---|---|---|
+| **Superset** | Agent-agnostic orchestration with remote/cloud | macOS now; Windows and Linux coming | Source-available |
+| **Orca** | Free cross-platform desktop workspace | macOS, Windows, Linux | Open source (MIT) |
+| **Crystal (Nimbalyst)** | Open-source Claude Code + Codex app | macOS, Windows, Linux | Open source (MIT) |
+| **Claude Squad** | Terminal-native parallel agents | macOS, Linux | Open source (AGPL) |
+| **Vibe Kanban** | Kanban board over agents | Cross-platform | Open source (Apache) |
+| **cmux** | Native terminal for agent sessions | macOS | Open source (GPL) |
+
+## Why Look for a Conductor Alternative?
+
+Conductor does one thing well: parallel agents in worktrees on a Mac. You might want an alternative if you need Windows or Linux, want an open-source tool, run agents beyond Claude Code, Codex, and Cursor, or want orchestration that extends to remote and cloud hosts. The tools below cover those gaps in different ways.
+
+## The Best Alternatives
+
+### Superset
+
+Superset is the closest alternative for anyone who likes Conductor's worktree model but wants more. It runs any CLI agent, such as Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, and Mistral Vibe, each in its own Git worktree, and adds a built-in diff editor, an in-app browser, MCP, and remote and cloud workspaces that run across your own network devices. It ships on macOS now, with Windows and Linux planned. Where Conductor is a focused Mac app for three agents, Superset is an agent-agnostic workspace built to scale.
+
+For the direct comparison, see [Superset vs Conductor](/compare/superset-vs-conductor).
+
+### Orca
+
+Orca is a free, open-source desktop "agent development environment" that runs many agents in parallel, each with its own worktree and browser tab. It is agent-agnostic with 25+ supported agents and runs on macOS, Windows, and Linux with mobile companions. It is the most direct cross-platform, open-source analog to Conductor's model.
+
+See [Superset vs Orca](/compare/superset-vs-orca).
+
+### Crystal (now Nimbalyst)
+
+Crystal is an open-source Electron app for running Claude Code and Codex in parallel worktrees, with strong in-app Git operations. It is cross-platform and MIT licensed, and its active development now continues under the name Nimbalyst. A good pick if you want an open-source, cross-platform Conductor-style app.
+
+See [Superset vs Crystal](/compare/superset-vs-crystal).
+
+### Claude Squad
+
+Claude Squad is an open-source terminal app that manages multiple agents in separate worktrees using tmux. It is lean, keyboard-driven, and agent-agnostic, ideal if you prefer the terminal over a desktop UI.
+
+See [Superset vs Claude Squad](/compare/superset-vs-claude-squad).
+
+### Vibe Kanban
+
+Vibe Kanban puts a Kanban board over coding agents, running them in parallel worktrees. It is open source and cross-platform. Note that it is sunsetting as a maintained product, continuing as community open source, so weigh long-term maintenance.
+
+See [Superset vs Vibe Kanban](/compare/superset-vs-vibe-kanban).
+
+### cmux
+
+cmux is a native macOS terminal built for agents, keeping many sessions organized in panes and tabs. It is not a worktree orchestrator, but if your goal is a great terminal for agents rather than automatic isolation, it is worth a look.
+
+See [Superset vs cmux](/compare/superset-vs-cmux).
+
+## How To Choose
+
+- For agent-agnostic orchestration with remote and cloud hosts, choose **Superset**.
+- For a free, cross-platform, open-source desktop workspace, choose **Orca**.
+- For an open-source Claude Code and Codex app, choose **Crystal (Nimbalyst)**.
+- For terminal-native parallel agents, choose **Claude Squad**.
+- For a Kanban metaphor, consider **Vibe Kanban** (note its sunset).
+
+## Verdict
+
+Conductor is excellent if you are on macOS and use Claude Code, Codex, or Cursor. If you need cross-platform support, open source, more agents, or remote and cloud hosting, the strongest alternative is Superset, with Orca and Crystal (Nimbalyst) as leading open-source options. For the full landscape, see [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is the best Conductor alternative?
+
+For most people wanting more than Conductor's Mac-only, three-agent focus, Superset is the closest alternative: agent-agnostic worktree orchestration with remote and cloud workspaces. Orca and Crystal (Nimbalyst) are strong open-source options.
+
+### Is there an open-source Conductor alternative?
+
+Yes. Orca (MIT), Crystal/Nimbalyst (MIT), Claude Squad (AGPL), and Vibe Kanban (Apache) are all open source. Superset is source-available under ELv2.
+
+### What is a cross-platform alternative to Conductor?
+
+Conductor is macOS only. Orca and Crystal (Nimbalyst) run on macOS, Windows, and Linux. Superset ships on macOS now with Windows and Linux planned.
+
+### Do these alternatives use Git worktrees like Conductor?
+
+Most do. Superset, Orca, Crystal, Claude Squad, and Vibe Kanban all isolate agents in Git worktrees. cmux is the exception, being a terminal rather than a worktree orchestrator.

--- a/apps/marketing/content/compare/conductor-vs-codex.mdx
+++ b/apps/marketing/content/compare/conductor-vs-codex.mdx
@@ -1,0 +1,86 @@
+---
+title: "Conductor vs Codex (2026): Local Orchestrator vs OpenAI's Agent"
+description: "Compare Conductor and OpenAI Codex for parallel AI coding. See how a Mac app that runs Codex in worktrees differs from Codex's own cloud app, plus where Superset fits."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - conductor
+  - codex
+keywords:
+  - conductor vs codex
+  - conductor vs codex app
+  - codex alternative
+  - conductor alternative
+  - parallel codex agents
+  - agentic ide
+---
+
+Conductor and Codex are compared often, but they are different kinds of thing. Codex is OpenAI's coding agent, available as a CLI, an editor extension, a desktop app, and a cloud service. Conductor is a macOS app that runs agents, including Codex, in parallel Git worktrees on your machine. So the real question is where you want Codex to run: inside OpenAI's own app and cloud, or inside a local orchestrator that gives each task its own worktree.
+
+If you want that local orchestration but agent-agnostic and cross-platform, [Superset](/compare/superset-vs-codex) is a third option. This page compares all three.
+
+---
+
+## At a Glance
+
+| | **Conductor** | **Codex** | **Superset** |
+|---|---|---|---|
+| **Category** | Mac app for parallel agents | OpenAI's coding agent (multi-surface) | Agent orchestration workspace |
+| **Runs Codex?** | Yes, as one of its agents | It is Codex | Yes, as one of many agents |
+| **Parallelism** | Worktree per task (local) | Isolated cloud environments | Worktree per task (local + your remote hosts) |
+| **Other agents** | Claude Code, Cursor | OpenAI Codex only | Claude Code, OpenCode, Cursor, Gemini, and more |
+| **Platform** | macOS only | CLI, editor, desktop, web, cloud | macOS now; Windows and Linux coming |
+| **Pricing** | Free, bring your own subscription | Included with ChatGPT plans | Free tier + Pro $20/seat/mo |
+
+---
+
+## What Is Conductor?
+
+Conductor is a native macOS app from Melty Labs for running Claude Code, Codex, and Cursor agents in parallel, each in an isolated Git worktree, with a review-and-merge and pull-request flow. It runs those agents locally on your Mac and is free, reusing your existing subscriptions.
+
+## What Is Codex?
+
+Codex is OpenAI's agentic coding system, delivered across a terminal CLI, an editor extension, a desktop app, a web experience, and a cloud service that runs tasks in isolated cloud environments. Its flagship parallelism is cloud-hosted: you describe a task, Codex clones your repo into a managed environment, runs it in the background, and returns a diff to review. It is included with ChatGPT plans, with usage scaling by tier.
+
+## Conductor vs Codex: Key Differences
+
+### Where the Work Runs
+
+This is the core difference. Conductor runs Codex (and other agents) locally, each task in a Git worktree on your Mac, using your real environment. Codex's own parallelism runs in OpenAI's cloud sandboxes, so your machine can be off but the work happens remotely. Local keeps everything on your disk and offline-capable; cloud is convenient for fire-and-forget tasks.
+
+### One Agent vs Several
+
+Codex runs OpenAI's Codex. Conductor runs Codex alongside Claude Code and Cursor, so you can compare agents on the same task. If you are all-in on OpenAI, Codex's own app is cohesive; if you want Codex plus other agents in one place, Conductor covers more.
+
+### Review Flow
+
+Conductor gives you a local review-and-merge dashboard across parallel worktrees. Codex returns diffs and logs from its cloud tasks for you to review before merging. Both end in a reviewed diff; they differ in whether the loop is local or cloud.
+
+## Where Superset Fits
+
+Superset is the option if you want Conductor's local worktree orchestration but agent-agnostic and not limited to macOS. It runs the Codex CLI as one of many agents, each in its own worktree, alongside Claude Code, OpenCode, Cursor, and Gemini, with built-in review, an in-app browser, MCP, and remote and cloud workspaces on your own devices. See [Superset vs Codex](/compare/superset-vs-codex), [Superset vs Codex App](/compare/superset-vs-codex-app), and [Superset vs Conductor](/compare/superset-vs-conductor).
+
+## Which Should You Choose?
+
+- **Choose Conductor** if you are on macOS and want a focused app to run Codex, Claude Code, and Cursor in parallel worktrees locally.
+- **Choose Codex** if you are standardized on OpenAI and want its cohesive suite with cloud tasks that run while your machine is off.
+- **Choose Superset** if you want agent-agnostic local orchestration across many agents, on your own machine and remote hosts, not tied to macOS or one vendor.
+
+**Verdict:** Codex is the agent; Conductor is a Mac app that runs it (and others) in local worktrees. Choose Codex for OpenAI's cloud-first suite, Conductor for a focused local Mac orchestrator, and Superset if you want the broadest agent-agnostic orchestration across platforms.
+
+---
+
+## Frequently Asked Questions
+
+### Is Conductor the same as Codex?
+
+No. Codex is OpenAI's coding agent. Conductor is a macOS app that can run Codex (plus Claude Code and Cursor) in parallel Git worktrees. Conductor orchestrates agents; Codex is one of the agents.
+
+### Does Conductor run Codex in the cloud?
+
+No. Conductor runs agents locally on your Mac, each in a Git worktree. Codex's own cloud service runs tasks in OpenAI-managed environments. Superset also runs Codex locally, and can use your own remote hosts.
+
+### What is the difference between Conductor and the Codex app?
+
+The Codex app is OpenAI's own desktop and cloud experience for Codex. Conductor is a third-party Mac app that runs Codex and other agents locally in worktrees. See [Superset vs Codex App](/compare/superset-vs-codex-app) for the app-specific comparison.

--- a/apps/marketing/content/compare/conductor-vs-crystal.mdx
+++ b/apps/marketing/content/compare/conductor-vs-crystal.mdx
@@ -1,0 +1,87 @@
+---
+title: "Conductor vs Crystal (2026): Parallel Claude Code Apps Compared"
+description: "Compare Conductor and Crystal (now Nimbalyst) for running Claude Code and Codex in parallel Git worktrees, plus where Superset fits as an agent-agnostic alternative."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - conductor
+  - crystal
+keywords:
+  - conductor vs crystal
+  - crystal vs conductor
+  - conductor alternative
+  - crystal alternative
+  - nimbalyst alternative
+  - parallel claude code
+---
+
+Conductor and Crystal are close competitors: both are desktop apps that run Claude Code and Codex in parallel Git worktrees, with in-app diff review and merge. The main differences are platform, licensing, and project direction. Conductor is a proprietary macOS app; Crystal is open source and cross-platform, and is now continuing under the name Nimbalyst. Neither is agent-agnostic, which is where a broader workspace like [Superset](/compare/superset-vs-conductor) comes in.
+
+This page compares all three.
+
+---
+
+## At a Glance
+
+| | **Conductor** | **Crystal (now Nimbalyst)** | **Superset** |
+|---|---|---|---|
+| **Agents** | Claude Code, Codex, Cursor | Claude Code, Codex | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, and more) |
+| **Isolation** | Git worktree per task | Git worktree per session | Git worktree per task |
+| **Platform** | macOS only | macOS, Windows, Linux | macOS now; Windows and Linux coming |
+| **License** | Proprietary | Open source (MIT) | Source-available (ELv2) |
+| **Remote / cloud** | Local | Local | Remote and cloud workspaces |
+| **Status** | Active | Renamed to Nimbalyst | Active |
+| **Pricing** | Free, bring your own subscription | Free (open source) | Free tier + Pro $20/seat/mo |
+
+---
+
+## What Is Conductor?
+
+Conductor is a native macOS app from Melty Labs for running Claude Code, Codex, and Cursor agents in parallel, each in an isolated Git worktree, with a review-and-merge and pull-request flow. It is Mac only, proprietary, and free, reusing your existing agent subscriptions.
+
+## What Is Crystal?
+
+Crystal is an open-source Electron desktop app for running Claude Code and Codex in parallel Git worktrees, with per-iteration commits, in-app diff review, and integrated Git operations like rebase, squash, and merge. It is MIT licensed and cross-platform. Its maintainers have renamed the project and now direct active development to Nimbalyst, so treat Crystal as the legacy name for what is now Nimbalyst.
+
+## Conductor vs Crystal: Key Differences
+
+### Platform and License
+
+Conductor is macOS only and proprietary. Crystal is open source (MIT) and runs on macOS, Windows, and Linux. If you need Windows or Linux, or want open-source code, Crystal (Nimbalyst) is the fit; if you want a polished native Mac app and do not mind proprietary, Conductor is strong.
+
+### Agents
+
+Conductor runs Claude Code, Codex, and Cursor. Crystal runs Claude Code and Codex. Both are focused on the popular agents rather than being agent-agnostic.
+
+### Project Direction
+
+Conductor is actively developed under its name. Crystal has been renamed and its active development moved to Nimbalyst, so evaluate Nimbalyst's current state rather than the legacy Crystal repo.
+
+## Where Superset Fits
+
+Both Conductor and Crystal are focused on a small set of agents. If you want the same worktree-per-task model but agent-agnostic, cross-platform, and extended with remote and cloud workspaces, Superset is the broader option. It runs Claude Code, Codex, OpenCode, Cursor, Gemini, Mistral Vibe, and custom agents, with review, an in-app browser, and MCP built in. See [Superset vs Conductor](/compare/superset-vs-conductor) and [Superset vs Crystal](/compare/superset-vs-crystal).
+
+## Which Should You Choose?
+
+- **Choose Conductor** if you want a polished native macOS app for Claude Code, Codex, and Cursor.
+- **Choose Crystal (Nimbalyst)** if you want an open-source, cross-platform app for Claude Code and Codex.
+- **Choose Superset** if you want agent-agnostic worktree orchestration across many agents, plus remote and cloud workspaces.
+
+**Verdict:** Conductor and Crystal are two takes on the same idea: a desktop app for parallel Claude Code and Codex in worktrees. Pick Conductor for a native Mac experience, Crystal (Nimbalyst) for open-source and cross-platform, and Superset if you want the broadest agent support and remote hosting.
+
+---
+
+## Frequently Asked Questions
+
+### Do Conductor and Crystal both use Git worktrees?
+
+Yes. Both give each agent session its own Git worktree and branch. Superset uses the same model with broader agent support.
+
+### Is Crystal still maintained?
+
+Crystal has been renamed and its maintainers now direct active development to Nimbalyst. Evaluate Nimbalyst for current development.
+
+### Which runs on Windows and Linux?
+
+Crystal (Nimbalyst) is cross-platform. Conductor is macOS only. Superset ships on macOS now with Windows and Linux planned.

--- a/apps/marketing/content/compare/conductor-vs-cursor.mdx
+++ b/apps/marketing/content/compare/conductor-vs-cursor.mdx
@@ -1,0 +1,90 @@
+---
+title: "Conductor vs Cursor (2026): Which Should You Use?"
+description: "Compare Conductor and Cursor for AI coding. See how a Mac app for parallel agents differs from an AI-first editor, and where Superset fits as an alternative."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - conductor
+  - cursor
+keywords:
+  - conductor vs cursor
+  - cursor vs conductor
+  - conductor alternative
+  - cursor alternative
+  - parallel ai coding agents
+  - agentic ide
+---
+
+Conductor and Cursor solve overlapping problems from opposite ends. Conductor is a macOS app that runs coding agents in parallel, each in an isolated Git worktree. Cursor is an AI-first editor that you type in, with an agent mode that can also run several agents at once. Interestingly, Conductor can run Cursor's agent as one of its options, so the question is often "do I want an orchestrator around my agents, or an editor that is itself the agent?"
+
+If you want an agent-agnostic workspace that does parallel worktrees but is not tied to macOS or one editor, [Superset](/compare/superset-vs-cursor) is worth a look too. This page compares all three.
+
+---
+
+## At a Glance
+
+| | **Conductor** | **Cursor** | **Superset** |
+|---|---|---|---|
+| **Category** | Mac app for parallel agents | AI-first code editor | Agent orchestration workspace |
+| **Agents** | Claude Code, Codex, Cursor | Cursor's own agent and models | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) |
+| **Parallel agents** | Yes, worktree per task | Yes, up to 8 in local worktrees | Yes, 100+ with worktree per task |
+| **Primary use** | Orchestrate and review agents | Write and edit code with AI | Orchestrate, review, and hand off across agents |
+| **Platform** | macOS only | macOS, Windows, Linux | macOS now; Windows and Linux coming |
+| **Pricing** | Free, bring your own subscription | Free tier; Pro $20/mo, higher tiers to $200 | Free tier + Pro $20/seat/mo |
+
+---
+
+## What Is Conductor?
+
+Conductor is a native macOS app from Melty Labs for running Claude Code, Codex, and Cursor agents in parallel, each in an isolated workspace backed by a Git worktree. It centers on a clean review-and-merge and pull-request flow: dispatch agents, review their diffs, and merge the ones you want. It is Mac only and free, reusing your existing agent subscriptions.
+
+## What Is Cursor?
+
+Cursor is an AI-first fork of VS Code. Its agent mode reads the codebase, edits across files, and runs terminal commands, and Cursor 2.0 added a multi-agent interface that runs up to eight agents in parallel, each in its own local Git worktree, plus background agents in the cloud. It is a full editor with its own models (including Composer) and runs on macOS, Windows, and Linux. Pricing starts with a free tier and Pro at $20/month, up to higher Ultra and team tiers.
+
+## Conductor vs Cursor: Key Differences
+
+### Orchestrator vs Editor
+
+Conductor is an orchestration layer: you do not primarily type code in it, you dispatch agents and review results. Cursor is an editor: you work in it directly, with an agent that can take over tasks. Conductor sits around agents; Cursor is the agent-and-editor in one. Notably, Conductor can run Cursor's agent, so they are not mutually exclusive.
+
+### Parallel Isolation
+
+Both now run parallel agents in local Git worktrees, which is a recent and important convergence. Conductor is built around that as its whole purpose. Cursor added it as a feature inside the editor (up to eight agents to compare results). If parallel isolation is the entire point of your workflow, Conductor's focus shows; if you want it inside a full editor, Cursor's integration is convenient.
+
+### Platform and Lock-In
+
+Conductor is macOS only. Cursor runs on macOS, Windows, and Linux but centers on its own models and editor. Neither is agent-agnostic in the way a dedicated orchestrator is: Conductor supports three agents, and Cursor is primarily its own.
+
+## Where Superset Fits
+
+If you like Conductor's parallel-worktree model but want it agent-agnostic and not tied to macOS, or you like Cursor's parallel agents but do not want to adopt its editor, Superset is the third option. It runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom agents, each in its own worktree, with built-in review, an in-app browser, MCP, and remote and cloud workspaces. It keeps the orchestration layer independent of any one editor or vendor, and hands off to VS Code, Cursor, JetBrains, or Xcode when you want a full editor. See [Superset vs Conductor](/compare/superset-vs-conductor) and [Superset vs Cursor](/compare/superset-vs-cursor).
+
+## Which Should You Choose?
+
+- **Choose Conductor** if you are on macOS and want a focused app to run Claude Code, Codex, and Cursor in parallel with a clean review-and-merge flow.
+- **Choose Cursor** if you want an AI-first editor to write code in, with parallel agents built into the editor across all platforms.
+- **Choose Superset** if you want agent-agnostic, worktree-based orchestration across many agents, remote and cloud hosts, and freedom from editor lock-in.
+
+**Verdict:** Conductor and Cursor increasingly overlap because both run parallel agents in worktrees, and Conductor can even run Cursor. Pick Conductor for a focused Mac orchestrator, Cursor for an AI-first editor, and Superset if you want the broadest, most agent-agnostic orchestration layer of the three.
+
+---
+
+## Frequently Asked Questions
+
+### Can Conductor run Cursor?
+
+Yes. Conductor runs Claude Code, Codex, and Cursor agents in parallel, each in its own Git worktree. So you can use Cursor's agent inside Conductor's orchestration flow.
+
+### Do Conductor and Cursor both use Git worktrees?
+
+Yes. Conductor uses a worktree per task, and Cursor 2.0 runs its parallel agents in local Git worktrees too. Superset also uses a worktree per task.
+
+### Which is better for parallel agents?
+
+Conductor is purpose-built for it on macOS; Cursor builds it into the editor across platforms. For agent-agnostic parallel orchestration with remote hosts, Superset is a strong alternative to both.
+
+### Is Conductor or Cursor free?
+
+Conductor's app is free (you bring your own agent subscriptions). Cursor has a free tier with paid plans from $20/month. Superset has a free tier plus Pro at $20/seat/month.

--- a/apps/marketing/content/compare/cursor-alternative.mdx
+++ b/apps/marketing/content/compare/cursor-alternative.mdx
@@ -1,0 +1,104 @@
+---
+title: "Best Cursor Alternatives in 2026"
+description: "The best alternatives to Cursor for AI coding in 2026, including Superset, Zed, VS Code with Copilot, Windsurf (Devin Desktop), JetBrains Junie, and Warp."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "roundup"
+competitors:
+  - zed
+  - github-copilot
+  - windsurf
+  - jetbrains-junie
+  - warp
+keywords:
+  - cursor alternative
+  - cursor alternatives
+  - cursor competitors
+  - open source cursor alternative
+  - ai code editor alternative
+  - agentic ide
+---
+
+Cursor is one of the most popular AI-first editors, but it is not the only option, and it is not the right shape for everyone. Some developers want an open-source editor, some want to keep their existing IDE, and some want to orchestrate many agents rather than work inside a single editor. Here are the best Cursor alternatives in 2026, grouped by what you are actually looking for.
+
+---
+
+## The Short Version
+
+| Alternative | Best for | Type | Pricing |
+|---|---|---|---|
+| **Superset** | Orchestrating many agents in parallel | Agent workspace | Free + Pro $20/seat |
+| **Zed** | Fast open-source editor hosting agents | AI editor | Free; Pro $10/mo |
+| **VS Code + Copilot** | Staying in VS Code | AI editor | Free; Pro $10/mo |
+| **Windsurf (Devin Desktop)** | Command center for local + cloud agents | AI IDE | Free; Pro $20/mo |
+| **JetBrains + Junie** | JetBrains users | AI in IDE | Free; Pro $10/mo |
+| **Warp** | Agentic terminal workflow | Terminal | Free; Build $20/mo |
+
+## Why Look for a Cursor Alternative?
+
+You might want an alternative if you prefer an open-source editor, do not want to switch away from your current IDE, want to host external CLI agents like Claude Code and Codex, or your real need is running many agents in parallel rather than editing in one place. Each tool below answers one of those.
+
+## The Best Alternatives
+
+### Superset
+
+If your reason for wanting parallel agents is bigger than one editor, Superset is the alternative to consider. Rather than being an editor you type in, it is a workspace that runs many agents, each in its own Git worktree, and hands off to any editor including Cursor. It runs Claude Code, Codex, OpenCode, Cursor, Copilot, and Gemini, with built-in review, an in-app browser, MCP, and remote and cloud workspaces. Choose it when orchestration and isolation matter more than the editing surface.
+
+See [Superset vs Cursor](/compare/superset-vs-cursor).
+
+### Zed
+
+Zed is a fast, GPU-accelerated, open-source editor whose signature strength is hosting external agents. Through the Agent Client Protocol it runs Claude Code, Codex, Gemini, and OpenCode inside its agent panel. It has a free personal tier and Pro at $10/month. A great pick if you want an open-source, high-performance editor that also hosts your CLI agents.
+
+### VS Code + GitHub Copilot
+
+If you would rather not leave VS Code, Copilot brings agent mode, a cloud coding agent, and MCP support to the editor you already use, with delegation to Claude and Codex on higher tiers. Plans run from free to Pro at $10/month. The most familiar path for existing VS Code users.
+
+See [Superset vs GitHub Copilot](/compare/superset-vs-github-copilot).
+
+### Windsurf (Devin Desktop)
+
+Windsurf, now Devin Desktop after Cognition's acquisition, is an AI IDE built around an agent command center for managing local and cloud agents, with ACP support for external agents. Pricing starts free, with Pro at $20/month. A strong alternative if you want a fleet-oriented IDE rather than a single-agent editor.
+
+See [Superset vs Windsurf](/compare/superset-vs-windsurf).
+
+### JetBrains + Junie
+
+If you use IntelliJ, PyCharm, or WebStorm, JetBrains' Junie agent brings agentic coding into the IDE you already know, with ACP support for external agents. AI pricing starts free, with Pro at $10/month. The natural choice for JetBrains loyalists.
+
+### Warp
+
+Warp is a fast, now open-source terminal repositioned as an agentic development environment. It runs Claude Code, Codex, Gemini, and OpenCode in panes and adds a cloud orchestrator for background agents. Pricing starts free, with Build at $20/month. A good fit if your workflow is terminal-first.
+
+See [Superset vs Warp](/compare/superset-vs-warp).
+
+## How To Choose
+
+- To orchestrate many agents in parallel, choose **Superset**.
+- For an open-source editor that hosts CLI agents, choose **Zed**.
+- To stay in VS Code, choose **Copilot**.
+- For a fleet-oriented AI IDE, choose **Windsurf (Devin Desktop)**.
+- For JetBrains IDEs, choose **Junie**.
+- For a terminal-first workflow, choose **Warp**.
+
+## Verdict
+
+Cursor is an excellent AI-first editor, but the best alternative depends on what you want. For an open-source editor, Zed leads. To stay in your current IDE, Copilot or Junie fit. If your real goal is running many agents in parallel with isolation and review, Superset is the alternative built for that. See [Best Agentic IDE in 2026](/compare/best-agentic-ide) for the full comparison.
+
+## Frequently Asked Questions
+
+### What is the best Cursor alternative?
+
+It depends on your goal: Zed for an open-source editor, Copilot or JetBrains Junie to stay in your current IDE, and Superset if you want to orchestrate many agents in parallel rather than edit in one editor.
+
+### Is there an open-source Cursor alternative?
+
+Yes. Zed is an open-source editor with strong agent support, and Superset is source-available. VS Code itself is open source, with Copilot as a paid add-on.
+
+### What is a good Cursor alternative for teams running many agents?
+
+Superset is designed for running many agents in parallel with worktree isolation, review, and remote and cloud workspaces, which is a different shape from a single-editor tool like Cursor.
+
+### Which alternatives can run Claude Code and Codex?
+
+Zed, JetBrains, and Windsurf (Devin Desktop) host external agents via ACP, Copilot delegates to Claude and Codex, and Superset and Warp run them directly. Cursor centers on its own agent.

--- a/apps/marketing/content/compare/cursor-vs-windsurf.mdx
+++ b/apps/marketing/content/compare/cursor-vs-windsurf.mdx
@@ -1,0 +1,90 @@
+---
+title: "Cursor vs Windsurf (2026): AI Editors Compared"
+description: "Compare Cursor and Windsurf, now Devin Desktop, as AI coding editors in 2026, across agents, parallelism, and pricing, plus where Superset fits as an alternative."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - cursor
+  - windsurf
+keywords:
+  - cursor vs windsurf
+  - windsurf vs cursor
+  - cursor alternative
+  - windsurf alternative
+  - devin desktop vs cursor
+  - ai code editor comparison
+---
+
+Cursor and Windsurf are the two best-known AI-first editors, both forks of VS Code with autonomous agent modes. One important 2026 update before comparing them: Windsurf has been acquired by Cognition and rebranded as Devin Desktop, and its original Cascade agent has been replaced by Devin Local. So "Cursor vs Windsurf" today is really Cursor vs Devin Desktop.
+
+Both are excellent editors. If your real goal is running many agents in parallel rather than editing in one IDE, an agent-agnostic workspace like [Superset](/compare/superset-vs-cursor) is a third path. This page compares all three.
+
+---
+
+## At a Glance
+
+| | **Cursor** | **Windsurf (Devin Desktop)** | **Superset** |
+|---|---|---|---|
+| **Category** | AI-first code editor | AI IDE with agent command center | Agent orchestration workspace |
+| **Agent** | Cursor agent + Composer | Devin Local + ACP agents | Any CLI agent (Claude Code, Codex, and more) |
+| **Parallel agents** | Up to 8 in local worktrees | Local and cloud agents via a Kanban board | 100+ with worktree per task |
+| **Hosts external agents** | Not advertised | Yes, via ACP (Codex, Claude, OpenCode) | Yes, any terminal agent |
+| **Platform** | macOS, Windows, Linux | macOS, Windows, Linux | macOS now; Windows and Linux coming |
+| **Pricing** | Free tier; Pro $20/mo | Free tier; Pro $20/mo, Max $200/mo | Free tier + Pro $20/seat/mo |
+
+---
+
+## What Is Cursor?
+
+Cursor is an AI-first fork of VS Code. Its agent mode reads the codebase, edits across files, and runs commands, and Cursor 2.0 added a multi-agent interface that runs up to eight agents in parallel, each in its own local Git worktree, plus background agents in the cloud. It uses its own models, including Composer, and runs on macOS, Windows, and Linux. Pricing starts free, with Pro at $20/month.
+
+## What Is Windsurf (Devin Desktop)?
+
+Windsurf began as a VS Code fork built around Cascade, its agentic flow engine. After Cognition acquired it, Windsurf became Devin Desktop, and Cascade was retired in favor of Devin Local, a from-scratch Rust rewrite with subagents. Devin Desktop makes an "Agent Command Center" the default surface, a Kanban view for managing local and cloud agents and pull requests, and it supports the Agent Client Protocol so agents like Codex, Claude, and OpenCode can run inside it. Pricing starts free, with Pro at $20/month and Max at $200/month.
+
+## Cursor vs Windsurf: Key Differences
+
+### Agent Approach
+
+Cursor centers on its own agent and models inside a familiar editor. Devin Desktop centers on a command center that manages many agents, local and cloud, and can host external ACP agents. Cursor is more "one editor, one great agent"; Devin Desktop is more "an IDE that manages a fleet."
+
+### Parallelism
+
+Both run parallel agents. Cursor runs up to eight in local Git worktrees for compare-and-pick workflows. Devin Desktop manages local and cloud agents from its Kanban board, with cloud agents running remotely. If you want local worktree comparison, Cursor is explicit about it; if you want a board spanning local and cloud, Devin Desktop leans that way.
+
+### Hosting External Agents
+
+Devin Desktop supports ACP, so you can run Codex, Claude, or OpenCode inside it. Cursor does not advertise hosting external CLI agents. If running your existing CLI agents inside the editor matters, Devin Desktop has the edge there.
+
+## Where Superset Fits
+
+Both Cursor and Devin Desktop are editors you work inside. If your bottleneck is orchestrating many agents rather than editing, Superset keeps the orchestration layer independent of any editor. It runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, and custom agents, each in its own worktree, with review, an in-app browser, MCP, and remote and cloud workspaces, then hands off to Cursor, VS Code, JetBrains, or Xcode. See [Superset vs Cursor](/compare/superset-vs-cursor) and [Superset vs Windsurf](/compare/superset-vs-windsurf).
+
+## Which Should You Choose?
+
+- **Choose Cursor** if you want a polished AI-first editor with your primary agent and parallel runs built in.
+- **Choose Windsurf (Devin Desktop)** if you want an IDE with a command center for local and cloud agents and ACP support for external agents.
+- **Choose Superset** if you want agent-agnostic orchestration across many agents, with worktree isolation and remote hosts, independent of any editor.
+
+**Verdict:** Cursor is the sharper single-editor experience; Devin Desktop is the more fleet-oriented IDE with ACP hosting. If you would rather orchestrate agents than commit to one editor, Superset is the agent-agnostic alternative to both.
+
+---
+
+## Frequently Asked Questions
+
+### Is Windsurf still called Windsurf?
+
+Windsurf is now Devin Desktop after Cognition's acquisition, shipped as a backwards-compatible update, with the original Cascade agent replaced by Devin Local. Many people still search "Cursor vs Windsurf," which is why this comparison keeps the name.
+
+### Is Cursor or Windsurf better for parallel agents?
+
+Cursor runs up to eight agents in local worktrees for compare-and-pick. Devin Desktop manages local and cloud agents from a board and hosts ACP agents. For agent-agnostic parallel orchestration with remote hosts, Superset is an alternative to both.
+
+### Do Cursor and Windsurf cost the same?
+
+Both start with a free tier and Pro at $20/month; Devin Desktop adds a Max tier at $200/month. Superset has a free tier plus Pro at $20/seat/month. Check each site for current plans.
+
+### Can I run Claude Code or Codex in these editors?
+
+Devin Desktop supports ACP, so it can host Codex, Claude, and OpenCode. Cursor does not advertise external CLI agent hosting. Superset runs any of them directly, each in its own worktree.

--- a/apps/marketing/content/compare/git-worktrees-for-ai-agents.mdx
+++ b/apps/marketing/content/compare/git-worktrees-for-ai-agents.mdx
@@ -1,0 +1,103 @@
+---
+title: "Git Worktrees for AI Coding Agents: The Parallel Workflow"
+description: "How Git worktrees let you run multiple AI coding agents in parallel without collisions. Learn the workflow, the tradeoffs, and the tools that automate it."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "tutorial"
+competitors:
+  - git-worktrees
+keywords:
+  - git worktree
+  - git worktrees
+  - git worktree ai agents
+  - parallel agents
+  - parallel ai coding
+  - visual studio code git worktree
+---
+
+If you run more than one AI coding agent on the same repository, the single most useful tool you can learn is the Git worktree. It is the clean, native way to give each agent its own isolated place to work, so parallel changes never collide. This guide explains what worktrees are, why they matter for agents, the exact workflow, and the tools that automate it.
+
+---
+
+## What Is a Git Worktree?
+
+A Git worktree is an additional working directory attached to the same repository. Instead of one checkout where you switch branches with `git checkout`, worktrees let you have several branches checked out at once, each in its own folder, all sharing the same underlying Git history.
+
+```bash
+# from your repo
+git worktree add ../myrepo-feature-a feature-a
+git worktree add ../myrepo-bugfix    bugfix-123
+```
+
+Now `feature-a` and `bugfix-123` each have their own directory. Edits in one do not touch the other, and both share the same `.git` data. When you are done, you remove the worktree and keep the branch.
+
+## Why Worktrees Matter for AI Agents
+
+AI coding agents edit files and run commands autonomously. Run two agents in the same directory and they overwrite each other's work, fight over the branch, and produce a tangled mess. Worktrees solve this cleanly:
+
+- **Isolation:** each agent gets its own directory and branch
+- **Parallelism:** many agents run at once without collisions
+- **Reviewability:** each worktree produces its own diff you can review independently
+- **Safety:** a bad run is contained to one worktree, not your main checkout
+
+This is why the strongest tools for running multiple agents, from [Conductor](/compare/superset-vs-conductor) to [Orca](/compare/superset-vs-orca) to [Superset](/compare/superset-vs-cursor), are built around a worktree per task. Even [Cursor 2.0](/compare/superset-vs-cursor) adopted local worktrees for its parallel agents.
+
+## The Parallel Agent Workflow
+
+### 1. Break work into independent tasks
+
+Worktrees shine when tasks do not overlap: one agent writing tests, another refactoring a module, a third updating docs. Overlapping tasks that touch the same files heavily are better run in sequence.
+
+### 2. Create a worktree per task
+
+Give each agent its own worktree and branch. Manually, that is a `git worktree add` per task; with a workspace tool, it happens automatically when you start a task.
+
+### 3. Launch an agent in each worktree
+
+Run your agent of choice, such as [Claude Code](/compare/best-ide-for-claude-code) or [Codex](/compare/best-ide-for-codex), inside each worktree with a narrow, focused prompt.
+
+### 4. Review each diff independently
+
+Each worktree produces its own diff. Review them one at a time and merge the ones you want. Isolation is what makes reviewing several parallel changes manageable.
+
+### 5. Clean up
+
+Remove finished worktrees with `git worktree remove`. The branch stays; only the extra directory goes.
+
+## Doing It Manually vs Automatically
+
+You can run this whole workflow by hand with `git worktree`, tmux, and discipline. It works, and for two or three occasional agents it may be all you need. The friction grows with scale: creating, tracking, and cleaning up worktrees, launching agents, managing ports for dev servers, and reviewing many diffs becomes real overhead.
+
+That is the gap workspace tools fill. Instead of managing worktrees by hand, they create one per task automatically, launch your agent inside it, and give you review and browser surfaces around the whole thing. See the roundup of [best agentic IDEs](/compare/best-agentic-ide) for the options.
+
+## Where Superset Fits
+
+Superset is built around this exact workflow. Every task gets its own Git worktree, branch, and persistent terminal, automatically. It runs any CLI agent, such as Claude Code, Codex, OpenCode, Cursor, or Gemini, adds a built-in diff editor, an in-app browser for docs and dev servers, port management, and MCP, and extends across remote and cloud hosts. It turns the manual worktree workflow into the default, so you can run many agents in parallel and review each one without the bookkeeping.
+
+## Worktrees in Your Editor
+
+You do not have to give up your editor. Most editors open a worktree directory like any other folder, and there is steady demand for tighter worktree support in tools like VS Code. A common pattern is to let a workspace tool manage the worktrees and then open any one of them in VS Code, Cursor, JetBrains, or Xcode for a full editor view when you want to dig in.
+
+## Verdict
+
+Git worktrees are the foundation of safe parallel AI coding. They give each agent its own isolated directory and branch so many agents can work one repository at once, each producing a reviewable diff. You can manage them by hand, or use a workspace like Superset that makes a worktree per task the automatic default across any agent.
+
+To go deeper, see [How to Run Multiple Claude Code Agents in Parallel](/compare/multiple-claude-code-agents-parallel), [How to Run Multiple OpenCode Agents in Parallel](/compare/multiple-opencode-agents-parallel), and [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+## Frequently Asked Questions
+
+### What is a Git worktree used for?
+
+A Git worktree lets you check out multiple branches at once, each in its own directory sharing the same repository. For AI coding, it gives each agent an isolated place to work so parallel changes do not collide.
+
+### How do I run multiple AI agents without conflicts?
+
+Give each agent its own Git worktree and branch so they never share a working directory. Do it manually with `git worktree add`, or automatically with a workspace like Superset that creates a worktree per task.
+
+### Do AI coding tools use Git worktrees?
+
+Many do. Conductor, Orca, Crystal, and Superset are built around a worktree per task, and Cursor 2.0 uses local worktrees for its parallel agents. See [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+### Can I use Git worktrees with VS Code?
+
+Yes. A worktree is just a directory, so you can open it in VS Code like any folder. Many developers let a workspace tool manage the worktrees and open individual ones in VS Code, Cursor, or JetBrains to review.

--- a/apps/marketing/content/compare/multiple-opencode-agents-parallel.mdx
+++ b/apps/marketing/content/compare/multiple-opencode-agents-parallel.mdx
@@ -1,0 +1,104 @@
+---
+title: "How to Run Multiple OpenCode Agents in Parallel"
+description: "Learn the ways to run multiple OpenCode agents at once, from built-in multi-session and community orchestrator plugins to Git worktrees and Superset's workspace."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "tutorial"
+competitors:
+  - opencode
+  - git-worktrees
+keywords:
+  - run multiple opencode agents
+  - opencode parallel agents
+  - opencode orchestrator
+  - opencode agent teams
+  - opencode worktrees
+  - opencode multi session
+---
+
+OpenCode is an open-source, terminal-first AI coding agent that is genuinely good at single-task work. The moment you want several OpenCode agents working at once, such as one writing tests, one refactoring, one updating docs, the bottleneck stops being the model and becomes workflow: how do you keep parallel work isolated and reviewable? This guide covers the real options, from OpenCode's built-in features to community orchestrators and worktree-based workspaces.
+
+---
+
+## The Real Problem
+
+Running one OpenCode agent is easy. Running several on the same repository is where things break down. Two agents editing the same working directory overwrite each other and tangle branches. So the question is not "can OpenCode do parallel work?" but "how do I isolate each agent so parallel work stays clean?"
+
+There are four practical approaches, in rough order of isolation.
+
+## The Approaches
+
+### 1. OpenCode's built-in multi-session
+
+OpenCode supports starting multiple agents in parallel on the same project, and ships with built-in agents (build and plan) plus a general subagent for multi-step tasks. This is the simplest way to parallelize and needs no extra tools. The limitation is isolation: multi-session parallelism runs within the client and does not, by itself, give each task its own Git worktree, so you still need discipline to avoid collisions on shared files.
+
+### 2. Community orchestrator plugins
+
+Because demand for heavier orchestration is high, the community has built plugins that add "orchestrator" or "agent teams" roles on top of OpenCode (for example, planner, worker, and reviewer roles). These are useful, but it is worth being clear: they are third-party community projects, not an official OpenCode product. If you adopt one, evaluate its maintenance and how it handles isolation.
+
+### 3. Manual Git worktrees
+
+The reliable way to isolate parallel agents is a Git worktree per task. A worktree gives each agent its own directory and branch that share the repository history, so agents cannot step on each other. You can set this up by hand: create a worktree per task, launch an OpenCode agent in each, and review the diffs separately. It works well but is manual to create, track, and clean up.
+
+### 4. Superset + OpenCode
+
+Superset automates the worktree approach. It runs OpenCode as a first-class agent, giving every task its own Git worktree, branch, and persistent terminal, so many OpenCode agents work the same repository in parallel without collisions. Review happens in a built-in diff editor, with an in-app browser and MCP alongside, and you can hand off to your editor. It removes the manual worktree bookkeeping while keeping full isolation.
+
+## Quick Comparison
+
+| Approach | Isolation | Setup | Review |
+|---|---|---|---|
+| **Built-in multi-session** | Shared working copy | None | In the terminal |
+| **Community plugins** | Varies by plugin | Moderate | Varies |
+| **Manual worktrees** | Full (per task) | Manual per task | You track each diff |
+| **Superset + OpenCode** | Full (automatic) | Automatic | Built-in diff review |
+
+## Recommended Workflow
+
+### 1. Break work into independent tasks
+
+Parallel agents work best on tasks that do not overlap: tests, a refactor, a bug fix, docs. If two tasks touch the same files heavily, keep them sequential.
+
+### 2. Give every agent its own worktree
+
+Whether manual or automatic, isolate each OpenCode agent in its own Git worktree so parallel changes never share a working directory.
+
+### 3. Keep prompts narrow
+
+A focused prompt per agent produces a reviewable diff. Broad prompts across many files are harder to isolate and review.
+
+### 4. Review each diff before merging
+
+Review each worktree's changes independently and merge the ones you want. Isolation is what makes this safe at more than one agent.
+
+## Why Superset Fits This Workflow
+
+Superset is built around exactly this: a Git worktree per task, persistent sessions, built-in diff review, and an in-app browser, all agent-agnostic. You can run OpenCode alongside Claude Code, Codex, Cursor, and Gemini in the same workspace, compare them on the same task, and extend across remote and cloud hosts. It turns the manual worktree workflow into the default. See [Superset vs OpenCode](/compare/superset-vs-opencode).
+
+## When Built-In Multi-Session Is Enough
+
+If you run two or three OpenCode agents occasionally and are careful about which files they touch, the built-in multi-session may be all you need. The case for worktrees grows with the number of agents and how much they overlap. Past a couple of concurrent agents on one repo, isolation stops being optional.
+
+## Verdict
+
+OpenCode can run multiple agents in parallel through its built-in multi-session, and the community has added orchestrator plugins on top. But the clean way to scale is a Git worktree per task, and the least manual way to get there is a workspace like Superset that creates and manages those worktrees for you, across OpenCode and any other agent.
+
+For the broader category, see [Best Agentic IDE in 2026](/compare/best-agentic-ide) and the guide to running [multiple Claude Code agents in parallel](/compare/multiple-claude-code-agents-parallel).
+
+## Frequently Asked Questions
+
+### Does OpenCode have an official orchestrator?
+
+OpenCode has built-in multi-session parallelism and built-in build, plan, and general subagents, but the heavier "orchestrator" and "agent teams" features widely searched for are community plugins, not an official OpenCode product. For managed worktree orchestration across agents, a workspace like Superset is an option.
+
+### How do I isolate parallel OpenCode agents?
+
+Give each agent its own Git worktree so they do not share a working directory. You can do this manually or automatically with a workspace like Superset that creates a worktree per task.
+
+### Can I run OpenCode alongside Claude Code and Codex?
+
+Yes. Superset is agent-agnostic and runs OpenCode, Claude Code, Codex, Cursor, Gemini, and custom agents in parallel, each in its own worktree.
+
+### Is OpenCode's desktop app good for parallel work?
+
+OpenCode offers a desktop app in beta alongside the terminal client, with multi-session support. For worktree-per-task isolation across many agents, developers often add a dedicated workspace on top.

--- a/apps/marketing/content/compare/superset-vs-aider.mdx
+++ b/apps/marketing/content/compare/superset-vs-aider.mdx
@@ -1,0 +1,104 @@
+---
+title: "Superset vs Aider (2026): Agent Workspace vs Terminal Pair Programmer"
+description: "Compare Superset and Aider for AI coding. See how a local-first workspace that runs many agents in parallel differs from a single terminal pair-programming CLI."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - aider
+keywords:
+  - superset vs aider
+  - aider alternative
+  - ai pair programming
+  - terminal ai coding agent
+  - parallel coding agents
+---
+
+Aider is one of the most popular open-source AI pair programmers — a single, focused CLI that edits your code and commits to Git from the terminal. Superset solves a broader problem: it is a local-first workspace that runs Aider (and other agents) across many isolated worktrees at once. In fact, Aider is one of the agents Superset can launch, so the real question is single-session pair programming versus multi-agent orchestration.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Aider** |
+|---|---|---|
+| **Category** | Agent orchestration workspace | Terminal AI pair programmer |
+| **AI approach** | Agent-agnostic — runs Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Model-agnostic — Claude, GPT, Gemini, DeepSeek, or local models |
+| **Parallelism** | Core feature — 10+ agents across isolated Git worktrees | One interactive session per terminal |
+| **Interface** | Desktop app: terminals, diff/file editor, chat, in-app browser | Command-line REPL in your terminal |
+| **Git model** | Isolated worktree per task | Auto-commits to your current branch |
+| **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Free, open source (Apache-2.0); bring your own API keys |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Aider, Copilot, Cursor Agent, Gemini CLI, Superset Chat, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+---
+
+## What Is Aider?
+
+Aider is an open-source AI pair programming tool that runs in your terminal. You point it at a repository, chat with it about changes, and it edits files and commits them to Git for you. It builds a map of your repo to work effectively in larger codebases, supports a wide range of models (Anthropic, OpenAI, Google, DeepSeek, and local models via OpenAI-compatible endpoints), and stays deliberately lightweight — no GUI, no vendor runtime, just a fast command-line loop. It is free and open source under Apache-2.0.
+
+---
+
+## Key Differences
+
+### Single Session vs Parallel Agents
+
+Aider is designed around one focused conversation: you and the model, iterating on a change in one terminal. Superset is built for parallelism — it runs many agents at once, each in its own Git worktree, so a refactor, a test-generation pass, and a bug fix can all progress simultaneously without stepping on each other.
+
+### Terminal Loop vs Full Workspace
+
+Aider is intentionally minimal: a terminal REPL that edits and commits. Superset wraps agents in a desktop workspace with a diff/file editor, chat, an in-app browser for previewing dev servers and docs, port management, and MCP tooling — so reviewing and steering agents does not require leaving the app.
+
+### Complementary, Not Mutually Exclusive
+
+Aider is one of the CLI agents Superset can run. You can use Aider standalone for quick, focused edits, and launch it inside Superset when you want to run it in an isolated worktree alongside other agents. Superset does not replace Aider; it orchestrates it.
+
+### Privacy
+
+Both keep the code on your machine and let you choose your own model provider. Superset runs agents locally in Git worktrees and is source-available; Aider is fully open source. Neither routes your repository through a required hosted runtime.
+
+---
+
+## Pricing
+
+Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex) — transparent provider costs, no platform credit system.
+
+Aider is free and open source (Apache-2.0). You only pay for the model API you point it at, or nothing at all if you run a local model. That makes Aider the cheapest possible way to start, at the cost of a single-session, terminal-only workflow.
+
+---
+
+## Which Should You Choose?
+
+**Choose Aider if you:**
+- Want a lightweight, open-source pair programmer that lives in your terminal
+- Work one focused change at a time and like fast, direct Git commits
+- Want maximum model flexibility, including local models, with zero platform cost
+- Prefer a minimal CLI over a full application
+
+**Choose Superset if you:**
+- Want to run Aider and other agents across 10+ tasks in parallel
+- Need isolated Git worktrees so parallel work never collides
+- Want a diff editor, chat, browser preview, and MCP tooling around your agents
+- Use any editor and do not want your workflow tied to a single tool
+
+Both tools work together. Use Aider for quick terminal edits, and run it inside Superset when you want worktree isolation and parallel agents around it.
+
+---
+
+## Frequently Asked Questions
+
+### Can Superset run Aider?
+
+Yes. Aider is one of the CLI agents Superset can launch inside an isolated Git worktree, alongside Claude Code, Codex, OpenCode, and others. Superset acts as the workspace and orchestration layer around Aider.
+
+### Is Aider free?
+
+Yes. Aider is open source under Apache-2.0 and free to use. You only pay for the model API you connect it to, or nothing if you run a local model.
+
+### Does Aider support parallel agents?
+
+Not on its own — Aider runs one interactive session per terminal. To run Aider (or a mix of agents) across many tasks at once, you can launch multiple instances inside Superset, each in its own worktree.

--- a/apps/marketing/content/compare/superset-vs-claude-code-app.mdx
+++ b/apps/marketing/content/compare/superset-vs-claude-code-app.mdx
@@ -1,0 +1,109 @@
+---
+title: "Superset vs Claude Code App (2026): Orchestrator vs Multi-Surface Agent"
+description: "Compare Superset and the Claude Code app across desktop, web, and mobile. See how worktree-based agent orchestration differs from a single multi-surface coding agent."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - claude-code-app
+keywords:
+  - superset vs claude code app
+  - claude code app alternative
+  - claude code app
+  - claude code desktop
+  - claude code web
+  - run claude code in parallel
+---
+
+Claude Code is Anthropic's coding agent, and the same engine now runs across six surfaces: a terminal CLI, a desktop app, VS Code, JetBrains, the web, and mobile. When people say "the Claude Code app," they usually mean the desktop app (a graphical interface over the local engine) or Claude Code on the web. Superset is not another Claude Code surface -- it is an orchestration workspace that runs Claude Code, and other agents, in parallel with Git worktree isolation. This page compares the two.
+
+For the general agent comparison, see [Superset vs Claude Code](/compare/superset-vs-claude-code).
+
+---
+
+## At a Glance
+
+| | **Superset** | **Claude Code App** |
+|---|---|---|
+| **Category** | Agent orchestration workspace | Anthropic's coding agent, multiple surfaces |
+| **Surfaces** | Desktop app, CLI, MCP server | CLI, desktop app, VS Code, JetBrains, web, mobile |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Claude Code (Anthropic models) |
+| **Parallelism** | Many agents on separate branches, one worktree each | Parallel sessions (desktop); cloud sessions (web) |
+| **Isolation** | Automatic Git worktree per task | No native per-task worktree isolation |
+| **Review tooling** | Built-in diff/file editor, staging, commit | Desktop diff viewer and app preview |
+| **Pricing** | Free tier + Pro $20/seat/mo | Claude Pro / Max plans; API pricing |
+| **License** | Source-available (ELv2) | Proprietary |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is the Claude Code App?
+
+Claude Code is Anthropic's AI coding agent, running the same underlying engine across six surfaces, each tuned for a different workflow. The CLI is the most complete surface. The desktop app wraps the local engine in a graphical interface with a diff viewer, app preview, and parallel sessions. VS Code and JetBrains extensions bring it into those editors. Claude Code on the web runs in Anthropic's cloud and keeps working after you disconnect. The mobile apps act as a thin client to start and monitor sessions. Configuration, project memory, and MCP servers are shared across the local surfaces. Claude Code is available on Claude Pro and Max plans and via the API.
+
+## Key Differences
+
+### One Agent, Many Surfaces vs Many Agents, One Workspace
+
+The Claude Code app is about running one excellent agent wherever you work -- terminal, editor, desktop, web, or phone. Superset is about running many agents in one place. It can run Claude Code as one of several agents, each in its own worktree, alongside Codex, OpenCode, Cursor, Gemini, and custom terminal agents. If Claude Code is your only agent, its app coverage is broad; if you run several agents or want to compare them on the same task, Superset is built for that.
+
+### Isolation Model
+
+The Claude Code desktop app supports parallel sessions, and the web surface runs in the cloud, but Claude Code does not natively give each parallel task its own Git worktree. Superset makes a worktree per task the default, so multiple agents can work on the same repository at once without sharing a working directory or stepping on each other's branch. If your reason for wanting parallelism is running several tasks on one repo safely, that isolation is the key difference.
+
+### Review and Orchestration in One Place
+
+Superset centralizes launching, isolating, reviewing, and merging across all your agents in a single workspace, with an in-app browser and one-click handoff to your editor. The Claude Code app gives you Claude's own desktop diff viewer and app preview per session. If you want a single orchestration and review layer that spans more than one agent, that is Superset's role.
+
+### They Work Together
+
+This is not strictly either/or. Many developers run Claude Code as their primary agent inside Superset, using the Claude Code app on its own for quick single-task work and Superset when several agents need isolated worktrees on the same repo. Superset wraps Claude Code rather than replacing it.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month, and you bring your own agent providers. Claude Code is available through Claude Pro and Max plans and via Anthropic's API. You pay Anthropic for Claude Code usage whether you run it directly or inside Superset.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want to run multiple agents, or Claude Code alongside others, in one workspace
+- Need automatic Git worktree isolation for parallel work on one repo
+- Want unified review and orchestration across agents
+- Prefer local-first work with your own remote/cloud hosts
+
+**Choose the Claude Code App if you:**
+
+- Use Claude Code as your single agent and want it on every surface
+- Want Anthropic's own desktop, web, and mobile experiences
+- Like starting a task on the web and monitoring it from your phone
+- Do not need multi-agent orchestration or per-task worktrees
+
+**Verdict:** The Claude Code app is excellent if Claude Code is your one agent and you want it everywhere. Superset is the better fit if you run several agents, want automatic worktree isolation for parallel work on the same repository, and want one workspace to orchestrate and review them all -- with Claude Code as a first-class agent inside it.
+
+---
+
+## Frequently Asked Questions
+
+### What does "Claude Code app" mean?
+
+It is ambiguous. It usually refers to the Claude Code desktop app (a GUI over the local engine), but can also mean Claude Code on the web or the mobile apps. Superset is a separate workspace that can run Claude Code as one of many agents.
+
+### Does the Claude Code app use Git worktrees?
+
+Not natively. The desktop app supports parallel sessions and the web runs in the cloud, but Claude Code does not automatically give each task its own worktree. Superset does.
+
+### Can I use Claude Code inside Superset?
+
+Yes. Superset runs Claude Code as a first-class agent, each session in its own worktree, alongside other agents. You still pay Anthropic for Claude Code usage.
+
+### Which should I use for running several tasks on one repo?
+
+If you want several agents working the same repository at once without collisions, Superset's worktree-per-task model is the safer answer. The Claude Code app is better for single-agent work across many surfaces.

--- a/apps/marketing/content/compare/superset-vs-claude-squad.mdx
+++ b/apps/marketing/content/compare/superset-vs-claude-squad.mdx
@@ -1,0 +1,104 @@
+---
+title: "Superset vs Claude Squad (2026): Desktop Workspace vs Terminal Multiplexer"
+description: "Compare Superset and Claude Squad for running multiple coding agents in Git worktrees. See how a desktop agent workspace differs from a terminal TUI."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - claude-squad
+keywords:
+  - superset vs claude squad
+  - claude squad alternative
+  - claude squad
+  - manage multiple claude code agents
+  - parallel claude code
+  - git worktree agents
+---
+
+Superset and Claude Squad both run multiple coding agents in parallel, each in its own Git worktree. Claude Squad does it as a terminal app: a TUI that manages agent sessions with Git worktrees and tmux. Superset does it as a desktop workspace, layering diff review, an in-app browser, MCP, and remote and cloud workspaces on the same worktree model. If you love the terminal, Claude Squad is lean and effective; if you want a graphical workspace around the same idea, Superset covers more.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Claude Squad** |
+|---|---|---|
+| **Category** | Desktop agent orchestration workspace | Terminal TUI for managing agents |
+| **What it does** | Runs 100+ agents in parallel with worktree isolation, review, and browser | Runs multiple agent sessions in isolated worktrees via tmux |
+| **Isolation** | Automatic Git worktree per task | Git worktree per agent + tmux sessions |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Agent-agnostic (Claude Code, Codex, Gemini, Aider, OpenCode, Amp, custom) |
+| **Interface** | Graphical desktop app with panes and diff review | Terminal TUI |
+| **Review tooling** | Built-in diff/file editor, staging, commit | Terminal-native; review in the agent or your editor |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | CLI (macOS, Linux) |
+| **License** | Source-available (ELv2) | Open source (AGPL-3.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Claude Squad?
+
+Claude Squad is an open-source terminal app that manages multiple AI coding agents in separate isolated workspaces so you can run several tasks at once. It combines Git worktrees for per-branch code isolation with tmux for per-agent terminal sessions, driven from a single TUI (`cs`). It is agent-agnostic -- Claude Code, Codex, Gemini, Aider, OpenCode, Amp, and any local agent via custom configuration -- and is AGPL-3.0 licensed, installable via Homebrew or a curl script on macOS and Linux.
+
+## Key Differences
+
+### Terminal TUI vs Desktop Workspace
+
+Claude Squad lives entirely in the terminal. It is fast, keyboard-driven, and pairs worktrees with tmux to keep sessions isolated. Superset is a graphical desktop workspace: the same worktree-per-task isolation, but with panes, a built-in diff and file editor, an in-app browser for docs and dev servers, and one-click handoff into your IDE. Which you prefer comes down to whether you want a lean terminal tool or a full workspace UI.
+
+### Review and Extras
+
+Because Claude Squad is terminal-native, review happens in the agent itself or in whatever editor you open. Superset adds review, browser preview, port management, and MCP tooling in one app. If you want those surfaces built in rather than assembled yourself, that is Superset's advantage.
+
+### Reach Beyond One Machine
+
+Superset extends past the local desktop with remote and cloud workspaces on your own network devices, plus a CLI and MCP server. Claude Squad runs locally. If moving work across machines or scripting the orchestration matters, Superset offers more.
+
+### Shared Foundation
+
+Both are agent-agnostic and both make a Git worktree per agent the unit of isolation, so the core workflow -- many agents, separate branches, review before merge -- is the same. The difference is the surface: a TUI versus a desktop workspace with more built in.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Claude Squad is free and open source (AGPL-3.0). In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want a graphical workspace with built-in review and browser
+- Need remote, cloud, CLI, or MCP surfaces
+- Prefer a full workspace over assembling terminal tooling yourself
+- Work on more than macOS and Linux, or plan to
+
+**Choose Claude Squad if you:**
+
+- Live in the terminal and want a lean, keyboard-driven TUI
+- Are comfortable with tmux and reviewing in your own editor
+- Want a free, open-source tool with minimal footprint
+- Only need local, single-machine orchestration
+
+**Verdict:** Claude Squad is a great fit if you want a lightweight terminal multiplexer for parallel agents and are happy managing review yourself. Superset is the better fit if you want the same worktree model wrapped in a desktop workspace with review, browser, remote hosting, and MCP built in.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and Claude Squad both use Git worktrees?
+
+Yes. Both isolate each agent in its own Git worktree and branch. Claude Squad adds tmux for terminal sessions; Superset adds a desktop UI, review, and browser around the same model.
+
+### Is Claude Squad only for Claude Code?
+
+No. Despite the name, Claude Squad is agent-agnostic and runs Claude Code, Codex, Gemini, Aider, OpenCode, Amp, and custom agents. Superset is likewise agent-agnostic.
+
+### Which one has a graphical interface?
+
+Superset is a graphical desktop app. Claude Squad is a terminal TUI. If you want built-in visual diff review and a browser, Superset provides them; if you prefer the terminal, Claude Squad is lighter.

--- a/apps/marketing/content/compare/superset-vs-cline.mdx
+++ b/apps/marketing/content/compare/superset-vs-cline.mdx
@@ -1,0 +1,104 @@
+---
+title: "Superset vs Cline (2026): Agent Workspace vs In-Editor Agent"
+description: "Compare Superset and Cline for AI coding. See how an editor-independent workspace running parallel agents differs from an autonomous agent embedded in VS Code."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - cline
+keywords:
+  - superset vs cline
+  - cline alternative
+  - vs code ai agent
+  - autonomous coding agent
+  - parallel coding agents
+---
+
+Cline is a popular open-source autonomous coding agent that lives inside VS Code. It plans, edits files, runs terminal commands, and uses your own API keys — all within the editor. Superset takes a different shape: it is an editor-independent, local-first workspace that runs many CLI agents in parallel across isolated Git worktrees, and treats your editor as a choice rather than the container.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Cline** |
+|---|---|---|
+| **Category** | Agent orchestration workspace | In-editor autonomous agent |
+| **Home** | Standalone desktop app | VS Code (and forks) extension |
+| **AI approach** | Agent-agnostic — Claude Code, Codex, Aider, Superset Chat, any CLI agent | Model-agnostic — Anthropic, OpenRouter, Bedrock, and more via your keys |
+| **Parallelism** | Core feature — 10+ agents across isolated Git worktrees | One agent per editor window/session |
+| **Isolation** | Git worktree per task | Works in your open workspace folder |
+| **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Free, open source; bring your own API keys |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Aider, Copilot, Cursor Agent, Gemini CLI, Superset Chat, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+---
+
+## What Is Cline?
+
+Cline is an open-source AI coding agent that runs as a VS Code extension. It works in Plan and Act modes: it can read and write files, run terminal commands, use a browser, and connect to MCP servers, all from inside the editor. You bring your own model access (Anthropic, OpenRouter, AWS Bedrock, and others), so there is no hosted runtime or credit system — the extension is free and you pay your provider directly. Its strength is tight, in-editor autonomy: the agent operates right where you already write code.
+
+---
+
+## Key Differences
+
+### In-Editor Agent vs Editor-Independent Workspace
+
+Cline is embedded in VS Code — its context is your open editor window. Superset sits outside any single editor: it orchestrates agents around the repository and lets you review in its own UI or in VS Code, Cursor, JetBrains, or Xcode. If you are not a VS Code user, Cline does not fit; Superset does not care which editor you use.
+
+### One Agent vs Many in Parallel
+
+Cline runs one agent session per editor window. Superset is built to run 10+ agents at once, each isolated in its own Git worktree, so parallel tasks never collide over the same files or branch. That is the difference between an in-editor assistant and a multi-agent orchestrator.
+
+### Worktree Isolation
+
+Cline operates in your currently open workspace folder. Superset gives every task its own Git worktree, so an experimental refactor and a hotfix can run at the same time on the same repo without interfering. Isolation is the core primitive Superset is built around.
+
+### Privacy
+
+Both keep code local and use your own model keys — no required hosted runtime. Cline is fully open source; Superset is source-available (ELv2) and runs agents locally in worktrees.
+
+---
+
+## Pricing
+
+Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex) — transparent provider costs, no platform credit system.
+
+Cline is free and open source. You pay only for the model API you connect it to. That makes both tools "bring your own keys" with no markup — the difference is form factor, not billing model.
+
+---
+
+## Which Should You Choose?
+
+**Choose Cline if you:**
+- Live in VS Code and want an autonomous agent right inside the editor
+- Work one task at a time and want the agent to share your open workspace context
+- Want a free, open-source extension with your own model keys
+- Value Plan/Act control and MCP support inside the editor
+
+**Choose Superset if you:**
+- Want to run many agents in parallel across isolated Git worktrees
+- Use JetBrains, Xcode, Neovim, or multiple editors — or want to stay editor-independent
+- Need a workspace with diff review, chat, browser preview, and port management around your agents
+- Want to mix agents (Claude Code, Codex, Aider, and more) rather than one in-editor agent
+
+Both can coexist: use Cline for in-editor autonomy, and Superset to dispatch parallel agents across worktrees for larger, concurrent work.
+
+---
+
+## Frequently Asked Questions
+
+### Is Superset a VS Code extension like Cline?
+
+No. Superset is a standalone desktop workspace, not an editor extension. It runs agents around your repository and lets you review in its own UI or open the code in VS Code, Cursor, JetBrains, or Xcode.
+
+### Does Cline support running multiple agents in parallel?
+
+Cline runs one agent per editor session. For many concurrent tasks, you would open multiple windows, but they share your workspace folder. Superset instead isolates each agent in its own Git worktree so parallel work does not collide.
+
+### Are Superset and Cline both bring-your-own-key?
+
+Yes. Both let you use your own model provider keys with no credit system. Cline is a free open-source extension; Superset has a free tier plus a $20/seat/month Pro plan for its workspace features.

--- a/apps/marketing/content/compare/superset-vs-cmux.mdx
+++ b/apps/marketing/content/compare/superset-vs-cmux.mdx
@@ -1,0 +1,108 @@
+---
+title: "Superset vs cmux (2026): Agent Terminal vs Agent Orchestrator"
+description: "Compare Superset and cmux for running AI coding agents. See how a native terminal for agents differs from a Git worktree orchestration workspace."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - cmux
+keywords:
+  - superset vs cmux
+  - cmux alternative
+  - cmux claude code
+  - terminal for ai agents
+  - agent terminal
+  - ai coding terminal
+---
+
+Superset and cmux both help you run many AI coding agents at once, but they sit in different categories. cmux is a native terminal built for agents: it makes concurrent sessions visible and controllable in one polished macOS app. Superset is an orchestration workspace: it gives every task its own Git worktree and layers review, browser, and automation around the agents. One organizes your agent sessions; the other isolates and manages the work each agent does.
+
+---
+
+## At a Glance
+
+| | **Superset** | **cmux** |
+|---|---|---|
+| **Category** | Agent orchestration workspace | Native terminal for AI agents |
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Runs agent sessions in vertical tabs and split panes with notifications and an embedded browser |
+| **Isolation** | Automatic Git worktree per task | None built in -- isolation is left to the agent or to you |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Any terminal agent (Claude Code, Codex, OpenCode, Gemini, Aider, Goose, and more) |
+| **Review tooling** | Built-in diff/file editor, staging, and commit | Terminal-native; review happens in the agent or your editor |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | macOS only |
+| **License** | Source-available (ELv2) | Open source (GPL-3.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is cmux?
+
+cmux is a native macOS terminal built specifically for running AI coding agents. Built on a GPU-accelerated core, it adds vertical tabs, split panes, notification "rings" around a pane when a process needs attention, an embedded scriptable browser, and a programmable socket API. Its goal is to make many concurrent agent sessions visible and controllable in one native app, including surfacing an agent's subagents as their own panes. cmux runs any terminal-launchable agent and is free and open source under GPL-3.0, on macOS only.
+
+> Note: two actively maintained tools share the name "cmux." This page is about the native macOS agent terminal from manaflow. A separate, smaller project (craigsc/cmux) is a Claude-Code-only bash CLI that does use Git worktrees per agent; if that is the tool you mean, its model is closer to Superset's but far narrower in scope.
+
+## Key Differences
+
+### Organizing Sessions vs Isolating Work
+
+This is the core distinction. cmux is a terminal: it makes your agent sessions easy to see, split, and switch between, but it does not isolate what each agent changes. If two agents work on the same repository, they share one working directory unless you set up isolation yourself. Superset makes a Git worktree per task the default, so every agent gets its own branch and directory automatically. cmux answers "how do I see all my agents?"; Superset answers "how do I run agents on the same repo without collisions?"
+
+### Review and Merge Flow
+
+Because cmux is terminal-native, reviewing and merging happens in the agent itself or in whatever editor you open afterward. Superset includes a built-in diff and file editor where you can review, stage, and commit each task's changes, then jump into VS Code, Cursor, JetBrains, or Xcode if you prefer. If you want the review layer inside the same app that runs the agents, that is a Superset feature rather than a cmux one.
+
+### Beyond the Terminal
+
+Superset extends past a single machine with remote and cloud workspaces, scheduled automations with a TypeScript SDK, and CLI and MCP server surfaces. cmux is focused on being an excellent native terminal on macOS, with an embedded browser and scripting API for driving sessions. They can even be complementary: some developers will keep cmux as their daily agent terminal and reach for a worktree orchestrator when multiple agents need to touch the same repo.
+
+### Platform
+
+cmux is macOS only today. Superset ships on macOS now, with Windows and Linux planned, and also runs as a CLI and MCP server. If you need anything beyond macOS, that is a practical difference.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. cmux is free and open source, with an optional paid edition for early access to upcoming features. In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want automatic Git worktree isolation so agents can share one repo safely
+- Want built-in diff review and merge inside the same app
+- Need remote, cloud, CLI, or MCP surfaces
+- Work on more than just macOS, or plan to
+
+**Choose cmux if you:**
+
+- Want a fast, native macOS terminal purpose-built for agent sessions
+- Mostly run one agent (or manage isolation yourself) and value terminal polish
+- Like an embedded browser and a scriptable API in your terminal
+- Prefer a fully open-source GPL tool
+
+**Verdict:** These tools are not really substitutes. cmux is the best fit if your goal is a beautiful native terminal that keeps many agent sessions organized. Superset is the better fit if your goal is running multiple agents on the same repository without collisions, with review and orchestration built in. Many developers will end up using a terminal like cmux alongside an orchestrator like Superset.
+
+---
+
+## Frequently Asked Questions
+
+### Does cmux use Git worktrees?
+
+The native macOS cmux terminal does not isolate tasks in Git worktrees itself -- that is left to the agent or to you. (A separate, smaller project that shares the name, craigsc/cmux, does use worktrees but only for Claude Code.) Superset makes a worktree per task automatic.
+
+### Is cmux only for macOS?
+
+Yes. The cmux agent terminal is macOS only today. Superset ships on macOS now with Windows and Linux planned, plus CLI and MCP surfaces.
+
+### Can I use cmux and Superset together?
+
+Yes. They solve different problems. You can keep cmux as your native agent terminal and use Superset when multiple agents need isolated worktrees on the same repository, with review and orchestration in one place.
+
+### What is the best terminal for AI coding agents?
+
+If you want a polished native terminal for agent sessions on macOS, cmux is a strong choice. If your bottleneck is coordinating several agents on one repository, the deciding factor becomes worktree isolation and review, which is what Superset is built around. See our roundup of the [best terminal for AI coding agents](/compare/best-terminal-for-ai-coding).

--- a/apps/marketing/content/compare/superset-vs-codex-app.mdx
+++ b/apps/marketing/content/compare/superset-vs-codex-app.mdx
@@ -1,0 +1,103 @@
+---
+title: "Superset vs Codex App (2026): Local Worktrees vs Cloud Coding Agents"
+description: "Compare Superset and the OpenAI Codex app for parallel AI coding. See how local Git worktree orchestration differs from Codex's cloud task environments."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - codex-app
+keywords:
+  - superset vs codex app
+  - codex app alternative
+  - codex app
+  - openai codex app
+  - codex cloud agents
+  - conductor vs codex app
+---
+
+Codex is OpenAI's coding agent, offered as one product across a terminal CLI, an editor extension, a cloud service, a desktop app, and a web experience that all share one account and usage limits. When people say "the Codex app," they usually mean the desktop and cloud experience that runs coding tasks in parallel cloud environments. Superset takes a different approach: it runs agents in parallel on your own machine, each in an isolated Git worktree. This page compares those two models.
+
+For the terminal-focused comparison, see [Superset vs Codex CLI](/compare/superset-vs-codex).
+
+---
+
+## At a Glance
+
+| | **Superset** | **Codex App** |
+|---|---|---|
+| **Category** | Local-first agent orchestration workspace | OpenAI's Codex coding suite (app + cloud) |
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Runs Codex coding tasks across CLI, editor, desktop, web, and cloud |
+| **Parallelism** | Many agents on separate branches on your machine | Multiple tasks in parallel cloud environments |
+| **Isolation** | Automatic local Git worktree per task | Isolated cloud environments per task |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | OpenAI Codex |
+| **Where code runs** | Your local machine (and your own remote/cloud hosts) | OpenAI-managed cloud sandboxes (plus local CLI/editor) |
+| **Pricing** | Free tier + Pro $20/seat/mo | Included with ChatGPT plans; usage scales by tier |
+| **License** | Source-available (ELv2) | Proprietary (Codex CLI is open source) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is the Codex App?
+
+Codex is OpenAI's agentic coding system, delivered as one product across several surfaces that share a single account, configuration, and usage limits: a terminal CLI, an editor extension, a cloud agent, a desktop app, and a web experience, plus ChatGPT integration. The cloud experience is the distinctive part: you describe a task, Codex clones your repo into an isolated cloud environment, works in the background without using your local machine, and returns a diff and logs to review before you merge. You can start multiple tasks in parallel this way. Codex is included with ChatGPT plans, and usage scales with the plan tier.
+
+## Key Differences
+
+### Where the Work Runs
+
+This is the core difference. The Codex app's flagship parallelism is cloud-hosted: your repository is cloned into OpenAI-managed environments, and tasks run remotely so your machine can be off. Superset runs agents locally, each in a Git worktree on your own disk, using your real environment, dependencies, and services. Cloud execution is convenient for fire-and-forget tasks; local execution keeps everything on your machine and works without a round-trip to a hosted sandbox. Superset also lets you run on your own remote hosts when you want that, but the default is local and under your control.
+
+### One Vendor's Suite vs Agent-Agnostic
+
+Codex runs OpenAI's Codex agent. Superset is agent-agnostic: it can run Codex itself as one of many agents, alongside Claude Code, OpenCode, Cursor, Gemini, and others, all in the same workspace. If you want to standardize on OpenAI's suite, the Codex app is cohesive. If you want to mix agents or avoid tying your workflow to one vendor, Superset is built for that.
+
+### Review and Environment
+
+With the Codex app's cloud tasks, you configure the environment once (dependencies, variables), then review the returned diff and logs. With Superset, each agent runs in your existing checkout as a worktree, so the environment is whatever your machine already has, and you review in the built-in diff editor or jump straight into your own IDE. Teams with complex local setups, private services, or offline constraints often prefer keeping the loop local.
+
+### Pricing Model
+
+The Codex app is included with ChatGPT plans, and usage scales with your tier. Superset offers a free tier and Pro at $20/seat/month, and you bring your own agent providers -- including OpenAI -- so spend on models stays with those providers.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want agents to run locally in isolated Git worktrees on your own machine
+- Run more than one agent, or want to avoid locking into a single vendor
+- Need your real local environment, private services, or offline work
+- Want review and orchestration in one workspace across many agents
+
+**Choose the Codex App if you:**
+
+- Are standardized on OpenAI and want a cohesive Codex suite
+- Like fire-and-forget cloud tasks that run while your machine is off
+- Already pay for a ChatGPT plan and want Codex bundled in
+- Prefer OpenAI-managed environments over local setup
+
+**Verdict:** The Codex app is a strong choice if you live in OpenAI's ecosystem and like cloud tasks that run in the background. Superset is the better fit if you want local, worktree-isolated agents on your own machine, the freedom to run Codex alongside other agents, and a single workspace to orchestrate and review them all.
+
+---
+
+## Frequently Asked Questions
+
+### Is the Codex app the same as Codex CLI?
+
+They are surfaces of the same product. Codex CLI runs in your terminal; the app and cloud experience add a desktop app, a web experience, and parallel cloud task environments. For the CLI-specific comparison, see [Superset vs Codex CLI](/compare/superset-vs-codex).
+
+### Does the Codex app use Git worktrees?
+
+The Codex app's parallel tasks run in isolated cloud environments, not local Git worktrees. Superset makes a local worktree per task the default so agents run on your own machine.
+
+### Can Superset run Codex?
+
+Yes. Superset is agent-agnostic and can run the Codex CLI as one of many agents, each in its own worktree, alongside Claude Code, OpenCode, Cursor, Gemini, and others.
+
+### Which is cheaper?
+
+It depends on usage. The Codex app is bundled with ChatGPT plans and scales with your tier. Superset has a free tier and Pro at $20/seat/month, and you pay OpenAI directly for model usage.

--- a/apps/marketing/content/compare/superset-vs-conductor.mdx
+++ b/apps/marketing/content/compare/superset-vs-conductor.mdx
@@ -2,7 +2,7 @@
 title: "Superset vs Conductor (2026): Comparing AI Agent Orchestration Platforms"
 description: "Compare Superset and Conductor for managing AI coding agents. See how these orchestration tools differ in agent support, workflow, and developer experience."
 date: 2026-02-02
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - conductor
@@ -14,7 +14,7 @@ keywords:
   - conductor vs superset
 ---
 
-Superset and Conductor both run multiple coding agents in parallel with Git worktrees. The difference is scope: Conductor is tightly focused on Claude Code and Codex on macOS, while Superset has grown into a broader local-first workspace for many agents, with chat, browser, and review surfaces around the orchestration core.
+Superset and Conductor both run multiple coding agents in parallel with Git worktrees. The difference is scope: Conductor is a focused macOS app for Claude Code, Codex, and Cursor, while Superset has grown into a broader local-first workspace for many agents, with chat, browser, and review surfaces around the orchestration core.
 
 ---
 
@@ -22,11 +22,11 @@ Superset and Conductor both run multiple coding agents in parallel with Git work
 
 | | **Superset** | **Conductor** |
 |---|---|---|
-| **What it does** | Runs 10+ AI agents in parallel with Git worktree isolation | Runs Claude Code / Codex agents in parallel with Git worktree isolation |
-| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Aider, etc.) | Claude Code and Codex |
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation | Runs Claude Code / Codex / Cursor agents in parallel with Git worktree isolation |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, etc.) | Claude Code, Codex, and Cursor |
 | **Repo model** | Uses your existing local repo and creates isolated worktrees per task | Clones your repo and creates isolated workspaces on your Mac |
 | **Editor handoff** | VS Code, Cursor, JetBrains, Xcode | Cursor and VS Code handoff documented directly |
-| **Workflow style** | Agent-agnostic workspace orchestration | Mac app centered on Claude Code / Codex task flow |
+| **Workflow style** | Agent-agnostic workspace orchestration | Mac app centered on Claude Code / Codex / Cursor task flow |
 | **Platform** | Local-first desktop app | macOS app |
 
 ---
@@ -39,7 +39,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is Conductor?
 
-Conductor is a macOS app from Melty Labs for running Claude Code and Codex in parallel. Its homepage positions it as a Mac app that clones your repo, creates isolated workspaces, and lets you review and merge changes from multiple agents. The docs emphasize workflow guides like issue-to-PR setup, provider configuration, Codex support, and opening workspaces in Cursor or VS Code.
+Conductor is a macOS app from Melty Labs for running Claude Code, Codex, and Cursor agents in parallel. Its homepage positions it as a Mac app that runs those agents in isolated workspaces, then lets you review and merge changes and open pull requests. The docs emphasize workflow guides like issue-to-PR setup, provider configuration, and opening workspaces in Cursor or VS Code.
 
 ---
 
@@ -47,7 +47,7 @@ Conductor is a macOS app from Melty Labs for running Claude Code and Codex in pa
 
 ### Agent Flexibility
 
-Superset is deliberately broad -- any process that runs in a shell can fit into its workflow, and the current product also layers chat, browser preview, and review tooling around those agents. Conductor currently supports Claude Code and Codex. If those are your two primary agents, that focus can be a feature. If you want to mix in OpenCode, Aider, custom scripts, or whatever launches next month, Superset gives you more room to adapt.
+Superset is deliberately broad -- any process that runs in a shell can fit into its workflow, and the current product also layers chat, browser preview, and review tooling around those agents. Conductor supports Claude Code, Codex, and Cursor. If those are your primary agents, that focus can be a feature. If you want to mix in OpenCode, Gemini, custom scripts, or whatever launches next month, Superset gives you more room to adapt.
 
 ### Mac App Workflow vs Agent-Agnostic Terminal
 
@@ -80,11 +80,11 @@ Superset offers a free tier and Pro at $20/seat/month. Conductor's current websi
 
 **Choose Conductor if you:**
 
-- Primarily use Claude Code and Codex and want a focused Mac app for them
-- Want a polished issue-to-PR style workflow around those two agents
+- Primarily use Claude Code, Codex, and Cursor and want a focused Mac app for them
+- Want a polished issue-to-PR style workflow around those agents
 - Prefer Conductor's workspace dashboard and documented Cursor/VS Code handoff
 
-**Verdict:** Conductor is strongest if your world already revolves around Claude Code and Codex on macOS. Superset is the better fit if you expect your agent mix to change, want the orchestration layer to stay editor-independent, or care more about breadth than a tightly scoped app workflow.
+**Verdict:** Conductor is strongest if your world already revolves around Claude Code, Codex, and Cursor on macOS. Superset is the better fit if you expect your agent mix to change, want the orchestration layer to stay editor-independent, or care more about breadth than a tightly scoped app workflow.
 
 ---
 
@@ -96,7 +96,7 @@ Conductor currently markets itself as a Mac app. Its homepage language and downl
 
 ### Can Conductor run agents other than Claude Code?
 
-Conductor's current public positioning is Claude Code and Codex. If you want OpenCode, Aider, or custom CLI tools in the same orchestrator, Superset is the more flexible choice.
+Conductor supports Claude Code, Codex, and Cursor. If you want OpenCode, Gemini, or custom CLI tools in the same orchestrator, Superset is the more flexible choice.
 
 ### Do both tools use Git worktrees?
 

--- a/apps/marketing/content/compare/superset-vs-crystal.mdx
+++ b/apps/marketing/content/compare/superset-vs-crystal.mdx
@@ -1,0 +1,104 @@
+---
+title: "Superset vs Crystal (2026): Comparing Parallel Claude Code Workspaces"
+description: "Compare Superset and Crystal (now Nimbalyst) for running Claude Code and Codex in parallel Git worktrees. See how agent breadth, remote workflows, and scope differ."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - crystal
+keywords:
+  - superset vs crystal
+  - crystal alternative
+  - nimbalyst alternative
+  - parallel claude code
+  - claude code worktrees
+  - agentic ide
+---
+
+Superset and Crystal both run multiple Claude Code and Codex sessions in parallel Git worktrees inside one desktop app, with per-session diff review and integrated Git operations. The difference is scope and direction: Crystal is a focused, open-source app for Claude Code and Codex, now continuing under the name Nimbalyst, while Superset is a broader, agent-agnostic workspace that adds more agents, an in-app browser, remote and cloud workspaces, and automation.
+
+Note: Crystal has been renamed and is being succeeded by [Nimbalyst](https://nimbalyst.com/) as of early 2026. If you are evaluating "Crystal" today, you are effectively evaluating Nimbalyst.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Crystal (now Nimbalyst)** |
+|---|---|---|
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, browser, and automation | Runs Claude Code and Codex sessions in parallel Git worktrees with review and Git ops |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, Mistral Vibe, and more) | Claude Code and Codex |
+| **Isolation** | Automatic Git worktree per task | Git worktree per session |
+| **Review tooling** | Built-in diff/file editor, staging, commit | In-app diff review, per-iteration commits, rebase/squash/merge |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local desktop |
+| **Automation** | Automations: scheduled sessions, TypeScript SDK, Slack bot | Focused on interactive sessions |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Windows, Linux) |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces and can schedule agent sessions as automations. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Crystal?
+
+Crystal is an open-source Electron desktop app for running multiple Claude Code and Codex sessions in parallel Git worktrees. Each session gets its own worktree, with per-iteration commits, in-app diff review, and integrated Git operations like rebase, squash, and merge without leaving the app. It is MIT licensed and runs on macOS, Windows, and Linux. Its maintainers have renamed the project and now direct active development to Nimbalyst, so treat "Crystal" as the legacy name for what is now Nimbalyst.
+
+## Key Differences
+
+### Agent Breadth
+
+Crystal is built around Claude Code and Codex. If those are your two agents, its focus is a feature. Superset is deliberately agent-agnostic: it runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents you define. If you want to mix agents or adopt new ones as they launch, Superset gives you more room.
+
+### Same Worktree Core, Wider Surface
+
+Both apps make a Git worktree per session the unit of work and both include strong in-app review and Git operations. Around that, Superset adds an in-app browser for docs and dev servers, port management, an MCP server, and one-click handoff into more editors. Crystal keeps a tighter footprint focused on the review-and-merge loop for Claude Code and Codex.
+
+### Reach and Automation
+
+Superset extends past the local desktop with remote and cloud workspaces on your own network devices, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. Crystal is a local, interactive desktop app. If you want unattended or scheduled runs, or work that moves across machines, Superset covers more of it.
+
+### Project Status
+
+Crystal is stable and open source, but its maintainers have moved active development to Nimbalyst. Superset is actively developed under its current name. If long-term maintenance direction matters to you, factor in the Nimbalyst transition when evaluating Crystal.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Crystal is free and open source (MIT). In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Use more than Claude Code and Codex, or want to adopt new agents freely
+- Want remote, cloud, CLI, or MCP surfaces around the same worktree model
+- Need scheduled or unattended runs through automations
+- Prefer an actively developed product under one name
+
+**Choose Crystal (Nimbalyst) if you:**
+
+- Primarily use Claude Code and Codex and want a focused desktop app
+- Want a free, MIT-licensed tool with strong in-app Git operations
+- Work on one machine and value a tight review-and-merge loop
+
+**Verdict:** Crystal is a clean, open-source choice if Claude Code and Codex are your world and you want a focused parallel-worktree app -- just note its transition to Nimbalyst. Superset is the better fit if you want the same worktree model with broader agent support, an in-app browser, remote and cloud workspaces, and automation.
+
+---
+
+## Frequently Asked Questions
+
+### Is Crystal still maintained?
+
+Crystal has been renamed and its maintainers now direct active development to Nimbalyst. It still works, but new development happens under the Nimbalyst name.
+
+### Do both use Git worktrees?
+
+Yes. Both give each session its own Git worktree, branch, and working directory. The isolation model is the same; the products differ in agent breadth and surrounding features.
+
+### Can Crystal run agents other than Claude Code and Codex?
+
+Crystal is built specifically for Claude Code and Codex. If you want OpenCode, Cursor, Gemini, or custom agents in the same workspace, Superset is the more flexible choice.

--- a/apps/marketing/content/compare/superset-vs-cursor.mdx
+++ b/apps/marketing/content/compare/superset-vs-cursor.mdx
@@ -2,7 +2,7 @@
 title: "Superset vs Cursor (2026): Parallel Agents vs AI Editor"
 description: "Compare Superset and Cursor for AI-assisted development. See how parallel agent orchestration differs from an AI-powered editor."
 date: 2026-02-02
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - cursor
@@ -23,7 +23,7 @@ Cursor started as an AI-native editor, but it now spans its own IDE, cloud agent
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI coding suite (editor + cloud agents) |
 | **AI approach** | Agent-agnostic — works with Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Managed platform with Cursor-hosted agents and access to frontier models |
-| **Parallelism** | Core feature — 10+ agents across isolated worktrees | Cloud agents, automations, and web/mobile agents can run remotely in parallel |
+| **Parallelism** | Core feature — 100+ agents across isolated worktrees | Up to 8 agents in local Git worktrees (Cursor 2.0), plus cloud agents |
 | **Editor surface** | Works alongside any editor (VS Code, Cursor, JetBrains, Xcode) | Cursor IDE first, plus JetBrains via ACP and web/mobile agent surfaces |
 | **Pricing** | Free tier + Pro $20/seat/mo | Hobby free, Pro $20/mo, Pro+ $60/mo, Ultra $200/mo, Teams $40/user/mo |
 | **Privacy** | Local Git worktrees; you control agent and provider choices | Requests route through Cursor's services for managed models and cloud agents |
@@ -38,7 +38,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is Cursor?
 
-Cursor is no longer just a VS Code fork with autocomplete. It is a broader AI coding suite: the desktop IDE still anchors the experience, but Cursor now also offers cloud agents, automations, web/mobile agent access, and JetBrains support through ACP. The common thread is that Cursor manages the model access and agent runtime for you, rather than asking you to bring your own CLI tools.
+Cursor is no longer just a VS Code fork with autocomplete. It is a broader AI coding suite: the desktop IDE still anchors the experience, but Cursor now also offers cloud agents, automations, web/mobile agent access, and JetBrains support through ACP. Cursor 2.0 added a multi-agent interface that runs up to eight agents in parallel, each in its own local Git worktree, so you can compare results and pick the best. The common thread is that Cursor manages the model access and agent runtime for you, rather than asking you to bring your own CLI tools.
 
 ---
 
@@ -96,7 +96,7 @@ Not as an IDE. Superset does not provide Cursor-style inline completions or repl
 
 ### Does Cursor support parallel agents?
 
-Yes. Cursor now supports cloud agents, automations, and web/mobile agent workflows that can run in parallel. The difference is where and how they run: Cursor's parallelism is tied to Cursor's hosted platform, while Superset runs local CLI agents in Git worktrees on your machine.
+Yes. Cursor 2.0 runs up to eight agents in parallel, each in its own local Git worktree, plus cloud agents and automations. The difference is agent choice: Cursor's parallelism runs its own agents inside the Cursor stack, while Superset runs any CLI agent (Claude Code, Codex, OpenCode, and more) in worktrees on your machine, independent of any one editor.
 
 ### Is Superset really free?
 

--- a/apps/marketing/content/compare/superset-vs-devin.mdx
+++ b/apps/marketing/content/compare/superset-vs-devin.mdx
@@ -2,7 +2,7 @@
 title: "Superset vs Devin (2026): Local Agent Orchestration vs Cloud AI Engineer"
 description: "Compare Superset and Devin for AI-powered development. See how local parallel agent orchestration differs from a fully remote AI software engineer."
 date: 2026-02-18
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - devin
@@ -25,9 +25,9 @@ Devin is a cloud-based AI software engineer that works autonomously in a remote 
 | **Category** | Agent orchestration workspace | Autonomous AI software engineer |
 | **Architecture** | Local-first today — worktrees, review, browser, and chat run on your machine | Fully remote — runs in cloud VMs |
 | **AI approach** | Agent-agnostic — orchestrates external agents plus Superset Chat and MCP tools | Proprietary AI with browser, editor, and terminal in cloud |
-| **Parallelism** | 10+ agents across isolated local worktrees | Multiple Devin sessions run as separate cloud VMs |
+| **Parallelism** | 100+ agents across isolated local worktrees | Parallel cloud sessions (10 concurrent on Pro, unlimited on Max) |
 | **Code privacy** | Local-first; outbound model traffic depends on your chosen agents/providers | Code runs on Cognition's cloud infrastructure |
-| **Pricing** | Free tier + Pro $20/seat/mo | Teams $500/seat/mo |
+| **Pricing** | Free tier + Pro $20/seat/mo | Free; Pro $20/mo, Max $200/mo, Teams $80 + $40/seat |
 | **License** | Source-available (ELv2) | Closed source |
 
 ---
@@ -40,7 +40,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is Devin?
 
-Devin is Cognition's AI software engineer — a cloud-based autonomous agent that runs in its own virtual machine with a browser, code editor, terminal, and planner. You assign tasks via chat or Slack, and Devin works independently: reading docs, writing code, debugging, running tests, and creating pull requests. It has event-driven workflows (triggers from Linear, Slack, etc.) and a review system that annotates PRs before human review.
+Devin is Cognition's AI software engineer — a cloud-based autonomous agent that runs in its own virtual machine with a browser, code editor, terminal, and planner. You assign tasks via chat or Slack, and Devin works independently: reading docs, writing code, debugging, running tests, and creating pull requests. It has event-driven workflows (triggers from Linear, Slack, etc.) and a review system that annotates PRs before human review. Since Devin 2.0, Cognition retired the old $500/month usage model for flat tiers starting at $20/month, with parallel cloud sessions (up to 10 concurrent on Pro, unlimited on Max). Devin and the former Windsurf editor are now sold as one product family, so every paid tier also bundles Devin Desktop; see [Superset vs Windsurf](/compare/superset-vs-windsurf) for the editor comparison.
 
 ---
 
@@ -64,7 +64,7 @@ Superset isolates agents using Git worktrees — lightweight, fast, and built in
 
 ### Pricing
 
-Superset offers a free tier and Pro at $20/seat/month plus your agents' API costs. Devin costs $500/seat/month for the Teams plan. The price difference is significant — Superset plus API usage for heavy agent use typically costs a fraction of Devin's monthly fee.
+Superset offers a free tier and Pro at $20/seat/month plus your agents' API costs. Devin, since Devin 2.0, starts with a free tier and Pro at $20/month (up to 10 concurrent cloud sessions), with Max at $200/month (unlimited sessions) and Teams at $80/month plus $40/seat. Both entry tiers now sit at $20, so the decision is less about price and more about local control versus cloud autonomy, and about whether you want one proprietary agent or many.
 
 ---
 
@@ -74,7 +74,7 @@ Superset offers a free tier and Pro at $20/seat/month plus your agents' API cost
 - Want a fully autonomous AI that works in the background with minimal oversight
 - Need event-driven workflows (auto-respond to Linear tickets, Slack messages)
 - Prefer cloud-based execution where you don't manage local compute
-- Have budget for $500/seat/month and the ROI justifies it
+- Want autonomous parallel cloud sessions and the ROI justifies the cloud usage
 
 **Choose Superset if you:**
 - Want direct control over each agent — see what they're doing, redirect in real time
@@ -91,9 +91,9 @@ Superset offers a free tier and Pro at $20/seat/month plus your agents' API cost
 
 They serve different workflows. Devin is a cloud-based autonomous engineer. Superset is a local agent orchestrator. You might use Devin for fully autonomous background tasks and Superset for interactive parallel work where you want more control.
 
-### Is Devin worth the price premium?
+### How much does Devin cost now?
 
-Devin's $500/seat/month buys full autonomy: assign tasks via Slack, get PRs back. If your workflow benefits from hands-off delegation and you have the budget, it can be valuable. If you prefer direct control and cost efficiency, Superset at $20/seat/month plus API costs delivers more throughput per dollar.
+Since Devin 2.0, Cognition retired the old $500/month model. Devin now starts free, with Pro at $20/month (up to 10 concurrent cloud sessions), Max at $200/month (unlimited), and Teams at $80/month plus $40/seat. Superset is $20/seat/month plus your own agent API costs. Both entry tiers are $20, so choose on control and agent flexibility rather than price alone.
 
 ### Is Superset open source?
 

--- a/apps/marketing/content/compare/superset-vs-github-copilot.mdx
+++ b/apps/marketing/content/compare/superset-vs-github-copilot.mdx
@@ -2,7 +2,7 @@
 title: "Superset vs GitHub Copilot (2026): Agent Orchestration vs AI Pair Programmer"
 description: "Compare Superset and GitHub Copilot for AI-assisted development. See how parallel agent orchestration differs from inline AI code completion and chat."
 date: 2026-02-18
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - github-copilot
@@ -25,10 +25,10 @@ GitHub Copilot is an AI pair programmer that lives inside your editor, offering 
 |---|---|---|
 | **Category** | Agent orchestration workspace | AI pair programmer (editor extension) |
 | **What it does** | Runs 10+ coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | Inline code completions, chat, and Copilot Agent mode in your editor |
-| **AI approach** | Agent-agnostic — orchestrates any CLI agent | Multiple models (GPT-4o, Claude, Gemini) via GitHub |
-| **Parallelism** | Core feature — many agents on separate branches simultaneously | Single-threaded; Copilot Coding Agent runs one task at a time in cloud |
-| **Editor** | Works alongside any editor | VS Code, JetBrains, Neovim (extension) |
-| **Pricing** | Free tier + Pro $20/seat/mo | Free tier (limited), Pro $10/mo, Business $19/user/mo, Enterprise $39/user/mo |
+| **AI approach** | Agent-agnostic — orchestrates any CLI agent | Multiple frontier models (Claude, GPT, Gemini) via GitHub |
+| **Parallelism** | Core feature — many agents on separate branches simultaneously | In-editor agent mode; cloud coding agent runs on a branch and opens a PR |
+| **Editor** | Works alongside any editor | VS Code, JetBrains, Visual Studio, Neovim (extension) |
+| **Pricing** | Free tier + Pro $20/seat/mo | Free; Pro $10/mo, Pro+ $39/mo, Max $100/mo; Business $19/user, Enterprise $39/user |
 | **License** | Source-available (ELv2) | Closed source |
 
 ---
@@ -41,7 +41,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is GitHub Copilot?
 
-GitHub Copilot is an AI coding assistant from GitHub (Microsoft). It integrates into your editor as an extension, providing inline code completions (ghost text as you type), a chat panel for questions and code generation, and Copilot Agent mode that can make multi-file changes autonomously. Copilot also offers a cloud-based Coding Agent that creates PRs from GitHub Issues. It uses multiple models including GPT-4o, Claude Sonnet, and Gemini, accessible through GitHub's infrastructure.
+GitHub Copilot is an AI coding assistant from GitHub (Microsoft). It integrates into your editor as an extension, providing inline code completions (ghost text as you type), a chat panel for questions and code generation, and Copilot agent mode that can make multi-file changes autonomously. Copilot also offers a cloud-based coding agent that creates PRs from GitHub Issues, MCP support across all plans, and delegation to third-party agents like Claude and Codex on higher tiers. It uses multiple frontier models including Claude, GPT, and Gemini, accessible through GitHub's infrastructure.
 
 ---
 
@@ -61,7 +61,7 @@ Copilot lives inside your editor (VS Code, JetBrains, Neovim). Superset is a sep
 
 ### Model and Agent Flexibility
 
-Copilot supports multiple models (GPT-4o, Claude, Gemini) through GitHub's infrastructure. Superset supports any CLI-based agent — and by extension, whatever models those agents support. The difference is direct vs proxied: with Superset, you bring your own API keys and pay providers directly. With Copilot, you use GitHub's model access through their pricing tiers.
+Copilot supports multiple frontier models (Claude, GPT, Gemini) through GitHub's infrastructure. Superset supports any CLI-based agent — and by extension, whatever models those agents support. The difference is direct vs proxied: with Superset, you bring your own API keys and pay providers directly. With Copilot, you use GitHub's model access through their pricing tiers.
 
 ### Privacy
 
@@ -71,7 +71,7 @@ Superset runs the workspace locally in Git worktrees, and its source-available c
 
 ## Pricing
 
-Superset offers a free tier and Pro at $20/seat/month, plus your agents' API costs. GitHub Copilot offers Free (limited), Pro ($10/mo or $100/year), Business ($19/user/mo), and Enterprise ($39/user/mo). Copilot's pricing includes model access; Superset's doesn't (you pay agents' API costs separately).
+Superset offers a free tier and Pro at $20/seat/month, plus your agents' API costs. GitHub Copilot offers Free (limited), Pro ($10/mo), Pro+ ($39/mo), and Max ($100/mo) for individuals, plus Business ($19/user/mo) and Enterprise ($39/user/mo); higher tiers add more usage and third-party agent delegation. Copilot's pricing includes model access; Superset's doesn't (you pay agents' API costs separately).
 
 ---
 

--- a/apps/marketing/content/compare/superset-vs-openhands.mdx
+++ b/apps/marketing/content/compare/superset-vs-openhands.mdx
@@ -1,0 +1,104 @@
+---
+title: "Superset vs OpenHands (2026): Local Worktrees vs Sandboxed Agent"
+description: "Compare Superset and OpenHands for AI coding. See how a local-first workspace running CLI agents in Git worktrees differs from a sandboxed autonomous software engineer."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - openhands
+keywords:
+  - superset vs openhands
+  - openhands alternative
+  - opendevin alternative
+  - autonomous software engineer
+  - parallel coding agents
+---
+
+OpenHands (formerly OpenDevin) is an open-source platform for autonomous AI software engineers that run inside a sandbox, editing code, running commands, and browsing the web to complete tasks. Superset takes a local-first approach instead: it runs your choice of CLI coding agents directly in isolated Git worktrees on your machine, wrapped in a desktop workspace. The core contrast is a sandboxed autonomous agent versus an agent-agnostic local workspace.
+
+---
+
+## At a Glance
+
+| | **Superset** | **OpenHands** |
+|---|---|---|
+| **Category** | Agent orchestration workspace | Autonomous agent platform |
+| **Execution** | Local Git worktrees on your machine | Sandboxed runtime (Docker) or OpenHands Cloud |
+| **AI approach** | Agent-agnostic — Claude Code, Codex, Aider, Superset Chat, any CLI agent | Model-agnostic agent framework (via LiteLLM) |
+| **Parallelism** | Core feature — 10+ agents across isolated worktrees | Multiple sessions, typically one sandbox per task |
+| **Interface** | Desktop app: terminals, diff/file editor, chat, in-app browser | Web UI / CLI over a sandboxed agent |
+| **Pricing** | Free tier + Pro $20/seat/mo (bring your own API keys) | Open source (MIT) to self-host; Cloud is usage-based |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Aider, Copilot, Cursor Agent, Gemini CLI, Superset Chat, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+---
+
+## What Is OpenHands?
+
+OpenHands, from All Hands AI, is an open-source platform for autonomous AI agents that perform software-engineering tasks. Agents run inside a sandboxed runtime (typically a Docker container) where they can edit files, execute commands, and use a browser to accomplish a goal. It is model-agnostic through LiteLLM, posts strong results on engineering benchmarks, and can be self-hosted under an MIT license or used through OpenHands Cloud. Its strength is hands-off autonomy: you describe a task and the agent works it inside its sandbox.
+
+---
+
+## Key Differences
+
+### Sandboxed Runtime vs Local Worktrees
+
+OpenHands executes agents inside a sandbox (Docker or cloud), which is great for isolation and reproducibility but adds a runtime layer between the agent and your working copy. Superset runs agents directly on your machine, each in its own Git worktree — no container to manage, and the code stays in your local repo the whole time.
+
+### Autonomous Agent vs Agent Orchestrator
+
+OpenHands is itself the agent: one framework that plans and executes. Superset does not ship its own single autonomous engine — it orchestrates the agents you already use (Claude Code, Codex, Aider, and more), letting you pick the right one per task and run several side by side.
+
+### Review and Workspace Surface
+
+OpenHands centers on the agent's task loop with a web or CLI view. Superset centers on the workspace: a diff/file editor, chat, an in-app browser for dev servers, port management, and MCP tooling, so steering and reviewing multiple agents happens in one desktop app.
+
+### Privacy
+
+Superset keeps everything local in Git worktrees and is source-available. OpenHands can be fully self-hosted (MIT) for local control, or run via OpenHands Cloud, where execution happens on hosted infrastructure. Both give you a local-control option; the default execution model differs.
+
+---
+
+## Pricing
+
+Superset offers a free tier and a Pro plan at $20/seat/month. You also pay for your agents' API keys (for example Anthropic for Claude Code or OpenAI for Codex) — transparent provider costs, no platform credit system.
+
+OpenHands is open source under MIT, so self-hosting is free apart from the model API and the compute you run the sandbox on. OpenHands Cloud is a managed, usage-based option if you would rather not run the runtime yourself.
+
+---
+
+## Which Should You Choose?
+
+**Choose OpenHands if you:**
+- Want a fully autonomous agent that works inside a reproducible sandbox
+- Prefer a containerized runtime for isolation, or a managed cloud option
+- Want an open-source agent framework you can extend and self-host
+- Optimize for hands-off, benchmark-style task completion
+
+**Choose Superset if you:**
+- Want to run your existing CLI agents locally, in isolated Git worktrees
+- Need 10+ agents in parallel with no container runtime to manage
+- Want a desktop workspace with diff review, chat, browser preview, and MCP
+- Prefer agent choice and editor independence over one autonomous engine
+
+The two can complement each other: use OpenHands for sandboxed autonomous runs, and Superset as your day-to-day local workspace for orchestrating CLI agents across worktrees.
+
+---
+
+## Frequently Asked Questions
+
+### Is OpenHands the same as OpenDevin?
+
+Yes. OpenHands is the current name for the project formerly known as OpenDevin, maintained by All Hands AI.
+
+### Does Superset run agents in a sandbox like OpenHands?
+
+No. Superset runs agents directly on your machine in isolated Git worktrees rather than in a Docker sandbox. That removes a runtime layer and keeps code in your local repo, while worktrees still keep parallel tasks separated.
+
+### Can I self-host either tool?
+
+OpenHands is open source (MIT) and designed to be self-hosted, with a managed cloud option. Superset is a source-available (ELv2) local-first desktop app — it already runs entirely on your machine, with a free tier and a $20/seat/month Pro plan.

--- a/apps/marketing/content/compare/superset-vs-orca.mdx
+++ b/apps/marketing/content/compare/superset-vs-orca.mdx
@@ -1,0 +1,107 @@
+---
+title: "Superset vs Orca (2026): Comparing Worktree-Based Agent Workspaces"
+description: "Compare Superset and Orca for running AI coding agents in parallel Git worktrees. See how these agent development environments differ in remote workflows, automation, and scope."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - orca
+keywords:
+  - superset vs orca
+  - orca alternative
+  - orca ade alternative
+  - agentic ide
+  - ai agent orchestration
+  - worktree agent workspace
+---
+
+Superset and Orca are unusually close in design. Both are desktop workspaces that run many AI coding agents in parallel, give each task its own Git worktree, and add diff review and an in-app browser around the orchestration core. The differences are not about the core idea -- they are about scope, remote and cloud workflows, automation, and how far each product extends beyond a single machine.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Orca** |
+|---|---|---|
+| **What it does** | Runs 100+ AI agents in parallel with Git worktree isolation, chat, review, and browser | Runs multiple AI agents in parallel with Git worktree isolation and per-task browser tabs |
+| **Category** | Local-first agent workspace with remote/cloud hosts | Local agent development environment (ADE) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and more) | Agent-agnostic (25+ CLI agents, including Claude Code, Codex, OpenCode, Cursor CLI, Gemini) |
+| **Isolation** | Automatic Git worktree per task | Automatic Git worktree per task |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local desktop, plus iOS and Android companion apps |
+| **Automation** | Automations: scheduled agent sessions, TypeScript SDK, Slack bot | Focused on interactive parallel runs |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Windows, Linux) + mobile companions |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces, and it can schedule agent sessions as automations with a TypeScript SDK and a Slack bot. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Orca?
+
+Orca is a free, open-source desktop "agent development environment" from Stably. It runs multiple coding agents in parallel, giving every task its own Git worktree, its own agent terminal, and its own browser tab, with a unified UI for diffs, pull request and CI inspection, file browsing, and agent-status tracking. Its pitch is to fan one prompt across several agents, compare the results, and merge the winner. Orca is agent-agnostic, supports 25+ CLI agents, ships on macOS, Windows, and Linux, and offers iOS and Android companion apps. It is MIT licensed.
+
+## Key Differences
+
+### Same Worktree Model, Different Reach
+
+Both products make one Git worktree per task the default primitive, so this is not where they diverge. The difference is reach. Superset extends past the local desktop into remote and cloud workspaces that run on your own network devices, so you can start a task on one machine and pick it up from another. Orca is a local desktop environment with mobile companion apps for monitoring and control. If your work stays on one machine, both feel similar. If you want to move work across machines or run agents on a remote host, Superset covers more of that surface.
+
+### Automation and Scheduling
+
+Superset includes Automations: you can schedule agent sessions like cron jobs, drive them with a TypeScript SDK, and trigger or receive them through a Slack bot. That makes it suited to recurring or unattended work such as nightly dependency bumps, scheduled test runs, or triage. Orca is centered on interactive parallel runs where you launch, compare, and merge in the moment. If you want agents to run on a schedule or as part of a larger pipeline, Superset has more built in.
+
+### Breadth of Surfaces
+
+Beyond the desktop app, Superset is also available as a command-line interface and an MCP server, so the same orchestration can be scripted or embedded into other tools. Orca focuses on its desktop ADE plus mobile companions. Both are agent-agnostic and both give each task a browser, so day to day they overlap heavily; Superset simply exposes more entry points around the same core.
+
+### Licensing
+
+Orca is MIT licensed, which is maximally permissive. Superset is source-available under the Elastic License 2.0. For most individual developers and teams the practical experience is the same, but if a fully permissive open-source license is a hard requirement, that is a real distinction worth noting.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Orca is free and open source, with a bring-your-own-subscription model. In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want remote and cloud workspaces, not just a single local desktop
+- Need scheduled or unattended agent runs through automations and an SDK
+- Want CLI and MCP server surfaces around the same orchestration
+- Care about enterprise features like SOC 2 and team workflows
+
+**Choose Orca if you:**
+
+- Want a free, MIT-licensed desktop ADE for parallel agents
+- Mostly work on one machine and value the fan-out-and-compare workflow
+- Want mobile companion apps to monitor runs
+- Prefer a fully permissive open-source license
+
+**Verdict:** Orca and Superset share the same foundation, so you will not go wrong with either for local parallel agent work. Orca is a clean, free, open-source choice if your work lives on one machine. Superset is the better fit if you want the orchestration to extend across remote and cloud hosts, run on a schedule, and expose CLI and MCP surfaces for larger workflows.
+
+---
+
+## Frequently Asked Questions
+
+### Do Superset and Orca both use Git worktrees?
+
+Yes. Both create an isolated Git worktree for each task, giving every agent its own branch and working directory. The isolation mechanism is the same; the products differ in reach, automation, and surfaces.
+
+### Is Orca open source?
+
+Yes. Orca is MIT licensed and free to use. Superset is source-available under the Elastic License 2.0 and offers a free tier plus paid Pro.
+
+### Can both run agents other than Claude Code?
+
+Yes. Both are agent-agnostic. Orca lists 25+ supported CLI agents, and Superset runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents.
+
+### Which one works across multiple machines?
+
+Superset adds remote and cloud workspaces that run across your own network devices, so a task can move between machines. Orca is a local desktop environment with iOS and Android companion apps for monitoring and control.

--- a/apps/marketing/content/compare/superset-vs-sculptor.mdx
+++ b/apps/marketing/content/compare/superset-vs-sculptor.mdx
@@ -1,0 +1,102 @@
+---
+title: "Superset vs Sculptor (2026): Comparing Parallel Coding Agent Desktops"
+description: "Compare Superset and Imbue's Sculptor for running coding agents in parallel. See how agent-agnostic worktree orchestration differs from a container-and-pairing model."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - sculptor
+keywords:
+  - superset vs sculptor
+  - sculptor alternative
+  - sculptor imbue
+  - parallel coding agents
+  - agentic ide
+  - claude code parallel
+---
+
+Superset and Sculptor are both desktop apps for running coding agents in parallel with isolated workspaces and built-in review. Sculptor, from the AI lab Imbue, centers on Claude Code and Imbue's own Pi harness, with an isolated environment per agent and a "Pairing Mode" that syncs an agent's work back into your local repo. Superset is broader and agent-agnostic, making a Git worktree per task the default across many agents, with an in-app browser, MCP, and remote and cloud workspaces around it.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Sculptor** |
+|---|---|---|
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Runs coding agents in parallel isolated environments with pairing back to your repo |
+| **Isolation** | Automatic Git worktree per task | Isolated worktrees per workspace, plus optional containers |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Claude Code and Imbue's Pi; can manage other terminal agents |
+| **Signature feature** | Broad agent-agnostic orchestration + remote/cloud hosts | Pairing Mode syncs an agent's work into your local repo/IDE |
+| **Review tooling** | Built-in diff/file editor, staging, commit | In-app review with pairing to local checkout |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS Apple Silicon, Linux; Intel Mac and Windows planned) |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Sculptor?
+
+Sculptor is a desktop app from Imbue for running coding agents in parallel. You connect a repository, create isolated workspaces, and prompt agents that each run in their own environment; a "Pairing Mode" syncs an agent's work back into your local repo and IDE. It isolates work with worktrees per workspace, plus an experimental container backend for remote or containerized execution. Sculptor ships with Claude Code and Imbue's Pi harness and can manage other terminal-based agents. It is MIT licensed, free in beta (bring your own Anthropic API key or Claude Pro/Max), and runs on Apple Silicon macOS and Linux, with Intel Mac and Windows planned.
+
+## Key Differences
+
+### Agent Breadth
+
+Sculptor centers on Claude Code and Imbue's Pi harness, though it can manage other terminal agents. Superset is agent-agnostic from the ground up, running Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom agents in the same workspace. If your work spans several agents or you want to swap them freely, Superset gives you more room; if you mainly use Claude Code and Pi, Sculptor is tailored to that.
+
+### Pairing vs Worktree-First Orchestration
+
+Sculptor's signature is Pairing Mode: an agent works in an isolated environment, and its changes sync back into your local checkout and IDE. Superset keeps the worktree itself as the unit you work in, with in-app review and one-click handoff to your editor. Both isolate agents; they differ in how the isolated work rejoins your main checkout.
+
+### Containers and Reach
+
+Sculptor offers an experimental container backend alongside worktrees. Superset's default is a local Git worktree per task, and it extends across your own network devices with remote and cloud workspaces, plus CLI and MCP surfaces. If you want containerized isolation specifically, Sculptor leans that way; if you want worktree-first orchestration that spans machines, Superset does.
+
+### Maturity and Platform
+
+Both are actively evolving. Superset ships on macOS today with Windows and Linux planned, plus CLI and MCP. Sculptor runs on Apple Silicon macOS and Linux, with Intel Mac and Windows on the way, and is in free beta. Match the platform support to your fleet.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Sculptor is open source and free in beta, using your own Anthropic API key or Claude plan. In both cases, you still pay the underlying providers for model usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Run several agents, or want to swap agents freely
+- Want worktree-first orchestration that spans local, remote, and cloud hosts
+- Want an in-app browser, MCP, and CLI surfaces built in
+- Need a workspace to rely on across a mixed platform fleet
+
+**Choose Sculptor if you:**
+
+- Mainly use Claude Code and Imbue's Pi harness
+- Like the Pairing Mode workflow that syncs agent work into your local IDE
+- Want an experimental container backend for isolation
+- Are comfortable with a free beta on macOS or Linux
+
+**Verdict:** Sculptor is a strong pick if Claude Code and Pi are your focus and you like its pairing and container model. Superset is the better fit if you want agent-agnostic, worktree-first orchestration across many agents, with review, browser, MCP, and remote and cloud workspaces in one place.
+
+---
+
+## Frequently Asked Questions
+
+### Does Sculptor use Git worktrees or containers?
+
+Both. Sculptor isolates workspaces with worktrees and also offers an experimental container backend. Superset's default is a local Git worktree per task, with remote and cloud hosts available when you want them.
+
+### Is Sculptor only for Claude Code?
+
+Sculptor ships with Claude Code and Imbue's Pi harness and can manage other terminal agents, but it is centered on that pair. Superset is agent-agnostic across many agents.
+
+### What is Pairing Mode?
+
+Pairing Mode is a Sculptor feature that syncs an agent's work from its isolated environment back into your local repository and IDE. Superset instead keeps the worktree as the place you review and hand off from.

--- a/apps/marketing/content/compare/superset-vs-t3-chat.mdx
+++ b/apps/marketing/content/compare/superset-vs-t3-chat.mdx
@@ -2,7 +2,7 @@
 title: "Superset vs T3 Chat (2026): Agent Orchestration vs Multi-Model AI Chat"
 description: "Compare Superset and T3 Chat for AI-assisted development. See how local coding-agent orchestration differs from a hosted multi-model chat app."
 date: 2026-03-21
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - t3-chat
@@ -40,7 +40,7 @@ Superset is a local-first desktop workspace for AI coding agents. It launches Cl
 
 ## What Is T3 Chat?
 
-T3 Chat is a hosted AI chat app built around fast access to many models from one interface. Its public product surfaces emphasize model selection, search, attachments, profiles, temporary chats, and sharable new-chat URLs with query parameters for model and search state. In practice, it is a strong place to compare model behavior, ask questions, draft prompts, and work through coding ideas before touching a repository.
+T3 Chat is a hosted AI chat app built around fast access to many models from one interface. Its public product surfaces emphasize model selection, search, attachments, profiles, temporary chats, and sharable new-chat URLs with query parameters for model and search state. In practice, it is a strong place to compare model behavior, ask questions, draft prompts, and work through coding ideas before touching a repository. Note that the T3 team also builds a separate coding product, T3 Code, an open-source desktop GUI that orchestrates coding agents in Git worktrees; if you want the coding-agent comparison rather than the chat one, see [Superset vs T3 Code](/compare/superset-vs-t3-code).
 
 ---
 

--- a/apps/marketing/content/compare/superset-vs-t3-code.mdx
+++ b/apps/marketing/content/compare/superset-vs-t3-code.mdx
@@ -1,0 +1,109 @@
+---
+title: "Superset vs T3 Code (2026): Comparing Coding Agent Control Planes"
+description: "Compare Superset and T3 Code for orchestrating AI coding agents in Git worktrees. See how a mature agent workspace differs from an early open-source control plane."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - t3-code
+keywords:
+  - superset vs t3 code
+  - t3 code alternative
+  - t3 code
+  - coding agent control plane
+  - agentic ide
+  - worktree agent workspace
+---
+
+Superset and T3 Code aim at the same idea: a single GUI that orchestrates multiple AI coding agents, each writing to its own branch in an isolated Git worktree. The main difference today is maturity and scope. T3 Code is a new, openly experimental control plane from the T3 team. Superset is a further-along workspace that wraps the same worktree model in review, browser, remote hosting, and automation surfaces.
+
+Note that T3 Code is a distinct product from T3 Chat, the AI chat app. For that comparison, see [Superset vs T3 Chat](/compare/superset-vs-t3-chat).
+
+---
+
+## At a Glance
+
+| | **Superset** | **T3 Code** |
+|---|---|---|
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, browser, and automation | A control plane that runs coding agents, each thread on its own branch/worktree |
+| **Isolation** | Automatic Git worktree per task | Git worktree per agent thread (worktree/local toggle) |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, Mistral Vibe, and more) | Claude Code, Codex, OpenCode, Cursor (more planned) |
+| **Maturity** | Established, with SOC 2 and remote/cloud workspaces | Very early alpha (expect rapid change) |
+| **Review tooling** | Built-in diff/file editor, staging, commit | Inline diff review, one-button commit/push/PR |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local desktop and CLI launcher |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Desktop (macOS, Windows, Linux) plus `npx` launcher |
+| **License** | Source-available (ELv2) | Open source (MIT) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces and can schedule agent sessions as automations. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is T3 Code?
+
+T3 Code is an open-source desktop and web GUI from Theo Browne's T3 team, described as a control plane for coding agents. It orchestrates multiple agents from one workspace, and every agent thread writes to its own branch, with a per-thread toggle between an isolated worktree and the local checkout. It wraps agents like Claude Code, Codex, OpenCode, and Cursor on a bring-your-own-subscription basis, adds inline diff review and one-button commit, push, and PR creation, and runs on macOS, Windows, and Linux (or via an `npx` launcher). It is MIT licensed and, by its maintainers' own description, very early alpha software.
+
+## Key Differences
+
+### Maturity and Scope
+
+The honest headline difference is maturity. T3 Code is new and openly labeled as early alpha, so features and stability are moving fast. Superset covers the same worktree-per-task idea but has grown a larger surface around it: remote and cloud workspaces, scheduled automations with a TypeScript SDK and Slack bot, an MCP server, and enterprise groundwork like a passed SOC 2 audit. If you want to experiment on the leading edge, T3 Code is appealing. If you want a workspace to rely on for daily multi-agent work, Superset is further along.
+
+### Same Isolation Idea, Different Surface Area
+
+Both make a per-task branch and worktree the unit of work, and both offer inline diff review with quick commit and PR flows. Around that shared core, Superset adds an in-app browser for docs and dev servers, port management, and one-click handoff into VS Code, Cursor, JetBrains, or Xcode. T3 Code keeps a tighter footprint as a front-end over your chosen agents. So the deciding question is less "does it use worktrees" -- both do -- and more how much surrounding workflow you want built in.
+
+### Agent Breadth
+
+T3 Code currently wraps Claude Code, Codex, OpenCode, and Cursor, with more planned. Superset runs those plus Copilot, Gemini, Mistral Vibe, and custom terminal agents you define with your own launch command. If your agent mix is broad or changes often, Superset gives you more room today; if you use the common four, T3 Code covers them.
+
+### Reach Beyond One Machine
+
+Superset extends past the local desktop with remote and cloud workspaces that run on your own network devices, plus CLI and MCP surfaces. T3 Code is a local desktop GUI with an `npx` launcher. If moving work across machines or scripting the orchestration matters, Superset has more of that built in.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. T3 Code is free and open source with a bring-your-own-subscription model -- no resold tokens and no quota caps. In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want a mature workspace with review, browser, and automation built in
+- Need remote, cloud, CLI, or MCP surfaces
+- Run a broad or changing set of agents
+- Care about enterprise readiness like SOC 2
+
+**Choose T3 Code if you:**
+
+- Want a free, MIT-licensed, openly experimental control plane
+- Use Claude Code, Codex, OpenCode, or Cursor and like the T3 approach
+- Are comfortable with early alpha software that changes quickly
+- Prefer the smallest possible front-end over your own agents
+
+**Verdict:** T3 Code and Superset share a philosophy: worktree-per-thread orchestration with bring-your-own agents. T3 Code is the choice if you want to ride an early, open, fast-moving project. Superset is the choice if you want the same model with more built-in workflow and the stability to depend on it day to day.
+
+---
+
+## Frequently Asked Questions
+
+### Is T3 Code the same as T3 Chat?
+
+No. T3 Chat is the AI chat app; T3 Code is a separate control plane for coding agents. For the chat comparison, see [Superset vs T3 Chat](/compare/superset-vs-t3-chat).
+
+### Do both use Git worktrees?
+
+Yes. Both give each agent thread its own branch and worktree (T3 Code offers a per-thread worktree-or-local toggle). The isolation model is shared; the products differ in maturity and surrounding features.
+
+### Is T3 Code production ready?
+
+Its maintainers describe it as very early alpha, so expect rapid change. Superset is further along and adds remote/cloud workspaces, automations, and a passed SOC 2 audit.
+
+### Can both run agents other than Claude Code?
+
+Yes. T3 Code supports Claude Code, Codex, OpenCode, and Cursor today. Superset runs those plus Copilot, Gemini, Mistral Vibe, and custom terminal agents.

--- a/apps/marketing/content/compare/superset-vs-vibe-kanban.mdx
+++ b/apps/marketing/content/compare/superset-vs-vibe-kanban.mdx
@@ -1,0 +1,106 @@
+---
+title: "Superset vs Vibe Kanban (2026): A Vibe Kanban Alternative for Parallel Agents"
+description: "Compare Superset and Vibe Kanban for orchestrating AI coding agents in Git worktrees. See why Superset is a natural home as Vibe Kanban sunsets."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - vibe-kanban
+keywords:
+  - superset vs vibe kanban
+  - vibe kanban alternative
+  - vibe kanban
+  - parallel coding agents
+  - agent orchestration board
+  - worktree agent workspace
+---
+
+Vibe Kanban put a Kanban board over AI coding agents: plan work as cards, then spin up workspaces where agents execute in parallel, each in its own Git worktree. It became one of the most popular tools in this category. Bloop has since announced that Vibe Kanban is sunsetting, with the project continuing as community open source, which makes "what do I move to?" a live question. Superset covers the same worktree-based parallel-agent model in an actively developed workspace, so it is a natural place to land.
+
+---
+
+## At a Glance
+
+| | **Superset** | **Vibe Kanban** |
+|---|---|---|
+| **What it does** | Runs 100+ agents in parallel with Git worktree isolation, review, and browser | Kanban board that runs coding agents in parallel workspaces |
+| **Interface** | Agent workspace with panes, diff review, and browser | Kanban board of tasks mapped to agent runs |
+| **Isolation** | Automatic Git worktree per task | Git worktree per workspace/task |
+| **Agent support** | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, Gemini, and more) | Agent-agnostic (10+, including Claude Code, Codex, Gemini, Copilot, Amp, Cursor, OpenCode) |
+| **Project status** | Actively developed | Sunsetting; continues as community open source |
+| **Remote / cloud** | Remote and cloud workspaces across your network devices | Local |
+| **Platform** | Desktop (macOS now; Windows and Linux coming), CLI, MCP server | Cross-platform (Node + Rust) |
+| **License** | Source-available (ELv2) | Open source (Apache-2.0) |
+
+---
+
+## What Is Superset?
+
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. It also runs across your own network devices through remote and cloud workspaces and can schedule agent sessions as automations. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+
+## What Is Vibe Kanban?
+
+Vibe Kanban is an open-source app from Bloop that puts a Kanban board over AI coding agents. You plan work as issues, then spin up workspaces where agents execute in parallel or in sequence, with centralized configuration and review. It is agent-agnostic, switching between 10+ coding agents including Claude Code, Codex, Gemini CLI, Copilot, Amp, Cursor, and OpenCode, and it uses Git worktrees per workspace. It is Apache-2.0 licensed and became the most-starred tool in this category. Bloop has announced that Vibe Kanban is sunsetting; the project continues as community open source, so evaluate its current maintenance state before adopting it.
+
+## Key Differences
+
+### Actively Developed vs Sunsetting
+
+The most practical difference today is direction. Vibe Kanban is sunsetting as a maintained product, even though the open-source code remains. Superset is actively developed, with ongoing work on remote and cloud workspaces, automations, and its review and browser surfaces. If you are choosing where to invest your workflow now, ongoing maintenance matters.
+
+### Board Metaphor vs Agent Workspace
+
+Vibe Kanban organizes work as a Kanban board, mapping cards to agent runs. Superset organizes work as a workspace of live agent sessions, each in its own pane and worktree, with review and an in-app browser alongside. Both run agents in parallel Git worktrees underneath. If you like planning work as a board, Vibe Kanban's metaphor is appealing; if you prefer a live workspace you drive directly, Superset fits better.
+
+### Reach and Surfaces
+
+Superset extends past the local desktop with remote and cloud workspaces on your own network devices, plus CLI and MCP server surfaces and scheduled automations. Vibe Kanban runs locally as a cross-platform app. If you want the orchestration to move across machines or be scripted, Superset offers more of that.
+
+### Shared Foundation
+
+Both are agent-agnostic and both make a Git worktree per task the unit of work, so migrating mental models is easy: your agents, your branches, your review flow. The move from Vibe Kanban to Superset is mostly about trading a board view for a live workspace, and gaining active development plus remote and automation surfaces.
+
+---
+
+## Pricing
+
+Superset offers a free tier and Pro at $20/seat/month. Vibe Kanban is free and open source (Apache-2.0). In both cases, you still pay the underlying providers for Claude Code, Codex, or any compatible API usage.
+
+---
+
+## Which Should You Choose?
+
+**Choose Superset if you:**
+
+- Want an actively developed home for parallel agent work
+- Prefer a live agent workspace with built-in review and browser
+- Need remote, cloud, CLI, or MCP surfaces
+- Want scheduled or unattended runs through automations
+
+**Choose Vibe Kanban if you:**
+
+- Specifically want a Kanban-board metaphor over your agents
+- Are comfortable running a sunsetting project as community open source
+- Want a fully permissive Apache-2.0 tool and will self-maintain
+
+**Verdict:** Vibe Kanban popularized the board-over-agents approach, but its sunset makes long-term reliance a question. Superset offers the same worktree-based, agent-agnostic parallel model in an actively developed workspace, with review, browser, remote hosting, and automation built in -- a natural place to move as Vibe Kanban winds down.
+
+---
+
+## Frequently Asked Questions
+
+### Is Vibe Kanban still maintained?
+
+Bloop has announced that Vibe Kanban is sunsetting. The open-source code continues as a community project, but it is no longer positioned as an actively maintained product. Check its current state before adopting it.
+
+### Is Superset a good Vibe Kanban alternative?
+
+Yes. Superset uses the same worktree-per-task, agent-agnostic model, and adds a live agent workspace with review, an in-app browser, remote and cloud workspaces, and automations, under active development.
+
+### Do both use Git worktrees?
+
+Yes. Both give each task its own Git worktree and branch. The isolation model is shared; the interfaces and project direction differ.
+
+### Can Superset run the same agents Vibe Kanban did?
+
+Largely yes. Superset runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom terminal agents, covering the common agents Vibe Kanban supported.

--- a/apps/marketing/content/compare/superset-vs-warp.mdx
+++ b/apps/marketing/content/compare/superset-vs-warp.mdx
@@ -2,7 +2,7 @@
 title: "Superset vs Warp (2026): Agent Orchestration vs AI-Powered Terminal"
 description: "Compare Superset and Warp for AI-enhanced development workflows. See how multi-agent orchestration differs from an AI-powered terminal experience."
 date: 2026-02-02
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - warp
@@ -25,9 +25,9 @@ Superset and Warp both help developers work with AI around the command line, but
 | **Category** | Agent orchestration workspace | AI-powered terminal emulator |
 | **What it does** | Runs 10+ AI coding agents in parallel with Git worktrees, chat, diff/file review, and browser tooling | Modern terminal with built-in AI agents, code editing, and collaboration |
 | **AI approach** | Agent-agnostic — works with Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Built-in agents (OpenAI, Anthropic, Google); supports BYOK and third-party CLI agents |
-| **Parallelism** | Core feature — every task gets its own worktree and branch | Agents run in terminal panes via Agent Management Panel |
-| **Pricing** | Free tier + Pro $20/seat/mo | Free tier (limited credits), Build $20/mo, Business $50/mo |
-| **License** | Source-available (ELv2) | Closed source |
+| **Parallelism** | Core feature — every task gets its own worktree and branch | Agents run in terminal panes; Oz cloud orchestrator for background agents |
+| **Pricing** | Free tier + Pro $20/seat/mo | Free; Build $20/mo, Max $200/mo, Business $50/seat |
+| **License** | Source-available (ELv2) | Open source |
 
 ---
 
@@ -39,7 +39,7 @@ Superset is a local-first desktop workspace for AI coding agents. You spin up 10
 
 ## What Is Warp?
 
-Warp is a Rust-based, GPU-accelerated terminal emulator that evolved into an Agentic Development Environment. Warp 2.0 added built-in AI agents, a code editor with diff review, and Warp Drive for team knowledge sharing. Agent Mode takes natural language prompts, runs multi-step workflows, and self-corrects on errors. Agents 3.0 lets agents interact with REPLs, debuggers, and interactive CLI tools. Available on macOS, Windows, and Linux.
+Warp is a Rust-based, GPU-accelerated terminal that evolved into an agentic development environment and went open source in 2026. It runs built-in Warp Agents plus third-party CLI agents like Claude Code, Codex, Gemini, and OpenCode side by side in panes, adds a code editor with diff review and Warp Drive for team knowledge sharing, and includes a cloud orchestrator called Oz for managing background and parallel agents. Available on macOS, Windows, and Linux, plus the Oz cloud.
 
 ---
 
@@ -67,7 +67,7 @@ Warp has team features via Warp Drive: shared commands, notebooks, environment v
 
 Superset offers a free tier and Pro at $20/seat/month. You also pay for the API keys your chosen agents consume.
 
-Warp's terminal features are free. AI features require the Build plan ($20/month, 1,500 credits) or BYOK. Business runs $50/user/month with SSO and zero data retention.
+Warp's terminal features are free, and the app is now open source. AI features come with the Build plan ($20/month, 1,500 credits) or BYOK, with Max at $200/month for higher credit volume and Business at $50/user/month with SSO and zero data retention.
 
 ---
 

--- a/apps/marketing/content/compare/superset-vs-windsurf.mdx
+++ b/apps/marketing/content/compare/superset-vs-windsurf.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Superset vs Windsurf (2026): Parallel Agent Orchestration vs AI IDE"
-description: "Compare Superset and Windsurf for AI-assisted development. See how parallel agent orchestration differs from an AI-powered integrated development environment."
+description: "Compare Superset and Windsurf, now Devin Desktop, for AI-assisted development. See how parallel worktree orchestration differs from an AI-powered IDE."
 date: 2026-02-18
-lastUpdated: 2026-03-21
+lastUpdated: 2026-07-13
 type: "1v1"
 competitors:
   - windsurf
@@ -10,103 +10,105 @@ keywords:
   - superset vs windsurf
   - windsurf alternative
   - windsurf vs superset
+  - devin desktop alternative
   - ai ide comparison
   - ai coding tool comparison
 ---
 
-Windsurf is an AI-powered IDE that embeds AI into every part of the editing experience. Superset is a local-first workspace that runs many AI coding agents in parallel, each in its own Git worktree. They solve fundamentally different problems: Windsurf replaces your editor with an AI-native one, while Superset scales autonomous agent work alongside any editor.
+Windsurf is an AI-powered IDE, now rebranded as Devin Desktop after Cognition's acquisition. Superset is a local-first workspace that runs many AI coding agents in parallel, each in its own Git worktree. They solve different problems: Windsurf, as Devin Desktop, is an AI-native editor with a command center for local and cloud agents, while Superset scales autonomous agent work across isolated worktrees alongside any editor.
+
+Note: as of mid-2026, Windsurf is now Devin Desktop, and the original Cascade agent has been retired in favor of Devin Local. This page uses both names. For Cognition's autonomous cloud engineer, see [Superset vs Devin](/compare/superset-vs-devin).
 
 ---
 
 ## At a Glance
 
-| | **Superset** | **Windsurf** |
+| | **Superset** | **Windsurf (Devin Desktop)** |
 |---|---|---|
-| **Category** | Agent orchestration workspace | AI-powered IDE (VS Code fork) |
-| **AI approach** | Agent-agnostic — works with Claude Code, Codex, Aider, Superset Chat, or any CLI agent | Built-in AI models proxied through Windsurf servers |
-| **Parallelism** | Core feature — 10+ agents across isolated worktrees | Sequential by default; Windsurf Flows handles multi-step tasks |
-| **Editor** | Works alongside any editor (VS Code, Cursor, JetBrains, Xcode) | You must use the Windsurf IDE |
-| **Pricing** | Free tier + Pro $20/seat/mo | Free tier (limited), Pro $15/mo, Ultra $60/mo, Teams $35/seat/mo |
-| **Privacy** | Local Git worktrees; you control agent and provider choices | Code sent to Windsurf servers and third-party AI providers |
+| **Category** | Agent orchestration workspace | AI-powered IDE with an agent command center |
+| **AI approach** | Agent-agnostic -- Claude Code, Codex, OpenCode, Cursor, Gemini, or any CLI agent | Devin Local plus ACP agents (Codex, Claude, OpenCode) |
+| **Parallelism** | Core feature -- 100+ agents across isolated worktrees | Manages local and cloud agents from a Kanban command center |
+| **Isolation** | Automatic Git worktree per task | Cloud isolated; local mechanism not clearly documented |
+| **Editor** | Works alongside any editor (VS Code, Cursor, JetBrains, Xcode) | You use the Devin Desktop IDE |
+| **Pricing** | Free tier + Pro $20/seat/mo | Free tier, Pro $20/mo, Max $200/mo |
 | **License** | Source-available (ELv2) | Closed source |
 
 ---
 
 ## What Is Superset?
 
-Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Aider, Copilot, Cursor Agent, Gemini CLI, Superset Chat, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
+Superset is a local-first desktop workspace for AI coding agents. It launches Claude Code, Codex, OpenCode, Cursor Agent, Copilot, Gemini CLI, Mistral Vibe, and other agent workflows inside isolated Git worktrees with persistent terminal sessions. Around that core, it adds a built-in diff/file editor, chat panel, in-app browser for docs and dev servers, port management, and MCP tooling. You can review inside Superset or jump into VS Code, Cursor, Windsurf, JetBrains, or Xcode. Source-available under Elastic License 2.0 (ELv2).
 
 ---
 
-## What Is Windsurf?
+## What Is Windsurf (Devin Desktop)?
 
-Windsurf (from Codeium) is a VS Code fork with AI integrated throughout the editing experience. Its core feature is Cascade, an agentic workflow engine that can read files, write code, run terminal commands, and search your codebase in multi-step flows. It also offers Tab completions, inline chat, and a Memories system that learns your project's patterns over time. Windsurf routes requests through its servers to provide access to multiple AI models.
+Windsurf began as a VS Code fork with AI integrated throughout the editing experience, built around Cascade, an agentic flow engine. After Cognition acquired Windsurf, it was rebranded as Devin Desktop, delivered as an over-the-air update and backwards-compatible with Windsurf. The original Cascade agent has been retired in favor of Devin Local, a from-scratch rewrite in Rust with subagent support. Devin Desktop makes an "Agent Command Center" the default surface -- a Kanban view to manage local and cloud agents, pull requests, and context -- and supports the Agent Client Protocol (ACP), so agents like Codex, Claude, and OpenCode can run inside it alongside Devin.
 
 ---
 
 ## Key Differences
 
-### Single Agent vs Many Agents
+### One IDE vs an Agent-Agnostic Workspace
 
-Windsurf's Cascade is a single agentic flow — it tackles one task at a time through multiple steps (reading code, writing changes, running commands). Superset runs many agents simultaneously in isolated worktrees: one writing tests, another refactoring a service, a third updating docs. Windsurf improves single-task depth; Superset adds multi-task breadth.
+Devin Desktop is an editor: you work inside its IDE, with Devin Local and a command center for managing agents. Superset is a workspace that sits around any editor. It runs Claude Code, Codex, OpenCode, Cursor, Copilot, Gemini, Mistral Vibe, and custom agents, each in its own worktree, and hands off to VS Code, Cursor, JetBrains, or Xcode. If you want one AI-native IDE, Devin Desktop is that; if you want an editor-independent orchestration layer, Superset is built for it.
 
-### Editor Lock-In vs Editor Freedom
+### Isolation Model
 
-Using Windsurf means adopting the Windsurf IDE. If you use JetBrains, Xcode, Neovim, or even Cursor, you have to switch. Superset runs alongside any editor. It now has its own chat, diff/file review, and browser surfaces, but it still treats your editor as interchangeable rather than something it needs to own.
+Superset makes a local Git worktree per task the default, so many agents can work the same repository at once without collisions. Devin Desktop manages multiple agents from its command center and runs autonomous work in the cloud (isolated remotely), but its local per-agent isolation mechanism is not clearly documented. If local worktree isolation is the point, that is Superset's core.
 
-### Model Lock-In vs Model Freedom
+### Hosting External Agents
 
-Windsurf routes all AI requests through its servers and credit system. You get access to multiple models (GPT-4, Claude, etc.) but Windsurf controls the routing and pricing. Superset runs whatever CLI agents you install — or Superset Chat when you want a built-in surface — with your own provider choices. When a new agent ships, you can use it immediately.
+Both can run external CLI agents now. Devin Desktop added ACP support, so ACP-compatible agents run inside it. Superset runs any terminal agent directly in a worktree. The difference is framing: Superset treats agent orchestration as the product, while Devin Desktop treats it as a capability inside an IDE.
 
-### Privacy
+### Reach and Automation
 
-Superset runs agents locally in Git worktrees, and the full source is on GitHub under Elastic License 2.0 (ELv2). Windsurf sends code to its servers and third-party AI providers. Windsurf is closed source, so you cannot audit what data is collected or how it's processed.
+Superset extends past the local desktop with remote and cloud workspaces on your own network devices, plus CLI and MCP surfaces and scheduled automations. Devin Desktop pairs its local IDE with Cognition's cloud agents. Both cross the local/cloud boundary; they differ in whether the center of gravity is a worktree workspace or an IDE.
 
-### Session Persistence
+### Privacy and Licensing
 
-Windsurf's Cascade sessions live within the IDE. Superset adds a stronger workspace layer around autonomous runs: persistent sessions, task-level worktrees, in-app diff/file review, and browser previews for local apps. Long-running tasks are easier to manage when they are attached to explicit worktrees instead of a single editor thread.
+Superset runs agents locally in Git worktrees and is source-available on GitHub under Elastic License 2.0 (ELv2). Windsurf/Devin Desktop is closed source. If auditability and local-first control matter, that is a real distinction.
 
 ---
 
 ## Pricing
 
-Superset offers a free tier and Pro at $20/seat/month. You also pay your agents' API providers directly — no markup, no credit system. Windsurf offers a free tier, Pro at $15/month, Ultra at $60/month, and Teams at $35/seat/month, all using a credit-based system for AI requests.
+Superset offers a free tier and Pro at $20/seat/month, and you pay your agents' providers directly with no markup. Devin Desktop offers a free tier, Pro at $20/month, and Max at $200/month, with team plans available; usage is governed by quotas.
 
 ---
 
 ## Which Should You Choose?
 
-**Choose Windsurf if you:**
-- Want AI deeply embedded in your editing experience (completions, inline chat, multi-step flows)
-- Primarily use VS Code and are comfortable switching to a fork
-- Prefer a single integrated tool that handles editing and AI in one app
-- Don't need to run multiple agents in parallel
+**Choose Windsurf (Devin Desktop) if you:**
+- Want an AI-native IDE with a command center for local and cloud agents
+- Like managing agents and pull requests from a Kanban board
+- Are comfortable adopting Cognition's editor and cloud agents
+- Want ACP agents hosted inside one IDE
 
 **Choose Superset if you:**
-- Run CLI-based coding agents and want to parallelize across 10+ tasks
-- Use JetBrains, Xcode, Neovim, or any non-VS Code editor
-- Need local worktrees and direct control over providers
-- Want agent and model flexibility with no vendor lock-in
-- Need sessions that survive crashes and app restarts
+- Run CLI-based agents and want to parallelize across many isolated worktrees
+- Use JetBrains, Xcode, Neovim, or any editor, and want orchestration to stay independent
+- Need local worktrees plus your own remote and cloud hosts
+- Want agent and model flexibility with no editor lock-in
 
-Both tools can coexist. Use Windsurf as your editor for inline AI assistance, and Superset alongside it to dispatch parallel agents for larger tasks like test generation, refactors, and migrations.
+Both can coexist. Use Devin Desktop as your AI IDE, and Superset alongside it to dispatch parallel agents for larger tasks like test generation, refactors, and migrations.
 
 ---
 
 ## Frequently Asked Questions
 
-### Is Superset a Windsurf replacement?
+### Is Windsurf still called Windsurf?
 
-No. Superset is not an AI IDE with inline completions. It does provide in-app chat, diff/file editing, browser previews, and worktree orchestration, but it is still not trying to replace Windsurf as your full editor. The two products can be used together.
+Windsurf is now Devin Desktop, following Cognition's acquisition. It shipped as a backwards-compatible update, and the original Cascade agent has been replaced by Devin Local. Many people still search for "Windsurf," which is why this comparison keeps the name.
 
-### Does Windsurf support parallel agents?
+### Does Windsurf (Devin Desktop) support parallel agents?
 
-Windsurf's Cascade handles multi-step tasks sequentially within a single flow. It does not run multiple independent agents in parallel across isolated environments. Superset's worktree-based isolation is specifically designed for parallel agent execution.
+Devin Desktop manages multiple local and cloud agents from its command center, and its cloud agents run in isolation. It does not clearly document a local worktree-per-agent model. Superset's worktree isolation is built specifically for parallel agent execution on one repository.
 
 ### Is Superset open source?
 
-No. Superset is source-available on GitHub under Elastic License 2.0 (ELv2). Windsurf is closed source from Codeium.
+Superset is source-available on GitHub under Elastic License 2.0 (ELv2). Windsurf/Devin Desktop is closed source.
 
-### Can I use Windsurf as my editor with Superset?
+### What is the difference between Windsurf and Devin?
 
-Yes. Superset integrates with any editor. You can open Superset worktrees in Windsurf to review agent changes in the full IDE context.
+Windsurf, now Devin Desktop, is the IDE. Devin is Cognition's autonomous cloud software engineer. They are related surfaces from the same company. See [Superset vs Devin](/compare/superset-vs-devin).

--- a/apps/marketing/content/compare/warp-vs-conductor.mdx
+++ b/apps/marketing/content/compare/warp-vs-conductor.mdx
@@ -1,0 +1,86 @@
+---
+title: "Warp vs Conductor (2026): Agentic Terminal vs Parallel Agent App"
+description: "Compare Warp and Conductor for AI coding. See how an agentic terminal with a cloud orchestrator differs from a Mac app for parallel worktree agents, plus where Superset fits."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "1v1"
+competitors:
+  - warp
+  - conductor
+keywords:
+  - warp vs conductor
+  - conductor vs warp
+  - warp alternative
+  - conductor alternative
+  - agentic terminal
+  - parallel ai coding agents
+---
+
+Warp and Conductor both help you run AI coding agents, but from different angles. Warp is a fast terminal that has grown into an agentic development environment, running multiple agents side by side and adding a cloud orchestrator for background work. Conductor is a macOS app focused on running agents in parallel, each isolated in its own Git worktree, with a review-and-merge flow. The choice comes down to whether you want an agentic terminal or a dedicated worktree orchestrator.
+
+If you want worktree-based orchestration that is agent-agnostic and cross-platform, [Superset](/compare/superset-vs-warp) is a third option. This page compares all three.
+
+---
+
+## At a Glance
+
+| | **Warp** | **Conductor** | **Superset** |
+|---|---|---|---|
+| **Category** | Agentic terminal and dev environment | Mac app for parallel agents | Agent orchestration workspace |
+| **Agents** | Runs Claude Code, Codex, Gemini, OpenCode, plus Warp Agent | Claude Code, Codex, Cursor | Any CLI agent (Claude Code, Codex, OpenCode, Cursor, and more) |
+| **Parallel model** | Multiple agents in panes; Oz cloud orchestrator | Worktree per task (local) | Worktree per task (local + remote/cloud) |
+| **Task isolation** | No named per-task worktree isolation | Git worktree per task | Git worktree per task |
+| **Platform** | macOS, Linux, Windows + cloud | macOS only | macOS now; Windows and Linux coming |
+| **Pricing** | Free; Build $20/mo, Max $200/mo, Business $50/seat | Free, bring your own subscription | Free tier + Pro $20/seat/mo |
+
+---
+
+## What Is Warp?
+
+Warp is a Rust-based, GPU-accelerated terminal that has repositioned as an agentic development environment. As of 2026 it is open source, runs multiple third-party coding agents such as Claude Code, Codex, Gemini, and OpenCode side by side in panes, and includes Warp Agent plus a cloud orchestrator called Oz for managing background and parallel agents. Pricing starts free, with Build at $20/month, Max at $200/month, and Business at $50/seat.
+
+## What Is Conductor?
+
+Conductor is a native macOS app from Melty Labs for running Claude Code, Codex, and Cursor agents in parallel, each in an isolated Git worktree, with a review-and-merge and pull-request flow. It is Mac only and free, reusing your existing agent subscriptions.
+
+## Warp vs Conductor: Key Differences
+
+### Terminal vs Worktree Orchestrator
+
+Warp's center of gravity is the terminal: it runs agents in panes and adds Oz for cloud orchestration, but it does not name a per-task Git worktree isolation model. Conductor's whole purpose is worktree-per-task isolation on your machine, with a dashboard to review and merge. If you want a great agentic terminal, Warp leads; if you want each task isolated in its own worktree, Conductor is built for that.
+
+### Local vs Cloud Parallelism
+
+Conductor runs agents locally in worktrees. Warp runs agents in local panes and offloads background and parallel work to its Oz cloud orchestrator. Local worktrees keep everything on your machine; a cloud orchestrator is convenient for background runs.
+
+### Platform
+
+Warp runs on macOS, Linux, and Windows, plus its cloud. Conductor is macOS only. If you need Linux or Windows, Warp is the option here.
+
+## Where Superset Fits
+
+If you like Conductor's worktree isolation but want it agent-agnostic and cross-platform, or you like Warp's multi-agent approach but want per-task worktrees rather than terminal panes, Superset combines the two ideas. It runs Claude Code, Codex, OpenCode, Cursor, Gemini, and custom agents, each in its own worktree, with review, an in-app browser, MCP, and remote and cloud workspaces. See [Superset vs Warp](/compare/superset-vs-warp) and [Superset vs Conductor](/compare/superset-vs-conductor).
+
+## Which Should You Choose?
+
+- **Choose Warp** if you want a fast, agentic terminal that runs multiple agents and offloads background work to a cloud orchestrator, on any platform.
+- **Choose Conductor** if you are on macOS and want a focused app for parallel agents in isolated worktrees.
+- **Choose Superset** if you want agent-agnostic worktree orchestration across many agents, local plus remote and cloud, not tied to a terminal or macOS.
+
+**Verdict:** Warp is the strongest agentic terminal; Conductor is a focused worktree orchestrator for the Mac. Superset sits between them: worktree isolation like Conductor, broad agent support and cross-platform reach like Warp.
+
+---
+
+## Frequently Asked Questions
+
+### Does Warp use Git worktrees?
+
+Warp runs multiple agents in panes and orchestrates background agents through its Oz cloud, but it does not name a per-task Git worktree isolation model. Conductor and Superset both use a worktree per task.
+
+### Is Warp or Conductor cross-platform?
+
+Warp runs on macOS, Linux, and Windows plus its cloud. Conductor is macOS only. Superset ships on macOS now with Windows and Linux planned.
+
+### Can both run Claude Code and Codex?
+
+Yes. Warp runs Claude Code, Codex, Gemini, and OpenCode in panes; Conductor runs Claude Code, Codex, and Cursor in worktrees. Superset runs all of these, each in its own worktree.

--- a/apps/marketing/content/compare/what-is-an-agentic-ide.mdx
+++ b/apps/marketing/content/compare/what-is-an-agentic-ide.mdx
@@ -1,0 +1,106 @@
+---
+title: "What Is an Agentic IDE? A 2026 Guide"
+description: "An agentic IDE lets AI agents plan and execute coding tasks, not just autocomplete. Learn what defines the category, how it differs from AI editors, and where to run agents."
+date: 2026-07-13
+lastUpdated: 2026-07-13
+type: "tutorial"
+competitors:
+  - cursor
+  - zed
+  - conductor
+keywords:
+  - what is an agentic ide
+  - agentic ide meaning
+  - agentic ide
+  - multi agent ide
+  - ai agent editor
+  - agentic coding
+---
+
+An agentic IDE is a development environment where AI agents can autonomously plan and carry out multi-step coding tasks -- reading the codebase, editing multiple files, running commands and tests, and iterating on the results -- rather than only suggesting the next line of code. The shift is from autocomplete to delegation: you describe an outcome, and the agent does the work while you review.
+
+The term is new and a little overloaded, so this guide defines it clearly, separates the two things people mean by it, and explains how to choose.
+
+---
+
+## Autocomplete vs Agent
+
+The first generation of AI coding tools completed code as you typed. You stayed in control of every keystroke; the AI predicted the next few.
+
+An agentic IDE inverts that. You give the agent a task -- "add pagination to the users endpoint and update the tests" -- and it plans the steps, edits the files, runs the test suite, reads the failures, and tries again. You move from writing code to directing and reviewing it. The editor is still there, but it is no longer the center of gravity.
+
+## What Makes an IDE "Agentic"
+
+A tool is meaningfully agentic when it can do most of the following without hand-holding:
+
+- **Plan** a multi-step task from a natural-language goal
+- **Edit across files**, not just the open buffer
+- **Run the terminal** -- build, test, lint, and read the output
+- **Iterate** on errors until the task is done or it asks for help
+- **Use tools** through protocols like MCP to reach docs, databases, and services
+
+Autocomplete and single-file chat do not clear this bar. Planning, multi-file edits, command execution, and iteration are what separate an agentic IDE from an AI-assisted editor.
+
+## The Two Kinds of Agentic IDE
+
+In practice, "agentic IDE" refers to two different product shapes.
+
+### 1. AI editors with an agent mode
+
+These start as editors and add an autonomous agent. You still open files and type, but an agent mode can take over a task end to end. [Cursor](/compare/superset-vs-cursor), Zed, VS Code with GitHub Copilot, and JetBrains with Junie fit here. They are excellent for hands-on work with agent assistance, and several now run multiple agents at once.
+
+### 2. Agent workspaces
+
+These treat the agent as the primary unit. The product is built around launching many agents, isolating each task, and reviewing and merging what they produce. [Superset](/compare/superset-vs-cursor), [Conductor](/compare/superset-vs-conductor), and [Orca](/compare/superset-vs-orca) fit here. You spend less time typing code and more time directing a fleet of agents.
+
+Both are legitimately agentic. The difference is whether the editor or the agent is the center of the product.
+
+## The Multi-Agent Problem
+
+The moment you run more than one agent on the same repository, a new problem appears: collisions. Two agents editing the same working directory will overwrite each other's changes and tangle their branches.
+
+The clean solution is a **Git worktree per task**. A worktree gives each agent its own directory and branch that share the same repository history, so agents can work in parallel without stepping on each other. You review each worktree's diff independently and merge the ones you want.
+
+This is why the strongest multi-agent IDEs are built around worktrees. It is also the dividing line in the category: some tools isolate parallel work in local worktrees ([Superset](/compare/superset-vs-orca), Orca, Conductor, and Cursor 2.0), some push isolation to the cloud as a branch and a pull request (Copilot, Devin, JetBrains), and some edit the working copy with review gating (Zed and most in-editor agent modes).
+
+## Where the Agents Actually Run
+
+An agentic IDE has to run agents somewhere:
+
+- **Locally**, in worktrees on your own machine, using your real environment and services
+- **On a remote host** you own, over the network
+- **In the cloud**, in a managed sandbox that clones your repo and runs tasks in the background
+
+Local execution keeps everything on your machine and works offline; cloud execution is convenient for fire-and-forget tasks. Some tools do one; a few, like Superset, do both.
+
+## How To Choose an Agentic IDE
+
+Start from your bottleneck:
+
+- If you mostly write code with agent assistance, an AI editor like Cursor, Zed, VS Code + Copilot, or JetBrains + Junie is the right home.
+- If you want to host external CLI agents inside an editor, look at Zed, JetBrains, and Devin Desktop, which support the Agent Client Protocol.
+- If your bottleneck is running many agents on one repository without collisions, use an agent workspace built around worktrees, like Superset, Conductor, or Orca.
+
+For a full head-to-head, see [Best Agentic IDE in 2026](/compare/best-agentic-ide). For agent-specific guides, see [Best IDE for Claude Code](/compare/best-ide-for-claude-code) and [Best IDE for OpenAI Codex](/compare/best-ide-for-codex).
+
+## Verdict
+
+An agentic IDE is not just an editor with a smarter autocomplete. It is an environment where agents plan, edit, run, and iterate, and where the hard problems become isolation, review, and orchestration. If you only need agent-assisted editing, an AI editor is enough. If you are running many agents at once, the worktree-per-task workspaces are what the category is really about -- and that is where [Superset](/compare/superset-vs-cursor) is built to live.
+
+## Frequently Asked Questions
+
+### What is an agentic IDE in simple terms?
+
+It is a coding environment where you give an AI agent a task and it plans and executes the steps -- editing files, running commands, and iterating -- instead of only autocompleting code. You direct and review rather than type every line.
+
+### What is the difference between an agentic IDE and an AI editor?
+
+An AI editor centers on you writing code with AI assistance. An agentic IDE centers on agents doing tasks autonomously. Many products blur the line: an AI editor with a strong agent mode is agentic, and an agent workspace can still hand off to an editor.
+
+### What is a multi-agent IDE?
+
+A multi-agent IDE runs several coding agents at once. The safest versions give each agent its own isolated Git worktree so parallel work does not collide. See [Best Agentic IDE in 2026](/compare/best-agentic-ide).
+
+### Do I need an agentic IDE?
+
+If you only occasionally use AI to complete code, a standard editor is fine. If you delegate whole tasks to agents -- especially several at a time -- an agentic IDE built around worktree isolation and review will save you from collisions and lost work.

--- a/apps/marketing/plans/marketplace-programmatic-seo.md
+++ b/apps/marketing/plans/marketplace-programmatic-seo.md
@@ -1,0 +1,32 @@
+# Marketplace programmatic SEO — scope
+
+**Goal:** turn each marketplace theme (and later, agent) into its own indexable landing page, so the marketplace generates long-tail search traffic instead of hiding behind three list pages.
+
+## Current state
+- Routes: only `/marketplace`, `/marketplace/themes`, `/marketplace/agents` (list pages). No per-item detail route.
+- Sitemap: only the three list pages are included.
+- Theme data: `apps/marketing/src/lib/marketplace.ts` → `themeListings: ThemeListing[]` (**28 themes**), rich per-item data (name, type, author, description, tags, full UI + terminal color palette).
+- Each theme is also a static download at `public/marketplace/themes/<slug>.json` (**27 files**) — these are what Google currently crawls as `*.json` (non-content noise).
+- Agents: no `agentListings` data source exists yet in `marketplace.ts`; `/marketplace/agents` needs a data model before agent detail pages are possible.
+
+## Proposal
+1. **Route:** add `apps/marketing/src/app/marketplace/themes/[slug]/page.tsx` (SSG via `generateStaticParams()` over `themeListings`).
+2. **Content per page** (enough to avoid thin-content): live palette preview (UI + terminal swatches from the existing data), short description, author/credit, tags, "how to install in Superset" steps, and a link to the raw `.json`.
+3. **Metadata:** self-canonical `${MARKETING_URL}/marketplace/themes/<slug>`, unique title/description per theme, OG image (reuse a templated OG route).
+4. **Structured data:** `CreativeWork`/`SoftwareApplication` JSON-LD + breadcrumb.
+5. **Sitemap:** map `themeListings` into `sitemap.ts` (mirrors how blog/changelog/compare are already generated).
+6. **Interlink:** list page cards link to detail pages; detail pages cross-link related themes (same `type`/tags).
+
+## SEO impact
+- ~28 net-new indexable pages immediately, targeting long-tail like "<theme> theme for Superset", "<theme> terminal colors", "<theme> for AI coding".
+- Converts the crawled `*.json` noise into real HTML pages with a canonical, so the JSON stays a download and the page is what ranks.
+- Compounds: every new submitted theme becomes a page automatically.
+
+## Risks / notes
+- **Thin content:** a bare palette isn't enough — include install steps + description + preview so each page has unique value.
+- **Keep the `.json` downloadable:** the detail page links to it; don't break the existing download URL.
+- **Dedupe:** canonical on detail pages; list page stays the hub (no canonical war).
+- **Agents:** out of scope until an `agentListings` data source exists — flag as a follow-up.
+
+## Rough effort
+Small–medium: one dynamic route + one preview component + sitemap wiring + metadata/JSON-LD. No new data (themes already structured). Agent pages are a separate, larger task (needs data model first).


### PR DESCRIPTION
## What

The complete `/compare` expansion for the **agentic IDE** and **parallel-agent** search space, driven by a Google Search Console audit. Data-driven MDX only — routing, `/compare` index, sitemap, and llms.txt pick everything up automatically. **23 new pages + freshness pass on 7 existing pages.**

### New roundups + explainers
`best-agentic-ide` · `best-ide-for-claude-code` · `best-ide-for-codex` · `what-is-an-agentic-ide` · `conductor-alternative` · `cursor-alternative`

### New head-to-head (Superset vs)
`orca` · `cmux` · `t3-code` · `crystal` · `codex-app` · `claude-code-app` · `vibe-kanban` · `claude-squad` · `sculptor`

### New competitor-vs-competitor (Superset positioned as the third option)
`conductor-vs-cursor` · `conductor-vs-codex` · `conductor-vs-crystal` · `cursor-vs-windsurf` · `claude-code-vs-codex` · `warp-vs-conductor`

### New tutorials / pillar
- `multiple-opencode-agents-parallel` — targets the large "opencode orchestrator" cluster (written accurately: native multi-session vs community plugins vs worktrees)
- `git-worktrees-for-ai-agents` — parallel-agents pillar page and internal-link hub

### Freshness pass (real fact updates, not just date bumps)
- `superset-vs-windsurf` — **Windsurf is now Devin Desktop** (Cascade retired)
- `superset-vs-conductor` — Conductor now runs **Cursor** (3 agents)
- `superset-vs-devin` — retire the stale **$500** model → Free / Pro $20 / Max $200 / Teams
- `superset-vs-warp` — Warp is now **open source** + **Oz** cloud orchestrator
- `superset-vs-cursor` — **Cursor 2.0** local worktrees (up to 8 agents)
- `superset-vs-github-copilot` — current tiers (Pro+/Max), MCP, agent delegation
- `superset-vs-t3-chat` — points to the new T3 Code page

## Why — Google Search Console audit
Targets real queries where we appear but under-rank: `conductor vs cursor` (392 impr, pos 6), `conductor competitors` (1,150 impr, pos 48), `conductor alternative` (pos 50), the `opencode orchestrator`/`opencode desktop` cluster, `git worktree`/`parallel agents`, `multi agent ide` (pos 5.6), and `conductor vs codex`. Competitor-vs-competitor and "alternative" pages capture high-intent comparison searches where we already rank on page one.

## Accuracy
Every competitor fact verified against official primary sources on 2026-07-13 (five research passes). Corrections baked in: Windsurf→Devin Desktop, Devin's $500→$20 repricing, Warp open-sourcing + Oz, Cursor 2.0 local worktrees, Vibe Kanban sunsetting (framed as an alternative), Crystal→Nimbalyst, T3 Code distinct from T3 Chat. No unverifiable specifics (no model names); Superset license/pricing kept consistent with existing pages.

## Validation
- gray-matter parse 36/36 · no em dashes · **no dead internal links**
- `bun run --cwd apps/marketing typecheck`: pass
- Dev-server render of new + refreshed + restored pages: **200** with tables + FAQ; Devin pricing confirmed corrected in the rendered HTML

## Note on branches
Batch-1 of this work (the 13 roundup/head-to-head pages + Windsurf/Conductor refresh) also currently lives in #5682. This branch contains the **complete** compare-pages set (batch-1 + batch-2), so #5682 can be reduced to SEO housekeeping only to avoid overlap.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5683">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded marketing compare coverage for agentic IDEs and parallel agents to capture high-intent searches. Adds 26 new pages and refreshes 7 existing pages with current facts, based on a Google Search Console audit.

- **New Features**
  - Roundups/explainers: best-agentic-ide, best-ide-for-claude-code, best-ide-for-codex, what-is-an-agentic-ide, conductor-alternative, cursor-alternative
  - Superset vs: orca, cmux, t3-code, crystal, codex-app, claude-code-app, vibe-kanban, claude-squad, sculptor, aider, cline, openhands
  - Competitor vs competitor: conductor-vs-cursor, conductor-vs-codex, conductor-vs-crystal, cursor-vs-windsurf, claude-code-vs-codex, warp-vs-conductor
  - Tutorials/pillars: multiple-opencode-agents-parallel, git-worktrees-for-ai-agents
  - Planning doc: marketplace programmatic SEO scope (per-theme pages route/sitemap proposal)

- **Bug Fixes**
  - Updated facts and pricing: superset-vs-windsurf (Windsurf → Devin Desktop), superset-vs-devin (current tiers), superset-vs-warp (open source + Oz), superset-vs-cursor (local worktrees), superset-vs-github-copilot (tiers/MCP/delegation), superset-vs-conductor (runs Cursor), superset-vs-t3-chat (links to T3 Code)

<sup>Written for commit c7b3441735ae4078f9b8ba4571d70306403f10b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new set of 2026 marketing articles: roundup “best” guides, head-to-head comparisons, and tutorials for running parallel AI coding agents (including Git worktrees and OpenCode).
  * Added a new “What Is an Agentic IDE?” guide and a “multi-session” workflow tutorial to help readers choose the right setup.
* **Documentation**
  * Refreshed multiple existing comparison pages with updated positioning, parallelism/isolation details, pricing, and platform notes.
  * Added a marketplace programmatic SEO plan for future theme detail pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->