### PR TITLE
feat(desktop): single-flight host services across concurrent app instances

### DIFF
--- a/apps/desktop/scripts/verify-single-flight.ts
+++ b/apps/desktop/scripts/verify-single-flight.ts
@@ -1,0 +1,272 @@
+/**
+ * Two-instance single-flight verification for host-service-coordinator.
+ *
+ * Drives the REAL HostServiceCoordinator (real spawn lock, manifest, health
+ * check, process-liveness code) in two separate OS processes racing to start
+ * the same org against an ISOLATED temp $SUPERSET_HOME_DIR. Only Electron and
+ * a couple of leaf deps are mocked; `spawn` is overridden to launch a countable
+ * stand-in child + a real localhost health server + write the real manifest,
+ * standing in for the (unbuilt) host-service bundle.
+ *
+ * Expectation: exactly one process spawns; the other adopts it over HTTP.
+ *
+ * Usage: bun run apps/desktop/scripts/verify-single-flight.ts
+ * (spawns itself with --worker for the two instances)
+ */
+import { spawn as spawnProc } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import * as fs from "node:fs";
+import { createServer } from "node:http";
+import * as os from "node:os";
+import path from "node:path";
+
+const ORG = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+async function waitForFile(p: string, timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (fs.existsSync(p)) return true;
+		await new Promise((r) => setTimeout(r, 50));
+	}
+	return false;
+}
+
+// ── Worker: one simulated app instance ─────────────────────────────────
+async function runWorker(home: string, marker: string, label: string) {
+	process.env.SUPERSET_HOME_DIR = home;
+
+	const { mock } = await import("bun:test");
+	mock.module("electron", () => ({
+		app: {
+			isPackaged: false,
+			getVersion: () => "0.0.0",
+			getAppPath: () => "/tmp/app",
+		},
+		dialog: { showErrorBox: () => {} },
+	}));
+	mock.module("electron-log/main", () => ({
+		default: {
+			info: (...a: unknown[]) => console.log(`[${label}]`, ...a),
+			warn: (...a: unknown[]) => console.log(`[${label}]`, ...a),
+			error: (...a: unknown[]) => console.log(`[${label}]`, ...a),
+		},
+	}));
+	const realHostInfo = await import("@superset/shared/host-info");
+	mock.module("@superset/shared/host-info", () => ({
+		...realHostInfo,
+		getHostId: () => `host-${label}`,
+		getHostName: () => `host-${label}`,
+	}));
+	// Real ./local-db loads better-sqlite3 (native, unsupported in Bun); stub it.
+	mock.module(
+		path.resolve(import.meta.dir, "../src/main/lib/local-db"),
+		() => ({
+			localDb: { select: () => ({ from: () => ({ get: () => null }) }) },
+		}),
+	);
+
+	const { HostServiceCoordinator } = await import(
+		"../src/main/lib/host-service-coordinator"
+	);
+	const { writeManifest } = await import(
+		"../src/main/lib/host-service-manifest"
+	);
+	const { findFreePort } = await import("../src/main/lib/host-service-utils");
+
+	const coordinator = new HostServiceCoordinator();
+	let didSpawn = false;
+	let childPid: number | null = null;
+	let healthServer: ReturnType<typeof createServer> | null = null;
+
+	// Stand in for the real host-service bundle: pick a port, serve health,
+	// launch a countable child, write the manifest exactly as the child would.
+	(
+		coordinator as unknown as {
+			spawn: (
+				org: string,
+				_cfg: unknown,
+				pref: Iterable<number>,
+			) => Promise<unknown>;
+		}
+	).spawn = async (org: string, _cfg: unknown, pref: Iterable<number>) => {
+		const port = await findFreePort(pref);
+		const secret = randomBytes(16).toString("hex");
+
+		healthServer = createServer((req, res) => {
+			const ok = req.headers.authorization === `Bearer ${secret}`;
+			res.writeHead(
+				ok && req.url?.startsWith("/trpc/health.check") ? 200 : 401,
+			);
+			res.end(ok ? '{"result":{"data":true}}' : "");
+		});
+		await new Promise<void>((resolve) =>
+			healthServer?.listen(port, "127.0.0.1", resolve),
+		);
+
+		// Long-lived stand-in for the host-service child; marker in argv so it's
+		// countable via `pgrep -f` and killable in teardown.
+		const child = spawnProc("bash", ["-c", `exec -a "${marker}" sleep 300`], {
+			stdio: "ignore",
+			detached: false,
+		});
+		child.unref();
+		childPid = child.pid ?? null;
+		didSpawn = true;
+
+		writeManifest({
+			pid: childPid ?? process.pid,
+			endpoint: `http://127.0.0.1:${port}`,
+			authToken: secret,
+			startedAt: Date.now(),
+			organizationId: org,
+		});
+
+		(
+			coordinator as unknown as {
+				instances: Map<string, unknown>;
+			}
+		).instances.set(org, {
+			pid: childPid ?? process.pid,
+			port,
+			secret,
+			status: "running",
+			owned: true,
+		});
+		console.log(`[${label}] SPAWNED port=${port} childPid=${childPid}`);
+		return { port, secret, machineId: `host-${label}` };
+	};
+
+	// Signal readiness, then race on the shared GO barrier.
+	fs.writeFileSync(path.join(home, `ready-${label}`), "1");
+	await waitForFile(path.join(home, "GO"), 10_000);
+
+	const conn = await coordinator.start(ORG, {
+		authToken: "t",
+		cloudApiUrl: "https://example.invalid",
+	});
+	const entry = (
+		coordinator as unknown as {
+			instances: Map<string, { owned: boolean }>;
+		}
+	).instances.get(ORG);
+
+	fs.writeFileSync(
+		path.join(home, `result-${label}.json`),
+		JSON.stringify({
+			label,
+			spawned: didSpawn,
+			owned: entry?.owned ?? null,
+			port: conn.port,
+			secret: conn.secret,
+			childPid,
+		}),
+	);
+
+	// Winner keeps its health server alive so the loser can adopt; both hold
+	// until told to stop, then tear down (owner SIGTERMs its child + de-manifests).
+	await waitForFile(path.join(home, "STOP"), 60_000);
+	coordinator.stopAll();
+	healthServer?.close();
+	process.exit(0);
+}
+
+// ── Orchestrator ───────────────────────────────────────────────────────
+async function main() {
+	const home = fs.mkdtempSync(path.join(os.tmpdir(), "hs-sf-verify-"));
+	const marker = `HS_SF_STANDIN_${randomBytes(4).toString("hex")}`;
+	fs.mkdirSync(path.join(home, "host", ORG), { recursive: true });
+	console.log(`isolated SUPERSET_HOME_DIR=${home}`);
+	console.log(`stand-in child marker=${marker}\n`);
+
+	const self = path.resolve(import.meta.dir, "verify-single-flight.ts");
+	const workers = ["A", "B"].map((label) =>
+		spawnProc("bun", ["run", self, "--worker", home, marker, label], {
+			stdio: "inherit",
+		}),
+	);
+
+	const ready =
+		(await waitForFile(path.join(home, "ready-A"), 15_000)) &&
+		(await waitForFile(path.join(home, "ready-B"), 15_000));
+	if (!ready) throw new Error("workers did not become ready");
+
+	// Fire both at once → real cross-process race for the lock.
+	fs.writeFileSync(path.join(home, "GO"), "1");
+
+	const gotResults =
+		(await waitForFile(path.join(home, "result-A.json"), 60_000)) &&
+		(await waitForFile(path.join(home, "result-B.json"), 60_000));
+
+	let pass = false;
+	try {
+		if (!gotResults) throw new Error("did not get both results in time");
+		const a = JSON.parse(
+			fs.readFileSync(path.join(home, "result-A.json"), "utf8"),
+		);
+		const b = JSON.parse(
+			fs.readFileSync(path.join(home, "result-B.json"), "utf8"),
+		);
+
+		const spawners = [a, b].filter((r) => r.spawned);
+		const adopters = [a, b].filter((r) => !r.spawned);
+		// Count host-service children that actually exist = live recorded child
+		// pids across both instances (adopter records none).
+		const childPids = [a.childPid, b.childPid].filter(
+			(p): p is number => typeof p === "number",
+		);
+		const standins = childPids.filter((pid) => {
+			try {
+				process.kill(pid, 0);
+				return true;
+			} catch {
+				return false;
+			}
+		}).length;
+
+		console.log("\n──────── RESULT ────────");
+		console.log("A:", JSON.stringify(a));
+		console.log("B:", JSON.stringify(b));
+		console.log(`\nspawned count: ${spawners.length} (expect 1)`);
+		console.log(`adopted count: ${adopters.length} (expect 1)`);
+		console.log(`live stand-in host children: ${standins} (expect 1)`);
+
+		const samePort = a.port === b.port;
+		const sameSecret = a.secret === b.secret;
+		const adopterOwnedFalse = adopters.every((r) => r.owned === false);
+		console.log(
+			`adopter connected to spawner's port+secret: ${samePort && sameSecret}`,
+		);
+		console.log(`adopter entry marked owned=false: ${adopterOwnedFalse}`);
+
+		pass =
+			spawners.length === 1 &&
+			adopters.length === 1 &&
+			standins === 1 &&
+			samePort &&
+			sameSecret &&
+			adopterOwnedFalse;
+		console.log(`\n${pass ? "✅ PASS" : "❌ FAIL"} single-flight verified`);
+	} finally {
+		// Teardown: release workers, kill stand-ins, remove temp home.
+		fs.writeFileSync(path.join(home, "STOP"), "1");
+		await new Promise((r) => setTimeout(r, 1_000));
+		for (const w of workers) {
+			try {
+				w.kill("SIGTERM");
+			} catch {}
+		}
+		spawnProc("bash", ["-c", `pkill -f "${marker}" || true`]);
+		await new Promise((r) => setTimeout(r, 300));
+		fs.rmSync(home, { recursive: true, force: true });
+		console.log(`\ncleaned up temp home: ${home}`);
+	}
+
+	process.exit(pass ? 0 : 1);
+}
+
+const args = process.argv.slice(2);
+if (args[0] === "--worker") {
+	void runWorker(args[1], args[2], args[3]);
+} else {
+	void main();
+}

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -116,8 +116,12 @@ function resetMocks(): void {
 	readManifestMock.mockClear();
 	removeManifestMock.mockClear();
 	isProcessAliveMock.mockClear();
+	isProcessAliveMock.mockImplementation(() => true);
 	killProcessMock.mockClear();
 	pollHealthCheckMock.mockClear();
+	pollHealthCheckMock.mockImplementation(() => Promise.resolve(true));
+	readManifestMock.mockClear();
+	readManifestMock.mockImplementation(() => manifestStore.current);
 	killedPids = [];
 	killProcessError = null;
 }
@@ -236,6 +240,133 @@ describe("HostServiceCoordinator.reset", () => {
 		expect(killedPids).toHaveLength(0);
 		expect(spawnMock).toHaveBeenCalledTimes(1);
 		expect(conn.port).toBe(60000);
+	});
+});
+
+interface AdoptableInternals {
+	instances: Map<
+		string,
+		{
+			pid: number;
+			port: number;
+			secret: string;
+			status: string;
+			owned: boolean;
+		}
+	>;
+	spawn: ReturnType<typeof mock>;
+}
+
+describe("HostServiceCoordinator single-flight / adoption", () => {
+	let coordinator: InstanceType<typeof HostServiceCoordinator>;
+	let spawnMock: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		resetMocks();
+		testManifestRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hsc-test-"));
+		coordinator = new HostServiceCoordinator();
+		spawnMock = mock(async () => ({
+			port: 60000,
+			secret: "fresh-secret",
+			machineId: "host-1",
+		}));
+		(coordinator as unknown as AdoptableInternals).spawn = spawnMock;
+	});
+
+	afterEach(() => {
+		coordinator.stopAll();
+		if (testManifestRoot) {
+			fs.rmSync(testManifestRoot, { recursive: true, force: true });
+			testManifestRoot = "";
+		}
+	});
+
+	test("adopts a healthy foreign host-service instead of spawning", async () => {
+		manifestStore.current = baseManifest(4321, "http://127.0.0.1:55555");
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(true));
+
+		const conn = await coordinator.start("org-1", spawnConfig);
+
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(conn.port).toBe(55555);
+		expect(conn.secret).toBe("manifest-secret");
+
+		const internals = coordinator as unknown as AdoptableInternals;
+		expect(internals.instances.get("org-1")?.owned).toBe(false);
+	});
+
+	test("spawns when the manifest health-check fails", async () => {
+		manifestStore.current = baseManifest(4321, "http://127.0.0.1:55555");
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+
+		const conn = await coordinator.start("org-1", spawnConfig);
+
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(conn.port).toBe(60000);
+	});
+
+	test("under-lock double-check adopts a manifest that appears after the first miss", async () => {
+		manifestStore.current = baseManifest(4321, "http://127.0.0.1:55555");
+		// Outer adopt attempt sees nothing; the re-check under the lock does.
+		readManifestMock.mockImplementationOnce(() => null);
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(true));
+
+		const conn = await coordinator.start("org-1", spawnConfig);
+
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(conn.port).toBe(55555);
+	});
+
+	test("adopted fast-path drops a dead foreign entry and re-spawns", async () => {
+		const internals = coordinator as unknown as AdoptableInternals;
+		internals.instances.set("org-1", {
+			pid: 4321,
+			port: 55555,
+			secret: "manifest-secret",
+			status: "running",
+			owned: false,
+		});
+		manifestStore.current = null;
+		isProcessAliveMock.mockImplementation(() => false);
+
+		const conn = await coordinator.start("org-1", spawnConfig);
+
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(conn.port).toBe(60000);
+	});
+
+	test("stop on an adopted entry does not SIGTERM and keeps the manifest", () => {
+		const internals = coordinator as unknown as AdoptableInternals;
+		internals.instances.set("org-1", {
+			pid: 4321,
+			port: 55555,
+			secret: "manifest-secret",
+			status: "running",
+			owned: false,
+		});
+
+		coordinator.stop("org-1");
+
+		expect(killedPids).toHaveLength(0);
+		expect(removeManifestMock).not.toHaveBeenCalled();
+		expect(internals.instances.get("org-1")).toBeUndefined();
+	});
+
+	test("stop on an owned entry SIGTERMs the child and removes the manifest", () => {
+		const internals = coordinator as unknown as AdoptableInternals;
+		internals.instances.set("org-1", {
+			pid: 4321,
+			port: 55555,
+			secret: "own-secret",
+			status: "running",
+			owned: true,
+		});
+
+		coordinator.stop("org-1");
+
+		expect(killedPids).toContainEqual({ pid: 4321, signal: "SIGTERM" });
+		expect(removeManifestMock).toHaveBeenCalled();
+		expect(internals.instances.get("org-1")).toBeUndefined();
 	});
 });
 

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -196,9 +196,9 @@ export class HostServiceCoordinator extends EventEmitter {
 		instance.status = "stopped";
 		this.rememberPort(organizationId, instance.port);
 
-		// Adopted entries belong to another live app instance. Drop our local
-		// reference only — never SIGTERM the foreign child or delete the manifest
-		// the owner still relies on.
+		// Only owned children are ours to kill + de-manifest. Adopted entries
+		// (owned=false) belong to another live instance — fall through and just
+		// drop our local reference below; never SIGTERM it or remove its manifest.
 		if (instance.owned) {
 			try {
 				killProcess(instance.pid, "SIGTERM");

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -11,6 +11,7 @@ import { env as sharedEnv } from "shared/env.shared";
 import { getProcessEnvWithShellPath } from "../../lib/trpc/routers/workspaces/utils/shell-env";
 import { SUPERSET_HOME_DIR } from "./app-environment";
 import { isInternalBuild } from "./build-channel";
+import { acquireSpawnLock } from "./host-service-lock";
 import {
 	isProcessAlive,
 	killProcess,
@@ -53,7 +54,34 @@ interface HostServiceProcess {
 	port: number;
 	secret: string;
 	status: HostServiceStatus;
+	/**
+	 * True when this instance spawned the child and owns its lifecycle (may
+	 * SIGTERM it and remove its manifest). False when the entry was *adopted*
+	 * from another live app instance's host-service — we connect to it but must
+	 * never kill it or delete its manifest.
+	 */
+	owned: boolean;
 }
+
+/**
+ * Short health check used when deciding whether to adopt a foreign
+ * host-service — the endpoint either answers within a couple of attempts or it
+ * doesn't. Distinct from the long spawn readiness gate (HEALTH_POLL_TIMEOUT_MS).
+ */
+const ADOPT_HEALTH_TIMEOUT_MS = 2_500;
+
+/**
+ * How long a spawn lock may be held before another instance treats it as
+ * wedged and steals it. A legitimate spawn holds the lock for the full health
+ * poll window, so allow that plus margin.
+ */
+const SPAWN_LOCK_STALE_MS = HEALTH_POLL_TIMEOUT_MS + 5_000;
+
+/** Overall budget for startOrAdopt to wait out a peer's in-flight spawn. */
+const START_OR_ADOPT_DEADLINE_MS = SPAWN_LOCK_STALE_MS + HEALTH_POLL_TIMEOUT_MS;
+
+/** Poll interval while waiting for a peer instance's spawn to go healthy. */
+const ADOPT_WAIT_INTERVAL_MS = 250;
 
 // High, uncommon user-space range: above usual web/dev server ports and below
 // macOS's default ephemeral range, while still falling back if occupied.
@@ -106,17 +134,24 @@ export class HostServiceCoordinator extends EventEmitter {
 	): Promise<Connection> {
 		const existing = this.instances.get(organizationId);
 		if (existing?.status === "running") {
-			return {
-				port: existing.port,
-				secret: existing.secret,
-				machineId: this.machineId,
-			};
+			// An adopted entry points at a foreign instance's child we don't
+			// supervise (no exit handler). Re-validate it's still alive before
+			// handing it back; if the owner died, drop it and start fresh.
+			if (existing.owned || isProcessAlive(existing.pid)) {
+				return {
+					port: existing.port,
+					secret: existing.secret,
+					machineId: this.machineId,
+				};
+			}
+			this.instances.delete(organizationId);
+			this.emitStatus(organizationId, "stopped", "running");
 		}
 
 		const pending = this.pendingStarts.get(organizationId);
 		if (pending) return pending;
 
-		const startPromise = this.spawn(
+		const startPromise = this.startOrAdopt(
 			organizationId,
 			config,
 			preferredPorts ?? this.getPreferredPorts(organizationId),
@@ -161,12 +196,17 @@ export class HostServiceCoordinator extends EventEmitter {
 		instance.status = "stopped";
 		this.rememberPort(organizationId, instance.port);
 
-		try {
-			killProcess(instance.pid, "SIGTERM");
-		} catch {}
+		// Adopted entries belong to another live app instance. Drop our local
+		// reference only — never SIGTERM the foreign child or delete the manifest
+		// the owner still relies on.
+		if (instance.owned) {
+			try {
+				killProcess(instance.pid, "SIGTERM");
+			} catch {}
+			removeManifest(organizationId);
+		}
 
 		this.instances.delete(organizationId);
-		removeManifest(organizationId);
 		this.emitStatus(organizationId, "stopped", previousStatus);
 	}
 
@@ -385,6 +425,99 @@ export class HostServiceCoordinator extends EventEmitter {
 		};
 	}
 
+	// ── Adopt + single-flight spawn ────────────────────────────────────
+
+	/**
+	 * Single-flight a host-service for `organizationId` across every app
+	 * instance sharing this machine's `$SUPERSET_HOME_DIR`.
+	 *
+	 * First tries to adopt a healthy host-service another instance already
+	 * spawned (reading its manifest for port + secret). Otherwise it takes a
+	 * cross-process spawn lock and spawns; a peer that can't get the lock waits
+	 * for the winner's manifest to go healthy and adopts it, so only one child
+	 * per org is ever spawned. Stale/dead-owner locks are stolen so a crashed or
+	 * wedged instance never wedges everyone else.
+	 */
+	private async startOrAdopt(
+		organizationId: string,
+		config: SpawnConfig,
+		preferredPorts: Iterable<number>,
+	): Promise<Connection> {
+		const adopted = await this.tryAdopt(organizationId);
+		if (adopted) return adopted;
+
+		const deadline = Date.now() + START_OR_ADOPT_DEADLINE_MS;
+		for (;;) {
+			const lock = acquireSpawnLock(organizationId, {
+				staleMs: SPAWN_LOCK_STALE_MS,
+			});
+			if (lock) {
+				try {
+					// A peer may have finished spawning between our first adopt
+					// attempt and taking the lock — re-check before spawning.
+					const raced = await this.tryAdopt(organizationId);
+					if (raced) return raced;
+					return await this.spawn(organizationId, config, preferredPorts);
+				} finally {
+					lock.release();
+				}
+			}
+
+			// A live peer holds the lock and is mid-spawn: wait for its manifest
+			// to become healthy, then adopt it.
+			const peer = await this.tryAdopt(organizationId);
+			if (peer) return peer;
+
+			if (Date.now() >= deadline) {
+				throw new Error(
+					`Timed out waiting to start or adopt host service for ${organizationId}`,
+				);
+			}
+			await new Promise((r) => setTimeout(r, ADOPT_WAIT_INTERVAL_MS));
+		}
+	}
+
+	/**
+	 * Adopt a host-service another live app instance spawned, if its manifest
+	 * points at a healthy endpoint. Registers a foreign-owned in-process entry
+	 * and returns its connection, or null when there's nothing healthy to adopt.
+	 */
+	private async tryAdopt(organizationId: string): Promise<Connection | null> {
+		const manifest = readManifest(organizationId);
+		if (!manifest) return null;
+
+		let port: number;
+		try {
+			port = Number(new URL(manifest.endpoint).port);
+		} catch {
+			return null;
+		}
+		if (!isValidPort(port)) return null;
+
+		const healthy = await pollHealthCheck(
+			manifest.endpoint,
+			manifest.authToken,
+			ADOPT_HEALTH_TIMEOUT_MS,
+		);
+		if (!healthy) return null;
+
+		const previous = this.instances.get(organizationId);
+		this.instances.set(organizationId, {
+			pid: manifest.pid,
+			port,
+			secret: manifest.authToken,
+			status: "running",
+			owned: false,
+		});
+		this.rememberPort(organizationId, port);
+		this.emitStatus(organizationId, "running", previous?.status ?? null);
+
+		log.info(
+			`[host-service:${organizationId}] adopted existing host on port ${port} (pid ${manifest.pid})`,
+		);
+		return { port, secret: manifest.authToken, machineId: this.machineId };
+	}
+
 	// ── Spawn ─────────────────────────────────────────────────────────
 
 	private async spawn(
@@ -401,6 +534,7 @@ export class HostServiceCoordinator extends EventEmitter {
 			port,
 			secret,
 			status: "starting",
+			owned: true,
 		};
 		this.instances.set(organizationId, instance);
 		this.emitStatus(organizationId, "starting", null);

--- a/apps/desktop/src/main/lib/host-service-lock.test.ts
+++ b/apps/desktop/src/main/lib/host-service-lock.test.ts
@@ -1,0 +1,124 @@
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import path from "node:path";
+
+let testRoot = "";
+const isProcessAliveMock = mock((_pid: number) => true);
+
+const realManifest = await import("./host-service-manifest");
+mock.module("./host-service-manifest", () => ({
+	...realManifest,
+	isProcessAlive: isProcessAliveMock,
+	manifestDir: (orgId: string) => path.join(testRoot, orgId),
+}));
+
+mock.module("@superset/shared/host-info", () => ({
+	getHostId: () => "host-1",
+	getHostName: () => "host",
+}));
+
+const { acquireSpawnLock, readSpawnLock } = await import("./host-service-lock");
+
+const ORG = "org-1";
+const lockFile = () => path.join(testRoot, ORG, "spawn.lock");
+
+describe("acquireSpawnLock", () => {
+	beforeEach(() => {
+		testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hsl-test-"));
+		isProcessAliveMock.mockClear();
+		isProcessAliveMock.mockImplementation(() => true);
+	});
+
+	afterEach(() => {
+		if (testRoot) {
+			fs.rmSync(testRoot, { recursive: true, force: true });
+			testRoot = "";
+		}
+	});
+
+	test("creates the lock file and records the owning pid", () => {
+		const handle = acquireSpawnLock(ORG, { staleMs: 30_000 });
+		expect(handle).not.toBeNull();
+
+		const lock = readSpawnLock(ORG);
+		expect(lock?.ownerPid).toBe(process.pid);
+		expect(lock?.machineId).toBe("host-1");
+		expect(fs.existsSync(lockFile())).toBe(true);
+	});
+
+	test("second acquire returns null while a live holder keeps the lock", () => {
+		const first = acquireSpawnLock(ORG, { staleMs: 30_000 });
+		expect(first).not.toBeNull();
+
+		const second = acquireSpawnLock(ORG, { staleMs: 30_000 });
+		expect(second).toBeNull();
+	});
+
+	test("release removes the file and lets the next caller acquire", () => {
+		const first = acquireSpawnLock(ORG, { staleMs: 30_000 });
+		first?.release();
+		expect(fs.existsSync(lockFile())).toBe(false);
+
+		const second = acquireSpawnLock(ORG, { staleMs: 30_000 });
+		expect(second).not.toBeNull();
+	});
+
+	test("steals the lock when the holder's pid is dead", () => {
+		fs.mkdirSync(path.join(testRoot, ORG), { recursive: true });
+		fs.writeFileSync(
+			lockFile(),
+			JSON.stringify({
+				ownerPid: 424242,
+				machineId: "host-1",
+				acquiredAt: Date.now(),
+			}),
+		);
+		isProcessAliveMock.mockImplementation(() => false);
+
+		const handle = acquireSpawnLock(ORG, { staleMs: 30_000 });
+
+		expect(handle).not.toBeNull();
+		expect(readSpawnLock(ORG)?.ownerPid).toBe(process.pid);
+	});
+
+	test("steals the lock when it is older than staleMs even if the pid is alive", () => {
+		fs.mkdirSync(path.join(testRoot, ORG), { recursive: true });
+		fs.writeFileSync(
+			lockFile(),
+			JSON.stringify({
+				ownerPid: 424242,
+				machineId: "host-1",
+				acquiredAt: Date.now() - 60_000,
+			}),
+		);
+		isProcessAliveMock.mockImplementation(() => true);
+
+		const handle = acquireSpawnLock(ORG, { staleMs: 30_000 });
+
+		expect(handle).not.toBeNull();
+		expect(readSpawnLock(ORG)?.ownerPid).toBe(process.pid);
+	});
+
+	test("steals a garbage/partial lock file", () => {
+		fs.mkdirSync(path.join(testRoot, ORG), { recursive: true });
+		fs.writeFileSync(lockFile(), "{ not valid json");
+
+		const handle = acquireSpawnLock(ORG, { staleMs: 30_000 });
+
+		expect(handle).not.toBeNull();
+		expect(readSpawnLock(ORG)?.ownerPid).toBe(process.pid);
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/apps/desktop/src/main/lib/host-service-lock.ts
+++ b/apps/desktop/src/main/lib/host-service-lock.ts
@@ -1,0 +1,124 @@
+import {
+	closeSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	unlinkSync,
+	writeSync,
+} from "node:fs";
+import { join } from "node:path";
+import { getHostId } from "@superset/shared/host-info";
+import { isProcessAlive, manifestDir } from "./host-service-manifest";
+
+/**
+ * Cross-instance spawn lock for a per-org host-service.
+ *
+ * Multiple Superset app instances share one `$SUPERSET_HOME_DIR`, so their
+ * in-process `pendingStarts` maps can't stop two instances from spawning the
+ * same org's host-service at once. This atomic exclusive-create lockfile
+ * single-flights the spawn+health-check critical section across processes.
+ *
+ * The lock records the *app instance's* pid (Electron main), not the child's —
+ * its liveness tracks the spawner so a crashed instance's lock can be stolen.
+ */
+export interface SpawnLock {
+	ownerPid: number;
+	machineId: string;
+	acquiredAt: number;
+}
+
+export interface SpawnLockHandle {
+	release(): void;
+}
+
+function lockPath(organizationId: string): string {
+	return join(manifestDir(organizationId), "spawn.lock");
+}
+
+export function readSpawnLock(organizationId: string): SpawnLock | null {
+	try {
+		const raw = readFileSync(lockPath(organizationId), "utf-8");
+		const data = JSON.parse(raw);
+		if (
+			typeof data.ownerPid !== "number" ||
+			typeof data.machineId !== "string" ||
+			typeof data.acquiredAt !== "number"
+		) {
+			return null;
+		}
+		return data as SpawnLock;
+	} catch {
+		return null;
+	}
+}
+
+function removeLock(organizationId: string): void {
+	try {
+		unlinkSync(lockPath(organizationId));
+	} catch {
+		// Already gone — fine.
+	}
+}
+
+function tryCreateLock(organizationId: string): SpawnLockHandle | null {
+	const path = lockPath(organizationId);
+	try {
+		mkdirSync(manifestDir(organizationId), { recursive: true, mode: 0o700 });
+	} catch {
+		// Best-effort; openSync below surfaces a real failure.
+	}
+
+	let fd: number;
+	try {
+		// "wx" = O_CREAT | O_EXCL: atomic exclusive create on POSIX and Windows.
+		fd = openSync(path, "wx", 0o600);
+	} catch {
+		return null;
+	}
+
+	try {
+		const lock: SpawnLock = {
+			ownerPid: process.pid,
+			machineId: getHostId(),
+			acquiredAt: Date.now(),
+		};
+		writeSync(fd, JSON.stringify(lock));
+	} finally {
+		try {
+			// Best-effort close; the lock's existence, not the fd, is what matters.
+			closeSync(fd);
+		} catch {}
+	}
+
+	return {
+		release() {
+			removeLock(organizationId);
+		},
+	};
+}
+
+/**
+ * Acquire the per-org spawn lock, stealing it when the current holder has
+ * crashed or wedged. Returns a handle on success, or `null` when a live
+ * instance is legitimately mid-spawn (the caller should wait and retry).
+ */
+export function acquireSpawnLock(
+	organizationId: string,
+	{ staleMs }: { staleMs: number },
+): SpawnLockHandle | null {
+	const handle = tryCreateLock(organizationId);
+	if (handle) return handle;
+
+	// Lock exists — decide whether the holder is dead/wedged and stealable.
+	const existing = readSpawnLock(organizationId);
+	const stealable =
+		!existing || // garbage / partial write
+		!isProcessAlive(existing.ownerPid) || // owner crashed mid-spawn
+		Date.now() - existing.acquiredAt > staleMs; // owner wedged
+
+	if (!stealable) return null;
+
+	removeLock(organizationId);
+	// One retry after stealing; if a third party grabbed it first, back off.
+	return tryCreateLock(organizationId);
+}

--- a/plans/host-service-single-flight.md
+++ b/plans/host-service-single-flight.md
@@ -158,3 +158,21 @@ Shipped as planned. PR: https://github.com/superset-sh/superset/pull/5791
 - `bun run lint` clean · `bun run typecheck` 35/35.
 - No production callers changed; `stop`/`stopAll`/`reset` keep their existing
   semantics for owned entries.
+
+### Two-instance end-to-end verification
+
+`apps/desktop/scripts/verify-single-flight.ts` drives the **real**
+`HostServiceCoordinator` (real spawn lock, manifest, health check, and
+process-liveness code) in **two separate OS processes** racing to start the same
+org against an **isolated temp `$SUPERSET_HOME_DIR`** (only Electron + leaf deps
+mocked; `spawn` overridden to launch a countable stand-in child + a real
+localhost health server + write the real manifest — the host-service bundle
+isn't built in a worktree). Run: `bun run apps/desktop/scripts/verify-single-flight.ts`.
+
+Result (`✅ PASS`): one instance spawns, the other logs
+`adopted existing host on port …` and connects to the **same port + secret**;
+exactly **1** host-service child exists; the adopter's entry is `owned=false`.
+Teeth-checked by breaking `tryAdopt` → both spawn → 2 children → `❌ FAIL`.
+The harness is prod-safe (temp home only) and self-cleaning (removes the temp
+dir + kills stand-ins in `finally`); confirmed the real `~/.superset/host` was
+untouched and no processes leaked.

--- a/plans/host-service-single-flight.md
+++ b/plans/host-service-single-flight.md
@@ -145,3 +145,16 @@ reference-counted survival is out of scope here.
   - existing `reset` / preferred-port tests still pass.
 
 Each test is verified to fail against the pre-change behavior (mutation check).
+
+## Result
+
+Shipped as planned. PR: https://github.com/superset-sh/superset/pull/5791
+
+- New `host-service-lock.ts` + `tryAdopt`/`startOrAdopt` + `owned` flag +
+  ownership-aware `stop`, exactly as designed above.
+- Tests: `host-service-lock.test.ts` (6) + 6 new coordinator tests — **18 pass**.
+  Mutation-verified: broke the ownership branch, health gate, lock-steal
+  condition, and adopted liveness re-check — each corresponding test failed.
+- `bun run lint` clean · `bun run typecheck` 35/35.
+- No production callers changed; `stop`/`stopAll`/`reset` keep their existing
+  semantics for owned entries.

--- a/plans/host-service-single-flight.md
+++ b/plans/host-service-single-flight.md
@@ -1,0 +1,147 @@
+# Host-service single-flight across concurrent app instances
+
+Follow-up to PR #5787. Scope: `apps/desktop` main-process host-service coordinator.
+
+## Problem
+
+Multiple Superset app instances on one machine (stable + canary + dev worktree
+builds) all share `$SUPERSET_HOME_DIR`. Each has its own in-process
+`HostServiceCoordinator` whose `instances` map starts empty at boot, and each
+independently runs `startAllKnown` → `start(org)` → `spawn` for **every** org
+under `$SUPERSET_HOME_DIR/host/*`.
+
+Result: the same org's host-service is spawned by several instances at once. The
+duplicates contend for:
+- the per-org `host.db` (SQLite WAL), and
+- the pty-daemon unix socket (hashed by orgId only — see
+  `project_ptyd_socket_shared_across_instances`), so concurrent same-org
+  host-services can mutually reap each other's sessions.
+
+The in-process `pendingStarts` / `instances` maps only single-flight **within**
+one instance. There is no cross-process coordination.
+
+## Goal
+
+Single-flight host services **per org across concurrent instances on one
+machine**. When instance B boots and instance A already has a healthy
+host-service for an org, B adopts it (connects to A's port + secret) instead of
+racing to spawn a duplicate. Handle stale locks after a crash, and make teardown
+ownership-aware: never kill or de-manifest a host-service another live instance
+spawned.
+
+## Existing building blocks
+
+- The **child** writes `manifest.json` (`pid`, `endpoint`, `authToken` = the
+  PSK secret, `startedAt`, `organizationId`) once it is listening
+  (`main/host-service/index.ts`). This already contains everything needed to
+  adopt: endpoint (→ port) + secret.
+- `pollHealthCheck(endpoint, secret, timeoutMs)` in `host-service-utils.ts`
+  hits `/trpc/health.check` with the bearer secret.
+- `isProcessAlive(pid)` in `host-service-manifest.ts`.
+- The pty-daemon is supervised separately and **outlives host-service
+  restarts**, so a brief host-service re-spawn does not drop terminals.
+
+## Design
+
+### 1. Cross-process spawn lock (new `host-service-lock.ts`)
+
+An atomic exclusive-create lockfile per org at
+`$SUPERSET_HOME_DIR/host/<org>/spawn.lock`, held only during the
+spawn+health-check critical section.
+
+- `acquireSpawnLock(org, { staleMs })`: `fs.openSync(path, "wx", 0o600)` (atomic
+  O_EXCL on POSIX and Windows). On success, write
+  `{ ownerPid: process.pid, machineId, acquiredAt: Date.now() }` and return a
+  handle whose `release()` unlinks the file.
+- On `EEXIST`, read the existing lock and decide:
+  - unparseable/garbage → **steal** (unlink + retry once),
+  - `ownerPid` not alive → **steal** (owner crashed mid-spawn),
+  - `acquiredAt` older than `staleMs` → **steal** (owner wedged),
+  - otherwise → return `null` (a live instance is legitimately spawning).
+- `mkdir -p` the org dir before opening (the dir may not exist yet).
+
+`ownerPid` is the **app instance's** (Electron main) pid, not the child's — the
+lock's liveness tracks the spawner. `staleMs` ≈ `HEALTH_POLL_TIMEOUT_MS` + margin
+(a legitimate spawn can hold the lock for the full health-poll window).
+
+### 2. Adopt-first start flow (`host-service-coordinator.ts`)
+
+Extend `HostServiceProcess` with `owned: boolean`.
+
+New `tryAdopt(org)`:
+1. `readManifest(org)`; bail if none.
+2. Parse port from `endpoint` (`new URL(endpoint).port`).
+3. `pollHealthCheck(endpoint, secret, ADOPT_HEALTH_TIMEOUT_MS)` — short (~2.5s),
+   not the full 30s. Bail if unhealthy.
+4. Register an in-process entry `{ pid, port, secret, status: "running",
+   owned: false }`, `rememberPort`, emit `running`, return the connection.
+
+Rework `startWithPreferredPorts`:
+1. Fast path: in-process `running` entry. For an **adopted** entry, first
+   re-validate with `isProcessAlive(pid)`; if the foreign child died, drop it and
+   fall through. (Owned entries keep the child `exit` handler, so no check
+   needed.)
+2. In-process `pendingStarts` → return pending (unchanged).
+3. Otherwise the pending promise is `startOrAdopt(org, config, preferredPorts)`:
+   - `tryAdopt` → return if healthy.
+   - Loop until an overall deadline (`staleMs + HEALTH_POLL_TIMEOUT + margin`):
+     - `lock = acquireSpawnLock(org, staleMs)`:
+       - **got lock** → double-check `tryAdopt` (another instance may have
+         finished between our first check and lock acquisition); else
+         `await this.spawn(...)` (owner = true). `finally lock.release()`.
+       - **no lock** → a live instance is spawning: `tryAdopt`; if healthy,
+         return. Otherwise `sleep(interval)` and retry the loop. Stale/dead-owner
+         locks become stealable via `acquireSpawnLock`, so a wedged owner is
+         eventually taken over.
+   - Throw a clear timeout error if the deadline passes.
+
+`spawn` is unchanged except it sets `owned: true` on the instance.
+
+### 3. Ownership-aware teardown
+
+- `stop(org)`:
+  - **owned** → current behavior (SIGTERM the child, `removeManifest`, drop
+    entry, emit `stopped`).
+  - **adopted** → **only** drop the local entry + emit `stopped`. Never SIGTERM
+    (that would kill a foreign live instance's child) and never `removeManifest`
+    (the owner still needs it). This is the core "don't kill what another
+    instance is using" requirement.
+- `stopAll()` (before-quit / sign-out) naturally does the right thing per entry.
+- `reset(org)` is an explicit user recovery command ("wedged host-service");
+  it keeps its force-SIGKILL-by-manifest-pid semantics even for a foreign child,
+  then respawns as owner. Documented.
+
+### Known limitation (documented, follow-up)
+
+If the **owner** instance quits while an **adopter** is still using the child,
+the child dies (SIGTERM on the owner's `stopAll`, or its `HOST_PARENT_PID`
+watchdog). The adopter recovers lazily: its next `start`/health failure re-runs
+`startOrAdopt` and re-spawns (becoming the new owner). Because the pty-daemon
+outlives host-service restarts, terminals survive the gap. True cross-instance
+reference-counted survival is out of scope here.
+
+## Files
+
+- **new** `apps/desktop/src/main/lib/host-service-lock.ts` — `acquireSpawnLock`,
+  `readSpawnLock`, lock-handle `release`.
+- `apps/desktop/src/main/lib/host-service-coordinator.ts` — `owned` flag,
+  `tryAdopt`, `startOrAdopt`, ownership-aware `stop`, adopted fast-path
+  re-validation.
+- `apps/desktop/src/main/lib/host-service-coordinator.ts` constants:
+  `ADOPT_HEALTH_TIMEOUT_MS`, lock stale/deadline constants.
+
+## Tests
+
+- **`host-service-lock.test.ts`** (new): exclusive acquire; second acquire
+  returns null while first held; steal on dead `ownerPid`; steal on stale
+  `acquiredAt`; steal on garbage file; `release` unlinks and allows re-acquire.
+- **`host-service-coordinator.test.ts`** (extend):
+  - adopts a healthy foreign manifest without calling `spawn`;
+  - does not adopt when the manifest health-check fails → spawns;
+  - `stop` on an adopted entry does **not** SIGTERM and does **not**
+    `removeManifest`; `stop` on an owned entry does both;
+  - under-lock double-check adopts if a manifest appears after the first miss;
+  - adopted fast-path drops a dead foreign entry and re-spawns;
+  - existing `reset` / preferred-port tests still pass.
+
+Each test is verified to fail against the pre-change behavior (mutation check).


### PR DESCRIPTION
## Problem

Follow-up to #5787. Multiple Superset app instances on one machine (stable + canary + dev worktree builds) share `$SUPERSET_HOME_DIR`, and each has its own in-process `HostServiceCoordinator` whose `instances` map starts empty at boot. Each independently runs `startAllKnown` → `start(org)` → `spawn` for **every** org, so the same org's host-service gets spawned by several instances at once. The duplicates contend for the per-org `host.db` (SQLite WAL) and the org-hashed pty-daemon socket, causing startup contention and mutual reaping. The existing `pendingStarts`/`instances` maps only single-flight *within* one instance.

## Fix

Single-flight host services **per org across concurrent instances on one machine**:

- **`host-service-lock.ts` (new)** — atomic exclusive-create (`openSync "wx"`) per-org `spawn.lock`, recording the app-instance pid + `acquiredAt`. `acquireSpawnLock` steals the lock when the holder's pid is dead, the lock is stale (wedged), or the file is garbage, so a crash never wedges the fleet.
- **`tryAdopt`** — reads a peer's manifest (endpoint → port + secret), health-checks it with a short timeout, and adopts the running host-service instead of spawning a duplicate.
- **`startOrAdopt`** — adopt-first, else take the cross-process lock (double-checking adoption once held), spawn under the lock, or — if a live peer holds the lock — wait for its manifest to go healthy and adopt it.
- **Ownership-aware teardown** — `HostServiceProcess` gains an `owned` flag. `stop` only SIGTERMs the child + removes the manifest for *owned* entries; adopted entries are dropped locally, so one instance quitting never kills a host-service another live instance is using. The running fast-path re-validates adopted entries and re-spawns if the owner died (terminals survive because the pty-daemon outlives host-service restarts).

Known limitation (documented in the plan): if the owner quits while an adopter is mid-use, the adopter re-spawns lazily on its next start/health failure. Cross-instance refcounted survival is a noted follow-up.

Plan: `plans/host-service-single-flight.md`.

## Test plan

- [x] `host-service-lock.test.ts` (6) + 6 new coordinator tests — 18 pass
- [x] Each new test mutation-verified (broke ownership branch, health gate, lock-steal condition, liveness re-check — each corresponding test fails)
- [x] `bun run lint` clean · `bun run typecheck` 35/35

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5791">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-flight host services across concurrent desktop app instances to prevent duplicate spawns per org. Verified with a two‑process E2E harness that proves adopt‑first behavior and lock correctness.

- **New Features**
  - Cross-process spawn lock per org (`spawn.lock`) using atomic exclusive create; steals stale/dead-owner locks to avoid wedges.
  - Adopt-first start: read manifest, quick health check, and adopt; if a peer is spawning, wait for healthy and adopt; otherwise spawn once under the lock.
  - Ownership-aware teardown: only SIGTERM and remove manifest for services we spawned; drop adopted entries without killing the shared process.

- **Documentation**
  - Updated `plans/host-service-single-flight.md` with results and PR link.
  - Clarified code comments for ownership-aware stop behavior.

<sup>Written for commit 4725802266783adc6d254e7813ef4f84128d4adb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cross-process, per-organization “single-flight” coordination so only one host-service is started across concurrent app instances.
  - Introduced adoption-first startup to reuse a healthy existing service via manifest + quick health checks.
  - Ownership-aware lifecycle: adopted services stay running while owned services are stopped and cleaned up.

- **Bug Fixes**
  - Improved lock handling, including reliable recovery from stale/wedged and malformed lock states.

- **Tests**
  - Expanded unit coverage for lock contention, adoption/double-check races, and stop semantics.
  - Added a two-process end-to-end verification script.

- **Documentation**
  - Documented the single-flight/adoption approach and validation plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->