### PR TITLE
fix(desktop): guard terminal release persistence

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	spyOn,
+	test,
+} from "bun:test";
 
 mock.module("renderer/lib/trpc-client", () => ({
 	electronTrpcClient: {
@@ -75,6 +83,127 @@ describe("terminalRuntimeRegistry eviction cleanup", () => {
 			"serialized scrollback",
 		);
 		expect(fakeStorage.values.has(`terminal-dims:${terminalId}`)).toBe(false);
+	});
+
+	test("release keeps runtimes on persist failure and warns once per terminal", () => {
+		const terminalIds = ["release-failure-a", "release-failure-b"];
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		const entries = terminalIds.map((terminalId) => ({
+			terminalId,
+			instanceId: terminalId,
+			runtime: {
+				terminalId,
+				serializeAddon: { serialize: () => "serialized scrollback" },
+				lastCols: 120,
+				lastRows: 32,
+			},
+			transport: {},
+			linkManager: null,
+			pendingLinkHandlers: null,
+			disposeBufferChangeListener: null,
+			lastUsedAt: 1,
+		}));
+		const registryInternals = terminalRuntimeRegistry as unknown as {
+			entries: Map<string, (typeof entries)[number]>;
+			entryKeysByTerminalId: Map<string, Set<string>>;
+			persistFailureWarnedTerminalIds: Set<string>;
+		};
+		fakeStorage.storage.setItem = () => {
+			throw new Error("storage unavailable");
+		};
+
+		for (const entry of entries) {
+			const key = `${entry.terminalId}\u0000${entry.instanceId}`;
+			registryInternals.entries.set(key, entry);
+			registryInternals.entryKeysByTerminalId.set(
+				entry.terminalId,
+				new Set([key]),
+			);
+		}
+
+		try {
+			terminalRuntimeRegistry.release(terminalIds[0]);
+			terminalRuntimeRegistry.release(terminalIds[0]);
+			terminalRuntimeRegistry.release(terminalIds[1]);
+
+			expect(terminalRuntimeRegistry.has(terminalIds[0])).toBe(true);
+			expect(terminalRuntimeRegistry.has(terminalIds[1])).toBe(true);
+			expect(warnSpy).toHaveBeenCalledTimes(2);
+			expect(warnSpy.mock.calls.map((call) => call[0])).toEqual([
+				`[terminal-registry] state persist failed for ${terminalIds[0]}; keeping runtime alive (localStorage quota?)`,
+				`[terminal-registry] state persist failed for ${terminalIds[1]}; keeping runtime alive (localStorage quota?)`,
+			]);
+		} finally {
+			for (const entry of entries) {
+				const key = `${entry.terminalId}\u0000${entry.instanceId}`;
+				registryInternals.entries.delete(key);
+				registryInternals.entryKeysByTerminalId.delete(entry.terminalId);
+				registryInternals.persistFailureWarnedTerminalIds.delete(
+					entry.terminalId,
+				);
+			}
+			warnSpy.mockRestore();
+		}
+	});
+
+	test("release persists once before disposing a runtime", () => {
+		const terminalId = "release-success";
+		const entry = {
+			terminalId,
+			instanceId: terminalId,
+			runtime: {
+				terminalId,
+				serializeAddon: { serialize: () => "serialized scrollback" },
+				lastCols: 120,
+				lastRows: 32,
+			},
+			transport: {},
+			linkManager: null,
+			pendingLinkHandlers: null,
+			disposeBufferChangeListener: null,
+			lastUsedAt: 1,
+		};
+		const registryInternals = terminalRuntimeRegistry as unknown as {
+			entries: Map<string, typeof entry>;
+			entryKeysByTerminalId: Map<string, Set<string>>;
+			persistFailureWarnedTerminalIds: Set<string>;
+			disposeEntry: (
+				disposedEntry: typeof entry,
+				options: { persistedState?: "clear" | "preserve" },
+			) => void;
+		};
+		const entryKey = `${terminalId}\u0000${terminalId}`;
+		const disposeCalls: { persistedState?: "clear" | "preserve" }[] = [];
+		registryInternals.entries.set(entryKey, entry);
+		registryInternals.entryKeysByTerminalId.set(
+			terminalId,
+			new Set([entryKey]),
+		);
+		registryInternals.persistFailureWarnedTerminalIds.add(terminalId);
+		registryInternals.disposeEntry = (_entry, options) => {
+			disposeCalls.push(options);
+		};
+
+		try {
+			terminalRuntimeRegistry.release(terminalId);
+
+			expect(fakeStorage.values.get(`terminal-buffer:${terminalId}`)).toBe(
+				"serialized scrollback",
+			);
+			expect(fakeStorage.values.get(`terminal-dims:${terminalId}`)).toBe(
+				JSON.stringify({ cols: 120, rows: 32 }),
+			);
+			expect(disposeCalls).toEqual([{ persistedState: "preserve" }]);
+			expect(
+				registryInternals.persistFailureWarnedTerminalIds.has(terminalId),
+			).toBe(false);
+		} finally {
+			delete (terminalRuntimeRegistry as unknown as { disposeEntry?: unknown })
+				.disposeEntry;
+			registryInternals.entries.delete(entryKey);
+			registryInternals.entryKeysByTerminalId.delete(terminalId);
+			registryInternals.persistFailureWarnedTerminalIds.delete(terminalId);
+		}
 	});
 
 	test("dispose clears persisted state even when eviction already removed the entry", () => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -56,6 +56,7 @@ class TerminalRuntimeRegistryImpl {
 	private entryKeysByTerminalId = new Map<string, Set<string>>();
 	private useSeq = 0;
 	private pendingEviction: ReturnType<typeof setTimeout> | null = null;
+	private persistFailureWarnedTerminalIds = new Set<string>();
 	/**
 	 * Cap on parked (hidden) xterm runtimes. Each live runtime holds its full
 	 * scrollback and a WebGL context (~55–70 MB RSS measured), so parked
@@ -339,9 +340,10 @@ class TerminalRuntimeRegistryImpl {
 		);
 		for (const entry of victims) {
 			if (!entry.runtime || !tryPersistRuntimeState(entry.runtime)) {
-				warnPersistFailureOnce(entry.terminalId);
+				this.warnPersistFailureOnce(entry.terminalId);
 				continue;
 			}
+			this.clearPersistFailureWarning(entry.terminalId);
 			// tryPersistRuntimeState already wrote the snapshot. Preserve it while
 			// disposing instead of serializing and writing the same buffer twice.
 			this.disposeEntry(entry, { persistedState: "preserve" });
@@ -367,7 +369,7 @@ class TerminalRuntimeRegistryImpl {
 
 	private disposeEntry(
 		entry: RegistryEntry,
-		options: { persistedState?: "clear" | "persist" | "preserve" } = {},
+		options: { persistedState?: "clear" | "preserve" } = {},
 	) {
 		entry.disposeBufferChangeListener?.();
 		entry.disposeBufferChangeListener = null;
@@ -391,8 +393,28 @@ class TerminalRuntimeRegistryImpl {
 				)
 			: this.getEntries(terminalId);
 		for (const entry of entries) {
-			this.disposeEntry(entry, { persistedState: "persist" });
+			if (entry.runtime && !tryPersistRuntimeState(entry.runtime)) {
+				this.warnPersistFailureOnce(entry.terminalId);
+				continue;
+			}
+			this.clearPersistFailureWarning(entry.terminalId);
+			// Persistence succeeded before any runtime or transport cleanup began.
+			this.disposeEntry(entry, { persistedState: "preserve" });
 		}
+	}
+
+	private warnPersistFailureOnce(terminalId: string) {
+		// HMR can preserve a registry instance created before this field existed.
+		this.persistFailureWarnedTerminalIds ??= new Set<string>();
+		if (this.persistFailureWarnedTerminalIds.has(terminalId)) return;
+		this.persistFailureWarnedTerminalIds.add(terminalId);
+		console.warn(
+			`[terminal-registry] state persist failed for ${terminalId}; keeping runtime alive (localStorage quota?)`,
+		);
+	}
+
+	private clearPersistFailureWarning(terminalId: string) {
+		this.persistFailureWarnedTerminalIds?.delete(terminalId);
 	}
 
 	/**
@@ -562,15 +584,6 @@ class TerminalRuntimeRegistryImpl {
 			entry.transport.logListeners.delete(listener);
 		};
 	}
-}
-
-let persistFailureWarned = false;
-function warnPersistFailureOnce(terminalId: string) {
-	if (persistFailureWarned) return;
-	persistFailureWarned = true;
-	console.warn(
-		`[terminal-registry] state persist failed for ${terminalId}; keeping runtime alive (localStorage quota?)`,
-	);
 }
 
 // Stable empty reference so useSyncExternalStore on a missing entry doesn't

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -78,11 +78,17 @@ function createTerminal(
 	return { terminal, fitAddon, serializeAddon };
 }
 
-function persistBuffer(terminalId: string, serializeAddon: SerializeAddon) {
+function persistBuffer(
+	terminalId: string,
+	serializeAddon: SerializeAddon,
+): boolean {
 	try {
 		const data = serializeAddon.serialize({ scrollback: SERIALIZE_SCROLLBACK });
 		localStorage.setItem(`${STORAGE_KEY_PREFIX}${terminalId}`, data);
-	} catch {}
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function restoreBuffer(terminalId: string, terminal: XTerm) {
@@ -97,12 +103,7 @@ function restoreBuffer(terminalId: string, terminal: XTerm) {
  * either write fails or the runtime could not be restored faithfully.
  */
 export function tryPersistRuntimeState(runtime: TerminalRuntime): boolean {
-	try {
-		const data = runtime.serializeAddon.serialize({
-			scrollback: SERIALIZE_SCROLLBACK,
-		});
-		localStorage.setItem(`${STORAGE_KEY_PREFIX}${runtime.terminalId}`, data);
-	} catch {
+	if (!persistBuffer(runtime.terminalId, runtime.serializeAddon)) {
 		return false;
 	}
 	return persistDimensions(
@@ -393,14 +394,10 @@ export function updateRuntimeAppearance(
 export function disposeRuntime(
 	runtime: TerminalRuntime,
 	options: {
-		persistedState?: "clear" | "persist" | "preserve";
+		persistedState?: "clear" | "preserve";
 	} = {},
 ) {
 	const persistedState = options.persistedState ?? "clear";
-	if (persistedState === "persist") {
-		persistBuffer(runtime.terminalId, runtime.serializeAddon);
-		persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
-	}
 	runtime._disposeImagePasteFallback?.();
 	runtime._disposeImagePasteFallback = null;
 	runtime._disposeAddons?.();


### PR DESCRIPTION
Follow-up to #5754.

## What changed
- preflight terminal buffer and dimensions persistence before `release()` disposes renderer state or closes its transport
- keep the live runtime intact when either localStorage write fails
- report the first persistence failure per terminal, while clearing warning state after a later successful write
- reuse one boolean-returning buffer persistence helper across guarded paths

## Why
The eviction path added in #5754 correctly retained runtimes when persistence failed, but the non-eviction `release()` lifecycle still swallowed localStorage failures and disposed the only full scrollback snapshot. A quota or storage error could therefore lose renderer scrollback during background/workspace cleanup.

## User impact
Terminal renderer state is no longer discarded when it cannot be saved. Successful release behavior is unchanged and still performs each buffer/dimensions write only once.

## Validation
- `bun test apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts apps/desktop/src/renderer/lib/terminal/terminal-runtime-eviction.test.ts` — 16 pass, 0 fail
- `bun run lint` — clean
- `bun run typecheck` — 35/35 tasks successful

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5771">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents terminal scrollback loss during release() by preflighting persistence and keeping the runtime alive if localStorage writes fail. Successful releases persist once, then dispose safely.

- **Bug Fixes**
  - Persist buffer and dimensions before `release()` disposes state or closes transport.
  - Keep the runtime alive on persist failure; warn once per terminal; clear warning after a later success.
  - Use a shared boolean-returning buffer persist helper across eviction and release.
  - Avoid double writes by disposing with `persistedState: "preserve"` after a successful preflight.

<sup>Written for commit d0e9c1dedf85182ad2ee5f30e266ceb9fe3557e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal state persistence reliability when saving fails.
  * Terminals are kept available instead of being discarded after a persistence failure.
  * Added clearer, one-time warnings for each affected terminal.
  * Successful persistence now correctly preserves terminal state during cleanup.
  * Improved recovery by allowing future persistence attempts after an earlier failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->