### PR TITLE
fix(desktop,host-service): make Clear Status clear wedged agent working state

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -1,10 +1,12 @@
 import { toast } from "@superset/ui/sonner";
+import { useQueryClient } from "@tanstack/react-query";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import {
 	useMarkWorkspaceTerminalsSeen,
 	useV2WorkspaceIsUnread,
 } from "renderer/hooks/host-service/useV2NotificationStatus";
+import { useWorkspaceHostUrl } from "renderer/hooks/host-service/useWorkspaceHostUrl";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unavailable";
@@ -42,6 +44,8 @@ export function useDashboardSidebarWorkspaceItemActions({
 	const clearManualUnread = useV2NotificationStore((s) => s.clearManualUnread);
 	const markWorkspaceTerminalsSeen = useMarkWorkspaceTerminalsSeen(workspaceId);
 	const isUnread = useV2WorkspaceIsUnread(workspaceId);
+	const workspaceHostUrl = useWorkspaceHostUrl(workspaceId);
+	const queryClient = useQueryClient();
 
 	const clearWorkspaceAttention = () => {
 		clearManualUnread(workspaceId);
@@ -155,10 +159,25 @@ export function useDashboardSidebarWorkspaceItemActions({
 		}
 	};
 
-	// Working/permission dots are live host state now and can't be wiped;
-	// "clear status" clears everything attention-shaped (manual + reviews).
-	const handleClearStatus = () => {
+	// Clears manual + review marks locally, then forces the host's bindings
+	// to Stop — the escape hatch for a wedged working/permission dot (an
+	// interrupted agent fires no Stop hook). Live agents re-assert on their
+	// next hook event, so this is safe to run on a genuinely busy workspace.
+	const handleClearStatus = async () => {
 		clearWorkspaceAttention();
+		if (!workspaceHostUrl) return;
+		try {
+			await getHostServiceClientByUrl(
+				workspaceHostUrl,
+			).terminalAgents.clearWorkspaceStatuses.mutate({ workspaceId });
+			await queryClient.invalidateQueries({
+				queryKey: ["terminal-agent-bindings", workspaceHostUrl, workspaceId],
+			});
+		} catch (error) {
+			toast.error(
+				`Failed to clear agent status: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
 	};
 
 	const handleCopyBranchName = async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalInterruptClear/useTerminalInterruptClear.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalInterruptClear/useTerminalInterruptClear.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useEffectEvent } from "react";
 import { useTerminalAgentBinding } from "renderer/hooks/host-service/useTerminalAgentBindings";
 import { useWorkspaceHostUrl } from "renderer/hooks/host-service/useWorkspaceHostUrl";
@@ -17,11 +18,11 @@ interface UseTerminalInterruptClearOptions {
 /**
  * Ctrl+C / Escape kills the foreground agent turn while the shell stays
  * alive, and Claude Code's Stop hook doesn't fire on user interrupt — so the
- * host binding (the status source of truth) would stay "working". Record a
- * synthetic Stop with the host; a real hook event arriving later harmlessly
- * overwrites it. The Stop may derive as `review` for one refetch cycle, then
- * `useClearActivePaneAttention` marks it seen with the host-clock timestamp
- * (the interrupted pane is by definition the active one).
+ * host binding (the status source of truth) would stay "working". Clear the
+ * binding via the silent status mutation (not a synthetic hook event, which
+ * would broadcast a completion chime); a real hook event arriving later
+ * harmlessly overwrites it. lastEventAt is preserved, so the visible pane's
+ * seen mark already covers it and no transient `review` appears.
  */
 export function useTerminalInterruptClear({
 	terminalId,
@@ -31,6 +32,7 @@ export function useTerminalInterruptClear({
 }: UseTerminalInterruptClearOptions): void {
 	const hostUrl = useWorkspaceHostUrl(workspaceId);
 	const binding = useTerminalAgentBinding(workspaceId, terminalId);
+	const queryClient = useQueryClient();
 
 	const recordInterrupt = useEffectEvent(() => {
 		const agentActive =
@@ -38,10 +40,15 @@ export function useTerminalInterruptClear({
 			binding?.lastEventType === "PermissionRequest";
 		if (!agentActive || !hostUrl) return;
 		getHostServiceClientByUrl(hostUrl)
-			.notifications.hook.mutate({ terminalId, eventType: "Stop" })
+			.terminalAgents.clearWorkspaceStatuses.mutate({ workspaceId, terminalId })
+			.then(() =>
+				queryClient.invalidateQueries({
+					queryKey: ["terminal-agent-bindings", hostUrl, workspaceId],
+				}),
+			)
 			.catch((error) => {
 				console.warn(
-					"[terminal] failed to record synthetic agent stop:",
+					"[terminal] failed to clear agent status on interrupt:",
 					error,
 				);
 			});

--- a/packages/host-service/src/terminal-agents/store.test.ts
+++ b/packages/host-service/src/terminal-agents/store.test.ts
@@ -204,6 +204,39 @@ describe("TerminalAgentStore", () => {
 		expect(events).toEqual([WORKSPACE, WORKSPACE]);
 	});
 
+	it("clearWorkspaceStatuses forces non-Stop bindings to Stop, keeping lastEventAt", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			agentId: "claude",
+			occurredAt: 100,
+		});
+		store.recordEvent({
+			terminalId: "t2",
+			workspaceId: "other",
+			eventType: "Start",
+			agentId: "claude",
+			occurredAt: 200,
+		});
+
+		const events: string[] = [];
+		store.on("change", (workspaceId: string) => {
+			events.push(workspaceId);
+		});
+
+		store.clearWorkspaceStatuses(WORKSPACE);
+
+		expect(store.get("t1")?.lastEventType).toBe("Stop");
+		expect(store.get("t1")?.lastEventAt).toBe(100);
+		expect(store.get("t2")?.lastEventType).toBe("Start");
+		expect(events).toEqual([WORKSPACE]);
+
+		// Everything already Stop → no-op, no change event.
+		store.clearWorkspaceStatuses(WORKSPACE);
+		expect(events).toEqual([WORKSPACE]);
+	});
+
 	it("filters listByWorkspace by agentId and definitionId", () => {
 		store.recordEvent({
 			terminalId: "t1",

--- a/packages/host-service/src/terminal-agents/store.test.ts
+++ b/packages/host-service/src/terminal-agents/store.test.ts
@@ -237,6 +237,23 @@ describe("TerminalAgentStore", () => {
 		expect(events).toEqual([WORKSPACE]);
 	});
 
+	it("clearWorkspaceStatuses scoped to a terminalId leaves siblings alone", () => {
+		for (const terminalId of ["t1", "t2"]) {
+			store.recordEvent({
+				terminalId,
+				workspaceId: WORKSPACE,
+				eventType: "Start",
+				agentId: "claude",
+				occurredAt: 100,
+			});
+		}
+
+		store.clearWorkspaceStatuses(WORKSPACE, "t1");
+
+		expect(store.get("t1")?.lastEventType).toBe("Stop");
+		expect(store.get("t2")?.lastEventType).toBe("Start");
+	});
+
 	it("filters listByWorkspace by agentId and definitionId", () => {
 		store.recordEvent({
 			terminalId: "t1",

--- a/packages/host-service/src/terminal-agents/store.ts
+++ b/packages/host-service/src/terminal-agents/store.ts
@@ -119,15 +119,18 @@ export class TerminalAgentStore extends EventEmitter {
 
 	/**
 	 * Escape hatch for wedged working/permission state (an agent whose final
-	 * Stop hook never fired — interrupts fire no hook at all). Forces every
-	 * binding in the workspace to `Stop`, keeping lastEventAt so seen-gating
-	 * still resolves to idle. Live agents re-assert within seconds via their
-	 * next hook event, so clearing a genuinely working agent self-corrects.
+	 * Stop hook never fired — interrupts fire no hook at all). Forces the
+	 * workspace's bindings (or just `terminalId`'s) to `Stop`, keeping
+	 * lastEventAt so seen-gating still resolves to idle. Live agents
+	 * re-assert within seconds via their next hook event, so clearing a
+	 * genuinely working agent self-corrects.
 	 */
-	clearWorkspaceStatuses(workspaceId: string): void {
+	clearWorkspaceStatuses(workspaceId: string, onlyTerminalId?: string): void {
 		let changed = false;
 		for (const [terminalId, binding] of this.byTerminal) {
 			if (binding.workspaceId !== workspaceId) continue;
+			if (onlyTerminalId !== undefined && terminalId !== onlyTerminalId)
+				continue;
 			if (binding.lastEventType === "Stop") continue;
 			const next: TerminalAgentBinding = { ...binding, lastEventType: "Stop" };
 			this.byTerminal.set(terminalId, next);

--- a/packages/host-service/src/terminal-agents/store.ts
+++ b/packages/host-service/src/terminal-agents/store.ts
@@ -117,6 +117,26 @@ export class TerminalAgentStore extends EventEmitter {
 		this.deleteTerminal(terminalId);
 	}
 
+	/**
+	 * Escape hatch for wedged working/permission state (an agent whose final
+	 * Stop hook never fired — interrupts fire no hook at all). Forces every
+	 * binding in the workspace to `Stop`, keeping lastEventAt so seen-gating
+	 * still resolves to idle. Live agents re-assert within seconds via their
+	 * next hook event, so clearing a genuinely working agent self-corrects.
+	 */
+	clearWorkspaceStatuses(workspaceId: string): void {
+		let changed = false;
+		for (const [terminalId, binding] of this.byTerminal) {
+			if (binding.workspaceId !== workspaceId) continue;
+			if (binding.lastEventType === "Stop") continue;
+			const next: TerminalAgentBinding = { ...binding, lastEventType: "Stop" };
+			this.byTerminal.set(terminalId, next);
+			this.persistence?.upsert(next);
+			changed = true;
+		}
+		if (changed) this.emit("change", workspaceId);
+	}
+
 	get(terminalId: string): TerminalAgentBinding | undefined {
 		return this.byTerminal.get(terminalId);
 	}

--- a/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
+++ b/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
@@ -77,14 +77,22 @@ export const terminalAgentsRouter = router({
 		}),
 
 	/**
-	 * "Clear status" escape hatch: force the workspace's bindings to `Stop` so
-	 * a wedged working/permission indicator resets. Safe on live agents — their
-	 * next hook event re-asserts the real state.
+	 * Status-clearing escape hatch: force the workspace's bindings (or just
+	 * `terminalId`'s) to `Stop` so a wedged working/permission indicator
+	 * resets. Used by sidebar "Clear Status" and the pane interrupt handler
+	 * (agents fire no hook on Esc/Ctrl+C). Deliberately not a hook event —
+	 * it must not broadcast a completion chime/notification. Safe on live
+	 * agents: their next hook event re-asserts the real state.
 	 */
 	clearWorkspaceStatuses: protectedProcedure
-		.input(z.object({ workspaceId: z.string() }))
+		.input(
+			z.object({ workspaceId: z.string(), terminalId: z.string().optional() }),
+		)
 		.mutation(({ ctx, input }) => {
-			ctx.terminalAgentStore.clearWorkspaceStatuses(input.workspaceId);
+			ctx.terminalAgentStore.clearWorkspaceStatuses(
+				input.workspaceId,
+				input.terminalId,
+			);
 			return { success: true };
 		}),
 

--- a/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
+++ b/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
@@ -77,6 +77,18 @@ export const terminalAgentsRouter = router({
 		}),
 
 	/**
+	 * "Clear status" escape hatch: force the workspace's bindings to `Stop` so
+	 * a wedged working/permission indicator resets. Safe on live agents — their
+	 * next hook event re-asserts the real state.
+	 */
+	clearWorkspaceStatuses: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
+		.mutation(({ ctx, input }) => {
+			ctx.terminalAgentStore.clearWorkspaceStatuses(input.workspaceId);
+			return { success: true };
+		}),
+
+	/**
 	 * Reuse-or-launch primitive. Returns an existing active binding for the
 	 * `(workspaceId, agentId, definitionId)` triple, or spawns a fresh
 	 * terminal and waits up to 10s for the agent's hook to register.


### PR DESCRIPTION
## Problem

Workspaces get stuck showing **running** with no recovery. Since #5449 the working dot derives from `terminal_agent_bindings.lastEventType` on the host; Clear Status only cleared manual-unread + review marks.

Debugged live on a wedged workspace and reproduced in a scripted tmux session against claude 2.1.212: **Esc-interrupt fires no hook at all** (verified empirically — last hook is `PostToolUse`, then silence), and a turn that dies silently (stream drop, hang) fires nothing either. #5449 already covers the interrupt-in-a-focused-pane case via `useTerminalInterruptClear`'s synthetic Stop, but silent turn deaths have no keypress to detect — the binding stays `Start` forever (shell outlives the agent, so the session-liveness join never hides it), and nothing can clear it.

## Why not zero new code

Considered and rejected:
- **Reuse `notifications.hook` synthetic Stops for Clear Status**: the hook path broadcasts `agent:lifecycle`, and for a non-visible pane `shouldSuppress` returns false → completion chime + native notification on a status you're explicitly clearing.
- **TTL / staleness heuristics on `Start`**: a genuinely working agent can go >30 min between hook events (one long tool call); any timeout wedges the opposite direction.
- **Deleting the Start→working derivation**: removes the feature.

## Fix (one clearing mechanism, not three)

- `TerminalAgentStore.clearWorkspaceStatuses(workspaceId, terminalId?)`: force non-`Stop` bindings to `Stop`, preserving `lastEventAt` so existing seen marks resolve to idle (no transient review). Memory + sqlite, `change` emitted only on real change.
- New silent `terminalAgents.clearWorkspaceStatuses` mutation (deliberately not a hook event — must not chime).
- Sidebar **Clear Status** calls it and invalidates the bindings query.
- `useTerminalInterruptClear` now calls the same mutation instead of posting a synthetic Stop through the public hook endpoint — removing that special case and its side effect (interrupts today chime/notify in any other window where the pane isn't visible).

Clearing a genuinely busy agent self-corrects: its next hook event (PostToolUse fires per tool call) re-asserts working.

## Testing

- Store tests: force-to-Stop with `lastEventAt` preserved, per-terminal scoping, workspace isolation, no-op emits no change. Verified the test fails against a broken impl.
- `bun test` (20 pass), `bun run typecheck`, `bun run lint` clean. Renderer→router wiring is type-checked (client types derive from the router).
- Interrupt repro: tmux-driven claude 2.1.212, Esc mid-turn → no hook fired (hooks debug log), confirming the gap this closes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to clear stuck workspace agent statuses, with support for scoping to a specific terminal when provided.
  * Workspace status indicators now reset reliably across related terminal sessions.

* **Bug Fixes**
  * Improved recovery from agents incorrectly remaining in working/permission states by forcing affected bindings to a stopped state while preserving timestamps.
  * Added toast error feedback when status clearing fails, and ensured the UI refreshes after a successful clear.

* **Tests**
  * Added test coverage to verify correct workspace scoping and idempotent behavior for status clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->