### PR TITLE
feat(marketing): add per-theme marketplace pages for SEO

### DIFF
--- a/apps/marketing/src/app/marketplace/themes/[slug]/page.tsx
+++ b/apps/marketing/src/app/marketplace/themes/[slug]/page.tsx
@@ -1,0 +1,282 @@
+import { COMPANY } from "@superset/shared/constants";
+import { Button } from "@superset/ui/button";
+import { ThemePreviewCard } from "@superset/ui/theme-preview-card";
+import { ArrowLeft, Download } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { BreadcrumbJsonLd, JsonLdScript } from "@/components/JsonLd";
+import {
+	getAllThemeSlugs,
+	getThemeListing,
+	themeListings,
+} from "@/lib/marketplace";
+
+interface PageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+	return getAllThemeSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const { slug } = await params;
+	const theme = getThemeListing(slug);
+
+	if (!theme) {
+		return { title: "Theme not found" };
+	}
+
+	const kind = theme.type === "dark" ? "Dark" : "Light";
+	const title = `${theme.name} — ${kind} Theme for Superset`;
+	const description = `${theme.description} Download the ${theme.name} ${kind.toLowerCase()} theme for Superset, the local-first AI coding workspace.`;
+	const url = `${COMPANY.MARKETING_URL}/marketplace/themes/${theme.slug}`;
+
+	return {
+		title,
+		description,
+		keywords: [
+			`${theme.name} theme`,
+			`${theme.name} superset theme`,
+			`superset ${theme.type} theme`,
+			...theme.tags,
+		],
+		alternates: { canonical: url },
+		openGraph: { title, description, url, type: "website" },
+		twitter: { card: "summary", title, description },
+	};
+}
+
+export default async function ThemeDetailPage({ params }: PageProps) {
+	const { slug } = await params;
+	const theme = getThemeListing(slug);
+
+	if (!theme) {
+		notFound();
+	}
+
+	const url = `${COMPANY.MARKETING_URL}/marketplace/themes/${theme.slug}`;
+	const kind = theme.type === "dark" ? "Dark" : "Light";
+
+	const uiColors = [
+		{ label: "Background", value: theme.ui.background },
+		{ label: "Foreground", value: theme.ui.foreground },
+		{ label: "Card", value: theme.ui.card },
+		{ label: "Primary", value: theme.ui.primary },
+		{ label: "Accent", value: theme.ui.accent },
+		{ label: "Border", value: theme.ui.border },
+		{ label: "Sidebar", value: theme.ui.sidebar },
+	];
+
+	const terminalColors = [
+		{ label: "Red", value: theme.terminal.red },
+		{ label: "Green", value: theme.terminal.green },
+		{ label: "Yellow", value: theme.terminal.yellow },
+		{ label: "Blue", value: theme.terminal.blue },
+		{ label: "Magenta", value: theme.terminal.magenta },
+		{ label: "Cyan", value: theme.terminal.cyan },
+		{ label: "Cursor", value: theme.terminal.cursor },
+	];
+
+	const related = themeListings
+		.filter((t) => t.slug !== theme.slug && t.type === theme.type)
+		.slice(0, 4);
+
+	const creativeWork = {
+		"@context": "https://schema.org",
+		"@type": "CreativeWork",
+		name: `${theme.name} Theme for Superset`,
+		description: theme.description,
+		url,
+		genre: `${kind} color theme`,
+		author: { "@type": "Person", name: theme.author },
+		keywords: theme.tags.join(", "),
+		isAccessibleForFree: true,
+		license: "https://github.com/superset-sh/superset",
+	};
+
+	return (
+		<main className="min-h-screen">
+			<BreadcrumbJsonLd
+				items={[
+					{ name: "Marketplace", url: `${COMPANY.MARKETING_URL}/marketplace` },
+					{
+						name: "Themes",
+						url: `${COMPANY.MARKETING_URL}/marketplace/themes`,
+					},
+					{ name: theme.name, url },
+				]}
+			/>
+			<JsonLdScript schema={creativeWork} />
+
+			<div className="mx-auto max-w-4xl px-6 py-10">
+				<Link
+					href="/marketplace/themes"
+					className="mb-6 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+				>
+					<ArrowLeft className="size-4" aria-hidden="true" />
+					All themes
+				</Link>
+
+				<div className="flex flex-col gap-8 md:flex-row md:items-start">
+					<div className="w-full max-w-sm shrink-0">
+						<ThemePreviewCard
+							name={theme.name}
+							subtitle={`${kind} · by ${theme.author}`}
+							backgroundColor={theme.terminal.background}
+							foregroundColor={theme.terminal.foreground}
+							promptColor={theme.terminal.green}
+							infoColor={theme.terminal.cyan}
+							readyColor={theme.terminal.yellow}
+							palette={[
+								theme.terminal.red,
+								theme.terminal.green,
+								theme.terminal.yellow,
+								theme.terminal.blue,
+								theme.terminal.magenta,
+								theme.terminal.cyan,
+							]}
+							className="rounded-none border-border"
+							paletteItemClassName="rounded-none"
+						/>
+					</div>
+
+					<div className="min-w-0 flex-1">
+						<span className="inline-block rounded-full border border-border px-2.5 py-0.5 text-xs text-muted-foreground">
+							{kind} theme
+						</span>
+						<h1 className="mt-3 text-2xl font-semibold text-foreground md:text-3xl">
+							{theme.name}
+						</h1>
+						<p className="mt-3 text-muted-foreground">{theme.description}</p>
+
+						<div className="mt-5 flex flex-wrap items-center gap-3">
+							<Button asChild className="rounded-none">
+								<a href={theme.source.href} download>
+									<Download className="size-4" aria-hidden="true" />
+									Download theme file
+								</a>
+							</Button>
+							<span className="text-xs text-muted-foreground">
+								by {theme.author} · submitted by {theme.submittedBy} · added{" "}
+								{theme.addedOn}
+							</span>
+						</div>
+
+						{theme.tags.length > 0 ? (
+							<div className="mt-4 flex flex-wrap gap-2">
+								{theme.tags.map((tag) => (
+									<span
+										key={tag}
+										className="rounded-full bg-card px-2.5 py-0.5 text-xs text-muted-foreground"
+									>
+										{tag}
+									</span>
+								))}
+							</div>
+						) : null}
+					</div>
+				</div>
+
+				<section className="mt-12">
+					<h2 className="text-lg font-semibold text-foreground">Palette</h2>
+					<div className="mt-4 grid gap-8 sm:grid-cols-2">
+						<div>
+							<h3 className="mb-3 text-sm font-medium text-muted-foreground">
+								Interface
+							</h3>
+							<ul className="space-y-2">
+								{uiColors.map((c) => (
+									<li key={c.label} className="flex items-center gap-3">
+										<span
+											className="size-6 rounded-sm border border-border"
+											style={{ backgroundColor: c.value }}
+											aria-hidden="true"
+										/>
+										<span className="text-sm text-foreground">{c.label}</span>
+										<span className="ml-auto font-mono text-xs text-muted-foreground uppercase">
+											{c.value}
+										</span>
+									</li>
+								))}
+							</ul>
+						</div>
+						<div>
+							<h3 className="mb-3 text-sm font-medium text-muted-foreground">
+								Terminal
+							</h3>
+							<ul className="space-y-2">
+								{terminalColors.map((c) => (
+									<li key={c.label} className="flex items-center gap-3">
+										<span
+											className="size-6 rounded-sm border border-border"
+											style={{ backgroundColor: c.value }}
+											aria-hidden="true"
+										/>
+										<span className="text-sm text-foreground">{c.label}</span>
+										<span className="ml-auto font-mono text-xs text-muted-foreground uppercase">
+											{c.value}
+										</span>
+									</li>
+								))}
+							</ul>
+						</div>
+					</div>
+				</section>
+
+				<section className="mt-12">
+					<h2 className="text-lg font-semibold text-foreground">
+						How to install {theme.name} in Superset
+					</h2>
+					<ol className="mt-4 list-decimal space-y-2 pl-5 text-sm text-muted-foreground">
+						<li>Download the theme file above.</li>
+						<li>
+							In the Superset desktop app, open{" "}
+							<span className="text-foreground">
+								Settings → Appearance → Theme
+							</span>
+							.
+						</li>
+						<li>
+							Click <span className="text-foreground">Import Theme</span> and
+							select the downloaded file.
+						</li>
+						<li>Pick {theme.name} from the theme grid to apply it.</li>
+					</ol>
+					<p className="mt-4 text-sm text-muted-foreground">
+						See the{" "}
+						<a
+							href={`${COMPANY.DOCS_URL}/custom-themes`}
+							className="text-foreground underline underline-offset-4"
+						>
+							custom themes guide
+						</a>{" "}
+						to edit a theme or build your own.
+					</p>
+				</section>
+
+				{related.length > 0 ? (
+					<section className="mt-12">
+						<h2 className="text-lg font-semibold text-foreground">
+							More {kind.toLowerCase()} themes
+						</h2>
+						<div className="mt-4 flex flex-wrap gap-2">
+							{related.map((t) => (
+								<Link
+									key={t.slug}
+									href={`/marketplace/themes/${t.slug}`}
+									className="rounded-full border border-border px-3 py-1 text-sm text-muted-foreground hover:text-foreground"
+								>
+									{t.name}
+								</Link>
+							))}
+						</div>
+					</section>
+				) : null}
+			</div>
+		</main>
+	);
+}

--- a/apps/marketing/src/app/marketplace/themes/page.tsx
+++ b/apps/marketing/src/app/marketplace/themes/page.tsx
@@ -1,8 +1,9 @@
 import { COMPANY } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
 import { ThemePreviewCard } from "@superset/ui/theme-preview-card";
-import { Download } from "lucide-react";
+import { ArrowUpRight, Download } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 import { themeListings } from "@/lib/marketplace";
 
 export const metadata: Metadata = {
@@ -43,21 +44,37 @@ export default function MarketplaceThemesPage() {
 							className="rounded-none border-border"
 							paletteItemClassName="rounded-none"
 							footerRight={
-								<Button
-									asChild
-									variant="outline"
-									size="icon-sm"
-									className="rounded-none"
-								>
-									<a
-										href={theme.source.href}
-										download
-										aria-label={`Download ${theme.name}`}
-										title={`Download ${theme.name}`}
+								<div className="flex items-center gap-1.5">
+									<Button
+										asChild
+										variant="outline"
+										size="icon-sm"
+										className="rounded-none"
 									>
-										<Download className="size-4" aria-hidden="true" />
-									</a>
-								</Button>
+										<Link
+											href={`/marketplace/themes/${theme.slug}`}
+											aria-label={`View ${theme.name}`}
+											title={`View ${theme.name}`}
+										>
+											<ArrowUpRight className="size-4" aria-hidden="true" />
+										</Link>
+									</Button>
+									<Button
+										asChild
+										variant="outline"
+										size="icon-sm"
+										className="rounded-none"
+									>
+										<a
+											href={theme.source.href}
+											download
+											aria-label={`Download ${theme.name}`}
+											title={`Download ${theme.name}`}
+										>
+											<Download className="size-4" aria-hidden="true" />
+										</a>
+									</Button>
+								</div>
 							}
 						/>
 					))}

--- a/apps/marketing/src/app/sitemap.ts
+++ b/apps/marketing/src/app/sitemap.ts
@@ -4,6 +4,7 @@ import { getBlogPosts } from "@/lib/blog";
 import { getChangelogEntries } from "@/lib/changelog";
 import { getComparisonPages } from "@/lib/compare";
 import { getAllLegalSlugs, getLegalPage } from "@/lib/legal";
+import { themeListings } from "@/lib/marketplace";
 import { getAllPeople } from "@/lib/people";
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -141,6 +142,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		};
 	});
 
+	const themePages: MetadataRoute.Sitemap = themeListings.map((theme) => ({
+		url: `${baseUrl}/marketplace/themes/${theme.slug}`,
+		lastModified: new Date(),
+		changeFrequency: "monthly" as const,
+		priority: 0.6,
+	}));
+
 	return [
 		...staticPages,
 		...blogPages,
@@ -148,5 +156,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		...teamPages,
 		...comparisonPages,
 		...legalPages,
+		...themePages,
 	];
 }

--- a/apps/marketing/src/lib/marketplace.ts
+++ b/apps/marketing/src/lib/marketplace.ts
@@ -1045,3 +1045,11 @@ export const marketplaceSubmissionLinks = {
 	theme: buildIssueUrl("[Marketplace] Theme submission"),
 	agent: buildIssueUrl("[Marketplace] Agent config submission"),
 };
+
+export function getAllThemeSlugs(): string[] {
+	return themeListings.map((theme) => theme.slug);
+}
+
+export function getThemeListing(slug: string): ThemeListing | undefined {
+	return themeListings.find((theme) => theme.slug === slug);
+}


### PR DESCRIPTION
## What

Adds per-theme marketplace pages for programmatic SEO — one indexable page per theme (27 themes) at `/marketplace/themes/[slug]`.

Each page includes:
- **Palette preview** — Interface + Terminal color swatches with hex values
- **How-to-install steps** — theme-specific, linking to the custom themes guide
- **Download button** for the theme file
- **Related-theme links** ("More <dark/light> themes") for interlinking
- **SEO/structured data** — canonical URL, `CreativeWork` + `BreadcrumbList` JSON-LD, theme-specific `<title>`/description

## Changes

- `apps/marketing/src/app/marketplace/themes/[slug]/page.tsx` — new SSG route (one page per theme)
- `apps/marketing/src/app/marketplace/themes/page.tsx` — theme cards now link to their detail pages (interlinking)
- `apps/marketing/src/lib/marketplace.ts` — added `getThemeListing(slug)` and `getAllThemeSlugs()` helpers
- `apps/marketing/src/app/sitemap.ts` — added the 27 theme detail pages (114 total URLs)

Implements `apps/marketing/plans/marketplace-programmatic-seo.md`.

## Verification

- `bun run lint` — clean
- `bun run typecheck --filter=@superset/marketing` — clean
- Sitemap renders 27 theme pages
- Spot-checked `/marketplace/themes/catppuccin-mocha` and `/marketplace/themes/tokyo-night` in dev: HTTP 200, canonical + all sections + JSON-LD render correctly

## Follow-up (not in this PR)

Agent marketplace pages (`/marketplace/agents/[slug]`) need an `agentListings` data model in `marketplace.ts` first — none exists yet.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-theme marketplace pages at `/marketplace/themes/[slug]` to boost programmatic SEO and improve navigation, shipping 27 SSG pages with structured data.

- **New Features**
  - New SSG route per theme (27 pages): palette preview, install steps, download, related-theme links.
  - SEO: canonical URLs and JSON‑LD (`CreativeWork`, `BreadcrumbList`) with theme-specific `<title>`/description.
  - List page: theme cards link to their detail pages.
  - Sitemap: adds all 27 theme detail URLs.
  - Lib: `getThemeListing(slug)` and `getAllThemeSlugs()` helpers.

<sup>Written for commit 5bfc0bf901f0dc3b73a817fa04aec67d9b38364e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated detail pages for marketplace themes, including previews, descriptions, tags, color palettes, installation instructions, related themes, and download options.
  - Added direct links from theme cards to view details or download themes.
  - Added support for clearer theme discovery through search-engine metadata and structured information.

- **Documentation**
  - Marketplace theme detail pages are now included in the site sitemap for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->