### PR TITLE
fix(workspace-fs): prune nested git repos/worktrees from the file watcher

### DIFF
--- a/packages/workspace-fs/src/find-nested-repos.test.ts
+++ b/packages/workspace-fs/src/find-nested-repos.test.ts
@@ -100,6 +100,38 @@ describe("findNestedRepoRoots", () => {
 		expect(roots.length).toBe(2);
 	});
 
+	it("reports truncation when the directory cap is hit", async () => {
+		const root = await createTempRoot();
+		// A wide, repo-free tree so the scan is bounded by maxDirs, not maxRoots.
+		for (let i = 0; i < 10; i++) {
+			await mkdirp(root, `d-${i}`, "child");
+		}
+
+		const { truncated } = await findNestedRepoRoots(root, {
+			pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+			maxDirs: 3,
+		});
+
+		expect(truncated).toBe(true);
+	});
+
+	it("reports truncation when the wall-clock deadline is hit", async () => {
+		const root = await createTempRoot();
+		await mkdirp(root, "a", "b");
+		await mkdirp(root, "c", "d");
+		// Clock jumps past the deadline on the second loop check.
+		let ticks = 0;
+		const now = () => ticks++ * 1_000;
+
+		const { truncated } = await findNestedRepoRoots(root, {
+			pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+			deadlineMs: 1,
+			now,
+		});
+
+		expect(truncated).toBe(true);
+	});
+
 	it("skips symlinked directories (no cycles, no escape)", async () => {
 		const root = await createTempRoot();
 		const realTree = await mkdirp(root, "real");

--- a/packages/workspace-fs/src/find-nested-repos.test.ts
+++ b/packages/workspace-fs/src/find-nested-repos.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { findNestedRepoRoots } from "./find-nested-repos";
+import { DEFAULT_IGNORE_DIR_NAMES } from "./search";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		tempRoots
+			.splice(0)
+			.map((root) => fs.rm(root, { recursive: true, force: true })),
+	);
+});
+
+async function createTempRoot(): Promise<string> {
+	const tempPath = await fs.mkdtemp(path.join(os.tmpdir(), "nested-repos-"));
+	const real = await fs.realpath(tempPath);
+	tempRoots.push(real);
+	return real;
+}
+
+async function mkdirp(...segments: string[]): Promise<string> {
+	const dir = path.join(...segments);
+	await fs.mkdir(dir, { recursive: true });
+	return dir;
+}
+
+async function makeGitDir(dir: string): Promise<void> {
+	await fs.mkdir(path.join(dir, ".git"), { recursive: true });
+}
+
+async function makeGitWorktreeFile(dir: string): Promise<void> {
+	await fs.mkdir(dir, { recursive: true });
+	await fs.writeFile(path.join(dir, ".git"), "gitdir: /somewhere/else\n");
+}
+
+describe("findNestedRepoRoots", () => {
+	it("discovers nested worktree roots (`.git` as a file) below the root", async () => {
+		const root = await createTempRoot();
+		await makeGitDir(root); // the root is itself a repo — must be exempt
+		const worktreeA = path.join(root, ".claude", "worktrees", "aaa");
+		const worktreeB = path.join(root, ".claude", "worktrees", "bbb");
+		await makeGitWorktreeFile(worktreeA);
+		await makeGitWorktreeFile(worktreeB);
+
+		const { roots, truncated } = await findNestedRepoRoots(root, {
+			pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+		});
+
+		expect(truncated).toBe(false);
+		expect(new Set(roots)).toEqual(new Set([worktreeA, worktreeB]));
+		expect(roots).not.toContain(root);
+	});
+
+	it("does not descend into a discovered nested repo", async () => {
+		const root = await createTempRoot();
+		const nested = path.join(root, "packages", "vendored");
+		await makeGitDir(nested);
+		// A deeper repo inside the nested one must never be reported — the scan
+		// prunes at the first boundary.
+		const deeper = path.join(nested, "sub", "inner");
+		await makeGitDir(deeper);
+
+		const { roots } = await findNestedRepoRoots(root, {
+			pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+		});
+
+		expect(roots).toEqual([nested]);
+	});
+
+	it("skips pruned directories (node_modules) without scanning into them", async () => {
+		const root = await createTempRoot();
+		// A repo buried inside node_modules must not be discovered — node_modules
+		// is pruned before we ever read its children.
+		const buried = path.join(root, "node_modules", "pkg");
+		await makeGitDir(buried);
+
+		const { roots } = await findNestedRepoRoots(root, {
+			pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+		});
+
+		expect(roots).toEqual([]);
+	});
+
+	it("reports truncation when the root cap is hit", async () => {
+		const root = await createTempRoot();
+		await makeGitWorktreeFile(path.join(root, "a"));
+		await makeGitWorktreeFile(path.join(root, "b"));
+		await makeGitWorktreeFile(path.join(root, "c"));
+
+		const { roots, truncated } = await findNestedRepoRoots(root, {
+			pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+			maxRoots: 2,
+		});
+
+		expect(truncated).toBe(true);
+		expect(roots.length).toBe(2);
+	});
+
+	it("skips symlinked directories (no cycles, no escape)", async () => {
+		const root = await createTempRoot();
+		const realTree = await mkdirp(root, "real");
+		await makeGitDir(path.join(realTree, "repo"));
+		// Symlink loop back to the root: isDirectory() is false for the link, so
+		// it's never followed and the scan terminates.
+		await fs.symlink(root, path.join(root, "loop"), "dir");
+
+		const { roots, truncated } = await findNestedRepoRoots(root, {
+			pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+		});
+
+		expect(truncated).toBe(false);
+		expect(roots).toEqual([path.join(realTree, "repo")]);
+	});
+});

--- a/packages/workspace-fs/src/find-nested-repos.ts
+++ b/packages/workspace-fs/src/find-nested-repos.ts
@@ -16,12 +16,19 @@ export interface FindNestedRepoRootsOptions {
 	maxDirs?: number;
 	/** Stop after discovering this many nested roots. */
 	maxRoots?: number;
+	/**
+	 * Wall-clock budget in ms. Bounds the scan on a slow/network-backed FS where
+	 * `readdir` latency (not directory count) is the limiter. Omit to disable.
+	 */
+	deadlineMs?: number;
+	/** Injectable clock (defaults to `Date.now`) so the deadline is testable. */
+	now?: () => number;
 }
 
 export interface FindNestedRepoRootsResult {
 	/** Absolute paths of nested git repo / worktree roots below `rootPath`. */
 	roots: string[];
-	/** A scan cap was hit; `roots` may be incomplete. */
+	/** A scan cap (count or time) was hit; `roots` may be incomplete. */
 	truncated: boolean;
 }
 
@@ -33,6 +40,10 @@ export interface FindNestedRepoRootsResult {
  * `pruneDirNames` entry, so it stays cheap even under a tree that has grown to
  * millions of directories via piled-up worktrees.
  *
+ * Traversal is breadth-first, so when a cap truncates the scan the shallow
+ * nested repos (the piled-up worktree roots near the top) are found before a
+ * deep non-repo subtree can exhaust the budget.
+ *
  * Symlinked directories are skipped (`Dirent.isDirectory()` is false for them),
  * which also avoids cycles and escaping the tree.
  */
@@ -42,15 +53,24 @@ export async function findNestedRepoRoots(
 ): Promise<FindNestedRepoRootsResult> {
 	const maxDirs = options.maxDirs ?? DEFAULT_MAX_DIRS;
 	const maxRoots = options.maxRoots ?? DEFAULT_MAX_ROOTS;
+	const now = options.now ?? Date.now;
+	const deadline =
+		options.deadlineMs !== undefined ? now() + options.deadlineMs : null;
 	const roots: string[] = [];
-	const stack: string[] = [rootPath];
+	// FIFO queue with a head cursor — plain `shift()` would be O(n) per dequeue.
+	const queue: string[] = [rootPath];
+	let head = 0;
 	let scanned = 0;
 
-	while (stack.length > 0) {
-		if (roots.length >= maxRoots || scanned >= maxDirs) {
+	while (head < queue.length) {
+		if (
+			roots.length >= maxRoots ||
+			scanned >= maxDirs ||
+			(deadline !== null && now() >= deadline)
+		) {
 			return { roots, truncated: true };
 		}
-		const dir = stack.pop() as string;
+		const dir = queue[head++] as string;
 		scanned += 1;
 
 		// Vanished or unreadable mid-scan — nothing to prune here.
@@ -73,7 +93,7 @@ export async function findNestedRepoRoots(
 			if (options.pruneDirNames.has(entry.name)) {
 				continue;
 			}
-			stack.push(path.join(dir, entry.name));
+			queue.push(path.join(dir, entry.name));
 		}
 	}
 

--- a/packages/workspace-fs/src/find-nested-repos.ts
+++ b/packages/workspace-fs/src/find-nested-repos.ts
@@ -1,0 +1,81 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+// Defensive caps: the whole point of this scan is to keep the watcher from
+// ballooning, so the scan itself must never balloon. It prunes at every nested
+// repo boundary and at every ignored directory, so a normal tree is scanned in
+// full and a pathological one (a project holding thousands of agent worktrees)
+// is bounded by the count of worktree roots, not their contents.
+const DEFAULT_MAX_DIRS = 50_000;
+const DEFAULT_MAX_ROOTS = 5_000;
+
+export interface FindNestedRepoRootsOptions {
+	/** Directory basenames to skip while traversing (node_modules, .git, …). */
+	pruneDirNames: ReadonlySet<string>;
+	/** Stop after scanning this many directories. */
+	maxDirs?: number;
+	/** Stop after discovering this many nested roots. */
+	maxRoots?: number;
+}
+
+export interface FindNestedRepoRootsResult {
+	/** Absolute paths of nested git repo / worktree roots below `rootPath`. */
+	roots: string[];
+	/** A scan cap was hit; `roots` may be incomplete. */
+	truncated: boolean;
+}
+
+/**
+ * Walk `rootPath` and return every nested git repo / worktree root beneath it.
+ * A directory is a nested root when it contains a `.git` entry (a directory for
+ * a normal clone, a file for a `git worktree`); the watch root itself is exempt.
+ * The scan prunes at each nested root (never descends into it) and at each
+ * `pruneDirNames` entry, so it stays cheap even under a tree that has grown to
+ * millions of directories via piled-up worktrees.
+ *
+ * Symlinked directories are skipped (`Dirent.isDirectory()` is false for them),
+ * which also avoids cycles and escaping the tree.
+ */
+export async function findNestedRepoRoots(
+	rootPath: string,
+	options: FindNestedRepoRootsOptions,
+): Promise<FindNestedRepoRootsResult> {
+	const maxDirs = options.maxDirs ?? DEFAULT_MAX_DIRS;
+	const maxRoots = options.maxRoots ?? DEFAULT_MAX_ROOTS;
+	const roots: string[] = [];
+	const stack: string[] = [rootPath];
+	let scanned = 0;
+
+	while (stack.length > 0) {
+		if (roots.length >= maxRoots || scanned >= maxDirs) {
+			return { roots, truncated: true };
+		}
+		const dir = stack.pop() as string;
+		scanned += 1;
+
+		// Vanished or unreadable mid-scan — nothing to prune here.
+		const entries = await readdir(dir, { withFileTypes: true }).catch(
+			() => null,
+		);
+		if (!entries) {
+			continue;
+		}
+
+		if (dir !== rootPath && entries.some((entry) => entry.name === ".git")) {
+			roots.push(dir);
+			continue; // prune: do not descend into the nested repo
+		}
+
+		for (const entry of entries) {
+			if (!entry.isDirectory()) {
+				continue;
+			}
+			if (options.pruneDirNames.has(entry.name)) {
+				continue;
+			}
+			stack.push(path.join(dir, entry.name));
+		}
+	}
+
+	return { roots, truncated: false };
+}

--- a/packages/workspace-fs/src/search.ts
+++ b/packages/workspace-fs/src/search.ts
@@ -52,8 +52,32 @@ export const DEFAULT_IGNORE_PATTERNS = [
 	"**/.gradle/**",
 	"**/.pnpm-store/**",
 	"**/.yarn/**",
+	// Agent/worktree tools pile up sibling git worktrees under these dirs — a
+	// full repo copy each, with its own node_modules. Left unignored, watching a
+	// project that contains one balloons the watcher to millions of directories.
+	// The nested-repo prune in watch.ts catches any worktree generically by its
+	// `.git` marker; these globs are the cheap native backstop for the known
+	// conventions (Claude Code, `git worktree` under `.worktrees`, Conductor),
+	// and still prune even if that scan is truncated on a pathological tree.
+	"**/.worktrees/**",
+	"**/.claude/worktrees/**",
+	"**/.conductor/**",
 	"**/*.tsbuildinfo",
 ];
+
+/**
+ * Directory basenames the nested-repo discovery scan (watch.ts) prunes as it
+ * walks, so it never descends into the heavy ignored trees (node_modules, .git,
+ * …). Derived from the single-segment `**\/<name>/**` entries above so the two
+ * ignore surfaces can't drift. Multi-segment globs (`.claude/worktrees`) are
+ * intentionally excluded: the scan still traverses `.claude/` and discovers the
+ * worktrees generically by their `.git` marker.
+ */
+export const DEFAULT_IGNORE_DIR_NAMES: ReadonlySet<string> = new Set(
+	DEFAULT_IGNORE_PATTERNS.map(
+		(pattern) => /^\*\*\/([^/*]+)\/\*\*$/.exec(pattern)?.[1],
+	).filter((name): name is string => name !== undefined),
+);
 
 interface SearchIndexEntry {
 	absolutePath: string;

--- a/packages/workspace-fs/src/watch-nested-repo-prune.test.ts
+++ b/packages/workspace-fs/src/watch-nested-repo-prune.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { FsWatcherManager } from "./watch";
+
+const tempRoots: string[] = [];
+const managers: FsWatcherManager[] = [];
+
+afterEach(async () => {
+	await Promise.all(managers.splice(0).map((m) => m.close()));
+	await Promise.all(
+		tempRoots
+			.splice(0)
+			.map((root) => fs.rm(root, { recursive: true, force: true })),
+	);
+});
+
+async function createTempRoot(): Promise<string> {
+	const tempPath = await fs.mkdtemp(path.join(os.tmpdir(), "watch-nested-"));
+	const real = await fs.realpath(tempPath);
+	tempRoots.push(real);
+	return real;
+}
+
+async function waitFor(
+	seen: string[],
+	needle: string,
+	timeoutMs = 8_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!seen.includes(needle)) {
+		if (Date.now() > deadline) {
+			throw new Error(
+				`Timed out waiting for ${needle}\nseen: ${seen.join(", ")}`,
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+}
+
+describe("FsWatcherManager nested-repo pruning", () => {
+	it("does not emit events for files inside a nested git worktree", async () => {
+		const rootPath = await createTempRoot();
+		// A nested git worktree present at subscribe time — the shape of a
+		// piled-up agent worktree. Deliberately NOT under `.claude/worktrees/` so
+		// this exercises the generic nested-repo prune, not the static glob.
+		const nested = path.join(rootPath, "vendor-checkout", "abc");
+		await fs.mkdir(nested, { recursive: true });
+		await fs.writeFile(path.join(nested, ".git"), "gitdir: /elsewhere\n");
+
+		const manager = new FsWatcherManager({ debounceMs: 50 });
+		managers.push(manager);
+
+		const seen: string[] = [];
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				seen.push(`${event.kind}:${event.absolutePath}`);
+			}
+		});
+
+		// A write inside the nested worktree must never surface...
+		await fs.writeFile(path.join(nested, "should-be-ignored.ts"), "x");
+		// ...while a write at the root must, proving the watcher is live and it's
+		// the prune (not a dead stream) that suppressed the nested event.
+		const rootFile = path.join(rootPath, "tracked.ts");
+		await fs.writeFile(rootFile, "x");
+
+		await waitFor(seen, `create:${rootFile}`);
+		expect(seen).not.toContain(
+			`create:${path.join(nested, "should-be-ignored.ts")}`,
+		);
+	}, 20_000);
+
+	it("prunes a nested repo whose path contains glob magic (e.g. `[id]`)", async () => {
+		const rootPath = await createTempRoot();
+		// A nested repo under a Next.js-style dynamic route segment. Passing this
+		// path to parcel bare would trip `is-glob` and mis-prune; the escaped-glob
+		// form must still match its subtree.
+		const nested = path.join(rootPath, "app", "[id]", "vendored");
+		await fs.mkdir(nested, { recursive: true });
+		await fs.writeFile(path.join(nested, ".git"), "gitdir: /elsewhere\n");
+
+		const manager = new FsWatcherManager({ debounceMs: 50 });
+		managers.push(manager);
+
+		const seen: string[] = [];
+		await manager.subscribe({ absolutePath: rootPath }, (batch) => {
+			for (const event of batch.events) {
+				seen.push(`${event.kind}:${event.absolutePath}`);
+			}
+		});
+
+		await fs.writeFile(path.join(nested, "should-be-ignored.ts"), "x");
+		// A sibling under `app/` (not the nested repo) must still surface — proves
+		// the escaped glob doesn't over-match the bracket segment.
+		const siblingFile = path.join(rootPath, "app", "other.ts");
+		await fs.writeFile(siblingFile, "x");
+
+		await waitFor(seen, `create:${siblingFile}`);
+		expect(seen).not.toContain(
+			`create:${path.join(nested, "should-be-ignored.ts")}`,
+		);
+	}, 20_000);
+});

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -51,8 +51,14 @@ const PROBE_TIMEOUT_MS = 4_000;
 // magic, so an absolute path is matched literally when embedded in a glob.
 // Mirrors the metacharacter set `is-glob`/picomatch@2 recognize.
 function escapeGlobMagic(input: string): string {
-	return input.replace(/[\\*?{}()[\]!+@|^]/g, (char) => `\\${char}`);
+	return input.replace(/[\\*?{}()[\]!+@|^$]/g, (char) => `\\${char}`);
 }
+
+// Wall-clock budget for the nested-repo scan (bounds attach latency on a slow
+// or network-backed FS, where readdir latency — not directory count — is the
+// limiter). The static ignore globs still cover the known worktree conventions
+// if the scan truncates here.
+const NESTED_REPO_SCAN_DEADLINE_MS = 3_000;
 
 // Watches are always recursive — @parcel/watcher offers no shallow mode.
 export interface WatchPathOptions {
@@ -520,6 +526,7 @@ export class FsWatcherManager {
 		try {
 			const { roots, truncated } = await findNestedRepoRoots(realPath, {
 				pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+				deadlineMs: NESTED_REPO_SCAN_DEADLINE_MS,
 			});
 			if (truncated) {
 				console.warn(

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -6,8 +6,10 @@ import {
 	subscribe as subscribeToFilesystem,
 } from "@parcel/watcher";
 import { toErrorMessage } from "./error-message";
+import { findNestedRepoRoots } from "./find-nested-repos";
 import { normalizeAbsolutePath } from "./paths";
 import {
+	DEFAULT_IGNORE_DIR_NAMES,
 	DEFAULT_IGNORE_PATTERNS,
 	invalidateSearchIndexesForRoot,
 	patchSearchIndexesForRoot,
@@ -44,6 +46,13 @@ const MAX_BUFFERED_EVENTS = 30_000;
 // probe file and only announces the resumed root once its event arrives.
 const PROBE_PREFIX = ".superset-watcher-probe-";
 const PROBE_TIMEOUT_MS = 4_000;
+
+// Backslash-escape every character picomatch (parcel's glob engine) treats as
+// magic, so an absolute path is matched literally when embedded in a glob.
+// Mirrors the metacharacter set `is-glob`/picomatch@2 recognize.
+function escapeGlobMagic(input: string): string {
+	return input.replace(/[\\*?{}()[\]!+@|^]/g, (char) => `\\${char}`);
+}
 
 // Watches are always recursive — @parcel/watcher offers no shallow mode.
 export interface WatchPathOptions {
@@ -421,14 +430,24 @@ export class FsWatcherManager {
 		state.realPathDiffers = realPathDiffers;
 		const generation = ++state.generation;
 
+		// Nested git repos/worktrees (agent tools pile these up — a full repo copy
+		// each) balloon a recursive watch to millions of dirs. Discover them and
+		// hand parcel a root-relative `<relative>/**` glob per repo, which prunes
+		// the subtree from traversal (same mechanism as the `**/node_modules/**`
+		// default — stops inotify watch creation on Linux, the ENOSPC trigger).
+		const nestedRepoIgnores = await this.computeNestedRepoIgnores(realPath);
+
 		// parcel dedupes native backends by (dir, ignore-set); a wedged backend
 		// from the dead stream (its unsubscribe can hang) would be silently
 		// joined and never deliver. The pattern matches nothing real — it only
 		// forces a distinct backend identity.
-		const ignore =
-			generation === 1
-				? this.ignore
-				: [...this.ignore, `**/.superset-watch-generation-${generation}/**`];
+		const ignore = [
+			...this.ignore,
+			...(generation === 1
+				? []
+				: [`**/.superset-watch-generation-${generation}/**`]),
+			...nestedRepoIgnores,
+		];
 
 		// Subscribe to the resolved real path so kernel paths come back in a
 		// consistent form; we map them back to `state.absolutePath` in
@@ -490,6 +509,41 @@ export class FsWatcherManager {
 				ignore,
 			},
 		);
+	}
+
+	/**
+	 * Best-effort discovery of nested repo/worktree roots to prune. Never blocks
+	 * watching: on failure or a truncated scan we watch with whatever we found
+	 * (an unpruned subtree degrades to the pre-existing behavior, not a crash).
+	 */
+	private async computeNestedRepoIgnores(realPath: string): Promise<string[]> {
+		try {
+			const { roots, truncated } = await findNestedRepoRoots(realPath, {
+				pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
+			});
+			if (truncated) {
+				console.warn(
+					"[workspace-fs/watch] nested-repo scan hit cap — some nested repos may still be watched",
+					{ absolutePath: realPath, found: roots.length },
+				);
+			}
+			// Emit each root as a root-relative, escaped `<relative>/**` glob.
+			// parcel matches ignore globs relative to the watch root (its defaults
+			// are all `**/…`), so an absolute path never matches. Bare absolute
+			// paths aren't a safe alternative either: parcel's `is-glob` check
+			// misclassifies any path containing glob magic (e.g. a Next.js
+			// `app/[id]/` route segment) as a pattern, so it lands in the glob set
+			// too and mis-prunes. Escaping + relativizing handles both.
+			return roots.map(
+				(root) => `${escapeGlobMagic(path.relative(realPath, root))}/**`,
+			);
+		} catch (error) {
+			console.error("[workspace-fs/watch] nested-repo scan failed", {
+				absolutePath: realPath,
+				error: toErrorMessage(error),
+			});
+			return [];
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Watching a project whose tree contains piled-up agent worktrees — a full repo copy each, with its own `node_modules` — ballooned the recursive `@parcel/watcher` to millions of directories (the reported case: `~/.../.claude/worktrees/` holding 1.6M dirs). Nothing ignored those nested trees.

Two complementary safeguards in `packages/workspace-fs`:

- **Primary (generic):** `findNestedRepoRoots` does a bounded stack-walk from the watch root and prunes any non-root directory carrying a `.git` marker (dir for a clone, file for a worktree). Every worktree convention shares that marker, so this catches them all regardless of parent-dir name. Caps at 50k dirs / 5k roots so the scan itself can't balloon; skips ignored dirs and symlinked dirs.
- **Backstop (cheap):** static globs for the known conventions — `**/.worktrees/**`, `**/.claude/worktrees/**`, `**/.conductor/**` — which also prune even if the scan truncates on a pathological tree.

### Ignore-form correctness

Discovered roots are emitted as **root-relative, glob-escaped `<rel>/**` globs**. parcel matches `ignore` globs relative to the watch root (its defaults are all `**/…`), so absolute-path entries never match; and parcel's `is-glob` reclassifies any path containing glob magic (e.g. a Next.js `app/[id]/` route segment) out of `ignorePaths`, so bare absolute paths silently under-prune there too. The relative escaped-glob form handles both — verified empirically against the real native watcher.

### Cross-repo validation

Checked real repos under `~/workplace`: the nested-worktree convention is not just `.claude/worktrees` — `.worktrees/`, `.conductor/`, and `.claude/worktrees/` all appear, and every one carries a `.git` marker. That's why the marker-based scan is the primary mechanism and the globs are only a backstop.

## Test Plan

- [x] Unit tests for `findNestedRepoRoots` (root exemption, prune, don't-descend, truncation, symlink) — each mutation-verified to fail when its guard is broken
- [x] Real-parcel integration tests: generic nested repo pruned, and a nested repo under a glob-magic `app/[id]/` path pruned (fails before the fix)
- [x] Full `packages/workspace-fs` suite (56 passing), typecheck, lint
- [x] CDP stress test against the running desktop with a 43,480-dir / 75-nested-repo tree: all conventions + generic + deep nested repos pruned; node_modules regression intact; ~9000-file burst in pruned areas → 0 events, 0 FSEvents overflow, RSS flat; 400-file burst in watched `src/` → 400/400 delivered

## Known limitation

`findNestedRepoRoots` is a subscribe-time snapshot, so a *generic* nested repo created mid-session (not under one of the backstop globs) isn't pruned until the watcher re-attaches (recovery re-runs the scan by construction). This covers the real balloon — piled-up worktrees exist before the project is opened.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes nested git repos/worktrees from the workspace watcher to stop `@parcel/watcher` from ballooning. Adds a bounded BFS `.git` scan with a 3s wall‑clock deadline and root‑relative, escaped ignore globs, plus backstop globs for common worktree folders.

- **Bug Fixes**
  - Discover nested repos via `.git` using BFS; skip symlinks; do not descend; honor pruned dir names (`node_modules`, `.git`, …).
  - Add per-root ignore globs as `<relative>/**`, escaping glob magic (incl. `$`) to safely handle paths like `app/[id]/`.
  - Add static ignores: `**/.worktrees/**`, `**/.claude/worktrees/**`, `**/.conductor/**`.
  - Bound scan by 50k dirs, 5k roots, and a 3s wall‑clock; on truncation, log and continue.
  - Tests cover maxRoots/maxDirs/wall‑clock truncation, discovery/prune behavior, glob‑magic paths, and event suppression for nested repos.

<sup>Written for commit 61c2ba4b3d75e1a72e91ed21d5fab8e21fda8d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically discovers nested Git repositories/worktrees and prunes scanning to prevent unnecessary descent.
  * File watching now ignores changes under detected nested roots while continuing to monitor the main repository.
* **Bug Fixes**
  * Improved handling for nested paths with special characters to ensure correct pruning behavior.
  * Expanded ignore patterns for additional worktree directories and build metadata.
* **Tests**
  * Added coverage for truncation limits (directory count and time deadline), pruning boundaries, and symlink-escape scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->