### PR TITLE
fix(desktop): stop the sign-in redirect render loop that can OOM the renderer

### DIFF
--- a/apps/desktop/src/renderer/hooks/useDelayElapsed/index.ts
+++ b/apps/desktop/src/renderer/hooks/useDelayElapsed/index.ts
@@ -1,0 +1,1 @@
+export { useDelayElapsed } from "./useDelayElapsed";

--- a/apps/desktop/src/renderer/hooks/useDelayElapsed/useDelayElapsed.ts
+++ b/apps/desktop/src/renderer/hooks/useDelayElapsed/useDelayElapsed.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/** True once `active` has stayed true for `delayMs`; resets when `active` drops. */
+export function useDelayElapsed(active: boolean, delayMs: number): boolean {
+	const [elapsed, setElapsed] = useState(false);
+
+	useEffect(() => {
+		if (!active) {
+			setElapsed(false);
+			return;
+		}
+		const timer = window.setTimeout(() => setElapsed(true), delayMs);
+		return () => window.clearTimeout(timer);
+	}, [active, delayMs]);
+
+	return elapsed;
+}

--- a/apps/desktop/src/renderer/hooks/useSignOut/useSignOut.ts
+++ b/apps/desktop/src/renderer/hooks/useSignOut/useSignOut.ts
@@ -5,6 +5,9 @@ import { posthog } from "renderer/lib/posthog";
 export const AUTH_COMPLETED_KEY = "superset_auth_completed";
 export const ACTIVE_ORG_ID_KEY = "active_organization_id";
 
+// An unreachable auth server must not block local sign-out (#5729)
+const SERVER_REVOKE_TIMEOUT_MS = 5_000;
+
 export function useSignOut() {
 	const signOutMutation = electronTrpc.auth.signOut.useMutation();
 	const setAnalyticsUserId = electronTrpc.analytics.setUserId.useMutation();
@@ -14,7 +17,12 @@ export function useSignOut() {
 		setAnalyticsUserId.mutate({ userId: null });
 		localStorage.removeItem(AUTH_COMPLETED_KEY);
 		localStorage.removeItem(ACTIVE_ORG_ID_KEY);
-		await authClient.signOut();
+		await Promise.race([
+			authClient.signOut({ fetchOptions: { throw: false } }).catch(() => {}),
+			new Promise((resolve) =>
+				window.setTimeout(resolve, SERVER_REVOKE_TIMEOUT_MS),
+			),
+		]);
 		signOutMutation.mutate();
 	};
 }

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -3,6 +3,8 @@ import { authClient, setAuthToken, setJwt } from "renderer/lib/auth-client";
 import { SupersetLogo } from "renderer/routes/sign-in/components/SupersetLogo/SupersetLogo";
 import { electronTrpc } from "../../lib/electron-trpc";
 
+const HYDRATION_TIMEOUT_MS = 15_000;
+
 export function AuthProvider({ children }: { children: ReactNode }) {
 	const [isHydrated, setIsHydrated] = useState(false);
 	const { refetch: refetchSession } = authClient.useSession();
@@ -18,30 +20,38 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 		let cancelled = false;
 
+		async function fetchSessionAndJwt() {
+			try {
+				await refetchSession();
+			} catch (err) {
+				console.warn(
+					"[AuthProvider] session refetch failed during hydration",
+					err,
+				);
+			}
+			try {
+				const res = await authClient.token();
+				if (res.data?.token) {
+					setJwt(res.data.token);
+				}
+			} catch (err) {
+				console.warn("[AuthProvider] JWT fetch failed during hydration", err);
+			}
+		}
+
 		async function hydrate() {
 			if (storedToken?.token && storedToken?.expiresAt) {
 				const isExpired = new Date(storedToken.expiresAt) < new Date();
 				if (!isExpired) {
 					setAuthToken(storedToken.token);
-					try {
-						await refetchSession();
-					} catch (err) {
-						console.warn(
-							"[AuthProvider] session refetch failed during hydration",
-							err,
-						);
-					}
-					try {
-						const res = await authClient.token();
-						if (res.data?.token) {
-							setJwt(res.data.token);
-						}
-					} catch (err) {
-						console.warn(
-							"[AuthProvider] JWT fetch failed during hydration",
-							err,
-						);
-					}
+					// A hung session fetch must not hold boot on the splash forever —
+					// proceed after a bound; the routes show session-pending UI (#5729).
+					await Promise.race([
+						fetchSessionAndJwt(),
+						new Promise((resolve) =>
+							window.setTimeout(resolve, HYDRATION_TIMEOUT_MS),
+						),
+					]);
 				}
 			}
 			if (!cancelled) {

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -1,5 +1,10 @@
 import { type ReactNode, useEffect, useState } from "react";
-import { authClient, setAuthToken, setJwt } from "renderer/lib/auth-client";
+import {
+	authClient,
+	getAuthToken,
+	setAuthToken,
+	setJwt,
+} from "renderer/lib/auth-client";
 import { SupersetLogo } from "renderer/routes/sign-in/components/SupersetLogo/SupersetLogo";
 import { electronTrpc } from "../../lib/electron-trpc";
 
@@ -20,7 +25,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 		let cancelled = false;
 
-		async function fetchSessionAndJwt() {
+		async function fetchSessionAndJwt(tokenAtStart: string) {
 			try {
 				await refetchSession();
 			} catch (err) {
@@ -31,7 +36,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 			}
 			try {
 				const res = await authClient.token();
-				if (res.data?.token) {
+				// A response outliving the hydration timeout must not resurrect a
+				// JWT after sign-out or a token change.
+				if (res.data?.token && getAuthToken() === tokenAtStart) {
 					setJwt(res.data.token);
 				}
 			} catch (err) {
@@ -47,7 +54,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 					// A hung session fetch must not hold boot on the splash forever —
 					// proceed after a bound; the routes show session-pending UI (#5729).
 					await Promise.race([
-						fetchSessionAndJwt(),
+						fetchSessionAndJwt(storedToken.token),
 						new Promise((resolve) =>
 							window.setTimeout(resolve, HYDRATION_TIMEOUT_MS),
 						),

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -14,6 +14,7 @@ import { HiOutlineWifi } from "react-icons/hi2";
 import { NewWorkspaceModal } from "renderer/components/NewWorkspaceModal";
 import { Paywall } from "renderer/components/Paywall";
 import { env } from "renderer/env.renderer";
+import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";
@@ -55,6 +56,8 @@ const createOrganizationRedirect = (
 );
 const onboardingRedirect = <Navigate to="/onboarding" replace />;
 
+const SESSION_PENDING_TIMEOUT_MS = 15_000;
+
 function AuthenticatedLayout() {
 	const {
 		data: session,
@@ -75,6 +78,15 @@ function AuthenticatedLayout() {
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION
 		? MOCK_ORG_ID
 		: session?.session?.activeOrganizationId;
+
+	const isAuthPending =
+		(isPending || (isRefetching && !session?.user && hasLocalToken)) &&
+		!env.SKIP_ENV_VALIDATION;
+	const authPendingTimedOut = useDelayElapsed(
+		isAuthPending,
+		SESSION_PENDING_TIMEOUT_MS,
+	);
+	const signOutMutation = electronTrpc.auth.signOut.useMutation();
 
 	useAgentHookListener();
 
@@ -169,13 +181,40 @@ function AuthenticatedLayout() {
 
 	// Never redirect while the session is unresolved — a redirect held open
 	// across re-renders loops the router until the renderer OOMs (#5729).
-	if (
-		(isPending || (isRefetching && !session?.user && hasLocalToken)) &&
-		!env.SKIP_ENV_VALIDATION
-	) {
+	if (isAuthPending) {
 		return (
-			<div className="flex h-screen w-screen items-center justify-center bg-background">
+			<div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-background">
 				<Spinner className="size-8" />
+				{authPendingTimedOut && (
+					<>
+						<div className="text-center select-text cursor-text">
+							<h2 className="text-lg font-medium">
+								Still restoring your session
+							</h2>
+							<p className="text-sm text-muted-foreground">
+								Superset can't confirm your sign-in with the server.
+							</p>
+						</div>
+						<div className="flex gap-2">
+							<Button variant="outline" size="sm" onClick={() => refetch()}>
+								Retry
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={signOutMutation.isPending}
+								onClick={() =>
+									signOutMutation.mutate(undefined, {
+										onSuccess: () =>
+											void navigate({ to: "/sign-in", replace: true }),
+									})
+								}
+							>
+								Sign out
+							</Button>
+						</div>
+					</>
+				)}
 			</div>
 		);
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -8,7 +8,7 @@ import {
 	useLocation,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HiOutlineWifi } from "react-icons/hi2";
 import { NewWorkspaceModal } from "renderer/components/NewWorkspaceModal";
@@ -17,6 +17,7 @@ import { env } from "renderer/env.renderer";
 import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
+import { useSignOut } from "renderer/hooks/useSignOut";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";
 import { dragDropManager } from "renderer/lib/dnd";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -86,7 +87,8 @@ function AuthenticatedLayout() {
 		isAuthPending,
 		SESSION_PENDING_TIMEOUT_MS,
 	);
-	const signOutMutation = electronTrpc.auth.signOut.useMutation();
+	const signOut = useSignOut();
+	const [isSigningOut, setIsSigningOut] = useState(false);
 
 	useAgentHookListener();
 
@@ -202,13 +204,15 @@ function AuthenticatedLayout() {
 							<Button
 								variant="outline"
 								size="sm"
-								disabled={signOutMutation.isPending}
-								onClick={() =>
-									signOutMutation.mutate(undefined, {
-										onSuccess: () =>
-											void navigate({ to: "/sign-in", replace: true }),
-									})
-								}
+								disabled={isSigningOut}
+								onClick={async () => {
+									setIsSigningOut(true);
+									try {
+										await signOut();
+									} finally {
+										void navigate({ to: "/sign-in", replace: true });
+									}
+								}}
 							>
 								Sign out
 							</Button>

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -48,6 +48,13 @@ export const Route = createFileRoute("/_authenticated")({
 	component: AuthenticatedLayout,
 });
 
+// Hoisted for stable props identity — <Navigate> re-navigates every re-render otherwise (react error #185 loop, #5729)
+const signInRedirect = <Navigate to="/sign-in" replace />;
+const createOrganizationRedirect = (
+	<Navigate to="/create-organization" replace />
+);
+const onboardingRedirect = <Navigate to="/onboarding" replace />;
+
 function AuthenticatedLayout() {
 	const {
 		data: session,
@@ -160,9 +167,8 @@ function AuthenticatedLayout() {
 		},
 	});
 
-	if (isPending && !hasLocalToken && !env.SKIP_ENV_VALIDATION) {
-		return <Navigate to="/sign-in" replace />;
-	}
+	// Never redirect while the session is unresolved — a redirect held open
+	// across re-renders loops the router until the renderer OOMs (#5729).
 	if (
 		(isPending || (isRefetching && !session?.user && hasLocalToken)) &&
 		!env.SKIP_ENV_VALIDATION
@@ -192,11 +198,11 @@ function AuthenticatedLayout() {
 	}
 
 	if (!isSignedIn) {
-		return <Navigate to="/sign-in" replace />;
+		return signInRedirect;
 	}
 
 	if (!activeOrganizationId) {
-		return <Navigate to="/create-organization" replace />;
+		return createOrganizationRedirect;
 	}
 
 	if (
@@ -204,7 +210,7 @@ function AuthenticatedLayout() {
 		!session.user.onboardedAt &&
 		!location.pathname.startsWith("/onboarding")
 	) {
-		return <Navigate to="/onboarding" replace />;
+		return onboardingRedirect;
 	}
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
@@ -17,6 +17,9 @@ export const Route = createFileRoute("/_authenticated/onboarding")({
 	component: OnboardingFlowLayout,
 });
 
+// Hoisted for stable props identity — <Navigate> re-navigates every re-render otherwise (react error #185 loop, #5729)
+const rootRedirect = <Navigate to="/" replace />;
+
 const STEPS = [
 	{
 		path: "/onboarding",
@@ -42,7 +45,7 @@ function OnboardingFlowLayout() {
 
 	if (isPending) return null;
 	if (session?.user?.onboardedAt) {
-		return <Navigate to="/" replace />;
+		return rootRedirect;
 	}
 
 	const currentStepIdx = STEPS.findIndex((s) => s.match(location.pathname));

--- a/apps/desktop/src/renderer/routes/create-organization/page.tsx
+++ b/apps/desktop/src/renderer/routes/create-organization/page.tsx
@@ -25,6 +25,9 @@ export const Route = createFileRoute("/create-organization/")({
 	component: CreateOrganization,
 });
 
+// Hoisted for stable props identity — <Navigate> re-navigates every re-render otherwise (react error #185 loop, #5729)
+const signInRedirect = <Navigate to="/sign-in" replace />;
+
 const formSchema = z.object({
 	name: z.string().min(1, "Organization name is required").max(100),
 	slug: z
@@ -153,7 +156,7 @@ export function CreateOrganization() {
 	}
 
 	if (!isSignedIn) {
-		return <Navigate to="/sign-in" replace />;
+		return signInRedirect;
 	}
 
 	const hasActiveOrganization = !!activeOrganizationId;

--- a/apps/desktop/src/renderer/routes/page.tsx
+++ b/apps/desktop/src/renderer/routes/page.tsx
@@ -4,6 +4,9 @@ export const Route = createFileRoute("/")({
 	component: RootIndexPage,
 });
 
+// Hoisted for stable props identity — <Navigate> re-navigates every re-render otherwise (react error #185 loop, #5729)
+const workspaceRedirect = <Navigate to="/workspace" replace />;
+
 function RootIndexPage() {
-	return <Navigate to="/workspace" replace />;
+	return workspaceRedirect;
 }

--- a/apps/desktop/src/renderer/routes/sign-in/page.tsx
+++ b/apps/desktop/src/renderer/routes/sign-in/page.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { FaGithub } from "react-icons/fa";
 import { FcGoogle } from "react-icons/fc";
 import { env } from "renderer/env.renderer";
+import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
 import { track } from "renderer/lib/analytics";
 import { setAuthToken } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -26,6 +27,8 @@ const LAST_USED_METHOD_KEY = "superset-last-auth-method";
 
 // Hoisted for stable props identity — <Navigate> re-navigates every re-render otherwise (react error #185 loop, #5729)
 const workspaceRedirect = <Navigate to="/workspace" replace />;
+
+const SESSION_PENDING_TIMEOUT_MS = 15_000;
 
 type AuthMethod = AuthProvider | "dev";
 
@@ -44,6 +47,12 @@ function SignInPage() {
 	const [devError, setDevError] = useState<string | null>(null);
 	const [lastUsedMethod, setLastUsedMethod] = useState(readLastUsedMethod);
 	const { hasLocalToken, isPending, session } = useSessionRecovery();
+	// A session fetch that never settles must not trap the user on a spinner —
+	// fall through to the sign-in buttons after a while (#5729).
+	const pendingTimedOut = useDelayElapsed(
+		isPending,
+		SESSION_PENDING_TIMEOUT_MS,
+	);
 
 	// Dev bypass: skip sign-in entirely
 	if (env.SKIP_ENV_VALIDATION) {
@@ -51,7 +60,7 @@ function SignInPage() {
 	}
 
 	// Show loading while session is being fetched
-	if (isPending) {
+	if (isPending && !pendingTimedOut) {
 		return (
 			<div className="flex h-screen w-screen items-center justify-center bg-background">
 				<Spinner className="size-8" />

--- a/apps/desktop/src/renderer/routes/sign-in/page.tsx
+++ b/apps/desktop/src/renderer/routes/sign-in/page.tsx
@@ -24,6 +24,9 @@ export const Route = createFileRoute("/sign-in/")({
 
 const LAST_USED_METHOD_KEY = "superset-last-auth-method";
 
+// Hoisted for stable props identity — <Navigate> re-navigates every re-render otherwise (react error #185 loop, #5729)
+const workspaceRedirect = <Navigate to="/workspace" replace />;
+
 type AuthMethod = AuthProvider | "dev";
 
 function readLastUsedMethod(): AuthMethod | null {
@@ -44,7 +47,7 @@ function SignInPage() {
 
 	// Dev bypass: skip sign-in entirely
 	if (env.SKIP_ENV_VALIDATION) {
-		return <Navigate to="/workspace" replace />;
+		return workspaceRedirect;
 	}
 
 	// Show loading while session is being fetched
@@ -58,7 +61,7 @@ function SignInPage() {
 
 	// If already signed in, redirect to workspace
 	if (session?.user) {
-		return <Navigate to="/workspace" replace />;
+		return workspaceRedirect;
 	}
 
 	const rememberLastUsedMethod = (method: AuthMethod) => {


### PR DESCRIPTION
Fixes #5729

## Summary
- Fixes the infinite navigate/render loop behind react error #185 ("Maximum update depth exceeded"), which fires on **every signed-out boot** — PostHog shows ~37k of these exceptions from ~3,600 distinct desktop users in the last 7 days, nearly all at `#/sign-in`.
- In the pathological case (a `get-session` request that never settles), the loop ran unbounded until the renderer OOMed at ~6GB — the "app hangs / white window after 20 seconds" in #5729.
- Adds an escape hatch for a genuinely unreachable auth server: boot no longer waits on the splash forever, and after 15s the user gets "Still restoring your session" with **Retry** / **Sign out** instead of an indefinite spinner.

## Why / Context
The reporter in #5729 blamed the Thai (`en_TH`) macOS locale, but that's a red herring: Chromium resolves the renderer's Intl/`navigator.language` to plain `en-US` even under Region=Thailand (verified four ways on real hardware, plus JS shims forcing `en-GB` / `th-TH` Buddhist Intl — no runaway in any config). Their PostHog event stream shows the real signature: 9× react error #185 within one second of their very first `desktop_opened`, with a stack of `commitHookEffectListMount → RouterCore.navigate → startTransition → dispatchSetState`.

## How It Works
Root cause is a composition of two things:

1. TanStack Router's `<Navigate>` runs `navigate(props)` in a layout effect whose deps include the raw `props` **object identity** — so any re-render that produces a fresh JSX element re-navigates.
2. `AuthenticatedLayout` rendered `<Navigate to="/sign-in">` while the session query was still pending, and it subscribes to router state (`useLocation`) — so the navigation it triggered re-rendered it, which created a fresh `<Navigate>`, which navigated again, synchronously, ~50 commits deep → react #185. The loop runs for as long as the redirect condition holds: ~2s of session-pending on a normal boot (a few #185s, error boundary recovers), forever when `get-session` hangs (renderer runaway → OOM).

The fix (commit 1):
- **Hoist boot-path redirect elements to module scope** (`/sign-in`, `/create-organization`, `/onboarding`, `/workspace`, `/`) so their props identity is stable and `Navigate` fires exactly once per mount instead of once per re-render. This kills the loop class structurally.
- **Never redirect while the session is unresolved**: the authenticated layout now shows its existing spinner during `isPending` and only redirects on a definitive signed-out result. This also stops kicking slow-booting cookie-session users off their restored deep route.

The escape hatch (commit 2), for a `get-session` that never settles:
- `AuthProvider` hydration races the session/JWT fetch against a 15s bound instead of awaiting it forever on the splash.
- The authenticated layout's pending screen upgrades after 15s to "Still restoring your session" with **Retry** (refetch) and **Sign out** (clears the local token via the existing main-process sign-out, then lands on `/sign-in`).
- The sign-in page falls through from its spinner to the actual sign-in buttons after 15s, so re-auth is always reachable even mid-outage.
- New shared `useDelayElapsed(active, delayMs)` hook under `renderer/hooks/`.

## Manual QA Checklist
All validated in the dev app over CDP with a diagnostic shim (history + console.error hooks), each scenario run before and after the fix:

- [x] Signed-out boot (token removed, cookies + localStorage cleared): lands at `#/sign-in` with **0** "Maximum update depth" errors (pre-fix: 1 per boot, every boot), and settles in ~500ms instead of ~2s
- [x] Signed-in boot: lands on the workspace route, 0 errors
- [x] Fatal scenario — `/api/auth/get-session` blackholed indefinitely via CDP request interception: renderer idles at ~10% CPU with flat memory (pre-fix behavior per #5729: 500–790% CPU, ~6GB RSS, renderer OOM); after ~30s total the timeout screen appears with Retry / Sign out
- [x] Clicking **Sign out** on the timeout screen (still blackholed) lands on `#/sign-in`; after its 15s fallthrough the GitHub/Google sign-in buttons render, so the user can re-auth during a full auth outage
- [x] OAuth token-replay path (`persistToken` → `onTokenChanged` → signOut/refetch): no navigation storm

## Testing
- `bun run lint` (exits 0)
- `bunx tsc --noEmit` in `apps/desktop` (clean)
- `bun test src/renderer/routes/sign-in` (7/7 pass)

## Known Limitations
- `getAuthToken()` is still a bare module variable read during render (it tears, but no longer feeds a redirect decision while the session is pending). Migrating it to `useSyncExternalStore` is a possible follow-up.
- Settings-page `<Navigate>` usages with dynamic params were left as-is: they aren't on the boot path and don't subscribe to router state, so they don't exhibit the loop.

## Risks / Rollout
- Risk: low — behavior changes are confined to boot-time redirect ordering and previously-unreachable hang states. Fresh installs briefly show a spinner (~300ms) before `/sign-in` instead of redirecting during pending; a hung boot proceeds past the splash after 15s instead of never.
- Rollback: revert both commits; no data or config involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect stability across workspace, sign-in, onboarding, and organization creation by keeping navigation elements consistent across re-renders.
  * Updated authentication/session restoration: the app now shows an “auth pending” spinner with a timed-out state that supports Retry or Sign out.
  * Prevented auth from getting stuck: added timeouts for hydration and sign-out so slow or unreachable auth services won’t block app initialization or sign-out completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->