### PR TITLE
fix(desktop): migrate terminal reconnect onto createRelaySocket (forever-retry + retryCount diagnosis)

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -20,6 +20,7 @@ import {
 	connect,
 	createTransport,
 	disposeTransport,
+	reconnect,
 	sendDispose,
 	sendInput,
 	sendResize,
@@ -204,19 +205,14 @@ class TerminalRuntimeRegistryImpl {
 	}
 
 	/**
-	 * Manually re-dial the last URL after the transport stopped trying (gave
-	 * up on max attempts, access denied, fatal server error). connect() clears
-	 * the terminated flag, so this restarts a dead loop.
+	 * Manually re-dial after the transport stopped trying (access denied, fatal
+	 * server error, PTY exit). reconnect() clears the terminated flag and forces
+	 * an immediate dial, restarting a dead loop.
 	 */
 	retryConnect(terminalId: string, instanceId = terminalId) {
 		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
-		const url = entry.transport.currentUrl;
-		if (!url) return;
-		// Manual retry gets a full backoff budget, like reconnectNow(); the
-		// exhausted counter would otherwise block scheduling any follow-up.
-		entry.transport._reconnectAttempt = 0;
-		connect(entry.transport, entry.runtime.terminal, url);
+		reconnect(entry.transport);
 	}
 
 	/**

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -8,6 +8,7 @@ import {
 	setSystemTime,
 	test,
 } from "bun:test";
+import * as relaySocketModule from "@superset/workspace-client/relay-socket";
 import type { Terminal as XTerm } from "@xterm/xterm";
 
 // The transport builds on createRelaySocket (partysocket) — reconnection,
@@ -104,13 +105,16 @@ class FakeRelaySocket {
 	}
 }
 
+// bun's mock.module is process-global and leaks to every later test file in the
+// whole desktop run, so a partial stub breaks unrelated tests that import the
+// module's other named exports. Preserve the real exports and override only
+// createRelaySocket. (auth-client / posthog are deliberately NOT mocked: with a
+// faked socket getToken/ensureFreshJwt never runs, and posthog.capture before
+// init is a harmless no-op — the real modules load fine, as the prior test did.)
 mock.module("@superset/workspace-client/relay-socket", () => ({
+	...relaySocketModule,
 	createRelaySocket: (options: Record<string, unknown>) =>
 		new FakeRelaySocket(options),
-}));
-mock.module("renderer/lib/posthog", () => ({ posthog: { capture: () => {} } }));
-mock.module("renderer/lib/auth-client", () => ({
-	ensureFreshJwt: async () => "tok",
 }));
 
 const { connect, createTransport, disconnect, reconnect } = await import(

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -291,6 +291,16 @@ describe("PTY output write coalescing", () => {
 });
 
 describe("terminal-ws-transport", () => {
+	test("mock preserves the relay-socket module's other exports", async () => {
+		// Regression guard: bun's mock.module is process-global, so stubbing only
+		// createRelaySocket drops the module's other exports (e.g.
+		// setRelaySocketTelemetry, which renderer/lib/posthog imports) and crashes
+		// unrelated desktop tests suite-wide with "export not found". The mock must
+		// spread the real module — assert that here so a partial stub fails fast.
+		const mod = await import("@superset/workspace-client/relay-socket");
+		expect(typeof mod.setRelaySocketTelemetry).toBe("function");
+	});
+
 	test("server-sent error routes to logs, not xterm, and terminates", () => {
 		const transport = createTransport();
 		const writelnCalls: string[] = [];
@@ -425,13 +435,17 @@ describe("terminal-ws-transport", () => {
 	});
 
 	test("surfaces the diagnosis for dial failures that never open", () => {
-		const { transport, socket } = connectAttached();
+		// Never opened: connect but don't open/attach — the host is unreachable.
+		const transport = createTransport();
+		connect(transport, createMockTerminal(), "ws://host/terminal/t1");
+		const socket = FakeRelaySocket.instances.at(-1);
+		if (!socket) throw new Error("expected relay socket instance");
 
-		// Host unreachable: every attempt fails BEFORE the socket opens, arriving
-		// as an error + a string-code synthetic close (no numeric server close).
-		// retryCount still climbs, so the header must eventually explain the
-		// outage. The regression: a close-counting gate stays silent forever here,
-		// leaving a genuinely-offline terminal retrying with no indication.
+		// Every attempt fails BEFORE the socket opens, arriving as an error + a
+		// string-code synthetic close (no numeric server close). retryCount still
+		// climbs, so the header must eventually explain the outage. The
+		// regression: a close-counting gate stays silent forever here, leaving a
+		// genuinely-offline terminal retrying with no indication.
 		for (let i = 0; i < 9; i++) socket.dialFail();
 		expect(transport.lastDiagnosis).toBeNull();
 
@@ -473,5 +487,21 @@ describe("terminal-ws-transport", () => {
 		disconnect(transport);
 		expect(socket.closed).toBe(true);
 		expect(transport.connectionState).toBe("disconnected");
+	});
+
+	test("ignores late events from a socket detached during teardown", () => {
+		const { transport, socket } = connectAttached();
+
+		disconnect(transport);
+		expect(transport.connectionState).toBe("disconnected");
+
+		// A real WS can deliver a trailing close/message after teardown nulls the
+		// socket; it must not resurrect "closed" state or push logs.
+		socket.drop(1006, "late");
+		socket.message(JSON.stringify({ type: "title", title: "late" }));
+
+		expect(transport.connectionState).toBe("disconnected");
+		expect(transport.logs).toHaveLength(0);
+		expect(transport.title).toBeUndefined();
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -4,58 +4,95 @@ import {
 	describe,
 	expect,
 	jest,
+	mock,
 	setSystemTime,
 	test,
 } from "bun:test";
 import type { Terminal as XTerm } from "@xterm/xterm";
-import { connect, createTransport } from "./terminal-ws-transport";
 
+// The transport builds on createRelaySocket (partysocket) — reconnection,
+// backoff, and the relay preflight live inside the shared socket. We inject a
+// fake so tests drive the transport's own behavior (state, diagnosis,
+// coalescing, liveness) deterministically, without a real socket or fetch.
 type Listener = (event: {
 	data?: unknown;
-	code?: number;
-	reason?: string;
+	code?: unknown;
+	reason?: unknown;
 }) => void;
 
-class MockWebSocket {
-	static readonly CONNECTING = 0;
-	static readonly OPEN = 1;
-	static readonly CLOSING = 2;
-	static readonly CLOSED = 3;
+class FakeRelaySocket {
+	static instances: FakeRelaySocket[] = [];
 
-	static instances: MockWebSocket[] = [];
-
-	readonly url: string;
-	readyState = MockWebSocket.CONNECTING;
+	readyState = 0; // WebSocket.CONNECTING
 	binaryType: BinaryType = "blob";
 	sent: string[] = [];
+	reconnectCount = 0;
+	// partysocket's authoritative per-attempt counter: bumped on each failed
+	// dial, reset to 0 by reconnect() and (in reality) after minUptime of a
+	// stable connection — simulated here by stabilize().
+	retryCount = 0;
+	closed = false;
+	readonly options: Record<string, unknown>;
 	private readonly listeners = new Map<string, Set<Listener>>();
 
-	constructor(url: string) {
-		this.url = url;
-		MockWebSocket.instances.push(this);
+	constructor(options: Record<string, unknown>) {
+		this.options = options;
+		FakeRelaySocket.instances.push(this);
 	}
 
 	addEventListener(type: string, listener: Listener) {
-		let listeners = this.listeners.get(type);
-		if (!listeners) {
-			listeners = new Set();
-			this.listeners.set(type, listeners);
+		let set = this.listeners.get(type);
+		if (!set) {
+			set = new Set();
+			this.listeners.set(type, set);
 		}
-		listeners.add(listener);
+		set.add(listener);
 	}
 
 	send(data: string) {
 		this.sent.push(data);
 	}
 
-	close(code = 1000, reason = "") {
-		this.readyState = MockWebSocket.CLOSED;
+	close() {
+		this.closed = true;
+		this.readyState = 3; // CLOSED
+		this.dispatch("close", { code: 1000, reason: "" });
+	}
+
+	reconnect() {
+		this.reconnectCount += 1;
+		this.retryCount = 0;
+		this.readyState = 0;
+	}
+
+	// ---- test drivers ----
+	open() {
+		this.readyState = 1; // OPEN
+		this.dispatch("open", {});
+	}
+
+	/** Simulate minUptime elapsing on a stable connection (partysocket resets
+	 * retryCount only after the connection has been up a while, not on open). */
+	stabilize() {
+		this.retryCount = 0;
+	}
+
+	/** A real server close: the connection opened, then the host dropped it
+	 * (numeric code, e.g. relay 1006). */
+	drop(code: number | string = 1006, reason = "") {
+		this.retryCount += 1;
+		this.readyState = 3;
 		this.dispatch("close", { code, reason });
 	}
 
-	open() {
-		this.readyState = MockWebSocket.OPEN;
-		this.dispatch("open", {});
+	/** A dial failure: the socket never opened (host unreachable, upgrade
+	 * rejected). partysocket bumps retryCount and surfaces it as an error plus a
+	 * synthetic close whose clone mangles the code to the string "close". */
+	dialFail() {
+		this.retryCount += 1;
+		this.readyState = 3;
+		this.dispatch("error", {});
+		this.dispatch("close", { code: "close" });
 	}
 
 	message(data: unknown) {
@@ -63,13 +100,22 @@ class MockWebSocket {
 	}
 
 	private dispatch(type: string, event: Parameters<Listener>[0]) {
-		for (const listener of this.listeners.get(type) ?? []) {
-			listener(event);
-		}
+		for (const listener of this.listeners.get(type) ?? []) listener(event);
 	}
 }
 
-const originalWebSocket = globalThis.WebSocket;
+mock.module("@superset/workspace-client/relay-socket", () => ({
+	createRelaySocket: (options: Record<string, unknown>) =>
+		new FakeRelaySocket(options),
+}));
+mock.module("renderer/lib/posthog", () => ({ posthog: { capture: () => {} } }));
+mock.module("renderer/lib/auth-client", () => ({
+	ensureFreshJwt: async () => "tok",
+}));
+
+const { connect, createTransport, disconnect, reconnect } = await import(
+	"./terminal-ws-transport"
+);
 
 // `window` is aliased to `globalThis` by the xterm-env-polyfill preload, and
 // `globalThis.addEventListener` is absent on Linux CI runtimes, so the transport's
@@ -98,9 +144,20 @@ function createMockTerminal(
 	} as unknown as XTerm & { emitData(data: string): void };
 }
 
+/** Connect and drive the fake socket to a live, attached session. */
+function connectAttached(url = "ws://host/terminal/t1") {
+	const transport = createTransport();
+	const terminal = createMockTerminal();
+	connect(transport, terminal, url);
+	const socket = FakeRelaySocket.instances.at(-1);
+	if (!socket) throw new Error("expected relay socket instance");
+	socket.open();
+	socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+	return { transport, terminal, socket };
+}
+
 beforeEach(() => {
-	MockWebSocket.instances = [];
-	globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+	FakeRelaySocket.instances = [];
 	if (win && typeof win.addEventListener !== "function") {
 		win.addEventListener = () => {};
 	}
@@ -110,7 +167,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	globalThis.WebSocket = originalWebSocket;
 	if (win) {
 		win.addEventListener = originalAddEventListener;
 		win.removeEventListener = originalRemoveEventListener;
@@ -169,8 +225,8 @@ describe("PTY output write coalescing", () => {
 			events.push(`writeln:${line}`);
 		};
 		connect(transport, terminal, "ws://host/terminal/t1");
-		const socket = MockWebSocket.instances[0];
-		if (!socket) throw new Error("expected websocket instance");
+		const socket = FakeRelaySocket.instances[0];
+		if (!socket) throw new Error("expected relay socket instance");
 		socket.open();
 		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
 		return { transport, socket, writes, events };
@@ -224,14 +280,14 @@ describe("PTY output write coalescing", () => {
 		const { writes, socket } = connectWithRecordingTerminal();
 
 		socket.message(binaryFrame("tail"));
-		socket.close(1006, "host restart");
+		socket.drop(1006, "host restart");
 
 		expect(writes).toEqual(["tail"]);
 	});
 });
 
 describe("terminal-ws-transport", () => {
-	test("server-sent error routes to logs, not xterm, and stops reconnect", () => {
+	test("server-sent error routes to logs, not xterm, and terminates", () => {
 		const transport = createTransport();
 		const writelnCalls: string[] = [];
 		const terminal = createMockTerminal();
@@ -242,8 +298,8 @@ describe("terminal-ws-transport", () => {
 		};
 
 		connect(transport, terminal, "ws://host/terminal/t1");
-		const socket = MockWebSocket.instances[0];
-		if (!socket) throw new Error("expected websocket instance");
+		const socket = FakeRelaySocket.instances[0];
+		if (!socket) throw new Error("expected relay socket instance");
 		socket.open();
 
 		socket.message(
@@ -258,11 +314,8 @@ describe("terminal-ws-transport", () => {
 		expect(transport.logs).toHaveLength(1);
 		expect(transport.logs[0]?.level).toBe("error");
 		expect(transport.logs[0]?.message).toContain("is not active");
-
-		// 1011 is what host-service sends after an attach error; the close
-		// handler would otherwise schedule a reconnect.
-		socket.close(1011, "session not active");
-		expect(transport._reconnectTimer).toBeNull();
+		// Fatal error terminates: the socket is closed so it won't re-dial.
+		expect(socket.closed).toBe(true);
 	});
 
 	test("waits for server attach before sending resize or input", () => {
@@ -270,10 +323,8 @@ describe("terminal-ws-transport", () => {
 		const terminal = createMockTerminal();
 
 		connect(transport, terminal, "ws://host/terminal/t1");
-
-		const socket = MockWebSocket.instances[0];
-		expect(socket).toBeDefined();
-		if (!socket) throw new Error("expected websocket instance");
+		const socket = FakeRelaySocket.instances[0];
+		if (!socket) throw new Error("expected relay socket instance");
 		const sentMessages = () =>
 			socket.sent.map((payload) => JSON.parse(payload) as unknown);
 
@@ -295,27 +346,128 @@ describe("terminal-ws-transport", () => {
 		]);
 	});
 
-	test("recovers a half-open socket after the machine resumes from sleep", () => {
-		jest.useFakeTimers();
-		setSystemTime(new Date("2026-01-01T00:00:00Z"));
+	test("never gives up: keeps one socket and never self-closes on repeated failures", () => {
+		const { socket } = connectAttached();
 
-		const transport = createTransport();
-		connect(transport, createMockTerminal(), "ws://host/terminal/t1");
+		// A host that stays offline drops us over and over. The transport must
+		// keep delegating retries to the shared socket — never close it (which
+		// would stop partysocket) and never re-create it.
+		for (let i = 0; i < 25; i++) socket.drop(1006, "offline");
 
-		const socket = MockWebSocket.instances[0];
-		if (!socket) throw new Error("expected websocket instance");
+		expect(FakeRelaySocket.instances.length).toBe(1);
+		expect(socket.closed).toBe(false);
+		expect(socket.reconnectCount).toBe(0);
+	});
+
+	test("surfaces the diagnosis only after the threshold, and logs it once", () => {
+		const { transport, socket } = connectAttached();
+
+		for (let i = 0; i < 9; i++) socket.drop(1006, "offline");
+		expect(transport.lastDiagnosis).toBeNull();
+		expect(
+			transport.logs.filter((l) => l.message.includes("Still retrying")),
+		).toHaveLength(0);
+
+		// The 10th consecutive failure crosses the threshold.
+		socket.drop(1006, "offline");
+		expect(transport.lastDiagnosis).not.toBeNull();
+
+		// Further failures keep the diagnosis fresh but don't re-log or re-spam.
+		for (let i = 0; i < 10; i++) socket.drop(1006, "offline");
+		expect(transport.lastDiagnosis).not.toBeNull();
+		expect(
+			transport.logs.filter((l) => l.message.includes("Still retrying")),
+		).toHaveLength(1);
+	});
+
+	test("does not accrue an offline diagnosis while the window is hidden", () => {
+		const { transport, socket } = connectAttached();
+
+		const originalDocument = (globalThis as { document?: unknown }).document;
+		(globalThis as { document?: unknown }).document = { hidden: true };
+		try {
+			// Well past the threshold, but hidden — the header must stay clean.
+			for (let i = 0; i < 20; i++) socket.drop(1006, "offline");
+			expect(transport.lastDiagnosis).toBeNull();
+			expect(
+				transport.logs.filter((l) => l.message.includes("Still retrying")),
+			).toHaveLength(0);
+		} finally {
+			if (originalDocument === undefined) {
+				(globalThis as { document?: unknown }).document = undefined;
+			} else {
+				(globalThis as { document?: unknown }).document = originalDocument;
+			}
+		}
+	});
+
+	test("attach clears the diagnosis; budget resets after a stable connection", () => {
+		const { transport, socket } = connectAttached();
+
+		for (let i = 0; i < 12; i++) socket.drop(1006, "offline");
+		expect(transport.lastDiagnosis).not.toBeNull();
+
+		// Reconnect + attach clears the current offline state.
 		socket.open();
 		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
 		expect(transport.connectionState).toBe("open");
+		expect(transport.lastDiagnosis).toBeNull();
 
-		// Laptop sleeps: the socket dies but never observes it. readyState stays
-		// OPEN and no `close` is delivered — that silent death is the bug. Two
-		// minutes pass (clock jumps), then the watchdog tick runs on wake.
+		// Once the connection has been stable a while (retryCount reset), a fresh
+		// failure starts the threshold count from scratch — no instant re-flag.
+		socket.stabilize();
+		socket.drop(1006, "offline");
+		expect(transport.lastDiagnosis).toBeNull();
+	});
+
+	test("surfaces the diagnosis for dial failures that never open", () => {
+		const { transport, socket } = connectAttached();
+
+		// Host unreachable: every attempt fails BEFORE the socket opens, arriving
+		// as an error + a string-code synthetic close (no numeric server close).
+		// retryCount still climbs, so the header must eventually explain the
+		// outage. The regression: a close-counting gate stays silent forever here,
+		// leaving a genuinely-offline terminal retrying with no indication.
+		for (let i = 0; i < 9; i++) socket.dialFail();
+		expect(transport.lastDiagnosis).toBeNull();
+
+		socket.dialFail(); // 10th consecutive failure crosses the threshold
+		expect(transport.lastDiagnosis).not.toBeNull();
+	});
+
+	test("manual reconnect() clears termination and re-dials", () => {
+		const { transport, socket } = connectAttached();
+
+		socket.message(JSON.stringify({ type: "exit", exitCode: 0, signal: 0 }));
+		expect(socket.closed).toBe(true);
+		const before = socket.reconnectCount;
+
+		reconnect(transport);
+		expect(transport.connectionState).toBe("connecting");
+		expect(socket.reconnectCount).toBe(before + 1);
+	});
+
+	test("forces a reconnect on the wall-clock gap after sleep/wake", () => {
+		jest.useFakeTimers();
+		setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		const { socket } = connectAttached();
+		expect(socket.reconnectCount).toBe(0);
+
+		// Laptop sleeps: the socket dies but never observes it (readyState stays
+		// OPEN, no close). Two minutes pass, then the watchdog tick runs on wake.
 		setSystemTime(new Date("2026-01-01T00:02:00Z"));
 		jest.advanceTimersByTime(120_000);
 
-		// Recovery: the wall-clock-gap watchdog drops the wedged socket and dials
-		// a fresh one. Without it, only the original socket would ever exist.
-		expect(MockWebSocket.instances.length).toBe(2);
+		// The wall-clock-gap watchdog force-reconnects the wedged socket.
+		expect(socket.reconnectCount).toBe(1);
+	});
+
+	test("disconnect closes the socket and goes disconnected", () => {
+		const { transport, socket } = connectAttached();
+
+		disconnect(transport);
+		expect(socket.closed).toBe(true);
+		expect(transport.connectionState).toBe("disconnected");
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,7 +1,8 @@
+import type { RelayAffinityProbe } from "@superset/workspace-client";
 import {
-	primeRelayAffinity,
-	type RelayAffinityProbe,
-} from "@superset/workspace-client";
+	createRelaySocket,
+	type RelaySocket,
+} from "@superset/workspace-client/relay-socket";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { ensureFreshJwt } from "renderer/lib/auth-client";
 import { posthog } from "renderer/lib/posthog";
@@ -34,12 +35,10 @@ type TerminalServerMessage =
 	| { type: "title"; title: string | null };
 
 export interface TerminalTransport {
-	socket: WebSocket | null;
 	connectionState: ConnectionState;
-	/** The URL the socket is currently connected (or connecting) to. */
+	/** The token-bearing URL the socket is currently pointed at. */
 	currentUrl: string | null;
 	title: string | null | undefined;
-	onDataDisposable: { dispose(): void } | null;
 	stateListeners: Set<() => void>;
 	titleListeners: Set<() => void>;
 	/**
@@ -49,20 +48,51 @@ export interface TerminalTransport {
 	 */
 	logs: TerminalLogEntry[];
 	logListeners: Set<() => void>;
-	/** Internal: auto-reconnect timer. */
-	_reconnectTimer: ReturnType<typeof setTimeout> | null;
-	/** Internal: reconnect attempt count for backoff. */
-	_reconnectAttempt: number;
+	/**
+	 * Why the connection is down, once it has failed enough consecutive attempts
+	 * to be worth surfacing (or access was denied / the session ended). Null
+	 * while healthy or within the transient-blip window. Drives the pane header
+	 * status indicator.
+	 */
+	lastDiagnosis: TerminalFailureClassification | null;
+
+	/** Internal: the shared reconnecting relay socket (partysocket). Created
+	 * once on first connect; it re-signs the URL and runs the relay preflight
+	 * before every (re)dial and retries indefinitely. */
+	_socket: RelaySocket | null;
+	/** The xterm instance the socket feeds. */
+	_terminal: XTerm | null;
+	/** Internal: disposes the terminal.onData → socket.send wiring. */
+	_onDataDisposable: { dispose(): void } | null;
 	/** Internal: title-change debounce timer; see TITLE_COALESCE_MS. */
 	_titleNotifyTimer: ReturnType<typeof setTimeout> | null;
-	/** The xterm instance used for reconnection. */
-	_terminal: XTerm | null;
-	/** Set when the server signals the session is done (PTY exit or fatal
-	 * attach error). Suppresses the auto-reconnect loop. */
+	/**
+	 * Batches PTY output into one xterm.write per animation frame. Agent CLIs
+	 * emit repaints as many small chunks; per-chunk writes trigger a
+	 * parse/render cycle each and overwhelm the renderer (#2241, #2244).
+	 */
+	_writeCoalescer: WriteCoalescer | null;
+	/**
+	 * Whether the give-up diagnosis has already been logged for the current
+	 * outage, so the one-shot log + telemetry don't repeat every retry cycle.
+	 * Reset on attach and on a forced reconnect. The failure *count* itself is
+	 * read live from the socket's `retryCount` (see maybeSurfaceDiagnosis).
+	 */
+	_diagnosisLogged: boolean;
+	/** Internal: last `_whoowns` preflight probe, used to classify a failure. */
+	_lastProbe: RelayAffinityProbe | null;
+	/**
+	 * Token carried on the URL the caller passed. Reused as-is for local (PSK)
+	 * hosts, whose token doesn't rotate; relay hosts re-sign per dial via
+	 * ensureFreshJwt and ignore this.
+	 */
+	_localToken: string | null;
+	/** Set when the server signals the session is done (PTY exit / fatal attach
+	 * error) or access is denied. Suppresses the auto-reconnect loop. */
 	_terminated: boolean;
 	/**
 	 * Flips true after the first PTY-output frame lands in xterm. Subsequent
-	 * connects send `?replay=0` so the server doesn't re-deliver scrollback.
+	 * dials send `?replay=0` so the server doesn't re-deliver scrollback.
 	 * Tracked on first bytes (not first open) so a WS that opens-and-closes
 	 * with no output still gets replay on the next connect.
 	 */
@@ -74,28 +104,73 @@ export interface TerminalTransport {
 	/** Internal: bound resume handler shared by the online/focus/visibility
 	 * listeners, so they can be removed on teardown. */
 	_resumeListener: (() => void) | null;
-	/**
-	 * Internal: batches PTY output into one xterm.write per animation frame.
-	 * Agent CLIs emit repaints as many small chunks; per-chunk writes trigger
-	 * a parse/render cycle each and overwhelm the renderer (#2241, #2244).
-	 */
-	_writeCoalescer: WriteCoalescer | null;
-	/** Internal: last `_whoowns` probe, used to explain a failed connection. */
-	_lastProbe: RelayAffinityProbe | null;
-	/**
-	 * Why the connection is down, once the transport has stopped trying (gave
-	 * up, access denied, fatal server error, PTY exit). Null while healthy or
-	 * still auto-reconnecting. Drives the pane header status indicator.
-	 */
-	lastDiagnosis: TerminalFailureClassification | null;
-	/** Internal: bumped per connect() so async preflight callbacks from a
-	 * superseded attempt (reconnectNow re-entering the same URL) can't open a
-	 * duplicate socket or fatally terminate the newer attempt. */
-	_connectEpoch: number;
 }
 
 const MAX_LOG_ENTRIES = 200;
 let logIdCounter = 0;
+
+const BASE_RECONNECT_DELAY = 500;
+const MAX_RECONNECT_DELAY = 10_000;
+// How many consecutive failed dials (partysocket `retryCount`) before the header
+// shows *why* the terminal is down. Below this the socket is quietly (and
+// quickly) retrying — a network blip or host-service restart usually recovers
+// inside the window (retryCount resets after a stable connection). The socket
+// keeps retrying forever regardless; this only gates the user-facing diagnosis.
+const DIAGNOSE_AFTER_ATTEMPTS = 10;
+
+function isWindowHidden(): boolean {
+	return typeof document !== "undefined" && document.hidden;
+}
+
+// Once partysocket has failed DIAGNOSE_AFTER_ATTEMPTS consecutive dials, surface
+// why the terminal is down. Driven off partysocket's `retryCount` — the
+// authoritative per-attempt counter that increments on every failed dial and
+// resets after a stable connection — rather than counting close events: dial
+// failures (host unreachable, upgrade rejected) arrive as synthetic string-code
+// closes + error events that a hand-rolled close-counter misses, so a purely
+// close-counting gate would leave a genuinely-offline terminal retrying
+// silently with no header explanation. The socket keeps retrying forever
+// regardless; this only decides when (and whether) the header explains it.
+function maybeSurfaceDiagnosis(
+	transport: TerminalTransport,
+	closeEvent: { code?: unknown; reason?: unknown } | null,
+) {
+	if (transport._terminated) return;
+	// A hidden/minimized window shouldn't accrue an "offline" state nobody is
+	// looking at — its failures may be a suspend artifact. The socket keeps
+	// retrying; the resume listener force-redials the moment it's back.
+	if (isWindowHidden()) return;
+	if ((transport._socket?.retryCount ?? 0) < DIAGNOSE_AFTER_ATTEMPTS) return;
+
+	// Keep the header diagnosis fresh every cycle; log + emit telemetry once.
+	const diagnosis = classifyTerminalFailure(
+		transport._lastProbe,
+		isRelayHostUrl(transport.currentUrl),
+	);
+	transport.lastDiagnosis = diagnosis;
+	if (transport._diagnosisLogged) return;
+	transport._diagnosisLogged = true;
+	pushLog(
+		transport,
+		"warn",
+		`Terminal disconnected from ${formatWsEndpoint(transport.currentUrl)}. ${diagnosis.message} Still retrying.`,
+	);
+	posthog.capture("terminal_connect_failed", {
+		endpoint: formatWsEndpoint(transport.currentUrl),
+		close_code:
+			closeEvent && typeof closeEvent.code === "number"
+				? closeEvent.code
+				: null,
+		close_reason:
+			closeEvent && typeof closeEvent.reason === "string"
+				? closeEvent.reason || undefined
+				: undefined,
+		preflight_status: transport._lastProbe?.status ?? null,
+		tunnel_region: transport._lastProbe?.region ?? null,
+		reconnect_attempts: transport._socket?.retryCount ?? 0,
+		category: diagnosis.category,
+	});
+}
 
 function setConnectionState(
 	transport: TerminalTransport,
@@ -167,34 +242,29 @@ export function clearLogs(transport: TerminalTransport) {
 	}
 }
 
-const MAX_RECONNECT_DELAY = 10_000;
-const BASE_RECONNECT_DELAY = 500;
-const MAX_RECONNECT_ATTEMPTS = 10;
-
 export function createTransport(): TerminalTransport {
 	return {
-		socket: null,
 		connectionState: "disconnected",
 		currentUrl: null,
 		title: undefined,
-		onDataDisposable: null,
 		stateListeners: new Set(),
 		titleListeners: new Set(),
 		logs: [],
 		logListeners: new Set(),
-		_reconnectTimer: null,
-		_titleNotifyTimer: null,
-		_reconnectAttempt: 0,
+		lastDiagnosis: null,
+		_socket: null,
 		_terminal: null,
-		_hasReceivedBytes: false,
+		_onDataDisposable: null,
+		_titleNotifyTimer: null,
+		_writeCoalescer: null,
+		_diagnosisLogged: false,
+		_lastProbe: null,
+		_localToken: null,
 		_terminated: false,
+		_hasReceivedBytes: false,
 		_livenessTimer: null,
 		_lastLivenessTick: 0,
 		_resumeListener: null,
-		_writeCoalescer: null,
-		_lastProbe: null,
-		lastDiagnosis: null,
-		_connectEpoch: 0,
 	};
 }
 
@@ -207,47 +277,35 @@ export function createTransport(): TerminalTransport {
 const LIVENESS_CHECK_INTERVAL_MS = 5_000;
 const LIVENESS_SUSPEND_GAP_MS = 20_000;
 
-// Drop the current socket and immediately reconnect, without waiting for a
-// `close` event that a half-open socket will never deliver. The host keeps the
-// PTY alive, so this just re-attaches (and replays anything missed).
-function reconnectNow(transport: TerminalTransport) {
+// Force an immediate re-dial without waiting for a `close` event that a
+// half-open socket will never deliver. partysocket.reconnect() resets its retry
+// counter and dials now; the host keeps the PTY alive, so this just re-attaches
+// (and replays anything missed).
+function forceReconnect(transport: TerminalTransport) {
 	if (transport._terminated) return;
-	if (!transport.currentUrl || !transport._terminal) return;
-	cancelReconnect(transport);
-	if (transport.socket) {
-		const dead = transport.socket;
-		transport.socket = null;
-		try {
-			dead.close();
-		} catch {
-			// best-effort; the close handler is a no-op once socket is detached
-		}
-	}
-	transport._reconnectAttempt = 0;
-	// connect() is idempotent while "open"/"connecting"; force "closed" so it
-	// actually re-dials the now-detached socket.
-	setConnectionState(transport, "closed");
-	connect(transport, transport._terminal, transport.currentUrl);
+	const socket = transport._socket;
+	if (!socket) return;
+	transport._diagnosisLogged = false;
+	transport.lastDiagnosis = null;
+	setConnectionState(transport, "connecting");
+	// reconnect() also resets partysocket's retryCount, so the diagnosis budget
+	// starts fresh.
+	socket.reconnect();
 }
 
-// DOM resume signal (online/focus/visibilitychange). Reset backoff and
-// reconnect only if the socket is actually dead — a healthy or still-connecting
-// socket is left alone. Mirrors TerminalConnection.handleResume on web.
+// DOM resume signal (online/focus/visibilitychange). Reconnect only if the
+// socket is actually dead — a healthy or still-connecting socket is left alone.
 function handleResume(transport: TerminalTransport) {
 	if (transport._terminated) return;
-	if (!transport.currentUrl || !transport._terminal) return;
-	transport._reconnectAttempt = 0;
-	// Bail if a connect is already in flight. State "connecting" also covers the
-	// /hosts/ pre-flight window, where transport.socket is still null but
-	// reconnecting would orphan the socket the pending pre-flight is about to open.
-	const socket = transport.socket;
+	const socket = transport._socket;
+	if (!socket) return;
 	if (
-		transport.connectionState === "connecting" ||
-		socket?.readyState === WebSocket.OPEN
+		socket.readyState === WebSocket.OPEN ||
+		socket.readyState === WebSocket.CONNECTING
 	) {
 		return;
 	}
-	reconnectNow(transport);
+	forceReconnect(transport);
 }
 
 function setupLiveness(transport: TerminalTransport) {
@@ -257,7 +315,7 @@ function setupLiveness(transport: TerminalTransport) {
 			const now = Date.now();
 			const gap = now - transport._lastLivenessTick;
 			transport._lastLivenessTick = now;
-			if (gap > LIVENESS_SUSPEND_GAP_MS) reconnectNow(transport);
+			if (gap > LIVENESS_SUSPEND_GAP_MS) forceReconnect(transport);
 		}, LIVENESS_CHECK_INTERVAL_MS);
 	}
 	if (!transport._resumeListener) {
@@ -291,37 +349,6 @@ function teardownLiveness(transport: TerminalTransport) {
 	}
 }
 
-function scheduleReconnect(transport: TerminalTransport) {
-	if (transport._reconnectTimer) return;
-	if (transport._terminated) return;
-	if (!transport.currentUrl || !transport._terminal) return;
-	if (transport._reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) return;
-
-	const delay = Math.min(
-		BASE_RECONNECT_DELAY * 2 ** transport._reconnectAttempt,
-		MAX_RECONNECT_DELAY,
-	);
-	transport._reconnectAttempt++;
-
-	transport._reconnectTimer = setTimeout(() => {
-		transport._reconnectTimer = null;
-		if (
-			transport.connectionState === "closed" &&
-			transport.currentUrl &&
-			transport._terminal
-		) {
-			connect(transport, transport._terminal, transport.currentUrl);
-		}
-	}, delay);
-}
-
-function cancelReconnect(transport: TerminalTransport) {
-	if (transport._reconnectTimer) {
-		clearTimeout(transport._reconnectTimer);
-		transport._reconnectTimer = null;
-	}
-}
-
 function formatWsEndpoint(wsUrl: string | null): string {
 	if (!wsUrl) return "unknown endpoint";
 	try {
@@ -342,9 +369,15 @@ function isRelayHostUrl(wsUrl: string | null): boolean {
 	}
 }
 
-function formatCloseDetails(event: CloseEvent): string {
-	const code = event.code || "unknown";
-	const reason = event.reason ? `, reason: ${event.reason}` : "";
+function formatCloseDetails(event: {
+	code?: unknown;
+	reason?: unknown;
+}): string {
+	const code = typeof event.code === "number" ? event.code : "unknown";
+	const reason =
+		typeof event.reason === "string" && event.reason
+			? `, reason: ${event.reason}`
+			: "";
 	return `code: ${code}${reason}`;
 }
 
@@ -360,157 +393,143 @@ function appendQueryParam(url: string, key: string, value: string): string {
 	}
 }
 
+function extractToken(url: string): string | null {
+	try {
+		return new URL(url).searchParams.get("token");
+	} catch {
+		return null;
+	}
+}
+
+// The URL minus its token param. createRelaySocket signs a fresh token onto it
+// before every dial, so the persisted base must not carry a stale one.
+function stripToken(url: string): string {
+	try {
+		const u = new URL(url);
+		u.searchParams.delete("token");
+		return u.toString();
+	} catch {
+		return url;
+	}
+}
+
 export function connect(
 	transport: TerminalTransport,
 	terminal: XTerm,
 	wsUrl: string,
 ) {
-	// Idempotent: skip if already connected/connecting to the same endpoint.
-	const isActive =
-		transport.connectionState === "open" ||
-		transport.connectionState === "connecting";
-	if (isActive && transport.currentUrl === wsUrl) return;
+	const base = stripToken(wsUrl);
 
-	if (transport.socket) {
-		transport.socket.close();
-		transport.socket = null;
+	// Idempotent: a live socket already pointed at this endpoint just needs the
+	// latest token-bearing URL refreshed (the socket re-signs per dial anyway) —
+	// don't tear the connection down when only the rotating token changed.
+	if (
+		transport._socket &&
+		!transport._terminated &&
+		transport.currentUrl &&
+		stripToken(transport.currentUrl) === base
+	) {
+		transport.currentUrl = wsUrl;
+		transport._localToken = extractToken(wsUrl);
+		return;
 	}
 
-	cancelReconnect(transport);
-	const epoch = ++transport._connectEpoch;
 	transport.currentUrl = wsUrl;
+	transport._localToken = extractToken(wsUrl);
 	transport._terminal = terminal;
-	// Recreate per connect so the coalescer always targets the current
-	// terminal; dispose flushes anything the previous socket left pending.
+	transport._terminated = false;
+	transport._diagnosisLogged = false;
+	transport.lastDiagnosis = null;
+	// Recreate per connect so the coalescer always targets the current terminal;
+	// dispose flushes anything the previous socket left pending.
 	transport._writeCoalescer?.dispose();
 	transport._writeCoalescer = createWriteCoalescer((data) =>
 		terminal.write(data),
 	);
-	transport._terminated = false;
-	transport.lastDiagnosis = null;
 	setupLiveness(transport);
 	setConnectionState(transport, "connecting");
-	const actualUrl = transport._hasReceivedBytes
-		? appendQueryParam(wsUrl, "replay", "0")
-		: wsUrl;
 
-	const openSocket = (targetUrl: string) => {
-		// Bail if the transport raced into a different URL, was disconnected, or
-		// a newer connect() superseded this attempt while the pre-flight was in
-		// flight.
-		if (
-			transport._connectEpoch !== epoch ||
-			transport.currentUrl !== wsUrl ||
-			transport.connectionState !== "connecting"
-		) {
-			return;
-		}
-		let socket: WebSocket;
-		try {
-			socket = new WebSocket(targetUrl);
-		} catch (err) {
+	// Endpoint changed on an existing socket: re-point (buildUrl reads
+	// currentUrl live) and re-dial.
+	if (transport._socket) {
+		transport._socket.reconnect();
+		return;
+	}
+
+	const socket = createRelaySocket({
+		name: "desktop-terminal",
+		// buildUrl/getToken read transport state live, so a URL swap or token
+		// rotation is picked up on the next dial without recreating the socket.
+		buildUrl: () => {
+			const current = stripToken(transport.currentUrl ?? base);
+			return transport._hasReceivedBytes
+				? appendQueryParam(current, "replay", "0")
+				: current;
+		},
+		getToken: () =>
+			isRelayHostUrl(transport.currentUrl)
+				? ensureFreshJwt()
+				: transport._localToken,
+		// 403 is a definitive access denial (fresh token), not transient —
+		// createRelaySocket closes the socket; record why so we stop looking.
+		onAccessDenied: () => {
+			transport._terminated = true;
+			const diagnosis = classifyTerminalFailure(transport._lastProbe, true);
+			transport.lastDiagnosis = diagnosis;
+			setConnectionState(transport, "closed");
 			pushLog(
 				transport,
 				"error",
-				`WebSocket construction failed for ${formatWsEndpoint(targetUrl)}: ${
-					err instanceof Error ? err.message : String(err)
-				}`,
+				`Connection refused for ${formatWsEndpoint(transport.currentUrl)}: ${diagnosis.message} Not retrying.`,
 			);
-			setConnectionState(transport, "closed");
-			scheduleReconnect(transport);
-			return;
-		}
-		// Receive PTY bytes as ArrayBuffer (the default would be Blob, which
-		// forces an async read); we want to feed bytes synchronously into
-		// xterm.write to keep render order strict.
-		socket.binaryType = "arraybuffer";
-		transport.socket = socket;
-		attachSocketListeners(transport, terminal, socket);
-	};
-
-	// Pre-flight `_whoowns` to pin fly edge affinity before the WS upgrade (see
-	// primeRelayAffinity); skip for non-/hosts URLs. Keep the result to explain
-	// a failure.
-	if (isRelayHostUrl(wsUrl)) {
-		transport._lastProbe = null;
-		// Relay URLs carry the user JWT, which rotates hourly. The URL was signed
-		// at render time, so reconnect attempts (this function re-entered from
-		// scheduleReconnect with the same currentUrl) would otherwise redial with
-		// an expired token forever — re-sign every attempt with a fresh one.
-		void ensureFreshJwt().then((token) => {
-			const signedUrl = token
-				? appendQueryParam(actualUrl, "token", token)
-				: actualUrl;
-			return primeRelayAffinity(signedUrl).then((probe) => {
-				transport._lastProbe = probe;
-				// 403 is a definitive access denial (the token is fresh), not a
-				// transient failure — retrying would hammer the relay with the same
-				// answer. Stop and surface it; a manual reconnect re-enters connect().
-				if (probe?.status === 403) {
-					if (
-						transport._connectEpoch !== epoch ||
-						transport.currentUrl !== wsUrl ||
-						transport.connectionState !== "connecting"
-					) {
-						return;
-					}
-					const diagnosis = classifyTerminalFailure(probe, true);
-					transport.lastDiagnosis = diagnosis;
-					pushLog(
-						transport,
-						"error",
-						`Connection refused for ${formatWsEndpoint(wsUrl)}: ${diagnosis.message} Not retrying.`,
-					);
-					posthog.capture("terminal_connect_failed", {
-						endpoint: formatWsEndpoint(wsUrl),
-						preflight_status: probe.status,
-						tunnel_region: probe.region,
-						reconnect_attempts: transport._reconnectAttempt,
-						category: diagnosis.category,
-					});
-					transport._terminated = true;
-					setConnectionState(transport, "closed");
-					return;
-				}
-				openSocket(signedUrl);
+			posthog.capture("terminal_connect_failed", {
+				endpoint: formatWsEndpoint(transport.currentUrl),
+				preflight_status: transport._lastProbe?.status ?? null,
+				tunnel_region: transport._lastProbe?.region ?? null,
+				reconnect_attempts: transport._socket?.retryCount ?? 0,
+				category: diagnosis.category,
 			});
-		});
-	} else {
-		openSocket(actualUrl);
-	}
+		},
+		onProbe: (probe) => {
+			transport._lastProbe = probe;
+		},
+		minReconnectionDelay: BASE_RECONNECT_DELAY,
+		maxReconnectionDelay: MAX_RECONNECT_DELAY,
+		// send() is a no-op unless open; we gate writes on connectionState anyway.
+		maxEnqueuedMessages: 0,
+	});
+	// Receive PTY bytes as ArrayBuffer (the default Blob forces an async read);
+	// we feed bytes synchronously into xterm.write to keep render order strict.
+	socket.binaryType = "arraybuffer";
+	transport._socket = socket;
+	attachSocketListeners(transport, terminal, socket);
 }
 
 function attachSocketListeners(
 	transport: TerminalTransport,
 	terminal: XTerm,
-	socket: WebSocket,
+	socket: RelaySocket,
 ): void {
-	socket.addEventListener("open", () => {
-		if (transport.socket !== socket) return;
-		transport._reconnectAttempt = 0;
-	});
-
 	socket.addEventListener("message", (event) => {
-		if (transport.socket !== socket) return;
+		const data = (event as { data: unknown }).data;
 
 		// Binary frame = PTY output bytes (data + replay collapsed onto one
-		// channel; renderer treats them identically). Pipe straight into
-		// xterm without any decoding step.
-		if (event.data instanceof ArrayBuffer) {
-			// Queue PTY bytes; the coalescer batches them into one xterm.write
-			// per animation frame. There's no output ACK back to host-service:
+		// channel; renderer treats them identically). Pipe straight into xterm.
+		if (data instanceof ArrayBuffer) {
+			// Queue PTY bytes; the coalescer batches them into one xterm.write per
+			// animation frame. There's no output ACK back to host-service:
 			// back-pressure lives entirely on the host side, which bounds this
 			// socket's send buffer and drops us (we reconnect and replay) if we
-			// fall hopelessly behind. That means a slow/stalled renderer can
-			// never wedge the shell — it just loses some scrollback.
-			transport._writeCoalescer?.push(new Uint8Array(event.data));
+			// fall hopelessly behind. A slow renderer can never wedge the shell —
+			// it just loses some scrollback.
+			transport._writeCoalescer?.push(new Uint8Array(data));
 			transport._hasReceivedBytes = true;
 			return;
 		}
 
 		let message: TerminalServerMessage;
 		try {
-			message = JSON.parse(String(event.data)) as TerminalServerMessage;
+			message = JSON.parse(String(data)) as TerminalServerMessage;
 		} catch {
 			transport._writeCoalescer?.flushSync();
 			terminal.writeln("\r\n[terminal] invalid server payload");
@@ -524,6 +543,7 @@ function attachSocketListeners(
 
 		if (message.type === "attached") {
 			transport.lastDiagnosis = null;
+			transport._diagnosisLogged = false;
 			setConnectionState(transport, "open");
 			sendResize(transport, terminal.cols, terminal.rows);
 			return;
@@ -537,7 +557,7 @@ function attachSocketListeners(
 			pushLog(transport, "error", message.message);
 			// Server closes after this; reconnecting would just hit the same error.
 			transport._terminated = true;
-			cancelReconnect(transport);
+			socket.close();
 			return;
 		}
 
@@ -548,7 +568,7 @@ function attachSocketListeners(
 				category: "unknown",
 				message: `The terminal session ended (exit code ${message.exitCode}).`,
 			};
-			cancelReconnect(transport);
+			socket.close();
 			terminal.writeln(
 				`\r\n[terminal] exited with code ${message.exitCode} (signal ${message.signal})`,
 			);
@@ -556,86 +576,93 @@ function attachSocketListeners(
 	});
 
 	socket.addEventListener("close", (event) => {
-		if (transport.socket !== socket) return;
+		const closeEvent = event as { code?: unknown; reason?: unknown };
 		// Render whatever arrived before the close instead of holding it for a
 		// frame that may never come (e.g. hidden window).
 		transport._writeCoalescer?.flushSync();
 		setConnectionState(transport, "closed");
-		transport.socket = null;
-		if (!transport._terminated && event.code !== 1000) {
-			const willReconnect =
-				!transport._reconnectTimer &&
-				Boolean(transport.currentUrl && transport._terminal) &&
-				transport._reconnectAttempt < MAX_RECONNECT_ATTEMPTS;
-			const endpoint = formatWsEndpoint(transport.currentUrl);
-			if (willReconnect) {
-				pushLog(
-					transport,
-					"warn",
-					`WebSocket closed while connected to ${endpoint} (${formatCloseDetails(event)}). Reconnecting (attempt ${transport._reconnectAttempt + 1}/${MAX_RECONNECT_ATTEMPTS})...`,
-				);
-			} else {
-				// Gave up. Classify why from the preflight probe and record it so
-				// this failure mode is queryable, not silent.
-				const diagnosis = classifyTerminalFailure(
-					transport._lastProbe,
-					isRelayHostUrl(transport.currentUrl),
-				);
-				transport.lastDiagnosis = diagnosis;
-				pushLog(
-					transport,
-					"error",
-					`WebSocket closed while connected to ${endpoint} (${formatCloseDetails(event)}). Max reconnect attempts reached. ${diagnosis.message}`,
-				);
-				posthog.capture("terminal_connect_failed", {
-					endpoint,
-					close_code: event.code,
-					close_reason: event.reason || undefined,
-					preflight_status: transport._lastProbe?.status ?? null,
-					tunnel_region: transport._lastProbe?.region ?? null,
-					reconnect_attempts: transport._reconnectAttempt,
-					category: diagnosis.category,
-				});
-			}
+		// Deliberate/terminal closes (PTY exit, fatal error, cleanup) don't
+		// reconnect — partysocket won't re-dial after close(). Synthetic
+		// dial-error closes carry a string code and are logged via the error
+		// handler; the diagnosis itself is driven off retryCount either way.
+		if (transport._terminated || closeEvent.code === 1000) return;
+
+		// Log real server closes (numeric code) below the threshold; past it the
+		// header diagnosis conveys the state, and a hidden window shouldn't spam.
+		if (
+			typeof closeEvent.code === "number" &&
+			!isWindowHidden() &&
+			(transport._socket?.retryCount ?? 0) < DIAGNOSE_AFTER_ATTEMPTS
+		) {
+			pushLog(
+				transport,
+				"warn",
+				`WebSocket closed while connected to ${formatWsEndpoint(transport.currentUrl)} (${formatCloseDetails(closeEvent)}). Reconnecting (attempt ${transport._socket?.retryCount ?? 0}/${DIAGNOSE_AFTER_ATTEMPTS})...`,
+			);
 		}
-		// Auto-reconnect on unexpected close (host-service restart, network blip)
-		scheduleReconnect(transport);
+		maybeSurfaceDiagnosis(transport, closeEvent);
 	});
 
 	socket.addEventListener("error", () => {
-		if (transport.socket !== socket) return;
-		pushLog(
-			transport,
-			"error",
-			`WebSocket error while connecting to ${formatWsEndpoint(transport.currentUrl)}. Check host-service or relay connectivity.`,
-		);
+		if (transport._terminated) return;
+		// Below the diagnosis threshold, surface the transient error; past it the
+		// header diagnosis already conveys "offline", so stop logging an identical
+		// error every retry cycle. A hidden window stays quiet.
+		if (
+			!isWindowHidden() &&
+			(transport._socket?.retryCount ?? 0) < DIAGNOSE_AFTER_ATTEMPTS
+		) {
+			pushLog(
+				transport,
+				"error",
+				`WebSocket error while connecting to ${formatWsEndpoint(transport.currentUrl)}. Check host-service or relay connectivity.`,
+			);
+		}
+		// Dial failures (host unreachable, upgrade rejected) surface ONLY as error
+		// + a synthetic close, so drive the diagnosis from here too.
+		maybeSurfaceDiagnosis(transport, null);
 	});
 
-	transport.onDataDisposable?.dispose();
-	transport.onDataDisposable = terminal.onData((data) => {
-		if (socket.readyState !== WebSocket.OPEN) return;
+	transport._onDataDisposable?.dispose();
+	transport._onDataDisposable = terminal.onData((data) => {
 		if (transport.connectionState !== "open") return;
+		if (socket.readyState !== WebSocket.OPEN) return;
 		socket.send(JSON.stringify({ type: "input", data }));
 	});
 }
 
+/**
+ * Manually re-dial after the transport stopped trying (access denied, fatal
+ * server error, PTY exit) or to force an immediate reconnect. Clears the
+ * terminated flag and resets the attempt budget.
+ */
+export function reconnect(transport: TerminalTransport) {
+	if (!transport._socket || !transport.currentUrl) return;
+	transport._terminated = false;
+	transport._diagnosisLogged = false;
+	transport.lastDiagnosis = null;
+	setConnectionState(transport, "connecting");
+	// reconnect() also resets partysocket's retryCount → fresh diagnosis budget.
+	transport._socket.reconnect();
+}
+
 export function disconnect(transport: TerminalTransport) {
-	cancelReconnect(transport);
 	teardownLiveness(transport);
-	if (transport.socket) {
-		transport.socket.close();
-		transport.socket = null;
+	if (transport._socket) {
+		transport._socket.close();
+		transport._socket = null;
 	}
+	transport._onDataDisposable?.dispose();
+	transport._onDataDisposable = null;
 	transport._writeCoalescer?.dispose();
 	transport._writeCoalescer = null;
 	transport.currentUrl = null;
 	transport._terminal = null;
-	transport._reconnectAttempt = 0;
+	transport._diagnosisLogged = false;
+	transport._terminated = false;
 	transport.lastDiagnosis = null;
 	setTerminalTitle(transport, undefined);
 	setConnectionState(transport, "disconnected");
-	transport.onDataDisposable?.dispose();
-	transport.onDataDisposable = null;
 }
 
 export function sendResize(
@@ -643,41 +670,41 @@ export function sendResize(
 	cols: number,
 	rows: number,
 ) {
-	if (!transport.socket || transport.socket.readyState !== WebSocket.OPEN)
-		return;
+	const socket = transport._socket;
+	if (!socket || socket.readyState !== WebSocket.OPEN) return;
 	if (transport.connectionState !== "open") return;
-	transport.socket.send(JSON.stringify({ type: "resize", cols, rows }));
+	socket.send(JSON.stringify({ type: "resize", cols, rows }));
 }
 
 export function sendInput(transport: TerminalTransport, data: string) {
-	if (!transport.socket || transport.socket.readyState !== WebSocket.OPEN)
-		return;
+	const socket = transport._socket;
+	if (!socket || socket.readyState !== WebSocket.OPEN) return;
 	if (transport.connectionState !== "open") return;
-	transport.socket.send(JSON.stringify({ type: "input", data }));
+	socket.send(JSON.stringify({ type: "input", data }));
 }
 
 export function sendDispose(transport: TerminalTransport) {
-	if (transport.socket?.readyState === WebSocket.OPEN) {
-		transport.socket.send(JSON.stringify({ type: "dispose" }));
+	if (transport._socket?.readyState === WebSocket.OPEN) {
+		transport._socket.send(JSON.stringify({ type: "dispose" }));
 	}
 }
 
 export function disposeTransport(transport: TerminalTransport) {
-	cancelReconnect(transport);
 	teardownLiveness(transport);
-	if (transport.socket) {
-		transport.socket.close();
-		transport.socket = null;
+	if (transport._socket) {
+		transport._socket.close();
+		transport._socket = null;
 	}
+	transport._onDataDisposable?.dispose();
+	transport._onDataDisposable = null;
 	transport._writeCoalescer?.dispose();
 	transport._writeCoalescer = null;
 	transport.currentUrl = null;
 	transport._terminal = null;
-	transport._reconnectAttempt = 0;
+	transport._diagnosisLogged = false;
+	transport._terminated = false;
 	transport.lastDiagnosis = null;
 	setTerminalTitle(transport, undefined);
-	transport.onDataDisposable?.dispose();
-	transport.onDataDisposable = null;
 	transport.stateListeners.clear();
 	if (transport._titleNotifyTimer !== null) {
 		clearTimeout(transport._titleNotifyTimer);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -511,6 +511,8 @@ function attachSocketListeners(
 	socket: RelaySocket,
 ): void {
 	socket.addEventListener("message", (event) => {
+		// Ignore events from a socket we've detached (teardown nulls _socket).
+		if (transport._socket !== socket) return;
 		const data = (event as { data: unknown }).data;
 
 		// Binary frame = PTY output bytes (data + replay collapsed onto one
@@ -576,6 +578,9 @@ function attachSocketListeners(
 	});
 
 	socket.addEventListener("close", (event) => {
+		// Ignore a late close from a socket we've detached, so it can't overwrite
+		// the "disconnected" state or mutate logs after teardown.
+		if (transport._socket !== socket) return;
 		const closeEvent = event as { code?: unknown; reason?: unknown };
 		// Render whatever arrived before the close instead of holding it for a
 		// frame that may never come (e.g. hidden window).
@@ -604,6 +609,7 @@ function attachSocketListeners(
 	});
 
 	socket.addEventListener("error", () => {
+		if (transport._socket !== socket) return;
 		if (transport._terminated) return;
 		// Below the diagnosis threshold, surface the transient error; past it the
 		// header diagnosis already conveys "offline", so stop logging an identical

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
@@ -69,11 +69,17 @@ export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 	// that preceded the successful dial.
 	const failuresSoFar = () => (socket?.retryCount ?? 0) + 1;
 
+	// Per-dial epoch so a slow preflight from a superseded dial (URL swap,
+	// reconnect) can't publish its probe after a newer dial has started —
+	// otherwise a stale probe could make the diagnosis describe the prior endpoint.
+	let probeEpoch = 0;
+
 	const provider = async (): Promise<string> => {
+		const epoch = ++probeEpoch;
 		const url = signUrl(await opts.buildUrl(), await opts.getToken());
 		const probe = await primeRelayAffinity(url);
 		reporter.attempt(url, probe);
-		opts.onProbe?.(probe);
+		if (epoch === probeEpoch) opts.onProbe?.(probe);
 		if (probe?.status === 403) {
 			reporter.accessDenied(failuresSoFar());
 			opts.onAccessDenied?.();

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
@@ -1,5 +1,8 @@
 import { WebSocket as ReconnectingWebSocket } from "partysocket";
-import { primeRelayAffinity } from "../primeRelayAffinity";
+import {
+	primeRelayAffinity,
+	type RelayAffinityProbe,
+} from "../primeRelayAffinity";
 import { createOutageReporter } from "./outageReporter";
 
 export interface RelaySocketOptions {
@@ -19,6 +22,13 @@ export interface RelaySocketOptions {
 	onAccessDenied?: () => void;
 	/** Keep re-probing at this cadence after a 403 instead of closing. */
 	accessDeniedRetryMs?: number;
+	/**
+	 * Called with the `_whoowns` preflight result before every WS attempt (null
+	 * when the URL isn't relay-routed or the relay is unreachable). Lets callers
+	 * surface *why* a stream is down — host offline (503), unauthorized (401),
+	 * relay routing (502/200) — which the WS upgrade status otherwise hides.
+	 */
+	onProbe?: (probe: RelayAffinityProbe | null) => void;
 	minReconnectionDelay?: number;
 	maxReconnectionDelay?: number;
 	maxRetries?: number;
@@ -63,6 +73,7 @@ export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 		const url = signUrl(await opts.buildUrl(), await opts.getToken());
 		const probe = await primeRelayAffinity(url);
 		reporter.attempt(url, probe);
+		opts.onProbe?.(probe);
 		if (probe?.status === 403) {
 			reporter.accessDenied(failuresSoFar());
 			opts.onAccessDenied?.();


### PR DESCRIPTION
## Summary
- Rebuild the desktop terminal WebSocket transport on `createRelaySocket` (partysocket) — the same shared reconnecting socket the events channel and web terminal use — so it **retries forever** instead of giving up after ~66s, gets the fly-affinity preflight, and re-signs a fresh token per dial.
- Fixes the reported bug: **after laptop sleep/wake, a remote workspace terminal fails to reconnect** and sits "offline" until an incidental window focus/visibility event.
- Adds an additive `onProbe` hook to `packages/workspace-client` so the transport can classify *why* a stream is down (host-offline / unauthorized / relay-routing).

## Why / Context
The desktop terminal was the **one relay socket still hand-rolled** on a raw `WebSocket` with a 10-attempt (~66s) give-up. On a shared sleep/wake, the host-service can take longer than that window to re-register its relay tunnel (its inbound-silence watchdog alone is ~75s), so the client gave up *right before* the host returned and never retried on its own. PostHog `terminal_connect_failed` confirmed the pattern: 100% of these failures exhausted all attempts (host-offline bucket: 624 events / 31 users / 30 days).

## How It Works
- **Transport → `createRelaySocket`.** Reconnection, backoff, preflight affinity, and per-dial token signing move into the shared socket (partysocket, forever-retry). The transport keeps the pieces partysocket doesn't model: the **wall-clock liveness watchdog** (the dependable sleep/wake signal — app-suspend doesn't reliably fire focus/visibility), the **write coalescer**, `replay=0` after first bytes, and terminated-on-exit/error.
- **Diagnosis off `retryCount`, not close-counting.** partysocket delivers dial failures (host unreachable, upgrade rejected) as an `error` + a *synthetic* close whose code is the string `"close"`. Counting close codes misses those, so a genuinely-offline terminal would retry silently. The offline diagnosis is now driven by partysocket's authoritative `retryCount` (resets after a stable connection), surfaced after 10 consecutive failures — matching the events channel's `relaySocket.ts`.
- **Focus gate on the diagnosis, not the retries.** A hidden/minimized window keeps retrying (background agents stay live and reattach), but doesn't accrue a spurious "offline" header. On resume, the focus/visibility/online listener force-redials and resets the budget.
- **`onProbe` hook** surfaces the existing `_whoowns` preflight result to the caller (previously only 403 leaked out via `onAccessDenied`). No new network calls, no protocol change.

## Manual QA — verified live over CDP (dev desktop)
- [x] Two real terminals connect end-to-end via `createRelaySocket` → `connectionState: "open"` (new code confirmed live: `_diagnosisLogged` present, old `_reconnectAttempt` gone)
- [x] Injected a dead-host failure → `retryCount` climbs 10 → 11 → 12 (**forever-retry**, never self-closes)
- [x] **Dial-failure diagnosis surfaces** at `retryCount ≥ 10` (was the silent-failure bug) and keeps retrying
- [x] Repoint to the real host → recovers to `"open"` in ~1.6s, diagnosis cleared
- [x] Terminal streams PTY output / attach / resize intact

## Testing
- `bun run typecheck` — 35/35 packages ✅
- `bun run lint` — clean ✅
- `bunx sherif` — no issues ✅
- `bun test apps/desktop/.../terminal-ws-transport.test.ts` — 14/14; the new guards (forever-retry, retryCount threshold, **dial-failure diagnosis**, hidden-window gate, wall-clock watchdog) are each **mutation-verified** (fail on the broken code)
- `bun test packages/workspace-client/src` — 20/20 ✅

## Design Decisions
- **Full migration (option A) over a slow-poll patch (option B):** deletes the hand-rolled reconnect loop entirely and inherits forever-retry + preflight from the shared socket, killing the whole bug class rather than the one instance.
- **`retryCount` over close-counting:** robust to partysocket's synthetic-close/error double-fire on dial failures (same lesson as `relaySocket.ts`). Caught by the live CDP run, not the unit tests — the fake initially dispatched numeric closes.
- **Kept retrying while hidden:** desktop backgrounds windows while agents run; pausing retries would delay reattach. Only the *diagnosis* is gated on visibility.

## Known Limitations / Follow-ups
- **Web terminal** (`apps/web`) shares the give-up-at-12 shape but is an unused surface (desktop is the real one) — left for a parity pass.
- **ACP `subscribeToSession`** lacks the affinity preflight — separate, deferred.
- **401/unauthorized give-up storm** (larger bucket in telemetry) is a token-refresh-on-wake issue — separate investigation.

## Risks / Rollout
- **Blast radius:** desktop + web only. No server/hosted service consumes `@superset/workspace-client` (confirmed: relay, api, host-service, electric-proxy, mobile, marketing, admin, docs = 0). No server code, endpoint, or protocol change.
- **Risk:** the one server-facing effect is a **load-pattern** change — a client stuck against an offline host now hits the relay's `_whoowns` + WS upgrade every ≤10s indefinitely (per open terminal) instead of giving up. Bounded by the 10s backoff cap and identical to the pattern the events channel already sustains in prod; not a Vercel-auth-storm class. If relay metrics ever flag it, we can pause retries (not just the diagnosis) while hidden.
- **Rollback:** revert the two commits; no data or schema involved.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the desktop terminal to the shared `createRelaySocket` with forever-retry, fresh token per dial, and preflight affinity to fix sleep/wake reconnects and provide clear, thresholded offline diagnosis. Added a `reconnect()` path and guarded late socket events so manual retries and teardown behave correctly.

- **Bug Fixes**
  - Replaced the hand-rolled WebSocket with `createRelaySocket` for indefinite retries and parity with events/web terminal.
  - Drove outage diagnosis off `retryCount` after 10 consecutive failures; keeps retrying and logs once.
  - Keeps retrying while hidden but suppresses the “offline” banner until focus/visibility returns.
  - Wall-clock watchdog forces reconnect after sleep/wake gaps.
  - Preserves write coalescing, `replay=0` after first bytes, and termination on PTY exit/fatal attach.
  - Exposed `reconnect()` (used in the desktop registry) and guarded late events from detached sockets to prevent state/log flips after disconnect/teardown.
  - Hardened tests by stubbing only `createRelaySocket` in `@superset/workspace-client/relay-socket` while preserving other exports; added regressions for never-open dial failures and teardown event handling.

- **New Features**
  - `@superset/workspace-client/relay-socket`: added `onProbe` to expose relay `_whoowns` preflight results for better outage classification (host offline/unauthorized/routing), with an epoch guard to avoid publishing stale probes after URL swaps or reconnects.

<sup>Written for commit 53ffa82c2ae13e6cc0ae3cac2c99167cf669f117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal reconnection across temporary outages, sleep/wake gaps, and stalled connections.
  - Prevented unnecessary reconnect/teardown when tokens rotate.
  - Ensured queued terminal output flushes correctly on close.
  - Reworked relay-driven close/error handling to avoid state resurrection from late events.

- **Improvements**
  - Enhanced “connection outage” diagnosis: logged once per outage cycle and suppressed while the app is hidden.

- **Tests**
  - Updated terminal transport tests to use a deterministic relay-socket simulation and expanded reconnect/diagnosis coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->