### PR TITLE
fix(desktop): stop the template gallery vanishing on outside focus

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/TemplateGalleryModal/TemplateGalleryModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/TemplateGalleryModal/TemplateGalleryModal.tsx
@@ -98,7 +98,7 @@ export function TemplateGalleryModal({
 	};
 
 	return (
-		<Dialog open={open} onOpenChange={handleOpenChange}>
+		<Dialog open={open} onOpenChange={handleOpenChange} modal>
 			<DialogContent
 				className="sm:max-w-5xl"
 				onOpenAutoFocus={(event) => event.preventDefault()}


### PR DESCRIPTION
## Summary
- Pass `modal` to the "Start from a template" gallery `Dialog`. It was the only add-repository modal missing the prop, so it inherited the design system's non-modal default and was dismissed by any background focus change.

## Why / Context
Users reported that "Start from a template" **sometimes** just disappears after clicking — no project created, no error.

`packages/ui/src/components/ui/dialog.tsx:10` overrides Radix's default:

```tsx
function Dialog({ modal = false, ...props })
```

So any `<Dialog>` that doesn't explicitly pass `modal` renders as a **non-modal `DismissableLayer`**, which Radix dismisses on *any* `focusin` whose target is outside it. Nothing has to be clicked — a background element merely **taking focus** kills the modal.

That's the intermittency: it depends on whether some background async (terminal attach, sidebar re-render, agent status tick) grabs focus during the modal's lifetime. Two existing details make it more likely:
- `onOpenAutoFocus` is prevented, so focus never enters the dialog to begin with.
- Clicking a card sets `cloningId`, which disables the focused `TemplateCard` and blurs focus out to `<body>`.

`TemplateGalleryModal` was the outlier — its sibling `NewProjectModal` ("Clone from URL") in the same `AddRepositoryModals` component already passes `modal`, as do `RenameBranchDialog`, `SetupProjectModal`, `PresetEditorDialog`, `Alert`, and essentially every other dialog in the app.

## How It Works
`modal` makes Radix render `DialogContentModal`, which sets `onFocusOutside={e => e.preventDefault()}` (plus a focus trap and `disableOutsidePointerEvents`). The focus-outside dismissal path that caused the bug is gone.

The existing `handleOpenChange` guard (`if (!next && cloningId) return`) only blocked closing *while cloning* — before a template is picked, every dismissal path was wide open. This fixes that window.

## Manual QA Checklist

Verified by driving the dev app over CDP (trusted `Input.dispatchMouseEvent`, dialog polled every 50ms to catch a flash-then-vanish). Confirmed the CDP port owner was this worktree's Electron before trusting results.

### UI Components — Interactions
- [x] Gallery opens from the "Add repository" dropdown (12/12 trials)
- [x] Gallery **survives an outside element taking focus** (0/10 before → 10/10 after)
- [x] All 6 template cards still render and are clickable
- [x] Close (X) still dismisses the gallery

### General Desktop
- [x] Body `pointer-events` restored to `auto` after close in 10/10 trials — no stuck-pointer-events regression, which matters here because `modal` sets `pointer-events: none` and this dialog is opened *from a DropdownMenu*

### Verified the test can actually fail
- [x] Reverting the one-word change took the suite to **0/10** (`survivedFocusSteal=false`); restoring it returned **10/10**. Not a passes-on-write check.

## Testing
- `bun run typecheck` — exit 0
- `bun run lint` — exit 0
- No unit test added: this is a one-prop fix to a Radix wiring default. A jsdom test would assert Radix's own focus-dismissal internals rather than our logic, and jsdom's focus/`focusin` behavior is exactly what diverges from Chromium here — the CDP before/after above is the real signal.

## Design Decisions
- **Why `modal` instead of `onFocusOutside={e => e.preventDefault()}` on `DialogContent`**: both stop the dismissal, but `modal` is what every comparable dialog in the app already does, so it fixes the outlier rather than inventing a second local pattern. It's also semantically right — picking a template is a blocking task, not a background one.
- **Why not flip the `packages/ui` default to `modal = true`**: that matches Radix and would prevent this class of bug repo-wide, but it silently changes behavior for every non-modal `Dialog` consumer. Out of scope for a bug fix — see Follow-ups.

## Known Limitations
- One refuted theory worth recording: disabling the focused card emits `blur`/`focusout` but **no** `focusin`, so it does not dismiss the dialog by itself — it only parks focus on `<body>`, priming the *next* outside focus event to kill it. The fix covers both.
- Other non-modal `Dialog` call-sites in the app may have the same latent fragility; this PR only fixes the reported one.

## Follow-ups
- Consider auditing `<Dialog>` call-sites that omit `modal`, and/or inverting the `packages/ui` default to match Radix so the safe case is the default. Deferred to keep this PR focused and low-risk.

## Risks / Rollout
- Risk: low. Single renderer prop, one component. The visible change is that the app behind the gallery is now inert while it's open (correct modal behavior, and consistent with "Clone from URL").
- Rollback: revert this commit.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the "Start from a template" gallery from disappearing when background elements take focus by making it a true modal. We now pass `modal` to the gallery's `Dialog`, preventing focus-outside dismissal and matching behavior with the other add-repository modals.

<sup>Written for commit d63b6e896cb72955827ac9543862aea1c84e583d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

