### PR TITLE
fix(desktop): copy/save markdown preview tables as GFM instead of [table]

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -16,11 +16,17 @@ import { ListItem } from "@tiptap/extension-list-item";
 import { OrderedList } from "@tiptap/extension-ordered-list";
 import { Paragraph } from "@tiptap/extension-paragraph";
 import { Strike } from "@tiptap/extension-strike";
-import { TableKit } from "@tiptap/extension-table";
+import { Table } from "@tiptap/extension-table";
+import { TableCell } from "@tiptap/extension-table-cell";
+import { TableHeader } from "@tiptap/extension-table-header";
+import { TableRow } from "@tiptap/extension-table-row";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { Text } from "@tiptap/extension-text";
 import { Underline } from "@tiptap/extension-underline";
+import type { Fragment, Slice } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { common, createLowlight } from "lowlight";
 import type { MutableRefObject } from "react";
@@ -28,6 +34,11 @@ import { Markdown } from "tiptap-markdown";
 import { EditableCodeBlockView } from "./components/EditableCodeBlockView";
 import { ReadOnlyCodeBlockView } from "./components/ReadOnlyCodeBlockView";
 import { ReadOnlySafeImageView } from "./components/ReadOnlySafeImageView";
+import {
+	serializeMarkdownTable,
+	serializeSelectionForClipboard,
+	sliceToPlainText,
+} from "./serializeMarkdownTable";
 
 const lowlight = createLowlight(common);
 const ENABLE_RAW_MARKDOWN_HTML = false;
@@ -99,6 +110,45 @@ const EditorHotkeys = Extension.create<{
 	},
 });
 
+/**
+ * Chooses the clipboard text/plain for a copied selection: a whole-table
+ * CellSelection becomes a GFM table, cell-text/partial selections become plain
+ * text, and everything else stays markdown. Higher priority than tiptap-markdown's
+ * Markdown extension (priority 50) so this serializer is consulted first.
+ */
+const TableClipboardMarkdown = Extension.create({
+	name: "tableClipboardMarkdown",
+	priority: 1000,
+	addProseMirrorPlugins() {
+		const editor = this.editor;
+		return [
+			new Plugin({
+				key: new PluginKey("tableClipboardMarkdown"),
+				props: {
+					clipboardTextSerializer: (slice: Slice, view: EditorView) => {
+						const markdownStorage = (
+							editor.storage as {
+								markdown?: {
+									serializer?: { serialize: (content: Fragment) => string };
+								};
+							}
+						).markdown;
+						const serializer = markdownStorage?.serializer;
+						if (!serializer) {
+							return sliceToPlainText(slice);
+						}
+						return serializeSelectionForClipboard(
+							view.state.selection,
+							slice,
+							(content) => serializer.serialize(content),
+						);
+					},
+				},
+			}),
+		];
+	},
+});
+
 interface CreateMarkdownExtensionsOptions {
 	editable: boolean;
 	onSaveRef: MutableRefObject<(() => void) | undefined>;
@@ -155,23 +205,34 @@ export function createMarkdownExtensions({
 			},
 		}),
 		SafeImage,
-		TableKit.configure({
-			table: {
-				resizable: false,
-				cellMinWidth: 192,
-				HTMLAttributes: {
-					class: "markdown-table my-4 min-w-full border-collapse",
-				},
+		// Individual table nodes (not TableKit) so a GFM markdown serializer can be
+		// attached to the `table` node's `storage.markdown`, replacing
+		// tiptap-markdown's built-in serializer that emits `[table]`. The
+		// CellSelection editing plugins live on the `Table` node, so rendering,
+		// parsing, and selection are unchanged.
+		Table.extend({
+			addStorage() {
+				return {
+					...this.parent?.(),
+					markdown: { serialize: serializeMarkdownTable },
+				};
 			},
-			tableHeader: {
-				HTMLAttributes: {
-					class: "bg-muted px-4 py-2 text-left text-sm font-semibold align-top",
-				},
+		}).configure({
+			resizable: false,
+			cellMinWidth: 192,
+			HTMLAttributes: {
+				class: "markdown-table my-4 min-w-full border-collapse",
 			},
-			tableCell: {
-				HTMLAttributes: {
-					class: "border-t border-border px-4 py-2 text-sm align-top",
-				},
+		}),
+		TableRow,
+		TableHeader.configure({
+			HTMLAttributes: {
+				class: "bg-muted px-4 py-2 text-left text-sm font-semibold align-top",
+			},
+		}),
+		TableCell.configure({
+			HTMLAttributes: {
+				class: "border-t border-border px-4 py-2 text-sm align-top",
 			},
 		}),
 		Markdown.configure({
@@ -180,6 +241,7 @@ export function createMarkdownExtensions({
 			transformPastedText: true,
 			transformCopiedText: true,
 		}),
+		TableClipboardMarkdown,
 		EditorHotkeys.configure({
 			onSaveRef,
 		}),

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/serializeMarkdownTable.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/serializeMarkdownTable.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "bun:test";
+import { getSchema } from "@tiptap/core";
+import { Bold } from "@tiptap/extension-bold";
+import { BulletList } from "@tiptap/extension-bullet-list";
+import { Document } from "@tiptap/extension-document";
+import { ListItem } from "@tiptap/extension-list-item";
+import { Paragraph } from "@tiptap/extension-paragraph";
+import { Table } from "@tiptap/extension-table";
+import { TableCell } from "@tiptap/extension-table-cell";
+import { TableHeader } from "@tiptap/extension-table-header";
+import { TableRow } from "@tiptap/extension-table-row";
+import { Text } from "@tiptap/extension-text";
+import {
+	defaultMarkdownSerializer,
+	MarkdownSerializer,
+} from "@tiptap/pm/markdown";
+import type { Fragment, Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { TextSelection } from "@tiptap/pm/state";
+import { CellSelection } from "@tiptap/pm/tables";
+import {
+	serializeMarkdownTable,
+	serializeSelectionForClipboard,
+} from "./serializeMarkdownTable";
+
+// Build the real schema so node names match production exactly
+// (table / tableRow / tableHeader / tableCell). getSchema does not touch the DOM.
+const schema = getSchema([
+	Document,
+	Text,
+	Paragraph,
+	Bold,
+	BulletList,
+	ListItem,
+	Table,
+	TableRow,
+	TableHeader,
+	TableCell,
+]);
+
+// serializeMarkdownTable renders descendants itself, so the nodes map only needs
+// `table` plus `text` (inline leaves are dispatched through the nodes map). In
+// the real app tiptap-markdown supplies the full map. `bold` maps to
+// prosemirror-markdown's `strong` serializer, the same one used for the Bold mark.
+const serializer = new MarkdownSerializer(
+	{
+		table: serializeMarkdownTable,
+		text: defaultMarkdownSerializer.nodes.text,
+		paragraph: defaultMarkdownSerializer.nodes.paragraph,
+		bulletList: defaultMarkdownSerializer.nodes.bullet_list,
+		listItem: defaultMarkdownSerializer.nodes.list_item,
+	},
+	{ bold: defaultMarkdownSerializer.marks.strong },
+);
+
+const paragraph = (content?: ProseMirrorNode) =>
+	schema.nodes.paragraph.create(null, content);
+const th = (text?: string) =>
+	schema.nodes.tableHeader.create(
+		null,
+		paragraph(text ? schema.text(text) : undefined),
+	);
+const cell = (text?: string) =>
+	schema.nodes.tableCell.create(
+		null,
+		paragraph(text ? schema.text(text) : undefined),
+	);
+const row = (cells: ProseMirrorNode[]) =>
+	schema.nodes.tableRow.create(null, cells);
+const toMarkdown = (table: ProseMirrorNode) =>
+	serializer.serialize(schema.nodes.doc.create(null, table));
+
+describe("serializeMarkdownTable", () => {
+	it("serializes a header + body table to GFM (never [table])", () => {
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [
+				row([th("a"), th("b")]),
+				row([cell("c"), cell("d")]),
+			]),
+		);
+
+		expect(md).toBe("| a | b |\n| --- | --- |\n| c | d |");
+		expect(md).not.toContain("[table]");
+	});
+
+	it("synthesizes an empty header for a headerless / partial cell selection", () => {
+		// This is the reported bug: a CellSelection copy of body cells has no
+		// header row, which made tiptap-markdown fall back to `[table]`.
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [row([cell("c"), cell("d")])]),
+		);
+
+		expect(md).toBe("|  |  |\n| --- | --- |\n| c | d |");
+		expect(md).not.toContain("[table]");
+	});
+
+	it("escapes pipes and renders empty cells", () => {
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [
+				row([th("a"), th("b")]),
+				row([cell("x|y"), cell()]),
+			]),
+		);
+
+		expect(md).toContain("| x\\|y |  |");
+		expect(md).not.toContain("[table]");
+	});
+
+	it("pads ragged rows to the widest row", () => {
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [
+				row([th("a"), th("b"), th("c")]),
+				row([cell("c")]),
+			]),
+		);
+
+		expect(md).toContain("| c |  |  |");
+	});
+
+	it("keeps inline marks inside cells", () => {
+		const boldCell = schema.nodes.tableCell.create(
+			null,
+			paragraph(schema.text("bold", [schema.marks.bold.create()])),
+		);
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [row([th("h")]), row([boldCell])]),
+		);
+
+		expect(md).toContain("**bold**");
+		expect(md).not.toContain("[table]");
+	});
+
+	it("preserves internal whitespace (meaningful inside code spans)", () => {
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [row([th("a")]), row([cell("x  y")])]),
+		);
+
+		expect(md).toContain("| x  y |");
+	});
+
+	it("does not treat a mixed header/body first row as a header", () => {
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [
+				row([th("a"), cell("b")]),
+				row([cell("c"), cell("d")]),
+			]),
+		);
+
+		expect(md).toBe("|  |  |\n| --- | --- |\n| a | b |\n| c | d |");
+	});
+
+	it("joins multiple blocks in a cell with a space", () => {
+		const multiCell = schema.nodes.tableCell.create(null, [
+			paragraph(schema.text("a")),
+			paragraph(schema.text("b")),
+		]);
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [row([th("h")]), row([multiCell])]),
+		);
+
+		expect(md).toContain("| a b |");
+	});
+
+	it("flattens block-level cell content (a list) onto the cell line", () => {
+		const listCell = schema.nodes.tableCell.create(
+			null,
+			schema.nodes.bulletList.create(null, [
+				schema.nodes.listItem.create(null, paragraph(schema.text("one"))),
+				schema.nodes.listItem.create(null, paragraph(schema.text("two"))),
+			]),
+		);
+		const md = toMarkdown(
+			schema.nodes.table.create(null, [row([th("h")]), row([listCell])]),
+		);
+
+		expect(md).not.toContain("[table]");
+		expect(md).toContain("one");
+		expect(md).toContain("two");
+	});
+});
+
+describe("serializeSelectionForClipboard", () => {
+	const serializeMarkdown = (content: Fragment) =>
+		serializer.serialize(schema.nodes.doc.create(null, content));
+
+	const testDoc = schema.nodes.doc.create(null, [
+		schema.nodes.table.create(null, [
+			row([th("Check"), th("Status")]),
+			row([cell("lint"), cell("pass/fail")]),
+		]),
+		schema.nodes.paragraph.create(
+			null,
+			schema.text("hi", [schema.marks.bold.create()]),
+		),
+	]);
+
+	const headerPositions: number[] = [];
+	const cellPositions: number[] = [];
+	let passFrom = -1;
+	let passTo = -1;
+	let boldFrom = -1;
+	let boldTo = -1;
+	testDoc.descendants((node, pos) => {
+		if (node.type.name === "tableHeader") headerPositions.push(pos);
+		if (node.type.name === "tableCell") cellPositions.push(pos);
+		if (node.isText && node.text === "pass/fail") {
+			passFrom = pos;
+			passTo = pos + node.text.length;
+		}
+		if (node.isText && node.text === "hi") {
+			boldFrom = pos;
+			boldTo = pos + node.text.length;
+		}
+		return true;
+	});
+	const lastCell = cellPositions[cellPositions.length - 1] ?? 0;
+
+	it("serializes a whole-table CellSelection as a GFM table", () => {
+		const selection = CellSelection.create(
+			testDoc,
+			headerPositions[0] ?? 0,
+			lastCell,
+		);
+		const result = serializeSelectionForClipboard(
+			selection,
+			selection.content(),
+			serializeMarkdown,
+		);
+
+		expect(result).toContain("| Check | Status |");
+		expect(result).toContain("| lint | pass/fail |");
+	});
+
+	it("copies a single-cell CellSelection as plain text", () => {
+		const selection = CellSelection.create(testDoc, lastCell, lastCell);
+		const result = serializeSelectionForClipboard(
+			selection,
+			selection.content(),
+			serializeMarkdown,
+		);
+
+		expect(result).toBe("pass/fail");
+		expect(result).not.toContain("|");
+	});
+
+	it("copies text selected inside a cell as plain text, not a table", () => {
+		const selection = TextSelection.create(testDoc, passFrom, passTo);
+		const result = serializeSelectionForClipboard(
+			selection,
+			selection.content(),
+			serializeMarkdown,
+		);
+
+		expect(result).toBe("pass/fail");
+		expect(result).not.toContain("|");
+	});
+
+	it("keeps markdown for a selection outside any table", () => {
+		const selection = TextSelection.create(testDoc, boldFrom, boldTo);
+		const result = serializeSelectionForClipboard(
+			selection,
+			selection.content(),
+			serializeMarkdown,
+		);
+
+		expect(result).toContain("**hi**");
+	});
+
+	it("copies a selection crossing the table boundary as plain text", () => {
+		// Starts outside the table and ends inside it: classified by $to, so it
+		// must not emit a partial table.
+		const doc = schema.nodes.doc.create(null, [
+			schema.nodes.paragraph.create(null, schema.text("before")),
+			schema.nodes.table.create(null, [
+				row([th("Check"), th("Status")]),
+				row([cell("lint"), cell("pass/fail")]),
+			]),
+		]);
+		let outsidePos = -1;
+		let insidePos = -1;
+		doc.descendants((node, pos) => {
+			if (node.isText && node.text === "before") outsidePos = pos + 1;
+			if (node.isText && node.text === "Check") insidePos = pos + 1;
+			return true;
+		});
+
+		const selection = TextSelection.create(doc, outsidePos, insidePos);
+		const result = serializeSelectionForClipboard(
+			selection,
+			selection.content(),
+			serializeMarkdown,
+		);
+
+		expect(result).not.toContain("|");
+	});
+});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/serializeMarkdownTable.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/serializeMarkdownTable.ts
@@ -1,0 +1,213 @@
+import type { MarkdownSerializerState } from "@tiptap/pm/markdown";
+import type {
+	Fragment,
+	Node as ProseMirrorNode,
+	ResolvedPos,
+	Slice,
+} from "@tiptap/pm/model";
+import type { Selection } from "@tiptap/pm/state";
+import { CellSelection } from "@tiptap/pm/tables";
+
+/**
+ * GFM markdown serialization for TipTap tables in the markdown preview.
+ *
+ * `tiptap-markdown@0.9.0` ships a `table` serializer that bails to a raw-HTML
+ * fallback — which, with `html: false`, writes the literal `[table]` — whenever
+ * a table isn't a clean header+body GFM table. `serializeMarkdownTable` replaces
+ * it (registered via each table node's `storage.markdown.serialize`) so both
+ * `getMarkdown()` (save) and a whole-table copy produce a real GFM table.
+ *
+ * `serializeSelectionForClipboard` then decides, per copied selection, whether
+ * the clipboard text/plain is a GFM table (whole-table selection), plain text
+ * (text within a cell / a subset of cells), or normal markdown (selection
+ * outside any table).
+ */
+
+/**
+ * prosemirror-markdown's serializer state exposes `out`/`closed` at runtime (its
+ * own serializers and `serialize()` read them) but does not declare them on the
+ * public type. We snapshot and restore them so a single cell's inline content
+ * can be rendered into an isolated buffer without leaking into the outer output.
+ */
+interface SerializerStateInternals {
+	out: string;
+	closed: ProseMirrorNode | null;
+}
+
+/**
+ * Render one table cell's content to a single-line markdown string.
+ *
+ * GFM cells must stay on one physical line, so hard breaks / newlines are
+ * collapsed to spaces and `|` is escaped so cell content can't split the row.
+ */
+function renderTableCellContent(
+	state: MarkdownSerializerState,
+	cell: ProseMirrorNode,
+): string {
+	const internals = state as unknown as SerializerStateInternals;
+	const previousOut = internals.out;
+	const previousClosed = internals.closed;
+	// Render into a clean buffer and don't let the outer pending block-close flush
+	// into the cell; both are restored before the table's own output is written.
+	internals.out = "";
+	internals.closed = null;
+
+	cell.forEach((block, _offset, index) => {
+		// A cell is `block+`; the common case is a single paragraph. Join multiple
+		// blocks with a space to keep the cell on one line.
+		if (index > 0) {
+			internals.out += " ";
+		}
+		if (block.isTextblock) {
+			state.renderInline(block);
+		} else {
+			state.render(block, cell, index);
+		}
+	});
+
+	const rendered = internals.out;
+	internals.out = previousOut;
+	internals.closed = previousClosed;
+
+	// Newlines become spaces (GFM cells are single-line) and pipes are escaped.
+	// Internal whitespace is left intact — it is meaningful inside code spans.
+	return rendered
+		.replace(/\\\r?\n/g, " ") // prosemirror hard break ("\\\n") -> space
+		.replace(/\r?\n/g, " ") // any remaining newline -> space
+		.replace(/\|/g, "\\|") // escape pipes so they don't split the cell
+		.trim();
+}
+
+/**
+ * A GFM header row is one whose cells are all `tableHeader`. A mixed or body row
+ * (e.g. a partial selection that clips a row-header column) must not be treated
+ * as a header, or its body cells get promoted to headers on round-trip.
+ */
+function isHeaderRow(row: ProseMirrorNode | null | undefined): boolean {
+	if (!row || row.childCount === 0) {
+		return false;
+	}
+	let allHeaderCells = true;
+	row.forEach((cell) => {
+		if (cell.type.name !== "tableHeader") {
+			allHeaderCells = false;
+		}
+	});
+	return allHeaderCells;
+}
+
+/**
+ * Serialize a `table` node to a GitHub-flavored markdown table. Called by
+ * `tiptap-markdown` as `(state, node) => void` via `storage.markdown.serialize`.
+ */
+export function serializeMarkdownTable(
+	state: MarkdownSerializerState,
+	node: ProseMirrorNode,
+): void {
+	const rows: string[][] = [];
+	node.forEach((rowNode) => {
+		const cells: string[] = [];
+		rowNode.forEach((cellNode) => {
+			cells.push(renderTableCellContent(state, cellNode));
+		});
+		rows.push(cells);
+	});
+
+	if (rows.length === 0) {
+		state.closeBlock(node);
+		return;
+	}
+
+	const columnCount = rows.reduce(
+		(max, cells) => Math.max(max, cells.length),
+		0,
+	);
+
+	const formatRow = (cells: string[]): string => {
+		const padded = cells.slice();
+		while (padded.length < columnCount) {
+			padded.push("");
+		}
+		return `| ${padded.join(" | ")} |`;
+	};
+
+	const lines: string[] = [];
+	let bodyStart = 0;
+
+	if (isHeaderRow(node.firstChild)) {
+		lines.push(formatRow(rows[0] ?? []));
+		bodyStart = 1;
+	} else {
+		// GFM requires a header + delimiter row. When the (possibly partial)
+		// selection has no header row, emit an empty header and keep every row as a
+		// body row — no data is lost.
+		lines.push(formatRow([]));
+	}
+
+	lines.push(
+		`| ${Array.from({ length: columnCount }, () => "---").join(" | ")} |`,
+	);
+
+	for (let i = bodyStart; i < rows.length; i += 1) {
+		const cells = rows[i];
+		if (cells) {
+			lines.push(formatRow(cells));
+		}
+	}
+
+	lines.forEach((line, index) => {
+		if (index > 0) {
+			state.ensureNewLine();
+		}
+		state.write(line);
+	});
+
+	state.closeBlock(node);
+}
+
+function isPosInsideTable($pos: ResolvedPos): boolean {
+	for (let depth = $pos.depth; depth > 0; depth -= 1) {
+		if ($pos.node(depth).type.name === "table") {
+			return true;
+		}
+	}
+	return false;
+}
+
+/** Flatten a copied slice to plain text, turning block boundaries into newlines. */
+export function sliceToPlainText(slice: Slice): string {
+	return slice.content.textBetween(0, slice.content.size, "\n");
+}
+
+/**
+ * Decide the clipboard `text/plain` for a copied selection.
+ *
+ * A text selection *inside* a cell copies a slice whose fragment is wrapped in
+ * an "open" `table` node (`doc.slice()` keeps the ancestor path). tiptap-markdown
+ * ignores the open depths and renders that wrapper as a full GFM table, so
+ * copying cell text produced a one-cell table on the clipboard. Decide by the
+ * selection instead of the slice shape:
+ *
+ * - whole-table `CellSelection` -> GFM markdown table
+ * - any other selection touching a table (partial cells, text within a cell, or
+ *   a range crossing the table boundary) -> plain text
+ * - selection outside any table -> normal markdown (preserves copy-as-markdown)
+ */
+export function serializeSelectionForClipboard(
+	selection: Selection,
+	slice: Slice,
+	serializeMarkdown: (content: Fragment) => string,
+): string {
+	if (selection instanceof CellSelection) {
+		const wholeTable = selection.isColSelection() && selection.isRowSelection();
+		return wholeTable
+			? serializeMarkdown(slice.content)
+			: sliceToPlainText(slice);
+	}
+
+	if (isPosInsideTable(selection.$from) || isPosInsideTable(selection.$to)) {
+		return sliceToPlainText(slice);
+	}
+
+	return serializeMarkdown(slice.content);
+}


### PR DESCRIPTION
## Summary
- Fixes markdown tables in the desktop `.md` preview being copied/saved as the literal string `[table]`. Selecting a table and pressing Cmd/Ctrl+C now yields a real GitHub-flavored markdown table, and saving a table-containing `.md` no longer corrupts it.

## Why / Context
The `.md` preview renders through `TipTapMarkdownRenderer`, configured with `tiptap-markdown`'s `transformCopiedText: true` — which installs a ProseMirror `clipboardTextSerializer` that re-serializes copied content back to markdown. The same serializer also backs `getEditorMarkdown()` (save / `onChange`).

`tiptap-markdown@0.9.0` ships a `table` serializer that bails to a raw-HTML fallback whenever the table isn't a "clean" header+body GFM table. Because `html: false`, that fallback writes the literal `[table]`. Two real cases hit it:

- **Copying content inside a table** — a text selection inside a cell produces a slice whose fragment is wrapped in an "open" `table` node (`doc.slice()` keeps the ancestor path); tiptap-markdown ignores the open depths and renders that wrapper as a table, so the clipboard got `[table]` (or a bogus one-cell table).
- **Saving a table-containing `.md`** in editable mode — `getEditorMarkdown()` uses the same serializer, so the file was rewritten to `[table]`.

(Right-click → Copy was unaffected: `SelectionContextMenu` reads `window.getSelection().toString()`.)

## How It Works
- **`serializeMarkdownTable.ts` (new)** — a GFM table serializer registered on the `table` node via `storage.markdown.serialize`, replacing tiptap-markdown's strict built-in. It renders each cell's inline content into an isolated buffer (snapshotting prosemirror-markdown's runtime `out`/`closed`), collapses newlines / hard-breaks to spaces so cells stay single-line, escapes `|`, pads ragged rows to the widest row, and **synthesizes an empty header** when the (possibly partial) table has no header row — so no data is lost. Drives both save and whole-table copy.
- **`serializeSelectionForClipboard` + a higher-priority `clipboardTextSerializer`** — decides the clipboard `text/plain` by *selection*, not by slice shape:
  - whole-table `CellSelection` (spans all rows + cols) → GFM markdown table
  - text within a cell / a subset of cells / a range crossing the table boundary → **plain text**
  - selection outside any table → normal markdown (copy-as-markdown preserved)

  A `TableClipboardMarkdown` extension registers this at priority 1000, above tiptap-markdown's Markdown extension (priority 50), so it's consulted first.
- **`createMarkdownExtensions.ts`** — replaced the `TableKit` bundle with the individual `Table`/`TableRow`/`TableHeader`/`TableCell` extensions (already declared deps) so the serializer can be attached via `Table.extend().addStorage()`. Existing classes/config are preserved, and the CellSelection editing plugins live on the `Table` node — so rendering, parsing, and selection are unchanged. `Markdown.configure(...)` is untouched.

## Design Decisions
- **Cell-text / partial selections copy as plain text, not markdown**: a partial slice can't form a valid GFM table, and re-serializing the "open" wrapper is exactly what produced `[table]`. Plain text is the honest result for "I selected some words in a cell."
- **Individual table extensions instead of `TableKit`**: `TableKit` doesn't expose a hook to override the per-node markdown serializer; `Table.extend().addStorage()` does. tiptap-markdown merges an extension's own markdown spec over its built-in one, so this overrides the strict default for both copy and save.

## Manual QA Checklist
- [x] Preview a `.md` with a header+body table → select the whole table → Cmd/Ctrl+C → paste into a plain text field shows a real GFM table (not `[table]`)
- [x] Select text inside a single cell → Cmd/Ctrl+C → clipboard holds that plain text (not a one-cell table, not `[table]`)
- [x] Select a range crossing the table boundary → copies as plain text
- [x] Select non-table content → copy still yields markdown (copy-as-markdown preserved)
- [x] Edit a table in editable preview and save → file on disk is a valid GFM table, not `[table]`
- [x] Table still renders with the same styling (header bg, borders, spacing) and cell selection still works
- [x] No console errors in DevTools (renderer)

## Testing
- [x] `bun test serializeMarkdownTable.test.ts` — 14 pass / 0 fail across both functions: header+body → GFM, headerless/partial → synthesized header, pipe escaping + empty cells, ragged-row padding, inline marks, whitespace preserved in code spans, mixed header/body first row not treated as header, multi-block cells, list flattening; plus selection routing: whole-table → GFM, single cell / cell-text / boundary-crossing → plain text, outside table → markdown
- [x] `bun run typecheck` (desktop) — clean
- [x] Biome `check` on the changed files — clean, no fixes

## Known Limitations / Follow-ups
- The shared editable `MarkdownEditor` (tasks, automations, new-workspace prompt, editable file viewer) uses the same `TableKit` + `transformCopiedText` combination and has the identical latent bug. Out of scope here; a follow-up can promote this serializer to a shared location and reuse it there.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5688">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop Markdown preview so tables copy and save as real GFM instead of “[table]”. Whole-table copies now output a proper GFM table; partial selections copy as plain text; saving files preserves tables.

- **Bug Fixes**
  - Added a custom GFM table serializer via `storage.markdown.serialize` to replace `tiptap-markdown`’s strict default (handles `|` escaping, single-line cells, row padding, and synthesizes an empty header when missing).
  - Registered a high-priority `clipboardTextSerializer` to choose output by selection: whole-table `CellSelection` → GFM; cell text/subsets/boundary-crossing → plain text; outside tables → normal markdown.
  - Replaced `TableKit` with `Table`/`TableRow`/`TableHeader`/`TableCell` to attach the serializer; rendering and selection behavior are unchanged.

<sup>Written for commit 42bd5e2268c7e050555bdc1ef8c6655fd730b3f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copying complete tables now preserves them as GitHub-Flavored Markdown tables.
  * Markdown table output now consistently handles headers, empty cells, uneven rows, formatting, and special characters.
  * Partial table selections and selections crossing table boundaries are copied as plain text to avoid malformed Markdown.

* **Tests**
  * Added comprehensive coverage for table serialization and clipboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->