### PR TITLE
fix(host-service): coordinate base-ref fetches across workers

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -74,8 +74,12 @@ The desktop hydrates a persisted token into an in-memory bearer-token closure. A
 
 This credentialed local-dev sign-in creates the browser session cookie needed by subsequent in-renderer fetches. If it fails, report the sign-in/session status codes only. For a non-local setup, use the app's normal sign-in flow; never substitute local dev credentials.
 
-**Use `Runtime.evaluate` (`awaitPromise`, `returnByValue`), not `Network.*` interception** — sniffing misses React-Query-cached responses, and `refetchInterval` is paused while the window is backgrounded. After verifying or repairing the session cookie above, run an in-renderer `fetch(url, { credentials: "include" })`. `API` below is the dev backend origin (`NEXT_PUBLIC_API_URL`, e.g. `http://localhost:5881`):
+For a non-local workspace, the normal desktop flow intentionally restores an encrypted bearer token into the renderer's in-memory auth client without creating a browser cookie. If the renderer is on an authenticated route but a raw cookie-only probe returns no session, use `Runtime.evaluate` to import `/lib/auth-client.ts` from the renderer dev server and call `authClient.getSession({ fetchOptions: { throw: false } })`. This still verifies `/api/auth/get-session` through the app's real authenticated request path. Return only the status and `session.activeOrganizationId`; never call or print `getAuthToken()`.
 
-- Active org: `fetch(API + "/api/auth/get-session", {credentials:"include"})` → `.session.activeOrganizationId`.
+Do not use setup `--force` to fix a stale connection string, a missing CDP cookie, or a corrupt generated Next.js cache. First rerun the applicable setup script without force. If every API route returns Next.js's HTML 404, stop the dev stack, move `apps/api/.next` aside, and restart. `--force` is only appropriate when the user explicitly intends to replace the copied local/host databases and encrypted auth token.
+
+**Use `Runtime.evaluate` (`awaitPromise`, `returnByValue`), not `Network.*` interception** — sniffing misses React-Query-cached responses, and `refetchInterval` is paused while the window is backgrounded. After verifying the session through the applicable cookie or bearer path above, run requests inside the renderer. `API` below is the dev backend origin (`NEXT_PUBLIC_API_URL`, e.g. `http://localhost:5881`):
+
+- Active org: local cookie flow uses `fetch(API + "/api/auth/get-session", {credentials:"include"})`; non-local bearer flow uses `authClient.getSession({ fetchOptions: { throw: false } })`. Require `.session.activeOrganizationId`.
 - A tRPC query (bypasses the cache): GET `API + "/api/trpc/<proc>?batch=1&input=" + encodeURIComponent(JSON.stringify({"0":{json:<input>}}))`; response is `[{result:{data:{json:...}}}]`.
 - `window.location.hash` nav may not remount the route — call the endpoint directly instead.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
 		"dev": "cross-env NODE_ENV=development NODE_OPTIONS=--max-old-space-size=8192 electron-vite dev --watch",
 		"compile:app": "cross-env NODE_OPTIONS=--max-old-space-size=8192 electron-vite build && bun run bundle:cli && bun run scripts/check-pty-daemon-bundle.ts",
 		"check:pty-daemon-bundle": "bun run scripts/check-pty-daemon-bundle.ts",
+		"profile:terminal-flood": "bun run scripts/cdp-terminal-flood-profile.ts",
 		"copy:native-modules": "bun run scripts/copy-native-modules.ts",
 		"validate:native-runtime": "bun run scripts/validate-native-runtime.ts",
 		"prebuild": "bun run clean:dev && bun run generate:icons && bun run compile:app && bun run copy:native-modules && bun run validate:native-runtime",

--- a/apps/desktop/scripts/cdp-terminal-flood-profile.ts
+++ b/apps/desktop/scripts/cdp-terminal-flood-profile.ts
@@ -524,8 +524,14 @@ async function runPhase({
 		const markerPromise = probe.waitForText(marker);
 		const echoStartedAt = performance.now();
 		probe.sendInput(`printf '${marker}\\n'\n`);
-		const [, health] = await Promise.all([markerPromise, healthRtt(manifest)]);
-		echoRtts.push(performance.now() - echoStartedAt);
+		const echoRttPromise = markerPromise.then(
+			() => performance.now() - echoStartedAt,
+		);
+		const [echo, health] = await Promise.all([
+			echoRttPromise,
+			healthRtt(manifest),
+		]);
+		echoRtts.push(echo);
 		healthRtts.push(health);
 
 		if (index % Math.max(1, Math.round(500 / options.intervalMs)) === 0) {

--- a/apps/desktop/scripts/cdp-terminal-flood-profile.ts
+++ b/apps/desktop/scripts/cdp-terminal-flood-profile.ts
@@ -6,12 +6,10 @@
  *   RENDERER_REMOTE_DEBUG_PORT=19322 bun --env-file=.env \
  *     apps/desktop/scripts/cdp-terminal-flood-profile.ts --repair-local-auth
  *
- * The harness verifies the renderer URL and normally resolves its authenticated
- * org through CDP. If the local API is unavailable, --organization-id selects
- * an already-running local host explicitly. It never prints the host token. It
- * attaches real WebSocket consumers to two PTYs, floods one, and measures
- * echo/health latency on the other while sampling host-service and pty-daemon
- * resources.
+ * The harness verifies the renderer URL and resolves its authenticated org
+ * through CDP. It never prints bearer or host tokens. It attaches real
+ * WebSocket consumers to two PTYs, floods one, and measures echo/health latency
+ * on the other while sampling host-service and pty-daemon resources.
  */
 
 import { Database } from "bun:sqlite";
@@ -32,7 +30,6 @@ interface Options {
 	samples: number;
 	intervalMs: number;
 	repairLocalAuth: boolean;
-	organizationId: string | null;
 	workspacePath: string;
 	outDir: string;
 }
@@ -108,7 +105,6 @@ function parseArgs(argv: string[]): Options {
 		samples: 60,
 		intervalMs: 150,
 		repairLocalAuth: false,
-		organizationId: null,
 		workspacePath: process.cwd(),
 		outDir: ".cache/terminal-flood-profiles",
 	};
@@ -132,9 +128,6 @@ function parseArgs(argv: string[]): Options {
 				break;
 			case "--repair-local-auth":
 				options.repairLocalAuth = true;
-				break;
-			case "--organization-id":
-				options.organizationId = next();
 				break;
 			case "--workspace-path":
 				options.workspacePath = resolve(next());
@@ -206,13 +199,25 @@ async function evaluateCdp<T>(
 			const message = JSON.parse(String(event.data)) as {
 				id?: number;
 				result?: {
-					exceptionDetails?: unknown;
+					exceptionDetails?: {
+						text?: string;
+						exception?: { description?: string };
+					};
 					result?: { value?: T };
 				};
 			};
 			if (message.id !== 1) return;
-			if (message.result?.exceptionDetails) {
-				settle(() => rejectValue(new Error("Renderer evaluation failed")));
+			const exception = message.result?.exceptionDetails;
+			if (exception) {
+				settle(() =>
+					rejectValue(
+						new Error(
+							exception.exception?.description ??
+								exception.text ??
+								"Renderer evaluation failed",
+						),
+					),
+				);
 				return;
 			}
 			settle(() => resolveValue(message.result?.result?.value as T));
@@ -231,6 +236,17 @@ function sessionProbeExpression(apiUrl: string): string {
 	})()`;
 }
 
+function bearerSessionProbeExpression(): string {
+	return `(async () => {
+		const { authClient } = await import("/lib/auth-client.ts");
+		const result = await authClient.getSession({ fetchOptions: { throw: false } });
+		return {
+			status: result.data ? 200 : 401,
+			organizationId: result.data?.session?.activeOrganizationId ?? null,
+		};
+	})()`;
+}
+
 async function resolveAuthenticatedOrg(
 	options: Options,
 	target: CdpTarget,
@@ -239,6 +255,15 @@ async function resolveAuthenticatedOrg(
 		target,
 		sessionProbeExpression(options.apiUrl),
 	);
+	// Non-local desktop auth intentionally uses an in-memory bearer token rather
+	// than browser cookies. Exercise the renderer's real auth client so the CDP
+	// probe verifies /api/auth/get-session without exposing that token.
+	if (!probe.organizationId) {
+		probe = await evaluateCdp<SessionProbe>(
+			target,
+			bearerSessionProbeExpression(),
+		);
+	}
 	if (!probe.organizationId && options.repairLocalAuth) {
 		const api = new URL(options.apiUrl);
 		if (
@@ -562,8 +587,7 @@ function sleep(ms: number): Promise<void> {
 async function main(): Promise<void> {
 	const options = parseArgs(process.argv.slice(2));
 	const target = await findRendererTarget(options);
-	const organizationId =
-		options.organizationId ?? (await resolveAuthenticatedOrg(options, target));
+	const organizationId = await resolveAuthenticatedOrg(options, target);
 	const organizationDir = join(options.homeDir, "host", organizationId);
 	const manifest = await readJson<HostManifest>(
 		join(organizationDir, "manifest.json"),

--- a/apps/desktop/scripts/cdp-terminal-flood-profile.ts
+++ b/apps/desktop/scripts/cdp-terminal-flood-profile.ts
@@ -1,0 +1,646 @@
+/**
+ * Profiles terminal relay coupling against this workspace's running desktop.
+ *
+ * Launch the app with an unused CDP port, then run:
+ *
+ *   RENDERER_REMOTE_DEBUG_PORT=19322 bun --env-file=.env \
+ *     apps/desktop/scripts/cdp-terminal-flood-profile.ts --repair-local-auth
+ *
+ * The harness verifies the renderer URL and normally resolves its authenticated
+ * org through CDP. If the local API is unavailable, --organization-id selects
+ * an already-running local host explicitly. It never prints the host token. It
+ * attaches real WebSocket consumers to two PTYs, floods one, and measures
+ * echo/health latency on the other while sampling host-service and pty-daemon
+ * resources.
+ */
+
+import { Database } from "bun:sqlite";
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { DEV_EMAIL, DEV_PASSWORD } from "@superset/shared/dev-credentials";
+
+const execFileAsync = promisify(execFile);
+
+interface Options {
+	cdpPort: number;
+	apiUrl: string;
+	desktopVitePort: number;
+	homeDir: string;
+	samples: number;
+	intervalMs: number;
+	repairLocalAuth: boolean;
+	organizationId: string | null;
+	workspacePath: string;
+	outDir: string;
+}
+
+interface CdpTarget {
+	type: string;
+	url: string;
+	webSocketDebuggerUrl?: string;
+}
+
+interface SessionProbe {
+	status: number;
+	organizationId: string | null;
+}
+
+interface HostManifest {
+	endpoint: string;
+	authToken: string;
+	organizationId: string;
+	pid: number;
+}
+
+interface PtyDaemonManifest {
+	pid: number;
+}
+
+interface ProcessSample {
+	cpu: number;
+	rssKb: number;
+}
+
+interface PhaseResult {
+	echoRttMs: MetricSummary;
+	healthRttMs: MetricSummary;
+	hostCpuPercent: MetricSummary;
+	daemonCpuPercent: MetricSummary;
+	hostRssKb: MetricSummary;
+	daemonRssKb: MetricSummary;
+	floodBytesReceived: number;
+	probeSocketStayedOpen: boolean;
+	floodSocketStayedOpen: boolean;
+}
+
+interface MetricSummary {
+	count: number;
+	p50: number;
+	p95: number;
+	p99: number;
+	max: number;
+}
+
+interface TerminalStream {
+	readonly socket: WebSocket;
+	readonly stayedOpen: () => boolean;
+	readonly bytesReceived: () => number;
+	sendInput(data: string): void;
+	waitForText(marker: string, timeoutMs?: number): Promise<void>;
+	close(): void;
+}
+
+interface TextWaiter {
+	resolve: () => void;
+	reject: (error: Error) => void;
+	timer: ReturnType<typeof setTimeout>;
+}
+
+function parseArgs(argv: string[]): Options {
+	const options: Options = {
+		cdpPort: Number(process.env.RENDERER_REMOTE_DEBUG_PORT ?? 9222),
+		apiUrl: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001",
+		desktopVitePort: Number(process.env.DESKTOP_VITE_PORT ?? 5173),
+		homeDir: process.env.SUPERSET_HOME_DIR ?? resolve("superset-dev-data"),
+		samples: 60,
+		intervalMs: 150,
+		repairLocalAuth: false,
+		organizationId: null,
+		workspacePath: process.cwd(),
+		outDir: ".cache/terminal-flood-profiles",
+	};
+
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		const next = () => {
+			const value = argv[++index];
+			if (!value) throw new Error(`Missing value after ${arg}`);
+			return value;
+		};
+		switch (arg) {
+			case "--samples":
+				options.samples = Number(next());
+				break;
+			case "--interval-ms":
+				options.intervalMs = Number(next());
+				break;
+			case "--out-dir":
+				options.outDir = next();
+				break;
+			case "--repair-local-auth":
+				options.repairLocalAuth = true;
+				break;
+			case "--organization-id":
+				options.organizationId = next();
+				break;
+			case "--workspace-path":
+				options.workspacePath = resolve(next());
+				break;
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+
+	for (const [name, value] of Object.entries({
+		cdpPort: options.cdpPort,
+		desktopVitePort: options.desktopVitePort,
+		samples: options.samples,
+		intervalMs: options.intervalMs,
+	})) {
+		if (!Number.isFinite(value) || value < 1) {
+			throw new Error(`${name} must be a positive number`);
+		}
+	}
+	return options;
+}
+
+async function findRendererTarget(options: Options): Promise<CdpTarget> {
+	const response = await fetch(`http://127.0.0.1:${options.cdpPort}/json/list`);
+	if (!response.ok)
+		throw new Error(`CDP target list returned ${response.status}`);
+	const targets = (await response.json()) as CdpTarget[];
+	const expectedOrigin = `http://localhost:${options.desktopVitePort}`;
+	const target = targets.find(
+		(candidate) =>
+			candidate.type === "page" &&
+			candidate.webSocketDebuggerUrl &&
+			candidate.url.startsWith(`${expectedOrigin}/`),
+	);
+	if (!target?.webSocketDebuggerUrl) {
+		throw new Error(
+			`No renderer for ${expectedOrigin} on CDP port ${options.cdpPort}`,
+		);
+	}
+	return target;
+}
+
+async function evaluateCdp<T>(
+	target: CdpTarget,
+	expression: string,
+): Promise<T> {
+	if (!target.webSocketDebuggerUrl) throw new Error("CDP target has no socket");
+	return new Promise<T>((resolveValue, rejectValue) => {
+		const socket = new WebSocket(target.webSocketDebuggerUrl as string);
+		const timer = setTimeout(() => {
+			socket.close();
+			rejectValue(new Error("CDP evaluation timed out"));
+		}, 15_000);
+		const settle = (callback: () => void) => {
+			clearTimeout(timer);
+			socket.close();
+			callback();
+		};
+		socket.addEventListener("open", () => {
+			socket.send(
+				JSON.stringify({
+					id: 1,
+					method: "Runtime.evaluate",
+					params: { expression, awaitPromise: true, returnByValue: true },
+				}),
+			);
+		});
+		socket.addEventListener("message", (event) => {
+			const message = JSON.parse(String(event.data)) as {
+				id?: number;
+				result?: {
+					exceptionDetails?: unknown;
+					result?: { value?: T };
+				};
+			};
+			if (message.id !== 1) return;
+			if (message.result?.exceptionDetails) {
+				settle(() => rejectValue(new Error("Renderer evaluation failed")));
+				return;
+			}
+			settle(() => resolveValue(message.result?.result?.value as T));
+		});
+		socket.addEventListener("error", () => {
+			settle(() => rejectValue(new Error("CDP WebSocket failed")));
+		});
+	});
+}
+
+function sessionProbeExpression(apiUrl: string): string {
+	return `(async () => {
+		const response = await fetch(${JSON.stringify(`${apiUrl}/api/auth/get-session`)}, { credentials: "include" });
+		const body = await response.json().catch(() => null);
+		return { status: response.status, organizationId: body?.session?.activeOrganizationId ?? null };
+	})()`;
+}
+
+async function resolveAuthenticatedOrg(
+	options: Options,
+	target: CdpTarget,
+): Promise<string> {
+	let probe = await evaluateCdp<SessionProbe>(
+		target,
+		sessionProbeExpression(options.apiUrl),
+	);
+	if (!probe.organizationId && options.repairLocalAuth) {
+		const api = new URL(options.apiUrl);
+		if (
+			api.protocol !== "http:" ||
+			!["localhost", "127.0.0.1"].includes(api.hostname)
+		) {
+			throw new Error("Local auth repair requires a localhost HTTP API");
+		}
+		const signIn = await evaluateCdp<{ status: number }>(
+			target,
+			`(async () => {
+				const response = await fetch(${JSON.stringify(`${options.apiUrl}/api/auth/sign-in/email`)}, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					credentials: "include",
+					body: JSON.stringify({ email: ${JSON.stringify(DEV_EMAIL)}, password: ${JSON.stringify(DEV_PASSWORD)} }),
+				});
+				return { status: response.status };
+			})()`,
+		);
+		if (signIn.status < 200 || signIn.status >= 300) {
+			throw new Error(`Local sign-in returned ${signIn.status}`);
+		}
+		probe = await evaluateCdp<SessionProbe>(
+			target,
+			sessionProbeExpression(options.apiUrl),
+		);
+	}
+	if (probe.status !== 200 || !probe.organizationId) {
+		throw new Error(`Renderer session is unavailable (status ${probe.status})`);
+	}
+	return probe.organizationId;
+}
+
+async function readJson<T>(path: string): Promise<T> {
+	return JSON.parse(await readFile(path, "utf8")) as T;
+}
+
+function resolveWorkspaceId(hostDbPath: string, workspacePath: string): string {
+	const db = new Database(hostDbPath, { readonly: true });
+	try {
+		const rows = db
+			.query<{ id: string; worktreePath: string }, []>(
+				"select id, worktree_path as worktreePath from workspaces order by case when type = 'main' then 0 else 1 end, created_at",
+			)
+			.all();
+		const workspace = rows.find(
+			(row) => resolve(row.worktreePath) === workspacePath,
+		);
+		if (!workspace) {
+			throw new Error(`Selected org has no workspace at ${workspacePath}`);
+		}
+		return workspace.id;
+	} finally {
+		db.close();
+	}
+}
+
+function authHeaders(token: string): Record<string, string> {
+	return {
+		Authorization: `Bearer ${token}`,
+		"content-type": "application/json",
+	};
+}
+
+async function createTerminal(
+	manifest: HostManifest,
+	workspaceId: string,
+): Promise<string> {
+	const terminalId = `profile-${randomUUID()}`;
+	const response = await fetch(`${manifest.endpoint}/terminal/sessions`, {
+		method: "POST",
+		headers: authHeaders(manifest.authToken),
+		body: JSON.stringify({ terminalId, workspaceId, cols: 120, rows: 32 }),
+	});
+	if (!response.ok) {
+		throw new Error(`Terminal create returned ${response.status}`);
+	}
+	return terminalId;
+}
+
+async function disposeTerminal(
+	manifest: HostManifest,
+	terminalId: string,
+): Promise<void> {
+	await fetch(`${manifest.endpoint}/terminal/sessions/${terminalId}`, {
+		method: "DELETE",
+		headers: authHeaders(manifest.authToken),
+	}).catch(() => undefined);
+}
+
+async function openTerminalStream(
+	manifest: HostManifest,
+	workspaceId: string,
+	terminalId: string,
+): Promise<TerminalStream> {
+	const endpoint = new URL(manifest.endpoint);
+	const socketUrl = new URL(
+		`${endpoint.protocol === "https:" ? "wss:" : "ws:"}//${endpoint.host}/terminal/${terminalId}`,
+	);
+	socketUrl.searchParams.set("workspaceId", workspaceId);
+	socketUrl.searchParams.set("token", manifest.authToken);
+	const socket = new WebSocket(socketUrl);
+	socket.binaryType = "arraybuffer";
+	const decoder = new TextDecoder();
+	const waiters = new Map<string, TextWaiter>();
+	let textTail = "";
+	let receivedBytes = 0;
+	let opened = false;
+	let unexpectedClose = false;
+
+	const attached = new Promise<void>((resolveAttached, rejectAttached) => {
+		const timer = setTimeout(
+			() => rejectAttached(new Error("Terminal attach timed out")),
+			10_000,
+		);
+		socket.addEventListener("message", (event) => {
+			if (typeof event.data === "string") {
+				const message = JSON.parse(event.data) as {
+					type?: string;
+					message?: string;
+				};
+				if (message.type === "attached") {
+					opened = true;
+					clearTimeout(timer);
+					resolveAttached();
+				} else if (message.type === "error") {
+					clearTimeout(timer);
+					rejectAttached(
+						new Error(message.message ?? "Terminal attach failed"),
+					);
+				}
+				return;
+			}
+			const bytes =
+				event.data instanceof ArrayBuffer
+					? new Uint8Array(event.data)
+					: new Uint8Array(event.data as ArrayBuffer);
+			receivedBytes += bytes.byteLength;
+			textTail = `${textTail}${decoder.decode(bytes, { stream: true })}`.slice(
+				-8_192,
+			);
+			for (const [marker, waiter] of waiters) {
+				if (!textTail.includes(marker)) continue;
+				clearTimeout(waiter.timer);
+				waiters.delete(marker);
+				waiter.resolve();
+			}
+		});
+		socket.addEventListener("close", () => {
+			unexpectedClose = opened;
+			clearTimeout(timer);
+			for (const waiter of waiters.values()) {
+				clearTimeout(waiter.timer);
+				waiter.reject(new Error("Terminal socket closed"));
+			}
+			waiters.clear();
+			if (!opened)
+				rejectAttached(new Error("Terminal socket closed on attach"));
+		});
+		socket.addEventListener("error", () => {
+			clearTimeout(timer);
+			if (!opened)
+				rejectAttached(new Error("Terminal socket failed on attach"));
+		});
+	});
+
+	await attached;
+	return {
+		socket,
+		stayedOpen: () => !unexpectedClose && socket.readyState === WebSocket.OPEN,
+		bytesReceived: () => receivedBytes,
+		sendInput(data) {
+			if (socket.readyState !== WebSocket.OPEN) {
+				throw new Error("Terminal socket is not open");
+			}
+			socket.send(JSON.stringify({ type: "input", data }));
+		},
+		waitForText(marker, timeoutMs = 5_000) {
+			if (textTail.includes(marker)) return Promise.resolve();
+			return new Promise<void>((resolveMarker, rejectMarker) => {
+				const timer = setTimeout(() => {
+					waiters.delete(marker);
+					rejectMarker(new Error(`Timed out waiting for terminal marker`));
+				}, timeoutMs);
+				waiters.set(marker, {
+					resolve: resolveMarker,
+					reject: rejectMarker,
+					timer,
+				});
+			});
+		},
+		close() {
+			socket.close();
+		},
+	};
+}
+
+async function healthRtt(manifest: HostManifest): Promise<number> {
+	const startedAt = performance.now();
+	const response = await fetch(`${manifest.endpoint}/trpc/health.check`, {
+		headers: authHeaders(manifest.authToken),
+	});
+	if (!response.ok) throw new Error(`Host health returned ${response.status}`);
+	await response.arrayBuffer();
+	return performance.now() - startedAt;
+}
+
+async function sampleProcesses(
+	hostPid: number,
+	daemonPid: number,
+): Promise<Map<number, ProcessSample>> {
+	const { stdout } = await execFileAsync("ps", [
+		"-p",
+		`${hostPid},${daemonPid}`,
+		"-o",
+		"pid=,%cpu=,rss=",
+	]);
+	const samples = new Map<number, ProcessSample>();
+	for (const line of stdout.trim().split("\n")) {
+		const [pidRaw, cpuRaw, rssRaw] = line.trim().split(/\s+/);
+		const pid = Number(pidRaw);
+		const cpu = Number(cpuRaw);
+		const rssKb = Number(rssRaw);
+		if ([pid, cpu, rssKb].every(Number.isFinite)) {
+			samples.set(pid, { cpu, rssKb });
+		}
+	}
+	return samples;
+}
+
+async function runPhase({
+	label,
+	options,
+	manifest,
+	daemonPid,
+	probe,
+	flood,
+}: {
+	label: string;
+	options: Options;
+	manifest: HostManifest;
+	daemonPid: number;
+	probe: TerminalStream;
+	flood: TerminalStream;
+}): Promise<PhaseResult> {
+	const echoRtts: number[] = [];
+	const healthRtts: number[] = [];
+	const hostCpu: number[] = [];
+	const daemonCpu: number[] = [];
+	const hostRss: number[] = [];
+	const daemonRss: number[] = [];
+	const floodBytesBefore = flood.bytesReceived();
+
+	for (let index = 0; index < options.samples; index++) {
+		const iterationStartedAt = performance.now();
+		const marker = `__superset_${label}_${index}_${randomUUID().slice(0, 8)}__`;
+		const markerPromise = probe.waitForText(marker);
+		const echoStartedAt = performance.now();
+		probe.sendInput(`printf '${marker}\\n'\n`);
+		const [, health] = await Promise.all([markerPromise, healthRtt(manifest)]);
+		echoRtts.push(performance.now() - echoStartedAt);
+		healthRtts.push(health);
+
+		if (index % Math.max(1, Math.round(500 / options.intervalMs)) === 0) {
+			const processes = await sampleProcesses(manifest.pid, daemonPid);
+			const host = processes.get(manifest.pid);
+			const daemon = processes.get(daemonPid);
+			if (host) {
+				hostCpu.push(host.cpu);
+				hostRss.push(host.rssKb);
+			}
+			if (daemon) {
+				daemonCpu.push(daemon.cpu);
+				daemonRss.push(daemon.rssKb);
+			}
+		}
+
+		const remaining =
+			options.intervalMs - (performance.now() - iterationStartedAt);
+		if (remaining > 0) await sleep(remaining);
+	}
+
+	return {
+		echoRttMs: summarize(echoRtts),
+		healthRttMs: summarize(healthRtts),
+		hostCpuPercent: summarize(hostCpu),
+		daemonCpuPercent: summarize(daemonCpu),
+		hostRssKb: summarize(hostRss),
+		daemonRssKb: summarize(daemonRss),
+		floodBytesReceived: flood.bytesReceived() - floodBytesBefore,
+		probeSocketStayedOpen: probe.stayedOpen(),
+		floodSocketStayedOpen: flood.stayedOpen(),
+	};
+}
+
+function summarize(values: number[]): MetricSummary {
+	const sorted = [...values].sort((a, b) => a - b);
+	const valueAt = (percentile: number) => {
+		if (sorted.length === 0) return 0;
+		const index = Math.min(
+			sorted.length - 1,
+			Math.max(0, Math.ceil(percentile * sorted.length) - 1),
+		);
+		return sorted[index] ?? 0;
+	};
+	const round = (value: number) => Math.round(value * 10) / 10;
+	return {
+		count: sorted.length,
+		p50: round(valueAt(0.5)),
+		p95: round(valueAt(0.95)),
+		p99: round(valueAt(0.99)),
+		max: round(sorted.at(-1) ?? 0),
+	};
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+async function main(): Promise<void> {
+	const options = parseArgs(process.argv.slice(2));
+	const target = await findRendererTarget(options);
+	const organizationId =
+		options.organizationId ?? (await resolveAuthenticatedOrg(options, target));
+	const organizationDir = join(options.homeDir, "host", organizationId);
+	const manifest = await readJson<HostManifest>(
+		join(organizationDir, "manifest.json"),
+	);
+	const daemonManifest = await readJson<PtyDaemonManifest>(
+		join(organizationDir, "pty-daemon-manifest.json"),
+	);
+	if (manifest.organizationId !== organizationId) {
+		throw new Error("Host manifest organization does not match selected org");
+	}
+	const workspaceId = resolveWorkspaceId(
+		join(organizationDir, "host.db"),
+		options.workspacePath,
+	);
+
+	let probeId: string | null = null;
+	let floodId: string | null = null;
+	let probe: TerminalStream | null = null;
+	let flood: TerminalStream | null = null;
+	try {
+		probeId = await createTerminal(manifest, workspaceId);
+		floodId = await createTerminal(manifest, workspaceId);
+		[probe, flood] = await Promise.all([
+			openTerminalStream(manifest, workspaceId, probeId),
+			openTerminalStream(manifest, workspaceId, floodId),
+		]);
+		probe.sendInput("\n");
+		flood.sendInput("\n");
+		await sleep(1_000);
+
+		const baseline = await runPhase({
+			label: "baseline",
+			options,
+			manifest,
+			daemonPid: daemonManifest.pid,
+			probe,
+			flood,
+		});
+
+		flood.sendInput(
+			"while :; do printf '\\033[31m0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\\033[0m\\r'; done\n",
+		);
+		await sleep(750);
+		const underFlood = await runPhase({
+			label: "flood",
+			options,
+			manifest,
+			daemonPid: daemonManifest.pid,
+			probe,
+			flood,
+		});
+		flood.sendInput("\u0003");
+		await sleep(500);
+
+		const summary = {
+			measuredAt: new Date().toISOString(),
+			rendererUrl: target.url,
+			options: { samples: options.samples, intervalMs: options.intervalMs },
+			baseline,
+			underFlood,
+		};
+		await mkdir(options.outDir, { recursive: true });
+		const summaryPath = join(options.outDir, `summary-${Date.now()}.json`);
+		await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+		console.log(JSON.stringify(summary, null, 2));
+		console.log(`Wrote summary: ${summaryPath}`);
+	} finally {
+		if (flood?.socket.readyState === WebSocket.OPEN) {
+			try {
+				flood.sendInput("\u0003");
+			} catch {}
+		}
+		probe?.close();
+		flood?.close();
+		if (probeId) await disposeTerminal(manifest, probeId);
+		if (floodId) await disposeTerminal(manifest, floodId);
+	}
+}
+
+await main();

--- a/packages/host-service/scripts/git-status-large-repo-profile.ts
+++ b/packages/host-service/scripts/git-status-large-repo-profile.ts
@@ -380,10 +380,11 @@ async function runScenario(
 		activeRefreshes++;
 		maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
 		try {
-			const status = await workerPool.run(gitStatusSnapshotTask, {
+			const result = await workerPool.run(gitStatusSnapshotTask, {
 				worktreePath: options.repoPath,
 				gitEnv,
 			});
+			const status = result.snapshot;
 			lastSummary = {
 				againstBase: status.againstBase.length,
 				staged: status.staged.length,
@@ -505,12 +506,12 @@ async function runEventBusScenario(
 		try {
 			const worktreePath =
 				worktreePathByWorkspaceId.get(workspaceId) ?? options.repoPath;
-			const status = await workerPool.run(gitStatusSnapshotTask, {
+			const result = await workerPool.run(gitStatusSnapshotTask, {
 				worktreePath,
 				gitEnv,
 			});
-			lastSummary = summarizeStatus(status);
-			return status;
+			lastSummary = summarizeStatus(result.snapshot);
+			return result.snapshot;
 		} finally {
 			activeRefreshes--;
 		}
@@ -711,7 +712,7 @@ async function startCdpCapture(
 }
 
 function summarizeStatus(
-	status: Awaited<ReturnType<typeof gitStatusSnapshotTask.handler>>,
+	status: Awaited<ReturnType<typeof gitStatusSnapshotTask.handler>>["snapshot"],
 ): ScenarioResult["statusSummary"] {
 	return {
 		againstBase: status.againstBase.length,

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -5,10 +5,12 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { pullRequests, workspaces } from "../../../db/schema";
 import { createGitEnvResolver } from "../../../runtime/git";
+import { createUserSimpleGit } from "../../../runtime/git/simple-git";
 import type { HostServiceContext } from "../../../types";
 import { getHostWorkerPool } from "../../../workers/host-worker-pool";
 import {
 	gitCommitFilesTask,
+	gitFetchBaseRefTask,
 	gitStatusSnapshotTask,
 } from "../../../workers/tasks/git";
 import { protectedProcedure, queryProcedure, router } from "../../index";
@@ -25,6 +27,7 @@ import type {
 	PullRequestReviewThread,
 	PullRequestState,
 } from "./types";
+import { scheduleBaseRefFetch } from "./utils/base-ref-freshness";
 import { gitConfigWrite } from "./utils/config-write";
 import {
 	getDefaultBranchName,
@@ -161,11 +164,32 @@ export const gitRouter = router({
 				run: async () => {
 					const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 					const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
-					return getHostWorkerPool().run(
+					const workerPool = getHostWorkerPool();
+					const result = await workerPool.run(
 						gitStatusSnapshotTask,
 						{ worktreePath, baseBranch: input.baseBranch, gitEnv },
 						{ timeoutMs: 15_000 },
 					);
+					if (result.baseRefFetchTarget) {
+						const target = result.baseRefFetchTarget;
+						const coordinatorGit =
+							createUserSimpleGit(worktreePath).env(gitEnv);
+						// The coordinator maps live in this process, not in individual
+						// workers, so worktrees sharing one common Git dir share one TTL
+						// and in-flight fetch. The network fetch itself remains off-loop.
+						scheduleBaseRefFetch(coordinatorGit, worktreePath, target, () =>
+							workerPool.run(
+								gitFetchBaseRefTask,
+								{ worktreePath, target, gitEnv },
+								{
+									timeoutMs: 30_000,
+									strategy: "coalesce",
+									dedupeKey: `${worktreePath}:base-ref:${target.remote}/${target.branch}`,
+								},
+							),
+						);
+					}
+					return result.snapshot;
 				},
 			});
 		}),

--- a/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.test.ts
@@ -3,14 +3,16 @@ import { scheduleBaseRefFetch } from "./base-ref-freshness";
 
 // Distinct remote/branch per test so the module-level TTL/in-flight maps
 // (keyed by commonDir#remote/branch) don't leak state across tests.
-function createGit(options: { fetch?: () => Promise<unknown> } = {}) {
+function createGit(
+	options: { fetch?: () => Promise<unknown>; commonDir?: string } = {},
+) {
 	const fetchCalls: string[][] = [];
 	const revParseCalls: string[][] = [];
 	const git = {
 		raw: mock(async (args: string[]) => {
 			revParseCalls.push(args);
 			if (args[0] === "rev-parse" && args[1] === "--git-common-dir") {
-				return ".git\n";
+				return `${options.commonDir ?? ".git"}\n`;
 			}
 			throw new Error(`Unexpected raw args: ${args.join(" ")}`);
 		}),
@@ -66,6 +68,23 @@ describe("scheduleBaseRefFetch", () => {
 		release();
 		await Promise.all([a, b]);
 		expect(fetchCalls).toHaveLength(1);
+	});
+
+	test("dedupes worktrees that resolve to the same common Git directory", async () => {
+		const target = { remote: "origin", branch: "shared-worktrees-branch" };
+		const a = createGit({ commonDir: "/repo/.git" });
+		const b = createGit({ commonDir: "/repo/.git" });
+		let fetches = 0;
+		const fetchBaseRef = async () => {
+			fetches++;
+		};
+
+		await Promise.all([
+			scheduleBaseRefFetch(a.git, "/repo/wt-a", target, fetchBaseRef),
+			scheduleBaseRefFetch(b.git, "/repo/wt-b", target, fetchBaseRef),
+		]);
+
+		expect(fetches).toBe(1);
 	});
 
 	test("never rejects when the fetch fails", async () => {

--- a/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
+++ b/packages/host-service/src/trpc/router/git/utils/base-ref-freshness.ts
@@ -39,6 +39,8 @@ export function scheduleBaseRefFetch(
 	git: SimpleGit,
 	worktreePath: string,
 	target: BaseRefFetchTarget,
+	fetchBaseRef: () => Promise<unknown> = () =>
+		git.fetch([target.remote, target.branch, "--quiet", "--no-tags"]),
 ): Promise<void> {
 	return (async () => {
 		const commonDir = await resolveCommonDir(git, worktreePath);
@@ -53,8 +55,7 @@ export function scheduleBaseRefFetch(
 		}
 
 		lastFetchStartedAt.set(key, Date.now());
-		const fetchPromise = git
-			.fetch([target.remote, target.branch, "--quiet", "--no-tags"])
+		const fetchPromise = fetchBaseRef()
 			.then(() => undefined)
 			.finally(() => {
 				inFlightFetches.delete(key);

--- a/packages/host-service/src/trpc/router/git/utils/git-status.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-status.ts
@@ -1,6 +1,6 @@
 import type { SimpleGit } from "simple-git";
 import type { Branch, ChangedFile } from "../types";
-import { scheduleBaseRefFetch } from "./base-ref-freshness";
+import type { BaseRefFetchTarget } from "./base-ref-freshness";
 import {
 	buildBranch,
 	countUntrackedFileLines,
@@ -20,6 +20,12 @@ export interface GitStatusSnapshot {
 	ignoredPaths: string[];
 }
 
+export interface GitStatusSnapshotComputation {
+	snapshot: GitStatusSnapshot;
+	/** Resolved in the worker, scheduled by the process-wide coordinator. */
+	baseRefFetchTarget: BaseRefFetchTarget | null;
+}
+
 export async function getGitStatusSnapshot({
 	git,
 	worktreePath,
@@ -28,19 +34,13 @@ export async function getGitStatusSnapshot({
 	git: SimpleGit;
 	worktreePath: string;
 	baseBranch?: string;
-}): Promise<GitStatusSnapshot> {
+}): Promise<GitStatusSnapshotComputation> {
 	const currentBranchName = (
 		await git.revparse(["--abbrev-ref", "HEAD"]).catch(() => "")
 	).trim();
 	const base = await resolveBaseComparison(git, baseBranch);
 	const defaultBranchName = base?.branchName ?? null;
 	const baseRef = base?.baseRef ?? "HEAD";
-
-	// Non-blocking refresh so the against-base diff stops ballooning after a
-	// rebase; see base-ref-freshness.
-	if (base?.fetchTarget) {
-		scheduleBaseRefFetch(git, worktreePath, base.fetchTarget);
-	}
 
 	const [currentBranch, defaultBranch, status, ignoredRaw] = await Promise.all([
 		buildBranch(git, currentBranchName, true, baseRef),
@@ -166,11 +166,14 @@ export async function getGitStatusSnapshot({
 	}
 
 	return {
-		currentBranch,
-		defaultBranch,
-		againstBase,
-		staged,
-		unstaged: mergedUnstaged,
-		ignoredPaths,
+		snapshot: {
+			currentBranch,
+			defaultBranch,
+			againstBase,
+			staged,
+			unstaged: mergedUnstaged,
+			ignoredPaths,
+		},
+		baseRefFetchTarget: base?.fetchTarget ?? null,
 	};
 }

--- a/packages/host-service/src/workers/host-worker-pool.test.ts
+++ b/packages/host-service/src/workers/host-worker-pool.test.ts
@@ -79,11 +79,13 @@ describe("HostWorkerPool", () => {
 		const inline = await gitStatusSnapshotTask.handler(input);
 
 		expect(fromWorker).toEqual(inline);
-		expect(fromWorker.unstaged.map((f) => f.path).sort()).toEqual([
+		expect(fromWorker.snapshot.unstaged.map((f) => f.path).sort()).toEqual([
 			"a.txt",
 			"c.txt",
 		]);
-		expect(fromWorker.staged.map((f) => f.path)).toEqual(["staged.txt"]);
+		expect(fromWorker.snapshot.staged.map((f) => f.path)).toEqual([
+			"staged.txt",
+		]);
 	});
 
 	test("unknown task type rejects with the worker's error", async () => {
@@ -120,7 +122,7 @@ describe("HostWorkerPool", () => {
 			gitEnv: { GIT_OPTIONAL_LOCKS: "0" },
 		});
 		expect(pool.getMode()).toBe("inline");
-		expect(result.unstaged.length).toBeGreaterThan(0);
+		expect(result.snapshot.unstaged.length).toBeGreaterThan(0);
 	});
 
 	test("worker crash retries inline; crash loop opens the circuit", async () => {

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -5,8 +5,9 @@
 
 import { createUserSimpleGit } from "../../runtime/git/simple-git.ts";
 import type { ChangedFile } from "../../trpc/router/git/types.ts";
+import type { BaseRefFetchTarget } from "../../trpc/router/git/utils/base-ref-freshness.ts";
 import { getChangedFilesForDiff } from "../../trpc/router/git/utils/git-helpers.ts";
-import type { GitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts";
+import type { GitStatusSnapshotComputation } from "../../trpc/router/git/utils/git-status.ts";
 import { getGitStatusSnapshot } from "../../trpc/router/git/utils/git-status.ts";
 import { defineWorkerTask } from "../define-worker-task.ts";
 
@@ -16,12 +17,27 @@ export interface GitTaskEnv {
 
 export const gitStatusSnapshotTask = defineWorkerTask<
 	{ worktreePath: string; baseBranch?: string; gitEnv: GitTaskEnv },
-	GitStatusSnapshot
+	GitStatusSnapshotComputation
 >({
 	type: "git/getStatusSnapshot",
 	handler: async ({ worktreePath, baseBranch, gitEnv }) => {
 		const git = createUserSimpleGit(worktreePath).env(gitEnv);
 		return getGitStatusSnapshot({ git, worktreePath, baseBranch });
+	},
+});
+
+export const gitFetchBaseRefTask = defineWorkerTask<
+	{
+		worktreePath: string;
+		target: BaseRefFetchTarget;
+		gitEnv: GitTaskEnv;
+	},
+	void
+>({
+	type: "git/fetchBaseRef",
+	handler: async ({ worktreePath, target, gitEnv }) => {
+		const git = createUserSimpleGit(worktreePath).env(gitEnv);
+		await git.fetch([target.remote, target.branch, "--quiet", "--no-tags"]);
 	},
 });
 
@@ -42,4 +58,8 @@ export const gitCommitFilesTask = defineWorkerTask<
 	},
 });
 
-export const gitTasks = [gitStatusSnapshotTask, gitCommitFilesTask];
+export const gitTasks = [
+	gitStatusSnapshotTask,
+	gitFetchBaseRefTask,
+	gitCommitFilesTask,
+];

--- a/plans/20260717-host-service-git-worker-pool.md
+++ b/plans/20260717-host-service-git-worker-pool.md
@@ -8,14 +8,14 @@
 
 | # | Finding | Severity | Fix |
 |---|---|---|---|
-| 1 | One flooding terminal destroys the org-wide daemon↔host-service socket (8 MiB cap, `Server.ts:595`); all terminals blip | Correctness bug, likely hitting users today | Per-session shedding in pty-daemon — **not** this pool |
+| 1 | One flooding terminal destroyed the org-wide daemon↔host-service socket (8 MiB cap, `Server.ts:595`); all terminals blipped | Correctness bug | **Fixed in #5747; verified below** |
 | 2 | 8-workspace churn stalls the loop (183ms stalls, query p95 127ms) via the **watcher path**, not status parsing | Loop health | Offload GitWatcher rescan/filtering to the pool |
 | 3 | Background `getStatus` takes 3.7–14.6s under churn — limiter queueing at concurrency 4 | UX staleness | Pool makes raising limiter concurrency safe |
 | 4 | Big-diff snapshot ≈1.2s (2k files) but does NOT stall the loop | Minor | Phase 1 offload, comes with #2/#3 infra |
 | 5 | Renderer freezes >60s under 8-workspace churn | Separate renderer workstream | Not host-service scope |
-| 6 | Daemon burns 50–77% CPU on unattached flooding PTYs; host-service RSS 320→570MB in one session | Investigate | With #1 / leak-check respectively |
+| 6 | Extreme subscribed terminal floods saturate host-service and daemon CPU | Measured | No sustained loop coupling; do not build a pinned worker yet |
 
-**Recommended order:** ship #1 (small daemon fix, no pool needed) → build the pool with git status + watcher rescan as tenants (#2–#4) → raise limiter concurrency → hand #5 to a renderer-side effort. Re-run the ModeTracker/terminal measurement only after #1 lands (the transport dies before the loop can be loaded).
+**Outcome:** #1 and the worker-pool/watcher-path work shipped; limiter concurrency stays at 4 because 6 did not improve completion time. The post-#5747 terminal rerun below rejects a pinned ModeTracker worker for now. #5 remains a separate renderer-side effort.
 
 ## Post-implementation measurement — 2026-07-18
 
@@ -44,6 +44,43 @@ Limiter comparison with eight identical snapshots: concurrency 4 completed in
 2.52 s (14 max active git processes); concurrency 6 took 2.59 s (17 processes).
 Keep the production limiter at 4: raising it did not improve completion time and
 increased subprocess pressure.
+
+## Post-daemon-fix terminal measurement — 2026-07-19
+
+The shared-socket backpressure fix landed in #5747. A reusable CDP harness now
+attaches real WebSocket consumers to two PTYs, floods one with continuous SGR
+output, probes echo latency on the other, probes host-service health, and samples
+host-service and pty-daemon CPU/RSS. Two 60-sample runs at 150 ms intervals moved
+279–288 MB through the subscribed flood terminal during each measured flood
+phase.
+
+| metric | baseline range | flood range |
+|---|---:|---:|
+| probe echo p50 | 8.1–8.7 ms | 9.2–9.3 ms |
+| probe echo p95 | 10.3–11.0 ms | 12.5–18.3 ms |
+| probe echo p99 | 11.4–19.4 ms | 21.1–52.5 ms |
+| host health p99 | 0.9–1.2 ms | 1.4–1.5 ms |
+| host-service CPU p95 | 4.6–9.5% | 88.9–89.3% |
+| pty-daemon CPU p95 | 0.9% | 83.2–84.0% |
+| probe/flood sockets | both open | both open |
+
+The transport now survives the load and the second terminal remains responsive.
+The flood is deliberately more aggressive than normal TUI output: it saturates
+most of a core in each process, but does not produce sustained health or echo
+latency above the ~20 ms promotion threshold. The one 52.5 ms p99 echo sample
+was a single tail sample; p95 remained below 20 ms in both runs. Do not add the
+pinned-worker/ModeTracker architecture from this plan based on these numbers.
+Keep the harness for regression measurements and reconsider only with a
+realistic workload that shows sustained loop coupling.
+
+## Cross-worker background fetch coordination — 2026-07-19
+
+Moving status snapshots into workers accidentally made the base-ref freshness
+Maps worker-local. Parallel worktrees sharing one Git common directory could
+therefore launch redundant background fetches. The main host-service thread now
+owns the common-dir TTL/in-flight coordinator again; the actual network fetch is
+still submitted to the worker pool. This restores process-wide deduplication
+without moving Git I/O back onto the host-service loop.
 
 ---
 

--- a/plans/20260717-host-service-git-worker-pool.md
+++ b/plans/20260717-host-service-git-worker-pool.md
@@ -13,9 +13,9 @@
 | 3 | Background `getStatus` takes 3.7–14.6s under churn — limiter queueing at concurrency 4 | UX staleness | Pool makes raising limiter concurrency safe |
 | 4 | Big-diff snapshot ≈1.2s (2k files) but does NOT stall the loop | Minor | Phase 1 offload, comes with #2/#3 infra |
 | 5 | Renderer freezes >60s under 8-workspace churn | Separate renderer workstream | Not host-service scope |
-| 6 | Extreme subscribed terminal floods saturate host-service and daemon CPU | Measured | No sustained loop coupling; do not build a pinned worker yet |
+| 6 | Extreme subscribed terminal floods saturate host-service and daemon CPU and raise second-terminal echo p95 to 48.5 ms | Loop health | Attribute ModeTracker/hint scan, then test a pinned worker |
 
-**Outcome:** #1 and the worker-pool/watcher-path work shipped; limiter concurrency stays at 4 because 6 did not improve completion time. The post-#5747 terminal rerun below rejects a pinned ModeTracker worker for now. #5 remains a separate renderer-side effort.
+**Outcome:** #1 and the worker-pool/watcher-path work shipped; limiter concurrency stays at 4 because a concurrency of 6 did not improve completion time. The authenticated post-#5747 terminal rerun below reproduces cross-terminal coupling and promotes ModeTracker attribution/pinned-worker work. #5 remains a separate renderer-side effort.
 
 ## Post-implementation measurement — 2026-07-18
 
@@ -50,28 +50,34 @@ increased subprocess pressure.
 The shared-socket backpressure fix landed in #5747. A reusable CDP harness now
 attaches real WebSocket consumers to two PTYs, floods one with continuous SGR
 output, probes echo latency on the other, probes host-service health, and samples
-host-service and pty-daemon CPU/RSS. Two 60-sample runs at 150 ms intervals moved
-279–288 MB through the subscribed flood terminal during each measured flood
-phase.
+host-service and pty-daemon CPU/RSS. The harness requires an authenticated CDP
+session and resolves the active organization through the renderer's real auth
+client; it has no organization-ID bypass.
 
-| metric | baseline range | flood range |
+The first two full runs used an explicit organization while the workspace API
+was misconfigured. They established transport survival but are not accepted as
+the final renderer reproduction. After refreshing the workspace Neon branch,
+clearing a corrupt generated API cache, and verifying the renderer on its real
+workspace route, a settled authenticated 60-sample run at 150 ms intervals
+moved 326 MB through the subscribed flood terminal:
+
+| metric | authenticated baseline | authenticated flood |
 |---|---:|---:|
-| probe echo p50 | 8.1–8.7 ms | 9.2–9.3 ms |
-| probe echo p95 | 10.3–11.0 ms | 12.5–18.3 ms |
-| probe echo p99 | 11.4–19.4 ms | 21.1–52.5 ms |
-| host health p99 | 0.9–1.2 ms | 1.4–1.5 ms |
-| host-service CPU p95 | 4.6–9.5% | 88.9–89.3% |
-| pty-daemon CPU p95 | 0.9% | 83.2–84.0% |
+| probe echo p50 | 8.7 ms | 12.3 ms |
+| probe echo p95 | 15.8 ms | **48.5 ms** |
+| probe echo p99 | 153.6 ms | 148.4 ms |
+| host health p95 | 2.5 ms | 4.9 ms |
+| host health p99 | 8.4 ms | **81.7 ms** |
+| host-service CPU p95 | 27.1% | **86.9%** |
+| pty-daemon CPU p95 | 1.6% | 76.1% |
 | probe/flood sockets | both open | both open |
 
-The transport now survives the load and the second terminal remains responsive.
-The flood is deliberately more aggressive than normal TUI output: it saturates
-most of a core in each process, but does not produce sustained health or echo
-latency above the ~20 ms promotion threshold. The one 52.5 ms p99 echo sample
-was a single tail sample; p95 remained below 20 ms in both runs. Do not add the
-pinned-worker/ModeTracker architecture from this plan based on these numbers.
-Keep the harness for regression measurements and reconsider only with a
-realistic workload that shows sustained loop coupling.
+The transport now survives the load, confirming #5747, but the second terminal
+shows sustained coupling above the ~20 ms promotion threshold. Promote the
+ModeTracker/hint-scan attribution work and a pinned-worker experiment. The
+flood is deliberately more aggressive than normal TUI output, so use the same
+harness to compare the experiment and require a material echo-p95 improvement
+without regressing attach/preamble behavior before shipping the architecture.
 
 ## Cross-worker background fetch coordination — 2026-07-19
 


### PR DESCRIPTION
## What

- restore process-wide TTL/in-flight coordination for background base-ref fetches across worker-backed status snapshots
- keep the actual network fetch in the host worker pool
- add a reusable CDP terminal-flood profiler and record two post-#5747 measurements
- update the worker-pool plan with the measured decision not to add a pinned ModeTracker worker

## Why

Moving status computation into worker threads made the base-ref freshness maps worker-local. Worktrees sharing one Git common directory could therefore launch redundant fetches. The coordinator now lives on the host-service main thread while the network operation remains off-loop.

The earlier terminal measurement was blocked by the shared daemon socket disconnect. After #5747, two full reruns moved 279–288 MB per flood phase while both terminal sockets survived. Host health p99 stayed at 1.4–1.5 ms and probe echo p95 stayed at 12.5–18.3 ms, so a pinned terminal worker is not justified by current evidence.

## Validation

- `bun run lint`
- 37 focused host-service tests, including worker parity, graph purity, limiter/watcher coverage, and cross-worktree fetch dedupe
- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd packages/host-service build:host`
- two 60-sample CDP terminal flood profiles at 150 ms intervals

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores process-wide coordination of background base-ref fetches across worker-backed status snapshots, and adds an authenticated CDP terminal flood profiler with isolated echo latency sampling. Network I/O stays in the worker pool; the coordinator runs on the host-service main thread and dedupes by Git common dir.

- **Bug Fixes**
  - Reintroduce common-dir TTL/in-flight coordination for base-ref fetches across worktrees.
  - `gitStatusSnapshotTask` now returns `{ snapshot, baseRefFetchTarget }`; `git.getStatus` schedules fetch via `scheduleBaseRefFetch` and runs it in a worker with `gitFetchBaseRefTask` (coalesced by a dedupe key).
  - Ensure cross-worktree dedupe by keying on Git common directory; add test coverage.
  - Update callers/tests to use `result.snapshot`.

- **New Features**
  - Add `apps/desktop/scripts/cdp-terminal-flood-profile.ts` and `profile:terminal-flood` script; requires an authenticated renderer session (cookie or bearer via `authClient`), isolates echo RTT sampling, and writes JSON summaries; update `apps/desktop/AGENTS.md`.
  - Update the plan with post-#5747 measurements: transport survives floods, but second-terminal coupling persists; promote ModeTracker attribution and a pinned-worker experiment.

<sup>Written for commit 282645c5fbf747fd5732e447275972dd4272851c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Git status now schedules a coordinated background refresh of outdated base-branch info after the initial snapshot, improving result freshness without delaying the first response.
  - Refresh work is de-duplicated across worktrees that share the same underlying Git common directory.

- **Documentation**
  - Updated desktop CDP authentication troubleshooting for local vs non-local workspaces, including safer session verification and recovery guidance.

- **Tools**
  - Added a terminal performance profiling harness (with a new npm script) to measure echo latency and flood behavior under sustained output.

- **Tests**
  - Updated git worker-pool and snapshot-shape assertions to match the new computation result format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->