### PR TITLE
fix(desktop): reliably auto-adopt agent terminals on workspace open

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useAutoAdoptBackgroundSessions/useAutoAdoptBackgroundSessions.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceStore } from "@superset/panes";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { logStressEvent } from "renderer/lib/performance/stress-instrumentation";
 import { getTerminalBackgroundMarkerIdsKey } from "renderer/lib/terminal/terminal-background-intents";
 import type { StoreApi } from "zustand/vanilla";
@@ -19,34 +19,37 @@ interface UseAutoAdoptBackgroundSessionsArgs {
 }
 
 /**
- * When a workspace is created or opened, running terminal daemon sessions
- * that have no pane get their panes created automatically instead of sitting
- * behind the background-terminals dropdown.
+ * When a workspace is opened, running terminal daemon sessions that have no
+ * pane get their panes created automatically instead of sitting behind the
+ * background-terminals dropdown — this is the only surface for sessions
+ * launched outside the desktop (e.g. `superset workspaces create --agent …`
+ * from the CLI, which writes no pane layout of its own).
  *
- * One pass per workspace open, gated on pane-layout hydration (adopting
- * earlier would duplicate panes the persisted layout already has, or get
- * clobbered by it). Deliberately backgrounded sessions (marker set) are
- * skipped and never re-adopted mid-session.
+ * Gated on pane-layout hydration so the attached-pane check runs against the
+ * real layout, not an empty store. The adoption itself is idempotent —
+ * already-attached panes are filtered out and re-adoption just focuses the
+ * existing pane — so it reruns freely as the session list settles. That's
+ * what lets a session that lands slightly after open (a CLI race, a poll
+ * refresh) still get a pane, instead of being stranded by a one-shot pass
+ * that fired on a premature or empty list. Deliberately backgrounded sessions
+ * (marker set) are always skipped.
  */
 export function useAutoAdoptBackgroundSessions({
 	store,
 	workspaceId,
 	isLayoutReady,
 }: UseAutoAdoptBackgroundSessionsArgs): void {
-	const adoptedForWorkspaceIdRef = useRef<string | null>(null);
 	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
 		{ workspaceId },
 		{ enabled: isLayoutReady, refetchOnWindowFocus: false },
 	);
 	const sessions = sessionsQuery.data?.sessions;
-	// While a refetch is in flight, data may be a stale cached list from a
-	// previous open — don't let the one-shot pass latch on it.
+	// Don't act on a cached list still being refetched — it may name a session
+	// killed while the workspace was closed, which would adopt a ghost pane.
 	const isFetchingSessions = sessionsQuery.isFetching;
 
 	useEffect(() => {
 		if (!isLayoutReady || !sessions || isFetchingSessions) return;
-		if (adoptedForWorkspaceIdRef.current === workspaceId) return;
-		adoptedForWorkspaceIdRef.current = workspaceId;
 
 		const state = store.getState();
 		const marked = new Set(


### PR DESCRIPTION
## Problem

A running terminal agent launched outside the desktop — e.g. `superset workspaces create --local --agent <id> --prompt …` then `superset workspaces open <id>` from a Linear custom-script integration — shows as running in the sidebar but is stranded in the **Background terminal sessions** dropdown. Opening the workspace lands on the empty "Open Terminal" state, so it looks like no agent spawned. (Refs #5800.)

PR #5740 added an on-open pass that turns paneless running sessions into panes. This makes it fire reliably.

## Root cause

`useAutoAdoptBackgroundSessions` latched **one-shot per workspace** via `adoptedForWorkspaceIdRef`. On remount, React Query serves the **stale cached** `listSessions` while it refetches, and there is a render window where `data` is that stale list and `isFetching` hasn't yet flipped `true`. The latch fired on the stale list, missed the just-launched session, and never ran again — leaving the agent stranded in the background dropdown.

The `isFetchingSessions` guard added in follow-up couldn't close that window.

## Fix — remove the bad code

Drop the one-shot latch. Adoption is already idempotent and self-correcting:

- `getBackgroundTerminalSessions` filters sessions that already have a pane → no duplicates
- `focusOrAddTerminalPane` focuses an existing pane instead of adding a second → re-runs are no-ops
- so the effect can rerun freely as the session list settles and pick up a session that lands slightly after open

Safety preserved:
- deliberately **backgrounded** sessions stay in the `marked` set and are still skipped
- **normally-closed** panes kill their session (`usePaneRegistry.tsx`), so a closed terminal never reappears
- a fresh CLI-launched workspace has no tabs, so `restoreActiveTabId` is null and the adopted agent pane comes up **foreground** — exactly what #5800 asked for
- the in-flight-refetch guard is kept, now solely to avoid adopting a ghost pane from a stale cached list

Net: **−13 / +16** lines, one file.

## Testing

- `biome check` clean; `tsc --noEmit` clean (0 errors)
- ⚠️ **Not** verified end-to-end via CDP: no dev instance for this worktree is running (the only running desktop app belongs to a different worktree), and per the repo CDP rules I won't attach to another worktree's renderer. Happy to launch this worktree's stack and verify the CLI create→open flow before merge if wanted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reliably auto-adopts CLI-launched agent terminal sessions into panes on workspace open, so users land on the agent pane instead of "Open Terminal". Aligns with #5800’s requirement to foreground the adopted agent pane.

- **Bug Fixes**
  - Removed the one-shot latch in `useAutoAdoptBackgroundSessions` so adoption can rerun and pick up sessions that arrive after open.
  - Kept the refetch guard to avoid adopting ghost panes from a stale cached list.
  - Adoption is idempotent: existing panes are filtered, re-runs only focus; marked background sessions are skipped; closed panes terminate sessions so they don’t reappear.

<sup>Written for commit 47edd2ac281bdebee4d7da5bdc59011c286a1542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic adoption of background sessions as session data settles.
  * Prevented adoption while pane layout is still loading or session data is being refreshed.
  * Ensured sessions already marked or running in the background are skipped.
  * Removed the limitation that allowed adoption only once each time a workspace was opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->