### PR TITLE
fix(release): open the bump PR from the commit path too

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -37,8 +37,8 @@ Releases are cut on a **dedicated release branch**, not on `main` and not on you
 feature branch. Two ways:
 
 **A — release a specific commit (canary-style).** Provisions an ephemeral release
-branch from the commit in a worktree, applies the version bump there, tags, and
-pushes; your working tree is untouched:
+branch from the commit in a worktree, applies the version bump there, tags,
+pushes, and opens the bump PR; your working tree is untouched:
 
 ```bash
 bun run release desktop 1.15.0 <commit-sha>   # commit to release (e.g. a main SHA)
@@ -52,9 +52,11 @@ git switch -c release-1.15.0
 bun run release desktop 1.15.0
 ```
 
-Either way, the `desktop-v<version>` tag triggers `release-desktop.yml`. The
-version-bump commit lives on the release branch/tag; merge it however you
-normally do.
+Either way, the `desktop-v<version>` tag triggers `release-desktop.yml`, and both
+open a `chore(desktop): bump version to <version>` PR into `main` — merge it (or
+pass `--merge`) so `main` carries the released version. Leaving it unmerged only
+drifts `main`'s `package.json`: the next release reads the latest `desktop-v` tag,
+not `package.json`.
 
 ## Desktop: draft → publish
 

--- a/scripts/release/desktop.ts
+++ b/scripts/release/desktop.ts
@@ -93,9 +93,6 @@ export async function runDesktop(argv: string[]): Promise<void> {
 			`Invalid version format: ${version}\nExpected MAJOR.MINOR.PATCH (e.g. 1.2.3). To release a specific commit: release desktop <version> <commit>`,
 		);
 	}
-	if (autoMerge && commitInput) {
-		warn("--merge has no effect with a commit SHA (no PR is created).");
-	}
 
 	if ((await exitCode($`gh auth status`)) !== 0) {
 		fail("Not authenticated with GitHub CLI. Run: gh auth login");
@@ -109,7 +106,8 @@ export async function runDesktop(argv: string[]): Promise<void> {
 
 	let prNumber = "";
 	if (commitInput) {
-		await releaseFromCommit(version, commitInput, tag, withDaemon);
+		prNumber = (await releaseFromCommit(version, commitInput, tag, withDaemon))
+			.prNumber;
 	} else {
 		prNumber = (await releaseFromHead(root, version, tag, withDaemon)).prNumber;
 	}
@@ -224,6 +222,30 @@ async function bumpUnified(
 	};
 }
 
+/** Open the bump PR into main, reusing an open one for `branch` if present. */
+async function openBumpPr(version: string, branch: string): Promise<string> {
+	const existing = (
+		await $`gh pr list --head ${branch} --json number --jq ${".[0].number"}`
+			.nothrow()
+			.text()
+	).trim();
+	if (existing) {
+		info(`Reusing existing PR #${existing}`);
+		return existing;
+	}
+	const r =
+		await $`gh pr create --title ${`chore(desktop): bump version to ${version}`} --body ${"Automated by scripts/release/desktop.ts."} --base main --head ${branch}`
+			.nothrow()
+			.text();
+	const m = r.match(/\/(\d+)\s*$/);
+	if (!m) {
+		warn("Could not create PR");
+		return "";
+	}
+	success(`PR #${m[1]} created`);
+	return m[1];
+}
+
 async function releaseFromHead(
 	root: string,
 	version: string,
@@ -251,29 +273,13 @@ async function releaseFromHead(
 	await $`git push -u origin ${`HEAD:${branch}`}`;
 
 	let prNumber = "";
-	if (branch !== "main") {
-		const existing = (
-			await $`gh pr list --head ${branch} --json number --jq ${".[0].number"}`
-				.nothrow()
-				.text()
-		).trim();
-		if (existing) {
-			prNumber = existing;
-		} else if (
-			Number(
-				(await $`git rev-list --count ${"main..HEAD"}`.nothrow().text()).trim(),
-			) > 0
-		) {
-			const r =
-				await $`gh pr create --title ${`chore(desktop): bump version to ${version}`} --body ${"Automated by scripts/release/desktop.ts."} --base main --head ${branch}`
-					.nothrow()
-					.text();
-			const m = r.match(/\/(\d+)\s*$/);
-			if (m) {
-				prNumber = m[1];
-				success(`PR #${prNumber} created`);
-			} else warn("Could not create PR");
-		}
+	if (
+		branch !== "main" &&
+		Number(
+			(await $`git rev-list --count ${"main..HEAD"}`.nothrow().text()).trim(),
+		) > 0
+	) {
+		prNumber = await openBumpPr(version, branch);
 	}
 
 	info(`Creating tag ${tag}...`);
@@ -288,7 +294,7 @@ async function releaseFromCommit(
 	commitInput: string,
 	tag: string,
 	withDaemon: boolean,
-): Promise<void> {
+): Promise<{ prNumber: string }> {
 	const fullSha = (
 		await $`git rev-parse --verify ${`${commitInput}^{commit}`}`
 			.nothrow()
@@ -302,6 +308,7 @@ async function releaseFromCommit(
 	await $`git push origin --delete ${tempBranch}`.nothrow().quiet();
 
 	const worktree = mkdtempSync(join(tmpdir(), "superset-release-"));
+	let bumped = false;
 	try {
 		await $`git worktree add --detach ${worktree} ${fullSha}`.quiet();
 		success(`Provisioned worktree at ${worktree}`);
@@ -322,6 +329,7 @@ async function releaseFromCommit(
 				worktree,
 			);
 			success(`Committed ${wtVersion} -> ${version} on top of ${shortSha}`);
+			bumped = true;
 		} else {
 			warn(`Commit ${shortSha} already has version ${version}; skipping bump`);
 		}
@@ -334,6 +342,9 @@ async function releaseFromCommit(
 		await $`git worktree remove --force ${worktree}`.nothrow().quiet();
 		rmSync(worktree, { recursive: true, force: true });
 	}
+
+	// The tag pins the release commit; the PR is what lands the bump back on main.
+	return { prNumber: bumped ? await openBumpPr(version, tempBranch) : "" };
 }
 
 async function monitorAndPublish(


### PR DESCRIPTION
## What

`bun run release desktop <version> <sha>` (path A — releasing a specific commit) pushed a `release-desktop-v<version>-<sha>` branch and tagged it, but never opened a PR. Path B (`releaseFromHead`) did.

So the version bump never landed on `main`, and each release left an orphaned branch behind. Hit this cutting 1.15.1 today: the bump had to be PR'd and merged by hand (#5722), and an equivalent orphan from 1.14.3 (#5579) had gone stale enough that merging it would have rolled `main`'s version *backwards*.

## How

- Extract the PR-opening logic `releaseFromHead` already had into `openBumpPr(version, branch)` — reuses an open PR for the branch instead of duplicating.
- Call it from `releaseFromCommit` once the tag is pushed, and only when a bump commit was actually made.
- `--merge` works on the commit path now (`monitorAndPublish` merges the returned `prNumber`), so the "`--merge` has no effect with a commit SHA" warning is gone.
- README: document that both paths open the bump PR.

## Verification

`openBumpPr`'s two paths were exercised against the real GitHub API while cutting 1.15.1:

- `gh pr create` with these exact args opened #5722.
- The reuse lookup `gh pr list --head <branch> --json number --jq '.[0].number'` then returned `5722`.
- The `/\/(\d+)\s*$/` regex captures `5722` from real `gh` output.

`bun run lint`, `tsc --noEmit`, and `bun test scripts/release/lib.test.ts` (15 pass) are clean. Note `lib.test.ts` only covers pure helpers — nothing in this diff has unit coverage, which is why I verified against the live API instead.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5724">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the commit-based desktop release path opens a bump PR so the version change lands on `main` and we stop creating orphaned release branches. Also enables `--merge` for this path and updates docs.

- **Bug Fixes**
  - Open or reuse a bump PR when releasing from a specific commit.
  - `--merge` now merges that PR for the commit path; removed the warning.
  - README updated to state both paths open the bump PR.

<sup>Written for commit 4609a04c0c0552e934a2f1e5654051b05ce90e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified desktop release instructions, including tagging, publishing, and version-bump pull request behavior.
  - Added guidance for merging version updates into the main branch to keep future releases aligned.

- **Bug Fixes**
  - Improved automated handling of version-bump pull requests during commit-based releases.
  - Existing pull requests are now reused when appropriate, and automatic merging works more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->