### PR TITLE
perf(host-service): bound large git watcher batches

### DIFF
--- a/packages/host-service/scripts/git-status-large-repo-profile.ts
+++ b/packages/host-service/scripts/git-status-large-repo-profile.ts
@@ -2,19 +2,18 @@ import { spawn } from "node:child_process";
 import { chmodSync, existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { monitorEventLoopDelay } from "node:perf_hooks";
 import type { HostDb } from "../src/db";
 import { EventBus } from "../src/events/event-bus";
 import { GitWatcher } from "../src/events/git-watcher";
 import type { ServerMessage } from "../src/events/types";
 import { WorkspaceFilesystemManager } from "../src/runtime/filesystem";
-import { createUserSimpleGit } from "../src/runtime/git/simple-git";
-import { gitRouter } from "../src/trpc/router/git/git";
-import { getGitStatusSnapshot } from "../src/trpc/router/git/utils/git-status";
 import {
 	GitStatusRefreshLimiter,
 	gitStatusRefreshLimiter,
 } from "../src/trpc/router/git/utils/git-status-refresh-limiter";
-import type { HostServiceContext } from "../src/types";
+import { getHostWorkerPool } from "../src/workers/host-worker-pool";
+import { gitStatusSnapshotTask } from "../src/workers/tasks/git";
 
 type Mode = "limited" | "unbounded";
 type Flow = "compute" | "event-bus";
@@ -27,9 +26,11 @@ interface Options {
 	events: number;
 	eventIntervalMs: number;
 	concurrency: number;
+	workspaces: number;
 	gitDelayMs: number;
 	mode: Mode | "both";
 	flow: Flow;
+	refreshOnGitChange: boolean;
 	recreate: boolean;
 	cdpPort: number | null;
 }
@@ -37,12 +38,14 @@ interface Options {
 interface ScenarioResult {
 	flow: Flow;
 	mode: Mode;
+	executionMode: "worker" | "inline";
 	requestedRefreshes: number;
 	worktreeMutations?: number;
 	gitChangedEvents?: number;
 	actualRefreshes: number;
 	durationMs: number;
 	maxActiveRefreshes: number;
+	eventLoopDelayMs: { p50: number; p99: number; max: number };
 	gitInvocations: number;
 	maxActiveGitProcesses: number;
 	topGitCommands: Array<{ command: string; count: number }>;
@@ -60,6 +63,7 @@ interface CdpCapture {
 
 const DEFAULT_REPO_PATH = ".cache/git-status-large-repo";
 const DEFAULT_OUT_DIR = ".cache/git-status-profiles";
+const GIT_DIR_WARMUP_SETTLE_MS = 1_200;
 
 function parseArgs(argv: string[]): Options {
 	const options: Options = {
@@ -70,9 +74,11 @@ function parseArgs(argv: string[]): Options {
 		events: 60,
 		eventIntervalMs: 50,
 		concurrency: 4,
+		workspaces: 1,
 		gitDelayMs: 0,
 		mode: "both",
 		flow: "compute",
+		refreshOnGitChange: true,
 		recreate: false,
 		cdpPort: null,
 	};
@@ -107,6 +113,9 @@ function parseArgs(argv: string[]): Options {
 			case "--concurrency":
 				options.concurrency = Number(next());
 				break;
+			case "--workspaces":
+				options.workspaces = Number(next());
+				break;
 			case "--git-delay-ms":
 				options.gitDelayMs = Number(next());
 				break;
@@ -126,6 +135,9 @@ function parseArgs(argv: string[]): Options {
 				options.flow = flow;
 				break;
 			}
+			case "--watcher-only":
+				options.refreshOnGitChange = false;
+				break;
 			case "--recreate":
 				options.recreate = true;
 				break;
@@ -147,6 +159,7 @@ function parseArgs(argv: string[]): Options {
 		events: options.events,
 		eventIntervalMs: options.eventIntervalMs,
 		concurrency: options.concurrency,
+		workspaces: options.workspaces,
 		gitDelayMs: options.gitDelayMs,
 	})) {
 		if (!Number.isFinite(value) || value < 0) {
@@ -157,6 +170,7 @@ function parseArgs(argv: string[]): Options {
 	if (options.events < 1) throw new Error("events must be at least 1");
 	if (options.concurrency < 1)
 		throw new Error("concurrency must be at least 1");
+	if (options.workspaces < 1) throw new Error("workspaces must be at least 1");
 
 	return options;
 }
@@ -173,11 +187,14 @@ Options:
   --events <n>                 Refresh invalidation count. Default: 60
   --event-interval-ms <n>      Delay between invalidations. Default: 50
   --concurrency <n>            Limiter concurrency. Default: 4
+  --workspaces <n>             Distinct limiter workspace keys. Default: 1
   --git-delay-ms <n>           Artificial delay before each git subprocess.
                                Useful for modeling EDR/exec overhead.
   --mode <limited|unbounded|both>
   --flow <compute|event-bus>   compute stresses getStatus directly; event-bus
                                runs GitWatcher → EventBus → client refresh.
+  --watcher-only              In event-bus flow, observe events without running
+                               status refreshes (isolates watcher loop cost).
   --recreate                   Delete and recreate the synthetic repo first
   --cdp-port <port>            Capture renderer CPU profile from Electron CDP
 `);
@@ -348,25 +365,24 @@ async function runScenario(
 	let actualRefreshes = 0;
 	let lastSummary: ScenarioResult["statusSummary"] | null = null;
 	const limiter = new GitStatusRefreshLimiter(options.concurrency);
-	const startedAt = performance.now();
+	const workerPool = getHostWorkerPool();
+	const executionMode = workerPool.getMode();
 	const promises: Array<Promise<unknown>> = [];
+	const gitEnv = createProfileGitEnv({
+		gitLogPath,
+		gitDelayMs: options.gitDelayMs,
+		realGitBinary,
+		wrapperDir,
+	});
 
 	const runRefresh = async () => {
 		actualRefreshes++;
 		activeRefreshes++;
 		maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
 		try {
-			const git = createUserSimpleGit(options.repoPath).env({
-				...process.env,
-				GIT_OPTIONAL_LOCKS: "0",
-				GIT_PROFILE_DELAY_SECONDS: (options.gitDelayMs / 1000).toFixed(3),
-				GIT_PROFILE_LOG: gitLogPath,
-				PATH: `${wrapperDir}:${process.env.PATH ?? ""}`,
-				REAL_GIT: realGitBinary,
-			});
-			const status = await getGitStatusSnapshot({
-				git,
+			const status = await workerPool.run(gitStatusSnapshotTask, {
 				worktreePath: options.repoPath,
+				gitEnv,
 			});
 			lastSummary = {
 				againstBase: status.againstBase.length,
@@ -380,12 +396,21 @@ async function runScenario(
 		}
 	};
 
+	// Exclude worker startup / source transpilation from the measured window.
+	await runRefresh();
+	actualRefreshes = 0;
+	activeRefreshes = 0;
+	maxActiveRefreshes = 0;
+	lastSummary = null;
+	await writeFile(gitLogPath, "");
+	const stopEventLoopMonitor = startEventLoopMonitor();
+	const startedAt = performance.now();
+
 	for (let event = 0; event < options.events; event++) {
-		await mutateChurnFile(options.repoPath, event);
 		const promise =
 			mode === "limited"
 				? limiter.run({
-						workspaceId: "large-repo",
+						workspaceId: `large-repo-${event % options.workspaces}`,
 						requestKey: JSON.stringify({ baseBranch: null }),
 						run: runRefresh,
 					})
@@ -408,14 +433,17 @@ async function runScenario(
 		);
 	}
 	const gitStats = await parseGitLog(gitLogPath);
+	const eventLoopDelayMs = stopEventLoopMonitor();
 
 	return {
 		flow: "compute",
 		mode,
+		executionMode,
 		requestedRefreshes: options.events,
 		actualRefreshes,
 		durationMs: Math.round(performance.now() - startedAt),
 		maxActiveRefreshes,
+		eventLoopDelayMs,
 		gitInvocations: gitStats.invocations,
 		maxActiveGitProcesses: gitStats.maxActive,
 		topGitCommands: gitStats.topCommands,
@@ -433,14 +461,25 @@ async function runEventBusScenario(
 	mode: Mode,
 	label: string,
 ): Promise<ScenarioResult> {
-	const workspaceId = "large-repo";
+	const workspaceIds = Array.from(
+		{ length: options.workspaces },
+		(_, index) => `large-repo-${index}`,
+	);
+	const workspaceIdSet = new Set(workspaceIds);
+	const workspacePaths = await prepareProfileWorktrees(options);
+	const worktreePathByWorkspaceId = new Map(
+		workspaceIds.map((id, index) => [
+			id,
+			workspacePaths[index] ?? options.repoPath,
+		]),
+	);
 	const gitLogPath = join(options.outDir, `${label}-git.log`);
 	const wrapperDir = join(options.outDir, `${label}-bin`);
 	const realGit = await commandOutput("git", ["--exec-path"]);
 	const realGitBinary = join(realGit.trim(), "git");
 	await installGitWrapper(wrapperDir, gitLogPath, realGitBinary);
 
-	const db = createSingleWorkspaceDb(workspaceId, options.repoPath);
+	const db = createWorkspaceDb(worktreePathByWorkspaceId);
 	const filesystem = new WorkspaceFilesystemManager({ db });
 	const gitWatcher = new GitWatcher(db, filesystem);
 	const eventBus = new EventBus({ db, filesystem, gitWatcher });
@@ -450,57 +489,30 @@ async function runEventBusScenario(
 	let activeRefreshes = 0;
 	let maxActiveRefreshes = 0;
 	let lastSummary: ScenarioResult["statusSummary"] | null = null;
+	const workerPool = getHostWorkerPool();
+	const executionMode = workerPool.getMode();
+	const gitEnv = createProfileGitEnv({
+		gitLogPath,
+		gitDelayMs: options.gitDelayMs,
+		realGitBinary,
+		wrapperDir,
+	});
 
-	const createProfiledGit = (worktreePath: string) =>
-		createUserSimpleGit(worktreePath).env({
-			...process.env,
-			GIT_OPTIONAL_LOCKS: "0",
-			GIT_PROFILE_DELAY_SECONDS: (options.gitDelayMs / 1000).toFixed(3),
-			GIT_PROFILE_LOG: gitLogPath,
-			PATH: `${wrapperDir}:${process.env.PATH ?? ""}`,
-			REAL_GIT: realGitBinary,
-		});
-
-	const runRefresh = async () => {
+	const runRefresh = async (workspaceId: string) => {
 		actualRefreshes++;
 		activeRefreshes++;
 		maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
 		try {
-			const status = await getGitStatusSnapshot({
-				git: createProfiledGit(options.repoPath),
-				worktreePath: options.repoPath,
+			const worktreePath =
+				worktreePathByWorkspaceId.get(workspaceId) ?? options.repoPath;
+			const status = await workerPool.run(gitStatusSnapshotTask, {
+				worktreePath,
+				gitEnv,
 			});
 			lastSummary = summarizeStatus(status);
 			return status;
 		} finally {
 			activeRefreshes--;
-		}
-	};
-
-	const runLimitedRefresh = async () => {
-		let counted = false;
-		const caller = gitRouter.createCaller(
-			createRouterContext({
-				db,
-				eventBus,
-				filesystem,
-				git: async (worktreePath) => {
-					if (!counted) {
-						counted = true;
-						actualRefreshes++;
-						activeRefreshes++;
-						maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
-					}
-					return createProfiledGit(worktreePath);
-				},
-			}),
-		);
-		try {
-			const status = await caller.getStatus({ workspaceId });
-			lastSummary = summarizeStatus(status);
-			return status;
-		} finally {
-			if (counted) activeRefreshes--;
 		}
 	};
 
@@ -514,12 +526,20 @@ async function runEventBusScenario(
 			const message = JSON.parse(data) as ServerMessage;
 			if (
 				message.type !== "git:changed" ||
-				message.workspaceId !== workspaceId
+				!workspaceIdSet.has(message.workspaceId)
 			) {
 				return;
 			}
 			gitChangedEvents++;
-			const promise = mode === "limited" ? runLimitedRefresh() : runRefresh();
+			if (!options.refreshOnGitChange) return;
+			const promise =
+				mode === "limited"
+					? gitStatusRefreshLimiter.run({
+							workspaceId: message.workspaceId,
+							requestKey: JSON.stringify({ baseBranch: null }),
+							run: () => runRefresh(message.workspaceId),
+						})
+					: runRefresh(message.workspaceId);
 			if (promise) refreshPromises.push(promise);
 		},
 		close: () => {
@@ -527,11 +547,24 @@ async function runEventBusScenario(
 		},
 	};
 
-	const startedAt = performance.now();
 	gitStatusRefreshLimiter.clear();
 	eventBus.start();
-	eventBus.handleOpen(socket);
 	await (gitWatcher as unknown as { rescan: () => Promise<void> }).rescan();
+	await sleep(500);
+
+	// Warm the worker and Git implementation before measuring watcher churn.
+	await Promise.all(workspaceIds.map((id) => runRefresh(id)));
+	// Let any watcher events caused by warm-up Git processes flush before the
+	// mock renderer attaches, so they cannot race the measurement counters.
+	await sleep(GIT_DIR_WARMUP_SETTLE_MS);
+	actualRefreshes = 0;
+	activeRefreshes = 0;
+	maxActiveRefreshes = 0;
+	lastSummary = null;
+	await writeFile(gitLogPath, "");
+	eventBus.handleOpen(socket);
+	const stopEventLoopMonitor = startEventLoopMonitor();
+	const startedAt = performance.now();
 
 	let closedEventSources = false;
 	const closeEventSources = async () => {
@@ -544,12 +577,15 @@ async function runEventBusScenario(
 	};
 
 	try {
-		for (let event = 0; event < options.events; event++) {
-			await mutateChurnFile(options.repoPath, event);
-			if (options.eventIntervalMs > 0) {
-				await sleep(options.eventIntervalMs);
-			}
-		}
+		// Keep the load generator off this process's event loop; otherwise a
+		// high-volume run measures its own mkdir/writeFile promises alongside
+		// GitWatcher and overstates watcher-induced delay.
+		await mutateChurnFilesInChild(
+			workspacePaths,
+			options.events,
+			options.eventIntervalMs,
+			options.files,
+		);
 
 		await sleep(Math.max(1_000, options.eventIntervalMs + 1_000));
 		await closeEventSources();
@@ -566,15 +602,18 @@ async function runEventBusScenario(
 		}
 
 		const gitStats = await parseGitLog(gitLogPath);
+		const eventLoopDelayMs = stopEventLoopMonitor();
 		return {
 			flow: "event-bus",
 			mode,
+			executionMode,
 			requestedRefreshes: gitChangedEvents,
 			worktreeMutations: options.events,
 			gitChangedEvents,
 			actualRefreshes,
 			durationMs: Math.round(performance.now() - startedAt),
 			maxActiveRefreshes,
+			eventLoopDelayMs,
 			gitInvocations: gitStats.invocations,
 			maxActiveGitProcesses: gitStats.maxActive,
 			topGitCommands: gitStats.topCommands,
@@ -672,7 +711,7 @@ async function startCdpCapture(
 }
 
 function summarizeStatus(
-	status: Awaited<ReturnType<typeof getGitStatusSnapshot>>,
+	status: Awaited<ReturnType<typeof gitStatusSnapshotTask.handler>>,
 ): ScenarioResult["statusSummary"] {
 	return {
 		againstBase: status.againstBase.length,
@@ -682,55 +721,108 @@ function summarizeStatus(
 	};
 }
 
-function createSingleWorkspaceDb(
-	workspaceId: string,
-	worktreePath: string,
+function createProfileGitEnv({
+	gitLogPath,
+	gitDelayMs,
+	realGitBinary,
+	wrapperDir,
+}: {
+	gitLogPath: string;
+	gitDelayMs: number;
+	realGitBinary: string;
+	wrapperDir: string;
+}): Record<string, string> {
+	const inheritedEnv = Object.fromEntries(
+		Object.entries(process.env).filter(
+			(entry): entry is [string, string] => typeof entry[1] === "string",
+		),
+	);
+	return {
+		...inheritedEnv,
+		GIT_OPTIONAL_LOCKS: "0",
+		GIT_PROFILE_DELAY_SECONDS: (gitDelayMs / 1000).toFixed(3),
+		GIT_PROFILE_LOG: gitLogPath,
+		PATH: `${wrapperDir}:${process.env.PATH ?? ""}`,
+		REAL_GIT: realGitBinary,
+	};
+}
+
+function startEventLoopMonitor(): () => ScenarioResult["eventLoopDelayMs"] {
+	const histogram = monitorEventLoopDelay({ resolution: 10 });
+	histogram.enable();
+	return () => {
+		histogram.disable();
+		const toMs = (nanoseconds: number) =>
+			Math.round((nanoseconds / 1_000_000) * 10) / 10;
+		return {
+			p50: toMs(histogram.percentile(50)),
+			p99: toMs(histogram.percentile(99)),
+			max: toMs(histogram.max),
+		};
+	};
+}
+
+async function prepareProfileWorktrees(options: Options): Promise<string[]> {
+	if (options.workspaces === 1) return [options.repoPath];
+
+	const worktreeRoot = `${options.repoPath}-worktrees`;
+	await mkdir(worktreeRoot, { recursive: true });
+	const paths: string[] = [];
+	for (let index = 0; index < options.workspaces; index++) {
+		const worktreePath = join(worktreeRoot, `workspace-${index}`);
+		if (!existsSync(join(worktreePath, ".git"))) {
+			await run(
+				"git",
+				["worktree", "add", "--detach", worktreePath, "HEAD"],
+				options.repoPath,
+			);
+		}
+		await resetDirtyState(worktreePath);
+		await makeDirtyState(worktreePath, options);
+		paths.push(worktreePath);
+	}
+	return paths;
+}
+
+function createWorkspaceDb(
+	worktreePathByWorkspaceId: Map<string, string>,
 ): HostDb {
-	const workspace = { id: workspaceId, worktreePath };
+	const workspaceRows = Array.from(
+		worktreePathByWorkspaceId,
+		([id, worktreePath]) => ({ id, worktreePath }),
+	);
 	return {
 		select: () => ({
 			from: () => ({
-				all: () => [workspace],
+				all: () => workspaceRows,
 			}),
 		}),
 		query: {
 			workspaces: {
-				findFirst: () => ({
-					sync: () => workspace,
+				findFirst: (config: unknown) => ({
+					sync: () => {
+						const chunks = (
+							config as {
+								where?: { queryChunks?: Array<{ value?: unknown }> };
+							}
+						).where?.queryChunks;
+						const workspaceId = chunks?.find(
+							(chunk) =>
+								typeof chunk.value === "string" &&
+								worktreePathByWorkspaceId.has(chunk.value),
+						)?.value;
+						return typeof workspaceId === "string"
+							? {
+									id: workspaceId,
+									worktreePath:
+										worktreePathByWorkspaceId.get(workspaceId) ?? "",
+								}
+							: undefined;
+					},
 				}),
 			},
 		},
 	} as unknown as HostDb;
-}
-
-function createRouterContext({
-	db,
-	eventBus,
-	filesystem,
-	git,
-}: {
-	db: HostDb;
-	eventBus: EventBus;
-	filesystem: WorkspaceFilesystemManager;
-	git: HostServiceContext["git"];
-}): HostServiceContext {
-	return {
-		api: {} as HostServiceContext["api"],
-		db,
-		eventBus,
-		execGh: (() => {
-			throw new Error("execGh is not used by git-status profiling");
-		}) as HostServiceContext["execGh"],
-		git,
-		github: (async () => {
-			throw new Error("github is not used by git-status profiling");
-		}) as HostServiceContext["github"],
-		isAuthenticated: true,
-		organizationId: "profile-org",
-		runtime: {
-			filesystem,
-		} as HostServiceContext["runtime"],
-	};
 }
 
 async function connectCdp(webSocketUrl: string): Promise<{
@@ -881,10 +973,42 @@ function summarizeGitCommand(args: string): string {
 	return command;
 }
 
-async function mutateChurnFile(repoPath: string, event: number): Promise<void> {
-	await writeTextFile(
-		join(repoPath, "churn", `event-${event % 20}.txt`),
-		`event ${event} at ${new Date().toISOString()}\n`,
+async function mutateChurnFilesInChild(
+	repoPaths: string[],
+	events: number,
+	eventIntervalMs: number,
+	files: number,
+): Promise<void> {
+	const script = [
+		'import { writeFile } from "node:fs/promises";',
+		'import { join } from "node:path";',
+		"const [repoPathsRaw, eventsRaw, intervalRaw, filesRaw] = process.argv.slice(1);",
+		"const repoPaths = JSON.parse(repoPathsRaw);",
+		"const events = Number(eventsRaw);",
+		"const interval = Number(intervalRaw);",
+		"const files = Number(filesRaw);",
+		"for (let event = 0; event < events; event++) {",
+		"  const id = event % files;",
+		"  const bucket = String(Math.floor(id / 1000)).padStart(4, '0');",
+		"  const file = String(id).padStart(6, '0');",
+		"  await Promise.all(repoPaths.map((repoPath, workspace) => writeFile(",
+		"    join(repoPath, 'src', bucket, 'file-' + file + '.ts'),",
+		"    'export const value' + id + ' = ' + id + ';\\nexport const churn' + workspace + ' = ' + event + ';\\n',",
+		"  )));",
+		"  if (interval > 0) await new Promise((resolve) => setTimeout(resolve, interval));",
+		"}",
+	].join("\n");
+	await run(
+		process.execPath,
+		[
+			"--eval",
+			script,
+			JSON.stringify(repoPaths),
+			String(events),
+			String(eventIntervalMs),
+			String(files),
+		],
+		process.cwd(),
 	);
 }
 

--- a/packages/host-service/src/events/git-watcher.test.ts
+++ b/packages/host-service/src/events/git-watcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import {
+	collectWorktreeBatchPaths,
 	DEBOUNCE_MS,
 	GIT_DIR_DEBOUNCE_MS,
 	type GitChangedEvent,
@@ -77,6 +78,27 @@ describe("isStatusRelevantGitDirEvent", () => {
 	test("does not confuse a top-level file that merely starts with an ignored name", () => {
 		expect(isStatusRelevantGitDirEvent("objects-are-cool")).toBe(true);
 		expect(isStatusRelevantGitDirEvent("logspam")).toBe(true);
+	});
+});
+
+describe("collectWorktreeBatchPaths", () => {
+	test("duplicate notifications do not hide a later distinct path", () => {
+		const duplicateEvents = Array.from(
+			{ length: MAX_WORKTREE_PATHS_PER_BATCH + 1 },
+			() => ({
+				kind: "update" as const,
+				absolutePath: "/repo/src/duplicate.ts",
+			}),
+		);
+		const paths = collectWorktreeBatchPaths(
+			[
+				...duplicateEvents,
+				{ kind: "update", absolutePath: "/repo/src/later.ts" },
+			],
+			"/repo",
+		);
+
+		expect([...paths]).toEqual(["src/duplicate.ts", "src/later.ts"]);
 	});
 });
 

--- a/packages/host-service/src/events/git-watcher.test.ts
+++ b/packages/host-service/src/events/git-watcher.test.ts
@@ -5,6 +5,7 @@ import {
 	type GitChangedEvent,
 	GitWatcher,
 	isStatusRelevantGitDirEvent,
+	MAX_WORKTREE_PATHS_PER_BATCH,
 } from "./git-watcher";
 
 /**
@@ -153,6 +154,24 @@ describe("GitWatcher adaptive debounce", () => {
 		expect(events).toEqual([
 			{ workspaceId: "workspace-1", paths: ["src/app.ts"] },
 		]);
+	});
+
+	test("large worktree batches collapse to one broad invalidation", () => {
+		const watcher = createWatcher();
+		const events: GitChangedEvent[] = [];
+		watcher.onChanged((event) => events.push(event));
+		const paths = Array.from(
+			{ length: MAX_WORKTREE_PATHS_PER_BATCH + 1 },
+			(_, index) => `src/file-${index}.ts`,
+		);
+
+		internals(watcher).addWorktreePaths("workspace-1", paths);
+		// Once broad, additional paths in the same window stay broad rather than
+		// rebuilding an unbounded Set.
+		internals(watcher).addWorktreePaths("workspace-1", ["src/later.ts"]);
+		jest.advanceTimersByTime(DEBOUNCE_MS);
+
+		expect(events).toEqual([{ workspaceId: "workspace-1" }]);
 	});
 
 	test("a worktree edit joining a `.git/` batch restores the short window", () => {

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -21,6 +21,11 @@ export const DEBOUNCE_MS = 300;
  */
 export const GIT_DIR_DEBOUNCE_MS = 1_000;
 
+/** Above this, clients are better served by one broad diff-cache invalidation
+ * than hundreds of per-path invalidations. The null sentinel also lets the
+ * watcher skip path normalization for the rest of the debounce window. */
+export const MAX_WORKTREE_PATHS_PER_BATCH = 128;
+
 /**
  * `.git/` top-level dirs whose churn never changes `git status`: `objects/**`
  * (fetch/gc/repack blobs — the bulk of idle churn), `lfs/**` (object cache),
@@ -55,8 +60,8 @@ export interface GitChangedEvent {
 	workspaceId: string;
 	/**
 	 * Worktree-relative paths that changed when the batch was worktree-only.
-	 * Absent when the batch included any `.git/*` activity, signaling a broad
-	 * state change (commit, staging, branch switch, fetch, etc.).
+	 * Absent when the batch included `.git/*` activity or exceeded the bounded
+	 * worktree path list, signaling a broad state change.
 	 */
 	paths?: string[];
 }
@@ -66,8 +71,8 @@ export type GitChangedListener = (event: GitChangedEvent) => void;
 interface PendingBatch {
 	/** Any `.git/*` event seen during this debounce window. */
 	hasGitDir: boolean;
-	/** Worktree-relative paths accumulated during this debounce window. */
-	paths: Set<string>;
+	/** Worktree-relative paths, or null once the batch requires broad refresh. */
+	paths: Set<string> | null;
 }
 
 interface WatchedWorkspace {
@@ -181,8 +186,15 @@ export class GitWatcher {
 
 	private addWorktreePaths(workspaceId: string, paths: Iterable<string>): void {
 		const batch = this.getOrCreateBatch(workspaceId);
-		for (const path of paths) {
-			if (path) batch.paths.add(path);
+		if (batch.paths) {
+			for (const path of paths) {
+				if (!path) continue;
+				batch.paths.add(path);
+				if (batch.paths.size > MAX_WORKTREE_PATHS_PER_BATCH) {
+					batch.paths = null;
+					break;
+				}
+			}
 		}
 		this.scheduleFlush(workspaceId);
 	}
@@ -194,7 +206,8 @@ export class GitWatcher {
 		// event arms it and later `.git/`-only events ride it rather than resetting,
 		// so a rapid metadata sequence (rebase, `git am`) can't push the flush past
 		// GIT_DIR_DEBOUNCE_MS. A worktree edit joining reverts to the short window.
-		const gitDirOnly = batch.hasGitDir && batch.paths.size === 0;
+		const gitDirOnly =
+			batch.hasGitDir && batch.paths !== null && batch.paths.size === 0;
 		if (gitDirOnly && existing) return;
 		if (existing) clearTimeout(existing);
 		const delay = gitDirOnly ? GIT_DIR_DEBOUNCE_MS : DEBOUNCE_MS;
@@ -206,7 +219,7 @@ export class GitWatcher {
 				this.pendingBatches.delete(workspaceId);
 				if (!batch) return;
 				const event: GitChangedEvent =
-					batch.hasGitDir || batch.paths.size === 0
+					batch.hasGitDir || batch.paths === null || batch.paths.size === 0
 						? { workspaceId }
 						: { workspaceId, paths: [...batch.paths] };
 				for (const listener of this.listeners) {
@@ -366,6 +379,10 @@ export class GitWatcher {
 				while (!disposed && iterator) {
 					const next = await iterator.next();
 					if (disposed || next.done) return;
+					if (this.pendingBatches.get(workspaceId)?.paths === null) {
+						this.scheduleFlush(workspaceId);
+						continue;
+					}
 
 					const relativePaths: string[] = [];
 					for (const event of next.value.events) {
@@ -375,6 +392,7 @@ export class GitWatcher {
 							const oldRel = toRelative(event.oldAbsolutePath);
 							if (oldRel) relativePaths.push(oldRel);
 						}
+						if (relativePaths.length > MAX_WORKTREE_PATHS_PER_BATCH) break;
 					}
 
 					if (relativePaths.length > 0) {

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -56,6 +56,42 @@ export function isStatusRelevantGitDirEvent(
 	return !IGNORED_GIT_DIR_TOP_LEVELS.has(topLevel);
 }
 
+/**
+ * Normalize one native worktree event batch while bounding unique path growth.
+ * Duplicate notifications must not consume the cap: a later distinct path still
+ * needs to be emitted unless the batch crosses into broad invalidation.
+ */
+export function collectWorktreeBatchPaths(
+	events: readonly FsWatchEvent[],
+	worktreePath: string,
+): Set<string> {
+	const worktreePrefix = worktreePath.endsWith("/")
+		? worktreePath
+		: `${worktreePath}/`;
+	const toRelative = (absolutePath: string): string | null => {
+		if (absolutePath === worktreePath) return null;
+		if (!absolutePath.startsWith(worktreePrefix)) return null;
+		const relative = absolutePath.slice(worktreePrefix.length);
+		// Defensive: ignore anything inside .git/ — the dedicated .git watcher
+		// handles those and the worktree fs watcher's default ignore patterns
+		// already exclude it, but a rare leak shouldn't pollute the paths list.
+		if (relative === ".git" || relative.startsWith(".git/")) return null;
+		return relative;
+	};
+
+	const relativePaths = new Set<string>();
+	for (const event of events) {
+		const relativePath = toRelative(event.absolutePath);
+		if (relativePath) relativePaths.add(relativePath);
+		if (event.oldAbsolutePath) {
+			const oldRelativePath = toRelative(event.oldAbsolutePath);
+			if (oldRelativePath) relativePaths.add(oldRelativePath);
+		}
+		if (relativePaths.size > MAX_WORKTREE_PATHS_PER_BATCH) break;
+	}
+	return relativePaths;
+}
+
 export interface GitChangedEvent {
 	workspaceId: string;
 	/**
@@ -359,21 +395,6 @@ export class GitWatcher {
 			return () => {};
 		}
 
-		const worktreePrefix = worktreePath.endsWith("/")
-			? worktreePath
-			: `${worktreePath}/`;
-
-		const toRelative = (absolutePath: string): string | null => {
-			if (absolutePath === worktreePath) return null;
-			if (!absolutePath.startsWith(worktreePrefix)) return null;
-			const relative = absolutePath.slice(worktreePrefix.length);
-			// Defensive: ignore anything inside .git/ — the dedicated .git watcher
-			// handles those and the worktree fs watcher's default ignore patterns
-			// already exclude it, but a rare leak shouldn't pollute the paths list.
-			if (relative === ".git" || relative.startsWith(".git/")) return null;
-			return relative;
-		};
-
 		void (async () => {
 			try {
 				while (!disposed && iterator) {
@@ -384,18 +405,12 @@ export class GitWatcher {
 						continue;
 					}
 
-					const relativePaths: string[] = [];
-					for (const event of next.value.events) {
-						const rel = toRelative(event.absolutePath);
-						if (rel) relativePaths.push(rel);
-						if (event.oldAbsolutePath) {
-							const oldRel = toRelative(event.oldAbsolutePath);
-							if (oldRel) relativePaths.push(oldRel);
-						}
-						if (relativePaths.length > MAX_WORKTREE_PATHS_PER_BATCH) break;
-					}
+					const relativePaths = collectWorktreeBatchPaths(
+						next.value.events,
+						worktreePath,
+					);
 
-					if (relativePaths.length > 0) {
+					if (relativePaths.size > 0) {
 						this.addWorktreePaths(workspaceId, relativePaths);
 					} else {
 						this.getOrCreateBatch(workspaceId);

--- a/plans/20260717-host-service-git-worker-pool.md
+++ b/plans/20260717-host-service-git-worker-pool.md
@@ -17,6 +17,34 @@
 
 **Recommended order:** ship #1 (small daemon fix, no pool needed) → build the pool with git status + watcher rescan as tenants (#2–#4) → raise limiter concurrency → hand #5 to a renderer-side effort. Re-run the ModeTracker/terminal measurement only after #1 lands (the transport dies before the loop can be loaded).
 
+## Post-implementation measurement — 2026-07-18
+
+The pool landed in `727af9d97` for status snapshots and commit-file reads. The
+profiling harness now exercises the real worker task, records worker vs inline
+mode and event-loop delay, generates churn outside the measured process, and
+can create eight real 20k-file worktrees with independent native watchers.
+
+Results from 400 paced tracked-file mutations per worktree (8 worktrees, 600
+pre-existing dirty files each):
+
+| run | p99 loop delay | max | duration |
+|---|---:|---:|---:|
+| watcher only, unbounded path collection | 87.2 ms | 125.7 ms | 5.09 s |
+| watcher only, paths capped at 128 then broad invalidation | **13.6 ms** | 27.1 ms | **3.51 s** |
+| watcher + worker-backed status refreshes, capped | **6.3 ms** | 107.4 ms | **5.34 s** |
+
+The hot watcher behavior was unbounded path normalization/Set growth, not work
+that benefits from another worker hop. A thresholded worker experiment made
+p99 worse (47.4 ms) because medium batches paid structured-clone and pool
+contention costs. The implemented fix keeps precise paths through 128 unique paths,
+then emits the already-supported broad invalidation and skips further path
+normalization until the debounce flush.
+
+Limiter comparison with eight identical snapshots: concurrency 4 completed in
+2.52 s (14 max active git processes); concurrency 6 took 2.59 s (17 processes).
+Keep the production limiter at 4: raising it did not improve completion time and
+increased subprocess pressure.
+
 ---
 
 Move CPU-bound compute off the host-service event loop into a generic `worker_threads` pool inside the host-service process. Today every byte of git output is drained, parsed, and assembled on the same loop that relays terminal I/O and serves all tRPC/WS traffic for the org; v1 had this work in a worker pool (`apps/desktop/src/main/git-task-worker.ts`) and v2 lost it. Git compute is the first tenant; the mechanism is domain-agnostic.

--- a/plans/20260717-host-service-git-worker-pool.md
+++ b/plans/20260717-host-service-git-worker-pool.md
@@ -1,0 +1,154 @@
+# Host-service worker pool (generic; git first)
+
+## TL;DR
+
+**What:** a generic `worker_threads` pool inside host-service (v2 lost v1's git worker pool; today everything shares one event loop). Git compute is the first tenant; adding a tenant = one task module.
+
+**What the stress tests actually showed (details in the two Measured sections):**
+
+| # | Finding | Severity | Fix |
+|---|---|---|---|
+| 1 | One flooding terminal destroys the org-wide daemon↔host-service socket (8 MiB cap, `Server.ts:595`); all terminals blip | Correctness bug, likely hitting users today | Per-session shedding in pty-daemon — **not** this pool |
+| 2 | 8-workspace churn stalls the loop (183ms stalls, query p95 127ms) via the **watcher path**, not status parsing | Loop health | Offload GitWatcher rescan/filtering to the pool |
+| 3 | Background `getStatus` takes 3.7–14.6s under churn — limiter queueing at concurrency 4 | UX staleness | Pool makes raising limiter concurrency safe |
+| 4 | Big-diff snapshot ≈1.2s (2k files) but does NOT stall the loop | Minor | Phase 1 offload, comes with #2/#3 infra |
+| 5 | Renderer freezes >60s under 8-workspace churn | Separate renderer workstream | Not host-service scope |
+| 6 | Daemon burns 50–77% CPU on unattached flooding PTYs; host-service RSS 320→570MB in one session | Investigate | With #1 / leak-check respectively |
+
+**Recommended order:** ship #1 (small daemon fix, no pool needed) → build the pool with git status + watcher rescan as tenants (#2–#4) → raise limiter concurrency → hand #5 to a renderer-side effort. Re-run the ModeTracker/terminal measurement only after #1 lands (the transport dies before the loop can be loaded).
+
+---
+
+Move CPU-bound compute off the host-service event loop into a generic `worker_threads` pool inside the host-service process. Today every byte of git output is drained, parsed, and assembled on the same loop that relays terminal I/O and serves all tRPC/WS traffic for the org; v1 had this work in a worker pool (`apps/desktop/src/main/git-task-worker.ts`) and v2 lost it. Git compute is the first tenant; the mechanism is domain-agnostic.
+
+## Shape
+
+```
+tRPC git.getStatus ──► gitStatusRefreshLimiter (unchanged front door)
+                            │ run()
+                            ▼
+                       hostWorkerPool.runTask("git/getStatusSnapshot", …)
+                            │ postMessage
+                            ▼
+                       host-worker.js (worker_threads, N = min(4, cpus−1))
+                         static registry: git/* today, other domains later
+```
+
+- **Pool**: copy `WorkerTaskRunner` + `worker-task-protocol` from `apps/desktop/src/lib/trpc/workers/` into `packages/host-service/src/workers/`. It is already task-agnostic (`taskType` string + payload). v1 is sunset — leave the desktop copy untouched; it dies with v1 (per v1/v2 duplication policy).
+- **Worker entry**: `packages/host-service/src/workers/host-worker.ts` — a thin dispatch loop over a **static, build-time registry** of task modules, namespaced `"<domain>/<task>"`. Day one it imports only `tasks/git.ts`.
+- **Typed task definitions**: each task module exports `defineWorkerTask<In, Out>({ type, handler })`. The worker entry imports the handlers; callers import only the types, so `runTask` is typed end-to-end and the caller graph never pulls handler code.
+- Git handlers call the existing `getGitStatusSnapshot` / `git-helpers` — Electron-free, and simple-git works in a worker (it just spawns child processes). **The worker spawns the git subprocesses itself** — draining and parsing both leave the main loop.
+
+## Genericity contract (what task modules must satisfy)
+
+1. **Static registry** — handlers are bundled into `host-worker.js` at build time; you cannot ship closures from the main thread. Adding a domain = add a task module + import it in the entry.
+2. **Clone-safe boundary** — payloads/results cross via structured clone: plain data only, no live handles (SimpleGit, DB, sockets, emitters).
+3. **No shared process state** — handlers get everything via payload. No host-service DB (the better-sqlite3 handle is per-process), no event bus, no config singletons, no native addons. Enforced by a `no-electron-coupling`-style import test on the worker entry graph.
+4. **One request → one result** — the protocol has no streaming; long incremental jobs stay on the main loop or get chunked into tasks.
+
+Work that violates 2–4 (DB queries, event-emitting watchers, terminal streams) does not belong in the pool.
+
+## Pool changes vs the v1 runner
+
+1. **Idle reaping** (new): terminate workers idle > 30s. host-service is long-lived and per-org — a 3-org machine must not hold 12 warm workers. v1 never needed this because the pool lived in the single Electron main process.
+2. **Inline fallback** (new): if the worker script is missing or workers crash ≥3 times in 60s, log once and run tasks in-process (current behavior). Keeps standalone deployments and tests working if a bundle is malformed. Mirrors DaemonSupervisor's crash circuit.
+3. Everything else stays: fifo/coalesce/latest-wins, per-task timeout + worker recycle, abort.
+
+## Scheduling interplay
+
+`gitStatusRefreshLimiter` remains the only queue for `getStatus` (per-workspace serialization, invalidation-coalescing, foreground/background priority). Pool concurrency = limiter concurrency (share `DEFAULT_CONCURRENCY` from `git-status-refresh-limiter.ts`) so pooled tasks never meaningfully queue behind the limiter. Limiter-fronted tasks use `fifo`; direct calls not behind the limiter (`getCommitFiles`, `getDiff`) use `coalesce` with a `workspaceId:proc:input` dedupe key. Procedure `timeoutMs` (15s/30s) carries into the pool task timeout.
+
+## Bundling (3 surfaces, same side-by-side pattern as pty-daemon)
+
+Resolution copies `daemon/singleton.ts`: env override `SUPERSET_HOST_WORKER_SCRIPT_PATH` → `host-worker.js` next to the running bundle → `packages/host-service/dist/host-worker.js` fallback.
+
+1. `apps/desktop/electron.vite.config.ts` — add input `"host-worker": packages/host-service/src/workers/host-worker.ts` (emits `dist/main/host-worker.js`, side-by-side with `host-service.js`).
+2. `packages/host-service/build.ts` — add `src/workers/host-worker.ts` as a second entrypoint.
+3. `packages/cli/scripts/build-dist.ts` — copy `dist/host-worker.js` into `lib/` next to `host-service.js`.
+
+Add a bundle-presence guard like `apps/desktop/scripts/check-pty-daemon-bundle.ts`.
+
+## What moves
+
+**Phase 1 — status snapshot** (the win): `getGitStatusSnapshot` and everything inside it — `parseNumstat`, `countUntrackedFileLines` (reads + line-counts untracked files on the loop today), `detectUnstagedRenames`, `getChangedFilesForDiff`. Serves `git.getStatus`, and the git-watcher/PR-runtime refreshes that funnel through the limiter.
+
+**Phase 2 — read-path procs**: `getCommitFiles`, `listCommits`, `getBranchSyncStatus`, and `getDiff`'s `git.show` content reads (large-file drains + string assembly).
+
+**Phase 3 — opportunistic**: git-watcher's `ls-files`/rescan subscription work; PR-runtime per-workspace git interrogation, where not already sharing Phase 1 tasks. Future non-git tenants (each is just a new task module): diff/patch text assembly, search/indexing if host-service ever grows one, large JSON parse/serialize hot spots.
+
+**Not moving**: port-scanner (already subprocess-based, trivial parsing), reaper/cloud-sync/tunnel (I/O-bound), git mutations (`stageAll`, `discardChanges`, … — rare, fast, want the loop's ordering). Future candidate, out of scope: better-sqlite3 queries are synchronous on the loop; if profiling ever shows DB stalls, the same pool pattern applies.
+
+## Measured 2026-07-17 (CDP stress, dev build, superset repo workspace)
+
+Method: dev desktop over CDP; 5 tRPC-created sessions with real WS clients attached; probe terminal echo RTT + cheap tRPC RTT + `git.getStatus`, vs `yes`-with-SGR-escapes floods; `ps` CPU sampling of host-service + pty-daemon.
+
+| metric | baseline | 1 flooder | 4 flooders |
+|---|---|---|---|
+| echo RTT p50/p95 | 1.8 / 3.1 ms | **dead (15/15 timeouts)** | dead |
+| tRPC query RTT p50 | 1.6 ms | 1.5 ms | 1.7 ms |
+| `git.getStatus` | ~310–325 ms | ~310 ms | ~315 ms |
+| host-service CPU p95 | 34% (git bursts) | 21% | 1% |
+| pty-daemon CPU | ~0% | 58–73% | 72–77% |
+
+**Finding 1 (blocks the ModeTracker question, real bug):** a single full-rate flooding terminal kills the shared daemon↔host-service socket within ~2s. `writeMessage` (`packages/pty-daemon/src/Server/Server.ts:595`) destroys the connection when `writableLength` exceeds the 8 MiB `DEFAULT_OUTBOUND_BUFFER_CAP_BYTES` — and it's ONE socket for the whole org, so host-service logs `pty-daemon disconnected; closing 5 terminal WS socket(s)` and every terminal's stream drops (renderer reconnect masks this as a blip for users). The SUPER-939 "bounded buffering" bounds by disconnecting everyone, not by shedding the offending session's data. Loop-contention on host-service was unmeasurable — the transport dies before the loop gets loaded.
+
+**Finding 2:** the daemon burns 50–77% of a core servicing a flooding PTY even with no subscriber attached (and keeps burning after destroying its client connection).
+
+**Priority update:** fixing the daemon's overflow behavior (per-session shedding/pause, not shared-socket destroy) now outranks the loop-offload work; re-run the ModeTracker/loop measurement after the transport survives floods. `git.getStatus` p50 held at ~310ms throughout — the limiter does its job under this load; the worker pool's win is loop availability, not getStatus latency.
+
+**Harness notes (for reruns):** sessions with no attached WS never stream to host-service — the daemon→host-service data path (ModeTracker, hint scan, broadcast) only runs for subscribed sessions, so a load test MUST attach sockets or host-service sits idle while only the daemon burns. A daemon disconnect wipes terminal session rows → later `writeInput` fails "Terminal session not found"; keep each measurement cycle short and re-create sessions per cycle.
+
+## Measured 2026-07-17 round 2 — many workspaces × many files (CDP + direct HTTP/WS)
+
+Setup: generated 20k-file repo, imported as project, 8 workspaces = 8 full worktrees. Churn = append to 200 tracked files per worktree every 500ms. Pollers = `git.getStatus` (background) on all 8 every 2s. "Direct" rounds measured from a bun script straight against host-service HTTP/WS (`Bearer` secret / `?token=`), bypassing the renderer. Loop probe = trivial-route HTTP RTT sampled at 100ms (event-loop availability from outside).
+
+| metric | idle baseline | churn-1 | churn-8 + pollers | heavy-burst (2k files modified × 8, no churn) | post-reset settle (16k reverts) |
+|---|---|---|---|---|---|
+| echo RTT p50/p95 ms | 2.1 / 3.7 | 1.8 / 2.4 | 5.7 / 19.9 | 3.0 / 6.9 | 8.3 / **138** |
+| query RTT p50/p95 ms | 1.8 / 3.2 | 1.5 / 4.4 | 4.1 / **127** | 0.8 / 4.3 | 6.4 / 48 |
+| loop probe p95/max ms | — | — | 27.9 / **183** | 4.2 / 9.4 | 39 / 104 |
+| `getStatus` ws1 ms | ~330 | 289–557 | 433–893 | ~1200 | 488–743 |
+| all-8 concurrent storm ms | 372–2259 | 670–3610 | 1569–**7497** | 771–4501 | 464–1305 |
+| bg pollers latency | — | — | p50 3.7s, p95 10.6s, max **14.6s** | — | — |
+| host-service CPU | ~7% p95 | p50 7 / max 39% | p50 29 / max 52% | p50 10 / max 46% | ~22% |
+
+Also observed during churn-8: **two renderer stalls >60s** (CDP evaluate timeouts; the app UI would freeze — renderer-side workstream, not host-service) and one window where renderer→host fetches failed outright while the process was alive at 40% CPU. Host-service RSS grew 320→570MB over the session (unverified whether leak or cache).
+
+**Interpretation:**
+1. **The loop stalls come from the watcher/event path, not status parsing.** Churn-8 stalls the loop to 183ms and drags query p95 to 127ms; heavy-burst (huge diffs, no fs churn) keeps the loop clean (p95 4.2ms) while statuses queue in the limiter + git subprocesses. GitWatcher event filtering/debounce/rescan is the strongest offload candidate for loop health — promote it from Phase 3.
+2. **User-visible status staleness under churn is limiter queueing.** Background refreshes take 3.7–14.6s at concurrency 4 with 8 hot workspaces. The worker pool makes raising that concurrency safe (in-process, more concurrent snapshots would multiply loop parse work; in workers it's just more cores).
+3. Snapshot cost scales with diff size (~1.2s at 2000 modified files) — worth offloading, but it wasn't the loop killer.
+4. Terminal I/O degrades 3–10× under churn (echo p50 1.8→5.7ms, p95 138ms during settle) — real but not catastrophic; consistent with conclusion 1.
+
+## Measuring what else deserves offload
+
+Known per-chunk work on the host-service loop besides git (found by audit, unmeasured):
+
+- **ModeTracker headless xterm** — `terminal.ts:271` feeds *every PTY output chunk* through `@xterm/headless` `writeSync` (full VT parse, `terminal-mode-tracker.ts`), per session, synchronously. Under agent-TUI repaint churn × N terminals this is likely the largest steady-state CPU on the loop.
+- **Port-hint scanning** — per-chunk `StringDecoder` + text pattern match (`portHintDecoder` → `portManager.checkOutputForHint`).
+- **WS fan-out** — per-chunk broadcast copies to attached sockets.
+- **better-sqlite3** — synchronous queries on the loop.
+- **pty-daemon's own loop** — mostly I/O relay + FIFO writes (no emulator; handoff snapshot is bookkeeping-only). Expected cheap; verify.
+
+These streaming/per-chunk workloads do **not** fit the request/response pool (contract §4). If measurement justifies it, the follow-up is a **pinned-worker (sharded/actor) mode** on the same worker entry: pin each session's tracker+hint-scan to a worker keyed by sessionId, stream chunks over a MessagePort with transferred ArrayBuffers, request/response only for `buildPreamble()` on attach. Do not build this before the numbers exist.
+
+Instrumentation (ship first, cheap, debug-flag or always-on):
+
+1. `perf_hooks.monitorEventLoopDelay` in host-service and pty-daemon; log p50/p99/max every 30s.
+2. Attribution counters: `performance.now()` + `eventLoopUtilization()` deltas around the suspects — `modeTracker.feed`, hint scan, `getGitStatusSnapshot`, db calls — emitting CPU-ms/s per subsystem.
+3. Synthetic loads: flood one terminal (`yes`, `cat bigfile`) and measure input-echo RTT on a *second* terminal (loop-coupling proof); run giant-repo `getStatus` during the flood; branch-storm from the existing 20k-file watcher stress suite.
+4. `node --cpu-prof` on host-service under the combined load for the flame.
+
+Promotion rule: a subsystem becomes a pool/pinned-worker tenant when it shows sustained CPU-ms/s on the loop **and** p99 loop delay > ~20ms under realistic load — not before.
+
+## Testing
+
+- Parity: fixture repo, assert worker-path snapshot deep-equals inline-path snapshot (staged/unstaged/renames/untracked).
+- Pool unit tests against a tiny JS fixture worker (timeout→recycle, idle-reap, crash→inline fallback, coalesce). Run under node like other host-service native-adjacent tests.
+- Prove each test can fail by mutating the impl once.
+
+## Risks
+
+- **ESM worker entry**: `new Worker(path.js)` must resolve as ESM in the CLI dist (`lib/` has no `package.json`); emit `.mjs` there if needed.
+- **Native externals**: worker bundle must not pull `better-sqlite3`/`node-pty` — the genericity-contract import test is the enforcement; it must run on the whole `host-worker.ts` entry graph so every future task module is covered.
+- **Payload cloning**: snapshots for huge repos serialize across the thread boundary; they already serialize to JSON for tRPC, so no regression.


### PR DESCRIPTION
## Summary

- cap exact GitWatcher worktree paths at 128 per debounce batch, then emit the existing broad invalidation signal
- skip further path normalization after a batch becomes broad
- update the large-repository profiler to exercise the real worker task, record worker/inline mode and event-loop delay, isolate watcher-only cost, and support multiple real worktrees
- record the post-implementation measurements and limiter decision in the worker-pool plan

## Why

The worker pool moved Git status parsing off the host-service event loop, but large native watcher batches still performed unbounded path normalization and Set growth on the main thread. Profiling showed that adding another worker hop increased latency because of structured-clone and pool-contention costs. Bounded broad invalidation preserves correctness while removing the sustained watcher-loop pressure.

## Impact

In representative eight-worktree profiling, watcher-only p99 event-loop delay dropped from 87.2 ms to 13.6 ms. The full watcher plus worker-backed status run dropped from 43.5 ms to 6.3 ms p99 and from 7.91 s to 5.34 s. Concurrency 6 did not improve completion time and increased active Git processes, so the production limiter remains at 4.

## Validation

- `bun run lint:fix`
- `bun run lint`
- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd packages/host-service build:host`
- 30 focused GitWatcher, worker-pool, limiter, and worker-import tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a plan detailing phased rollout for moving Git status processing off the shared event loop, including worker fallback behavior, bundling guidance, and parity/testing risks.
* **Improvements**
  * Updated Git watcher debounce batching to cap collected paths; exceeding the limit now triggers broad refresh signaling (no per-path payload).
  * Enhanced Git status profiling to run via the host worker pool and report worker-vs-inline execution with event-loop delay metrics, including workspace sharding.
* **Tools / Testing**
  * Added new profiling flags (`--workspaces`, `--watcher-only`) and expanded worker/inline execution parity and worker behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->