### PR TITLE
feat(desktop): add right-click actions to sidebar agent chips

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/components/DashboardSidebarWorkspaceAgentBadge/DashboardSidebarWorkspaceAgentBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/components/DashboardSidebarWorkspaceAgentBadge/DashboardSidebarWorkspaceAgentBadge.tsx
@@ -1,7 +1,14 @@
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
-import { LuBot } from "react-icons/lu";
+import { LuBot, LuSquareTerminal, LuTrash2 } from "react-icons/lu";
 import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import {
@@ -9,6 +16,7 @@ import {
 	StatusIndicator,
 } from "renderer/screens/main/components/StatusIndicator";
 import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
+import { useDashboardSidebarAgentKill } from "../../hooks/useDashboardSidebarAgentKill";
 import type { DashboardSidebarRunningAgent } from "../../hooks/useDashboardSidebarWorkspaceRunningAgents";
 
 interface DashboardSidebarWorkspaceAgentBadgeProps {
@@ -21,7 +29,8 @@ interface DashboardSidebarWorkspaceAgentBadgeProps {
  * circle (icon + status dot) overlapping its neighbors; when the strip is
  * `details-expanded` it morphs into a labeled pill — the overlap margin and
  * the label's max-width animate, so the circle visibly grows into the pill
- * and retracts back. Clickable in both states.
+ * and retracts back. Clickable in both states; right-click opens a menu to
+ * open or kill the agent.
  */
 export function DashboardSidebarWorkspaceAgentBadge({
 	workspaceId,
@@ -29,8 +38,10 @@ export function DashboardSidebarWorkspaceAgentBadge({
 }: DashboardSidebarWorkspaceAgentBadgeProps) {
 	const navigate = useNavigate();
 	const iconUrl = usePresetIcon(agent.agentId);
+	const { isPending: isKilling, killAgent } =
+		useDashboardSidebarAgentKill(workspaceId);
 
-	const handleClick = () => {
+	const handleOpen = () => {
 		void navigateToV2Workspace(workspaceId, navigate, {
 			search: {
 				terminalId: agent.terminalId,
@@ -39,58 +50,84 @@ export function DashboardSidebarWorkspaceAgentBadge({
 		});
 	};
 
+	const handleKill = () => {
+		if (isKilling) return;
+		void killAgent(agent.terminalId);
+	};
+
 	const statusLabel =
 		agent.status === "idle" ? "Idle" : getStatusTooltip(agent.status);
 
 	return (
-		<Tooltip delayDuration={700}>
-			<TooltipTrigger asChild>
-				<button
-					type="button"
-					onClick={handleClick}
-					className={cn(
-						"flex h-[18px] shrink-0 items-center rounded-full px-[3px]",
-						"bg-muted text-[11px] text-muted-foreground",
-						"-ml-1.5 first:ml-0",
-						"transition-[margin,padding,color] duration-500 ease-out motion-reduce:transition-none",
-						"details-expanded:ml-1 details-expanded:pl-1 details-expanded:pr-1.5 details-expanded:duration-200 details-expanded:first:ml-0",
-						"hover:text-foreground",
-						"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-					)}
-				>
-					<span className="relative flex size-3 shrink-0 items-center justify-center">
-						{iconUrl ? (
-							<img src={iconUrl} alt="" className="size-3 object-contain" />
-						) : (
-							<LuBot className="size-3" strokeWidth={STROKE_WIDTH} />
-						)}
-						{agent.status !== "idle" && (
-							<StatusIndicator
-								status={agent.status}
-								className="absolute -top-0.5 -right-0.5"
-							/>
-						)}
-					</span>
-					<span
-						className={cn(
-							"max-w-0 truncate opacity-0",
-							"transition-[max-width,margin,opacity] duration-500 ease-out motion-reduce:transition-none",
-							"details-expanded:ml-1 details-expanded:max-w-28 details-expanded:opacity-100 details-expanded:duration-200",
-						)}
-					>
-						{agent.label}
-					</span>
-				</button>
-			</TooltipTrigger>
-			<TooltipContent side="top" sideOffset={6} showArrow={false}>
-				<div className="space-y-1 text-xs">
-					<div className="font-medium">{agent.label}</div>
-					<div className="text-background/70">{statusLabel}</div>
-					<div className="text-[10px] text-background/60">
-						Click to open agent
+		<ContextMenu>
+			<Tooltip delayDuration={700}>
+				<TooltipTrigger asChild>
+					<ContextMenuTrigger asChild>
+						<button
+							type="button"
+							onClick={handleOpen}
+							aria-busy={isKilling}
+							className={cn(
+								"flex h-[18px] shrink-0 items-center rounded-full px-[3px]",
+								"bg-muted text-[11px] text-muted-foreground",
+								"-ml-1.5 first:ml-0",
+								"transition-[margin,padding,color] duration-500 ease-out motion-reduce:transition-none",
+								"details-expanded:ml-1 details-expanded:pl-1 details-expanded:pr-1.5 details-expanded:duration-200 details-expanded:first:ml-0",
+								"hover:text-foreground",
+								"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+								isKilling && "opacity-70",
+							)}
+						>
+							<span className="relative flex size-3 shrink-0 items-center justify-center">
+								{iconUrl ? (
+									<img src={iconUrl} alt="" className="size-3 object-contain" />
+								) : (
+									<LuBot className="size-3" strokeWidth={STROKE_WIDTH} />
+								)}
+								{agent.status !== "idle" && (
+									<StatusIndicator
+										status={agent.status}
+										className="absolute -top-0.5 -right-0.5"
+									/>
+								)}
+							</span>
+							<span
+								className={cn(
+									"max-w-0 truncate opacity-0",
+									"transition-[max-width,margin,opacity] duration-500 ease-out motion-reduce:transition-none",
+									"details-expanded:ml-1 details-expanded:max-w-28 details-expanded:opacity-100 details-expanded:duration-200",
+								)}
+							>
+								{agent.label}
+							</span>
+						</button>
+					</ContextMenuTrigger>
+				</TooltipTrigger>
+				<TooltipContent side="top" sideOffset={6} showArrow={false}>
+					<div className="space-y-1 text-xs">
+						<div className="font-medium">{agent.label}</div>
+						<div className="text-background/70">{statusLabel}</div>
+						<div className="text-[10px] text-background/60">
+							Click to open · right-click for actions
+						</div>
 					</div>
-				</div>
-			</TooltipContent>
-		</Tooltip>
+				</TooltipContent>
+			</Tooltip>
+			<ContextMenuContent onCloseAutoFocus={(event) => event.preventDefault()}>
+				<ContextMenuItem onSelect={handleOpen}>
+					<LuSquareTerminal />
+					Open Agent
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem
+					variant="destructive"
+					onSelect={handleKill}
+					disabled={isKilling}
+				>
+					<LuTrash2 />
+					Kill Agent
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/hooks/useDashboardSidebarAgentKill/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/hooks/useDashboardSidebarAgentKill/index.ts
@@ -1,0 +1,1 @@
+export { useDashboardSidebarAgentKill } from "./useDashboardSidebarAgentKill";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/hooks/useDashboardSidebarAgentKill/useDashboardSidebarAgentKill.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/hooks/useDashboardSidebarAgentKill/useDashboardSidebarAgentKill.ts
@@ -1,0 +1,53 @@
+import { toast } from "@superset/ui/sonner";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+import { useWorkspaceHostUrl } from "renderer/hooks/host-service/useWorkspaceHostUrl";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+
+interface UseDashboardSidebarAgentKillResult {
+	isPending: boolean;
+	killAgent: (terminalId: string) => Promise<void>;
+}
+
+/**
+ * Kill the host terminal session an agent is bound to. Disposing the session
+ * ends the agent process; its sidebar chip drops once the bindings query
+ * refreshes (the `agent:lifecycle` event invalidates it too, but we invalidate
+ * eagerly so the chip disappears without waiting on the event).
+ */
+export function useDashboardSidebarAgentKill(
+	workspaceId: string,
+): UseDashboardSidebarAgentKillResult {
+	const hostUrl = useWorkspaceHostUrl(workspaceId);
+	const queryClient = useQueryClient();
+	const [isPending, setIsPending] = useState(false);
+
+	const killAgent = useCallback(
+		async (terminalId: string): Promise<void> => {
+			if (!hostUrl) {
+				toast.error("Failed to kill agent", {
+					description: "No host is available for this workspace",
+				});
+				return;
+			}
+			setIsPending(true);
+			try {
+				await getHostServiceClientByUrl(hostUrl).terminal.killSession.mutate({
+					terminalId,
+					workspaceId,
+				});
+			} catch (error) {
+				console.error("[sidebar-agent] Failed to kill agent:", error);
+				toast.error("Failed to kill agent");
+			} finally {
+				void queryClient.invalidateQueries({
+					queryKey: ["terminal-agent-bindings", hostUrl, workspaceId],
+				});
+				setIsPending(false);
+			}
+		},
+		[hostUrl, workspaceId, queryClient],
+	);
+
+	return { isPending, killAgent };
+}


### PR DESCRIPTION
## What
Adds a right-click **context menu** to the agent chip in the dashboard sidebar's workspace activity strip:

- **Open Agent** — navigates to the workspace and opens the agent's terminal pane (same as left-click).
- **Kill Agent** (destructive) — disposes the host terminal session via `terminal.killSession`, which marks the terminal exited and removes the agent binding, so the chip drops. Toast on failure, no confirmation dialog (matches every existing terminal/port kill path).

## Why
There was no way to act on a running agent straight from the sidebar — you had to open the workspace and find its terminal to kill it.

## Notes / decisions
- **Kill *is* remove.** There's no separate unbind mutation; `killSession` disposes the PTY and deletes the binding in one shot, so a single Kill Agent item covers it.
- **Host-service client, not `workspaceTrpc`.** The chip lives outside the workspace-client provider, so kill mirrors the sibling port-kill path (`getHostServiceClientByUrl(hostUrl).terminal.killSession`).
- **Scope note:** an earlier revision also changed the *open* path to create/adopt a terminal for "backgrounded" agents. That was dropped — an agent chip always maps to a live terminal session (the binding *is* the association), and the consume path already gates on the session being live in `listSessions`, so simply adding the pane (existing `focusOrAddTerminalPane`) is sufficient. This PR is now the right-click menu only.
- The strip only renders individual agent chips when a workspace has **more than one** running agent (pre-existing `hasMultipleAgents` gate), so the menu is reachable only in that case. Left unchanged.

## Testing
- `bun run lint` clean, `bun run typecheck` green across the monorepo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-click actions for workspace agents, including options to open or stop an agent.
  * Added loading feedback while an agent is being stopped.
  * Updated agent tooltips to explain available click and right-click actions.

* **Bug Fixes**
  * Sidebar agent status now refreshes after an agent stop attempt.
  * Added error notifications when stopping an agent fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->