### PR TITLE
chore(desktop): fleet memory telemetry — periodic resource_snapshot to PostHog

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -36,6 +36,10 @@ import { getHostServiceCoordinator } from "./lib/host-service-coordinator";
 import { localDb } from "./lib/local-db";
 import { requestLocalNetworkAccess } from "./lib/local-network-permission";
 import {
+	startMemoryTelemetry,
+	stopMemoryTelemetry,
+} from "./lib/memory-telemetry";
+import {
 	initTanstackDbPersistence,
 	shutdownTanstackDbPersistence,
 } from "./lib/persistence/persistence";
@@ -225,6 +229,7 @@ app.on("before-quit", async (event) => {
 
 	isQuitting = true;
 	try {
+		stopMemoryTelemetry();
 		getHostServiceCoordinator().stopAll();
 		if (isDev || forceFullCleanup) {
 			await teardownTerminalHost();
@@ -446,6 +451,7 @@ if (!gotTheLock) {
 
 		await makeAppSetup(() => MainWindow());
 		setupAutoUpdater();
+		startMemoryTelemetry();
 		initTray();
 
 		const coldStartUrl = findDeepLinkInArgv(process.argv);

--- a/apps/desktop/src/main/lib/memory-telemetry/index.ts
+++ b/apps/desktop/src/main/lib/memory-telemetry/index.ts
@@ -1,0 +1,1 @@
+export * from "./memory-telemetry";

--- a/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.test.ts
+++ b/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.test.ts
@@ -49,6 +49,7 @@ function createDeps(overrides: Partial<MemoryTelemetryDeps> = {}): {
 
 afterEach(() => {
 	stopMemoryTelemetry();
+	jest.useRealTimers();
 });
 
 describe("buildResourceSnapshot", () => {
@@ -115,47 +116,35 @@ describe("emitResourceSnapshot payload allowlist", () => {
 describe("startMemoryTelemetry cadence", () => {
 	it("emits on the ~5-minute cadence and keeps ticking", () => {
 		jest.useFakeTimers();
-		try {
-			const { deps, calls } = createDeps();
-			startMemoryTelemetry(deps);
+		const { deps, calls } = createDeps();
+		startMemoryTelemetry(deps);
 
-			expect(calls).toHaveLength(0);
-			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
-			expect(calls).toHaveLength(1);
-			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
-			expect(calls).toHaveLength(2);
-		} finally {
-			jest.useRealTimers();
-		}
+		expect(calls).toHaveLength(0);
+		jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
+		expect(calls).toHaveLength(1);
+		jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
+		expect(calls).toHaveLength(2);
 	});
 
 	it("does not create a duplicate timer when started twice", () => {
 		jest.useFakeTimers();
-		try {
-			const { deps, calls } = createDeps();
-			startMemoryTelemetry(deps);
-			startMemoryTelemetry(deps);
+		const { deps, calls } = createDeps();
+		startMemoryTelemetry(deps);
+		startMemoryTelemetry(deps);
 
-			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
-			expect(calls).toHaveLength(1); // one tick, not two
-		} finally {
-			jest.useRealTimers();
-		}
+		jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
+		expect(calls).toHaveLength(1); // one tick, not two
 	});
 });
 
 describe("startMemoryTelemetry disabled state", () => {
 	it("never schedules or emits when disabled", () => {
 		jest.useFakeTimers();
-		try {
-			const { deps, calls } = createDeps({ isEnabled: () => false });
-			startMemoryTelemetry(deps);
+		const { deps, calls } = createDeps({ isEnabled: () => false });
+		startMemoryTelemetry(deps);
 
-			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS * 10);
-			expect(calls).toHaveLength(0);
-		} finally {
-			jest.useRealTimers();
-		}
+		jest.advanceTimersByTime(SAMPLE_INTERVAL_MS * 10);
+		expect(calls).toHaveLength(0);
 	});
 
 	it("is disabled under the test environment by default", () => {
@@ -177,19 +166,15 @@ describe("startMemoryTelemetry disabled state", () => {
 describe("stopMemoryTelemetry cleanup", () => {
 	it("stops emitting after cleanup", () => {
 		jest.useFakeTimers();
-		try {
-			const { deps, calls } = createDeps();
-			startMemoryTelemetry(deps);
+		const { deps, calls } = createDeps();
+		startMemoryTelemetry(deps);
 
-			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
-			expect(calls).toHaveLength(1);
+		jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
+		expect(calls).toHaveLength(1);
 
-			stopMemoryTelemetry();
-			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS * 5);
-			expect(calls).toHaveLength(1); // no further ticks
-		} finally {
-			jest.useRealTimers();
-		}
+		stopMemoryTelemetry();
+		jest.advanceTimersByTime(SAMPLE_INTERVAL_MS * 5);
+		expect(calls).toHaveLength(1); // no further ticks
 	});
 
 	it("unrefs the pending timer so it can't keep the process alive", () => {

--- a/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.test.ts
+++ b/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it, jest, mock } from "bun:test";
+import {
+	buildResourceSnapshot,
+	emitResourceSnapshot,
+	isMemoryTelemetryEnabled,
+	type MemoryTelemetryDeps,
+	RESOURCE_SNAPSHOT_EVENT,
+	RESOURCE_SNAPSHOT_KEYS,
+	SAMPLE_INTERVAL_MS,
+	startMemoryTelemetry,
+	stopMemoryTelemetry,
+} from "./memory-telemetry";
+
+type TrackCall = { event: string; properties: Record<string, number> };
+
+function createDeps(overrides: Partial<MemoryTelemetryDeps> = {}): {
+	deps: MemoryTelemetryDeps;
+	calls: TrackCall[];
+} {
+	const calls: TrackCall[] = [];
+	const deps: MemoryTelemetryDeps = {
+		getAppMetrics: () =>
+			[
+				{ type: "Browser", memory: { workingSetSize: 100 } },
+				{ type: "Tab", memory: { workingSetSize: 200 } },
+				{ type: "Renderer", memory: { workingSetSize: 300 } },
+				{ type: "GPU", memory: { workingSetSize: 50 } },
+				// biome-ignore lint/suspicious/noExplicitAny: minimal ProcessMetric stub
+			] as any,
+		getMemoryUsage: () =>
+			({
+				rss: 1_000,
+				heapTotal: 800,
+				heapUsed: 500,
+				external: 40,
+				arrayBuffers: 20,
+				// biome-ignore lint/suspicious/noExplicitAny: minimal MemoryUsage stub
+			}) as any,
+		getUptimeSeconds: () => 123.7,
+		getWindowCount: () => 2,
+		getWebContentsCount: () => 5,
+		track: (event, properties) => calls.push({ event, properties }),
+		isEnabled: () => true,
+		random: () => 0,
+		...overrides,
+	};
+	return { deps, calls };
+}
+
+afterEach(() => {
+	stopMemoryTelemetry();
+});
+
+describe("buildResourceSnapshot", () => {
+	it("aggregates Electron process classes and process memory", () => {
+		const { deps } = createDeps();
+		const snapshot = buildResourceSnapshot(deps);
+
+		// Browser -> main, Tab + Renderer -> renderer, GPU -> other. KB -> bytes.
+		expect(snapshot.electron_main_rss_bytes).toBe(100 * 1024);
+		expect(snapshot.electron_renderer_rss_bytes).toBe((200 + 300) * 1024);
+		expect(snapshot.electron_other_rss_bytes).toBe(50 * 1024);
+		expect(snapshot.electron_total_rss_bytes).toBe(
+			(100 + 200 + 300 + 50) * 1024,
+		);
+
+		expect(snapshot.electron_main_process_count).toBe(1);
+		expect(snapshot.electron_renderer_process_count).toBe(2);
+		expect(snapshot.electron_other_process_count).toBe(1);
+		expect(snapshot.electron_process_count).toBe(4);
+
+		expect(snapshot.process_rss_bytes).toBe(1_000);
+		expect(snapshot.process_heap_used_bytes).toBe(500);
+		expect(snapshot.process_array_buffers_bytes).toBe(20);
+
+		expect(snapshot.uptime_seconds).toBe(124); // rounded
+		expect(snapshot.window_count).toBe(2);
+		expect(snapshot.web_contents_count).toBe(5);
+	});
+});
+
+describe("emitResourceSnapshot payload allowlist", () => {
+	it("emits only allowlisted keys and every value is a finite number", () => {
+		const { deps, calls } = createDeps();
+		emitResourceSnapshot(deps);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].event).toBe(RESOURCE_SNAPSHOT_EVENT);
+
+		const keys = Object.keys(calls[0].properties);
+		const allowlist = new Set<string>(RESOURCE_SNAPSHOT_KEYS);
+		for (const key of keys) {
+			expect(allowlist.has(key)).toBe(true);
+		}
+		for (const value of Object.values(calls[0].properties)) {
+			expect(typeof value).toBe("number");
+			expect(Number.isFinite(value)).toBe(true);
+		}
+
+		// No string/identifier-shaped fields could ever slip through.
+		const forbidden = /id|name|path|command|repo|url|user|org|title/i;
+		expect(keys.some((key) => forbidden.test(key))).toBe(false);
+	});
+
+	it("drops non-finite values instead of emitting them", () => {
+		const { deps, calls } = createDeps({
+			getUptimeSeconds: () => Number.NaN,
+		});
+		emitResourceSnapshot(deps);
+
+		expect("uptime_seconds" in calls[0].properties).toBe(false);
+	});
+});
+
+describe("startMemoryTelemetry cadence", () => {
+	it("emits on the ~5-minute cadence and keeps ticking", () => {
+		jest.useFakeTimers();
+		try {
+			const { deps, calls } = createDeps();
+			startMemoryTelemetry(deps);
+
+			expect(calls).toHaveLength(0);
+			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
+			expect(calls).toHaveLength(1);
+			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
+			expect(calls).toHaveLength(2);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it("does not create a duplicate timer when started twice", () => {
+		jest.useFakeTimers();
+		try {
+			const { deps, calls } = createDeps();
+			startMemoryTelemetry(deps);
+			startMemoryTelemetry(deps);
+
+			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
+			expect(calls).toHaveLength(1); // one tick, not two
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+});
+
+describe("startMemoryTelemetry disabled state", () => {
+	it("never schedules or emits when disabled", () => {
+		jest.useFakeTimers();
+		try {
+			const { deps, calls } = createDeps({ isEnabled: () => false });
+			startMemoryTelemetry(deps);
+
+			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS * 10);
+			expect(calls).toHaveLength(0);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it("is disabled under the test environment by default", () => {
+		// NODE_ENV is "test" while this suite runs.
+		expect(isMemoryTelemetryEnabled()).toBe(false);
+
+		const prev = process.env.NODE_ENV;
+		try {
+			process.env.NODE_ENV = "development";
+			expect(isMemoryTelemetryEnabled()).toBe(false);
+			process.env.NODE_ENV = "production";
+			expect(isMemoryTelemetryEnabled()).toBe(true);
+		} finally {
+			process.env.NODE_ENV = prev;
+		}
+	});
+});
+
+describe("stopMemoryTelemetry cleanup", () => {
+	it("stops emitting after cleanup", () => {
+		jest.useFakeTimers();
+		try {
+			const { deps, calls } = createDeps();
+			startMemoryTelemetry(deps);
+
+			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS);
+			expect(calls).toHaveLength(1);
+
+			stopMemoryTelemetry();
+			jest.advanceTimersByTime(SAMPLE_INTERVAL_MS * 5);
+			expect(calls).toHaveLength(1); // no further ticks
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it("unrefs the pending timer so it can't keep the process alive", () => {
+		const unref = mock(() => {});
+		const realSetTimeout = globalThis.setTimeout;
+		const setTimeoutSpy = mock((fn: () => void, ms?: number) => {
+			const handle = realSetTimeout(fn, ms);
+			(handle as { unref?: () => void }).unref = unref;
+			return handle;
+		});
+		globalThis.setTimeout = setTimeoutSpy as unknown as typeof setTimeout;
+		try {
+			const { deps } = createDeps();
+			startMemoryTelemetry(deps);
+			expect(unref).toHaveBeenCalledTimes(1);
+		} finally {
+			globalThis.setTimeout = realSetTimeout;
+			stopMemoryTelemetry();
+		}
+	});
+});

--- a/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.ts
+++ b/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.ts
@@ -65,7 +65,7 @@ export interface MemoryTelemetryDeps {
 }
 
 function normalizeBytes(value: number | undefined): number {
-	return typeof value === "number" && Number.isFinite(value) && value > 0
+	return typeof value === "number" && Number.isFinite(value) && value >= 0
 		? value
 		: 0;
 }
@@ -152,8 +152,10 @@ export function buildResourceSnapshot(
 
 /**
  * Emit one snapshot, filtered to exactly the allowlisted numeric keys.
+ * Honors the enabled gate itself so any direct caller can't bypass it.
  */
 export function emitResourceSnapshot(deps: MemoryTelemetryDeps): void {
+	if (!deps.isEnabled()) return;
 	const snapshot = buildResourceSnapshot(deps);
 	const payload: Record<string, number> = {};
 	for (const key of RESOURCE_SNAPSHOT_KEYS) {

--- a/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.ts
+++ b/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.ts
@@ -1,0 +1,207 @@
+// Namespace import (not named) so this module links even when a test replaces
+// the `electron` mock with a shape missing some exports — the real values are
+// only dereferenced lazily inside defaultDeps at runtime.
+import * as electron from "electron";
+import { track } from "main/lib/analytics";
+import { DEFAULT_TELEMETRY_ENABLED } from "shared/constants";
+
+/**
+ * Privacy-safe aggregate memory telemetry (SUPER-1550).
+ *
+ * Every ~5 minutes the main process emits one flat, numbers-only
+ * `resource_snapshot` event so the fleet has memory percentiles to reason
+ * about (renderer RSS vs process/window/webview counts, release regressions,
+ * before/after proof for perf fixes).
+ *
+ * Hard privacy rules — the payload NEVER contains IDs, names, paths, commands,
+ * repo/terminal/user data, or anything derived from them. It is only Electron
+ * process-class RSS (via `app.getAppMetrics()`, no subprocess), this process's
+ * heap/RSS (`process.memoryUsage()`), uptime, and a handful of bounded counts.
+ * Sampling never spawns `ps` — `getAppMetrics()` reads Electron internals.
+ */
+export const RESOURCE_SNAPSHOT_EVENT = "resource_snapshot";
+
+// ~5 minutes between samples.
+export const SAMPLE_INTERVAL_MS = 5 * 60_000;
+// Up to 60s of extra delay per tick so the fleet never emits in lockstep.
+export const SAMPLE_JITTER_MS = 60_000;
+
+/**
+ * The complete set of properties this event may ever carry. Emission filters
+ * the payload down to exactly these keys, and each value must be a finite
+ * number — a hard allowlist that makes leaking non-aggregate data impossible.
+ */
+export const RESOURCE_SNAPSHOT_KEYS = [
+	"uptime_seconds",
+	"process_rss_bytes",
+	"process_heap_used_bytes",
+	"process_heap_total_bytes",
+	"process_external_bytes",
+	"process_array_buffers_bytes",
+	"electron_total_rss_bytes",
+	"electron_main_rss_bytes",
+	"electron_renderer_rss_bytes",
+	"electron_other_rss_bytes",
+	"electron_process_count",
+	"electron_main_process_count",
+	"electron_renderer_process_count",
+	"electron_other_process_count",
+	"window_count",
+	"web_contents_count",
+] as const;
+
+export type ResourceSnapshotKey = (typeof RESOURCE_SNAPSHOT_KEYS)[number];
+export type ResourceSnapshot = Record<ResourceSnapshotKey, number>;
+
+export interface MemoryTelemetryDeps {
+	getAppMetrics: () => Electron.ProcessMetric[];
+	getMemoryUsage: () => NodeJS.MemoryUsage;
+	getUptimeSeconds: () => number;
+	getWindowCount: () => number;
+	getWebContentsCount: () => number;
+	track: (event: string, properties: Record<string, number>) => void;
+	isEnabled: () => boolean;
+	random: () => number;
+}
+
+function normalizeBytes(value: number | undefined): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? value
+		: 0;
+}
+
+function isRendererProcessType(type: string): boolean {
+	const normalized = type.toLowerCase();
+	return normalized === "renderer" || normalized === "tab";
+}
+
+/**
+ * Telemetry is off in test and dev so analytics only reflects real usage, and
+ * honors the global telemetry-enabled flag. `track()` additionally no-ops
+ * until a user is identified and a PostHog key is configured.
+ */
+export function isMemoryTelemetryEnabled(): boolean {
+	const nodeEnv = process.env.NODE_ENV;
+	if (nodeEnv === "test" || nodeEnv === "development") return false;
+	return DEFAULT_TELEMETRY_ENABLED;
+}
+
+const defaultDeps: MemoryTelemetryDeps = {
+	getAppMetrics: () => electron.app.getAppMetrics(),
+	getMemoryUsage: () => process.memoryUsage(),
+	getUptimeSeconds: () => process.uptime(),
+	getWindowCount: () => electron.BrowserWindow.getAllWindows().length,
+	getWebContentsCount: () => electron.webContents.getAllWebContents().length,
+	track,
+	isEnabled: isMemoryTelemetryEnabled,
+	random: Math.random,
+};
+
+/**
+ * Build the aggregate snapshot. Electron reports `workingSetSize` in KB;
+ * everything here is bytes/seconds/counts and nothing else.
+ */
+export function buildResourceSnapshot(
+	deps: MemoryTelemetryDeps,
+): ResourceSnapshot {
+	const mem = deps.getMemoryUsage();
+
+	let mainRss = 0;
+	let rendererRss = 0;
+	let otherRss = 0;
+	let mainCount = 0;
+	let rendererCount = 0;
+	let otherCount = 0;
+
+	for (const proc of deps.getAppMetrics()) {
+		const rss = normalizeBytes(proc.memory?.workingSetSize) * 1024;
+		if (proc.type === "Browser") {
+			mainRss += rss;
+			mainCount += 1;
+		} else if (
+			typeof proc.type === "string" &&
+			isRendererProcessType(proc.type)
+		) {
+			rendererRss += rss;
+			rendererCount += 1;
+		} else {
+			otherRss += rss;
+			otherCount += 1;
+		}
+	}
+
+	return {
+		uptime_seconds: Math.round(deps.getUptimeSeconds()),
+		process_rss_bytes: normalizeBytes(mem.rss),
+		process_heap_used_bytes: normalizeBytes(mem.heapUsed),
+		process_heap_total_bytes: normalizeBytes(mem.heapTotal),
+		process_external_bytes: normalizeBytes(mem.external),
+		process_array_buffers_bytes: normalizeBytes(mem.arrayBuffers),
+		electron_total_rss_bytes: mainRss + rendererRss + otherRss,
+		electron_main_rss_bytes: mainRss,
+		electron_renderer_rss_bytes: rendererRss,
+		electron_other_rss_bytes: otherRss,
+		electron_process_count: mainCount + rendererCount + otherCount,
+		electron_main_process_count: mainCount,
+		electron_renderer_process_count: rendererCount,
+		electron_other_process_count: otherCount,
+		window_count: deps.getWindowCount(),
+		web_contents_count: deps.getWebContentsCount(),
+	};
+}
+
+/**
+ * Emit one snapshot, filtered to exactly the allowlisted numeric keys.
+ */
+export function emitResourceSnapshot(deps: MemoryTelemetryDeps): void {
+	const snapshot = buildResourceSnapshot(deps);
+	const payload: Record<string, number> = {};
+	for (const key of RESOURCE_SNAPSHOT_KEYS) {
+		const value = snapshot[key];
+		if (typeof value === "number" && Number.isFinite(value)) {
+			payload[key] = value;
+		}
+	}
+	deps.track(RESOURCE_SNAPSHOT_EVENT, payload);
+}
+
+let sampleTimer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+function scheduleNext(deps: MemoryTelemetryDeps): void {
+	const delay =
+		SAMPLE_INTERVAL_MS + Math.floor(deps.random() * SAMPLE_JITTER_MS);
+	sampleTimer = setTimeout(() => {
+		try {
+			emitResourceSnapshot(deps);
+		} catch {
+			// Telemetry must never crash the app; drop the sample.
+		}
+		if (running) scheduleNext(deps);
+	}, delay);
+	// Never keep the process alive for a telemetry sample.
+	sampleTimer.unref?.();
+}
+
+/**
+ * Start the periodic sampler. Idempotent: a second call while already running
+ * is a no-op, so startup + HMR re-entry can't create duplicate timers.
+ */
+export function startMemoryTelemetry(
+	overrides?: Partial<MemoryTelemetryDeps>,
+): void {
+	if (running) return;
+	const deps = { ...defaultDeps, ...overrides };
+	if (!deps.isEnabled()) return;
+	running = true;
+	scheduleNext(deps);
+}
+
+/** Stop the sampler and clear the pending timer. */
+export function stopMemoryTelemetry(): void {
+	running = false;
+	if (sampleTimer) {
+		clearTimeout(sampleTimer);
+		sampleTimer = null;
+	}
+}

--- a/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.ts
+++ b/apps/desktop/src/main/lib/memory-telemetry/memory-telemetry.ts
@@ -21,7 +21,6 @@ import { DEFAULT_TELEMETRY_ENABLED } from "shared/constants";
  */
 export const RESOURCE_SNAPSHOT_EVENT = "resource_snapshot";
 
-// ~5 minutes between samples.
 export const SAMPLE_INTERVAL_MS = 5 * 60_000;
 // Up to 60s of extra delay per tick so the fleet never emits in lockstep.
 export const SAMPLE_JITTER_MS = 60_000;
@@ -97,10 +96,7 @@ const defaultDeps: MemoryTelemetryDeps = {
 	random: Math.random,
 };
 
-/**
- * Build the aggregate snapshot. Electron reports `workingSetSize` in KB;
- * everything here is bytes/seconds/counts and nothing else.
- */
+// Electron reports `workingSetSize` in KB, hence the `* 1024`.
 export function buildResourceSnapshot(
 	deps: MemoryTelemetryDeps,
 ): ResourceSnapshot {


### PR DESCRIPTION
## What

Adds a privacy-safe aggregate memory telemetry sampler in the desktop **main process** (SUPER-1550). Every ~5 minutes it emits one flat, numbers-only `resource_snapshot` PostHog event so we finally have fleet memory data (renderer RSS vs process/window/webview counts, release-over-release regression detection, before/after proof for perf fixes). ~12 tiny events/user/hour.

Closes SUPER-1550.

## Schema — `resource_snapshot`

All properties are finite numbers. Enforced by the `RESOURCE_SNAPSHOT_KEYS` allowlist; emission filters the payload to exactly these keys.

| key | source |
| --- | --- |
| `uptime_seconds` | `process.uptime()` (rounded) |
| `process_rss_bytes`, `process_heap_used_bytes`, `process_heap_total_bytes`, `process_external_bytes`, `process_array_buffers_bytes` | `process.memoryUsage()` |
| `electron_main_rss_bytes`, `electron_renderer_rss_bytes`, `electron_other_rss_bytes`, `electron_total_rss_bytes` | `app.getAppMetrics()` by process class (KB→bytes) |
| `electron_main_process_count`, `electron_renderer_process_count`, `electron_other_process_count`, `electron_process_count` | `app.getAppMetrics()` counts |
| `window_count` | `BrowserWindow.getAllWindows().length` |
| `web_contents_count` | `webContents.getAllWebContents().length` |

(plus the standard `track()` context: `app_name`, `platform`, `desktop_version`.)

## Privacy

- **Hard allowlist**: `emitResourceSnapshot` copies only allowlisted keys whose value is a finite number. Anything else is structurally impossible to emit. A test asserts no key matches `/id|name|path|command|repo|url|user|org|title/i`.
- **No** IDs, names, paths, commands, or repo/terminal/user data — deliberately excluded terminal/workspace/org counts to avoid coupling to those subsystems and keep scope narrow.
- **No `ps` subprocess**: `app.getAppMetrics()` reads Electron internals; `process.memoryUsage()` is in-process. Never spawns per-sample process scans (does not touch the existing `resource-metrics` `ps` path).

## Perf / lifecycle

- Self-rescheduling `setTimeout` at ~5 min with up to 60s per-tick jitter (fleet doesn't emit in lockstep).
- `.unref()`ed — never keeps the process alive.
- Idempotent `startMemoryTelemetry()` (dup-timer guard) so startup + HMR re-entry can't double-schedule.
- `stopMemoryTelemetry()` wired into `before-quit` cleanup; `emit` is wrapped so a telemetry error can never crash the app.
- Gated off in test/dev and honors `DEFAULT_TELEMETRY_ENABLED`; `track()` additionally no-ops until a user is identified and a PostHog key is set.

`electron` is imported as a namespace and dereferenced lazily inside `defaultDeps`, so the module links in the test suite regardless of which per-file `electron` mock is active (a static named `import { webContents }` breaks when another test replaces the mock).

## Validation

- `bun test` (full desktop suite) — **2173 pass, 0 fail** across 221 files. The memory-telemetry unit tests (9) are fake-timer based and cover cadence, payload allowlist, disabled state, and cleanup/unref; each was verified to fail under a deliberate mutation (leaked key / broken cleanup).
- `bun run lint` — clean (0 warnings). `tsc --noEmit` — clean across all packages.
- **CDP (real dev app, this worktree)**: app boots with the telemetry wiring (Tray + notifications up, no crash); renderer renders the full signed-in workspace UI (no white screen); `resourceMetrics.getSnapshot` — which calls the same `app.getAppMetrics()` the sampler uses — returns valid live per-class RSS (main 425MB / renderer 735MB). The `resource_snapshot` emission itself is intentionally disabled in dev (gated, no PostHog key), so it is not observable in dev by design; that path is covered by the unit tests above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added privacy-safe, aggregated memory and resource usage telemetry to the desktop app.
  - Resource snapshots are collected periodically with an allowlisted set of numeric metrics.
  - Telemetry automatically starts on app startup and stops during app shutdown.

- **Reliability**
  - Telemetry emissions are guarded so failures won’t disrupt normal app operation.
  - Background sampling is prevented from keeping the app alive after shutdown.

- **Tests**
  - Added a comprehensive unit test suite covering snapshot building, emission rules, start/stop behavior, and enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->