### PR TITLE
fix(desktop): stop Changes panel rows from measuring layout on mount

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CategorySection/CategorySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CategorySection/CategorySection.tsx
@@ -1,13 +1,10 @@
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@superset/ui/collapsible";
+import { Collapsible, CollapsibleTrigger } from "@superset/ui/collapsible";
 import { cn } from "@superset/ui/utils";
-import type { ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 import { VscChevronRight } from "react-icons/vsc";
 import { useChangesSectionDnd } from "renderer/screens/main/components/WorkspaceView/hooks/useChangesSectionDnd";
 import type { ChangeCategory } from "shared/changes-types";
+import { PlainCollapsibleContent } from "../PlainCollapsibleContent";
 
 interface CategorySectionProps {
 	id: ChangeCategory;
@@ -32,6 +29,7 @@ export function CategorySection({
 }: CategorySectionProps) {
 	const { containerRef, isDragging, isOver } =
 		useChangesSectionDnd<HTMLDivElement>({ id, onMove });
+	const contentId = useId();
 
 	if (count === 0) {
 		return null;
@@ -61,6 +59,7 @@ export function CategorySection({
 				)}
 			>
 				<CollapsibleTrigger
+					aria-controls={contentId}
 					className={cn(
 						"flex-1 flex items-center gap-1.5 px-2 py-1.5 text-left min-w-0",
 						"hover:bg-accent/30 cursor-pointer transition-colors",
@@ -97,9 +96,13 @@ export function CategorySection({
 				{actions && <div className="pr-1.5 shrink-0">{actions}</div>}
 			</div>
 
-			<CollapsibleContent className="px-0.5 pb-1 min-w-0 overflow-hidden">
+			<PlainCollapsibleContent
+				id={contentId}
+				isOpen={isExpanded}
+				className="px-0.5 pb-1 min-w-0 overflow-hidden"
+			>
 				{children}
-			</CollapsibleContent>
+			</PlainCollapsibleContent>
 		</Collapsible>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CollapsibleRow/CollapsibleRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CollapsibleRow/CollapsibleRow.tsx
@@ -1,11 +1,8 @@
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@superset/ui/collapsible";
+import { Collapsible, CollapsibleTrigger } from "@superset/ui/collapsible";
 import { cn } from "@superset/ui/utils";
-import type { ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 import { VscChevronRight } from "react-icons/vsc";
+import { PlainCollapsibleContent } from "../PlainCollapsibleContent";
 
 interface CollapsibleRowProps {
 	isExpanded: boolean;
@@ -28,6 +25,8 @@ export function CollapsibleRow({
 	triggerClassName,
 	contentClassName,
 }: CollapsibleRowProps) {
+	const contentId = useId();
+
 	return (
 		<Collapsible
 			open={isExpanded}
@@ -35,6 +34,7 @@ export function CollapsibleRow({
 			className={cn("min-w-0", className)}
 		>
 			<CollapsibleTrigger
+				aria-controls={contentId}
 				className={cn(
 					"w-full flex items-center gap-1.5 px-1.5 py-1 text-left rounded-sm",
 					"hover:bg-accent/50 cursor-pointer transition-colors",
@@ -51,9 +51,13 @@ export function CollapsibleRow({
 				)}
 				{header}
 			</CollapsibleTrigger>
-			<CollapsibleContent className={cn("min-w-0", contentClassName)}>
+			<PlainCollapsibleContent
+				id={contentId}
+				isOpen={isExpanded}
+				className={cn("min-w-0", contentClassName)}
+			>
 				{children}
-			</CollapsibleContent>
+			</PlainCollapsibleContent>
 		</Collapsible>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FolderRow/FolderRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FolderRow/FolderRow.tsx
@@ -1,9 +1,5 @@
 import type { ExternalApp } from "@superset/local-db";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@superset/ui/collapsible";
+import { Collapsible, CollapsibleTrigger } from "@superset/ui/collapsible";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -12,7 +8,7 @@ import {
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
 import { cn } from "@superset/ui/utils";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useId, useState } from "react";
 import {
 	VscAdd,
 	VscChevronRight,
@@ -25,6 +21,7 @@ import {
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import { usePathActions } from "../../hooks";
 import { DiscardConfirmDialog } from "../DiscardConfirmDialog";
+import { PlainCollapsibleContent } from "../PlainCollapsibleContent";
 import type { RowHoverAction } from "../RowHoverActions";
 import { RowHoverActions } from "../RowHoverActions";
 
@@ -123,6 +120,7 @@ export function FolderRow({
 	defaultApp,
 }: FolderRowProps) {
 	const [showDiscardDialog, setShowDiscardDialog] = useState(false);
+	const contentId = useId();
 	const isGrouped = variant === "grouped";
 	const isRoot = folderPath === "";
 	const absolutePath = isRoot
@@ -180,6 +178,7 @@ export function FolderRow({
 
 	const triggerContent = (
 		<CollapsibleTrigger
+			aria-controls={contentId}
 			className={cn(
 				"flex-1 min-w-0 flex gap-1.5 text-left overflow-hidden",
 				"text-xs items-stretch py-0.5",
@@ -268,14 +267,16 @@ export function FolderRow({
 					</ContextMenuTrigger>
 					{contextMenuContent}
 				</ContextMenu>
-				<CollapsibleContent
+				<PlainCollapsibleContent
+					id={contentId}
+					isOpen={isExpanded}
 					className={cn(
 						"min-w-0",
 						isGrouped && "ml-1.5 border-l border-border pl-0.5",
 					)}
 				>
 					{children}
-				</CollapsibleContent>
+				</PlainCollapsibleContent>
 			</Collapsible>
 
 			<DiscardConfirmDialog

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PlainCollapsibleContent/PlainCollapsibleContent.test.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PlainCollapsibleContent/PlainCollapsibleContent.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PlainCollapsibleContent } from "./PlainCollapsibleContent";
+
+describe("PlainCollapsibleContent", () => {
+	test("renders children and drops the hidden attribute when open", () => {
+		const html = renderToStaticMarkup(
+			<PlainCollapsibleContent id="row-1" isOpen>
+				<span>file.ts</span>
+			</PlainCollapsibleContent>,
+		);
+
+		expect(html).toContain('id="row-1"');
+		expect(html).toContain('data-state="open"');
+		expect(html).not.toContain("hidden");
+		expect(html).toContain("file.ts");
+	});
+
+	test("sets the hidden attribute and omits children when closed", () => {
+		const html = renderToStaticMarkup(
+			<PlainCollapsibleContent id="row-1" isOpen={false}>
+				<span>file.ts</span>
+			</PlainCollapsibleContent>,
+		);
+
+		expect(html).toContain("hidden=");
+		expect(html).toContain('data-state="closed"');
+		expect(html).not.toContain("file.ts");
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PlainCollapsibleContent/PlainCollapsibleContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PlainCollapsibleContent/PlainCollapsibleContent.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@superset/ui/utils";
+import type { ReactNode } from "react";
+
+interface PlainCollapsibleContentProps {
+	id: string;
+	isOpen: boolean;
+	className?: string;
+	children: ReactNode;
+}
+
+/**
+ * Drop-in replacement for `@superset/ui/collapsible`'s Radix-backed
+ * `CollapsibleContent`, for spots that mount many rows at once (e.g. one per
+ * file/folder/commit in the Changes panel).
+ *
+ * Radix's `CollapsibleContent` runs a mount layout effect that calls
+ * `node.getBoundingClientRect()` on every instance so it can expose
+ * `--radix-collapsible-content-height`/`-width` for CSS height transitions.
+ * None of the Changes panel rows animate height, so that measurement is pure
+ * overhead — with hundreds of rows mounting in one commit it becomes layout
+ * thrashing that freezes the renderer (superset-sh/superset#5521). This
+ * renders straight off the `isOpen` state the caller already tracks, with no
+ * measurement and no forced reflow.
+ *
+ * Pair with a trigger that sets `aria-controls={id}` to preserve the a11y
+ * link Radix would otherwise wire up automatically.
+ */
+export function PlainCollapsibleContent({
+	id,
+	isOpen,
+	className,
+	children,
+}: PlainCollapsibleContentProps) {
+	return (
+		<div
+			id={id}
+			data-state={isOpen ? "open" : "closed"}
+			hidden={!isOpen}
+			className={cn(className)}
+		>
+			{isOpen ? children : null}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PlainCollapsibleContent/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PlainCollapsibleContent/index.ts
@@ -1,0 +1,1 @@
+export { PlainCollapsibleContent } from "./PlainCollapsibleContent";


### PR DESCRIPTION
fix(desktop): stop Changes panel rows from measuring layout on mount

## Summary

Fixes #5521 — reported by @kbrady1 with an excellent DevTools performance
trace that pinpointed the freeze to `commitLayoutEffectOnFiber` recursion
and `getBoundingClientRect()` calls from the Radix Collapsible bundle.

Root cause: Radix's `CollapsibleContent` (used by `@superset/ui/collapsible`,
which backs `CategorySection`, `FolderRow`, and `CollapsibleRow` in the
Changes panel) runs a mount **layout effect** on every instance that reads
`node.getBoundingClientRect()` and writes `transitionDuration`/`animationName`
styles. This exists so `CollapsibleContent` can expose
`--radix-collapsible-content-height`/`-width` for CSS height transitions —
but nothing in the Changes panel (or anywhere else in this repo, as far as I
could find) actually uses those variables to animate height. The measurement
is pure overhead here.

When `git.getStatus` resolves for a workspace with a large diff, React
synchronously mounts the whole Changes panel — one `CategorySection` per
category and one `FolderRow`/`CollapsibleRow` per folder/file/commit, all
already expanded. Each of those runs its own write-then-read layout effect
in the same commit; because the writes and reads interleave across
hundreds of freshly-mounted nodes, this becomes classic layout thrashing —
matching the reporter's profile (~46% render, ~44% commit phase with deep
`commitLayoutEffectOnFiber` recursion, ~10% `getBoundingClientRect`).

## Fix

Added `PlainCollapsibleContent` — a drop-in, effect-free replacement for
`@superset/ui/collapsible`'s `CollapsibleContent` that renders straight off
the `isOpen` boolean the caller already tracks (via the same `isExpanded`
prop that already drives `Collapsible`'s `open`), with no
`getBoundingClientRect`, no style mutation, no layout effect at all. It
preserves the `aria-controls`/`id` link and `hidden`/`data-state`
attributes Radix would otherwise wire up.

Scoped to the three Changes-panel components responsible for the fan-out
(`CategorySection`, `FolderRow`, `CollapsibleRow`) rather than the shared
`@superset/ui/collapsible` wrapper itself, since that wrapper has ~15 other
consumers across admin/chat/settings and I didn't want to change behavior
there in a perf-only PR. `Collapsible`/`CollapsibleTrigger` from Radix are
kept as-is in all three — they're plain context/click wiring with no
layout effect, so they aren't part of the freeze.

## Testing

- `bun run typecheck` — clean.
- `bun run lint` — clean (Biome, 5197 files).
- `bun test` (scoped to `ChangesView/`) — 24/24 pass, including two new
  tests for `PlainCollapsibleContent` (renders children + `data-state=open`
  when open; sets `hidden` and omits children when closed) using
  `react-dom/server`'s `renderToStaticMarkup`, since this repo's `bun:test`
  setup doesn't include a DOM environment (no jsdom/happy-dom, no
  `@testing-library/react`) for full component-mount assertions.

**Manual verification I could not complete in this environment:** I don't
have a way to drive the actual Electron app end-to-end here. Per
`apps/desktop/AGENTS.md`, the intended way to confirm this against a real
large changeset is: `RENDERER_REMOTE_DEBUG_PORT=9222 bun dev`, open a
workspace with a big diff, expand the Changes panel, and re-record a
DevTools performance trace the way the original report did — the
`getBoundingClientRect` samples under `commitLayoutEffectOnFiber` for
`CategorySection`/`FolderRow`/`CollapsibleRow` should disappear. Flagging
this so a maintainer/reviewer can do that pass before merge.

## Screenshot / recording

None — this is a perf-only change with no visual difference (same classes,
same DOM shape, same expand/collapse behavior). Happy to add a before/after
trace if a maintainer can point me at a repro workspace.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5761">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates renderer freezes in the Changes panel on large repos by replacing Radix `CollapsibleContent` with a lightweight `PlainCollapsibleContent` that avoids mount-time layout measurement; behavior and UI are unchanged. Fixes #5521.

- Bug Fixes
  - Added `PlainCollapsibleContent` (no layout effect, no `getBoundingClientRect()`), used in `CategorySection`, `FolderRow`, and `CollapsibleRow`.
  - Kept `Collapsible`/`CollapsibleTrigger` from `@superset/ui/collapsible`; preserved `aria-controls`, `id`, `hidden`, and `data-state`.
  - Added tests for open/closed rendering with `renderToStaticMarkup`; typecheck, lint, and scoped tests pass.

<sup>Written for commit ab41012cf38bf72716f74e50f0c58b815e18c8b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved collapsible sections in the changes sidebar with clearer relationships between controls and their content.
  - Added appropriate state and visibility indicators for expanded and collapsed sections.

- **Bug Fixes**
  - Improved collapsible content behavior to prevent unnecessary rendering and layout measurement.

- **Tests**
  - Added coverage for expanded and collapsed content states, including visibility and child rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->