### PR TITLE
fix(host-service): scope default worktrees root to SUPERSET_WORKSPACE_NAME

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { defaultWorktreesRoot, safeResolveWorktreePath } from "./worktree-paths";
+
+const ORIGINAL_WORKSPACE_NAME = process.env.SUPERSET_WORKSPACE_NAME;
+
+afterEach(() => {
+	if (ORIGINAL_WORKSPACE_NAME === undefined) {
+		delete process.env.SUPERSET_WORKSPACE_NAME;
+	} else {
+		process.env.SUPERSET_WORKSPACE_NAME = ORIGINAL_WORKSPACE_NAME;
+	}
+});
+
+describe("defaultWorktreesRoot", () => {
+	test("defaults to ~/.superset/worktrees when no workspace name is set", () => {
+		delete process.env.SUPERSET_WORKSPACE_NAME;
+		expect(defaultWorktreesRoot()).toBe(
+			join(homedir(), ".superset", "worktrees"),
+		);
+	});
+
+	test("treats the production name 'superset' as unset", () => {
+		process.env.SUPERSET_WORKSPACE_NAME = "superset";
+		expect(defaultWorktreesRoot()).toBe(
+			join(homedir(), ".superset", "worktrees"),
+		);
+	});
+
+	test("isolates dev workspaces under ~/.superset-<workspace>/worktrees", () => {
+		process.env.SUPERSET_WORKSPACE_NAME = "michael/billowy-interest";
+		expect(defaultWorktreesRoot()).toBe(
+			join(homedir(), ".superset-michael-billowy-interest", "worktrees"),
+		);
+	});
+
+	test("sanitizes and truncates the workspace name like SUPERSET_DIR_NAME", () => {
+		process.env.SUPERSET_WORKSPACE_NAME =
+			"Team/Some_Very Long Workspace Name That Keeps Going";
+		expect(defaultWorktreesRoot()).toBe(
+			join(
+				homedir(),
+				".superset-team-some-very-long-workspace-na",
+				"worktrees",
+			),
+		);
+	});
+
+	test("falls back to .superset when the name sanitizes to nothing", () => {
+		process.env.SUPERSET_WORKSPACE_NAME = "   ";
+		expect(defaultWorktreesRoot()).toBe(
+			join(homedir(), ".superset", "worktrees"),
+		);
+	});
+});
+
+describe("safeResolveWorktreePath", () => {
+	test("resolves under the workspace-scoped default root", () => {
+		process.env.SUPERSET_WORKSPACE_NAME = "michael/billowy-interest";
+		expect(safeResolveWorktreePath("project-id", "my-branch")).toBe(
+			join(
+				homedir(),
+				".superset-michael-billowy-interest",
+				"worktrees",
+				"project-id",
+				"my-branch",
+			),
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/worktree-paths.ts
@@ -2,10 +2,24 @@ import { homedir } from "node:os";
 import { isAbsolute, join, normalize, resolve, sep } from "node:path";
 import { TRPCError } from "@trpc/server";
 
+// Dev instances run under a SUPERSET_WORKSPACE_NAME (written to the worktree
+// .env by .superset/setup.local.sh) and must not share the production app's
+// ~/.superset/worktrees. Mirrors SUPERSET_DIR_NAME in the desktop app's
+// shared/constants.ts, which the v1 resolver used for the same default.
+function supersetDirName(): string {
+	const workspace = process.env.SUPERSET_WORKSPACE_NAME?.trim();
+	if (!workspace || workspace === "superset") return ".superset";
+	const slug = workspace
+		.toLowerCase()
+		.replace(/[^a-z0-9-]/g, "-")
+		.slice(0, 32);
+	return slug ? `.superset-${slug}` : ".superset";
+}
+
 // Kept outside the primary checkout so editors, file watchers, and
 // ignore rules treat worktrees as separate trees, not nested ones.
 export function defaultWorktreesRoot(): string {
-	return join(homedir(), ".superset", "worktrees");
+	return join(homedir(), supersetDirName(), "worktrees");
 }
 
 export function normalizeWorktreeBaseDir(


### PR DESCRIPTION
## Problem

Dev instances of the desktop app (`.superset/setup.local.sh` writes `SUPERSET_WORKSPACE_NAME` and `SUPERSET_HOME_DIR` into the worktree `.env`) are otherwise fully isolated — own host-service, own host.db, own pty daemon — but **create their worktrees in the production app's `~/.superset/worktrees`**, because `defaultWorktreesRoot()` hard-codes that path.

The v1 resolver (`apps/desktop` `resolve-worktree-path.ts`) already scoped this default via `SUPERSET_DIR_NAME` (`~/.superset-<workspace>`); the v2 host-service path lost that isolation.

## Fix

Derive the directory name from `SUPERSET_WORKSPACE_NAME` in `defaultWorktreesRoot()`, using the same sanitization as `SUPERSET_DIR_NAME` in `apps/desktop/src/shared/constants.ts`:

- dev workspace `michael/billowy-interest` → `~/.superset-michael-billowy-interest/worktrees`
- unset or `superset` (production) → `~/.superset/worktrees` (unchanged)

No coordinator or setup-script changes needed: the coordinator already spreads `process.env` into the host-service child, and `setup.local.sh` already writes `SUPERSET_WORKSPACE_NAME` to the worktree `.env`. Explicit host-level and project-level `worktree_base_dir` settings still take precedence over the default.

## Testing

- New unit tests for `defaultWorktreesRoot()` (unset / `superset` / dev workspace / sanitization+truncation / whitespace-only) and `safeResolveWorktreePath()` under a scoped root.
- `bun test` + `tsc --noEmit` clean in `packages/host-service`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5707">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev instances writing worktrees into the production `~/.superset/worktrees`. The default root now scopes to the workspace using `SUPERSET_WORKSPACE_NAME` so dev and prod stay isolated.

- **Bug Fixes**
  - Scope default root to a sanitized, 32-char slug of `SUPERSET_WORKSPACE_NAME` (mirrors desktop `SUPERSET_DIR_NAME`), e.g., `~/.superset-michael-billowy-interest/worktrees`.
  - Preserve production behavior: fallback to `~/.superset/worktrees` when unset or `superset`, and respect explicit `worktree_base_dir`. Added unit tests for `defaultWorktreesRoot()` and `safeResolveWorktreePath()`.

<sup>Written for commit f6fe3e4dcc5792eb27882300755805381e1f1dca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktree storage now supports workspace-specific directories.
  * Workspace names are safely normalized and limited in length for consistent filesystem paths.
  * Default behavior remains unchanged for production or unspecified workspace names.

* **Bug Fixes**
  * Added safer fallback handling when a workspace name cannot produce a valid directory name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->