### PR TITLE
fix(shared): refresh cursor-agent model catalog against live model list

### DIFF
--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -103,14 +103,17 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "cursor-agent",
 		modelFlag: "--model",
 		models: [
-			// cursor-agent has no effort flag, so Fable's thinking level is
-			// baked into the model id (`--list-models` exposes high and xhigh).
+			// cursor-agent has no effort flag, so effort/thinking levels are
+			// baked into the model ids. Ids verified against a live account's
+			// `--list-models` (2026-07-17); the list is account-dependent and
+			// unknown ids are rejected by the CLI, not silently ignored.
 			{ id: "claude-fable-5-thinking-high", label: "Fable 5" },
 			{ id: "claude-fable-5-thinking-xhigh", label: "Fable 5 xHigh" },
-			{ id: "opus", label: "Opus" },
-			{ id: "sonnet-4.5", label: "Sonnet 4.5" },
-			{ id: "gpt-5", label: "GPT-5" },
-			{ id: "composer-1", label: "Composer 1" },
+			{ id: "claude-opus-4-8-high", label: "Opus 4.8" },
+			{ id: "claude-4.6-sonnet-medium", label: "Sonnet 4.6" },
+			{ id: "gpt-5.6-sol-medium", label: "GPT-5.6 Sol" },
+			{ id: "gpt-5.3-codex", label: "Codex 5.3" },
+			{ id: "composer-2.5", label: "Composer 2.5" },
 		],
 	},
 	{

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -107,6 +107,10 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 			// baked into the model ids. Ids verified against a live account's
 			// `--list-models` (2026-07-17); the list is account-dependent and
 			// unknown ids are rejected by the CLI, not silently ignored.
+			// "auto" is the only id free-plan accounts can use (besides
+			// composer) — named models fail there with "Named models
+			// unavailable", so keep an explicit working choice in the picker.
+			{ id: "auto", label: "Auto" },
 			{ id: "claude-fable-5-thinking-high", label: "Fable 5" },
 			{ id: "claude-fable-5-thinking-xhigh", label: "Fable 5 xHigh" },
 			{ id: "claude-opus-4-8-high", label: "Opus 4.8" },


### PR DESCRIPTION
Follow-up from #5742.

## Summary
- Refreshes the curated `cursor-agent` entry in `AGENT_MODEL_SUPPORT`: every non-Fable id (`opus`, `sonnet-4.5`, `gpt-5`, `composer-1`) had drifted off Cursor's live model list, and `cursor-agent` rejects unknown ids outright ("Cannot use this model") — so picking any of them in the workspace-create model picker broke the launch.

## Why / Context
Found while live-testing #5742's naming fallback: pinning `composer-1` (a catalog id) failed against an authed cursor-agent because the account's `--list-models` no longer contains it. The catalog comment says these lists are hand-maintained and drift with CLI releases; Cursor's has drifted a lot (193 models, gpt-5.3-codex family, Composer 2.5).

## What changed
| Old id | New id | Label |
|---|---|---|
| `claude-fable-5-thinking-high` | unchanged | Fable 5 |
| `claude-fable-5-thinking-xhigh` | unchanged | Fable 5 xHigh |
| `opus` | `claude-opus-4-8-high` | Opus 4.8 |
| `sonnet-4.5` | `claude-4.6-sonnet-medium` | Sonnet 4.6 |
| `gpt-5` | `gpt-5.6-sol-medium` | GPT-5.6 Sol |
| — | `gpt-5.3-codex` | Codex 5.3 |
| `composer-1` | `composer-2.5` | Composer 2.5 |

## Manual QA
- [x] All catalog ids verified present in a live account's `cursor-agent --list-models` (2026-07-17)
- [x] **CDP E2E in the real app** (agents.run with `model` through the picker plumbing, terminals observed via screenshots): `--model auto` → agent replies OK (footer "Auto · 7.5%"); `--model composer-2.5` → replies OK; `--model claude-opus-4-8-high` → red in-terminal error "Named models unavailable — Free plans can only use Auto" (free-tier account). Confirms both the fix and the plan-gating repro end-to-end.
- [x] Live invocation attempted for **every** id (`cursor-agent --model <id> --trust --mode ask -p`): `composer-2.5` serves end-to-end; the other 6 fail with `ActionRequiredError: Named models unavailable — Free plans can only use Auto` (the test account is free-tier). That error is distinct from the unknown-id rejection (`Cannot use this model: <id>`), which is what the old stale ids produce — so the ids are confirmed real and recognized; serving them needs a paid Cursor plan.

## Testing
- `bun run typecheck` (shared + desktop + host-service)
- `bun test` (shared: 693 pass)
- `bun run lint`

## Known Limitations
- Cursor's model list is account-dependent; ids valid on one account may be absent on another, and the CLI hard-rejects unknown ids. A longer-term fix could query `--list-models` at picker time instead of curating.
- Free-tier Cursor accounts can only use `auto` (and `composer-2.5`): picking other named models breaks the launch for them (CDP-reproduced). The catalog now includes an explicit **Auto** entry so every plan has a working choice; the deeper fix (querying `--list-models` / plan capabilities at picker time) remains future work.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5753">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed the AI model catalog for the `cursor-agent` preset with newly validated model options.
  * Added an explicit `auto` option in the model picker.
* **Bug Fixes**
  * Improved model validation to reject unknown or unsupported model identifiers instead of silently ignoring them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

