### PR TITLE
feat(marketing): ItemList schema on compare roundups + blog internal links

### DIFF
--- a/apps/marketing/content/blog/agent-orchestration-not-another-agent.mdx
+++ b/apps/marketing/content/blog/agent-orchestration-not-another-agent.mdx
@@ -119,3 +119,7 @@ Running parallel agents has a compound effect on productivity:
 The developers we work with who've adopted parallel agent workflows don't go back to single-agent work. The throughput difference is too large. The question shifts from "which agent should I use?" to "how many agents can I effectively manage?"
 
 That's the right question. And the answer is: as many as your orchestrator supports and your review speed allows.
+
+---
+
+**Related:** [Best Agentic IDE in 2026](/compare/best-agentic-ide) · [Best AI Coding Tools and Agents (2026)](/compare/best-ai-coding-agents-2026) · [Best Conductor Alternatives](/compare/conductor-alternative)

--- a/apps/marketing/content/blog/git-worktrees-history-deep-dive.mdx
+++ b/apps/marketing/content/blog/git-worktrees-history-deep-dive.mdx
@@ -416,3 +416,7 @@ The implementation is elegant: share the expensive stuff (object store), separat
 Whether you're reviewing PRs, testing branches, or letting an AI agent work in parallel, worktrees provide isolation without duplication. They're not new technology. They're old technology that suddenly fits the moment.
 
 If you've been stashing to switch branches, maybe stop. There's a better way, and it's been there all along.
+
+---
+
+**Related:** [Git Worktrees for AI Coding Agents](/compare/git-worktrees-for-ai-agents) · [Best Agentic IDE in 2026](/compare/best-agentic-ide)

--- a/apps/marketing/content/blog/parallel-coding-agents-guide.mdx
+++ b/apps/marketing/content/blog/parallel-coding-agents-guide.mdx
@@ -40,7 +40,7 @@ Agent 2: Writes its version of login.ts (overwrites Agent 1)
 Agent 1: Commits — but the file is Agent 2's version
 ```
 
-This isn't a theoretical risk. It happens every time two agents touch overlapping files. Even if they're editing different files, a shared `git index` means their commits can include each other's uncommitted changes.
+This isn't a theoretical risk. It happens every time two agents touch overlapping files. Even if they're editing different files, a shared `git index` means their commits can include each other's uncommitted changes. The clean fix is [a Git worktree per agent](/compare/git-worktrees-for-ai-agents).
 
 ### Solution: One Worktree Per Agent
 
@@ -208,3 +208,7 @@ If the agent doesn't run tests, you're reviewing blind. Either include "run test
 5. **Scale gradually** — Add more agents as your review speed improves
 
 The goal isn't to run the most agents possible. It's to maximize useful throughput — tasks completed per hour that meet your quality bar. Parallel agents get you there faster than sequential work, but only if the orchestration and review workflow supports it.
+
+---
+
+**Related:** [Best Agentic IDE in 2026](/compare/best-agentic-ide) · [Git Worktrees for AI Coding Agents](/compare/git-worktrees-for-ai-agents) · [How to Run Multiple Claude Code Agents in Parallel](/compare/multiple-claude-code-agents-parallel)

--- a/apps/marketing/content/blog/roadmap-to-100-agents.mdx
+++ b/apps/marketing/content/blog/roadmap-to-100-agents.mdx
@@ -148,3 +148,7 @@ But the throughput framing gives us a clear test for every feature we build: doe
 per agent interaction? 
 
 If you're running agents at scale and hitting these walls, we'd love to compare notes, reach out to us at founders@superset.sh
+
+---
+
+**Related:** [Best Agentic IDE in 2026](/compare/best-agentic-ide) · [How to Run Multiple OpenCode Agents in Parallel](/compare/multiple-opencode-agents-parallel)

--- a/apps/marketing/content/blog/working-with-worktrees-in-superset.mdx
+++ b/apps/marketing/content/blog/working-with-worktrees-in-superset.mdx
@@ -170,3 +170,7 @@ If you're already using a CLI coding agent, adding Superset takes about two minu
 The first time you see three agents working in parallel — each on its own branch, none interfering with each other — the workflow clicks. It's not three times faster (review is still human-speed), but it's dramatically more throughput than running agents one at a time.
 
 Git worktrees have been in Git since 2015. They were designed for a world where humans needed to work on multiple branches. Turns out, they're even more useful in a world where AI agents do.
+
+---
+
+**Related:** [Git Worktrees for AI Coding Agents](/compare/git-worktrees-for-ai-agents) · [How to Run Multiple Claude Code Agents in Parallel](/compare/multiple-claude-code-agents-parallel) · [Best IDE for Claude Code](/compare/best-ide-for-claude-code)

--- a/apps/marketing/src/app/compare/[slug]/page.tsx
+++ b/apps/marketing/src/app/compare/[slug]/page.tsx
@@ -8,10 +8,12 @@ import {
 	BreadcrumbJsonLd,
 	ComparisonJsonLd,
 	FAQPageJsonLd,
+	ItemListJsonLd,
 } from "@/components/JsonLd";
 import { getAllComparisonSlugs, getComparisonPage } from "@/lib/compare";
 import {
 	extractComparisonFaqItems,
+	extractRoundupItems,
 	getComparisonPageTypeLabel,
 } from "@/lib/compare-utils";
 import { CompareLayout } from "./components/CompareLayout";
@@ -30,9 +32,14 @@ export default async function ComparePageRoute({ params }: PageProps) {
 
 	const url = `${COMPANY.MARKETING_URL}/compare/${slug}`;
 	const faqItems = extractComparisonFaqItems(page.content);
+	const roundupItems =
+		page.type === "roundup" ? extractRoundupItems(page.content) : [];
 
 	return (
 		<main>
+			{roundupItems.length > 1 && (
+				<ItemListJsonLd name={page.title} items={roundupItems} />
+			)}
 			<ComparisonJsonLd
 				title={page.title}
 				description={page.description}

--- a/apps/marketing/src/app/compare/[slug]/page.tsx
+++ b/apps/marketing/src/app/compare/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
 	extractRoundupItems,
 	getComparisonPageTypeLabel,
 } from "@/lib/compare-utils";
+import { slugify } from "@/lib/content-utils";
 import { CompareLayout } from "./components/CompareLayout";
 
 interface PageProps {
@@ -33,7 +34,12 @@ export default async function ComparePageRoute({ params }: PageProps) {
 	const url = `${COMPANY.MARKETING_URL}/compare/${slug}`;
 	const faqItems = extractComparisonFaqItems(page.content);
 	const roundupItems =
-		page.type === "roundup" ? extractRoundupItems(page.content) : [];
+		page.type === "roundup"
+			? extractRoundupItems(page.content).map((item) => ({
+					name: item,
+					url: `${url}#${slugify(item)}`,
+				}))
+			: [];
 
 	return (
 		<main>

--- a/apps/marketing/src/components/JsonLd/JsonLd.tsx
+++ b/apps/marketing/src/components/JsonLd/JsonLd.tsx
@@ -209,7 +209,7 @@ export function FAQPageJsonLd({ items }: FAQPageJsonLdProps) {
 
 interface ItemListJsonLdProps {
 	name: string;
-	items: string[];
+	items: Array<{ name: string; url?: string }>;
 }
 
 export function ItemListJsonLd({ name, items }: ItemListJsonLdProps) {
@@ -220,7 +220,8 @@ export function ItemListJsonLd({ name, items }: ItemListJsonLdProps) {
 		itemListElement: items.map((item, index) => ({
 			"@type": "ListItem",
 			position: index + 1,
-			name: item,
+			name: item.name,
+			...(item.url && { url: item.url }),
 		})),
 	};
 

--- a/apps/marketing/src/components/JsonLd/JsonLd.tsx
+++ b/apps/marketing/src/components/JsonLd/JsonLd.tsx
@@ -207,6 +207,26 @@ export function FAQPageJsonLd({ items }: FAQPageJsonLdProps) {
 	return <JsonLdScript schema={schema} />;
 }
 
+interface ItemListJsonLdProps {
+	name: string;
+	items: string[];
+}
+
+export function ItemListJsonLd({ name, items }: ItemListJsonLdProps) {
+	const schema = {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		name,
+		itemListElement: items.map((item, index) => ({
+			"@type": "ListItem",
+			position: index + 1,
+			name: item,
+		})),
+	};
+
+	return <JsonLdScript schema={schema} />;
+}
+
 interface BreadcrumbJsonLdProps {
 	items: Array<{ name: string; url: string }>;
 }

--- a/apps/marketing/src/components/JsonLd/index.ts
+++ b/apps/marketing/src/components/JsonLd/index.ts
@@ -3,6 +3,7 @@ export {
 	BreadcrumbJsonLd,
 	ComparisonJsonLd,
 	FAQPageJsonLd,
+	ItemListJsonLd,
 	JsonLdScript,
 	OrganizationJsonLd,
 	SoftwareApplicationJsonLd,

--- a/apps/marketing/src/lib/compare-utils.ts
+++ b/apps/marketing/src/lib/compare-utils.ts
@@ -152,7 +152,9 @@ export function extractRoundupItems(content: string): string[] {
 			continue; // skip header and separator rows
 		}
 
-		const firstCell = trimmed.slice(1, trimmed.indexOf("|", 1));
+		// Split the row into cells on unescaped pipes, then unescape "\|".
+		const cells = trimmed.slice(1, -1).split(/(?<!\\)\|/);
+		const firstCell = (cells[0] ?? "").replace(/\\\|/g, "|");
 		const name = stripMarkdownFormatting(firstCell);
 		if (name) {
 			items.push(name);

--- a/apps/marketing/src/lib/compare-utils.ts
+++ b/apps/marketing/src/lib/compare-utils.ts
@@ -115,3 +115,49 @@ export function extractComparisonFaqItems(
 
 	return items;
 }
+
+/**
+ * Extracts the ranked list of tools from the first Markdown table in a roundup,
+ * reading the first column of each data row. Used to emit ItemList structured
+ * data so "best X" listicles are eligible for rich results.
+ */
+export function extractRoundupItems(content: string): string[] {
+	const lines = content.split("\n");
+	const items: string[] = [];
+
+	let inTable = false;
+	let seenSeparator = false;
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+		const isTableRow = trimmed.startsWith("|") && trimmed.endsWith("|");
+
+		if (!inTable) {
+			if (isTableRow) {
+				inTable = true;
+				seenSeparator = false;
+			}
+			continue;
+		}
+
+		if (!isTableRow) {
+			break; // table ended
+		}
+
+		// The row after the header is the |---|---| separator.
+		if (!seenSeparator) {
+			if (/^\|[\s:|-]+\|$/.test(trimmed)) {
+				seenSeparator = true;
+			}
+			continue; // skip header and separator rows
+		}
+
+		const firstCell = trimmed.slice(1, trimmed.indexOf("|", 1));
+		const name = stripMarkdownFormatting(firstCell);
+		if (name) {
+			items.push(name);
+		}
+	}
+
+	return items;
+}


### PR DESCRIPTION
## What

Two SEO follow-ups to the merged `/compare` expansion (#5682, #5683), adding only what was missing.

### 1. ItemList structured data on roundups
- New `ItemListJsonLd` component + `extractRoundupItems()` helper that reads the ranked tools from each roundup's first comparison table.
- Wired into `compare/[slug]/page.tsx`: emitted only for `type: "roundup"` pages, so "best X" listicles become eligible for list rich results. 1v1 and tutorial pages are unaffected.
- Applies to all 7 roundups automatically (incl. the pre-existing best-ai-coding-agents-2026 and best-terminal-for-ai-coding).

### 2. Blog internal links into the compare cluster
The hidden compare pages had no inbound links from indexed content. Added contextual links (one inline + a "Related" line) from 5 topically-matched posts:
- `parallel-coding-agents-guide`, `working-with-worktrees-in-superset`, `git-worktrees-history-deep-dive` → git-worktrees / parallel-agents pages
- `agent-orchestration-not-another-agent` → best-agentic-ide, best-ai-coding-agents, conductor-alternative
- `roadmap-to-100-agents` → best-agentic-ide, multiple-opencode-agents-parallel

This passes link equity to the otherwise-unlinked pages and strengthens topical clustering.

## Validation
- `typecheck`: pass · `lint`: clean (no fixes)
- Dev-server render: `ItemList` emits on `/compare/best-agentic-ide` (8 items) and is absent on `/compare/superset-vs-orca` (1v1); blog posts render 200 with resolving `/compare` links
- All 7 blog→compare links resolve to real pages

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5684">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ItemList` structured data with per-item anchors on roundup compare pages to qualify for list rich results. Also adds internal links from five blog posts into the compare cluster to improve crawlability and link equity.

- **New Features**
  - Added `ItemListJsonLd` and `extractRoundupItems` to build ranked items from the first comparison table; emitted in `compare/[slug]/page.tsx` only for `type: "roundup"` pages when items > 1, with each `ListItem` getting a `url` anchor via `slugify`. 1v1/tutorial pages are unchanged.
  - Added contextual internal links from five related blog posts into `/compare` pages.

- **Bug Fixes**
  - Hardened `extractRoundupItems` parsing to split on unescaped pipes and unescape `\|`, preventing truncated item names.

<sup>Written for commit 1fd9a26093ad0ba94db141840099d8118ce4a09d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Related” links at the end of multiple blog posts to make it easier to discover relevant content.
  * Enhanced roundup compare pages with structured “item list” metadata for improved search visibility.
* **Improvements**
  * Clarified how overlapping parallel agent work can contaminate commits, with pointers to the Git worktree isolation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->