### PR TITLE
fix(pty-daemon): patch node-pty /dev/ptmx leak that exhausts system ptys

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1207,6 +1207,9 @@
     "bufferutil",
     "workerd",
   ],
+  "patchedDependencies": {
+    "node-pty@1.1.0": "patches/node-pty@1.1.0.patch",
+  },
   "overrides": {
     "axios": "1.14.0",
     "hono": "4.12.25",

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
 		"sharp",
 		"utf-8-validate",
 		"workerd"
-	]
+	],
+	"patchedDependencies": {
+		"node-pty@1.1.0": "patches/node-pty@1.1.0.patch"
+	}
 }

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -30,7 +30,7 @@
 		"build:daemon": "bun run build.ts",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
 		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/process-tree.test.ts test/no-encoding-hops.test.ts",
-		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts test/flow-control.test.ts test/kill-tree.test.ts",
+		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts test/flow-control.test.ts test/kill-tree.test.ts test/fd-release.test.ts",
 		"build:types": "tsc -p tsconfig.types.json"
 	},
 	"dependencies": {

--- a/packages/pty-daemon/test/fd-release.test.ts
+++ b/packages/pty-daemon/test/fd-release.test.ts
@@ -1,0 +1,104 @@
+// Regression test for superset-sh/superset#5699.
+//
+// node-pty 1.1.0's macOS `pty_posix_spawn` leaks one /dev/ptmx master fd on
+// EVERY spawn: its low-fd workaround probes `posix_openpt` into `low_fds`,
+// but the cleanup loop (`for (; count > 0; count--)`) never closes
+// `low_fds[0]` — and in practice the first probe always lands at fd >= 3, so
+// nothing is ever closed. Each leaked master counts against the system-wide
+// pty cap (kern.tty.ptmx_max = 511 on macOS); a long-lived daemon eventually
+// starves the whole machine of ptys and no app can open a terminal until
+// reboot. Fixed upstream in microsoft/node-pty#882 (unreleased as of 1.1.0);
+// backported via patches/node-pty@1.1.0.patch.
+//
+// These tests spawn real shells, so they run under Node with the rest of the
+// integration suite.
+
+import { strict as assert } from "node:assert";
+import * as cp from "node:child_process";
+import * as fs from "node:fs";
+import { test } from "node:test";
+import { spawn as spawnPty } from "../src/Pty/Pty.ts";
+
+/** Count this process's open pty fds (masters and slaves), like upstream's
+ * regression test for microsoft/node-pty#882 does. */
+function ptyFdCount(): number {
+	const out = cp.execSync(`lsof -p ${process.pid} 2>/dev/null || true`, {
+		encoding: "utf8",
+	});
+	return out.split("\n").filter((line) => /\/dev\/(ptmx|ttys)/.test(line))
+		.length;
+}
+
+function fdIsOpen(fd: number): boolean {
+	try {
+		fs.fstatSync(fd);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitUntil(
+	pred: () => boolean,
+	timeoutMs = 5_000,
+): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (pred()) return true;
+		await new Promise((r) => setTimeout(r, 50));
+	}
+	return pred();
+}
+
+function spawnAndAwaitExit(argv: string[]): Promise<void> {
+	const pty = spawnPty({
+		meta: { shell: "/bin/sh", argv, cols: 80, rows: 24 },
+	});
+	return new Promise((resolve) => pty.onExit(() => resolve()));
+}
+
+test("spawning and exiting sessions does not accumulate pty fds", async () => {
+	const initial = ptyFdCount();
+
+	for (let i = 0; i < 10; i++) {
+		await spawnAndAwaitExit(["-c", "exit 0"]);
+	}
+
+	assert.equal(
+		await waitUntil(() => ptyFdCount() <= initial),
+		true,
+		`leaked ${ptyFdCount() - initial} pty fds after 10 spawn/exit cycles (initial ${initial})`,
+	);
+});
+
+test("no pty fd accumulates when a background child outlives the shell", async () => {
+	// The backgrounded sleep inherits the slave tty and outlives the shell —
+	// the pattern agent/background-helper sessions hit constantly.
+	const initial = ptyFdCount();
+
+	for (let i = 0; i < 5; i++) {
+		await spawnAndAwaitExit(["-c", "sleep 30 & exit 0"]);
+	}
+
+	assert.equal(
+		await waitUntil(() => ptyFdCount() <= initial),
+		true,
+		`leaked ${ptyFdCount() - initial} pty fds after 5 bg-child sessions (initial ${initial})`,
+	);
+});
+
+test("master fd is closed after the shell exits", async () => {
+	const pty = spawnPty({
+		meta: { shell: "/bin/sh", argv: ["-c", "exit 0"], cols: 80, rows: 24 },
+	});
+	const fd = pty.getMasterFd();
+	assert.equal(fdIsOpen(fd), true, "master fd should be open while running");
+
+	await new Promise<void>((resolve) => pty.onExit(() => resolve()));
+
+	assert.equal(
+		await waitUntil(() => !fdIsOpen(fd)),
+		true,
+		"master fd must be closed once the session exits",
+	);
+});

--- a/packages/pty-daemon/test/fd-release.test.ts
+++ b/packages/pty-daemon/test/fd-release.test.ts
@@ -10,6 +10,11 @@
 // reboot. Fixed upstream in microsoft/node-pty#882 (unreleased as of 1.1.0);
 // backported via patches/node-pty@1.1.0.patch.
 //
+// The same macOS path also leaks one kqueue fd per spawn (`SetupExitCallback`
+// opens a kqueue to wait on NOTE_EXIT and never closes it) — that one counts
+// against the process's RLIMIT_NOFILE rather than the pty cap. Fixed upstream
+// in microsoft/node-pty#931 and backported in the same patch.
+//
 // These tests spawn real shells, so they run under Node with the rest of the
 // integration suite.
 
@@ -45,6 +50,24 @@ function ptyFdCount(): number {
 	}
 	return out.split("\n").filter((line) => /\/dev\/(ptmx|ttys|pts\/)/.test(line))
 		.length;
+}
+
+/** Count this process's open kqueue fds, like upstream's regression test
+ * for microsoft/node-pty#931 does. macOS-only (lsof TYPE column). */
+function kqueueFdCount(): number {
+	let out: string;
+	try {
+		out = cp.execSync(`lsof -p ${process.pid}`, {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+	} catch (err) {
+		out = (err as { stdout?: string }).stdout ?? "";
+	}
+	if (!out.trim()) {
+		throw new Error("lsof produced no output — cannot count kqueue fds");
+	}
+	return out.split("\n").filter((line) => line.includes("KQUEUE")).length;
 }
 
 function fdIsOpen(fd: number): boolean {
@@ -93,6 +116,26 @@ test("no pty fd accumulates when a background child outlives the shell", async (
 	if (!converged) {
 		assert.fail(
 			`leaked ${ptyFdCount() - initial} pty fds after 5 bg-child sessions (initial ${initial})`,
+		);
+	}
+});
+
+test("spawning and exiting sessions does not accumulate kqueue fds", async (t) => {
+	if (process.platform !== "darwin") {
+		// The kqueue exit-watcher only exists on the macOS native path.
+		t.skip("kqueue exit-watcher is macOS-only");
+		return;
+	}
+	const initial = kqueueFdCount();
+
+	for (let i = 0; i < 10; i++) {
+		await spawnAndAwaitExit(["-c", "exit 0"]);
+	}
+
+	const converged = await waitFor(() => kqueueFdCount() <= initial);
+	if (!converged) {
+		assert.fail(
+			`leaked ${kqueueFdCount() - initial} kqueue fds after 10 spawn/exit cycles (initial ${initial})`,
 		);
 	}
 });

--- a/packages/pty-daemon/test/fd-release.test.ts
+++ b/packages/pty-daemon/test/fd-release.test.ts
@@ -18,14 +18,32 @@ import * as cp from "node:child_process";
 import * as fs from "node:fs";
 import { test } from "node:test";
 import { spawn as spawnPty } from "../src/Pty/Pty.ts";
+import { waitFor } from "./helpers/wait-for.ts";
 
-/** Count this process's open pty fds (masters and slaves), like upstream's
- * regression test for microsoft/node-pty#882 does. */
+/**
+ * Count this process's open pty fds (masters and slaves), like upstream's
+ * regression test for microsoft/node-pty#882 does. Matches macOS
+ * (/dev/ptmx, /dev/ttysNNN) and Linux (/dev/ptmx, /dev/pts/N) names.
+ * Throws when lsof yields nothing — a live process always has some open
+ * fds, so empty output means the count is broken, and returning 0 would
+ * make every assertion below pass vacuously.
+ */
 function ptyFdCount(): number {
-	const out = cp.execSync(`lsof -p ${process.pid} 2>/dev/null || true`, {
-		encoding: "utf8",
-	});
-	return out.split("\n").filter((line) => /\/dev\/(ptmx|ttys)/.test(line))
+	let out: string;
+	try {
+		out = cp.execSync(`lsof -p ${process.pid}`, {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+	} catch (err) {
+		// lsof exits non-zero for some unresolvable fds while still printing
+		// the rest — use whatever it produced.
+		out = (err as { stdout?: string }).stdout ?? "";
+	}
+	if (!out.trim()) {
+		throw new Error("lsof produced no output — cannot count pty fds");
+	}
+	return out.split("\n").filter((line) => /\/dev\/(ptmx|ttys|pts\/)/.test(line))
 		.length;
 }
 
@@ -36,18 +54,6 @@ function fdIsOpen(fd: number): boolean {
 	} catch {
 		return false;
 	}
-}
-
-async function waitUntil(
-	pred: () => boolean,
-	timeoutMs = 5_000,
-): Promise<boolean> {
-	const deadline = Date.now() + timeoutMs;
-	while (Date.now() < deadline) {
-		if (pred()) return true;
-		await new Promise((r) => setTimeout(r, 50));
-	}
-	return pred();
 }
 
 function spawnAndAwaitExit(argv: string[]): Promise<void> {
@@ -64,27 +70,31 @@ test("spawning and exiting sessions does not accumulate pty fds", async () => {
 		await spawnAndAwaitExit(["-c", "exit 0"]);
 	}
 
-	assert.equal(
-		await waitUntil(() => ptyFdCount() <= initial),
-		true,
-		`leaked ${ptyFdCount() - initial} pty fds after 10 spawn/exit cycles (initial ${initial})`,
-	);
+	const converged = await waitFor(() => ptyFdCount() <= initial);
+	if (!converged) {
+		assert.fail(
+			`leaked ${ptyFdCount() - initial} pty fds after 10 spawn/exit cycles (initial ${initial})`,
+		);
+	}
 });
 
 test("no pty fd accumulates when a background child outlives the shell", async () => {
 	// The backgrounded sleep inherits the slave tty and outlives the shell —
-	// the pattern agent/background-helper sessions hit constantly.
+	// the pattern agent/background-helper sessions hit constantly. The child
+	// holds the slave in its own process; the daemon's fd table must still
+	// return to baseline.
 	const initial = ptyFdCount();
 
 	for (let i = 0; i < 5; i++) {
-		await spawnAndAwaitExit(["-c", "sleep 30 & exit 0"]);
+		await spawnAndAwaitExit(["-c", "sleep 5 & exit 0"]);
 	}
 
-	assert.equal(
-		await waitUntil(() => ptyFdCount() <= initial),
-		true,
-		`leaked ${ptyFdCount() - initial} pty fds after 5 bg-child sessions (initial ${initial})`,
-	);
+	const converged = await waitFor(() => ptyFdCount() <= initial);
+	if (!converged) {
+		assert.fail(
+			`leaked ${ptyFdCount() - initial} pty fds after 5 bg-child sessions (initial ${initial})`,
+		);
+	}
 });
 
 test("master fd is closed after the shell exits", async () => {
@@ -97,7 +107,7 @@ test("master fd is closed after the shell exits", async () => {
 	await new Promise<void>((resolve) => pty.onExit(() => resolve()));
 
 	assert.equal(
-		await waitUntil(() => !fdIsOpen(fd)),
+		await waitFor(() => !fdIsOpen(fd)),
 		true,
 		"master fd must be closed once the session exits",
 	);

--- a/packages/pty-daemon/test/foreground-process.test.ts
+++ b/packages/pty-daemon/test/foreground-process.test.ts
@@ -8,6 +8,7 @@ import { strict as assert } from "node:assert";
 import { after, test } from "node:test";
 import { type Pty, spawn as spawnPty } from "../src/Pty/Pty.ts";
 import { hasRunningForegroundProcess } from "../src/process-tree.ts";
+import { waitFor } from "./helpers/wait-for.ts";
 
 const ptys: Pty[] = [];
 
@@ -20,20 +21,6 @@ after(() => {
 		}
 	}
 });
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-async function waitFor(
-	predicate: () => boolean,
-	timeoutMs: number,
-): Promise<boolean> {
-	const deadline = Date.now() + timeoutMs;
-	while (Date.now() < deadline) {
-		if (predicate()) return true;
-		await sleep(50);
-	}
-	return predicate();
-}
 
 test("idle prompt -> running command -> idle again", async () => {
 	const pty = spawnPty({

--- a/packages/pty-daemon/test/helpers/wait-for.ts
+++ b/packages/pty-daemon/test/helpers/wait-for.ts
@@ -1,0 +1,16 @@
+/**
+ * Poll a synchronous predicate every 50ms until it holds or the deadline
+ * passes, then evaluate it one final time so a truth that lands exactly at
+ * the deadline still counts.
+ */
+export async function waitFor(
+	predicate: () => boolean,
+	timeoutMs = 5_000,
+): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await new Promise((r) => setTimeout(r, 50));
+	}
+	return predicate();
+}

--- a/patches/node-pty@1.1.0.patch
+++ b/patches/node-pty@1.1.0.patch
@@ -1,0 +1,26 @@
+diff --git a/src/unix/pty.cc b/src/unix/pty.cc
+index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..b75e54fd541968619f1c5507e93e019f702af5fc 100644
+--- a/src/unix/pty.cc
++++ b/src/unix/pty.cc
+@@ -778,8 +778,19 @@ done:
+   posix_spawn_file_actions_destroy(&acts);
+   posix_spawnattr_destroy(&attrs);
+ 
+-  for (; count > 0; count--) {
+-    close(low_fds[count]);
++  // The child received the slave via posix_spawn file actions; close the
++  // parent's copy. Backported from microsoft/node-pty#882.
++  close(slave);
++
++  // Close every probe fd opened by the low-fd workaround above. The
++  // original loop (`for (; count > 0; count--)`) never closed low_fds[0],
++  // leaking one /dev/ptmx master per spawn — which counts against the
++  // system-wide kern.tty.ptmx_max cap until the process exits.
++  // Backported from microsoft/node-pty#882.
++  for (size_t i = 0; i <= count && i < 3; i++) {
++    if (low_fds[i] >= 0) {
++      close(low_fds[i]);
++    }
+   }
+ }
+ #endif

--- a/patches/node-pty@1.1.0.patch
+++ b/patches/node-pty@1.1.0.patch
@@ -1,8 +1,19 @@
 diff --git a/src/unix/pty.cc b/src/unix/pty.cc
-index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..b75e54fd541968619f1c5507e93e019f702af5fc 100644
+index 7b4b9e1..0f3375b 100644
 --- a/src/unix/pty.cc
 +++ b/src/unix/pty.cc
-@@ -778,8 +778,19 @@ done:
+@@ -167,6 +167,10 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pid_t pid) {
+         }
+       }
+     }
++    // The kqueue opened above waits on NOTE_EXIT once per spawned pty and
++    // was never closed, leaking one fd per session against the process's
++    // RLIMIT_NOFILE. Backported from microsoft/node-pty#931.
++    close(kq);
+ #else
+     while (true) {
+       errno = 0;
+@@ -778,8 +782,19 @@ done:
    posix_spawn_file_actions_destroy(&acts);
    posix_spawnattr_destroy(&attrs);
  


### PR DESCRIPTION
## What & why

Fixes #5699 — the root cause this time, found by reproducing the reporter's exact state on a live machine.

**The bug (upstream node-pty 1.1.0, macOS):** `pty_posix_spawn` leaks one `/dev/ptmx` master fd on **every** spawn. Its low-fd workaround probes `posix_openpt` into `low_fds[]`, but the cleanup loop —

```c
for (; count > 0; count--) {
    close(low_fds[count]);
}
```

— never closes `low_fds[0]`, and in practice the first probe always lands at fd ≥ 3 (`break` with `count == 0`), so **nothing is ever closed**.

**Why this becomes #5699:** each leaked master counts against the system-wide pty cap (`kern.tty.ptmx_max` = 511 on macOS). Field evidence from the machine where this was diagnosed: a 28-day-old pty-daemon held **509 pty fds while tracking only 20 live sessions**; the system sat at 527/511 ptys. At the cap, PTY allocation fails machine-wide — presets toast `Failed to run preset`, session spawns die with `spawn failed (... errno=ok): posix_spawnp failed.` (the re-probe in `Pty.ts` succeeds because plain spawns need no pty — that `errno=ok` is the leak's signature), and every other terminal app on the machine breaks too. Reboot "fixes" it by releasing all ptys, exactly as the reporter described.

**The fix:** upstream already fixed this in [microsoft/node-pty#882](https://github.com/microsoft/node-pty/pull/882) (`fix: /dev/ptmx leak on macOS`), but it's unreleased — 1.1.0 is still the latest stable and the fix only exists in 1.2.0 betas. This PR backports the two fd-hygiene changes onto our pinned 1.1.0 as a bun patch (`patches/node-pty@1.1.0.patch`): close **all** `low_fds` probes, and close the parent's slave copy after `posix_spawn`. Native rebuild picks the patch up automatically (`build/Release` is checked before `prebuilds/` in node-pty's loader).

## How I tested it

Reproduced and verified end-to-end on macOS (arm64):

- **Repro (before):** a standalone daemon (both the packaged 1.150 app bundle and a fresh repo build) leaks exactly **+1 ptmx per session opened, 15/15** across clean-exit, background-child, and held-tty scenarios — the leak happens at spawn time, independent of exit handling. `lsof` shows the extra fd is the `low_fds[0]` probe.
- **After the patch:** same repro leaks **0 fds**; a session while alive holds exactly one pty fd (the real master), and it closes on exit.
- **Regression tests:** `test/fd-release.test.ts` counts the process's open pty fds across spawn/exit cycles (mirroring upstream #882's own test), wired into `test:integration`.
- Full pty-daemon integration suite passes under Node: **52/52**. `bun run lint` and `tsc --noEmit` (pty-daemon) pass.

Related: #5711 adds host-service wedge auto-recovery for the same issue's secondary failure mode (`Failed to fetch` toasts); this PR fixes the resource leak that starves the machine in the first place.

## Known gap: macOS CLI dist still ships the unpatched prebuild

A self-review pass surfaced one important limitation that needs a maintainer decision: `packages/cli/scripts/build-dist.ts` deliberately deletes node-pty's `build/` on darwin ("removing node-pty build/ so bindings falls back to prebuilds/", presumably for cross-arch packaging), so the **macOS CLI dist — including the CLI binary bundled into the desktop app — loads the npm-shipped `prebuilds/darwin-*/pty.node`, which this source patch cannot reach.** The desktop app's own runtime is fixed (electron-rebuild compiles the patched source into `build/Release`, which the loader prefers), but pty-daemon/host-service processes spawned by the macOS CLI keep leaking. Fixing that means either rebuilding the patched source per-arch during CLI packaging and replacing the prebuilds, or forcing `npm_config_build_from_source` on darwin — both touch the release pipeline, so I left it out of this PR rather than risk the builds. Happy to do it as a follow-up if you tell me which direction you prefer.

## Notes for reviewers

- The backport is intentionally minimal (the two leak fixes only) rather than the full #882 refactor of error paths — the deterministic per-spawn leak is what matters in the field. When node-pty 1.2.0 goes stable, bumping the dependency supersedes this patch.
- The patch approach follows the same precedent used by comparable Electron terminal apps pinning node-pty 1.1.0.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5714">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved macOS PTY file-descriptor leaks by ensuring exit watchers and PTY spawn/cleanup fully close all required descriptors.
  * Prevented lingering `/dev/ptmx` master descriptors across repeated spawn/exit cycles.
* **Tests**
  * Added a macOS regression suite that verifies no descriptor accumulation after repeated PTY sessions.
  * Improved integration test reliability by switching to a shared `waitFor` polling helper and expanding the integration test run to include the new regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports macOS `/dev/ptmx` and kqueue fd leak fixes to `node-pty@1.1.0`, stopping per-spawn leaks that can exhaust system ptys or the process fd limit and break terminal spawns. Resolves #5699 and keeps long‑lived daemons stable.

- **Bug Fixes**
  - Close all `low_fds` probe fds and the parent’s slave fd after `posix_spawn` (backported from microsoft/node-pty#882).
  - Close the kqueue opened in `SetupExitCallback` on macOS to stop per‑spawn fd leaks (backported from microsoft/node-pty#931).
  - Add `fd-release.test.ts` to verify pty and macOS kqueue fd counts; use a shared `waitFor` helper and harden checks (fail on empty `lsof`, count Linux `/dev/pts/`).

- **Dependencies**
  - Add `patches/node-pty@1.1.0.patch` and enable via `patchedDependencies` in `package.json` and `bun.lock`.

<sup>Written for commit 1f0c6135d26dc56232aeefcbd9d24ef1844486f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

