### PR TITLE
fix(marketing): improve Tokyo Night comment & muted-text contrast

### DIFF
--- a/apps/marketing/public/marketplace/themes/tokyo-night.json
+++ b/apps/marketing/public/marketplace/themes/tokyo-night.json
@@ -16,7 +16,7 @@
 		"secondary": "#24283b",
 		"secondaryForeground": "#c0caf5",
 		"muted": "#24283b",
-		"mutedForeground": "#565f89",
+		"mutedForeground": "#787c99",
 		"accent": "#292e42",
 		"accentForeground": "#c0caf5",
 		"tertiary": "#13141d",
@@ -66,5 +66,10 @@
 		"brightMagenta": "#c8a4ff",
 		"brightCyan": "#a4dfff",
 		"brightWhite": "#c0caf5"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#9aa5ce"
+		}
 	}
 }


### PR DESCRIPTION
## What & why

Since #5404 the diff view renders code with the active theme's syntax colors. Themes without an explicit `editor.syntax.comment` inherit the comment color from ANSI `terminal.brightBlack` (`shared/themes/editor-theme.ts`), which is dim by design. In Tokyo Night that's `#414868` on `#1a1b26` — ~1.9:1 in plain code, and it bottoms out around ~1.0:1 inside a deleted-word highlight once the diff view composites its line tints. Comments are effectively invisible on added/removed lines.

The same theme's `mutedForeground` (`#565f89`) drives muted/secondary text across the app — side-menu labels, hints, timestamps — and sits at ~2.96:1 on the side-menu background, also below WCAG AA.

Both are fixed with the theme's **own** palette colors (no new colors introduced):

- **`editor.syntax.comment: #9aa5ce`** — a palette color the theme already uses for variable/parameter tokens. ~7:1 on plain background, ~5:1 on the green added-line overlay. This is the sanctioned per-theme override (the built-in dark theme already pins its comment color, enforced by `editor.test.ts`).
- **`ui.mutedForeground: #565f89 → #787c99`** — `#787c99` is Tokyo Night's actual muted-UI color (its `foreground`, `sideBar.foreground`, `activityBar.foreground`, `tab.inactiveForeground`), so it's the role-exact value for muted text. Side menu goes 2.96:1 → 4.49:1.

`terminal.brightBlack` is left unchanged — it stays the correct ANSI dim slot for the actual terminal.

Relates to #5662. #5663 raises the engine's fallback floor, but it falls back to `mutedForeground` without flooring *that* — so real Tokyo Night, whose `mutedForeground` is itself dim, would still land sub-AA. Pinning the theme's own values fixes it regardless of the engine change, and the two are complementary.

### Contrast (Tokyo Night)

| element | before | after |
|---|---|---|
| diff comment (plain bg) | 1.9:1 | 7.0:1 |
| diff comment (green added line) | ~1.5:1 | ~5.0:1 |
| side-menu muted label | 2.96:1 | 4.49:1 |
| muted text (main bg) | 2.76:1 | 4.18:1 |

### Opening the way for the other dark themes

Most marketplace dark themes inherit the same dim `brightBlack` for comments. Measured comment contrast on each theme's own background — everything below is under the 3:1 floor:

| theme | comment | contrast |
|---|---|---|
| console | `#0e2010` | 1.17 |
| kintsugi | `#2a221a` | 1.26 |
| supernova | `#1a2040` | 1.27 |
| reactor | `#26323a` | 1.43 |
| brutalist | `#2e2e2e` | 1.46 |
| twilight-run | `#2e3a4e` | 1.51 |
| hangar | `#3a3d42` | 1.55 |
| ferro | `#3a3d44` | 1.64 |
| nord | `#4c566a` | 1.69 |
| **tokyo-night** | `#414868` | **1.91** |
| catppuccin-frappe | `#626880` | 2.23 |
| one-dark-pro | `#5c6370` | 2.32 |
| catppuccin-macchiato | `#5b6078` | 2.38 |
| catppuccin-mocha | `#585b70` | 2.46 |
| ember | `#5c5856` | 2.67 |
| solarized-dark | `#586e75` | 2.79 |

(`dracula` 3.03, `monokai-classic` 3.03, `rose-pine` 3.42, `gruvbox-dark` 4.02, `github-dark-colorblind` 4.12 already clear it.)

Each can be fixed the same way — a per-theme `editor.syntax.comment` from the theme's own palette, plus `mutedForeground` where it's dim. Happy to follow up across the rest if this approach looks right.

## How I tested it

- Imported the updated theme into the desktop app: diff-view comments on added/removed lines are legible, side-menu muted labels are readable, and the muted palette still reads as *muted* (not primary text).
- Contrast ratios computed with WCAG 2.1 relative luminance; added-line values account for the diff view's green line tint.
- Both hex values are existing Tokyo Night palette colors (comment `#9aa5ce` = variable-token color; muted `#787c99` = the theme's `foreground`/`sideBar.foreground`), not new colors.
- The file parses against the theme import schema (`shared/themes/import.ts` — all fields optional/passthrough).

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] "Allow edits from maintainers" is checked
- [ ] `bun run lint` / `typecheck` — N/A: this is a JSON theme data file under `public/`, no compiled/typed code changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Tokyo Night theme’s muted foreground color for improved readability.
  * Added a dedicated color for editor comments to enhance syntax highlighting clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->