### PR TITLE
perf(desktop): evict prior-org synced collections on org switch

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
@@ -10,7 +10,11 @@ import {
 import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import { MOCK_ORG_ID } from "shared/constants";
-import { getCollections, preloadCollections } from "./collections";
+import {
+	evictInactiveOrgCollections,
+	getCollections,
+	preloadCollections,
+} from "./collections";
 
 type CollectionsContextType = ReturnType<typeof getCollections> & {
 	switchOrganization: (organizationId: string) => Promise<void>;
@@ -54,6 +58,14 @@ export function CollectionsProvider({ children }: { children: ReactNode }) {
 
 	useEffect(() => {
 		preloadActiveOrganizationCollections(activeOrganizationId);
+		// Once the active org is current (its collections are already cached by the
+		// `collections` memo above, which runs during render), evict every prior
+		// org's set to free the synced tables they hold. This effect is the single
+		// trigger for all switch paths, including callers that set the active org
+		// directly without going through `switchOrganization`.
+		if (activeOrganizationId) {
+			evictInactiveOrgCollections(activeOrganizationId);
+		}
 	}, [activeOrganizationId]);
 
 	const collections = useMemo(

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -70,10 +70,7 @@ import {
 	type WorkspacesCreateInput,
 	workspaceLocalStateSchema,
 } from "./dashboardSidebarLocal";
-import {
-	type EvictableCollection,
-	evictInactiveOrgs,
-} from "./evictInactiveOrgs";
+import { evictInactiveOrgs } from "./evictInactiveOrgs";
 import { withReadHeal } from "./withReadHeal";
 
 const columnMapper = snakeCamelMapper();
@@ -970,15 +967,11 @@ export function evictInactiveOrgCollections(
 	activeOrganizationId: string,
 ): void {
 	evictInactiveOrgs(
-		// OrgCollections values are all `Collection`s exposing `cleanup()`.
-		collectionsCache as unknown as Map<
-			string,
-			Record<string, EvictableCollection>
-		>,
+		collectionsCache as unknown as Map<string, Record<string, unknown>>,
 		getCollectionsCacheKey(activeOrganizationId),
-		(orgKey, error) => {
+		(orgKey, collectionName, error) => {
 			console.error(
-				`[collections] Failed to clean up evicted collection for org ${orgKey}`,
+				`[collections] Failed to clean up evicted collection ${collectionName} for org ${orgKey}`,
 				error,
 			);
 		},

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -70,6 +70,10 @@ import {
 	type WorkspacesCreateInput,
 	workspaceLocalStateSchema,
 } from "./dashboardSidebarLocal";
+import {
+	type EvictableCollection,
+	evictInactiveOrgs,
+} from "./evictInactiveOrgs";
 import { withReadHeal } from "./withReadHeal";
 
 const columnMapper = snakeCamelMapper();
@@ -949,6 +953,36 @@ export function getCollections(organizationId: string) {
 		...orgCollections,
 		organizations: organizationsCollection,
 	};
+}
+
+/**
+ * Evict the collection sets of every cached org except `activeOrganizationId`,
+ * stopping their Electric/localStorage sync, clearing their in-memory rows, and
+ * dropping them from the cache. Call this when the active org changes so prior
+ * orgs stop holding entire synced tables in the heap.
+ *
+ * The shared `organizationsCollection` singleton lives outside `collectionsCache`
+ * and is never touched. Recovery is handled by `getCollections`, which rebuilds
+ * fresh instances (rehydrating cache-first from the untouched on-disk rows) when
+ * an evicted org is re-entered.
+ */
+export function evictInactiveOrgCollections(
+	activeOrganizationId: string,
+): void {
+	evictInactiveOrgs(
+		// OrgCollections values are all `Collection`s exposing `cleanup()`.
+		collectionsCache as unknown as Map<
+			string,
+			Record<string, EvictableCollection>
+		>,
+		getCollectionsCacheKey(activeOrganizationId),
+		(orgKey, error) => {
+			console.error(
+				`[collections] Failed to clean up evicted collection for org ${orgKey}`,
+				error,
+			);
+		},
+	);
 }
 
 export type AppCollections = ReturnType<typeof getCollections>;

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/evictInactiveOrgs.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/evictInactiveOrgs.test.ts
@@ -85,11 +85,19 @@ describe("evictInactiveOrgs", () => {
 			["org-A", prior],
 			["org-B", active],
 		]);
-		const errors: Array<{ orgKey: string; error: unknown }> = [];
+		const errors: Array<{
+			orgKey: string;
+			collectionName: string;
+			error: unknown;
+		}> = [];
 
-		const evicted = evictInactiveOrgs(cache, "org-B", (orgKey, error) => {
-			errors.push({ orgKey, error });
-		});
+		const evicted = evictInactiveOrgs(
+			cache,
+			"org-B",
+			(orgKey, collectionName, error) => {
+				errors.push({ orgKey, collectionName, error });
+			},
+		);
 
 		// The rejecting collection does not abort the sweep.
 		expect(evicted).toEqual(["org-A"]);
@@ -100,7 +108,29 @@ describe("evictInactiveOrgs", () => {
 		await flushMicrotasks();
 		expect(errors).toHaveLength(1);
 		expect(errors[0]?.orgKey).toBe("org-A");
+		// The failing collection is identified by name for traceable logs.
+		expect(errors[0]?.collectionName).toBe("tasks");
 		expect(errors[0]?.error).toBeInstanceOf(Error);
+	});
+
+	it("skips values without a cleanup() method (structural safety)", () => {
+		const prior: Record<string, unknown> = {
+			tasks: fakeCollection(),
+			// A non-collection field must not crash the sweep.
+			someConfig: { url: "x" },
+			nullish: null,
+		};
+		const active = fakeOrg();
+		const cache = new Map<string, Record<string, unknown>>([
+			["org-A", prior],
+			["org-B", active],
+		]);
+
+		const evicted = evictInactiveOrgs(cache, "org-B");
+
+		expect(evicted).toEqual(["org-A"]);
+		expect(cache.has("org-A")).toBe(false);
+		expect((prior.tasks as FakeCollection).cleanupCalls).toBe(1);
 	});
 
 	it("never evicts the active org across a rapid A→B→A switch", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/evictInactiveOrgs.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/evictInactiveOrgs.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type EvictableCollection,
+	evictInactiveOrgs,
+} from "./evictInactiveOrgs";
+
+interface FakeCollection extends EvictableCollection {
+	cleanupCalls: number;
+}
+
+function fakeCollection(
+	behavior: "resolve" | "reject" = "resolve",
+): FakeCollection {
+	const collection: FakeCollection = {
+		cleanupCalls: 0,
+		cleanup() {
+			collection.cleanupCalls += 1;
+			return behavior === "reject"
+				? Promise.reject(new Error("cleanup failed"))
+				: Promise.resolve();
+		},
+	};
+	return collection;
+}
+
+function fakeOrg(): Record<string, FakeCollection> {
+	return { tasks: fakeCollection(), projects: fakeCollection() };
+}
+
+// Let queued fire-and-forget cleanup rejections settle their `.catch`.
+const flushMicrotasks = () => Promise.resolve();
+
+describe("evictInactiveOrgs", () => {
+	it("leaves the active org untouched (identity)", () => {
+		const active = fakeOrg();
+		const cache = new Map([["org-A", active]]);
+
+		const evicted = evictInactiveOrgs(cache, "org-A");
+
+		expect(evicted).toEqual([]);
+		expect(cache.has("org-A")).toBe(true);
+		expect(active.tasks.cleanupCalls).toBe(0);
+		expect(active.projects.cleanupCalls).toBe(0);
+	});
+
+	it("evicts a prior org: cleans up every collection and drops it", () => {
+		const prior = fakeOrg();
+		const active = fakeOrg();
+		const cache = new Map([
+			["org-A", prior],
+			["org-B", active],
+		]);
+
+		const evicted = evictInactiveOrgs(cache, "org-B");
+
+		expect(evicted).toEqual(["org-A"]);
+		expect(cache.has("org-A")).toBe(false);
+		expect(cache.has("org-B")).toBe(true);
+		// Prior org fully torn down...
+		expect(prior.tasks.cleanupCalls).toBe(1);
+		expect(prior.projects.cleanupCalls).toBe(1);
+		// ...active org never touched.
+		expect(active.tasks.cleanupCalls).toBe(0);
+		expect(active.projects.cleanupCalls).toBe(0);
+	});
+
+	it("is a no-op when only the active org is cached (same-org switch)", () => {
+		const active = fakeOrg();
+		const cache = new Map([["org-A", active]]);
+
+		const evicted = evictInactiveOrgs(cache, "org-A");
+
+		expect(evicted).toEqual([]);
+		expect(cache.size).toBe(1);
+		expect(active.tasks.cleanupCalls).toBe(0);
+	});
+
+	it("survives a collection whose cleanup rejects (failed switch)", async () => {
+		const prior: Record<string, FakeCollection> = {
+			tasks: fakeCollection("reject"),
+			projects: fakeCollection("resolve"),
+		};
+		const active = fakeOrg();
+		const cache = new Map([
+			["org-A", prior],
+			["org-B", active],
+		]);
+		const errors: Array<{ orgKey: string; error: unknown }> = [];
+
+		const evicted = evictInactiveOrgs(cache, "org-B", (orgKey, error) => {
+			errors.push({ orgKey, error });
+		});
+
+		// The rejecting collection does not abort the sweep.
+		expect(evicted).toEqual(["org-A"]);
+		expect(cache.has("org-A")).toBe(false);
+		expect(prior.tasks.cleanupCalls).toBe(1);
+		expect(prior.projects.cleanupCalls).toBe(1);
+
+		await flushMicrotasks();
+		expect(errors).toHaveLength(1);
+		expect(errors[0]?.orgKey).toBe("org-A");
+		expect(errors[0]?.error).toBeInstanceOf(Error);
+	});
+
+	it("never evicts the active org across a rapid A→B→A switch", () => {
+		const orgA = fakeOrg();
+		const orgB = fakeOrg();
+		const cache = new Map<string, Record<string, FakeCollection>>([
+			["org-A", orgA],
+		]);
+
+		// A active, switch to B: B gets cached (as getCollections would), evict A.
+		cache.set("org-B", orgB);
+		expect(evictInactiveOrgs(cache, "org-B")).toEqual(["org-A"]);
+		expect(cache.has("org-A")).toBe(false);
+		expect(orgA.tasks.cleanupCalls).toBe(1);
+		expect(orgB.tasks.cleanupCalls).toBe(0);
+
+		// Switch back to A: a FRESH A instance is recreated (recoverable), evict B.
+		const orgAFresh = fakeOrg();
+		cache.set("org-A", orgAFresh);
+		expect(evictInactiveOrgs(cache, "org-A")).toEqual(["org-B"]);
+		expect(cache.has("org-B")).toBe(false);
+		expect(cache.has("org-A")).toBe(true);
+		// The re-entered active org is never cleaned up.
+		expect(orgAFresh.tasks.cleanupCalls).toBe(0);
+		expect(orgB.tasks.cleanupCalls).toBe(1);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/evictInactiveOrgs.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/evictInactiveOrgs.ts
@@ -1,0 +1,45 @@
+/**
+ * Minimal shape of a TanStack DB collection needed for eviction: the supported
+ * public `cleanup()` (stops sync + clears in-memory data). Kept dependency-free
+ * so this module — and its tests — never pulls in Electric/persistence/`window`.
+ */
+export interface EvictableCollection {
+	cleanup(): Promise<void>;
+}
+
+/**
+ * Evict every org in `cache` except `activeCacheKey`.
+ *
+ * For each inactive org: drop it from the cache, then `cleanup()` each of its
+ * collections (stops Electric/localStorage sync and clears the in-memory rows).
+ * Cleanup runs fire-and-forget because it tears sync down synchronously; the
+ * returned Promise only settles bookkeeping. Rejections are routed to
+ * `onCleanupError` so one bad collection never aborts the sweep.
+ *
+ * On-disk SQLite/localStorage rows are intentionally left untouched so a later
+ * switch back rehydrates cache-first (AGENTS.md §9). Removing the org from the
+ * cache means `getCollections` rebuilds fresh instances on return, which keeps
+ * rapid A→B→A switching recoverable and race-safe: the active org is never
+ * evicted, and a re-entered org gets brand-new instances rather than a
+ * half-disposed one.
+ *
+ * @returns the cache keys that were evicted.
+ */
+export function evictInactiveOrgs(
+	cache: Map<string, Record<string, EvictableCollection>>,
+	activeCacheKey: string,
+	onCleanupError?: (orgKey: string, error: unknown) => void,
+): string[] {
+	const evicted: string[] = [];
+	for (const [cacheKey, orgCollections] of cache) {
+		if (cacheKey === activeCacheKey) continue;
+		cache.delete(cacheKey);
+		evicted.push(cacheKey);
+		for (const collection of Object.values(orgCollections)) {
+			void collection.cleanup().catch((error) => {
+				onCleanupError?.(cacheKey, error);
+			});
+		}
+	}
+	return evicted;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/evictInactiveOrgs.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/evictInactiveOrgs.ts
@@ -7,14 +7,25 @@ export interface EvictableCollection {
 	cleanup(): Promise<void>;
 }
 
+function isEvictable(value: unknown): value is EvictableCollection {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { cleanup?: unknown }).cleanup === "function"
+	);
+}
+
 /**
  * Evict every org in `cache` except `activeCacheKey`.
  *
  * For each inactive org: drop it from the cache, then `cleanup()` each of its
  * collections (stops Electric/localStorage sync and clears the in-memory rows).
- * Cleanup runs fire-and-forget because it tears sync down synchronously; the
- * returned Promise only settles bookkeeping. Rejections are routed to
- * `onCleanupError` so one bad collection never aborts the sweep.
+ * Values without a `cleanup()` method are skipped, so the sweep stays safe even
+ * if `OrgCollections` later gains a non-collection field. Cleanup runs
+ * fire-and-forget because it tears sync down synchronously; the returned Promise
+ * only settles bookkeeping. Rejections are routed to `onCleanupError` (with the
+ * failing org key and collection name) so one bad collection never aborts the
+ * sweep.
  *
  * On-disk SQLite/localStorage rows are intentionally left untouched so a later
  * switch back rehydrates cache-first (AGENTS.md §9). Removing the org from the
@@ -25,19 +36,24 @@ export interface EvictableCollection {
  *
  * @returns the cache keys that were evicted.
  */
-export function evictInactiveOrgs(
-	cache: Map<string, Record<string, EvictableCollection>>,
+export function evictInactiveOrgs<T extends Record<string, unknown>>(
+	cache: Map<string, T>,
 	activeCacheKey: string,
-	onCleanupError?: (orgKey: string, error: unknown) => void,
+	onCleanupError?: (
+		orgKey: string,
+		collectionName: string,
+		error: unknown,
+	) => void,
 ): string[] {
 	const evicted: string[] = [];
 	for (const [cacheKey, orgCollections] of cache) {
 		if (cacheKey === activeCacheKey) continue;
 		cache.delete(cacheKey);
 		evicted.push(cacheKey);
-		for (const collection of Object.values(orgCollections)) {
+		for (const [collectionName, collection] of Object.entries(orgCollections)) {
+			if (!isEvictable(collection)) continue;
 			void collection.cleanup().catch((error) => {
-				onCleanupError?.(cacheKey, error);
+				onCleanupError?.(cacheKey, collectionName, error);
 			});
 		}
 	}


### PR DESCRIPTION
## What & why

Prior-org TanStack DB / Electric collections were **never freed**. The per-org `collectionsCache` Map in `collections.ts` had no delete path and `Collection.cleanup()` was never called, so every organization a user visited kept its **entire synced tables resident in the renderer heap for the whole session** (CDP-measured ~50 MB on the dev org alone; grows with org age and with each org a multi-org user visits).

This is **SUPER-1547a** — step 1 of [SUPER-1547](https://linear.app/superset-sh/issue/SUPER-1547). Steps 2 (trim preload) and 3 (window unbounded tables) are intentionally **out of scope** here.

## Change

- New pure helper `evictInactiveOrgs.ts` (dependency-free — no Electric/persistence/`window` imports, so it's unit-testable).
- `evictInactiveOrgCollections(activeOrgId)` in `collections.ts` calls it over the real cache.
- Triggered from the `activeOrganizationId` effect in `CollectionsProvider` — the **single** trigger that also covers the two callers that set the active org directly (`create-organization`, `MemberActions`) and bypass `switchOrganization`.

For each **inactive** org: `cleanup()` every collection (stops sync, clears in-memory rows) then drop it from the cache so instances are GC'd.

## Safety properties (verified against compiled library source, `@tanstack/db@0.6.14`)

- **Supported public API** — `Collection.cleanup(): Promise<void>` ("stops sync and clears data"). No private internals.
- **Race-safe for rapid A→B→A** — `cleanup()` tears the ShapeStream down **synchronously** (the Promise is just a resolved wrapper); the active org is never evicted; a re-entered org gets **fresh** instances, never a half-disposed one.
- **Recoverable** — lifecycle allows `cleaned-up → loading`; `getCollections` rebuilds fresh on return.
- **Never destroys shared/unrelated state** — the shared `organizations` collection lives outside the cache; the persisted-wrapper cleanup calls per-collection `runtime.cleanup()`, never the shared coordinator's `dispose()` (that's main-process shutdown only).
- **Cache-first preserved (AGENTS.md §9)** — on-disk SQLite/localStorage rows are left in place, so switching back rehydrates cache-first. No preload/windowing changes.

## Tests

`evictInactiveOrgs.test.ts` — 5 scenarios: **identity** (active untouched), **eviction** (inactive fully cleaned + dropped), **same-org** (no-op), **failed switch** (one rejecting `cleanup()` doesn't abort the sweep; error routed), **rapid A→B→A** (active org never cleaned across the sequence). Each verified to fail under mutated impl.

## Verification notes

- ✅ `bun run lint` clean, `tsc --noEmit` clean, `bun test` (26 pass in this dir).
- ✅ **Drove the real `evictInactiveOrgCollections` end-to-end on this worktree's live dev stack via CDP** — before/after results (prior org `ready`+resident → `cleaned-up`+evicted, active org untouched, recovery to `ready`) are in the [CDP verification comment](https://github.com/superset-sh/superset/pull/5778#issuecomment-5016793545). Single-org dev account, so a synthetic prior org was used against the real Electric/persistence stack (active org kept — never evicted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved organization switching by automatically clearing cached collection data for inactive organizations, keeping the active organization intact for faster continuity.
  * Reduced retained in-memory collection state so revisiting an organization reloads fresh collection instances.

* **Reliability**
  * Eviction/cleanup now tolerates failures: if cleanup for an inactive organization fails, eviction still completes for the rest and the error is reported without interrupting switching.

* **Tests**
  * Added coverage for inactive-organization eviction behavior, including rapid switching and cleanup failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->