### PR TITLE
fix(desktop): reuse onboarding chat IPC client

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.test.tsx
@@ -1,0 +1,57 @@
+import { expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const createChatServiceIpcClient = mock(() => ({ kind: "chat-client" }));
+const navigate = mock(() => {});
+
+mock.module("renderer/components/Chat/utils/chat-service-client", () => ({
+	createChatServiceIpcClient,
+}));
+mock.module("@superset/chat/client", () => ({
+	ChatServiceProvider: ({ children }: { children: ReactNode }) => children,
+}));
+mock.module("@tanstack/react-router", () => ({
+	createFileRoute:
+		() =>
+		<TOptions,>(options: TOptions) =>
+			options,
+	Navigate: () => null,
+	Outlet: () => null,
+	useLocation: () => ({ pathname: "/onboarding" }),
+	useNavigate: () => navigate,
+}));
+mock.module("renderer/lib/auth-client", () => ({
+	authClient: {
+		useSession: () => ({ data: null, isPending: false }),
+	},
+}));
+mock.module("renderer/lib/electron-trpc", () => ({
+	electronTrpc: {
+		window: {
+			getPlatform: {
+				useQuery: () => ({ data: "darwin" }),
+			},
+		},
+	},
+}));
+mock.module("renderer/providers/ElectronTRPCProvider", () => ({
+	electronQueryClient: {},
+}));
+mock.module("./components/OnboardingNavigation", () => ({
+	OnboardingNavigation: () => null,
+}));
+
+test("reuses one IPC client when the onboarding layout remounts", async () => {
+	const { Route } = await import("./layout");
+	const Layout = (
+		Route as unknown as {
+			component: () => ReactNode;
+		}
+	).component;
+
+	renderToStaticMarkup(createElement(Layout));
+	renderToStaticMarkup(createElement(Layout));
+
+	expect(createChatServiceIpcClient).toHaveBeenCalledTimes(1);
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
@@ -6,7 +6,6 @@ import {
 	useLocation,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useMemo } from "react";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -32,11 +31,12 @@ const STEPS = [
 	},
 ] as const;
 
+const chatServiceIpcClient = createChatServiceIpcClient();
+
 function OnboardingFlowLayout() {
 	const { data: session, isPending } = authClient.useSession();
 	const { data: platform } = electronTrpc.window.getPlatform.useQuery();
 	const isMac = platform === undefined || platform === "darwin";
-	const chatClient = useMemo(() => createChatServiceIpcClient(), []);
 	const location = useLocation();
 	const navigate = useNavigate();
 
@@ -64,7 +64,10 @@ function OnboardingFlowLayout() {
 		: null;
 
 	return (
-		<ChatServiceProvider client={chatClient} queryClient={electronQueryClient}>
+		<ChatServiceProvider
+			client={chatServiceIpcClient}
+			queryClient={electronQueryClient}
+		>
 			<div className="flex h-full w-full flex-col bg-background">
 				<div
 					className="drag h-12 w-full shrink-0"


### PR DESCRIPTION
## Summary

- Reuse a module-scoped chat IPC client in the desktop onboarding route.
- Prevent route remounts from registering additional permanent `trpc-electron` renderer listeners.
- Add a regression test that mounts the layout twice and verifies the client factory runs once.

## Root cause

`trpc-electron@0.1.2` registers its renderer IPC listener when a client is constructed and does not expose a teardown API. Constructing the client inside the route component therefore adds another listener after every remount.

## Test plan

- `bun test src/renderer/routes/_authenticated/onboarding/layout.test.tsx`
- `bun run typecheck` in `apps/desktop`
- `bun run lint` at repository root
- `PATH="/usr/local/sbin:$PATH" bun test` in `apps/desktop` (2141 passing)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5728">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reused a module-scoped chat IPC client in the desktop onboarding route to stop multiple permanent renderer listeners from being registered. Added a regression test to ensure the client is created once across remounts.

- **Bug Fixes**
  - Moved `createChatServiceIpcClient()` to module scope and pass the shared instance to `ChatServiceProvider`.
  - Added a test that mounts the layout twice and asserts the factory runs once, preventing extra `trpc-electron` listeners (`trpc-electron@0.1.2` has no teardown).

<sup>Written for commit b27966a9f09793c08cfd0d648f050aeded0265dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding chat reliability by reusing a single chat connection when the onboarding screen is remounted.

* **Tests**
  * Added coverage verifying that the onboarding chat connection is created only once across remounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->