### PR TITLE
fix(pty-daemon): re-snapshot kill escalation, tty/pgid straggler targeting, shutdown drain

### DIFF
--- a/apps/desktop/src/main/pty-daemon/index.ts
+++ b/apps/desktop/src/main/pty-daemon/index.ts
@@ -33,6 +33,7 @@
 import {
 	clearSnapshot,
 	DAEMON_PACKAGE_VERSION,
+	drainPendingKills,
 	readSnapshot,
 	Server,
 } from "@superset/pty-daemon";
@@ -182,6 +183,9 @@ function wireShutdown(server: Server): void {
 		process.stderr.write(`[pty-daemon] received ${signal}, shutting down\n`);
 		try {
 			await server.close();
+			// A requested close may still be mid-escalation; process.exit()
+			// would drop it and leak the SIGHUP-trapping survivors.
+			await drainPendingKills(2000);
 		} catch (err) {
 			process.stderr.write(
 				`[pty-daemon] shutdown error: ${(err as Error).stack ?? err}\n`,

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -29,8 +29,8 @@
 		"start": "node --experimental-strip-types src/main.ts",
 		"build:daemon": "bun run build.ts",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
-		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts test/no-encoding-hops.test.ts",
-		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts",
+		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/process-tree.test.ts test/no-encoding-hops.test.ts",
+		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts test/kill-tree.test.ts",
 		"build:types": "tsc -p tsconfig.types.json"
 	},
 	"dependencies": {

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -57,105 +57,133 @@ export async function drainPendingKills(timeoutMs: number): Promise<void> {
 }
 
 /**
- * The session root's durable coordinates: controlling tty plus every process
- * group ever observed for it. A ppid walk can't rediscover either once the
- * intermediate parents die, so kill passes target through these too.
+ * Kill orchestration shared by both adapters, which differ only in how they
+ * signal the root and how they know it's dead.
+ *
+ * Owns the session root's durable coordinates — controlling tty plus every
+ * process group ever observed (a ppid walk can't rediscover either once the
+ * intermediate parents die) — and the SIGKILL escalation chain: each round
+ * takes a fresh process-table snapshot, because the initial volley's target
+ * list goes stale the moment a descendant forks. Timers stay ref'd on
+ * purpose: a naturally-exiting daemon must not drop a half-finished kill.
  */
-interface RootIdentity {
-	ttyName: string | null;
-	knownPgids: Set<number>;
-}
+class TreeKiller {
+	private ttyName: string | null = null;
+	private readonly knownPgids = new Set<number>();
+	private killChain: Promise<void> | null = null;
+	private readonly rootPid: number;
+	private readonly isRootAlive: () => boolean;
+	/** Best-effort signal to the root process itself; must not throw. */
+	private readonly signalRoot: (signal: NodeJS.Signals) => void;
 
-/**
- * One kill pass: collect the current tree + known-group members + same-tty
- * stragglers, record the root's and any newly seen groups, signal everything.
- * The root pid itself is excluded — each adapter signals its root its own way.
- * Pass a pre-read `table` from async paths; the sync fallback (one ps, same
- * cost as the pre-hardening kill) is for the synchronous kill() entrypoint.
- */
-function killVolley(
-	rootPid: number,
-	signal: NodeJS.Signals,
-	identity: RootIdentity,
-	table?: ProcessInfo[],
-): { survivors: boolean } {
-	const psTable = table ?? readProcessTable();
-	const rootRow = psTable.find((r) => r.pid === rootPid);
-	if (rootRow) {
-		if (rootRow.tty !== null) identity.ttyName = rootRow.tty;
-		identity.knownPgids.add(rootRow.pgid);
+	// No parameter properties: the daemon runs under node's strip-only TS
+	// mode, which rejects them.
+	constructor(
+		rootPid: number,
+		isRootAlive: () => boolean,
+		signalRoot: (signal: NodeJS.Signals) => void,
+	) {
+		this.rootPid = rootPid;
+		this.isRootAlive = isRootAlive;
+		this.signalRoot = signalRoot;
 	}
-	const targets = collectProcessSignalTargets(rootPid, {
-		includeRoot: false,
-		// tty targeting only while the root is alive in this same snapshot:
-		// the kernel recycles the pty slot the moment the master fd closes,
-		// so after root death a tty match can only ever hit a NEW session
-		// that inherited the slot (legit stragglers show "??" by then).
-		ttyName: rootRow ? identity.ttyName : null,
-		knownPgids: identity.knownPgids,
-		table: psTable,
-		onSignalError: logProcessSignalError,
-	});
-	for (const t of targets) {
-		if (t.target === "pgid") identity.knownPgids.add(t.id);
+
+	/**
+	 * Record the root's pgid + tty. Called at construction (if the shell exits
+	 * before the first kill, nothing else can rediscover them) and refreshed
+	 * by every volley from its own table. Async — session-open path.
+	 */
+	async captureIdentity(): Promise<void> {
+		const { pgid, tty } = await getProcessGroupAndTty(this.rootPid);
+		if (tty !== null) this.ttyName = tty;
+		if (pgid !== null) this.knownPgids.add(pgid);
 	}
-	signalProcessTargets(targets, signal, logProcessSignalError);
-	return { survivors: targets.some((t) => t.target === "pid") };
-}
 
-interface KillEscalationOptions {
-	rootPid: number;
-	identity: RootIdentity;
-	isRootAlive: () => boolean;
-	/** Best-effort SIGKILL to the root process itself. */
-	killRoot: () => void;
-}
+	kill(signal: NodeJS.Signals): void {
+		this.volley(signal);
+		this.signalRoot(signal);
+		if (signal === "SIGKILL" || this.killChain) return;
+		const chain = registerPendingKill(this.runEscalation());
+		this.killChain = chain;
+		// Reset when done so a retried close can escalate again.
+		void chain.then(() => {
+			if (this.killChain === chain) this.killChain = null;
+		});
+	}
 
-/**
- * SIGKILL escalation with a fresh process-table snapshot each round: the
- * initial volley's target list goes stale the moment a descendant forks, so
- * every pass re-collects (tree walk + known pgids + tty) and repeats until
- * nothing is left or the round budget runs out. Timers stay ref'd on purpose:
- * a naturally-exiting daemon must not drop a half-finished kill.
- */
-async function runKillEscalation(opts: KillEscalationOptions): Promise<void> {
-	const { rootPid, identity, isRootAlive, killRoot } = opts;
-	await delay(KILL_ESCALATION_TIMEOUT_MS);
-	for (let round = 0; ; round++) {
-		const table = await readProcessTableAsync();
-		const rootAlive = isRootAlive();
-		if (table !== null) {
-			const { survivors } = killVolley(rootPid, "SIGKILL", identity, table);
-			if (!survivors && !rootAlive) return;
+	/**
+	 * One kill pass: collect the current tree + known-group members + same-tty
+	 * stragglers, record the root's and any newly seen groups, signal all of
+	 * it (root excluded — signalRoot handles that). Pass a pre-read `table`
+	 * from async paths; the sync fallback (one ps, same cost as the
+	 * pre-hardening kill) is for the synchronous kill() entrypoint.
+	 */
+	private volley(
+		signal: NodeJS.Signals,
+		table?: ProcessInfo[],
+	): { survivors: boolean } {
+		const psTable = table ?? readProcessTable();
+		const rootRow = psTable.find((r) => r.pid === this.rootPid);
+		if (rootRow) {
+			if (rootRow.tty !== null) this.ttyName = rootRow.tty;
+			this.knownPgids.add(rootRow.pgid);
 		}
-		// A null table means ps failed — state unknown; keep the root kill
-		// and burn a round rather than concluding the kill is complete.
-		if (rootAlive) killRoot();
-		const nextDelay = KILL_VERIFY_DELAYS_MS[round];
-		if (nextDelay === undefined) break;
-		await delay(nextDelay);
+		const targets = collectProcessSignalTargets(this.rootPid, {
+			includeRoot: false,
+			// tty targeting only while the root is alive in this same snapshot:
+			// the kernel recycles the pty slot the moment the master fd closes,
+			// so after root death a tty match can only ever hit a NEW session
+			// that inherited the slot (legit stragglers show "??" by then).
+			ttyName: rootRow ? this.ttyName : null,
+			knownPgids: this.knownPgids,
+			table: psTable,
+			onSignalError: logProcessSignalError,
+		});
+		for (const t of targets) {
+			if (t.target === "pgid") this.knownPgids.add(t.id);
+		}
+		signalProcessTargets(targets, signal, logProcessSignalError);
+		return { survivors: targets.some((t) => t.target === "pid") };
 	}
-	// Let the final volley's SIGKILLs land before declaring survivors.
-	await delay(300);
-	const finalTable = await readProcessTableAsync();
-	if (finalTable === null) {
-		process.stderr.write(
-			`[pty-daemon] kill escalation for pid ${rootPid}: final ps failed, survivor state unknown\n`,
-		);
-		return;
-	}
-	const finalRootRow = finalTable.find((r) => r.pid === rootPid);
-	const leftovers = collectProcessSignalTargets(rootPid, {
-		includeRoot: false,
-		ttyName: finalRootRow ? identity.ttyName : null,
-		knownPgids: identity.knownPgids,
-		table: finalTable,
-	}).filter((t) => t.target === "pid");
-	if (leftovers.length > 0 || isRootAlive()) {
-		process.stderr.write(
-			`[pty-daemon] kill escalation for pid ${rootPid} left survivors: ` +
-				`root=${isRootAlive()} pids=[${leftovers.map((t) => t.id).join(",")}]\n`,
-		);
+
+	private async runEscalation(): Promise<void> {
+		await delay(KILL_ESCALATION_TIMEOUT_MS);
+		for (let round = 0; ; round++) {
+			const table = await readProcessTableAsync();
+			const rootAlive = this.isRootAlive();
+			if (table !== null) {
+				const { survivors } = this.volley("SIGKILL", table);
+				if (!survivors && !rootAlive) return;
+			}
+			// A null table means ps failed — state unknown; keep the root kill
+			// and burn a round rather than concluding the kill is complete.
+			if (rootAlive) this.signalRoot("SIGKILL");
+			const nextDelay = KILL_VERIFY_DELAYS_MS[round];
+			if (nextDelay === undefined) break;
+			await delay(nextDelay);
+		}
+		// Let the final volley's SIGKILLs land before declaring survivors.
+		await delay(300);
+		const finalTable = await readProcessTableAsync();
+		if (finalTable === null) {
+			process.stderr.write(
+				`[pty-daemon] kill escalation for pid ${this.rootPid}: final ps failed, survivor state unknown\n`,
+			);
+			return;
+		}
+		const finalRootRow = finalTable.find((r) => r.pid === this.rootPid);
+		const leftovers = collectProcessSignalTargets(this.rootPid, {
+			includeRoot: false,
+			ttyName: finalRootRow ? this.ttyName : null,
+			knownPgids: this.knownPgids,
+			table: finalTable,
+		}).filter((t) => t.target === "pid");
+		if (leftovers.length > 0 || this.isRootAlive()) {
+			process.stderr.write(
+				`[pty-daemon] kill escalation for pid ${this.rootPid} left survivors: ` +
+					`root=${this.isRootAlive()} pids=[${leftovers.map((t) => t.id).join(",")}]\n`,
+			);
+		}
 	}
 }
 
@@ -193,11 +221,7 @@ class NodePtyAdapter implements Pty {
 	meta: SessionMeta;
 	private term: nodePty.IPty;
 	private exited = false;
-	private readonly identity: RootIdentity = {
-		ttyName: null,
-		knownPgids: new Set(),
-	};
-	private killChain: Promise<void> | null = null;
+	private readonly killer: TreeKiller;
 	private exitInfo: { code: number | null; signal: number | null } | null =
 		null;
 	private exitCallbacks: PtyOnExit[] = [];
@@ -206,16 +230,24 @@ class NodePtyAdapter implements Pty {
 		this.term = term;
 		this.pid = term.pid;
 		this.meta = meta;
-		// Capture the group + tty: if the shell exits before the first kill,
-		// a ppid walk can't rediscover either, and orphans reparented to
-		// pid 1 keep the root pgid. Async — this is the session-open path.
+		this.killer = new TreeKiller(
+			this.pid,
+			() => !this.exited,
+			(sig) => {
+				try {
+					this.term.kill(sig);
+				} catch {
+					// PTY root may have already exited; detached targets still matter.
+				}
+			},
+		);
 		// The immediate capture races the child's setsid/login_tty (it may
 		// still show the daemon's own pgid — collect's current-pgid guard
 		// covers that — and no tty), so re-capture once the child has
-		// certainly run; kill volleys refresh again from their own table.
-		void this.captureRootIdentity();
+		// certainly run.
+		void this.killer.captureIdentity();
 		setTimeout(() => {
-			if (!this.exited) void this.captureRootIdentity();
+			if (!this.exited) void this.killer.captureIdentity();
 		}, 100).unref();
 		this.term.onExit(({ exitCode, signal }) => {
 			if (this.exited) return;
@@ -253,20 +285,7 @@ class NodePtyAdapter implements Pty {
 	}
 
 	kill(signal?: NodeJS.Signals): void {
-		const killSignal = signal ?? "SIGHUP";
-		killVolley(this.pid, killSignal, this.identity);
-		try {
-			this.term.kill(killSignal);
-		} catch {
-			// PTY root may have already exited; detached targets still matter.
-		}
-		this.startKillEscalation(killSignal);
-	}
-
-	private async captureRootIdentity(): Promise<void> {
-		const { pgid, tty: ttyName } = await getProcessGroupAndTty(this.pid);
-		if (ttyName !== null) this.identity.ttyName = ttyName;
-		if (pgid !== null) this.identity.knownPgids.add(pgid);
+		this.killer.kill(signal ?? "SIGHUP");
 	}
 
 	onData(cb: PtyOnData): void {
@@ -281,29 +300,6 @@ class NodePtyAdapter implements Pty {
 			return;
 		}
 		this.exitCallbacks.push(cb);
-	}
-
-	private startKillEscalation(signal: NodeJS.Signals): void {
-		if (signal === "SIGKILL" || this.killChain) return;
-		const chain = registerPendingKill(
-			runKillEscalation({
-				rootPid: this.pid,
-				identity: this.identity,
-				isRootAlive: () => !this.exited,
-				killRoot: () => {
-					try {
-						this.term.kill("SIGKILL");
-					} catch {
-						// already exited
-					}
-				},
-			}),
-		);
-		this.killChain = chain;
-		// Reset when done so a retried close can escalate again.
-		void chain.then(() => {
-			if (this.killChain === chain) this.killChain = null;
-		});
 	}
 }
 
@@ -405,18 +401,26 @@ class AdoptedPty implements Pty {
 	private readonly reader: tty.ReadStream;
 	private exitFired = false;
 	private livenessTimer: NodeJS.Timeout | null = null;
-	private readonly identity: RootIdentity = {
-		ttyName: null,
-		knownPgids: new Set(),
-	};
-	private killChain: Promise<void> | null = null;
+	private readonly killer: TreeKiller;
 	private exitCallbacks: PtyOnExit[] = [];
 
 	constructor(fd: number, pid: number, meta: SessionMeta) {
 		this.fd = fd;
 		this.pid = pid;
 		this.meta = meta;
-		void this.captureRootIdentity();
+		this.killer = new TreeKiller(
+			pid,
+			() => !this.exitFired && isPidAlive(pid),
+			(sig) => {
+				// No node-pty here — signal the adopted root directly.
+				try {
+					process.kill(pid, sig);
+				} catch {
+					// already dead
+				}
+			},
+		);
+		void this.killer.captureIdentity();
 		this.reader = new tty.ReadStream(fd);
 
 		// onExit signal sources:
@@ -493,21 +497,7 @@ class AdoptedPty implements Pty {
 	}
 
 	kill(signal?: NodeJS.Signals): void {
-		const killSignal = signal ?? "SIGHUP";
-		killVolley(this.pid, killSignal, this.identity);
-		// No node-pty here — signal the adopted root directly.
-		try {
-			process.kill(this.pid, killSignal);
-		} catch {
-			// already dead
-		}
-		this.startKillEscalation(killSignal);
-	}
-
-	private async captureRootIdentity(): Promise<void> {
-		const { pgid, tty: ttyName } = await getProcessGroupAndTty(this.pid);
-		if (ttyName !== null) this.identity.ttyName = ttyName;
-		if (pgid !== null) this.identity.knownPgids.add(pgid);
+		this.killer.kill(signal ?? "SIGHUP");
 	}
 
 	onData(cb: PtyOnData): void {
@@ -518,29 +508,6 @@ class AdoptedPty implements Pty {
 
 	onExit(cb: PtyOnExit): void {
 		this.exitCallbacks.push(cb);
-	}
-
-	private startKillEscalation(signal: NodeJS.Signals): void {
-		if (signal === "SIGKILL" || this.killChain) return;
-		const chain = registerPendingKill(
-			runKillEscalation({
-				rootPid: this.pid,
-				identity: this.identity,
-				isRootAlive: () => !this.exitFired && isPidAlive(this.pid),
-				killRoot: () => {
-					try {
-						process.kill(this.pid, "SIGKILL");
-					} catch {
-						// already dead
-					}
-				},
-			}),
-		);
-		this.killChain = chain;
-		// Reset when done so a retried close can escalate again.
-		void chain.then(() => {
-			if (this.killChain === chain) this.killChain = null;
-		});
 	}
 }
 

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -3,14 +3,138 @@ import * as fs from "node:fs";
 import * as tty from "node:tty";
 import * as nodePty from "node-pty";
 import {
+	collectProcessSignalTargets,
+	getProcessGroupAndTty,
+	type ProcessInfo,
 	type ProcessSignalError,
-	type ProcessSignalTarget,
+	readProcessTable,
+	readProcessTableAsync,
 	signalProcessTargets,
-	signalProcessTreeAndGroups,
 } from "../process-tree.ts";
 import type { SessionMeta } from "../protocol/index.ts";
 
 const KILL_ESCALATION_TIMEOUT_MS = 1000;
+/**
+ * Verify-round backoff after the SIGKILL escalation. The long tail exists
+ * for loaded machines: a SIGHUP-trapping shell that only gets scheduled
+ * seconds after the volley can still fork (agent MCP spawn bursts) — a
+ * short fixed window would hand those forks eternal life. Rounds stop
+ * early the moment nothing is left, so a clean kill never pays the tail.
+ */
+const KILL_VERIFY_DELAYS_MS = [300, 700, 1500, 2500];
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Kill chains still running (SIGKILL escalation + verify rounds). The daemon
+ * exits via explicit process.exit(), which would silently drop a chain mid
+ * kill — shutdown awaits this first so a requested close always finishes.
+ */
+const pendingKills = new Set<Promise<void>>();
+
+function registerPendingKill(chain: Promise<void>): void {
+	pendingKills.add(chain);
+	void chain.finally(() => pendingKills.delete(chain));
+}
+
+export async function drainPendingKills(timeoutMs: number): Promise<void> {
+	if (pendingKills.size === 0) return;
+	let timer: NodeJS.Timeout | undefined;
+	await Promise.race([
+		Promise.allSettled([...pendingKills]),
+		new Promise<void>((r) => {
+			timer = setTimeout(r, timeoutMs);
+		}),
+	]);
+	clearTimeout(timer);
+}
+
+/**
+ * The session root's durable coordinates: controlling tty plus every process
+ * group ever observed for it. A ppid walk can't rediscover either once the
+ * intermediate parents die, so kill passes target through these too.
+ */
+interface RootIdentity {
+	ttyName: string | null;
+	knownPgids: Set<number>;
+}
+
+/**
+ * One kill pass: collect the current tree + known-group members + same-tty
+ * stragglers, record the root's and any newly seen groups, signal everything.
+ * The root pid itself is excluded — each adapter signals its root its own way.
+ * Pass a pre-read `table` from async paths; the sync fallback (one ps, same
+ * cost as the pre-hardening kill) is for the synchronous kill() entrypoint.
+ */
+function killVolley(
+	rootPid: number,
+	signal: NodeJS.Signals,
+	identity: RootIdentity,
+	table?: ProcessInfo[],
+): { survivors: boolean } {
+	const psTable = table ?? readProcessTable();
+	const rootRow = psTable.find((r) => r.pid === rootPid);
+	if (rootRow) {
+		if (rootRow.tty !== null) identity.ttyName = rootRow.tty;
+		identity.knownPgids.add(rootRow.pgid);
+	}
+	const targets = collectProcessSignalTargets(rootPid, {
+		includeRoot: false,
+		ttyName: identity.ttyName,
+		knownPgids: identity.knownPgids,
+		table: psTable,
+		onSignalError: logProcessSignalError,
+	});
+	for (const t of targets) {
+		if (t.target === "pgid") identity.knownPgids.add(t.id);
+	}
+	signalProcessTargets(targets, signal, logProcessSignalError);
+	return { survivors: targets.some((t) => t.target === "pid") };
+}
+
+interface KillEscalationOptions {
+	rootPid: number;
+	identity: RootIdentity;
+	isRootAlive: () => boolean;
+	/** Best-effort SIGKILL to the root process itself. */
+	killRoot: () => void;
+}
+
+/**
+ * SIGKILL escalation with a fresh process-table snapshot each round: the
+ * initial volley's target list goes stale the moment a descendant forks, so
+ * every pass re-collects (tree walk + known pgids + tty) and repeats until
+ * nothing is left or the round budget runs out. Timers stay ref'd on purpose:
+ * a naturally-exiting daemon must not drop a half-finished kill.
+ */
+async function runKillEscalation(opts: KillEscalationOptions): Promise<void> {
+	const { rootPid, identity, isRootAlive, killRoot } = opts;
+	await delay(KILL_ESCALATION_TIMEOUT_MS);
+	for (let round = 0; ; round++) {
+		const table = await readProcessTableAsync();
+		const rootAlive = isRootAlive();
+		const { survivors } = killVolley(rootPid, "SIGKILL", identity, table);
+		if (!survivors && !rootAlive) return;
+		if (rootAlive) killRoot();
+		const nextDelay = KILL_VERIFY_DELAYS_MS[round];
+		if (nextDelay === undefined) break;
+		await delay(nextDelay);
+	}
+	// Let the final volley's SIGKILLs land before declaring survivors.
+	await delay(300);
+	const leftovers = collectProcessSignalTargets(rootPid, {
+		includeRoot: false,
+		ttyName: identity.ttyName,
+		knownPgids: identity.knownPgids,
+		table: await readProcessTableAsync(),
+	}).filter((t) => t.target === "pid");
+	if (leftovers.length > 0 || isRootAlive()) {
+		process.stderr.write(
+			`[pty-daemon] kill escalation for pid ${rootPid} left survivors: ` +
+				`root=${isRootAlive()} pids=[${leftovers.map((t) => t.id).join(",")}]\n`,
+		);
+	}
+}
 
 export type PtyOnData = (data: Buffer) => void;
 export type PtyOnExit = (info: {
@@ -46,7 +170,11 @@ class NodePtyAdapter implements Pty {
 	meta: SessionMeta;
 	private term: nodePty.IPty;
 	private exited = false;
-	private killEscalationTimer: NodeJS.Timeout | null = null;
+	private readonly identity: RootIdentity = {
+		ttyName: null,
+		knownPgids: new Set(),
+	};
+	private killChain: Promise<void> | null = null;
 	private exitInfo: { code: number | null; signal: number | null } | null =
 		null;
 	private exitCallbacks: PtyOnExit[] = [];
@@ -55,6 +183,17 @@ class NodePtyAdapter implements Pty {
 		this.term = term;
 		this.pid = term.pid;
 		this.meta = meta;
+		// Capture the group + tty: if the shell exits before the first kill,
+		// a ppid walk can't rediscover either, and orphans reparented to
+		// pid 1 keep the root pgid. Async — this is the session-open path.
+		// The immediate capture races the child's setsid/login_tty (it may
+		// still show the daemon's own pgid — collect's current-pgid guard
+		// covers that — and no tty), so re-capture once the child has
+		// certainly run; kill volleys refresh again from their own table.
+		void this.captureRootIdentity();
+		setTimeout(() => {
+			if (!this.exited) void this.captureRootIdentity();
+		}, 100).unref();
 		this.term.onExit(({ exitCode, signal }) => {
 			if (this.exited) return;
 			this.exited = true;
@@ -92,12 +231,19 @@ class NodePtyAdapter implements Pty {
 
 	kill(signal?: NodeJS.Signals): void {
 		const killSignal = signal ?? "SIGHUP";
-		const escalationTargets = signalProcessTreeAndGroups(this.pid, killSignal, {
-			includeRoot: false,
-			onSignalError: logProcessSignalError,
-		});
-		this.term.kill(killSignal);
-		this.scheduleKillEscalation(killSignal, escalationTargets);
+		killVolley(this.pid, killSignal, this.identity);
+		try {
+			this.term.kill(killSignal);
+		} catch {
+			// PTY root may have already exited; detached targets still matter.
+		}
+		this.startKillEscalation(killSignal);
+	}
+
+	private async captureRootIdentity(): Promise<void> {
+		const { pgid, tty: ttyName } = await getProcessGroupAndTty(this.pid);
+		if (ttyName !== null) this.identity.ttyName = ttyName;
+		if (pgid !== null) this.identity.knownPgids.add(pgid);
 	}
 
 	onData(cb: PtyOnData): void {
@@ -114,22 +260,21 @@ class NodePtyAdapter implements Pty {
 		this.exitCallbacks.push(cb);
 	}
 
-	private scheduleKillEscalation(
-		signal: NodeJS.Signals,
-		targets: ProcessSignalTarget[],
-	): void {
-		if (signal === "SIGKILL" || this.exited || this.killEscalationTimer) return;
-
-		this.killEscalationTimer = setTimeout(() => {
-			this.killEscalationTimer = null;
-			signalProcessTargets(targets, "SIGKILL", logProcessSignalError);
-			try {
-				this.term.kill("SIGKILL");
-			} catch {
-				// PTY root may have already exited; detached targets still matter.
-			}
-		}, KILL_ESCALATION_TIMEOUT_MS);
-		this.killEscalationTimer.unref();
+	private startKillEscalation(signal: NodeJS.Signals): void {
+		if (signal === "SIGKILL" || this.killChain) return;
+		this.killChain = runKillEscalation({
+			rootPid: this.pid,
+			identity: this.identity,
+			isRootAlive: () => !this.exited,
+			killRoot: () => {
+				try {
+					this.term.kill("SIGKILL");
+				} catch {
+					// already exited
+				}
+			},
+		});
+		registerPendingKill(this.killChain);
 	}
 }
 
@@ -231,13 +376,18 @@ class AdoptedPty implements Pty {
 	private readonly reader: tty.ReadStream;
 	private exitFired = false;
 	private livenessTimer: NodeJS.Timeout | null = null;
-	private killEscalationTimer: NodeJS.Timeout | null = null;
+	private readonly identity: RootIdentity = {
+		ttyName: null,
+		knownPgids: new Set(),
+	};
+	private killChain: Promise<void> | null = null;
 	private exitCallbacks: PtyOnExit[] = [];
 
 	constructor(fd: number, pid: number, meta: SessionMeta) {
 		this.fd = fd;
 		this.pid = pid;
 		this.meta = meta;
+		void this.captureRootIdentity();
 		this.reader = new tty.ReadStream(fd);
 
 		// onExit signal sources:
@@ -315,10 +465,20 @@ class AdoptedPty implements Pty {
 
 	kill(signal?: NodeJS.Signals): void {
 		const killSignal = signal ?? "SIGHUP";
-		const escalationTargets = signalProcessTreeAndGroups(this.pid, killSignal, {
-			onSignalError: logProcessSignalError,
-		});
-		this.scheduleKillEscalation(killSignal, escalationTargets);
+		killVolley(this.pid, killSignal, this.identity);
+		// No node-pty here — signal the adopted root directly.
+		try {
+			process.kill(this.pid, killSignal);
+		} catch {
+			// already dead
+		}
+		this.startKillEscalation(killSignal);
+	}
+
+	private async captureRootIdentity(): Promise<void> {
+		const { pgid, tty: ttyName } = await getProcessGroupAndTty(this.pid);
+		if (ttyName !== null) this.identity.ttyName = ttyName;
+		if (pgid !== null) this.identity.knownPgids.add(pgid);
 	}
 
 	onData(cb: PtyOnData): void {
@@ -331,18 +491,21 @@ class AdoptedPty implements Pty {
 		this.exitCallbacks.push(cb);
 	}
 
-	private scheduleKillEscalation(
-		signal: NodeJS.Signals,
-		targets: ProcessSignalTarget[],
-	): void {
-		if (signal === "SIGKILL" || this.exitFired || this.killEscalationTimer)
-			return;
-
-		this.killEscalationTimer = setTimeout(() => {
-			this.killEscalationTimer = null;
-			signalProcessTargets(targets, "SIGKILL", logProcessSignalError);
-		}, KILL_ESCALATION_TIMEOUT_MS);
-		this.killEscalationTimer.unref();
+	private startKillEscalation(signal: NodeJS.Signals): void {
+		if (signal === "SIGKILL" || this.killChain) return;
+		this.killChain = runKillEscalation({
+			rootPid: this.pid,
+			identity: this.identity,
+			isRootAlive: () => !this.exitFired && isPidAlive(this.pid),
+			killRoot: () => {
+				try {
+					process.kill(this.pid, "SIGKILL");
+				} catch {
+					// already dead
+				}
+			},
+		});
+		registerPendingKill(this.killChain);
 	}
 }
 

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -32,9 +32,16 @@ const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
  */
 const pendingKills = new Set<Promise<void>>();
 
-function registerPendingKill(chain: Promise<void>): void {
-	pendingKills.add(chain);
-	void chain.finally(() => pendingKills.delete(chain));
+/** Returns a never-rejecting wrapper so callers can chain without leaks. */
+function registerPendingKill(chain: Promise<void>): Promise<void> {
+	const tracked = chain.catch((err) => {
+		process.stderr.write(
+			`[pty-daemon] kill escalation crashed: ${(err as Error)?.stack ?? err}\n`,
+		);
+	});
+	pendingKills.add(tracked);
+	void tracked.then(() => pendingKills.delete(tracked));
+	return tracked;
 }
 
 export async function drainPendingKills(timeoutMs: number): Promise<void> {
@@ -80,7 +87,11 @@ function killVolley(
 	}
 	const targets = collectProcessSignalTargets(rootPid, {
 		includeRoot: false,
-		ttyName: identity.ttyName,
+		// tty targeting only while the root is alive in this same snapshot:
+		// the kernel recycles the pty slot the moment the master fd closes,
+		// so after root death a tty match can only ever hit a NEW session
+		// that inherited the slot (legit stragglers show "??" by then).
+		ttyName: rootRow ? identity.ttyName : null,
 		knownPgids: identity.knownPgids,
 		table: psTable,
 		onSignalError: logProcessSignalError,
@@ -113,8 +124,12 @@ async function runKillEscalation(opts: KillEscalationOptions): Promise<void> {
 	for (let round = 0; ; round++) {
 		const table = await readProcessTableAsync();
 		const rootAlive = isRootAlive();
-		const { survivors } = killVolley(rootPid, "SIGKILL", identity, table);
-		if (!survivors && !rootAlive) return;
+		if (table !== null) {
+			const { survivors } = killVolley(rootPid, "SIGKILL", identity, table);
+			if (!survivors && !rootAlive) return;
+		}
+		// A null table means ps failed — state unknown; keep the root kill
+		// and burn a round rather than concluding the kill is complete.
 		if (rootAlive) killRoot();
 		const nextDelay = KILL_VERIFY_DELAYS_MS[round];
 		if (nextDelay === undefined) break;
@@ -122,11 +137,19 @@ async function runKillEscalation(opts: KillEscalationOptions): Promise<void> {
 	}
 	// Let the final volley's SIGKILLs land before declaring survivors.
 	await delay(300);
+	const finalTable = await readProcessTableAsync();
+	if (finalTable === null) {
+		process.stderr.write(
+			`[pty-daemon] kill escalation for pid ${rootPid}: final ps failed, survivor state unknown\n`,
+		);
+		return;
+	}
+	const finalRootRow = finalTable.find((r) => r.pid === rootPid);
 	const leftovers = collectProcessSignalTargets(rootPid, {
 		includeRoot: false,
-		ttyName: identity.ttyName,
+		ttyName: finalRootRow ? identity.ttyName : null,
 		knownPgids: identity.knownPgids,
-		table: await readProcessTableAsync(),
+		table: finalTable,
 	}).filter((t) => t.target === "pid");
 	if (leftovers.length > 0 || isRootAlive()) {
 		process.stderr.write(
@@ -262,19 +285,25 @@ class NodePtyAdapter implements Pty {
 
 	private startKillEscalation(signal: NodeJS.Signals): void {
 		if (signal === "SIGKILL" || this.killChain) return;
-		this.killChain = runKillEscalation({
-			rootPid: this.pid,
-			identity: this.identity,
-			isRootAlive: () => !this.exited,
-			killRoot: () => {
-				try {
-					this.term.kill("SIGKILL");
-				} catch {
-					// already exited
-				}
-			},
+		const chain = registerPendingKill(
+			runKillEscalation({
+				rootPid: this.pid,
+				identity: this.identity,
+				isRootAlive: () => !this.exited,
+				killRoot: () => {
+					try {
+						this.term.kill("SIGKILL");
+					} catch {
+						// already exited
+					}
+				},
+			}),
+		);
+		this.killChain = chain;
+		// Reset when done so a retried close can escalate again.
+		void chain.then(() => {
+			if (this.killChain === chain) this.killChain = null;
 		});
-		registerPendingKill(this.killChain);
 	}
 }
 
@@ -493,19 +522,25 @@ class AdoptedPty implements Pty {
 
 	private startKillEscalation(signal: NodeJS.Signals): void {
 		if (signal === "SIGKILL" || this.killChain) return;
-		this.killChain = runKillEscalation({
-			rootPid: this.pid,
-			identity: this.identity,
-			isRootAlive: () => !this.exitFired && isPidAlive(this.pid),
-			killRoot: () => {
-				try {
-					process.kill(this.pid, "SIGKILL");
-				} catch {
-					// already dead
-				}
-			},
+		const chain = registerPendingKill(
+			runKillEscalation({
+				rootPid: this.pid,
+				identity: this.identity,
+				isRootAlive: () => !this.exitFired && isPidAlive(this.pid),
+				killRoot: () => {
+					try {
+						process.kill(this.pid, "SIGKILL");
+					} catch {
+						// already dead
+					}
+				},
+			}),
+		);
+		this.killChain = chain;
+		// Reset when done so a retried close can escalate again.
+		void chain.then(() => {
+			if (this.killChain === chain) this.killChain = null;
 		});
-		registerPendingKill(this.killChain);
 	}
 }
 

--- a/packages/pty-daemon/src/Pty/index.ts
+++ b/packages/pty-daemon/src/Pty/index.ts
@@ -5,4 +5,4 @@ export type {
 	PtyOnExit,
 	SpawnOptions,
 } from "./Pty.ts";
-export { adoptFromFd, spawn } from "./Pty.ts";
+export { adoptFromFd, drainPendingKills, spawn } from "./Pty.ts";

--- a/packages/pty-daemon/src/index.ts
+++ b/packages/pty-daemon/src/index.ts
@@ -5,6 +5,7 @@
 
 import packageJson from "../package.json" with { type: "json" };
 
+export { drainPendingKills } from "./Pty/index.ts";
 export { Server, type ServerOptions } from "./Server/index.ts";
 export type {
 	HandoffSnapshot,

--- a/packages/pty-daemon/src/main.ts
+++ b/packages/pty-daemon/src/main.ts
@@ -17,6 +17,7 @@
 
 import * as os from "node:os";
 import packageJson from "../package.json" with { type: "json" };
+import { drainPendingKills } from "./Pty/index.ts";
 import type { HandoffMessage } from "./protocol/index.ts";
 import { Server } from "./Server/index.ts";
 import { clearSnapshot, readSnapshot } from "./SessionStore/index.ts";
@@ -200,6 +201,9 @@ function wireShutdown(server: Server): void {
 		process.stderr.write(`[pty-daemon] received ${signal}, shutting down\n`);
 		try {
 			await server.close();
+			// A requested close may still be mid-escalation; process.exit()
+			// would drop it and leak the SIGHUP-trapping survivors.
+			await drainPendingKills(2000);
 		} catch (err) {
 			process.stderr.write(
 				`[pty-daemon] shutdown error: ${(err as Error).stack ?? err}\n`,

--- a/packages/pty-daemon/src/process-tree.test.ts
+++ b/packages/pty-daemon/src/process-tree.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { parseProcessTable } from "./process-tree.ts";
+
+describe("parseProcessTable", () => {
+	test("parses pid/ppid/pgid/tty columns", () => {
+		const rows = parseProcessTable(
+			[
+				"  100   1  100 ttys012  Ss",
+				"  200 100  100 ttys012  S",
+				"  300   1  300 ??       S",
+			].join("\n"),
+		);
+		expect(rows).toEqual([
+			{ pid: 100, ppid: 1, pgid: 100, tty: "ttys012" },
+			{ pid: 200, ppid: 100, pgid: 100, tty: "ttys012" },
+			{ pid: 300, ppid: 1, pgid: 300, tty: null },
+		]);
+	});
+
+	test("normalizes no-tty markers to null", () => {
+		for (const marker of ["??", "?", "-"]) {
+			const rows = parseProcessTable(`  100   1  100 ${marker}  S`);
+			expect(rows[0]?.tty).toBeNull();
+		}
+	});
+
+	test("drops zombie rows", () => {
+		const rows = parseProcessTable(
+			["  100   1  100 ttys000  Ss", "  200 100  100 ttys000  Z"].join("\n"),
+		);
+		expect(rows.map((r) => r.pid)).toEqual([100]);
+	});
+
+	test("drops malformed rows", () => {
+		const rows = parseProcessTable(
+			["garbage", "  0  1  1 ?? S", "  100  1  0 ?? S", ""].join("\n"),
+		);
+		expect(rows).toEqual([]);
+	});
+});

--- a/packages/pty-daemon/src/process-tree.ts
+++ b/packages/pty-daemon/src/process-tree.ts
@@ -128,18 +128,34 @@ export function signalProcessTargets(
 }
 
 const PS_TABLE_ARGS = ["-axo", "pid=,ppid=,pgid=,tty=,stat="];
+// Bound every ps: a hung ps (stale NFS mount, kernel proc stalls) must fail
+// the read, not wedge the kill chain or the daemon shutdown drain.
+const PS_TIMEOUT_MS = 5_000;
 
 export function readProcessTable(): ProcessInfo[] {
-	const result = spawnSync("ps", PS_TABLE_ARGS, { encoding: "utf8" });
+	const result = spawnSync("ps", PS_TABLE_ARGS, {
+		encoding: "utf8",
+		timeout: PS_TIMEOUT_MS,
+	});
 	if (result.error || result.status !== 0) return [];
 	return parseProcessTable(result.stdout);
 }
 
-export function readProcessTableAsync(): Promise<ProcessInfo[]> {
+/**
+ * Resolves null when ps itself fails — callers making liveness decisions
+ * (e.g. "no survivors, stop escalating") must treat null as unknown, never
+ * as an empty table.
+ */
+export function readProcessTableAsync(): Promise<ProcessInfo[] | null> {
 	return new Promise((resolve) => {
-		execFile("ps", PS_TABLE_ARGS, { encoding: "utf8" }, (error, stdout) => {
-			resolve(error ? [] : parseProcessTable(stdout));
-		});
+		execFile(
+			"ps",
+			PS_TABLE_ARGS,
+			{ encoding: "utf8", timeout: PS_TIMEOUT_MS },
+			(error, stdout) => {
+				resolve(error ? null : parseProcessTable(stdout));
+			},
+		);
 	});
 }
 
@@ -189,7 +205,7 @@ export function getProcessGroupAndTty(
 		execFile(
 			"ps",
 			["-o", "pgid=,tty=", "-p", String(pid)],
-			{ encoding: "utf8" },
+			{ encoding: "utf8", timeout: PS_TIMEOUT_MS },
 			(error, stdout) => {
 				if (error) return resolve({ pgid: null, tty: null });
 				const [pgidText, ttyText] = stdout.trim().split(/\s+/);

--- a/packages/pty-daemon/src/process-tree.ts
+++ b/packages/pty-daemon/src/process-tree.ts
@@ -1,9 +1,11 @@
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 
 export interface ProcessInfo {
 	pid: number;
 	ppid: number;
 	pgid: number;
+	/** Controlling terminal name as ps reports it (e.g. "ttys012"), or null for none ("??"). */
+	tty: string | null;
 }
 
 export interface ProcessSignalError {
@@ -28,6 +30,24 @@ export interface SignalProcessTreeAndGroupsOptions {
 	signalGroups?: boolean;
 	signalPids?: boolean;
 	excludeCurrentProcessGroup?: boolean;
+	/**
+	 * Also target live processes whose controlling terminal matches — catches
+	 * descendants that reparented to pid 1 in a new process group but kept
+	 * the session's tty.
+	 */
+	ttyName?: string | null;
+	/**
+	 * Also target live members of these process groups — groups recorded on
+	 * earlier kill passes. A ppid walk can't rediscover a group once its
+	 * last tree-reachable member died, but reparented stragglers keep it.
+	 */
+	knownPgids?: ReadonlySet<number>;
+	/**
+	 * Pre-read process table. Pass one (from readProcessTableAsync) when
+	 * calling from the daemon's async paths — the sync fallback blocks the
+	 * event loop for the duration of a ps spawn.
+	 */
+	table?: ProcessInfo[];
 	onSignalError?: (error: ProcessSignalError) => void;
 }
 
@@ -51,12 +71,20 @@ export function collectProcessSignalTargets(
 	const signalGroups = options.signalGroups ?? true;
 	const signalPids = options.signalPids ?? true;
 	const excludeCurrentProcessGroup = options.excludeCurrentProcessGroup ?? true;
-	const table = readProcessTable();
+	const table = options.table ?? readProcessTable();
 	const currentPgid = excludeCurrentProcessGroup
 		? getProcessGroupId(process.pid, table)
 		: null;
 	const rootPgid = getProcessGroupId(rootPid, table);
 	const pids = collectProcessTree(rootPid, table);
+	for (const row of table) {
+		if (pids.has(row.pid)) continue;
+		if (row.pid === process.pid) continue;
+		if (currentPgid !== null && row.pgid === currentPgid) continue;
+		const onSessionTty = options.ttyName != null && row.tty === options.ttyName;
+		const inKnownGroup = options.knownPgids?.has(row.pgid) ?? false;
+		if (onSessionTty || inKnownGroup) pids.add(row.pid);
+	}
 	const infoByPid = new Map(table.map((row) => [row.pid, row]));
 	const pgids = new Set<number>();
 	const targets: ProcessSignalTarget[] = [];
@@ -99,18 +127,30 @@ export function signalProcessTargets(
 	}
 }
 
-export function readProcessTable(): ProcessInfo[] {
-	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid="], {
-		encoding: "utf8",
-	});
-	if (result.error || result.status !== 0) return [];
+const PS_TABLE_ARGS = ["-axo", "pid=,ppid=,pgid=,tty=,stat="];
 
-	return result.stdout
+export function readProcessTable(): ProcessInfo[] {
+	const result = spawnSync("ps", PS_TABLE_ARGS, { encoding: "utf8" });
+	if (result.error || result.status !== 0) return [];
+	return parseProcessTable(result.stdout);
+}
+
+export function readProcessTableAsync(): Promise<ProcessInfo[]> {
+	return new Promise((resolve) => {
+		execFile("ps", PS_TABLE_ARGS, { encoding: "utf8" }, (error, stdout) => {
+			resolve(error ? [] : parseProcessTable(stdout));
+		});
+	});
+}
+
+export function parseProcessTable(stdout: string): ProcessInfo[] {
+	return stdout
 		.split("\n")
 		.map((line) => line.trim())
 		.filter(Boolean)
 		.flatMap((line) => {
-			const [pidText, ppidText, pgidText] = line.split(/\s+/);
+			const [pidText, ppidText, pgidText, ttyText, statText] =
+				line.split(/\s+/);
 			if (
 				pidText === undefined ||
 				ppidText === undefined ||
@@ -118,6 +158,10 @@ export function readProcessTable(): ProcessInfo[] {
 			) {
 				return [];
 			}
+			// Zombies are unkillable and childless (their children already
+			// reparented); including them would make verify passes see
+			// permanent "survivors".
+			if (statText?.startsWith("Z")) return [];
 			const pid = Number(pidText);
 			const ppid = Number(ppidText);
 			const pgid = Number(pgidText);
@@ -125,8 +169,46 @@ export function readProcessTable(): ProcessInfo[] {
 				return [];
 			}
 			if (!isPositiveInteger(pgid)) return [];
-			return [{ pid, ppid, pgid }];
+			return [{ pid, ppid, pgid, tty: normalizeTtyName(ttyText) }];
 		});
+}
+
+/**
+ * Process group + controlling terminal of a process (tty e.g. "ttys012",
+ * null if none). Captured at session spawn so later kill passes can target
+ * stragglers by group membership or tty after the ppid tree is gone.
+ * Async on purpose: this runs on the daemon's session-open path, where a
+ * spawnSync would stall every session's output for the ps duration.
+ */
+export function getProcessGroupAndTty(
+	pid: number,
+): Promise<{ pgid: number | null; tty: string | null }> {
+	if (!isPositiveInteger(pid))
+		return Promise.resolve({ pgid: null, tty: null });
+	return new Promise((resolve) => {
+		execFile(
+			"ps",
+			["-o", "pgid=,tty=", "-p", String(pid)],
+			{ encoding: "utf8" },
+			(error, stdout) => {
+				if (error) return resolve({ pgid: null, tty: null });
+				const [pgidText, ttyText] = stdout.trim().split(/\s+/);
+				const pgid = Number(pgidText);
+				resolve({
+					pgid: isPositiveInteger(pgid) ? pgid : null,
+					tty: normalizeTtyName(ttyText),
+				});
+			},
+		);
+	});
+}
+
+function normalizeTtyName(raw: string | undefined): string | null {
+	if (!raw) return null;
+	// ps prints "??" (macOS) or "?" (Linux) for processes with no
+	// controlling terminal; "-" shows up in some BSD ps variants.
+	if (raw === "??" || raw === "?" || raw === "-") return null;
+	return raw;
 }
 
 /**

--- a/packages/pty-daemon/test/integration.test.ts
+++ b/packages/pty-daemon/test/integration.test.ts
@@ -121,7 +121,7 @@ test("adoptFromFd validates inputs", () => {
 	);
 });
 
-test("adoptFromFd wraps a real PTY master fd without crashing", () => {
+test("adoptFromFd wraps a real PTY master fd without crashing", async () => {
 	// API-surface check only. End-to-end I/O on an adopted fd is validated
 	// in the cross-process handoff integration test — in this test process,
 	// node-pty's native worker is actively reading from the master fd, so
@@ -130,19 +130,33 @@ test("adoptFromFd wraps a real PTY master fd without crashing", () => {
 	const original = spawnPty({
 		meta: { shell: "/bin/sh", argv: ["-c", "sleep 1"], cols: 80, rows: 24 },
 	});
+	// Adopt a /dev/fd dup, not node-pty's own fd: AdoptedPty owns (and
+	// closes) the fd it's given, and closing node-pty's copy under its
+	// internal ReadStream surfaces as an uncaught EBADF. Only this test
+	// double-owns a master fd; a real successor daemon owns it exclusively.
+	const dupFd = fs.openSync(`/dev/fd/${original.getMasterFd()}`, "r+");
+	let adopted: ReturnType<typeof adoptFromFd> | null = null;
 	try {
-		const adopted = adoptFromFd({
-			fd: original.getMasterFd(),
+		adopted = adoptFromFd({
+			fd: dupFd,
 			pid: original.pid,
 			meta: original.meta,
 		});
 		assert.equal(adopted.pid, original.pid);
-		assert.equal(adopted.getMasterFd(), original.getMasterFd());
+		assert.equal(adopted.getMasterFd(), dupFd);
 		// resize updates meta but not kernel-side window (TODO: koffi ioctl)
 		adopted.resize(120, 40);
 		assert.equal(adopted.meta.cols, 120);
 		assert.equal(adopted.meta.rows, 40);
 	} finally {
 		original.kill("SIGKILL");
+		// Let both sides observe the exit inside the test window so no
+		// async tail gets attributed to after-test activity.
+		await Promise.all([
+			new Promise<void>((r) => original.onExit(() => r())),
+			new Promise<void>((r) => {
+				adopted ? adopted.onExit(() => r()) : r();
+			}),
+		]);
 	}
 });

--- a/packages/pty-daemon/test/kill-tree.test.ts
+++ b/packages/pty-daemon/test/kill-tree.test.ts
@@ -1,0 +1,223 @@
+// Kill-path integration tests with real PTYs and real process trees.
+// Each scenario is an escape class the tree kill must close:
+//
+//   1. orphan-same-pgid  — descendant's parent exited; the orphan reparented
+//      to pid 1 but kept the session leader's pgid. Must die on the first
+//      volley via the recorded root pgid.
+//   2. fork-during-escalation — HUP-trapping shell forks a new-pgid child
+//      after the first volley. Must die because escalation re-snapshots
+//      instead of replaying the stale target list.
+//   3. tty-straggler — new-pgid child whose parent subshell exited before
+//      the kill: not in the ppid tree, group never observed. Must die via
+//      controlling-tty targeting.
+//
+// Runs under Node (`node --experimental-strip-types --test`): node-pty's
+// native binding requires the Node ABI.
+
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import { after, describe, test } from "node:test";
+import { spawn } from "../src/Pty/index.ts";
+import type { SessionMeta } from "../src/protocol/index.ts";
+
+interface PsRow {
+	pid: number;
+	ppid: number;
+	pgid: number;
+	tty: string;
+	command: string;
+}
+
+const trackedPgids = new Set<number>();
+
+function ps(): PsRow[] {
+	const out = spawnSync("ps", ["-axo", "pid=,ppid=,pgid=,tty=,command="], {
+		encoding: "utf8",
+	}).stdout;
+	return out
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean)
+		.map((l) => {
+			const m = l.split(/\s+/);
+			return {
+				pid: Number(m[0]),
+				ppid: Number(m[1]),
+				pgid: Number(m[2]),
+				tty: m[3] ?? "??",
+				command: m.slice(4).join(" "),
+			};
+		})
+		.filter((r) => Number.isInteger(r.pid) && r.pid > 0);
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor<T>(
+	label: string,
+	fn: () => T | undefined,
+	timeoutMs: number,
+): Promise<T> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		const value = fn();
+		if (value !== undefined) return value;
+		if (Date.now() > deadline) throw new Error(`timed out waiting: ${label}`);
+		// 250ms: full-table ps polls at a tighter cadence destabilize the
+		// other suites running in parallel with this one.
+		await sleep(250);
+	}
+}
+
+function spawnScript(script: string) {
+	const meta: SessionMeta = {
+		shell: "/bin/bash",
+		argv: ["-c", script],
+		cols: 80,
+		rows: 24,
+	};
+	const pty = spawn({ meta });
+	trackedPgids.add(pty.pid);
+	const output: string[] = [];
+	pty.onData((d) => output.push(d.toString("utf8")));
+	return {
+		pty,
+		getOutput: () => output.join(""),
+		waitForMarker: (marker: string, timeoutMs = 8000) =>
+			waitFor(
+				`marker ${marker}`,
+				() => (output.join("").includes(marker) ? true : undefined),
+				timeoutMs,
+			),
+	};
+}
+
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+after(() => {
+	// Belt and braces: nuke every group the tests created.
+	for (const pgid of trackedPgids) {
+		try {
+			process.kill(-pgid, "SIGKILL");
+		} catch {
+			// already gone
+		}
+	}
+	for (const row of ps()) {
+		if (row.command.startsWith("sleep 3")) {
+			// stray sleeper from a failed run — only ours use 300/333/344s
+			if (["sleep 300", "sleep 333", "sleep 344"].includes(row.command)) {
+				try {
+					process.kill(row.pid, "SIGKILL");
+				} catch {
+					// already gone
+				}
+			}
+		}
+	}
+});
+
+describe("PTY tree kill", () => {
+	test("kills an orphan that reparented to pid 1 but kept the root pgid", async () => {
+		// The orphan ignores SIGHUP (SIG_IGN survives exec): the kernel's
+		// foreground-group HUP on session-leader death does NOT reap it, so
+		// only the escalation's pid-level SIGKILL via the recorded root pgid
+		// can. A default-disposition orphan would die to the kernel HUP and
+		// prove nothing.
+		const { pty, waitForMarker } = spawnScript(
+			"( bash -c 'trap \"\" HUP; exec sleep 300' & ); echo READY; exec sleep 344",
+		);
+		await waitForMarker("READY");
+		const orphan = await waitFor(
+			"orphan in root pgid",
+			() =>
+				ps().find(
+					(r) =>
+						r.command === "sleep 300" && r.pgid === pty.pid && r.ppid === 1,
+				),
+			8000,
+		);
+
+		pty.kill();
+
+		await waitFor(
+			"orphan killed",
+			() => (isPidAlive(orphan.pid) ? undefined : true),
+			8000,
+		);
+	});
+
+	test("kills a new-pgid child forked after the first volley (re-snapshot)", async () => {
+		// The HUP trap itself forks the escaper and echoes its pid, so it is
+		// born after the first volley's snapshot by construction (the trap
+		// runs on the volley's own SIGHUP) — only an escalation re-snapshot
+		// can find it, through the still-alive shell's ppid link. bash blocks
+		// in the `wait` builtin so the trap runs the instant the signal
+		// lands, and the wait loop keeps bash alive afterwards: if the shell
+		// exited, the session tty would dissolve and the new-pgid escaper
+		// would join the untraceable daemonizer class no kill path can see.
+		const { pty, waitForMarker, getOutput } = spawnScript(
+			"set -m; trap 'sleep 333 & echo SPAWNED:$!' HUP; echo READY; sleep 500 & while :; do wait; done",
+		);
+		await waitForMarker("READY");
+
+		pty.kill(); // the volley's own SIGHUP triggers the trap
+
+		await waitForMarker("SPAWNED:", 5000);
+		const match = /SPAWNED:(\d+)/.exec(getOutput());
+		assert.ok(match?.[1], "setup: trap should echo the escaper pid");
+		const escaperPid = Number(match[1]);
+
+		// Escalation fires at ~1s and must re-snapshot to see this process.
+		await waitFor(
+			"escaper killed",
+			() => (isPidAlive(escaperPid) ? undefined : true),
+			8000,
+		);
+		await waitFor(
+			"trapped shell killed",
+			() => (isPidAlive(pty.pid) ? undefined : true),
+			4000,
+		);
+	});
+
+	test("kills a straggler findable only by controlling tty", async () => {
+		const { pty, waitForMarker } = spawnScript(
+			"set -m; ( sleep 300 & ); echo READY; exec sleep 344",
+		);
+		await waitForMarker("READY");
+		const rootRow = await waitFor(
+			"root row",
+			() => ps().find((r) => r.pid === pty.pid),
+			5000,
+		);
+		const straggler = await waitFor(
+			"tty straggler",
+			() =>
+				ps().find(
+					(r) =>
+						r.command === "sleep 300" &&
+						r.tty === rootRow.tty &&
+						r.ppid === 1 &&
+						r.pgid !== pty.pid,
+				),
+			8000,
+		);
+		trackedPgids.add(straggler.pgid);
+
+		pty.kill();
+
+		await waitFor(
+			"straggler killed",
+			() => (isPidAlive(straggler.pid) ? undefined : true),
+			8000,
+		);
+	});
+});

--- a/plans/pty-lifecycle-cleanup.md
+++ b/plans/pty-lifecycle-cleanup.md
@@ -1,0 +1,96 @@
+# PTY accumulation & terminal lifecycle cleanup
+
+User report: M1 Max hits the macOS PTY-master limit (509/511) after 4–7 parallel workspaces. 16 daemon sessions with 103 descendant processes; largest 7hr old, 42 processes, 5.4 GB. Renderer crawls. Reproduces with Claude and Codex. v1 felt faster.
+
+## Progress (2026-07-17)
+
+- [x] **PR 1 — daemon kill hardening**: implemented + verified on branch `pty-lifecycle-diagnosis` (uncommitted). Full `test:integration` 3/3 green, unit 61/61, lint/typecheck clean; each new kill-tree test proven to fail on the old implementation. Details in the PR 1 section below.
+- [ ] **PR 2 — reliable dispose** (renderer awaits + `disposeRequestedAt` retry): not started.
+- [ ] **Backstops** (liveness reaping, idle TTL + cap, renderer park=disconnect, registry reconcile): deferred until PR 1+2 are measured in the wild.
+
+## Root cause (TLDR)
+
+The per-terminal kill path is solid. Accumulation comes from everything around it:
+
+1. **No idle/TTL reaping, no session cap** — a daemon session lives forever unless its DB row is explicitly marked dead.
+2. **Reaper only kills on deleted-workspace FK set-null** — closed-but-not-deleted workspaces, or any missed dispose, leak forever.
+3. **Workspace-close dispose is fire-and-forget** — a transient host-service failure silently leaks all sessions.
+4. **Prod app-quit kills nothing by design** — detached daemon + all descendants survive.
+5. **Daemonizing descendants (double-fork + setsid) escape the tree kill** — MCP servers, build daemons, watchers.
+6. **Renderer: parked ≠ disconnected** — every visited terminal keeps a live WS, xterm instance, 5s timer, and live output parsing forever.
+
+## Findings by area
+
+### 1. Terminal close kill path (works, with escapes)
+
+Tab close branches at `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx:342-351`:
+- background intent → `release()` — park, no kill
+- default → `dispose()` + tRPC `terminal.killSession`
+
+Host-service `disposeSessionAndWait` (`packages/host-service/src/terminal/terminal.ts:738-826`) → daemon `{type:"close", signal:"SIGHUP"}` (`packages/pty-daemon/src/handlers/handlers.ts:116-130`; SIGHUP because `zsh -l` traps SIGTERM) → `NodePtyAdapter.kill` (`packages/pty-daemon/src/Pty/Pty.ts:93-101`):
+- `signalProcessTreeAndGroups` (`packages/pty-daemon/src/process-tree.ts:34-90`): full ppid tree walk via `ps -axo pid,ppid,pgid`, signals every descendant pid AND `kill(-pgid)` per descendant group; SIGKILL escalation after 1s to the same target set (`Pty.ts:117-133`).
+
+**Escapes:**
+- Double-fork + setsid daemonizers: reparent to pid 1 + fresh pgid → invisible to both the ppid walk and the group set. Explains the 7hr orphan trees.
+- Snapshot race: SIGKILL reuses the target set captured at SIGHUP time; anything forked in the 1s window slips through (agent MCP spawn bursts).
+- `.unref()`'d escalation timer (`Pty.ts:132`): SIGHUP-trapping shell survives if the daemon is exiting.
+
+### 2. Workspace close/delete cleanup (the weak link)
+
+- `useCloseWorkspace.ts:114` / `useDeleteWorkspace.ts:94` fire `void disposeHostSessionsForWorkspace(...)` — fire-and-forget broadcast that swallows all errors (`renderer/lib/dispose-host-sessions.ts:24-43`).
+- Electron `workspaces.close` (`apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts:345-369`) kills only main-process terminals; `deleteWorktree` (`delete.ts:456-556`) does no terminal kill at all — relies on the renderer broadcast.
+- Worktree removal never kills by actual process cwd — disposal keyed on DB workspace→worktreePath mapping only (`terminal.ts:882-899`); `git worktree remove --force` deletes the dir under running shells.
+- The enumerate-and-kill logic itself is correct when reached: `disposeSessionsByWorkspaceId` (`terminal.ts:835-875`).
+
+### 3. Daemon orphan tracking: none
+
+- `SessionStore` (`packages/pty-daemon/src/SessionStore/SessionStore.ts`): in-memory Map, no TTL, no idle tracking, no max-session limit. Zero-subscriber sessions indistinguishable from active.
+- Reaper (`packages/host-service/src/terminal/reaper/reaper.ts`, 5 min): kills only if row is `disposed`/`exited`/null `originWorkspaceId`, or rowless (two-pass). "Workspace gone" reaches it only via FK `onDelete: "set null"` (`packages/host-service/src/db/schema.ts:20-22`) — i.e. only on actual local workspace row deletion. Active row + live workspace id = immortal session, re-adopted for port scanning forever.
+- macOS ~511 PTY ceiling: no guard; surfaces as `ESPAWN` at next open (`handlers.ts:60-66`).
+
+### 4. Renderer slowdown: parked ≠ disconnected
+
+Registry is a module-level singleton outliving React (`terminal-runtime-registry.ts:467-470`). Pane unmount calls `detach` → parks DOM, keeps WS + xterm alive (`terminal-runtime.ts:319-331`). Per parked session, forever:
+- Live WS + reconnect loop; 5s liveness `setInterval` (`terminal-ws-transport.ts:277,311-319`); 3 global focus/online/visibility listeners (`:321-331`). Focus fans out reconnects to all N transports, no jitter/cap (v1 capped at 3, `attach-scheduler.ts:11`) → Chromium WS handshake throttle bursts.
+- Host keeps broadcasting live PTY output to hidden terminals (parked sockets stay in `sockets` set, `terminal.ts:221`); renderer parses it into xterm every RAF (`terminal-ws-transport.ts:513-530`). Chatty hidden agents = linear invisible CPU drain. The 8 MB `bufferedAmount` cap is a safety valve, not flow-hold.
+- 5000-line scrollback per retained xterm (`shared/constants.ts:42`) — linear aggregate memory.
+- Cleanup is layout-driven, no reconcile: registry entries whose pane vanished abnormally leak transport + timer (`useDashboardSidebarState.ts:180-187` vs `registry.getAllTerminalIds()`).
+
+### 5. v1 vs v2
+
+v1 PTYs were Electron children (`apps/desktop/src/main/lib/terminal/session.ts:70`): app quit = free SIGHUP reaping; one IPC hop. v2 = detached org daemon (`DaemonSupervisor.ts:1067`, `detached: !isDev`) via renderer → relay WS → host-service → unix socket → daemon. v2 replaced OS-level cleanup with "explicit kill + reaper", and the reaper's trigger condition is the missing half.
+
+### 6. MCP/agent subprocess cleanup
+
+No dedicated cleanup anywhere — agents run inside the PTY shell; cleanup relies 100% on the tree/group kill. Fine for well-behaved children; wrong for daemonizers and the snapshot race.
+
+## Fix plan (kill-path-first, revised)
+
+Direction: make the kill path airtight at kill time before adding any new reaping machinery. Sweeps stay as a later backstop only.
+
+### PR 1 — daemon kill hardening (`Pty.ts`, `process-tree.ts`) — IMPLEMENTED
+
+1. **Re-snapshot at SIGKILL escalation** ✓: every escalation round re-reads the process table (async) instead of replaying the SIGHUP-time target list — closes the fork-window race.
+2. **Verify-and-repeat with backoff** ✓: rounds at 1s then +0.3/0.7/1.5/2.5s (~6s window for loaded machines); early-exit when clean so a normal kill pays one extra ps; stderr warning if survivors remain.
+3. **Kill by controlling tty + durable pgids** ✓: `RootIdentity` per session (tty + every pgid ever observed, seeded async at spawn, refreshed from each volley's own table); volleys target tree ∪ known-group members ∪ same-tty rows. Also fixed: the `includeRoot:false` path never group-signaled the root's own pgid, so same-pgid orphans (`npm` grandchildren) leaked — now pid-targeted via knownPgids.
+4. **No dropped escalations** ✓: kill-chain timers are ref'd, and `main.ts` shutdown awaits `drainPendingKills(2000)` before `process.exit`.
+
+Perf constraint learned the hard way: all identity capture is **async** (`execFile`) — a spawnSync ps on the session-open path stalls the daemon's event loop and broke multi-client output delivery under load.
+
+**Discovered residual**: when the session leader *exits*, the controlling tty dissolves (`ps` shows `??`) — a child forked into a new pgid around leader death is untraceable by any kill path (same class as setsid daemonizers). Backstop remains the TTL reaper (item 8).
+
+Tests: `test/kill-tree.test.ts` (real-PTY node tests, one per escape class, each verified to fail on the old implementation) + `src/process-tree.test.ts` (parsing).
+
+### PR 2 — reliable dispose (kill the fire-and-forget)
+
+Host already awaits kills and returns `{terminated, failed}` (`disposeSessionsByWorkspaceId`, `terminal.ts:835-875`); the result is discarded at the renderer boundary.
+
+5. **Renderer awaits and surfaces**: `disposeHostSessionsForWorkspace` returns aggregated counts + RPC errors; `useCloseWorkspace`/`useDeleteWorkspace` await it. Close still proceeds; failure → actionable toast with Retry.
+6. **Durable retry via `disposeRequestedAt`**: stamp the row when dispose is requested; failed kills keep the stamp and the *existing* 5-min reaper retries them regardless of workspace liveness. Records intent-to-kill durably — no new sweep, no heuristics. (Today a failed kill on close leaves an `active` row the reaper never matches while the workspace row exists — immortal.)
+
+### Later — backstops (only after 1–6 measured)
+
+7. **Reap by liveness** (`reaper.ts` predicate widening): kill sessions whose workspace row is gone or worktreePath deleted. Covers renderer-crashed-before-broadcast and older-build leftovers — the one class PR 2 can't reach.
+8. **Idle TTL + session cap in the daemon**: zero-subscriber idle > ~12h reaped; cap well below 511 with oldest-idle eviction. Covers true `daemon()` escapees (setsid + closed fds — invisible to any kill path).
+9. **Renderer: park = disconnect** — close WS on detach, replay host 64 KB tail on reattach; jitter + concurrency cap (3) on resume-reconnect fan-out. Addresses the machine-wide slowdown.
+10. **Registry reconcile pass**: diff `registry.getAllTerminalIds()` against live pane layouts; release orphans.


### PR DESCRIPTION
## Summary

First PR of the PTY-accumulation cleanup (`plans/pty-lifecycle-cleanup.md`): make the daemon's tree kill airtight at kill time. Context: users hit the macOS ~511 PTY ceiling after a few parallel workspaces, with 100+ descendant processes surviving terminal closes.

- **Re-snapshot at SIGKILL escalation** — escalation rounds re-read the process table (async) instead of replaying the SIGHUP-time target list, closing the fork-window race (agent MCP spawn bursts).
- **Verify-and-repeat with backoff** — SIGKILL rounds at 1s then +0.3/0.7/1.5/2.5s (~6s coverage for loaded machines), early-exit when clean so a normal kill pays one extra `ps`; stderr warning if survivors remain.
- **Durable root identity (tty + pgids)** — each session records its controlling tty and every pgid ever observed (seeded async at spawn, refreshed from each volley's own table). Volleys target tree ∪ known-group members ∪ same-tty stragglers, so reparented orphans and pgid-escapees die too. This also fixes a real hole: the `includeRoot:false` kill path never group-signaled the root's own pgid, leaking same-pgid orphans (e.g. `npm` grandchildren).
- **No dropped escalations** — kill-chain timers are ref'd and daemon shutdown drains in-flight kill chains (bounded 2s) before `process.exit`, so a SIGHUP-trapping shell can't outlive a daemon that exits mid-kill.

All identity capture is async (`execFile`) — a `spawnSync ps` on the session-open path stalls the daemon event loop and measurably broke multi-client output delivery under load.

Known residual (documented in the plan): a child forked into a new pgid around session-leader death is untraceable by any kill path (tty dissolves on leader exit) — that class stays with the TTL-reaper backstop.

## Test Plan

- [x] `test/kill-tree.test.ts`: real-PTY scenarios, one per escape class (HUP-immune orphan in root pgid, fork-during-escalation via HUP trap, tty-only straggler) — each verified to fail against the old implementation
- [x] `src/process-tree.test.ts`: ps table parsing (tty column, zombie/malformed row filtering)
- [x] Full `bun run test:integration` (52 tests) green 3/3 consecutive runs; `bun run test` 61/61
- [x] Repo-wide `bun run lint` and `bun run typecheck` clean

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5748">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens terminal kill behavior in `@superset/pty-daemon` to reliably reap descendants and prevent PTY accumulation. Adds re-snapshot SIGKILL escalation, tty/pgid straggler targeting, shutdown drain, and a shared `TreeKiller` to unify kill orchestration across PTY adapters.

- **Bug Fixes**
  - Re-snapshots the process table on each SIGKILL round, with verify backoffs and early exit when clean; logs survivors if any remain.
  - Records the root’s controlling tty and all seen pgids; targets tree ∪ known groups ∪ same-tty processes; only tty-targets while the root is present in the snapshot to avoid PTY reuse; fixes missing root-pgid signaling in `includeRoot:false`.
  - Prevents dropped escalations by keeping chains ref’d and awaiting `drainPendingKills(2000)` during shutdown in both the daemon and the desktop wrapper; `killChain` resets so retried closes re-escalate; exports `drainPendingKills`.
  - Uses async, timeout-bounded `ps` for identity capture and snapshots; filters zombies; treats `ps` failures as unknown so escalation never falsely concludes clean.
  - Adds real-PTY integration tests for orphan-same-pgid, fork-during-escalation, and tty-straggler cases, plus parser unit tests; updates test scripts to include them.

<sup>Written for commit 8bd0c5d78d6acb145a3b2d9c566664e22c5f4301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - More reliably terminate orphaned, newly spawned, and terminal-associated processes using controlling-terminal aware targeting and iterative escalation.
  - Strengthened kill escalation to re-evaluate process state until survivors are gone.
  - Improved graceful shutdown to wait for any in-progress kill escalations to finish.

- **Tests**
  - Added unit tests for process-table parsing (TTY extraction, normalization, and zombie filtering).
  - Added integration tests covering PTY process-tree “escape” scenarios.
  - Expanded the test suite and integration coverage.

- **Documentation**
  - Added a PTY lifecycle cleanup/remediation plan document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->