### PR TITLE
fix(desktop): keep agent TUIs in primary buffer

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
@@ -272,14 +272,19 @@ export function getOpenCodePluginContent(notifyPath: string): string {
 }
 
 /**
- * Pass-through wrapper for Claude. Hooks live in ~/.claude/settings.json
- * (createClaudeSettingsJson); the wrapper exists only to forward SUPERSET_*
- * env vars into the agent process tree.
+ * Wrapper for Claude. Hooks live in ~/.claude/settings.json
+ * (createClaudeSettingsJson); the wrapper forwards SUPERSET_* env vars and
+ * keeps output in xterm's primary buffer so reconnects retain scrollback.
  */
 export function createClaudeWrapper(): void {
-	const script = buildWrapperScript("claude", `exec "$REAL_BIN" "$@"`, {
-		agentId: "claude",
-	});
+	const script = buildWrapperScript(
+		"claude",
+		`export CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN="\${CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN:-1}"
+exec "$REAL_BIN" "$@"`,
+		{
+			agentId: "claude",
+		},
+	);
 	createWrapper("claude", script);
 }
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -64,6 +64,7 @@ const {
 	buildCopilotWrapperExecLine,
 	buildWrapperScript,
 	createClaudeSettingsJson,
+	createClaudeWrapper,
 	createCodexHooksJson,
 	createCodexWrapper,
 	COPILOT_HOOK_MARKER,
@@ -191,7 +192,7 @@ describe("agent-wrappers copilot", () => {
 		const wrapper = readFileSync(wrapperPath, "utf-8");
 
 		expect(wrapper).toContain(
-			`"$REAL_BIN" "\${_superset_codex_args[@]}" --enable hooks -c 'notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]' "$@"`,
+			`"$REAL_BIN" "\${_superset_codex_args[@]}" --enable hooks --no-alt-screen -c 'notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]' "$@"`,
 		);
 		expect(wrapper).toContain('export SUPERSET_AGENT_ID="codex"');
 
@@ -230,6 +231,27 @@ describe("agent-wrappers copilot", () => {
 		);
 		expect(execLine).not.toContain("{{NOTIFY_PATH}}");
 		expect(wrapper).toContain(execLine);
+	});
+
+	it("keeps managed Claude and Codex sessions in the primary screen buffer", () => {
+		createClaudeWrapper();
+		createCodexWrapper();
+
+		const claudeWrapper = readFileSync(
+			path.join(TEST_BIN_DIR, "claude"),
+			"utf-8",
+		);
+		const codexWrapper = readFileSync(
+			path.join(TEST_BIN_DIR, "codex"),
+			"utf-8",
+		);
+
+		expect(claudeWrapper).toContain(
+			`export CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN="\${CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN:-1}"`,
+		);
+		expect(codexWrapper).toContain(
+			"--enable hooks --no-alt-screen -c 'notify=",
+		);
 	});
 
 	it("trusts the Superset workspace codex project config without replacing CODEX_HOME", () => {
@@ -275,6 +297,7 @@ exit 0
 				`projects={"${workspacePath}"={trust_level="trusted"}}`,
 				"--enable",
 				"hooks",
+				"--no-alt-screen",
 				"-c",
 				`notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]`,
 			].join("\n")}\n`,
@@ -314,6 +337,7 @@ exit 0
 			`${[
 				"--enable",
 				"hooks",
+				"--no-alt-screen",
 				"-c",
 				`notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]`,
 				"exec",

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -121,7 +121,8 @@ fi
 
 # `hooks` (formerly `codex_hooks`) is stable and default-enabled in codex
 # >=0.129; the legacy `notify=...` callback remains the completion source.
-"$REAL_BIN" "${_superset_codex_args[@]}" --enable hooks -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
+# Keep Codex in xterm's primary buffer so reconnects retain scrollback.
+"$REAL_BIN" "${_superset_codex_args[@]}" --enable hooks --no-alt-screen -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
 SUPERSET_CODEX_STATUS=$?
 _superset_debug "codex exited status=$SUPERSET_CODEX_STATUS"
 


### PR DESCRIPTION
## What

- launch managed Codex sessions with `--no-alt-screen`
- default managed Claude sessions to `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` while preserving an explicit user override
- cover both generated wrappers and forwarded Codex arguments with regression tests

## Why

Fullscreen alternate-screen TUIs can leave a freshly reattached xterm pane blank or visually corrupted because their visible state is not part of the primary scrollback that Superset persists across renderer lifecycle changes. Keeping managed agent sessions in the primary buffer makes their transcript and prompt available to Superset across pane parking, reconnects, and app restarts.

## Scope boundary

This PR only changes the managed-agent launch defaults for Codex and Claude. It does not implement atomic terminal snapshots, renderer storage flushing, terminal-state hydration ordering, exact resize behavior, or theme/ANSI handling.

The packaged app was field-tested as part of a combined local repair. That validation is useful supporting evidence, but it is not claimed as isolated proof for this PR or for the excluded persistence fixes.

## Validation

- `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts` — 41 pass, 0 fail after rebasing onto current `upstream/main`
- `bun run lint` — passed before the rebase; this rebase did not change the feature diff
- `bun run --cwd apps/desktop typecheck` — passed before the rebase; this rebase did not change the feature diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output persistence for Claude and Codex sessions.
  * Reconnecting to a session now retains scrollback history more reliably.
  * Codex runs without the alternate screen when hooks are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->