### PR TITLE
feat(mobile): local-first projects visible on mobile — freeze-audit results

### DIFF
--- a/apps/mobile/hooks/useHostProjects/index.ts
+++ b/apps/mobile/hooks/useHostProjects/index.ts
@@ -1,0 +1,6 @@
+export {
+	type HostProjectItem,
+	toHostProjectItem,
+	type UseHostProjectsResult,
+	useHostProjects,
+} from "./useHostProjects";

--- a/apps/mobile/hooks/useHostProjects/useHostProjects.ts
+++ b/apps/mobile/hooks/useHostProjects/useHostProjects.ts
@@ -1,0 +1,81 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { WorkspacesHost } from "@/hooks/useHostWorkspaces";
+import {
+	buildRelayHostUrl,
+	getHostServiceClientByUrl,
+	type HostProjectRow,
+} from "@/lib/host-service/client";
+
+export interface HostProjectItem {
+	id: string;
+	name: string;
+	iconUrl: string | null;
+	repoOwner: string | null;
+	repoName: string | null;
+}
+
+const PROJECTS_REFETCH_INTERVAL_MS = 30_000;
+
+/**
+ * Normalize a project.list row from any host version — hosts on
+ * pre-local-first builds don't serve `name`, so fall back to the folder
+ * basename (both path separators), matching the desktop rule.
+ */
+export function toHostProjectItem(
+	row: Partial<HostProjectRow> & { id: string; repoPath: string },
+): HostProjectItem {
+	const repoOwner = row.repoOwner ?? null;
+	return {
+		id: row.id,
+		name: row.name || row.repoPath.split(/[\\/]/).pop() || row.id,
+		iconUrl: repoOwner ? `https://github.com/${repoOwner}.png?size=64` : null,
+		repoOwner,
+		repoName: row.repoName ?? null,
+	};
+}
+
+export interface UseHostProjectsResult {
+	projects: HostProjectItem[];
+	/** True once the host answered or failed. Gates empty states only. */
+	isReady: boolean;
+}
+
+/**
+ * Projects served by one host's `project.list` over the relay — projects
+ * are fully local (host.db owns them; the cloud collection is retired), so
+ * the host is the only source that includes local-first projects.
+ */
+export function useHostProjects(
+	host: WorkspacesHost | null,
+): UseHostProjectsResult {
+	const hostUrl = host
+		? buildRelayHostUrl(host.organizationId, host.machineId)
+		: null;
+
+	const query = useQuery({
+		queryKey: ["host-service", "projects", "list", host?.machineId, hostUrl],
+		enabled: hostUrl !== null && (host?.isOnline ?? false),
+		refetchInterval: PROJECTS_REFETCH_INTERVAL_MS,
+		networkMode: "always" as const,
+		retry: 1,
+		queryFn: async () => {
+			if (!hostUrl) return [];
+			return getHostServiceClientByUrl(hostUrl).project.list.query();
+		},
+	});
+
+	const projects = useMemo(
+		() => (query.data ?? []).map(toHostProjectItem),
+		[query.data],
+	);
+
+	return {
+		projects,
+		isReady:
+			query.isSuccess ||
+			query.isError ||
+			host === null ||
+			host.isOnline === false,
+	};
+}

--- a/apps/mobile/screens/(authenticated)/(home)/filter/FilterScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/filter/FilterScreen.tsx
@@ -1,7 +1,7 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { useLiveQuery } from "@tanstack/react-db";
 import { Stack, useRouter } from "expo-router";
 import { View } from "react-native";
+import { useHostProjects } from "@/hooks/useHostProjects";
 import { useTheme } from "@/hooks/useTheme";
 import {
 	SORT_OPTIONS,
@@ -17,19 +17,17 @@ import { ProjectAvatar } from "./components/ProjectAvatar";
 export function FilterScreen() {
 	const router = useRouter();
 	const theme = useTheme();
-	const collections = useCollections();
+	const _collections = useCollections();
 	const projectFilter = useWorkspacesFilterStore(
 		(store) => store.projectFilter,
 	);
 	const selectedHost = useSelectedHost();
 	const sort = useWorkspacesFilterStore((store) => store.sort);
 
-	const { data: projects } = useLiveQuery(
-		(q) => q.from({ v2Projects: collections.v2Projects }),
-		[collections],
-	);
+	// Projects are fully local — served by the selected host, not Electric.
+	const { projects } = useHostProjects(selectedHost);
 
-	const sortedProjects = [...(projects ?? [])].sort((a, b) =>
+	const sortedProjects = [...projects].sort((a, b) =>
 		a.name.localeCompare(b.name),
 	);
 	const selectedProject =

--- a/apps/mobile/screens/(authenticated)/(home)/filter/project/ProjectFilterScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/filter/project/ProjectFilterScreen.tsx
@@ -1,7 +1,7 @@
-import { useLiveQuery } from "@tanstack/react-db";
 import { useRouter } from "expo-router";
 import { useMemo } from "react";
 import { ScrollView, Text } from "react-native";
+import { useHostProjects } from "@/hooks/useHostProjects";
 import { useHostWorkspaces } from "@/hooks/useHostWorkspaces";
 import { useTheme } from "@/hooks/useTheme";
 import { useWorkspacesFilterStore } from "@/screens/(authenticated)/(home)/home/stores/workspacesFilterStore";
@@ -14,7 +14,7 @@ import { ProjectAvatar } from "../components/ProjectAvatar";
 export function ProjectFilterScreen() {
 	const router = useRouter();
 	const theme = useTheme();
-	const collections = useCollections();
+	const _collections = useCollections();
 	const selectedHost = useSelectedHost();
 	const { workspaces } = useHostWorkspaces(selectedHost);
 	const projectFilter = useWorkspacesFilterStore(
@@ -24,13 +24,11 @@ export function ProjectFilterScreen() {
 		(store) => store.setProjectFilter,
 	);
 
-	const { data: projects } = useLiveQuery(
-		(q) => q.from({ v2Projects: collections.v2Projects }),
-		[collections],
-	);
+	// Projects are fully local — served by the selected host, not Electric.
+	const { projects } = useHostProjects(selectedHost);
 
 	const sortedProjects = useMemo(
-		() => [...(projects ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+		() => [...projects].sort((a, b) => a.name.localeCompare(b.name)),
 		[projects],
 	);
 

--- a/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
@@ -9,6 +9,7 @@ import { useCallback, useMemo, useState } from "react";
 import { RefreshControl, useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/ui/text";
+import { useHostProjects } from "@/hooks/useHostProjects";
 import {
 	type HostWorkspaceItem,
 	useHostWorkspaces,
@@ -88,10 +89,8 @@ export function HomeScreen() {
 	const { workspaces, isReady, cache } = useHostWorkspaces(selectedHost);
 	const attentionByWorkspace = useHostTerminalAgents(selectedHost);
 
-	const { data: projects } = useLiveQuery(
-		(q) => q.from({ v2Projects: collections.v2Projects }),
-		[collections],
-	);
+	// Projects are fully local — served by the selected host, not Electric.
+	const { projects } = useHostProjects(selectedHost);
 	const { data: pullRequests } = useLiveQuery(
 		(q) => q.from({ githubPullRequests: collections.githubPullRequests }),
 		[collections],
@@ -99,15 +98,14 @@ export function HomeScreen() {
 	const { sessionsByWorkspace } = useHostAcpSessions(selectedHost);
 
 	const sortedProjects = useMemo(
-		() => [...(projects ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+		() => [...projects].sort((a, b) => a.name.localeCompare(b.name)),
 		[projects],
 	);
 
 	const selectedProjectId = projectFilter ?? sortedProjects[0]?.id ?? null;
 
 	const projectNamesById = useMemo(
-		() =>
-			new Map((projects ?? []).map((project) => [project.id, project.name])),
+		() => new Map(projects.map((project) => [project.id, project.name])),
 		[projects],
 	);
 
@@ -204,7 +202,12 @@ export function HomeScreen() {
 		const rank = { closed: 3, draft: 1, merged: 2, open: 0 } as const;
 		const byRepoBranch = new Map<string, SelectGithubPullRequest>();
 		for (const pullRequest of pullRequests ?? []) {
-			const key = `${pullRequest.repositoryId}::${pullRequest.headBranch}`;
+			// Key on repo coordinates from the PR URL — host projects don't
+			// know cloud repo UUIDs.
+			const repoPrefix = pullRequest.url
+				.toLowerCase()
+				.replace(/pull\/\d+.*$/, "");
+			const key = `${repoPrefix}::${pullRequest.headBranch}`;
 			const existing = byRepoBranch.get(key);
 			if (!existing) {
 				byRepoBranch.set(key, pullRequest);
@@ -264,12 +267,16 @@ export function HomeScreen() {
 		setRefreshing(false);
 	}, [queryClient]);
 
-	const repositoryIdsByProject = useMemo(
+	// Projects are fully local: PR rows are matched by repo coordinates
+	// parsed from the PR URL (cloud repo UUIDs aren't known host-side).
+	const repoPrefixesByProject = useMemo(
 		() =>
 			new Map(
-				(projects ?? []).map((project) => [
+				projects.map((project) => [
 					project.id,
-					project.githubRepositoryId,
+					project.repoOwner && project.repoName
+						? `https://github.com/${project.repoOwner}/${project.repoName}/`.toLowerCase()
+						: null,
 				]),
 			),
 		[projects],
@@ -291,14 +298,14 @@ export function HomeScreen() {
 					);
 				case "workspace": {
 					const { workspace } = item;
-					const repositoryId = repositoryIdsByProject.get(workspace.projectId);
+					const repoPrefix = repoPrefixesByProject.get(workspace.projectId);
 					return (
 						<WorkspaceRow
 							workspace={workspace}
 							pullRequest={
-								repositoryId
+								repoPrefix
 									? pullRequestsByRepoBranch.get(
-											`${repositoryId}::${workspace.branch}`,
+											`${repoPrefix}::${workspace.branch}`,
 										)
 									: undefined
 							}
@@ -333,7 +340,7 @@ export function HomeScreen() {
 		},
 		[
 			pullRequestsByRepoBranch,
-			repositoryIdsByProject,
+			repoPrefixesByProject,
 			diffStats,
 			cache,
 			router,

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
@@ -2,6 +2,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries } from "@tanstack/react-query";
 import { compareDesc } from "date-fns";
 import { useMemo } from "react";
+import { toHostProjectItem } from "@/hooks/useHostProjects";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
 import {
 	buildRelayHostUrl,
@@ -47,11 +48,6 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 		(q) => q.from({ v2Hosts: collections.v2Hosts }),
 		[collections],
 	);
-	const { data: projects } = useLiveQuery(
-		(q) => q.from({ v2Projects: collections.v2Projects }),
-		[collections],
-	);
-
 	const onlineHosts = useMemo(
 		() =>
 			(hosts ?? [])
@@ -76,14 +72,12 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 	});
 
 	const targets = useMemo<NewChatTarget[]>(() => {
-		const projectsById = new Map(
-			(projects ?? []).map((project) => [project.id, project]),
-		);
 		const result: NewChatTarget[] = [];
 		onlineHosts.forEach((host, index) => {
 			for (const row of projectListQueries[index]?.data ?? []) {
-				const project = projectsById.get(row.id);
-				if (!project) continue;
+				// Projects are fully local — the host row is the identity
+				// (the frozen Electric lookup dropped local-first projects).
+				const project = toHostProjectItem(row);
 				result.push({
 					key: targetKeyFor(project.id, host.machineId),
 					projectId: project.id,
@@ -96,7 +90,7 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 			}
 		});
 		return result.sort((a, b) => a.projectName.localeCompare(b.projectName));
-	}, [onlineHosts, projectListQueries, projects]);
+	}, [onlineHosts, projectListQueries]);
 
 	const defaultTarget = useMemo<NewChatTarget | null>(() => {
 		if (targets.length === 0) return null;

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/useWorkspacePullRequest.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/hooks/useWorkspacePullRequest/useWorkspacePullRequest.ts
@@ -1,6 +1,7 @@
 import type { SelectGithubPullRequest } from "@superset/db/schema";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
+import { useHostProjects } from "@/hooks/useHostProjects";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
 import { prStateFor } from "@/screens/(authenticated)/(home)/home/utils/prStateFor";
 import { useCollections } from "@/screens/(authenticated)/providers/CollectionsProvider";
@@ -12,12 +13,17 @@ export function useWorkspacePullRequest(
 	workspaceId: string | null,
 ): SelectGithubPullRequest | null {
 	const collections = useCollections();
-	const { workspace } = useWorkspaceHost(workspaceId);
-
-	const { data: projects } = useLiveQuery(
-		(q) => q.from({ v2Projects: collections.v2Projects }),
-		[collections],
+	const { workspace, host } = useWorkspaceHost(workspaceId);
+	const { projects } = useHostProjects(
+		host
+			? {
+					organizationId: host.organizationId,
+					machineId: host.machineId,
+					isOnline: host.isOnline,
+				}
+			: null,
 	);
+
 	const { data: pullRequests } = useLiveQuery(
 		(q) => q.from({ githubPullRequests: collections.githubPullRequests }),
 		[collections],
@@ -25,13 +31,15 @@ export function useWorkspacePullRequest(
 
 	return useMemo(() => {
 		if (!workspace) return null;
-		const repositoryId = (projects ?? []).find(
-			(project) => project.id === workspace.projectId,
-		)?.githubRepositoryId;
-		if (!repositoryId) return null;
+		// Projects are fully local: match PRs by repo coordinates parsed from
+		// the PR URL (the cloud repo UUID isn't known host-side).
+		const project = projects.find((item) => item.id === workspace.projectId);
+		if (!project?.repoOwner || !project.repoName) return null;
+		const repoPrefix =
+			`https://github.com/${project.repoOwner}/${project.repoName}/`.toLowerCase();
 		const candidates = (pullRequests ?? []).filter(
 			(pullRequest) =>
-				pullRequest.repositoryId === repositoryId &&
+				pullRequest.url.toLowerCase().startsWith(repoPrefix) &&
 				pullRequest.headBranch === workspace.branch,
 		);
 		candidates.sort(


### PR DESCRIPTION
Completes the freeze audit from #5731/#5786 and fixes the one real gap it found.

## Summary
- **Mobile projects now come from the host** (`useHostProjects(host)`, mirroring mobile's existing `useHostWorkspaces` relay pattern): HomeScreen filter/names, FilterScreen, ProjectFilterScreen, NewChatWidget targets, and workspace PR lookup. Local-first projects created post-#5731 are now visible and filterable on mobile.
- **PR matching re-keyed to repo coordinates**: mobile matched PRs by the cloud repo UUID, which hosts can't know. HomeScreen and `useWorkspacePullRequest` now match by `owner/repo` parsed from the PR URL against the host project's git-remote coordinates.
- **`useNewChatTargets` dropped-row bug fixed**: it already fanned `project.list` to hosts but cross-filtered against the frozen Electric collection (`if (!project) continue`), silently dropping local-first projects from chat targets.
- Rows from pre-local-first hosts are normalized (basename name fallback, both path separators) — same mixed-version rule as desktop.

## Audit results (the rest of the freeze surface)
- **Web: clean** — zero readers of `v2_projects`/`v2_workspaces` in `apps/web/src`. Nothing to do.
- **Mobile workspaces were never frozen** — they were already host-served over the relay; only project metadata froze. The design doc's "mobile loses workspace visibility" was too pessimistic; with this PR mobile is fully local-first-compatible for reachable hosts.
- **Desktop Electric `v2Workspaces` fallback: left in place deliberately — product decision needed.** The merge uses cloud rows only for hosts that never answer, which in practice means teammates' unreachable machines. Removing it → Workspaces page shows only your own hosts; keeping it → teammates' rows shown frozen-as-of-upgrade forever (increasingly stale). Flagging for an explicit call rather than deciding in a follow-up PR.
- **`packages/trpc` `v2-workspace` router**: frozen endpoints kept for old clients until adoption telemetry clears (as planned in #5731).

## Testing
- `bun run lint` clean; `turbo run typecheck --filter=@superset/mobile` — zero errors in changed files (remaining errors are pre-existing cross-package Node-timer typings in `port-scanner`/`pty-daemon`/`workspace-fs`, present on main)
- Mobile is iOS-only and not drivable via CDP here — Maestro E2E covers it in CI; a manual pass on a device before release would be prudent since five screens changed sources.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5789">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes local-first projects visible on mobile by fetching projects from the host, and re-keys PR matching to repo coordinates so PRs appear correctly. Also fixes chat targets dropping local-first projects.

- **New Features**
  - Added `useHostProjects` (relay `project.list`) and switched HomeScreen, FilterScreen, and ProjectFilterScreen to use it.
  - PR matching now uses `owner/repo` parsed from the PR URL to link workspaces to PRs on mobile.

- **Bug Fixes**
  - NewChatWidget no longer filters host projects through the frozen collection; includes local-first projects.
  - Normalizes legacy host rows (folder-name fallback for project name; supports both path separators).

<sup>Written for commit 82aea61e6de699ff2c7b06978cd90f6bba7ad1d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host-based project loading for mobile screens.
  * Project names and repository details are now derived directly from the selected host.
* **Bug Fixes**
  * Improved pull request matching across home, workspace, and project views.
  * Added support for repository paths using different path separators.
  * Improved handling when hosts, projects, or repository information are unavailable.
* **Updates**
  * New chat targets and filtering now use projects served by the selected host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->