### PR TITLE
fix(desktop): project settings v1/v2 visibility and location field layout

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/projects/components/ProjectsSettingsSidebar/ProjectsSettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/projects/components/ProjectsSettingsSidebar/ProjectsSettingsSidebar.tsx
@@ -3,6 +3,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { Link } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { env } from "renderer/env.renderer";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
@@ -30,6 +31,7 @@ export function ProjectsSettingsSidebar({
 }: ProjectsSettingsSidebarProps) {
 	const collections = useCollections();
 	const { data: session } = authClient.useSession();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION
 		? MOCK_ORG_ID
@@ -54,32 +56,24 @@ export function ProjectsSettingsSidebar({
 	);
 
 	const listGroups = useMemo<Array<SettingsListGroup<ProjectRow>>>(() => {
-		const loadedV2Ids = new Set(v2Projects.map((p) => p.id));
-
-		const v2Rows: ProjectRow[] = v2Projects.map((p) => ({
-			kind: "v2",
-			id: p.id,
-			name: p.name,
-			iconUrl: p.iconUrl ?? null,
-		}));
-
-		const v1Rows: ProjectRow[] = groups
-			.filter(
-				(g) =>
-					!g.project.neonProjectId || !loadedV2Ids.has(g.project.neonProjectId),
-			)
-			.map((g) => ({
-				kind: "v1",
-				id: g.project.id,
-				name: g.project.name,
-				iconUrl: g.project.iconUrl,
+		if (isV2CloudEnabled) {
+			const v2Rows: ProjectRow[] = v2Projects.map((p) => ({
+				kind: "v2",
+				id: p.id,
+				name: p.name,
+				iconUrl: p.iconUrl ?? null,
 			}));
+			return [{ id: "v2", title: "v2", rows: v2Rows }];
+		}
 
-		return [
-			{ id: "v2", title: "v2", rows: v2Rows },
-			{ id: "v1", title: "v1", rows: v1Rows },
-		];
-	}, [groups, v2Projects]);
+		const v1Rows: ProjectRow[] = groups.map((g) => ({
+			kind: "v1",
+			id: g.project.id,
+			name: g.project.name,
+			iconUrl: g.project.iconUrl,
+		}));
+		return [{ id: "v1", title: "v1", rows: v1Rows }];
+	}, [groups, v2Projects, isV2CloudEnabled]);
 
 	return (
 		<SettingsListSidebar

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/projects/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/projects/page.tsx
@@ -3,6 +3,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo } from "react";
 import { env } from "renderer/env.renderer";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -16,6 +17,7 @@ function ProjectsIndexPage() {
 	const collections = useCollections();
 	const { data: session } = authClient.useSession();
 	const navigate = useNavigate();
+	const isV2CloudEnabled = useIsV2CloudEnabled();
 
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION
 		? MOCK_ORG_ID
@@ -39,21 +41,18 @@ function ProjectsIndexPage() {
 	);
 
 	const firstProjectId = useMemo(() => {
-		const v2Sorted = [...v2Projects].sort((a, b) =>
-			a.name.localeCompare(b.name),
-		);
-		if (v2Sorted[0]) return v2Sorted[0].id;
+		if (isV2CloudEnabled) {
+			const v2Sorted = [...v2Projects].sort((a, b) =>
+				a.name.localeCompare(b.name),
+			);
+			return v2Sorted[0]?.id ?? null;
+		}
 
-		const loadedV2Ids = new Set(v2Projects.map((p) => p.id));
 		const v1Sorted = groups
-			.filter(
-				(g) =>
-					!g.project.neonProjectId || !loadedV2Ids.has(g.project.neonProjectId),
-			)
 			.map((g) => g.project)
 			.sort((a, b) => a.name.localeCompare(b.name));
 		return v1Sorted[0]?.id ?? null;
-	}, [v2Projects, groups]);
+	}, [v2Projects, groups, isV2CloudEnabled]);
 
 	useEffect(() => {
 		if (firstProjectId) {
@@ -65,7 +64,9 @@ function ProjectsIndexPage() {
 		}
 	}, [firstProjectId, navigate]);
 
-	const isEmpty = v2Projects.length === 0 && groups.length === 0;
+	const isEmpty = isV2CloudEnabled
+		? v2Projects.length === 0
+		: groups.length === 0;
 	if (isEmpty) {
 		if (!isReady || groupsLoading) return null;
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/projects/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/projects/page.tsx
@@ -68,7 +68,7 @@ function ProjectsIndexPage() {
 		? v2Projects.length === 0
 		: groups.length === 0;
 	if (isEmpty) {
-		if (!isReady || groupsLoading) return null;
+		if (isV2CloudEnabled ? !isReady : groupsLoading) return null;
 		return (
 			<div className="flex items-center justify-center h-full p-6 text-sm text-muted-foreground">
 				No projects yet.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
@@ -143,17 +143,17 @@ export function ProjectLocationSection({
 	return (
 		<>
 			{currentPath ? (
-				<div className="relative w-96">
-					<div className="flex h-9 items-center overflow-x-auto whitespace-nowrap rounded-md border bg-transparent px-3 pr-9 dark:bg-input/30">
+				<div className="flex w-[28rem] max-w-full items-center gap-2">
+					<div className="flex h-9 min-w-0 flex-1 items-center overflow-x-auto whitespace-nowrap rounded-md border bg-transparent px-3 dark:bg-input/30">
 						<ClickablePath path={currentPath} className="max-w-none shrink-0" />
 					</div>
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<Button
 								type="button"
-								variant="ghost"
+								variant="outline"
 								size="icon"
-								className="absolute right-1 top-1 size-7 text-muted-foreground hover:text-foreground"
+								className="size-9 shrink-0"
 								onClick={handleChange}
 								disabled={selectDirectory.isPending || isSubmitting}
 								aria-label="Change location"


### PR DESCRIPTION
## Summary
- Project settings now shows only the project list matching the user's active mode: v2 users see v2 projects, v1 users see v1 projects (gated on `useIsV2CloudEnabled()`, same as Terminal settings).
- Fixed the Location field in v2 project settings so long paths no longer scroll underneath the folder icon.

## Why / Context
- The projects settings sidebar listed both "v2" and "v1" groups regardless of which mode the user is in, which is confusing — users should only see the projects for the mode they've chosen.
- The Location field's browse button was a transparent ghost button absolutely positioned inside the scrollable path container, so long paths rendered beneath the icon (see screenshot context). The Worktrees row right below uses a separate outline button, so the two rows also looked inconsistent.

## How It Works
- `ProjectsSettingsSidebar` builds a single group based on `useIsV2CloudEnabled()`. In v1 mode the old "has a v2 twin" dedupe filter is dropped — it only existed to avoid duplicates when both lists were shown, and v1 users should still see migrated projects.
- The `/settings/projects` index redirect and empty state follow the same gate, so the auto-selected first project always comes from the visible list.
- `ProjectLocationSection` now mirrors the `V2WorktreeLocationPicker` layout: a `min-w-0 flex-1` scrollable path box plus a separate `size-9` outline browse button, at the same `w-[28rem]` width as the Worktrees row.
- The project detail route is unchanged: it still resolves v1 vs v2 settings by project ID, so direct links keep working in either mode.

## Manual QA Checklist
- [ ] v2 mode: Settings → Projects lists only v2 projects, no group header
- [ ] v1 mode (opt-out in Experimental): lists only v1 projects, including ones migrated to v2
- [ ] `/settings/projects` auto-selects the first project of the visible group in both modes
- [ ] Empty state shows when the active mode has no projects
- [ ] Location field: long path scrolls inside the box without sliding under the browse icon; Location and Worktrees rows are visually consistent

## Testing
- `bun run typecheck`
- `bun run lint`
- Manual QA above not yet run in the app (styling change mirrors the existing Worktrees picker markup; gating mirrors the existing TerminalSettings pattern)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5749">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show only v1 or only v2 projects in Project Settings based on the active mode, and fix the v2 Location field so long paths don’t slide under the browse icon.

- **Bug Fixes**
  - Gate sidebar, index redirect, empty state, and empty-state loading on `useIsV2CloudEnabled()`: v2 mode shows only v2 projects; v1 shows only v1 (including migrated).
  - Removed the v1 “has v2 twin” dedupe since lists are no longer combined.
  - Updated v2 Location row to match Worktrees: scrollable `min-w-0 flex-1` path box with a separate `size-9` outline button at `w-[28rem]` to prevent overlap.
  - Deep links still resolve v1 vs v2 by project ID, so existing URLs keep working.

<sup>Written for commit 27bc729e8faad9403f33f6318d1864c6a2e0a581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Project Settings**
  - Project lists now display the appropriate project set based on the enabled cloud experience.
  - Project selection and empty states now accurately reflect the available projects.
  - Projects are consistently ordered by name when selecting the initial project.

- **Interface Improvements**
  - Updated the project location section layout for improved spacing and alignment.
  - The location-change action now uses a clearer outlined button style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->