### PR TITLE
fix(desktop): allow blob video preview to play via media-src CSP

### DIFF
--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -13,11 +13,12 @@
       - style-src 'self' 'unsafe-inline': Allow styles from same origin + inline (needed for CSS-in-JS)
       - connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc: Allow WebSocket + API + Electric proxy + PostHog + Sentry + data URIs (file attachment upload via data URL) + blob URIs + local host-service (127.0.0.1) + relay + relay override target (for staging/failover via PostHog flag)
       - img-src 'self' data: blob: https: http:: Allow images from any source (needed for favicons, browser pane webview content, and file attachment previews)
+      - media-src 'self' data: blob:: Allow <video>/<audio> from blob + data URIs (file preview); without this, media falls back to default-src 'self' and blob video won't play
       - font-src 'self': Allow fonts from same origin
       - frame-src https: http: data: blob:: Allow webview browser pane to load any URL
       - child-src 'self' blob:: Allow workers from same origin + blob workers
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: blob: https: http:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %RELAY_URL% https://relay-backup.superset.sh %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: blob: https: http:; media-src 'self' data: blob:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary

Video file previews in the v2 workspace file pane rendered the `<video>` element with controls but never played. Root cause: the renderer CSP (`apps/desktop/src/renderer/index.html`) declared no `media-src` directive, so `<video>`/`<audio>` sources fell back to `default-src 'self'` — which blocks the `blob:` URL that `VideoView` creates from in-memory bytes. Images preview fine only because `img-src` explicitly lists `blob:`.

Fix: add `media-src 'self' data: blob:` to the CSP so blob/data video sources are permitted to load.

## Verification (CDP)

Drove two minimal pages differing only in the `media-src` directive, each building a `blob:` video from a real H.264 MP4:

- **Without `media-src`** → `securitypolicyviolation` on `media-src`, video errors with code 4 (blocked) — reproduces the bug.
- **With `media-src 'self' data: blob:`** → no CSP violation, no CSP error; the source passes CSP and enters the media pipeline (same as a no-CSP baseline).

## Test Plan

- [ ] Open a `.mp4`/`.webm` (≤10 MB) in the v2 workspace file pane and confirm it plays
- [ ] Image previews still work
- [ ] Browser pane / file-attachment previews unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes video previews in the v2 workspace file pane by adding a `media-src 'self' data: blob:` directive to the desktop renderer CSP so blob-based videos can load and play. Image and other previews are unchanged.

<sup>Written for commit dba24adc9ad8aa0b2f1b30c9bd1e1343fa5b1ebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media playback and loading for content sourced from browser-generated blobs and data URLs.
  * Updated the app’s security policy to handle media resources explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->