### PR TITLE
feat(desktop): add Token Usage screen for AI provider limits, cost & usage

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -27,6 +27,7 @@ import { createSettingsRouter } from "./settings";
 import { createSystemRouter } from "./system";
 import { createTerminalRouter } from "./terminal";
 import { createUiStateRouter } from "./ui-state";
+import { createUsageRouter } from "./usage";
 import { createWindowRouter } from "./window";
 import { createWorkspacesRouter } from "./workspaces";
 
@@ -57,6 +58,7 @@ export const createAppRouter = (getWindow: () => BrowserWindow | null) => {
 		config: createConfigRouter(),
 		device: createDeviceRouter(),
 		uiState: createUiStateRouter(),
+		usage: createUsageRouter(),
 		ringtone: createRingtoneRouter(getWindow),
 		hostServiceCoordinator: createHostServiceCoordinatorRouter(),
 		keyboardLayout: createKeyboardLayoutRouter(),

--- a/apps/desktop/src/lib/trpc/routers/menu.ts
+++ b/apps/desktop/src/lib/trpc/routers/menu.ts
@@ -11,7 +11,8 @@ type MenuEvent =
 	| { type: "open-settings"; data: OpenSettingsEvent }
 	| { type: "open-workspace"; data: OpenWorkspaceEvent }
 	| { type: "open-project" }
-	| { type: "toggle-presets-bar" };
+	| { type: "toggle-presets-bar" }
+	| { type: "navigate"; data: { to: string } };
 
 export const createMenuRouter = () => {
 	return router({
@@ -33,16 +34,22 @@ export const createMenuRouter = () => {
 					emit.next({ type: "toggle-presets-bar" });
 				};
 
+				const onNavigate = (to: string) => {
+					emit.next({ type: "navigate", data: { to } });
+				};
+
 				menuEmitter.on("open-settings", onOpenSettings);
 				menuEmitter.on("open-workspace", onOpenWorkspace);
 				menuEmitter.on("open-project", onOpenProject);
 				menuEmitter.on("toggle-presets-bar", onTogglePresetsBar);
+				menuEmitter.on("navigate", onNavigate);
 
 				return () => {
 					menuEmitter.off("open-settings", onOpenSettings);
 					menuEmitter.off("open-workspace", onOpenWorkspace);
 					menuEmitter.off("open-project", onOpenProject);
 					menuEmitter.off("toggle-presets-bar", onTogglePresetsBar);
+					menuEmitter.off("navigate", onNavigate);
 				};
 			});
 		}),

--- a/apps/desktop/src/lib/trpc/routers/usage.ts
+++ b/apps/desktop/src/lib/trpc/routers/usage.ts
@@ -1,4 +1,5 @@
 import { observable } from "@trpc/server/observable";
+import { refreshTray } from "main/lib/tray";
 import {
 	getUsageCollector,
 	USAGE_UPDATED_EVENT,
@@ -45,6 +46,11 @@ export const createUsageRouter = () => {
 
 		updateSettings: publicProcedure
 			.input(updateSettingsInputSchema)
-			.mutation(({ input }) => updateUsageDisplaySettings(input)),
+			.mutation(({ input }) => {
+				const settings = updateUsageDisplaySettings(input);
+				// Reflect the tray-percentage toggle without waiting for the next poll.
+				refreshTray();
+				return settings;
+			}),
 	});
 };

--- a/apps/desktop/src/lib/trpc/routers/usage.ts
+++ b/apps/desktop/src/lib/trpc/routers/usage.ts
@@ -1,0 +1,50 @@
+import { observable } from "@trpc/server/observable";
+import {
+	getUsageCollector,
+	USAGE_UPDATED_EVENT,
+} from "main/lib/usage/usage-collector";
+import {
+	getUsageDisplaySettings,
+	updateUsageDisplaySettings,
+} from "main/lib/usage/usage-settings";
+import type { ProviderSnapshot } from "main/lib/usage/usage-snapshot";
+import { z } from "zod";
+import { publicProcedure, router } from "..";
+
+const updateSettingsInputSchema = z.object({
+	showSidebarBadge: z.boolean().optional(),
+	showTrayPercentage: z.boolean().optional(),
+	notifyAt80Pct: z.boolean().optional(),
+	notifyAt95Pct: z.boolean().optional(),
+});
+
+export const createUsageRouter = () => {
+	return router({
+		getSnapshot: publicProcedure.query(() =>
+			getUsageCollector().getSnapshots(),
+		),
+
+		refresh: publicProcedure.mutation(() => getUsageCollector().refresh()),
+
+		subscribe: publicProcedure.subscription(() => {
+			return observable<ProviderSnapshot[]>((emit) => {
+				const collector = getUsageCollector();
+				// Push the cached reading immediately so a late subscriber isn't blank
+				// until the next poll cycle.
+				emit.next(collector.getSnapshots());
+
+				const handler = (snapshots: ProviderSnapshot[]) => emit.next(snapshots);
+				collector.on(USAGE_UPDATED_EVENT, handler);
+				return () => {
+					collector.off(USAGE_UPDATED_EVENT, handler);
+				};
+			});
+		}),
+
+		getSettings: publicProcedure.query(() => getUsageDisplaySettings()),
+
+		updateSettings: publicProcedure
+			.input(updateSettingsInputSchema)
+			.mutation(({ input }) => updateUsageDisplaySettings(input)),
+	});
+};

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -54,6 +54,7 @@ import {
 	getTerminalHostClient,
 } from "./lib/terminal-host/client";
 import { disposeTray, initTray } from "./lib/tray";
+import { getUsageCollector } from "./lib/usage/usage-collector";
 import { startNetworkLogger, stopNetworkLogger } from "./network-logger";
 import { MainWindow } from "./windows/main";
 
@@ -237,6 +238,7 @@ app.on("before-quit", async (event) => {
 			disposeTerminalHostClient();
 		}
 		shutdownTanstackDbPersistence();
+		getUsageCollector().dispose();
 		disposeTray();
 	} catch (error) {
 		console.error("[main] Cleanup during quit failed:", error);
@@ -453,6 +455,7 @@ if (!gotTheLock) {
 		setupAutoUpdater();
 		startMemoryTelemetry();
 		initTray();
+		getUsageCollector().start();
 
 		const coldStartUrl = findDeepLinkInArgv(process.argv);
 		if (coldStartUrl) {

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -16,6 +16,17 @@ import {
 } from "main/lib/host-service-coordinator";
 import { menuEmitter } from "main/lib/menu-events";
 import { confirmAndQuitCompletely } from "main/lib/quit-completely";
+import {
+	getUsageCollector,
+	USAGE_UPDATED_EVENT,
+} from "main/lib/usage/usage-collector";
+import { getUsageDisplaySettings } from "main/lib/usage/usage-settings";
+import {
+	type ProviderSnapshot,
+	type RateLimitWindow,
+	USAGE_PROVIDER_LABELS,
+	worstWindowAcrossProviders,
+} from "main/lib/usage/usage-snapshot";
 
 /** Must have "Template" suffix for macOS dark/light mode support */
 const TRAY_ICON_FILENAME = "iconTemplate.png";
@@ -186,6 +197,69 @@ function buildHostServiceSubmenu(
 	return menuItems;
 }
 
+function formatTimeToReset(resetAt: Date | null): string | null {
+	if (!resetAt) return null;
+	const ms = resetAt.getTime() - Date.now();
+	if (ms <= 0) return "now";
+	const totalMinutes = Math.floor(ms / 60_000);
+	const days = Math.floor(totalMinutes / 1440);
+	const hours = Math.floor((totalMinutes % 1440) / 60);
+	const minutes = totalMinutes % 60;
+	if (days > 0) return `${days}d ${hours}h`;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	return `${minutes}m`;
+}
+
+function worstWindow(snapshot: ProviderSnapshot): RateLimitWindow | null {
+	let worst: RateLimitWindow | null = null;
+	for (const window of snapshot.windows) {
+		if (!worst || window.usedPct > worst.usedPct) worst = window;
+	}
+	return worst;
+}
+
+function buildUsageSection(
+	snapshots: ProviderSnapshot[],
+): MenuItemConstructorOptions[] {
+	const rows: MenuItemConstructorOptions[] = [];
+	for (const snapshot of snapshots) {
+		const window = worstWindow(snapshot);
+		if (!window) continue;
+		const resetLabel = formatTimeToReset(window.resetAt);
+		const suffix = resetLabel ? ` · resets in ${resetLabel}` : "";
+		rows.push({
+			label: `${USAGE_PROVIDER_LABELS[snapshot.providerId]}  ${Math.round(window.usedPct)}%${suffix}`,
+			enabled: false,
+		});
+	}
+
+	if (rows.length === 0) return [];
+
+	return [
+		{ type: "separator" },
+		{ label: "AI provider usage", enabled: false },
+		...rows,
+		{
+			label: "View details →",
+			click: () => {
+				focusMainWindow();
+				menuEmitter.emit("navigate", "/usage");
+			},
+		},
+	];
+}
+
+function updateTrayTooltip(snapshots: ProviderSnapshot[]): void {
+	if (!tray) return;
+	const worst = worstWindowAcrossProviders(snapshots);
+	const showPercentage = getUsageDisplaySettings().showTrayPercentage;
+	if (showPercentage && worst !== null) {
+		tray.setToolTip(`Superset · ${Math.round(worst)}%`);
+	} else {
+		tray.setToolTip("Superset");
+	}
+}
+
 async function updateTrayMenu(): Promise<void> {
 	if (!tray) return;
 
@@ -209,11 +283,15 @@ async function updateTrayMenu(): Promise<void> {
 
 	const hostServiceSubmenu = buildHostServiceSubmenu(orgIds, infos);
 
+	const usageSnapshots = getUsageCollector().getSnapshots();
+	updateTrayTooltip(usageSnapshots);
+
 	const menu = Menu.buildFromTemplate([
 		{
 			label: hostServiceLabel,
 			submenu: hostServiceSubmenu,
 		},
+		...buildUsageSection(usageSnapshots),
 		{ type: "separator" },
 		{
 			label: "Open Superset",
@@ -273,6 +351,10 @@ export function initTray(): void {
 
 		const manager = getHostServiceCoordinator();
 		manager.on("status-changed", (_event: HostServiceStatusEvent) => {
+			void updateTrayMenu();
+		});
+
+		getUsageCollector().on(USAGE_UPDATED_EVENT, () => {
 			void updateTrayMenu();
 		});
 

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -368,6 +368,11 @@ export function initTray(): void {
 	}
 }
 
+/** Rebuild the tray menu + tooltip immediately (e.g. after a settings change). */
+export function refreshTray(): void {
+	void updateTrayMenu();
+}
+
 /** Call on app quit */
 export function disposeTray(): void {
 	if (tray) {

--- a/apps/desktop/src/main/lib/usage/log-parsers/claude-log-parser.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/claude-log-parser.ts
@@ -58,7 +58,11 @@ function parseLine(raw: string, sessionId: string): UsageEntry | null {
 
 /** Returns null on missing logs or an unrecognized format. */
 export async function parseClaudeLogs(): Promise<CostStats | null> {
-	const files = await collectLogFiles(CLAUDE_PROJECTS_DIR, ".jsonl", MAX_AGE_DAYS);
+	const files = await collectLogFiles(
+		CLAUDE_PROJECTS_DIR,
+		".jsonl",
+		MAX_AGE_DAYS,
+	);
 	if (files.length === 0) return null;
 
 	const entries: UsageEntry[] = [];

--- a/apps/desktop/src/main/lib/usage/log-parsers/claude-log-parser.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/claude-log-parser.ts
@@ -1,0 +1,82 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { CostStats } from "../usage-snapshot";
+import { aggregateUsage, type UsageEntry } from "./cost-aggregator";
+import { collectLogFiles } from "./log-files";
+
+const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
+const MAX_AGE_DAYS = 31;
+
+interface ClaudeUsage {
+	input_tokens?: number;
+	output_tokens?: number;
+	cache_creation_input_tokens?: number;
+	cache_read_input_tokens?: number;
+}
+
+interface ClaudeLogLine {
+	type?: string;
+	timestamp?: string;
+	message?: {
+		model?: string;
+		usage?: ClaudeUsage;
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseLine(raw: string, sessionId: string): UsageEntry | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (!isRecord(parsed)) return null;
+	const line = parsed as ClaudeLogLine;
+
+	if (line.type !== "assistant") return null;
+	const usage = line.message?.usage;
+	const model = line.message?.model;
+	if (!usage || typeof model !== "string") return null;
+
+	const timestamp = line.timestamp ? new Date(line.timestamp) : null;
+	if (!timestamp || Number.isNaN(timestamp.getTime())) return null;
+
+	const inputTokens =
+		(usage.input_tokens ?? 0) +
+		(usage.cache_creation_input_tokens ?? 0) +
+		(usage.cache_read_input_tokens ?? 0);
+	const outputTokens = usage.output_tokens ?? 0;
+	if (inputTokens === 0 && outputTokens === 0) return null;
+
+	return { timestamp, model, sessionId, inputTokens, outputTokens };
+}
+
+/** Returns null on missing logs or an unrecognized format. */
+export async function parseClaudeLogs(): Promise<CostStats | null> {
+	const files = await collectLogFiles(CLAUDE_PROJECTS_DIR, ".jsonl", MAX_AGE_DAYS);
+	if (files.length === 0) return null;
+
+	const entries: UsageEntry[] = [];
+	for (const file of files) {
+		let content: string;
+		try {
+			content = await readFile(file.path, "utf8");
+		} catch {
+			continue;
+		}
+		for (const raw of content.split("\n")) {
+			const trimmed = raw.trim();
+			if (!trimmed) continue;
+			const entry = parseLine(trimmed, file.sessionId);
+			if (entry) entries.push(entry);
+		}
+	}
+
+	if (entries.length === 0) return null;
+	return aggregateUsage("claude", entries);
+}

--- a/apps/desktop/src/main/lib/usage/log-parsers/claude-log-parser.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/claude-log-parser.ts
@@ -46,14 +46,28 @@ function parseLine(raw: string, sessionId: string): UsageEntry | null {
 	const timestamp = line.timestamp ? new Date(line.timestamp) : null;
 	if (!timestamp || Number.isNaN(timestamp.getTime())) return null;
 
-	const inputTokens =
-		(usage.input_tokens ?? 0) +
-		(usage.cache_creation_input_tokens ?? 0) +
-		(usage.cache_read_input_tokens ?? 0);
+	const inputTokens = usage.input_tokens ?? 0;
 	const outputTokens = usage.output_tokens ?? 0;
-	if (inputTokens === 0 && outputTokens === 0) return null;
+	const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
+	const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
+	if (
+		inputTokens === 0 &&
+		outputTokens === 0 &&
+		cacheCreationTokens === 0 &&
+		cacheReadTokens === 0
+	) {
+		return null;
+	}
 
-	return { timestamp, model, sessionId, inputTokens, outputTokens };
+	return {
+		timestamp,
+		model,
+		sessionId,
+		inputTokens,
+		outputTokens,
+		cacheCreationTokens,
+		cacheReadTokens,
+	};
 }
 
 /** Returns null on missing logs or an unrecognized format. */

--- a/apps/desktop/src/main/lib/usage/log-parsers/codex-log-parser.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/codex-log-parser.ts
@@ -8,94 +8,140 @@ import { collectLogFiles, type LogFile } from "./log-files";
 const CODEX_SESSIONS_DIR = join(homedir(), ".codex", "sessions");
 const MAX_AGE_DAYS = 31;
 
-interface CodexUsage {
-	prompt_tokens?: number;
-	completion_tokens?: number;
-	input_tokens?: number;
-	output_tokens?: number;
-}
-
-interface CodexLogEntry {
-	model?: string;
-	timestamp?: string;
-	usage?: CodexUsage;
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
 
-function entryFromRecord(
-	record: Record<string, unknown>,
-	file: LogFile,
-): UsageEntry | null {
-	const entry = record as CodexLogEntry;
-	const usage = entry.usage;
-	const model = entry.model;
-	if (!usage || typeof model !== "string") return null;
+function num(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
 
-	const inputTokens = usage.prompt_tokens ?? usage.input_tokens ?? 0;
-	const outputTokens = usage.completion_tokens ?? usage.output_tokens ?? 0;
-	if (inputTokens === 0 && outputTokens === 0) return null;
+interface ExtractedUsage {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+}
 
-	const parsed = entry.timestamp ? new Date(entry.timestamp) : null;
-	const timestamp =
-		parsed && !Number.isNaN(parsed.getTime()) ? parsed : new Date(file.mtimeMs);
-
+/** Pulls per-turn token counts from the many shapes Codex has shipped. */
+function extractUsage(obj: Record<string, unknown>): ExtractedUsage | null {
+	const input =
+		num(obj.input_tokens) || num(obj.prompt_tokens) || num(obj.inputTokens);
+	const output =
+		num(obj.output_tokens) ||
+		num(obj.completion_tokens) ||
+		num(obj.outputTokens);
+	const cacheRead =
+		num(obj.cached_input_tokens) ||
+		num(obj.cache_read_input_tokens) ||
+		num(obj.cached_tokens);
+	if (input === 0 && output === 0 && cacheRead === 0) return null;
 	return {
-		timestamp,
-		model,
-		sessionId: file.sessionId,
-		inputTokens,
-		outputTokens,
+		inputTokens: input,
+		outputTokens: output,
+		cacheReadTokens: cacheRead,
 	};
 }
 
-function parseFile(content: string, file: LogFile): UsageEntry[] {
-	const entries: UsageEntry[] = [];
+function findModel(record: Record<string, unknown>): string | null {
+	if (typeof record.model === "string") return record.model;
+	const payload = record.payload;
+	if (isRecord(payload) && typeof payload.model === "string") {
+		return payload.model;
+	}
+	return null;
+}
 
-	// Codex writes newline-delimited JSON; fall back to a single JSON document
-	// (object or array) for older/edge formats.
-	const lines = content.split("\n");
-	let matchedAnyLine = false;
-	for (const raw of lines) {
-		const trimmed = raw.trim();
-		if (!trimmed) continue;
-		let parsed: unknown;
-		try {
-			parsed = JSON.parse(trimmed);
-		} catch {
-			continue;
+function findUsage(record: Record<string, unknown>): ExtractedUsage | null {
+	const direct = extractUsage(record);
+	if (direct) return direct;
+	if (isRecord(record.usage)) {
+		const fromUsage = extractUsage(record.usage);
+		if (fromUsage) return fromUsage;
+	}
+	// Rollout events wrap data in a `payload`; the usage may sit there or under
+	// a nested `usage`/`info` object.
+	const payload = record.payload;
+	if (isRecord(payload)) {
+		const fromPayload = extractUsage(payload);
+		if (fromPayload) return fromPayload;
+		if (isRecord(payload.usage)) {
+			const nested = extractUsage(payload.usage);
+			if (nested) return nested;
 		}
-		if (!isRecord(parsed)) continue;
-		matchedAnyLine = true;
-		const entry = entryFromRecord(parsed, file);
-		if (entry) entries.push(entry);
+		if (isRecord(payload.info) && isRecord(payload.info.last_token_usage)) {
+			const info = extractUsage(payload.info.last_token_usage);
+			if (info) return info;
+		}
 	}
-	if (matchedAnyLine) return entries;
+	return null;
+}
 
-	let doc: unknown;
-	try {
-		doc = JSON.parse(content);
-	} catch {
-		return entries;
-	}
-	const records = Array.isArray(doc) ? doc : [doc];
+function parseRecords(records: unknown[], file: LogFile): UsageEntry[] {
+	const entries: UsageEntry[] = [];
+	// Codex records the model once in session/turn metadata, then emits
+	// model-less token-count events; carry the last-seen model forward.
+	let currentModel = "unknown";
+
 	for (const record of records) {
 		if (!isRecord(record)) continue;
-		const entry = entryFromRecord(record, file);
-		if (entry) entries.push(entry);
+		const model = findModel(record);
+		if (model) currentModel = model;
+
+		const usage = findUsage(record);
+		if (!usage) continue;
+
+		const rawTimestamp = record.timestamp ?? record.time ?? record.ts;
+		const parsed =
+			typeof rawTimestamp === "string" || typeof rawTimestamp === "number"
+				? new Date(rawTimestamp)
+				: null;
+		const timestamp =
+			parsed && !Number.isNaN(parsed.getTime())
+				? parsed
+				: new Date(file.mtimeMs);
+
+		entries.push({
+			timestamp,
+			model: currentModel,
+			sessionId: file.sessionId,
+			inputTokens: usage.inputTokens,
+			outputTokens: usage.outputTokens,
+			cacheReadTokens: usage.cacheReadTokens,
+		});
 	}
 	return entries;
 }
 
+function parseFile(content: string, file: LogFile): UsageEntry[] {
+	const lineRecords: unknown[] = [];
+	let matchedAnyLine = false;
+	for (const raw of content.split("\n")) {
+		const trimmed = raw.trim();
+		if (!trimmed) continue;
+		try {
+			lineRecords.push(JSON.parse(trimmed));
+			matchedAnyLine = true;
+		} catch {
+			// Not JSONL; fall through to whole-document parsing below.
+		}
+	}
+	if (matchedAnyLine) return parseRecords(lineRecords, file);
+
+	try {
+		const doc: unknown = JSON.parse(content);
+		return parseRecords(Array.isArray(doc) ? doc : [doc], file);
+	} catch {
+		return [];
+	}
+}
+
 /** Returns null on missing logs or an unrecognized format. */
 export async function parseCodexLogs(): Promise<CostStats | null> {
-	const files = await collectLogFiles(
-		CODEX_SESSIONS_DIR,
-		".json",
-		MAX_AGE_DAYS,
-	);
+	const [jsonl, json] = await Promise.all([
+		collectLogFiles(CODEX_SESSIONS_DIR, ".jsonl", MAX_AGE_DAYS),
+		collectLogFiles(CODEX_SESSIONS_DIR, ".json", MAX_AGE_DAYS),
+	]);
+	const files = [...jsonl, ...json];
 	if (files.length === 0) return null;
 
 	const entries: UsageEntry[] = [];

--- a/apps/desktop/src/main/lib/usage/log-parsers/codex-log-parser.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/codex-log-parser.ts
@@ -1,0 +1,112 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { CostStats } from "../usage-snapshot";
+import { aggregateUsage, type UsageEntry } from "./cost-aggregator";
+import { collectLogFiles, type LogFile } from "./log-files";
+
+const CODEX_SESSIONS_DIR = join(homedir(), ".codex", "sessions");
+const MAX_AGE_DAYS = 31;
+
+interface CodexUsage {
+	prompt_tokens?: number;
+	completion_tokens?: number;
+	input_tokens?: number;
+	output_tokens?: number;
+}
+
+interface CodexLogEntry {
+	model?: string;
+	timestamp?: string;
+	usage?: CodexUsage;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function entryFromRecord(
+	record: Record<string, unknown>,
+	file: LogFile,
+): UsageEntry | null {
+	const entry = record as CodexLogEntry;
+	const usage = entry.usage;
+	const model = entry.model;
+	if (!usage || typeof model !== "string") return null;
+
+	const inputTokens = usage.prompt_tokens ?? usage.input_tokens ?? 0;
+	const outputTokens = usage.completion_tokens ?? usage.output_tokens ?? 0;
+	if (inputTokens === 0 && outputTokens === 0) return null;
+
+	const parsed = entry.timestamp ? new Date(entry.timestamp) : null;
+	const timestamp =
+		parsed && !Number.isNaN(parsed.getTime())
+			? parsed
+			: new Date(file.mtimeMs);
+
+	return {
+		timestamp,
+		model,
+		sessionId: file.sessionId,
+		inputTokens,
+		outputTokens,
+	};
+}
+
+function parseFile(content: string, file: LogFile): UsageEntry[] {
+	const entries: UsageEntry[] = [];
+
+	// Codex writes newline-delimited JSON; fall back to a single JSON document
+	// (object or array) for older/edge formats.
+	const lines = content.split("\n");
+	let matchedAnyLine = false;
+	for (const raw of lines) {
+		const trimmed = raw.trim();
+		if (!trimmed) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(trimmed);
+		} catch {
+			continue;
+		}
+		if (!isRecord(parsed)) continue;
+		matchedAnyLine = true;
+		const entry = entryFromRecord(parsed, file);
+		if (entry) entries.push(entry);
+	}
+	if (matchedAnyLine) return entries;
+
+	let doc: unknown;
+	try {
+		doc = JSON.parse(content);
+	} catch {
+		return entries;
+	}
+	const records = Array.isArray(doc) ? doc : [doc];
+	for (const record of records) {
+		if (!isRecord(record)) continue;
+		const entry = entryFromRecord(record, file);
+		if (entry) entries.push(entry);
+	}
+	return entries;
+}
+
+/** Returns null on missing logs or an unrecognized format. */
+export async function parseCodexLogs(): Promise<CostStats | null> {
+	const files = await collectLogFiles(CODEX_SESSIONS_DIR, ".json", MAX_AGE_DAYS);
+	if (files.length === 0) return null;
+
+	const entries: UsageEntry[] = [];
+	for (const file of files) {
+		let content: string;
+		try {
+			content = await readFile(file.path, "utf8");
+		} catch {
+			continue;
+		}
+		entries.push(...parseFile(content, file));
+	}
+
+	if (entries.length === 0) return null;
+	return aggregateUsage("codex", entries);
+}

--- a/apps/desktop/src/main/lib/usage/log-parsers/codex-log-parser.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/codex-log-parser.ts
@@ -24,7 +24,7 @@ interface ExtractedUsage {
 
 /** Pulls per-turn token counts from the many shapes Codex has shipped. */
 function extractUsage(obj: Record<string, unknown>): ExtractedUsage | null {
-	const input =
+	const rawInput =
 		num(obj.input_tokens) || num(obj.prompt_tokens) || num(obj.inputTokens);
 	const output =
 		num(obj.output_tokens) ||
@@ -34,9 +34,11 @@ function extractUsage(obj: Record<string, unknown>): ExtractedUsage | null {
 		num(obj.cached_input_tokens) ||
 		num(obj.cache_read_input_tokens) ||
 		num(obj.cached_tokens);
-	if (input === 0 && output === 0 && cacheRead === 0) return null;
+	if (rawInput === 0 && output === 0 && cacheRead === 0) return null;
+	// OpenAI's input_tokens is inclusive of cached tokens; split them so cache
+	// reads aren't billed twice (full input rate + cache rate).
 	return {
-		inputTokens: input,
+		inputTokens: Math.max(0, rawInput - cacheRead),
 		outputTokens: output,
 		cacheReadTokens: cacheRead,
 	};

--- a/apps/desktop/src/main/lib/usage/log-parsers/codex-log-parser.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/codex-log-parser.ts
@@ -40,9 +40,7 @@ function entryFromRecord(
 
 	const parsed = entry.timestamp ? new Date(entry.timestamp) : null;
 	const timestamp =
-		parsed && !Number.isNaN(parsed.getTime())
-			? parsed
-			: new Date(file.mtimeMs);
+		parsed && !Number.isNaN(parsed.getTime()) ? parsed : new Date(file.mtimeMs);
 
 	return {
 		timestamp,
@@ -93,7 +91,11 @@ function parseFile(content: string, file: LogFile): UsageEntry[] {
 
 /** Returns null on missing logs or an unrecognized format. */
 export async function parseCodexLogs(): Promise<CostStats | null> {
-	const files = await collectLogFiles(CODEX_SESSIONS_DIR, ".json", MAX_AGE_DAYS);
+	const files = await collectLogFiles(
+		CODEX_SESSIONS_DIR,
+		".json",
+		MAX_AGE_DAYS,
+	);
 	if (files.length === 0) return null;
 
 	const entries: UsageEntry[] = [];

--- a/apps/desktop/src/main/lib/usage/log-parsers/cost-aggregator.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/cost-aggregator.ts
@@ -1,0 +1,117 @@
+import { resolveModelRate } from "../pricing-table";
+import type { CostStats, DailyBucket, ProviderId } from "../usage-snapshot";
+
+export interface UsageEntry {
+	timestamp: Date;
+	model: string;
+	sessionId: string;
+	inputTokens: number;
+	outputTokens: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WINDOW_DAYS = 30;
+
+function localDateKey(date: Date): string {
+	const year = date.getFullYear();
+	const month = `${date.getMonth() + 1}`.padStart(2, "0");
+	const day = `${date.getDate()}`.padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+function entryUsd(
+	providerId: ProviderId,
+	entry: UsageEntry,
+): { usd: number; approximate: boolean } {
+	const resolved = resolveModelRate(providerId, entry.model);
+	if (!resolved) return { usd: 0, approximate: true };
+	const usd =
+		(entry.inputTokens / 1_000_000) * resolved.rate.inputPerMillion +
+		(entry.outputTokens / 1_000_000) * resolved.rate.outputPerMillion;
+	return { usd, approximate: resolved.approximate };
+}
+
+export function aggregateUsage(
+	providerId: ProviderId,
+	entries: UsageEntry[],
+): CostStats {
+	const now = new Date();
+	const todayKey = localDateKey(now);
+	const cutoff = now.getTime() - WINDOW_DAYS * DAY_MS;
+
+	const buckets = new Map<string, DailyBucket>();
+	for (let i = 0; i < WINDOW_DAYS; i++) {
+		const key = localDateKey(new Date(now.getTime() - i * DAY_MS));
+		buckets.set(key, { date: key, tokens: 0, usd: 0 });
+	}
+
+	const tokensByModel = new Map<string, number>();
+	let todayUsd = 0;
+	let thirtyDayUsd = 0;
+	let thirtyDayTokens = 0;
+	let approximate = false;
+
+	let latestTimestamp = 0;
+	let latestSessionId: string | null = null;
+	const tokensBySession = new Map<string, number>();
+
+	for (const entry of entries) {
+		const tokens = entry.inputTokens + entry.outputTokens;
+		const time = entry.timestamp.getTime();
+
+		if (time > latestTimestamp) {
+			latestTimestamp = time;
+			latestSessionId = entry.sessionId;
+		}
+		tokensBySession.set(
+			entry.sessionId,
+			(tokensBySession.get(entry.sessionId) ?? 0) + tokens,
+		);
+
+		if (time < cutoff) continue;
+
+		const { usd, approximate: entryApproximate } = entryUsd(providerId, entry);
+		if (entryApproximate) approximate = true;
+
+		thirtyDayUsd += usd;
+		thirtyDayTokens += tokens;
+		tokensByModel.set(
+			entry.model,
+			(tokensByModel.get(entry.model) ?? 0) + tokens,
+		);
+
+		const key = localDateKey(entry.timestamp);
+		if (key === todayKey) todayUsd += usd;
+		const bucket = buckets.get(key);
+		if (bucket) {
+			bucket.tokens += tokens;
+			bucket.usd += usd;
+		}
+	}
+
+	let topModel: string | null = null;
+	let topModelTokens = -1;
+	for (const [model, tokens] of tokensByModel) {
+		if (tokens > topModelTokens) {
+			topModelTokens = tokens;
+			topModel = model;
+		}
+	}
+
+	const dailyBuckets = [...buckets.values()].sort((a, b) =>
+		a.date.localeCompare(b.date),
+	);
+
+	return {
+		todayUsd,
+		thirtyDayUsd,
+		thirtyDayTokens,
+		latestSessionTokens: latestSessionId
+			? (tokensBySession.get(latestSessionId) ?? 0)
+			: 0,
+		topModel,
+		dailyBuckets,
+		estimatedFromLogs: true,
+		approximate,
+	};
+}

--- a/apps/desktop/src/main/lib/usage/log-parsers/cost-aggregator.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/cost-aggregator.ts
@@ -7,7 +7,14 @@ export interface UsageEntry {
 	sessionId: string;
 	inputTokens: number;
 	outputTokens: number;
+	cacheReadTokens?: number;
+	cacheCreationTokens?: number;
 }
+
+// Anthropic-style prompt caching bills reads at ~0.1x and 5-minute writes at
+// ~1.25x the base input rate. Providers without caching pass 0 and are unaffected.
+const CACHE_READ_MULTIPLIER = 0.1;
+const CACHE_WRITE_MULTIPLIER = 1.25;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const WINDOW_DAYS = 30;
@@ -25,9 +32,16 @@ function entryUsd(
 ): { usd: number; approximate: boolean } {
 	const resolved = resolveModelRate(providerId, entry.model);
 	if (!resolved) return { usd: 0, approximate: true };
+	const { inputPerMillion, outputPerMillion } = resolved.rate;
 	const usd =
-		(entry.inputTokens / 1_000_000) * resolved.rate.inputPerMillion +
-		(entry.outputTokens / 1_000_000) * resolved.rate.outputPerMillion;
+		(entry.inputTokens / 1_000_000) * inputPerMillion +
+		(entry.outputTokens / 1_000_000) * outputPerMillion +
+		((entry.cacheReadTokens ?? 0) / 1_000_000) *
+			inputPerMillion *
+			CACHE_READ_MULTIPLIER +
+		((entry.cacheCreationTokens ?? 0) / 1_000_000) *
+			inputPerMillion *
+			CACHE_WRITE_MULTIPLIER;
 	return { usd, approximate: resolved.approximate };
 }
 
@@ -56,7 +70,11 @@ export function aggregateUsage(
 	const tokensBySession = new Map<string, number>();
 
 	for (const entry of entries) {
-		const tokens = entry.inputTokens + entry.outputTokens;
+		const tokens =
+			entry.inputTokens +
+			entry.outputTokens +
+			(entry.cacheReadTokens ?? 0) +
+			(entry.cacheCreationTokens ?? 0);
 		const time = entry.timestamp.getTime();
 
 		if (time > latestTimestamp) {

--- a/apps/desktop/src/main/lib/usage/log-parsers/cost-aggregator.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/cost-aggregator.ts
@@ -51,7 +51,11 @@ export function aggregateUsage(
 ): CostStats {
 	const now = new Date();
 	const todayKey = localDateKey(now);
-	const cutoff = now.getTime() - WINDOW_DAYS * DAY_MS;
+	// Align the cutoff to the oldest daily bucket's local midnight so every entry
+	// counted in the 30-day totals also lands in one of the chart buckets.
+	const oldestBucket = new Date(now.getTime() - (WINDOW_DAYS - 1) * DAY_MS);
+	oldestBucket.setHours(0, 0, 0, 0);
+	const cutoff = oldestBucket.getTime();
 
 	const buckets = new Map<string, DailyBucket>();
 	for (let i = 0; i < WINDOW_DAYS; i++) {

--- a/apps/desktop/src/main/lib/usage/log-parsers/log-files.ts
+++ b/apps/desktop/src/main/lib/usage/log-parsers/log-files.ts
@@ -1,0 +1,56 @@
+import type { Dirent } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface LogFile {
+	path: string;
+	/** Filename without extension; used as a session identifier. */
+	sessionId: string;
+	mtimeMs: number;
+}
+
+/**
+ * Recursively collect files under `root` whose name ends with `ext` and were
+ * modified within `maxAgeDays`. Returns [] when the root is missing or unreadable.
+ */
+export async function collectLogFiles(
+	root: string,
+	ext: string,
+	maxAgeDays: number,
+): Promise<LogFile[]> {
+	const cutoff = Date.now() - maxAgeDays * DAY_MS;
+	const results: LogFile[] = [];
+
+	async function walk(dir: string): Promise<void> {
+		let entries: Dirent[];
+		try {
+			entries = await readdir(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const full = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				await walk(full);
+				continue;
+			}
+			if (!entry.name.endsWith(ext)) continue;
+			try {
+				const info = await stat(full);
+				if (info.mtimeMs < cutoff) continue;
+				results.push({
+					path: full,
+					sessionId: entry.name.slice(0, -ext.length),
+					mtimeMs: info.mtimeMs,
+				});
+			} catch {
+				// File vanished between readdir and stat; skip.
+			}
+		}
+	}
+
+	await walk(root);
+	return results;
+}

--- a/apps/desktop/src/main/lib/usage/pricing-table.ts
+++ b/apps/desktop/src/main/lib/usage/pricing-table.ts
@@ -1,0 +1,87 @@
+import type { ProviderId } from "./usage-snapshot";
+
+/**
+ * Single place to update when a provider changes prices. Bump
+ * PRICING_TABLE_UPDATED whenever a rate is edited. Rates are USD per 1M tokens.
+ *
+ * Sources (verify here before editing):
+ * - Claude:  https://www.anthropic.com/pricing#api
+ * - Codex:   https://openai.com/api/pricing/
+ * - Gemini:  https://ai.google.dev/gemini-api/docs/pricing
+ */
+export const PRICING_TABLE_UPDATED = "2026-07-20";
+
+export interface ModelRate {
+	inputPerMillion: number;
+	outputPerMillion: number;
+}
+
+type ProviderPricing = {
+	models: Record<string, ModelRate>;
+	cheapest: ModelRate;
+};
+
+const CLAUDE_MODELS: Record<string, ModelRate> = {
+	"claude-opus-4": { inputPerMillion: 15, outputPerMillion: 75 },
+	"claude-sonnet-4": { inputPerMillion: 3, outputPerMillion: 15 },
+	"claude-haiku-4": { inputPerMillion: 1, outputPerMillion: 5 },
+	"claude-fable-5": { inputPerMillion: 5, outputPerMillion: 25 },
+};
+
+const CODEX_MODELS: Record<string, ModelRate> = {
+	"gpt-4o": { inputPerMillion: 2.5, outputPerMillion: 10 },
+	"gpt-4.1": { inputPerMillion: 2, outputPerMillion: 8 },
+	"gpt-4.5": { inputPerMillion: 75, outputPerMillion: 150 },
+};
+
+const GEMINI_MODELS: Record<string, ModelRate> = {
+	"gemini-2.5-pro": { inputPerMillion: 1.25, outputPerMillion: 10 },
+	"gemini-2.5-flash": { inputPerMillion: 0.3, outputPerMillion: 2.5 },
+};
+
+function cheapestRate(models: Record<string, ModelRate>): ModelRate {
+	return Object.values(models).reduce((cheapest, rate) =>
+		rate.inputPerMillion + rate.outputPerMillion <
+		cheapest.inputPerMillion + cheapest.outputPerMillion
+			? rate
+			: cheapest,
+	);
+}
+
+const PRICING_TABLE: Partial<Record<ProviderId, ProviderPricing>> = {
+	claude: { models: CLAUDE_MODELS, cheapest: cheapestRate(CLAUDE_MODELS) },
+	codex: { models: CODEX_MODELS, cheapest: cheapestRate(CODEX_MODELS) },
+	gemini: { models: GEMINI_MODELS, cheapest: cheapestRate(GEMINI_MODELS) },
+};
+
+export interface ResolvedRate {
+	rate: ModelRate;
+	/** True when the model is unknown and the provider's cheapest rate was used. */
+	approximate: boolean;
+}
+
+function matchModelRate(
+	models: Record<string, ModelRate>,
+	model: string,
+): ModelRate | null {
+	const normalized = model.toLowerCase();
+	if (models[normalized]) return models[normalized];
+	// CLI logs carry dated/suffixed ids (e.g. "claude-opus-4-8", "gpt-4.1-mini");
+	// match against the longest known prefix.
+	const keys = Object.keys(models).sort((a, b) => b.length - a.length);
+	for (const key of keys) {
+		if (normalized.startsWith(key)) return models[key];
+	}
+	return null;
+}
+
+export function resolveModelRate(
+	providerId: ProviderId,
+	model: string,
+): ResolvedRate | null {
+	const pricing = PRICING_TABLE[providerId];
+	if (!pricing) return null;
+	const match = matchModelRate(pricing.models, model);
+	if (match) return { rate: match, approximate: false };
+	return { rate: pricing.cheapest, approximate: true };
+}

--- a/apps/desktop/src/main/lib/usage/providers/base-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/base-provider.ts
@@ -1,0 +1,97 @@
+import type {
+	ProviderId,
+	ProviderSnapshot,
+	ProviderStatus,
+} from "../usage-snapshot";
+
+const FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_BACKOFF_MS = 60_000;
+
+export class RateLimitError extends Error {
+	constructor(readonly retryAfterMs: number) {
+		super("Rate limited");
+		this.name = "RateLimitError";
+	}
+}
+
+export function emptySnapshot(
+	providerId: ProviderId,
+	status: ProviderStatus,
+	overrides: Partial<ProviderSnapshot> = {},
+): ProviderSnapshot {
+	return {
+		providerId,
+		status,
+		updatedAt: new Date(),
+		email: null,
+		planLabel: null,
+		windows: [],
+		credits: null,
+		cost: null,
+		errorMessage: null,
+		...overrides,
+	};
+}
+
+export abstract class ProviderCollector {
+	abstract readonly providerId: ProviderId;
+
+	private lastGood: ProviderSnapshot | null = null;
+	private backoffUntil = 0;
+
+	/** Subclasses read credentials + probe the provider and build a snapshot. */
+	protected abstract fetchSnapshot(): Promise<ProviderSnapshot>;
+
+	async collect(): Promise<ProviderSnapshot> {
+		if (Date.now() < this.backoffUntil && this.lastGood) {
+			return this.lastGood;
+		}
+
+		try {
+			const snapshot = await this.fetchSnapshot();
+			// Only cache readings that actually reached the provider; keep the last
+			// good value behind transient no-credentials/auth blips.
+			if (snapshot.status === "ok") {
+				this.lastGood = snapshot;
+			}
+			return snapshot;
+		} catch (error) {
+			if (error instanceof RateLimitError) {
+				this.backoffUntil = Date.now() + error.retryAfterMs;
+			}
+			if (this.lastGood) {
+				return this.lastGood;
+			}
+			return emptySnapshot(this.providerId, "auth-error", {
+				errorMessage:
+					error instanceof Error ? error.message : "Failed to load usage",
+			});
+		}
+	}
+
+	protected async fetchWithTimeout(
+		url: string,
+		init: RequestInit = {},
+	): Promise<Response> {
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+		try {
+			const response = await fetch(url, {
+				...init,
+				signal: controller.signal,
+			});
+			if (response.status === 429) {
+				const retryAfter = response.headers.get("retry-after");
+				const retryMs = retryAfter
+					? Number.parseInt(retryAfter, 10) * 1000
+					: DEFAULT_BACKOFF_MS;
+				throw new RateLimitError(
+					Number.isFinite(retryMs) ? retryMs : DEFAULT_BACKOFF_MS,
+				);
+			}
+			return response;
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+}

--- a/apps/desktop/src/main/lib/usage/providers/claude-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/claude-provider.ts
@@ -101,16 +101,12 @@ export class ClaudeProvider extends ProviderCollector {
 			},
 		});
 
-		if (response.status === 401 || response.status === 403) {
-			return emptySnapshot(this.providerId, "auth-error", {
-				cost,
-				errorMessage: "Session expired — re-authenticate the Claude CLI.",
-			});
-		}
+		// A subscription (Max/Pro) OAuth token frequently cannot call /v1/models,
+		// so a 401/403 here is not proof the session is dead — it just means we
+		// can't harvest rate-limit headers. Keep showing locally-estimated cost
+		// with no windows rather than a misleading "session expired" error.
+		const windows = response.ok ? windowsFromHeaders(response.headers) : [];
 
-		return emptySnapshot(this.providerId, "ok", {
-			cost,
-			windows: windowsFromHeaders(response.headers),
-		});
+		return emptySnapshot(this.providerId, "ok", { cost, windows });
 	}
 }

--- a/apps/desktop/src/main/lib/usage/providers/claude-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/claude-provider.ts
@@ -132,12 +132,27 @@ export class ClaudeProvider extends ProviderCollector {
 			}),
 		});
 
+		// We only read headers, never the body — cancel it so undici releases the
+		// TCP socket instead of leaking one on every 5-minute probe.
+		await response.body?.cancel().catch(() => undefined);
+
 		if (response.status === 401 || response.status === 403) {
 			return emptySnapshot(this.providerId, "auth-error", {
 				cost,
 				email,
 				planLabel,
 				errorMessage: "Session expired — re-authenticate the Claude CLI.",
+			});
+		}
+
+		if (!response.ok) {
+			// A transient non-auth failure (e.g. 500/503) must not clear the shown
+			// windows or report the provider as healthy.
+			return emptySnapshot(this.providerId, "auth-error", {
+				cost,
+				email,
+				planLabel,
+				errorMessage: `Anthropic API returned ${response.status} — usage data unavailable.`,
 			});
 		}
 

--- a/apps/desktop/src/main/lib/usage/providers/claude-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/claude-provider.ts
@@ -1,0 +1,116 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseClaudeLogs } from "../log-parsers/claude-log-parser";
+import type { ProviderSnapshot, RateLimitWindow } from "../usage-snapshot";
+import { emptySnapshot, ProviderCollector } from "./base-provider";
+import { readJsonFile, readKeychainSecret } from "./credentials";
+import { buildWindow } from "./window-pace";
+
+const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
+const MODELS_ENDPOINT = "https://api.anthropic.com/v1/models?limit=1";
+const ANTHROPIC_VERSION = "2023-06-01";
+
+interface ClaudeCredentials {
+	claudeAiOauth?: { accessToken?: string };
+	access_token?: string;
+	accessToken?: string;
+}
+
+async function resolveToken(): Promise<string | null> {
+	const creds = await readJsonFile<ClaudeCredentials>(CREDENTIALS_PATH);
+	const fromFile =
+		creds?.claudeAiOauth?.accessToken ??
+		creds?.access_token ??
+		creds?.accessToken ??
+		null;
+	if (fromFile) return fromFile;
+	return readKeychainSecret("claude");
+}
+
+function pctFromHeaders(
+	headers: Headers,
+	limitKey: string,
+	remainingKey: string,
+): number | null {
+	const limit = Number.parseFloat(headers.get(limitKey) ?? "");
+	const remaining = Number.parseFloat(headers.get(remainingKey) ?? "");
+	if (!Number.isFinite(limit) || limit <= 0 || !Number.isFinite(remaining)) {
+		return null;
+	}
+	return ((limit - remaining) / limit) * 100;
+}
+
+function resetFromHeader(headers: Headers, key: string): Date | null {
+	const raw = headers.get(key);
+	if (!raw) return null;
+	const date = new Date(raw);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function windowsFromHeaders(headers: Headers): RateLimitWindow[] {
+	const windows: RateLimitWindow[] = [];
+
+	const requestsPct = pctFromHeaders(
+		headers,
+		"anthropic-ratelimit-requests-limit",
+		"anthropic-ratelimit-requests-remaining",
+	);
+	if (requestsPct !== null) {
+		windows.push(
+			buildWindow({
+				label: "Requests",
+				usedPct: requestsPct,
+				resetAt: resetFromHeader(headers, "anthropic-ratelimit-requests-reset"),
+			}),
+		);
+	}
+
+	const tokensPct = pctFromHeaders(
+		headers,
+		"anthropic-ratelimit-tokens-limit",
+		"anthropic-ratelimit-tokens-remaining",
+	);
+	if (tokensPct !== null) {
+		windows.push(
+			buildWindow({
+				label: "Tokens",
+				usedPct: tokensPct,
+				resetAt: resetFromHeader(headers, "anthropic-ratelimit-tokens-reset"),
+			}),
+		);
+	}
+
+	return windows;
+}
+
+export class ClaudeProvider extends ProviderCollector {
+	readonly providerId = "claude" as const;
+
+	protected async fetchSnapshot(): Promise<ProviderSnapshot> {
+		const token = await resolveToken();
+		const cost = await parseClaudeLogs();
+
+		if (!token) {
+			return emptySnapshot(this.providerId, "no-credentials", { cost });
+		}
+
+		const response = await this.fetchWithTimeout(MODELS_ENDPOINT, {
+			headers: {
+				authorization: `Bearer ${token}`,
+				"anthropic-version": ANTHROPIC_VERSION,
+			},
+		});
+
+		if (response.status === 401 || response.status === 403) {
+			return emptySnapshot(this.providerId, "auth-error", {
+				cost,
+				errorMessage: "Session expired — re-authenticate the Claude CLI.",
+			});
+		}
+
+		return emptySnapshot(this.providerId, "ok", {
+			cost,
+			windows: windowsFromHeaders(response.headers),
+		});
+	}
+}

--- a/apps/desktop/src/main/lib/usage/providers/claude-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/claude-provider.ts
@@ -7,79 +7,92 @@ import { readJsonFile, readKeychainSecret } from "./credentials";
 import { buildWindow } from "./window-pace";
 
 const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
-const MODELS_ENDPOINT = "https://api.anthropic.com/v1/models?limit=1";
+// Claude Code stores the live (refreshed) OAuth token in the macOS Keychain
+// under this service; the on-disk file is often a stale/revoked copy.
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+const MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
+// The subscription rate-limit windows only ride on /v1/messages responses when
+// the request is made with an OAuth (subscription) token + this beta header.
+const OAUTH_BETA = "oauth-2025-04-20";
+const PROBE_MODEL = "claude-haiku-4-5-20251001";
+
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface ClaudeOAuth {
+	accessToken?: string;
+	subscriptionType?: string;
+	account?: { email_address?: string; email?: string };
+}
 
 interface ClaudeCredentials {
-	claudeAiOauth?: { accessToken?: string };
+	claudeAiOauth?: ClaudeOAuth;
 	access_token?: string;
 	accessToken?: string;
 }
 
-async function resolveToken(): Promise<string | null> {
-	const creds = await readJsonFile<ClaudeCredentials>(CREDENTIALS_PATH);
-	const fromFile =
-		creds?.claudeAiOauth?.accessToken ??
-		creds?.access_token ??
-		creds?.accessToken ??
-		null;
-	if (fromFile) return fromFile;
-	return readKeychainSecret("claude");
+async function readCredentials(): Promise<ClaudeCredentials | null> {
+	const raw = await readKeychainSecret(KEYCHAIN_SERVICE);
+	if (raw) {
+		try {
+			return JSON.parse(raw) as ClaudeCredentials;
+		} catch {
+			// Fall through to the on-disk file.
+		}
+	}
+	return readJsonFile<ClaudeCredentials>(CREDENTIALS_PATH);
 }
 
-function pctFromHeaders(
-	headers: Headers,
-	limitKey: string,
-	remainingKey: string,
-): number | null {
-	const limit = Number.parseFloat(headers.get(limitKey) ?? "");
-	const remaining = Number.parseFloat(headers.get(remainingKey) ?? "");
-	if (!Number.isFinite(limit) || limit <= 0 || !Number.isFinite(remaining)) {
-		return null;
-	}
-	return ((limit - remaining) / limit) * 100;
+function resolveToken(creds: ClaudeCredentials): string | null {
+	return (
+		creds.claudeAiOauth?.accessToken ??
+		creds.access_token ??
+		creds.accessToken ??
+		null
+	);
 }
 
 function resetFromHeader(headers: Headers, key: string): Date | null {
 	const raw = headers.get(key);
 	if (!raw) return null;
-	const date = new Date(raw);
-	return Number.isNaN(date.getTime()) ? null : date;
+	const seconds = Number.parseInt(raw, 10);
+	if (!Number.isFinite(seconds)) return null;
+	return new Date(seconds * 1000);
+}
+
+function unifiedWindow(
+	headers: Headers,
+	prefix: string,
+	label: string,
+	windowMs: number,
+): RateLimitWindow | null {
+	const utilization = Number.parseFloat(
+		headers.get(`anthropic-ratelimit-unified-${prefix}-utilization`) ?? "",
+	);
+	if (!Number.isFinite(utilization)) return null;
+	return buildWindow({
+		label,
+		usedPct: utilization * 100,
+		resetAt: resetFromHeader(
+			headers,
+			`anthropic-ratelimit-unified-${prefix}-reset`,
+		),
+		windowMs,
+	});
 }
 
 function windowsFromHeaders(headers: Headers): RateLimitWindow[] {
 	const windows: RateLimitWindow[] = [];
-
-	const requestsPct = pctFromHeaders(
+	const session = unifiedWindow(headers, "5h", "5-hour session", FIVE_HOURS_MS);
+	if (session) windows.push(session);
+	const weekly = unifiedWindow(
 		headers,
-		"anthropic-ratelimit-requests-limit",
-		"anthropic-ratelimit-requests-remaining",
+		"7d",
+		"Weekly (all models)",
+		SEVEN_DAYS_MS,
 	);
-	if (requestsPct !== null) {
-		windows.push(
-			buildWindow({
-				label: "Requests",
-				usedPct: requestsPct,
-				resetAt: resetFromHeader(headers, "anthropic-ratelimit-requests-reset"),
-			}),
-		);
-	}
-
-	const tokensPct = pctFromHeaders(
-		headers,
-		"anthropic-ratelimit-tokens-limit",
-		"anthropic-ratelimit-tokens-remaining",
-	);
-	if (tokensPct !== null) {
-		windows.push(
-			buildWindow({
-				label: "Tokens",
-				usedPct: tokensPct,
-				resetAt: resetFromHeader(headers, "anthropic-ratelimit-tokens-reset"),
-			}),
-		);
-	}
-
+	if (weekly) windows.push(weekly);
 	return windows;
 }
 
@@ -87,26 +100,52 @@ export class ClaudeProvider extends ProviderCollector {
 	readonly providerId = "claude" as const;
 
 	protected async fetchSnapshot(): Promise<ProviderSnapshot> {
-		const token = await resolveToken();
+		const creds = await readCredentials();
 		const cost = await parseClaudeLogs();
 
+		const token = creds ? resolveToken(creds) : null;
 		if (!token) {
 			return emptySnapshot(this.providerId, "no-credentials", { cost });
 		}
 
-		const response = await this.fetchWithTimeout(MODELS_ENDPOINT, {
+		const oauth = creds?.claudeAiOauth;
+		const email =
+			oauth?.account?.email_address ?? oauth?.account?.email ?? null;
+		const planLabel = oauth?.subscriptionType
+			? oauth.subscriptionType.toUpperCase()
+			: null;
+
+		// A minimal 1-token request is the cheapest way to harvest the unified
+		// rate-limit headers; it consumes one request against the 5h window.
+		const response = await this.fetchWithTimeout(MESSAGES_ENDPOINT, {
+			method: "POST",
 			headers: {
 				authorization: `Bearer ${token}`,
 				"anthropic-version": ANTHROPIC_VERSION,
+				"anthropic-beta": OAUTH_BETA,
+				"content-type": "application/json",
 			},
+			body: JSON.stringify({
+				model: PROBE_MODEL,
+				max_tokens: 1,
+				messages: [{ role: "user", content: "hi" }],
+			}),
 		});
 
-		// A subscription (Max/Pro) OAuth token frequently cannot call /v1/models,
-		// so a 401/403 here is not proof the session is dead — it just means we
-		// can't harvest rate-limit headers. Keep showing locally-estimated cost
-		// with no windows rather than a misleading "session expired" error.
-		const windows = response.ok ? windowsFromHeaders(response.headers) : [];
+		if (response.status === 401 || response.status === 403) {
+			return emptySnapshot(this.providerId, "auth-error", {
+				cost,
+				email,
+				planLabel,
+				errorMessage: "Session expired — re-authenticate the Claude CLI.",
+			});
+		}
 
-		return emptySnapshot(this.providerId, "ok", { cost, windows });
+		return emptySnapshot(this.providerId, "ok", {
+			cost,
+			email,
+			planLabel,
+			windows: windowsFromHeaders(response.headers),
+		});
 	}
 }

--- a/apps/desktop/src/main/lib/usage/providers/codex-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/codex-provider.ts
@@ -1,9 +1,19 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseCodexLogs } from "../log-parsers/codex-log-parser";
-import type { ProviderSnapshot } from "../usage-snapshot";
+import type {
+	ProviderCredits,
+	ProviderSnapshot,
+	RateLimitWindow,
+} from "../usage-snapshot";
 import { emptySnapshot, ProviderCollector } from "./base-provider";
+import {
+	type CodexWindow,
+	labelForWindowMinutes,
+	readLatestCodexRateLimits,
+} from "./codex-rate-limits";
 import { decodeJwtPayload, readJsonFile } from "./credentials";
+import { buildWindow } from "./window-pace";
 
 const AUTH_PATH = join(homedir(), ".codex", "auth.json");
 
@@ -31,6 +41,15 @@ function extractPlan(auth: CodexAuth): string | null {
 	return typeof plan === "string" ? plan.toUpperCase() : null;
 }
 
+function toWindow(window: CodexWindow): RateLimitWindow {
+	return buildWindow({
+		label: labelForWindowMinutes(window.windowMinutes),
+		usedPct: window.usedPercent,
+		resetAt: window.resetsAt ? new Date(window.resetsAt * 1000) : null,
+		windowMs: window.windowMinutes * 60 * 1000,
+	});
+}
+
 export class CodexProvider extends ProviderCollector {
 	readonly providerId = "codex" as const;
 
@@ -45,12 +64,24 @@ export class CodexProvider extends ProviderCollector {
 			return emptySnapshot(this.providerId, "no-credentials", { cost });
 		}
 
-		// OpenAI does not expose a documented subscription rate-limit endpoint;
-		// surface identity + locally-estimated cost until one is available.
+		// Codex writes its subscription rate-limit snapshot into rollout session
+		// logs, so we read it passively rather than probing the backend.
+		const rateLimits = await readLatestCodexRateLimits();
+		const windows: RateLimitWindow[] = [];
+		if (rateLimits?.primary) windows.push(toWindow(rateLimits.primary));
+		if (rateLimits?.secondary) windows.push(toWindow(rateLimits.secondary));
+
+		const credits: ProviderCredits | null =
+			rateLimits?.creditBalance != null
+				? { balance: rateLimits.creditBalance, resetCredits: 0 }
+				: null;
+
 		return emptySnapshot(this.providerId, "ok", {
 			cost,
 			email: extractEmail(auth),
-			planLabel: extractPlan(auth),
+			planLabel: rateLimits?.planType?.toUpperCase() ?? extractPlan(auth),
+			windows,
+			credits,
 		});
 	}
 }

--- a/apps/desktop/src/main/lib/usage/providers/codex-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/codex-provider.ts
@@ -1,0 +1,56 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseCodexLogs } from "../log-parsers/codex-log-parser";
+import type { ProviderSnapshot } from "../usage-snapshot";
+import { emptySnapshot, ProviderCollector } from "./base-provider";
+import { decodeJwtPayload, readJsonFile } from "./credentials";
+
+const AUTH_PATH = join(homedir(), ".codex", "auth.json");
+
+interface CodexAuth {
+	tokens?: { access_token?: string; id_token?: string };
+	access_token?: string;
+	OPENAI_API_KEY?: string;
+}
+
+function extractEmail(auth: CodexAuth): string | null {
+	const idToken = auth.tokens?.id_token;
+	if (!idToken) return null;
+	const payload = decodeJwtPayload(idToken);
+	const email = payload?.email;
+	return typeof email === "string" ? email : null;
+}
+
+function extractPlan(auth: CodexAuth): string | null {
+	const idToken = auth.tokens?.id_token;
+	if (!idToken) return null;
+	const payload = decodeJwtPayload(idToken);
+	const auth0 = payload?.["https://api.openai.com/auth"];
+	if (typeof auth0 !== "object" || auth0 === null) return null;
+	const plan = (auth0 as Record<string, unknown>).chatgpt_plan_type;
+	return typeof plan === "string" ? plan.toUpperCase() : null;
+}
+
+export class CodexProvider extends ProviderCollector {
+	readonly providerId = "codex" as const;
+
+	protected async fetchSnapshot(): Promise<ProviderSnapshot> {
+		const auth = await readJsonFile<CodexAuth>(AUTH_PATH);
+		const cost = await parseCodexLogs();
+
+		const hasToken = Boolean(
+			auth?.tokens?.access_token ?? auth?.access_token ?? auth?.OPENAI_API_KEY,
+		);
+		if (!auth || !hasToken) {
+			return emptySnapshot(this.providerId, "no-credentials", { cost });
+		}
+
+		// OpenAI does not expose a documented subscription rate-limit endpoint;
+		// surface identity + locally-estimated cost until one is available.
+		return emptySnapshot(this.providerId, "ok", {
+			cost,
+			email: extractEmail(auth),
+			planLabel: extractPlan(auth),
+		});
+	}
+}

--- a/apps/desktop/src/main/lib/usage/providers/codex-rate-limits.ts
+++ b/apps/desktop/src/main/lib/usage/providers/codex-rate-limits.ts
@@ -1,0 +1,115 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { collectLogFiles } from "../log-parsers/log-files";
+
+const CODEX_SESSIONS_DIR = join(homedir(), ".codex", "sessions");
+const MAX_AGE_DAYS = 14;
+// The rate-limit snapshot only changes with new sessions; scanning the newest
+// few rollout files is enough to find the most recent reading.
+const MAX_FILES = 12;
+
+export interface CodexWindow {
+	usedPercent: number;
+	windowMinutes: number;
+	resetsAt: number | null;
+}
+
+export interface CodexRateLimits {
+	primary: CodexWindow | null;
+	secondary: CodexWindow | null;
+	creditBalance: number | null;
+	planType: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseWindow(value: unknown): CodexWindow | null {
+	if (!isRecord(value)) return null;
+	const usedPercent = value.used_percent;
+	const windowMinutes = value.window_minutes;
+	if (typeof usedPercent !== "number" || typeof windowMinutes !== "number") {
+		return null;
+	}
+	return {
+		usedPercent,
+		windowMinutes,
+		resetsAt: typeof value.resets_at === "number" ? value.resets_at : null,
+	};
+}
+
+function parseRateLimits(
+	payload: Record<string, unknown>,
+): CodexRateLimits | null {
+	const rateLimits = payload.rate_limits;
+	if (!isRecord(rateLimits)) return null;
+	const credits = isRecord(rateLimits.credits) ? rateLimits.credits : null;
+	return {
+		primary: parseWindow(rateLimits.primary),
+		secondary: parseWindow(rateLimits.secondary),
+		creditBalance:
+			credits && typeof credits.balance === "number" ? credits.balance : null,
+		planType:
+			typeof rateLimits.plan_type === "string" ? rateLimits.plan_type : null,
+	};
+}
+
+/** Reads the most recent `rate_limits` snapshot Codex wrote to its rollout logs. */
+export async function readLatestCodexRateLimits(): Promise<CodexRateLimits | null> {
+	const files = await collectLogFiles(
+		CODEX_SESSIONS_DIR,
+		".jsonl",
+		MAX_AGE_DAYS,
+	);
+	if (files.length === 0) return null;
+
+	const newest = files
+		.sort((a, b) => b.mtimeMs - a.mtimeMs)
+		.slice(0, MAX_FILES);
+
+	let latestTime = Number.NEGATIVE_INFINITY;
+	let latest: CodexRateLimits | null = null;
+
+	for (const file of newest) {
+		let content: string;
+		try {
+			content = await readFile(file.path, "utf8");
+		} catch {
+			continue;
+		}
+		for (const raw of content.split("\n")) {
+			const trimmed = raw.trim();
+			if (!trimmed.includes("rate_limits")) continue;
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(trimmed);
+			} catch {
+				continue;
+			}
+			if (!isRecord(parsed) || !isRecord(parsed.payload)) continue;
+			const rateLimits = parseRateLimits(parsed.payload);
+			if (!rateLimits) continue;
+
+			const time =
+				typeof parsed.timestamp === "string"
+					? new Date(parsed.timestamp).getTime()
+					: file.mtimeMs;
+			if (time > latestTime) {
+				latestTime = time;
+				latest = rateLimits;
+			}
+		}
+	}
+
+	return latest;
+}
+
+export function labelForWindowMinutes(minutes: number): string {
+	if (minutes >= 43200) return "Monthly";
+	if (minutes >= 10080) return "Weekly";
+	if (minutes >= 1440) return `${Math.round(minutes / 1440)}-day`;
+	if (minutes >= 60) return `${Math.round(minutes / 60)}-hour`;
+	return `${minutes}-min`;
+}

--- a/apps/desktop/src/main/lib/usage/providers/codex-rate-limits.ts
+++ b/apps/desktop/src/main/lib/usage/providers/codex-rate-limits.ts
@@ -92,10 +92,11 @@ export async function readLatestCodexRateLimits(): Promise<CodexRateLimits | nul
 			const rateLimits = parseRateLimits(parsed.payload);
 			if (!rateLimits) continue;
 
-			const time =
+			const parsedTime =
 				typeof parsed.timestamp === "string"
 					? new Date(parsed.timestamp).getTime()
-					: file.mtimeMs;
+					: Number.NaN;
+			const time = Number.isNaN(parsedTime) ? file.mtimeMs : parsedTime;
 			if (time > latestTime) {
 				latestTime = time;
 				latest = rateLimits;

--- a/apps/desktop/src/main/lib/usage/providers/copilot-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/copilot-provider.ts
@@ -1,0 +1,63 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ProviderSnapshot } from "../usage-snapshot";
+import { emptySnapshot, ProviderCollector } from "./base-provider";
+import { decodeJwtPayload, readJsonFile } from "./credentials";
+
+const HOSTS_PATH = join(homedir(), ".config", "github-copilot", "hosts.json");
+const APPS_PATH = join(homedir(), ".config", "github-copilot", "apps.json");
+const TOKEN_ENDPOINT = "https://api.github.com/copilot_internal/v2/token";
+
+type CopilotHosts = Record<string, { oauth_token?: string } | undefined>;
+
+interface CopilotTokenResponse {
+	token?: string;
+	expires_at?: number;
+}
+
+async function resolveOauthToken(): Promise<string | null> {
+	for (const path of [HOSTS_PATH, APPS_PATH]) {
+		const hosts = await readJsonFile<CopilotHosts>(path);
+		if (!hosts) continue;
+		for (const entry of Object.values(hosts)) {
+			if (entry?.oauth_token) return entry.oauth_token;
+		}
+	}
+	return null;
+}
+
+function planFromToken(token: string): string | null {
+	const payload = decodeJwtPayload(token);
+	const sku = payload?.sku ?? payload?.copilot_plan;
+	if (typeof sku !== "string") return null;
+	return sku.replace(/_/g, " ").toUpperCase();
+}
+
+export class CopilotProvider extends ProviderCollector {
+	readonly providerId = "copilot" as const;
+
+	protected async fetchSnapshot(): Promise<ProviderSnapshot> {
+		const oauthToken = await resolveOauthToken();
+		if (!oauthToken) {
+			return emptySnapshot(this.providerId, "no-credentials");
+		}
+
+		const response = await this.fetchWithTimeout(TOKEN_ENDPOINT, {
+			headers: {
+				authorization: `token ${oauthToken}`,
+				accept: "application/json",
+			},
+		});
+
+		if (!response.ok) {
+			return emptySnapshot(this.providerId, "auth-error", {
+				errorMessage: "Session expired — re-authenticate the Copilot CLI.",
+			});
+		}
+
+		const body = (await response.json()) as CopilotTokenResponse;
+		return emptySnapshot(this.providerId, "ok", {
+			planLabel: body.token ? planFromToken(body.token) : null,
+		});
+	}
+}

--- a/apps/desktop/src/main/lib/usage/providers/credentials.ts
+++ b/apps/desktop/src/main/lib/usage/providers/credentials.ts
@@ -1,0 +1,63 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Reads and JSON-parses a credential file. Returns null if missing/invalid. */
+export async function readJsonFile<T>(path: string): Promise<T | null> {
+	let content: string;
+	try {
+		content = await readFile(path, "utf8");
+	} catch {
+		return null;
+	}
+	try {
+		return JSON.parse(content) as T;
+	} catch {
+		return null;
+	}
+}
+
+/** Decodes a JWT payload without verifying its signature. */
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+	const parts = token.split(".");
+	if (parts.length < 2) return null;
+	try {
+		const json = Buffer.from(parts[1], "base64url").toString("utf8");
+		const parsed = JSON.parse(json);
+		return typeof parsed === "object" && parsed !== null ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+/** macOS Keychain lookup; returns null off-darwin or when the item is absent. */
+export async function readKeychainSecret(
+	service: string,
+): Promise<string | null> {
+	if (process.platform !== "darwin") return null;
+	try {
+		const { stdout } = await execFileAsync("security", [
+			"find-generic-password",
+			"-s",
+			service,
+			"-w",
+		]);
+		const trimmed = stdout.trim();
+		return trimmed.length > 0 ? trimmed : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Resolves an executable's absolute path via `which`, or null if not found. */
+export async function whichBinary(name: string): Promise<string | null> {
+	try {
+		const { stdout } = await execFileAsync("which", [name]);
+		const path = stdout.trim().split("\n")[0];
+		return path.length > 0 ? path : null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/desktop/src/main/lib/usage/providers/credentials.ts
+++ b/apps/desktop/src/main/lib/usage/providers/credentials.ts
@@ -20,7 +20,9 @@ export async function readJsonFile<T>(path: string): Promise<T | null> {
 }
 
 /** Decodes a JWT payload without verifying its signature. */
-export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+export function decodeJwtPayload(
+	token: string,
+): Record<string, unknown> | null {
 	const parts = token.split(".");
 	if (parts.length < 2) return null;
 	try {

--- a/apps/desktop/src/main/lib/usage/providers/gemini-provider.ts
+++ b/apps/desktop/src/main/lib/usage/providers/gemini-provider.ts
@@ -1,0 +1,69 @@
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { ProviderSnapshot } from "../usage-snapshot";
+import { emptySnapshot, ProviderCollector } from "./base-provider";
+import { readJsonFile, whichBinary } from "./credentials";
+
+const CREDS_PATH = join(homedir(), ".gemini", "oauth_creds.json");
+
+interface GeminiCreds {
+	access_token?: string;
+	client_id?: string;
+}
+
+interface OAuthClientFile {
+	client_id?: string;
+	installed?: { client_id?: string };
+	web?: { client_id?: string };
+}
+
+/**
+ * The OAuth client id must never be hardcoded — it belongs to the installed
+ * gemini-cli. Resolve it from the binary's bundled config, then fall back to
+ * the id recorded in the user's own creds file.
+ */
+async function resolveClientId(creds: GeminiCreds): Promise<string | null> {
+	for (const name of ["gemini", "gemini-cli"]) {
+		const binary = await whichBinary(name);
+		if (!binary) continue;
+		const candidate = join(
+			dirname(binary),
+			"..",
+			"lib",
+			"node_modules",
+			"@google",
+			"generative-ai-cli",
+			"oauth-client.json",
+		);
+		const file = await readJsonFile<OAuthClientFile>(candidate);
+		const clientId =
+			file?.client_id ?? file?.installed?.client_id ?? file?.web?.client_id;
+		if (clientId) return clientId;
+	}
+	return creds.client_id ?? null;
+}
+
+export class GeminiProvider extends ProviderCollector {
+	readonly providerId = "gemini" as const;
+
+	protected async fetchSnapshot(): Promise<ProviderSnapshot> {
+		const creds = await readJsonFile<GeminiCreds>(CREDS_PATH);
+		if (!creds?.access_token) {
+			return emptySnapshot(this.providerId, "no-credentials", {
+				errorMessage: "Not signed in — log in via the Gemini CLI to see usage.",
+			});
+		}
+
+		const clientId = await resolveClientId(creds);
+		if (!clientId) {
+			return emptySnapshot(this.providerId, "auth-error", {
+				errorMessage:
+					"Could not resolve Gemini OAuth client — ensure gemini-cli is installed.",
+			});
+		}
+
+		// Gemini exposes no documented quota headers on an unauthenticated probe;
+		// mark the session healthy and leave windows empty until one is available.
+		return emptySnapshot(this.providerId, "ok");
+	}
+}

--- a/apps/desktop/src/main/lib/usage/providers/window-pace.ts
+++ b/apps/desktop/src/main/lib/usage/providers/window-pace.ts
@@ -1,0 +1,47 @@
+import type { RateLimitWindow } from "../usage-snapshot";
+
+function clampPct(value: number): number {
+	if (Number.isNaN(value)) return 0;
+	return Math.max(0, Math.min(100, value));
+}
+
+/**
+ * Estimate whether current burn rate lasts until the window resets. When the
+ * window's total duration is known we project usage forward at the average
+ * pace; otherwise we degrade to a simple "have we exhausted it yet" check.
+ */
+export function buildWindow(params: {
+	label: string;
+	usedPct: number;
+	resetAt: Date | null;
+	windowMs?: number;
+}): RateLimitWindow {
+	const usedPct = clampPct(params.usedPct);
+	const remainingPct = 100 - usedPct;
+
+	if (!params.resetAt || !params.windowMs) {
+		return {
+			label: params.label,
+			usedPct,
+			resetAt: params.resetAt,
+			lastsUntilReset: usedPct < 100,
+			reservePct: remainingPct,
+		};
+	}
+
+	const timeToReset = params.resetAt.getTime() - Date.now();
+	const elapsed = params.windowMs - timeToReset;
+	const elapsedFraction = Math.max(
+		0.01,
+		Math.min(1, elapsed / params.windowMs),
+	);
+	const projectedUsedAtReset = usedPct / elapsedFraction;
+
+	return {
+		label: params.label,
+		usedPct,
+		resetAt: params.resetAt,
+		lastsUntilReset: projectedUsedAtReset <= 100,
+		reservePct: clampPct(100 - projectedUsedAtReset),
+	};
+}

--- a/apps/desktop/src/main/lib/usage/usage-collector.ts
+++ b/apps/desktop/src/main/lib/usage/usage-collector.ts
@@ -6,16 +6,13 @@ import {
 	ensureSupersetHomeDirExists,
 	SUPERSET_HOME_DIR,
 } from "main/lib/app-environment";
+import type { ProviderCollector } from "./providers/base-provider";
 import { ClaudeProvider } from "./providers/claude-provider";
 import { CodexProvider } from "./providers/codex-provider";
 import { CopilotProvider } from "./providers/copilot-provider";
 import { GeminiProvider } from "./providers/gemini-provider";
-import type { ProviderCollector } from "./providers/base-provider";
 import { getUsageDisplaySettings } from "./usage-settings";
-import {
-	type ProviderSnapshot,
-	USAGE_PROVIDER_LABELS,
-} from "./usage-snapshot";
+import { type ProviderSnapshot, USAGE_PROVIDER_LABELS } from "./usage-snapshot";
 
 const SNAPSHOT_PATH = join(SUPERSET_HOME_DIR, "usage-snapshot.json");
 const POLL_INTERVAL_MS = 5 * 60 * 1000;

--- a/apps/desktop/src/main/lib/usage/usage-collector.ts
+++ b/apps/desktop/src/main/lib/usage/usage-collector.ts
@@ -1,0 +1,143 @@
+import { EventEmitter } from "node:events";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Notification } from "electron";
+import {
+	ensureSupersetHomeDirExists,
+	SUPERSET_HOME_DIR,
+} from "main/lib/app-environment";
+import { ClaudeProvider } from "./providers/claude-provider";
+import { CodexProvider } from "./providers/codex-provider";
+import { CopilotProvider } from "./providers/copilot-provider";
+import { GeminiProvider } from "./providers/gemini-provider";
+import type { ProviderCollector } from "./providers/base-provider";
+import { getUsageDisplaySettings } from "./usage-settings";
+import {
+	type ProviderSnapshot,
+	USAGE_PROVIDER_LABELS,
+} from "./usage-snapshot";
+
+const SNAPSHOT_PATH = join(SUPERSET_HOME_DIR, "usage-snapshot.json");
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+const NOTIFY_THRESHOLDS = [95, 80] as const;
+
+export const USAGE_UPDATED_EVENT = "usage-updated";
+
+function reviveSnapshots(raw: unknown): ProviderSnapshot[] {
+	if (!Array.isArray(raw)) return [];
+	return raw.map((entry) => {
+		const snapshot = entry as ProviderSnapshot;
+		return {
+			...snapshot,
+			updatedAt: new Date(snapshot.updatedAt),
+			windows: (snapshot.windows ?? []).map((window) => ({
+				...window,
+				resetAt: window.resetAt ? new Date(window.resetAt) : null,
+			})),
+		};
+	});
+}
+
+export class UsageCollector extends EventEmitter {
+	private readonly providers: ProviderCollector[] = [
+		new ClaudeProvider(),
+		new CodexProvider(),
+		new CopilotProvider(),
+		new GeminiProvider(),
+	];
+	private snapshots: ProviderSnapshot[] = [];
+	private timer: NodeJS.Timeout | null = null;
+	private polling: Promise<ProviderSnapshot[]> | null = null;
+	private readonly notifiedKeys = new Set<string>();
+
+	start(): void {
+		this.snapshots = this.loadPersisted();
+		void this.poll();
+		this.timer = setInterval(() => void this.poll(), POLL_INTERVAL_MS);
+	}
+
+	dispose(): void {
+		if (this.timer) clearInterval(this.timer);
+		this.timer = null;
+		this.removeAllListeners();
+	}
+
+	getSnapshots(): ProviderSnapshot[] {
+		return this.snapshots;
+	}
+
+	async refresh(): Promise<ProviderSnapshot[]> {
+		return this.poll();
+	}
+
+	private async poll(): Promise<ProviderSnapshot[]> {
+		if (this.polling) return this.polling;
+		this.polling = (async () => {
+			const results = await Promise.all(
+				this.providers.map((provider) => provider.collect()),
+			);
+			this.snapshots = results;
+			this.persist(results);
+			this.maybeNotify(results);
+			this.emit(USAGE_UPDATED_EVENT, results);
+			return results;
+		})();
+		try {
+			return await this.polling;
+		} finally {
+			this.polling = null;
+		}
+	}
+
+	private loadPersisted(): ProviderSnapshot[] {
+		try {
+			return reviveSnapshots(JSON.parse(readFileSync(SNAPSHOT_PATH, "utf8")));
+		} catch {
+			return [];
+		}
+	}
+
+	private persist(snapshots: ProviderSnapshot[]): void {
+		try {
+			ensureSupersetHomeDirExists();
+			writeFileSync(SNAPSHOT_PATH, JSON.stringify(snapshots), { mode: 0o600 });
+		} catch (error) {
+			console.warn("[usage] Failed to persist snapshot:", error);
+		}
+	}
+
+	private maybeNotify(snapshots: ProviderSnapshot[]): void {
+		const settings = getUsageDisplaySettings();
+		if (!settings.notifyAt80Pct && !settings.notifyAt95Pct) return;
+		if (!Notification.isSupported()) return;
+
+		for (const snapshot of snapshots) {
+			for (const window of snapshot.windows) {
+				for (const threshold of NOTIFY_THRESHOLDS) {
+					if (threshold === 80 && !settings.notifyAt80Pct) continue;
+					if (threshold === 95 && !settings.notifyAt95Pct) continue;
+					if (window.usedPct < threshold) continue;
+
+					const resetCycle = window.resetAt?.toISOString() ?? "none";
+					const key = `${snapshot.providerId}:${window.label}:${threshold}:${resetCycle}`;
+					if (this.notifiedKeys.has(key)) break;
+					this.notifiedKeys.add(key);
+
+					new Notification({
+						title: `${USAGE_PROVIDER_LABELS[snapshot.providerId]} usage at ${Math.round(window.usedPct)}%`,
+						body: `${window.label} is ${Math.round(window.usedPct)}% used.`,
+						silent: true,
+					}).show();
+					break;
+				}
+			}
+		}
+	}
+}
+
+let collector: UsageCollector | null = null;
+
+export function getUsageCollector(): UsageCollector {
+	if (!collector) collector = new UsageCollector();
+	return collector;
+}

--- a/apps/desktop/src/main/lib/usage/usage-settings.ts
+++ b/apps/desktop/src/main/lib/usage/usage-settings.ts
@@ -1,0 +1,57 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	ensureSupersetHomeDirExists,
+	SUPERSET_HOME_DIR,
+} from "main/lib/app-environment";
+import {
+	DEFAULT_USAGE_DISPLAY_SETTINGS,
+	type UsageDisplaySettings,
+} from "./usage-snapshot";
+
+const SETTINGS_PATH = join(SUPERSET_HOME_DIR, "usage-settings.json");
+
+let cached: UsageDisplaySettings | null = null;
+
+function coerce(raw: unknown): UsageDisplaySettings {
+	const source = (
+		typeof raw === "object" && raw !== null ? raw : {}
+	) as Partial<UsageDisplaySettings>;
+	return {
+		showSidebarBadge:
+			source.showSidebarBadge ?? DEFAULT_USAGE_DISPLAY_SETTINGS.showSidebarBadge,
+		showTrayPercentage:
+			source.showTrayPercentage ??
+			DEFAULT_USAGE_DISPLAY_SETTINGS.showTrayPercentage,
+		notifyAt80Pct:
+			source.notifyAt80Pct ?? DEFAULT_USAGE_DISPLAY_SETTINGS.notifyAt80Pct,
+		notifyAt95Pct:
+			source.notifyAt95Pct ?? DEFAULT_USAGE_DISPLAY_SETTINGS.notifyAt95Pct,
+	};
+}
+
+export function getUsageDisplaySettings(): UsageDisplaySettings {
+	if (cached) return cached;
+	try {
+		cached = coerce(JSON.parse(readFileSync(SETTINGS_PATH, "utf8")));
+	} catch {
+		cached = { ...DEFAULT_USAGE_DISPLAY_SETTINGS };
+	}
+	return cached;
+}
+
+export function updateUsageDisplaySettings(
+	patch: Partial<UsageDisplaySettings>,
+): UsageDisplaySettings {
+	const next = coerce({ ...getUsageDisplaySettings(), ...patch });
+	cached = next;
+	try {
+		ensureSupersetHomeDirExists();
+		writeFileSync(SETTINGS_PATH, JSON.stringify(next, null, 2), {
+			mode: 0o600,
+		});
+	} catch (error) {
+		console.warn("[usage] Failed to persist usage settings:", error);
+	}
+	return next;
+}

--- a/apps/desktop/src/main/lib/usage/usage-settings.ts
+++ b/apps/desktop/src/main/lib/usage/usage-settings.ts
@@ -19,7 +19,8 @@ function coerce(raw: unknown): UsageDisplaySettings {
 	) as Partial<UsageDisplaySettings>;
 	return {
 		showSidebarBadge:
-			source.showSidebarBadge ?? DEFAULT_USAGE_DISPLAY_SETTINGS.showSidebarBadge,
+			source.showSidebarBadge ??
+			DEFAULT_USAGE_DISPLAY_SETTINGS.showSidebarBadge,
 		showTrayPercentage:
 			source.showTrayPercentage ??
 			DEFAULT_USAGE_DISPLAY_SETTINGS.showTrayPercentage,

--- a/apps/desktop/src/main/lib/usage/usage-snapshot.ts
+++ b/apps/desktop/src/main/lib/usage/usage-snapshot.ts
@@ -1,0 +1,94 @@
+export type ProviderId = "claude" | "codex" | "copilot" | "gemini";
+
+export type ProviderStatus =
+	| "ok"
+	| "auth-error"
+	| "no-credentials"
+	| "unsupported"
+	| "loading";
+
+export interface RateLimitWindow {
+	label: string;
+	usedPct: number;
+	resetAt: Date | null;
+	lastsUntilReset: boolean;
+	reservePct: number;
+}
+
+export interface DailyBucket {
+	date: string;
+	tokens: number;
+	usd: number;
+}
+
+export interface CostStats {
+	todayUsd: number;
+	thirtyDayUsd: number;
+	thirtyDayTokens: number;
+	latestSessionTokens: number;
+	topModel: string | null;
+	dailyBuckets: DailyBucket[];
+	estimatedFromLogs: boolean;
+	/** True when at least one model fell back to the provider's cheapest rate. */
+	approximate: boolean;
+}
+
+export interface ProviderCredits {
+	balance: number;
+	resetCredits: number;
+}
+
+export interface ProviderSnapshot {
+	providerId: ProviderId;
+	status: ProviderStatus;
+	updatedAt: Date;
+	email: string | null;
+	planLabel: string | null;
+	windows: RateLimitWindow[];
+	credits: ProviderCredits | null;
+	cost: CostStats | null;
+	errorMessage: string | null;
+}
+
+export interface UsageDisplaySettings {
+	showSidebarBadge: boolean;
+	showTrayPercentage: boolean;
+	notifyAt80Pct: boolean;
+	notifyAt95Pct: boolean;
+}
+
+export const DEFAULT_USAGE_DISPLAY_SETTINGS: UsageDisplaySettings = {
+	showSidebarBadge: true,
+	showTrayPercentage: true,
+	notifyAt80Pct: true,
+	notifyAt95Pct: true,
+};
+
+export const USAGE_PROVIDER_LABELS: Record<ProviderId, string> = {
+	claude: "Claude",
+	codex: "Codex",
+	copilot: "Copilot",
+	gemini: "Gemini",
+};
+
+/** Highest used-percentage across all windows of a snapshot, or null if none. */
+export function worstWindowUsedPct(snapshot: ProviderSnapshot): number | null {
+	if (snapshot.windows.length === 0) return null;
+	return snapshot.windows.reduce(
+		(max, window) => Math.max(max, window.usedPct),
+		0,
+	);
+}
+
+/** Highest used-percentage across every provider that has window data. */
+export function worstWindowAcrossProviders(
+	snapshots: ProviderSnapshot[],
+): number | null {
+	let worst: number | null = null;
+	for (const snapshot of snapshots) {
+		const pct = worstWindowUsedPct(snapshot);
+		if (pct === null) continue;
+		worst = worst === null ? pct : Math.max(worst, pct);
+	}
+	return worst;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -13,6 +13,7 @@ import {
 	LuClock,
 	LuFolderInput,
 	LuFolderPlus,
+	LuGauge,
 	LuLayers,
 	LuLayoutTemplate,
 	LuPlus,
@@ -28,6 +29,7 @@ import { SidebarToggle } from "renderer/routes/_authenticated/_dashboard/compone
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
 import { ResourceConsumption } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption";
 import { useFailedAutomations } from "renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations";
+import { useUsageBadge } from "renderer/routes/_authenticated/_dashboard/hooks/useUsageBadge";
 import {
 	tasksSearchFromFilters,
 	useTasksFilterStore,
@@ -82,7 +84,9 @@ export function DashboardSidebarHeader({
 	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
 	const isTasksOpen = !!matchRoute({ to: "/tasks", fuzzy: true });
 	const isAutomationsOpen = !!matchRoute({ to: "/automations", fuzzy: true });
+	const isUsageOpen = !!matchRoute({ to: "/usage", fuzzy: true });
 	const { myFailedCount } = useFailedAutomations();
+	const { tone: usageTone } = useUsageBadge();
 
 	const {
 		tab: lastTab,
@@ -99,6 +103,10 @@ export function DashboardSidebarHeader({
 
 	const handleAutomationsClick = () => {
 		navigate({ to: "/automations" });
+	};
+
+	const handleUsageClick = () => {
+		navigate({ to: "/usage" });
 	};
 
 	const handleTasksClick = () => {
@@ -189,6 +197,34 @@ export function DashboardSidebarHeader({
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="right">Tasks & PRs</TooltipContent>
+				</Tooltip>
+
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={handleUsageClick}
+							aria-label="Token Usage"
+							className={cn(
+								"relative flex size-8 items-center justify-center rounded-md transition-colors",
+								isUsageOpen
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+							)}
+						>
+							<LuGauge className="size-4" />
+							{usageTone && (
+								<span
+									aria-hidden="true"
+									className={cn(
+										"absolute right-1 top-1 size-1.5 rounded-full",
+										usageTone === "red" ? "bg-red-500" : "bg-amber-500",
+									)}
+								/>
+							)}
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Token Usage</TooltipContent>
 				</Tooltip>
 
 				<Tooltip delayDuration={300}>
@@ -327,6 +363,29 @@ export function DashboardSidebarHeader({
 			>
 				<HiOutlineClipboardDocumentList className="size-4 shrink-0" />
 				<span className="flex-1 text-left">Tasks & PRs</span>
+			</button>
+
+			<button
+				type="button"
+				onClick={handleUsageClick}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
+					isUsageOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<LuGauge className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Token Usage</span>
+				{usageTone && (
+					<span
+						aria-hidden="true"
+						className={cn(
+							"size-2 shrink-0 rounded-full",
+							usageTone === "red" ? "bg-red-500" : "bg-amber-500",
+						)}
+					/>
+				)}
 			</button>
 
 			<div className="flex items-center gap-1">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useUsageBadge/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useUsageBadge/index.ts
@@ -1,0 +1,1 @@
+export { useUsageBadge } from "./useUsageBadge";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useUsageBadge/useUsageBadge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useUsageBadge/useUsageBadge.ts
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+type UsageBadgeTone = "amber" | "red" | null;
+
+interface UsageBadge {
+	/** Worst window used-% across every provider, or null if none has data. */
+	worstUsedPct: number | null;
+	/** Badge color by urgency, gated by the showSidebarBadge setting. */
+	tone: UsageBadgeTone;
+}
+
+function toneFor(usedPct: number | null): UsageBadgeTone {
+	if (usedPct === null) return null;
+	if (usedPct >= 95) return "red";
+	if (usedPct >= 80) return "amber";
+	return null;
+}
+
+export function useUsageBadge(): UsageBadge {
+	const { data: initial } = electronTrpc.usage.getSnapshot.useQuery();
+	const [live, setLive] = useState<typeof initial>();
+	electronTrpc.usage.subscribe.useSubscription(undefined, {
+		onData: setLive,
+	});
+	const { data: settings } = electronTrpc.usage.getSettings.useQuery();
+
+	const snapshots = live ?? initial ?? [];
+	let worst: number | null = null;
+	for (const snapshot of snapshots) {
+		for (const window of snapshot.windows) {
+			worst = worst === null ? window.usedPct : Math.max(worst, window.usedPct);
+		}
+	}
+
+	if (settings && !settings.showSidebarBadge) {
+		return { worstUsedPct: worst, tone: null };
+	}
+
+	return { worstUsedPct: worst, tone: toneFor(worst) };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/CostStats/CostStats.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/CostStats/CostStats.tsx
@@ -7,11 +7,11 @@ interface CostStatsProps {
 
 function StatCell({ label, value }: { label: string; value: string }) {
 	return (
-		<div className="space-y-0.5">
-			<div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+		<div className="space-y-1">
+			<div className="text-[10px] uppercase tracking-widest text-muted-foreground">
 				{label}
 			</div>
-			<div className="font-mono text-sm font-bold tabular-nums text-foreground">
+			<div className="text-[15px] font-bold tabular-nums text-foreground">
 				{value}
 			</div>
 		</div>
@@ -22,14 +22,14 @@ export function CostStats({ cost }: CostStatsProps) {
 	const prefix = cost.approximate ? "~" : "";
 
 	return (
-		<div className="grid grid-cols-2 gap-x-4 gap-y-3">
+		<div className="grid grid-cols-2 gap-x-4 gap-y-4">
 			<StatCell label="Today" value={`${prefix}$${formatUsd(cost.todayUsd)}`} />
 			<StatCell
-				label="30d cost"
+				label="30D cost"
 				value={`${prefix}$${formatUsd(cost.thirtyDayUsd)}`}
 			/>
 			<StatCell
-				label="30d tokens"
+				label="30D tokens"
 				value={`${prefix}${formatCompactTokens(cost.thirtyDayTokens)}`}
 			/>
 			<StatCell

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/CostStats/CostStats.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/CostStats/CostStats.tsx
@@ -1,0 +1,41 @@
+import type { CostStatsData } from "../../types";
+import { formatCompactTokens, formatUsd } from "../../utils/format";
+
+interface CostStatsProps {
+	cost: CostStatsData;
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="space-y-0.5">
+			<div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+				{label}
+			</div>
+			<div className="font-mono text-sm font-bold tabular-nums text-foreground">
+				{value}
+			</div>
+		</div>
+	);
+}
+
+export function CostStats({ cost }: CostStatsProps) {
+	const prefix = cost.approximate ? "~" : "";
+
+	return (
+		<div className="grid grid-cols-2 gap-x-4 gap-y-3">
+			<StatCell label="Today" value={`${prefix}$${formatUsd(cost.todayUsd)}`} />
+			<StatCell
+				label="30d cost"
+				value={`${prefix}$${formatUsd(cost.thirtyDayUsd)}`}
+			/>
+			<StatCell
+				label="30d tokens"
+				value={`${prefix}${formatCompactTokens(cost.thirtyDayTokens)}`}
+			/>
+			<StatCell
+				label="Latest tokens"
+				value={`${prefix}${formatCompactTokens(cost.latestSessionTokens)}`}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/CostStats/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/CostStats/index.ts
@@ -1,0 +1,1 @@
+export { CostStats } from "./CostStats";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/DailyBarChart/DailyBarChart.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/DailyBarChart/DailyBarChart.tsx
@@ -4,7 +4,7 @@ interface DailyBarChartProps {
 	buckets: CostStatsData["dailyBuckets"];
 }
 
-const CHART_HEIGHT = 48;
+const CHART_HEIGHT = 44;
 const MIN_BAR_HEIGHT = 2;
 
 export function DailyBarChart({ buckets }: DailyBarChartProps) {
@@ -12,7 +12,7 @@ export function DailyBarChart({ buckets }: DailyBarChartProps) {
 
 	return (
 		<div
-			className="flex items-end gap-px"
+			className="flex items-end gap-[3px]"
 			style={{ height: CHART_HEIGHT }}
 			aria-hidden
 		>
@@ -24,7 +24,7 @@ export function DailyBarChart({ buckets }: DailyBarChartProps) {
 				return (
 					<div
 						key={bucket.date}
-						className="flex-1 rounded-sm bg-muted-foreground/40"
+						className="flex-1 rounded-[2px] bg-foreground/25"
 						style={{ height }}
 					/>
 				);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/DailyBarChart/DailyBarChart.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/DailyBarChart/DailyBarChart.tsx
@@ -1,0 +1,34 @@
+import type { CostStatsData } from "../../types";
+
+interface DailyBarChartProps {
+	buckets: CostStatsData["dailyBuckets"];
+}
+
+const CHART_HEIGHT = 48;
+const MIN_BAR_HEIGHT = 2;
+
+export function DailyBarChart({ buckets }: DailyBarChartProps) {
+	const max = buckets.reduce((acc, b) => Math.max(acc, b.tokens), 0);
+
+	return (
+		<div
+			className="flex items-end gap-px"
+			style={{ height: CHART_HEIGHT }}
+			aria-hidden
+		>
+			{buckets.map((bucket) => {
+				const height =
+					max > 0
+						? Math.max(MIN_BAR_HEIGHT, (bucket.tokens / max) * CHART_HEIGHT)
+						: MIN_BAR_HEIGHT;
+				return (
+					<div
+						key={bucket.date}
+						className="flex-1 rounded-sm bg-muted-foreground/40"
+						style={{ height }}
+					/>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/DailyBarChart/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/DailyBarChart/index.ts
@@ -1,0 +1,1 @@
+export { DailyBarChart } from "./DailyBarChart";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/NoDataStrip/NoDataStrip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/NoDataStrip/NoDataStrip.tsx
@@ -1,0 +1,29 @@
+const AGENTS = [
+	"Amp",
+	"Mastracode",
+	"OpenCode",
+	"Pi",
+	"Mistral Vibe",
+	"Cursor Agent",
+	"Droid",
+	"Polygraph",
+] as const;
+
+export function NoDataStrip() {
+	return (
+		<div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 pt-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+			<span className="flex items-center gap-1">
+				<span aria-hidden>○</span> No data yet
+			</span>
+			{AGENTS.map((agent) => (
+				<span
+					key={agent}
+					className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5"
+				>
+					<span aria-hidden>◦</span>
+					{agent}
+				</span>
+			))}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/NoDataStrip/NoDataStrip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/NoDataStrip/NoDataStrip.tsx
@@ -1,5 +1,6 @@
 import { BUILTIN_TERMINAL_AGENTS } from "@superset/shared/agent-command";
 import type { ProviderId } from "../../types";
+import { ProviderLogo } from "../ProviderLogo";
 
 // Providers with their own card; everything else in the registry falls into the
 // "no data yet" strip, so new builtin agents appear here automatically.
@@ -16,16 +17,16 @@ const STRIP_AGENTS = BUILTIN_TERMINAL_AGENTS.filter(
 
 export function NoDataStrip() {
 	return (
-		<div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 pt-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-			<span className="flex items-center gap-1">
-				<span aria-hidden>○</span> No data yet
+		<div className="flex flex-wrap items-center gap-x-2.5 gap-y-2 pt-1 pb-2">
+			<span className="text-[10px] uppercase tracking-widest text-muted-foreground/70">
+				○ No data yet
 			</span>
 			{STRIP_AGENTS.map((agent) => (
 				<span
 					key={agent.id}
-					className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5"
+					className="flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-1 text-[11px] text-muted-foreground"
 				>
-					<span aria-hidden>◦</span>
+					<ProviderLogo id={agent.id} className="size-3.5" />
 					{agent.label}
 				</span>
 			))}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/NoDataStrip/NoDataStrip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/NoDataStrip/NoDataStrip.tsx
@@ -1,13 +1,18 @@
-const AGENTS = [
-	"Amp",
-	"Mastracode",
-	"OpenCode",
-	"Pi",
-	"Mistral Vibe",
-	"Cursor Agent",
-	"Droid",
-	"Polygraph",
-] as const;
+import { BUILTIN_TERMINAL_AGENTS } from "@superset/shared/agent-command";
+import type { ProviderId } from "../../types";
+
+// Providers with their own card; everything else in the registry falls into the
+// "no data yet" strip, so new builtin agents appear here automatically.
+const CARD_PROVIDER_IDS: ProviderId[] = [
+	"claude",
+	"codex",
+	"copilot",
+	"gemini",
+];
+
+const STRIP_AGENTS = BUILTIN_TERMINAL_AGENTS.filter(
+	(agent) => !CARD_PROVIDER_IDS.includes(agent.id as ProviderId),
+);
 
 export function NoDataStrip() {
 	return (
@@ -15,13 +20,13 @@ export function NoDataStrip() {
 			<span className="flex items-center gap-1">
 				<span aria-hidden>○</span> No data yet
 			</span>
-			{AGENTS.map((agent) => (
+			{STRIP_AGENTS.map((agent) => (
 				<span
-					key={agent}
+					key={agent.id}
 					className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5"
 				>
 					<span aria-hidden>◦</span>
-					{agent}
+					{agent.label}
 				</span>
 			))}
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/NoDataStrip/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/NoDataStrip/index.ts
@@ -1,0 +1,1 @@
+export { NoDataStrip } from "./NoDataStrip";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderCard/ProviderCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderCard/ProviderCard.tsx
@@ -2,6 +2,7 @@ import type { ProviderId, ProviderSnapshot } from "../../types";
 import { formatRelativeAgo } from "../../utils/format";
 import { CostStats } from "../CostStats";
 import { DailyBarChart } from "../DailyBarChart";
+import { ProviderLogo } from "../ProviderLogo";
 import { RateLimitBar } from "../RateLimitBar";
 
 interface ProviderCardProps {
@@ -9,42 +10,51 @@ interface ProviderCardProps {
 	snapshot: ProviderSnapshot | undefined;
 }
 
-const PROVIDER_META: Record<ProviderId, { name: string; icon: string }> = {
-	claude: { name: "Claude", icon: "✳" },
-	codex: { name: "Codex", icon: "◇" },
-	copilot: { name: "Copilot", icon: "⧉" },
-	gemini: { name: "Gemini", icon: "✦" },
+const PROVIDER_NAME: Record<ProviderId, string> = {
+	claude: "Claude",
+	codex: "Codex",
+	copilot: "Copilot",
+	gemini: "Gemini",
 };
 
+function StatLine({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="flex items-center justify-between text-xs">
+			<span className="text-muted-foreground">{label}</span>
+			<span className="font-bold tabular-nums text-foreground">{value}</span>
+		</div>
+	);
+}
+
 export function ProviderCard({ providerId, snapshot }: ProviderCardProps) {
-	const meta = PROVIDER_META[providerId];
 	const cost = snapshot?.cost ?? null;
 	const credits = snapshot?.credits ?? null;
 	const windows = snapshot?.windows ?? [];
 	const errorMessage = snapshot?.errorMessage ?? null;
-
 	const hasBody = !errorMessage && (windows.length > 0 || !!cost);
 
 	return (
-		<div className="rounded-lg border border-border p-4">
+		<div className="rounded-xl border border-border bg-card/30 px-5 py-4">
 			<header className="flex items-start justify-between gap-3">
-				<div className="flex items-center gap-2">
-					<span aria-hidden className="text-base leading-none">
-						{meta.icon}
-					</span>
-					<div>
-						<div className="font-semibold text-foreground">{meta.name}</div>
-						{snapshot && (
-							<div className="text-[10px] text-muted-foreground">
-								Updated {formatRelativeAgo(snapshot.updatedAt)}
-							</div>
-						)}
+				<div className="min-w-0">
+					<div className="flex items-center gap-2">
+						<ProviderLogo id={providerId} className="size-[18px]" />
+						<span className="text-[15px] font-bold tracking-tight text-foreground">
+							{PROVIDER_NAME[providerId]}
+						</span>
+					</div>
+					<div className="mt-1 text-[11px] text-muted-foreground">
+						{snapshot
+							? `Updated ${formatRelativeAgo(snapshot.updatedAt)}`
+							: "No data yet"}
 					</div>
 				</div>
-				<div className="flex flex-col items-end text-[10px] text-muted-foreground">
-					{snapshot?.email && <span>{snapshot.email}</span>}
+				<div className="flex flex-col items-end gap-0.5 text-[11px] text-muted-foreground">
+					{snapshot?.email && (
+						<span className="truncate">{snapshot.email}</span>
+					)}
 					{snapshot?.planLabel && (
-						<span className="uppercase tracking-wider">
+						<span className="uppercase tracking-widest text-foreground/70">
 							{snapshot.planLabel}
 						</span>
 					)}
@@ -52,13 +62,13 @@ export function ProviderCard({ providerId, snapshot }: ProviderCardProps) {
 			</header>
 
 			{errorMessage ? (
-				<p className="mt-3 select-text cursor-text text-xs text-amber-500">
+				<p className="mt-4 select-text cursor-text text-xs leading-relaxed text-amber-500">
 					{errorMessage}
 				</p>
 			) : hasBody ? (
-				<div className="mt-4 space-y-4">
+				<div className="mt-5 space-y-5">
 					{windows.length > 0 && (
-						<div className="space-y-3">
+						<div className="space-y-4">
 							{windows.map((window) => (
 								<RateLimitBar key={window.label} window={window} />
 							))}
@@ -66,29 +76,23 @@ export function ProviderCard({ providerId, snapshot }: ProviderCardProps) {
 					)}
 
 					{credits && (
-						<div className="space-y-1 text-xs">
-							<div className="flex items-center justify-between">
-								<span className="text-muted-foreground">Credits</span>
-								<span className="font-mono tabular-nums text-foreground">
-									{credits.balance}
-								</span>
-							</div>
-							<div className="flex items-center justify-between">
-								<span className="text-muted-foreground">
-									Limit reset credits
-								</span>
-								<span className="font-mono tabular-nums text-foreground">
-									{credits.resetCredits}
-								</span>
-							</div>
+						<div className="space-y-2 border-t border-border/60 pt-4">
+							<StatLine
+								label="Credits"
+								value={`${credits.balance.toLocaleString()} credits`}
+							/>
+							<StatLine
+								label="Limit reset credits"
+								value={`${credits.resetCredits} available`}
+							/>
 						</div>
 					)}
 
 					{cost && (
-						<div className="space-y-3">
+						<div className="space-y-4 border-t border-border/60 pt-4">
 							<CostStats cost={cost} />
 							<DailyBarChart buckets={cost.dailyBuckets} />
-							<div className="space-y-0.5 text-[10px] text-muted-foreground">
+							<div className="space-y-0.5 text-[11px] text-muted-foreground">
 								{cost.topModel && <div>Top model: {cost.topModel}</div>}
 								{cost.estimatedFromLogs && (
 									<div>Estimated from local logs at API rates.</div>
@@ -97,9 +101,7 @@ export function ProviderCard({ providerId, snapshot }: ProviderCardProps) {
 						</div>
 					)}
 				</div>
-			) : (
-				<p className="mt-3 text-xs text-muted-foreground">no data yet</p>
-			)}
+			) : null}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderCard/ProviderCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderCard/ProviderCard.tsx
@@ -1,0 +1,105 @@
+import type { ProviderId, ProviderSnapshot } from "../../types";
+import { formatRelativeAgo } from "../../utils/format";
+import { CostStats } from "../CostStats";
+import { DailyBarChart } from "../DailyBarChart";
+import { RateLimitBar } from "../RateLimitBar";
+
+interface ProviderCardProps {
+	providerId: ProviderId;
+	snapshot: ProviderSnapshot | undefined;
+}
+
+const PROVIDER_META: Record<ProviderId, { name: string; icon: string }> = {
+	claude: { name: "Claude", icon: "✳" },
+	codex: { name: "Codex", icon: "◇" },
+	copilot: { name: "Copilot", icon: "⧉" },
+	gemini: { name: "Gemini", icon: "✦" },
+};
+
+export function ProviderCard({ providerId, snapshot }: ProviderCardProps) {
+	const meta = PROVIDER_META[providerId];
+	const cost = snapshot?.cost ?? null;
+	const credits = snapshot?.credits ?? null;
+	const windows = snapshot?.windows ?? [];
+	const errorMessage = snapshot?.errorMessage ?? null;
+
+	const hasBody = !errorMessage && (windows.length > 0 || !!cost);
+
+	return (
+		<div className="rounded-lg border border-border p-4">
+			<header className="flex items-start justify-between gap-3">
+				<div className="flex items-center gap-2">
+					<span aria-hidden className="text-base leading-none">
+						{meta.icon}
+					</span>
+					<div>
+						<div className="font-semibold text-foreground">{meta.name}</div>
+						{snapshot && (
+							<div className="text-[10px] text-muted-foreground">
+								Updated {formatRelativeAgo(snapshot.updatedAt)}
+							</div>
+						)}
+					</div>
+				</div>
+				<div className="flex flex-col items-end text-[10px] text-muted-foreground">
+					{snapshot?.email && <span>{snapshot.email}</span>}
+					{snapshot?.planLabel && (
+						<span className="uppercase tracking-wider">
+							{snapshot.planLabel}
+						</span>
+					)}
+				</div>
+			</header>
+
+			{errorMessage ? (
+				<p className="mt-3 select-text cursor-text text-xs text-amber-500">
+					{errorMessage}
+				</p>
+			) : hasBody ? (
+				<div className="mt-4 space-y-4">
+					{windows.length > 0 && (
+						<div className="space-y-3">
+							{windows.map((window) => (
+								<RateLimitBar key={window.label} window={window} />
+							))}
+						</div>
+					)}
+
+					{credits && (
+						<div className="space-y-1 text-xs">
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground">Credits</span>
+								<span className="font-mono tabular-nums text-foreground">
+									{credits.balance}
+								</span>
+							</div>
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground">
+									Limit reset credits
+								</span>
+								<span className="font-mono tabular-nums text-foreground">
+									{credits.resetCredits}
+								</span>
+							</div>
+						</div>
+					)}
+
+					{cost && (
+						<div className="space-y-3">
+							<CostStats cost={cost} />
+							<DailyBarChart buckets={cost.dailyBuckets} />
+							<div className="space-y-0.5 text-[10px] text-muted-foreground">
+								{cost.topModel && <div>Top model: {cost.topModel}</div>}
+								{cost.estimatedFromLogs && (
+									<div>Estimated from local logs at API rates.</div>
+								)}
+							</div>
+						</div>
+					)}
+				</div>
+			) : (
+				<p className="mt-3 text-xs text-muted-foreground">no data yet</p>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderCard/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderCard/index.ts
@@ -1,0 +1,1 @@
+export { ProviderCard } from "./ProviderCard";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderLogo/ProviderLogo.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderLogo/ProviderLogo.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@superset/ui/utils";
+import {
+	getPresetIcon,
+	useIsDarkTheme,
+} from "renderer/assets/app-icons/preset-icons";
+
+interface ProviderLogoProps {
+	/** Preset-icon key, e.g. "claude", "codex", "cursor-agent". */
+	id: string;
+	className?: string;
+}
+
+export function ProviderLogo({ id, className }: ProviderLogoProps) {
+	const isDark = useIsDarkTheme();
+	const icon = getPresetIcon(id, isDark);
+	if (!icon) return null;
+	return (
+		<img
+			src={icon}
+			alt=""
+			aria-hidden
+			className={cn("shrink-0 object-contain", className)}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderLogo/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/ProviderLogo/index.ts
@@ -1,0 +1,1 @@
+export { ProviderLogo } from "./ProviderLogo";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/RateLimitBar/RateLimitBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/RateLimitBar/RateLimitBar.tsx
@@ -7,6 +7,10 @@ interface RateLimitBarProps {
 
 export function RateLimitBar({ window }: RateLimitBarProps) {
 	const remainingPct = Math.max(0, Math.min(100, 100 - window.usedPct));
+	// The reserve marker only carries information when pace projection pulls it
+	// below the plain remaining budget; otherwise it sits at the bar end and reads
+	// as a dead pixel.
+	const showReserveTick = window.reservePct < remainingPct - 1;
 
 	return (
 		<div className="space-y-1.5">
@@ -22,7 +26,7 @@ export function RateLimitBar({ window }: RateLimitBarProps) {
 					className="h-full rounded-full bg-foreground/70"
 					style={{ width: `${remainingPct}%` }}
 				/>
-				{window.reservePct > 0 && (
+				{showReserveTick && (
 					<div
 						className="absolute top-0 h-full w-px bg-foreground/30"
 						style={{

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/RateLimitBar/RateLimitBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/RateLimitBar/RateLimitBar.tsx
@@ -13,22 +13,25 @@ export function RateLimitBar({ window }: RateLimitBarProps) {
 	const showReserveTick = window.reservePct < remainingPct - 1;
 
 	return (
-		<div className="space-y-1.5">
-			<div className="flex items-baseline justify-between">
-				<span className="text-xs text-foreground">{window.label}</span>
-				<span className="font-mono text-xs font-bold tabular-nums text-foreground">
-					{Math.round(remainingPct)}% left
+		<div className="space-y-2">
+			<div className="flex items-baseline justify-between gap-3">
+				<span className="truncate text-xs text-foreground">{window.label}</span>
+				<span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+					<span className="font-bold text-foreground">
+						{Math.round(remainingPct)}%
+					</span>{" "}
+					left
 				</span>
 			</div>
 
-			<div className="relative h-1 w-full overflow-hidden rounded-full bg-muted">
+			<div className="relative h-1 w-full overflow-hidden rounded-full bg-foreground/10">
 				<div
-					className="h-full rounded-full bg-foreground/70"
+					className="h-full rounded-full bg-foreground/60"
 					style={{ width: `${remainingPct}%` }}
 				/>
 				{showReserveTick && (
 					<div
-						className="absolute top-0 h-full w-px bg-foreground/30"
+						className="absolute top-0 h-full w-px bg-foreground"
 						style={{
 							left: `${Math.max(0, Math.min(100, 100 - window.reservePct))}%`,
 						}}
@@ -36,9 +39,9 @@ export function RateLimitBar({ window }: RateLimitBarProps) {
 				)}
 			</div>
 
-			<div className="flex items-start justify-between text-[10px] text-muted-foreground">
+			<div className="flex items-start justify-between gap-3 text-[11px] text-muted-foreground">
 				<span>{Math.round(window.reservePct)}% in reserve</span>
-				<div className="flex flex-col items-end">
+				<div className="flex flex-col items-end leading-tight">
 					{window.resetAt && (
 						<span>Resets in {formatTimeUntil(window.resetAt)}</span>
 					)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/RateLimitBar/RateLimitBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/RateLimitBar/RateLimitBar.tsx
@@ -1,0 +1,46 @@
+import type { RateLimitWindow } from "../../types";
+import { formatTimeUntil } from "../../utils/format";
+
+interface RateLimitBarProps {
+	window: RateLimitWindow;
+}
+
+export function RateLimitBar({ window }: RateLimitBarProps) {
+	const remainingPct = Math.max(0, Math.min(100, 100 - window.usedPct));
+
+	return (
+		<div className="space-y-1.5">
+			<div className="flex items-baseline justify-between">
+				<span className="text-xs text-foreground">{window.label}</span>
+				<span className="font-mono text-xs font-bold tabular-nums text-foreground">
+					{Math.round(remainingPct)}% left
+				</span>
+			</div>
+
+			<div className="relative h-1 w-full overflow-hidden rounded-full bg-muted">
+				<div
+					className="h-full rounded-full bg-foreground/70"
+					style={{ width: `${remainingPct}%` }}
+				/>
+				{window.reservePct > 0 && (
+					<div
+						className="absolute top-0 h-full w-px bg-foreground/30"
+						style={{
+							left: `${Math.max(0, Math.min(100, 100 - window.reservePct))}%`,
+						}}
+					/>
+				)}
+			</div>
+
+			<div className="flex items-start justify-between text-[10px] text-muted-foreground">
+				<span>{Math.round(window.reservePct)}% in reserve</span>
+				<div className="flex flex-col items-end">
+					{window.resetAt && (
+						<span>Resets in {formatTimeUntil(window.resetAt)}</span>
+					)}
+					{window.lastsUntilReset && <span>Lasts until reset</span>}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/RateLimitBar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/RateLimitBar/index.ts
@@ -1,0 +1,1 @@
+export { RateLimitBar } from "./RateLimitBar";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageSettingsPopover/UsageSettingsPopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageSettingsPopover/UsageSettingsPopover.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@superset/ui/button";
+import { Checkbox } from "@superset/ui/checkbox";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { LuSettings2 } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { UsageDisplaySettings } from "../../types";
+
+interface SettingRowProps {
+	label: string;
+	checked: boolean;
+	disabled: boolean;
+	onChange: (next: boolean) => void;
+}
+
+function SettingRow({ label, checked, disabled, onChange }: SettingRowProps) {
+	return (
+		// biome-ignore lint/a11y/noLabelWithoutControl: Checkbox renders the control
+		<label className="flex cursor-pointer items-center justify-between gap-4 text-sm">
+			<span className="text-foreground">{label}</span>
+			<Checkbox
+				checked={checked}
+				disabled={disabled}
+				onCheckedChange={(value) => onChange(value === true)}
+			/>
+		</label>
+	);
+}
+
+export function UsageSettingsPopover() {
+	const utils = electronTrpc.useUtils();
+	const { data: settings } = electronTrpc.usage.getSettings.useQuery();
+	const updateSettings = electronTrpc.usage.updateSettings.useMutation({
+		onSuccess: () => {
+			utils.usage.getSettings.invalidate();
+		},
+	});
+
+	const apply = (patch: Partial<UsageDisplaySettings>) => {
+		updateSettings.mutate(patch);
+	};
+
+	const disabled = !settings || updateSettings.isPending;
+	const notifyEnabled = !!settings?.notifyAt80Pct && !!settings?.notifyAt95Pct;
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-sm"
+					className="size-8 text-muted-foreground"
+					aria-label="Usage display settings"
+				>
+					<LuSettings2 className="size-4" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="end" className="w-64 space-y-3">
+				<div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+					Usage display
+				</div>
+				<div className="space-y-2.5">
+					<SettingRow
+						label="Sidebar badge"
+						checked={!!settings?.showSidebarBadge}
+						disabled={disabled}
+						onChange={(next) => apply({ showSidebarBadge: next })}
+					/>
+					<SettingRow
+						label="Percentage in menu bar"
+						checked={!!settings?.showTrayPercentage}
+						disabled={disabled}
+						onChange={(next) => apply({ showTrayPercentage: next })}
+					/>
+					<SettingRow
+						label="Notify at 80% / 95% usage"
+						checked={notifyEnabled}
+						disabled={disabled}
+						onChange={(next) =>
+							apply({ notifyAt80Pct: next, notifyAt95Pct: next })
+						}
+					/>
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageSettingsPopover/UsageSettingsPopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageSettingsPopover/UsageSettingsPopover.tsx
@@ -1,7 +1,6 @@
-import { Button } from "@superset/ui/button";
-import { Checkbox } from "@superset/ui/checkbox";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
-import { LuSettings2 } from "react-icons/lu";
+import { cn } from "@superset/ui/utils";
+import { LuCheck, LuSettings2 } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { UsageDisplaySettings } from "../../types";
 
@@ -9,20 +8,26 @@ interface SettingRowProps {
 	label: string;
 	checked: boolean;
 	disabled: boolean;
-	onChange: (next: boolean) => void;
+	onToggle: () => void;
 }
 
-function SettingRow({ label, checked, disabled, onChange }: SettingRowProps) {
+function SettingRow({ label, checked, disabled, onToggle }: SettingRowProps) {
 	return (
-		// biome-ignore lint/a11y/noLabelWithoutControl: Checkbox renders the control
-		<label className="flex cursor-pointer items-center justify-between gap-4 text-sm">
-			<span className="text-foreground">{label}</span>
-			<Checkbox
-				checked={checked}
-				disabled={disabled}
-				onCheckedChange={(value) => onChange(value === true)}
-			/>
-		</label>
+		<button
+			type="button"
+			disabled={disabled}
+			onClick={onToggle}
+			className="flex w-full items-center gap-2.5 rounded-md px-1.5 py-1.5 text-left text-sm transition-colors hover:bg-accent/50 disabled:opacity-50"
+		>
+			<span className="flex w-3.5 shrink-0 justify-center">
+				<LuCheck
+					className={cn("size-3.5", checked ? "opacity-100" : "opacity-0")}
+				/>
+			</span>
+			<span className={checked ? "text-foreground" : "text-muted-foreground"}>
+				{label}
+			</span>
+		</button>
 	);
 }
 
@@ -45,42 +50,46 @@ export function UsageSettingsPopover() {
 	return (
 		<Popover>
 			<PopoverTrigger asChild>
-				<Button
+				<button
 					type="button"
-					variant="ghost"
-					size="icon-sm"
-					className="size-8 text-muted-foreground"
 					aria-label="Usage display settings"
+					className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
 				>
 					<LuSettings2 className="size-4" />
-				</Button>
+				</button>
 			</PopoverTrigger>
-			<PopoverContent align="end" className="w-64 space-y-3">
-				<div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+			<PopoverContent align="end" className="w-60 p-2">
+				<div className="px-1.5 pb-1.5 pt-1 text-xs font-medium text-muted-foreground">
 					Usage display
 				</div>
-				<div className="space-y-2.5">
-					<SettingRow
-						label="Sidebar badge"
-						checked={!!settings?.showSidebarBadge}
-						disabled={disabled}
-						onChange={(next) => apply({ showSidebarBadge: next })}
-					/>
-					<SettingRow
-						label="Percentage in menu bar"
-						checked={!!settings?.showTrayPercentage}
-						disabled={disabled}
-						onChange={(next) => apply({ showTrayPercentage: next })}
-					/>
-					<SettingRow
-						label="Notify at 80% / 95% usage"
-						checked={notifyEnabled}
-						disabled={disabled}
-						onChange={(next) =>
-							apply({ notifyAt80Pct: next, notifyAt95Pct: next })
-						}
-					/>
-				</div>
+				<SettingRow
+					label="Sidebar badge"
+					checked={!!settings?.showSidebarBadge}
+					disabled={disabled}
+					onToggle={() =>
+						apply({ showSidebarBadge: !settings?.showSidebarBadge })
+					}
+				/>
+				<SettingRow
+					label="Percentage in menu bar"
+					checked={!!settings?.showTrayPercentage}
+					disabled={disabled}
+					onToggle={() =>
+						apply({ showTrayPercentage: !settings?.showTrayPercentage })
+					}
+				/>
+				<div className="my-1 border-t border-border/60" />
+				<SettingRow
+					label="Notify at 80% / 95% usage"
+					checked={notifyEnabled}
+					disabled={disabled}
+					onToggle={() =>
+						apply({
+							notifyAt80Pct: !notifyEnabled,
+							notifyAt95Pct: !notifyEnabled,
+						})
+					}
+				/>
 			</PopoverContent>
 		</Popover>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageSettingsPopover/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageSettingsPopover/index.ts
@@ -1,0 +1,1 @@
+export { UsageSettingsPopover } from "./UsageSettingsPopover";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/page.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { LuRefreshCw } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { NoDataStrip } from "./components/NoDataStrip";
+import { ProviderCard } from "./components/ProviderCard";
+import { UsageSettingsPopover } from "./components/UsageSettingsPopover";
+import type { ProviderId, ProviderSnapshot } from "./types";
+
+export const Route = createFileRoute("/_authenticated/_dashboard/usage/")({
+	component: UsagePage,
+});
+
+const PROVIDER_ORDER: ProviderId[] = ["claude", "codex", "copilot", "gemini"];
+
+function UsagePage() {
+	const initial = electronTrpc.usage.getSnapshot.useQuery();
+	const [snapshots, setSnapshots] = useState<ProviderSnapshot[]>([]);
+	electronTrpc.usage.subscribe.useSubscription(undefined, {
+		onData: setSnapshots,
+	});
+	const refresh = electronTrpc.usage.refresh.useMutation({
+		onSuccess: setSnapshots,
+	});
+
+	// The subscription pushes the cached value immediately, but seeding from the
+	// query avoids a blank first paint before that arrives.
+	const active = snapshots.length > 0 ? snapshots : (initial.data ?? []);
+	const byProvider = new Map(active.map((s) => [s.providerId, s]));
+
+	return (
+		<div className="flex h-full w-full flex-1 flex-col overflow-hidden">
+			<header className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
+				<h1 className="text-sm font-semibold tracking-tight">Token Usage</h1>
+				<div className="flex items-center gap-1">
+					<UsageSettingsPopover />
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="h-8 gap-1.5 px-3"
+						onClick={() => refresh.mutate()}
+						disabled={refresh.isPending}
+					>
+						<LuRefreshCw
+							className={cn("size-4", refresh.isPending && "animate-spin")}
+						/>
+						<span>Refresh</span>
+					</Button>
+				</div>
+			</header>
+
+			<div className="min-h-0 flex-1 overflow-y-auto px-4 py-6">
+				<div className="mx-auto flex w-full max-w-[540px] flex-col gap-4">
+					{PROVIDER_ORDER.map((providerId) => (
+						<ProviderCard
+							key={providerId}
+							providerId={providerId}
+							snapshot={byProvider.get(providerId)}
+						/>
+					))}
+					<NoDataStrip />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/page.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@superset/ui/button";
 import { cn } from "@superset/ui/utils";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
@@ -31,29 +30,29 @@ function UsagePage() {
 	const byProvider = new Map(active.map((s) => [s.providerId, s]));
 
 	return (
-		<div className="flex h-full w-full flex-1 flex-col overflow-hidden">
+		<div className="flex h-full w-full flex-1 flex-col overflow-hidden font-mono">
 			<header className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
-				<h1 className="text-sm font-semibold tracking-tight">Token Usage</h1>
-				<div className="flex items-center gap-1">
+				<h1 className="text-[13px] font-semibold tracking-wide text-foreground">
+					Token Usage
+				</h1>
+				<div className="flex items-center gap-0.5">
 					<UsageSettingsPopover />
-					<Button
+					<button
 						type="button"
-						variant="outline"
-						size="sm"
-						className="h-8 gap-1.5 px-3"
 						onClick={() => refresh.mutate()}
 						disabled={refresh.isPending}
+						className="flex h-8 items-center gap-1.5 rounded-md px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground disabled:opacity-50"
 					>
 						<LuRefreshCw
-							className={cn("size-4", refresh.isPending && "animate-spin")}
+							className={cn("size-3.5", refresh.isPending && "animate-spin")}
 						/>
 						<span>Refresh</span>
-					</Button>
+					</button>
 				</div>
 			</header>
 
-			<div className="min-h-0 flex-1 overflow-y-auto px-4 py-6">
-				<div className="mx-auto flex w-full max-w-[540px] flex-col gap-4">
+			<div className="min-h-0 flex-1 overflow-y-auto px-4 py-8">
+				<div className="mx-auto flex w-full max-w-[620px] flex-col gap-4">
 					{PROVIDER_ORDER.map((providerId) => (
 						<ProviderCard
 							key={providerId}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/types.ts
@@ -1,0 +1,9 @@
+import type { ElectronRouterOutputs } from "renderer/lib/electron-trpc";
+
+export type ProviderSnapshot =
+	ElectronRouterOutputs["usage"]["getSnapshot"][number];
+export type RateLimitWindow = ProviderSnapshot["windows"][number];
+export type CostStatsData = NonNullable<ProviderSnapshot["cost"]>;
+export type UsageDisplaySettings =
+	ElectronRouterOutputs["usage"]["getSettings"];
+export type ProviderId = ProviderSnapshot["providerId"];

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/utils/format.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/utils/format.ts
@@ -1,0 +1,41 @@
+export function formatCompactTokens(value: number): string {
+	if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+	if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+	if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+	return `${value}`;
+}
+
+export function formatUsd(value: number): string {
+	return value.toLocaleString(undefined, {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	});
+}
+
+export function formatRelativeAgo(from: Date): string {
+	const seconds = Math.max(0, Math.round((Date.now() - from.getTime()) / 1000));
+	if (seconds < 45) return "just now";
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.round(hours / 24);
+	return `${days}d ago`;
+}
+
+// Humanize a future reset instant into a coarse "20m" / "1d 23h" / "7d" string.
+export function formatTimeUntil(target: Date): string {
+	const totalMinutes = Math.max(
+		0,
+		Math.round((target.getTime() - Date.now()) / 60000),
+	);
+	if (totalMinutes < 60) return `${totalMinutes}m`;
+	const totalHours = Math.floor(totalMinutes / 60);
+	if (totalHours < 24) {
+		const mins = totalMinutes % 60;
+		return mins > 0 ? `${totalHours}h ${mins}m` : `${totalHours}h`;
+	}
+	const days = Math.floor(totalHours / 24);
+	const hours = totalHours % 24;
+	return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -187,6 +187,8 @@ function AuthenticatedLayout() {
 				navigate({ to: `/settings/${section}` as "/settings/account" });
 			} else if (event.type === "open-workspace") {
 				navigate({ to: `/workspace/${event.data.workspaceId}` });
+			} else if (event.type === "navigate") {
+				navigate({ to: event.data.to as "/usage" });
 			}
 		},
 	});


### PR DESCRIPTION
  <!--
  PR titles become the squash-merge commit subject, so use conventional commit format:
    feat(desktop): add copy-logs button to failed CI checks
    fix(web): guard against missing PR in workspace header
  -->
  
  ## What & why
  
fixes #5733

Adds a **Token Usage** screen to the desktop sidebar that shows, per AI provider, how much quota is left, when it resets, and 30-day cost — so you can see you're about to hit a rate limit *before* an agent run does.

Everything is computed **on-device**. No telemetry, nothing sent to Superset servers; credential files are read-only and refreshed tokens stay in memory.

**What's included**
- **Main-process collector** (`src/main/lib/usage/`) — polls providers every 5 min, persists the last snapshot to `~/.superset/usage-snapshot.json`, emits updates over an `EventEmitter`. Per-provider 10s timeout, 429 backoff, last-good-value fallback.
- **Real limit data (verified live):**
  - **Claude** — reads the live OAuth token from the `Claude Code-credentials` Keychain entry and harvests the `anthropic-ratelimit-unified-{5h,7d}-*` headers from a minimal `/v1/messages` probe → real **5-hour** + **weekly** windows with reserve/pace projection.
  - **Codex** — reads the `rate_limits` snapshot Codex writes into its rollout session logs (passive, zero quota cost) → real weekly/monthly + Spark windows, credits, and plan.
  - **Copilot / Gemini** — show identity/cost or a "not signed in" state until authed (no fabricated data).
- **Cost stats** estimated locally from CLI logs at API rates, with a bundled pricing table (cache-read/write priced separately).
- **Ambient indicators** — tray menu section + worst-window % tooltip, sidebar dot badge (amber ≥80%, red ≥95%), and 80%/95% native notifications. All toggleable from a settings popover.
- **tRPC** router (`usage.*`) using the observable subscription pattern; renderer route at `/usage`.

No feature gating — it's a local utility that benefits every user running agents.
  
  ## How I tested it
  
- `bun run typecheck` and `bun run lint` both pass clean (lint exit 0, warnings-as-errors).
- **Claude limits verified live** against a real Pro account — confirmed the `anthropic-ratelimit-unified-5h/7d` headers return real utilization + reset times.
- **Codex limits verified** against real `~/.codex/sessions/**/rollout-*.jsonl` files — confirmed `rate_limits.primary/secondary`, `credits`, and `plan_type` parse correctly.
- Cost parsing validated against real `~/.claude/projects` and `~/.codex` logs; format guards return `null` (not a crash) on unknown shapes.
- Renders safely with no provider credentials — every provider falls back to a "no data yet" state.

  
  ## Checklist
  
  - [x] PR title follows conventional commits (`type(scope): subject`)
  - [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
  - [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Token Usage screen in the desktop app to show provider limits, remaining quota, and 30‑day cost so you can spot limits before runs fail. All data is computed on-device from provider headers and local CLI logs—no telemetry.

- **New Features**
  - Main-process usage collector: polls every 5 min, 10s timeout, 429 backoff, persists last snapshot to ~/.superset/usage-snapshot.json, emits updates.
  - Providers: Claude (live unified 5h/7d headers via OAuth; plan/email), Codex (rate_limits, credits, plan from rollout logs), Copilot & Gemini (auth/plan state; no fabricated data).
  - Cost: local estimates from Claude/Codex logs with a bundled pricing table (cache reads/writes priced separately); 30‑day buckets and today’s spend.
  - UI: new /usage route with provider cards, rate‑limit bars, cost stats, and a 30‑day mini chart; “No data yet” strip for other agents.
  - Tray and alerts: tray section with per‑provider % and reset hints, “View details” action, tooltip shows worst %, sidebar dot badge (amber ≥80%, red ≥95%), native notifications at 80%/95%.
  - Settings: popover to toggle sidebar badge, tray percentage, and notifications; settings persisted per user.
  - API: `usage.*` tRPC router for get/refresh/subscribe plus settings; menu router gains `navigate` to open /usage.
  - Lifecycle: collector starts with the app and disposes on quit; tray menu/tooltip refresh on usage updates and setting changes.

- **Bug Fixes**
  - Claude: surface probe failures as card messages and cancel probe response bodies to avoid socket leaks.
  - Cost data: align 30‑day buckets to local midnight and fall back to file modified time when Codex timestamps are missing.

<sup>Written for commit cf31b3a3c7cdf22f6fc04fa917386ff54820696d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Token Usage dashboard with provider cards, cost/token summaries, daily activity charts, and rate-limit windows, plus a manual refresh action.
  * Added live usage tracking for major providers and a sidebar gauge badge that reflects the worst active window, with optional notifications.
  * Enhanced the desktop tray with provider usage/tooltips and a “view details” section, kept in sync automatically; added settings to control badge and percentage display.
* **Bug Fixes**
  * Improved resilience for missing/expired credentials, partial/unavailable usage data, rate-limit backoff behavior, and approximate cost reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->