### PR TITLE
fix(desktop): restore editor and diff scroll positions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,17 @@ Cut releases on a dedicated release branch (not `main`); `bun run release deskto
 
 **Biome runs at root level** (not per-package) for speed — use `bun run lint:fix` to fix all issues automatically.
 
+## CDP UI Verification
+
+When a user asks for UI verification through the Chrome DevTools Protocol (CDP):
+
+1. **Target the correct app instance** - confirm and report the worktree, renderer URL/port, and active route before testing. Follow any task-provided CDP/auth guidance and verify the expected signed-in session. Do not treat a different running desktop instance as equivalent.
+2. **Reproduce the exact user journey** - use real browser input and visible UI navigation for the steps the user performs. Directly assigning DOM properties, invoking internal app APIs, or running component-only scripts is diagnostic support, not proof of end-to-end behavior.
+3. **Capture visual and numeric evidence** - take before/after screenshots and pair them with relevant CDP measurements (for example, `scrollTop`, focused element, route, or persisted state). Confirm that the screenshot and measured state agree.
+4. **Exercise the relevant lifecycle** - include the actual route change, workspace/pane/file switch, remount, close/reopen, or other teardown boundary from the report. A narrower synthetic flow cannot substitute for the reported interaction.
+5. **Treat a mismatch as an incomplete reproduction** - if the test passes but the user still observes the bug, re-check the target instance, exact steps, input method, persisted keys, and lifecycle timing. Reproduce the failure before changing code; do not assume the report is disproven by a synthetic smoke test.
+6. **Use a before-fix/after-fix gate** - do not claim the bug is verified until the original interaction demonstrably fails before the fix and passes after it under the same observations. State clearly which checks were end-to-end, which were synthetic, and whether screenshots were actually captured.
+
 ## Agent Rules
 1. **Type safety** - avoid `any` unless necessary
 2. **Prefer `gh` CLI** - when performing git operations (PRs, issues, checkout, etc.), prefer the GitHub CLI (`gh`) over raw `git` commands where possible

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ When a user asks for UI verification through the Chrome DevTools Protocol (CDP):
 3. **Capture visual and numeric evidence** - take before/after screenshots and pair them with relevant CDP measurements (for example, `scrollTop`, focused element, route, or persisted state). Confirm that the screenshot and measured state agree.
 4. **Exercise the relevant lifecycle** - include the actual route change, workspace/pane/file switch, remount, close/reopen, or other teardown boundary from the report. A narrower synthetic flow cannot substitute for the reported interaction.
 5. **Treat a mismatch as an incomplete reproduction** - if the test passes but the user still observes the bug, re-check the target instance, exact steps, input method, persisted keys, and lifecycle timing. Reproduce the failure before changing code; do not assume the report is disproven by a synthetic smoke test.
-6. **Use a before-fix/after-fix gate** - do not claim the bug is verified until the original interaction demonstrably fails before the fix and passes after it under the same observations. State clearly which checks were end-to-end, which were synthetic, and whether screenshots were actually captured.
+6. **Use an evidence gate** - for a reported bug or regression, do not claim it is verified until the original interaction demonstrably fails before the fix and passes after it under the same observations. For a new feature, record equivalent baseline evidence and demonstrate the expected behavior. In all cases, state clearly which checks were end-to-end, which were synthetic, and whether screenshots were actually captured.
 
 ## Agent Rules
 1. **Type safety** - avoid `any` unless necessary

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -8,6 +8,11 @@ import type { RendererContext } from "@superset/panes";
 import { Button } from "@superset/ui/button";
 import { useCallback, useMemo, useRef } from "react";
 import { LuFileCode } from "react-icons/lu";
+import {
+	createPaneScrollStateKey,
+	getPaneScrollState,
+	savePaneScrollState,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache";
 import { MarkdownSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/MarkdownSearch";
 import type { DiffPaneData, PaneViewerData } from "../../../../types";
 import {
@@ -60,6 +65,20 @@ export function DiffPane({
 	const searchContainerRef = useRef<HTMLDivElement>(null);
 
 	const ref = useSidebarDiffRef(workspaceId);
+	const scrollStateKey = useMemo(
+		() =>
+			createPaneScrollStateKey({
+				workspaceId,
+				paneId: context.pane.id,
+				viewId: "diff",
+				resourceId: JSON.stringify(ref),
+			}),
+		[workspaceId, context.pane.id, ref],
+	);
+	const initialScrollState = useMemo(
+		() => getPaneScrollState(scrollStateKey),
+		[scrollStateKey],
+	);
 	const { files, isLoading } = useChangeset({ workspaceId, ref });
 	const { viewedSet, setViewed } = useViewedFiles(workspaceId);
 	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
@@ -138,6 +157,8 @@ export function DiffPane({
 		items,
 		collapsedSet,
 		setCollapsed,
+		scrollStateKey,
+		initialScrollState,
 	});
 
 	// The section bar lives outside the scroller: Pierre pins one header at a
@@ -149,7 +170,13 @@ export function DiffPane({
 		fileByItemId,
 		files,
 	});
-
+	const handleScroll = useCallback(
+		(scrollTop: number) => {
+			savePaneScrollState(scrollStateKey, { scrollTop, scrollLeft: 0 });
+			onScroll();
+		},
+		[scrollStateKey, onScroll],
+	);
 	const { options, style } = useDiffCodeViewTheme();
 
 	const codeViewOptions = useMemo(
@@ -314,7 +341,7 @@ export function DiffPane({
 					style={style}
 					items={items}
 					options={codeViewOptions}
-					onScroll={onScroll}
+					onScroll={handleScroll}
 					renderHeaderPrefix={renderHeaderPrefix}
 					renderHeaderMetadata={renderHeaderMetadata}
 					renderAnnotation={renderAnnotation}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldRestoreCachedScrollState/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldRestoreCachedScrollState/index.ts
@@ -1,0 +1,1 @@
+export { shouldRestoreCachedScrollState } from "./shouldRestoreCachedScrollState";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldRestoreCachedScrollState/shouldRestoreCachedScrollState.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldRestoreCachedScrollState/shouldRestoreCachedScrollState.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { shouldRestoreCachedScrollState } from "./useDiffCodeViewScroll";
+import { shouldRestoreCachedScrollState } from "./shouldRestoreCachedScrollState";
 
 const cachedState = {
 	scrollTop: 320,
-	scrollLeft: 0,
 	updatedAt: 20,
 };
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldRestoreCachedScrollState/shouldRestoreCachedScrollState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/shouldRestoreCachedScrollState/shouldRestoreCachedScrollState.ts
@@ -1,0 +1,14 @@
+interface CachedScrollState {
+	scrollTop: number;
+	updatedAt: number;
+}
+
+export function shouldRestoreCachedScrollState(
+	state: CachedScrollState | undefined,
+	navigationTick: number | undefined,
+): state is CachedScrollState {
+	return (
+		state !== undefined &&
+		(navigationTick === undefined || state.updatedAt > navigationTick)
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { shouldRestoreCachedScrollState } from "./useDiffCodeViewScroll";
+
+const cachedState = {
+	scrollTop: 320,
+	scrollLeft: 0,
+	updatedAt: 20,
+};
+
+describe("shouldRestoreCachedScrollState", () => {
+	test("restores cached state when there is no pending navigation", () => {
+		expect(shouldRestoreCachedScrollState(cachedState, undefined)).toBe(true);
+	});
+
+	test("lets a newer navigation override cached state", () => {
+		expect(shouldRestoreCachedScrollState(cachedState, 21)).toBe(false);
+	});
+
+	test("restores state saved after the last navigation", () => {
+		expect(shouldRestoreCachedScrollState(cachedState, 19)).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
@@ -15,10 +15,22 @@ interface UseDiffCodeViewScrollOptions {
 	items: CodeViewItem<DiffAnnotationMetadata>[];
 	collapsedSet: ReadonlySet<string>;
 	setCollapsed: (path: string, value: boolean) => void;
+	scrollStateKey: string;
+	initialScrollState?: { scrollTop: number; updatedAt: number };
 }
 
 interface UseDiffCodeViewScrollResult {
 	targetItemId?: string;
+}
+
+export function shouldRestoreCachedScrollState(
+	state: { scrollTop: number; updatedAt: number } | undefined,
+	navigationTick: number | undefined,
+): state is { scrollTop: number; updatedAt: number } {
+	return (
+		state !== undefined &&
+		(navigationTick === undefined || state.updatedAt > navigationTick)
+	);
 }
 
 export function useDiffCodeViewScroll({
@@ -28,8 +40,11 @@ export function useDiffCodeViewScroll({
 	items,
 	collapsedSet,
 	setCollapsed,
+	scrollStateKey,
+	initialScrollState,
 }: UseDiffCodeViewScrollOptions): UseDiffCodeViewScrollResult {
 	const lastScrollTargetRef = useRef<string | null>(null);
+	const resolvedScrollStateKeyRef = useRef<string | null>(null);
 	const itemById = useMemo(() => {
 		const map = new Map<string, CodeViewItem<DiffAnnotationMetadata>>();
 		for (const item of items) {
@@ -50,6 +65,29 @@ export function useDiffCodeViewScroll({
 	}, [data.changeKey, data.path, items, fileByItemId]);
 
 	useEffect(() => {
+		const scrollKey = [
+			targetItemId ?? "",
+			data.focusLine ?? "",
+			data.focusSide ?? "",
+			data.focusTick ?? "",
+		].join(":");
+		if (resolvedScrollStateKeyRef.current !== scrollStateKey) {
+			lastScrollTargetRef.current = null;
+			if (shouldRestoreCachedScrollState(initialScrollState, data.focusTick)) {
+				const instance = codeViewRef.current?.getInstance();
+				if (!instance || items.length === 0) return;
+				codeViewRef.current?.scrollTo({
+					type: "position",
+					position: initialScrollState.scrollTop,
+					behavior: "instant",
+				});
+				lastScrollTargetRef.current = scrollKey;
+				resolvedScrollStateKeyRef.current = scrollStateKey;
+				return;
+			}
+			resolvedScrollStateKeyRef.current = scrollStateKey;
+		}
+
 		if (!targetItemId) return;
 		const file = fileByItemId.get(targetItemId);
 		if (!file) return;
@@ -60,12 +98,6 @@ export function useDiffCodeViewScroll({
 			return;
 		}
 
-		const scrollKey = [
-			targetItemId,
-			data.focusLine ?? "",
-			data.focusSide ?? "",
-			data.focusTick ?? "",
-		].join(":");
 		if (lastScrollTargetRef.current === scrollKey) return;
 
 		const targetItem = itemById.get(targetItemId);
@@ -93,6 +125,9 @@ export function useDiffCodeViewScroll({
 		data.focusLine,
 		data.focusSide,
 		data.focusTick,
+		initialScrollState,
+		items.length,
+		scrollStateKey,
 		targetItemId,
 		fileByItemId,
 		itemById,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewScroll/useDiffCodeViewScroll.ts
@@ -7,6 +7,7 @@ import {
 	getChangesetFileKey,
 } from "../../../../../useChangeset";
 import type { DiffAnnotationMetadata } from "../useDiffAnnotations";
+import { shouldRestoreCachedScrollState } from "./shouldRestoreCachedScrollState";
 
 interface UseDiffCodeViewScrollOptions {
 	codeViewRef: RefObject<CodeViewHandle<DiffAnnotationMetadata> | null>;
@@ -21,16 +22,6 @@ interface UseDiffCodeViewScrollOptions {
 
 interface UseDiffCodeViewScrollResult {
 	targetItemId?: string;
-}
-
-export function shouldRestoreCachedScrollState(
-	state: { scrollTop: number; updatedAt: number } | undefined,
-	navigationTick: number | undefined,
-): state is { scrollTop: number; updatedAt: number } {
-	return (
-		state !== undefined &&
-		(navigationTick === undefined || state.updatedAt > navigationTick)
-	);
 }
 
 export function useDiffCodeViewScroll({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -147,6 +147,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 					document={document}
 					filePath={filePath}
 					workspaceId={workspaceId}
+					paneId={context.pane.id}
 					isActive={context.isActive}
 					onChangeView={handleChangeView}
 					onForceView={handleForceView}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/types.ts
@@ -34,6 +34,7 @@ export interface ViewProps {
 	document: SharedFileDocument;
 	filePath: string;
 	workspaceId: string;
+	paneId: string;
 	isActive: boolean;
 	onChangeView: (viewId: string) => void;
 	onForceView: (viewId: string) => void;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/CodeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/CodeView.tsx
@@ -1,8 +1,40 @@
+import { useCallback, useMemo } from "react";
+import {
+	createPaneScrollStateKey,
+	getPaneScrollState,
+	savePaneScrollState,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache";
 import { detectLanguage } from "shared/detect-language";
 import type { ViewProps } from "../../types";
 import { CodeEditor } from "./components/CodeEditor";
 
-export function CodeView({ document, filePath }: ViewProps) {
+export function CodeView({
+	document,
+	filePath,
+	workspaceId,
+	paneId,
+}: ViewProps) {
+	const scrollStateKey = useMemo(
+		() =>
+			createPaneScrollStateKey({
+				workspaceId,
+				paneId,
+				viewId: "editor",
+				resourceId: filePath,
+			}),
+		[workspaceId, paneId, filePath],
+	);
+	const initialScrollPosition = useMemo(
+		() => getPaneScrollState(scrollStateKey),
+		[scrollStateKey],
+	);
+	const handleScrollPositionChange = useCallback(
+		(position: { scrollTop: number; scrollLeft: number }) => {
+			savePaneScrollState(scrollStateKey, position);
+		},
+		[scrollStateKey],
+	);
+
 	if (document.content.kind !== "text") {
 		return null;
 	}
@@ -14,6 +46,8 @@ export function CodeView({ document, filePath }: ViewProps) {
 			language={detectLanguage(filePath)}
 			onChange={(next) => document.setContent(next)}
 			onSave={() => void document.save()}
+			initialScrollPosition={initialScrollPosition}
+			onScrollPositionChange={handleScrollPositionChange}
 			fillHeight
 		/>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/CodeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/CodeView.tsx
@@ -8,21 +8,17 @@ import { detectLanguage } from "shared/detect-language";
 import type { ViewProps } from "../../types";
 import { CodeEditor } from "./components/CodeEditor";
 
-export function CodeView({
-	document,
-	filePath,
-	workspaceId,
-	paneId,
-}: ViewProps) {
+export function CodeView({ document, filePath, workspaceId }: ViewProps) {
+	// Quick Open replaces preview panes with new pane IDs, so the file path is
+	// the stable editor identity when a user switches away and back.
 	const scrollStateKey = useMemo(
 		() =>
 			createPaneScrollStateKey({
 				workspaceId,
-				paneId,
 				viewId: "editor",
 				resourceId: filePath,
 			}),
-		[workspaceId, paneId, filePath],
+		[workspaceId, filePath],
 	);
 	const initialScrollPosition = useMemo(
 		() => getPaneScrollState(scrollStateKey),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
@@ -50,6 +50,11 @@ interface CodeEditorProps {
 	editorRef?: MutableRefObject<CodeEditorAdapter | null>;
 	onChange?: (value: string) => void;
 	onSave?: () => void;
+	initialScrollPosition?: { scrollTop: number; scrollLeft: number };
+	onScrollPositionChange?: (position: {
+		scrollTop: number;
+		scrollLeft: number;
+	}) => void;
 }
 
 export function CodeEditor({
@@ -61,6 +66,8 @@ export function CodeEditor({
 	editorRef,
 	onChange,
 	onSave,
+	initialScrollPosition,
+	onScrollPositionChange,
 }: CodeEditorProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const viewRef = useRef<EditorView | null>(null);
@@ -69,6 +76,8 @@ export function CodeEditor({
 	const editableCompartment = useRef(new Compartment()).current;
 	const onChangeRef = useRef(onChange);
 	const onSaveRef = useRef(onSave);
+	const onScrollPositionChangeRef = useRef(onScrollPositionChange);
+	const initialScrollPositionRef = useRef(initialScrollPosition);
 	// Guards against re-entrant onChange calls triggered by the value-sync effect's own dispatch.
 	const isExternalUpdateRef = useRef(false);
 	const { data: fontSettings } = useQuery({
@@ -82,6 +91,7 @@ export function CodeEditor({
 
 	onChangeRef.current = onChange;
 	onSaveRef.current = onSave;
+	onScrollPositionChangeRef.current = onScrollPositionChange;
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: Editor instance is created once and reconfigured via dedicated effects below
 	useEffect(() => {
@@ -155,6 +165,25 @@ export function CodeEditor({
 			parent: containerRef.current,
 		});
 		const adapter = createCodeMirrorAdapter(view);
+		const reportScrollPosition = () => {
+			onScrollPositionChangeRef.current?.({
+				scrollTop: view.scrollDOM.scrollTop,
+				scrollLeft: view.scrollDOM.scrollLeft,
+			});
+		};
+		view.scrollDOM.addEventListener("scroll", reportScrollPosition, {
+			passive: true,
+		});
+		const savedScrollPosition = initialScrollPositionRef.current;
+		if (savedScrollPosition) {
+			view.requestMeasure({
+				read: () => savedScrollPosition,
+				write: (position) => {
+					view.scrollDOM.scrollTop = position.scrollTop;
+					view.scrollDOM.scrollLeft = position.scrollLeft;
+				},
+			});
+		}
 
 		viewRef.current = view;
 		if (editorRef) {
@@ -162,6 +191,8 @@ export function CodeEditor({
 		}
 
 		return () => {
+			reportScrollPosition();
+			view.scrollDOM.removeEventListener("scroll", reportScrollPosition);
 			if (editorRef?.current === adapter) {
 				editorRef.current = null;
 			}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/CodeView/components/CodeEditor/CodeEditor.tsx
@@ -191,7 +191,9 @@ export function CodeEditor({
 		}
 
 		return () => {
-			reportScrollPosition();
+			// The passive effect cleanup can run after the editor DOM has been
+			// detached and its scroll offset clamped to zero. The scroll listener
+			// already saved the last real position, so do not overwrite it here.
 			view.scrollDOM.removeEventListener("scroll", reportScrollPosition);
 			if (editorRef?.current === adapter) {
 				editorRef.current = null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -48,17 +48,13 @@ export function useWorkspacePaneOpeners({
 			changeKey?: string,
 		) => {
 			const state = store.getState();
-			// Bump tick on every request so the scroll effect re-fires on repeat
-			// clicks; clear when no line is given so reused panes don't jump
-			// to a stale focus.
-			const focusFields =
-				line != null
-					? { focusLine: line, focusSide: side, focusTick: Date.now() }
-					: {
-							focusLine: undefined,
-							focusSide: undefined,
-							focusTick: undefined,
-						};
+			// Bump the tick on every request so repeat clicks re-scroll and a
+			// navigation into an unmounted pane wins over its older cached position.
+			const focusFields = {
+				focusLine: line,
+				focusSide: line != null ? side : undefined,
+				focusTick: Date.now(),
+			};
 			if (openInNewTab) {
 				state.addTab({
 					panes: [

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/index.ts
@@ -1,0 +1,9 @@
+export type {
+	PaneScrollPosition,
+	PaneScrollState,
+} from "./paneScrollStateCache";
+export {
+	createPaneScrollStateKey,
+	getPaneScrollState,
+	savePaneScrollState,
+} from "./paneScrollStateCache";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/paneScrollStateCache.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/paneScrollStateCache.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	clearPaneScrollStateCache,
+	createPaneScrollStateKey,
+	flushPaneScrollStateCache,
+	getPaneScrollState,
+	savePaneScrollState,
+} from "./paneScrollStateCache";
+
+beforeEach(clearPaneScrollStateCache);
+afterEach(clearPaneScrollStateCache);
+
+describe("paneScrollStateCache", () => {
+	test("saves scroll positions and persists them to localStorage", () => {
+		savePaneScrollState("editor", { scrollTop: 480, scrollLeft: 32 });
+
+		expect(getPaneScrollState("editor")).toMatchObject({
+			scrollTop: 480,
+			scrollLeft: 32,
+		});
+		flushPaneScrollStateCache();
+		expect(localStorage.getItem("v2-pane-scroll-state-v1")).toContain(
+			'"editor"',
+		);
+	});
+
+	test("evicts the oldest saved entry", () => {
+		for (let index = 0; index <= 250; index += 1) {
+			savePaneScrollState(String(index), {
+				scrollTop: index,
+				scrollLeft: 0,
+			});
+		}
+
+		expect(getPaneScrollState("0")).toBeUndefined();
+		expect(getPaneScrollState("250")?.scrollTop).toBe(250);
+	});
+
+	test("scopes keys by workspace, pane, and resource", () => {
+		const base = {
+			workspaceId: "workspace-a",
+			paneId: "pane-a",
+			viewId: "editor" as const,
+			resourceId: "/repo/file.ts",
+		};
+
+		expect(createPaneScrollStateKey(base)).not.toBe(
+			createPaneScrollStateKey({ ...base, workspaceId: "workspace-b" }),
+		);
+		expect(createPaneScrollStateKey(base)).not.toBe(
+			createPaneScrollStateKey({ ...base, paneId: "pane-b" }),
+		);
+		expect(createPaneScrollStateKey(base)).not.toBe(
+			createPaneScrollStateKey({ ...base, resourceId: "/repo/other.ts" }),
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/paneScrollStateCache.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/paneScrollStateCache.test.ts
@@ -36,10 +36,9 @@ describe("paneScrollStateCache", () => {
 		expect(getPaneScrollState("250")?.scrollTop).toBe(250);
 	});
 
-	test("scopes keys by workspace, pane, and resource", () => {
+	test("scopes keys by workspace, resource, and optional pane", () => {
 		const base = {
 			workspaceId: "workspace-a",
-			paneId: "pane-a",
 			viewId: "editor" as const,
 			resourceId: "/repo/file.ts",
 		};
@@ -48,10 +47,10 @@ describe("paneScrollStateCache", () => {
 			createPaneScrollStateKey({ ...base, workspaceId: "workspace-b" }),
 		);
 		expect(createPaneScrollStateKey(base)).not.toBe(
-			createPaneScrollStateKey({ ...base, paneId: "pane-b" }),
-		);
-		expect(createPaneScrollStateKey(base)).not.toBe(
 			createPaneScrollStateKey({ ...base, resourceId: "/repo/other.ts" }),
+		);
+		expect(createPaneScrollStateKey({ ...base, paneId: "pane-a" })).not.toBe(
+			createPaneScrollStateKey({ ...base, paneId: "pane-b" }),
 		);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/paneScrollStateCache.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/paneScrollStateCache.ts
@@ -1,0 +1,122 @@
+const STORAGE_KEY = "v2-pane-scroll-state-v1";
+const MAX_ENTRIES = 250;
+const WRITE_DELAY_MS = 200;
+
+export interface PaneScrollPosition {
+	scrollTop: number;
+	scrollLeft: number;
+}
+
+export interface PaneScrollState extends PaneScrollPosition {
+	updatedAt: number;
+}
+
+let cache: Map<string, PaneScrollState> | null = null;
+let writeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function getStorage(): Storage | null {
+	try {
+		return typeof localStorage === "undefined" ? null : localStorage;
+	} catch {
+		return null;
+	}
+}
+
+function getCache(): Map<string, PaneScrollState> {
+	if (cache) return cache;
+	try {
+		const saved = JSON.parse(getStorage()?.getItem(STORAGE_KEY) ?? "[]");
+		cache = new Map(Array.isArray(saved) ? saved : []);
+	} catch {
+		cache = new Map();
+	}
+	while (cache.size > MAX_ENTRIES) {
+		const oldestKey = cache.keys().next().value;
+		if (oldestKey === undefined) break;
+		cache.delete(oldestKey);
+	}
+	return cache;
+}
+
+function scheduleWrite(): void {
+	if (writeTimer !== null || !getStorage()) return;
+	writeTimer = setTimeout(flushPaneScrollStateCache, WRITE_DELAY_MS);
+}
+
+export function flushPaneScrollStateCache(): void {
+	if (writeTimer !== null) clearTimeout(writeTimer);
+	writeTimer = null;
+	if (!cache) return;
+	try {
+		getStorage()?.setItem(STORAGE_KEY, JSON.stringify([...cache]));
+	} catch {
+		// Scroll restoration is best-effort and must not break an editor pane.
+	}
+}
+
+/** Used by tests and by any future "reset local UI state" action. */
+export function clearPaneScrollStateCache(): void {
+	if (writeTimer !== null) clearTimeout(writeTimer);
+	writeTimer = null;
+	cache = new Map();
+	try {
+		getStorage()?.removeItem(STORAGE_KEY);
+	} catch {
+		// Keep the in-memory cache usable when localStorage is unavailable.
+	}
+}
+
+export function createPaneScrollStateKey({
+	workspaceId,
+	paneId,
+	viewId,
+	resourceId,
+}: {
+	workspaceId: string;
+	paneId: string;
+	viewId: "diff" | "editor";
+	resourceId: string;
+}): string {
+	return JSON.stringify([workspaceId, paneId, viewId, resourceId]);
+}
+
+export function getPaneScrollState(key: string): PaneScrollState | undefined {
+	const state = getCache().get(key);
+	if (
+		!state ||
+		!Number.isFinite(state.scrollTop) ||
+		!Number.isFinite(state.scrollLeft) ||
+		!Number.isFinite(state.updatedAt)
+	) {
+		return undefined;
+	}
+	return { ...state };
+}
+
+export function savePaneScrollState(
+	key: string,
+	position: PaneScrollPosition,
+): void {
+	if (
+		!Number.isFinite(position.scrollTop) ||
+		!Number.isFinite(position.scrollLeft)
+	) {
+		return;
+	}
+	const entries = getCache();
+	entries.delete(key);
+	entries.set(key, {
+		scrollTop: Math.max(0, position.scrollTop),
+		scrollLeft: Math.max(0, position.scrollLeft),
+		updatedAt: Date.now(),
+	});
+	if (entries.size > MAX_ENTRIES) {
+		const oldestKey = entries.keys().next().value;
+		if (oldestKey !== undefined) entries.delete(oldestKey);
+	}
+	scheduleWrite();
+}
+
+if (typeof window !== "undefined") {
+	window.addEventListener("pagehide", flushPaneScrollStateCache);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/paneScrollStateCache.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/paneScrollStateCache/paneScrollStateCache.ts
@@ -73,11 +73,11 @@ export function createPaneScrollStateKey({
 	resourceId,
 }: {
 	workspaceId: string;
-	paneId: string;
+	paneId?: string;
 	viewId: "diff" | "editor";
 	resourceId: string;
 }): string {
-	return JSON.stringify([workspaceId, paneId, viewId, resourceId]);
+	return JSON.stringify([workspaceId, paneId ?? null, viewId, resourceId]);
 }
 
 export function getPaneScrollState(key: string): PaneScrollState | undefined {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -46,8 +46,8 @@ export interface DiffPaneData {
 	path: string;
 	changeKey?: string;
 	collapsedFiles: string[];
-	/** Line to scroll to within `path`. `focusTick` bumps on each request
-	 *  so repeated clicks of the same line still re-scroll. */
+	/** Line to scroll to within `path`. `focusTick` bumps on each navigation
+	 *  request so it can take precedence over an older cached scroll state. */
 	focusLine?: number;
 	focusSide?: DiffFocusSide;
 	focusTick?: number;


### PR DESCRIPTION
## What changed

- persist editor scroll positions per workspace and file, so Quick Open preview-pane replacements restore the file's previous offset
- persist diff scroll positions per workspace, pane, and diff reference
- restore CodeMirror vertical and horizontal offsets when file editors remount
- restore Pierre diff offsets while keeping explicit file/line navigation authoritative
- keep the local cache bounded and debounced, with focused cache and precedence tests
- preserve the last genuine editor scroll event during teardown instead of overwriting it with the detached DOM's zero offset
- require exact-flow, screenshot-backed, fail-before/pass-after CDP verification in `AGENTS.md`

## Why

Switching between workspaces or panes unmounted the active editor/diff surface and reset its local scroll position. File preview replacement also creates a new underlying pane ID, so editor cache entries must use the stable workspace-and-file identity to survive an A → B → A switch.

React passive cleanup can run after CodeMirror's scroll DOM is detached and clamped to zero. Saving from cleanup therefore replaced the genuine last scroll event with zero during a workspace-route switch.

## Impact

Scroll state remains local to the desktop renderer and is capped at 250 entries. Existing pane layout and navigation behavior is unchanged; a fresh navigation request still wins over an older cached diff position.

## Validation

- `bun run test` from `apps/desktop` — 2,153 passed, 0 failed
- focused cache/precedence tests — 6 passed
- `bun run lint:fix`
- `bun run lint` — 5,210 files checked, no findings
- `bun run typecheck` — 35 tasks passed across the monorepo
- exact file-editor regression via CDP and the visible Electron UI: sent a real mouse-wheel event, measured and cached `scrollTop: 1200`, captured the editor around line 60, navigated out through **Workspaces**, returned through the visible workspace row, and captured the same editor region with both live and cached `scrollTop: 1200`
- CDP smoke against the matched worktree renderer (CDP 9222, Vite 7265, API 7261): CodeMirror restored horizontal offset 120; Pierre restored vertical offset 2400 after remount
- focused CDP Quick Open smoke: file A scrolled to 900 → file B → file A restored exactly to 900 under the pane-independent editor key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved vertical/horizontal scroll positions for both editor and diff panes when navigating or reopening.
  * Added per-pane scroll persistence with automatic restoration, scoped to the current workspace/file/view context.
* **Bug Fixes**
  * Prevented outdated scroll restoration by prioritizing newer navigation requests over older cached positions.
* **Tests**
  * Added automated tests for scroll-state restoration logic and cache behavior (persistence, eviction, scoping).
* **Documentation**
  * Updated UI verification guidance with a CDP-based workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
