### PR TITLE
feat(desktop): clear automations failure badge when the page is opened

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -30,7 +30,7 @@ import { cn } from "@superset/ui/utils";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { LuPlus, LuSearchX, LuTerminal, LuX } from "react-icons/lu";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
@@ -135,7 +135,13 @@ function AutomationsPage() {
 			})),
 		[collections.users],
 	);
-	const { lastRunStatusById } = useFailedAutomations();
+	const { lastRunStatusById, markMyFailuresSeen } = useFailedAutomations();
+
+	// Opening the page clears the sidebar failure badge; failures that sync in
+	// while it stays open are marked seen too, until a newer run fails.
+	useEffect(() => {
+		markMyFailuresSeen();
+	}, [markMyFailuresSeen]);
 
 	const recentProjects = useRecentProjects();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations/useFailedAutomations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations/useFailedAutomations.ts
@@ -1,8 +1,9 @@
 import type { SelectAutomationRun } from "@superset/db/schema";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useAutomationFailuresStore } from "renderer/stores/automation-failures";
 
 const FAILED_STATUSES: SelectAutomationRun["status"][] = [
 	"skipped_offline",
@@ -14,14 +15,22 @@ interface FailedAutomations {
 	lastRunStatusById: Map<string, SelectAutomationRun["status"]>;
 	/** Automations whose most recent run failed. */
 	failedIds: Set<string>;
-	/** How many of the current user's automations are in that set. */
+	/** How many of the current user's failures the user hasn't seen yet. */
 	myFailedCount: number;
+	/** Clear the failure badge by acknowledging the user's current failures. */
+	markMyFailuresSeen: () => void;
 }
 
 export function useFailedAutomations(): FailedAutomations {
 	const collections = useCollections();
 	const { data: session } = authClient.useSession();
 	const currentUserId = session?.user?.id;
+	const lastSeenFailureAt = useAutomationFailuresStore(
+		(s) => s.lastSeenFailureAt,
+	);
+	const markFailuresSeen = useAutomationFailuresStore(
+		(s) => s.markFailuresSeen,
+	);
 
 	const { data: runRows = [] } = useLiveQuery(
 		(q) =>
@@ -41,7 +50,7 @@ export function useFailedAutomations(): FailedAutomations {
 		[collections.automations],
 	);
 
-	return useMemo(() => {
+	const { lastRunStatusById, failedIds, myFailureTimes } = useMemo(() => {
 		const latest = new Map<
 			string,
 			{ status: SelectAutomationRun["status"]; at: number }
@@ -60,12 +69,29 @@ export function useFailedAutomations(): FailedAutomations {
 			lastRunStatusById.set(id, run.status);
 			if (FAILED_STATUSES.includes(run.status)) failedIds.add(id);
 		}
-		const myFailedCount = currentUserId
-			? automationRows.filter(
-					(a) =>
-						a != null && a.ownerUserId === currentUserId && failedIds.has(a.id),
-				).length
-			: 0;
-		return { lastRunStatusById, failedIds, myFailedCount };
+		// createdAt of each of the current user's failing runs.
+		const myFailureTimes = currentUserId
+			? automationRows
+					.filter(
+						(a) =>
+							a != null &&
+							a.ownerUserId === currentUserId &&
+							failedIds.has(a.id),
+					)
+					.map((a) => latest.get(a.id)?.at ?? 0)
+			: [];
+		return { lastRunStatusById, failedIds, myFailureTimes };
 	}, [runRows, automationRows, currentUserId]);
+
+	const myFailedCount = useMemo(
+		() => myFailureTimes.filter((at) => at > lastSeenFailureAt).length,
+		[myFailureTimes, lastSeenFailureAt],
+	);
+
+	const markMyFailuresSeen = useCallback(() => {
+		const newest = myFailureTimes.reduce((max, at) => Math.max(max, at), 0);
+		if (newest > 0) markFailuresSeen(newest);
+	}, [myFailureTimes, markFailuresSeen]);
+
+	return { lastRunStatusById, failedIds, myFailedCount, markMyFailuresSeen };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations/useFailedAutomations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations/useFailedAutomations.ts
@@ -69,7 +69,8 @@ export function useFailedAutomations(): FailedAutomations {
 			lastRunStatusById.set(id, run.status);
 			if (FAILED_STATUSES.includes(run.status)) failedIds.add(id);
 		}
-		// createdAt of each of the current user's failing runs.
+		// createdAt of each of the current user's failing runs. Drop non-finite
+		// times (unparseable createdAt) so one bad run can't poison the max below.
 		const myFailureTimes = currentUserId
 			? automationRows
 					.filter(
@@ -79,6 +80,7 @@ export function useFailedAutomations(): FailedAutomations {
 							failedIds.has(a.id),
 					)
 					.map((a) => latest.get(a.id)?.at ?? 0)
+					.filter((at) => Number.isFinite(at))
 			: [];
 		return { lastRunStatusById, failedIds, myFailureTimes };
 	}, [runRows, automationRows, currentUserId]);

--- a/apps/desktop/src/renderer/stores/automation-failures/index.ts
+++ b/apps/desktop/src/renderer/stores/automation-failures/index.ts
@@ -1,0 +1,4 @@
+export {
+	type AutomationFailuresState,
+	useAutomationFailuresStore,
+} from "./store";

--- a/apps/desktop/src/renderer/stores/automation-failures/store.test.ts
+++ b/apps/desktop/src/renderer/stores/automation-failures/store.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { useAutomationFailuresStore } from "./store";
+
+describe("automation failures store", () => {
+	beforeEach(() => {
+		useAutomationFailuresStore.setState({ lastSeenFailureAt: 0 });
+	});
+
+	it("advances the watermark to the newest acknowledged failure", () => {
+		useAutomationFailuresStore.getState().markFailuresSeen(200);
+		expect(useAutomationFailuresStore.getState().lastSeenFailureAt).toBe(200);
+	});
+
+	it("is monotonic and ignores older acknowledgements", () => {
+		const store = useAutomationFailuresStore.getState();
+		store.markFailuresSeen(200);
+		store.markFailuresSeen(100);
+		expect(useAutomationFailuresStore.getState().lastSeenFailureAt).toBe(200);
+		store.markFailuresSeen(300);
+		expect(useAutomationFailuresStore.getState().lastSeenFailureAt).toBe(300);
+	});
+
+	it("keeps the same state reference when nothing changes", () => {
+		const store = useAutomationFailuresStore.getState();
+		store.markFailuresSeen(200);
+		const before = useAutomationFailuresStore.getState();
+		store.markFailuresSeen(200);
+		expect(useAutomationFailuresStore.getState()).toBe(before);
+	});
+});

--- a/apps/desktop/src/renderer/stores/automation-failures/store.ts
+++ b/apps/desktop/src/renderer/stores/automation-failures/store.ts
@@ -9,9 +9,9 @@ import { devtools, persist } from "zustand/middleware";
  */
 export interface AutomationFailuresState {
 	/**
-	 * createdAt (ms, host clock) of the newest failed run the user has
-	 * acknowledged. Must be a host-clock value, never the renderer clock, which
-	 * can drift and mask or resurface failures incorrectly.
+	 * createdAt (ms) of the newest failed run the user has acknowledged. This is
+	 * the run's DB timestamp (a single server clock), so it's comparable across
+	 * hosts without skew — never substitute the renderer clock here.
 	 */
 	lastSeenFailureAt: number;
 	/** Acknowledge failures up to `at`. Monotonic — never moves backward. */

--- a/apps/desktop/src/renderer/stores/automation-failures/store.ts
+++ b/apps/desktop/src/renderer/stores/automation-failures/store.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+/**
+ * Renderer-local watermark of the newest automation failure the user has seen,
+ * so opening the Automations page clears the sidebar failure badge until a
+ * newer run fails. The failure count itself is DERIVED from run data (see
+ * `useFailedAutomations`); the only fact stored here is the user's seen mark.
+ */
+export interface AutomationFailuresState {
+	/**
+	 * createdAt (ms, host clock) of the newest failed run the user has
+	 * acknowledged. Must be a host-clock value, never the renderer clock, which
+	 * can drift and mask or resurface failures incorrectly.
+	 */
+	lastSeenFailureAt: number;
+	/** Acknowledge failures up to `at`. Monotonic — never moves backward. */
+	markFailuresSeen: (at: number) => void;
+}
+
+export const useAutomationFailuresStore = create<AutomationFailuresState>()(
+	devtools(
+		persist(
+			(set) => ({
+				lastSeenFailureAt: 0,
+				markFailuresSeen: (at) => {
+					set((state) =>
+						at > state.lastSeenFailureAt ? { lastSeenFailureAt: at } : state,
+					);
+				},
+			}),
+			{
+				name: "automation-failures-v1",
+				version: 1,
+				partialize: (state) => ({ lastSeenFailureAt: state.lastSeenFailureAt }),
+			},
+		),
+		{ name: "AutomationFailures" },
+	),
+);


### PR DESCRIPTION
## What

The sidebar **Automations** item shows a red badge counting the current user's automations whose last run failed. That count was derived purely from run data, so it only cleared when a *newer* non-failing run arrived — opening the Automations page did nothing.

Now opening the page clears the badge, and it re-appears only when a genuinely new failure occurs.

## How

Added a small renderer-local, persisted store holding a single **watermark**: `lastSeenFailureAt` — the `createdAt` of the newest failure the user has acknowledged (the run's DB timestamp, a single server clock).

- `useFailedAutomations` counts only failures whose latest run is newer than the watermark, and exposes `markMyFailuresSeen()`. Non-finite run times are dropped so one unparseable `createdAt` can't wedge the badge.
- `AutomationsPage` calls it in an effect, so opening the page (and any failures that sync in while it stays open) acknowledges the current failures. A new failed run always has a newer `createdAt`, so the badge re-surfaces.
- `lastRunStatusById` / `failedIds` are unchanged — the page still renders each row's real last-run status.

Mirrors the existing `v2-notifications` seen-timestamp pattern, but collapsed to a scalar watermark (no per-automation map) so there's no unbounded state to prune.

### Tradeoff
A watermark can mask a *late-syncing older* failure (one that failed before your last acknowledgement but synced to this device afterward). Rare with Electric sync, and avoiding it isn't worth an unbounded-growth map. True cross-device precision would need a server-side per-run acknowledged flag.

## Test plan

- [x] `bun run lint` clean, `tsc --noEmit` clean
- [x] Store unit tests: watermark advances, monotonic (ignores older acks), stable state reference on no-op
- [x] **Verified end-to-end in the real dev app over CDP** (account had exactly 3 failing automations, matching the reported badge):
  - Badge shows "3" → open Automations → badge disappears; `lastSeenFailureAt` persisted as the newest failure's timestamp
  - Survives full app reload (persisted watermark rehydrates, badge stays cleared)
  - Rewinding the watermark resurfaces the correct count (watermark `0`→3, `2nd-newest`→1, `oldest`→2), confirming a newer failure re-badges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation failure badges are now acknowledged automatically when the Automations dashboard is opened.
  * Failure counts now distinguish between newly failed automations and failures already viewed.
  * Acknowledgement status is preserved between sessions and advances only when newer failures are seen.
* **Bug Fixes**
  * Prevented previously viewed automation failures from continuing to appear as new.
* **Tests**
  * Added tests to verify acknowledgement watermark monotonicity and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->