### PR TITLE
fix(security): validate org membership on MCP OAuth tokens to close cross-tenant access

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
 		"clean": "git clean -xdf .cache .next .turbo node_modules",
 		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${API_PORT:-3001}'",
 		"start": "next start --port 3001",
+		"test": "bun test",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/apps/api/src/app/api/agent/[transport]/auth-flow.test.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import { type McpRequestDeps, verifyToken } from "./auth-flow";
+
+const JWT_SHAPED_TOKEN = "header.payload.signature";
+
+function makeDeps(payload: Record<string, unknown>): McpRequestDeps {
+	return {
+		apiUrl: "http://localhost:3001",
+		authApi: {
+			getSession: async () => null,
+			verifyApiKey: async () => ({ valid: false, key: null }),
+		},
+		createServer: (() => {
+			throw new Error("createServer should not be called");
+		}) as unknown as McpRequestDeps["createServer"],
+		createTransport: () => {
+			throw new Error("createTransport should not be called");
+		},
+		verifyAccessToken: (async () =>
+			payload) as unknown as McpRequestDeps["verifyAccessToken"],
+	};
+}
+
+function makeRequest(): Request {
+	return new Request("http://localhost:3001/api/agent/mcp", {
+		method: "POST",
+		headers: { authorization: `Bearer ${JWT_SHAPED_TOKEN}` },
+	});
+}
+
+describe("verifyToken cross-tenant organization guard", () => {
+	it("rejects a token whose organizationId is not one of the subject's memberships", async () => {
+		// The reported attack: a token minted for one identity naming a victim's
+		// organization the subject never belonged to.
+		const deps = makeDeps({
+			sub: "user-1",
+			organizationId: "victim-org",
+			organizationIds: ["attacker-own-org"],
+			scope: "mcp:full",
+		});
+
+		const authInfo = await verifyToken(makeRequest(), deps);
+
+		expect(authInfo).toBeUndefined();
+	});
+
+	it("accepts a token whose organizationId is one of the subject's memberships", async () => {
+		const deps = makeDeps({
+			sub: "user-1",
+			organizationId: "org-1",
+			organizationIds: ["org-1", "org-2"],
+			scope: "mcp:full",
+		});
+
+		const authInfo = await verifyToken(makeRequest(), deps);
+
+		expect(authInfo?.extra?.mcpContext).toEqual({
+			userId: "user-1",
+			organizationId: "org-1",
+		});
+	});
+
+	it("rejects a token that carries no organizationIds membership claim", async () => {
+		const deps = makeDeps({
+			sub: "user-1",
+			organizationId: "org-1",
+			scope: "mcp:full",
+		});
+
+		const authInfo = await verifyToken(makeRequest(), deps);
+
+		expect(authInfo).toBeUndefined();
+	});
+
+	it("still accepts a third-party client's token (azp is not gated)", async () => {
+		// Regression guard: a legitimate third-party MCP client (Claude Code,
+		// OpenCode, etc.) acting for its own authenticated user must pass.
+		const deps = makeDeps({
+			sub: "user-1",
+			azp: "some-dynamically-registered-client-id",
+			organizationId: "org-1",
+			organizationIds: ["org-1"],
+			scope: "mcp:full",
+		});
+
+		const authInfo = await verifyToken(makeRequest(), deps);
+
+		expect(authInfo?.extra?.mcpContext).toEqual({
+			userId: "user-1",
+			organizationId: "org-1",
+		});
+	});
+});

--- a/apps/api/src/app/api/agent/[transport]/auth-flow.test.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.test.ts
@@ -44,9 +44,12 @@ describe("verifyToken cross-tenant organization guard", () => {
 		expect(authInfo).toBeUndefined();
 	});
 
-	it("accepts a token whose organizationId is one of the subject's memberships", async () => {
+	it("accepts a member's token, including a third-party client's (azp is not gated)", async () => {
+		// A legitimate third-party MCP client (Claude Code, OpenCode, ...) acting
+		// for its own authenticated user must pass — azp is deliberately not gated.
 		const deps = makeDeps({
 			sub: "user-1",
+			azp: "some-dynamically-registered-client-id",
 			organizationId: "org-1",
 			organizationIds: ["org-1", "org-2"],
 			scope: "mcp:full",
@@ -70,24 +73,5 @@ describe("verifyToken cross-tenant organization guard", () => {
 		const authInfo = await verifyToken(makeRequest(), deps);
 
 		expect(authInfo).toBeUndefined();
-	});
-
-	it("still accepts a third-party client's token (azp is not gated)", async () => {
-		// Regression guard: a legitimate third-party MCP client (Claude Code,
-		// OpenCode, etc.) acting for its own authenticated user must pass.
-		const deps = makeDeps({
-			sub: "user-1",
-			azp: "some-dynamically-registered-client-id",
-			organizationId: "org-1",
-			organizationIds: ["org-1"],
-			scope: "mcp:full",
-		});
-
-		const authInfo = await verifyToken(makeRequest(), deps);
-
-		expect(authInfo?.extra?.mcpContext).toEqual({
-			userId: "user-1",
-			organizationId: "org-1",
-		});
 	});
 });

--- a/apps/api/src/app/api/agent/[transport]/auth-flow.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.ts
@@ -169,6 +169,23 @@ function buildOAuthAuthInfo(
 		return undefined;
 	}
 
+	// Cross-tenant guard (parity with the v2 boundary's membership check): the
+	// `organizationId` claim is only honored when it is one of the user's own
+	// memberships. Both claims are server-signed, so `organizationIds` is the
+	// authoritative membership list minted at token issuance. Without this, a
+	// token could name an organization the subject never belonged to.
+	const organizationIds = Array.isArray(payload.organizationIds)
+		? payload.organizationIds.filter(
+				(id): id is string => typeof id === "string",
+			)
+		: [];
+	if (!organizationIds.includes(payload.organizationId)) {
+		console.error(
+			"[mcp/auth] Access token organizationId is not one of the subject's memberships",
+		);
+		return undefined;
+	}
+
 	const scopes = Array.isArray(payload.scope)
 		? (payload.scope as string[])
 		: typeof payload.scope === "string"

--- a/apps/api/src/app/api/agent/[transport]/auth-flow.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.ts
@@ -169,17 +169,13 @@ function buildOAuthAuthInfo(
 		return undefined;
 	}
 
-	// Cross-tenant guard (parity with the v2 boundary's membership check): the
-	// `organizationId` claim is only honored when it is one of the user's own
-	// memberships. Both claims are server-signed, so `organizationIds` is the
-	// authoritative membership list minted at token issuance. Without this, a
-	// token could name an organization the subject never belonged to.
-	const organizationIds = Array.isArray(payload.organizationIds)
-		? payload.organizationIds.filter(
-				(id): id is string => typeof id === "string",
-			)
-		: [];
-	if (!organizationIds.includes(payload.organizationId)) {
+	// Cross-tenant guard (parity with v2): only honor `organizationId` when it
+	// is one of the subject's own memberships. Both claims are server-signed, so
+	// `organizationIds` is the authoritative membership list at token issuance.
+	if (
+		!Array.isArray(payload.organizationIds) ||
+		!payload.organizationIds.includes(payload.organizationId)
+	) {
 		console.error(
 			"[mcp/auth] Access token organizationId is not one of the subject's memberships",
 		);

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -125,6 +125,16 @@ describe("agentConfigsRouter", () => {
 			);
 		});
 
+		it("rejects env keys that are not valid POSIX names", async () => {
+			const caller = createCaller();
+			await expect(
+				caller.add({
+					...presetBody("claude"),
+					env: { "PATH=$(id)": "x" },
+				}),
+			).rejects.toThrow();
+		});
+
 		it("allows duplicate presetId tags with distinct ids", async () => {
 			const caller = createCaller();
 			await caller.list();

--- a/packages/host-service/src/trpc/router/settings/agent-configs.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.ts
@@ -14,7 +14,11 @@ import { protectedProcedure, router } from "../../index";
 const promptTransportSchema = z.enum(["argv", "stdin"]);
 
 const argvSchema = z.array(z.string());
-const envSchema = z.record(z.string(), z.string());
+// Input hygiene (not an auth control): keys are interpolated into launch command strings, so constrain them to POSIX env-var names.
+const envSchema = z.record(
+	z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/),
+	z.string(),
+);
 
 export interface HostAgentConfig {
 	id: string;


### PR DESCRIPTION
## The vulnerability

`/api/agent/mcp` (v1) accepted an OAuth access token's `organizationId` claim without checking the subject was a member of that organization. A token naming an organization the subject never belonged to was accepted, granting cross-tenant MCP access. The v2 boundary (`resolveMcpContext` in `@superset/mcp-v2`) already validated membership; v1 did not.

## The fix

`buildOAuthAuthInfo` now honors `organizationId` only when it appears in the token's server-signed `organizationIds` (the subject's membership list minted at token issuance) — parity with v2. Regression test added; verified it **fails against the pre-fix code** (cross-tenant token accepted) and passes after.

## Why not an `azp` allowlist

The first draft of this PR mirrored the tRPC trusted-client (`azp`) gate at the MCP boundary. **That was wrong** and would have caused an outage. Verifying against the production OAuth client registry showed the MCP endpoint is used, over OAuth + dynamic client registration, by a large base of legitimate third-party clients:

| Client | Users (valid tokens now) |
|---|---|
| Claude Code | 137 |
| Codex | 16 |
| OpenCode | 10 |
| Claude.ai | 8 |
| Warp / ChatGPT / Grok / others | ~9 |

~180 users hold valid third-party MCP tokens right now (447 have used it overall). An `azp` allowlist (`superset-cli` only) would `401` all of them. MCP is a **third-party client protocol** advertised via `.well-known` OAuth discovery, not a first-party-only surface like tRPC — so the membership check is the correct guard: it closes cross-tenant access while every legitimate client (acting for its own authenticated user) keeps working.

tRPC's existing `azp` gate is left untouched — that traffic really is first-party.

## Secondary: env-key input hygiene (not a standalone vulnerability)

`envOverlayPrefix()` interpolates env-var keys raw into the launch command string (values are already quoted). `agentConfigs.env` keys are now constrained to POSIX names (`/^[A-Za-z_][A-Za-z0-9_]*$/`) at the schema boundary. Defense-in-depth hygiene, not an RCE fix.

## Out of scope / follow-ups

- **Consent-phishing / client-name impersonation**: unauthenticated dynamic client registration lets an attacker register a client named e.g. "Claude Code (superset)" and phish a victim's consent. Neither an `azp` gate nor a membership check closes this — it needs a product decision (consent-screen clarity, client-name reservation, or gating unauthenticated DCR). Filing separately.
- Chat BOLA #5017 is already fixed and out of scope.

Reported by **Jemin Khunt** (cyber.jemin@gmail.com) and **Hitarth Shah** (shahhits12@gmail.com).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added cross-tenant authorization checks to ensure tokens only access their permitted organization.
  * Rejected tokens missing required organization membership information.
  * Preserved support for valid third-party client tokens.
  * Tightened environment variable validation to accept only valid POSIX-style names.

* **Tests**
  * Added coverage for organization authorization and environment variable validation.
  * Added a test command for running the API test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->