### PR TITLE
docs(marketing): sharpen performance changelog copy

### DIFF
--- a/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
+++ b/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
@@ -3,9 +3,9 @@ title: "Performance: lighter memory and smoother under heavy load"
 date: 2026-07-19
 ---
 
-We spent the week on performance.
+We spent the week on performance: reducing memory consumption, smoothing out git hitches, and cutting background CPU.
 
-Every number below is a real before/after measurement, not an estimate.
+Every number below is a measured before/after, not an estimate.
 
 **TL;DR**
 
@@ -37,7 +37,7 @@ The test: 16 background terminals, each filled with about 5,000 lines.
 
 You set the limit in **Settings → Terminal → Background terminal memory** (default 12).
 
-Active terminals are never touched. Neither are running TUIs like vim or a coding agent. Hidden in-app browser tabs get the same treatment.
+Active terminals are never touched, and neither are running TUIs like vim or a coding agent. Hidden in-app browser tabs are offloaded the same way, and rebuilt when you switch back.
 
 ## Smoother While Git Churns in Big Repos <PRBadge url="https://github.com/superset-sh/superset/pull/5750" /> <PRBadge url="https://github.com/superset-sh/superset/pull/5746" />
 

--- a/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
+++ b/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
@@ -11,15 +11,19 @@ Every number below is a measured before/after, not an estimate.
 
 - **Less memory, fewer crashes.** Sessions with lots of terminals stay responsive and are far less likely to white-screen, even on 8 or 16 GB machines.
 
-  Renderer memory 1,127 → 838 MB (−26%), JS heap 581 → 286 MB (−51%), 4× fewer GPU contexts.
+  - Renderer memory 1,127 → 838 MB (−26%)
+  - JS heap 581 → 286 MB (−51%)
+  - 4× fewer GPU contexts
 
 - **No more hitching from git.** Switching branches or changing lots of files at once no longer stutters the app.
 
-  Worst-case stall on the UI thread 82.3 → 28.0 ms (3× smaller), typical 24.5 → 9.5 ms.
+  - Worst-case stall on the UI thread 82.3 → 28.0 ms (3× smaller)
+  - Typical stall 24.5 → 9.5 ms
 
 - **Quieter in the background.** Port detection uses far less CPU, so quieter fans and better battery, even with many terminals open.
 
-  Background scans 15 → 1 per cycle (15× fewer), idle terminals scan every 30s instead of every 2.5s (12× less).
+  - Background scans 15 → 1 per cycle (15× fewer)
+  - Idle terminals scan every 30s instead of every 2.5s (12× less)
 
 ## Lower Memory When You Keep Many Terminals Open <PRBadge url="https://github.com/superset-sh/superset/pull/5751" /> <PRBadge url="https://github.com/superset-sh/superset/pull/5754" />
 

--- a/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
+++ b/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
@@ -71,3 +71,7 @@ The test: the real scanner with 15 terminals registered, counting every `ps` spa
 ![Idle terminals scan every 30 seconds instead of every 2.5 seconds, 12 times less often](/changelog/2026-07-19-port-idle-cadence-ab.png)
 
 Idle terminals also slow down, from a scan every 2.5 seconds to every 30. They speed back up the moment they print output. So a machine full of quiet terminals nearly stops scanning.
+
+## More to come
+
+This is an ongoing effort. We want Superset to be the single workspace you need for engineering, and performance stays top of mind from here on.

--- a/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
+++ b/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
@@ -74,4 +74,4 @@ Idle terminals also slow down, from a scan every 2.5 seconds to every 30. They s
 
 ## More to come
 
-This is an ongoing effort. We want Superset to be the single workspace you need for engineering, and performance stays top of mind from here on.
+This is just the start. We're building Superset to be the single workspace you need for engineering: the fastest, most capable place to ship software. Speed is part of that craft, and we'll keep sharpening it with every release until working here feels effortless.

--- a/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
+++ b/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
@@ -10,18 +10,13 @@ Every number below is a measured before/after, not an estimate.
 **TL;DR**
 
 - **Less memory, fewer crashes.** Sessions with lots of terminals stay responsive and are far less likely to white-screen, even on 8 or 16 GB machines.
-
   - Renderer memory 1,127 → 838 MB (−26%)
   - JS heap 581 → 286 MB (−51%)
   - 4× fewer GPU contexts
-
 - **No more hitching from git.** Switching branches or changing lots of files at once no longer stutters the app.
-
   - Worst-case stall on the UI thread 82.3 → 28.0 ms (3× smaller)
   - Typical stall 24.5 → 9.5 ms
-
 - **Quieter in the background.** Port detection uses far less CPU, so quieter fans and better battery, even with many terminals open.
-
   - Background scans 15 → 1 per cycle (15× fewer)
   - Idle terminals scan every 30s instead of every 2.5s (12× less)
 

--- a/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
+++ b/apps/marketing/content/changelog/2026-07-19-performance-memory-and-load.mdx
@@ -74,4 +74,4 @@ Idle terminals also slow down, from a scan every 2.5 seconds to every 30. They s
 
 ## More to come
 
-This is just the start. We're building Superset to be the single workspace you need for engineering: the fastest, most capable place to ship software. Speed is part of that craft, and we'll keep sharpening it with every release until working here feels effortless.
+This is just the start. We want Superset to be the one workspace you need to build software, and being fast is a big part of that. We'll keep pushing on performance every release.


### PR DESCRIPTION
Two focused edits to the 2026-07-19 performance changelog entry.

## Opening line
Turned the flat intro into a tricolon that maps to the three sections:
> We spent the week on performance: reducing memory consumption, smoothing out git hitches, and cutting background CPU.

Also softened "a real before/after measurement" → "a measured before/after".

## Browser-tab note
"Get the same treatment" was ambiguous right after two "never touched" sentences (read like tabs were protected, when they're actually offloaded). Now explicit:
> Hidden in-app browser tabs are offloaded the same way, and rebuilt when you switch back.

No structural or data changes; tables and numbers untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the 2026-07-19 performance changelog for clarity.

Aligned the opener to the three sections, softened measurement wording, nested TL;DR metrics, clarified that hidden in‑app browser tabs are offloaded and rebuilt, and rewrote the closing note in Kiet’s voice to emphasize ongoing performance work; no tables or numbers changed.

<sup>Written for commit 372d7e16589202da0c836a5cd05f5375b88f3f14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog introduction and TL;DR to highlight three performance improvements: lower memory usage, smoother Git hitches, and reduced background CPU.
  * Revised the measurement wording to “measured before/after” and refreshed the before/after presentation for clarity.
  * Clarified that hidden in-app browser tabs are offloaded and rebuilt when you switch back.
  * Added a closing “More to come” section indicating the work is ongoing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->