### PR TITLE
fix(pty-daemon): release macOS PTY master descriptors

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -201,7 +201,7 @@
 		"nanoid": "5.1.7",
 		"native-keymap": "3.3.9",
 		"node-addon-api": "7.1.1",
-		"node-pty": "1.1.0",
+		"node-pty": "1.2.0-beta.14",
 		"os-locale": "6.0.2",
 		"pidtree": "0.6.0",
 		"pidusage": "4.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -280,7 +280,7 @@
         "nanoid": "5.1.7",
         "native-keymap": "3.3.9",
         "node-addon-api": "7.1.1",
-        "node-pty": "1.1.0",
+        "node-pty": "1.2.0-beta.14",
         "os-locale": "6.0.2",
         "pidtree": "0.6.0",
         "pidusage": "4.0.1",
@@ -865,7 +865,7 @@
         "hono": "4.12.25",
         "mastracode": "0.18.1",
         "mime-types": "3.0.2",
-        "node-pty": "1.1.0",
+        "node-pty": "1.2.0-beta.14",
         "semver": "7.7.4",
         "simple-git": "3.36.0",
         "superjson": "2.2.6",
@@ -989,7 +989,7 @@
         "pty-daemon": "./src/main.ts",
       },
       "dependencies": {
-        "node-pty": "1.1.0",
+        "node-pty": "1.2.0-beta.14",
       },
       "devDependencies": {
         "@superset/typescript": "workspace:*",
@@ -5330,7 +5330,7 @@
 
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+    "node-pty": ["node-pty@1.2.0-beta.14", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA=="],
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -88,7 +88,7 @@
 		"hono": "4.12.25",
 		"mastracode": "0.18.1",
 		"mime-types": "3.0.2",
-		"node-pty": "1.1.0",
+		"node-pty": "1.2.0-beta.14",
 		"semver": "7.7.4",
 		"simple-git": "3.36.0",
 		"superjson": "2.2.6",

--- a/packages/pty-daemon/README.md
+++ b/packages/pty-daemon/README.md
@@ -63,6 +63,8 @@ test/
 ├── byte-fidelity.test.ts       # daemon → host byte-perfectness canary
 ├── handoff.test.ts             # Phase 2 fd-handoff end-to-end
 ├── signal-recovery.test.ts     # SIGKILL-during-handoff teardown
+├── server-fd-lifecycle.test.ts # server ownership paths with real OS fds
+├── fd-lifecycle.test.ts        # real master-fd disposal under churn
 └── no-encoding-hops.test.ts    # source-level grep: no base64 / per-chunk utf8 in the data path
 
 build.ts                        # Bun bundler → dist/pty-daemon.js (target: node)
@@ -79,6 +81,11 @@ build.ts                        # Bun bundler → dist/pty-daemon.js (target: no
 - **Buffer is in-memory only.** Survives host-service restarts (because the
   daemon does), but never persisted to disk. No SQLite, no scrollback files.
   v1's `HistoryManager` is explicitly out of scope.
+- **PTY master ownership is explicit.** Natural exit, pane close, failed open,
+  and normal daemon shutdown idempotently dispose native and adopted master
+  descriptors. A predecessor intentionally skips disposal only after a
+  successor acknowledges fd handoff, so TreeKiller and session continuity are
+  preserved.
 - **Protocol versioned from day one.** Handshake (`hello` / `hello-ack`)
   picks the highest mutually supported version.
 
@@ -95,6 +102,8 @@ What the integration suites prove:
 
 - **`control-plane.test.ts`**: handshake/version negotiation; session lifecycle (invalid dims, duplicate ids, ENOENT, instant-exit, hung-shell SIGKILL); I/O (resize, burst, multi-byte UTF-8); multi-subscriber fan-out; detach + reattach (replay); concurrency; hostile input; framing across split chunks.
 - **`handoff.test.ts`**: Phase 2 — sessions survive a daemon-binary swap with the same shell PIDs.
+- **`fd-lifecycle.test.ts`**: native and adopted real master fds close
+  idempotently, including repeated natural-exit churn.
 - **`byte-fidelity.test.ts`**: random bytes (including non-UTF-8) flow daemon → host byte-perfect on live and replay.
 - **`signal-recovery.test.ts`**: SIGKILL of the daemon mid-flight; clients see a clean close.
 - **`no-encoding-hops.test.ts`** (bun): source-level guard — fails the moment anyone reintroduces a base64 hop or per-chunk `chunk.toString("utf8")` on the data path.

--- a/packages/pty-daemon/README.md
+++ b/packages/pty-daemon/README.md
@@ -22,10 +22,15 @@ Bun is the build tool, not a runtime. **No new runtime in the desktop
 app bundle.**
 
 **Why not Bun at runtime:** verified during development that node-pty
-1.1's master fd handling is incompatible with Bun 1.3 (`tty.ReadStream`
+1.2's master fd handling is incompatible with Bun 1.3 (`tty.ReadStream`
 closes immediately, alternate `fs.createReadStream(null, { fd })`
 returns EAGAIN with no recovery). The daemon needs a runtime where
 node-pty actually works.
+
+The dependency is pinned to `1.2.0-beta.14`: `1.1.0` leaked the temporary
+`/dev/ptmx` descriptor opened by its macOS `posix_spawn` path once per PTY
+spawn. The beta contains the upstream `/dev/ptmx` and kqueue descriptor fixes;
+do not downgrade without rerunning the process-wide real-FD churn test.
 
 **Dev:** unit tests run under Bun (`bun test`) for speed; integration
 tests run under Node (`bun run test:integration`) since they touch real

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -34,7 +34,7 @@
 		"build:types": "tsc -p tsconfig.types.json"
 	},
 	"dependencies": {
-		"node-pty": "1.1.0"
+		"node-pty": "1.2.0-beta.14"
 	},
 	"devDependencies": {
 		"@superset/typescript": "workspace:*",

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -29,8 +29,8 @@
 		"start": "node --experimental-strip-types src/main.ts",
 		"build:daemon": "bun run build.ts",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
-		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/process-tree.test.ts test/no-encoding-hops.test.ts",
-		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts test/flow-control.test.ts test/kill-tree.test.ts",
+		"test": "bun test src/protocol src/SessionStore src/handlers src/Pty/Pty.test.ts src/process-tree.test.ts test/server-fd-lifecycle.test.ts test/no-encoding-hops.test.ts",
+		"test:integration": "node --experimental-strip-types --test test/integration.test.ts test/control-plane.test.ts test/signal-recovery.test.ts test/byte-fidelity.test.ts test/handoff.test.ts test/foreground-process.test.ts test/flow-control.test.ts test/kill-tree.test.ts test/fd-lifecycle.test.ts",
 		"build:types": "tsc -p tsconfig.types.json"
 	},
 	"dependencies": {

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -193,6 +193,11 @@ export type PtyOnExit = (info: {
 	signal: number | null;
 }) => void;
 
+export interface DisposeOptions {
+	/** Stop adopted-PTY exit polling when the caller has already untracked it. */
+	keepExitPolling?: boolean;
+}
+
 export interface Pty {
 	readonly pid: number;
 	readonly meta: SessionMeta;
@@ -216,7 +221,7 @@ export interface Pty {
 	 * exception — the predecessor must leave its adapter untouched because
 	 * node-pty disposal also signals the shell after closing its stream.
 	 */
-	dispose(): void;
+	dispose(options?: DisposeOptions): void;
 	/**
 	 * The kernel master fd backing this PTY. Required for daemon-upgrade
 	 * fd-handoff (Phase 2): the successor daemon process inherits this fd
@@ -275,7 +280,7 @@ class NodePtyAdapter implements Pty {
 		});
 	}
 
-	dispose(): void {
+	dispose(_options?: DisposeOptions): void {
 		if (this.disposed) return;
 		this.disposed = true;
 		// Keep TreeKiller's escalation chain intact. A root shell can exit while
@@ -291,8 +296,8 @@ class NodePtyAdapter implements Pty {
 	}
 
 	getMasterFd(): number {
-		// node-pty 1.1.x exposes the master fd as the private property `_fd`.
-		// Pinned to "1.1.0" in package.json so a future bump can't break this
+		// node-pty 1.2 beta exposes the master fd as the private property `_fd`.
+		// Pinned exactly in package.json so a future bump can't break this
 		// silently — assert here so a missing/changed field surfaces at the
 		// first spawn, not when the user clicks "Update" months later.
 		const fd = (this.term as unknown as { _fd?: unknown })._fd;
@@ -300,7 +305,7 @@ class NodePtyAdapter implements Pty {
 			throw new Error(
 				`node-pty master fd unavailable (got ${typeof fd}: ${fd}). ` +
 					`Phase 2 fd-handoff depends on node-pty's private _fd property — ` +
-					`pin node-pty to 1.1.x or update Pty.ts to match the new shape.`,
+					`keep node-pty pinned or update Pty.ts to match the new shape.`,
 			);
 		}
 		return fd;
@@ -521,12 +526,18 @@ class AdoptedPty implements Pty {
 		this.livenessTimer.unref();
 	}
 
-	dispose(): void {
+	dispose(options: DisposeOptions = {}): void {
+		if (options.keepExitPolling === false && this.livenessTimer) {
+			clearInterval(this.livenessTimer);
+			this.livenessTimer = null;
+		}
 		if (this.disposed) return;
 		this.disposed = true;
-		// Deliberately leave livenessTimer running after an explicit dispose.
-		// Adopted PTYs have no native exit event, so the poll must still deliver
-		// onExit to let Server remove the session; onExit clears the timer above.
+		// Normally leave livenessTimer running after an explicit dispose. Adopted
+		// PTYs have no native exit event, so the poll must still deliver onExit to
+		// let Server remove the session. Failed handoff rollback passes
+		// keepExitPolling=false because that session is already untracked and the
+		// predecessor's shell may intentionally remain alive indefinitely.
 		// Do not touch TreeKiller or its pending escalation. Closing the adopted
 		// stream releases only this daemon's inherited descriptor; kill() owns
 		// process-tree signaling and may still be finishing in the background.

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -209,6 +209,15 @@ export interface Pty {
 	pause(): void;
 	resume(): void;
 	/**
+	 * Release this process's ownership of the PTY master fd. Idempotent.
+	 *
+	 * Disposal is separate from TreeKiller: callers signal the process tree
+	 * first, then release the descriptor. A successful daemon handoff is the
+	 * exception — the predecessor must leave its adapter untouched because
+	 * node-pty disposal also signals the shell after closing its stream.
+	 */
+	dispose(): void;
+	/**
 	 * The kernel master fd backing this PTY. Required for daemon-upgrade
 	 * fd-handoff (Phase 2): the successor daemon process inherits this fd
 	 * via stdio so the slave-side shell stays alive across the binary swap.
@@ -232,6 +241,7 @@ class NodePtyAdapter implements Pty {
 	private exitInfo: { code: number | null; signal: number | null } | null =
 		null;
 	private exitCallbacks: PtyOnExit[] = [];
+	private disposed = false;
 
 	constructor(term: nodePty.IPty, meta: SessionMeta) {
 		this.term = term;
@@ -260,8 +270,24 @@ class NodePtyAdapter implements Pty {
 			if (this.exited) return;
 			this.exited = true;
 			this.exitInfo = { code: exitCode ?? null, signal: signal ?? null };
+			this.dispose();
 			for (const cb of this.exitCallbacks) cb(this.exitInfo);
 		});
+	}
+
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		// Keep TreeKiller's escalation chain intact. A root shell can exit while
+		// a detached descendant that ignored SIGHUP is still alive; the kill
+		// chain's later snapshots are what find and reap those survivors.
+		try {
+			// UnixTerminal.destroy() closes the read socket/master fd and its
+			// write stream. node-pty omits destroy() from IPty's public typings.
+			(this.term as unknown as { destroy(): void }).destroy();
+		} catch {
+			// node-pty may already have torn the socket down on its exit path.
+		}
 	}
 
 	getMasterFd(): number {
@@ -310,12 +336,12 @@ class NodePtyAdapter implements Pty {
 	}
 
 	pause(): void {
-		if (this.exited) return;
+		if (this.exited || this.disposed) return;
 		this.term.pause();
 	}
 
 	resume(): void {
-		if (this.exited) return;
+		if (this.exited || this.disposed) return;
 		this.term.resume();
 	}
 }
@@ -387,10 +413,37 @@ export function spawn({ meta }: SpawnOptions): Pty {
 			`spawn failed (shell=${meta.shell} cwd=${meta.cwd ?? "(none)"} errno=${reprobeErrno(meta)}): ${(err as Error).message}`,
 		);
 	}
-	const adapter = new NodePtyAdapter(term, meta);
-	// Validate the private-fd dependency at spawn time, not handoff time.
-	adapter.getMasterFd();
-	return adapter;
+	let adapter: NodePtyAdapter | null = null;
+	try {
+		adapter = new NodePtyAdapter(term, meta);
+		// Validate the private-fd dependency at spawn time, not handoff time.
+		adapter.getMasterFd();
+		return adapter;
+	} catch (err) {
+		// node-pty has already forked and opened the master fd at this point.
+		// Tear down both a fully constructed adapter and a partial constructor
+		// before returning the spawn failure to the caller.
+		if (adapter) {
+			try {
+				adapter.kill("SIGKILL");
+			} catch {
+				// Disposal below still releases the native descriptor.
+			}
+			adapter.dispose();
+		} else {
+			try {
+				term.kill("SIGKILL");
+			} catch {
+				// Continue with raw descriptor disposal.
+			}
+			try {
+				(term as unknown as { destroy(): void }).destroy();
+			} catch {
+				// Preserve the original construction error.
+			}
+		}
+		throw err;
+	}
 }
 
 /**
@@ -417,6 +470,9 @@ class AdoptedPty implements Pty {
 	private readonly fd: number;
 	private readonly reader: tty.ReadStream;
 	private exitFired = false;
+	private exitInfo: { code: number | null; signal: number | null } | null =
+		null;
+	private disposed = false;
 	private livenessTimer: NodeJS.Timeout | null = null;
 	private readonly killer: TreeKiller;
 	private exitCallbacks: PtyOnExit[] = [];
@@ -449,13 +505,12 @@ class AdoptedPty implements Pty {
 		const onExit = (info: { code: number | null; signal: number | null }) => {
 			if (this.exitFired) return;
 			this.exitFired = true;
-			if (this.livenessTimer) clearInterval(this.livenessTimer);
-			// tty.ReadStream owns the inherited fd; destroying the stream closes it.
-			try {
-				this.reader.destroy();
-			} catch {
-				// already closed
+			this.exitInfo = info;
+			if (this.livenessTimer) {
+				clearInterval(this.livenessTimer);
+				this.livenessTimer = null;
 			}
+			this.dispose();
 			for (const cb of this.exitCallbacks) cb(info);
 		};
 		this.reader.on("end", () => onExit({ code: null, signal: null }));
@@ -464,6 +519,19 @@ class AdoptedPty implements Pty {
 			if (!isPidAlive(this.pid)) onExit({ code: null, signal: null });
 		}, 1000);
 		this.livenessTimer.unref();
+	}
+
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		// Do not touch TreeKiller or its pending escalation. Closing the adopted
+		// stream releases only this daemon's inherited descriptor; kill() owns
+		// process-tree signaling and may still be finishing in the background.
+		try {
+			this.reader.destroy();
+		} catch {
+			// The stream may already have closed after EOF/EIO.
+		}
 	}
 
 	getMasterFd(): number {
@@ -524,16 +592,20 @@ class AdoptedPty implements Pty {
 	}
 
 	onExit(cb: PtyOnExit): void {
+		if (this.exitInfo) {
+			cb(this.exitInfo);
+			return;
+		}
 		this.exitCallbacks.push(cb);
 	}
 
 	pause(): void {
-		if (this.exitFired) return;
+		if (this.exitFired || this.disposed) return;
 		this.reader.pause();
 	}
 
 	resume(): void {
-		if (this.exitFired) return;
+		if (this.exitFired || this.disposed) return;
 		this.reader.resume();
 	}
 }
@@ -571,5 +643,17 @@ export function adoptFromFd({ fd, pid, meta }: AdoptOptions): Pty {
 		throw new Error(`invalid pid: ${pid}`);
 	}
 	validateDims(meta.cols, meta.rows);
-	return new AdoptedPty(fd, pid, meta);
+	try {
+		return new AdoptedPty(fd, pid, meta);
+	} catch (err) {
+		// Ownership transfers to this process at adoption. If construction
+		// fails after handoff, close this inherited copy; the predecessor still
+		// owns its descriptor and can continue serving the live session.
+		try {
+			fs.closeSync(fd);
+		} catch {
+			// Preserve the adoption error.
+		}
+		throw err;
+	}
 }

--- a/packages/pty-daemon/src/Pty/Pty.ts
+++ b/packages/pty-daemon/src/Pty/Pty.ts
@@ -524,6 +524,9 @@ class AdoptedPty implements Pty {
 	dispose(): void {
 		if (this.disposed) return;
 		this.disposed = true;
+		// Deliberately leave livenessTimer running after an explicit dispose.
+		// Adopted PTYs have no native exit event, so the poll must still deliver
+		// onExit to let Server remove the session; onExit clears the timer above.
 		// Do not touch TreeKiller or its pending escalation. Closing the adopted
 		// stream releases only this daemon's inherited descriptor; kill() owns
 		// process-tree signaling and may still be finishing in the background.
@@ -639,16 +642,16 @@ export function adoptFromFd({ fd, pid, meta }: AdoptOptions): Pty {
 	if (!Number.isInteger(fd) || fd < 0) {
 		throw new Error(`invalid fd: ${fd}`);
 	}
-	if (!Number.isInteger(pid) || pid <= 0) {
-		throw new Error(`invalid pid: ${pid}`);
-	}
-	validateDims(meta.cols, meta.rows);
 	try {
+		if (!Number.isInteger(pid) || pid <= 0) {
+			throw new Error(`invalid pid: ${pid}`);
+		}
+		validateDims(meta.cols, meta.rows);
 		return new AdoptedPty(fd, pid, meta);
 	} catch (err) {
-		// Ownership transfers to this process at adoption. If construction
-		// fails after handoff, close this inherited copy; the predecessor still
-		// owns its descriptor and can continue serving the live session.
+		// Ownership transfers once a valid fd reaches adoption. Close this
+		// inherited copy on validation or construction failure; the predecessor
+		// still owns its descriptor and can continue serving the live session.
 		try {
 			fs.closeSync(fd);
 		} catch {

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -150,7 +150,7 @@ export class Server {
 				} catch (err) {
 					if (session) this.store.delete(session.id);
 					try {
-						pty.dispose();
+						pty.dispose({ keepExitPolling: false });
 					} catch {
 						// Preserve the original adoption error.
 					}
@@ -163,7 +163,7 @@ export class Server {
 			// the shared shells from a failed/partial handoff.
 			for (const session of adopted) {
 				try {
-					session.pty.dispose();
+					session.pty.dispose({ keepExitPolling: false });
 				} catch {
 					// Best-effort; keep rolling back the remaining sessions.
 				}

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -149,7 +149,11 @@ export class Server {
 					adopted.push(session);
 				} catch (err) {
 					if (session) this.store.delete(session.id);
-					pty.dispose();
+					try {
+						pty.dispose();
+					} catch {
+						// Preserve the original adoption error.
+					}
 					throw err;
 				}
 			}
@@ -158,7 +162,11 @@ export class Server {
 			// serving. Close only this successor's inherited copies; never signal
 			// the shared shells from a failed/partial handoff.
 			for (const session of adopted) {
-				session.pty.dispose();
+				try {
+					session.pty.dispose();
+				} catch {
+					// Best-effort; keep rolling back the remaining sessions.
+				}
 				this.store.delete(session.id);
 			}
 			throw err;
@@ -526,6 +534,15 @@ export class Server {
 			session.exited = true;
 			session.exitCode = info.code;
 			session.exitSignal = info.signal;
+			try {
+				session.pty.dispose();
+			} catch {
+				// Continue state cleanup if fd disposal was already attempted.
+			}
+			// An explicitly closed session id can be recycled before its delayed
+			// process-exit notification arrives. Never let that stale callback
+			// broadcast an exit for or delete the replacement session.
+			if (this.store.get(session.id) !== session) return;
 			const ev: ServerMessage = {
 				type: "exit",
 				id: session.id,
@@ -538,11 +555,6 @@ export class Server {
 					c.subscriptions.delete(session.id);
 				}
 				c.pausedSessions.delete(session.id);
-			}
-			try {
-				session.pty.dispose();
-			} catch {
-				// The session must still leave the store if fd cleanup was already done.
 			}
 			// Delete the session immediately. Without this, every closed
 			// terminal pane left a row in the store forever — list-reply

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -125,23 +125,43 @@ export class Server {
 	 * building its spawn args).
 	 */
 	adoptSnapshot(snapshot: HandoffSnapshot): void {
-		for (const s of snapshot.sessions) {
-			const pty = adoptFromFd({
-				fd: s.fdIndex,
-				pid: s.pid,
-				meta: s.meta,
-			});
-			const session = this.store.add(s.id, pty);
-			if (s.buffer.byteLength > 0) {
-				const buf = Buffer.from(
-					s.buffer.buffer,
-					s.buffer.byteOffset,
-					s.buffer.byteLength,
-				);
-				session.buffer = [buf];
-				session.bufferBytes = buf.byteLength;
+		const adopted: Session[] = [];
+		try {
+			for (const s of snapshot.sessions) {
+				const pty = adoptFromFd({
+					fd: s.fdIndex,
+					pid: s.pid,
+					meta: s.meta,
+				});
+				let session: Session | null = null;
+				try {
+					session = this.store.add(s.id, pty);
+					if (s.buffer.byteLength > 0) {
+						const buf = Buffer.from(
+							s.buffer.buffer,
+							s.buffer.byteOffset,
+							s.buffer.byteLength,
+						);
+						session.buffer = [buf];
+						session.bufferBytes = buf.byteLength;
+					}
+					this.wireSession(session);
+					adopted.push(session);
+				} catch (err) {
+					if (session) this.store.delete(session.id);
+					pty.dispose();
+					throw err;
+				}
 			}
-			this.wireSession(session);
+		} catch (err) {
+			// Adoption failed, so the predecessor retains ownership and keeps
+			// serving. Close only this successor's inherited copies; never signal
+			// the shared shells from a failed/partial handoff.
+			for (const session of adopted) {
+				session.pty.dispose();
+				this.store.delete(session.id);
+			}
+			throw err;
 		}
 	}
 
@@ -310,6 +330,11 @@ export class Server {
 					session.pty.kill("SIGKILL");
 				} catch {
 					// already dead, ignore
+				}
+				try {
+					session.pty.dispose();
+				} catch {
+					// best-effort teardown; continue closing the remaining sessions
 				}
 			}
 		}
@@ -513,6 +538,11 @@ export class Server {
 					c.subscriptions.delete(session.id);
 				}
 				c.pausedSessions.delete(session.id);
+			}
+			try {
+				session.pty.dispose();
+			} catch {
+				// The session must still leave the store if fd cleanup was already done.
 			}
 			// Delete the session immediately. Without this, every closed
 			// terminal pane left a row in the store forever — list-reply

--- a/packages/pty-daemon/src/SessionStore/SessionStore.test.ts
+++ b/packages/pty-daemon/src/SessionStore/SessionStore.test.ts
@@ -16,6 +16,7 @@ function fakePty(meta: { cols: number; rows: number }): Pty {
 		kill: () => {},
 		onData: () => {},
 		onExit: () => {},
+		dispose: () => {},
 		getMasterFd: () => -1,
 		pause: () => {},
 		resume: () => {},

--- a/packages/pty-daemon/src/SessionStore/snapshot.test.ts
+++ b/packages/pty-daemon/src/SessionStore/snapshot.test.ts
@@ -21,6 +21,7 @@ function fakePty(pid: number, meta: { cols: number; rows: number }): Pty {
 		kill: () => {},
 		onData: () => {},
 		onExit: () => {},
+		dispose: () => {},
 		getMasterFd: () => -1,
 		pause: () => {},
 		resume: () => {},

--- a/packages/pty-daemon/src/handlers/handlers.test.ts
+++ b/packages/pty-daemon/src/handlers/handlers.test.ts
@@ -19,6 +19,7 @@ interface FakePtyState {
 	rows: number;
 	written: Buffer[];
 	killed: boolean;
+	disposed: boolean;
 }
 
 function makeFakePty(state: FakePtyState, meta: SpawnOptions["meta"]): Pty {
@@ -37,6 +38,9 @@ function makeFakePty(state: FakePtyState, meta: SpawnOptions["meta"]): Pty {
 		},
 		onData: () => {},
 		onExit: () => {},
+		dispose: () => {
+			state.disposed = true;
+		},
 		getMasterFd: () => -1,
 		pause: () => {},
 		resume: () => {},
@@ -80,6 +84,7 @@ function makeCtx(): HandlerCtx & {
 				rows: opts.meta.rows,
 				written: [],
 				killed: false,
+				disposed: false,
 			};
 			states.push(state);
 			return makeFakePty(state, opts.meta);
@@ -155,7 +160,7 @@ describe("handlers", () => {
 		expect(states[0]?.rows).toBe(30);
 	});
 
-	test("close kills the pty and replies closed", () => {
+	test("close kills and disposes the pty before replying closed", () => {
 		const ctx = makeCtx();
 		handleOpen(ctx, {
 			type: "open",
@@ -165,6 +170,24 @@ describe("handlers", () => {
 		const reply = handleClose(ctx, { type: "close", id: "s0" });
 		expect(reply.type).toBe("closed");
 		expect(states[0]?.killed).toBe(true);
+		expect(states[0]?.disposed).toBe(true);
+		expect(ctx.store.get("s0")?.exited).toBe(true);
+	});
+
+	test("open disposes a spawned pty when session wiring fails", () => {
+		const ctx = makeCtx();
+		ctx.wireSession = () => {
+			throw new Error("wire failed");
+		};
+		const reply = handleOpen(ctx, {
+			type: "open",
+			id: "partial",
+			meta: { shell: "/bin/sh", argv: [], cols: 80, rows: 24 },
+		});
+		expect(reply).toMatchObject({ type: "error", code: "ESPAWN" });
+		expect(states[0]?.killed).toBe(true);
+		expect(states[0]?.disposed).toBe(true);
+		expect(ctx.store.get("partial")).toBeUndefined();
 	});
 
 	test("list returns all sessions", () => {

--- a/packages/pty-daemon/src/handlers/handlers.ts
+++ b/packages/pty-daemon/src/handlers/handlers.ts
@@ -56,15 +56,32 @@ export function handleOpen(ctx: HandlerCtx, msg: OpenMessage): ServerMessage {
 			return errorFor(msg.id, `session already exists: ${msg.id}`, "EEXIST");
 		}
 	}
-	let session: Session;
+	let session: Session | null = null;
+	let pty: Pty | null = null;
 	const spawnFn = ctx.spawnPty ?? defaultSpawn;
 	try {
-		const pty = spawnFn({ meta: msg.meta });
+		pty = spawnFn({ meta: msg.meta });
 		session = ctx.store.add(msg.id, pty);
+		ctx.wireSession(session);
 	} catch (err) {
+		if (session) ctx.store.delete(session.id);
+		if (pty) {
+			// A factory can fail after the native fork, or later open setup can
+			// fail after the factory returns. Do not strand either the process
+			// tree or the master descriptor in those partial-open paths.
+			try {
+				pty.kill("SIGKILL");
+			} catch {
+				// Preserve the original open error.
+			}
+			try {
+				pty.dispose();
+			} catch {
+				// Preserve the original open error.
+			}
+		}
 		return errorFor(msg.id, (err as Error).message, "ESPAWN");
 	}
-	ctx.wireSession(session);
 	const reply: OpenOkMessage = {
 		type: "open-ok",
 		id: msg.id,
@@ -116,6 +133,7 @@ export function handleResize(
 export function handleClose(ctx: HandlerCtx, msg: CloseMessage): ServerMessage {
 	const session = ctx.store.get(msg.id);
 	if (!session) return errorFor(msg.id, `unknown session: ${msg.id}`, "ENOENT");
+	let killError: unknown = null;
 	try {
 		// SIGHUP is the right signal for "your terminal is going away" —
 		// what the kernel sends when a TTY actually closes. Interactive
@@ -124,8 +142,21 @@ export function handleClose(ctx: HandlerCtx, msg: CloseMessage): ServerMessage {
 		// pane close. Callers can still pass an explicit signal.
 		session.pty.kill(msg.signal ?? "SIGHUP");
 	} catch (err) {
-		return errorFor(msg.id, (err as Error).message, "EKILL");
+		killError = err;
 	}
+	try {
+		// kill() preserves TreeKiller's process-tree semantics; dispose() then
+		// releases the daemon's master fd immediately. Both are idempotent and
+		// the kill escalation intentionally continues after descriptor close.
+		session.pty.dispose();
+	} catch {
+		// A close request is still acknowledged once signaling succeeded. The
+		// concrete adapters make disposal best-effort and non-throwing.
+	}
+	// The descriptor is no longer eligible for fd handoff even if process-exit
+	// notification arrives later (notably the adopted-PTY liveness poll).
+	session.exited = true;
+	if (killError) return errorFor(msg.id, (killError as Error).message, "EKILL");
 	return { type: "closed", id: msg.id };
 }
 

--- a/packages/pty-daemon/test/byte-fidelity.test.ts
+++ b/packages/pty-daemon/test/byte-fidelity.test.ts
@@ -63,6 +63,7 @@ function makeDriveablePty(meta: SpawnOptions["meta"]): DriveablePty {
 		},
 		resize: () => {},
 		kill: () => {},
+		dispose: () => {},
 		getMasterFd: () => -1,
 		pause: () => {},
 		resume: () => {},

--- a/packages/pty-daemon/test/fd-lifecycle.test.ts
+++ b/packages/pty-daemon/test/fd-lifecycle.test.ts
@@ -2,6 +2,7 @@
 // tty.ReadStream cannot safely own node-pty master descriptors.
 
 import { strict as assert } from "node:assert";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import { test } from "node:test";
 import { adoptFromFd, spawn } from "../src/Pty/index.ts";
@@ -27,7 +28,16 @@ function waitForExit(pty: ReturnType<typeof spawn>): Promise<void> {
 	return new Promise((resolve) => pty.onExit(() => resolve()));
 }
 
+function processPtmxCount(): number | null {
+	if (process.platform !== "darwin") return null;
+	const output = execFileSync("lsof", ["-nP", "-p", String(process.pid)], {
+		encoding: "utf8",
+	});
+	return output.split("\n").filter((line) => /\/dev\/ptmx$/.test(line)).length;
+}
+
 test("real PTY masters close across high natural-exit churn", async () => {
+	const processMastersBefore = processPtmxCount();
 	for (let i = 0; i < 128; i++) {
 		const pty = spawn({ meta: META });
 		const fd = pty.getMasterFd();
@@ -37,6 +47,12 @@ test("real PTY masters close across high natural-exit churn", async () => {
 		pty.dispose();
 		pty.dispose();
 	}
+	const processMastersAfter = processPtmxCount();
+	assert.equal(
+		processMastersAfter,
+		processMastersBefore,
+		"node-pty must not retain hidden /dev/ptmx descriptors outside term._fd",
+	);
 });
 
 test("native and adopted disposal are idempotent on real fds", async () => {

--- a/packages/pty-daemon/test/fd-lifecycle.test.ts
+++ b/packages/pty-daemon/test/fd-lifecycle.test.ts
@@ -1,0 +1,78 @@
+// Real node-pty descriptor lifecycle coverage. Runs under Node because Bun's
+// tty.ReadStream cannot safely own node-pty master descriptors.
+
+import { strict as assert } from "node:assert";
+import * as fs from "node:fs";
+import { test } from "node:test";
+import { adoptFromFd, spawn } from "../src/Pty/index.ts";
+
+const META = {
+	shell: "/bin/sh",
+	argv: ["-c", ":"],
+	cols: 80,
+	rows: 24,
+};
+
+function fdIsOpen(fd: number): boolean {
+	try {
+		fs.fstatSync(fd);
+		return true;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "EBADF") return false;
+		throw err;
+	}
+}
+
+function waitForExit(pty: ReturnType<typeof spawn>): Promise<void> {
+	return new Promise((resolve) => pty.onExit(() => resolve()));
+}
+
+test("real PTY masters close across high natural-exit churn", async () => {
+	for (let i = 0; i < 128; i++) {
+		const pty = spawn({ meta: META });
+		const fd = pty.getMasterFd();
+		assert.equal(fdIsOpen(fd), true, `cycle ${i}: master should start open`);
+		await waitForExit(pty);
+		assert.equal(fdIsOpen(fd), false, `cycle ${i}: master fd ${fd} leaked`);
+		pty.dispose();
+		pty.dispose();
+	}
+});
+
+test("native and adopted disposal are idempotent on real fds", async () => {
+	const native = spawn({
+		meta: { ...META, argv: ["-c", "sleep 30"] },
+	});
+	const nativeExit = waitForExit(native);
+	const nativeFd = native.getMasterFd();
+	const adoptedFd = fs.openSync(`/dev/fd/${nativeFd}`, "r+");
+	const adopted = adoptFromFd({
+		fd: adoptedFd,
+		pid: native.pid,
+		meta: native.meta,
+	});
+
+	try {
+		adopted.dispose();
+		adopted.dispose();
+		assert.equal(
+			fdIsOpen(adoptedFd),
+			false,
+			"adopted master copy should close",
+		);
+
+		native.kill("SIGKILL");
+		native.dispose();
+		native.dispose();
+		assert.equal(fdIsOpen(nativeFd), false, "native master should close");
+		await nativeExit;
+	} finally {
+		adopted.dispose();
+		try {
+			native.kill("SIGKILL");
+		} catch {
+			// already exited
+		}
+		native.dispose();
+	}
+});

--- a/packages/pty-daemon/test/handoff.test.ts
+++ b/packages/pty-daemon/test/handoff.test.ts
@@ -223,9 +223,11 @@ test("prepare-upgrade hands off live sessions to a successor binary", async () =
 		);
 		for (const id of sessionIds) {
 			adoptedClient.send({ type: "close", id, signal: "SIGKILL" });
+			// Close includes TreeKiller's synchronous process-table snapshot, which
+			// can exceed two seconds while the other process-heavy suites run.
 			await adoptedClient.waitFor(
 				(m) => m.type === "closed" && m.id === id,
-				2_000,
+				5_000,
 			);
 		}
 		await Promise.all(exitAfterClose.values());

--- a/packages/pty-daemon/test/integration.test.ts
+++ b/packages/pty-daemon/test/integration.test.ts
@@ -109,16 +109,47 @@ test("Pty.getMasterFd returns a usable kernel fd", () => {
 test("adoptFromFd validates inputs", () => {
 	const meta = { shell: "/bin/sh", argv: [], cols: 80, rows: 24 };
 	assert.throws(() => adoptFromFd({ fd: -1, pid: 1, meta }), /invalid fd/);
-	assert.throws(() => adoptFromFd({ fd: 3, pid: 0, meta }), /invalid pid/);
-	assert.throws(
-		() =>
-			adoptFromFd({
-				fd: 3,
-				pid: 1,
-				meta: { ...meta, cols: 0 },
-			}),
-		/invalid cols/,
-	);
+
+	const invalidPidFd = fs.openSync("/dev/null", "r");
+	try {
+		assert.throws(
+			() => adoptFromFd({ fd: invalidPidFd, pid: 0, meta }),
+			/invalid pid/,
+		);
+		assert.throws(
+			() => fs.fstatSync(invalidPidFd),
+			(err: unknown) => (err as NodeJS.ErrnoException).code === "EBADF",
+		);
+	} finally {
+		try {
+			fs.closeSync(invalidPidFd);
+		} catch {
+			// adoptFromFd closed it as required
+		}
+	}
+
+	const invalidDimsFd = fs.openSync("/dev/null", "r");
+	try {
+		assert.throws(
+			() =>
+				adoptFromFd({
+					fd: invalidDimsFd,
+					pid: 1,
+					meta: { ...meta, cols: 0 },
+				}),
+			/invalid cols/,
+		);
+		assert.throws(
+			() => fs.fstatSync(invalidDimsFd),
+			(err: unknown) => (err as NodeJS.ErrnoException).code === "EBADF",
+		);
+	} finally {
+		try {
+			fs.closeSync(invalidDimsFd);
+		} catch {
+			// adoptFromFd closed it as required
+		}
+	}
 });
 
 test("adoptFromFd wraps a real PTY master fd without crashing", async () => {

--- a/packages/pty-daemon/test/server-fd-lifecycle.test.ts
+++ b/packages/pty-daemon/test/server-fd-lifecycle.test.ts
@@ -55,7 +55,8 @@ function fdIsOpen(fd: number): boolean {
 		fs.fstatSync(fd);
 		return true;
 	} catch (err) {
-		return (err as NodeJS.ErrnoException).code !== "EBADF";
+		if ((err as NodeJS.ErrnoException).code === "EBADF") return false;
+		throw err;
 	}
 }
 
@@ -135,6 +136,54 @@ describe("PTY master-fd ownership", () => {
 			expect(pty.killSignals).toEqual(["SIGHUP"]);
 			expect(fdIsOpen(pty.fd)).toBe(false);
 			pty.fireExit();
+		} finally {
+			await client.close();
+		}
+	});
+
+	test("a stale exit cannot delete a replacement with the same id", async () => {
+		const { socket, spawned } = await listenWithFds("recycled-id");
+		const client = await connectAndHello(socket);
+		try {
+			client.send({
+				type: "open",
+				id: "recycled",
+				meta: { shell: "/bin/sh", argv: [], cols: 80, rows: 24 },
+			});
+			await client.waitFor((m) => m.type === "open-ok" && m.id === "recycled");
+			const original = spawned[0];
+			if (!original) throw new Error("missing original PTY");
+
+			client.send({ type: "close", id: "recycled" });
+			await client.waitFor((m) => m.type === "closed" && m.id === "recycled");
+
+			const replacementOpened = client.waitForNext(
+				(m) => m.type === "open-ok" && m.id === "recycled",
+			);
+			client.send({
+				type: "open",
+				id: "recycled",
+				meta: { shell: "/bin/sh", argv: [], cols: 80, rows: 24 },
+			});
+			await replacementOpened;
+			const replacement = spawned[1];
+			if (!replacement) throw new Error("missing replacement PTY");
+
+			original.fireExit();
+			const listed = client.waitForNext((m) => m.type === "list-reply");
+			client.send({ type: "list" });
+			const reply = await listed;
+			expect(reply.type).toBe("list-reply");
+			if (reply.type === "list-reply") {
+				expect(reply.sessions).toEqual([
+					expect.objectContaining({
+						id: "recycled",
+						pid: replacement.pid,
+						alive: true,
+					}),
+				]);
+			}
+			expect(fdIsOpen(replacement.fd)).toBe(true);
 		} finally {
 			await client.close();
 		}

--- a/packages/pty-daemon/test/server-fd-lifecycle.test.ts
+++ b/packages/pty-daemon/test/server-fd-lifecycle.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Pty, PtyOnExit, SpawnOptions } from "../src/Pty/index.ts";
+import type { SessionMeta } from "../src/protocol/index.ts";
+import { Server } from "../src/Server/Server.ts";
+import { connectAndHello } from "./helpers/client.ts";
+
+let nextPid = 50_000;
+let server: Server | null = null;
+
+class FdBackedPty implements Pty {
+	readonly pid = nextPid++;
+	meta: SessionMeta;
+	readonly fd = fs.openSync("/dev/null", "r");
+	disposeCalls = 0;
+	killSignals: NodeJS.Signals[] = [];
+	private disposed = false;
+	private readonly exitCallbacks: PtyOnExit[] = [];
+
+	constructor(meta: SessionMeta) {
+		this.meta = meta;
+	}
+
+	write(): void {}
+	resize(cols: number, rows: number): void {
+		this.meta = { ...this.meta, cols, rows };
+	}
+	kill(signal: NodeJS.Signals = "SIGHUP"): void {
+		this.killSignals.push(signal);
+	}
+	onData(): void {}
+	onExit(cb: PtyOnExit): void {
+		this.exitCallbacks.push(cb);
+	}
+	pause(): void {}
+	resume(): void {}
+	getMasterFd(): number {
+		return this.fd;
+	}
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.disposeCalls++;
+		fs.closeSync(this.fd);
+	}
+	fireExit(): void {
+		for (const cb of this.exitCallbacks) cb({ code: 0, signal: null });
+	}
+}
+
+function fdIsOpen(fd: number): boolean {
+	try {
+		fs.fstatSync(fd);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code !== "EBADF";
+	}
+}
+
+function socketPath(label: string): string {
+	return path.join(
+		os.tmpdir(),
+		`pty-daemon-${label}-${process.pid}-${nextPid}.sock`,
+	);
+}
+
+async function listenWithFds(
+	label: string,
+): Promise<{ socket: string; spawned: FdBackedPty[] }> {
+	const socket = socketPath(label);
+	const spawned: FdBackedPty[] = [];
+	server = new Server({
+		socketPath: socket,
+		daemonVersion: "test",
+		spawnPty: ({ meta }: SpawnOptions) => {
+			const pty = new FdBackedPty(meta);
+			spawned.push(pty);
+			return pty;
+		},
+	});
+	await server.listen();
+	return { socket, spawned };
+}
+
+afterEach(async () => {
+	if (server) await server.close();
+	server = null;
+});
+
+describe("PTY master-fd ownership", () => {
+	test("natural exits do not leak real fds across high churn", async () => {
+		const { socket, spawned } = await listenWithFds("natural-churn");
+		const client = await connectAndHello(socket);
+		try {
+			for (let i = 0; i < 128; i++) {
+				const id = `churn-${i}`;
+				const opened = client.waitForNext(
+					(m) => m.type === "open-ok" && m.id === id,
+				);
+				client.send({
+					type: "open",
+					id,
+					meta: { shell: "/bin/sh", argv: [], cols: 80, rows: 24 },
+				});
+				await opened;
+				const pty = spawned[i];
+				if (!pty) throw new Error(`missing PTY ${i}`);
+				expect(fdIsOpen(pty.fd)).toBe(true);
+				pty.fireExit();
+				expect(fdIsOpen(pty.fd)).toBe(false);
+				pty.dispose();
+				expect(pty.disposeCalls).toBe(1);
+			}
+		} finally {
+			await client.close();
+		}
+	});
+
+	test("explicit close signals before disposing the master fd", async () => {
+		const { socket, spawned } = await listenWithFds("explicit-close");
+		const client = await connectAndHello(socket);
+		try {
+			client.send({
+				type: "open",
+				id: "close-me",
+				meta: { shell: "/bin/sh", argv: [], cols: 80, rows: 24 },
+			});
+			await client.waitFor((m) => m.type === "open-ok" && m.id === "close-me");
+			const pty = spawned[0];
+			if (!pty) throw new Error("missing PTY");
+			client.send({ type: "close", id: "close-me" });
+			await client.waitFor((m) => m.type === "closed" && m.id === "close-me");
+			expect(pty.killSignals).toEqual(["SIGHUP"]);
+			expect(fdIsOpen(pty.fd)).toBe(false);
+			pty.fireExit();
+		} finally {
+			await client.close();
+		}
+	});
+
+	test("normal daemon shutdown disposes every owned master fd", async () => {
+		const { socket, spawned } = await listenWithFds("shutdown");
+		const client = await connectAndHello(socket);
+		client.send({
+			type: "open",
+			id: "shutdown-me",
+			meta: { shell: "/bin/sh", argv: [], cols: 80, rows: 24 },
+		});
+		await client.waitFor((m) => m.type === "open-ok" && m.id === "shutdown-me");
+		const pty = spawned[0];
+		if (!pty) throw new Error("missing PTY");
+		await server?.close();
+		server = null;
+		expect(pty.killSignals).toEqual(["SIGKILL"]);
+		expect(fdIsOpen(pty.fd)).toBe(false);
+	});
+
+	test("successful handoff close leaves predecessor descriptors untouched", async () => {
+		const { socket, spawned } = await listenWithFds("handoff");
+		const client = await connectAndHello(socket);
+		client.send({
+			type: "open",
+			id: "handoff-me",
+			meta: { shell: "/bin/sh", argv: [], cols: 80, rows: 24 },
+		});
+		await client.waitFor((m) => m.type === "open-ok" && m.id === "handoff-me");
+		const pty = spawned[0];
+		if (!pty) throw new Error("missing PTY");
+		await server?.close({ killSessions: false });
+		server = null;
+		expect(pty.killSignals).toEqual([]);
+		expect(pty.disposeCalls).toBe(0);
+		expect(fdIsOpen(pty.fd)).toBe(true);
+		pty.dispose();
+	});
+});


### PR DESCRIPTION
## Summary

- add idempotent master-fd disposal for native node-pty adapters and inherited/adopted PTYs
- dispose owned descriptors on natural exit, explicit close, failed or partial open/adoption, and normal daemon shutdown
- preserve successful handoff ownership by skipping predecessor signaling and disposal after the successor acknowledges adoption
- keep TreeKiller escalation and socket backpressure behavior intact

## Root cause

The standalone pty-daemon removed exited sessions from its store but did not have an explicit descriptor-ownership teardown contract. The host-service reaper cannot close fds held by the detached daemon process, so master descriptors could accumulate across long-lived, high-churn workloads until macOS exhausted `kern.tty.ptmx_max`.

## Implementation

`Pty.dispose()` now releases the process-owned master descriptor exactly once. Native PTYs destroy node-pty's read/write streams, while adopted PTYs destroy their inherited `tty.ReadStream`. Close paths signal through the existing TreeKiller before disposal, and its escalation chain continues independently so detached/background descendants are still reaped.

Failed native construction and later partial-open setup kill and dispose the newly created PTY. Partial successor adoption closes only the successor's inherited copies without signaling shells that remain owned by the predecessor. Explicitly closed sessions are immediately excluded from fd handoff while their eventual exit notification still completes normal store cleanup.

Successful handoff still calls `close({ killSessions: false })`, which neither kills nor disposes predecessor adapters.

The package README now documents the ownership rule and lifecycle coverage.

## Validation

- `bun run test` — 66 passed
- `bun run build:daemon`
- `bun run test:integration` — 56 passed, including control-plane, handoff, flow-control, TreeKiller, signal recovery, and new real-fd lifecycle suites
- 128-cycle server churn with real OS descriptors
- 128-cycle real node-pty master-fd churn plus native/adopted idempotency checks
- `bun run typecheck` — repo-wide, 35 tasks passed
- `bun run lint:fix`
- `bun run lint`

Closes #5305

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5795">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PTY master-fd leaks by disposing descriptors on teardown across `pty-daemon`. Also prevents hidden macOS `/dev/ptmx` leaks by pinning `node-pty` to a fixed version.

- **Bug Fixes**
  - Added `dispose()` to `Pty` (idempotent) for native `node-pty` and adopted PTYs.
  - Dispose on natural exit, explicit close (kill then dispose), failed/partial spawn or adoption, and daemon shutdown; skip after successful handoff.
  - Hardened open/adoption rollback: close only the successor’s inherited copies on failure.
  - Mark sessions exited on close and ignore stale exit events so recycled ids aren’t deleted.

- **Dependencies**
  - Pin `node-pty` to `1.2.0-beta.14` to fix hidden macOS `/dev/ptmx` descriptor leaks; applied in `apps/desktop`, `packages/host-service`, and `packages/pty-daemon`.

<sup>Written for commit f22fb4a786b04e23358c1de70ec7063be32b980c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an idempotent `dispose()` API for PTY instances (optionally preserving exit polling).
* **Bug Fixes**
  * Improved PTY/session cleanup on open/adopt failures, close, shutdown, and natural exits.
  * Ensured stale exit events won’t affect newer sessions using the same id.
  * Prevented fd/PTY leaks during partial adoption and exit callback ordering.
* **Tests**
  * Expanded coverage for native/adopted master fd lifecycle, churn, forced termination, and handoff behavior.
  * Strengthened integration and handler tests with dispose-aware fakes.
* **Documentation**
  * Updated PTY daemon README with clearer fd lifecycle and testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->