### PR TITLE
fix(desktop,host-service): make workspace-close terminal disposal reliable

### DIFF
--- a/apps/desktop/src/renderer/lib/dispose-host-sessions.ts
+++ b/apps/desktop/src/renderer/lib/dispose-host-sessions.ts
@@ -11,6 +11,11 @@ export interface DisposeHostSessionsResult {
 	failed: number;
 	/** Hosts that errored before reporting counts — nothing stamped, nothing retrying. */
 	unreachableHosts: number;
+	/**
+	 * The coordinator lookup itself failed, so we don't even know which hosts
+	 * to ask — the dispose never happened and nothing was stamped.
+	 */
+	coordinatorUnavailable: boolean;
 }
 
 /**
@@ -18,11 +23,21 @@ export interface DisposeHostSessionsResult {
  * org). Disposal is broadcast to all of them because the electron delete path
  * doesn't know which org owns the workspace; each host no-ops for workspaces it
  * doesn't own, so this is safe and covers non-active-org workspaces too.
+ *
+ * Returns null (not []) when the coordinator lookup FAILS — the caller must
+ * distinguish "no hosts running" (safe: nothing to dispose) from "couldn't ask"
+ * (a real failure that would otherwise masquerade as success).
  */
 async function localHostClients(utils: ElectronTrpcUtils) {
-	const connections = await utils.hostServiceCoordinator.getConnections
-		.fetch(undefined, { staleTime: 0 })
-		.catch(() => []);
+	let connections: { port: number; secret: string }[];
+	try {
+		connections = await utils.hostServiceCoordinator.getConnections.fetch(
+			undefined,
+			{ staleTime: 0 },
+		);
+	} catch {
+		return null;
+	}
 	return (connections ?? []).map(({ port, secret }) => {
 		const url = `http://127.0.0.1:${port}`;
 		setHostServiceSecret(url, secret);
@@ -37,8 +52,20 @@ async function disposeViaHosts(
 	) => Promise<{ terminated: number; failed: number }>,
 	logContext: Record<string, string>,
 ): Promise<DisposeHostSessionsResult> {
+	const result: DisposeHostSessionsResult = {
+		terminated: 0,
+		failed: 0,
+		unreachableHosts: 0,
+		coordinatorUnavailable: false,
+	};
+	const clients = await localHostClients(utils);
+	if (clients === null) {
+		console.warn("Failed to enumerate host services for dispose", logContext);
+		result.coordinatorUnavailable = true;
+		return result;
+	}
 	const outcomes = await Promise.all(
-		(await localHostClients(utils)).map((client) =>
+		clients.map((client) =>
 			run(client).catch((error) => {
 				console.warn("Failed to dispose host sessions", {
 					...logContext,
@@ -48,11 +75,6 @@ async function disposeViaHosts(
 			}),
 		),
 	);
-	const result: DisposeHostSessionsResult = {
-		terminated: 0,
-		failed: 0,
-		unreachableHosts: 0,
-	};
 	for (const outcome of outcomes) {
 		if (!outcome) {
 			result.unreachableHosts += 1;
@@ -102,27 +124,43 @@ export function disposeHostSessionsForWorktreePath(
 /**
  * Surface a failed dispose with a Retry action. Failed kills the host
  * confirmed are stamped (`disposeRequestedAt`) and its reaper retries them;
- * an unreachable host wrote no stamp, so the renderer retry is the only
- * recovery path there.
+ * an unreachable host (or an unavailable coordinator) wrote no stamp, so the
+ * renderer retry is the only recovery path there.
  */
 export function toastDisposeFailures(
 	result: DisposeHostSessionsResult,
 	retry: () => Promise<DisposeHostSessionsResult>,
 ): void {
-	if (result.failed === 0 && result.unreachableHosts === 0) return;
+	const unreached =
+		result.unreachableHosts > 0 || result.coordinatorUnavailable;
+	if (result.failed === 0 && !unreached) return;
+
 	const retryAction = {
 		label: "Retry",
 		onClick: () => {
-			void retry().then((next) => toastDisposeFailures(next, retry));
+			retry()
+				.then((next) => toastDisposeFailures(next, retry))
+				.catch((error) => {
+					console.warn("Retry of host session dispose failed", { error });
+				});
 		},
 	};
-	if (result.unreachableHosts > 0) {
+
+	// A no-stamp failure (couldn't reach a host, or couldn't even enumerate
+	// them) is the more urgent line: those sessions have no background retry,
+	// so lead with that even when confirmed failures also exist.
+	if (unreached) {
+		const alsoFailed =
+			result.failed > 0
+				? ` ${result.failed} more will be retried in the background.`
+				: "";
 		toast.error("Couldn't reach the host to close terminal sessions", {
-			description: "Its terminal processes may keep running.",
+			description: `Its terminal processes may keep running.${alsoFailed}`,
 			action: retryAction,
 		});
 		return;
 	}
+
 	toast.error(
 		`Failed to close ${result.failed} terminal session${result.failed === 1 ? "" : "s"}`,
 		{

--- a/apps/desktop/src/renderer/lib/dispose-host-sessions.ts
+++ b/apps/desktop/src/renderer/lib/dispose-host-sessions.ts
@@ -1,8 +1,17 @@
+import { toast } from "@superset/ui/sonner";
 import type { electronTrpc } from "renderer/lib/electron-trpc";
 import { setHostServiceSecret } from "renderer/lib/host-service-auth";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 
 type ElectronTrpcUtils = ReturnType<typeof electronTrpc.useUtils>;
+
+export interface DisposeHostSessionsResult {
+	terminated: number;
+	/** Kills a host attempted but could not confirm (stamped — its reaper retries). */
+	failed: number;
+	/** Hosts that errored before reporting counts — nothing stamped, nothing retrying. */
+	unreachableHosts: number;
+}
 
 /**
  * Build a host-service client for every running local host-service (one per
@@ -21,44 +30,104 @@ async function localHostClients(utils: ElectronTrpcUtils) {
 	});
 }
 
+async function disposeViaHosts(
+	utils: ElectronTrpcUtils,
+	run: (
+		client: ReturnType<typeof getHostServiceClientByUrl>,
+	) => Promise<{ terminated: number; failed: number }>,
+	logContext: Record<string, string>,
+): Promise<DisposeHostSessionsResult> {
+	const outcomes = await Promise.all(
+		(await localHostClients(utils)).map((client) =>
+			run(client).catch((error) => {
+				console.warn("Failed to dispose host sessions", {
+					...logContext,
+					error,
+				});
+				return null;
+			}),
+		),
+	);
+	const result: DisposeHostSessionsResult = {
+		terminated: 0,
+		failed: 0,
+		unreachableHosts: 0,
+	};
+	for (const outcome of outcomes) {
+		if (!outcome) {
+			result.unreachableHosts += 1;
+			continue;
+		}
+		result.terminated += outcome.terminated;
+		result.failed += outcome.failed;
+	}
+	return result;
+}
+
 /**
  * The electron delete/close/deleteWorktree paths only kill the main-process
  * daemon's terminals, so a workspace's host-service sessions (backgrounded,
- * renderer-detached ones included) would leak. Best-effort: tell every local
- * host-service to dispose them. Never throws — it must not block the mutation.
+ * renderer-detached ones included) would leak. Tell every local host-service
+ * to dispose them and report what happened — callers surface failures via
+ * {@link toastDisposeFailures}. Never throws.
  */
-export async function disposeHostSessionsForWorkspace(
+export function disposeHostSessionsForWorkspace(
 	utils: ElectronTrpcUtils,
 	workspaceId: string,
-): Promise<void> {
-	for (const client of await localHostClients(utils)) {
-		client.terminal.disposeWorkspaceSessions
-			.mutate({ workspaceId })
-			.catch((error) => {
-				console.warn("Failed to dispose host sessions for workspace", {
-					workspaceId,
-					error,
-				});
-			});
-	}
+): Promise<DisposeHostSessionsResult> {
+	return disposeViaHosts(
+		utils,
+		(client) =>
+			client.terminal.disposeWorkspaceSessions.mutate({ workspaceId }),
+		{ workspaceId },
+	);
 }
 
 /**
  * Same as {@link disposeHostSessionsForWorkspace} but keyed by worktree path —
  * used when deleting a closed worktree, which no longer has a workspace id.
  */
-export async function disposeHostSessionsForWorktreePath(
+export function disposeHostSessionsForWorktreePath(
 	utils: ElectronTrpcUtils,
 	worktreePath: string,
-): Promise<void> {
-	for (const client of await localHostClients(utils)) {
-		client.terminal.disposeWorktreeSessions
-			.mutate({ worktreePath })
-			.catch((error) => {
-				console.warn("Failed to dispose host sessions for worktree", {
-					worktreePath,
-					error,
-				});
-			});
+): Promise<DisposeHostSessionsResult> {
+	return disposeViaHosts(
+		utils,
+		(client) =>
+			client.terminal.disposeWorktreeSessions.mutate({ worktreePath }),
+		{ worktreePath },
+	);
+}
+
+/**
+ * Surface a failed dispose with a Retry action. Failed kills the host
+ * confirmed are stamped (`disposeRequestedAt`) and its reaper retries them;
+ * an unreachable host wrote no stamp, so the renderer retry is the only
+ * recovery path there.
+ */
+export function toastDisposeFailures(
+	result: DisposeHostSessionsResult,
+	retry: () => Promise<DisposeHostSessionsResult>,
+): void {
+	if (result.failed === 0 && result.unreachableHosts === 0) return;
+	const retryAction = {
+		label: "Retry",
+		onClick: () => {
+			void retry().then((next) => toastDisposeFailures(next, retry));
+		},
+	};
+	if (result.unreachableHosts > 0) {
+		toast.error("Couldn't reach the host to close terminal sessions", {
+			description: "Its terminal processes may keep running.",
+			action: retryAction,
+		});
+		return;
 	}
+	toast.error(
+		`Failed to close ${result.failed} terminal session${result.failed === 1 ? "" : "s"}`,
+		{
+			description: "The host will keep retrying in the background.",
+			action: retryAction,
+		},
+	);
 }

--- a/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspace.ts
@@ -1,5 +1,8 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { disposeHostSessionsForWorkspace } from "renderer/lib/dispose-host-sessions";
+import {
+	disposeHostSessionsForWorkspace,
+	toastDisposeFailures,
+} from "renderer/lib/dispose-host-sessions";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import {
@@ -111,7 +114,9 @@ export function useCloseWorkspace(
 		onSuccess: async (data, variables, ...rest) => {
 			// Close keeps the worktree but tears down the workspace's runtime;
 			// dispose its host-service terminals so backgrounded sessions don't leak.
-			void disposeHostSessionsForWorkspace(utils, variables.id);
+			const retryDispose = () =>
+				disposeHostSessionsForWorkspace(utils, variables.id);
+			toastDisposeFailures(await retryDispose(), retryDispose);
 			// Invalidate to ensure consistency with backend state
 			await utils.workspaces.invalidate();
 			// Invalidate project queries since close updates project metadata

--- a/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspace.ts
@@ -1,5 +1,8 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { disposeHostSessionsForWorkspace } from "renderer/lib/dispose-host-sessions";
+import {
+	disposeHostSessionsForWorkspace,
+	toastDisposeFailures,
+} from "renderer/lib/dispose-host-sessions";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import {
@@ -91,7 +94,9 @@ export function useDeleteWorkspace(
 			// Delete succeeded on the electron path — dispose the workspace's
 			// host-service terminals so backgrounded sessions don't leak.
 			if (data.success) {
-				void disposeHostSessionsForWorkspace(utils, variables.id);
+				const retryDispose = () =>
+					disposeHostSessionsForWorkspace(utils, variables.id);
+				toastDisposeFailures(await retryDispose(), retryDispose);
 			}
 			// tRPC treats { success: false } as a successful response, so roll back optimistic updates
 			if (!data.success) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -8,7 +8,10 @@ import {
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { disposeHostSessionsForWorktreePath } from "renderer/lib/dispose-host-sessions";
+import {
+	disposeHostSessionsForWorktreePath,
+	toastDisposeFailures,
+} from "renderer/lib/dispose-host-sessions";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useDeleteWorktree } from "renderer/react-query/workspaces/useDeleteWorktree";
 import { deleteWithToast } from "renderer/routes/_authenticated/components/TeardownLogsDialog";
@@ -35,7 +38,11 @@ export function DeleteWorktreeDialog({
 			// Worktree removed — dispose its host-service terminals so backgrounded
 			// sessions don't leak in the daemon.
 			if (data.success) {
-				void disposeHostSessionsForWorktreePath(utils, worktreePath);
+				const retryDispose = () =>
+					disposeHostSessionsForWorktreePath(utils, worktreePath);
+				void retryDispose().then((result) =>
+					toastDisposeFailures(result, retryDispose),
+				);
 			}
 		},
 	});

--- a/packages/host-service/drizzle/0010_reflective_cerebro.sql
+++ b/packages/host-service/drizzle/0010_reflective_cerebro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `terminal_sessions` ADD `dispose_requested_at` integer;

--- a/packages/host-service/drizzle/meta/0010_snapshot.json
+++ b/packages/host-service/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,911 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "00579670-b258-4f90-8d99-c0f053274f0c",
+  "prevId": "89a9aa1f-c779-400c-a606-0c1ba504c442",
+  "tables": {
+    "acp_sessions": {
+      "name": "acp_sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_stop_reason": {
+          "name": "last_stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "acp_sessions_workspace_id_idx": {
+          "name": "acp_sessions_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "tableTo": "terminal_sessions",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_cloud_deletes": {
+      "name": "workspace_cloud_deletes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cloud_synced_at": {
+          "name": "cloud_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true,
+          "where": "type = 'main'"
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1783753971421,
       "tag": "0009_add_acp_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1784330905233,
+      "tag": "0010_reflective_cerebro",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -27,6 +27,13 @@ export const terminalSessions = sqliteTable(
 			.$defaultFn(() => Date.now()),
 		lastAttachedAt: integer("last_attached_at"),
 		endedAt: integer("ended_at"),
+		/**
+		 * Set the moment a dispose is requested — durable intent-to-kill. A
+		 * failed kill leaves the row `active` with this stamp, and the reaper
+		 * retries it regardless of workspace liveness (a one-shot renderer
+		 * broadcast must not be the only chance to kill a session).
+		 */
+		disposeRequestedAt: integer("dispose_requested_at"),
 	},
 	(table) => [
 		index("terminal_sessions_origin_workspace_id_idx").on(

--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -3,6 +3,7 @@ import {
 	PORT_SCAN_WARMUP_DELAYS_MS,
 	planPortScanSync,
 	REAP_INTERVAL_MS,
+	shouldReapRow,
 } from "./reaper.ts";
 
 const noneLive = () => false;
@@ -112,5 +113,42 @@ describe("planPortScanSync", () => {
 		});
 
 		expect(plan.unregister).toEqual([]);
+	});
+});
+
+describe("shouldReapRow", () => {
+	it("reaps rows whose dispose was requested but never confirmed", () => {
+		expect(
+			shouldReapRow({
+				status: "active",
+				originWorkspaceId: "ws-1",
+				disposeRequestedAt: 1_000,
+			}),
+		).toBe(true);
+	});
+
+	it("keeps live sessions with a workspace and no dispose request", () => {
+		expect(shouldReapRow({ status: "active", originWorkspaceId: "ws-1" })).toBe(
+			false,
+		);
+		expect(
+			shouldReapRow({
+				status: "active",
+				originWorkspaceId: "ws-1",
+				disposeRequestedAt: null,
+			}),
+		).toBe(false);
+	});
+
+	it("still reaps dead-status and workspace-less rows", () => {
+		expect(
+			shouldReapRow({ status: "disposed", originWorkspaceId: "ws-1" }),
+		).toBe(true);
+		expect(shouldReapRow({ status: "exited", originWorkspaceId: "ws-1" })).toBe(
+			true,
+		);
+		expect(shouldReapRow({ status: "active", originWorkspaceId: null })).toBe(
+			true,
+		);
 	});
 });

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -28,6 +28,22 @@ export const PORT_SCAN_WARMUP_DELAYS_MS = [
 interface TerminalRow {
 	status: string;
 	originWorkspaceId: string | null;
+	disposeRequestedAt?: number | null;
+}
+
+/**
+ * Rows the reaper must kill even though the daemon still lists them alive.
+ * `disposeRequestedAt` is the durable intent-to-kill stamp: a dispose was
+ * requested but never confirmed (success deletes the row or marks it
+ * disposed), so retry it regardless of workspace liveness.
+ */
+export function shouldReapRow(row: TerminalRow): boolean {
+	return (
+		row.status === "disposed" ||
+		row.status === "exited" ||
+		!row.originWorkspaceId ||
+		row.disposeRequestedAt != null
+	);
 }
 
 export interface PortScanSyncPlan {
@@ -97,6 +113,7 @@ function loadTerminalRowsById(db: HostDb): Map<string, TerminalRow> {
 			id: terminalSessions.id,
 			status: terminalSessions.status,
 			originWorkspaceId: terminalSessions.originWorkspaceId,
+			disposeRequestedAt: terminalSessions.disposeRequestedAt,
 		})
 		.from(terminalSessions)
 		.all();
@@ -190,11 +207,7 @@ async function reapOrphanedSessions(
 			}
 			continue;
 		}
-		if (
-			row.status === "disposed" ||
-			row.status === "exited" ||
-			!row.originWorkspaceId
-		) {
+		if (shouldReapRow(row)) {
 			orphans.push({ id: session.id, rowless: false });
 		}
 	}

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -14,7 +14,7 @@ import {
 	scanForTerminalTitle,
 	type TerminalTitleScanState,
 } from "@superset/shared/terminal-title-scanner";
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, isNull, ne } from "drizzle-orm";
 import type { Hono } from "hono";
 import { isProcessAlive, readPtyDaemonManifest } from "../daemon/manifest.ts";
 import type { HostDb } from "../db/index.ts";
@@ -739,6 +739,19 @@ export async function disposeSessionAndWait(
 	terminalId: string,
 	db: HostDb,
 ): Promise<DisposeSessionResult> {
+	// Durable intent-to-kill: if this attempt fails (daemon hiccup, host
+	// restart mid-kill), the reaper retries any stamped row — a one-shot
+	// renderer broadcast must not be the only chance to kill a session.
+	// First request time wins so retries don't look like fresh requests.
+	db.update(terminalSessions)
+		.set({ disposeRequestedAt: Date.now() })
+		.where(
+			and(
+				eq(terminalSessions.id, terminalId),
+				isNull(terminalSessions.disposeRequestedAt),
+			),
+		)
+		.run();
 	const session = sessions.get(terminalId);
 	let closePromise: Promise<DaemonCloseResult> | null = null;
 

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -13,6 +13,8 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Server } from "@superset/pty-daemon";
 import { TRPCClientError } from "@trpc/client";
+import { eq } from "drizzle-orm";
+import { terminalSessions } from "../../src/db/schema";
 import {
 	disposeDaemonClient,
 	getDaemonClient,
@@ -21,6 +23,7 @@ import {
 	initTerminalBaseEnv,
 	resetTerminalBaseEnvForTests,
 } from "../../src/terminal/env";
+import { startTerminalReaper } from "../../src/terminal/reaper";
 import { listTerminalResourceSessions } from "../../src/terminal/resource-sessions";
 import {
 	__resetSessionsForTesting,
@@ -294,6 +297,93 @@ describe("terminal router integration", () => {
 		// Two full kill sequences, each blocking on the ~1s SIGKILL escalation,
 		// plus daemon boot and two login-shell starts — the 5s default budget
 		// is marginal under load.
+	}, 20_000);
+
+	test("reaper kills a dispose-stamped session and spares a live one", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "host-service-reaper-retry-"));
+		const socketPath = join(tmp, "pty-daemon.sock");
+		const stampedId = randomUUID();
+		const sparedId = randomUUID();
+		let daemonProcess: ChildProcess | null = null;
+		let stopReaper: (() => void) | null = null;
+		try {
+			const daemonBundlePath = fileURLToPath(
+				new URL("../../../pty-daemon/dist/pty-daemon.js", import.meta.url),
+			);
+			ensureDaemonBundle(daemonBundlePath);
+			daemonProcess = spawn(
+				"node",
+				[daemonBundlePath, `--socket=${socketPath}`],
+				{
+					stdio: ["ignore", "ignore", "pipe"],
+					env: { ...process.env },
+				},
+			);
+			await waitFor(() => existsSync(socketPath), 3000);
+			process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
+			process.env.SUPERSET_HOME_DIR = tmp;
+
+			await scenario.host.trpc.terminal.createSession.mutate({
+				workspaceId: scenario.workspaceId,
+				terminalId: stampedId,
+			});
+			await scenario.host.trpc.terminal.createSession.mutate({
+				workspaceId: scenario.workspaceId,
+				terminalId: sparedId,
+			});
+			const daemon = await getDaemonClient();
+			const aliveIds = async () =>
+				new Set(
+					(await daemon.list())
+						.filter((session) => session.alive)
+						.map((session) => session.id),
+				);
+			const waitForAlive = async (
+				predicate: (alive: Set<string>) => boolean,
+				timeoutMs: number,
+				label: string,
+			) => {
+				const deadline = Date.now() + timeoutMs;
+				for (;;) {
+					if (predicate(await aliveIds())) return;
+					if (Date.now() > deadline) {
+						throw new Error(`timed out waiting: ${label}`);
+					}
+					await new Promise((resolve) => setTimeout(resolve, 150));
+				}
+			};
+			await waitForAlive(
+				(alive) => alive.has(stampedId) && alive.has(sparedId),
+				5000,
+				"both sessions alive",
+			);
+
+			// Simulate an earlier dispose whose kill failed: the request was
+			// stamped but the row is still active and the daemon session lives.
+			scenario.host.db
+				.update(terminalSessions)
+				.set({ disposeRequestedAt: Date.now() })
+				.where(eq(terminalSessions.id, stampedId))
+				.run();
+			__resetSessionsForTesting();
+
+			// First reap pass runs immediately on start.
+			stopReaper = startTerminalReaper(scenario.host.db);
+			await waitForAlive(
+				(alive) => !alive.has(stampedId),
+				10_000,
+				"stamped session reaped",
+			);
+			expect((await aliveIds()).has(sparedId)).toBe(true);
+		} finally {
+			stopReaper?.();
+			await scenario.host.trpc.terminal.killSession
+				.mutate({ workspaceId: scenario.workspaceId, terminalId: sparedId })
+				.catch(() => {});
+			await disposeDaemonClient();
+			await stopDaemonProcess(daemonProcess);
+			rmSync(tmp, { recursive: true, force: true });
+		}
 	}, 20_000);
 
 	test("resource sessions are daemon-sourced and joined to active DB rows", () => {

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -291,7 +291,10 @@ describe("terminal router integration", () => {
 			await stopDaemonProcess(daemonProcess);
 			rmSync(tmp, { recursive: true, force: true });
 		}
-	});
+		// Two full kill sequences, each blocking on the ~1s SIGKILL escalation,
+		// plus daemon boot and two login-shell starts — the 5s default budget
+		// is marginal under load.
+	}, 20_000);
 
 	test("resource sessions are daemon-sourced and joined to active DB rows", () => {
 		const activeTerminalId = randomUUID();

--- a/plans/pty-lifecycle-cleanup.md
+++ b/plans/pty-lifecycle-cleanup.md
@@ -4,8 +4,8 @@ User report: M1 Max hits the macOS PTY-master limit (509/511) after 4–7 parall
 
 ## Progress (2026-07-17)
 
-- [x] **PR 1 — daemon kill hardening**: implemented + verified on branch `pty-lifecycle-diagnosis` (uncommitted). Full `test:integration` 3/3 green, unit 61/61, lint/typecheck clean; each new kill-tree test proven to fail on the old implementation. Details in the PR 1 section below.
-- [ ] **PR 2 — reliable dispose** (renderer awaits + `disposeRequestedAt` retry): not started.
+- [x] **PR 1 — daemon kill hardening**: MERGED as #5748 (2026-07-17). Includes bot-review fixes (tty-reuse guard, ps-failure handling, killChain reset, desktop entrypoint drain) and the TreeKiller dedupe. Verified: unit, per-scenario kill-tree tests (mutation-checked), 54-test integration suite, end-to-end old-vs-new daemon repro (3 leaked → 0).
+- [x] **PR 2 — reliable dispose**: implemented (renderer awaits + failure toast w/ Retry; `disposeRequestedAt` stamp + reaper retry; migration 0010). CDP verification pending.
 - [ ] **Backstops** (liveness reaping, idle TTL + cap, renderer park=disconnect, registry reconcile): deferred until PR 1+2 are measured in the wild.
 
 ## Root cause (TLDR)


### PR DESCRIPTION
## Summary

PR 2 of the PTY-accumulation cleanup (`plans/pty-lifecycle-cleanup.md`; PR 1 was #5748). Workspace close/delete disposal was fire-and-forget: the renderer broadcast swallowed every error, so a transient host-service failure silently leaked all of a workspace's sessions — and a failed kill left an `active` row the reaper's predicate never matched while the workspace row existed, making the session immortal.

**Host-service — durable intent-to-kill:**
- New `terminal_sessions.dispose_requested_at` column (migration 0010, single ALTER). `disposeSessionAndWait` stamps it on entry (first request time wins).
- Reaper predicate extracted as pure `shouldReapRow` and widened: any stamped row is retried regardless of workspace liveness. Success still deletes the row / marks it disposed, so retries converge; the reaper only acts on daemon-live sessions, so there's no perpetual no-op loop.

**Renderer — await and surface:**
- `disposeHostSessionsForWorkspace`/`ForWorktreePath` now await every host and return `{terminated, failed, unreachableHosts}` instead of swallowing results.
- All three call sites (`useCloseWorkspace`, `useDeleteWorkspace`, `DeleteWorktreeDialog`) await the result; failures surface as a toast with a Retry action. Copy reflects reality: a host-confirmed failure says the host keeps retrying (it's stamped); an unreachable host warns processes may keep running (nothing was stamped — the renderer Retry is the only recovery there).
- The close/delete itself still proceeds — a stubborn shell never holds the workspace open.

Also: bumped the marginal 5s budget on the two-kill-sequence daemon integration test (flaky on main under load, each sequence blocks on the ~1s SIGKILL escalation).

The remaining uncovered class — renderer crashes before the broadcast ever fires — is the liveness-reaping backstop deliberately deferred in the plan.

## Test Plan

- [x] `shouldReapRow` unit tests: stamped-active rows reaped; live unstamped sessions kept; dead-status/workspace-less rows still reaped
- [x] Full host-service suite 901/901, including the real-daemon disposal integration test 3/3 after the timeout fix
- [x] Repo-wide typecheck + lint clean
- [ ] CDP verification of the close-workspace flow (incl. host-service-down failure toast) — pending, requires a dev-desktop session

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes terminal disposal reliable when closing or deleting a workspace. Prevents leaked sessions and shows a single retryable error when a kill fails, a host is unreachable, or the coordinator is down.

- **Bug Fixes**
  - `host-service`: Added durable intent-to-kill stamp `dispose_requested_at` and widened the reaper via `shouldReapRow` to retry stamped sessions regardless of workspace liveness.
  - Desktop renderer: Disposal now awaits per-host results and combines failures into one toast with Retry. Prioritizes unreachable hosts and coordinator-unavailable cases; close/delete proceeds either way.
  - Tests: Added an end-to-end reaper retry test for dispose-stamped sessions and bumped related integration timeouts to 20s to reduce flakiness.

- **Migration**
  - Adds `terminal_sessions.dispose_requested_at` (migration `0010_reflective_cerebro`).

<sup>Written for commit 1061f5af8f240ae194c2d635715be49411a4d9b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace and worktree terminal cleanup now reports counts for successful, failed, and unreachable sessions.
  * Cleanup failures now show clearer error toasts with a Retry action.
* **Bug Fixes**
  * Improved reliability when closing, deleting, or cleaning up workspaces and worktrees.
  * Prevented terminal sessions from remaining indefinitely active after an unsuccessful shutdown by persisting a retry intent and having the background cleanup reattempt disposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->