### PR TITLE
docs(desktop): document CDP port and auth recovery

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -47,9 +47,34 @@ export const createMyRouter = () => {
 
 ## Verifying renderer changes via CDP
 
-To check a change end-to-end against the real API/DB, drive the running dev app over CDP. Launch with `RENDERER_REMOTE_DEBUG_PORT=9222 bun dev` (full stack; the app restores a signed-in session), attach via the page target's `webSocketDebuggerUrl` from `localhost:9222/json` over a WebSocket (Bun built-in, no deps). Example: `scripts/cdp-smoke-integrations.ts`.
+To check a change end-to-end against the real API/DB, drive the running dev app over CDP. Launch with an unused port, for example `RENDERER_REMOTE_DEBUG_PORT=9222 bun dev` (full stack; the app may restore a signed-in session), then attach via the page target's `webSocketDebuggerUrl` over a WebSocket (Bun built-in, no deps). Example: `scripts/cdp-smoke-integrations.ts`.
 
-**Use `Runtime.evaluate` (`awaitPromise`, `returnByValue`), not `Network.*` interception** — sniffing misses React-Query-cached responses, and `refetchInterval` is paused while the window is backgrounded. Run an in-renderer `fetch(url, { credentials: "include" })` (the bearer token is in a closure, but the session cookie works). `API` below is the dev backend origin (`NEXT_PUBLIC_API_URL`, e.g. `http://localhost:5881`):
+**Never assume port 9222 or attach to a renderer from another worktree.** Multiple Superset workspaces commonly run at once, each with different renderer, API, and CDP ports. Before testing:
+
+1. Read this workspace's final `DESKTOP_VITE_PORT` and `NEXT_PUBLIC_API_URL` values from the root `.env`.
+2. Find the Electron process whose executable/parent command path is inside this workspace. Its renderer command line contains `--remote-debugging-port=<port>`; `lsof -nP -iTCP -sTCP:LISTEN` can confirm the owning PID.
+3. Fetch `http://127.0.0.1:<port>/json/list` and require a `page` target whose URL uses this workspace's `DESKTOP_VITE_PORT`. A responding CDP endpoint alone is not sufficient proof that it belongs to this branch.
+4. Pass the matched values explicitly when using a script, e.g. `RENDERER_REMOTE_DEBUG_PORT=<port> NEXT_PUBLIC_API_URL=<api-origin> bun run apps/desktop/scripts/cdp-smoke-integrations.ts`.
+
+Do not borrow another worktree's signed-in renderer when this workspace has no usable session; that tests different code. Verify `/api/auth/get-session` from inside the matched renderer first.
+
+### Repairing CDP auth
+
+Check which setup script provisioned the workspace before repairing auth:
+
+- `.superset/setup.local.sh` creates a per-workspace local stack and runs the idempotent `bun run db:seed-dev`, but intentionally leaves sign-in as a separate step. If the account may be missing, rerun `bun run db:seed-dev` while the local DB stack is running.
+- `.superset/setup.sh` seeds `superset-dev-data/auth-token.enc` from `$HOME/.superset/auth-token.enc` when available. Rerunning it without `--force` can fill a missing token. Do not use `--force` merely to repair auth: it resets `superset-dev-data/` before reseeding.
+
+The desktop hydrates a persisted token into an in-memory bearer-token closure. A raw `Runtime.evaluate` `fetch` cannot read that closure, and the local-dev sign-in button persists a bearer token but uses `credentials: "omit"`; neither guarantees the cookie required by a raw CDP probe. For a workspace created by `setup.local.sh`, repair the CDP session as follows:
+
+1. Require a localhost API origin and confirm the matched renderer/API processes belong to this worktree. Never send dev credentials to a remote or shared API.
+2. From `apps/desktop` (so workspace imports resolve), import `DEV_EMAIL` and `DEV_PASSWORD` from `@superset/shared/dev-credentials`; do not copy their literal values into scripts or logs.
+3. Through `Runtime.evaluate` in the matched renderer, POST them to `${NEXT_PUBLIC_API_URL}/api/auth/sign-in/email` with JSON content type and `credentials: "include"`. Do not print the returned token or response body.
+4. Re-fetch `/api/auth/get-session` with `credentials: "include"` and require both `session` and `session.activeOrganizationId` before running the test.
+
+This credentialed local-dev sign-in creates the browser session cookie needed by subsequent in-renderer fetches. If it fails, report the sign-in/session status codes only. For a non-local setup, use the app's normal sign-in flow; never substitute local dev credentials.
+
+**Use `Runtime.evaluate` (`awaitPromise`, `returnByValue`), not `Network.*` interception** — sniffing misses React-Query-cached responses, and `refetchInterval` is paused while the window is backgrounded. After verifying or repairing the session cookie above, run an in-renderer `fetch(url, { credentials: "include" })`. `API` below is the dev backend origin (`NEXT_PUBLIC_API_URL`, e.g. `http://localhost:5881`):
 
 - Active org: `fetch(API + "/api/auth/get-session", {credentials:"include"})` → `.session.activeOrganizationId`.
 - A tRPC query (bypasses the cache): GET `API + "/api/trpc/<proc>?batch=1&input=" + encodeURIComponent(JSON.stringify({"0":{json:<input>}}))`; response is `[{result:{data:{json:...}}}]`.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -56,7 +56,7 @@ To check a change end-to-end against the real API/DB, drive the running dev app 
 3. Fetch `http://127.0.0.1:<port>/json/list` and require a `page` target whose URL uses this workspace's `DESKTOP_VITE_PORT`. A responding CDP endpoint alone is not sufficient proof that it belongs to this branch.
 4. Pass the matched values explicitly when using a script, e.g. `RENDERER_REMOTE_DEBUG_PORT=<port> NEXT_PUBLIC_API_URL=<api-origin> bun run apps/desktop/scripts/cdp-smoke-integrations.ts`.
 
-Do not borrow another worktree's signed-in renderer when this workspace has no usable session; that tests different code. Verify `/api/auth/get-session` from inside the matched renderer first.
+Verify `/api/auth/get-session` from inside the matched renderer before testing.
 
 ### Repairing CDP auth
 
@@ -67,7 +67,7 @@ Check which setup script provisioned the workspace before repairing auth:
 
 The desktop hydrates a persisted token into an in-memory bearer-token closure. A raw `Runtime.evaluate` `fetch` cannot read that closure, and the local-dev sign-in button persists a bearer token but uses `credentials: "omit"`; neither guarantees the cookie required by a raw CDP probe. For a workspace created by `setup.local.sh`, repair the CDP session as follows:
 
-1. Require a localhost API origin and confirm the matched renderer/API processes belong to this worktree. Never send dev credentials to a remote or shared API.
+1. Require a localhost API origin; never send dev credentials to a remote or shared API.
 2. From `apps/desktop` (so workspace imports resolve), import `DEV_EMAIL` and `DEV_PASSWORD` from `@superset/shared/dev-credentials`; do not copy their literal values into scripts or logs.
 3. Through `Runtime.evaluate` in the matched renderer, POST them to `${NEXT_PUBLIC_API_URL}/api/auth/sign-in/email` with JSON content type and `credentials: "include"`. Do not print the returned token or response body.
 4. Re-fetch `/api/auth/get-session` with `credentials: "include"` and require both `session` and `session.activeOrganizationId` before running the test.


### PR DESCRIPTION
## What changed

- document how to match a CDP endpoint to the correct Superset workspace and renderer
- add safeguards for validating renderer, API, and session ownership before testing
- document local CDP authentication recovery using shared development credentials

## Why

Multiple Superset workspaces can run simultaneously, so assuming port 9222 or borrowing another worktree's renderer can test the wrong code. Persisted desktop bearer tokens also do not guarantee that raw in-renderer CDP fetches have the session cookie they need.

## Impact

Desktop contributors get a safer, reproducible workflow for end-to-end renderer checks without exposing credentials or accidentally targeting another workspace.

## Validation

- `bun run lint:fix`
- `bun run lint`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates desktop CDP docs to ensure you attach to the correct renderer and have a valid local session. Adds safety guardrails to avoid cross-worktree ports and unsafe auth handling so CDP tests hit the right workspace.

- **Docs**
  - Match the CDP endpoint to this workspace: read `DESKTOP_VITE_PORT` and `NEXT_PUBLIC_API_URL`, find the Electron process in this worktree, confirm `--remote-debugging-port`/PID via `lsof`, and require a `page` from `/json/list` that uses this workspace’s Vite port; pass the matched port/origin to scripts. Never assume 9222 or borrow another worktree’s renderer.
  - Verify the session in-renderer (`/api/auth/get-session`) before tests. Repair auth by setup type: for `.superset/setup.local.sh`, sign in via `Runtime.evaluate` to `${NEXT_PUBLIC_API_URL}/api/auth/sign-in/email` using `@superset/shared/dev-credentials` with `credentials: "include"`; for `.superset/setup.sh`, prefer reseeding the local token without `--force`. Localhost API only, don’t log tokens, and require `session.activeOrganizationId`.
  - Prefer in-renderer `fetch(..., { credentials: "include" })` over `Network.*`; use direct tRPC GETs to bypass caches when needed.

<sup>Written for commit 48105d6d43eb9ed672b921afde31535f0789a55e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for verifying desktop renderer changes through CDP.
  * Added troubleshooting steps to identify the correct debugging endpoint and confirm session availability.
  * Documented how to repair authentication sessions and verify access to an active organization before testing.
  * Clarified recommended procedures for running in-renderer requests and performing follow-up endpoint checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->