### PR TITLE
fix(pty-daemon): pause flooding PTYs on backpressure instead of destroying the shared socket

### DIFF
--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -30,7 +30,7 @@
 		"build:daemon": "bun run build.ts",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
 		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts test/no-encoding-hops.test.ts",
-		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts",
+		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts test/flow-control.test.ts",
 		"build:types": "tsc -p tsconfig.types.json"
 	},
 	"dependencies": {

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -27,6 +27,13 @@ export interface Pty {
 	onData(cb: PtyOnData): void;
 	onExit(cb: PtyOnExit): void;
 	/**
+	 * Flow control: stop reading from the PTY master. The kernel PTY buffer
+	 * (~64KB) fills and the foreground process blocks on write, throttling
+	 * itself — same mechanism as VS Code's ptyHost pause/resume.
+	 */
+	pause(): void;
+	resume(): void;
+	/**
 	 * The kernel master fd backing this PTY. Required for daemon-upgrade
 	 * fd-handoff (Phase 2): the successor daemon process inherits this fd
 	 * via stdio so the slave-side shell stays alive across the binary swap.
@@ -112,6 +119,16 @@ class NodePtyAdapter implements Pty {
 			return;
 		}
 		this.exitCallbacks.push(cb);
+	}
+
+	pause(): void {
+		if (this.exited) return;
+		this.term.pause();
+	}
+
+	resume(): void {
+		if (this.exited) return;
+		this.term.resume();
 	}
 
 	private scheduleKillEscalation(
@@ -329,6 +346,16 @@ class AdoptedPty implements Pty {
 
 	onExit(cb: PtyOnExit): void {
 		this.exitCallbacks.push(cb);
+	}
+
+	pause(): void {
+		if (this.exitFired) return;
+		this.reader.pause();
+	}
+
+	resume(): void {
+		if (this.exitFired) return;
+		this.reader.resume();
 	}
 
 	private scheduleKillEscalation(

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -35,6 +35,8 @@ export interface ServerOptions {
 	daemonVersion: string;
 	bufferCap?: number;
 	outboundBufferCap?: number;
+	/** Pause producing PTYs when a subscriber buffers past this (flow control). */
+	outboundPauseThreshold?: number;
 	/**
 	 * Override for the PTY-spawn factory. Production leaves this unset;
 	 * `defaultSpawn` (real node-pty) is used. Tests inject a fake here so
@@ -45,10 +47,20 @@ export interface ServerOptions {
 
 const DEFAULT_OUTBOUND_BUFFER_CAP_BYTES = 8 * 1024 * 1024;
 
+// Flow control: when a subscriber's socket buffers more than this, pause the
+// producing PTYs instead of letting the buffer grow toward the destroy cap.
+// The kernel PTY buffer then fills and the foreground process blocks on
+// write — the flood throttles itself at the source (VS Code ptyHost does the
+// same via pause/resume; our congestion signal is local writableLength
+// instead of renderer ACKs). Resume on socket 'drain'.
+const DEFAULT_OUTBOUND_PAUSE_THRESHOLD_BYTES = 1 * 1024 * 1024;
+
 interface ConnState extends Conn {
 	socket: net.Socket;
 	decoder: FrameDecoder;
 	negotiated: number | null;
+	/** Session ids whose PTYs we paused because this conn was congested. */
+	pausedSessions: Set<string>;
 }
 
 export class Server {
@@ -317,10 +329,16 @@ export class Server {
 			decoder: new FrameDecoder(),
 			negotiated: null,
 			subscriptions: new Set(),
+			pausedSessions: new Set(),
 			send: (msg, payload) =>
 				writeMessage(socket, msg, payload, outboundBufferCap),
 		};
 		this.conns.add(conn);
+
+		// Flow control: the buffer only reaches the pause threshold after
+		// write() has returned false, so a 'drain' (buffer fully flushed) is
+		// guaranteed to follow and is our resume signal.
+		socket.on("drain", () => this.resumePausedSessions(conn));
 
 		socket.on("data", (chunk) => {
 			try {
@@ -460,13 +478,24 @@ export class Server {
 	 * subscribed to this session id receives the output / exit frames.
 	 */
 	private wireSession(session: Session): void {
+		const pauseThreshold =
+			this.opts.outboundPauseThreshold ??
+			DEFAULT_OUTBOUND_PAUSE_THRESHOLD_BYTES;
 		session.pty.onData((chunk) => {
 			this.store.appendOutput(session, chunk);
 			const out: ServerMessage = { type: "output", id: session.id };
+			let congested = false;
 			for (const c of this.conns) {
 				if (!c.subscriptions.has(session.id)) continue;
 				c.send(out, chunk);
+				if (!c.socket.destroyed && c.socket.writableLength > pauseThreshold) {
+					c.pausedSessions.add(session.id);
+					congested = true;
+				}
 			}
+			// Paused PTYs emit no further onData, so this fires at most once
+			// per congestion episode; the conn's 'drain' resumes us.
+			if (congested) session.pty.pause();
 		});
 		session.pty.onExit((info) => {
 			session.exited = true;
@@ -483,6 +512,7 @@ export class Server {
 					c.send(ev);
 					c.subscriptions.delete(session.id);
 				}
+				c.pausedSessions.delete(session.id);
 			}
 			// Delete the session immediately. Without this, every closed
 			// terminal pane left a row in the store forever — list-reply
@@ -500,6 +530,28 @@ export class Server {
 
 	private dropConn(conn: ConnState): void {
 		this.conns.delete(conn);
+		// A destroyed socket never drains — release its paused producers here.
+		this.resumePausedSessions(conn);
+	}
+
+	/**
+	 * Resume every PTY paused on behalf of `conn`, unless another congested
+	 * conn still holds it paused. Called on socket 'drain' and on conn drop.
+	 */
+	private resumePausedSessions(conn: ConnState): void {
+		for (const id of conn.pausedSessions) {
+			conn.pausedSessions.delete(id);
+			let heldElsewhere = false;
+			for (const other of this.conns) {
+				if (other !== conn && other.pausedSessions.has(id)) {
+					heldElsewhere = true;
+					break;
+				}
+			}
+			if (heldElsewhere) continue;
+			const session = this.store.get(id);
+			if (session && !session.exited) session.pty.resume();
+		}
 	}
 }
 

--- a/packages/pty-daemon/src/SessionStore/SessionStore.test.ts
+++ b/packages/pty-daemon/src/SessionStore/SessionStore.test.ts
@@ -17,6 +17,8 @@ function fakePty(meta: { cols: number; rows: number }): Pty {
 		onData: () => {},
 		onExit: () => {},
 		getMasterFd: () => -1,
+		pause: () => {},
+		resume: () => {},
 	};
 }
 

--- a/packages/pty-daemon/src/SessionStore/snapshot.test.ts
+++ b/packages/pty-daemon/src/SessionStore/snapshot.test.ts
@@ -22,6 +22,8 @@ function fakePty(pid: number, meta: { cols: number; rows: number }): Pty {
 		onData: () => {},
 		onExit: () => {},
 		getMasterFd: () => -1,
+		pause: () => {},
+		resume: () => {},
 	};
 }
 

--- a/packages/pty-daemon/src/handlers/handlers.test.ts
+++ b/packages/pty-daemon/src/handlers/handlers.test.ts
@@ -38,6 +38,8 @@ function makeFakePty(state: FakePtyState, meta: SpawnOptions["meta"]): Pty {
 		onData: () => {},
 		onExit: () => {},
 		getMasterFd: () => -1,
+		pause: () => {},
+		resume: () => {},
 	};
 }
 

--- a/packages/pty-daemon/test/byte-fidelity.test.ts
+++ b/packages/pty-daemon/test/byte-fidelity.test.ts
@@ -64,6 +64,8 @@ function makeDriveablePty(meta: SpawnOptions["meta"]): DriveablePty {
 		resize: () => {},
 		kill: () => {},
 		getMasterFd: () => -1,
+		pause: () => {},
+		resume: () => {},
 		onData: (cb: PtyOnData) => {
 			onDataCbs.push(cb);
 		},

--- a/packages/pty-daemon/test/flow-control.test.ts
+++ b/packages/pty-daemon/test/flow-control.test.ts
@@ -1,0 +1,107 @@
+// Flow control: a flooding PTY with a slow consumer must pause the producer
+// (kernel backpressure) instead of destroying the shared daemon socket.
+//
+// Regression: writeMessage() used to socket.destroy() when writableLength
+// exceeded the outbound cap — one flooding terminal severed the connection
+// for every session in the org.
+//
+// Runs under Node (`node --experimental-strip-types --test`).
+
+import { strict as assert } from "node:assert";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, test } from "node:test";
+import { Server } from "../src/Server/index.ts";
+import { connectAndHello, payloadAsString } from "./helpers/client.ts";
+
+const sockPath = path.join(os.tmpdir(), `pty-daemon-flow-${process.pid}.sock`);
+let server: Server;
+
+// Small thresholds so the flood trips them in milliseconds. The old destroy
+// behavior fires at outboundBufferCap; with flow control the buffer must stop
+// growing at outboundPauseThreshold, far below the cap.
+const PAUSE_THRESHOLD = 64 * 1024;
+const DESTROY_CAP = 4 * 1024 * 1024;
+
+const FLOOD_META = {
+	shell: "/bin/sh",
+	argv: ["-c", 'yes "flood-line-0123456789-abcdefghijklmnopqrstuvwxyz"'],
+	cols: 80,
+	rows: 24,
+};
+
+before(async () => {
+	server = new Server({
+		socketPath: sockPath,
+		daemonVersion: "0.0.0-test",
+		outboundPauseThreshold: PAUSE_THRESHOLD,
+		outboundBufferCap: DESTROY_CAP,
+	});
+	await server.listen();
+});
+
+after(async () => {
+	await server.close();
+});
+
+test("slow consumer pauses the flood instead of destroying the connection", async () => {
+	const c = await connectAndHello(sockPath);
+	c.send({ type: "open", id: "flow-0", meta: FLOOD_META });
+	await c.waitFor((m) => m.type === "open-ok" && m.id === "flow-0");
+	c.send({ type: "subscribe", id: "flow-0", replay: false });
+	await c.waitFor(
+		(m) => m.type === "output" && payloadAsString(m).includes("flood-line"),
+		3000,
+	);
+
+	// Stop reading. At full `yes` rate the old behavior blows through any
+	// buffer cap within this window and destroys the socket.
+	c.socket.pause();
+	await new Promise((r) => setTimeout(r, 1500));
+	assert.equal(
+		c.closed(),
+		false,
+		"daemon destroyed the shared connection under flood (flow control missing)",
+	);
+
+	// Resume reading: buffered output drains, PTY resumes, data flows again.
+	c.socket.resume();
+	await c.waitForNext(
+		(m) => m.type === "output" && payloadAsString(m).includes("flood-line"),
+		3000,
+	);
+	assert.equal(c.closed(), false);
+
+	c.send({ type: "close", id: "flow-0", signal: "SIGKILL" });
+	await c.waitFor((m) => m.type === "closed" && m.id === "flow-0", 3000);
+	await c.close();
+});
+
+test("consumer disconnect while paused resumes the PTY for the next subscriber", async () => {
+	const c1 = await connectAndHello(sockPath);
+	c1.send({ type: "open", id: "flow-1", meta: FLOOD_META });
+	await c1.waitFor((m) => m.type === "open-ok" && m.id === "flow-1");
+	c1.send({ type: "subscribe", id: "flow-1", replay: false });
+	await c1.waitFor((m) => m.type === "output" && m.id === "flow-1", 3000);
+
+	// Congest c1 until the PTY is paused, then drop the socket hard. The
+	// daemon must resume the PTY via the conn-drop path (a destroyed socket
+	// never emits 'drain').
+	c1.socket.pause();
+	await new Promise((r) => setTimeout(r, 800));
+	c1.socket.destroy();
+
+	const c2 = await connectAndHello(sockPath);
+	c2.send({ type: "subscribe", id: "flow-1", replay: false });
+	await c2.waitFor(
+		(m) =>
+			m.type === "output" &&
+			m.id === "flow-1" &&
+			payloadAsString(m).includes("flood-line"),
+		3000,
+	);
+
+	c2.send({ type: "close", id: "flow-1", signal: "SIGKILL" });
+	await c2.waitFor((m) => m.type === "closed" && m.id === "flow-1", 3000);
+	await c2.close();
+});


### PR DESCRIPTION
**Links**
- Findings + design context: `plans/20260717-host-service-git-worker-pool.md` (#5746)

## Summary
- One full-rate flooding terminal (e.g. `yes`, a huge build log) used to trip the daemon's 8 MiB outbound cap and `socket.destroy()` the daemon↔host-service connection — severing **every** terminal in the org (host-service logs `pty-daemon disconnected; closing N terminal WS socket(s)`; users see all terminals blip). Reproduced deterministically in the 2026-07-17 stress test.
- Fix: per-session flow control. When a subscriber's socket buffers past 1 MiB, pause the producing PTYs (`pty.pause()`); resume on socket `drain`. The kernel PTY buffer fills and the flooding process blocks on its own write — it throttles itself at the source. The 8 MiB destroy stays as a last-resort for pathological control-message floods.

## How It Works
- `Pty` gains `pause()`/`resume()`: node-pty's public pause/resume (added upstream for VS Code's ptyHost flow control, same actuator) for spawned sessions, `ReadStream.pause()` for adopted-fd sessions.
- `Server.wireSession`: after fanning out a chunk, any subscribed conn with `writableLength > outboundPauseThreshold` records the session in `conn.pausedSessions` and the PTY is paused. Paused PTYs emit no further data, so this fires once per congestion episode.
- Resume paths: socket `drain` (guaranteed to fire — the buffer only passes the threshold after `write()` returned false), and conn drop (a destroyed socket never drains). A session held paused by another still-congested conn stays paused.
- This is **not** a return of the removed ACK flow control (SUPER-939): no client involvement, no protocol change — the congestion signal is the daemon's own socket buffer. Renderer-slow congestion is still handled by host-service's existing bounded buffering; this covers the daemon→host-service hop.

## Manual QA Checklist
- [x] Flood a terminal (`yes`) with other terminals open — no org-wide disconnect, other terminals stay live (covered by integration test with real shells + real unix socket; app-level re-run of the CDP flood stress is a follow-up)

## Testing
- New `test/flow-control.test.ts` (node --test, real `/bin/sh` + `yes` flood + real unix socket):
  - slow consumer → connection survives, output resumes after the consumer drains
  - consumer hard-disconnect while paused → next subscriber still gets output (conn-drop resume path)
  - Both proven to fail against the old behavior (mutation-tested: destroy-only → test 1 fails; no conn-drop resume → test 2 fails)
- Full `bun run test:integration` (51/51) and `bun test` unit suite (57/57) pass
- `bun run typecheck` (pty-daemon + host-service), `bun run lint` clean

## Risks / Rollout
- Risk: a paused PTY blocks the foreground process's writes — that's the intended semantics (same as VS Code), and pause windows are bounded by drain/disconnect. Sessions with no subscriber are never paused, so background jobs in unattached terminals are unaffected.
- Rollback: revert; behavior returns to destroy-on-overflow.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5747">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent org-wide terminal disconnects by pausing flooding PTYs on backpressure instead of destroying the shared daemon socket. Adds per-session flow control to `pty-daemon` so heavy output (e.g., yes/build logs) doesn’t take down other terminals.

- **Bug Fixes**
  - Implemented per-connection flow control: when a subscriber’s `socket.writableLength` exceeds a threshold (default 1 MiB via `outboundPauseThreshold`), pause the session’s PTY; resume on socket `drain` or connection drop. The 8 MiB `outboundBufferCap` remains a last-resort.
  - Extended `Pty` with `pause()`/`resume()` and wired both `node-pty` sessions and adopted-fd sessions.
  - Tracked `pausedSessions` per connection to avoid resuming while another subscriber is still congested.
  - Added `test/flow-control.test.ts` and included it in `test:integration` to cover slow consumer and disconnect-resume paths.

<sup>Written for commit cc9b321f802e94d169bb74786195139137d4d232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PTY flow-control support to pause output when clients cannot keep up and resume it when capacity is available.
  * Added configurable outbound pause thresholds for server connections.
  * Improved handling of disconnected clients so shared sessions remain available and recover correctly.

* **Tests**
  * Added integration coverage for slow, interrupted, and reconnecting consumers during high-volume PTY output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
