### PR TITLE
feat(desktop): auto-create panes for background terminal sessions on workspace open

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/index.ts
@@ -1,0 +1,1 @@
+export { useAutoAdoptBackgroundSessions } from "./useAutoAdoptBackgroundSessions";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
@@ -1,0 +1,75 @@
+import type { WorkspaceStore } from "@superset/panes";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useEffect, useRef } from "react";
+import { logStressEvent } from "renderer/lib/performance/stress-instrumentation";
+import { getTerminalBackgroundMarkerIdsKey } from "renderer/lib/terminal/terminal-background-intents";
+import type { StoreApi } from "zustand/vanilla";
+import {
+	getAttachedTerminalIdsKey,
+	getBackgroundTerminalSessions,
+	parseAttachedTerminalIdsKey,
+} from "../../components/BackgroundTerminalsButton/BackgroundTerminalsButton.utils";
+import type { PaneViewerData } from "../../types";
+import { focusOrAddTerminalPane } from "../../utils/focusTerminalPane";
+
+interface UseAutoAdoptBackgroundSessionsArgs {
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+	workspaceId: string;
+	isLayoutReady: boolean;
+}
+
+/**
+ * When a workspace is created or opened, running terminal daemon sessions
+ * that have no pane get their panes created automatically instead of sitting
+ * behind the background-terminals dropdown.
+ *
+ * Runs exactly one adoption pass per workspace open, after the persisted pane
+ * layout has hydrated (adopting earlier would double-create panes the layout
+ * already has, or get clobbered by hydration). Sessions the user deliberately
+ * backgrounded (marker set) are skipped, and the one-shot guard means a
+ * session backgrounded after the pass is never re-adopted.
+ */
+export function useAutoAdoptBackgroundSessions({
+	store,
+	workspaceId,
+	isLayoutReady,
+}: UseAutoAdoptBackgroundSessionsArgs): void {
+	const adoptedForWorkspaceIdRef = useRef<string | null>(null);
+	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
+		{ workspaceId },
+		{ enabled: isLayoutReady, refetchOnWindowFocus: false },
+	);
+	const sessions = sessionsQuery.data?.sessions;
+
+	useEffect(() => {
+		if (!isLayoutReady || !sessions) return;
+		if (adoptedForWorkspaceIdRef.current === workspaceId) return;
+		adoptedForWorkspaceIdRef.current = workspaceId;
+
+		const state = store.getState();
+		const marked = new Set(
+			parseAttachedTerminalIdsKey(
+				getTerminalBackgroundMarkerIdsKey(workspaceId),
+			),
+		);
+		const toAdopt = getBackgroundTerminalSessions(
+			sessions,
+			parseAttachedTerminalIdsKey(getAttachedTerminalIdsKey(state.tabs)),
+		).filter((session) => !marked.has(session.terminalId));
+		if (toAdopt.length === 0) return;
+
+		// Adopt oldest→newest so tabs read chronologically, then restore focus so
+		// adoption never steals the active tab from an already-open workspace.
+		const restoreActiveTabId = state.tabs.length > 0 ? state.activeTabId : null;
+		for (const session of toAdopt.reverse()) {
+			focusOrAddTerminalPane(store, session.terminalId);
+		}
+		if (restoreActiveTabId) {
+			store.getState().setActiveTab(restoreActiveTabId);
+		}
+		logStressEvent("background-terminals.auto-adopt", {
+			count: toAdopt.length,
+			workspaceId,
+		});
+	}, [isLayoutReady, sessions, store, workspaceId]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
@@ -40,9 +40,14 @@ export function useAutoAdoptBackgroundSessions({
 		{ enabled: isLayoutReady, refetchOnWindowFocus: false },
 	);
 	const sessions = sessionsQuery.data?.sessions;
+	// While a (re)fetch is in flight, `data` may be a cached list from a
+	// previous open — wait for it so the one-shot pass doesn't latch on stale
+	// sessions. If the refetch errors, isFetching clears and the cached list is
+	// still used as a fallback.
+	const isFetchingSessions = sessionsQuery.isFetching;
 
 	useEffect(() => {
-		if (!isLayoutReady || !sessions) return;
+		if (!isLayoutReady || !sessions || isFetchingSessions) return;
 		if (adoptedForWorkspaceIdRef.current === workspaceId) return;
 		adoptedForWorkspaceIdRef.current = workspaceId;
 
@@ -71,5 +76,5 @@ export function useAutoAdoptBackgroundSessions({
 			count: toAdopt.length,
 			workspaceId,
 		});
-	}, [isLayoutReady, sessions, store, workspaceId]);
+	}, [isLayoutReady, isFetchingSessions, sessions, store, workspaceId]);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
@@ -23,11 +23,10 @@ interface UseAutoAdoptBackgroundSessionsArgs {
  * that have no pane get their panes created automatically instead of sitting
  * behind the background-terminals dropdown.
  *
- * Runs exactly one adoption pass per workspace open, after the persisted pane
- * layout has hydrated (adopting earlier would double-create panes the layout
- * already has, or get clobbered by hydration). Sessions the user deliberately
- * backgrounded (marker set) are skipped, and the one-shot guard means a
- * session backgrounded after the pass is never re-adopted.
+ * One pass per workspace open, gated on pane-layout hydration (adopting
+ * earlier would duplicate panes the persisted layout already has, or get
+ * clobbered by it). Deliberately backgrounded sessions (marker set) are
+ * skipped and never re-adopted mid-session.
  */
 export function useAutoAdoptBackgroundSessions({
 	store,
@@ -40,10 +39,8 @@ export function useAutoAdoptBackgroundSessions({
 		{ enabled: isLayoutReady, refetchOnWindowFocus: false },
 	);
 	const sessions = sessionsQuery.data?.sessions;
-	// While a (re)fetch is in flight, `data` may be a cached list from a
-	// previous open — wait for it so the one-shot pass doesn't latch on stale
-	// sessions. If the refetch errors, isFetching clears and the cached list is
-	// still used as a fallback.
+	// While a refetch is in flight, data may be a stale cached list from a
+	// previous open — don't let the one-shot pass latch on it.
 	const isFetchingSessions = sessionsQuery.isFetching;
 
 	useEffect(() => {
@@ -63,8 +60,8 @@ export function useAutoAdoptBackgroundSessions({
 		).filter((session) => !marked.has(session.terminalId));
 		if (toAdopt.length === 0) return;
 
-		// Adopt oldest→newest so tabs read chronologically, then restore focus so
-		// adoption never steals the active tab from an already-open workspace.
+		// Oldest→newest so tabs read chronologically; restore the active tab so
+		// adoption never steals focus.
 		const restoreActiveTabId = state.tabs.length > 0 ? state.activeTabId : null;
 		for (const session of toAdopt.reverse()) {
 			focusOrAddTerminalPane(store, session.terminalId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -39,15 +39,16 @@ export function useV2WorkspacePaneLayout() {
 		lastSyncedSnapshot: getSnapshot(EMPTY_STATE),
 	});
 
-	const { data: localWorkspaceRows = [] } = useLiveQuery(
-		(query) =>
-			query
-				.from({ v2WorkspaceLocalState: collections.v2WorkspaceLocalState })
-				.where(({ v2WorkspaceLocalState }) =>
-					eq(v2WorkspaceLocalState.workspaceId, workspaceId),
-				),
-		[collections, workspaceId],
-	);
+	const { data: localWorkspaceRows = [], isReady: isLayoutReady } =
+		useLiveQuery(
+			(query) =>
+				query
+					.from({ v2WorkspaceLocalState: collections.v2WorkspaceLocalState })
+					.where(({ v2WorkspaceLocalState }) =>
+						eq(v2WorkspaceLocalState.workspaceId, workspaceId),
+					),
+			[collections, workspaceId],
+		);
 	const localWorkspaceState =
 		localWorkspaceRows.find((row) => row.workspaceId === workspaceId) ?? null;
 	const persistedPaneLayout = useMemo(
@@ -104,5 +105,5 @@ export function useV2WorkspacePaneLayout() {
 		};
 	}, [collections, store, workspaceId]);
 
-	return { store };
+	return { store, isLayoutReady };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -18,6 +18,7 @@ import { V2WorkspaceRunButton } from "./components/V2WorkspaceRunButton";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
 import { WorkspaceMissingWorktreeState } from "./components/WorkspaceMissingWorktreeState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
+import { useAutoAdoptBackgroundSessions } from "./hooks/useAutoAdoptBackgroundSessions";
 import { useBrowserShellInteractionPassthrough } from "./hooks/useBrowserShellInteractionPassthrough";
 import { useClearActivePaneAttention } from "./hooks/useClearActivePaneAttention";
 import { useConsumeAutomationRunLink } from "./hooks/useConsumeAutomationRunLink";
@@ -123,7 +124,7 @@ function V2WorkspaceContent() {
 	} = useV2UserPreferences();
 	const showPresetsBar = v2UserPreferences.showPresetsBar;
 	const sidebarOpen = v2UserPreferences.rightSidebarOpen;
-	const { store } = useV2WorkspacePaneLayout();
+	const { store, isLayoutReady } = useV2WorkspacePaneLayout();
 	useClearActivePaneAttention({ store });
 	const launcher = useV2TerminalLauncher();
 	const {
@@ -148,6 +149,7 @@ function V2WorkspaceContent() {
 		chatSessionId,
 		focusRequestId,
 	});
+	useAutoAdoptBackgroundSessions({ store, workspaceId, isLayoutReady });
 	useConsumeOpenUrlRequest({
 		store,
 		url: openUrl,


### PR DESCRIPTION
## Summary
- When a v2 workspace is created or opened, running terminal daemon sessions that have no pane get their panes created automatically, instead of requiring the user to adopt them one by one from the background-terminals dropdown.
- One idempotent adoption pass per workspace open; the dropdown remains for sessions deliberately sent to the background mid-session.

## Why / Context
Sessions can exist on the host with no pane in the workspace UI (created by automations, host-side launches, or left over from a previous app run). Today they only surface in the `BackgroundTerminalsButton` dropdown and users have to adopt each manually. Opening a workspace should just show its running sessions.

## How It Works
New `useAutoAdoptBackgroundSessions` hook (75 lines), mounted in the workspace page next to the automation deep-link consumer. It composes existing, already-tested primitives rather than introducing new derivations:

- Waits for the persisted pane layout to hydrate — `useV2WorkspacePaneLayout` now exposes the live query's `isReady` as `isLayoutReady`. Adopting earlier would double-create panes the layout already has, or get clobbered by `replaceState` (per the TanStack DB strict-readiness-before-writes rule).
- Fetches `terminal.listSessions` once (no polling), derives paneless sessions with the dropdown's own `getBackgroundTerminalSessions` + `getAttachedTerminalIdsKey`, so auto-adopt and the dropdown can never disagree.
- Skips sessions with a background marker (deliberately backgrounded in this app run).
- Adopts each via the idempotent `focusOrAddTerminalPane`, oldest→newest so tabs read chronologically, then restores the previously active tab so adoption never steals focus. A one-shot ref guarantees exactly one pass per workspace open — no re-adoption loop when the user backgrounds a session afterwards.

## Manual QA Checklist
Validated live over CDP against the dev app (create daemon session via host-service tRPC with no pane, then drive the router):

- [x] Open workspace with a paneless running session → terminal pane auto-created (~500ms after mount), background-terminals button disappears
- [x] Reopen the same workspace → still exactly one pane for that session (no duplicates)
- [x] Background a session (marker set) and reopen → stays in the dropdown, not re-adopted, marker intact
- [x] Focus: adoption into a workspace with existing tabs keeps the previously active tab focused

## Testing
- `bun run typecheck`
- `bun run lint`
- `bun test` (v2-workspace suite: 102 tests pass; reused helpers are covered by `BackgroundTerminalsButton.utils.test.ts` and `focusTerminalPane.test.ts`)

## Design Decisions
- **One-shot pass instead of a polling window**: earlier drafts kept a 10s window with 2s refetches and min-age/retry timers to catch late-registering sessions. Dropped — the ask is about sessions that exist when the workspace opens; the only near-mount pane creators in v2 (automation deep link) go through the same idempotent `focusOrAddTerminalPane`, so races can't produce duplicates. Late arrivals still land in the dropdown as today.
- **Reuse the dropdown's derivation instead of a parallel selector**: one source of truth for "background session", and the new hook carries almost no logic of its own.

## Known Limitations
- Background markers are in-memory, so a session deliberately backgrounded before an app restart gets a pane again on next open. Making backgrounding survive restarts would need the marker persisted in local state — deferred until we know it's wanted.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5740">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-create terminal panes for running sessions when a v2 workspace opens, so users see their terminals immediately. Runs one idempotent pass after pane-layout hydration and a fresh sessions refetch, keeping the active tab focused.

- **New Features**
  - Added `useAutoAdoptBackgroundSessions` to adopt paneless daemon sessions on workspace open.
  - Waits for `isLayoutReady`, fetches sessions once, and skips sessions with a background marker.
  - Adopts oldest→newest via `focusOrAddTerminalPane`, then restores the previously active tab (no duplicates).
  - Exposed `isLayoutReady` from `useV2WorkspacePaneLayout` and mounted the hook in `$workspaceId/page.tsx`.

- **Bug Fixes**
  - Avoids stale cached session lists on remount by waiting for the mount-time refetch before the one-shot pass, falling back only if the refetch fails.

<sup>Written for commit 038099cc90c27ab64907a375c18e601bbed6a8fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically adopts eligible background terminal sessions after the workspace dashboard layout finishes loading.
  * Restores the previously active tab and focuses existing terminal panes when possible; otherwise, creates new panes.
  * Skips sessions the workspace has marked to stay in the background, and runs the adoption only once per workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->