### PR TITLE
feat(desktop): reinstate v2 changes refresh button next to tree/folder toggle

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -43,6 +43,7 @@ interface ChangesTabContentProps {
 	onOpenInEditor?: (path: string) => void;
 	onFilterChange: (filter: ChangesFilter) => void;
 	onViewModeChange: (viewMode: ChangesViewMode) => void;
+	onRefresh: () => void;
 	onBaseBranchChange: (branchName: string) => void;
 	onRenameBranch: (newName: string) => void;
 	canRenameBranch: boolean;
@@ -68,6 +69,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 	onOpenInEditor,
 	onFilterChange,
 	onViewModeChange,
+	onRefresh,
 	onBaseBranchChange,
 	onRenameBranch,
 	canRenameBranch,
@@ -131,6 +133,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 				isRefreshing={status.isFetching}
 				viewMode={viewMode}
 				onViewModeChange={onViewModeChange}
+				onRefresh={onRefresh}
 				collapsed={foldCollapsed}
 				onToggleFold={toggleFold}
 			/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesToolbar/ChangesToolbar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesToolbar/ChangesToolbar.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@superset/ui/button";
 import { Spinner } from "@superset/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { FoldVertical, UnfoldVertical } from "lucide-react";
+import { cn } from "@superset/ui/utils";
+import { FoldVertical, RefreshCw, UnfoldVertical } from "lucide-react";
 import type {
 	ChangesFilter,
 	ChangesViewMode,
@@ -21,6 +22,8 @@ interface ChangesToolbarProps {
 	isRefreshing: boolean;
 	viewMode: ChangesViewMode;
 	onViewModeChange: (next: ChangesViewMode) => void;
+	/** Re-fetch git status, diff, commits, and branches. */
+	onRefresh: () => void;
 	/** Whether the last fold action was "collapse all". */
 	collapsed: boolean;
 	/** Toggle between collapse-all and expand-all across every section. */
@@ -44,6 +47,7 @@ export function ChangesToolbar({
 	isRefreshing,
 	viewMode,
 	onViewModeChange,
+	onRefresh,
 	collapsed,
 	onToggleFold,
 }: ChangesToolbarProps) {
@@ -80,6 +84,23 @@ export function ChangesToolbar({
 			</div>
 			<div className="flex shrink-0 items-center gap-1">
 				<ViewModeToggle viewMode={viewMode} onChange={onViewModeChange} />
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="size-5 text-muted-foreground hover:text-foreground"
+							onClick={onRefresh}
+							disabled={isRefreshing}
+							aria-label="Refresh changes"
+						>
+							<RefreshCw
+								className={cn("size-3", isRefreshing && "animate-spin")}
+							/>
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">Refresh changes</TooltipContent>
+				</Tooltip>
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<Button

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -145,6 +145,23 @@ export function useChangesTab({
 	const totalAdditions = files.reduce((sum, f) => sum + f.additions, 0);
 	const totalDeletions = files.reduce((sum, f) => sum + f.deletions, 0);
 
+	const handleRefresh = useCallback(async () => {
+		try {
+			await Promise.all([
+				utils.git.getStatus.invalidate({ workspaceId }),
+				utils.git.getDiff.invalidate({ workspaceId }),
+				utils.git.listCommits.invalidate({ workspaceId }),
+				utils.git.listBranches.invalidate({ workspaceId }),
+				utils.git.getBaseBranch.invalidate({ workspaceId }),
+			]);
+		} catch (error) {
+			console.warn("Failed to refresh changes tab", error);
+			toast.error(
+				error instanceof Error ? error.message : "Failed to refresh changes",
+			);
+		}
+	}, [utils, workspaceId]);
+
 	const content = (
 		<ChangesTabContent
 			workspaceId={workspaceId}
@@ -166,6 +183,7 @@ export function useChangesTab({
 			onOpenInEditor={handleOpenInEditor}
 			onFilterChange={setFilter}
 			onViewModeChange={setViewMode}
+			onRefresh={handleRefresh}
 			onBaseBranchChange={setBaseBranch}
 			onRenameBranch={handleRenameBranch}
 			canRenameBranch={canRenameBranch}


### PR DESCRIPTION
## What

Reinstates the refresh button for v2 changes, this time placed inside the changes toolbar right next to the folders/tree (`ViewModeToggle`) button instead of the sidebar header where it previously lived (removed in #5703).

## Changes

- **`useChangesTab.tsx`** — reinstated `handleRefresh` (invalidates git status/diff/commits/branches/base-branch, toast-on-error), passed down as `onRefresh`.
- **`ChangesTabContent.tsx`** — threads `onRefresh` through to the toolbar.
- **`ChangesToolbar.tsx`** — renders a `RefreshCw` ghost icon button immediately after the tree/folder toggle, spinning + disabled while `isRefreshing` (wired to `status.isFetching`), with a "Refresh changes" tooltip.

Toolbar right-group order is now: folders | tree | refresh | collapse/expand.

## Verification

- `bun run lint` clean
- desktop `typecheck` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reinstates the "Refresh changes" button in the v2 Changes tab, placed in the toolbar next to the folder/tree toggle. It invalidates git status, diff, commits, branches, and base branch; shows a spinning icon and disables while fetching; and sits after the view toggle before collapse/expand.

<sup>Written for commit 4fb527030c69c62eb45a7f2bef95a12fbfc23c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refresh button to the Changes tab toolbar.
  * Refreshing now updates status, diffs, commits, branches, and base branch information.
  * The refresh control is disabled and displays a loading animation while updates are in progress.
* **Bug Fixes**
  * Added error feedback when refreshing changes fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->