### PR TITLE
fix(desktop): keep external hash navigation in sync

### DIFF
--- a/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts
+++ b/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts
@@ -23,13 +23,28 @@ const mockLocalStorage = {
 
 // Mock window.history.replaceState
 const mockReplaceState = mock(
-	(_state: unknown, _unused: string, _url?: string | URL | null) => {},
+	(_state: unknown, _unused: string, url?: string | URL | null) => {
+		if (typeof url !== "string") return;
+		const hashIndex = url.indexOf("#");
+		window.location.hash = hashIndex >= 0 ? url.slice(hashIndex) : "";
+	},
 );
 const hashChangeListeners = new Set<EventListener>();
+const currentEntryChangeListeners = new Set<EventListener>();
 
 function dispatchHashChange() {
 	for (const listener of hashChangeListeners) {
 		listener(new Event("hashchange"));
+	}
+}
+
+function dispatchCurrentEntryChange(navigationType: NavigationType) {
+	const event = new Event(
+		"currententrychange",
+	) as NavigationCurrentEntryChangeEvent;
+	Object.defineProperty(event, "navigationType", { value: navigationType });
+	for (const listener of currentEntryChangeListeners) {
+		listener(event);
 	}
 }
 
@@ -64,6 +79,18 @@ Object.defineProperty(globalThis, "window", {
 		removeEventListener: mock((type: string, listener: EventListener) => {
 			if (type === "hashchange") hashChangeListeners.delete(listener);
 		}),
+		navigation: {
+			addEventListener: mock((type: string, listener: EventListener) => {
+				if (type === "currententrychange") {
+					currentEntryChangeListeners.add(listener);
+				}
+			}),
+			removeEventListener: mock((type: string, listener: EventListener) => {
+				if (type === "currententrychange") {
+					currentEntryChangeListeners.delete(listener);
+				}
+			}),
+		},
 	},
 	writable: true,
 	configurable: true,
@@ -79,6 +106,7 @@ beforeEach(() => {
 	storage.clear();
 	mockReplaceState.mockClear();
 	hashChangeListeners.clear();
+	currentEntryChangeListeners.clear();
 	window.location.hash = "#/";
 });
 
@@ -225,7 +253,7 @@ describe("createPersistentHashHistory", () => {
 			history.subscribe(({ action }) => actions.push(action.type));
 
 			window.location.hash = "#/v2-workspace/workspace-b";
-			dispatchHashChange();
+			dispatchCurrentEntryChange("push");
 
 			expect(history.location.pathname).toBe("/v2-workspace/workspace-b");
 			expect(actions).toEqual(["PUSH"]);
@@ -234,13 +262,13 @@ describe("createPersistentHashHistory", () => {
 				index: 1,
 			});
 
-			dispatchHashChange();
+			dispatchCurrentEntryChange("push");
 			expect(history.length).toBe(2);
 			expect(actions).toEqual(["PUSH"]);
 
 			history.destroy();
 			window.location.hash = "#/v2-workspace/workspace-c";
-			dispatchHashChange();
+			dispatchCurrentEntryChange("push");
 			expect(history.location.pathname).toBe("/v2-workspace/workspace-b");
 		});
 
@@ -253,7 +281,7 @@ describe("createPersistentHashHistory", () => {
 			actions.length = 0;
 
 			window.location.hash = "#/a";
-			dispatchHashChange();
+			dispatchCurrentEntryChange("traverse");
 			expect(history.location.pathname).toBe("/a");
 			expect(history.length).toBe(3);
 			expect(actions).toEqual(["BACK"]);
@@ -263,7 +291,7 @@ describe("createPersistentHashHistory", () => {
 			});
 
 			window.location.hash = "#/b";
-			dispatchHashChange();
+			dispatchCurrentEntryChange("traverse");
 			expect(history.location.pathname).toBe("/b");
 			expect(history.length).toBe(3);
 			expect(actions).toEqual(["BACK", "FORWARD"]);
@@ -271,6 +299,80 @@ describe("createPersistentHashHistory", () => {
 				entries: ["/", "/a", "/b"],
 				index: 2,
 			});
+		});
+
+		it("preserves the stack for non-adjacent traversal", () => {
+			const history = createPersistentHashHistory();
+			const actions: string[] = [];
+			history.subscribe(({ action }) => actions.push(action.type));
+			history.push("/a");
+			history.push("/b");
+			history.push("/c");
+			history.push("/d");
+			actions.length = 0;
+
+			window.location.hash = "#/a";
+			dispatchCurrentEntryChange("traverse");
+			expect(history.location.pathname).toBe("/a");
+			expect(history.length).toBe(5);
+			expect(actions).toEqual(["GO"]);
+			expect(JSON.parse(storage.get("router-history") ?? "{}")).toMatchObject({
+				entries: ["/", "/a", "/b", "/c", "/d"],
+				index: 1,
+			});
+
+			window.location.hash = "#/d";
+			dispatchCurrentEntryChange("traverse");
+			expect(history.location.pathname).toBe("/d");
+			expect(history.length).toBe(5);
+			expect(actions).toEqual(["GO", "GO"]);
+			expect(JSON.parse(storage.get("router-history") ?? "{}")).toMatchObject({
+				entries: ["/", "/a", "/b", "/c", "/d"],
+				index: 4,
+			});
+		});
+
+		it("observes pushState and replaceState through the Navigation API", () => {
+			const history = createPersistentHashHistory();
+			const actions: string[] = [];
+			history.subscribe(({ action }) => actions.push(action.type));
+
+			window.location.hash = "#/pushed";
+			dispatchCurrentEntryChange("push");
+			window.location.hash = "#/replaced";
+			dispatchCurrentEntryChange("replace");
+
+			expect(history.location.pathname).toBe("/replaced");
+			expect(history.length).toBe(2);
+			expect(actions).toEqual(["PUSH", "REPLACE"]);
+			expect(JSON.parse(storage.get("router-history") ?? "{}")).toMatchObject({
+				entries: ["/", "/replaced"],
+				index: 1,
+			});
+		});
+
+		it("falls back to hashchange when the Navigation API is unavailable", () => {
+			const originalNavigation = window.navigation;
+			Object.defineProperty(window, "navigation", {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			});
+
+			try {
+				const history = createPersistentHashHistory();
+				expect(hashChangeListeners.size).toBe(1);
+				window.location.hash = "#/fallback";
+				dispatchHashChange();
+				expect(history.location.pathname).toBe("/fallback");
+				history.destroy();
+			} finally {
+				Object.defineProperty(window, "navigation", {
+					value: originalNavigation,
+					writable: true,
+					configurable: true,
+				});
+			}
 		});
 
 		it("keeps the router synchronized when a blocker is registered", async () => {
@@ -287,7 +389,7 @@ describe("createPersistentHashHistory", () => {
 				history.block({ blockerFn });
 
 				window.location.hash = "#/v2-workspace/workspace-b";
-				dispatchHashChange();
+				dispatchCurrentEntryChange("push");
 				await Promise.resolve();
 
 				expect(history.location.pathname).toBe("/v2-workspace/workspace-b");
@@ -338,6 +440,46 @@ describe("createPersistentHashHistory", () => {
 			const history = createPersistentHashHistory();
 			expect(history.length).toBe(3);
 			expect(history.location.pathname).toBe("/tasks");
+		});
+
+		it("uses a specific initial hash as a deep link", () => {
+			storage.set(
+				"router-history",
+				JSON.stringify({
+					entries: ["/", "/previous", "/forward"],
+					index: 1,
+				}),
+			);
+			window.location.hash = "#/v2-workspace/deep-linked";
+
+			const history = createPersistentHashHistory();
+
+			expect(window.location.hash).toBe("#/v2-workspace/deep-linked");
+			expect(history.location.pathname).toBe("/v2-workspace/deep-linked");
+			expect(JSON.parse(storage.get("router-history") ?? "{}")).toMatchObject({
+				entries: ["/", "/previous", "/v2-workspace/deep-linked"],
+				index: 2,
+			});
+		});
+
+		it("restores an existing deep-linked entry without duplicating it", () => {
+			storage.set(
+				"router-history",
+				JSON.stringify({
+					entries: ["/", "/a", "/b", "/c"],
+					index: 3,
+				}),
+			);
+			window.location.hash = "#/a";
+
+			const history = createPersistentHashHistory();
+
+			expect(history.location.pathname).toBe("/a");
+			expect(history.length).toBe(4);
+			expect(JSON.parse(storage.get("router-history") ?? "{}")).toMatchObject({
+				entries: ["/", "/a", "/b", "/c"],
+				index: 1,
+			});
 		});
 
 		it("falls back to / when localStorage is empty", () => {

--- a/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts
+++ b/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts
@@ -25,6 +25,13 @@ const mockLocalStorage = {
 const mockReplaceState = mock(
 	(_state: unknown, _unused: string, _url?: string | URL | null) => {},
 );
+const hashChangeListeners = new Set<EventListener>();
+
+function dispatchHashChange() {
+	for (const listener of hashChangeListeners) {
+		listener(new Event("hashchange"));
+	}
+}
 
 // Set up globals BEFORE importing the module (the singleton runs at import time).
 // The originals MUST be restored afterAll: later test files in the same process
@@ -49,20 +56,30 @@ Object.defineProperty(globalThis, "window", {
 		location: {
 			pathname: "/",
 			search: "",
+			hash: "#/",
 		},
+		addEventListener: mock((type: string, listener: EventListener) => {
+			if (type === "hashchange") hashChangeListeners.add(listener);
+		}),
+		removeEventListener: mock((type: string, listener: EventListener) => {
+			if (type === "hashchange") hashChangeListeners.delete(listener);
+		}),
 	},
 	writable: true,
 	configurable: true,
 });
 
 // Now safe to import — the module-level singleton will find window/localStorage
-const { createPersistentHashHistory } = await import(
+const { createPersistentHashHistory, persistentHistory } = await import(
 	"./persistent-hash-history"
 );
+persistentHistory.destroy();
 
 beforeEach(() => {
 	storage.clear();
 	mockReplaceState.mockClear();
+	hashChangeListeners.clear();
+	window.location.hash = "#/";
 });
 
 afterEach(() => {
@@ -198,6 +215,90 @@ describe("createPersistentHashHistory", () => {
 			history.replace("/b");
 			expect(history.location.pathname).toBe("/b");
 			expect(history.length).toBe(2); // "/" and "/b"
+		});
+	});
+
+	describe("external hash navigation", () => {
+		it("updates subscribers and persistent history when the URL hash changes outside the router", () => {
+			const history = createPersistentHashHistory();
+			const actions: string[] = [];
+			history.subscribe(({ action }) => actions.push(action.type));
+
+			window.location.hash = "#/v2-workspace/workspace-b";
+			dispatchHashChange();
+
+			expect(history.location.pathname).toBe("/v2-workspace/workspace-b");
+			expect(actions).toEqual(["PUSH"]);
+			expect(JSON.parse(storage.get("router-history") ?? "{}")).toMatchObject({
+				entries: ["/", "/v2-workspace/workspace-b"],
+				index: 1,
+			});
+
+			dispatchHashChange();
+			expect(history.length).toBe(2);
+			expect(actions).toEqual(["PUSH"]);
+
+			history.destroy();
+			window.location.hash = "#/v2-workspace/workspace-c";
+			dispatchHashChange();
+			expect(history.location.pathname).toBe("/v2-workspace/workspace-b");
+		});
+
+		it("preserves the existing stack for external back and forward navigation", () => {
+			const history = createPersistentHashHistory();
+			const actions: string[] = [];
+			history.subscribe(({ action }) => actions.push(action.type));
+			history.push("/a");
+			history.push("/b");
+			actions.length = 0;
+
+			window.location.hash = "#/a";
+			dispatchHashChange();
+			expect(history.location.pathname).toBe("/a");
+			expect(history.length).toBe(3);
+			expect(actions).toEqual(["BACK"]);
+			expect(JSON.parse(storage.get("router-history") ?? "{}")).toMatchObject({
+				entries: ["/", "/a", "/b"],
+				index: 1,
+			});
+
+			window.location.hash = "#/b";
+			dispatchHashChange();
+			expect(history.location.pathname).toBe("/b");
+			expect(history.length).toBe(3);
+			expect(actions).toEqual(["BACK", "FORWARD"]);
+			expect(JSON.parse(storage.get("router-history") ?? "{}")).toMatchObject({
+				entries: ["/", "/a", "/b"],
+				index: 2,
+			});
+		});
+
+		it("keeps the router synchronized when a blocker is registered", async () => {
+			const originalDocument = globalThis.document;
+			Object.defineProperty(globalThis, "document", {
+				value: {},
+				writable: true,
+				configurable: true,
+			});
+
+			try {
+				const history = createPersistentHashHistory();
+				const blockerFn = mock(() => true);
+				history.block({ blockerFn });
+
+				window.location.hash = "#/v2-workspace/workspace-b";
+				dispatchHashChange();
+				await Promise.resolve();
+
+				expect(history.location.pathname).toBe("/v2-workspace/workspace-b");
+				expect(blockerFn).not.toHaveBeenCalled();
+			} finally {
+				Object.defineProperty(globalThis, "document", {
+					value: originalDocument,
+					writable: true,
+					configurable: true,
+				});
+			}
 		});
 	});
 

--- a/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.ts
+++ b/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.ts
@@ -68,6 +68,33 @@ function getHashPath(): string {
 	return hash.startsWith("#") ? hash.slice(1) : hash;
 }
 
+function getInitialHashPath(): string | null {
+	const hash = window.location.hash;
+	// registerRoute bootstraps the app at #/ so persisted history can restore the
+	// last route. Any more specific initial hash is an intentional deep link.
+	if (!hash || hash === "#" || hash === "#/") return null;
+	return getHashPath();
+}
+
+function findNearestEntryIndex(
+	entries: string[],
+	currentIndex: number,
+	path: string,
+): number {
+	for (let distance = 1; distance < entries.length; distance++) {
+		const backwardIndex = currentIndex - distance;
+		if (backwardIndex >= 0 && entries[backwardIndex] === path) {
+			return backwardIndex;
+		}
+
+		const forwardIndex = currentIndex + distance;
+		if (forwardIndex < entries.length && entries[forwardIndex] === path) {
+			return forwardIndex;
+		}
+	}
+	return -1;
+}
+
 function createRandomKey(): string {
 	return (Math.random() + 1).toString(36).substring(7);
 }
@@ -117,11 +144,28 @@ export function createPersistentHashHistory(): PersistentHashHistory {
 	const persisted = loadPersistedState();
 
 	const entries: string[] = [...persisted.entries];
+	let index = persisted.index;
+	const initialHashPath = getInitialHashPath();
+	if (initialHashPath && initialHashPath !== entries[index]) {
+		const existingIndex = findNearestEntryIndex(
+			entries,
+			index,
+			initialHashPath,
+		);
+		if (existingIndex >= 0) {
+			index = existingIndex;
+		} else {
+			entries.splice(index + 1);
+			entries.push(initialHashPath);
+			index = entries.length - 1;
+		}
+		persistState(entries, index);
+	}
+
 	const timestamps: number[] = entries.map(() => Date.now());
 	const states: LocationState[] = entries.map((_entry, i) =>
 		assignKeyAndIndex(i),
 	);
-	let index = persisted.index;
 
 	const getLocation = () =>
 		parseHref(entries[index] ?? "/", states[index] ?? assignKeyAndIndex(index));
@@ -133,23 +177,44 @@ export function createPersistentHashHistory(): PersistentHashHistory {
 	syncHash(entries[index] ?? "/");
 
 	let history: RouterHistory;
-	const handleExternalHashChange = () => {
+	const synchronizeExternalNavigation = (
+		navigationType?: NavigationCurrentEntryChangeEvent["navigationType"],
+	) => {
 		const path = getHashPath();
 		if (path === (entries[index] ?? "/")) return;
 
 		// The browser URL has already changed, so a blocker cannot safely cancel
 		// this navigation without leaving the URL and router out of sync.
 		const navigateOptions = { ignoreBlocker: true };
-		if (path === entries[index - 1]) {
-			history.back(navigateOptions);
+		if (navigationType === "replace") {
+			history.replace(path, undefined, navigateOptions);
 			return;
 		}
-		if (path === entries[index + 1]) {
-			history.forward(navigateOptions);
+		if (navigationType === "push") {
+			history.push(path, undefined, navigateOptions);
+			return;
+		}
+
+		const existingIndex = findNearestEntryIndex(entries, index, path);
+		if (existingIndex >= 0) {
+			const delta = existingIndex - index;
+			if (delta === -1) {
+				history.back(navigateOptions);
+				return;
+			}
+			if (delta === 1) {
+				history.forward(navigateOptions);
+				return;
+			}
+			history.go(delta, navigateOptions);
 			return;
 		}
 		history.push(path, undefined, navigateOptions);
 	};
+	const handleExternalHashChange = () => synchronizeExternalNavigation();
+	const handleCurrentEntryChange = (event: NavigationCurrentEntryChangeEvent) =>
+		synchronizeExternalNavigation(event.navigationType);
+	const navigationApi = window.navigation;
 
 	history = createHistory({
 		getLocation,
@@ -196,10 +261,24 @@ export function createPersistentHashHistory(): PersistentHashHistory {
 			blockers = newBlockers;
 		},
 		destroy: () => {
-			window.removeEventListener("hashchange", handleExternalHashChange);
+			if (navigationApi) {
+				navigationApi.removeEventListener(
+					"currententrychange",
+					handleCurrentEntryChange,
+				);
+			} else {
+				window.removeEventListener("hashchange", handleExternalHashChange);
+			}
 		},
 	});
-	window.addEventListener("hashchange", handleExternalHashChange);
+	if (navigationApi) {
+		navigationApi.addEventListener(
+			"currententrychange",
+			handleCurrentEntryChange,
+		);
+	} else {
+		window.addEventListener("hashchange", handleExternalHashChange);
+	}
 
 	return Object.assign(history, {
 		getEntries: (): HistoryEntry[] =>

--- a/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.ts
+++ b/apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.ts
@@ -62,6 +62,12 @@ function syncHash(path: string) {
 	window.history.replaceState(window.history.state, "", `#${path}`);
 }
 
+function getHashPath(): string {
+	const hash = window.location.hash;
+	if (!hash || hash === "#") return "/";
+	return hash.startsWith("#") ? hash.slice(1) : hash;
+}
+
 function createRandomKey(): string {
 	return (Math.random() + 1).toString(36).substring(7);
 }
@@ -126,7 +132,26 @@ export function createPersistentHashHistory(): PersistentHashHistory {
 
 	syncHash(entries[index] ?? "/");
 
-	const history = createHistory({
+	let history: RouterHistory;
+	const handleExternalHashChange = () => {
+		const path = getHashPath();
+		if (path === (entries[index] ?? "/")) return;
+
+		// The browser URL has already changed, so a blocker cannot safely cancel
+		// this navigation without leaving the URL and router out of sync.
+		const navigateOptions = { ignoreBlocker: true };
+		if (path === entries[index - 1]) {
+			history.back(navigateOptions);
+			return;
+		}
+		if (path === entries[index + 1]) {
+			history.forward(navigateOptions);
+			return;
+		}
+		history.push(path, undefined, navigateOptions);
+	};
+
+	history = createHistory({
 		getLocation,
 		getLength: () => entries.length,
 		pushState: (path, state) => {
@@ -170,7 +195,11 @@ export function createPersistentHashHistory(): PersistentHashHistory {
 		setBlockers: (newBlockers) => {
 			blockers = newBlockers;
 		},
+		destroy: () => {
+			window.removeEventListener("hashchange", handleExternalHashChange);
+		},
 	});
+	window.addEventListener("hashchange", handleExternalHashChange);
 
 	return Object.assign(history, {
 		getEntries: (): HistoryEntry[] =>


### PR DESCRIPTION
## Summary

- synchronize persistent hash history when Electron or the browser changes the URL outside the TanStack router
- preserve the existing back/forward stack for adjacent and non-adjacent traversal
- observe Navigation API events while retaining a hashchange fallback
- keep deep links and blocked router transitions synchronized

## Testing

- `bun test apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts` (32 passed)
- `bun run --filter @superset/desktop typecheck`
- `bunx biome check apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.ts apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts`
- `git diff --check upstream/main...HEAD`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the desktop app’s hash-based navigation in sync when the URL changes outside the router. Preserves back/forward behavior and deep links while using the Navigation API with a safe fallback.

- **Bug Fixes**
  - Sync external hash changes (Electron/browser) to the router and persistent history, and notify subscribers.
  - Preserve back/forward semantics, including non-adjacent traversal; reuse the nearest existing entry or push when new.
  - Treat an initial hash as a deep link over persisted state; restore existing entries without duplicating them.
  - Observe `window.navigation` `currententrychange` with a `hashchange` fallback; ignore blockers for external changes and clean up listeners on `destroy()`.

<sup>Written for commit d6752ada9e0c29a7176c05149f6d36a12d7f5a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization between browser URL hash changes and in-app navigation.
  * Preserved back, forward, and non-adjacent navigation history when URLs change externally.
  * Added fallback support for environments without the Navigation API.
  * Prevented duplicate entries when opening or restoring deep-linked URLs.
  * Ensured external navigation remains synchronized when navigation blockers are active.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->