### PR TITLE
refactor(desktop): remove refresh button from v2 changes sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
@@ -20,7 +20,7 @@ export function SidebarHeader({
 
 	return (
 		<div className="flex h-10 shrink-0 items-stretch border-b border-border">
-			<div className="flex min-w-0 items-center h-full overflow-hidden">
+			<div className="flex min-w-0 flex-1 items-center h-full overflow-hidden">
 				{tabs.map((tab) => {
 					const isActive = activeTab === tab.id;
 					const badge =
@@ -39,7 +39,7 @@ export function SidebarHeader({
 									isActive,
 									compact,
 								}),
-								"relative",
+								"relative flex-1 justify-center",
 							)}
 						>
 							{tab.icon && <tab.icon className="size-3" />}
@@ -74,7 +74,6 @@ export function SidebarHeader({
 					return btn;
 				})}
 			</div>
-			<div className="flex-1" />
 			{actions && (
 				<div className="flex shrink-0 items-center h-10 pr-2 gap-0.5">
 					{actions}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -1,10 +1,6 @@
-import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { RefreshCw } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { useChangeset } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
 import { useSidebarDiffRef } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useSidebarDiffRef";
@@ -149,47 +145,6 @@ export function useChangesTab({
 	const totalAdditions = files.reduce((sum, f) => sum + f.additions, 0);
 	const totalDeletions = files.reduce((sum, f) => sum + f.deletions, 0);
 
-	const [isRefreshing, setIsRefreshing] = useState(false);
-	const handleRefresh = useCallback(async () => {
-		if (isRefreshing) return;
-		setIsRefreshing(true);
-		try {
-			await Promise.all([
-				utils.git.getStatus.invalidate({ workspaceId }),
-				utils.git.getDiff.invalidate({ workspaceId }),
-				utils.git.listCommits.invalidate({ workspaceId }),
-				utils.git.listBranches.invalidate({ workspaceId }),
-				utils.git.getBaseBranch.invalidate({ workspaceId }),
-			]);
-		} catch (error) {
-			console.warn("Failed to refresh changes tab", error);
-			toast.error(
-				error instanceof Error ? error.message : "Failed to refresh changes",
-			);
-		} finally {
-			setIsRefreshing(false);
-		}
-	}, [utils, workspaceId, isRefreshing]);
-
-	const actions = (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<Button
-					variant="ghost"
-					size="icon"
-					className="size-6"
-					onClick={() => void handleRefresh()}
-					disabled={isRefreshing}
-				>
-					<RefreshCw
-						className={cn("size-3.5", isRefreshing && "animate-spin")}
-					/>
-				</Button>
-			</TooltipTrigger>
-			<TooltipContent side="bottom">Refresh changes</TooltipContent>
-		</Tooltip>
-	);
-
 	const content = (
 		<ChangesTabContent
 			workspaceId={workspaceId}
@@ -221,7 +176,6 @@ export function useChangesTab({
 		id: "changes",
 		label: "Changes",
 		badge: totalChanges > 0 ? totalChanges : undefined,
-		actions,
 		content,
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -16,12 +16,11 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import {
 	VscCheck,
 	VscGitStash,
 	VscGitStashApply,
-	VscRefresh,
 	VscSourceControl,
 } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -200,45 +199,6 @@ function StashDropdown({
 	);
 }
 
-function RefreshButton({ onRefresh }: { onRefresh: () => void }) {
-	const [isSpinning, setIsSpinning] = useState(false);
-	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-	const handleClick = () => {
-		setIsSpinning(true);
-		onRefresh();
-		if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		timeoutRef.current = setTimeout(() => setIsSpinning(false), 600);
-	};
-
-	useEffect(() => {
-		return () => {
-			if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		};
-	}, []);
-
-	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<Button
-					variant="ghost"
-					size="icon"
-					onClick={handleClick}
-					disabled={isSpinning}
-					className="size-6 p-0"
-				>
-					<VscRefresh
-						className={`size-3.5 ${isSpinning ? "animate-spin" : ""}`}
-					/>
-				</Button>
-			</TooltipTrigger>
-			<TooltipContent side="top" showArrow={false}>
-				Refresh changes
-			</TooltipContent>
-		</Tooltip>
-	);
-}
-
 export function ChangesHeader({
 	onRefresh,
 	viewMode,
@@ -269,7 +229,6 @@ export function ChangesHeader({
 					onViewModeChange={onViewModeChange}
 				/>
 			)}
-			<RefreshButton onRefresh={onRefresh} />
 			<PRButton
 				pr={pr}
 				isLoading={isPRStatusLoading}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -16,11 +16,12 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
 	VscCheck,
 	VscGitStash,
 	VscGitStashApply,
+	VscRefresh,
 	VscSourceControl,
 } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -199,6 +200,45 @@ function StashDropdown({
 	);
 }
 
+function RefreshButton({ onRefresh }: { onRefresh: () => void }) {
+	const [isSpinning, setIsSpinning] = useState(false);
+	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+	const handleClick = () => {
+		setIsSpinning(true);
+		onRefresh();
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		timeoutRef.current = setTimeout(() => setIsSpinning(false), 600);
+	};
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		};
+	}, []);
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={handleClick}
+					disabled={isSpinning}
+					className="size-6 p-0"
+				>
+					<VscRefresh
+						className={`size-3.5 ${isSpinning ? "animate-spin" : ""}`}
+					/>
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="top" showArrow={false}>
+				Refresh changes
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
 export function ChangesHeader({
 	onRefresh,
 	viewMode,
@@ -229,6 +269,7 @@ export function ChangesHeader({
 					onViewModeChange={onViewModeChange}
 				/>
 			)}
+			<RefreshButton onRefresh={onRefresh} />
 			<PRButton
 				pr={pr}
 				isLoading={isPRStatusLoading}


### PR DESCRIPTION
## Summary

Removes the manual **Refresh changes** button from the v2 workspace sidebar's Changes tab header. The changes pane already refreshes automatically, so the button was redundant:

- **`git:changed` host-service subscription** — `useGitStatus` invalidates git status/diff on real filesystem-driven git changes (`useWorkspaceEvent("git:changed", ...)`)
- **refetch-on-window-focus** on the status/diff/commits queries

Removes the `actions` button block plus its `handleRefresh`/`isRefreshing` state from `useChangesTab`, and cleans up the now-unused imports (`Button`, `Tooltip*`, `cn`, `RefreshCw`, `useState`). The tab's `actions` field is optional, so the header simply renders nothing there now.

## Test Plan

- [x] `bun run lint` passes
- [x] `apps/desktop` typecheck passes
- [ ] Changes tab still updates automatically on file edits / branch switches without the button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the Changes sidebar tab by removing the refresh control.
  * Preserved existing change totals and content display.
* **UI Improvements**
  * Updated the sidebar header/tab layout for better spacing and overflow handling, including refined styling of tab button containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->