### PR TITLE
fix(desktop): re-send terminal PTY dims when a hidden pane becomes visible

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -184,9 +184,6 @@ function createResizeScheduler(
 	dispose: () => void;
 } {
 	let timeoutId: ReturnType<typeof setTimeout> | null = null;
-	// On reveal after a zero-size hide, re-send PTY dims even when unchanged
-	// (VS Code setVisible parity) — resyncs a PTY resized elsewhere meanwhile.
-	let revealPending = false;
 
 	const dispose = () => {
 		if (timeoutId !== null) {
@@ -197,9 +194,10 @@ function createResizeScheduler(
 
 	const run = () => {
 		timeoutId = null;
-		const forceNotify = revealPending;
-		revealPending = false;
-		measureAndResize(runtime, onResize, { forceNotify });
+		// Notify unconditionally (VS Code parity): a reveal after a zero-size
+		// hide re-sends PTY dims even when unchanged, resyncing a PTY resized
+		// elsewhere meanwhile. Same-size re-sends are kernel no-ops.
+		measureAndResize(runtime, onResize, { forceNotify: true });
 	};
 
 	const observe: ResizeObserverCallback = (entries) => {
@@ -209,7 +207,6 @@ function createResizeScheduler(
 					entry.contentRect.width <= 0 || entry.contentRect.height <= 0,
 			)
 		) {
-			revealPending = true;
 			dispose();
 			return;
 		}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -137,6 +137,7 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 function measureAndResize(
 	runtime: TerminalRuntime,
 	onResize?: () => void,
+	options: { forceNotify?: boolean } = {},
 ): void {
 	if (!hostIsVisible(runtime.container)) return;
 	const { terminal } = runtime;
@@ -165,7 +166,11 @@ function measureAndResize(
 
 		terminal.refresh(0, Math.max(0, terminal.rows - 1));
 
-		if (terminal.cols !== prevCols || terminal.rows !== prevRows) {
+		if (
+			options.forceNotify ||
+			terminal.cols !== prevCols ||
+			terminal.rows !== prevRows
+		) {
 			onResize?.();
 		}
 	});
@@ -179,6 +184,9 @@ function createResizeScheduler(
 	dispose: () => void;
 } {
 	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	// On reveal after a zero-size hide, re-send PTY dims even when unchanged
+	// (VS Code setVisible parity) — resyncs a PTY resized elsewhere meanwhile.
+	let revealPending = false;
 
 	const dispose = () => {
 		if (timeoutId !== null) {
@@ -189,7 +197,9 @@ function createResizeScheduler(
 
 	const run = () => {
 		timeoutId = null;
-		measureAndResize(runtime, onResize);
+		const forceNotify = revealPending;
+		revealPending = false;
+		measureAndResize(runtime, onResize, { forceNotify });
 	};
 
 	const observe: ResizeObserverCallback = (entries) => {
@@ -199,6 +209,7 @@ function createResizeScheduler(
 					entry.contentRect.width <= 0 || entry.contentRect.height <= 0,
 			)
 		) {
+			revealPending = true;
 			dispose();
 			return;
 		}


### PR DESCRIPTION
## Summary
- v2 terminal panes hidden via CSS (zero-size container) and shown again now re-send their PTY dimensions on reveal, even when the fitted dims are unchanged — mirroring VS Code's `setVisible` → `_resize` behavior.
- Fixes the case where the PTY was resized elsewhere while the pane was hidden (another window on the same terminal, host-side drift): the re-send is then a real size change, the program gets its SIGWINCH, and the TUI repaints at the correct size on reveal.
- Implementation: the ResizeObserver scheduler's post-fit notification is now unconditional (`forceNotify`) instead of gated on changed dims. The observer only fires on genuine container changes, so this covers the reveal edge with no state — dims either changed (a resize was being sent anyway) or it's a reveal / sub-cell wiggle, where a same-size re-send is a kernel no-op on both ends (host `modeTracker.resize` also early-returns on same dims). VS Code's resize debouncer likewise has no changed-dims gate. Net +9/−2 in one file.

## Notes
- When both ends already agree on the size, the re-send is a kernel no-op by design — a same-size `TIOCSWINSZ` delivers no SIGWINCH (verified against a real pty + Node child), so idle reveals stay invisible to running programs.
- Deliberately minimal: SIGWINCH-jiggle variants (host-side nudge on attach, a new `nudge` protocol message, a rows−1→rows resize dance, a reveal-edge latch) were prototyped and rejected in favor of this VS Code-parity re-send.

## Testing
- CDP against the real dev app (live PTY, 136×48): idle/hidden → 0 resize sends; reveal → exactly 1 send with unchanged dims (the forced path — old code sent nothing); 3× rapid hide/show → 1 send (debounced). See PR comment for the run against the first revision; re-ran identically on the final one.
- `bun test src/renderer/lib/terminal/` (264 tests), desktop typecheck, repo lint all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal resizing behavior when switching from a hidden or collapsed view.
  * Ensured resize notifications are reliably triggered even when terminal dimensions remain unchanged, so layout updates continue to apply after non-visible observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->