### PR TITLE
fix(desktop): restore missing terminal presets

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/AgentHooks.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/AgentHooks.tsx
@@ -9,12 +9,12 @@ import { usePlaceLocalWorktreesInSidebar } from "./hooks/usePlaceLocalWorktreesI
  * useCommandWatcher uses useCollections which must be inside the provider.
  */
 export function AgentHooks() {
-	const { activeHostUrl } = useLocalHostService();
+	const { activeHostUrl, activeOrganizationId } = useLocalHostService();
 	useDevicePresence();
 	useCommandWatcher();
 	// Seeds the default v2 terminal presets and warms the local host's agent
 	// config cache for Settings.
-	useDefaultV2TerminalPresets(activeHostUrl);
+	useDefaultV2TerminalPresets(activeHostUrl, activeOrganizationId);
 	usePlaceLocalWorktreesInSidebar();
 	return null;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { HostAgentConfig } from "@superset/host-service/settings";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
-import { createDefaultV2TerminalPresetRows } from "./default-v2-terminal-presets";
+import {
+	createDefaultV2TerminalPresetRows,
+	shouldInitializeV2TerminalPresets,
+} from "./default-v2-terminal-presets";
 
 const createdAt = new Date("2026-05-14T12:00:00.000Z");
 
@@ -150,5 +153,47 @@ describe("createDefaultV2TerminalPresetRows", () => {
 		});
 
 		expect(rows).toEqual([]);
+	});
+});
+
+describe("shouldInitializeV2TerminalPresets", () => {
+	it("repairs a missing preset collection despite a stale initialized flag", () => {
+		expect(
+			shouldInitializeV2TerminalPresets({
+				initialized: true,
+				presetCount: 0,
+				hasPersistedCollection: false,
+			}),
+		).toBe(true);
+	});
+
+	it("preserves an intentionally empty persisted collection", () => {
+		expect(
+			shouldInitializeV2TerminalPresets({
+				initialized: true,
+				presetCount: 0,
+				hasPersistedCollection: true,
+			}),
+		).toBe(false);
+	});
+
+	it("seeds a never-initialized collection", () => {
+		expect(
+			shouldInitializeV2TerminalPresets({
+				initialized: false,
+				presetCount: 0,
+				hasPersistedCollection: true,
+			}),
+		).toBe(true);
+	});
+
+	it("finalizes initialization when presets already exist", () => {
+		expect(
+			shouldInitializeV2TerminalPresets({
+				initialized: false,
+				presetCount: 1,
+				hasPersistedCollection: false,
+			}),
+		).toBe(true);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.ts
@@ -18,6 +18,21 @@ interface CreateDefaultV2TerminalPresetRowsInput {
 	createdAt: Date;
 }
 
+interface ShouldInitializeV2TerminalPresetsInput {
+	initialized: boolean;
+	presetCount: number;
+	hasPersistedCollection: boolean;
+}
+
+export function shouldInitializeV2TerminalPresets({
+	initialized,
+	presetCount,
+	hasPersistedCollection,
+}: ShouldInitializeV2TerminalPresetsInput): boolean {
+	if (!initialized) return true;
+	return presetCount === 0 && !hasPersistedCollection;
+}
+
 export function createDefaultV2TerminalPresetRows({
 	agents,
 	existingPresets,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/useDefaultV2TerminalPresets.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/useDefaultV2TerminalPresets.ts
@@ -7,9 +7,29 @@ import {
 	V2_USER_PREFERENCES_ID,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { useCollections } from "../../../../providers/CollectionsProvider";
-import { createDefaultV2TerminalPresetRows } from "./default-v2-terminal-presets";
+import { getV2TerminalPresetsStorageKey } from "../../../../providers/CollectionsProvider/collections";
+import {
+	createDefaultV2TerminalPresetRows,
+	shouldInitializeV2TerminalPresets,
+} from "./default-v2-terminal-presets";
 
-export function useDefaultV2TerminalPresets(hostUrl: string | null): void {
+function hasPersistedPresetCollection(organizationId: string): boolean {
+	try {
+		return (
+			localStorage.getItem(getV2TerminalPresetsStorageKey(organizationId)) !==
+			null
+		);
+	} catch {
+		// If storage is unavailable, preserve an initialized empty collection
+		// instead of risking an unexpected reset.
+		return true;
+	}
+}
+
+export function useDefaultV2TerminalPresets(
+	hostUrl: string | null,
+	organizationId: string | null,
+): void {
 	const collections = useCollections();
 	const { data: agents = [], isFetched: agentsFetched } =
 		useV2AgentConfigs(hostUrl);
@@ -27,14 +47,22 @@ export function useDefaultV2TerminalPresets(hostUrl: string | null): void {
 	);
 
 	const preferences = preferenceRows[0] ?? DEFAULT_V2_USER_PREFERENCES;
+	const hasPersistedCollection = organizationId
+		? hasPersistedPresetCollection(organizationId)
+		: true;
 
 	useEffect(() => {
 		if (
 			!hostUrl ||
+			!organizationId ||
 			!agentsFetched ||
 			!presetsReady ||
 			!preferencesReady ||
-			preferences.terminalPresetsInitialized
+			!shouldInitializeV2TerminalPresets({
+				initialized: preferences.terminalPresetsInitialized,
+				presetCount: v2Presets.length,
+				hasPersistedCollection,
+			})
 		) {
 			return;
 		}
@@ -74,6 +102,8 @@ export function useDefaultV2TerminalPresets(hostUrl: string | null): void {
 		collections.v2TerminalPresets,
 		collections.v2UserPreferences,
 		hostUrl,
+		hasPersistedCollection,
+		organizationId,
 		preferences.terminalPresetsInitialized,
 		preferencesReady,
 		presetsReady,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -72,6 +72,10 @@ import { withReadHeal } from "./withReadHeal";
 
 const columnMapper = snakeCamelMapper();
 
+export function getV2TerminalPresetsStorageKey(organizationId: string): string {
+	return `v2-terminal-presets-${organizationId}`;
+}
+
 const electricUrl = `${env.NEXT_PUBLIC_ELECTRIC_URL}/v1/shape`;
 
 export const ELECTRIC_WRITE_SYNC_TIMEOUT_MS = 30_000;
@@ -831,7 +835,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	const v2TerminalPresets = createIndexedCollection(
 		localStorageCollectionOptions({
 			id: `v2_terminal_presets-${organizationId}`,
-			storageKey: `v2-terminal-presets-${organizationId}`,
+			storageKey: getV2TerminalPresetsStorageKey(organizationId),
 			schema: v2TerminalPresetSchema,
 			getKey: (item) => item.id,
 		}),


### PR DESCRIPTION
## What

- detect when the organization-scoped v2 terminal-preset storage collection is missing even though the initialized preference is stale
- reseed defaults only for a missing collection
- preserve an intentionally empty persisted collection
- centralize the organization-scoped localStorage key and add regression coverage

## Why

A migration or local-storage cleanup can leave `terminalPresetsInitialized` set to true while the v2 terminal-presets collection is absent. The existing initialization hook then exits permanently and Settings shows no presets. Presence of the collection key distinguishes this from a user intentionally deleting every preset, because deleting the final row persists an empty collection.

## Scope boundary

This PR intentionally covers only terminal-preset self-healing. It does not address the broader `persist:superset` DOMStorage flush before application Quit/Restart, atomic terminal buffer persistence, or the SQLite persistence hydration-order race. Those are separate bug classes and should land as independent scoped changes.

## Validation

- rebased onto current `upstream/main`
- `bun test apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts` — 8 pass
- `bun run lint` — passed on the original patch
- `bun run --cwd apps/desktop typecheck` — passed on the original patch

The end-to-end installed-app recovery on 2026-07-15 confirmed that missing renderer-local collections can coexist with a stale initialization state, but the broader recovery included additional fixes; it is not presented as isolated proof of this PR.
