### PR TITLE
fix(desktop): show only the hotkey in preset bar tooltips, after a long hover

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/components/HotkeyTooltip/HotkeyTooltip.tsx
+++ b/apps/desktop/src/renderer/hotkeys/components/HotkeyTooltip/HotkeyTooltip.tsx
@@ -1,4 +1,3 @@
-import { Kbd, KbdGroup } from "@superset/ui/kbd";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import type { ComponentProps, ReactNode } from "react";
 import { useHotkeyDisplay } from "../../hooks/useHotkeyDisplay";
@@ -6,8 +5,8 @@ import type { HotkeyId } from "../../registry";
 
 /**
  * Wraps a trigger with a shortcut-only tooltip: after a long hover it shows
- * just the hotkey's kbd chips. Renders children bare when no hotkey is
- * assigned.
+ * the hotkey as a single kbd-style chip. Renders children bare when no
+ * hotkey is assigned.
  */
 export function HotkeyTooltip({
 	id,
@@ -18,22 +17,18 @@ export function HotkeyTooltip({
 	side?: ComponentProps<typeof TooltipContent>["side"];
 	children: ReactNode;
 }) {
-	const { keys } = useHotkeyDisplay(id ?? ("" as HotkeyId));
-	if (!id || keys[0] === "Unassigned") return <>{children}</>;
+	const { text } = useHotkeyDisplay(id ?? ("" as HotkeyId));
+	if (!id || text === "Unassigned") return <>{children}</>;
 	return (
-		<Tooltip delayDuration={700}>
+		<Tooltip delayDuration={1000}>
 			<TooltipTrigger asChild>{children}</TooltipTrigger>
 			<TooltipContent
 				side={side}
 				sideOffset={4}
 				showArrow={false}
-				className="px-1.5 py-1"
+				className="rounded-sm border border-border bg-background px-1.5 py-0.5 font-medium text-muted-foreground shadow-sm"
 			>
-				<KbdGroup>
-					{keys.map((k) => (
-						<Kbd key={k}>{k}</Kbd>
-					))}
-				</KbdGroup>
+				{text}
 			</TooltipContent>
 		</Tooltip>
 	);

--- a/apps/desktop/src/renderer/hotkeys/components/HotkeyTooltip/HotkeyTooltip.tsx
+++ b/apps/desktop/src/renderer/hotkeys/components/HotkeyTooltip/HotkeyTooltip.tsx
@@ -1,0 +1,40 @@
+import { Kbd, KbdGroup } from "@superset/ui/kbd";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import type { ComponentProps, ReactNode } from "react";
+import { useHotkeyDisplay } from "../../hooks/useHotkeyDisplay";
+import type { HotkeyId } from "../../registry";
+
+/**
+ * Wraps a trigger with a shortcut-only tooltip: after a long hover it shows
+ * just the hotkey's kbd chips. Renders children bare when no hotkey is
+ * assigned.
+ */
+export function HotkeyTooltip({
+	id,
+	side = "bottom",
+	children,
+}: {
+	id?: HotkeyId;
+	side?: ComponentProps<typeof TooltipContent>["side"];
+	children: ReactNode;
+}) {
+	const { keys } = useHotkeyDisplay(id ?? ("" as HotkeyId));
+	if (!id || keys[0] === "Unassigned") return <>{children}</>;
+	return (
+		<Tooltip delayDuration={700}>
+			<TooltipTrigger asChild>{children}</TooltipTrigger>
+			<TooltipContent
+				side={side}
+				sideOffset={4}
+				showArrow={false}
+				className="px-1.5 py-1"
+			>
+				<KbdGroup>
+					{keys.map((k) => (
+						<Kbd key={k}>{k}</Kbd>
+					))}
+				</KbdGroup>
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/hotkeys/components/HotkeyTooltip/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/components/HotkeyTooltip/index.ts
@@ -1,0 +1,1 @@
+export { HotkeyTooltip } from "./HotkeyTooltip";

--- a/apps/desktop/src/renderer/hotkeys/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/index.ts
@@ -1,4 +1,5 @@
 export { HotkeyLabel } from "./components/HotkeyLabel";
+export { HotkeyTooltip } from "./components/HotkeyTooltip";
 export { formatHotkeyDisplay } from "./display";
 export {
 	getBinding,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
@@ -7,12 +7,11 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useEffect, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { HiMiniCommandLine } from "react-icons/hi2";
 import type { HotkeyId } from "renderer/hotkeys";
-import { HotkeyLabel } from "renderer/hotkeys";
+import { HotkeyTooltip } from "renderer/hotkeys";
 import { resolveV2PresetIcon } from "renderer/lib/preset-icon";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 
@@ -43,7 +42,6 @@ export function V2PresetBarItem({
 }: V2PresetBarItemProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const icon = resolveV2PresetIcon(preset, agents, isDark);
-	const label = preset.description || preset.name || "default";
 
 	const [{ isDragging }, drag] = useDrag(
 		() => ({
@@ -87,32 +85,27 @@ export function V2PresetBarItem({
 					className={isDragging ? "opacity-40" : undefined}
 					style={{ cursor: isDragging ? "grabbing" : "grab" }}
 				>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant="ghost"
-								size="sm"
-								className="h-6 max-w-32 min-w-0 shrink-0 gap-1.5 rounded-md px-1.5 text-xs font-normal text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-								onClick={() => onExecutePreset(preset)}
-							>
-								{icon ? (
-									<img
-										src={icon}
-										alt=""
-										className="size-3.5 shrink-0 object-contain opacity-90"
-									/>
-								) : (
-									<HiMiniCommandLine className="size-3.5 shrink-0" />
-								)}
-								<span className="min-w-0 truncate">
-									{preset.name || "default"}
-								</span>
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="bottom" sideOffset={4}>
-							<HotkeyLabel label={label} id={hotkeyId} />
-						</TooltipContent>
-					</Tooltip>
+					<HotkeyTooltip id={hotkeyId}>
+						<Button
+							variant="ghost"
+							size="sm"
+							className="h-6 max-w-32 min-w-0 shrink-0 gap-1.5 rounded-md px-1.5 text-xs font-normal text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+							onClick={() => onExecutePreset(preset)}
+						>
+							{icon ? (
+								<img
+									src={icon}
+									alt=""
+									className="size-3.5 shrink-0 object-contain opacity-90"
+								/>
+							) : (
+								<HiMiniCommandLine className="size-3.5 shrink-0" />
+							)}
+							<span className="min-w-0 truncate">
+								{preset.name || "default"}
+							</span>
+						</Button>
+					</HotkeyTooltip>
 				</div>
 			</ContextMenuTrigger>
 			<ContextMenuContent>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
@@ -7,13 +7,12 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useEffect, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { HiMiniCommandLine } from "react-icons/hi2";
 import { getPresetIcon } from "renderer/assets/app-icons/preset-icons";
 import type { HotkeyId } from "renderer/hotkeys";
-import { HotkeyLabel } from "renderer/hotkeys";
+import { HotkeyTooltip } from "renderer/hotkeys";
 
 const PRESET_BAR_ITEM_TYPE = "PRESET_BAR_ITEM";
 
@@ -50,7 +49,6 @@ export function PresetBarItem({
 }: PresetBarItemProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const icon = getPresetIcon(preset.name, isDark);
-	const label = preset.description || preset.name || "default";
 
 	const [{ isDragging }, drag] = useDrag(
 		() => ({
@@ -94,28 +92,23 @@ export function PresetBarItem({
 					className={isDragging ? "opacity-40" : undefined}
 					style={{ cursor: isDragging ? "grabbing" : "grab" }}
 				>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant="ghost"
-								size="sm"
-								className="h-6 px-2 gap-1.5 text-xs shrink-0"
-								onClick={() => onOpenDefault(preset)}
-							>
-								{icon ? (
-									<img src={icon} alt="" className="size-3.5 object-contain" />
-								) : (
-									<HiMiniCommandLine className="size-3.5" />
-								)}
-								<span className="truncate max-w-[120px]">
-									{preset.name || "default"}
-								</span>
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="bottom" sideOffset={4}>
-							<HotkeyLabel label={label} id={hotkeyId} />
-						</TooltipContent>
-					</Tooltip>
+					<HotkeyTooltip id={hotkeyId}>
+						<Button
+							variant="ghost"
+							size="sm"
+							className="h-6 px-2 gap-1.5 text-xs shrink-0"
+							onClick={() => onOpenDefault(preset)}
+						>
+							{icon ? (
+								<img src={icon} alt="" className="size-3.5 object-contain" />
+							) : (
+								<HiMiniCommandLine className="size-3.5" />
+							)}
+							<span className="truncate max-w-[120px]">
+								{preset.name || "default"}
+							</span>
+						</Button>
+					</HotkeyTooltip>
 				</div>
 			</ContextMenuTrigger>
 			<ContextMenuContent>


### PR DESCRIPTION
## Summary

Preset bar tooltips previously showed the preset's full description text plus the hotkey in the default heavy inverted tooltip bubble, immediately on hover. This replaces them with a minimal shortcut-only hint:

- New shared `HotkeyTooltip` component in `renderer/hotkeys` that shows just the hotkey's kbd chips in a compact, arrow-less bubble after a 700ms hover delay, and renders the trigger bare when no hotkey is assigned.
- Both the v1 `PresetBarItem` and v2 `V2PresetBarItem` now use it, dropping the redundant description/name text (the button already shows the preset name).

## Test Plan

- [ ] Hover a pinned preset in the presets bar (v1 and v2): after ~700ms only the shortcut chips (e.g. ⌘1) appear, no description text
- [ ] A preset without an assigned shortcut shows no tooltip
- [ ] `bun run lint` and desktop `typecheck` pass

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5730">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preset bar tooltips now show only the hotkey after a 1s hover, using a flat, theme-aware chip. Applies to v1 and v2 preset bars; no tooltip if no hotkey.

- **New Features**
  - Added `HotkeyTooltip` to display a compact, arrow-less hotkey chip after a delay and render bare when unassigned.
  - Replaced previous tooltip usage in `PresetBarItem` and `V2PresetBarItem` with `HotkeyTooltip`.

<sup>Written for commit b59b90f31e3b331803b84bd7733e52b08cf43976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hotkey tooltips that show only when a shortcut is assigned.
  * Tooltips wrap the related control and reveal the resolved hotkey after a brief delay.
  * Tooltip placement is configurable (defaulting to below the control).
* **Improvements**
  * Updated preset bar controls to use the unified hotkey tooltip experience across relevant workspace views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->