### PR TITLE
docs(development): clarify worktree setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,21 @@ Thanks for contributing! Please follow our [code of conduct](./CODE_OF_CONDUCT.m
 
 ## Local development
 
-See [**DEVELOPMENT.md**](./DEVELOPMENT.md) for the full guide. TL;DR:
+Development is expected to run from a Superset workspace, which is a managed
+git worktree. Add your clone to the installed Superset app, create a workspace
+for your change, then run the following commands in that workspace:
 
 ```bash
 ./.superset/setup.local.sh
 bun run dev
 ```
 
-No Neon or third-party credentials needed.
+Run `setup.local.sh` once in every new worktree before starting development. It
+configures workspace-specific app identity, ports, local services, and a seeded
+development account so the dev desktop app can run alongside the installed app.
+No Neon or third-party credentials are needed.
+
+See [**DEVELOPMENT.md**](./DEVELOPMENT.md) for the full guide.
 
 ## Opening a pull request
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,16 +14,29 @@ This guide is for contributors building Superset from source. If you just want t
 
 macOS is the primary supported platform. Windows / Linux are untested.
 
-## Run it (one command)
+## Run it from a Superset workspace
 
 ```bash
 git clone https://github.com/superset-sh/superset.git
-cd superset
+```
+
+Add the clone to the installed Superset app and create a workspace for your
+change. Superset creates that workspace as an isolated git worktree. In the new
+workspace terminal, run:
+
+```bash
 ./.superset/setup.local.sh
 bun run dev
 ```
 
-That's it. **You do not need a Neon account, Stripe keys, or any other third-party credentials.** `.env.local.example` ships fake placeholders that pass env validation, and `setup.local.sh` runs everything against a local Docker stack.
+Run `setup.local.sh` separately in every new worktree before `bun run dev`. The
+setup and workspace-specific app identity allow the development desktop app to
+run alongside the installed Superset app and development apps from other
+worktrees.
+
+**You do not need a Neon account, Stripe keys, or any other third-party
+credentials.** `.env.local.example` ships fake placeholders that pass env
+validation, and `setup.local.sh` runs everything against a local Docker stack.
 
 ### What `setup.local.sh` does
 
@@ -81,6 +94,9 @@ See [`AGENTS.md`](./AGENTS.md) for repo structure, monorepo conventions, and dat
 
 ## Troubleshooting
 
+- **Dev desktop exits while the installed app is running**: launch development
+  from a Superset workspace instead of the repository's main checkout, run
+  `./.superset/setup.local.sh` in that worktree, then run `bun run dev` again.
 - **`caddy trust` prompts for sudo**: expected, once per machine. Without it Chromium rejects `https://localhost:*` with `ERR_CERT_AUTHORITY_INVALID`.
 - **Port collision**: `setup.local.sh` allocates a fresh port window per worktree. If you ran the script before this change landed, re-run it to migrate.
 - **DB connection errors after pulling main**: re-run `./.superset/setup.local.sh`; it's idempotent and will apply any new migrations.

--- a/README.md
+++ b/README.md
@@ -235,16 +235,27 @@ Builds for Windows and Linux are not yet available.
 
 ## Development
 
-Want to hack on Superset or contribute a PR? Spin up a local dev environment in one command:
+Want to hack on Superset or contribute a PR? Clone the repository, add it to the
+installed Superset app, and create a workspace for your change:
 
 ```bash
 git clone https://github.com/superset-sh/superset.git
-cd superset
+```
+
+Then run the development setup from that workspace terminal:
+
+```bash
 ./.superset/setup.local.sh
 bun run dev
 ```
 
-No Neon account or third-party credentials needed. `setup.local.sh` brings up a local Postgres + Electric stack via Docker and seeds a dev account. Sign in with the **"Sign in as dev"** button (or `admin@local.test` / `supersetdev`).
+Run `setup.local.sh` once in every new worktree. It configures workspace-specific
+app identity and ports so the development desktop app can run alongside the
+installed Superset app and other development worktrees.
+
+No Neon account or third-party credentials are needed. `setup.local.sh` brings
+up a local Postgres + Electric stack via Docker and seeds a dev account. Sign in
+with the **"Sign in as dev"** button (or `admin@local.test` / `supersetdev`).
 
 Prereqs: `bun`, `docker`, `jq`, `caddy` (`brew install jq caddy && caddy trust`).
 


### PR DESCRIPTION
## What & why

The development desktop app can run alongside an installed Superset app when it is launched from a Superset-managed worktree after that worktree's local setup has run.

The existing contributor docs showed the setup commands after a normal clone but did not make the worktree requirement explicit. That made a repository-root launch look like a supported side-by-side setup and led to an unnecessary Electron isolation change.

## What changed

- explain that desktop development should run from a Superset workspace
- require `./.superset/setup.local.sh` in every new worktree before `bun run dev`
- document why the per-worktree identity and ports allow installed and development apps to run together
- add troubleshooting for a dev desktop app that exits while the installed app is running

## How I tested it

- created `~/.superset/worktrees/superset/pr-5726-baseline` at unmodified `upstream/main`
- ran `./.superset/setup.local.sh` in that worktree
- kept `/Applications/Superset.app` open while launching `bun run dev`
- confirmed `Superset (pr-5726-baseline)` and the installed app ran simultaneously
- confirmed the dev app signed in as the seeded Local Admin and reached the workspaces screen
- `bun run lint:fix`
- `bun run lint`

## Checklist

- [x] PR title follows conventional commits
- [x] `bun run lint` passes
- [x] "Allow edits from maintainers" is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded local development setup instructions with workspace-specific guidance.
  * Clarified that setup must be run once for each new worktree.
  * Added details about local services, isolated ports, workspace configuration, and seeded development access.
  * Documented troubleshooting steps for recovering when the development desktop exits while the app is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->