### PR TITLE
fix(host-service): wait for shell readiness before preset commands

### DIFF
--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
 	buildV2TerminalEnv,
 	getShellBootstrapEnv,
@@ -8,6 +11,7 @@ import {
 	normalizeUtf8Locale,
 	resetTerminalBaseEnvForTests,
 	resolveLaunchShell,
+	shellLaunchExpectsReadyMarker,
 	stripTerminalRuntimeEnv,
 } from "./env";
 
@@ -288,6 +292,85 @@ describe("getShellLaunchArgs", () => {
 		expect(
 			getShellLaunchArgs({ shell: "/usr/bin/pwsh", supersetHomeDir }),
 		).toEqual([]);
+	});
+});
+
+describe("shellLaunchExpectsReadyMarker", () => {
+	test("recognizes current zsh and bash wrappers", () => {
+		const supersetHomeDir = mkdtempSync(
+			path.join(tmpdir(), "superset-shell-ready-"),
+		);
+		try {
+			mkdirSync(path.join(supersetHomeDir, "zsh"), { recursive: true });
+			mkdirSync(path.join(supersetHomeDir, "bash"), { recursive: true });
+			writeFileSync(path.join(supersetHomeDir, "zsh", ".zshrc"), "# rc\n");
+			writeFileSync(
+				path.join(supersetHomeDir, "zsh", ".zlogin"),
+				'printf "\\033]133;A\\007"\n',
+			);
+			writeFileSync(
+				path.join(supersetHomeDir, "bash", "rcfile"),
+				'printf "\\033]133;A\\007"\n',
+			);
+
+			expect(
+				shellLaunchExpectsReadyMarker({
+					shell: "/bin/zsh",
+					supersetHomeDir,
+				}),
+			).toBe(true);
+			expect(
+				shellLaunchExpectsReadyMarker({
+					shell: "/bin/bash",
+					supersetHomeDir,
+				}),
+			).toBe(true);
+		} finally {
+			rmSync(supersetHomeDir, { recursive: true, force: true });
+		}
+	});
+
+	test("does not trust stale or incomplete wrapper files", () => {
+		const supersetHomeDir = mkdtempSync(
+			path.join(tmpdir(), "superset-shell-stale-"),
+		);
+		try {
+			mkdirSync(path.join(supersetHomeDir, "zsh"), { recursive: true });
+			mkdirSync(path.join(supersetHomeDir, "bash"), { recursive: true });
+			writeFileSync(path.join(supersetHomeDir, "zsh", ".zshrc"), "# rc\n");
+			writeFileSync(
+				path.join(supersetHomeDir, "zsh", ".zlogin"),
+				"# stale wrapper\n",
+			);
+			writeFileSync(
+				path.join(supersetHomeDir, "bash", "rcfile"),
+				"# stale wrapper\n",
+			);
+
+			expect(
+				shellLaunchExpectsReadyMarker({
+					shell: "/bin/zsh",
+					supersetHomeDir,
+				}),
+			).toBe(false);
+			expect(
+				shellLaunchExpectsReadyMarker({
+					shell: "/bin/bash",
+					supersetHomeDir,
+				}),
+			).toBe(false);
+		} finally {
+			rmSync(supersetHomeDir, { recursive: true, force: true });
+		}
+	});
+
+	test("recognizes fish's injected marker without wrapper files", () => {
+		expect(
+			shellLaunchExpectsReadyMarker({
+				shell: "/usr/bin/fish",
+				supersetHomeDir: "/tmp/missing-superset-home",
+			}),
+		).toBe(true);
 	});
 });
 

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -15,6 +15,7 @@ export {
 	getShellLaunchArgs,
 	getSupersetShellPaths,
 	resolveLaunchShell,
+	shellLaunchExpectsReadyMarker,
 } from "./shell-launch.ts";
 
 import fs from "node:fs";

--- a/packages/host-service/src/terminal/shell-launch.ts
+++ b/packages/host-service/src/terminal/shell-launch.ts
@@ -7,7 +7,7 @@
  * - VS Code: ZDOTDIR for zsh, --init-file for bash, --init-command for fish
  * - Kitty: KITTY_ORIG_ZDOTDIR for zsh, ENV for bash, XDG_DATA_DIRS for fish
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import {
@@ -37,6 +37,16 @@ export function getSupersetShellPaths(supersetHomeDir: string): {
 
 function getShellName(shell: string): string {
 	return path.basename(shell);
+}
+
+const SHELL_READY_MARKER_SCRIPT = "\\033]133;A\\007";
+
+function fileContainsShellReadyMarker(filePath: string): boolean {
+	try {
+		return readFileSync(filePath, "utf8").includes(SHELL_READY_MARKER_SCRIPT);
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -93,6 +103,37 @@ export function getShellBootstrapEnv(
 export interface ShellLaunchParams {
 	shell: string;
 	supersetHomeDir: string;
+}
+
+/**
+ * Whether this exact launch configuration installs Superset's prompt marker.
+ *
+ * Shell name alone is not enough: stale or missing wrapper files mean zsh and
+ * bash never emit OSC 133;A. Callers use this capability check to decide
+ * whether automation can safely wait for the first prompt without risking an
+ * indefinite stall on an unwrapped shell.
+ */
+export function shellLaunchExpectsReadyMarker(
+	params: ShellLaunchParams,
+): boolean {
+	const { shell, supersetHomeDir } = params;
+	const shellName = getShellName(shell);
+	const paths = getSupersetShellPaths(supersetHomeDir);
+
+	if (shellName === "zsh") {
+		return (
+			existsSync(path.join(paths.ZSH_DIR, ".zshrc")) &&
+			fileContainsShellReadyMarker(path.join(paths.ZSH_DIR, ".zlogin"))
+		);
+	}
+
+	if (shellName === "bash") {
+		return fileContainsShellReadyMarker(path.join(paths.BASH_DIR, "rcfile"));
+	}
+
+	// Fish receives the marker hook directly in --init-command, so it does not
+	// depend on wrapper files on disk.
+	return shellName === "fish";
 }
 
 export function getShellLaunchArgs(params: ShellLaunchParams): string[] {

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -159,7 +159,7 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 			workspaceId,
 			db,
 			listed: true,
-			initialCommand: `echo ok > ${sentinelFile}`,
+			initialCommand: `echo ok > "${sentinelFile}"`,
 		});
 		assert.ok(!("error" in second));
 		if ("error" in second) return;
@@ -183,7 +183,7 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 				workspaceId,
 				db,
 				listed: true,
-				initialCommand: `echo ok > ${sentinelFile}`,
+				initialCommand: `echo ok > "${sentinelFile}"`,
 			});
 			assert.ok(!("error" in result));
 			if ("error" in result) return;
@@ -241,7 +241,7 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 				workspaceId,
 				db,
 				listed: true,
-				initialCommand: `echo ok > ${sentinelFile}`,
+				initialCommand: `echo ok > "${sentinelFile}"`,
 			});
 			assert.ok(!("error" in result));
 			if ("error" in result) return;
@@ -288,7 +288,7 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 				workspaceId,
 				db,
 				listed: true,
-				initialCommand: `echo should-not-run > ${sentinelFile}`,
+				initialCommand: `echo should-not-run > "${sentinelFile}"`,
 			});
 			assert.ok(!("error" in result));
 			if ("error" in result) return;

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -170,9 +170,8 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 	});
 
 	test("initialCommand runs promptly even when OSC 133;A never fires", async () => {
-		// Regression guard against reintroducing the SHELL_READY_TIMEOUT_MS
-		// stall: bash with no Superset wrapper on disk never emits OSC 133;A,
-		// but the preset command should still run as soon as the shell reads.
+		// A shell name is not proof that the active launch config emits a marker.
+		// Missing/stale wrappers must keep the immediate-write fallback.
 		__setAccountShellForTesting("/bin/bash");
 		try {
 			const terminalId = `e2e-no-marker-${randomUUID().slice(0, 8)}`;
@@ -202,6 +201,107 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 			await disposeSessionAndWait(terminalId, db);
 		} finally {
 			__setAccountShellForTesting("/bin/sh");
+		}
+	});
+
+	test("initialCommand waits for a verified shell-ready marker", async () => {
+		const terminalId = `e2e-delayed-marker-${randomUUID().slice(0, 8)}`;
+		const sentinelFile = path.join(TEST_HOME, `delayed-marker-${terminalId}`);
+		const fakeShellDir = path.join(TEST_HOME, `fake-shell-${terminalId}`);
+		const fakeZsh = path.join(fakeShellDir, "zsh");
+		const zshWrapperDir = path.join(TEST_HOME, "zsh");
+
+		fs.mkdirSync(fakeShellDir, { recursive: true });
+		fs.mkdirSync(zshWrapperDir, { recursive: true });
+		fs.writeFileSync(
+			fakeZsh,
+			[
+				"#!/bin/bash",
+				// Simulate an interactive startup process consuming already-buffered
+				// input before returning control to the shell.
+				"sleep 0.5",
+				"IFS= read -r -t 0.5 _discarded || true",
+				"printf '\\033]133;A\\007'",
+				"exec /bin/bash --noprofile --norc -i",
+				"",
+			].join("\n"),
+			{ mode: 0o755 },
+		);
+		fs.writeFileSync(path.join(zshWrapperDir, ".zshrc"), "# wrapper\n");
+		fs.writeFileSync(
+			path.join(zshWrapperDir, ".zlogin"),
+			'printf "\\033]133;A\\007"\n',
+		);
+
+		__setAccountShellForTesting(fakeZsh);
+		try {
+			const start = Date.now();
+			const result = await createTerminalSessionInternal({
+				terminalId,
+				workspaceId,
+				db,
+				listed: true,
+				initialCommand: `echo ok > ${sentinelFile}`,
+			});
+			assert.ok(!("error" in result));
+			if ("error" in result) return;
+
+			await waitFor(() => fs.existsSync(sentinelFile), 5000);
+			assert.ok(
+				Date.now() - start >= 450,
+				"expected initialCommand to wait for delayed shell readiness",
+			);
+		} finally {
+			await disposeSessionAndWait(terminalId, db);
+			// Restore the suite-wide shell override established in before().
+			__setAccountShellForTesting("/bin/sh");
+			fs.rmSync(fakeShellDir, { recursive: true, force: true });
+			fs.rmSync(zshWrapperDir, { recursive: true, force: true });
+		}
+	});
+
+	test("cancels initialCommand when the shell exits before readiness", async () => {
+		const terminalId = `e2e-exit-before-marker-${randomUUID().slice(0, 8)}`;
+		const sentinelFile = path.join(
+			TEST_HOME,
+			`exit-before-marker-${terminalId}`,
+		);
+		const fakeShellDir = path.join(TEST_HOME, `fake-shell-${terminalId}`);
+		const fakeZsh = path.join(fakeShellDir, "zsh");
+		const zshWrapperDir = path.join(TEST_HOME, "zsh");
+
+		fs.mkdirSync(fakeShellDir, { recursive: true });
+		fs.mkdirSync(zshWrapperDir, { recursive: true });
+		fs.writeFileSync(fakeZsh, "#!/bin/bash\nsleep 0.1\nexit 17\n", {
+			mode: 0o755,
+		});
+		fs.writeFileSync(path.join(zshWrapperDir, ".zshrc"), "# wrapper\n");
+		fs.writeFileSync(
+			path.join(zshWrapperDir, ".zlogin"),
+			'printf "\\033]133;A\\007"\n',
+		);
+
+		__setAccountShellForTesting(fakeZsh);
+		try {
+			const result = await createTerminalSessionInternal({
+				terminalId,
+				workspaceId,
+				db,
+				listed: true,
+				initialCommand: `echo should-not-run > ${sentinelFile}`,
+			});
+			assert.ok(!("error" in result));
+			if ("error" in result) return;
+
+			await waitFor(() => result.exited, 5000);
+			await result.shellReadyPromise;
+			assert.equal(result.shellReadyState, "cancelled");
+			assert.equal(fs.existsSync(sentinelFile), false);
+		} finally {
+			await disposeSessionAndWait(terminalId, db);
+			__setAccountShellForTesting("/bin/sh");
+			fs.rmSync(fakeShellDir, { recursive: true, force: true });
+			fs.rmSync(zshWrapperDir, { recursive: true, force: true });
 		}
 	});
 

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -5,7 +5,6 @@ import type { NodeWebSocket } from "@hono/node-ws";
 import { hasRunningForegroundProcess } from "@superset/pty-daemon/process-tree";
 import {
 	createScanState,
-	SHELLS_WITH_READY_MARKER,
 	type ShellReadyScanState,
 	scanForShellReady,
 } from "@superset/shared/shell-ready-scanner";
@@ -34,6 +33,7 @@ import {
 	getShellLaunchArgs,
 	getTerminalBaseEnv,
 	resolveLaunchShell,
+	shellLaunchExpectsReadyMarker,
 	waitForTerminalBaseEnv,
 } from "./env.ts";
 import { listTerminalResourceSessions } from "./resource-sessions.ts";
@@ -199,17 +199,14 @@ type TerminalSocket = {
 // Scanner logic lives in @superset/shared/shell-ready-scanner.
 // ---------------------------------------------------------------------------
 
-/** Flush partial OSC 133;A prefix bytes the scanner is holding if a full marker never arrives. */
-const SHELL_READY_TIMEOUT_MS = 3_000;
-
 /**
  * Shell readiness lifecycle:
  * - `pending`     — shell initialising; scanner active
  * - `ready`       — OSC 133;A detected; scanner off
- * - `timed_out`   — marker never arrived within timeout; scanner off
- * - `unsupported` — shell has no marker (sh, ksh); scanner never started
+ * - `unsupported` — launch config has no marker; scanner never started
+ * - `cancelled`   — session ended before readiness; queued automation cancelled
  */
-type ShellReadyState = "pending" | "ready" | "timed_out" | "unsupported";
+type ShellReadyState = "pending" | "ready" | "unsupported" | "cancelled";
 
 interface TerminalSession {
 	terminalId: string;
@@ -251,7 +248,6 @@ interface TerminalSession {
 	shellReadyState: ShellReadyState;
 	shellReadyResolve: (() => void) | null;
 	shellReadyPromise: Promise<void>;
-	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
 	scanState: ShellReadyScanState;
 	initialCommandQueued: boolean;
 
@@ -291,6 +287,7 @@ onDaemonDisconnect((err) => {
 		`[terminal] pty-daemon disconnected (${err?.message ?? "no message"}); closing ${sessionCount} terminal WS socket(s) to trigger renderer reconnect`,
 	);
 	for (const session of sessions.values()) {
+		cancelShellReady(session);
 		for (const socket of session.sockets) {
 			try {
 				socket.close(1011, "pty-daemon disconnected");
@@ -326,6 +323,7 @@ onDaemonDisconnect((err) => {
  */
 export function __resetSessionsForTesting(): void {
 	for (const session of sessions.values()) {
+		cancelShellReady(session);
 		if (session.unsubscribeDaemon) {
 			try {
 				session.unsubscribeDaemon();
@@ -611,28 +609,20 @@ export function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
 	sendBytes(socket, combined);
 }
 
-/**
- * Transition out of `pending`. Flushes any partially-matched marker
- * bytes as terminal output (they weren't a real marker). Idempotent.
- */
-function resolveShellReady(
-	session: TerminalSession,
-	state: "ready" | "timed_out",
-): void {
+/** Transition out of `pending` after the scanner matches the prompt marker. */
+function resolveShellReady(session: TerminalSession): void {
 	if (session.shellReadyState !== "pending") return;
-	session.shellReadyState = state;
-	if (session.shellReadyTimeoutId) {
-		clearTimeout(session.shellReadyTimeoutId);
-		session.shellReadyTimeoutId = null;
+	session.shellReadyState = "ready";
+	if (session.shellReadyResolve) {
+		session.shellReadyResolve();
+		session.shellReadyResolve = null;
 	}
-	// Flush held marker bytes — they weren't part of a full marker
-	if (session.scanState.heldBytes.length > 0) {
-		const heldBytes = Uint8Array.from(session.scanState.heldBytes);
-		session.modeTracker.feed(heldBytes);
-		bufferOutput(session, heldBytes);
-		session.scanState.heldBytes.length = 0;
-	}
-	session.scanState.matchPos = 0;
+}
+
+/** Release pending readiness waiters without allowing queued input to run. */
+function cancelShellReady(session: TerminalSession): void {
+	if (session.shellReadyState !== "pending") return;
+	session.shellReadyState = "cancelled";
 	if (session.shellReadyResolve) {
 		session.shellReadyResolve();
 		session.shellReadyResolve = null;
@@ -648,9 +638,15 @@ function queueInitialCommand(
 	const cmd = initialCommand.endsWith("\n")
 		? initialCommand
 		: `${initialCommand}\n`;
-	// Don't gate on OSC 133;A: PTY stdin buffers until the shell reads it,
-	// and gating turned broken/missing markers into a guaranteed stall.
-	session.pty.write(cmd);
+	// Marker-backed shells can run interactive startup hooks that read or flush
+	// PTY input before the first prompt (direnv/devenv is one example). Wait for
+	// that prompt so the command cannot be consumed as startup input. Launches
+	// without a verified marker resolve this promise immediately.
+	void session.shellReadyPromise.then(() => {
+		if (!session.exited && session.shellReadyState !== "cancelled") {
+			session.pty.write(cmd);
+		}
+	});
 }
 
 interface DaemonCloseResult {
@@ -757,10 +753,7 @@ export async function disposeSessionAndWait(
 	let closePromise: Promise<DaemonCloseResult> | null = null;
 
 	if (session) {
-		if (session.shellReadyTimeoutId) {
-			clearTimeout(session.shellReadyTimeoutId);
-			session.shellReadyTimeoutId = null;
-		}
+		cancelShellReady(session);
 		for (const socket of session.sockets) {
 			socket.close(1000, "Session disposed");
 		}
@@ -1153,9 +1146,8 @@ export async function createTerminalSessionInternal({
 	// Determine shell readiness support. Adopted sessions are already past
 	// shell startup, so treat them as immediately ready — the OSC 133;A
 	// marker has already flown by and we don't want to gate writes on it.
-	const shellName = shell.split("/").pop() || shell;
 	const shellSupportsReady =
-		!isAdopted && SHELLS_WITH_READY_MARKER.has(shellName);
+		!isAdopted && shellLaunchExpectsReadyMarker({ shell, supersetHomeDir });
 
 	let shellReadyResolve: (() => void) | null = null;
 	const shellReadyPromise = shellSupportsReady
@@ -1191,7 +1183,6 @@ export async function createTerminalSessionInternal({
 				: "unsupported",
 		shellReadyResolve,
 		shellReadyPromise,
-		shellReadyTimeoutId: null,
 		scanState: createScanState(),
 		// Adopted sessions have already run their initialCommand in the prior
 		// host-service lifetime — flag it as queued so we don't double-fire it.
@@ -1201,14 +1192,6 @@ export async function createTerminalSessionInternal({
 	};
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
-
-	// If the marker never arrives (broken wrapper, unsupported config),
-	// the timeout unblocks so the session degrades gracefully.
-	if (session.shellReadyState === "pending") {
-		session.shellReadyTimeoutId = setTimeout(() => {
-			resolveShellReady(session, "timed_out");
-		}, SHELL_READY_TIMEOUT_MS);
-	}
 
 	session.unsubscribeDaemon = daemon.subscribe(
 		terminalId,
@@ -1231,7 +1214,7 @@ export async function createTerminalSessionInternal({
 					const result = scanForShellReady(session.scanState, chunk);
 					bytes = result.output;
 					if (result.matched) {
-						resolveShellReady(session, "ready");
+						resolveShellReady(session);
 					}
 				}
 				if (bytes.byteLength === 0) return;
@@ -1259,6 +1242,7 @@ export async function createTerminalSessionInternal({
 			},
 			onExit({ code, signal }) {
 				session.exited = true;
+				cancelShellReady(session);
 				session.exitCode = code ?? 0;
 				session.exitSignal = signal ?? 0;
 				const occurredAt = Date.now();


### PR DESCRIPTION
## What & why

Preset commands were written to the PTY immediately after spawning the login shell. That assumed stdin would remain buffered until shell initialization completed, but interactive startup tools can read or flush queued input before the first prompt. In worktrees using direnv/devenv, the preset command was visibly echoed and then disappeared without launching.

This change makes readiness capability-based rather than shell-name- or timeout-based:

- verify that the exact zsh/bash launch wrappers contain Superset's OSC 133;A prompt marker; fish remains verified through its injected init command
- wait for the first prompt marker before writing an initial preset command when that marker is guaranteed
- retain immediate launch behavior for missing, stale, or unsupported wrappers
- avoid a fixed readiness deadline, so this works for any slow or interactive shell startup rather than only devenv

The result protects Claude and every other preset command from being consumed during shell initialization while preserving the no-marker fallback introduced for stale wrapper installs.

## How I tested it

- `bun run lint`
- `bun run typecheck` (35/35 tasks successful)
- `bun test packages/host-service/src/terminal/env.test.ts` (46 passing)
- real PTY/adoption suite via the installed Superset Node runtime (19 passing), including:
  - delayed startup that consumes prematurely queued stdin
  - bash without a readiness marker launching promptly

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5774">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits for a verified shell prompt marker before sending preset commands, so interactive startup (e.g., direnv/devenv) can’t consume them. Falls back to immediate send when no marker is guaranteed or for adopted sessions; cancels queued commands if the shell exits or the daemon disconnects.

- **Bug Fixes**
  - Added `shellLaunchExpectsReadyMarker` to verify zsh/bash wrappers actually emit `OSC 133;A`; fish is trusted via its injected init command.
  - Deferred `initialCommand` until the first verified marker; removed the timeout fallback and partial-marker flushing.
  - Introduced a cancellable readiness state; never writes after cancellation or exit.
  - Switched from shell-name heuristics to a capability check; kept immediate launch for missing/stale wrappers and adopted sessions.
  - Expanded tests for wrapper verification, delayed readiness, no-marker fallback, and exit-before-readiness; quoted sentinel paths in adoption tests to avoid tmpdir-with-spaces flakiness.

<sup>Written for commit a6b6e77c56f40ba7e2868fd51f3f9d4c963e647a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal shell readiness detection by checking shell-specific wrapper content to confirm the expected OSC “ready” marker will be emitted (with correct handling for zsh, bash, and fish).
  * Updated the adoption flow so initial commands are queued until readiness is confirmed; readiness now cancels cleanly if the shell exits early.
  * Simplified readiness state transitions to avoid incorrect “ready” signals during partial/incomplete marker scenarios.
* **Tests**
  * Added end-to-end tests for delayed marker emission and for cancellation when a shell exits before the marker appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->