### PR TITLE
feat(desktop): finish SUPER-1545 — alt-screen exemption, persist guard, hidden-webview LRU

### DIFF
--- a/apps/desktop/docs/MEMORY_AND_WORKERS_REVIEW.md
+++ b/apps/desktop/docs/MEMORY_AND_WORKERS_REVIEW.md
@@ -6,7 +6,7 @@
 
 | Item | Ticket | Status |
 |---|---|---|
-| Parked-terminal LRU eviction (terminal half) | SUPER-1545 | **Implemented**, uncommitted. Cap defaults to 12 parked, user-configurable (Settings → Terminal → "Background terminal memory"; local-db `terminal_parked_runtime_cap`, migration 0042, zod-clamped 2–64, live-applied via `terminalRuntimeRegistry.setParkedRuntimeCap`). CDP-verified: default seeds at boot, 16-tab cycle parks exactly 12, lowering to 6 sweeps immediately, persists, out-of-range rejected. Two controlled A/Bs below (18-terminal fill, 24-terminal live-stream; both measured at cap 5 — savings scale down as the cap rises) |
+| Parked-terminal LRU eviction (terminal half) | SUPER-1545 | **Shipped** in PR #5751. Cap defaults to 12 parked, user-configurable (Settings → Terminal → "Background terminal memory"; local-db `terminal_parked_runtime_cap`, migration 0042, zod-clamped 2–64, live-applied via `terminalRuntimeRegistry.setParkedRuntimeCap`). CDP-verified: default seeds at boot, 16-tab cycle parks exactly 12, lowering to 6 sweeps immediately, persists, out-of-range rejected. Two controlled A/Bs below (18-terminal fill, 24-terminal live-stream; both measured at cap 5 — savings scale down as the cap rises) |
 | Parked-webview eviction + alt-screen exemption + quota guard | SUPER-1545 | **Implemented** (hidden-webview LRU cap 3 in `browserRuntimeRegistry`; alternate-screen TUIs exempt from terminal eviction; eviction skipped when the buffer cannot persist). CDP-verified 2026-07-18 |
 | Chat shiki off main thread | SUPER-1546 | Not started |
 | Collections preload/window/evict | SUPER-1547 | Not started |

--- a/apps/desktop/docs/MEMORY_AND_WORKERS_REVIEW.md
+++ b/apps/desktop/docs/MEMORY_AND_WORKERS_REVIEW.md
@@ -7,7 +7,7 @@
 | Item | Ticket | Status |
 |---|---|---|
 | Parked-terminal LRU eviction (terminal half) | SUPER-1545 | **Implemented**, uncommitted. Cap defaults to 12 parked, user-configurable (Settings → Terminal → "Background terminal memory"; local-db `terminal_parked_runtime_cap`, migration 0042, zod-clamped 2–64, live-applied via `terminalRuntimeRegistry.setParkedRuntimeCap`). CDP-verified: default seeds at boot, 16-tab cycle parks exactly 12, lowering to 6 sweeps immediately, persists, out-of-range rejected. Two controlled A/Bs below (18-terminal fill, 24-terminal live-stream; both measured at cap 5 — savings scale down as the cap rises) |
-| Parked-webview eviction (second half) | SUPER-1545 | Not started |
+| Parked-webview eviction + alt-screen exemption + quota guard | SUPER-1545 | **Implemented** (hidden-webview LRU cap 3 in `browserRuntimeRegistry`; alternate-screen TUIs exempt from terminal eviction; eviction skipped when the buffer cannot persist). CDP-verified 2026-07-18 |
 | Chat shiki off main thread | SUPER-1546 | Not started |
 | Collections preload/window/evict | SUPER-1547 | Not started |
 | Async process-tree probes | SUPER-1548 | Not started |

--- a/apps/desktop/docs/MEMORY_AND_WORKERS_REVIEW.md
+++ b/apps/desktop/docs/MEMORY_AND_WORKERS_REVIEW.md
@@ -1,6 +1,6 @@
 # Memory Profile & Worker Offload Review
 
-2026-07-17. Code sweep across renderer / Electron main / host-service / pty-daemon, then every load-bearing claim verified against the live dev app over CDP (18-terminal stress, heap + RSS sampling, process-table spawn sampling). Claims marked **CDP** were observed at runtime; **code** means verified at the cited line but not behaviorally driven.
+2026-07-18. Code sweep across renderer / Electron main / host-service / pty-daemon, then every load-bearing claim verified against the live dev app over CDP (18-terminal stress, heap + RSS sampling, process-table spawn sampling). Claims marked **CDP** were observed at runtime; **code** means verified at the cited line but not behaviorally driven.
 
 ## Progress
 
@@ -62,7 +62,7 @@ Same A/B discipline, harder load: 24 terminal tabs, each running a real PTY proc
 | Host-service / daemon / GPU CPU | 2% / 1% / 5% | 2% / 1% / 4% |
 | Tab-switch p50 / p95 under load | 52 / 95 ms | 68 / 114 ms |
 
-The CPU gap is structural: eviction closes the WebSocket of released terminals, so their streams are neither delivered nor parsed — the before build parses all 24 streams into 23 live xterms forever. Heap is also flat under load in the eviction build vs climbing in the before build.
+Under this real-PTY streaming workload, eviction closes the WebSocket of released terminals, so their streams are neither delivered nor parsed — the before build parses all 24 streams into 23 live xterms forever. Heap is also flat under load in the eviction build vs climbing in the before build. A later 18-terminal synthetic-output rerun confirmed the memory result (−46% JS heap, −30% renderer RSS) but did not reproduce a CPU reduction (`TaskDuration` 1.41 s before vs 1.80 s after), so treat the 30% → 21% CPU sample as workload-specific rather than a general CPU claim.
 
 ## Verified findings — renderer
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-eviction.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-eviction.test.ts
@@ -57,6 +57,26 @@ describe("selectRuntimesToEvict", () => {
 		expect(selectRuntimesToEvict(entries, 2)).toEqual([]);
 		expect(ids(selectRuntimesToEvict(entries, 1))).toEqual(["a"]);
 	});
+
+	it("never selects exempt entries, even when they are the oldest", () => {
+		const entries = [parked("tui", 1), parked("a", 2), parked("b", 3)];
+		const isExempt = (e: { id: string }) => e.id === "tui";
+		expect(ids(selectRuntimesToEvict(entries, 2, isExempt))).toEqual(["a"]);
+	});
+
+	it("stops early when only exempt entries remain over the cap", () => {
+		const entries = [parked("tui1", 1), parked("tui2", 2), parked("a", 3)];
+		const isExempt = (e: { id: string }) => e.id.startsWith("tui");
+		// excess is 2 but only one evictable entry exists
+		expect(ids(selectRuntimesToEvict(entries, 1, isExempt))).toEqual(["a"]);
+	});
+
+	it("exempt entries still occupy the parked count", () => {
+		const entries = [parked("tui", 1), parked("a", 2)];
+		const isExempt = (e: { id: string }) => e.id === "tui";
+		// cap 1: tui fills the single slot, so "a" must go despite being newer
+		expect(ids(selectRuntimesToEvict(entries, 1, isExempt))).toEqual(["a"]);
+	});
 });
 
 describe("normalizeParkedRuntimeCap", () => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-eviction.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-eviction.ts
@@ -1,7 +1,8 @@
 /**
  * Pure selection policy for parked-runtime LRU eviction (SUPER-1545).
  * Kept dependency-free so it can be unit-tested without pulling the
- * xterm/transport import graph into the test process.
+ * xterm/transport import graph into the test process. Also reused by the
+ * browser pane registry for hidden-webview eviction.
  */
 
 interface EvictionCandidate {
@@ -18,16 +19,21 @@ export function normalizeParkedRuntimeCap(cap: number): number | null {
 /**
  * Pick the parked (live runtime, no container) entries to release, oldest
  * `lastUsedAt` first, so at most `cap` parked runtimes remain. Attached
- * runtimes and runtime-less entries are never candidates.
+ * runtimes and runtime-less entries are never candidates. Exempt entries
+ * (e.g. an active alternate-screen TUI) still occupy the parked count but
+ * are never selected — eviction stops early when only exempt entries remain.
  */
 export function selectRuntimesToEvict<T extends EvictionCandidate>(
 	entries: Iterable<T>,
 	cap: number,
+	isExempt: (entry: T) => boolean = () => false,
 ): T[] {
 	const parked = Array.from(entries).filter(
 		(entry) => entry.runtime !== null && entry.runtime.container === null,
 	);
-	if (parked.length <= cap) return [];
-	parked.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-	return parked.slice(0, parked.length - cap);
+	const excess = parked.length - cap;
+	if (excess <= 0) return [];
+	const evictable = parked.filter((entry) => !isExempt(entry));
+	evictable.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+	return evictable.slice(0, excess);
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("renderer/lib/trpc-client", () => ({
+	electronTrpcClient: {
+		keyboardLayout: {
+			changes: { subscribe: () => {} },
+		},
+	},
+}));
+
+const { terminalRuntimeRegistry } = await import("./terminal-runtime-registry");
+const { tryPersistRuntimeState } = await import("./terminal-runtime");
+
+interface FakeStorageState {
+	values: Map<string, string>;
+	storage: Storage;
+}
+
+function createFakeStorage(): FakeStorageState {
+	const values = new Map<string, string>();
+	const storage = {
+		get length() {
+			return values.size;
+		},
+		clear: () => values.clear(),
+		getItem: (key: string) => values.get(key) ?? null,
+		key: (index: number) => Array.from(values.keys())[index] ?? null,
+		removeItem: (key: string) => values.delete(key),
+		setItem: (key: string, value: string) => values.set(key, value),
+	} as Storage;
+	return { values, storage };
+}
+
+const originalLocalStorage = globalThis.localStorage;
+let fakeStorage: FakeStorageState;
+
+beforeEach(() => {
+	fakeStorage = createFakeStorage();
+	Object.defineProperty(globalThis, "localStorage", {
+		configurable: true,
+		value: fakeStorage.storage,
+	});
+});
+
+afterEach(() => {
+	Object.defineProperty(globalThis, "localStorage", {
+		configurable: true,
+		value: originalLocalStorage,
+	});
+});
+
+describe("terminalRuntimeRegistry eviction cleanup", () => {
+	test("keeps a runtime when dimensions fail to persist", () => {
+		const terminalId = "dimensions-write-failure";
+		const setItem = fakeStorage.storage.setItem.bind(fakeStorage.storage);
+		fakeStorage.storage.setItem = (key: string, value: string) => {
+			if (key === `terminal-dims:${terminalId}`) {
+				throw new Error("dimensions write failed");
+			}
+			setItem(key, value);
+		};
+		const runtime = {
+			terminalId,
+			serializeAddon: { serialize: () => "serialized scrollback" },
+			lastCols: 120,
+			lastRows: 32,
+		};
+
+		expect(
+			tryPersistRuntimeState(
+				runtime as Parameters<typeof tryPersistRuntimeState>[0],
+			),
+		).toBe(false);
+		expect(fakeStorage.values.get(`terminal-buffer:${terminalId}`)).toBe(
+			"serialized scrollback",
+		);
+		expect(fakeStorage.values.has(`terminal-dims:${terminalId}`)).toBe(false);
+	});
+
+	test("dispose clears persisted state even when eviction already removed the entry", () => {
+		const terminalId = "evicted-terminal";
+		fakeStorage.values.set(`terminal-buffer:${terminalId}`, "scrollback");
+		fakeStorage.values.set(
+			`terminal-dims:${terminalId}`,
+			JSON.stringify({ cols: 120, rows: 32 }),
+		);
+
+		expect(terminalRuntimeRegistry.has(terminalId)).toBe(false);
+		terminalRuntimeRegistry.dispose(terminalId);
+
+		expect(fakeStorage.values.has(`terminal-buffer:${terminalId}`)).toBe(false);
+		expect(fakeStorage.values.has(`terminal-dims:${terminalId}`)).toBe(false);
+	});
+
+	test("reschedules eviction when a parked terminal changes buffers", () => {
+		let emitBufferChange: () => void = () => {
+			throw new Error("buffer listener was not installed");
+		};
+		let listenerDisposed = false;
+		const runtime = {
+			container: {} as HTMLDivElement | null,
+			terminal: {
+				buffer: {
+					onBufferChange: (listener: () => void) => {
+						emitBufferChange = listener;
+						return { dispose: () => (listenerDisposed = true) };
+					},
+				},
+			},
+		};
+		const entry = {
+			runtime,
+			disposeBufferChangeListener: null as (() => void) | null,
+		};
+		const registryInternals = terminalRuntimeRegistry as unknown as {
+			observeBufferChanges: (observedEntry: typeof entry) => void;
+			pendingEviction: ReturnType<typeof setTimeout> | null;
+		};
+
+		if (registryInternals.pendingEviction !== null) {
+			clearTimeout(registryInternals.pendingEviction);
+			registryInternals.pendingEviction = null;
+		}
+		registryInternals.observeBufferChanges(entry);
+		emitBufferChange();
+		expect(registryInternals.pendingEviction).toBeNull();
+
+		runtime.container = null;
+		emitBufferChange();
+		expect(registryInternals.pendingEviction).not.toBeNull();
+
+		if (registryInternals.pendingEviction !== null) {
+			clearTimeout(registryInternals.pendingEviction);
+			registryInternals.pendingEviction = null;
+		}
+		entry.disposeBufferChangeListener?.();
+		expect(listenerDisposed).toBe(true);
+	});
+
+	test("defers eviction while flushed output is still being parsed", () => {
+		const terminalId = "parser-busy-terminal";
+		let flushed = false;
+		const gate = { pending: 1, queued: null as (() => void) | null };
+		const entry = {
+			terminalId,
+			instanceId: terminalId,
+			runtime: {
+				container: null,
+				gate,
+				terminal: { buffer: { active: { type: "normal" } } },
+			},
+			transport: {
+				_writeCoalescer: {
+					flushSync: () => {
+						flushed = true;
+					},
+				},
+			},
+			linkManager: null,
+			pendingLinkHandlers: null,
+			lastUsedAt: 1,
+		};
+		const registryInternals = terminalRuntimeRegistry as unknown as {
+			entries: Map<string, typeof entry>;
+			evictExcessParkedRuntimes: () => void;
+		};
+		const entryKey = `${terminalId}\u0000${terminalId}`;
+		registryInternals.entries.set(entryKey, entry);
+
+		try {
+			registryInternals.evictExcessParkedRuntimes();
+
+			expect(flushed).toBe(true);
+			expect(gate.queued).not.toBeNull();
+			expect(registryInternals.entries.has(entryKey)).toBe(true);
+		} finally {
+			registryInternals.entries.delete(entryKey);
+		}
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -2,6 +2,7 @@ import type { ProgressAddon } from "@xterm/addon-progress";
 import type { SearchAddon } from "@xterm/addon-search";
 import { DEFAULT_TERMINAL_PARKED_RUNTIME_CAP } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
+import { runWhenParserIdle } from "./parser-idle-gate";
 import {
 	type LinkHoverInfo,
 	type TerminalLinkHandlers,
@@ -9,6 +10,7 @@ import {
 } from "./terminal-link-manager";
 import {
 	attachToContainer,
+	clearPersistedRuntimeState,
 	createRuntime,
 	detachFromContainer,
 	disposeRuntime,
@@ -43,6 +45,8 @@ interface RegistryEntry {
 	linkManager: TerminalLinkManager | null;
 	/** Stored until linkManager is created (mount called after setLinkHandlers). */
 	pendingLinkHandlers: TerminalLinkHandlers | null;
+	/** Stops the alternate/normal buffer observer installed with the runtime. */
+	disposeBufferChangeListener: (() => void) | null;
 	/** Monotonic use counter; bumped on mount/detach, drives parked-LRU eviction. */
 	lastUsedAt: number;
 }
@@ -87,6 +91,7 @@ class TerminalRuntimeRegistryImpl {
 			transport: createTransport(),
 			linkManager: null,
 			pendingLinkHandlers: null,
+			disposeBufferChangeListener: null,
 			lastUsedAt: 0,
 		};
 
@@ -178,6 +183,7 @@ class TerminalRuntimeRegistryImpl {
 			entry.runtime = createRuntime(terminalId, appearance, {
 				initialBuffer: this.serializeExistingRuntime(terminalId, instanceId),
 			});
+			this.observeBufferChanges(entry);
 			entry.linkManager = new TerminalLinkManager(entry.runtime.terminal);
 			if (entry.pendingLinkHandlers) {
 				entry.linkManager.setHandlers(entry.pendingLinkHandlers);
@@ -196,6 +202,22 @@ class TerminalRuntimeRegistryImpl {
 			},
 			{ focus: false },
 		);
+	}
+
+	private observeBufferChanges(entry: RegistryEntry) {
+		entry.disposeBufferChangeListener?.();
+		entry.disposeBufferChangeListener = null;
+		const runtime = entry.runtime;
+		if (!runtime) return;
+
+		const subscription = runtime.terminal.buffer.onBufferChange(() => {
+			// Exempt alternate-screen TUIs may put the registry over cap. As soon as
+			// a parked TUI returns to its normal buffer, reconsider it for eviction.
+			if (entry.runtime?.container === null) {
+				this.scheduleParkedEviction();
+			}
+		});
+		entry.disposeBufferChangeListener = () => subscription.dispose();
 	}
 
 	/**
@@ -286,6 +308,29 @@ class TerminalRuntimeRegistryImpl {
 	}
 
 	private evictExcessParkedRuntimes() {
+		const parkedEntries = Array.from(this.entries.values()).filter(
+			(entry) => entry.runtime?.container === null,
+		);
+
+		// A pane can detach before the animation-frame output batch has reached
+		// xterm. Flush it, then wait for xterm's parser callback before checking
+		// alternate-screen mode or serializing the buffer.
+		for (const entry of parkedEntries) {
+			entry.transport._writeCoalescer?.flushSync();
+		}
+		const parsingEntries = parkedEntries.filter(
+			(entry) => (entry.runtime?.gate.pending ?? 0) > 0,
+		);
+		if (parsingEntries.length > 0) {
+			for (const entry of parsingEntries) {
+				const gate = entry.runtime?.gate;
+				if (gate) {
+					runWhenParserIdle(gate, () => this.scheduleParkedEviction());
+				}
+			}
+			return;
+		}
+
 		const victims = selectRuntimesToEvict(
 			this.entries.values(),
 			this.parkedRuntimeCap,
@@ -297,7 +342,9 @@ class TerminalRuntimeRegistryImpl {
 				warnPersistFailureOnce(entry.terminalId);
 				continue;
 			}
-			this.disposeEntry(entry, { clearPersistedState: false });
+			// tryPersistRuntimeState already wrote the snapshot. Preserve it while
+			// disposing instead of serializing and writing the same buffer twice.
+			this.disposeEntry(entry, { persistedState: "preserve" });
 		}
 	}
 
@@ -320,8 +367,10 @@ class TerminalRuntimeRegistryImpl {
 
 	private disposeEntry(
 		entry: RegistryEntry,
-		options: { clearPersistedState?: boolean } = {},
+		options: { persistedState?: "clear" | "persist" | "preserve" } = {},
 	) {
+		entry.disposeBufferChangeListener?.();
+		entry.disposeBufferChangeListener = null;
 		entry.linkManager?.dispose();
 		disposeTransport(entry.transport);
 		if (entry.runtime) {
@@ -342,7 +391,7 @@ class TerminalRuntimeRegistryImpl {
 				)
 			: this.getEntries(terminalId);
 		for (const entry of entries) {
-			this.disposeEntry(entry, { clearPersistedState: false });
+			this.disposeEntry(entry, { persistedState: "persist" });
 		}
 	}
 
@@ -355,6 +404,9 @@ class TerminalRuntimeRegistryImpl {
 			sendDispose(entry.transport);
 			this.disposeEntry(entry);
 		}
+		// Eviction deletes the live registry entry but deliberately leaves its
+		// snapshot behind. Closing that pane must still clear the orphaned keys.
+		clearPersistedRuntimeState(terminalId);
 	}
 
 	getSelection(terminalId: string, instanceId?: string): string {
@@ -517,7 +569,7 @@ function warnPersistFailureOnce(terminalId: string) {
 	if (persistFailureWarned) return;
 	persistFailureWarned = true;
 	console.warn(
-		`[terminal-registry] buffer persist failed for ${terminalId}; keeping runtime alive (localStorage quota?)`,
+		`[terminal-registry] state persist failed for ${terminalId}; keeping runtime alive (localStorage quota?)`,
 	);
 }
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -13,6 +13,7 @@ import {
 	detachFromContainer,
 	disposeRuntime,
 	type TerminalRuntime,
+	tryPersistRuntimeState,
 	updateRuntimeAppearance,
 } from "./terminal-runtime";
 import {
@@ -288,8 +289,14 @@ class TerminalRuntimeRegistryImpl {
 		const victims = selectRuntimesToEvict(
 			this.entries.values(),
 			this.parkedRuntimeCap,
+			// Alternate-screen TUIs restore as a garbled static snapshot — never evict them.
+			(entry) => entry.runtime?.terminal.buffer.active.type === "alternate",
 		);
 		for (const entry of victims) {
+			if (!entry.runtime || !tryPersistRuntimeState(entry.runtime)) {
+				warnPersistFailureOnce(entry.terminalId);
+				continue;
+			}
 			this.disposeEntry(entry, { clearPersistedState: false });
 		}
 	}
@@ -503,6 +510,15 @@ class TerminalRuntimeRegistryImpl {
 			entry.transport.logListeners.delete(listener);
 		};
 	}
+}
+
+let persistFailureWarned = false;
+function warnPersistFailureOnce(terminalId: string) {
+	if (persistFailureWarned) return;
+	persistFailureWarned = true;
+	console.warn(
+		`[terminal-registry] buffer persist failed for ${terminalId}; keeping runtime alive (localStorage quota?)`,
+	);
 }
 
 // Stable empty reference so useSyncExternalStore on a missing entry doesn't

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -94,8 +94,7 @@ function restoreBuffer(terminalId: string, terminal: XTerm) {
 
 /**
  * Persist buffer + dims, reporting success. Eviction must not proceed when
- * the buffer cannot be saved (e.g. localStorage quota) or scrollback would
- * be silently lost.
+ * either write fails or the runtime could not be restored faithfully.
  */
 export function tryPersistRuntimeState(runtime: TerminalRuntime): boolean {
 	try {
@@ -106,8 +105,11 @@ export function tryPersistRuntimeState(runtime: TerminalRuntime): boolean {
 	} catch {
 		return false;
 	}
-	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
-	return true;
+	return persistDimensions(
+		runtime.terminalId,
+		runtime.lastCols,
+		runtime.lastRows,
+	);
 }
 
 function clearPersistedBuffer(terminalId: string) {
@@ -116,13 +118,20 @@ function clearPersistedBuffer(terminalId: string) {
 	} catch {}
 }
 
-function persistDimensions(terminalId: string, cols: number, rows: number) {
+function persistDimensions(
+	terminalId: string,
+	cols: number,
+	rows: number,
+): boolean {
 	try {
 		localStorage.setItem(
 			`${DIMS_KEY_PREFIX}${terminalId}`,
 			JSON.stringify({ cols, rows }),
 		);
-	} catch {}
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function loadSavedDimensions(
@@ -145,6 +154,12 @@ function clearPersistedDimensions(terminalId: string) {
 	try {
 		localStorage.removeItem(`${DIMS_KEY_PREFIX}${terminalId}`);
 	} catch {}
+}
+
+/** Clear persisted renderer state even when no live runtime entry remains. */
+export function clearPersistedRuntimeState(terminalId: string): void {
+	clearPersistedBuffer(terminalId);
+	clearPersistedDimensions(terminalId);
 }
 
 function hostIsVisible(container: HTMLDivElement | null): boolean {
@@ -377,10 +392,12 @@ export function updateRuntimeAppearance(
 
 export function disposeRuntime(
 	runtime: TerminalRuntime,
-	options: { clearPersistedState?: boolean } = {},
+	options: {
+		persistedState?: "clear" | "persist" | "preserve";
+	} = {},
 ) {
-	const clearPersistedState = options.clearPersistedState ?? true;
-	if (!clearPersistedState) {
+	const persistedState = options.persistedState ?? "clear";
+	if (persistedState === "persist") {
 		persistBuffer(runtime.terminalId, runtime.serializeAddon);
 		persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	}
@@ -396,8 +413,7 @@ export function disposeRuntime(
 	runtime.container = null;
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
-	if (clearPersistedState) {
-		clearPersistedBuffer(runtime.terminalId);
-		clearPersistedDimensions(runtime.terminalId);
+	if (persistedState === "clear") {
+		clearPersistedRuntimeState(runtime.terminalId);
 	}
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -92,6 +92,24 @@ function restoreBuffer(terminalId: string, terminal: XTerm) {
 	} catch {}
 }
 
+/**
+ * Persist buffer + dims, reporting success. Eviction must not proceed when
+ * the buffer cannot be saved (e.g. localStorage quota) or scrollback would
+ * be silently lost.
+ */
+export function tryPersistRuntimeState(runtime: TerminalRuntime): boolean {
+	try {
+		const data = runtime.serializeAddon.serialize({
+			scrollback: SERIALIZE_SCROLLBACK,
+		});
+		localStorage.setItem(`${STORAGE_KEY_PREFIX}${runtime.terminalId}`, data);
+	} catch {
+		return false;
+	}
+	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
+	return true;
+}
+
 function clearPersistedBuffer(terminalId: string) {
 	try {
 		localStorage.removeItem(`${STORAGE_KEY_PREFIX}${terminalId}`);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, mock, spyOn, test } from "bun:test";
+
+const unregister = mock(async () => ({ success: true }));
+
+mock.module("renderer/lib/trpc-client", () => ({
+	electronTrpcClient: {
+		browser: {
+			register: { mutate: async () => ({ success: true }) },
+			unregister: { mutate: unregister },
+		},
+		browserHistory: {
+			upsert: { mutate: async () => ({ success: true }) },
+		},
+	},
+}));
+
+const { browserRuntimeRegistry } = await import("./browserRuntimeRegistry");
+
+describe("browserRuntimeRegistry detached persistence", () => {
+	test("retains its persistence callback for navigation completion after detach", async () => {
+		const paneId = "detached-navigation-pane";
+		const persisted: string[] = [];
+		const onPersist = (state: { url: string }) => persisted.push(state.url);
+		const entry = {
+			webview: { style: { visibility: "visible" } },
+			state: {},
+			onPersist,
+			webContentsId: null,
+			detachHandlers: () => {},
+			placeholder: {},
+			resizeObserver: { disconnect: () => {} },
+			visible: true,
+			lastUsedAt: 1,
+		};
+		const registryInternals = browserRuntimeRegistry as unknown as {
+			entries: Map<string, typeof entry>;
+		};
+		registryInternals.entries.set(paneId, entry);
+
+		try {
+			browserRuntimeRegistry.detach(paneId);
+			entry.onPersist?.({ url: "https://example.com/finished-navigation" });
+
+			expect(persisted).toEqual(["https://example.com/finished-navigation"]);
+		} finally {
+			registryInternals.entries.delete(paneId);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+	});
+
+	test("surfaces BrowserManager unregister failures", async () => {
+		const paneId = "unregister-failure-pane";
+		const failure = new Error("unregister failed");
+		unregister.mockImplementationOnce(() => Promise.reject(failure));
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		const entry = {
+			webview: { remove: () => {} },
+			onPersist: () => {},
+			detachHandlers: () => {},
+			resizeObserver: { disconnect: () => {} },
+		};
+		const registryInternals = browserRuntimeRegistry as unknown as {
+			entries: Map<string, typeof entry>;
+		};
+		registryInternals.entries.set(paneId, entry);
+
+		try {
+			browserRuntimeRegistry.destroy(paneId);
+			await Promise.resolve();
+
+			expect(errorSpy).toHaveBeenCalledWith(
+				`[browserRuntimeRegistry] unregister failed for ${paneId}:`,
+				failure,
+			);
+		} finally {
+			errorSpy.mockRestore();
+			registryInternals.entries.delete(paneId);
+		}
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -1,3 +1,4 @@
+import { selectRuntimesToEvict } from "renderer/lib/terminal/terminal-runtime-eviction";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { BrowserLoadError } from "shared/tabs-types";
 import { sanitizeUrl } from "./sanitizeUrl";
@@ -27,7 +28,16 @@ interface RegistryEntry {
 	placeholder: HTMLElement | null;
 	resizeObserver: ResizeObserver | null;
 	visible: boolean;
+	/** Monotonic use counter; bumped on attach/detach, drives hidden-LRU eviction. */
+	lastUsedAt: number;
 }
+
+/**
+ * Cap on hidden (detached) webviews kept alive. Each one is a full guest
+ * Chromium process; past the cap the least-recently-visible are destroyed
+ * and rebuilt from the pane's persisted URL on next attach. (SUPER-1545)
+ */
+const MAX_HIDDEN_WEBVIEWS = 3;
 
 const EMPTY_STATE: BrowserRuntimeState = Object.freeze({
 	currentUrl: "about:blank",
@@ -44,6 +54,8 @@ const ROOT_CONTAINER_ID = "browser-runtime-root";
 class BrowserRuntimeRegistryImpl {
 	private entries = new Map<string, RegistryEntry>();
 	private listenersByPaneId = new Map<string, Set<() => void>>();
+	private useSeq = 0;
+	private pendingEviction: ReturnType<typeof setTimeout> | null = null;
 	private rootContainer: HTMLDivElement | null = null;
 	private globalListenersInstalled = false;
 	private windowDragPassthrough = false;
@@ -212,6 +224,7 @@ class BrowserRuntimeRegistryImpl {
 			placeholder: null,
 			resizeObserver: null,
 			visible: false,
+			lastUsedAt: 0,
 		};
 
 		const firePersist = () => {
@@ -381,6 +394,7 @@ class BrowserRuntimeRegistryImpl {
 		entry.onPersist = onPersist;
 		entry.placeholder = placeholder;
 		entry.visible = true;
+		entry.lastUsedAt = ++this.useSeq;
 
 		entry.resizeObserver?.disconnect();
 		const observer = new ResizeObserver(() => {
@@ -403,6 +417,33 @@ class BrowserRuntimeRegistryImpl {
 		entry.resizeObserver = null;
 		entry.visible = false;
 		entry.webview.style.visibility = "hidden";
+		entry.lastUsedAt = ++this.useSeq;
+		this.scheduleHiddenEviction();
+	}
+
+	/** Deferred so a pane-switch (detach then attach) re-adopts before the sweep counts. */
+	private scheduleHiddenEviction() {
+		if (this.pendingEviction !== null) return;
+		this.pendingEviction = setTimeout(() => {
+			this.pendingEviction = null;
+			this.evictExcessHiddenWebviews();
+		}, 0);
+	}
+
+	private evictExcessHiddenWebviews() {
+		const candidates = Array.from(this.entries.entries()).map(
+			([paneId, entry]) => ({
+				paneId,
+				runtime: { container: entry.visible ? entry : null },
+				lastUsedAt: entry.lastUsedAt,
+			}),
+		);
+		for (const victim of selectRuntimesToEvict(
+			candidates,
+			MAX_HIDDEN_WEBVIEWS,
+		)) {
+			this.destroy(victim.paneId);
+		}
 	}
 
 	destroy(paneId: string): void {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -411,7 +411,9 @@ class BrowserRuntimeRegistryImpl {
 	detach(paneId: string): void {
 		const entry = this.entries.get(paneId);
 		if (!entry) return;
-		entry.onPersist = null;
+		// Keep the persistence callback while hidden. A navigation can finish
+		// after React detaches the pane; clearing it here would leave only the
+		// previous URL to rebuild from if this webview is then LRU-evicted.
 		entry.placeholder = null;
 		entry.resizeObserver?.disconnect();
 		entry.resizeObserver = null;
@@ -431,7 +433,8 @@ class BrowserRuntimeRegistryImpl {
 	}
 
 	private evictExcessHiddenWebviews() {
-		const candidates = Array.from(this.entries.entries()).map(
+		const candidates = Array.from(
+			this.entries.entries(),
 			([paneId, entry]) => ({
 				paneId,
 				runtime: { container: entry.visible ? entry : null },
@@ -449,12 +452,18 @@ class BrowserRuntimeRegistryImpl {
 	destroy(paneId: string): void {
 		const entry = this.entries.get(paneId);
 		if (!entry) return;
+		entry.onPersist = null;
 		entry.resizeObserver?.disconnect();
 		entry.detachHandlers();
 		entry.webview.remove();
 		this.entries.delete(paneId);
 		this.listenersByPaneId.delete(paneId);
-		electronTrpcClient.browser.unregister.mutate({ paneId }).catch(() => {});
+		electronTrpcClient.browser.unregister.mutate({ paneId }).catch((err) => {
+			console.error(
+				`[browserRuntimeRegistry] unregister failed for ${paneId}:`,
+				err,
+			);
+		});
 	}
 
 	navigate(paneId: string, url: string): void {


### PR DESCRIPTION
**Links**
- Completes SUPER-1545 (terminal half shipped in #5751)

## Summary
- **Alt-screen exemption**: terminal eviction never selects runtimes in the alternate screen — in-place TUIs (vim, less, agent TUIs) restore as garbled static snapshots, the worst failure mode of #5751. Exempt entries still occupy the parked count, so plain shells evict sooner in their place and the memory bound holds when possible.
- **Persist guard**: eviction now persists the buffer *first* and skips the eviction (runtime kept alive, one-shot console warning) if the write fails — previously a localStorage-quota failure would have silently destroyed scrollback.
- **Hidden-webview LRU**: v2 browser panes get the same policy — hidden webviews (each a full guest Chromium process) are destroyed past a cap of 3, oldest-first, and rebuilt from the pane's persisted URL on next attach.

## How It Works
- The pure policy (`terminal-runtime-eviction.ts`) gains an optional `isExempt` predicate: excess is computed over all parked entries, but only non-exempt ones are selectable, so eviction stops early when only exempt entries remain. The terminal registry passes `buffer.active.type === "alternate"`; the browser registry reuses the same function through a small candidate adapter (`visible` → container).
- `tryPersistRuntimeState` (new export from `terminal-runtime.ts`) reports persist success; the sweep only disposes runtimes whose buffers are safely on disk.
- `browserRuntimeRegistry` mirrors the terminal design: `lastUsedAt` bumped on attach/detach, deferred one-tick sweep (so pane switches re-adopt before counting), eviction via the existing `destroy()` (which also unregisters main-process handlers), restore via the existing `attach(initialUrl)` path.

## Manual QA Checklist
Exercised live over CDP (dev app):
- [x] Alt-screen exemption: `less` running in tab 0 (buffer type `alternate` confirmed), cap lowered to 2, 6 other tabs cycled → TUI survives parked and occupies a cap slot; 1 recent shell kept; 5 plain shells evicted
- [x] **Claude Code specifically** (v2.1.214): confirmed it runs in the alternate buffer; parked under cap-2 pressure with 6 tabs cycled → survived eviction with its UI intact in the live buffer, and re-revealed pixel-perfect (screenshot-verified)
- [x] Hidden-webview cap: 5 browser panes opened → registry holds exactly 1 visible + 3 hidden; oldest destroyed; DOM webview count matches
- [x] Evicted browser tab re-open: new registry entry created, webview rebuilt from persisted URL, cap still held afterwards
- [x] Persist guard: unit-covered (quota simulation isn't practical in CDP); failure path keeps the runtime alive and warns once

## Testing
- `bun run lint`, `bun run typecheck` — clean
- `bun test` (full desktop suite) — 0 fail
- Policy tests extended to 10 (exemption ordering, exempt-slot semantics, shortfall stop); each new behavior mutation-verified (exemption ignored, exempt-excluded-from-count, both caught). One equivalent mutant found and eliminated by simplifying the impl (`slice` already clamps; dropped a redundant `Math.min`).

## Design Decisions
- **Exempt entries occupy the parked count** rather than being invisible to it: with N TUIs parked, plain shells evict more aggressively, keeping total parked ≤ cap whenever possible instead of letting TUIs raise the ceiling silently.
- **Webview cap is a constant (3), not a setting**: webviews are much heavier than terminals and rarer; a second knob isn't warranted until someone asks.

## Known Limitations
- Navigations that happen while a webview is hidden aren't persisted (`onPersist` is detached), so an evicted webview restores to its last *visible* URL. Same class as app-restart behavior.
- Many parked alt-screen TUIs can exceed the cap (they're never evicted) — the memory bound is best-effort in that case, by design.

## Infra note
This worktree's Neon dev branch had been deleted by the daily cleanup; re-provisioned (`br-curly-scene-afdvq3jq`) to run the CDP verification. No code impact.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5754">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes SUPER-1545 by protecting TUIs and scrollback while keeping background memory bounded. Adds alt-screen exemption, a persist guard, and an LRU cap for hidden webviews, plus tighter eviction timing and cleanup.

- **New Features**
  - Alt-screen exemption: terminal eviction skips alternate-screen TUIs (e.g., vim, less). Exempt entries still count toward the cap so plain shells evict first.
  - Persist guard: eviction now saves buffer and dims first; on persist failure the runtime is kept alive and a one-time warning is logged.
  - Hidden-webview LRU: v2 browser panes keep up to 3 hidden webviews; oldest are destroyed and later rebuilt from the persisted URL, reusing `selectRuntimesToEvict` in `browserRuntimeRegistry`.

- **Bug Fixes**
  - Eviction flushes pending output and waits for the parser to go idle before checking alt-screen state or persisting, preventing bad snapshots and wrong evictions.
  - Parked TUIs that switch back to the normal buffer trigger a re-check, making them eligible for eviction again.
  - Closing a terminal clears any orphaned persisted state left by earlier eviction.
  - Browser panes retain `onPersist` after detach to capture late navigation completion; unregister errors are now logged; hidden-webview eviction is deferred one tick to avoid pane-switch races.

<sup>Written for commit cd09fdd2eb1b214b76a1074866896c6d33b46624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically limits inactive terminal and hidden browser webviews to improve resource usage.
  - Preserves terminal scrollback and dimensions across eviction; re-attempts eviction when buffers change.
  - Adds eviction exemptions so specific runtimes are not selected, while still counting toward capacity.
  - Improves alternate-screen protection during eviction.

- **Bug Fixes**
  - If terminal-state persistence fails, the runtime is not released; warnings are shown only once.
  - Cleans up persisted terminal state when a terminal is fully disposed.

- **Tests**
  - Expanded eviction and persistence coverage for terminal and browser registries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
