### PR TITLE
feat(host-service): generic worker_threads pool — git status + commit-files off the event loop

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -114,6 +114,9 @@ export default defineConfig({
 					// pty-daemon - long-lived per-org Unix-socket server that owns PTYs.
 					// Spawned by PtyDaemonCoordinator; survives host-service restarts.
 					"pty-daemon": resolve("src/main/pty-daemon/index.ts"),
+					// host-service worker thread — emitted side-by-side with
+					// host-service.js so the pool's script resolution finds it.
+					"host-worker": resolve("src/main/host-worker/index.ts"),
 				},
 				output: {
 					dir: resolve(devPath, "main"),

--- a/apps/desktop/src/main/host-worker/index.ts
+++ b/apps/desktop/src/main/host-worker/index.ts
@@ -1,0 +1,4 @@
+// Desktop bundle entry for the host-service worker thread. Emitted as
+// dist/main/host-worker.js, side-by-side with host-service.js so the pool's
+// script resolution finds it (see host-worker-pool.ts).
+import "@superset/host-service/host-worker";

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -446,6 +446,13 @@ async function main(): Promise<void> {
 	const hostServiceBundle = await buildHostService();
 	cpSync(hostServiceBundle, join(stagingRoot, "lib", "host-service.js"));
 
+	// host-worker.js ships side-by-side too: the worker pool resolves it
+	// next to host-service.js (falling back to inline execution if absent).
+	cpSync(
+		join(dirname(hostServiceBundle), "host-worker.js"),
+		join(stagingRoot, "lib", "host-worker.js"),
+	);
+
 	// pty-daemon ships side-by-side with host-service.js. The host-service
 	// resolves the script path via `resolveSupervisorScriptPath()` which
 	// looks for `pty-daemon.js` next to itself first; without this copy the

--- a/packages/host-service/build.ts
+++ b/packages/host-service/build.ts
@@ -51,4 +51,27 @@ if (!result.success) {
 	process.exit(1);
 }
 
-console.log(`[host-service] bundled to ${outdir}/host-service.js`);
+// Worker-thread bundle, emitted side-by-side so the pool's script
+// resolution finds it next to host-service.js (see host-worker-pool.ts).
+const workerResult = await Bun.build({
+	entrypoints: ["src/workers/host-worker.ts"],
+	target: "node",
+	outdir,
+	naming: "host-worker.js",
+	format: "esm",
+	define: {
+		"process.env.NODE_ENV": JSON.stringify("production"),
+	},
+});
+
+if (!workerResult.success) {
+	console.error("[host-service] host-worker build failed:");
+	for (const log of workerResult.logs) {
+		console.error(log);
+	}
+	process.exit(1);
+}
+
+console.log(
+	`[host-service] bundled to ${outdir}/host-service.js + ${outdir}/host-worker.js`,
+);

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -28,6 +28,10 @@
 			"types": "./src/trpc/index.ts",
 			"default": "./src/trpc/index.ts"
 		},
+		"./host-worker": {
+			"types": "./src/workers/host-worker.ts",
+			"default": "./src/workers/host-worker.ts"
+		},
 		"./terminal-env": {
 			"types": "./src/terminal/env.ts",
 			"default": "./src/terminal/env.ts"

--- a/packages/host-service/src/runtime/git/git.ts
+++ b/packages/host-service/src/runtime/git/git.ts
@@ -2,17 +2,28 @@ import { createUserSimpleGit } from "./simple-git";
 import type { GitCredentialProvider, GitFactory } from "./types";
 import { getRemoteUrl } from "./utils";
 
-export function createGitFactory(provider: GitCredentialProvider): GitFactory {
-	return async (repoPath: string) => {
+/**
+ * Resolve the env a git invocation for `repoPath` needs (credentials for the
+ * repo's remote + lock hygiene). Split out from the factory so worker tasks
+ * can receive the env as plain data and build their own SimpleGit off-thread.
+ */
+export function createGitEnvResolver(provider: GitCredentialProvider) {
+	return async (repoPath: string): Promise<Record<string, string>> => {
 		const initialCredentials = await provider.getCredentials(null);
 		const git = createUserSimpleGit(repoPath).env(initialCredentials.env);
 		const remoteUrl = await getRemoteUrl(git);
 		const credentials = await provider.getCredentials(remoteUrl);
 
-		return git.env({
+		return {
 			...initialCredentials.env,
 			...credentials.env,
 			GIT_OPTIONAL_LOCKS: "0",
-		});
+		};
 	};
+}
+
+export function createGitFactory(provider: GitCredentialProvider): GitFactory {
+	const resolveEnv = createGitEnvResolver(provider);
+	return async (repoPath: string) =>
+		createUserSimpleGit(repoPath).env(await resolveEnv(repoPath));
 }

--- a/packages/host-service/src/runtime/git/index.ts
+++ b/packages/host-service/src/runtime/git/index.ts
@@ -1,4 +1,4 @@
-export { createGitFactory } from "./git";
+export { createGitEnvResolver, createGitFactory } from "./git";
 export type { ResolvedRef, ResolveRefOptions } from "./refs";
 export {
 	asLocalRef,

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -14,6 +14,7 @@ import {
 import { protectedProcedure, queryProcedure, router } from "../../index";
 import { resolveGithubRepo } from "../workspace-creation/shared/project-helpers";
 import type {
+	ChangedFile,
 	CheckConclusionState,
 	CheckRun,
 	CheckStatusState,
@@ -54,6 +55,23 @@ async function withCommitFilesSlot<T>(fn: () => Promise<T>): Promise<T> {
 		activeCommitFileTasks--;
 		commitFileWaiters.shift()?.();
 	}
+}
+
+// Identical requests share one slot AND one task — deduping outside the
+// semaphore keeps same-commit bursts from consuming both cap slots or
+// re-running a task that finished while they waited for a slot.
+const inFlightCommitFiles = new Map<string, Promise<ChangedFile[]>>();
+function runCommitFilesDeduped(
+	key: string,
+	fn: () => Promise<ChangedFile[]>,
+): Promise<ChangedFile[]> {
+	const existing = inFlightCommitFiles.get(key);
+	if (existing) return existing;
+	const task = withCommitFilesSlot(fn).finally(() => {
+		inFlightCommitFiles.delete(key);
+	});
+	inFlightCommitFiles.set(key, task);
+	return task;
 }
 
 /** Credential env for a worker git task, resolved in-process (the provider
@@ -204,7 +222,8 @@ export const gitRouter = router({
 		.query(async ({ ctx, input }) => {
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
-			const files = await withCommitFilesSlot(() =>
+			const dedupeKey = `${input.workspaceId}:commit-files:${input.fromHash ?? ""}:${input.commitHash}`;
+			const files = await runCommitFilesDeduped(dedupeKey, () =>
 				getHostWorkerPool().run(
 					gitCommitFilesTask,
 					{
@@ -216,7 +235,7 @@ export const gitRouter = router({
 					{
 						timeoutMs: 15_000,
 						strategy: "coalesce",
-						dedupeKey: `${input.workspaceId}:commit-files:${input.fromHash ?? ""}:${input.commitHash}`,
+						dedupeKey,
 					},
 				),
 			);

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -4,6 +4,13 @@ import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { pullRequests, workspaces } from "../../../db/schema";
+import { createGitEnvResolver } from "../../../runtime/git";
+import type { HostServiceContext } from "../../../types";
+import { getHostWorkerPool } from "../../../workers/host-worker-pool";
+import {
+	gitCommitFilesTask,
+	gitStatusSnapshotTask,
+} from "../../../workers/tasks/git";
 import { protectedProcedure, queryProcedure, router } from "../../index";
 import { resolveGithubRepo } from "../workspace-creation/shared/project-helpers";
 import type {
@@ -19,11 +26,9 @@ import type {
 } from "./types";
 import { gitConfigWrite } from "./utils/config-write";
 import {
-	getChangedFilesForDiff,
 	getDefaultBranchName,
 	resolveBaseComparison,
 } from "./utils/git-helpers";
-import { getGitStatusSnapshot } from "./utils/git-status";
 import { gitStatusRefreshLimiter } from "./utils/git-status-refresh-limiter";
 import {
 	type GraphQLThreadsResult,
@@ -31,6 +36,15 @@ import {
 	REVIEW_THREADS_QUERY,
 } from "./utils/graphql";
 import { resolveWorktreePath } from "./utils/resolve-worktree";
+
+/** Credential env for a worker git task, resolved in-process (the provider
+ * can't cross the thread boundary) and passed to the worker as plain data. */
+function resolveGitTaskEnv(
+	ctx: Pick<HostServiceContext, "credentials">,
+	worktreePath: string,
+): Promise<Record<string, string>> {
+	return createGitEnvResolver(ctx.credentials)(worktreePath);
+}
 
 function assertSafeRelativePath(filePath: string): void {
 	if (isAbsolute(filePath)) {
@@ -109,12 +123,12 @@ export const gitRouter = router({
 				priority: input.priority,
 				run: async () => {
 					const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
-					const git = await ctx.git(worktreePath);
-					return getGitStatusSnapshot({
-						git,
-						worktreePath,
-						baseBranch: input.baseBranch,
-					});
+					const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
+					return getHostWorkerPool().run(
+						gitStatusSnapshotTask,
+						{ worktreePath, baseBranch: input.baseBranch, gitEnv },
+						{ timeoutMs: 15_000 },
+					);
 				},
 			});
 		}),
@@ -170,10 +184,21 @@ export const gitRouter = router({
 		)
 		.query(async ({ ctx, input }) => {
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
-			const git = await ctx.git(worktreePath);
-
-			const from = input.fromHash ? input.fromHash : `${input.commitHash}^`;
-			const files = await getChangedFilesForDiff(git, [from, input.commitHash]);
+			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
+			const files = await getHostWorkerPool().run(
+				gitCommitFilesTask,
+				{
+					worktreePath,
+					commitHash: input.commitHash,
+					fromHash: input.fromHash,
+					gitEnv,
+				},
+				{
+					timeoutMs: 15_000,
+					strategy: "coalesce",
+					dedupeKey: `${input.workspaceId}:commit-files:${input.fromHash ?? ""}:${input.commitHash}`,
+				},
+			);
 
 			return { files };
 		}),

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -37,6 +37,25 @@ import {
 } from "./utils/graphql";
 import { resolveWorktreePath } from "./utils/resolve-worktree";
 
+// Front-door cap for commit-file diffs. Statuses are admitted by
+// gitStatusRefreshLimiter; without a cap here, a burst of distinct-commit
+// diffs could occupy every pool worker ahead of limiter-admitted statuses.
+const MAX_CONCURRENT_COMMIT_FILE_TASKS = 2;
+let activeCommitFileTasks = 0;
+const commitFileWaiters: (() => void)[] = [];
+async function withCommitFilesSlot<T>(fn: () => Promise<T>): Promise<T> {
+	if (activeCommitFileTasks >= MAX_CONCURRENT_COMMIT_FILE_TASKS) {
+		await new Promise<void>((resolve) => commitFileWaiters.push(resolve));
+	}
+	activeCommitFileTasks++;
+	try {
+		return await fn();
+	} finally {
+		activeCommitFileTasks--;
+		commitFileWaiters.shift()?.();
+	}
+}
+
 /** Credential env for a worker git task, resolved in-process (the provider
  * can't cross the thread boundary) and passed to the worker as plain data. */
 function resolveGitTaskEnv(
@@ -185,19 +204,21 @@ export const gitRouter = router({
 		.query(async ({ ctx, input }) => {
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
-			const files = await getHostWorkerPool().run(
-				gitCommitFilesTask,
-				{
-					worktreePath,
-					commitHash: input.commitHash,
-					fromHash: input.fromHash,
-					gitEnv,
-				},
-				{
-					timeoutMs: 15_000,
-					strategy: "coalesce",
-					dedupeKey: `${input.workspaceId}:commit-files:${input.fromHash ?? ""}:${input.commitHash}`,
-				},
+			const files = await withCommitFilesSlot(() =>
+				getHostWorkerPool().run(
+					gitCommitFilesTask,
+					{
+						worktreePath,
+						commitHash: input.commitHash,
+						fromHash: input.fromHash,
+						gitEnv,
+					},
+					{
+						timeoutMs: 15_000,
+						strategy: "coalesce",
+						dedupeKey: `${input.workspaceId}:commit-files:${input.fromHash ?? ""}:${input.commitHash}`,
+					},
+				),
 			);
 
 			return { files };

--- a/packages/host-service/src/workers/WorkerTaskRunner.ts
+++ b/packages/host-service/src/workers/WorkerTaskRunner.ts
@@ -1,0 +1,554 @@
+// worker_threads task pool. Ported from
+// apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.ts (v1 keeps its copy),
+// plus idle reaping: host-service is a long-lived per-org process, so idle
+// workers are terminated instead of held warm forever.
+
+import { randomUUID } from "node:crypto";
+import { Worker } from "node:worker_threads";
+import type {
+	SerializedWorkerError,
+	WorkerTaskRequestMessage,
+	WorkerTaskResponseMessage,
+} from "./worker-task-protocol.ts";
+
+export class WorkerTaskError extends Error {
+	public readonly code?: string;
+
+	constructor(message: string, error?: SerializedWorkerError) {
+		super(message);
+		this.name = error?.name ?? "WorkerTaskError";
+		this.code = error?.code;
+		this.stack = error?.stack ?? this.stack;
+	}
+}
+
+export class WorkerTaskAbortedError extends Error {
+	constructor(message = "Worker task aborted") {
+		super(message);
+		this.name = "WorkerTaskAbortedError";
+	}
+}
+
+/** Marker name for failures of the worker itself (crash/exit), as opposed to
+ * errors thrown by the task handler. Callers use this to decide on inline
+ * retry / crash-circuit accounting. */
+export const WORKER_CRASH_ERROR_NAME = "WorkerCrashedError";
+
+type QueueStrategy = "fifo" | "coalesce" | "latest-wins";
+
+interface WorkerTaskOptions {
+	dedupeKey?: string;
+	timeoutMs?: number;
+	signal?: AbortSignal;
+	strategy?: QueueStrategy;
+}
+
+interface WorkerTaskRunnerOptions {
+	workerScriptPath: string;
+	concurrency: number;
+	name?: string;
+	debug?: boolean;
+	/** Terminate workers idle longer than this. Undefined = never reap. */
+	idleTimeoutMs?: number;
+	/** Extra execArgv for spawned workers (tests pass strip-types flags). */
+	execArgv?: string[];
+}
+
+interface WorkerSlot {
+	id: number;
+	worker: Worker;
+	activeTaskId: string | null;
+	terminating: boolean;
+	idleTimer?: NodeJS.Timeout;
+}
+
+interface QueuedTask {
+	taskId: string;
+	taskType: string;
+	payload: unknown;
+	resolve: (value: unknown) => void;
+	reject: (reason?: unknown) => void;
+	dedupeKey?: string;
+	strategy: QueueStrategy;
+	generation: number;
+	abortSignal?: AbortSignal;
+	abortHandler?: () => void;
+	timeoutMs: number;
+	timeoutHandle?: NodeJS.Timeout;
+	slotId?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export class WorkerTaskRunner {
+	private readonly workerScriptPath: string;
+	private readonly concurrency: number;
+	private readonly name: string;
+	private readonly debug: boolean;
+	private readonly idleTimeoutMs?: number;
+	private readonly execArgv?: string[];
+	private readonly workerSlots = new Map<number, WorkerSlot>();
+	private readonly queue: string[] = [];
+	private readonly tasks = new Map<string, QueuedTask>();
+	private readonly inFlightByKey = new Map<string, Promise<unknown>>();
+	private readonly generationByKey = new Map<string, number>();
+	private workerCounter = 0;
+	private disposed = false;
+
+	constructor(options: WorkerTaskRunnerOptions) {
+		this.workerScriptPath = options.workerScriptPath;
+		this.concurrency = Math.max(1, options.concurrency);
+		this.name = options.name ?? "worker-runner";
+		this.debug = options.debug ?? false;
+		this.idleTimeoutMs = options.idleTimeoutMs;
+		this.execArgv = options.execArgv;
+	}
+
+	/** Live (non-terminating) worker count — exposed for idle-reap tests. */
+	getWorkerCount(): number {
+		return this.getActiveSlotCount();
+	}
+
+	runTask<TResult>(
+		taskType: string,
+		payload: unknown,
+		options?: WorkerTaskOptions,
+	): Promise<TResult> {
+		if (this.disposed) {
+			return Promise.reject(
+				new WorkerTaskError(`[${this.name}] Runner has been disposed`),
+			);
+		}
+
+		const strategy = options?.strategy ?? "fifo";
+		const dedupeKey = options?.dedupeKey;
+		const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		const useGeneration = strategy === "latest-wins" && Boolean(dedupeKey);
+
+		if (strategy === "coalesce" && dedupeKey) {
+			const inFlight = this.inFlightByKey.get(dedupeKey);
+			if (inFlight) {
+				return inFlight as Promise<TResult>;
+			}
+		}
+
+		const generation =
+			useGeneration && dedupeKey
+				? (this.generationByKey.get(dedupeKey) ?? 0) + 1
+				: 0;
+		if (useGeneration && dedupeKey) {
+			this.generationByKey.set(dedupeKey, generation);
+		}
+
+		const taskId = randomUUID();
+
+		const taskPromise = new Promise<TResult>((resolve, reject) => {
+			const task: QueuedTask = {
+				taskId,
+				taskType,
+				payload,
+				resolve: (value) => resolve(value as TResult),
+				reject,
+				dedupeKey,
+				strategy,
+				generation,
+				abortSignal: options?.signal,
+				timeoutMs,
+			};
+
+			if (task.abortSignal) {
+				const abortTask = () => this.abortTask(task.taskId);
+				task.abortHandler = abortTask;
+				task.abortSignal.addEventListener("abort", abortTask, { once: true });
+			}
+
+			this.tasks.set(taskId, task);
+
+			if (strategy === "latest-wins" && dedupeKey) {
+				this.dropQueuedTasksByKey(dedupeKey, taskId);
+			}
+
+			this.queue.push(taskId);
+			this.drainQueue();
+		});
+
+		if (dedupeKey && (strategy === "coalesce" || strategy === "latest-wins")) {
+			this.inFlightByKey.set(dedupeKey, taskPromise);
+		}
+
+		return taskPromise.finally(() => {
+			if (dedupeKey && this.inFlightByKey.get(dedupeKey) === taskPromise) {
+				this.inFlightByKey.delete(dedupeKey);
+			}
+			if (
+				useGeneration &&
+				dedupeKey &&
+				this.generationByKey.get(dedupeKey) === generation
+			) {
+				this.generationByKey.delete(dedupeKey);
+			}
+		});
+	}
+
+	async dispose(): Promise<void> {
+		this.disposed = true;
+
+		for (const taskId of [...this.queue]) {
+			this.rejectTask(
+				taskId,
+				new WorkerTaskAbortedError("Worker runner disposed"),
+			);
+		}
+		this.queue.length = 0;
+
+		for (const slot of this.workerSlots.values()) {
+			slot.terminating = true;
+			this.clearIdleTimer(slot);
+			if (slot.activeTaskId) {
+				this.rejectTask(
+					slot.activeTaskId,
+					new WorkerTaskAbortedError("Worker runner disposed"),
+				);
+			}
+			await slot.worker.terminate();
+		}
+
+		this.workerSlots.clear();
+	}
+
+	private spawnWorker(): void {
+		const slotId = ++this.workerCounter;
+		const worker = new Worker(this.workerScriptPath, {
+			execArgv: this.execArgv,
+		});
+		const slot: WorkerSlot = {
+			id: slotId,
+			worker,
+			activeTaskId: null,
+			terminating: false,
+		};
+
+		worker.on("message", (message: unknown) => {
+			this.handleWorkerMessage(slot.id, message);
+		});
+
+		worker.on("error", (error) => {
+			this.log(`worker ${slot.id} error: ${error.message}`);
+			this.handleWorkerFailure(
+				slot.id,
+				new WorkerTaskError(error.message, {
+					name: WORKER_CRASH_ERROR_NAME,
+					message: error.message,
+				}),
+			);
+		});
+
+		worker.on("exit", (code) => {
+			if (this.disposed) return;
+			if (code !== 0) {
+				this.log(`worker ${slot.id} exited with code ${code}`);
+			}
+			this.handleWorkerFailure(
+				slot.id,
+				new WorkerTaskError(`Worker exited with code ${code}`, {
+					name: WORKER_CRASH_ERROR_NAME,
+					message: `Worker exited with code ${code}`,
+				}),
+			);
+		});
+
+		this.workerSlots.set(slot.id, slot);
+	}
+
+	private drainQueue(): void {
+		if (this.disposed) return;
+		if (this.queue.length > 0) {
+			this.ensureWorkerCapacity();
+
+			for (const slot of this.workerSlots.values()) {
+				if (slot.activeTaskId || slot.terminating) continue;
+				if (this.queue.length === 0) break;
+
+				const nextTaskId = this.queue.shift();
+				if (!nextTaskId) continue;
+				const task = this.tasks.get(nextTaskId);
+				if (!task) continue;
+
+				if (task.abortSignal?.aborted) {
+					this.rejectTask(task.taskId, new WorkerTaskAbortedError());
+					continue;
+				}
+
+				this.clearIdleTimer(slot);
+				slot.activeTaskId = task.taskId;
+				task.slotId = slot.id;
+				task.timeoutHandle = setTimeout(() => {
+					this.handleTaskTimeout(task.taskId);
+				}, task.timeoutMs);
+
+				const request: WorkerTaskRequestMessage = {
+					kind: "task",
+					taskId: task.taskId,
+					taskType: task.taskType,
+					payload: task.payload,
+				};
+				slot.worker.postMessage(request);
+			}
+		}
+		this.scheduleIdleReaping();
+	}
+
+	private scheduleIdleReaping(): void {
+		if (this.idleTimeoutMs === undefined) return;
+		for (const slot of this.workerSlots.values()) {
+			if (slot.activeTaskId || slot.terminating || slot.idleTimer) continue;
+			slot.idleTimer = setTimeout(() => {
+				slot.idleTimer = undefined;
+				if (slot.activeTaskId || slot.terminating || this.disposed) return;
+				this.log(`reaping idle worker ${slot.id}`);
+				slot.terminating = true;
+				this.workerSlots.delete(slot.id);
+				void slot.worker.terminate();
+			}, this.idleTimeoutMs);
+			slot.idleTimer.unref?.();
+		}
+	}
+
+	private clearIdleTimer(slot: WorkerSlot): void {
+		if (slot.idleTimer) {
+			clearTimeout(slot.idleTimer);
+			slot.idleTimer = undefined;
+		}
+	}
+
+	private handleWorkerMessage(slotId: number, message: unknown): void {
+		const slot = this.workerSlots.get(slotId);
+		if (!slot) return;
+
+		if (!this.isWorkerResultMessage(message)) {
+			return;
+		}
+		const response = message;
+
+		if (slot.activeTaskId !== response.taskId) {
+			this.log(
+				`worker ${slot.id} sent unexpected task result ${response.taskId} (active: ${slot.activeTaskId ?? "none"})`,
+			);
+			return;
+		}
+
+		const task = this.tasks.get(response.taskId);
+		if (!task) {
+			this.log(
+				`worker ${slot.id} reported result for missing active task ${response.taskId}; recycling worker`,
+			);
+			if (!slot.terminating) {
+				slot.terminating = true;
+				void slot.worker.terminate();
+			}
+			return;
+		}
+
+		this.clearTaskTimeout(task);
+		slot.activeTaskId = null;
+
+		if (response.ok) {
+			if (
+				task.strategy === "latest-wins" &&
+				task.dedupeKey &&
+				(this.generationByKey.get(task.dedupeKey) ?? 0) !== task.generation
+			) {
+				this.rejectTask(
+					task.taskId,
+					new WorkerTaskAbortedError("Task superseded by a newer request"),
+				);
+			} else {
+				this.resolveTask(task.taskId, response.result);
+			}
+		} else {
+			this.rejectTask(
+				task.taskId,
+				new WorkerTaskError(response.error.message, response.error),
+			);
+		}
+
+		this.drainQueue();
+	}
+
+	private isWorkerResultMessage(
+		message: unknown,
+	): message is WorkerTaskResponseMessage {
+		if (!message || typeof message !== "object") return false;
+		const candidate = message as {
+			kind?: unknown;
+			taskId?: unknown;
+			ok?: unknown;
+			error?: unknown;
+		};
+		if (
+			candidate.kind !== "result" ||
+			typeof candidate.taskId !== "string" ||
+			typeof candidate.ok !== "boolean"
+		) {
+			return false;
+		}
+		if (candidate.ok) return true;
+		if (!candidate.error || typeof candidate.error !== "object") return false;
+		const error = candidate.error as Partial<SerializedWorkerError>;
+		return typeof error.name === "string" && typeof error.message === "string";
+	}
+
+	private handleTaskTimeout(taskId: string): void {
+		const task = this.tasks.get(taskId);
+		if (!task) return;
+
+		this.rejectTask(
+			taskId,
+			new WorkerTaskError(
+				`[${this.name}] Task "${task.taskType}" timed out after ${task.timeoutMs}ms`,
+			),
+		);
+
+		if (task.slotId) {
+			const slot = this.workerSlots.get(task.slotId);
+			if (slot && !slot.terminating) {
+				slot.terminating = true;
+				void slot.worker.terminate();
+				if (this.hasOutstandingWork()) {
+					this.ensureWorkerCapacity();
+					this.drainQueue();
+				}
+			}
+		}
+	}
+
+	private abortTask(taskId: string): void {
+		const task = this.tasks.get(taskId);
+		if (!task) return;
+
+		this.rejectTask(taskId, new WorkerTaskAbortedError());
+
+		if (task.slotId) {
+			const slot = this.workerSlots.get(task.slotId);
+			if (slot && !slot.terminating) {
+				slot.terminating = true;
+				void slot.worker.terminate();
+				if (this.hasOutstandingWork()) {
+					this.ensureWorkerCapacity();
+					this.drainQueue();
+				}
+			}
+		}
+	}
+
+	private handleWorkerFailure(slotId: number, error: WorkerTaskError): void {
+		const slot = this.workerSlots.get(slotId);
+		if (!slot) return;
+
+		const activeTaskId = slot.activeTaskId;
+		this.clearIdleTimer(slot);
+		this.workerSlots.delete(slot.id);
+
+		if (activeTaskId) {
+			this.rejectTask(activeTaskId, error);
+		}
+
+		if (!this.disposed && this.hasOutstandingWork()) {
+			this.ensureWorkerCapacity();
+			this.drainQueue();
+		}
+	}
+
+	private dropQueuedTasksByKey(dedupeKey: string, keepTaskId: string): void {
+		for (let i = this.queue.length - 1; i >= 0; i--) {
+			const queuedTaskId = this.queue[i];
+			if (!queuedTaskId) continue;
+			const queuedTask = this.tasks.get(queuedTaskId);
+			if (!queuedTask) continue;
+			if (queuedTask.taskId === keepTaskId) continue;
+			if (queuedTask.dedupeKey !== dedupeKey) continue;
+
+			this.queue.splice(i, 1);
+			this.rejectTask(
+				queuedTask.taskId,
+				new WorkerTaskAbortedError("Task superseded by a newer request"),
+			);
+		}
+	}
+
+	private resolveTask(taskId: string, result: unknown): void {
+		const task = this.tasks.get(taskId);
+		if (!task) return;
+		this.cleanupTask(task);
+		task.resolve(result);
+	}
+
+	private rejectTask(taskId: string, reason: unknown): void {
+		const task = this.tasks.get(taskId);
+		if (!task) return;
+
+		const queueIndex = this.queue.indexOf(taskId);
+		if (queueIndex >= 0) {
+			this.queue.splice(queueIndex, 1);
+		}
+
+		const slot = task.slotId ? this.workerSlots.get(task.slotId) : null;
+		if (slot?.activeTaskId === taskId) {
+			slot.activeTaskId = null;
+		}
+
+		this.cleanupTask(task);
+		task.reject(reason);
+	}
+
+	private cleanupTask(task: QueuedTask): void {
+		this.clearTaskTimeout(task);
+		if (task.abortSignal && task.abortHandler) {
+			task.abortSignal.removeEventListener("abort", task.abortHandler);
+		}
+		this.tasks.delete(task.taskId);
+	}
+
+	private clearTaskTimeout(task: QueuedTask): void {
+		if (task.timeoutHandle) {
+			clearTimeout(task.timeoutHandle);
+			task.timeoutHandle = undefined;
+		}
+	}
+
+	private log(message: string): void {
+		if (!this.debug) return;
+		console.log(`[WorkerTaskRunner:${this.name}] ${message}`);
+	}
+
+	// Unlike the v1 runner (which spawned the full pool on any work), spawn
+	// only enough workers to cover the queue — idle reaping would otherwise
+	// churn spawn/terminate cycles for single-task workloads.
+	private ensureWorkerCapacity(): void {
+		let idle = 0;
+		for (const slot of this.workerSlots.values()) {
+			if (!slot.terminating && !slot.activeTaskId) idle += 1;
+		}
+		let deficit = this.queue.length - idle;
+		while (deficit > 0 && this.getActiveSlotCount() < this.concurrency) {
+			this.spawnWorker();
+			deficit -= 1;
+		}
+	}
+
+	private getActiveSlotCount(): number {
+		let count = 0;
+		for (const slot of this.workerSlots.values()) {
+			if (!slot.terminating) {
+				count += 1;
+			}
+		}
+		return count;
+	}
+
+	private hasOutstandingWork(): boolean {
+		return this.tasks.size > 0 || this.queue.length > 0;
+	}
+}
+
+export type { WorkerTaskOptions };

--- a/packages/host-service/src/workers/WorkerTaskRunner.ts
+++ b/packages/host-service/src/workers/WorkerTaskRunner.ts
@@ -292,7 +292,19 @@ export class WorkerTaskRunner {
 					taskType: task.taskType,
 					payload: task.payload,
 				};
-				slot.worker.postMessage(request);
+				try {
+					slot.worker.postMessage(request);
+				} catch (error) {
+					// Non-cloneable payload: reject THIS task and free the slot —
+					// otherwise the slot stays occupied until the task timeout.
+					slot.activeTaskId = null;
+					this.rejectTask(
+						task.taskId,
+						new WorkerTaskError(
+							`postMessage failed for task "${task.taskType}": ${(error as Error).message}`,
+						),
+					);
+				}
 			}
 		}
 		this.scheduleIdleReaping();

--- a/packages/host-service/src/workers/WorkerTaskRunner.ts
+++ b/packages/host-service/src/workers/WorkerTaskRunner.ts
@@ -78,7 +78,7 @@ interface QueuedTask {
 	slotId?: number;
 }
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+export const DEFAULT_TIMEOUT_MS = 60_000;
 
 export class WorkerTaskRunner {
 	private readonly workerScriptPath: string;
@@ -190,6 +190,15 @@ export class WorkerTaskRunner {
 		});
 	}
 
+	/** Reject every queued (not yet dispatched) task; active tasks keep
+	 * running. Used at circuit-open so queued work stops feeding crashing
+	 * workers and callers take their own fallback path. */
+	rejectQueuedTasks(reason: unknown): void {
+		for (const taskId of [...this.queue]) {
+			this.rejectTask(taskId, reason);
+		}
+	}
+
 	async dispose(): Promise<void> {
 		this.disposed = true;
 
@@ -269,41 +278,47 @@ export class WorkerTaskRunner {
 				if (slot.activeTaskId || slot.terminating) continue;
 				if (this.queue.length === 0) break;
 
-				const nextTaskId = this.queue.shift();
-				if (!nextTaskId) continue;
-				const task = this.tasks.get(nextTaskId);
-				if (!task) continue;
+				// Keep pulling until this slot actually dispatches or the queue
+				// drains — rejection paths (pre-aborted signal, non-cloneable
+				// payload) must not strand tasks behind a slot the iteration
+				// already passed.
+				while (this.queue.length > 0 && !slot.activeTaskId) {
+					const nextTaskId = this.queue.shift();
+					if (!nextTaskId) continue;
+					const task = this.tasks.get(nextTaskId);
+					if (!task) continue;
 
-				if (task.abortSignal?.aborted) {
-					this.rejectTask(task.taskId, new WorkerTaskAbortedError());
-					continue;
-				}
+					if (task.abortSignal?.aborted) {
+						this.rejectTask(task.taskId, new WorkerTaskAbortedError());
+						continue;
+					}
 
-				this.clearIdleTimer(slot);
-				slot.activeTaskId = task.taskId;
-				task.slotId = slot.id;
-				task.timeoutHandle = setTimeout(() => {
-					this.handleTaskTimeout(task.taskId);
-				}, task.timeoutMs);
+					this.clearIdleTimer(slot);
+					slot.activeTaskId = task.taskId;
+					task.slotId = slot.id;
+					task.timeoutHandle = setTimeout(() => {
+						this.handleTaskTimeout(task.taskId);
+					}, task.timeoutMs);
 
-				const request: WorkerTaskRequestMessage = {
-					kind: "task",
-					taskId: task.taskId,
-					taskType: task.taskType,
-					payload: task.payload,
-				};
-				try {
-					slot.worker.postMessage(request);
-				} catch (error) {
-					// Non-cloneable payload: reject THIS task and free the slot —
-					// otherwise the slot stays occupied until the task timeout.
-					slot.activeTaskId = null;
-					this.rejectTask(
-						task.taskId,
-						new WorkerTaskError(
-							`postMessage failed for task "${task.taskType}": ${(error as Error).message}`,
-						),
-					);
+					const request: WorkerTaskRequestMessage = {
+						kind: "task",
+						taskId: task.taskId,
+						taskType: task.taskType,
+						payload: task.payload,
+					};
+					try {
+						slot.worker.postMessage(request);
+					} catch (error) {
+						// Non-cloneable payload: reject THIS task and free the slot —
+						// otherwise the slot stays occupied until the task timeout.
+						slot.activeTaskId = null;
+						this.rejectTask(
+							task.taskId,
+							new WorkerTaskError(
+								`postMessage failed for task "${task.taskType}": ${(error as Error).message}`,
+							),
+						);
+					}
 				}
 			}
 		}

--- a/packages/host-service/src/workers/define-worker-task.ts
+++ b/packages/host-service/src/workers/define-worker-task.ts
@@ -1,0 +1,18 @@
+// Typed worker task definitions. A task module exports defs; the worker
+// entry (host-worker.ts) imports them into its static registry, and callers
+// pass the same def to HostWorkerPool.run() for end-to-end typing. The
+// handler also runs in-process for the inline fallback, so defs must stay
+// clone-safe and free of DB/event-bus/native imports (see
+// no-native-worker-imports.test.ts).
+
+export interface WorkerTaskDefinition<TInput, TResult> {
+	/** Namespaced as "<domain>/<task>", e.g. "git/getStatusSnapshot". */
+	type: string;
+	handler: (input: TInput) => Promise<TResult>;
+}
+
+export function defineWorkerTask<TInput, TResult>(
+	def: WorkerTaskDefinition<TInput, TResult>,
+): WorkerTaskDefinition<TInput, TResult> {
+	return def;
+}

--- a/packages/host-service/src/workers/host-worker-pool.test.ts
+++ b/packages/host-service/src/workers/host-worker-pool.test.ts
@@ -33,6 +33,23 @@ afterEach(async () => {
 	}
 });
 
+async function withTimeout<T>(promise: Promise<T>, timeoutMs = 5_000) {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`test timed out after ${timeoutMs}ms`)),
+					timeoutMs,
+				);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
 function makeFixtureRepo(): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "host-worker-git-"));
 	fixtureDirs.push(dir);
@@ -84,14 +101,14 @@ describe("HostWorkerPool", () => {
 
 	test("idle workers are reaped after idleTimeoutMs", async () => {
 		const worktreePath = makeFixtureRepo();
-		const pool = makePool({ idleTimeoutMs: 250 });
+		const pool = makePool({ idleTimeoutMs: 0 });
 		await pool.run(gitStatusSnapshotTask, {
 			worktreePath,
 			gitEnv: { GIT_OPTIONAL_LOCKS: "0" },
 		});
 		const runner = pool.getRunner();
 		expect(runner?.getWorkerCount()).toBe(1);
-		await new Promise((r) => setTimeout(r, 600));
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
 		expect(runner?.getWorkerCount()).toBe(0);
 	});
 
@@ -155,7 +172,7 @@ describe("HostWorkerPool", () => {
 		const pool = makePool({ scriptPathResolver: () => null });
 		const slow = defineWorkerTask<Record<string, never>, string>({
 			type: "test/slow",
-			handler: () => new Promise((r) => setTimeout(() => r("done"), 5_000)),
+			handler: () => new Promise(() => {}),
 		});
 
 		const aborted = new AbortController();
@@ -164,11 +181,9 @@ describe("HostWorkerPool", () => {
 			pool.run(slow, {}, { signal: aborted.signal }),
 		).rejects.toThrow("Worker task aborted");
 
-		const t0 = performance.now();
-		await expect(pool.run(slow, {}, { timeoutMs: 200 })).rejects.toThrow(
-			"timed out after 200ms",
+		await expect(pool.run(slow, {}, { timeoutMs: 0 })).rejects.toThrow(
+			"timed out after 0ms",
 		);
-		expect(performance.now() - t0).toBeLessThan(2_000);
 	});
 
 	test("a task queued behind a poison payload still completes", async () => {
@@ -187,12 +202,7 @@ describe("HostWorkerPool", () => {
 			.catch((e: Error) => e.message);
 		const t3 = pool.run(echo, { v: 3 }).catch((e: Error) => e.message);
 
-		const results = await Promise.race([
-			Promise.all([t1, t2, t3]),
-			new Promise<"stranded">((r) => setTimeout(() => r("stranded"), 5_000)),
-		]);
-		expect(results).not.toBe("stranded");
-		const [r1, r2, r3] = results as string[];
+		const [r1, r2, r3] = await withTimeout(Promise.all([t1, t2, t3]));
 		expect(r1).toContain("unknown worker task type");
 		expect(r2).toContain("postMessage failed");
 		expect(r3).toContain("unknown worker task type");
@@ -218,10 +228,9 @@ describe("HostWorkerPool", () => {
 			// Distinct payloads (no dedupe): serial crashes burn the budget while
 			// the rest queue. At circuit-open the queued tasks must reject into
 			// the inline retry instead of each feeding a fresh crashing worker.
-			const results = await Promise.race([
+			const results = await withTimeout(
 				Promise.all([1, 2, 3, 4, 5].map((v) => pool.run(echo, { v }))),
-				new Promise<"stranded">((r) => setTimeout(() => r("stranded"), 15_000)),
-			]);
+			);
 			expect(results).toEqual([1, 2, 3, 4, 5]);
 			expect(pool.getMode()).toBe("inline");
 			// Budget is 3; one more task may already be mid-dispatch when the
@@ -247,10 +256,8 @@ describe("HostWorkerPool", () => {
 		// The slot must be free again: a valid task completes promptly via the
 		// worker path (registry rejects the unknown type — still a worker round
 		// trip, which is what proves the slot isn't wedged).
-		const t0 = performance.now();
-		await expect(pool.run(echo, { v: 2 })).rejects.toThrow(
+		await expect(withTimeout(pool.run(echo, { v: 2 }))).rejects.toThrow(
 			"unknown worker task type",
 		);
-		expect(performance.now() - t0).toBeLessThan(5_000);
 	});
 });

--- a/packages/host-service/src/workers/host-worker-pool.test.ts
+++ b/packages/host-service/src/workers/host-worker-pool.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { defineWorkerTask } from "./define-worker-task.ts";
+import { HostWorkerPool } from "./host-worker-pool.ts";
+import { gitStatusSnapshotTask } from "./tasks/git.ts";
+
+const WORKER_ENTRY = path.resolve(import.meta.dirname, "host-worker.ts");
+const CRASH_WORKER = path.resolve(
+	import.meta.dirname,
+	"test-fixtures",
+	"crashing-worker.ts",
+);
+
+const pools: HostWorkerPool[] = [];
+function makePool(options?: ConstructorParameters<typeof HostWorkerPool>[0]) {
+	const pool = new HostWorkerPool({
+		scriptPathResolver: () => WORKER_ENTRY,
+		...options,
+	});
+	pools.push(pool);
+	return pool;
+}
+
+afterEach(async () => {
+	await Promise.all(pools.splice(0).map((p) => p.dispose()));
+});
+
+function makeFixtureRepo(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "host-worker-git-"));
+	const git = (...args: string[]) =>
+		execFileSync("git", args, { cwd: dir, stdio: "pipe" });
+	git("init", "-q", "-b", "main");
+	fs.writeFileSync(path.join(dir, "a.txt"), "one\ntwo\n");
+	fs.writeFileSync(path.join(dir, "b.txt"), "alpha\n");
+	git("add", "-A", "--", ".");
+	git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init");
+	// one modified, one staged, one untracked — exercises every snapshot bucket
+	fs.appendFileSync(path.join(dir, "a.txt"), "three\n");
+	fs.writeFileSync(path.join(dir, "c.txt"), "new file\n");
+	fs.writeFileSync(path.join(dir, "staged.txt"), "staged\n");
+	git("add", "--", "staged.txt");
+	return dir;
+}
+
+describe("HostWorkerPool", () => {
+	test("worker result matches inline handler result (parity)", async () => {
+		const worktreePath = makeFixtureRepo();
+		const input = { worktreePath, gitEnv: { GIT_OPTIONAL_LOCKS: "0" } };
+
+		const pool = makePool();
+		expect(pool.getMode()).toBe("worker");
+		const fromWorker = await pool.run(gitStatusSnapshotTask, input);
+		const inline = await gitStatusSnapshotTask.handler(input);
+
+		expect(fromWorker).toEqual(inline);
+		expect(fromWorker.unstaged.map((f) => f.path).sort()).toEqual([
+			"a.txt",
+			"c.txt",
+		]);
+		expect(fromWorker.staged.map((f) => f.path)).toEqual(["staged.txt"]);
+	});
+
+	test("unknown task type rejects with the worker's error", async () => {
+		const pool = makePool();
+		const bogus = defineWorkerTask<Record<string, never>, never>({
+			type: "nope/missing",
+			handler: () => {
+				throw new Error("inline handler must not run for worker-mode errors");
+			},
+		});
+		await expect(pool.run(bogus, {})).rejects.toThrow(
+			"unknown worker task type: nope/missing",
+		);
+	});
+
+	test("idle workers are reaped after idleTimeoutMs", async () => {
+		const worktreePath = makeFixtureRepo();
+		const pool = makePool({ idleTimeoutMs: 250 });
+		await pool.run(gitStatusSnapshotTask, {
+			worktreePath,
+			gitEnv: { GIT_OPTIONAL_LOCKS: "0" },
+		});
+		const runner = pool.getRunner();
+		expect(runner?.getWorkerCount()).toBe(1);
+		await new Promise((r) => setTimeout(r, 600));
+		expect(runner?.getWorkerCount()).toBe(0);
+	});
+
+	test("missing bundle falls back to inline execution", async () => {
+		const worktreePath = makeFixtureRepo();
+		const pool = makePool({ scriptPathResolver: () => null });
+		const result = await pool.run(gitStatusSnapshotTask, {
+			worktreePath,
+			gitEnv: { GIT_OPTIONAL_LOCKS: "0" },
+		});
+		expect(pool.getMode()).toBe("inline");
+		expect(result.unstaged.length).toBeGreaterThan(0);
+	});
+
+	test("worker crash retries inline; crash loop opens the circuit", async () => {
+		const pool = makePool({ scriptPathResolver: () => CRASH_WORKER });
+		const echo = defineWorkerTask<{ v: number }, number>({
+			type: "test/echo",
+			handler: async ({ v }) => v,
+		});
+
+		// Every worker run crashes; each call must still succeed via the
+		// inline retry. After the crash budget the pool goes inline-only.
+		expect(await pool.run(echo, { v: 1 })).toBe(1);
+		expect(await pool.run(echo, { v: 2 })).toBe(2);
+		expect(await pool.run(echo, { v: 3 })).toBe(3);
+		expect(pool.getMode()).toBe("inline");
+		// Circuit open: no worker involved anymore, still correct results.
+		expect(await pool.run(echo, { v: 4 })).toBe(4);
+	});
+});

--- a/packages/host-service/src/workers/host-worker-pool.test.ts
+++ b/packages/host-service/src/workers/host-worker-pool.test.ts
@@ -24,12 +24,18 @@ function makePool(options?: ConstructorParameters<typeof HostWorkerPool>[0]) {
 	return pool;
 }
 
+const fixtureDirs: string[] = [];
+
 afterEach(async () => {
 	await Promise.all(pools.splice(0).map((p) => p.dispose()));
+	for (const dir of fixtureDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 function makeFixtureRepo(): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "host-worker-git-"));
+	fixtureDirs.push(dir);
 	const git = (...args: string[]) =>
 		execFileSync("git", args, { cwd: dir, stdio: "pipe" });
 	git("init", "-q", "-b", "main");
@@ -157,6 +163,69 @@ describe("HostWorkerPool", () => {
 			"timed out after 200ms",
 		);
 		expect(performance.now() - t0).toBeLessThan(2_000);
+	});
+
+	test("a task queued behind a poison payload still completes", async () => {
+		const pool = makePool({ concurrency: 1 });
+		const echo = defineWorkerTask<{ v: number; fn?: unknown }, number>({
+			type: "test/echo-drain",
+			handler: async ({ v }) => v,
+		});
+
+		// One slot: t1 occupies it (worker round trip), t2's payload fails
+		// postMessage at dispatch, t3 sits behind it. Without a re-drain, t3
+		// strands with no timeout armed and only settles via t3's own timeout.
+		const t1 = pool.run(echo, { v: 1 }).catch((e: Error) => e.message);
+		const t2 = pool
+			.run(echo, { v: 2, fn: () => 2 })
+			.catch((e: Error) => e.message);
+		const t3 = pool.run(echo, { v: 3 }).catch((e: Error) => e.message);
+
+		const results = await Promise.race([
+			Promise.all([t1, t2, t3]),
+			new Promise<"stranded">((r) => setTimeout(() => r("stranded"), 5_000)),
+		]);
+		expect(results).not.toBe("stranded");
+		const [r1, r2, r3] = results as string[];
+		expect(r1).toContain("unknown worker task type");
+		expect(r2).toContain("postMessage failed");
+		expect(r3).toContain("unknown worker task type");
+	});
+
+	test("circuit-open rejects the queued backlog into the inline retry", async () => {
+		const marker = path.join(
+			fs.mkdtempSync(path.join(os.tmpdir(), "host-worker-crash-")),
+			"spawns",
+		);
+		fixtureDirs.push(path.dirname(marker));
+		process.env.CRASH_MARKER_FILE = marker;
+		try {
+			const pool = makePool({
+				scriptPathResolver: () => CRASH_WORKER,
+				concurrency: 1,
+			});
+			const echo = defineWorkerTask<{ v: number }, number>({
+				type: "test/echo-backlog",
+				handler: async ({ v }) => v,
+			});
+
+			// Distinct payloads (no dedupe): serial crashes burn the budget while
+			// the rest queue. At circuit-open the queued tasks must reject into
+			// the inline retry instead of each feeding a fresh crashing worker.
+			const results = await Promise.race([
+				Promise.all([1, 2, 3, 4, 5].map((v) => pool.run(echo, { v }))),
+				new Promise<"stranded">((r) => setTimeout(() => r("stranded"), 15_000)),
+			]);
+			expect(results).toEqual([1, 2, 3, 4, 5]);
+			expect(pool.getMode()).toBe("inline");
+			// Budget is 3; one more task may already be mid-dispatch when the
+			// circuit opens. Without the queued-backlog rejection, every task
+			// spawns its own crashing worker (5 here).
+			const spawns = fs.readFileSync(marker, "utf8").length;
+			expect(spawns).toBeLessThanOrEqual(4);
+		} finally {
+			delete process.env.CRASH_MARKER_FILE;
+		}
 	});
 
 	test("non-cloneable payload rejects without wedging the worker slot", async () => {

--- a/packages/host-service/src/workers/host-worker-pool.test.ts
+++ b/packages/host-service/src/workers/host-worker-pool.test.ts
@@ -125,14 +125,19 @@ describe("HostWorkerPool", () => {
 
 	test("one crash with coalesced callers counts once toward the budget", async () => {
 		const pool = makePool({ scriptPathResolver: () => CRASH_WORKER });
+		let handlerRuns = 0;
 		const echo = defineWorkerTask<{ v: number }, number>({
 			type: "test/echo",
-			handler: async ({ v }) => v,
+			handler: async ({ v }) => {
+				handlerRuns++;
+				return v;
+			},
 		});
 
 		// Three callers coalesced onto one worker task; the single crash must
 		// be recorded once — per-caller counting would consume the whole
-		// budget (3) and open the circuit off a single worker death.
+		// budget (3) and open the circuit off a single worker death — and the
+		// inline retry must also be shared, not run once per caller.
 		const opts = { strategy: "coalesce" as const, dedupeKey: "same" };
 		const [a, b, c] = await Promise.all([
 			pool.run(echo, { v: 7 }, opts),
@@ -142,6 +147,7 @@ describe("HostWorkerPool", () => {
 		expect(a).toBe(7);
 		expect(b).toBe(7);
 		expect(c).toBe(7);
+		expect(handlerRuns).toBe(1);
 		expect(pool.getMode()).toBe("worker");
 	});
 

--- a/packages/host-service/src/workers/host-worker-pool.test.ts
+++ b/packages/host-service/src/workers/host-worker-pool.test.ts
@@ -116,4 +116,66 @@ describe("HostWorkerPool", () => {
 		// Circuit open: no worker involved anymore, still correct results.
 		expect(await pool.run(echo, { v: 4 })).toBe(4);
 	});
+
+	test("one crash with coalesced callers counts once toward the budget", async () => {
+		const pool = makePool({ scriptPathResolver: () => CRASH_WORKER });
+		const echo = defineWorkerTask<{ v: number }, number>({
+			type: "test/echo",
+			handler: async ({ v }) => v,
+		});
+
+		// Three callers coalesced onto one worker task; the single crash must
+		// be recorded once — per-caller counting would consume the whole
+		// budget (3) and open the circuit off a single worker death.
+		const opts = { strategy: "coalesce" as const, dedupeKey: "same" };
+		const [a, b, c] = await Promise.all([
+			pool.run(echo, { v: 7 }, opts),
+			pool.run(echo, { v: 7 }, opts),
+			pool.run(echo, { v: 7 }, opts),
+		]);
+		expect(a).toBe(7);
+		expect(b).toBe(7);
+		expect(c).toBe(7);
+		expect(pool.getMode()).toBe("worker");
+	});
+
+	test("inline fallback honors abort signal and timeout", async () => {
+		const pool = makePool({ scriptPathResolver: () => null });
+		const slow = defineWorkerTask<Record<string, never>, string>({
+			type: "test/slow",
+			handler: () => new Promise((r) => setTimeout(() => r("done"), 5_000)),
+		});
+
+		const aborted = new AbortController();
+		aborted.abort();
+		await expect(
+			pool.run(slow, {}, { signal: aborted.signal }),
+		).rejects.toThrow("Worker task aborted");
+
+		const t0 = performance.now();
+		await expect(pool.run(slow, {}, { timeoutMs: 200 })).rejects.toThrow(
+			"timed out after 200ms",
+		);
+		expect(performance.now() - t0).toBeLessThan(2_000);
+	});
+
+	test("non-cloneable payload rejects without wedging the worker slot", async () => {
+		const pool = makePool();
+		const echo = defineWorkerTask<{ v: number; fn?: unknown }, number>({
+			type: "test/echo-clone",
+			handler: async ({ v }) => v,
+		});
+
+		await expect(
+			pool.run(echo, { v: 1, fn: () => 1 }, { timeoutMs: 10_000 }),
+		).rejects.toThrow("postMessage failed");
+		// The slot must be free again: a valid task completes promptly via the
+		// worker path (registry rejects the unknown type — still a worker round
+		// trip, which is what proves the slot isn't wedged).
+		const t0 = performance.now();
+		await expect(pool.run(echo, { v: 2 })).rejects.toThrow(
+			"unknown worker task type",
+		);
+		expect(performance.now() - t0).toBeLessThan(5_000);
+	});
 });

--- a/packages/host-service/src/workers/host-worker-pool.ts
+++ b/packages/host-service/src/workers/host-worker-pool.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { WorkerTaskDefinition } from "./define-worker-task.ts";
 import {
+	DEFAULT_TIMEOUT_MS,
 	WORKER_CRASH_ERROR_NAME,
 	WorkerTaskAbortedError,
 	WorkerTaskError,
@@ -154,21 +155,21 @@ export class HostWorkerPool {
 				fn();
 			};
 			const onAbort = () => settle(() => reject(new WorkerTaskAbortedError()));
-			const timeoutHandle = options?.timeoutMs
-				? setTimeout(
-						() =>
-							settle(() =>
-								reject(
-									new WorkerTaskError(
-										`[host-worker] Task "${def.type}" timed out after ${options.timeoutMs}ms (inline)`,
-									),
-								),
+			// Same default and zero-means-instant semantics as the worker path.
+			const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+			const timeoutHandle = setTimeout(
+				() =>
+					settle(() =>
+						reject(
+							new WorkerTaskError(
+								`[host-worker] Task "${def.type}" timed out after ${timeoutMs}ms (inline)`,
 							),
-						options.timeoutMs,
-					)
-				: null;
+						),
+					),
+				timeoutMs,
+			);
 			const cleanup = () => {
-				if (timeoutHandle) clearTimeout(timeoutHandle);
+				clearTimeout(timeoutHandle);
 				options?.signal?.removeEventListener("abort", onAbort);
 			};
 			options?.signal?.addEventListener("abort", onAbort, { once: true });
@@ -206,7 +207,13 @@ export class HostWorkerPool {
 			// outstanding tasks with abort errors that bypass the inline
 			// retry. Detach it instead — in-flight tasks settle on their own
 			// merits and the idle reaper terminates its workers afterward.
-			if (this.runner) this.drainingRunners.push(this.runner);
+			// Queued tasks WOULD keep feeding fresh crashing workers, so
+			// reject them with this same crash error: their callers take the
+			// inline retry and seenCrashErrors keeps the accounting at one.
+			if (this.runner) {
+				this.drainingRunners.push(this.runner);
+				this.runner.rejectQueuedTasks(error);
+			}
 			this.runner = null;
 		}
 	}

--- a/packages/host-service/src/workers/host-worker-pool.ts
+++ b/packages/host-service/src/workers/host-worker-pool.ts
@@ -1,0 +1,164 @@
+// HostWorkerPool — lazy singleton over WorkerTaskRunner with:
+//  - script resolution mirroring daemon/singleton.ts (env override →
+//    side-by-side host-worker.js → workspace dist fallback)
+//  - inline fallback: missing bundle or crash-looping workers degrade to
+//    running handlers on the main thread (current behavior), never failing
+//    the caller because of pool infrastructure
+//  - worker-crash retry: a task that dies with the worker is retried inline
+//    once, so callers only ever see real handler errors
+
+import { existsSync } from "node:fs";
+// Shared with gitStatusRefreshLimiter's DEFAULT_CONCURRENCY intent: the
+// limiter is the front-door queue for status refreshes; the pool must be
+// able to execute what the limiter admits without queueing behind it.
+import { cpus } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { WorkerTaskDefinition } from "./define-worker-task.ts";
+import {
+	WORKER_CRASH_ERROR_NAME,
+	WorkerTaskError,
+	type WorkerTaskOptions,
+	WorkerTaskRunner,
+} from "./WorkerTaskRunner.ts";
+
+const DEFAULT_CONCURRENCY = Math.max(1, Math.min(4, cpus().length - 1));
+
+const IDLE_TIMEOUT_MS = 30_000;
+const CRASH_BUDGET = 3;
+const CRASH_WINDOW_MS = 60_000;
+
+export function resolveHostWorkerScriptPath(): string | null {
+	const override = process.env.SUPERSET_HOST_WORKER_SCRIPT_PATH;
+	if (override) return existsSync(override) ? override : null;
+
+	const here = path.dirname(fileURLToPath(import.meta.url));
+	// Production (electron-vite / standalone dist): host-service.js and
+	// host-worker.js are emitted side-by-side in the same dist directory.
+	const sideBySide = path.resolve(here, "host-worker.js");
+	if (existsSync(sideBySide)) return sideBySide;
+
+	// Source-running fallback (`bun run` from packages/host-service): `here`
+	// is `packages/host-service/src/workers/`; the built entry sits at
+	// `packages/host-service/dist/host-worker.js` after `bun run build`.
+	const workspaceDist = path.resolve(
+		here,
+		"..",
+		"..",
+		"dist",
+		"host-worker.js",
+	);
+	if (existsSync(workspaceDist)) return workspaceDist;
+
+	return null;
+}
+
+export class HostWorkerPool {
+	private runner: WorkerTaskRunner | null = null;
+	private inlineOnly = false;
+	private warnedInline = false;
+	private crashTimestamps: number[] = [];
+	private readonly scriptPathResolver: () => string | null;
+	private readonly concurrency: number;
+	private readonly idleTimeoutMs: number;
+	private readonly execArgv?: string[];
+
+	constructor(options?: {
+		scriptPathResolver?: () => string | null;
+		concurrency?: number;
+		idleTimeoutMs?: number;
+		execArgv?: string[];
+	}) {
+		this.scriptPathResolver =
+			options?.scriptPathResolver ?? resolveHostWorkerScriptPath;
+		this.concurrency = options?.concurrency ?? DEFAULT_CONCURRENCY;
+		this.idleTimeoutMs = options?.idleTimeoutMs ?? IDLE_TIMEOUT_MS;
+		this.execArgv = options?.execArgv;
+	}
+
+	/** Exposed for tests. */
+	getMode(): "worker" | "inline" {
+		return this.inlineOnly || !this.getRunner() ? "inline" : "worker";
+	}
+
+	getRunner(): WorkerTaskRunner | null {
+		if (this.inlineOnly) return null;
+		if (this.runner) return this.runner;
+		const scriptPath = this.scriptPathResolver();
+		if (!scriptPath) {
+			this.inlineOnly = true;
+			this.warnInlineOnce(
+				"host-worker bundle not found — running worker tasks inline on the main thread",
+			);
+			return null;
+		}
+		this.runner = new WorkerTaskRunner({
+			workerScriptPath: scriptPath,
+			concurrency: this.concurrency,
+			name: "host-worker",
+			idleTimeoutMs: this.idleTimeoutMs,
+			execArgv: this.execArgv,
+		});
+		return this.runner;
+	}
+
+	async run<TInput, TResult>(
+		def: WorkerTaskDefinition<TInput, TResult>,
+		input: TInput,
+		options?: WorkerTaskOptions,
+	): Promise<TResult> {
+		const runner = this.getRunner();
+		if (!runner) return def.handler(input);
+
+		try {
+			return await runner.runTask<TResult>(def.type, input, options);
+		} catch (error) {
+			if (
+				error instanceof WorkerTaskError &&
+				error.name === WORKER_CRASH_ERROR_NAME
+			) {
+				this.recordCrash();
+				// The task died with the worker, not on its own merits — run it
+				// inline so the caller sees a real result or a real error.
+				return def.handler(input);
+			}
+			throw error;
+		}
+	}
+
+	async dispose(): Promise<void> {
+		const runner = this.runner;
+		this.runner = null;
+		await runner?.dispose();
+	}
+
+	private recordCrash(): void {
+		const now = Date.now();
+		this.crashTimestamps = this.crashTimestamps.filter(
+			(t) => now - t < CRASH_WINDOW_MS,
+		);
+		this.crashTimestamps.push(now);
+		if (this.crashTimestamps.length >= CRASH_BUDGET && !this.inlineOnly) {
+			this.inlineOnly = true;
+			this.warnInlineOnce(
+				`host-worker crashed ${CRASH_BUDGET}x within ${CRASH_WINDOW_MS / 1000}s — falling back to inline execution for the rest of this process`,
+			);
+			const runner = this.runner;
+			this.runner = null;
+			void runner?.dispose();
+		}
+	}
+
+	private warnInlineOnce(message: string): void {
+		if (this.warnedInline) return;
+		this.warnedInline = true;
+		console.warn(`[host-worker-pool] ${message}`);
+	}
+}
+
+let pool: HostWorkerPool | null = null;
+
+export function getHostWorkerPool(): HostWorkerPool {
+	if (!pool) pool = new HostWorkerPool();
+	return pool;
+}

--- a/packages/host-service/src/workers/host-worker-pool.ts
+++ b/packages/host-service/src/workers/host-worker-pool.ts
@@ -64,6 +64,9 @@ export class HostWorkerPool {
 	private warnedInline = false;
 	private crashTimestamps: number[] = [];
 	private readonly seenCrashErrors = new WeakSet<WorkerTaskError>();
+	/** Coalesced callers share one inline crash-retry per dedupe key —
+	 * otherwise a single worker death fans out into N duplicate inline runs. */
+	private readonly inlineRetryByKey = new Map<string, Promise<unknown>>();
 	/** Runners detached at circuit-open; disposed with the pool. */
 	private readonly drainingRunners: WorkerTaskRunner[] = [];
 	private readonly scriptPathResolver: () => string | null;
@@ -128,6 +131,19 @@ export class HostWorkerPool {
 				this.recordCrash(error);
 				// The task died with the worker, not on its own merits — run it
 				// inline so the caller sees a real result or a real error.
+				const key =
+					options?.strategy === "coalesce" && options.dedupeKey
+						? options.dedupeKey
+						: null;
+				if (key) {
+					const existing = this.inlineRetryByKey.get(key);
+					if (existing) return existing as Promise<TResult>;
+					const retry = this.runInline(def, input, options).finally(() => {
+						this.inlineRetryByKey.delete(key);
+					});
+					this.inlineRetryByKey.set(key, retry);
+					return retry;
+				}
 				return this.runInline(def, input, options);
 			}
 			throw error;
@@ -174,8 +190,10 @@ export class HostWorkerPool {
 			};
 			options?.signal?.addEventListener("abort", onAbort, { once: true });
 
-			def
-				.handler(input)
+			// Promise.resolve() wrapper: a synchronously-throwing handler must
+			// route through settle() too, or the timer and abort listener leak.
+			Promise.resolve()
+				.then(() => def.handler(input))
 				.then((result) => settle(() => resolve(result)))
 				.catch((error) => settle(() => reject(error)));
 		});

--- a/packages/host-service/src/workers/host-worker-pool.ts
+++ b/packages/host-service/src/workers/host-worker-pool.ts
@@ -17,12 +17,16 @@ import { fileURLToPath } from "node:url";
 import type { WorkerTaskDefinition } from "./define-worker-task.ts";
 import {
 	WORKER_CRASH_ERROR_NAME,
+	WorkerTaskAbortedError,
 	WorkerTaskError,
 	type WorkerTaskOptions,
 	WorkerTaskRunner,
 } from "./WorkerTaskRunner.ts";
 
-const DEFAULT_CONCURRENCY = Math.max(1, Math.min(4, cpus().length - 1));
+// min(4, cpus−1) matches gitStatusRefreshLimiter, +2 headroom so occasional
+// non-limiter tasks (getCommitFiles) can't occupy every worker ahead of
+// status refreshes. Idle reaping keeps the extra threads free when unused.
+const DEFAULT_CONCURRENCY = Math.max(1, Math.min(4, cpus().length - 1)) + 2;
 
 const IDLE_TIMEOUT_MS = 30_000;
 const CRASH_BUDGET = 3;
@@ -58,6 +62,9 @@ export class HostWorkerPool {
 	private inlineOnly = false;
 	private warnedInline = false;
 	private crashTimestamps: number[] = [];
+	private readonly seenCrashErrors = new WeakSet<WorkerTaskError>();
+	/** Runners detached at circuit-open; disposed with the pool. */
+	private readonly drainingRunners: WorkerTaskRunner[] = [];
 	private readonly scriptPathResolver: () => string | null;
 	private readonly concurrency: number;
 	private readonly idleTimeoutMs: number;
@@ -108,7 +115,7 @@ export class HostWorkerPool {
 		options?: WorkerTaskOptions,
 	): Promise<TResult> {
 		const runner = this.getRunner();
-		if (!runner) return def.handler(input);
+		if (!runner) return this.runInline(def, input, options);
 
 		try {
 			return await runner.runTask<TResult>(def.type, input, options);
@@ -117,22 +124,74 @@ export class HostWorkerPool {
 				error instanceof WorkerTaskError &&
 				error.name === WORKER_CRASH_ERROR_NAME
 			) {
-				this.recordCrash();
+				this.recordCrash(error);
 				// The task died with the worker, not on its own merits — run it
 				// inline so the caller sees a real result or a real error.
-				return def.handler(input);
+				return this.runInline(def, input, options);
 			}
 			throw error;
 		}
 	}
 
-	async dispose(): Promise<void> {
-		const runner = this.runner;
-		this.runner = null;
-		await runner?.dispose();
+	/**
+	 * Inline execution with the same caller-visible timeout/abort semantics as
+	 * the worker path. The handler itself is not cancellable — like a worker
+	 * task, it may keep running after the caller's promise settles.
+	 */
+	private async runInline<TInput, TResult>(
+		def: WorkerTaskDefinition<TInput, TResult>,
+		input: TInput,
+		options?: WorkerTaskOptions,
+	): Promise<TResult> {
+		if (options?.signal?.aborted) throw new WorkerTaskAbortedError();
+
+		return new Promise<TResult>((resolve, reject) => {
+			let settled = false;
+			const settle = (fn: () => void) => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				fn();
+			};
+			const onAbort = () => settle(() => reject(new WorkerTaskAbortedError()));
+			const timeoutHandle = options?.timeoutMs
+				? setTimeout(
+						() =>
+							settle(() =>
+								reject(
+									new WorkerTaskError(
+										`[host-worker] Task "${def.type}" timed out after ${options.timeoutMs}ms (inline)`,
+									),
+								),
+							),
+						options.timeoutMs,
+					)
+				: null;
+			const cleanup = () => {
+				if (timeoutHandle) clearTimeout(timeoutHandle);
+				options?.signal?.removeEventListener("abort", onAbort);
+			};
+			options?.signal?.addEventListener("abort", onAbort, { once: true });
+
+			def
+				.handler(input)
+				.then((result) => settle(() => resolve(result)))
+				.catch((error) => settle(() => reject(error)));
+		});
 	}
 
-	private recordCrash(): void {
+	async dispose(): Promise<void> {
+		const runners = [this.runner, ...this.drainingRunners.splice(0)];
+		this.runner = null;
+		await Promise.all(runners.map((r) => r?.dispose()));
+	}
+
+	private recordCrash(error: WorkerTaskError): void {
+		// Coalesced callers all reject with the SAME error instance for one
+		// worker death — count each underlying crash once, not per caller.
+		if (this.seenCrashErrors.has(error)) return;
+		this.seenCrashErrors.add(error);
+
 		const now = Date.now();
 		this.crashTimestamps = this.crashTimestamps.filter(
 			(t) => now - t < CRASH_WINDOW_MS,
@@ -143,9 +202,12 @@ export class HostWorkerPool {
 			this.warnInlineOnce(
 				`host-worker crashed ${CRASH_BUDGET}x within ${CRASH_WINDOW_MS / 1000}s — falling back to inline execution for the rest of this process`,
 			);
-			const runner = this.runner;
+			// Do NOT dispose the old runner: dispose() would reject its
+			// outstanding tasks with abort errors that bypass the inline
+			// retry. Detach it instead — in-flight tasks settle on their own
+			// merits and the idle reaper terminates its workers afterward.
+			if (this.runner) this.drainingRunners.push(this.runner);
 			this.runner = null;
-			void runner?.dispose();
 		}
 	}
 

--- a/packages/host-service/src/workers/host-worker.ts
+++ b/packages/host-service/src/workers/host-worker.ts
@@ -1,0 +1,64 @@
+// host-worker thread entry: dispatch loop over the static task registry.
+// Adding a worker domain = create a task module and import it here; the
+// registry is fixed at build time (you cannot ship closures to a worker).
+
+import { parentPort } from "node:worker_threads";
+import type { WorkerTaskDefinition } from "./define-worker-task.ts";
+import { gitTasks } from "./tasks/git.ts";
+import {
+	serializeWorkerError,
+	type WorkerTaskRequestMessage,
+} from "./worker-task-protocol.ts";
+
+if (!parentPort) {
+	throw new Error("host-worker must be run in a worker thread");
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: heterogenous task registry; typing is enforced at the defineWorkerTask/run() boundary
+const registry = new Map<string, WorkerTaskDefinition<any, unknown>>();
+for (const def of [...gitTasks]) {
+	if (registry.has(def.type)) {
+		throw new Error(`duplicate worker task type: ${def.type}`);
+	}
+	registry.set(def.type, def);
+}
+
+function isWorkerTaskRequestMessage(
+	message: unknown,
+): message is WorkerTaskRequestMessage {
+	if (!message || typeof message !== "object") {
+		return false;
+	}
+	const candidate = message as Partial<WorkerTaskRequestMessage>;
+	return (
+		candidate.kind === "task" &&
+		typeof candidate.taskId === "string" &&
+		typeof candidate.taskType === "string"
+	);
+}
+
+parentPort.on("message", async (message: unknown) => {
+	if (!isWorkerTaskRequestMessage(message)) return;
+	const task = message;
+
+	try {
+		const def = registry.get(task.taskType);
+		if (!def) {
+			throw new Error(`unknown worker task type: ${task.taskType}`);
+		}
+		const result = await def.handler(task.payload);
+		parentPort?.postMessage({
+			kind: "result",
+			taskId: task.taskId,
+			ok: true,
+			result,
+		});
+	} catch (error) {
+		parentPort?.postMessage({
+			kind: "result",
+			taskId: task.taskId,
+			ok: false,
+			error: serializeWorkerError(error),
+		});
+	}
+});

--- a/packages/host-service/src/workers/no-native-worker-imports.test.ts
+++ b/packages/host-service/src/workers/no-native-worker-imports.test.ts
@@ -1,0 +1,47 @@
+// The worker graph must stay free of native addons and process-singleton
+// state: handlers run both in the worker thread AND inline (fallback), and
+// the worker bundle is built without native externals. This grep test guards
+// direct imports in src/workers/**; the bundle build catches transitive
+// regressions (a native import fails the host-worker.js build).
+
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const WORKERS_DIR = path.resolve(import.meta.dirname);
+
+const FORBIDDEN = [
+	/from\s+["']better-sqlite3["']/,
+	/from\s+["']node-pty["']/,
+	/from\s+["']@parcel\/watcher["']/,
+	/from\s+["']electron["']/,
+	// host-service process singletons — workers get inputs via payload only
+	/from\s+["'][./]*\.\.\/db(\/|["'])/,
+	/from\s+["'][./]*\.\.\/events(\/|["'])/,
+	/from\s+["'][./]*\.\.\/daemon(\/|["'])/,
+];
+
+function walk(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...walk(full));
+		else if (entry.name.endsWith(".ts")) out.push(full);
+	}
+	return out;
+}
+
+describe("worker graph purity", () => {
+	test("src/workers/** has no native/singleton imports", () => {
+		const offenders: string[] = [];
+		for (const file of walk(WORKERS_DIR)) {
+			const content = fs.readFileSync(file, "utf8");
+			for (const pattern of FORBIDDEN) {
+				if (pattern.test(content)) {
+					offenders.push(`${path.relative(WORKERS_DIR, file)}: ${pattern}`);
+				}
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -1,0 +1,45 @@
+// git/* worker tasks. Handlers build their own SimpleGit — the worker spawns
+// the git subprocesses itself, so stdout draining AND parsing leave the
+// host-service event loop. Credential env is resolved in-process (it needs
+// the credential provider) and crosses as plain data.
+
+import { createUserSimpleGit } from "../../runtime/git/simple-git.ts";
+import type { ChangedFile } from "../../trpc/router/git/types.ts";
+import { getChangedFilesForDiff } from "../../trpc/router/git/utils/git-helpers.ts";
+import type { GitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts";
+import { getGitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts";
+import { defineWorkerTask } from "../define-worker-task.ts";
+
+export interface GitTaskEnv {
+	[key: string]: string;
+}
+
+export const gitStatusSnapshotTask = defineWorkerTask<
+	{ worktreePath: string; baseBranch?: string; gitEnv: GitTaskEnv },
+	GitStatusSnapshot
+>({
+	type: "git/getStatusSnapshot",
+	handler: async ({ worktreePath, baseBranch, gitEnv }) => {
+		const git = createUserSimpleGit(worktreePath).env(gitEnv);
+		return getGitStatusSnapshot({ git, worktreePath, baseBranch });
+	},
+});
+
+export const gitCommitFilesTask = defineWorkerTask<
+	{
+		worktreePath: string;
+		commitHash: string;
+		fromHash?: string;
+		gitEnv: GitTaskEnv;
+	},
+	ChangedFile[]
+>({
+	type: "git/getCommitFiles",
+	handler: async ({ worktreePath, commitHash, fromHash, gitEnv }) => {
+		const git = createUserSimpleGit(worktreePath).env(gitEnv);
+		const from = fromHash ? fromHash : `${commitHash}^`;
+		return getChangedFilesForDiff(git, [from, commitHash]);
+	},
+});
+
+export const gitTasks = [gitStatusSnapshotTask, gitCommitFilesTask];

--- a/packages/host-service/src/workers/test-fixtures/crashing-worker.ts
+++ b/packages/host-service/src/workers/test-fixtures/crashing-worker.ts
@@ -1,6 +1,12 @@
 // Test fixture: a worker that dies on its first task, for exercising the
-// pool's inline-retry and crash-circuit paths.
+// pool's inline-retry and crash-circuit paths. CRASH_MARKER_FILE lets tests
+// count how many crashing workers were ever spawned.
+import { appendFileSync } from "node:fs";
 import { parentPort } from "node:worker_threads";
+
+if (process.env.CRASH_MARKER_FILE) {
+	appendFileSync(process.env.CRASH_MARKER_FILE, "x");
+}
 
 parentPort?.on("message", () => {
 	process.exit(1);

--- a/packages/host-service/src/workers/test-fixtures/crashing-worker.ts
+++ b/packages/host-service/src/workers/test-fixtures/crashing-worker.ts
@@ -1,0 +1,7 @@
+// Test fixture: a worker that dies on its first task, for exercising the
+// pool's inline-retry and crash-circuit paths.
+import { parentPort } from "node:worker_threads";
+
+parentPort?.on("message", () => {
+	process.exit(1);
+});

--- a/packages/host-service/src/workers/worker-task-protocol.ts
+++ b/packages/host-service/src/workers/worker-task-protocol.ts
@@ -1,0 +1,52 @@
+// Wire protocol between WorkerTaskRunner and the host-worker thread.
+// Ported from apps/desktop/src/lib/trpc/workers/worker-task-protocol.ts
+// (v1 desktop keeps its own copy; it retires with v1).
+
+export interface SerializedWorkerError {
+	name: string;
+	message: string;
+	stack?: string;
+	code?: string;
+}
+
+export interface WorkerTaskRequestMessage {
+	kind: "task";
+	taskId: string;
+	taskType: string;
+	payload: unknown;
+}
+
+export type WorkerTaskResponseMessage =
+	| {
+			kind: "result";
+			taskId: string;
+			ok: true;
+			result: unknown;
+	  }
+	| {
+			kind: "result";
+			taskId: string;
+			ok: false;
+			error: SerializedWorkerError;
+	  };
+
+export function serializeWorkerError(error: unknown): SerializedWorkerError {
+	if (error instanceof Error) {
+		const serialized: SerializedWorkerError = {
+			name: error.name,
+			message: error.message,
+			stack: error.stack,
+		};
+
+		if ("code" in error && typeof error.code === "string") {
+			serialized.code = error.code;
+		}
+
+		return serialized;
+	}
+
+	return {
+		name: "Error",
+		message: String(error),
+	};
+}

--- a/packages/host-service/test/integration/no-native-worker-imports.test.ts
+++ b/packages/host-service/test/integration/no-native-worker-imports.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-const WORKERS_DIR = path.resolve(import.meta.dirname);
+const WORKERS_DIR = path.resolve(import.meta.dirname, "../../src/workers");
 
 const FORBIDDEN = [
 	/from\s+["']better-sqlite3["']/,


### PR DESCRIPTION
**Links**
- Linear: SUPER-1544
- Design + measurements: `plans/20260717-host-service-git-worker-pool.md` (#5746)

## Summary
- Adds a generic `worker_threads` pool inside host-service (`packages/host-service/src/workers/`) and moves `git.getStatus` + `git.getCommitFiles` compute onto it. The worker spawns the git subprocesses itself, so stdout draining AND parsing leave the event loop that also relays terminal I/O and serves all tRPC/WS for the org.
- v1 had exactly this offload (`git-task-worker`); v2 lost it. Stress tests showed background `getStatus` queueing 3.7–14.6s under 8-workspace churn — this PR is the infrastructure that makes raising the limiter's concurrency safe (deferred, see Follow-ups).

## How It Works
- **Runner**: `WorkerTaskRunner` ported from v1 desktop (v1 keeps its copy; it retires with v1) with two changes: idle reaping (workers terminated after 30s idle — host-service is per-org and long-lived, a 3-org machine must not hold 12 warm workers) and demand-sized spawning (v1 spawned the full pool on any task).
- **Static registry**: task modules export `defineWorkerTask<In, Out>` defs, namespaced `git/*`; `host-worker.ts` imports them into a build-time registry. Callers pass the same def to `HostWorkerPool.run()` for end-to-end typing. Adding a domain = one task module + one import.
- **Inline fallback**: missing bundle → run handlers on the main thread (pre-PR behavior) with one warning; worker crash → task retried inline, 3 crashes/60s opens a circuit to inline-only. Pool infrastructure can never fail a caller.
- **Credential env**: `createGitEnvResolver` split out of `createGitFactory` — the env is resolved in-process (needs the credential provider) and crosses to the worker as plain data; the worker builds its own SimpleGit.
- **Bundling** (side-by-side with host-service.js, same pattern as pty-daemon): electron-vite input via `apps/desktop/src/main/host-worker/index.ts`, second `Bun.build` in `packages/host-service/build.ts`, copy in `packages/cli/scripts/build-dist.ts`. Resolution: `SUPERSET_HOST_WORKER_SCRIPT_PATH` → side-by-side → workspace dist → inline fallback.

## Manual QA Checklist
- [x] Dev app E2E: `git.getStatus` on the superset repo through the real app returns a correct snapshot in worker mode (435ms; zero `[host-worker-pool]` fallback warnings in the host-service log; `dist/main/host-worker.js` emitted)
- [x] Standalone bundle: `bun run build:host` emits `dist/host-worker.js`; plain-node smoke (`new Worker('./dist/host-worker.js')`) round-trips the task protocol (ESM entry works under node)

## Testing
- `src/workers/host-worker-pool.test.ts` (6 tests): worker↔inline **parity** on a real fixture repo (modified/staged/untracked buckets), unknown-task error propagation, idle reaping, missing-bundle inline fallback, crash → inline retry → circuit open. Mutation-verified: disabling reaping fails the reap test; removing the inline retry fails the crash test.
- `src/workers/no-native-worker-imports.test.ts`: worker graph stays free of native addons and process singletons (db/events/daemon); transitive regressions fail the host-worker bundle build.
- Full host-service suite (904 tests), `bun run typecheck` (host-service + desktop), `bun run lint` clean.

## Design Decisions
- **Copy the v1 runner instead of extracting a shared package**: v1 is sunset; its copy dies with it (repo v1/v2 duplication policy).
- **Handlers ship in both the main bundle and the worker bundle**: the inline fallback requires them in-process anyway; the git helpers were already in the main bundle.
- **Pool concurrency mirrors the limiter's `min(4, cpus−1)`**: the limiter stays the only queue for status refreshes; pooled tasks never meaningfully queue behind it.

## Known Limitations
- `scheduleBaseRefFetch`'s dedupe state is per-thread now — N workers can, worst case, schedule up to N base-ref fetches for the same worktree within one freshness window. Bounded and rare; noting rather than complicating the payload.

## Follow-ups
- Raise `gitStatusRefreshLimiter` concurrency now that snapshots don't cost loop time (measure first)
- GitWatcher rescan/filtering offload — the actual loop-stall driver under many-workspace churn (per the measured findings)
- `getDiff` / `listCommits` / `getBranchSyncStatus` tenants

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a generic `worker_threads` pool for `packages/host-service` and moves `git.getStatus` and `git.getCommitFiles` off the event loop to cut stalls and improve responsiveness. Addresses SUPER-1544 by restoring v1’s offload pattern, adding commit-file task deduping ahead of a small cap, and hardening the inline fallback (sync-throw safe, coalesced inline crash-retry).

- New Features
  - Added `WorkerTaskRunner` pool with demand-based spawning and 30s idle reaping; concurrency defaults to `min(4, cpus−1)+2`.
  - Inline fallback and crash handling: worker crashes retry inline; coalesced crashes count once; after 3 crashes/60s open an inline-only circuit and reject the queued backlog; inline path mirrors timeout/abort semantics and is sync-throw safe; re-drains after `postMessage` failures so bad payloads don’t wedge a slot.
  - Typed task registry and worker entry for `git/*` tasks; `createGitEnvResolver` resolves credential env in-process and passes plain data to the worker.
  - Switched tRPC `git.getStatusSnapshot` and `git.getCommitFiles` to the pool with 15s timeouts; commit-file tasks capped at 2 and deduped by key outside the cap so identical requests share one slot and one run.

- Dependencies
  - Built and ship `host-worker.js` side-by-side with `host-service.js`:
    - `apps/desktop` adds `src/main/host-worker/index.ts` to electron-vite.
    - `packages/host-service/build.ts` emits `host-worker.js` (ESM); `packages/cli/scripts/build-dist.ts` copies it next to `host-service.js`.
  - Added `exports` entry `./host-worker` in `packages/host-service/package.json` and resolution order `SUPERSET_HOST_WORKER_SCRIPT_PATH` → side-by-side → workspace `dist` → inline fallback.

<sup>Written for commit c6ecda61a06db6e56aa747a33c5dc258f91b2d34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git status and commit-file operations now run in the background for improved app responsiveness.
  * Added support for efficient handling of repeated Git requests.
* **Bug Fixes**
  * Improved resilience when background processing is unavailable or interrupted by automatically retrying operations through a fallback path.
  * Added safeguards for timeouts, cancellation, and worker failures.
* **Chores**
  * Updated desktop and distribution packaging to include the required background-processing support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->