### PR TITLE
fix(host-service): re-ensure pty-daemon on request after post-bootstrap death

### DIFF
--- a/packages/host-service/src/daemon/singleton.test.ts
+++ b/packages/host-service/src/daemon/singleton.test.ts
@@ -58,8 +58,9 @@ describe("fire-and-track bootstrap", () => {
 
 		// Now await readiness — should complete after ensure resolves.
 		await waitForDaemonReady("org-fnt");
-		// Sanity: ensure was invoked exactly once across both calls.
-		expect(ensureMock).toHaveBeenCalledTimes(1);
+		// Readiness re-ensures (ensure is an idempotent map lookup when the
+		// daemon is alive) so a daemon that died post-bootstrap gets revived.
+		expect(ensureMock).toHaveBeenCalledTimes(2);
 	});
 
 	test("startDaemonBootstrap is idempotent", () => {
@@ -86,7 +87,26 @@ describe("fire-and-track bootstrap", () => {
 			ensureMock as typeof sup.ensure;
 
 		await waitForDaemonReady("org-lazy");
-		expect(ensureMock).toHaveBeenCalledTimes(1);
+		// Once for the kicked-off bootstrap, once for the readiness re-check.
+		expect(ensureMock).toHaveBeenCalledTimes(2);
+	});
+
+	test("waitForDaemonReady re-ensures after a successful bootstrap", async () => {
+		const sup = getSupervisor("/nonexistent");
+		const ensureMock = mock(async () => {
+			return {} as Awaited<ReturnType<typeof sup.ensure>>;
+		});
+		(sup as unknown as { ensure: typeof sup.ensure }).ensure =
+			ensureMock as typeof sup.ensure;
+
+		await waitForDaemonReady("org-revive");
+		const callsAfterFirst = ensureMock.mock.calls.length;
+		// The bootstrap promise stays resolved forever, so if the daemon dies
+		// later (adopted-daemon death, crash circuit) only a fresh ensure()
+		// can revive it. Each wait must go through ensure, not just the
+		// stale bootstrap promise.
+		await waitForDaemonReady("org-revive");
+		expect(ensureMock.mock.calls.length).toBe(callsAfterFirst + 1);
 	});
 
 	test("a failed bootstrap is retryable", async () => {
@@ -107,8 +127,9 @@ describe("fire-and-track bootstrap", () => {
 			"simulated spawn failure",
 		);
 		// Second wait kicks off a new bootstrap (the failed promise was
-		// cleared) and succeeds.
+		// cleared) and succeeds: one ensure for the bootstrap, one for the
+		// readiness re-check.
 		await waitForDaemonReady("org-retry");
-		expect(ensureMock).toHaveBeenCalledTimes(2);
+		expect(ensureMock).toHaveBeenCalledTimes(3);
 	});
 });

--- a/packages/host-service/src/daemon/singleton.ts
+++ b/packages/host-service/src/daemon/singleton.ts
@@ -95,6 +95,12 @@ export async function waitForDaemonReady(
 	if (bootstrapPromise) {
 		await bootstrapPromise;
 	}
+	// The bootstrap promise is one-shot: it stays resolved after the daemon
+	// it started dies later (adopted-daemon death, crash circuit), leaving
+	// getSocketPath() null forever. ensure() is a map lookup while the
+	// instance is alive; when it's gone it re-adopts/respawns, or throws
+	// the real circuit-open error instead of "no socket path".
+	await getSupervisor().ensure(organizationId);
 }
 
 /** Test-only — reset the singleton between tests. */


### PR DESCRIPTION
## Problem

Repeated customer-visible errors:

```
pty-daemon is not available: supervisor returned no socket path. The bootstrap must have failed — check host-service logs for spawn errors.
```

The message is misleading — bootstrap did NOT fail. `waitForDaemonReady` treats the one-shot bootstrap promise as proof the daemon is ready, but that promise stays resolved forever. When the daemon dies later, the supervisor clears its instance and expects a "next-ensure respawn" — which never comes, because `ensure()` is only ever reached through the one-shot `startDaemonBootstrap`. Two paths land here:

1. **Adopted daemon dies** (the common prod case — every daemon is adopted after a host-service restart): the adopted-liveness poll deletes the instance; no respawn path exists. Every terminal request fails with the error above until the host-service restarts.
2. **Crash circuit opens**: instance deleted, respawn refused — and the informative "crash circuit open" error is never surfaced because requests never call `ensure()`.

## Fix

`waitForDaemonReady` now falls through to `supervisor.ensure(orgId)` after awaiting the bootstrap promise. While the daemon is alive this is an in-memory map lookup; when it's gone it re-adopts/respawns (coalesced across concurrent requests by the supervisor's existing `pendingStarts` guard); when the circuit is open it throws the real circuit-open error instead of the misleading one.

## Verification

- New regression test + updated call-count assertions in `singleton.test.ts`; verified the tests fail against the old implementation (4 fail stashed, 7 pass fixed). All 445 host-service tests pass; lint + typecheck clean.
- **CDP-reproduced live A/B** on the dev desktop from this worktree: staged a true adopted daemon via `terminal.daemon.update.mutate()` (fd-handoff successor is not a host-service child), SIGKILL'd it, waited for `adopted process <pid> died — clearing instance`, then issued 3 `terminal.createSession` calls 8s apart.
  - **Before**: all 3 fail with the exact reported error (permanent wedge, zero respawns logged).
  - **After**: first request triggers a fresh spawn (`spawning … → spawned pid=…` in the log) and all 3 return `{status: "active"}`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5759">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wedge where `pty-daemon` could die after bootstrap and never respawn, causing terminal requests to fail with a misleading “no socket path” error. `waitForDaemonReady` now re-ensures on each request to revive or correctly report a circuit-open error.

- Bug Fixes
  - After awaiting the one-shot bootstrap, call `supervisor.ensure(orgId)` to re-adopt/respawn or throw the real circuit-open error.
  - Concurrent requests are coalesced via existing `pendingStarts`; if alive, ensure is a fast map lookup.
  - Updated and added tests in `packages/host-service/src/daemon/singleton.test.ts` to assert the re-ensure behavior.

<sup>Written for commit ddde85dee1aee3b53a35bbf844b1e2a905dddd11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon readiness checks to recover when the daemon stops after initial startup.
  * Added more reliable retry behavior following failed daemon startup attempts.
  * Readiness checks now surface current startup or circuit-breaker errors instead of relying on outdated status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->