### PR TITLE
fix(desktop): start the local host service from the session, not Electric sync

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import {
 } from "electron";
 import { makeAppSetup } from "lib/electron-app/factories/app/setup";
 import {
+	authEvents,
 	handleAuthCallback,
 	loadToken,
 	parseAuthDeepLink,
@@ -405,6 +406,24 @@ if (!gotTheLock) {
 		// Must happen before renderer restore runs
 		await reconcileDaemonSessions();
 		prewarmTerminalRuntime();
+
+		// Host services for previously-hosted orgs start from main, so
+		// background reachability and port detection never wait on a renderer
+		// or cloud sync. Non-blocking: boot must not wait on spawns.
+		const startKnownHostServices = async () => {
+			try {
+				const { token } = await loadToken();
+				if (!token) return;
+				await getHostServiceCoordinator().startAllKnown({
+					authToken: token,
+					cloudApiUrl: mainEnv.NEXT_PUBLIC_API_URL,
+				});
+			} catch (error) {
+				console.error("[main] host-service boot reconcile failed:", error);
+			}
+		};
+		void startKnownHostServices();
+		authEvents.on("token-saved", () => void startKnownHostServices());
 
 		try {
 			setupAgentHooks();

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -263,6 +263,36 @@ export class HostServiceCoordinator extends EventEmitter {
 	}
 
 	/**
+	 * Start host services for every org this machine has hosted before
+	 * ($SUPERSET_HOME_DIR/host/*). Runs at boot and on sign-in so background
+	 * reachability and port detection never wait for a renderer or cloud sync
+	 * to name orgs; a brand-new org (no dir yet) is started by the renderer
+	 * from its session.
+	 */
+	async startAllKnown(config: SpawnConfig): Promise<void> {
+		const hostRoot = path.join(SUPERSET_HOME_DIR, "host");
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(hostRoot, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		const orgIdPattern = /^[0-9a-f]{8}-[0-9a-f-]{27}$/i;
+		await Promise.allSettled(
+			entries
+				.filter((e) => e.isDirectory() && orgIdPattern.test(e.name))
+				.map((e) =>
+					this.start(e.name, config).catch((error) => {
+						log.warn(
+							`[host-service-coordinator] boot start failed for org ${e.name}:`,
+							error,
+						);
+					}),
+				),
+		);
+	}
+
+	/**
 	 * Dev-only: watch the built host-service bundle and restart running
 	 * instances when it changes. Gives a fast edit→reload loop for code
 	 * under packages/host-service and src/main/host-service without

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -273,8 +273,15 @@ export class HostServiceCoordinator extends EventEmitter {
 		const hostRoot = path.join(SUPERSET_HOME_DIR, "host");
 		let entries: fs.Dirent[];
 		try {
-			entries = fs.readdirSync(hostRoot, { withFileTypes: true });
-		} catch {
+			entries = await fs.promises.readdir(hostRoot, { withFileTypes: true });
+		} catch (error) {
+			// No dir yet = nothing hosted before; anything else is worth seeing.
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+				log.warn(
+					`[host-service-coordinator] cannot read host root ${hostRoot}:`,
+					error,
+				);
+			}
 			return;
 		}
 		const orgIdPattern = /^[0-9a-f]{8}-[0-9a-f-]{27}$/i;

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
@@ -5,6 +5,7 @@ import { toast } from "@superset/ui/sonner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { type FormEvent, type ReactNode, useState } from "react";
 import { LuFolderOpen, LuGitBranch, LuLayoutTemplate } from "react-icons/lu";
+import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
@@ -32,6 +33,7 @@ function OnboardingProjectPage() {
 	const { refetch: refetchSession } = authClient.useSession();
 	const { activeHostUrl } = useLocalHostService();
 	const hostReady = !isV2CloudEnabled || activeHostUrl !== null;
+	const hostConnectTimedOut = useDelayElapsed(!hostReady, 15_000);
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const { data: homeDir } = electronTrpc.window.getHomeDir.useQuery();
 	const cloneTargetDir = homeDir ? `${homeDir}/.superset/projects` : null;
@@ -203,6 +205,20 @@ function OnboardingProjectPage() {
 					{hostReady ? "Browse…" : "Connecting…"}
 				</Button>
 			</Card>
+
+			{hostConnectTimedOut && (
+				<p className="text-xs text-muted-foreground text-center select-text cursor-text">
+					Still connecting to the local host service.{" "}
+					<button
+						type="button"
+						className="underline hover:text-foreground transition-colors"
+						onClick={() => window.location.reload()}
+					>
+						Reload
+					</button>{" "}
+					if this persists.
+				</p>
+			)}
 
 			<TemplateGalleryModal
 				open={templateOpen}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -254,6 +254,7 @@ const handleElectricSyncError: ElectricSyncErrorHandler = async (error) => {
 		message: error instanceof Error ? error.message.slice(0, 200) : undefined,
 	});
 	toast.error("Cloud sync stopped", {
+		id: "electric-sync-stopped",
 		description: "Synced data may be stale until Superset reconnects.",
 		action: { label: "Reload", onClick: () => window.location.reload() },
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -30,6 +30,7 @@ import type {
 } from "@superset/db/schema";
 import type { AppRouter as HostServiceAppRouter } from "@superset/host-service";
 import type { AppRouter } from "@superset/trpc";
+import { toast } from "@superset/ui/sonner";
 import { BasicIndex } from "@tanstack/db";
 import { electricCollectionOptions } from "@tanstack/electric-db-collection";
 import {
@@ -47,6 +48,7 @@ import {
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 import type { inferRouterOutputs } from "@trpc/server";
 import { env } from "renderer/env.renderer";
+import { track } from "renderer/lib/analytics";
 import { getAuthToken, getJwt } from "renderer/lib/auth-client";
 import { refreshJwtAfterUnauthorized } from "renderer/lib/jwt-refresh";
 import superjson from "superjson";
@@ -246,6 +248,15 @@ const handleElectricSyncError: ElectricSyncErrorHandler = async (error) => {
 	// a 4xx that does is terminal — return void to stop the stream instead of
 	// looping the same doomed request until Electric's 50-retry guard trips.
 	console.error("[collections] Electric sync stopped", error);
+	const status = error instanceof FetchError ? error.status : undefined;
+	track("electric_sync_stopped", {
+		status,
+		message: error instanceof Error ? error.message.slice(0, 200) : undefined,
+	});
+	toast.error("Cloud sync stopped", {
+		description: "Synced data may be stale until Superset reconnects.",
+		action: { label: "Reload", onClick: () => window.location.reload() },
+	});
 	return;
 };
 

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -1,5 +1,4 @@
 import { toast } from "@superset/ui/sonner";
-import { useLiveQuery } from "@tanstack/react-db";
 import {
 	createContext,
 	type ReactNode,
@@ -16,7 +15,6 @@ import {
 } from "renderer/lib/host-service-auth";
 import type { HostServiceAvailabilityStatus } from "renderer/lib/host-service-unavailable";
 import { MOCK_ORG_ID } from "shared/constants";
-import { useCollections } from "../CollectionsProvider";
 
 interface LocalHostServiceContextValue {
 	machineId: string;
@@ -35,7 +33,7 @@ export function LocalHostServiceProvider({
 	children: ReactNode;
 }) {
 	const { data: session } = authClient.useSession();
-	const collections = useCollections();
+	const { data: activeOrganization } = authClient.useActiveOrganization();
 	const { mutate: startHostService } =
 		electronTrpc.hostServiceCoordinator.start.useMutation({
 			onError: (error) => {
@@ -53,30 +51,14 @@ export function LocalHostServiceProvider({
 		? MOCK_ORG_ID
 		: (session?.session?.activeOrganizationId ?? null);
 
-	const { data: organizations } = useLiveQuery(
-		(q) => q.from({ organizations: collections.organizations }),
-		[collections],
-	);
-
-	const organizationIds = useMemo(
-		() => organizations?.map((organization) => organization.id) ?? [],
-		[organizations],
-	);
-
-	// Local capability must never wait on cloud sync: the active org's host
-	// service starts straight from the session; the Electric-synced list below
-	// only adds any remaining orgs.
+	// Local capability must never wait on cloud sync: main starts services for
+	// every previously-hosted org at boot; this covers a brand-new active org
+	// (no host dir yet) straight from the session.
 	useEffect(() => {
 		if (activeOrganizationId) {
 			startHostService({ organizationId: activeOrganizationId });
 		}
 	}, [activeOrganizationId, startHostService]);
-
-	useEffect(() => {
-		for (const organizationId of organizationIds) {
-			startHostService({ organizationId });
-		}
-	}, [organizationIds, startHostService]);
 
 	const { data: machineIdData } = electronTrpc.device.getMachineId.useQuery(
 		undefined,
@@ -104,13 +86,7 @@ export function LocalHostServiceProvider({
 			},
 		);
 
-	const activeOrganizationName = useMemo(
-		() =>
-			organizations?.find(
-				(organization) => organization.id === activeOrganizationId,
-			)?.name ?? null,
-		[organizations, activeOrganizationId],
-	);
+	const activeOrganizationName = activeOrganization?.name ?? null;
 
 	const value = useMemo<LocalHostServiceContextValue | null>(() => {
 		if (!machineIdData) return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -63,6 +63,15 @@ export function LocalHostServiceProvider({
 		[organizations],
 	);
 
+	// Local capability must never wait on cloud sync: the active org's host
+	// service starts straight from the session; the Electric-synced list below
+	// only adds any remaining orgs.
+	useEffect(() => {
+		if (activeOrganizationId) {
+			startHostService({ organizationId: activeOrganizationId });
+		}
+	}, [activeOrganizationId, startHostService]);
+
 	useEffect(() => {
 		for (const organizationId of organizationIds) {
 			startHostService({ organizationId });


### PR DESCRIPTION
Follow-up to #5734's investigation. While diagnosing #5729 we found onboarding stuck on "Connecting…" whenever the Electric sync couldn't deliver the `organizations` collection (container down at boot, or a terminal 4xx after a dev-DB reseed). Root cause: a purely local capability — spawning the local host service — was gated on a cloud sync round-trip.

## Summary
- **Host-service startup no longer involves Electric at all.** Main starts services for every previously-hosted org (`$SUPERSET_HOME_DIR/host/*`) at boot and on sign-in; the renderer keeps a single session-keyed start covering only a brand-new org with no host dir yet.
- **`LocalHostServiceProvider` is now Electric-free**: the `useLiveQuery(organizations)` start loop is deleted and `activeOrganizationName` comes from `authClient.useActiveOrganization()` instead of the synced collection.
- A terminally stopped Electric stream (non-401 4xx) now emits an `electric_sync_stopped` telemetry event and an actionable "Cloud sync stopped" toast with a Reload action, instead of a silent `console.error`.
- The onboarding project step shows a reload hint after 15s of "Connecting…" (via `useDelayElapsed` from #5734) instead of waiting silently forever.

## Why / Context
Design rule this enforces (and that makes the eventual Electric removal cheaper): **cloud sync may enrich, it must never be load-bearing for local function.** The second commit goes further than guarding the gate — it deletes the renderer→Electric edge for host-service lifecycle entirely. `coordinator.start` needs nothing from the renderer: main already loads the auth token itself and knows the org list from its own host directories.

Starting services for *all* known orgs (not just the active one) is preserved deliberately — cross-org workspace-session disposal (`getConnections` consumer) and background relay reachability depend on it. Main-side boot startup also closes a known gap: host services previously only started when a renderer attached, so port detection had nothing to reconcile against at boot.

## How It Works
- `HostServiceCoordinator.startAllKnown(config)`: enumerates UUID-named dirs under `$SUPERSET_HOME_DIR/host/`, starts each (idempotent, failures logged per-org, never throws).
- `main/index.ts`: calls it non-blocking after daemon reconcile at boot, and again on the `token-saved` auth event (sign-in after boot).
- `activeHostUrl` derivation is untouched — it always came from the local `getConnection` poll, never Electric.

## Manual QA Checklist
- [x] With the worktree's Electric container **stopped mid-boot**: `getConnections` returns **6 live host services — one per known org dir** (verified over CDP). The 5 non-active orgs can only have been started by the main reconcile, since the renderer starts just the active org and the Electric org list was unreachable. Previously this state produced the indefinite "Connecting…".
- [x] Renderer boots and serves the workspace UI normally in the same run; no error dialogs or toasts.
- [x] Electric restored afterwards; normal boot unaffected.
- [ ] Fresh-machine first sign-in (no host dirs at all) — not runnable in this dev profile; covered by the renderer's session-keyed start, which depends only on the session.

## Testing
- `bun run lint` (exits 0)
- `bunx tsc --noEmit` in `apps/desktop` (clean)

## Known Limitations
- `startAllKnown` starts services for historic orgs the user may have left; the host service's own cloud registration handles rejection, and local terminals for those orgs' workspaces still need disposal, so the superset is intentional.
- Other Electric-gated behavior elsewhere is tracked by SUPER-1543 (behavior-gating vs render-only inventory); SUPER-1542 tracks dev self-heal for post-reseed terminal 4xxs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On the onboarding project page, if the local service is still connecting after 15 seconds, an inline notice appears with a **Reload** button (and guidance if it persists).
  * The app now attempts to automatically start known local services after startup and again when auth tokens are saved.
* **Bug Fixes**
  * Cloud sync interruptions now surface a “Cloud sync stopped” toast with a **Reload** action, and sync stop events are recorded for diagnostics.
  * Local service startup is now tied to the currently active context for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->