### PR TITLE
fix: show Open in Editor for folders and enable folder double-click

### DIFF
--- a/apps/desktop/src/renderer/lib/clickPolicy/usePierreRowClickPolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/usePierreRowClickPolicy.ts
@@ -21,6 +21,7 @@ interface UsePierreRowClickPolicyOptions {
 interface UsePierreRowClickPolicyResult {
 	/** Capture-phase handler — attach to the wrapper holding the `PierreFileTree`. */
 	onClickCapture: (e: React.MouseEvent<HTMLDivElement>) => void;
+	onDoubleClickCapture: (e: React.MouseEvent<HTMLDivElement>) => void;
 	/** Find the file-row element under a mouse event (skips folder rows). */
 	findFileRow: (e: React.MouseEvent) => HTMLElement | null;
 }
@@ -33,7 +34,7 @@ interface UsePierreRowClickPolicyResult {
  *
  *   - folder rows → `folderIntentFor` (meta=reveal/no-op, metaShift=external)
  *   - file rows   → settings-driven via the injected `filePolicy`
- *
+ * 
  * Every resolved action is intercepted (preventDefault + stopPropagation) —
  * we never defer to Pierre's own click → `onSelectionChange` pipeline.
  * Pierre's `selectOnlyPath` no-ops when the clicked row is already selected,
@@ -96,5 +97,18 @@ export function usePierreRowClickPolicy({
 		[filePolicy, onSelectFile, openInExternalEditor, findRow],
 	);
 
-	return { onClickCapture, findFileRow };
+	const onDoubleClickCapture = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			const treePath = findRow(e)?.getAttribute("data-item-path");
+			if (!treePath) return;
+			const trimmed = treePath.endsWith("/") ? treePath.slice(0, -1) : treePath;
+
+			e.preventDefault();
+			e.stopPropagation();
+			openInExternalEditor(trimmed);
+		},
+		[findRow, openInExternalEditor],
+	);
+
+	return { onClickCapture, onDoubleClickCapture, findFileRow };
 }

--- a/apps/desktop/src/renderer/lib/clickPolicy/usePierreRowClickPolicy.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/usePierreRowClickPolicy.ts
@@ -1,7 +1,8 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { folderIntentFor } from "./policies/folderPolicy";
 import type { ClickPolicy } from "./policies/policy";
 
+const SINGLE_CLICK_DELAY_MS = 250;
 interface UsePierreRowClickPolicyOptions {
 	/** Resolved file-row click policy (settings-driven, e.g. `useSidebarFilePolicy`). */
 	filePolicy: ClickPolicy;
@@ -34,7 +35,7 @@ interface UsePierreRowClickPolicyResult {
  *
  *   - folder rows → `folderIntentFor` (meta=reveal/no-op, metaShift=external)
  *   - file rows   → settings-driven via the injected `filePolicy`
- * 
+ *
  * Every resolved action is intercepted (preventDefault + stopPropagation) —
  * we never defer to Pierre's own click → `onSelectionChange` pipeline.
  * Pierre's `selectOnlyPath` no-ops when the clicked row is already selected,
@@ -47,6 +48,18 @@ export function usePierreRowClickPolicy({
 	onSelectFile,
 	openInExternalEditor,
 }: UsePierreRowClickPolicyOptions): UsePierreRowClickPolicyResult {
+	const singleClickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+
+	const clearSingleClickTimer = useCallback(() => {
+		if (singleClickTimerRef.current === null) return;
+		clearTimeout(singleClickTimerRef.current);
+		singleClickTimerRef.current = null;
+	}, []);
+
+	useEffect(() => () => clearSingleClickTimer(), [clearSingleClickTimer]);
+
 	const findRow = useCallback((e: React.MouseEvent): HTMLElement | null => {
 		const path = e.nativeEvent.composedPath();
 		for (const node of path) {
@@ -73,6 +86,11 @@ export function usePierreRowClickPolicy({
 			const trimmed = treePath.endsWith("/") ? treePath.slice(0, -1) : treePath;
 
 			if (treePath.endsWith("/")) {
+				if (e.detail > 1) {
+					e.preventDefault();
+					e.stopPropagation();
+					return;
+				}
 				const intent = folderIntentFor(e);
 				if (intent === null) return;
 				e.preventDefault();
@@ -90,11 +108,32 @@ export function usePierreRowClickPolicy({
 			// (e.g. click-to-pin, or reopening a file after Cmd+W).
 			e.preventDefault();
 			e.stopPropagation();
-			if (action === "external") openInExternalEditor(trimmed);
-			else if (action === "newTab") onSelectFile(trimmed, true);
-			else if (action === "pane") onSelectFile(trimmed, false);
+			if (e.detail > 1) return;
+			if (action === "external") {
+				clearSingleClickTimer();
+				openInExternalEditor(trimmed);
+				return;
+			}
+			if (action === "newTab") {
+				clearSingleClickTimer();
+				onSelectFile(trimmed, true);
+				return;
+			}
+			if (action === "pane") {
+				clearSingleClickTimer();
+				singleClickTimerRef.current = setTimeout(() => {
+					singleClickTimerRef.current = null;
+					onSelectFile(trimmed, false);
+				}, SINGLE_CLICK_DELAY_MS);
+			}
 		},
-		[filePolicy, onSelectFile, openInExternalEditor, findRow],
+		[
+			filePolicy,
+			onSelectFile,
+			openInExternalEditor,
+			findRow,
+			clearSingleClickTimer,
+		],
 	);
 
 	const onDoubleClickCapture = useCallback(
@@ -103,11 +142,12 @@ export function usePierreRowClickPolicy({
 			if (!treePath) return;
 			const trimmed = treePath.endsWith("/") ? treePath.slice(0, -1) : treePath;
 
+			clearSingleClickTimer();
 			e.preventDefault();
 			e.stopPropagation();
 			openInExternalEditor(trimmed);
 		},
-		[findRow, openInExternalEditor],
+		[findRow, openInExternalEditor, clearSingleClickTimer],
 	);
 
 	return { onClickCapture, onDoubleClickCapture, findFileRow };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -203,13 +203,16 @@ export function FilesTab({
 	// Folders are excluded since folder intents are hardcoded.
 	// The hook fires Pierre's relative path; this surface's external
 	// contract is absolute, so wrap each callback to join with `rootPath`.
-	const { onClickCapture: handleClickCapture, findFileRow } =
-		usePierreRowClickPolicy({
-			filePolicy,
-			onSelectFile: (rel, openInNewTab) =>
-				onSelectFile(toAbs(rootPath, rel), openInNewTab),
-			openInExternalEditor: (rel) => openInExternalEditor(toAbs(rootPath, rel)),
-		});
+	const {
+		onClickCapture: handleClickCapture,
+		onDoubleClickCapture: handleDoubleClickCapture,
+		findFileRow,
+	} = usePierreRowClickPolicy({
+		filePolicy,
+		onSelectFile: (rel, openInNewTab) =>
+			onSelectFile(toAbs(rootPath, rel), openInNewTab),
+		openInExternalEditor: (rel) => openInExternalEditor(toAbs(rootPath, rel)),
+	});
 
 	const renderContextMenu = useCallback(
 		(item: PierreContextMenuItem, ctx: PierreContextMenuOpenContext) => {
@@ -231,6 +234,7 @@ export function FilesTab({
 							relativePath={rel}
 							onNewFile={() => void startCreating("file", abs)}
 							onNewFolder={() => void startCreating("folder", abs)}
+							onOpenInEditor={() => openInExternalEditor(abs)}
 							onRename={() => model.startRenaming(treePath)}
 							onDelete={() => handleDelete(abs, item.name, true)}
 						/>
@@ -278,6 +282,7 @@ export function FilesTab({
 		<div
 			className="relative flex h-full min-h-0 flex-col overflow-hidden"
 			onClickCapture={handleClickCapture}
+			onDoubleClickCapture={handleDoubleClickCapture}
 			onDragOver={drop.onDragOver}
 			onDragLeave={drop.onDragLeave}
 			onDrop={drop.onDrop}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FolderMenuItems/FolderMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FolderMenuItems/FolderMenuItems.tsx
@@ -1,8 +1,10 @@
 import {
 	DropdownMenuItem,
 	DropdownMenuSeparator,
+	DropdownMenuShortcut,
 } from "@superset/ui/dropdown-menu";
-import { FilePlus, FolderPlus, Pencil, Trash2 } from "lucide-react";
+import { ExternalLink, FilePlus, FolderPlus, Pencil, Trash2 } from "lucide-react";
+import { modifierLabel } from "renderer/lib/clickPolicy";
 import { PathActions } from "../PathActions";
 
 interface FolderMenuItemsProps {
@@ -10,6 +12,7 @@ interface FolderMenuItemsProps {
 	relativePath: string;
 	onNewFile: () => void;
 	onNewFolder: () => void;
+	onOpenInEditor: () => void;
 	onRename: () => void;
 	onDelete: () => void;
 }
@@ -19,6 +22,7 @@ export function FolderMenuItems({
 	relativePath,
 	onNewFile,
 	onNewFolder,
+	onOpenInEditor,
 	onRename,
 	onDelete,
 }: FolderMenuItemsProps) {
@@ -33,6 +37,13 @@ export function FolderMenuItems({
 				New Folder...
 			</DropdownMenuItem>
 			<DropdownMenuSeparator />
+			<DropdownMenuItem onSelect={onOpenInEditor}>
+				<ExternalLink />
+				Open in Editor
+				<DropdownMenuShortcut>
+					{modifierLabel("metaShift")}
+				</DropdownMenuShortcut>
+			</DropdownMenuItem>
 			<PathActions absolutePath={absolutePath} relativePath={relativePath} />
 			<DropdownMenuSeparator />
 			<DropdownMenuItem onSelect={() => setTimeout(onRename, 0)}>


### PR DESCRIPTION
## What & why

Fixes #4930.

The v2 workspace file tree showed **Open in Editor** for files but not folders, even though `⌘⇧ click` already opened folders in the external editor. Double-click also did nothing for files and only expanded/collapsed folders.

This PR:
- Adds **Open in Editor** to the folder right-click menu (with `⌘⇧ click` shortcut label)
- Wires double-click on files and folders to open in the external editor
- Leaves single-click behavior unchanged (files → Superset pane, folders → expand/collapse)

## How I tested it

1. Started the desktop app with `bun dev`
2. Opened a workspace and switched the right sidebar to **Files**
3. Right-clicked a folder → confirmed **Open in Editor** appears and opens the folder in the external editor
4. Right-clicked a file → confirmed **Open in Editor** still works
5. Double-clicked a folder → opened in external editor
6. Double-clicked a file → opened in external editor
7. Single-clicked a folder → still expands/collapses
8. Single-clicked a file → still opens in Superset pane
9. `⌘⇧ click` on a folder → still opens in external editor

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Open in Editor to the folder context menu and wires double-click on files and folders to open them in the external editor. Adds click debouncing so double-click skips the single-click action; single-click stays the same (files → Superset pane, folders → expand/collapse).

<sup>Written for commit 8d36c703e967a8a7f05bf75f54103c42c964c67d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added double-click support for opening items directly in an external editor.
  * Added an “Open in Editor” option to folder context menus.
  * Included a keyboard shortcut indicator for the new folder action.
* **Bug Fixes**
  * Improved tree row click/double-click behavior to prevent conflicting single-click actions and ensure the correct item is opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->