### PR TITLE
fix(desktop): disarm leaked TUI input modes on live kill in v2 terminals

### DIFF
--- a/apps/desktop/docs/TERMINAL_INPUT_MODE_RECLAIM.md
+++ b/apps/desktop/docs/TERMINAL_INPUT_MODE_RECLAIM.md
@@ -1,0 +1,66 @@
+# Reclaiming leaked terminal input modes on a live kill (#4949)
+
+## The bug
+
+An in-terminal TUI (mastracode/pi-tui, Claude Code, …) arms input-reporting modes
+on startup — the **kitty keyboard protocol**, **mouse tracking**, **focus
+reporting** — and disarms them on clean exit. Killed uncleanly (`kill -9`, crash,
+OOM) while its pane is attached, it never writes the restore sequences, so the
+shell that reclaims the pty inherits them:
+
+- **kitty keyboard** (the severe one): every keystroke reaches the shell CSI-u
+  encoded — `Ctrl+C` → `^[[99;5u`, `whoami` → `^[[119;1:3u…` → `command not found` —
+  so the pane is unusable by keyboard until `reset`.
+- **mouse / focus**: pointer moves and focus changes spray escape junk into the
+  prompt.
+
+xterm arms the kitty protocol because the terminal advertises it
+(`vtExtensions: { kittyKeyboard: true }`).
+
+## Why it wasn't already handled
+
+v2 workspace terminals stream PTY output straight to the renderer xterm; they do
+**not** route through the host-side `HeadlessEmulator`, so its foreground-reclaim
+never runs for them. The existing renderer disarm (`disarmStaleInputModes`) only
+fires on **cold restore** and **terminal restart** — not on a TUI killed while the
+pane stays attached.
+
+## The fix
+
+A renderer reclaimer installed on every xterm in `createTerminal`:
+
+- `shared/leaked-input-mode-reclaim.ts` — a transport-agnostic core
+  (`createLeakedInputModeReclaimer`: `noteArm` / `noteShellReady` / `collectDisarm`)
+  holding only the decision logic: a **shell-owned epoch** (modes armed before the
+  first prompt marker belong to shell init and are never reclaimed) and a
+  **mark-then-recheck flush** (a mode re-armed before the flush keeps its state).
+  Reusable by any surface that observes the stream (a host-side VT scanner later).
+- `renderer/lib/terminal/terminalInputModeReclaimer.ts` — a thin xterm-parser
+  adapter: handlers for kitty (`CSI >/=/< u`), mouse (`?1000/1002/1003`), focus
+  (`?1004`), and the `OSC 777;superset-shell-ready` marker feed the core; the
+  disarm is written back on a microtask.
+
+**Marker choice:** reclaim keys on `OSC 777;superset-shell-ready` (emitted only by
+Superset's shell wrappers), **not** the co-emitted FinalTerm `OSC 133;A` — `133;A`
+is also produced by third-party shell integrations and forwarded by tmux, so
+disarming on it would clear a live tmux's own modes.
+
+**Guard:** the reclaimer only acts at a shell prompt (when no TUI owns the
+foreground) and re-checks at flush, so a live/suspended/racing TUI keeps its modes.
+
+## Reproduction
+
+1. Open a v2 workspace terminal; run a kitty-keyboard TUI (`mastracode`).
+2. `kill -9 $(pgrep -f 'bin/mastracode')` from another shell.
+3. Before the fix: `Ctrl+C` prints `^[[99;5u` and can't interrupt; typing is junk;
+   only `reset` recovers. After the fix: `Ctrl+C` interrupts and typing works with
+   no `reset`.
+
+CDP-verified with trusted key events (mastracode killed while attached): `whoami`
+→ `kietho`, `Ctrl+C` → `^C`, no reset; a live mastracode still receives keystrokes.
+
+## Scope
+
+Covers the input-mode leak (kitty / mouse / focus). A leaked **alternate screen**
+from a live-killed full-screen TUI is not exited by this path (cold-restore/restart
+handle alt-screen) — separate follow-up.

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -21,6 +21,7 @@ import { loadAddons } from "./terminal-addons";
 import { installImagePasteFallback } from "./terminal-image-paste-fallback";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
 import { getTerminalParkingContainer } from "./terminal-parking";
+import { installInputModeReclaimer } from "./terminalInputModeReclaimer";
 
 const SERIALIZE_SCROLLBACK = 1000;
 const STORAGE_KEY_PREFIX = "terminal-buffer:";
@@ -75,6 +76,10 @@ function createTerminal(
 	});
 	terminal.loadAddon(fitAddon);
 	terminal.loadAddon(serializeAddon);
+	// Disarm TUI-only input modes (kitty keyboard / mouse / focus) leaked into a
+	// live shell prompt by a TUI killed while attached (#4949). The parser
+	// handlers are owned by the terminal and cleaned up on terminal.dispose().
+	installInputModeReclaimer(terminal);
 	return { terminal, fitAddon, serializeAddon };
 }
 

--- a/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import {
+	createLeakedInputModeReclaimer,
+	KITTY_KEYBOARD_DISARM_SEQUENCE,
+} from "shared/leaked-input-mode-reclaim";
+import { installInputModeReclaimer } from "./terminalInputModeReclaimer";
+
+// The transport-agnostic decision core (shared). The renderer, and any future
+// host-side surface, feed it the same arm/marker events.
+describe("createLeakedInputModeReclaimer", () => {
+	it("disarms kitty leaked by a dead TUI at the next prompt", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteShellReady(); // session's first prompt
+		r.noteArm("kitty", true); // TUI arms kitty after the prompt
+		r.noteShellReady(); // shell reprompts after the kill
+		expect(r.collectDisarm()).toContain(KITTY_KEYBOARD_DISARM_SEQUENCE);
+	});
+
+	it("does not disarm kitty a TUI popped itself on clean exit", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteShellReady();
+		r.noteArm("kitty", true);
+		r.noteArm("kitty", false); // clean pop
+		r.noteShellReady();
+		expect(r.collectDisarm()).toBe("");
+	});
+
+	it("leaves modes armed by shell init alone (shell-owned)", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteArm("kitty", true); // armed before the first marker → shell owns it
+		r.noteShellReady();
+		expect(r.collectDisarm()).toBe("");
+	});
+
+	it("suppresses the disarm when a TUI re-arms before collection", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteShellReady();
+		r.noteArm("kitty", true);
+		r.noteShellReady(); // marks kitty leaked
+		r.noteArm("kitty", true); // a new TUI grabs it before the flush
+		expect(r.collectDisarm()).toBe("");
+	});
+
+	it("reclaims leaked mouse and focus reporting", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteShellReady();
+		r.noteArm("mouse", true);
+		r.noteArm("focus", true);
+		r.noteShellReady();
+		const out = r.collectDisarm();
+		expect(out).toContain("\x1b[?1003l"); // mouse protocol cleared
+		expect(out).toContain("\x1b[?1004l"); // focus reporting off
+	});
+
+	it("consumes the pending set — a second collect is empty", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteShellReady();
+		r.noteArm("kitty", true);
+		r.noteShellReady();
+		expect(r.collectDisarm()).not.toBe("");
+		expect(r.collectDisarm()).toBe("");
+	});
+
+	it("writes nothing when no TUI mode leaked", () => {
+		const r = createLeakedInputModeReclaimer();
+		r.noteShellReady();
+		r.noteShellReady();
+		expect(r.collectDisarm()).toBe("");
+	});
+});
+
+// The xterm wiring: parser handlers → core, marker → deferred terminal.write.
+describe("installInputModeReclaimer (xterm adapter)", () => {
+	type CsiCb = (params: (number | number[])[]) => boolean;
+	type OscCb = (data: string) => boolean;
+
+	function makeFakeTerminal() {
+		const csi = new Map<string, CsiCb>();
+		const osc = new Map<number, OscCb>();
+		const writes: string[] = [];
+		const terminal = {
+			parser: {
+				registerCsiHandler(id: { prefix?: string; final: string }, cb: CsiCb) {
+					csi.set(`${id.prefix ?? ""}${id.final}`, cb);
+					return { dispose() {} };
+				},
+				registerOscHandler(id: number, cb: OscCb) {
+					osc.set(id, cb);
+					return { dispose() {} };
+				},
+			},
+			write(data: string) {
+				writes.push(data);
+			},
+		} as unknown as XTerm;
+		return {
+			terminal,
+			writes,
+			csi: (key: string, params: (number | number[])[] = []) =>
+				csi.get(key)?.(params),
+			marker: (data = "superset-shell-ready") => osc.get(777)?.(data),
+		};
+	}
+
+	const flush = () => new Promise<void>((r) => queueMicrotask(r));
+
+	it("disarms kitty on the marker via a deferred write", async () => {
+		const t = makeFakeTerminal();
+		installInputModeReclaimer(t.terminal);
+		t.marker(); // first prompt
+		t.csi(">u", [7]); // kitty arm
+		t.marker(); // reprompt after kill
+		await flush();
+		expect(t.writes.join("")).toContain(KITTY_KEYBOARD_DISARM_SEQUENCE);
+	});
+
+	it("ignores OSC 777 payloads that are not the shell-ready marker", async () => {
+		const t = makeFakeTerminal();
+		installInputModeReclaimer(t.terminal);
+		t.marker();
+		t.csi(">u", [7]);
+		t.marker("notify;something"); // urxvt-style OSC 777, not our marker
+		await flush();
+		expect(t.writes).toHaveLength(0);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminalInputModeReclaimer.ts
@@ -1,0 +1,105 @@
+import type { IDisposable, Terminal } from "@xterm/xterm";
+import {
+	createLeakedInputModeReclaimer,
+	SHELL_READY_MARKER_PAYLOAD,
+	SHELL_READY_OSC_ID,
+} from "shared/leaked-input-mode-reclaim";
+
+/**
+ * Renderer adapter that wires xterm's parser to the shared leaked-input-mode
+ * reclaimer (#4949).
+ *
+ * v2 workspace terminals stream PTY output straight to this xterm and never route
+ * through the terminal-host daemon's HeadlessEmulator, so the host-side foreground
+ * reclaim never runs for them. A TUI (mastracode/pi-tui, Claude Code) that arms
+ * the kitty keyboard protocol / mouse / focus reporting and is killed while
+ * attached leaves every keystroke CSI-u encoded — Ctrl+C dead, shell unusable
+ * until `reset`. #5519's renderer disarm only fires on cold restore / terminal
+ * restart, not a live kill.
+ *
+ * This observes mode arming and the OSC 777 shell-ready marker via xterm parser
+ * handlers (chunk-safe, exact) and feeds them to the shared reclaimer, which
+ * decides what to disarm. The disarm is written back on a microtask so a TUI that
+ * re-arms right after the marker (fg after ^Z, or a new TUI racing the prompt)
+ * keeps its modes. The decision logic lives in the shared module so a host-side
+ * surface can reuse it later.
+ */
+export function installInputModeReclaimer(terminal: Terminal): IDisposable {
+	const reclaimer = createLeakedInputModeReclaimer();
+	const parser = terminal.parser;
+	const disposables: IDisposable[] = [];
+	let scheduled = false;
+
+	// Kitty keyboard protocol: `CSI > flags u` push/arm, `CSI = flags ; mode u`
+	// set (0 disarms), `CSI < n u` pop/disarm. Return false so xterm still applies.
+	disposables.push(
+		parser.registerCsiHandler({ prefix: ">", final: "u" }, () => {
+			reclaimer.noteArm("kitty", true);
+			return false;
+		}),
+	);
+	disposables.push(
+		parser.registerCsiHandler({ prefix: "=", final: "u" }, (params) => {
+			const raw = params[0];
+			const flags = typeof raw === "number" ? raw : (raw?.[0] ?? 0);
+			reclaimer.noteArm("kitty", flags !== 0);
+			return false;
+		}),
+	);
+	disposables.push(
+		parser.registerCsiHandler({ prefix: "<", final: "u" }, () => {
+			reclaimer.noteArm("kitty", false);
+			return false;
+		}),
+	);
+
+	// Mouse tracking (?1000/1002/1003) and focus reporting (?1004).
+	const applyDecMode = (
+		params: (number | number[])[],
+		armed: boolean,
+	): void => {
+		for (const param of params) {
+			const primary = typeof param === "number" ? param : param[0];
+			if (primary === 1000 || primary === 1002 || primary === 1003) {
+				reclaimer.noteArm("mouse", armed);
+			} else if (primary === 1004) {
+				reclaimer.noteArm("focus", armed);
+			}
+		}
+	};
+	disposables.push(
+		parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+			applyDecMode(params, true);
+			return false;
+		}),
+	);
+	disposables.push(
+		parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+			applyDecMode(params, false);
+			return false;
+		}),
+	);
+
+	disposables.push(
+		parser.registerOscHandler(SHELL_READY_OSC_ID, (data) => {
+			// Exact match: OSC 777 is also urxvt's notification channel.
+			if (data !== SHELL_READY_MARKER_PAYLOAD) return false;
+			reclaimer.noteShellReady();
+			if (!scheduled) {
+				scheduled = true;
+				queueMicrotask(() => {
+					scheduled = false;
+					const disarm = reclaimer.collectDisarm();
+					if (disarm) terminal.write(disarm);
+				});
+			}
+			return false;
+		}),
+	);
+
+	return {
+		dispose(): void {
+			for (const d of disposables) d.dispose();
+		},
+	};
+}

--- a/apps/desktop/src/shared/leaked-input-mode-reclaim.ts
+++ b/apps/desktop/src/shared/leaked-input-mode-reclaim.ts
@@ -1,0 +1,122 @@
+/**
+ * Reclaiming TUI-only input-reporting modes leaked into a live shell prompt (#4949).
+ *
+ * A TUI (mastracode/pi-tui, Claude Code) arms the kitty keyboard protocol / mouse
+ * tracking / focus reporting and disarms them on clean exit. Killed uncleanly
+ * (SIGKILL, crash) it never writes the restore sequences, so the shell that
+ * reclaims the pty inherits them: every keystroke is CSI-u encoded (Ctrl+C ->
+ * `^[[99;5u`), mouse moves spray reports, and the terminal is unusable until
+ * `reset`.
+ *
+ * This module owns only the decision logic — a shell-owned epoch (modes armed
+ * before the first prompt marker belong to shell init and are never reclaimed)
+ * and a mark-then-recheck flush (a mode re-armed before the flush keeps its
+ * state). It is transport-agnostic so any surface that can observe the terminal
+ * stream can reuse it: the renderer xterm parser today (see
+ * renderer/lib/terminal/terminalInputModeReclaimer.ts), a host-side VT scanner
+ * later.
+ */
+
+const ESC = "\x1b";
+
+/**
+ * Superset's app-private prompt marker (`OSC 777;superset-shell-ready`), emitted
+ * by the shell wrappers before every prompt. Its arrival means the shell owns the
+ * foreground again. Reclaim keys on this — NOT the co-emitted FinalTerm `OSC
+ * 133;A` — because 133;A is also emitted by third-party shell integrations and
+ * forwarded by tmux for shells Superset did not wrap, so disarming on it would
+ * clear a live tmux's own modes. Only Superset's wrappers emit 777.
+ */
+export const SHELL_READY_OSC_ID = 777;
+export const SHELL_READY_MARKER_PAYLOAD = "superset-shell-ready";
+
+/**
+ * Kitty keyboard protocol disarm: a stack unwind (`CSI < 255 u` pops more than
+ * the stack holds, emptying it) plus an explicit set-to-0 (`CSI = 0 ; 1 u`) that
+ * covers flags armed without a push.
+ */
+export const KITTY_KEYBOARD_DISARM_SEQUENCE = `${ESC}[<255u${ESC}[=0;1u`;
+
+/** TUI-only input-reporting modes a killed TUI can leak into a shell prompt. */
+export type LeakableInputMode = "kitty" | "mouse" | "focus";
+
+/**
+ * Disarm bytes per leakable mode. Mouse tracking is one xterm group — any level
+ * low (`?1003l`) clears the whole protocol — so a single reset covers 9/1000/
+ * 1002/1003. Shells never arm these, so reclaiming them at a prompt is safe.
+ */
+export const LEAKED_MODE_DISARM: Record<LeakableInputMode, string> = {
+	kitty: KITTY_KEYBOARD_DISARM_SEQUENCE,
+	mouse: `${ESC}[?1003l`,
+	focus: `${ESC}[?1004l`,
+};
+
+export interface LeakedInputModeReclaimer {
+	/** Record a mode arming (true) or restore (false) seen in the stream. */
+	noteArm(mode: LeakableInputMode, armed: boolean): void;
+	/**
+	 * A shell-ready marker arrived: mark still-armed, non-shell-owned modes as
+	 * leaked and clear their shadow (in stream order). Call `collectDisarm` after
+	 * the parse settles.
+	 */
+	noteShellReady(): void;
+	/**
+	 * Disarm bytes for modes leaked at the last marker and not re-armed since — so
+	 * a live/suspended/racing TUI that owns the foreground keeps its modes.
+	 * Consumes the pending set; returns "" when nothing leaked.
+	 */
+	collectDisarm(): string;
+}
+
+/**
+ * Create a transport-agnostic reclaimer. Feed it arm/marker events from any
+ * source and write whatever `collectDisarm` returns back to the terminal.
+ */
+export function createLeakedInputModeReclaimer(): LeakedInputModeReclaimer {
+	const modeNames: LeakableInputMode[] = ["kitty", "mouse", "focus"];
+	const state = new Map<
+		LeakableInputMode,
+		{ armed: boolean; shellOwned: boolean; pending: boolean }
+	>(
+		modeNames.map((m) => [
+			m,
+			{ armed: false, shellOwned: false, pending: false },
+		]),
+	);
+	let sawMarker = false;
+
+	return {
+		noteArm(mode, armed) {
+			const s = state.get(mode);
+			if (!s) return;
+			s.armed = armed;
+			if (armed) {
+				// A re-arm cancels a pending reclaim — the mode is live again.
+				s.pending = false;
+				// Armed before the first marker → shell init owns it.
+				if (!sawMarker) s.shellOwned = true;
+			} else {
+				s.shellOwned = false;
+			}
+		},
+		noteShellReady() {
+			sawMarker = true;
+			for (const s of state.values()) {
+				if (s.armed && !s.shellOwned) {
+					s.pending = true;
+					s.armed = false;
+				}
+			}
+		},
+		collectDisarm() {
+			let disarm = "";
+			for (const mode of modeNames) {
+				const s = state.get(mode);
+				if (!s) continue;
+				if (s.pending && !s.armed) disarm += LEAKED_MODE_DISARM[mode];
+				s.pending = false;
+			}
+			return disarm;
+		},
+	};
+}


### PR DESCRIPTION
## What & why

A TUI in a v2 workspace terminal (mastracode/pi-tui, Claude Code, …) arms input-reporting modes on startup — the **kitty keyboard protocol**, mouse tracking, focus reporting — and disarms them on clean exit. Killed uncleanly (`kill -9`, crash, OOM) **while its pane is attached**, it never writes the restore sequences, so the shell that reclaims the pty inherits them. For kitty this is severe: every keystroke reaches the shell CSI-u encoded (`Ctrl+C` → `^[[99;5u`, `whoami` → `^[[119;1:3u…` → `command not found`), so the pane is unusable by keyboard until `reset`.

Why it slipped through: v2 workspace terminals stream PTY output straight to the renderer xterm and don't route through the host-side `HeadlessEmulator`, so its foreground-reclaim never runs for them. The existing renderer disarm (`disarmStaleInputModes`) only fires on cold restore and terminal restart — not on a TUI killed while the pane stays attached. (xterm arms kitty because the terminal advertises `vtExtensions: { kittyKeyboard: true }`.)

## The fix

A renderer-side reclaimer installed on every xterm in `createTerminal`:

- **`shared/leaked-input-mode-reclaim.ts`** — a transport-agnostic core (`createLeakedInputModeReclaimer`: `noteArm` / `noteShellReady` / `collectDisarm`) that owns only the decision logic: a **shell-owned epoch** (modes armed before the first prompt marker belong to shell init and are never reclaimed) and a **mark-then-recheck flush** (a mode re-armed before the flush keeps its state). Kept separate so a host-side surface can reuse it later.
- **`renderer/lib/terminal/terminalInputModeReclaimer.ts`** — a thin xterm-parser adapter: handlers for kitty (`CSI >/=/< u`), mouse (`?1000/1002/1003`), focus (`?1004`) and the `OSC 777;superset-shell-ready` marker feed the core; the disarm is written back on a microtask.

**Marker choice:** reclaim keys on `OSC 777;superset-shell-ready` (emitted only by Superset's shell wrappers), **not** the co-emitted FinalTerm `OSC 133;A` — `133;A` is also produced by third-party shell integrations and forwarded by tmux, so disarming on it would clear a live tmux's own modes.

**Guard:** the reclaimer only acts at a shell prompt (no TUI owns the foreground then) and re-checks at flush, so a live/suspended/racing TUI keeps its modes.

## How I tested it

- **Unit:** 9 tests (core decision logic + xterm-adapter wiring), mutation-verified (breaking the shell-owned guard fails a test).
- **CDP live (trusted key events), the exact repro:** ran `mastracode`, `kill -9` while attached — after the fix, `whoami` → `kietho` and `Ctrl+C` → `^C` with **no `reset`**; before the fix the same keys were kitty-junk. Guard confirmed: a **live** mastracode still receives real keystrokes into its input box.
- `bun run --cwd apps/desktop typecheck` and Biome — pass.

## Scope

Covers the input-mode leak (kitty / mouse / focus). A leaked **alternate screen** from a live-killed full-screen TUI is not exited by this path (cold-restore/restart already handle alt-screen) — noted as a follow-up. Related to the same underlying issue (#4949) as the in-flight #5519, which fixes the cold-restore / terminal-restart paths; this is the missing live-attached-kill path for v2 and is independent of it.

Docs: `apps/desktop/docs/TERMINAL_INPUT_MODE_RECLAIM.md`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaked TUI input modes (kitty keyboard, mouse, focus) from breaking v2 workspace terminals after a live kill. A renderer-side reclaimer detects leaks at the next shell prompt and disarms them so the shell works without reset.

- **Bug Fixes**
  - Installed an input-mode reclaimer on each xterm in `createTerminal`.
  - Added shared core `createLeakedInputModeReclaimer` (shell-owned epoch + mark-then-recheck flush).
  - Xterm adapter watches kitty (`CSI >/=/< u`), mouse (`?1000/1002/1003`), focus (`?1004`), and `OSC 777;superset-shell-ready`; writes disarms on a microtask.
  - Acts only at a shell prompt and cancels if a TUI re-arms; avoids tmux conflicts by not using `OSC 133;A`.
  - Added tests and docs. Alternate screen leaks are out of scope here.

<sup>Written for commit 480cd7eb377f681c709fd1921677fc84eeed4224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where terminal input settings—such as keyboard protocols, mouse tracking, and focus reporting—could remain active after an interrupted terminal application.
  * Restored normal shell input behavior when returning to a live prompt after an unclean exit.
  * Preserved input modes intentionally configured by shell startup settings.
* **Documentation**
  * Added troubleshooting and reproduction guidance for leaked terminal input modes, including current scope limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->