### PR TITLE
feat(desktop): add close-all ports workspace action

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -152,6 +152,7 @@ export function DashboardSidebarWorkspaceItem({
 						content
 					) : (
 						<DashboardSidebarWorkspaceContextMenu
+							workspaceId={id}
 							projectId={projectId}
 							isInSection={isInSection}
 							isUnread={isUnread}
@@ -248,6 +249,7 @@ export function DashboardSidebarWorkspaceItem({
 					expandedContent
 				) : (
 					<DashboardSidebarWorkspaceContextMenu
+						workspaceId={id}
 						projectId={projectId}
 						isInSection={isInSection}
 						isUnread={isUnread}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -22,14 +22,18 @@ import {
 	LuFolderPlus,
 	LuGitBranch,
 	LuPencil,
+	LuRadioTower,
 	LuTrash2,
 	LuX,
 } from "react-icons/lu";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useDashboardSidebarHover } from "../../../../providers/DashboardSidebarHoverProvider";
+import { useDashboardSidebarWorkspacePorts } from "../../../../providers/DashboardSidebarPortsProvider";
+import { useDashboardSidebarPortKill } from "../../../DashboardSidebarPortsList/hooks/useDashboardSidebarPortKill";
 
 interface DashboardSidebarWorkspaceContextMenuProps {
+	workspaceId: string;
 	projectId: string;
 	isInSection?: boolean;
 	isLocalWorkspace: boolean;
@@ -51,6 +55,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 }
 
 export function DashboardSidebarWorkspaceContextMenu({
+	workspaceId,
 	projectId,
 	isInSection,
 	isLocalWorkspace,
@@ -72,6 +77,10 @@ export function DashboardSidebarWorkspaceContextMenu({
 }: DashboardSidebarWorkspaceContextMenuProps) {
 	const collections = useCollections();
 	const { setContextMenuOpen } = useDashboardSidebarHover();
+	const portGroup = useDashboardSidebarWorkspacePorts(workspaceId);
+	const { isPending: isKillingPorts, killPorts } =
+		useDashboardSidebarPortKill();
+	const ports = portGroup?.ports ?? [];
 	const deleteHotkeyText = useHotkeyDisplay("CLOSE_WORKSPACE").text;
 	const showDeleteShortcut =
 		showDeleteHotkey && deleteHotkeyText !== "Unassigned";
@@ -90,6 +99,10 @@ export function DashboardSidebarWorkspaceContextMenu({
 				})),
 		[collections, projectId],
 	);
+	const handleCloseAllPorts = () => {
+		if (isKillingPorts) return;
+		void killPorts(ports);
+	};
 
 	return (
 		<ContextMenu onOpenChange={setContextMenuOpen}>
@@ -180,6 +193,16 @@ export function DashboardSidebarWorkspaceContextMenu({
 					</>
 				)}
 				<ContextMenuSeparator />
+				{ports.length > 0 && (
+					<ContextMenuItem
+						onSelect={handleCloseAllPorts}
+						disabled={isKillingPorts}
+						variant="destructive"
+					>
+						<LuRadioTower className="size-4 mr-2" />
+						Close all ports
+					</ContextMenuItem>
+				)}
 				<ContextMenuItem
 					onSelect={onRemoveFromSidebar}
 					className="text-destructive focus:text-destructive"


### PR DESCRIPTION
## What

- add a destructive Close all ports action to each workspace row context menu
- show the action only when that workspace has active ports
- reuse the existing host-aware port kill flow for local and remote workspaces

## Verification

- bun run lint:fix
- bun run lint
- bun run --cwd apps/desktop typecheck
- bun test apps/desktop/src/renderer/hooks/ports/usePortKillActions
- git diff --check
- CDP end-to-end: started an HTTP server on port 7619 from the target workspace terminal, opened the workspace context menu with a real right click, selected Close all ports with a real pointer click, and verified the port indicator disappeared and the listener terminated

## CDP target

- worktree: workspace-close-all-ports
- renderer: http://localhost:7565
- route: /v2-workspace/4398b7bd-13dd-4e4c-b985-5b8d15f7c663
- remote debugging port: 9780

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5779">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Close all ports” action to each workspace’s context menu in Desktop. It only shows when the workspace has active ports and closes all listeners in one click.

- New Features
  - Reuses the existing host-aware port kill flow for local and remote workspaces; disables the item while closing.
  - Scopes to the selected workspace via a new `workspaceId` prop and a workspace ports provider.

<sup>Written for commit de23763dbd76089fce0712d1f27608908cf01ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Close all ports” option to the workspace context menu.
  * The option appears only when the workspace has active ports and is temporarily disabled while ports are being closed.
  * Supports closing all active workspace ports in a single action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->