### PR TITLE
fix: wrap long commit messages in range modal

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
@@ -29,7 +29,7 @@ export function CommitRow({ commit, isSelected, wrap = false }: CommitRowProps) 
 				<div
 					className={
 						wrap
-							? "text-sm break-words whitespace-normal"
+							? "text-sm wrap-break-word"
 							: "truncate text-sm"
 					}
 				>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
@@ -19,18 +19,27 @@ function timeAgo(date: string): string {
 interface CommitRowProps {
 	commit: Commit;
 	isSelected?: boolean;
+	wrap?: boolean;
 }
 
-export function CommitRow({ commit, isSelected }: CommitRowProps) {
+export function CommitRow({ commit, isSelected, wrap = false }: CommitRowProps) {
 	return (
-		<div className="flex flex-1 items-center justify-between">
-			<div className="min-w-0">
-				<div className="truncate text-sm">{commit.message}</div>
-				<div className="text-xs text-muted-foreground">
+		<div className="flex min-w-0 flex-1 items-start justify-between gap-2">
+			<div className="min-w-0 flex-1 overflow-hidden">
+				<div
+					className={
+						wrap
+							? "text-sm break-words whitespace-normal"
+							: "truncate text-sm"
+					}
+				>
+					{commit.message}
+				</div>
+				<div className="truncate text-xs text-muted-foreground">
 					{commit.shortHash} · {commit.author} · {timeAgo(commit.date)}
 				</div>
 			</div>
-			{isSelected && <Check className="size-3.5 shrink-0" />}
+			{isSelected && <Check className="mt-0.5 size-3.5 shrink-0" />}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/RangeModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/RangeModal.tsx
@@ -72,7 +72,7 @@ export function RangeModal({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange} modal>
-			<DialogContent className="sm:max-w-md">
+			<DialogContent className="overflow-hidden sm:max-w-md">
 				<DialogHeader>
 					<DialogTitle>Select commit range</DialogTitle>
 					<DialogDescription>
@@ -80,8 +80,8 @@ export function RangeModal({
 					</DialogDescription>
 				</DialogHeader>
 
-				<ScrollArea className="max-h-[300px]">
-					<div className="space-y-0.5">
+				<ScrollArea className="max-h-[300px] min-w-0">
+					<div className="min-w-0 space-y-0.5">
 						{commits.map((commit, idx) => {
 							const inRange = idx >= minIdx && idx <= maxIdx;
 							return (
@@ -89,13 +89,13 @@ export function RangeModal({
 									key={commit.hash}
 									type="button"
 									onClick={() => handleClick(idx)}
-									className={`flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm ${
+									className={`flex w-full min-w-0 items-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm ${
 										inRange
 											? "bg-accent text-accent-foreground"
 											: "hover:bg-accent/50"
 									}`}
 								>
-									<CommitRow commit={commit} />
+									<CommitRow commit={commit} wrap />
 								</button>
 							);
 						})}


### PR DESCRIPTION
## What & why

Long commit messages in the **Select commit range** modal overflowed the dialog width and were clipped mid-line. Messages now wrap within the modal (`CommitRow` wrap mode + width containment on the dialog/scroll list) so the full text stays readable. 

Fixes #4943.

## How I tested it

1. Opened a workspace with a git history that includes long commit messages
2. Changes tab → commit filter → **Select range...**
3. Confirmed long messages wrap onto additional lines inside the modal instead of overflowing or truncating mid-word
4. Confirmed Cancel/Apply stay inside the footer and the dropdown still truncates compactly

before : 
<img width="548" height="535" alt="before" src="https://github.com/user-attachments/assets/c9810f5c-c321-4db5-b493-154fb9a73f1a" />

after:
<img width="548" height="535" alt="after" src="https://github.com/user-attachments/assets/b1566327-59a6-4825-accc-172cd70aeaa0" />


## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved commit selection and range dialogs to prevent overflow and ensure better sizing behavior.
  - Updated commit row message rendering to support clean word-wrapping in constrained layouts.
  - Kept compact, single-line display via truncation when wrapping is not enabled, improving overall readability and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->