### PR TITLE
fix(desktop,host-service): unblock host-service startup from the shell-env probe

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -454,7 +454,9 @@ export class HostServiceCoordinator extends EventEmitter {
 		}
 
 		instance.pid = childPid;
+		let childExited = false;
 		child.on("exit", (code, signal) => {
+			childExited = true;
 			log.info(
 				`[host-service:${organizationId}] exited with code ${code} signal ${signal}`,
 			);
@@ -478,12 +480,19 @@ export class HostServiceCoordinator extends EventEmitter {
 		child.unref();
 
 		const endpoint = `http://127.0.0.1:${port}`;
-		const healthy = await pollHealthCheck(endpoint, secret);
+		const healthy = await pollHealthCheck(
+			endpoint,
+			secret,
+			HEALTH_POLL_TIMEOUT_MS,
+			() => childExited,
+		);
 		if (!healthy) {
-			child.kill("SIGTERM");
+			if (!childExited) child.kill("SIGTERM");
 			this.instances.delete(organizationId);
 			throw new Error(
-				`Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,
+				childExited
+					? "Host service process exited during startup"
+					: `Host service failed to start within ${HEALTH_POLL_TIMEOUT_MS}ms`,
 			);
 		}
 

--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -5,7 +5,13 @@ import path from "node:path";
 /** Rotate per-org host-service.log once it exceeds this size. */
 export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
 
-export const HEALTH_POLL_TIMEOUT_MS = 10_000;
+// Startup must clear the shell-env snapshot (up to SHELL_ENV_TIMEOUT_MS = 8s,
+// awaited before the server listens) plus DB migrate and daemon bootstrap. At
+// boot every known org starts at once, and multiple app instances sharing one
+// $SUPERSET_HOME_DIR compound the contention, so a healthy-but-slow child can
+// need well over 10s. Give it generous headroom; a genuinely dead child is
+// detected early via the poll's abort hook rather than by this deadline.
+export const HEALTH_POLL_TIMEOUT_MS = 30_000;
 
 const HEALTH_POLL_INTERVAL_MS = 200;
 
@@ -97,9 +103,14 @@ export async function pollHealthCheck(
 	endpoint: string,
 	secret: string,
 	timeoutMs = HEALTH_POLL_TIMEOUT_MS,
+	// Bail out before the deadline once the child is known dead — otherwise a
+	// crash-on-startup would stall the caller for the full (now generous)
+	// timeout instead of failing fast.
+	shouldAbort?: () => boolean,
 ): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
+		if (shouldAbort?.()) return false;
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), 2_000);
 		try {

--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -5,12 +5,13 @@ import path from "node:path";
 /** Rotate per-org host-service.log once it exceeds this size. */
 export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
 
-// Startup must clear the shell-env snapshot (up to SHELL_ENV_TIMEOUT_MS = 8s,
-// awaited before the server listens) plus DB migrate and daemon bootstrap. At
-// boot every known org starts at once, and multiple app instances sharing one
-// $SUPERSET_HOME_DIR compound the contention, so a healthy-but-slow child can
-// need well over 10s. Give it generous headroom; a genuinely dead child is
-// detected early via the poll's abort hook rather than by this deadline.
+// Before the server becomes reachable, startup must still clear DB migrate and
+// the daemon bootstrap (the shell-env snapshot now runs in the background, off
+// the critical path). At boot every known org starts at once, and multiple app
+// instances sharing one $SUPERSET_HOME_DIR compound the contention, so a
+// healthy-but-slow child can need well over 10s. Give it generous headroom; a
+// genuinely dead child is detected early via the poll's abort hook rather than
+// by this deadline.
 export const HEALTH_POLL_TIMEOUT_MS = 30_000;
 
 const HEALTH_POLL_INTERVAL_MS = 200;

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -10,7 +10,7 @@ import { LocalGitCredentialProvider } from "./providers/git";
 import { PskHostAuthProvider } from "./providers/host-auth";
 import { LocalModelProvider } from "./providers/model-providers";
 import { installProcessSafetyNet } from "./safety";
-import { initTerminalBaseEnv, resolveTerminalBaseEnv } from "./terminal/env";
+import { startTerminalBaseEnvResolution } from "./terminal/env";
 import { startTerminalReaper } from "./terminal/reaper";
 import { connectRelay } from "./tunnel";
 
@@ -19,8 +19,11 @@ async function main(): Promise<void> {
 		`[host-service] starting (org=${env.ORGANIZATION_ID}, port=${env.PORT}, NODE_ENV=${process.env.NODE_ENV ?? "unset"})`,
 	);
 
-	const terminalBaseEnv = await resolveTerminalBaseEnv();
-	initTerminalBaseEnv(terminalBaseEnv);
+	// Resolve the shell-env snapshot in the background — it must not block the
+	// server from listening (the login-shell probe can burn the full 8s
+	// budget). PTY creation awaits waitForTerminalBaseEnv() before it reads the
+	// snapshot; every other request path is unaffected.
+	startTerminalBaseEnvResolution();
 
 	// Fire-and-track: kick off pty-daemon spawn-or-adopt without blocking
 	// host-service startup. Terminal request handlers `await

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -116,9 +116,18 @@ let _terminalBaseEnvReady: Promise<void> | null = null;
  */
 export function startTerminalBaseEnvResolution(): void {
 	if (_terminalBaseEnvReady) return;
-	_terminalBaseEnvReady = resolveTerminalBaseEnv().then((baseEnv) => {
-		initTerminalBaseEnv(baseEnv);
+	const promise = resolveTerminalBaseEnv().then((baseEnv) => {
+		// Ignore a stale resolution whose gate was already reset (tests) so it
+		// can't clobber fresh state.
+		if (_terminalBaseEnvReady === promise) initTerminalBaseEnv(baseEnv);
 	});
+	// Fire-and-forget: nothing awaits the gate until the first PTY is created,
+	// so swallow a background failure rather than crash on an unhandled
+	// rejection. resolveTerminalBaseEnv already falls back internally.
+	promise.catch((err) => {
+		console.warn("[host-service] terminal base env resolution failed:", err);
+	});
+	_terminalBaseEnvReady = promise;
 }
 
 /**

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -101,8 +101,38 @@ export function getTerminalBaseEnv(): Record<string, string> {
 	return { ..._terminalBaseEnv };
 }
 
+let _terminalBaseEnvReady: Promise<void> | null = null;
+
+/**
+ * Kick off the shell-env snapshot in the background and stash it once resolved.
+ *
+ * Startup must NOT await this. The login-shell probe can take up to
+ * SHELL_ENV_TIMEOUT_MS (8s) — often the full budget when the user's shell is
+ * slow (e.g. a wedged powerlevel10k/gitstatus init) — and gating the HTTP
+ * listen on it pushes cold starts past the desktop coordinator's health-check
+ * window, especially when every org boots at once. PTY creation awaits
+ * `waitForTerminalBaseEnv()` instead, so terminals still get the preserved
+ * snapshot without blocking the server from becoming reachable.
+ */
+export function startTerminalBaseEnvResolution(): void {
+	if (_terminalBaseEnvReady) return;
+	_terminalBaseEnvReady = resolveTerminalBaseEnv().then((baseEnv) => {
+		initTerminalBaseEnv(baseEnv);
+	});
+}
+
+/**
+ * Await the background shell-env snapshot before reading getTerminalBaseEnv().
+ * Resolves immediately when resolution was never started (tests and helpers
+ * that call initTerminalBaseEnv() directly).
+ */
+export async function waitForTerminalBaseEnv(): Promise<void> {
+	if (_terminalBaseEnvReady) await _terminalBaseEnvReady;
+}
+
 export function resetTerminalBaseEnvForTests(): void {
 	_terminalBaseEnv = null;
+	_terminalBaseEnvReady = null;
 	cachedMacosSystemCertAvailable = null;
 	clearStrictShellEnvCache();
 }

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -34,6 +34,7 @@ import {
 	getShellLaunchArgs,
 	getTerminalBaseEnv,
 	resolveLaunchShell,
+	waitForTerminalBaseEnv,
 } from "./env.ts";
 import { listTerminalResourceSessions } from "./resource-sessions.ts";
 import {
@@ -1046,7 +1047,10 @@ export async function createTerminalSessionInternal({
 		DEFAULT_TERMINAL_ROWS,
 	);
 
-	// Use the preserved shell snapshot — never live process.env
+	// Use the preserved shell snapshot — never live process.env. Resolution
+	// runs in the background at startup so the server can listen immediately;
+	// wait for it here before the first PTY needs the snapshot.
+	await waitForTerminalBaseEnv();
 	const baseEnv = getTerminalBaseEnv();
 	const supersetHomeDir = process.env.SUPERSET_HOME_DIR || "";
 	const shell = resolveLaunchShell(baseEnv);


### PR DESCRIPTION
## Problem

Canary host-services were failing to start in a boot storm: `main.log` showed every org logging `[host-service-coordinator] boot start failed for org …: Host service failed to start within 10000ms`, then the child dying on `SIGTERM` — repeating on every relaunch.

Key facts from the logs:
- The child was **SIGTERMed while still alive** (not a self-exit), i.e. it hadn't passed the coordinator's health check in time — a hang, not a crash.
- The **same** canary build worked at 11:36, failed 13:38–14:12, then recovered ~14:27. Same binary, different outcome → load/state, not a code regression.
- Per-org `~/.superset/host/<org>/host-service.log` shows startup spawning an interactive login shell whose zsh/powerlevel10k **gitstatus was failing to initialize**.
- Multiple app instances (stable + canary + several dev worktree builds) were each running `startKnownHostServices` for **all** orgs against one shared `$SUPERSET_HOME_DIR`.

## Root cause

`serve.ts` `await`s `resolveTerminalBaseEnv()` — an interactive login-shell env snapshot (`zsh -i -l`, `SHELL_ENV_TIMEOUT_MS = 8s`) — **before the server listens**. The coordinator's readiness gate is a 10s health poll (`HEALTH_POLL_TIMEOUT_MS`). When every org cold-starts at once (and multiple instances contend for CPU + the shared home dir), that 8s probe + migrate + daemon bootstrap slips past 10s. The coordinator SIGTERMs the healthy-but-slow child and retries → thundering herd. A slow/wedged shell (p10k gitstatus here) makes it deterministic.

## Fix

- **Background the shell-env snapshot** (`startTerminalBaseEnvResolution`). Startup no longer blocks on it; PTY creation `await`s `waitForTerminalBaseEnv()` before reading the snapshot, so the server becomes reachable immediately and terminals still get the preserved shell env. This mirrors how `startDaemonBootstrap` is already fire-and-forget.
- **Raise `HEALTH_POLL_TIMEOUT_MS` 10s → 30s** as defense-in-depth for contention, and **bail the health poll early when the child exits** (`shouldAbort`) so a genuine crash-on-startup still fails fast instead of stalling for the longer timeout.

## Validation

Unit/type:
- `env.test.ts` + `host-service-coordinator.test.ts`: 49 pass / 0 fail
- `bun run lint`: clean · `bun run typecheck`: 35/35 packages

End-to-end via CDP (real dev app, this worktree):
- All 9 host-services reached `listening` + passed health check within the same second — **0 timeouts, 0 boot failures**; none hit the 8s shell fallback (probe now runs concurrently).
- Host reachable in **~1ms**; `terminal.createSession` succeeded in **32ms** (`sessionLive: true`) — the readiness gate resolves.
- Attached a WS to the live PTY in the `~/workplace/superset` workspace; it reported `TERM_PROGRAM=kitty` and `SUPERSET_WORKSPACE_ID=1dad53c6…`, confirming `buildV2TerminalEnv` ran with the preserved snapshot. Terminals are intact after backgrounding the probe.

Caveat: on the validated boot the shell probe happened to return fast, so there's no isolated "8s gap disappears" A/B here — the decoupling is proven by construction (listen no longer awaits the probe) plus the clean end-to-end run.

## Not included (separate follow-ups)
- Relay `host.ensure` rejects synthetic org ids (400 invalid-UUID) / non-member orgs (403). Non-fatal (relay registration is caught), tracked separately.
- Single-flighting host services across concurrent app instances sharing one home dir.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5787">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks `host-service` startup by running the shell env snapshot in the background and widening the health-check window. Prevents boot storms where healthy children were SIGTERMed before passing readiness.

- **Bug Fixes**
  - Background the terminal base env snapshot (`startTerminalBaseEnvResolution`) so the server listens immediately; PTY creation awaits `waitForTerminalBaseEnv()` to keep terminal env intact.
  - Guard the background env resolution: attach a catch to avoid unhandled rejections and ignore stale resolutions after test resets.
  - Increase `HEALTH_POLL_TIMEOUT_MS` from 10s to 30s; abort health polling early if the child exits.
  - Skip sending `SIGTERM` when the child already exited and surface a clear startup error.

<sup>Written for commit a77ea7b3b7e9780cddd8c4ab012143a4b802e9c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved responsiveness during server startup by resolving terminal environment initialization in the background.
  * Terminal session creation now waits for terminal environment readiness before launching the first PTY.

* **Bug Fixes**
  * Enhanced startup health checks with a longer timeout and earlier detection when the spawned process exits.
  * Avoided unnecessary termination attempts after exit and provided clearer messages for startup timeout vs premature exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->