### PR TITLE
feat(desktop): keep agent + ports strip expanded for the active workspace

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -8,12 +8,18 @@
 
 /*
  * Active when the sidebar workspace activity strip should show its expanded
- * (pill) state: the workspace item (`group/item`) is hovered or keyboard
- * focused, or one of the strip's own dropdown menus (`group/details` scope)
- * is open so it can't collapse under the pointer.
+ * (pill) state: the workspace item (`group/item`) is hovered, keyboard
+ * focused, or the active workspace (`data-active`), or one of the strip's own
+ * dropdown menus (`group/details` scope) is open so it can't collapse under
+ * the pointer.
  */
 @custom-variant details-expanded (&:is(
-		:where(.group\/item:hover, .group\/item:focus-within) *,
+		:where(
+				.group\/item:hover,
+				.group\/item:focus-within,
+				.group\/item[data-active]
+			)
+			*,
 		.group\/details:has([data-state="open"]) *
 	));
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -211,7 +211,9 @@ export function DashboardSidebarWorkspaceItem({
 			onMouseEnter={handleMouseEnter}
 			onMouseLeave={handleMouseLeave}
 			// Hover/focus scope for the details strip below the row: it swaps its
-			// summary cluster for the full badges while the item is hovered.
+			// summary cluster for the full badges while the item is hovered, or
+			// while this is the active workspace.
+			data-active={isActive || undefined}
 			className="group/item"
 		>
 			<DashboardSidebarExpandedWorkspaceRow


### PR DESCRIPTION
## What

The sidebar workspace activity strip (agent badges + individual port pills) previously only expanded on hover/focus. Now it also stays expanded whenever the workspace is the **active** one (route-matched), so you can always see the agents and ports for the workspace you're currently in.

## How

- **`DashboardSidebarWorkspaceItem.tsx`** — add `data-active={isActive || undefined}` to the `group/item` row wrapper. `isActive` is already derived from route matching (`/v2-workspace/$workspaceId`), so this reuses the existing signal.
- **`globals.css`** — extend the `details-expanded` custom Tailwind variant to also match `.group\/item[data-active]`, alongside the existing `:hover` / `:focus-within` / open-menu triggers. Since the whole expansion is driven by this one variant, every consumer (agent badges, port pills, collapsing summary cluster) picks it up automatically.

## Behavior

The active workspace shows the full agent + port pills at rest; hovering any other workspace still expands it transiently, and the active one stays expanded whether hovered or not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the sidebar’s agent and port strip expanded for the active workspace, so the current workspace’s agents and ports are always visible. Other workspaces still expand on hover or focus.

- **New Features**
  - Add `data-active` to the `DashboardSidebarWorkspaceItem` row using existing `isActive` route match.
  - Extend the `details-expanded` Tailwind variant to include `.group/item[data-active]` in addition to hover, focus, and open menu states.

<sup>Written for commit b2c6329fa175bdd4d28d98001f7dffbb7373f791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace items in the dashboard sidebar now remain expanded when the workspace is active.
  - Active workspace styling and behavior are preserved alongside hover and focus interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->