### PR TITLE
perf(port-scanner): shared ps per scan, lsof -a, idle-session decay

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -191,7 +191,7 @@ export class DaemonTerminalManager extends EventEmitter {
 				session.lastActive = Date.now();
 			}
 
-			portManager.checkOutputForHint(data);
+			portManager.checkOutputForHint(paneId, data);
 			this.historyManager.writeToHistory(paneId, data, () =>
 				this.sessions.get(paneId),
 			);

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1228,9 +1228,8 @@ export async function createTerminalSessionInternal({
 						? bytes
 						: Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength),
 				);
-				// Called even when the decoder buffers a partial codepoint and
-				// returns "" — the chunk is still real output and must refresh
-				// the session's idle clock (hint matching on "" is a no-op).
+				// Runs even when the decoder buffers a partial codepoint into ""
+				// — the chunk is still output and must refresh the idle clock.
 				portManager.checkOutputForHint(terminalId, hintText);
 
 				// Feed the tracker on every byte — broadcast skips the FIFO,

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1228,7 +1228,8 @@ export async function createTerminalSessionInternal({
 						? bytes
 						: Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength),
 				);
-				if (hintText.length > 0) portManager.checkOutputForHint(hintText);
+				if (hintText.length > 0)
+					portManager.checkOutputForHint(terminalId, hintText);
 
 				// Feed the tracker on every byte — broadcast skips the FIFO,
 				// so this is the only path that catches startup mode escapes.

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1228,8 +1228,10 @@ export async function createTerminalSessionInternal({
 						? bytes
 						: Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength),
 				);
-				if (hintText.length > 0)
-					portManager.checkOutputForHint(terminalId, hintText);
+				// Called even when the decoder buffers a partial codepoint and
+				// returns "" — the chunk is still real output and must refresh
+				// the session's idle clock (hint matching on "" is a no-op).
+				portManager.checkOutputForHint(terminalId, hintText);
 
 				// Feed the tracker on every byte — broadcast skips the FIFO,
 				// so this is the only path that catches startup mode escapes.

--- a/packages/port-scanner/src/index.ts
+++ b/packages/port-scanner/src/index.ts
@@ -5,7 +5,7 @@ export {
 } from "./port-manager.ts";
 export {
 	getListeningPortsForPids,
-	getProcessTree,
+	getProcessTreesForPids,
 	type PortInfo,
 } from "./scanner.ts";
 export {

--- a/packages/port-scanner/src/port-manager.test.ts
+++ b/packages/port-scanner/src/port-manager.test.ts
@@ -612,4 +612,25 @@ describe("PortManager — idle decay (sessions without output scan rarely)", () 
 		await manager.forceScan();
 		expect(spy.getProcessTrees).toBe(1);
 	});
+
+	it("forceScan arriving mid-scan keeps its bypass in the coalesced follow-up", async () => {
+		lsofDelayMs = 50;
+		manager.upsertSession("active", "ws1", 1000);
+		manager.upsertSession("idle", "ws1", 2000);
+		const entry = session("idle");
+		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
+		entry.lastScannedAt = Date.now();
+
+		// Periodic (non-forced) scan picks up only the active session…
+		const periodic = scan();
+		await sleep(10);
+		// …and a force scan lands while it is still in flight.
+		await manager.forceScan();
+
+		await periodic;
+		await sleep(100); // let the coalesced follow-up finish
+
+		// The follow-up must run forced: the idle session's pid is included.
+		expect(spy.lastTreeRootPids).toContain(2000);
+	});
 });

--- a/packages/port-scanner/src/port-manager.test.ts
+++ b/packages/port-scanner/src/port-manager.test.ts
@@ -1,5 +1,20 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+} from "bun:test";
 import type { DetectedPort } from "./types";
+
+// mock.module leaks across test files in the same bun process — hold the real
+// module and restore it after this file so scanner.test.ts tests the real one.
+const realScanner = { ...(await import("./scanner.ts")) };
+afterAll(() => {
+	mock.module("./scanner", () => realScanner);
+});
 
 /**
  * Regression tests for #3372 ("excessive lsof spawning").
@@ -17,7 +32,8 @@ import type { DetectedPort } from "./types";
  */
 
 interface ScannerSpy {
-	getProcessTree: number;
+	getProcessTrees: number;
+	lastTreeRootPids: number[];
 	getListeningPortsForPids: number;
 	inFlight: number;
 	maxInFlight: number;
@@ -33,7 +49,8 @@ interface MockPortInfo {
 }
 
 const spy: ScannerSpy = {
-	getProcessTree: 0,
+	getProcessTrees: 0,
+	lastTreeRootPids: [],
 	getListeningPortsForPids: 0,
 	inFlight: 0,
 	maxInFlight: 0,
@@ -45,9 +62,10 @@ let lsofDelayMs = 0;
 let listeningPorts: MockPortInfo[] = [];
 
 mock.module("./scanner", () => ({
-	getProcessTree: async (pid: number) => {
-		spy.getProcessTree++;
-		return [pid, pid + 1];
+	getProcessTreesForPids: async (rootPids: number[]) => {
+		spy.getProcessTrees++;
+		spy.lastTreeRootPids = rootPids;
+		return new Map(rootPids.map((pid) => [pid, [pid, pid + 1]]));
 	},
 	getListeningPortsForPids: async (_pids: number[], signal?: AbortSignal) => {
 		spy.getListeningPortsForPids++;
@@ -74,7 +92,9 @@ mock.module("./scanner", () => ({
 	},
 }));
 
-const { PortManager } = await import("./port-manager");
+const { PortManager, IDLE_AFTER_MS, IDLE_SCAN_INTERVAL_MS } = await import(
+	"./port-manager"
+);
 
 const HINT_DEBOUNCE_MS = 500;
 const PAST_DEBOUNCE_MS = HINT_DEBOUNCE_MS + 50;
@@ -88,10 +108,21 @@ let manager: InstanceType<typeof PortManager>;
 const pmInternals = () =>
 	manager as unknown as {
 		scanInterval: ReturnType<typeof setInterval> | null;
+		sessions: Map<
+			string,
+			{
+				workspaceId: string;
+				pid: number | null;
+				lastActivityAt: number;
+				lastScannedAt: number;
+			}
+		>;
+		scanAllSessions: (force?: boolean) => Promise<void>;
 	};
 
 function resetSpy(): void {
-	spy.getProcessTree = 0;
+	spy.getProcessTrees = 0;
+	spy.lastTreeRootPids = [];
 	spy.getListeningPortsForPids = 0;
 	spy.inFlight = 0;
 	spy.maxInFlight = 0;
@@ -113,7 +144,7 @@ afterEach(() => {
 describe("PortManager — #3372 lifecycle (interval runs only with sessions)", () => {
 	it("forceScan is a no-op when no sessions are registered", async () => {
 		await manager.forceScan();
-		expect(spy.getProcessTree).toBe(0);
+		expect(spy.getProcessTrees).toBe(0);
 		expect(spy.getListeningPortsForPids).toBe(0);
 	});
 
@@ -159,18 +190,22 @@ describe("PortManager — #3372 lifecycle (interval runs only with sessions)", (
 		manager.upsertSession("p1", "ws1", null);
 		await manager.forceScan();
 		// No PID → no process-tree walk and no lsof batch.
-		expect(spy.getProcessTree).toBe(0);
+		expect(spy.getProcessTrees).toBe(0);
 		expect(spy.getListeningPortsForPids).toBe(0);
 	});
 });
 
 describe("PortManager — #3372 concurrency (at most one lsof in flight)", () => {
-	it("bulk scan batches every session into a single lsof call", async () => {
+	it("bulk scan batches every session into one tree read and one lsof call", async () => {
 		for (let i = 0; i < 10; i++) {
 			manager.upsertSession(`p${i}`, `ws${i}`, 1000 + i);
 		}
 		await manager.forceScan();
 
+		// One system-wide process-table read covers all sessions — a
+		// per-session pidtree call spawned a full `ps` each.
+		expect(spy.getProcessTrees).toBe(1);
+		expect(spy.lastTreeRootPids).toHaveLength(10);
 		expect(spy.getListeningPortsForPids).toBe(1);
 		expect(spy.maxInFlight).toBe(1);
 	});
@@ -183,7 +218,7 @@ describe("PortManager — #3372 concurrency (at most one lsof in flight)", () =>
 
 		// 100 hints while the first scan is running — all on the hot path.
 		for (let i = 0; i < 100; i++) {
-			manager.checkOutputForHint("listening on port 3000\n");
+			manager.checkOutputForHint("p1", "listening on port 3000\n");
 		}
 
 		await firstScan;
@@ -376,43 +411,47 @@ describe("PortManager — #3372 hint regex narrowing", () => {
 	});
 
 	it("does NOT scan on a bare 'port 22' (old loose pattern)", async () => {
-		manager.checkOutputForHint("connection reached port 22\n");
+		manager.checkOutputForHint("p1", "connection reached port 22\n");
 		await sleep(PAST_DEBOUNCE_MS);
 		expect(spy.getListeningPortsForPids).toBe(0);
 	});
 
 	it("does NOT scan on a trailing ':12345' (old loose pattern)", async () => {
-		manager.checkOutputForHint("commit abc123def:12345\n");
+		manager.checkOutputForHint("p1", "commit abc123def:12345\n");
 		await sleep(PAST_DEBOUNCE_MS);
 		expect(spy.getListeningPortsForPids).toBe(0);
 	});
 
 	it("DOES scan on 'listening on port 3000'", async () => {
-		manager.checkOutputForHint("listening on port 3000\n");
+		manager.checkOutputForHint("p1", "listening on port 3000\n");
 		await sleep(PAST_DEBOUNCE_MS);
 		expect(spy.getListeningPortsForPids).toBe(1);
 	});
 
 	it("DOES scan on 'server running at http://localhost:3000'", async () => {
-		manager.checkOutputForHint("server running at http://localhost:3000\n");
+		manager.checkOutputForHint(
+			"p1",
+			"server running at http://localhost:3000\n",
+		);
 		await sleep(PAST_DEBOUNCE_MS);
 		expect(spy.getListeningPortsForPids).toBe(1);
 	});
 
 	it("DOES scan on 'ready on http://localhost:5173' (Vite-style)", async () => {
-		manager.checkOutputForHint("ready on http://localhost:5173\n");
+		manager.checkOutputForHint("p1", "ready on http://localhost:5173\n");
 		await sleep(PAST_DEBOUNCE_MS);
 		expect(spy.getListeningPortsForPids).toBe(1);
 	});
 
 	it("DOES scan on Vite's 'Local:  http://localhost:5173/' banner", async () => {
-		manager.checkOutputForHint("  ➜  Local:   http://localhost:5173/\n");
+		manager.checkOutputForHint("p1", "  ➜  Local:   http://localhost:5173/\n");
 		await sleep(PAST_DEBOUNCE_MS);
 		expect(spy.getListeningPortsForPids).toBe(1);
 	});
 
 	it("DOES scan on Django's 'Starting development server at http://...'", async () => {
 		manager.checkOutputForHint(
+			"p1",
 			"Starting development server at http://127.0.0.1:8000/\n",
 		);
 		await sleep(PAST_DEBOUNCE_MS);
@@ -458,9 +497,9 @@ describe("PortManager — #3372 teardown (no orphan children)", () => {
 		// rather than passing `undefined` and losing abortability.
 		manager.upsertSession("p1", "ws1", 1000);
 
-		manager.checkOutputForHint("listening on port 3000\n");
-		// Unregister immediately — this triggers stopPeriodicScanIfIdle which
-		// clears the hint timer. If any code path regresses and the timer
+		manager.checkOutputForHint("p1", "listening on port 3000\n");
+		// Unregister immediately — this triggers stopPeriodicScanIfNoSessions
+		// which clears the hint timer. If any code path regresses and the timer
 		// survives past abort-nulling, ensureScanAbort must still produce a
 		// valid signal rather than throwing.
 		manager.unregisterSession("p1");
@@ -469,5 +508,108 @@ describe("PortManager — #3372 teardown (no orphan children)", () => {
 		manager.upsertSession("p2", "ws2", 2000);
 		await manager.forceScan();
 		expect(spy.getListeningPortsForPids).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("PortManager — idle decay (sessions without output scan rarely)", () => {
+	const scan = () => pmInternals().scanAllSessions();
+	const session = (terminalId: string) => {
+		const entry = pmInternals().sessions.get(terminalId);
+		if (!entry) throw new Error(`session ${terminalId} not registered`);
+		return entry;
+	};
+
+	it("a freshly registered session is scanned on periodic ticks", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+		await scan();
+		expect(spy.getProcessTrees).toBe(1);
+	});
+
+	it("an idle session is skipped until the slow cadence elapses", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+		const entry = session("p1");
+		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
+		entry.lastScannedAt = Date.now();
+
+		await scan();
+		expect(spy.getProcessTrees).toBe(0);
+		expect(spy.getListeningPortsForPids).toBe(0);
+
+		entry.lastScannedAt = Date.now() - IDLE_SCAN_INTERVAL_MS - 1;
+		await scan();
+		expect(spy.getProcessTrees).toBe(1);
+	});
+
+	it("any PTY output puts a session back on the fast cadence", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+		const entry = session("p1");
+		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
+		entry.lastScannedAt = Date.now();
+
+		// Plain output — not a port hint — still counts as activity.
+		manager.checkOutputForHint("p1", "make: nothing to be done\n");
+		await scan();
+		expect(spy.getProcessTrees).toBe(1);
+	});
+
+	it("re-upserting the same pid does not reset the idle clock", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+		const entry = session("p1");
+		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
+		entry.lastScannedAt = Date.now();
+
+		// The reaper's periodic port-scan sync re-registers unattached
+		// sessions every pass; that must not count as activity.
+		manager.upsertSession("p1", "ws1", 1000);
+		await scan();
+		expect(spy.getProcessTrees).toBe(0);
+
+		// A new shell pid is a fresh session and is active again.
+		manager.upsertSession("p1", "ws1", 2000);
+		await scan();
+		expect(spy.getProcessTrees).toBe(1);
+	});
+
+	it("only due sessions are included in the batch", async () => {
+		manager.upsertSession("active", "ws1", 1000);
+		manager.upsertSession("idle", "ws1", 2000);
+		const entry = session("idle");
+		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
+		entry.lastScannedAt = Date.now();
+
+		await scan();
+		expect(spy.lastTreeRootPids).toEqual([1000]);
+	});
+
+	it("a skipped idle session keeps its previously detected ports", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 1001, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+		expect(manager.getAllPorts()).toHaveLength(1);
+
+		const entry = session("p1");
+		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
+		entry.lastScannedAt = Date.now();
+
+		// The server "dies" while the session is skipped — its port must
+		// survive untouched until the session's own next scan.
+		listeningPorts = [];
+		await scan();
+		expect(manager.getAllPorts()).toHaveLength(1);
+
+		await manager.forceScan();
+		expect(manager.getAllPorts()).toHaveLength(0);
+	});
+
+	it("forceScan includes idle sessions regardless of cadence", async () => {
+		manager.upsertSession("p1", "ws1", 1000);
+		const entry = session("p1");
+		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
+		entry.lastScannedAt = Date.now();
+
+		await manager.forceScan();
+		expect(spy.getProcessTrees).toBe(1);
 	});
 });

--- a/packages/port-scanner/src/port-manager.test.ts
+++ b/packages/port-scanner/src/port-manager.test.ts
@@ -60,11 +60,14 @@ const spy: ScannerSpy = {
 
 let lsofDelayMs = 0;
 let listeningPorts: MockPortInfo[] = [];
+/** When set, the tree mock blocks until the test resolves this promise. */
+let treeGate: Promise<void> | null = null;
 
 mock.module("./scanner", () => ({
 	getProcessTreesForPids: async (rootPids: number[]) => {
 		spy.getProcessTrees++;
 		spy.lastTreeRootPids = rootPids;
+		if (treeGate) await treeGate;
 		return new Map(rootPids.map((pid) => [pid, [pid, pid + 1]]));
 	},
 	getListeningPortsForPids: async (_pids: number[], signal?: AbortSignal) => {
@@ -130,6 +133,7 @@ function resetSpy(): void {
 	spy.aborted = 0;
 	lsofDelayMs = 0;
 	listeningPorts = [];
+	treeGate = null;
 }
 
 beforeEach(() => {
@@ -614,23 +618,41 @@ describe("PortManager — idle decay (sessions without output scan rarely)", () 
 	});
 
 	it("forceScan arriving mid-scan keeps its bypass in the coalesced follow-up", async () => {
-		lsofDelayMs = 50;
 		manager.upsertSession("active", "ws1", 1000);
 		manager.upsertSession("idle", "ws1", 2000);
 		const entry = session("idle");
 		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
 		entry.lastScannedAt = Date.now();
 
-		// Periodic (non-forced) scan picks up only the active session…
+		// scanAllSessions marks itself in-flight synchronously, so with no await
+		// in between the force scan is guaranteed to coalesce — and the follow-up
+		// is awaited inside the periodic promise, so no timers are needed.
 		const periodic = scan();
-		await sleep(10);
-		// …and a force scan lands while it is still in flight.
 		await manager.forceScan();
-
 		await periodic;
-		await sleep(100); // let the coalesced follow-up finish
 
 		// The follow-up must run forced: the idle session's pid is included.
 		expect(spy.lastTreeRootPids).toContain(2000);
+	});
+
+	it("discards results for a session whose pid changed during the table read", async () => {
+		let release!: () => void;
+		treeGate = new Promise((resolve) => {
+			release = resolve;
+		});
+		manager.upsertSession("p1", "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 1000, address: "127.0.0.1", processName: "node" },
+		];
+
+		const scanPromise = scan();
+		// The shell is replaced (new pid) while the table read is blocked — the
+		// stale tree for pid 1000 must not be attributed to the new session.
+		manager.upsertSession("p1", "ws1", 9999);
+		release();
+		await scanPromise;
+
+		expect(manager.getAllPorts()).toHaveLength(0);
+		expect(session("p1").lastScannedAt).toBe(0);
 	});
 });

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -136,6 +136,8 @@ export class PortManager extends EventEmitter {
 	private isScanning = false;
 	/** Set when a hint arrives during a scan; triggers one follow-up scan. */
 	private scanRequested = false;
+	/** Set when a force scan arrives mid-scan; the follow-up keeps the bypass. */
+	private forceRequested = false;
 	/** Aborts any in-flight scan children (lsof/netstat) on teardown. */
 	private scanAbort: AbortController | null = null;
 	private readonly killFn: KillFn;
@@ -245,6 +247,7 @@ export class PortManager extends EventEmitter {
 		}
 
 		this.scanRequested = false;
+		this.forceRequested = false;
 	}
 
 	/**
@@ -409,6 +412,7 @@ export class PortManager extends EventEmitter {
 		if (this.isScanning) {
 			// A hint or tick fired mid-scan; queue exactly one follow-up.
 			this.scanRequested = true;
+			if (force) this.forceRequested = true;
 			return;
 		}
 		if (!this.hasAnySessions()) return;
@@ -438,7 +442,9 @@ export class PortManager extends EventEmitter {
 
 		if (this.scanRequested && this.hasAnySessions()) {
 			this.scanRequested = false;
-			await this.scanAllSessions();
+			const followUpForce = this.forceRequested;
+			this.forceRequested = false;
+			await this.scanAllSessions(followUpForce);
 		}
 	}
 

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -296,28 +296,23 @@ export class PortManager extends EventEmitter {
 		force: boolean,
 	): Promise<void> {
 		const now = Date.now();
-		const dueSessions: {
-			terminalId: string;
-			workspaceId: string;
-			pid: number;
-		}[] = [];
+		const dueSessions: { terminalId: string; pid: number }[] = [];
 		for (const [terminalId, entry] of this.sessions) {
 			if (entry.pid === null) continue;
 			if (!force && !this.isSessionDue(entry, now)) continue;
-			dueSessions.push({
-				terminalId,
-				workspaceId: entry.workspaceId,
-				pid: entry.pid,
-			});
+			dueSessions.push({ terminalId, pid: entry.pid });
 		}
 		if (dueSessions.length === 0) return;
 
 		const trees = await getProcessTreesForPids(
 			dueSessions.map((session) => session.pid),
 		);
-		for (const { terminalId, workspaceId, pid } of dueSessions) {
+		for (const { terminalId, pid } of dueSessions) {
 			const entry = this.sessions.get(terminalId);
-			if (entry) entry.lastScannedAt = now;
+			// The session may have been replaced (new pid) or unregistered while
+			// the table read was in flight; its tree is stale — don't apply it.
+			if (!entry || entry.pid !== pid) continue;
+			entry.lastScannedAt = now;
 
 			const pids = trees.get(pid) ?? [];
 			if (pids.length === 0) {
@@ -325,6 +320,7 @@ export class PortManager extends EventEmitter {
 				scanState.emptyTreeTerminals.add(terminalId);
 				continue;
 			}
+			const { workspaceId } = entry;
 			scanState.terminalPortMap.set(terminalId, { workspaceId, pids });
 			this.addTerminalPids({ terminalId, workspaceId, pids, scanState });
 		}

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -1,13 +1,23 @@
 import { EventEmitter } from "node:events";
 import {
 	getListeningPortsForPids,
-	getProcessTree,
+	getProcessTreesForPids,
 	type PortInfo,
 } from "./scanner.ts";
 import type { DetectedPort } from "./types.ts";
 
 /** How often to poll for port changes (in ms) */
 const SCAN_INTERVAL_MS = 2500;
+
+/** A session with no PTY output for this long is considered idle (in ms) */
+export const IDLE_AFTER_MS = 60_000;
+
+/**
+ * How often idle sessions are still scanned (in ms). Ports can appear without
+ * terminal output (a silently daemonized server), so idle sessions decay to
+ * this cadence rather than being skipped outright.
+ */
+export const IDLE_SCAN_INTERVAL_MS = 30_000;
 
 /** Delay before scanning after a port hint is detected (in ms) */
 const HINT_SCAN_DELAY_MS = 500;
@@ -91,6 +101,10 @@ interface SessionEntry {
 	workspaceId: string;
 	/** PTY process ID — null when the terminal isn't yet spawned (or has exited). */
 	pid: number | null;
+	/** Last time this session produced PTY output or was registered with a new pid. */
+	lastActivityAt: number;
+	/** Last time this session was included in a scan. */
+	lastScannedAt: number;
 }
 
 interface ScanState {
@@ -141,7 +155,19 @@ export class PortManager extends EventEmitter {
 		workspaceId: string,
 		pid: number | null,
 	): void {
-		this.sessions.set(terminalId, { workspaceId, pid });
+		const existing = this.sessions.get(terminalId);
+		if (existing && existing.pid === pid) {
+			// Re-upserts (e.g. the reaper's periodic sync of unattached daemon
+			// sessions) must not reset the idle clock.
+			existing.workspaceId = workspaceId;
+		} else {
+			this.sessions.set(terminalId, {
+				workspaceId,
+				pid,
+				lastActivityAt: Date.now(),
+				lastScannedAt: 0,
+			});
+		}
 		this.ensurePeriodicScanRunning();
 	}
 
@@ -151,10 +177,16 @@ export class PortManager extends EventEmitter {
 	unregisterSession(terminalId: string): void {
 		this.sessions.delete(terminalId);
 		this.removePortsForTerminal(terminalId);
-		this.stopPeriodicScanIfIdle();
+		this.stopPeriodicScanIfNoSessions();
 	}
 
-	checkOutputForHint(data: string): void {
+	/**
+	 * Called on every PTY output chunk: any output keeps the session on the
+	 * fast scan cadence, and server-startup phrases trigger a prompt scan.
+	 */
+	checkOutputForHint(terminalId: string, data: string): void {
+		const session = this.sessions.get(terminalId);
+		if (session) session.lastActivityAt = Date.now();
 		if (this.hintScanTimeout || this.scanRequested) return;
 		if (!containsPortHint(data)) return;
 		this.scheduleHintScan();
@@ -191,7 +223,7 @@ export class PortManager extends EventEmitter {
 		return this.scanAbort;
 	}
 
-	private stopPeriodicScanIfIdle(): void {
+	private stopPeriodicScanIfNoSessions(): void {
 		if (!this.hasAnySessions()) this.stopPeriodicScan();
 	}
 
@@ -246,44 +278,54 @@ export class PortManager extends EventEmitter {
 		};
 	}
 
-	private async collectSessionPids(scanState: ScanState): Promise<void> {
-		const tasks: Promise<void>[] = [];
-		for (const [terminalId, { workspaceId, pid }] of this.sessions) {
-			if (pid === null) continue;
-			tasks.push(
-				this.collectPidTree({
-					terminalId,
-					workspaceId,
-					pid,
-					scanState,
-				}),
-			);
-		}
-		await Promise.all(tasks);
+	/**
+	 * Active sessions (recent PTY output) are scanned on every tick; idle ones
+	 * decay to the IDLE_SCAN_INTERVAL_MS cadence. Skipped sessions keep their
+	 * previously detected ports untouched until their next scan.
+	 */
+	private isSessionDue(entry: SessionEntry, now: number): boolean {
+		if (now - entry.lastActivityAt < IDLE_AFTER_MS) return true;
+		return now - entry.lastScannedAt >= IDLE_SCAN_INTERVAL_MS;
 	}
 
-	private async collectPidTree({
-		terminalId,
-		workspaceId,
-		pid,
-		scanState,
-	}: {
-		terminalId: string;
-		workspaceId: string;
-		pid: number;
-		scanState: ScanState;
-	}): Promise<void> {
-		try {
-			const pids = await getProcessTree(pid);
-			if (pids.length === 0) {
-				scanState.emptyTreeTerminals.add(terminalId);
-				return;
-			}
+	private async collectSessionPids(
+		scanState: ScanState,
+		force: boolean,
+	): Promise<void> {
+		const now = Date.now();
+		const dueSessions: {
+			terminalId: string;
+			workspaceId: string;
+			pid: number;
+		}[] = [];
+		for (const [terminalId, entry] of this.sessions) {
+			if (entry.pid === null) continue;
+			if (!force && !this.isSessionDue(entry, now)) continue;
+			dueSessions.push({
+				terminalId,
+				workspaceId: entry.workspaceId,
+				pid: entry.pid,
+			});
+		}
+		if (dueSessions.length === 0) return;
 
+		// One system-wide table read serves every due session; per-session
+		// pidtree calls each spawned a full `ps`, scaling linearly with sessions.
+		const trees = await getProcessTreesForPids(
+			dueSessions.map((session) => session.pid),
+		);
+		for (const { terminalId, workspaceId, pid } of dueSessions) {
+			const entry = this.sessions.get(terminalId);
+			if (entry) entry.lastScannedAt = now;
+
+			const pids = trees.get(pid) ?? [];
+			if (pids.length === 0) {
+				// Root pid absent from the process table — the session exited.
+				scanState.emptyTreeTerminals.add(terminalId);
+				continue;
+			}
 			scanState.terminalPortMap.set(terminalId, { workspaceId, pids });
 			this.addTerminalPids({ terminalId, workspaceId, pids, scanState });
-		} catch {
-			// Session may have exited
 		}
 	}
 
@@ -363,7 +405,7 @@ export class PortManager extends EventEmitter {
 		}
 	}
 
-	private async scanAllSessions(): Promise<void> {
+	private async scanAllSessions(force = false): Promise<void> {
 		if (this.isScanning) {
 			// A hint or tick fired mid-scan; queue exactly one follow-up.
 			this.scanRequested = true;
@@ -374,7 +416,7 @@ export class PortManager extends EventEmitter {
 
 		try {
 			const scanState = this.createScanState();
-			await this.collectSessionPids(scanState);
+			await this.collectSessionPids(scanState, force);
 
 			const portsByTerminal = await this.buildPortsByTerminal({
 				allPids: scanState.allPids,
@@ -499,7 +541,7 @@ export class PortManager extends EventEmitter {
 	}
 
 	async forceScan(): Promise<void> {
-		await this.scanAllSessions();
+		await this.scanAllSessions(true);
 	}
 
 	/**

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -312,8 +312,6 @@ export class PortManager extends EventEmitter {
 		}
 		if (dueSessions.length === 0) return;
 
-		// One system-wide table read serves every due session; per-session
-		// pidtree calls each spawned a full `ps`, scaling linearly with sessions.
 		const trees = await getProcessTreesForPids(
 			dueSessions.map((session) => session.pid),
 		);

--- a/packages/port-scanner/src/scanner.test.ts
+++ b/packages/port-scanner/src/scanner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { getListeningPortsForPids, getProcessTreesForPids } from "./scanner.ts";
 
 /**
  * Tests for lsof output parsing logic.
@@ -84,6 +85,52 @@ function parseLsofOutput(
 
 	return ports;
 }
+
+describe("getProcessTreesForPids (real process table)", () => {
+	it("returns an empty map for no roots", async () => {
+		expect((await getProcessTreesForPids([])).size).toBe(0);
+	});
+
+	it("includes the root pid and its descendants from one table read", async () => {
+		const child = Bun.spawn(["sleep", "5"]);
+		try {
+			const trees = await getProcessTreesForPids([process.pid]);
+			const tree = trees.get(process.pid);
+			expect(tree).toContain(process.pid);
+			expect(tree).toContain(child.pid);
+		} finally {
+			child.kill();
+		}
+	});
+
+	it("omits roots that are not running", async () => {
+		// PID_MAX on macOS is 99998 and on Linux defaults to 4194304, so this
+		// pid can never exist.
+		const trees = await getProcessTreesForPids([process.pid, 99_999_999]);
+		expect(trees.has(99_999_999)).toBe(false);
+		expect(trees.has(process.pid)).toBe(true);
+	});
+});
+
+describe("getListeningPortsForPids (real sockets)", () => {
+	it("finds a genuinely listening port for our own pid", async () => {
+		const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+		try {
+			const listeningPort = server.port;
+			if (listeningPort === undefined) throw new Error("server has no port");
+			const ports = await getListeningPortsForPids([process.pid]);
+			expect(ports.map((info) => info.port)).toContain(listeningPort);
+			expect(ports.every((info) => info.pid === process.pid)).toBe(true);
+		} finally {
+			server.stop(true);
+		}
+	});
+
+	it("returns nothing for a pid that is not running", async () => {
+		const ports = await getListeningPortsForPids([99_999_999]);
+		expect(ports).toHaveLength(0);
+	});
+});
 
 describe("port-scanner", () => {
 	describe("parseLsofOutput", () => {

--- a/packages/port-scanner/src/scanner.test.ts
+++ b/packages/port-scanner/src/scanner.test.ts
@@ -92,7 +92,12 @@ describe("getProcessTreesForPids (real process table)", () => {
 	});
 
 	it("includes the root pid and its descendants from one table read", async () => {
-		const child = Bun.spawn(["sleep", "5"]);
+		// Not `sleep` — this package supports win32, where that binary is absent.
+		const child = Bun.spawn([
+			process.execPath,
+			"-e",
+			"setTimeout(() => {}, 5000)",
+		]);
 		try {
 			const trees = await getProcessTreesForPids([process.pid]);
 			const tree = trees.get(process.pid);

--- a/packages/port-scanner/src/scanner.ts
+++ b/packages/port-scanner/src/scanner.ts
@@ -138,9 +138,7 @@ async function getListeningPortsLsof(
 		const pidArg = pids.join(",");
 		const pidSet = new Set(pids);
 		// -a: AND the selectors — without it lsof ORs -p with -iTCP and
-		//     enumerates every TCP listener on the machine (walking every
-		//     process's fd table), only for the pidSet check below to
-		//     discard the lot
+		//     walks every process on the machine, only to be filtered below
 		// -p: filter by PIDs
 		// -iTCP: only TCP connections
 		// -sTCP:LISTEN: only listening sockets

--- a/packages/port-scanner/src/scanner.ts
+++ b/packages/port-scanner/src/scanner.ts
@@ -57,15 +57,49 @@ export interface PortInfo {
 }
 
 /**
- * Get all child PIDs of a process (including the process itself)
+ * Get the process tree (root + descendants) for each of the given root PIDs
+ * using a single system-wide process-table read. pidtree spawns a full
+ * `ps`/`wmic` per invocation, so calling it once per session made scan cost
+ * scale linearly with session count.
+ *
+ * Roots that are no longer running are absent from the returned map. Throws
+ * when the process table itself can't be read, so callers can keep previous
+ * state instead of treating every session as exited.
  */
-export async function getProcessTree(pid: number): Promise<number[]> {
-	try {
-		return await pidtree(pid, { root: true });
-	} catch {
-		// Process may have exited
-		return [];
+export async function getProcessTreesForPids(
+	rootPids: number[],
+): Promise<Map<number, number[]>> {
+	const trees = new Map<number, number[]>();
+	if (rootPids.length === 0) return trees;
+
+	const table = await pidtree(-1, { advanced: true });
+
+	const childrenByPpid = new Map<number, number[]>();
+	const alivePids = new Set<number>();
+	for (const { pid, ppid } of table) {
+		alivePids.add(pid);
+		const siblings = childrenByPpid.get(ppid);
+		if (siblings) siblings.push(pid);
+		else childrenByPpid.set(ppid, [pid]);
 	}
+
+	for (const rootPid of rootPids) {
+		if (!alivePids.has(rootPid)) continue;
+		const pids: number[] = [];
+		const seen = new Set<number>();
+		const stack = [rootPid];
+		while (stack.length > 0) {
+			const pid = stack.pop();
+			if (pid === undefined || seen.has(pid)) continue;
+			seen.add(pid);
+			pids.push(pid);
+			const children = childrenByPpid.get(pid);
+			if (children) stack.push(...children);
+		}
+		trees.set(rootPid, pids);
+	}
+
+	return trees;
 }
 
 /**
@@ -103,16 +137,18 @@ async function getListeningPortsLsof(
 	try {
 		const pidArg = pids.join(",");
 		const pidSet = new Set(pids);
+		// -a: AND the selectors — without it lsof ORs -p with -iTCP and
+		//     enumerates every TCP listener on the machine (walking every
+		//     process's fd table), only for the pidSet check below to
+		//     discard the lot
 		// -p: filter by PIDs
 		// -iTCP: only TCP connections
 		// -sTCP:LISTEN: only listening sockets
 		// -P: don't convert port numbers to names
 		// -n: don't resolve hostnames
-		// Note: lsof may ignore -p filter if PIDs don't exist or have no matches,
-		// so we must validate PIDs in the output against our requested set
 		const output = await runTolerant(
 			"lsof",
-			["-p", pidArg, "-iTCP", "-sTCP:LISTEN", "-P", "-n"],
+			["-a", "-p", pidArg, "-iTCP", "-sTCP:LISTEN", "-P", "-n"],
 			{ maxBuffer: 10 * 1024 * 1024, timeout: EXEC_TIMEOUT_MS, signal },
 		);
 
@@ -141,8 +177,8 @@ async function getListeningPortsLsof(
 
 			const pid = Number.parseInt(pidStr, 10);
 
-			// CRITICAL: Verify the PID is in our requested set
-			// lsof ignores -p filter when PIDs don't exist, returning all TCP listeners
+			// Defense in depth: -a should guarantee only requested PIDs appear,
+			// but a stray line must never attribute another process's port to a session
 			if (!pidSet.has(pid)) continue;
 
 			// Parse address:port from NAME column


### PR DESCRIPTION
## Problem

Customer report (validated + reproduced empirically with CDP on a live dev desktop): the port scanner is a major source of background system load, in both v1 and v2 (shared `packages/port-scanner`).

1. **Per-session full-system `ps` every 2.5s.** `getProcessTree()` used pidtree, whose darwin backend spawns `ps -A` per call — one per registered session per tick. Measured: 13 sessions → 35 distinct `ps` spawns/12s, 26 sessions → 60/12s (lower bounds, ~50% sampler catch rate). Linear scaling confirmed; extrapolates to the customer's ~13/sec at 32 panes.
2. **`lsof` without `-a`.** lsof ORs the `-p` and `-iTCP` selectors, enumerating every TCP listener on the machine (observed: 721 lines from 56 unrelated processes, zero requested pids) only for the JS-side pid filter to discard everything.
3. **No idle handling at all.** Fixed 2.5s cadence forever — no decay after 5 min untouched (measured), scanning continues for unattached sessions with no renderer (boot-restored and reaper-registered ones included). `stopPeriodicScanIfIdle` only stopped at zero sessions.

## Fix

- **One shared process-table read per scan cycle**: new `getProcessTreesForPids()` calls `pidtree(-1, {advanced: true})` once (one `ps`/`wmic` total) and walks the parent/child table in memory for every due session. O(sessions) full-table dumps → O(1). Same shape as `readProcessTable()` in pty-daemon.
- **`lsof -a`**: selectors are now ANDed; the pid check stays as defense in depth. (~23% faster measured; the big win is not walking every process's fd table.)
- **Idle decay**: sessions with no PTY output for 60s drop from the 2.5s cadence to 30s. Any output (not just port hints) restores the fast cadence — `checkOutputForHint` now takes the terminalId and doubles as the activity signal. Ports are still detected for silently-daemonized servers, just slower; skipped sessions keep their previously detected ports untouched. Re-upserting the same pid (the reaper's periodic sync of unattached daemon sessions) does not reset the idle clock. Addresses the intent of #3238/#3239.
- **Rename** `stopPeriodicScanIfIdle` → `stopPeriodicScanIfNoSessions` (it never handled idleness).

Steady-state for a fully idle machine: from `sessions × 0.4` ps/sec to ~0.03 ps/sec + ~0.03 lsof/sec, regardless of session count.

## Tests

- New regression tests: single tree read per bulk scan, idle skip/slow cadence, output restores fast cadence, same-pid re-upsert preserves the idle clock, skipped sessions keep their ports, forceScan bypasses cadence.
- Real-process integration tests for `getProcessTreesForPids` (spawned child appears in tree, dead roots omitted) and `getListeningPortsForPids` (Bun.serve listener found with `-a` in place).
- Each new behavior verified by mutation: always-due, always-reset-on-upsert, and no-activity-marking mutations each fail exactly the intended tests.
- `bun test` (port-scanner 65 ✓, desktop daemon-manager 10 ✓, host-service terminal 89 ✓), turbo typecheck on all three packages ✓, `bun run lint` ✓.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5723">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal output hint detection so hints are correctly attributed to the originating terminal session.
  - Fixed fragmented/partial output handling to avoid incorrect hint matches.
  - Reduced false-positive port scans from unrelated terminal output.
  - Refined idle-session port refresh behavior so previously detected ports persist until the next due scan.

- **Performance**
  - Reduced scanning overhead by batching process-tree discovery for sessions that are due to be scanned.
  - Improved scan scheduling and force-scan coalescing to maintain consistent scan cadence.

- **Tests**
  - Updated scanner/port-manager tests to validate the new bulk scanning and cadence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->