### PR TITLE
fix(host-service): never kill PTYs during daemon adoption, and say when the daemon goes quiet

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
@@ -1,7 +1,19 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
-import { useCallback, useSyncExternalStore } from "react";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import {
 	type TerminalLogEntry,
 	terminalRuntimeRegistry,
@@ -11,6 +23,16 @@ interface TerminalConnectionIndicatorProps {
 	terminalId: string;
 	terminalInstanceId: string;
 }
+
+/** How often to re-ask the host whether the daemon is answering. */
+const DAEMON_HEALTH_POLL_MS = 5_000;
+/**
+ * How long the daemon must stay silent before we tell the user. The only fix
+ * we can offer closes every shell, so a stall has to look permanent before we
+ * suggest it — a post-update load spike resolves itself well inside this, and
+ * the shells come back on their own.
+ */
+const DAEMON_UNREACHABLE_WARN_MS = 10_000;
 
 function formatTime(timestamp: number): string {
 	const d = new Date(timestamp);
@@ -30,11 +52,18 @@ function formatLogsForClipboard(logs: readonly TerminalLogEntry[]): string {
 }
 
 /**
- * Pane-header connection status for the terminal WebSocket. Hidden while the
- * connection is healthy; shows an amber "Reconnecting" dot while the
- * auto-reconnect loop runs and a red "Disconnected" dot once the transport
- * stops trying. The popover carries the human diagnosis, a manual reconnect,
- * and the raw transport log for bug reports.
+ * Pane-header health for the terminal, across both things that can break it.
+ *
+ * The WebSocket: hidden while healthy, amber "Reconnecting" while the
+ * auto-reconnect loop runs, red "Disconnected" once the transport gives up.
+ * The popover carries the diagnosis, a manual reconnect, and the raw log.
+ *
+ * The pty-daemon: red "Terminals aren't responding" when the host reports it
+ * has stopped answering for {@link DAEMON_UNREACHABLE_WARN_MS}. That outranks
+ * the WebSocket's story because the daemon owns the shells — and it's shown
+ * even when the socket looks fine, since a wedged daemon closes nothing and
+ * simply freezes the shell. The only fix closes every terminal, so it sits
+ * behind a confirm and we wait out short stalls rather than offer it.
  */
 export function TerminalConnectionIndicator({
 	terminalId,
@@ -71,19 +100,61 @@ export function TerminalConnectionIndicator({
 			terminalInstanceId,
 		),
 	);
+	const [confirmRestartOpen, setConfirmRestartOpen] = useState(false);
 
-	if (connectionState === "open" || connectionState === "disconnected") {
+	const connectionHealthy =
+		connectionState === "open" || connectionState === "disconnected";
+	// Polled even while this pane looks fine: a daemon that wedges under a live
+	// session closes nothing, so the socket stays "open" and the shell just
+	// freezes. The query takes no input, so React Query collapses every pane's
+	// copy into one request per workspace.
+	const healthQuery = workspaceTrpc.terminal.daemon.getHealth.useQuery(
+		undefined,
+		{ refetchInterval: DAEMON_HEALTH_POLL_MS },
+	);
+	const restartDaemon = workspaceTrpc.terminal.daemon.restart.useMutation({
+		onSuccess: () => {
+			toast.success("Daemon restarted", {
+				description: "All terminal sessions were closed.",
+			});
+			void healthQuery.refetch();
+		},
+		onError: (error) => {
+			toast.error("Failed to restart daemon", { description: error.message });
+		},
+	});
+
+	// The daemon owns the shells, so if it has gone quiet that's the root
+	// cause and it outranks whatever the WebSocket is reporting. Wait for a
+	// sustained silence: the fix closes every terminal, and a brief stall
+	// (e.g. an update relaunch) recovers on its own.
+	const health = healthQuery.data;
+	const daemonUnreachable =
+		!!health &&
+		!health.reachable &&
+		health.unreachableForMs >= DAEMON_UNREACHABLE_WARN_MS;
+
+	if (connectionHealthy && !daemonUnreachable) {
 		return null;
 	}
 	// First connect hasn't had trouble yet — don't flash a status.
-	if (connectionState === "connecting" && logs.length === 0 && !diagnosis) {
+	if (
+		connectionState === "connecting" &&
+		logs.length === 0 &&
+		!diagnosis &&
+		!daemonUnreachable
+	) {
 		return null;
 	}
 
 	// Red only once the transport has stopped trying; amber covers both the
 	// in-flight dial and the backoff pause between attempts.
 	const gaveUp = diagnosis !== null && connectionState === "closed";
-	const label = gaveUp ? "Disconnected" : "Reconnecting…";
+	const label = daemonUnreachable
+		? "Terminals aren't responding"
+		: gaveUp
+			? "Disconnected"
+			: "Reconnecting…";
 
 	return (
 		<Popover>
@@ -96,7 +167,9 @@ export function TerminalConnectionIndicator({
 					<span
 						className={cn(
 							"size-1.5 rounded-full",
-							gaveUp ? "bg-destructive" : "animate-pulse bg-yellow-500",
+							gaveUp || daemonUnreachable
+								? "bg-destructive"
+								: "animate-pulse bg-yellow-500",
 						)}
 					/>
 					<span>{label}</span>
@@ -105,23 +178,37 @@ export function TerminalConnectionIndicator({
 			<PopoverContent align="end" className="w-80 p-3 text-xs">
 				<div className="flex flex-col gap-2">
 					<p className="cursor-text select-text text-muted-foreground">
-						{diagnosis?.message ??
-							"The terminal connection dropped. Retrying automatically…"}
+						{daemonUnreachable
+							? "Trying to reconnect — your sessions should come back on their own. Restarting closes every terminal."
+							: (diagnosis?.message ??
+								"The terminal connection dropped. Retrying automatically…")}
 					</p>
 					<div className="flex items-center gap-2">
-						<Button
-							size="sm"
-							variant="outline"
-							className="h-6 px-2 text-xs"
-							onClick={() =>
-								terminalRuntimeRegistry.retryConnect(
-									terminalId,
-									terminalInstanceId,
-								)
-							}
-						>
-							Reconnect
-						</Button>
+						{daemonUnreachable ? (
+							<Button
+								size="sm"
+								variant="outline"
+								className="h-6 px-2 text-xs"
+								disabled={restartDaemon.isPending}
+								onClick={() => setConfirmRestartOpen(true)}
+							>
+								Restart anyway
+							</Button>
+						) : (
+							<Button
+								size="sm"
+								variant="outline"
+								className="h-6 px-2 text-xs"
+								onClick={() =>
+									terminalRuntimeRegistry.retryConnect(
+										terminalId,
+										terminalInstanceId,
+									)
+								}
+							>
+								Reconnect
+							</Button>
+						)}
 						{logs.length > 0 && (
 							<button
 								type="button"
@@ -167,6 +254,32 @@ export function TerminalConnectionIndicator({
 					)}
 				</div>
 			</PopoverContent>
+			<AlertDialog
+				open={confirmRestartOpen}
+				onOpenChange={setConfirmRestartOpen}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Restart terminal daemon?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This closes every terminal session in this workspace and any
+							other, and can't be undone. If the daemon is only briefly stuck,
+							waiting will bring your sessions back instead.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => {
+								setConfirmRestartOpen(false);
+								restartDaemon.mutate();
+							}}
+						>
+							Restart daemon
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</Popover>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
@@ -13,6 +13,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
+import { Loader2, RotateCw, TriangleAlert } from "lucide-react";
 import { useCallback, useState, useSyncExternalStore } from "react";
 import {
 	type TerminalLogEntry,
@@ -53,17 +54,17 @@ function formatLogsForClipboard(logs: readonly TerminalLogEntry[]): string {
 
 /**
  * Pane-header health for the terminal, across both things that can break it.
+ * Three modes: "reconnecting" (amber, auto-retry in flight), "unresponsive"
+ * (amber — the daemon owns the shells and has gone quiet, usually self-heals),
+ * and "disconnected" (red — the transport gave up and needs a manual retry).
+ * Amber means "still working itself out"; red is reserved for the one state
+ * that needs the user. User-facing copy says "terminals", never "daemon".
  *
- * The WebSocket: hidden while healthy, amber "Reconnecting" while the
- * auto-reconnect loop runs, red "Disconnected" once the transport gives up.
- * The popover carries the diagnosis, a manual reconnect, and the raw log.
- *
- * The pty-daemon: red "Terminals aren't responding" when the host reports it
- * has stopped answering for {@link DAEMON_UNREACHABLE_WARN_MS}. That outranks
- * the WebSocket's story because the daemon owns the shells — and it's shown
- * even when the socket looks fine, since a wedged daemon closes nothing and
- * simply freezes the shell. The only fix closes every terminal, so it sits
- * behind a confirm and we wait out short stalls rather than offer it.
+ * The WebSocket drives reconnecting/disconnected; the host-reported pty-daemon
+ * health drives unresponsive (shown after {@link DAEMON_UNREACHABLE_WARN_MS}),
+ * which outranks the socket story since a wedged daemon closes nothing and just
+ * freezes the shell. Restart closes every terminal, so it sits behind a confirm
+ * and we surface a live "quiet for Ns" hint to encourage waiting out a stall.
  */
 export function TerminalConnectionIndicator({
 	terminalId,
@@ -101,6 +102,7 @@ export function TerminalConnectionIndicator({
 		),
 	);
 	const [confirmRestartOpen, setConfirmRestartOpen] = useState(false);
+	const [showLog, setShowLog] = useState(false);
 
 	const connectionHealthy =
 		connectionState === "open" || connectionState === "disconnected";
@@ -114,13 +116,13 @@ export function TerminalConnectionIndicator({
 	);
 	const restartDaemon = workspaceTrpc.terminal.daemon.restart.useMutation({
 		onSuccess: () => {
-			toast.success("Daemon restarted", {
+			toast.success("Terminals restarted", {
 				description: "All terminal sessions were closed.",
 			});
 			void healthQuery.refetch();
 		},
 		onError: (error) => {
-			toast.error("Failed to restart daemon", { description: error.message });
+			toast.error("Couldn't restart terminals", { description: error.message });
 		},
 	});
 
@@ -147,14 +149,31 @@ export function TerminalConnectionIndicator({
 		return null;
 	}
 
-	// Red only once the transport has stopped trying; amber covers both the
-	// in-flight dial and the backoff pause between attempts.
+	// Three failure modes so copy + colour name the fix that applies. Amber =
+	// still working itself out (auto-retry, or a stall that usually self-heals);
+	// red = we've stopped trying and need the user.
 	const gaveUp = diagnosis !== null && connectionState === "closed";
-	const label = daemonUnreachable
-		? "Terminals aren't responding"
+	const mode = daemonUnreachable
+		? "unresponsive"
 		: gaveUp
-			? "Disconnected"
-			: "Reconnecting…";
+			? "disconnected"
+			: "reconnecting";
+	const reconnecting = connectionState === "connecting";
+	const label =
+		mode === "unresponsive"
+			? "Terminals aren't responding"
+			: mode === "disconnected"
+				? "Disconnected"
+				: "Reconnecting…";
+	const StatusIcon = mode === "reconnecting" ? Loader2 : TriangleAlert;
+	const accentClass =
+		mode === "disconnected" ? "text-destructive" : "text-yellow-500";
+	const dotClass =
+		mode === "disconnected"
+			? "bg-destructive"
+			: mode === "unresponsive"
+				? "bg-yellow-500"
+				: "animate-pulse bg-yellow-500";
 
 	return (
 		<Popover>
@@ -162,43 +181,38 @@ export function TerminalConnectionIndicator({
 				<button
 					type="button"
 					aria-label={`Terminal connection: ${label}`}
-					className="flex h-5 items-center gap-1.5 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+					className="flex h-5 items-center gap-1.5 rounded px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
 				>
-					<span
-						className={cn(
-							"size-1.5 rounded-full",
-							gaveUp || daemonUnreachable
-								? "bg-destructive"
-								: "animate-pulse bg-yellow-500",
-						)}
-					/>
+					<span className={cn("size-1.5 rounded-full", dotClass)} />
 					<span>{label}</span>
 				</button>
 			</PopoverTrigger>
-			<PopoverContent align="end" className="w-80 p-3 text-xs">
-				<div className="flex flex-col gap-2">
-					<p className="cursor-text select-text text-muted-foreground">
-						{daemonUnreachable
-							? "Trying to reconnect — your sessions should come back on their own. Restarting closes every terminal."
-							: (diagnosis?.message ??
-								"The terminal connection dropped. Retrying automatically…")}
-					</p>
-					<div className="flex items-center gap-2">
-						{daemonUnreachable ? (
+			<PopoverContent
+				align="end"
+				className={cn("overflow-hidden p-0 text-sm", showLog ? "w-96" : "w-64")}
+			>
+				<div className="flex flex-col gap-3 p-4">
+					<div className="flex items-center gap-2.5">
+						<StatusIcon
+							className={cn(
+								"size-4 shrink-0",
+								accentClass,
+								mode === "reconnecting" && "animate-spin",
+							)}
+						/>
+						<p className="font-medium text-foreground">{label}</p>
+					</div>
+					{/* Reconnect (solid) leads as the safe primary; Restart (outline)
+					    is distinct but quieter, red only on hover so the destructive path
+					    never looks like the obvious one. Both can apply at once (a wedged
+					    daemon doesn't close the socket, but after sleep/wake the transport
+					    may have given up too), so we never leave restart as the only offer.
+					    A lone button flexes to full width. */}
+					<div className="flex gap-2">
+						{!connectionHealthy && (
 							<Button
-								size="sm"
-								variant="outline"
-								className="h-6 px-2 text-xs"
-								disabled={restartDaemon.isPending}
-								onClick={() => setConfirmRestartOpen(true)}
-							>
-								Restart anyway
-							</Button>
-						) : (
-							<Button
-								size="sm"
-								variant="outline"
-								className="h-6 px-2 text-xs"
+								className="flex-1 gap-2"
+								disabled={reconnecting}
 								onClick={() =>
 									terminalRuntimeRegistry.retryConnect(
 										terminalId,
@@ -206,43 +220,61 @@ export function TerminalConnectionIndicator({
 									)
 								}
 							>
-								Reconnect
+								{reconnecting ? (
+									<>
+										<Loader2 className="animate-spin" />
+										Reconnecting…
+									</>
+								) : (
+									<>
+										<RotateCw />
+										Reconnect
+									</>
+								)}
 							</Button>
 						)}
-						{logs.length > 0 && (
-							<button
-								type="button"
-								onClick={() =>
-									navigator.clipboard
-										.writeText(formatLogsForClipboard(logs))
-										.catch((error) =>
-											console.error("[terminal] copy log failed:", error),
-										)
-								}
-								className="text-muted-foreground transition-colors hover:text-foreground"
+						{daemonUnreachable && (
+							<Button
+								variant="outline"
+								className="flex-1 hover:border-destructive/50 hover:bg-destructive/10 hover:text-destructive"
+								disabled={restartDaemon.isPending}
+								onClick={() => setConfirmRestartOpen(true)}
 							>
-								Copy log · {logs.length}
-							</button>
+								Restart
+							</Button>
 						)}
 					</div>
 					{logs.length > 0 && (
-						/* column-reverse pins the scroll to the newest entry; the list
-						   is reversed so reading order stays chronological. */
-						<div className="flex max-h-48 flex-col-reverse overflow-y-auto rounded border border-border bg-muted/30 p-2 font-mono">
+						<button
+							type="button"
+							onClick={() => setShowLog((v) => !v)}
+							className="self-center text-xs text-muted-foreground/70 transition-colors hover:text-foreground"
+						>
+							{showLog ? "Hide log" : "View log"}
+						</button>
+					)}
+				</div>
+				{showLog && logs.length > 0 && (
+					<div className="flex flex-col gap-2 border-t border-border bg-muted/30 p-3">
+						{/* column-reverse pins the scroll to the newest entry; the list
+						   is reversed so reading order stays chronological. Timestamp is a
+						   small header above each line, not a left column, so the message
+						   gets the full width instead of wrapping in a narrow gutter. */}
+						<div className="flex max-h-44 flex-col-reverse overflow-y-auto font-mono text-xs">
 							{logs
 								.slice()
 								.reverse()
 								.map((entry) => (
 									<div
 										key={entry.id}
-										className="flex cursor-text select-text gap-2 py-0.5"
+										className="flex cursor-text select-text flex-col gap-0.5 py-1"
 									>
-										<span className="shrink-0 tabular-nums opacity-60">
+										<span className="text-[10px] tabular-nums text-muted-foreground/50">
 											{formatTime(entry.timestamp)}
 										</span>
 										<span
 											className={cn(
-												"break-all",
+												"[overflow-wrap:anywhere]",
 												entry.level === "error" && "text-destructive",
 											)}
 										>
@@ -251,8 +283,21 @@ export function TerminalConnectionIndicator({
 									</div>
 								))}
 						</div>
-					)}
-				</div>
+						<button
+							type="button"
+							onClick={() =>
+								navigator.clipboard
+									.writeText(formatLogsForClipboard(logs))
+									.catch((error) =>
+										console.error("[terminal] copy log failed:", error),
+									)
+							}
+							className="self-start text-muted-foreground transition-colors hover:text-foreground"
+						>
+							Copy log
+						</button>
+					</div>
+				)}
 			</PopoverContent>
 			<AlertDialog
 				open={confirmRestartOpen}
@@ -260,22 +305,22 @@ export function TerminalConnectionIndicator({
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Restart terminal daemon?</AlertDialogTitle>
+						<AlertDialogTitle>Restart all terminals?</AlertDialogTitle>
 						<AlertDialogDescription>
-							This closes every terminal session in this workspace and any
-							other, and can't be undone. If the daemon is only briefly stuck,
-							waiting will bring your sessions back instead.
+							This closes every terminal session — in this workspace and any
+							others — and can't be undone. If they're only briefly stuck,
+							waiting usually brings them back.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogCancel>Keep waiting</AlertDialogCancel>
 						<AlertDialogAction
 							onClick={() => {
 								setConfirmRestartOpen(false);
 								restartDaemon.mutate();
 							}}
 						>
-							Restart daemon
+							Restart terminals
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalConnectionIndicator/TerminalConnectionIndicator.tsx
@@ -64,7 +64,8 @@ function formatLogsForClipboard(logs: readonly TerminalLogEntry[]): string {
  * health drives unresponsive (shown after {@link DAEMON_UNREACHABLE_WARN_MS}),
  * which outranks the socket story since a wedged daemon closes nothing and just
  * freezes the shell. Restart closes every terminal, so it sits behind a confirm
- * and we surface a live "quiet for Ns" hint to encourage waiting out a stall.
+ * (with a "Keep waiting" cancel) and we wait out short stalls rather than offer
+ * it eagerly — a transient stall usually clears on its own.
  */
 export function TerminalConnectionIndicator({
 	terminalId,

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -290,7 +290,7 @@ describe("DaemonSupervisor.tryAdopt", () => {
 		}
 	});
 
-	test("rejects and replaces a pid-alive daemon that stays unreachable for the whole grace window", async () => {
+	test("adopts an unprobeable but pid-alive daemon instead of killing its shells", async () => {
 		const orgId = "org-unprobeable";
 		const fake = await startFakeDaemon({ silent: true });
 		const child = childProcess.spawn(
@@ -317,23 +317,26 @@ describe("DaemonSupervisor.tryAdopt", () => {
 				organizationId: orgId,
 			});
 
-			const sup = new DaemonSupervisor({
-				scriptPath: "/nonexistent",
-				// Short grace so the wedged-recovery path doesn't wait the full
-				// production window; a healthy daemon is never force-killed here.
-				adoptionWedgeGraceMs: 300,
-			});
-			const adopted = await invokeTryAdopt(sup, orgId);
-			expect(adopted).toBeNull();
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			const adopted = (await invokeTryAdopt(
+				sup,
+				orgId,
+			)) as AdoptedForTest | null;
+			// Adopted, not rejected: the pid is alive so it still owns PTYs.
+			expect(adopted).not.toBeNull();
+			expect(adopted?.pid).toBe(childPid);
+			expect(adopted?.runningVersion).toBe("unknown");
+			// A failed probe must not be mistaken for version drift.
+			expect(adopted?.updatePending).toBe(false);
 			expect(
 				loggedEvents.some(
 					(e) =>
-						e.event === "pty_daemon_adopt_rejected" &&
-						e.props.reason === "probe_failed_after_grace" &&
-						e.props.pid === childPid,
+						e.event === "pty_daemon_adopt_unprobed" && e.props.pid === childPid,
 				),
 			).toBe(true);
-			expect(await waitForProcessExit(childPid, 2500)).toBe(true);
+			// The whole point of SUPER-833: the daemon is left running.
+			expect(await waitForProcessExit(childPid, 1500)).toBe(false);
+			expect(isProcessAliveForTest(childPid)).toBe(true);
 		} finally {
 			await fake.close();
 			if (isProcessAliveForTest(childPid)) {
@@ -382,9 +385,6 @@ describe("DaemonSupervisor.tryAdopt", () => {
 			const sup = new DaemonSupervisor({
 				scriptPath: "/nonexistent",
 				autoUpdate: false,
-				// Even a short grace must adopt this answering daemon; it only
-				// bounds how long a genuinely wedged one is tolerated.
-				adoptionWedgeGraceMs: 300,
 			});
 			const adopted = (await invokeTryAdopt(
 				sup,

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -411,6 +411,87 @@ describe("DaemonSupervisor.tryAdopt", () => {
 	});
 });
 
+describe("DaemonSupervisor daemon health", () => {
+	test("returns null when there's no daemon for the org", () => {
+		const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+		expect(sup.getHealth("org-none")).toBeNull();
+	});
+
+	test("reports reachable while the daemon is answering", () => {
+		const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+		seedInstance(sup, "org-ok", {
+			runningVersion: "0.1.0",
+			expectedVersion: "0.1.0",
+			updatePending: false,
+			unreachableSince: null,
+		});
+		expect(sup.getHealth("org-ok")).toEqual({
+			reachable: true,
+			unreachableForMs: 0,
+		});
+	});
+
+	test("reports how long the daemon has been silent", () => {
+		const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+		seedInstance(sup, "org-quiet", {
+			runningVersion: "unknown",
+			expectedVersion: "0.1.0",
+			updatePending: false,
+			unreachableSince: Date.now() - 12_000,
+		});
+		const health = sup.getHealth("org-quiet");
+		expect(health?.reachable).toBe(false);
+		// The UI's warn threshold keys off this, so it has to be a real duration.
+		expect(health?.unreachableForMs).toBeGreaterThanOrEqual(12_000);
+	});
+
+	test("starts the clock when a live daemon stops answering", async () => {
+		const fake = await startFakeDaemon({ silent: true });
+		try {
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			seedInstance(sup, "org-goes-quiet", {
+				runningVersion: "0.1.0",
+				expectedVersion: "0.1.0",
+				updatePending: false,
+				unreachableSince: null,
+				pid: process.pid,
+				socketPath: fake.socketPath,
+			});
+			await invokeRefreshReachability(sup, "org-goes-quiet", process.pid);
+			expect(sup.getHealth("org-goes-quiet")?.reachable).toBe(false);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("clears the silence and backfills the version once it answers again", async () => {
+		const fake = await startFakeDaemon({ respondWithVersion: "0.1.0" });
+		try {
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			// An adopt-unprobed instance: alive, version unknown, gone quiet.
+			seedInstance(sup, "org-recovers", {
+				runningVersion: "unknown",
+				expectedVersion: "0.1.0",
+				updatePending: false,
+				unreachableSince: Date.now() - 30_000,
+				pid: process.pid,
+				socketPath: fake.socketPath,
+			});
+			await invokeRefreshReachability(sup, "org-recovers", process.pid);
+			// Recovery must clear itself so the UI's warning disappears without
+			// the user destroying shells that came back on their own.
+			expect(sup.getHealth("org-recovers")).toEqual({
+				reachable: true,
+				unreachableForMs: 0,
+			});
+			// And the version we couldn't read at adoption is now resolved.
+			expect(sup.getUpdateStatus("org-recovers")?.running).toBe("0.1.0");
+		} finally {
+			await fake.close();
+		}
+	});
+});
+
 describe("DaemonSupervisor.getUpdateStatus", () => {
 	let sup: DaemonSupervisor;
 
@@ -945,6 +1026,9 @@ interface SeededFields {
 	runningVersion: string;
 	expectedVersion: string;
 	updatePending: boolean;
+	unreachableSince?: number | null;
+	pid?: number;
+	socketPath?: string;
 }
 
 function seedPredecessor(
@@ -985,6 +1069,7 @@ function seedInstance(
 		pid: 9999,
 		socketPath: "/tmp/seeded.sock",
 		startedAt: Date.now(),
+		unreachableSince: null,
 		...fields,
 	});
 }
@@ -1032,6 +1117,7 @@ function freshInstance() {
 		runningVersion: "0.1.0",
 		expectedVersion: "0.1.0",
 		updatePending: false,
+		unreachableSince: null,
 	};
 }
 
@@ -1068,6 +1154,18 @@ function invokeKickoffAutoUpdate(
 			kickoffAutoUpdate: (id: string, inst: typeof instance) => void;
 		}
 	).kickoffAutoUpdate(organizationId, instance);
+}
+
+function invokeRefreshReachability(
+	sup: DaemonSupervisor,
+	organizationId: string,
+	pid: number,
+): Promise<void> {
+	return (
+		sup as unknown as {
+			refreshReachability: (id: string, pid: number) => Promise<void>;
+		}
+	).refreshReachability(organizationId, pid);
 }
 
 function invokeTryAdopt(

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -328,12 +328,6 @@ describe("DaemonSupervisor.tryAdopt", () => {
 			expect(adopted?.runningVersion).toBe("unknown");
 			// A failed probe must not be mistaken for version drift.
 			expect(adopted?.updatePending).toBe(false);
-			expect(
-				loggedEvents.some(
-					(e) =>
-						e.event === "pty_daemon_adopt_unprobed" && e.props.pid === childPid,
-				),
-			).toBe(true);
 			// The whole point of SUPER-833: the daemon is left running.
 			expect(await waitForProcessExit(childPid, 1500)).toBe(false);
 			expect(isProcessAliveForTest(childPid)).toBe(true);

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -229,11 +229,26 @@ describe("shouldKillStaleDaemonForDev", () => {
 });
 
 describe("DaemonSupervisor.tryAdopt", () => {
+	let originalHome: string | undefined;
+	let tmpHome: string;
+
+	beforeEach(() => {
+		originalHome = process.env.SUPERSET_HOME_DIR;
+		tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pty-daemon-unit-"));
+		process.env.SUPERSET_HOME_DIR = tmpHome;
+	});
+
+	afterEach(() => {
+		if (originalHome !== undefined) {
+			process.env.SUPERSET_HOME_DIR = originalHome;
+		} else {
+			delete process.env.SUPERSET_HOME_DIR;
+		}
+		fs.rmSync(tmpHome, { recursive: true, force: true });
+	});
+
 	test("recovers adoption from a live expected socket when the manifest is missing", async () => {
 		const orgId = "org-socket-fallback";
-		const originalHome = process.env.SUPERSET_HOME_DIR;
-		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pty-daemon-unit-"));
-		process.env.SUPERSET_HOME_DIR = tmpHome;
 		const socketPath = ptyDaemonSocketPath(orgId);
 		try {
 			try {
@@ -276,12 +291,6 @@ describe("DaemonSupervisor.tryAdopt", () => {
 				await fake.close();
 			}
 		} finally {
-			if (originalHome !== undefined) {
-				process.env.SUPERSET_HOME_DIR = originalHome;
-			} else {
-				delete process.env.SUPERSET_HOME_DIR;
-			}
-			fs.rmSync(tmpHome, { recursive: true, force: true });
 			try {
 				fs.unlinkSync(socketPath);
 			} catch {
@@ -292,22 +301,10 @@ describe("DaemonSupervisor.tryAdopt", () => {
 
 	test("adopts an unprobeable but pid-alive daemon instead of killing its shells", async () => {
 		const orgId = "org-unprobeable";
+		// Silent but listening: connects succeed, hello never answered —
+		// a wedged/overloaded daemon, not a dead one.
 		const fake = await startFakeDaemon({ silent: true });
-		const child = childProcess.spawn(
-			process.execPath,
-			["-e", "setInterval(() => {}, 1000)"],
-			{ stdio: "ignore" },
-		);
-		const childPid = child.pid;
-		expect(typeof childPid).toBe("number");
-		if (!childPid) {
-			await fake.close();
-			return;
-		}
-
-		const originalHome = process.env.SUPERSET_HOME_DIR;
-		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pty-daemon-unit-"));
-		process.env.SUPERSET_HOME_DIR = tmpHome;
+		const childPid = spawnIdleChild();
 		try {
 			writePtyDaemonManifest({
 				pid: childPid,
@@ -333,41 +330,19 @@ describe("DaemonSupervisor.tryAdopt", () => {
 			expect(isProcessAliveForTest(childPid)).toBe(true);
 		} finally {
 			await fake.close();
-			if (isProcessAliveForTest(childPid)) {
-				try {
-					process.kill(childPid, "SIGKILL");
-				} catch {
-					// already gone
-				}
-			}
-			if (originalHome !== undefined) {
-				process.env.SUPERSET_HOME_DIR = originalHome;
-			} else {
-				delete process.env.SUPERSET_HOME_DIR;
-			}
-			fs.rmSync(tmpHome, { recursive: true, force: true });
+			killIfAlive(childPid);
 		}
-	});
+	}, 15_000);
 
 	test("adopts a pid-alive daemon that answers the probe without force-killing it", async () => {
 		// Regression guard for SUPER-833: a reachable, probeable daemon that
 		// owns live shells must be adopted, never terminated during adoption.
-		const child = childProcess.spawn(
-			process.execPath,
-			["-e", "setInterval(() => {}, 1000)"],
-			{ stdio: "ignore" },
-		);
-		const childPid = child.pid;
-		expect(typeof childPid).toBe("number");
-		if (!childPid) return;
+		const childPid = spawnIdleChild();
 		const orgId = "org-healthy-adopt";
 		const fake = await startFakeDaemon({
 			respondWithVersion: "0.1.0",
 			daemonPid: childPid,
 		});
-		const originalHome = process.env.SUPERSET_HOME_DIR;
-		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pty-daemon-unit-"));
-		process.env.SUPERSET_HOME_DIR = tmpHome;
 		try {
 			writePtyDaemonManifest({
 				pid: childPid,
@@ -394,21 +369,91 @@ describe("DaemonSupervisor.tryAdopt", () => {
 			expect(isProcessAliveForTest(childPid)).toBe(true);
 		} finally {
 			await fake.close();
-			if (isProcessAliveForTest(childPid)) {
-				try {
-					process.kill(childPid, "SIGKILL");
-				} catch {
-					// already gone
-				}
-			}
-			if (originalHome !== undefined) {
-				process.env.SUPERSET_HOME_DIR = originalHome;
-			} else {
-				delete process.env.SUPERSET_HOME_DIR;
-			}
-			fs.rmSync(tmpHome, { recursive: true, force: true });
+			killIfAlive(childPid);
 		}
 	});
+
+	test("refuses to adopt a recycled pid whose socket has no listener", async () => {
+		// After a reboot the manifest's pid can belong to an unrelated live
+		// process while the daemon (and its socket) are gone. Adopting it
+		// would wedge terminals behind a phantom instance forever.
+		const orgId = "org-recycled-pid";
+		const childPid = spawnIdleChild();
+		try {
+			writePtyDaemonManifest({
+				pid: childPid,
+				socketPath: path.join(os.tmpdir(), `dead-${process.pid}.sock`),
+				protocolVersions: [1],
+				startedAt: Date.now(),
+				organizationId: orgId,
+			});
+
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			const adopted = await invokeTryAdopt(sup, orgId);
+			// No listener anywhere → not adoptable; the caller spawns fresh.
+			expect(adopted).toBeNull();
+			// The stale manifest is gone so the next boot doesn't re-trip.
+			expect(readPtyDaemonManifest(orgId)).toBeNull();
+			expect(
+				loggedEvents.some((e) => e.event === "pty_daemon_manifest_stale"),
+			).toBe(true);
+			// The unrelated process must never be signalled.
+			expect(isProcessAliveForTest(childPid)).toBe(true);
+		} finally {
+			killIfAlive(childPid);
+		}
+	}, 15_000);
+
+	test("falls back to the expected socket when the manifest socket is dead", async () => {
+		// A stale manifest can point at a dead socket while a healthy daemon
+		// answers at the expected path — adopt the healthy one.
+		const orgId = "org-manifest-socket-dead";
+		const socketPath = ptyDaemonSocketPath(orgId);
+		const childPid = spawnIdleChild();
+		try {
+			try {
+				fs.unlinkSync(socketPath);
+			} catch {
+				// best-effort cleanup from a failed prior run
+			}
+			const fake = await startFakeDaemon({
+				socketPath,
+				respondWithVersion: "0.1.0",
+				daemonPid: process.pid,
+			});
+			try {
+				writePtyDaemonManifest({
+					pid: childPid,
+					socketPath: path.join(os.tmpdir(), `dead-${process.pid}.sock`),
+					protocolVersions: [1],
+					startedAt: Date.now(),
+					organizationId: orgId,
+				});
+
+				const sup = new DaemonSupervisor({
+					scriptPath: "/nonexistent",
+					autoUpdate: false,
+				});
+				const adopted = (await invokeTryAdopt(
+					sup,
+					orgId,
+				)) as AdoptedForTest | null;
+				expect(adopted).not.toBeNull();
+				expect(adopted?.pid).toBe(process.pid);
+				expect(adopted?.socketPath).toBe(socketPath);
+				expect(isProcessAliveForTest(childPid)).toBe(true);
+			} finally {
+				await fake.close();
+			}
+		} finally {
+			killIfAlive(childPid);
+			try {
+				fs.unlinkSync(socketPath);
+			} catch {
+				// best-effort
+			}
+		}
+	}, 15_000);
 });
 
 describe("DaemonSupervisor daemon health", () => {
@@ -467,7 +512,10 @@ describe("DaemonSupervisor daemon health", () => {
 	test("clears the silence and backfills the version once it answers again", async () => {
 		const fake = await startFakeDaemon({ respondWithVersion: "0.1.0" });
 		try {
-			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			const sup = new DaemonSupervisor({
+				scriptPath: "/nonexistent",
+				autoUpdate: false,
+			});
 			// An adopt-unprobed instance: alive, version unknown, gone quiet.
 			seedInstance(sup, "org-recovers", {
 				runningVersion: "unknown",
@@ -486,6 +534,69 @@ describe("DaemonSupervisor daemon health", () => {
 			});
 			// And the version we couldn't read at adoption is now resolved.
 			expect(sup.getUpdateStatus("org-recovers")?.running).toBe("0.1.0");
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("kicks off auto-update when the late probe reveals a stale version", async () => {
+		// The adopt-time probe failed (version "unknown"), so the adopt path
+		// skipped auto-update. The late read is the same discovery and must
+		// take the same action — this is exactly the post-update-load boot
+		// the adoption change is for.
+		const fake = await startFakeDaemon({ respondWithVersion: "0.0.1" });
+		try {
+			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			const kickoffMock = mock(() => {});
+			(
+				sup as unknown as { kickoffAutoUpdate: typeof kickoffMock }
+			).kickoffAutoUpdate = kickoffMock;
+			seedInstance(sup, "org-late-stale", {
+				runningVersion: "unknown",
+				expectedVersion: "0.2.5",
+				updatePending: false,
+				unreachableSince: Date.now() - 5_000,
+				pid: process.pid,
+				socketPath: fake.socketPath,
+			});
+			await invokeRefreshReachability(sup, "org-late-stale", process.pid);
+			expect(sup.getUpdateStatus("org-late-stale")?.pending).toBe(true);
+			expect(kickoffMock).toHaveBeenCalledTimes(1);
+			expect(
+				loggedEvents.some((e) => e.event === "pty_daemon_update_pending"),
+			).toBe(true);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("late stale-version discovery respects autoUpdate: false", async () => {
+		const fake = await startFakeDaemon({ respondWithVersion: "0.0.1" });
+		try {
+			const sup = new DaemonSupervisor({
+				scriptPath: "/nonexistent",
+				autoUpdate: false,
+			});
+			const kickoffMock = mock(() => {});
+			(
+				sup as unknown as { kickoffAutoUpdate: typeof kickoffMock }
+			).kickoffAutoUpdate = kickoffMock;
+			seedInstance(sup, "org-late-stale-noauto", {
+				runningVersion: "unknown",
+				expectedVersion: "0.2.5",
+				updatePending: false,
+				unreachableSince: Date.now() - 5_000,
+				pid: process.pid,
+				socketPath: fake.socketPath,
+			});
+			await invokeRefreshReachability(
+				sup,
+				"org-late-stale-noauto",
+				process.pid,
+			);
+			// Still flagged for the UI, but no background handoff.
+			expect(sup.getUpdateStatus("org-late-stale-noauto")?.pending).toBe(true);
+			expect(kickoffMock).not.toHaveBeenCalled();
 		} finally {
 			await fake.close();
 		}
@@ -1177,6 +1288,28 @@ function invokeTryAdopt(
 			tryAdopt: (id: string) => Promise<unknown | null>;
 		}
 	).tryAdopt(organizationId);
+}
+
+/** A live pid that is definitely not a pty-daemon. */
+function spawnIdleChild(): number {
+	const child = childProcess.spawn(
+		process.execPath,
+		["-e", "setInterval(() => {}, 1000)"],
+		{ stdio: "ignore" },
+	);
+	const childPid = child.pid;
+	expect(typeof childPid).toBe("number");
+	if (!childPid) throw new Error("failed to spawn idle child");
+	return childPid;
+}
+
+function killIfAlive(pid: number): void {
+	if (!isProcessAliveForTest(pid)) return;
+	try {
+		process.kill(pid, "SIGKILL");
+	} catch {
+		// already gone
+	}
 }
 
 async function waitForProcessExit(

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -290,7 +290,7 @@ describe("DaemonSupervisor.tryAdopt", () => {
 		}
 	});
 
-	test("rejects and replaces a reachable daemon that cannot answer the version probe", async () => {
+	test("rejects and replaces a pid-alive daemon that stays unreachable for the whole grace window", async () => {
 		const orgId = "org-unprobeable";
 		const fake = await startFakeDaemon({ silent: true });
 		const child = childProcess.spawn(
@@ -317,18 +317,87 @@ describe("DaemonSupervisor.tryAdopt", () => {
 				organizationId: orgId,
 			});
 
-			const sup = new DaemonSupervisor({ scriptPath: "/nonexistent" });
+			const sup = new DaemonSupervisor({
+				scriptPath: "/nonexistent",
+				// Short grace so the wedged-recovery path doesn't wait the full
+				// production window; a healthy daemon is never force-killed here.
+				adoptionWedgeGraceMs: 300,
+			});
 			const adopted = await invokeTryAdopt(sup, orgId);
 			expect(adopted).toBeNull();
 			expect(
 				loggedEvents.some(
 					(e) =>
 						e.event === "pty_daemon_adopt_rejected" &&
-						e.props.reason === "version_probe_failed" &&
+						e.props.reason === "probe_failed_after_grace" &&
 						e.props.pid === childPid,
 				),
 			).toBe(true);
 			expect(await waitForProcessExit(childPid, 2500)).toBe(true);
+		} finally {
+			await fake.close();
+			if (isProcessAliveForTest(childPid)) {
+				try {
+					process.kill(childPid, "SIGKILL");
+				} catch {
+					// already gone
+				}
+			}
+			if (originalHome !== undefined) {
+				process.env.SUPERSET_HOME_DIR = originalHome;
+			} else {
+				delete process.env.SUPERSET_HOME_DIR;
+			}
+			fs.rmSync(tmpHome, { recursive: true, force: true });
+		}
+	});
+
+	test("adopts a pid-alive daemon that answers the probe without force-killing it", async () => {
+		// Regression guard for SUPER-833: a reachable, probeable daemon that
+		// owns live shells must be adopted, never terminated during adoption.
+		const child = childProcess.spawn(
+			process.execPath,
+			["-e", "setInterval(() => {}, 1000)"],
+			{ stdio: "ignore" },
+		);
+		const childPid = child.pid;
+		expect(typeof childPid).toBe("number");
+		if (!childPid) return;
+		const orgId = "org-healthy-adopt";
+		const fake = await startFakeDaemon({
+			respondWithVersion: "0.1.0",
+			daemonPid: childPid,
+		});
+		const originalHome = process.env.SUPERSET_HOME_DIR;
+		const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pty-daemon-unit-"));
+		process.env.SUPERSET_HOME_DIR = tmpHome;
+		try {
+			writePtyDaemonManifest({
+				pid: childPid,
+				socketPath: fake.socketPath,
+				protocolVersions: [2],
+				startedAt: Date.now(),
+				organizationId: orgId,
+			});
+			const sup = new DaemonSupervisor({
+				scriptPath: "/nonexistent",
+				autoUpdate: false,
+				// Even a short grace must adopt this answering daemon; it only
+				// bounds how long a genuinely wedged one is tolerated.
+				adoptionWedgeGraceMs: 300,
+			});
+			const adopted = (await invokeTryAdopt(
+				sup,
+				orgId,
+			)) as AdoptedForTest | null;
+			expect(adopted).not.toBeNull();
+			expect(adopted?.pid).toBe(childPid);
+			expect(adopted?.runningVersion).toBe("0.1.0");
+			// The live daemon must not have taken the destructive reject path.
+			expect(
+				loggedEvents.some((e) => e.event === "pty_daemon_adopt_rejected"),
+			).toBe(false);
+			expect(isProcessAliveForTest(childPid)).toBe(true);
 		} finally {
 			await fake.close();
 			if (isProcessAliveForTest(childPid)) {

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -793,69 +793,31 @@ export class DaemonSupervisor {
 				reason: "manifest_pid_dead",
 			});
 		}
-		// The pid is alive, so it still owns the user's PTYs. Adoption never
-		// kills it: `terminateProcessTreeAndGroups` would signal the daemon's
-		// whole process tree — every live shell — which is what made updates
-		// kill terminals (SUPER-833). A failed probe means we couldn't read its
-		// version, not that it's disposable. Recovering a genuinely wedged
-		// daemon stays an explicit user action (Settings > Restart daemon).
+		// The pid is alive, so it still owns the user's PTYs — adopt it. Killing
+		// it here signalled the daemon's whole process tree, taking every live
+		// shell with it (SUPER-833). A failed probe only means we couldn't read
+		// its version; a wedged daemon is recovered by an explicit user restart.
 		const probe = await probeDaemonHelloWithRetry(
 			manifest.socketPath,
 			ADOPTION_PROBE_TOTAL_TIMEOUT_MS,
 		);
-		if (probe) {
-			const runningVersion = probe.daemonVersion;
-			return {
-				pid: manifest.pid,
-				socketPath: manifest.socketPath,
-				startedAt: manifest.startedAt,
-				runningVersion,
-				expectedVersion: EXPECTED_DAEMON_VERSION,
-				updatePending: !semver.satisfies(
-					runningVersion,
-					`>=${EXPECTED_DAEMON_VERSION}`,
-				),
-			};
-		}
-
-		// Couldn't read a version off the manifest socket. If the socket path
-		// scheme changed under us, a daemon may be answering on the expected
-		// path — prefer that one.
-		if (manifest.socketPath !== expectedSocketPath) {
-			const viaSocket = await this.tryAdoptFromSocket(
-				organizationId,
-				expectedSocketPath,
-				{ reason: "manifest_probe_failed", previousManifest: manifest },
-			);
-			if (viaSocket) return viaSocket;
-		}
-
-		// Adopt unprobed. `runningVersion: "unknown"` is the documented state
-		// for a failed probe, and it leaves updatePending false so a probe
-		// failure is never mistaken for version drift.
-		logEvent("pty_daemon_adopt_unprobed", {
-			organizationId,
-			pid: manifest.pid,
-			socketPath: manifest.socketPath,
-			reason: "version_probe_failed",
-		});
+		const runningVersion = probe?.daemonVersion ?? "unknown";
 		return {
 			pid: manifest.pid,
 			socketPath: manifest.socketPath,
 			startedAt: manifest.startedAt,
-			runningVersion: "unknown",
+			runningVersion,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
-			updatePending: false,
+			updatePending:
+				probe != null &&
+				!semver.satisfies(runningVersion, `>=${EXPECTED_DAEMON_VERSION}`),
 		};
 	}
 
 	private async tryAdoptFromSocket(
 		organizationId: string,
 		socketPath: string,
-		context: {
-			reason: string;
-			previousManifest?: PtyDaemonManifest;
-		},
+		context: { reason: string },
 	): Promise<DaemonInstance | null> {
 		const reachable = await isSocketConnectable(socketPath, 1000);
 		if (!reachable) return null;
@@ -886,7 +848,7 @@ export class DaemonSupervisor {
 			return null;
 		}
 
-		const startedAt = context.previousManifest?.startedAt ?? Date.now();
+		const startedAt = Date.now();
 		writePtyDaemonManifest({
 			pid: resolvedPid,
 			socketPath,

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -77,6 +77,16 @@ const HANDOFF_PROBE_TOTAL_TIMEOUT_MS = 3_000;
 const DAEMON_TERMINATE_TIMEOUT_MS = 1_000;
 const AUTO_UPDATE_SESSION_LIST_TIMEOUT_MS = 1_500;
 const ADOPTION_PROBE_TOTAL_TIMEOUT_MS = 3_000;
+/**
+ * How long to keep retrying to reach a pid-alive daemon during adoption before
+ * treating it as wedged. A daemon that owns live shells must never be
+ * force-killed for a transient stall: post-update relaunch spikes (Squirrel
+ * finishing + every org's host-service booting at once) can make a healthy
+ * daemon miss a 1-3s probe, and terminating it SIGKILLs the user's shells
+ * (SUPER-833). Long enough to ride out that spike before escalating to a
+ * destructive respawn.
+ */
+const ADOPTION_WEDGE_GRACE_MS = 15_000;
 
 /**
  * Crash supervision parameters. If the daemon for an organization crashes
@@ -152,6 +162,13 @@ export interface DaemonSupervisorOptions {
 	 * real handoff.
 	 */
 	autoUpdate?: boolean;
+	/**
+	 * Grace window (ms) to keep retrying a pid-alive daemon's adoption probe
+	 * before treating it as wedged and force-respawning. Defaults to
+	 * {@link ADOPTION_WEDGE_GRACE_MS}; tests override it to a small value so the
+	 * wedged-recovery path doesn't take the full production window.
+	 */
+	adoptionWedgeGraceMs?: number;
 }
 
 export class DaemonSupervisor {
@@ -793,55 +810,57 @@ export class DaemonSupervisor {
 				reason: "manifest_pid_dead",
 			});
 		}
-		const reachable = await isSocketConnectable(manifest.socketPath, 1000);
-		if (!reachable) {
-			// PID alive but socket gone — daemon is wedged. Kill and respawn.
-			await terminateProcessTreeAndGroups(manifest.pid, "SIGTERM");
-			removePtyDaemonManifest(organizationId);
-			if (manifest.socketPath !== expectedSocketPath) {
-				return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
-					reason: "manifest_socket_unreachable",
-					previousManifest: manifest,
-				});
-			}
-			return null;
-		}
-
-		const probe = await probeDaemonHelloWithRetry(
-			manifest.socketPath,
-			ADOPTION_PROBE_TOTAL_TIMEOUT_MS,
-		);
-		if (!probe) {
-			logEvent("pty_daemon_adopt_rejected", {
-				organizationId,
+		// PID alive: probe the daemon patiently before doing anything
+		// destructive. `terminateProcessTreeAndGroups` here would SIGKILL the
+		// daemon's whole process tree — i.e. every live user shell — so a
+		// transient stall (post-update relaunch load spike) must not reach it.
+		// Retry across the grace window; only treat the daemon as wedged once
+		// it stays unreachable the entire time (SUPER-833).
+		const graceMs = this.opts.adoptionWedgeGraceMs ?? ADOPTION_WEDGE_GRACE_MS;
+		const probe = await probeDaemonHelloWithRetry(manifest.socketPath, graceMs);
+		if (probe) {
+			const runningVersion = probe.daemonVersion;
+			return {
 				pid: manifest.pid,
 				socketPath: manifest.socketPath,
-				reason: "version_probe_failed",
-			});
-			await terminateProcessTreeAndGroups(manifest.pid, "SIGTERM");
-			removePtyDaemonManifest(organizationId);
-			if (manifest.socketPath !== expectedSocketPath) {
-				return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
-					reason: "manifest_version_probe_failed",
-					previousManifest: manifest,
-				});
-			}
-			return null;
+				startedAt: manifest.startedAt,
+				runningVersion,
+				expectedVersion: EXPECTED_DAEMON_VERSION,
+				updatePending: !semver.satisfies(
+					runningVersion,
+					`>=${EXPECTED_DAEMON_VERSION}`,
+				),
+			};
 		}
-		const runningVersion = probe.daemonVersion;
-		const updatePending = !semver.satisfies(
-			runningVersion,
-			`>=${EXPECTED_DAEMON_VERSION}`,
-		);
 
-		return {
+		// Daemon exited on its own during the grace window — nothing to kill;
+		// fall through to a socket adopt / fresh spawn.
+		if (!isProcessAlive(manifest.pid)) {
+			removePtyDaemonManifest(organizationId);
+			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+				reason: "manifest_pid_dead",
+			});
+		}
+
+		// Pid stayed alive but never answered across the whole grace window:
+		// genuinely wedged. Recover by force-respawning — destructive, but only
+		// after we're convinced it isn't merely slow.
+		logEvent("pty_daemon_adopt_rejected", {
+			organizationId,
 			pid: manifest.pid,
 			socketPath: manifest.socketPath,
-			startedAt: manifest.startedAt,
-			runningVersion,
-			expectedVersion: EXPECTED_DAEMON_VERSION,
-			updatePending,
-		};
+			reason: "probe_failed_after_grace",
+			graceMs,
+		});
+		await terminateProcessTreeAndGroups(manifest.pid, "SIGTERM");
+		removePtyDaemonManifest(organizationId);
+		if (manifest.socketPath !== expectedSocketPath) {
+			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+				reason: "manifest_probe_failed_after_grace",
+				previousManifest: manifest,
+			});
+		}
+		return null;
 	}
 
 	private async tryAdoptFromSocket(

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -77,16 +77,6 @@ const HANDOFF_PROBE_TOTAL_TIMEOUT_MS = 3_000;
 const DAEMON_TERMINATE_TIMEOUT_MS = 1_000;
 const AUTO_UPDATE_SESSION_LIST_TIMEOUT_MS = 1_500;
 const ADOPTION_PROBE_TOTAL_TIMEOUT_MS = 3_000;
-/**
- * How long to keep retrying to reach a pid-alive daemon during adoption before
- * treating it as wedged. A daemon that owns live shells must never be
- * force-killed for a transient stall: post-update relaunch spikes (Squirrel
- * finishing + every org's host-service booting at once) can make a healthy
- * daemon miss a 1-3s probe, and terminating it SIGKILLs the user's shells
- * (SUPER-833). Long enough to ride out that spike before escalating to a
- * destructive respawn.
- */
-const ADOPTION_WEDGE_GRACE_MS = 15_000;
 
 /**
  * Crash supervision parameters. If the daemon for an organization crashes
@@ -162,13 +152,6 @@ export interface DaemonSupervisorOptions {
 	 * real handoff.
 	 */
 	autoUpdate?: boolean;
-	/**
-	 * Grace window (ms) to keep retrying a pid-alive daemon's adoption probe
-	 * before treating it as wedged and force-respawning. Defaults to
-	 * {@link ADOPTION_WEDGE_GRACE_MS}; tests override it to a small value so the
-	 * wedged-recovery path doesn't take the full production window.
-	 */
-	adoptionWedgeGraceMs?: number;
 }
 
 export class DaemonSupervisor {
@@ -810,14 +793,16 @@ export class DaemonSupervisor {
 				reason: "manifest_pid_dead",
 			});
 		}
-		// PID alive: probe the daemon patiently before doing anything
-		// destructive. `terminateProcessTreeAndGroups` here would SIGKILL the
-		// daemon's whole process tree — i.e. every live user shell — so a
-		// transient stall (post-update relaunch load spike) must not reach it.
-		// Retry across the grace window; only treat the daemon as wedged once
-		// it stays unreachable the entire time (SUPER-833).
-		const graceMs = this.opts.adoptionWedgeGraceMs ?? ADOPTION_WEDGE_GRACE_MS;
-		const probe = await probeDaemonHelloWithRetry(manifest.socketPath, graceMs);
+		// The pid is alive, so it still owns the user's PTYs. Adoption never
+		// kills it: `terminateProcessTreeAndGroups` would signal the daemon's
+		// whole process tree — every live shell — which is what made updates
+		// kill terminals (SUPER-833). A failed probe means we couldn't read its
+		// version, not that it's disposable. Recovering a genuinely wedged
+		// daemon stays an explicit user action (Settings > Restart daemon).
+		const probe = await probeDaemonHelloWithRetry(
+			manifest.socketPath,
+			ADOPTION_PROBE_TOTAL_TIMEOUT_MS,
+		);
 		if (probe) {
 			const runningVersion = probe.daemonVersion;
 			return {
@@ -833,34 +818,35 @@ export class DaemonSupervisor {
 			};
 		}
 
-		// Daemon exited on its own during the grace window — nothing to kill;
-		// fall through to a socket adopt / fresh spawn.
-		if (!isProcessAlive(manifest.pid)) {
-			removePtyDaemonManifest(organizationId);
-			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
-				reason: "manifest_pid_dead",
-			});
+		// Couldn't read a version off the manifest socket. If the socket path
+		// scheme changed under us, a daemon may be answering on the expected
+		// path — prefer that one.
+		if (manifest.socketPath !== expectedSocketPath) {
+			const viaSocket = await this.tryAdoptFromSocket(
+				organizationId,
+				expectedSocketPath,
+				{ reason: "manifest_probe_failed", previousManifest: manifest },
+			);
+			if (viaSocket) return viaSocket;
 		}
 
-		// Pid stayed alive but never answered across the whole grace window:
-		// genuinely wedged. Recover by force-respawning — destructive, but only
-		// after we're convinced it isn't merely slow.
-		logEvent("pty_daemon_adopt_rejected", {
+		// Adopt unprobed. `runningVersion: "unknown"` is the documented state
+		// for a failed probe, and it leaves updatePending false so a probe
+		// failure is never mistaken for version drift.
+		logEvent("pty_daemon_adopt_unprobed", {
 			organizationId,
 			pid: manifest.pid,
 			socketPath: manifest.socketPath,
-			reason: "probe_failed_after_grace",
-			graceMs,
+			reason: "version_probe_failed",
 		});
-		await terminateProcessTreeAndGroups(manifest.pid, "SIGTERM");
-		removePtyDaemonManifest(organizationId);
-		if (manifest.socketPath !== expectedSocketPath) {
-			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
-				reason: "manifest_probe_failed_after_grace",
-				previousManifest: manifest,
-			});
-		}
-		return null;
+		return {
+			pid: manifest.pid,
+			socketPath: manifest.socketPath,
+			startedAt: manifest.startedAt,
+			runningVersion: "unknown",
+			expectedVersion: EXPECTED_DAEMON_VERSION,
+			updatePending: false,
+		};
 	}
 
 	private async tryAdoptFromSocket(

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -50,6 +50,19 @@ interface DaemonInstance {
 	updatePending: boolean;
 	/** Last failed background update attempt for this still-running daemon. */
 	autoUpdateFailure?: DaemonAutoUpdateFailure;
+	/**
+	 * When the daemon first stopped answering probes; null while reachable.
+	 * Drives the UI's "terminals aren't responding" state, which waits for a
+	 * sustained silence so a transient stall doesn't prompt a destructive
+	 * restart of shells that were about to come back.
+	 */
+	unreachableSince: number | null;
+}
+
+export interface DaemonHealth {
+	reachable: boolean;
+	/** 0 while reachable. */
+	unreachableForMs: number;
 }
 
 interface DaemonProbeResult {
@@ -365,6 +378,7 @@ export class DaemonSupervisor {
 			updatePending:
 				!!probedVersion &&
 				!semver.satisfies(probedVersion, `>=${EXPECTED_DAEMON_VERSION}`),
+			unreachableSince: probedVersion ? null : Date.now(),
 		};
 		this.instances.set(organizationId, successorInstance);
 		this.stopping.delete(organizationId);
@@ -505,20 +519,98 @@ export class DaemonSupervisor {
 	 * `ensure()` call respawns.
 	 */
 	private startAdoptedLivenessCheck(organizationId: string, pid: number): void {
-		this.stopAdoptedLivenessCheck(organizationId);
-		const timer = setInterval(() => {
-			if (isProcessAlive(pid)) return;
+		this.startHealthPoll(organizationId, pid, () => {
 			console.log(
 				`[pty-daemon:${organizationId}] adopted process ${pid} died — clearing instance for next-ensure respawn`,
 			);
-			this.stopAdoptedLivenessCheck(organizationId);
 			const current = this.instances.get(organizationId);
 			if (current?.pid === pid) {
 				this.instances.delete(organizationId);
 				removePtyDaemonManifest(organizationId);
 			}
+		});
+	}
+
+	/**
+	 * Poll a daemon's health. Reachability is tracked for every daemon — one
+	 * can wedge no matter how we came by it — but death handling differs:
+	 * adopted daemons have no child handle, so `onDeath` cleans up for them,
+	 * while spawned ones pass null because `child.on("exit")` already owns
+	 * that (and the crash-respawn that goes with it). Clearing the instance
+	 * from here for a spawned daemon would make its exit handler no-op and
+	 * silently disable respawn.
+	 */
+	private startHealthPoll(
+		organizationId: string,
+		pid: number,
+		onDeath: (() => void) | null,
+	): void {
+		this.stopAdoptedLivenessCheck(organizationId);
+		let probing = false;
+		const timer = setInterval(() => {
+			if (!isProcessAlive(pid)) {
+				// Never keep polling a dead pid, whoever handles the death.
+				this.stopAdoptedLivenessCheck(organizationId);
+				onDeath?.();
+				return;
+			}
+			// A probe can outlast the interval; don't stack them.
+			if (probing) return;
+			probing = true;
+			void this.refreshReachability(organizationId, pid).finally(() => {
+				probing = false;
+			});
 		}, ADOPTED_LIVENESS_INTERVAL_MS);
 		this.adoptedLivenessTimers.set(organizationId, timer);
+	}
+
+	/**
+	 * Track whether the daemon is still answering. An alive pid says nothing
+	 * about whether the socket works — a wedged daemon holds its shells but
+	 * serves nobody. Recording *when* it went quiet lets the UI wait out a
+	 * stall instead of offering a restart that would kill recoverable shells.
+	 *
+	 * Doubles as the retry for a version we couldn't read at adoption time.
+	 */
+	private async refreshReachability(
+		organizationId: string,
+		pid: number,
+	): Promise<void> {
+		const instance = this.instances.get(organizationId);
+		if (!instance || instance.pid !== pid) return;
+		const probe = await probeDaemonHello(
+			instance.socketPath,
+			VERSION_PROBE_TIMEOUT_MS,
+		);
+		// Re-read: the instance can be replaced while the probe is in flight.
+		const current = this.instances.get(organizationId);
+		if (!current || current.pid !== pid) return;
+		if (!probe) {
+			current.unreachableSince ??= Date.now();
+			return;
+		}
+		current.unreachableSince = null;
+		if (current.runningVersion === "unknown") {
+			current.runningVersion = probe.daemonVersion;
+			current.updatePending = !semver.satisfies(
+				probe.daemonVersion,
+				`>=${EXPECTED_DAEMON_VERSION}`,
+			);
+		}
+	}
+
+	/**
+	 * Daemon reachability for the UI. Null when there's no daemon for the org.
+	 */
+	getHealth(organizationId: string): DaemonHealth | null {
+		const instance = this.instances.get(organizationId);
+		if (!instance) return null;
+		const { unreachableSince } = instance;
+		return {
+			reachable: unreachableSince === null,
+			unreachableForMs:
+				unreachableSince === null ? 0 : Date.now() - unreachableSince,
+		};
 	}
 
 	private stopAdoptedLivenessCheck(organizationId: string): void {
@@ -811,6 +903,9 @@ export class DaemonSupervisor {
 			updatePending:
 				probe != null &&
 				!semver.satisfies(runningVersion, `>=${EXPECTED_DAEMON_VERSION}`),
+			// Start the clock here when it didn't answer: the liveness poll
+			// clears it the moment it does.
+			unreachableSince: probe ? null : Date.now(),
 		};
 	}
 
@@ -875,6 +970,7 @@ export class DaemonSupervisor {
 				probe.daemonVersion,
 				`>=${EXPECTED_DAEMON_VERSION}`,
 			),
+			unreachableSince: null,
 		};
 	}
 
@@ -1065,8 +1161,11 @@ export class DaemonSupervisor {
 			runningVersion: EXPECTED_DAEMON_VERSION,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
 			updatePending: false,
+			unreachableSince: null,
 		};
 		this.instances.set(organizationId, instance);
+		// Reachability only — `child.on("exit")` above owns death + respawn.
+		this.startHealthPoll(organizationId, childPid, null);
 		console.log(
 			`[pty-daemon:${organizationId}] spawned pid=${childPid} socket=${socketPath}`,
 		);

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -99,8 +99,21 @@ const ADOPTION_PROBE_TOTAL_TIMEOUT_MS = 3_000;
  */
 const CRASH_BUDGET = 3;
 const CRASH_WINDOW_MS = 60_000;
-/** How often to poll an adopted daemon's PID for liveness. */
-const ADOPTED_LIVENESS_INTERVAL_MS = 2_000;
+/** How often to poll a daemon's PID for liveness. */
+const PID_LIVENESS_INTERVAL_MS = 2_000;
+/**
+ * How often to probe the daemon socket for reachability. Slower than the
+ * pid poll: a probe is a full connect+hello handshake, and the UI only
+ * samples health every 5s anyway.
+ */
+const REACHABILITY_PROBE_INTERVAL_MS = 5_000;
+/**
+ * Total retry budget for a steady-state reachability probe. A daemon
+ * relaying heavy PTY output can miss a single 1.5s deadline while still
+ * healthy; retrying across 3s keeps a busy daemon from being reported
+ * unreachable (which would offer the user a destructive restart).
+ */
+const REACHABILITY_PROBE_TOTAL_TIMEOUT_MS = 3_000;
 const ADOPT_IN_DEV_ENV = "SUPERSET_PTY_DAEMON_ADOPT_IN_DEV";
 
 export function shouldKillStaleDaemonForDev(
@@ -183,12 +196,12 @@ export class DaemonSupervisor {
 	 */
 	private readonly lastUpdatePendingPair = new Map<string, string>();
 	/**
-	 * Liveness pollers per org. We only attach a `child.on("exit")` handler
-	 * to daemons we *spawned* — adopted daemons (PIDs from a manifest) have
-	 * no child handle, so we'd never notice if they died externally. This
-	 * timer polls `process.kill(pid, 0)` to bridge that gap.
+	 * Health pollers per org, for every daemon however we came by it: pid
+	 * liveness each tick, plus a slower socket reachability probe. For
+	 * adopted daemons (no child handle) this is also how we notice death;
+	 * spawned daemons get death handling from `child.on("exit")`.
 	 */
-	private readonly adoptedLivenessTimers = new Map<
+	private readonly healthPollTimers = new Map<
 		string,
 		ReturnType<typeof setInterval>
 	>();
@@ -293,7 +306,7 @@ export class DaemonSupervisor {
 		// or adopted (liveness poll); either way, marking `stopping` makes
 		// the exit handler treat it as expected.
 		this.stopping.add(organizationId);
-		this.stopAdoptedLivenessCheck(organizationId);
+		this.stopHealthPoll(organizationId);
 
 		// Mark the manifest so a host-service crash mid-handoff is
 		// debuggable. We restore on failure or replace on success.
@@ -375,9 +388,7 @@ export class DaemonSupervisor {
 			startedAt: successorStartedAt,
 			runningVersion,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
-			updatePending:
-				!!probedVersion &&
-				!semver.satisfies(probedVersion, `>=${EXPECTED_DAEMON_VERSION}`),
+			updatePending: isVersionUpdatePending(probedVersion),
 			unreachableSince: probedVersion ? null : Date.now(),
 		};
 		this.instances.set(organizationId, successorInstance);
@@ -500,7 +511,7 @@ export class DaemonSupervisor {
 	async stop(organizationId: string): Promise<void> {
 		const instance = this.instances.get(organizationId);
 		this.instances.delete(organizationId);
-		this.stopAdoptedLivenessCheck(organizationId);
+		this.stopHealthPoll(organizationId);
 		if (!instance) return;
 		this.stopping.add(organizationId);
 		await terminateProcessTreeAndGroups(instance.pid, "SIGTERM");
@@ -545,23 +556,26 @@ export class DaemonSupervisor {
 		pid: number,
 		onDeath: (() => void) | null,
 	): void {
-		this.stopAdoptedLivenessCheck(organizationId);
+		this.stopHealthPoll(organizationId);
 		let probing = false;
+		let lastProbeAt = 0;
 		const timer = setInterval(() => {
 			if (!isProcessAlive(pid)) {
 				// Never keep polling a dead pid, whoever handles the death.
-				this.stopAdoptedLivenessCheck(organizationId);
+				this.stopHealthPoll(organizationId);
 				onDeath?.();
 				return;
 			}
-			// A probe can outlast the interval; don't stack them.
-			if (probing) return;
+			// The socket probe runs on its own slower cadence, one at a time.
+			if (probing || Date.now() - lastProbeAt < REACHABILITY_PROBE_INTERVAL_MS)
+				return;
 			probing = true;
+			lastProbeAt = Date.now();
 			void this.refreshReachability(organizationId, pid).finally(() => {
 				probing = false;
 			});
-		}, ADOPTED_LIVENESS_INTERVAL_MS);
-		this.adoptedLivenessTimers.set(organizationId, timer);
+		}, PID_LIVENESS_INTERVAL_MS);
+		this.healthPollTimers.set(organizationId, timer);
 	}
 
 	/**
@@ -578,9 +592,9 @@ export class DaemonSupervisor {
 	): Promise<void> {
 		const instance = this.instances.get(organizationId);
 		if (!instance || instance.pid !== pid) return;
-		const probe = await probeDaemonHello(
+		const probe = await probeDaemonHelloWithRetry(
 			instance.socketPath,
-			VERSION_PROBE_TIMEOUT_MS,
+			REACHABILITY_PROBE_TOTAL_TIMEOUT_MS,
 		);
 		// Re-read: the instance can be replaced while the probe is in flight.
 		const current = this.instances.get(organizationId);
@@ -592,10 +606,13 @@ export class DaemonSupervisor {
 		current.unreachableSince = null;
 		if (current.runningVersion === "unknown") {
 			current.runningVersion = probe.daemonVersion;
-			current.updatePending = !semver.satisfies(
-				probe.daemonVersion,
-				`>=${EXPECTED_DAEMON_VERSION}`,
-			);
+			current.updatePending = isVersionUpdatePending(probe.daemonVersion);
+			// The adopt path couldn't see the version, so it skipped these —
+			// this late read is the same "adopted a stale daemon" discovery.
+			this.maybeFireUpdatePending(organizationId, current);
+			if (current.updatePending && this.opts.autoUpdate !== false) {
+				this.kickoffAutoUpdate(organizationId, current);
+			}
 		}
 	}
 
@@ -613,11 +630,11 @@ export class DaemonSupervisor {
 		};
 	}
 
-	private stopAdoptedLivenessCheck(organizationId: string): void {
-		const timer = this.adoptedLivenessTimers.get(organizationId);
+	private stopHealthPoll(organizationId: string): void {
+		const timer = this.healthPollTimers.get(organizationId);
 		if (timer) {
 			clearInterval(timer);
-			this.adoptedLivenessTimers.delete(organizationId);
+			this.healthPollTimers.delete(organizationId);
 		}
 	}
 
@@ -885,14 +902,32 @@ export class DaemonSupervisor {
 				reason: "manifest_pid_dead",
 			});
 		}
-		// The pid is alive, so it still owns the user's PTYs — adopt it. Killing
-		// it here signalled the daemon's whole process tree, taking every live
-		// shell with it (SUPER-833). A failed probe only means we couldn't read
-		// its version; a wedged daemon is recovered by an explicit user restart.
+		// The pid is alive, so it may still own the user's PTYs — adopt it.
+		// Killing it here signalled the daemon's whole process tree, taking
+		// every live shell with it (SUPER-833). A failed probe only means we
+		// couldn't read its version; a wedged daemon is recovered by an
+		// explicit user restart.
 		const probe = await probeDaemonHelloWithRetry(
 			manifest.socketPath,
 			ADOPTION_PROBE_TOTAL_TIMEOUT_MS,
 		);
+		if (!probe && !(await isSocketConnectable(manifest.socketPath, 1000))) {
+			// Nothing is even accepting on the socket. A live daemon keeps its
+			// listener no matter how overloaded it is, so this pid isn't our
+			// daemon — most likely recycled after a reboot. Adopting it would
+			// wedge terminals behind a phantom instance and aim a later user
+			// restart at an innocent process. Never signal it; drop the manifest
+			// and fall back to socket adoption / a fresh spawn.
+			logEvent("pty_daemon_manifest_stale", {
+				organizationId,
+				pid: manifest.pid,
+				socketPath: manifest.socketPath,
+			});
+			removePtyDaemonManifest(organizationId);
+			return this.tryAdoptFromSocket(organizationId, expectedSocketPath, {
+				reason: "manifest_socket_unreachable",
+			});
+		}
 		const runningVersion = probe?.daemonVersion ?? "unknown";
 		return {
 			pid: manifest.pid,
@@ -900,9 +935,7 @@ export class DaemonSupervisor {
 			startedAt: manifest.startedAt,
 			runningVersion,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
-			updatePending:
-				probe != null &&
-				!semver.satisfies(runningVersion, `>=${EXPECTED_DAEMON_VERSION}`),
+			updatePending: isVersionUpdatePending(probe?.daemonVersion ?? null),
 			// Start the clock here when it didn't answer: the liveness poll
 			// clears it the moment it does.
 			unreachableSince: probe ? null : Date.now(),
@@ -966,10 +999,7 @@ export class DaemonSupervisor {
 			startedAt,
 			runningVersion: probe.daemonVersion,
 			expectedVersion: EXPECTED_DAEMON_VERSION,
-			updatePending: !semver.satisfies(
-				probe.daemonVersion,
-				`>=${EXPECTED_DAEMON_VERSION}`,
-			),
+			updatePending: isVersionUpdatePending(probe.daemonVersion),
 			unreachableSince: null,
 		};
 	}
@@ -1201,6 +1231,19 @@ function pipeWithPrefix(
 
 function countAliveSessions(sessions: SessionInfo[]): number {
 	return sessions.filter((session) => session.alive).length;
+}
+
+/**
+ * "Running < expected" per semver. An unreadable version (probe failed)
+ * is never pending — probe failure ≠ stale.
+ */
+function isVersionUpdatePending(
+	probedVersion: string | null | undefined,
+): boolean {
+	return (
+		probedVersion != null &&
+		!semver.satisfies(probedVersion, `>=${EXPECTED_DAEMON_VERSION}`)
+	);
 }
 
 async function waitForSocket(

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -68,6 +68,16 @@ const daemonRouter = router({
 		getSupervisor().getUpdateStatus(ctx.organizationId),
 	),
 
+	/**
+	 * Whether the daemon is still answering, and for how long it hasn't.
+	 * Deliberately does not `waitForDaemonReady` — this is polled by the
+	 * terminal UI to decide whether a stall is worth surfacing, so it has to
+	 * answer immediately rather than block on the thing that may be wedged.
+	 */
+	getHealth: protectedProcedure.query(({ ctx }) =>
+		getSupervisor().getHealth(ctx.organizationId),
+	),
+
 	listSessions: protectedProcedure.query(async ({ ctx }) => {
 		// Wait for the bootstrap so the supervisor has a socket path.
 		await waitForDaemonReady(ctx.organizationId);

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -26,7 +26,8 @@
 		"VERCEL_ENV",
 		"VERCEL_URL",
 		"npm_lifecycle_event",
-		"RENDERER_REMOTE_DEBUG_PORT"
+		"RENDERER_REMOTE_DEBUG_PORT",
+		"SUPERSET_PTY_DAEMON_ADOPT_IN_DEV"
 	],
 	"tasks": {
 		"build": {


### PR DESCRIPTION
**Links**
- Issue: [SUPER-833 — V2 after update terminals killed](https://linear.app/superset-sh/issue/SUPER-833/v2-after-update-terminals-killed) (closed May 2026, recurring)

## Summary
1. **Stop killing shells.** `tryAdopt` destroyed a live pty-daemon — and every shell under it — whenever post-update adoption was uncertain. That logic is deleted; `tryAdopt` is now one probe and one return.
2. **Say something when the daemon goes quiet.** Not killing it means the rare wedged daemon now shows up as a terminal that hangs. Name it, and offer the (destructive) fix behind a confirm.
3. **Harden the new path + polish the UX.** With the kill gone, guard adoption against recycled pids, keep auto-update working for daemons adopted under load, and rework the connection indicator into a plain-language popover.

## Part 1 — never kill PTYs during adoption

Terminals are meant to survive an update: the daemon is spawned `detached: true` and the relaunched host-service **adopts** it. Since #4739, PTY survival rests entirely on that adoption being non-destructive.

It wasn't. `tryAdopt` called `terminateProcessTreeAndGroups(manifest.pid, …)` when the socket wasn't connectable within **1s**, or the hello probe went unanswered within **3s**. That walks the daemon's **entire process tree + process groups** — every live shell — and SIGTERM→SIGKILLs them.

Those budgets are spent at the worst moment: adoption runs **eagerly at host-service boot** (reaper → `getDaemonClient → waitForDaemonReady → ensure → tryAdopt`), i.e. during the post-update relaunch spike — exactly when a healthy-but-CPU-starved daemon misses a 1–3s probe.

The codebase already said what should happen. `expected-version.ts`: *"We do NOT auto-kill … sessions live in the daemon; the user explicitly triggers restart."* And `DaemonInstance` documents `runningVersion: "unknown"` for a failed probe, with *"Probe failure does NOT set"* `updatePending`. Adopting-on-probe-failure was the intended design; the kill was the bug.

Also removed as dead weight once the kill went: the `previousManifest` plumbing. (The expected-socket fallback that used to run only as post-kill recovery now has a real job again — it's the stale-manifest recovery path below.)

### Hardening the adoption path (post-review)

Now that adoption never signals the daemon, two edge cases need care:

- **Recycled pid / stale manifest.** After a reboot the manifest's pid can belong to an unrelated live process. `isProcessAlive` (a bare `kill(pid, 0)`) passes, so blindly adopting would bind to a phantom: every terminal fails with `ECONNREFUSED`, and the user's only recovery — Restart — would SIGTERM an innocent process tree. `tryAdopt` now treats *pid alive **but** probe failed **and** socket not connectable* as stale: log `pty_daemon_manifest_stale`, drop the manifest, fall through to socket adoption / a fresh spawn. A genuinely wedged-but-listening daemon (socket bound, hello unanswered) is still adopted — SUPER-833 preserved.
- **Auto-update after a probe-failed adoption.** A daemon adopted under the post-update spike comes up `runningVersion: "unknown"`. `refreshReachability` already backfills the real version on the next successful probe; it now also fires update-pending and kicks off the background auto-update, so a stale daemon adopted under load still self-updates instead of running outdated indefinitely.
- **Probe cost.** The reachability probe runs on a slower **5s** cadence with a **3s** retry budget (was one 1.5s attempt every 2s). A single-threaded daemon streaming heavy PTY output can miss one 1.5s deadline while perfectly healthy; retrying on a slower beat keeps it from being false-flagged "unresponsive" (which offers a destructive restart). The cheap `kill(pid,0)` liveness check stays at 2s. (`adoptedLivenessTimers` → `healthPollTimers`; the four copies of the update-pending semver check are now one `isVersionUpdatePending` helper.)

## Part 2 — "Terminals aren't responding"

Keeping a wedged daemon alive is right, but it left the tail case as a mystery: the terminal hangs ~15s and dies with `daemon open: timed out after 15000ms`.

**Host-service** tracks reachability on the poll that already watches daemons: probe each tick, record when it first went quiet, clear on recovery. Two things fell out of the E2E:
- That poll only ran for **adopted** daemons. A daemon wedges regardless of how we got it, so the signal was dead for freshly spawned ones — the common case. It now runs for both; spawned daemons pass no death handler, since `child.on("exit")` owns death **and** crash-respawn (clearing the instance from the poll would have silently disabled respawn).
- The probe doubles as the retry for a version adoption couldn't read, so `runningVersion` no longer stays stuck at `"unknown"`.

New `terminal.daemon.getHealth` procedure surfaces `{ reachable, unreachableForMs }`; it deliberately does **not** `waitForDaemonReady` (it must answer immediately rather than block on the thing that may be wedged).

**Renderer** — the pane's connection indicator, reworked into a plain-language popover:

```
⚠  Terminals aren't responding

[ ↻ Reconnect ]   [ Restart ]

                    View log
```

- **Reconnect** (solid, primary) retries the WebSocket — the safe first move, shown whenever the transport is unhealthy, and it flips to a spinner + "Reconnecting…" once clicked. **Restart** (outline, red only on hover) → *"Restart all terminals?"* confirm with a **Keep waiting** cancel → `terminal.daemon.restart`. **Both can show at once**, so a stale daemon-health flag never leaves restart as the only option after sleep/wake (the transport can give up while the daemon flag is still catching up).
- **No "daemon" jargon** anywhere user-facing — it's all "terminals". "Daemon" stays in logs/telemetry.
- **Amber for recoverable** states (reconnecting; unresponsive-but-usually-self-heals); **red reserved** for the one destructive control and the hard "Disconnected" (transport gave up) state.
- **Log collapsed** behind "View log"; expanding widens the popover to a readable full-width layout with the timestamp as a header line rather than a narrow left gutter.

Design decisions worth calling out:
- **Waits 10s.** The only fix closes every terminal, so a stall must look permanent before we offer it — a post-update spike clears well inside that and shells come back on their own. Warning eagerly would have recreated SUPER-833 via the user's own click.
- **Auto-clears** on recovery, so a transient stall never leaves a standing invitation to nuke.
- **Polls even when the socket looks healthy.** A daemon that wedges under a live session closes nothing — the WS stays `open` and the shell just freezes. The query takes no input, so React Query collapses every pane onto one request per workspace.
- **Outranks the WebSocket's message**, because the daemon owns the shells and is the root cause.
- **No system popup.** `dialog.showErrorBox` (the `alertChildCrashed` path) blocks Electron's main process — it wedged the whole app during this work. It would also demand a decision during the exact stall where waiting is correct, with a button that destroys every shell.

**turbo.jsonc**: pass `SUPERSET_PTY_DAEMON_ADOPT_IN_DEV` through. Turbo filters unlisted env vars, so the flag never reached host-service and the dev app always took the kill-stale-daemon path — making adoption (and this warning) impossible to exercise in dev. One line; no behavior change unless you set it.

## Testing
- `bun run lint` ✅ · `bun run typecheck` (host-service + desktop) ✅
- `bun test src/daemon/DaemonSupervisor.test.ts` — **50 pass**. Adds recycled-pid + expected-socket-fallback adoption tests and late-stale-version auto-update tests on top of the "adopts an unprobeable but pid-alive daemon instead of killing its shells" regression guard and the health suite.
- **Mutation-verified** (each fails only its own guard): reintroduce the kill; adopt the recycled pid blindly; skip the late auto-update kickoff; never clear the silence on recovery; never start the clock; don't backfill the version.
- `bun run test:integration:daemon` (real daemons: DaemonClient + DaemonSupervisor) — **18 pass** (crash-respawn + fd-handoff intact after the poller change).

### Stress harness — real daemons + real shells, isolated orgIds
`SIGSTOP` = a CPU-starved daemon (socket bound, hello unanswered).

| Scenario | Result |
|---|---|
| Healthy | adopted, shell survives |
| Stalled 5s then resumes | adopted, shell survives |
| **Wedged forever** | **adopted (`unknown`, `updatePending:false`); daemon NOT killed; SHELL SURVIVES** |
| Daemon dead | clean fresh spawn |
| Concurrent `ensure()` during stall | single adopt, shell survives |

### Manual QA — real app, over CDP
Driven against the real dev app (production adoption via `SUPERSET_PTY_DAEMON_ADOPT_IN_DEV`), with a real workspace + terminal under the real daemon. All paths confirmed:
- [x] **Never kills the shell:** real terminal; `SIGSTOP`; `hostServiceCoordinator.restart` (= the update's stop+start); hold past the old budget; `SIGCONT` → **daemon and shell both survived**, log shows `adopted existing daemon`.
- [x] **Recycled-pid guard:** manifest pointed at a live impostor pid + dead socket; restart → log shows `pty_daemon_manifest_stale`, a fresh daemon spawns, **the impostor is never signalled**.
- [x] **Late auto-update:** adopted a stale `0.0.1` daemon as `unknown` (probe failed via `SIGSTOP`), then `SIGCONT` → `pty_daemon_update_pending` → `auto_update_attempt` → `auto_update_ok` (fd-handoff to the fresh version).
- [x] **Rendered popover:** forced daemon-unreachable (`SIGSTOP`) **and** WS give-up together → both **Reconnect** and **Restart** render; the red "Terminals aren't responding" pill appears at the 10s threshold; `SIGCONT` → the retrying probe clears it, host `getHealth` returns `reachable:true`, **shell alive throughout**.
- [x] **Health signal on a spawned daemon:** `reachable:true` → `SIGSTOP` → `false` (crosses the 10s warn threshold) → `SIGCONT` → `true` within 3s.

## Known Limitations
- A wedged daemon needs an explicit user restart instead of auto-respawning. Deliberate: never silently destroy shells.
- Only the *adoption* kill is removed. `killStaleDaemonForDev` (dev-only) and the user-triggered restart stay destructive by design.

## Risks / Rollout
- **Risk:** low. Part 1 strictly removes a destructive action and adds a stale-pid guard. Part 2 is additive (a read-only signal + an indicator state); worst case the warning doesn't fire and users see today's timeout.
- **Rollback:** revert the commits; no data/schema changes.
