### PR TITLE
fix(desktop): auto-recover unresponsive host-service with a health watchdog

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -441,12 +441,14 @@ if (!gotTheLock) {
 			console.error("[main] Failed to install bundled CLI shim:", error);
 		}
 
+		const hostServiceConfigProvider = async () => {
+			const { token } = await loadToken();
+			if (!token) return null;
+			return { authToken: token, cloudApiUrl: mainEnv.NEXT_PUBLIC_API_URL };
+		};
+		getHostServiceCoordinator().enableHealthWatchdog(hostServiceConfigProvider);
 		if (IS_DEV) {
-			getHostServiceCoordinator().enableDevReload(async () => {
-				const { token } = await loadToken();
-				if (!token) return null;
-				return { authToken: token, cloudApiUrl: mainEnv.NEXT_PUBLIC_API_URL };
-			});
+			getHostServiceCoordinator().enableDevReload(hostServiceConfigProvider);
 		}
 
 		await makeAppSetup(() => MainWindow());

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -94,7 +94,8 @@ mock.module("./local-db", () => ({
 	},
 }));
 
-const { HostServiceCoordinator } = await import("./host-service-coordinator");
+const { HostServiceCoordinator, HEALTH_WATCHDOG_FAILURE_THRESHOLD } =
+	await import("./host-service-coordinator");
 
 const baseManifest = (pid: number, endpoint = "http://127.0.0.1:55555") => ({
 	pid,
@@ -367,6 +368,345 @@ describe("HostServiceCoordinator single-flight / adoption", () => {
 		expect(killedPids).toContainEqual({ pid: 4321, signal: "SIGTERM" });
 		expect(removeManifestMock).toHaveBeenCalled();
 		expect(internals.instances.get("org-1")).toBeUndefined();
+	});
+});
+
+describe("HostServiceCoordinator health watchdog", () => {
+	let coordinator: InstanceType<typeof HostServiceCoordinator>;
+	let spawnMock: ReturnType<typeof mock>;
+
+	type WatchdogStatus = "starting" | "running" | "stopped";
+
+	interface WatchdogInternals {
+		instances: Map<
+			string,
+			{
+				pid: number;
+				port: number;
+				secret: string;
+				status: WatchdogStatus;
+				owned: boolean;
+			}
+		>;
+		watchdogFailures: Map<string, { pid: number; count: number }>;
+		runWatchdogTick(
+			configProvider: () => Promise<{
+				authToken: string;
+				cloudApiUrl: string;
+			} | null>,
+		): Promise<void>;
+	}
+
+	const configProvider = async () => spawnConfig;
+	const nullConfigProvider = async () => null;
+
+	function internals(): WatchdogInternals {
+		return coordinator as unknown as WatchdogInternals;
+	}
+
+	function seedInstance(
+		organizationId: string,
+		overrides: Partial<{
+			pid: number;
+			port: number;
+			secret: string;
+			status: WatchdogStatus;
+			owned: boolean;
+		}> = {},
+	) {
+		internals().instances.set(organizationId, {
+			pid: 1234,
+			port: 48123,
+			secret: "secret",
+			status: "running",
+			// The watchdog only supervises children this instance owns; adopted
+			// entries are another instance's responsibility.
+			owned: true,
+			...overrides,
+		});
+	}
+
+	async function runTicks(
+		count: number,
+		provider: () => Promise<{
+			authToken: string;
+			cloudApiUrl: string;
+		} | null> = configProvider,
+	) {
+		for (let i = 0; i < count; i++) {
+			await internals().runWatchdogTick(provider);
+		}
+	}
+
+	beforeEach(() => {
+		resetMocks();
+		testManifestRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hsc-test-"));
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(true));
+
+		coordinator = new HostServiceCoordinator();
+		spawnMock = mock(async () => ({
+			port: 60000,
+			secret: "fresh-secret",
+			machineId: "host-1",
+		}));
+		(coordinator as unknown as { spawn: typeof spawnMock }).spawn = spawnMock;
+	});
+
+	afterEach(() => {
+		coordinator.stopAll();
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(true));
+		if (testManifestRoot) {
+			fs.rmSync(testManifestRoot, { recursive: true, force: true });
+			testManifestRoot = "";
+		}
+	});
+
+	test("healthy instance clears the failure counter and is never restarted", async () => {
+		seedInstance("org-1");
+		internals().watchdogFailures.set("org-1", { pid: 1234, count: 2 });
+
+		await runTicks(1);
+
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(killedPids).toHaveLength(0);
+	});
+
+	test("does not restart before the failure threshold", async () => {
+		seedInstance("org-1");
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD - 1);
+
+		expect(internals().watchdogFailures.get("org-1")).toEqual({
+			pid: 1234,
+			count: HEALTH_WATCHDOG_FAILURE_THRESHOLD - 1,
+		});
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(killedPids).toHaveLength(0);
+	});
+
+	test("force-restarts after consecutive failures reach the threshold", async () => {
+		seedInstance("org-1", { pid: 4321 });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD);
+
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		// stop() SIGTERMs the tracked pid, then the watchdog escalates to
+		// SIGKILL because the wedged process is still alive.
+		expect(killedPids).toContainEqual({ pid: 4321, signal: "SIGTERM" });
+		expect(killedPids).toContainEqual({ pid: 4321, signal: "SIGKILL" });
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+	});
+
+	test("stays armed when no spawn config is available and recovers on the next tick", async () => {
+		seedInstance("org-1", { pid: 4321 });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD, nullConfigProvider);
+
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(killedPids).toHaveLength(0);
+		// The counter survives the missing config, so recovery does not have
+		// to wait out another full threshold once a config is available.
+		expect(internals().watchdogFailures.get("org-1")?.count).toBe(
+			HEALTH_WATCHDOG_FAILURE_THRESHOLD,
+		);
+
+		await runTicks(1);
+
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(killedPids).toContainEqual({ pid: 4321, signal: "SIGKILL" });
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+	});
+
+	test("skips the restart when the child is replaced while fetching config", async () => {
+		seedInstance("org-1", { pid: 1111 });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		const replacingProvider = async () => {
+			// Simulate a manual restart landing while the config was fetched.
+			seedInstance("org-1", { pid: 2222 });
+			return spawnConfig;
+		};
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD, replacingProvider);
+
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(killedPids).toHaveLength(0);
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+	});
+
+	test("ignores instances that are not running", async () => {
+		seedInstance("org-1", { status: "starting" });
+
+		await runTicks(1);
+
+		expect(pollHealthCheckMock).not.toHaveBeenCalled();
+		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	test("ignores adopted instances it does not own", async () => {
+		// An adopted entry points at another live app instance's child. Even if
+		// it stops responding, force-restarting it would SIGKILL a process this
+		// instance doesn't control — the owner runs its own watchdog.
+		seedInstance("org-1", { pid: 4321, owned: false });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD + 1);
+
+		expect(pollHealthCheckMock).not.toHaveBeenCalled();
+		expect(killedPids).toHaveLength(0);
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+	});
+
+	test("a probe failure does not count against a replaced child", async () => {
+		seedInstance("org-1", { pid: 1111 });
+		pollHealthCheckMock.mockImplementation(() => {
+			// Simulate a restart landing while the probe was in flight.
+			seedInstance("org-1", { pid: 2222 });
+			return Promise.resolve(false);
+		});
+
+		await runTicks(1);
+
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	test("failure counter rebinds when a new child replaces the old one between ticks", async () => {
+		seedInstance("org-1", { pid: 1111 });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD - 1);
+		expect(internals().watchdogFailures.get("org-1")?.count).toBe(
+			HEALTH_WATCHDOG_FAILURE_THRESHOLD - 1,
+		);
+
+		// A new child spawned between ticks must not inherit its
+		// predecessor's failures and get restarted on its first bad probe.
+		seedInstance("org-1", { pid: 2222 });
+		await runTicks(1);
+
+		expect(internals().watchdogFailures.get("org-1")).toEqual({
+			pid: 2222,
+			count: 1,
+		});
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(killedPids).toHaveLength(0);
+	});
+
+	test("escalates the wedged pid to SIGKILL before the replacement spawns", async () => {
+		seedInstance("org-1", { pid: 4321 });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		// If the SIGKILL only landed after reset() returned, a slow spawn
+		// would leave a window where the OS recycles the pid and the kill
+		// hits an innocent process.
+		let sigkilledBeforeSpawn = false;
+		spawnMock.mockImplementation(async () => {
+			sigkilledBeforeSpawn = killedPids.some(
+				(k) => k.pid === 4321 && k.signal === "SIGKILL",
+			);
+			return { port: 60000, secret: "fresh-secret", machineId: "host-1" };
+		});
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD);
+
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(sigkilledBeforeSpawn).toBe(true);
+	});
+
+	test("a failed recovery is retried until a spawn sticks", async () => {
+		seedInstance("org-1", { pid: 4321 });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		spawnMock.mockImplementationOnce(async () => {
+			throw new Error("spawn blew up");
+		});
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD);
+
+		// The failed reset() left no instance behind; the retry pass respawns
+		// the org instead of forgetting it.
+		expect(spawnMock).toHaveBeenCalledTimes(2);
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+	});
+
+	test("stays armed while respawns keep failing", async () => {
+		seedInstance("org-1", { pid: 4321 });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		spawnMock.mockImplementation(async () => {
+			throw new Error("spawn keeps failing");
+		});
+
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD + 1);
+
+		expect(internals().watchdogFailures.get("org-1")?.count).toBe(
+			HEALTH_WATCHDOG_FAILURE_THRESHOLD,
+		);
+		expect(spawnMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+	});
+
+	test("stop() disarms the watchdog for that org", () => {
+		internals().watchdogFailures.set("org-1", {
+			pid: 1234,
+			count: HEALTH_WATCHDOG_FAILURE_THRESHOLD,
+		});
+
+		coordinator.stop("org-1");
+
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+	});
+
+	test("retry pass aborts when the org is stopped while fetching config", async () => {
+		internals().watchdogFailures.set("org-1", {
+			pid: 4321,
+			count: HEALTH_WATCHDOG_FAILURE_THRESHOLD,
+		});
+		const stoppingProvider = async () => {
+			// A deliberate shutdown lands while the config is being fetched.
+			coordinator.stop("org-1");
+			return spawnConfig;
+		};
+
+		await runTicks(1, stoppingProvider);
+
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(internals().watchdogFailures.has("org-1")).toBe(false);
+	});
+
+	test("a rejecting config lookup fails the tick quietly", async () => {
+		seedInstance("org-1", { pid: 4321 });
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		const rejectingProvider = async (): Promise<{
+			authToken: string;
+			cloudApiUrl: string;
+		} | null> => {
+			throw new Error("token lookup failed");
+		};
+
+		// The tick runs detached from a timer — it must swallow the rejection
+		// instead of surfacing an unhandled rejection.
+		await runTicks(HEALTH_WATCHDOG_FAILURE_THRESHOLD, rejectingProvider);
+
+		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	test("a spawn failure leaves no ghost 'starting' instance behind", async () => {
+		// Use the real spawn() with a failing buildEnv — pre-fix, the instance
+		// stayed tracked as "starting" forever, permanently blocking both
+		// startWithPreferredPorts status readers and the watchdog retry pass.
+		delete (coordinator as unknown as { spawn?: unknown }).spawn;
+		(coordinator as unknown as { buildEnv: () => Promise<never> }).buildEnv =
+			async () => {
+				throw new Error("env resolution failed");
+			};
+
+		await expect(coordinator.start("org-1", spawnConfig)).rejects.toThrow(
+			"env resolution failed",
+		);
+
+		expect(internals().instances.has("org-1")).toBe(false);
 	});
 });
 

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -88,6 +88,15 @@ const ADOPT_WAIT_INTERVAL_MS = 250;
 const STABLE_PORT_BASE = 48_000;
 const STABLE_PORT_COUNT = 1_000;
 
+// A "running" child can wedge without exiting (blocked event loop, fd
+// exhaustion) — the exit listener never fires, so the coordinator keeps
+// reporting it as healthy while every renderer request fails with
+// "Failed to fetch" (superset-sh/superset#5699). The watchdog probes each
+// running instance and force-restarts it after enough consecutive failures.
+export const HEALTH_WATCHDOG_INTERVAL_MS = 15_000;
+export const HEALTH_WATCHDOG_PROBE_TIMEOUT_MS = 3_000;
+export const HEALTH_WATCHDOG_FAILURE_THRESHOLD = 3;
+
 function getStablePortForOrganization(organizationId: string): number {
 	let hash = 2_166_136_261;
 	for (let index = 0; index < organizationId.length; index++) {
@@ -119,6 +128,15 @@ export class HostServiceCoordinator extends EventEmitter {
 	private scriptPath = path.join(__dirname, "host-service.js");
 	private machineId = getHostId();
 	private devReloadWatcher: fs.FSWatcher | null = null;
+	private watchdogTimer: ReturnType<typeof setInterval> | null = null;
+	private watchdogTickInFlight = false;
+	/**
+	 * Consecutive failed health probes per org, bound to the probed child's
+	 * pid so a freshly-spawned child never inherits its predecessor's count.
+	 * Entries at/over the threshold whose org has no live instance mark a
+	 * failed recovery that the watchdog keeps retrying each tick.
+	 */
+	private watchdogFailures = new Map<string, { pid: number; count: number }>();
 
 	async start(
 		organizationId: string,
@@ -189,6 +207,10 @@ export class HostServiceCoordinator extends EventEmitter {
 	}
 
 	stop(organizationId: string): void {
+		// A deliberate stop disarms the watchdog for this org — it must not
+		// auto-respawn something the caller just chose to shut down.
+		this.watchdogFailures.delete(organizationId);
+
 		const instance = this.instances.get(organizationId);
 		if (!instance) return;
 
@@ -237,21 +259,30 @@ export class HostServiceCoordinator extends EventEmitter {
 	async reset(
 		organizationId: string,
 		config: SpawnConfig,
+		opts: { alsoKillPid?: number } = {},
 	): Promise<Connection> {
 		// Capture the manifest pid *before* stop() — stop() removes the manifest
 		// for tracked instances and only sends SIGTERM, which a wedged process
-		// can ignore. We escalate to SIGKILL on whatever pid the manifest named.
+		// can ignore. We escalate to SIGKILL on whatever pid the manifest named,
+		// plus any caller-provided pid (the watchdog passes the wedged child's
+		// tracked pid, which can differ from the manifest when the manifest is
+		// missing or stale). Escalation happens here, before the slow respawn,
+		// so the pid can't be recycled by the OS in the meantime.
 		const preferredPorts = this.getPreferredPorts(organizationId);
 		const manifestPid = readManifest(organizationId)?.pid;
 
 		this.stop(organizationId);
 
-		if (manifestPid != null && isProcessAlive(manifestPid)) {
+		const pidsToKill = new Set<number>();
+		if (manifestPid != null) pidsToKill.add(manifestPid);
+		if (opts.alsoKillPid != null) pidsToKill.add(opts.alsoKillPid);
+		for (const pid of pidsToKill) {
+			if (!isProcessAlive(pid)) continue;
 			try {
-				killProcess(manifestPid, "SIGKILL");
+				killProcess(pid, "SIGKILL");
 			} catch (error) {
 				log.warn(
-					`[host-service:${organizationId}] reset: SIGKILL of pid=${manifestPid} failed`,
+					`[host-service:${organizationId}] reset: SIGKILL of pid=${pid} failed`,
 					error,
 				);
 			}
@@ -518,6 +549,187 @@ export class HostServiceCoordinator extends EventEmitter {
 		return { port, secret: manifest.authToken, machineId: this.machineId };
 	}
 
+	/**
+	 * Periodically health-check every "running" instance and force-restart the
+	 * ones that stop responding. The exit listener only catches children that
+	 * die; a wedged child stays "running" forever and the only recovery today
+	 * is the manual tray restart (or rebooting the machine).
+	 */
+	enableHealthWatchdog(
+		configProvider: () => Promise<SpawnConfig | null>,
+	): () => void {
+		if (this.watchdogTimer) return () => {};
+
+		const timer = setInterval(() => {
+			void this.runWatchdogTick(configProvider);
+		}, HEALTH_WATCHDOG_INTERVAL_MS);
+		timer.unref();
+		this.watchdogTimer = timer;
+
+		return () => {
+			clearInterval(timer);
+			this.watchdogTimer = null;
+			this.watchdogFailures.clear();
+		};
+	}
+
+	private async runWatchdogTick(
+		configProvider: () => Promise<SpawnConfig | null>,
+	): Promise<void> {
+		// A wedged instance makes each probe wait out its full timeout — skip
+		// the tick instead of stacking probes against the same instance.
+		if (this.watchdogTickInFlight) return;
+		this.watchdogTickInFlight = true;
+
+		try {
+			for (const [organizationId, instance] of [...this.instances]) {
+				if (
+					instance.status !== "running" ||
+					this.pendingStarts.has(organizationId)
+				) {
+					continue;
+				}
+
+				// Only supervise children we own. An adopted entry (owned=false)
+				// points at another live app instance's host-service — force-
+				// restarting it would SIGKILL a process we don't control. That
+				// instance runs its own watchdog; if its owner has died the entry
+				// is dropped lazily on the next startWithPreferredPorts.
+				if (!instance.owned) continue;
+
+				const healthy = await pollHealthCheck(
+					`http://127.0.0.1:${instance.port}`,
+					instance.secret,
+					HEALTH_WATCHDOG_PROBE_TIMEOUT_MS,
+				);
+
+				// The instance may have been stopped or replaced while the probe
+				// was in flight — a stale probe result must not count against the
+				// replacement child.
+				const current = this.instances.get(organizationId);
+				if (
+					!current ||
+					current.pid !== instance.pid ||
+					current.status !== "running"
+				) {
+					continue;
+				}
+
+				if (healthy) {
+					this.watchdogFailures.delete(organizationId);
+					continue;
+				}
+
+				// Bind the count to this child's pid: a freshly-spawned child
+				// starts from 1 instead of inheriting its predecessor's failures.
+				const prev = this.watchdogFailures.get(organizationId);
+				const failureCount = prev?.pid === instance.pid ? prev.count + 1 : 1;
+				this.watchdogFailures.set(organizationId, {
+					pid: instance.pid,
+					count: failureCount,
+				});
+				log.warn(
+					`[host-service:${organizationId}] health check failed (${failureCount}/${HEALTH_WATCHDOG_FAILURE_THRESHOLD}) on port ${instance.port}`,
+				);
+				if (failureCount < HEALTH_WATCHDOG_FAILURE_THRESHOLD) continue;
+
+				// Keep the counter until recovery actually runs — if no config is
+				// available (logged out) the watchdog stays armed and retries on
+				// the next tick instead of waiting out a full threshold again.
+				const config = await configProvider();
+				if (!config) continue;
+
+				// Revalidate after the await — a manual restart may have replaced
+				// the child while the config was being fetched.
+				const latest = this.instances.get(organizationId);
+				if (
+					!latest ||
+					latest.pid !== instance.pid ||
+					latest.status !== "running" ||
+					this.pendingStarts.has(organizationId)
+				) {
+					this.watchdogFailures.delete(organizationId);
+					continue;
+				}
+
+				log.error(
+					`[host-service:${organizationId}] unresponsive for ${HEALTH_WATCHDOG_FAILURE_THRESHOLD} consecutive health checks — force-restarting`,
+				);
+				try {
+					// alsoKillPid escalates the wedged child to SIGKILL inside
+					// reset(), after stop() but before the slow respawn — waiting
+					// until reset() returned would leave a window where the pid is
+					// recycled and the SIGKILL hits an innocent process.
+					await this.reset(organizationId, config, {
+						alsoKillPid: instance.pid,
+					});
+					this.watchdogFailures.delete(organizationId);
+				} catch (error) {
+					log.error(
+						`[host-service:${organizationId}] watchdog restart failed:`,
+						error,
+					);
+					// reset()'s stop() disarmed the entry; re-arm it so the
+					// no-instance retry pass below keeps trying on later ticks.
+					this.watchdogFailures.set(organizationId, {
+						pid: instance.pid,
+						count: failureCount,
+					});
+				}
+			}
+
+			// Orgs whose recovery failed have no tracked instance and are
+			// invisible to the loop above — keep retrying those each tick until
+			// a spawn sticks. Deliberate stops never land here: stop() disarms
+			// the entry.
+			for (const [organizationId, entry] of [...this.watchdogFailures]) {
+				if (
+					this.instances.has(organizationId) ||
+					this.pendingStarts.has(organizationId)
+				) {
+					continue;
+				}
+				if (entry.count < HEALTH_WATCHDOG_FAILURE_THRESHOLD) {
+					// Stale sub-threshold entry (e.g. the child crashed on its
+					// own after a blip) — nothing to recover, drop it.
+					this.watchdogFailures.delete(organizationId);
+					continue;
+				}
+				const config = await configProvider();
+				if (!config) continue;
+				// Revalidate after the await — a concurrent stop() disarms the
+				// entry (deliberate shutdown) and a concurrent start() makes the
+				// respawn redundant; neither must be overridden here.
+				if (
+					this.watchdogFailures.get(organizationId) !== entry ||
+					this.instances.has(organizationId) ||
+					this.pendingStarts.has(organizationId)
+				) {
+					continue;
+				}
+				log.warn(
+					`[host-service:${organizationId}] retrying respawn after failed watchdog recovery`,
+				);
+				try {
+					await this.startWithPreferredPorts(organizationId, config);
+					this.watchdogFailures.delete(organizationId);
+				} catch (error) {
+					log.error(
+						`[host-service:${organizationId}] watchdog respawn retry failed:`,
+						error,
+					);
+				}
+			}
+		} catch (error) {
+			// The tick runs detached from a timer — a rejection here (e.g. the
+			// config lookup throwing) would otherwise surface as an unhandled
+			// rejection. Log and let the next tick retry.
+			log.error("[host-service] watchdog tick failed:", error);
+		} finally {
+			this.watchdogTickInFlight = false;
+		}
+	}
+
 	// ── Spawn ─────────────────────────────────────────────────────────
 
 	private async spawn(
@@ -539,102 +751,122 @@ export class HostServiceCoordinator extends EventEmitter {
 		this.instances.set(organizationId, instance);
 		this.emitStatus(organizationId, "starting", null);
 
-		const childEnv = await this.buildEnv(organizationId, port, secret, config);
-		const logFd = openRotatingLogFd(
-			path.join(manifestDir(organizationId), "host-service.log"),
-			MAX_HOST_LOG_BYTES,
-		);
-		// Dev: pipe child stdout/stderr through this process so log lines
-		// land in the developer's `bun dev` terminal. Production: hard-back
-		// stdio with the rotating log file.
-		const isDev = !app.isPackaged;
-		const stdio: childProcess.StdioOptions = isDev
-			? ["ignore", "pipe", "pipe"]
-			: logFd >= 0
-				? ["ignore", logFd, logFd]
-				: ["ignore", "ignore", "ignore"];
-
-		let child: ReturnType<typeof childProcess.spawn>;
 		try {
-			child = childProcess.spawn(process.execPath, [this.scriptPath], {
-				detached: false,
-				stdio,
-				env: childEnv,
-				// Avoid a flashing CMD window on Windows.
-				windowsHide: true,
-			});
-		} finally {
-			if (logFd >= 0) {
-				try {
-					fs.closeSync(logFd);
-				} catch {
-					// Best-effort — child has its own dup of the fd.
+			const childEnv = await this.buildEnv(
+				organizationId,
+				port,
+				secret,
+				config,
+			);
+			const logFd = openRotatingLogFd(
+				path.join(manifestDir(organizationId), "host-service.log"),
+				MAX_HOST_LOG_BYTES,
+			);
+			// Dev: pipe child stdout/stderr through this process so log lines
+			// land in the developer's `bun dev` terminal. Production: hard-back
+			// stdio with the rotating log file.
+			const isDev = !app.isPackaged;
+			const stdio: childProcess.StdioOptions = isDev
+				? ["ignore", "pipe", "pipe"]
+				: logFd >= 0
+					? ["ignore", logFd, logFd]
+					: ["ignore", "ignore", "ignore"];
+
+			let child: ReturnType<typeof childProcess.spawn>;
+			try {
+				child = childProcess.spawn(process.execPath, [this.scriptPath], {
+					detached: false,
+					stdio,
+					env: childEnv,
+					// Avoid a flashing CMD window on Windows.
+					windowsHide: true,
+				});
+			} finally {
+				if (logFd >= 0) {
+					try {
+						fs.closeSync(logFd);
+					} catch {
+						// Best-effort — child has its own dup of the fd.
+					}
 				}
 			}
-		}
 
-		// In dev, fan child output through to parent stdout/stderr with a
-		// prefix so it's identifiable in `bun dev`.
-		if (isDev && child.stdout && child.stderr) {
-			const tag = `[hs:${organizationId.slice(0, 8)}]`;
-			pipeWithPrefix(child.stdout, process.stdout, tag);
-			pipeWithPrefix(child.stderr, process.stderr, tag);
-		}
-
-		const childPid = child.pid;
-		if (!childPid) {
-			this.instances.delete(organizationId);
-			throw new Error("Failed to spawn host service process");
-		}
-
-		instance.pid = childPid;
-		let childExited = false;
-		child.on("exit", (code, signal) => {
-			childExited = true;
-			log.info(
-				`[host-service:${organizationId}] exited with code ${code} signal ${signal}`,
-			);
-			const current = this.instances.get(organizationId);
-			if (!current || current.pid !== childPid || current.status === "stopped")
-				return;
-
-			// Only alert a crash of a running child; startup deaths surface via
-			// start()'s rejection instead.
-			const previousStatus = current.status;
-			this.rememberPort(organizationId, current.port);
-			this.instances.delete(organizationId);
-			removeManifest(organizationId);
-			this.emitStatus(organizationId, "stopped", previousStatus);
-
-			if (previousStatus === "running") {
-				this.alertChildCrashed(organizationId, code, signal);
+			// In dev, fan child output through to parent stdout/stderr with a
+			// prefix so it's identifiable in `bun dev`.
+			if (isDev && child.stdout && child.stderr) {
+				const tag = `[hs:${organizationId.slice(0, 8)}]`;
+				pipeWithPrefix(child.stdout, process.stdout, tag);
+				pipeWithPrefix(child.stderr, process.stderr, tag);
 			}
-		});
-		// Don't let the child block Electron's exit — stopAll() handles teardown.
-		child.unref();
 
-		const endpoint = `http://127.0.0.1:${port}`;
-		const healthy = await pollHealthCheck(
-			endpoint,
-			secret,
-			HEALTH_POLL_TIMEOUT_MS,
-			() => childExited,
-		);
-		if (!healthy) {
-			if (!childExited) child.kill("SIGTERM");
-			this.instances.delete(organizationId);
-			throw new Error(
-				childExited
-					? "Host service process exited during startup"
-					: `Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,
+			const childPid = child.pid;
+			if (!childPid) {
+				throw new Error("Failed to spawn host service process");
+			}
+
+			instance.pid = childPid;
+			let childExited = false;
+			child.on("exit", (code, signal) => {
+				childExited = true;
+				log.info(
+					`[host-service:${organizationId}] exited with code ${code} signal ${signal}`,
+				);
+				const current = this.instances.get(organizationId);
+				if (
+					!current ||
+					current.pid !== childPid ||
+					current.status === "stopped"
+				)
+					return;
+
+				// Only alert a crash of a running child; startup deaths surface via
+				// start()'s rejection instead.
+				const previousStatus = current.status;
+				this.rememberPort(organizationId, current.port);
+				this.instances.delete(organizationId);
+				removeManifest(organizationId);
+				this.emitStatus(organizationId, "stopped", previousStatus);
+
+				if (previousStatus === "running") {
+					this.alertChildCrashed(organizationId, code, signal);
+				}
+			});
+			// Don't let the child block Electron's exit — stopAll() handles teardown.
+			child.unref();
+
+			const endpoint = `http://127.0.0.1:${port}`;
+			const healthy = await pollHealthCheck(
+				endpoint,
+				secret,
+				HEALTH_POLL_TIMEOUT_MS,
+				() => childExited,
 			);
+			if (!healthy) {
+				if (!childExited) child.kill("SIGTERM");
+				throw new Error(
+					childExited
+						? "Host service process exited during startup"
+						: `Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,
+				);
+			}
+
+			instance.status = "running";
+
+			log.info(`[host-service:${organizationId}] listening on port ${port}`);
+			this.emitStatus(organizationId, "running", "starting");
+			return { port, secret, machineId: this.machineId };
+		} catch (error) {
+			// Every startup failure must remove the "starting" entry — a stale
+			// ghost (e.g. buildEnv rejecting) would make status readers and the
+			// watchdog's retry pass treat the org as occupied forever. The child
+			// exit handler may have cleaned up already; only act if this call's
+			// instance is still the registered one.
+			if (this.instances.get(organizationId) === instance) {
+				this.instances.delete(organizationId);
+				this.emitStatus(organizationId, "stopped", "starting");
+			}
+			throw error;
 		}
-
-		instance.status = "running";
-
-		log.info(`[host-service:${organizationId}] listening on port ${port}`);
-		this.emitStatus(organizationId, "running", "starting");
-		return { port, secret, machineId: this.machineId };
 	}
 
 	private async buildEnv(

--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -113,7 +113,11 @@ export async function pollHealthCheck(
 	while (Date.now() < deadline) {
 		if (shouldAbort?.()) return false;
 		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 2_000);
+		// Clamp both the fetch and the retry sleep to the remaining budget so
+		// a call never runs meaningfully past its advertised timeout — the
+		// watchdog probes instances serially and relies on this bound.
+		const fetchBudget = Math.min(2_000, deadline - Date.now());
+		const timeout = setTimeout(() => controller.abort(), fetchBudget);
 		try {
 			const res = await fetch(`${endpoint}/trpc/health.check`, {
 				signal: controller.signal,
@@ -125,7 +129,12 @@ export async function pollHealthCheck(
 		} finally {
 			clearTimeout(timeout);
 		}
-		await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
+		const sleepBudget = Math.min(
+			HEALTH_POLL_INTERVAL_MS,
+			deadline - Date.now(),
+		);
+		if (sleepBudget <= 0) break;
+		await new Promise((r) => setTimeout(r, sleepBudget));
 	}
 	return false;
 }


### PR DESCRIPTION
## What & why

Related to #5699 — "Failed to run preset / Failed to fetch (127.0.0.1:48135)". (The primary root cause — a node-pty fd leak that exhausts the system-wide pty cap — is fixed in #5714; this PR fixes the secondary failure mode where a wedged host-service is never detected.)

The `HostServiceCoordinator` only listens for the child process **exit** event. A host-service that wedges without dying (blocked event loop, fd exhaustion after extended usage) therefore stays `"running"` forever: `getConnection` keeps handing the renderer the same port, every `terminal.createSession` fetch fails with `Failed to fetch (127.0.0.1:<port>)`, and the only recovery is the manual tray restart — or rebooting the machine, as the reporter did. (The port in the report, 48135, is in the coordinator's stable-port range 48000–48999, confirming the renderer was talking to a local host-service the coordinator still considered healthy.)

This adds a health watchdog to the coordinator:

- Probes every `"running"` instance's `/trpc/health.check` every 15s (3s probe timeout), skipping instances with a pending start and discarding probe results if the instance was stopped/replaced mid-probe.
- After **3 consecutive** failed checks, force-restarts that org's host-service via the existing `reset()` recovery path, escalating to SIGKILL on the wedged pid (a wedged process can ignore `stop()`'s SIGTERM).
- Terminals survive the restart through the pty-daemon adoption path `createSession` already implements; renderer picks up the fresh connection through the existing 5s `getConnection` poll + status events.

Related: #5700 retries transient network blips on the create path; this PR addresses the persistent-until-reboot failure mode by making the coordinator detect and heal a wedged child.

## How I tested it

- Added 6 unit tests in `host-service-coordinator.test.ts` covering: healthy probe clears the failure counter; no restart below threshold; force-restart at threshold with SIGTERM→SIGKILL escalation; skip when no spawn config (logged-out); non-running instances not probed; probe failures don't count against a replaced child.
- `bun test apps/desktop/src/main/lib/host-service-coordinator.test.ts` — 12 pass (6 existing + 6 new).
- `bun run lint` and `tsc --noEmit` (apps/desktop) pass.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5711">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a health watchdog to the desktop `HostServiceCoordinator` to auto-recover unresponsive host-service processes. It detects wedged, still-running children and restarts them, removing persistent “Failed to fetch (127.0.0.1:PORT)” errors without manual restarts.

- **Bug Fixes**
  - Probe running, owned instances’ `/trpc/health.check` every 15s (3s timeout); clamp fetch/sleep to the remaining budget; avoid overlapping ticks.
  - Bind failure counts to the child pid; ignore stale probe results; clear on success or deliberate `stop()`.
  - After 3 consecutive failures, force-restart via `reset()` and SIGKILL the wedged pid before respawn; skip adopted (non-owned) instances.
  - Revalidate after config awaits; keep counters armed when config is missing; retry respawn when recovery fails or no instance is tracked without overriding a concurrent `stop()`/start.
  - Remove ghost “starting” entries on spawn errors; watchdog tick logs and swallows its own failures; wire `enableHealthWatchdog` in `main` with a shared auth/config provider; tests cover thresholds, pid-binding, retries, escalation ordering, revalidation, adopted-skip, and startup failure cleanup.

<sup>Written for commit a1d032a2ab901814dae0e7ab152492487fc8c39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Added a health watchdog that periodically probes running host services and recovers stalled instances by force-resetting them after consecutive failures.
  * Recovery includes retries when no healthy instance is available, and escalates from graceful termination to force-kill; intentional stops now prevent auto-respawn.
  * Improved health-check timing to ensure probes and retries always respect the overall timeout budget.
* **Development Experience**
  * Streamlined development reload by reusing shared auth/API configuration for host-service startup.
* **Tests**
  * Expanded watchdog coverage for thresholds, replacement edge cases, retry behavior, and cleanup/disarm scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
