### PR TITLE
feat(shared): auto-approve permissions and default-preset the opencode agent

### DIFF
--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -110,9 +110,10 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		id: "opencode",
 		label: "OpenCode",
 		description: "Open-source coding agent for the terminal, IDE, and desktop.",
-		command: "opencode",
-		promptCommand: "opencode --prompt",
+		command: "opencode --auto",
+		promptCommand: "opencode --auto --prompt",
 		nonInteractiveCommand: "opencode run --agent plan",
+		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
 		id: "pi",


### PR DESCRIPTION
Brings the built-in `opencode` terminal-agent preset to parity with `claude`:

- `command`/`promptCommand` now pass `--auto` (opencode's equivalent of Claude's `--dangerously-skip-permissions`), so tool calls auto-approve instead of prompting.
- Adds `includeInDefaultTerminalPresets: true`, matching `claude` and closing the gap with `DEFAULT_V2_TERMINAL_PRESET_IDS`, which already includes `opencode`.
- `nonInteractiveCommand` is left untouched, mirroring how `claude`'s `-p` also omits the skip-permissions flag.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5760">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--auto` to `opencode` `command` and `promptCommand` to auto-approve tool calls, and sets `includeInDefaultTerminalPresets: true` to match `claude`. `nonInteractiveCommand` remains `opencode run --agent plan`.

<sup>Written for commit 0f159a36c6ab762bdf30bbd65912ec78881c5977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the OpenCode terminal agent to use the latest automated and one-shot invocation options.
  * Added OpenCode to the default terminal presets for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->