### PR TITLE
fix(host-service): don't link workspaces to default-branch PRs

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -1,9 +1,13 @@
 import type { CheckItem } from "@superset/local-db";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { useMemo, useRef } from "react";
 import { env } from "renderer/env.renderer";
+import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { authClient } from "renderer/lib/auth-client";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { derivePullRequestQueryTargets } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/derivePullRequestQueryTargets";
 import {
 	DEVICE_FILTER_ALL,
 	DEVICE_FILTER_THIS_DEVICE,
@@ -212,6 +216,27 @@ function mapChecks(rawChecks: RawCheckEntry[] | null | undefined): CheckItem[] {
 	}));
 }
 
+// The `useQueries` result array gets a fresh identity every render, so memoize
+// the derived workspace→PR-number map on its content to keep `enriched` stable.
+function useStableWorkspacePrNumbers(
+	entries: [string, number][],
+): Map<string, number> {
+	const previousRef = useRef<{
+		fingerprint: string;
+		map: Map<string, number>;
+	} | null>(null);
+	return useMemo(() => {
+		const sorted = [...entries].sort(([a], [b]) => a.localeCompare(b));
+		const fingerprint = JSON.stringify(sorted);
+		if (previousRef.current?.fingerprint === fingerprint) {
+			return previousRef.current.map;
+		}
+		const map = new Map(sorted);
+		previousRef.current = { fingerprint, map };
+		return map;
+	}, [entries]);
+}
+
 export function useAccessibleV2Workspaces(
 	options: UseAccessibleV2WorkspacesOptions = {},
 ): UseAccessibleV2WorkspacesResult {
@@ -220,7 +245,8 @@ export function useAccessibleV2Workspaces(
 	const projectFilter = options.projectFilter ?? PROJECT_FILTER_ALL;
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
-	const { machineId } = useLocalHostService();
+	const { machineId, activeHostUrl } = useLocalHostService();
+	const relayUrl = useRelayUrl();
 
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION
 		? MOCK_ORG_ID
@@ -232,6 +258,7 @@ export function useAccessibleV2Workspaces(
 	const { data: hostRows = [] } = useLiveQuery(
 		(q) =>
 			q.from({ hosts: collections.v2Hosts }).select(({ hosts }) => ({
+				organizationId: hosts.organizationId,
 				machineId: hosts.machineId,
 				name: hosts.name,
 				isOnline: hosts.isOnline,
@@ -370,6 +397,58 @@ export function useAccessibleV2Workspaces(
 		creatorRows,
 	]);
 
+	// Authoritative workspace→PR link. The host-service owns
+	// `workspace.pullRequestId` (default-branch guard and head-SHA checks
+	// applied there); re-deriving it client-side from a `repositoryId::branch`
+	// map mistracks on branch-name collisions across forks and can disagree
+	// with the sidebar. Fan `getByWorkspaces` out per host exactly as
+	// `useDashboardSidebarData` does, then key the rich PR row by the resolved
+	// (repositoryId, prNumber) — a unique pair, unlike the branch.
+	const pullRequestQueryTargets = useMemo(
+		() =>
+			derivePullRequestQueryTargets({
+				activeHostUrl,
+				hosts: hostRows,
+				machineId,
+				relayUrl,
+				workspaces: rows,
+			}),
+		[activeHostUrl, hostRows, machineId, relayUrl, rows],
+	);
+
+	const pullRequestQueries = useQueries({
+		queries: pullRequestQueryTargets.map((target) => ({
+			queryKey: [
+				"v2-workspaces",
+				"pull-requests",
+				target.machineId,
+				target.hostUrl,
+				target.workspaceIds,
+			] as const,
+			refetchInterval: 10_000,
+			queryFn: async () => {
+				const client = getHostServiceClientByUrl(target.hostUrl);
+				return client.pullRequests.getByWorkspaces.query({
+					workspaceIds: target.workspaceIds,
+				});
+			},
+		})),
+	});
+
+	const prNumberEntries = useMemo<[string, number][]>(() => {
+		const entries: [string, number][] = [];
+		for (const query of pullRequestQueries) {
+			const data = query.data;
+			if (!data) continue;
+			for (const row of data.workspaces) {
+				if (row.pullRequest)
+					entries.push([row.workspaceId, row.pullRequest.number]);
+			}
+		}
+		return entries;
+	}, [pullRequestQueries]);
+	const prNumberByWorkspaceId = useStableWorkspacePrNumbers(prNumberEntries);
+
 	const { data: prRows = [] } = useLiveQuery(
 		(q) =>
 			q
@@ -379,7 +458,6 @@ export function useAccessibleV2Workspaces(
 					id: prs.id,
 					repositoryId: prs.repositoryId,
 					prNumber: prs.prNumber,
-					headBranch: prs.headBranch,
 					title: prs.title,
 					url: prs.url,
 					state: prs.state,
@@ -395,17 +473,12 @@ export function useAccessibleV2Workspaces(
 		[collections, activeOrganizationId],
 	);
 
-	const prsByRepoBranch = useMemo(() => {
+	// Keyed by the unique (repositoryId, prNumber) so the authoritative link
+	// selects an exact PR — no branch-name collisions, no first-match-wins.
+	const prByRepoNumber = useMemo(() => {
 		const map = new Map<string, V2WorkspacePrSummary>();
-		const stateRank: Record<string, number> = {
-			open: 0,
-			draft: 1,
-			merged: 2,
-			closed: 3,
-		};
 		for (const row of prRows) {
-			const key = `${row.repositoryId}::${row.headBranch}`;
-			const candidate: V2WorkspacePrSummary = {
+			map.set(`${row.repositoryId}::${row.prNumber}`, {
 				prNumber: row.prNumber,
 				title: row.title,
 				url: row.url,
@@ -416,21 +489,7 @@ export function useAccessibleV2Workspaces(
 				additions: row.additions,
 				deletions: row.deletions,
 				updatedAt: new Date(row.updatedAt),
-			};
-			const existing = map.get(key);
-			if (!existing) {
-				map.set(key, candidate);
-				continue;
-			}
-			const cmpState = stateRank[candidate.state] - stateRank[existing.state];
-			if (cmpState < 0) {
-				map.set(key, candidate);
-			} else if (
-				cmpState === 0 &&
-				candidate.updatedAt.getTime() > existing.updatedAt.getTime()
-			) {
-				map.set(key, candidate);
-			}
+			});
 		}
 		return map;
 	}, [prRows]);
@@ -448,9 +507,11 @@ export function useAccessibleV2Workspaces(
 			const isInSidebar =
 				isSidebarWorkspaceVisible({ isHidden: row.sidebarIsHidden }) &&
 				(row.sidebarWorkspaceId != null || isAutoVisibleMain);
-			const pr = row.projectRepoId
-				? (prsByRepoBranch.get(`${row.projectRepoId}::${row.branch}`) ?? null)
-				: null;
+			const prNumber = prNumberByWorkspaceId.get(row.id);
+			const pr =
+				row.projectRepoId != null && prNumber != null
+					? (prByRepoNumber.get(`${row.projectRepoId}::${prNumber}`) ?? null)
+					: null;
 
 			deduped.set(row.id, {
 				id: row.id,
@@ -478,7 +539,7 @@ export function useAccessibleV2Workspaces(
 		return Array.from(deduped.values()).sort(
 			(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
 		);
-	}, [rows, machineId, currentUserId, prsByRepoBranch]);
+	}, [rows, machineId, currentUserId, prByRepoNumber, prNumberByWorkspaceId]);
 
 	const searchFiltered = useMemo(
 		() =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -2,7 +2,7 @@ import type { CheckItem } from "@superset/local-db";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries } from "@tanstack/react-query";
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { env } from "renderer/env.renderer";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { authClient } from "renderer/lib/auth-client";
@@ -216,24 +216,19 @@ function mapChecks(rawChecks: RawCheckEntry[] | null | undefined): CheckItem[] {
 	}));
 }
 
-// useQueries returns a fresh array each render; memoize by content to keep `enriched` stable.
+// useQueries returns a fresh array each render; key the map on a content
+// fingerprint so its identity only changes when the entries do.
 function useStableWorkspacePrNumbers(
 	entries: [string, number][],
 ): Map<string, number> {
-	const previousRef = useRef<{
-		fingerprint: string;
-		map: Map<string, number>;
-	} | null>(null);
-	return useMemo(() => {
-		const sorted = [...entries].sort(([a], [b]) => a.localeCompare(b));
-		const fingerprint = JSON.stringify(sorted);
-		if (previousRef.current?.fingerprint === fingerprint) {
-			return previousRef.current.map;
-		}
-		const map = new Map(sorted);
-		previousRef.current = { fingerprint, map };
-		return map;
-	}, [entries]);
+	const fingerprint = useMemo(
+		() => JSON.stringify([...entries].sort(([a], [b]) => a.localeCompare(b))),
+		[entries],
+	);
+	return useMemo<Map<string, number>>(
+		() => new Map(JSON.parse(fingerprint) as [string, number][]),
+		[fingerprint],
+	);
 }
 
 export function useAccessibleV2Workspaces(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -216,8 +216,7 @@ function mapChecks(rawChecks: RawCheckEntry[] | null | undefined): CheckItem[] {
 	}));
 }
 
-// The `useQueries` result array gets a fresh identity every render, so memoize
-// the derived workspace→PR-number map on its content to keep `enriched` stable.
+// useQueries returns a fresh array each render; memoize by content to keep `enriched` stable.
 function useStableWorkspacePrNumbers(
 	entries: [string, number][],
 ): Map<string, number> {
@@ -397,13 +396,9 @@ export function useAccessibleV2Workspaces(
 		creatorRows,
 	]);
 
-	// Authoritative workspace→PR link. The host-service owns
-	// `workspace.pullRequestId` (default-branch guard and head-SHA checks
-	// applied there); re-deriving it client-side from a `repositoryId::branch`
-	// map mistracks on branch-name collisions across forks and can disagree
-	// with the sidebar. Fan `getByWorkspaces` out per host exactly as
-	// `useDashboardSidebarData` does, then key the rich PR row by the resolved
-	// (repositoryId, prNumber) — a unique pair, unlike the branch.
+	// The authoritative link lives in host.db (`workspace.pullRequestId`), not any
+	// collection, so fan `getByWorkspaces` out per host like the sidebar. A
+	// client-side `repositoryId::branch` map mistracks on fork branch collisions.
 	const pullRequestQueryTargets = useMemo(
 		() =>
 			derivePullRequestQueryTargets({
@@ -473,8 +468,7 @@ export function useAccessibleV2Workspaces(
 		[collections, activeOrganizationId],
 	);
 
-	// Keyed by the unique (repositoryId, prNumber) so the authoritative link
-	// selects an exact PR — no branch-name collisions, no first-match-wins.
+	// Unique (repositoryId, prNumber) key — no branch collisions, no first-match-wins.
 	const prByRepoNumber = useMemo(() => {
 		const map = new Map<string, V2WorkspacePrSummary>();
 		for (const row of prRows) {

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -121,11 +121,29 @@ function getPrByNumber(db: HostDb, prNumber: number) {
 		.get();
 }
 
+// A git factory whose only answer is the remote's default branch, via the
+// `refs/remotes/origin/HEAD` symref that `resolveDefaultBranch` reads. Every
+// other git call throws — the refresh path must not depend on live git.
+function defaultBranchGit(defaultBranch: string) {
+	return (async () => ({
+		raw: async (args: string[]) => {
+			if (
+				args[0] === "symbolic-ref" &&
+				args.includes("refs/remotes/origin/HEAD")
+			) {
+				return `origin/${defaultBranch}\n`;
+			}
+			throw new Error(`unexpected git raw: ${args.join(" ")}`);
+		},
+	})) as never;
+}
+
 function createManager(
 	db: HostDb,
 	overrides: {
 		execGh?: (args: string[]) => Promise<unknown>;
 		github?: () => Promise<never>;
+		git?: unknown;
 	} = {},
 ) {
 	return new PullRequestRuntimeManager({
@@ -135,9 +153,11 @@ function createManager(
 			((async () => {
 				throw new Error("gh should not be used for direct PR linking");
 			}) as never),
-		git: (async () => {
-			throw new Error("git should not be used when project metadata is set");
-		}) as never,
+		git:
+			(overrides.git as never) ??
+			((async () => {
+				throw new Error("git should not be used when project metadata is set");
+			}) as never),
 		github:
 			(overrides.github as never) ??
 			((async () => {
@@ -502,7 +522,7 @@ function routeGh(prsByHeadRef: Record<string, ReturnType<typeof makePrNode>>) {
 		if (path === `repos/${REPO.owner}/${REPO.name}/pulls`) {
 			const headArg = args.find((a) => a.startsWith("head="));
 			if (headArg) {
-				const ref = headArg.slice(`head=${REPO.owner}:`.length);
+				const ref = headArg.slice(headArg.indexOf(":") + 1);
 				const pr = prsByHeadRef[ref];
 				return pr ? [pr] : [];
 			}
@@ -609,6 +629,115 @@ describe("case-variant branch isolation", () => {
 		);
 		expect(getWorkspace(db, "ws-upper")?.pullRequestId).toBe(
 			getPrByNumber(db, 102)?.id,
+		);
+	});
+});
+
+// A workspace branched off `main` keeps tracking `origin/main` until its own
+// branch is pushed, so its resolved upstream branch is `main`. Keying on `main`
+// links it to whatever open PR has head=main (e.g. a "sync main into X" PR).
+describe("default-branch guard", () => {
+	test("does not link a workspace tracking origin/main to a head=main PR", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		// The mislink as observed on screen: the workspace already points at the
+		// head=main PR. A refresh must clear it, not re-affirm it.
+		seedPullRequest(db, {
+			id: "pr-sync-main",
+			prNumber: 1522,
+			headBranch: "main",
+			headSha: "main-sha",
+			title: "chore: sync main into feat/signal-pages",
+		});
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "roshvan/mcp-1703-mcp-surface-area",
+			headSha: "workspace-sha",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "main",
+			pullRequestId: "pr-sync-main",
+		});
+		const manager = createManager(db, {
+			git: defaultBranchGit("main"),
+			execGh: routeGh({
+				main: makePrNode({
+					number: 1522,
+					headRef: "main",
+					headSha: "main-sha",
+					title: "chore: sync main into feat/signal-pages",
+				}),
+			}),
+		});
+
+		await withSilencedWarnings(() =>
+			manager.refreshPullRequestsByWorkspaces(["ws"]),
+		);
+
+		expect(getWorkspace(db, "ws")?.pullRequestId).toBeNull();
+	});
+
+	test("still links the workspace whose local branch is the default branch", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws-main",
+			branch: "main",
+			headSha: "main-sha",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "main",
+		});
+		const manager = createManager(db, {
+			git: defaultBranchGit("main"),
+			execGh: routeGh({
+				main: makePrNode({
+					number: 1522,
+					headRef: "main",
+					headSha: "main-sha",
+					title: "chore: sync main into feat/signal-pages",
+				}),
+			}),
+		});
+
+		await manager.refreshPullRequestsByWorkspaces(["ws-main"]);
+
+		expect(getWorkspace(db, "ws-main")?.pullRequestId).toBe(
+			getPrByNumber(db, 1522)?.id,
+		);
+	});
+
+	// The guard is scoped to the base repo: a fork PR whose head branch happens
+	// to be named `main` (e.g. a `gh pr checkout` rename) must still link.
+	test("still links a fork PR whose head branch is named main", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws-fork",
+			branch: "quueli-main",
+			headSha: "fork-sha",
+			upstreamOwner: "fork-owner",
+			upstreamRepo: "fork-repo",
+			upstreamBranch: "main",
+		});
+		const manager = createManager(db, {
+			git: defaultBranchGit("main"),
+			execGh: routeGh({
+				main: makePrNode({
+					number: 88,
+					headRef: "main",
+					headSha: "fork-sha",
+					headOwner: "fork-owner",
+					headRepo: "fork-repo",
+					title: "Fork feature",
+				}),
+			}),
+		});
+
+		await manager.refreshPullRequestsByWorkspaces(["ws-fork"]);
+
+		expect(getWorkspace(db, "ws-fork")?.pullRequestId).toBe(
+			getPrByNumber(db, 88)?.id,
 		);
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -121,9 +121,8 @@ function getPrByNumber(db: HostDb, prNumber: number) {
 		.get();
 }
 
-// A git factory whose only answer is the remote's default branch, via the
-// `refs/remotes/origin/HEAD` symref that `resolveDefaultBranch` reads. Every
-// other git call throws — the refresh path must not depend on live git.
+// Answers only the origin/HEAD symref (default branch); every other git call
+// throws, asserting the refresh path never depends on live git.
 function defaultBranchGit(defaultBranch: string) {
 	return (async () => ({
 		raw: async (args: string[]) => {
@@ -633,15 +632,13 @@ describe("case-variant branch isolation", () => {
 	});
 });
 
-// A workspace branched off `main` keeps tracking `origin/main` until its own
-// branch is pushed, so its resolved upstream branch is `main`. Keying on `main`
-// links it to whatever open PR has head=main (e.g. a "sync main into X" PR).
+// A workspace branched off `main` still tracks `origin/main`, so its upstream
+// branch is `main`; without the guard it links to any head=main PR.
 describe("default-branch guard", () => {
 	test("does not link a workspace tracking origin/main to a head=main PR", async () => {
 		const db = createRealDb();
 		seedProject(db);
-		// The mislink as observed on screen: the workspace already points at the
-		// head=main PR. A refresh must clear it, not re-affirm it.
+		// Pre-linked like the real bug: the refresh must clear it, not re-affirm it.
 		seedPullRequest(db, {
 			id: "pr-sync-main",
 			prNumber: 1522,
@@ -707,8 +704,6 @@ describe("default-branch guard", () => {
 		);
 	});
 
-	// The guard is scoped to the base repo: a fork PR whose head branch happens
-	// to be named `main` (e.g. a `gh pr checkout` rename) must still link.
 	test("still links a fork PR whose head branch is named main", async () => {
 		const db = createRealDb();
 		seedProject(db);

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -223,9 +223,7 @@ interface NormalizedRepoIdentity {
 	name: string;
 	url: string;
 	remoteName: string;
-	// Repo's default branch (e.g. `main`), or null when the repo can't be
-	// opened. Used to keep workspaces that merely track `origin/<default>` from
-	// linking to whatever open PR happens to have head=<default>.
+	// Null when the repo can't be opened. Drives the default-branch link guard.
 	defaultBranch: string | null;
 }
 
@@ -763,9 +761,7 @@ export class PullRequestRuntimeManager {
 		return { ...identity, defaultBranch };
 	}
 
-	// Delegates to the shared `resolveDefaultBranchName` (the same
-	// `origin/HEAD` symref used by git status / branch search), catching a
-	// failure to open the repo so a missing worktree just disables the guard
+	// Shared origin/HEAD resolver; a repo-open failure disables the guard
 	// rather than aborting the whole refresh.
 	private async resolveDefaultBranch(repoPath: string): Promise<string | null> {
 		try {
@@ -775,16 +771,10 @@ export class PullRequestRuntimeManager {
 		}
 	}
 
-	// Dedup + link key for a workspace, with the default-branch guard applied.
-	// A workspace branched off the repo's default branch still tracks
-	// `origin/<default>` until its own branch is pushed, so its resolved
-	// upstream branch is `<default>` even though no PR has this workspace's
-	// branch as head. Keying on `<default>` would glue it to whatever open PR
-	// has head=<default> (e.g. a "sync <default> into X" PR). Only the
-	// workspace whose LOCAL branch actually is the default branch may key on
-	// it. Restricted to the base repo so fork PRs whose head happens to be
-	// named `<default>` (e.g. a `gh pr checkout` rename) still link. Branch
-	// stays case-sensitive to match `upstreamKey`.
+	// Guard: a workspace that merely tracks `origin/<default>` (branched off it,
+	// never pushed) must not key on `<default>` and grab a head=<default> PR —
+	// only its own default-branch workspace may. Base repo only, so fork /
+	// `gh pr checkout` renames whose head is `<default>` still link.
 	private effectiveUpstreamKey(
 		workspace: typeof workspaces.$inferSelect,
 		repo: NormalizedRepoIdentity,

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -6,7 +6,7 @@ import type { HostDb } from "../../db";
 import { projects, pullRequests, workspaces } from "../../db/schema";
 import type { GitWatcher } from "../../events/git-watcher";
 import type { ExecGh } from "../../trpc/router/workspace-creation/utils/exec-gh";
-import type { GitFactory } from "../git";
+import { type GitFactory, resolveDefaultBranchName } from "../git";
 import {
 	fetchOpenPullRequests,
 	fetchOpenPullRequestsFromGh,
@@ -223,9 +223,9 @@ interface NormalizedRepoIdentity {
 	name: string;
 	url: string;
 	remoteName: string;
-	// Repo's default branch (e.g. `main`), or null when it can't be resolved.
-	// Used to keep workspaces that merely track `origin/<default>` from linking
-	// to whatever open PR happens to have head=<default>.
+	// Repo's default branch (e.g. `main`), or null when the repo can't be
+	// opened. Used to keep workspaces that merely track `origin/<default>` from
+	// linking to whatever open PR happens to have head=<default>.
 	defaultBranch: string | null;
 }
 
@@ -290,10 +290,6 @@ export class PullRequestRuntimeManager {
 		string,
 		{ promise: Promise<GitHubPullRequestNode[]>; fetchedAt: number }
 	>();
-	// Default branch rarely changes; cache successful resolutions for the
-	// process lifetime. Nulls are not cached so a later `git remote set-head`
-	// heals without a restart.
-	private readonly defaultBranchCache = new Map<string, string>();
 
 	constructor(options: PullRequestRuntimeManagerOptions) {
 		this.db = options.db;
@@ -763,35 +759,17 @@ export class PullRequestRuntimeManager {
 			identity = { ...parsedRemote, remoteName };
 		}
 
-		const defaultBranch = await this.resolveDefaultBranch(
-			projectId,
-			project.repoPath,
-			identity.remoteName,
-		);
+		const defaultBranch = await this.resolveDefaultBranch(project.repoPath);
 		return { ...identity, defaultBranch };
 	}
 
-	private async resolveDefaultBranch(
-		projectId: string,
-		repoPath: string,
-		remoteName: string,
-	): Promise<string | null> {
-		const cached = this.defaultBranchCache.get(projectId);
-		if (cached) return cached;
+	// Delegates to the shared `resolveDefaultBranchName` (the same
+	// `origin/HEAD` symref used by git status / branch search), catching a
+	// failure to open the repo so a missing worktree just disables the guard
+	// rather than aborting the whole refresh.
+	private async resolveDefaultBranch(repoPath: string): Promise<string | null> {
 		try {
-			const git = await this.git(repoPath);
-			// `refs/remotes/<remote>/HEAD` is a symref to the remote's default
-			// branch, written by `git clone` / `git remote set-head`.
-			const ref = await tryRaw(git, [
-				"symbolic-ref",
-				"--short",
-				`refs/remotes/${remoteName}/HEAD`,
-			]);
-			if (!ref) return null;
-			const prefix = `${remoteName}/`;
-			const branch = ref.startsWith(prefix) ? ref.slice(prefix.length) : ref;
-			this.defaultBranchCache.set(projectId, branch);
-			return branch;
+			return await resolveDefaultBranchName(await this.git(repoPath));
 		} catch {
 			return null;
 		}

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -223,6 +223,10 @@ interface NormalizedRepoIdentity {
 	name: string;
 	url: string;
 	remoteName: string;
+	// Repo's default branch (e.g. `main`), or null when it can't be resolved.
+	// Used to keep workspaces that merely track `origin/<default>` from linking
+	// to whatever open PR happens to have head=<default>.
+	defaultBranch: string | null;
 }
 
 type PullRequestRow = typeof pullRequests.$inferSelect;
@@ -286,6 +290,10 @@ export class PullRequestRuntimeManager {
 		string,
 		{ promise: Promise<GitHubPullRequestNode[]>; fetchedAt: number }
 	>();
+	// Default branch rarely changes; cache successful resolutions for the
+	// process lifetime. Nulls are not cached so a later `git remote set-head`
+	// heals without a restart.
+	private readonly defaultBranchCache = new Map<string, string>();
 
 	constructor(options: PullRequestRuntimeManagerOptions) {
 		this.db = options.db;
@@ -644,7 +652,7 @@ export class PullRequestRuntimeManager {
 			const upstreamOwner = workspace.upstreamOwner;
 			const upstreamRepo = workspace.upstreamRepo;
 			const upstreamBranch = workspace.upstreamBranch ?? workspace.branch;
-			const key = upstreamKey(upstreamOwner, upstreamRepo, upstreamBranch);
+			const key = this.effectiveUpstreamKey(workspace, repo);
 			if (key && upstreamOwner && upstreamRepo) {
 				wantedRefs.set(key, {
 					owner: upstreamOwner,
@@ -658,11 +666,7 @@ export class PullRequestRuntimeManager {
 			await this.fetchRepoPullRequests(projectId, repo, wantedRefs, options);
 
 		for (const workspace of projectWorkspaces) {
-			const key = upstreamKey(
-				workspace.upstreamOwner,
-				workspace.upstreamRepo,
-				workspace.upstreamBranch ?? workspace.branch,
-			);
+			const key = this.effectiveUpstreamKey(workspace, repo);
 			if (!key) {
 				// PR checkouts recovered from GitHub's archived refs intentionally
 				// have no upstream. Keep the explicit PR link only while the
@@ -712,6 +716,7 @@ export class PullRequestRuntimeManager {
 			.sync();
 		if (!project) return null;
 
+		let identity: Omit<NormalizedRepoIdentity, "defaultBranch">;
 		if (
 			project.repoProvider === "github" &&
 			project.repoOwner &&
@@ -719,47 +724,108 @@ export class PullRequestRuntimeManager {
 			project.repoUrl &&
 			project.remoteName
 		) {
-			return {
+			identity = {
 				provider: "github",
 				owner: project.repoOwner,
 				name: project.repoName,
 				url: project.repoUrl,
 				remoteName: project.remoteName,
 			};
-		}
-
-		const git = await this.git(project.repoPath);
-		const remoteName = "origin";
-		let remoteUrl: string;
-		try {
-			const value = await git.remote(["get-url", remoteName]);
-			if (typeof value !== "string") {
+		} else {
+			const git = await this.git(project.repoPath);
+			const remoteName = "origin";
+			let remoteUrl: string;
+			try {
+				const value = await git.remote(["get-url", remoteName]);
+				if (typeof value !== "string") {
+					return null;
+				}
+				remoteUrl = value.trim();
+			} catch {
 				return null;
 			}
-			remoteUrl = value.trim();
+
+			const parsedRemote = parseGitHubRemote(remoteUrl);
+			if (!parsedRemote) return null;
+
+			this.db
+				.update(projects)
+				.set({
+					repoProvider: parsedRemote.provider,
+					repoOwner: parsedRemote.owner,
+					repoName: parsedRemote.name,
+					repoUrl: parsedRemote.url,
+					remoteName,
+				})
+				.where(eq(projects.id, projectId))
+				.run();
+
+			identity = { ...parsedRemote, remoteName };
+		}
+
+		const defaultBranch = await this.resolveDefaultBranch(
+			projectId,
+			project.repoPath,
+			identity.remoteName,
+		);
+		return { ...identity, defaultBranch };
+	}
+
+	private async resolveDefaultBranch(
+		projectId: string,
+		repoPath: string,
+		remoteName: string,
+	): Promise<string | null> {
+		const cached = this.defaultBranchCache.get(projectId);
+		if (cached) return cached;
+		try {
+			const git = await this.git(repoPath);
+			// `refs/remotes/<remote>/HEAD` is a symref to the remote's default
+			// branch, written by `git clone` / `git remote set-head`.
+			const ref = await tryRaw(git, [
+				"symbolic-ref",
+				"--short",
+				`refs/remotes/${remoteName}/HEAD`,
+			]);
+			if (!ref) return null;
+			const prefix = `${remoteName}/`;
+			const branch = ref.startsWith(prefix) ? ref.slice(prefix.length) : ref;
+			this.defaultBranchCache.set(projectId, branch);
+			return branch;
 		} catch {
 			return null;
 		}
+	}
 
-		const parsedRemote = parseGitHubRemote(remoteUrl);
-		if (!parsedRemote) return null;
-
-		this.db
-			.update(projects)
-			.set({
-				repoProvider: parsedRemote.provider,
-				repoOwner: parsedRemote.owner,
-				repoName: parsedRemote.name,
-				repoUrl: parsedRemote.url,
-				remoteName,
-			})
-			.where(eq(projects.id, projectId))
-			.run();
-
-		return {
-			...parsedRemote,
-			remoteName,
-		};
+	// Dedup + link key for a workspace, with the default-branch guard applied.
+	// A workspace branched off the repo's default branch still tracks
+	// `origin/<default>` until its own branch is pushed, so its resolved
+	// upstream branch is `<default>` even though no PR has this workspace's
+	// branch as head. Keying on `<default>` would glue it to whatever open PR
+	// has head=<default> (e.g. a "sync <default> into X" PR). Only the
+	// workspace whose LOCAL branch actually is the default branch may key on
+	// it. Restricted to the base repo so fork PRs whose head happens to be
+	// named `<default>` (e.g. a `gh pr checkout` rename) still link. Branch
+	// stays case-sensitive to match `upstreamKey`.
+	private effectiveUpstreamKey(
+		workspace: typeof workspaces.$inferSelect,
+		repo: NormalizedRepoIdentity,
+	): string | null {
+		const upstreamBranch = workspace.upstreamBranch ?? workspace.branch;
+		if (
+			repo.defaultBranch &&
+			upstreamBranch === repo.defaultBranch &&
+			workspace.branch !== repo.defaultBranch &&
+			workspace.upstreamOwner?.toLowerCase() === repo.owner.toLowerCase() &&
+			workspace.upstreamRepo?.toLowerCase() === repo.name.toLowerCase()
+		) {
+			return null;
+		}
+		return upstreamKey(
+			workspace.upstreamOwner,
+			workspace.upstreamRepo,
+			upstreamBranch,
+		);
 	}
 
 	private findPullRequestRow(


### PR DESCRIPTION
## Problem

A workspace on branch `roshvan/mcp-1703-mcp-surface-area` showed PR #1522 "chore: sync main into feat/signal-pages" (head branch = `main`) in its right-sidebar Review panel — a PR unrelated to the workspace. A reviewer even flagged it: "Wrong direction — head=main can't be up-to-date with feat/signal-pages".

## Root cause (primary — what renders)

`resolveWorkspaceUpstream()` keys the PR match on the branch's tracked remote **merge** ref (`branch.<name>.merge`) rather than the local branch name. A workspace branched off `main` keeps tracking `origin/main` until its own branch is pushed (`@{push}` unconfigured), so the resolved upstream branch is `main`. `performProjectRefresh` then builds the key `owner/repo#main` and links whatever open PR has `head=main` — here the "sync main into X" PR. Any workspace still tracking `origin/main` gets glued to a default-branch-headed PR.

The sidebar Review panel reads this authoritative link (`git.getPullRequest` → `workspace.pullRequestId`), so the bad link written by `PullRequestRuntimeManager` is exactly what shows on screen.

### Fix (commit 1 — `fix(host-service)`)

Guard link assignment: a workspace may only key on the base repo's **default branch** when its local branch actually **is** that default branch. When the resolved upstream branch equals the repo default but the local branch differs (and the upstream is the base repo), treat it as "no upstream PR". The default branch is derived from the `refs/remotes/<remote>/HEAD` symref and cached per project.

- Fork PRs whose head happens to be named `main` (e.g. a `gh pr checkout` rename) **still link** — the guard is scoped to the base repo.
- The workspace whose local branch **is** the default branch still links correctly.
- `upstreamKey` case-sensitivity is preserved.

Unit tests added; each was verified to fail without the guard (mutation-tested): the origin/main-tracking workspace must not link to the head=main PR, the default-branch workspace must still link, and a fork PR head-named `main` must still link.

## Secondary latent bug (commit 2 — `fix(desktop)`)

`useAccessibleV2Workspaces` re-derived the workspace→PR link **client-side** for the workspaces list rows / hover cards using a fuzzy `repositoryId::branch` map — no head-SHA verification, no fork/owner qualifier, first-match-wins on a non-unique key. Two PRs sharing a head branch (`main`, `patch-1`) across forks mistracked, and the list could visibly disagree with the sidebar, which reads the authoritative `pullRequestId`.

Fix: fan `getByWorkspaces` out per host exactly as `useDashboardSidebarData` does to obtain the authoritative PR **number** per workspace, then key the rich collection row by the **unique** `(repositoryId, prNumber)` pair instead of the branch. The list and the sidebar now agree.

## Testing

- `bun test` (host-service pull-requests): 27 pass
- `bun run typecheck`: clean (35/35)
- `bun run lint`: exit 0


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5692">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents workspaces from linking to default-branch-headed PRs (e.g., “sync main into X”), and switches the v2 workspaces list to the host’s authoritative workspace→PR link so the list and sidebar always agree.

- **Bug Fixes**
  - `host-service`: Add a default-branch guard when deriving the workspace upstream key; only link on the base repo’s default branch if the local branch is that branch. Fork PRs with head named `main` still link. Default branch is resolved via shared `resolveDefaultBranchName` (`origin/HEAD`).
  - `desktop`: `useAccessibleV2Workspaces` now queries `pullRequests.getByWorkspaces` per host and keys PRs by `(repositoryId, prNumber)` instead of `repositoryId::branch`, fixing fork branch-name collisions and keeping the list in sync with the sidebar. Also stabilizes the PR-number map to reduce unnecessary re-renders.

<sup>Written for commit 5920738899cc109f79fcdddaf7143502671b73f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request linking across workspaces using authoritative host-aware associations instead of branch-based inference.
  - Updated refresh/enrichment so workspace PR matching no longer relies on head branch data.
  - Added a default-branch guard to prevent incorrect links when an upstream tracks the repo default but the workspace’s local branch differs.
  - More reliably clears stale or mismatched pull request links, while preserving correct behavior for forks and local default branches.
- **Tests**
  - Added default-branch guard coverage and improved test stubs/fixture parsing for deterministic refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->