### PR TITLE
fix(host-service): apply prompt-command suffix so Kimi launches interactively

### DIFF
--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -23,6 +23,17 @@ const stdinConfig = {
 	env: {},
 };
 
+const kimiConfig = {
+	id: "00000000-0000-0000-0000-000000000003",
+	presetId: "kimi",
+	label: "Kimi Code",
+	command: "kimi",
+	args: [],
+	promptTransport: "argv" as const,
+	promptArgs: ["-p"],
+	env: {},
+};
+
 const RANDOM_ID = "test-1234";
 const DELIMITER = "SUPERSET_PROMPT_test1234";
 
@@ -88,6 +99,21 @@ describe("buildAgentCommandString", () => {
 		);
 		expect(buildAgentCommandString(stdinConfig, "", [], RANDOM_ID)).toBe(
 			"'amp'",
+		);
+	});
+
+	it("appends the interactive-resume suffix after the prompt (kimi)", () => {
+		// kimi -p is non-interactive; the suffix re-enters the TUI so the pane
+		// stays interactive after the headless prompt turn.
+		expect(
+			buildAgentCommandString(kimiConfig, "do the thing", [], RANDOM_ID),
+		).toBe("'kimi' '-p' 'do the thing' ; kimi --auto --continue");
+	});
+
+	it("omits the resume suffix on a promptless launch (kimi)", () => {
+		// The base command is already interactive without a prompt.
+		expect(buildAgentCommandString(kimiConfig, "", [], RANDOM_ID)).toBe(
+			"'kimi'",
 		);
 	});
 });

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { getAgentPromptSuffix } from "@superset/shared/agent-command";
 import {
 	buildAgentEffortArgs,
 	buildAgentModelArgs,
@@ -129,14 +130,26 @@ export function buildAgentCommandString(
 		return buildArgvCommand(baseArgv);
 	}
 
+	// Interactive-resume suffix for CLIs that can't seed a prompt into their
+	// TUI (kimi, mastracode): the prompt runs headlessly, then this re-enters
+	// the TUI. Empty-prompt launches skip it — the base command is already
+	// interactive.
+	const suffix = getAgentPromptSuffix(config.presetId);
+
 	if (config.promptTransport === "argv") {
 		// Plain quoted positional, not the shared "$(cat <<…)" form: the command
 		// is typed into the user's configured shell, and fish has no heredocs.
-		return buildArgvCommand([...baseArgv, ...config.promptArgs, prompt]);
+		const command = buildArgvCommand([
+			...baseArgv,
+			...config.promptArgs,
+			prompt,
+		]);
+		return suffix ? `${command} ${suffix}` : command;
 	}
 
 	return buildPromptCommandString({
 		command: buildArgvCommand([...baseArgv, ...config.promptArgs]),
+		suffix,
 		transport: "stdin",
 		prompt,
 		randomId,

--- a/packages/shared/src/agent-command.ts
+++ b/packages/shared/src/agent-command.ts
@@ -69,6 +69,20 @@ function getAgentPromptCommandDefaults(
 	return promptCommand;
 }
 
+/**
+ * The interactive-resume suffix for a preset, if any. Some CLIs (kimi,
+ * mastracode) have no way to seed a prompt into their TUI, so a prompt launch
+ * runs the prompt headlessly and then re-enters the TUI via this suffix (e.g.
+ * `; kimi --auto --continue`). Keyed by preset id so the host launch path can
+ * append it after the prompt command, mirroring the per-preset model/effort
+ * arg hooks. Returns undefined for unknown/custom presets.
+ */
+export function getAgentPromptSuffix(presetId: string): string | undefined {
+	const defaults: AgentPromptCommandDefaults | undefined =
+		AGENT_PROMPT_COMMANDS[presetId as AgentType];
+	return defaults?.suffix;
+}
+
 export function buildAgentFileCommand({
 	filePath,
 	agent = "claude",


### PR DESCRIPTION
## Problem

A V2 Kimi **task launch** ran headlessly and exited instead of dropping into an interactive TUI.

The live V2 launch path (`buildLaunchSpec` → host `runTerminalAgent` → `buildAgentCommandString`) builds the agent command from `command` / `args` / `promptArgs` only. It never applied `promptCommandSuffix`. Agents whose prompt flag is non-interactive and that have no way to seed a prompt into their TUI (Kimi, Mastracode) depend on that suffix to run the prompt headlessly and then re-enter the TUI:

```
kimi -p '<prompt>' ; kimi --auto --continue
```

Without the suffix, a Kimi task launch resolved to just `kimi -p '<prompt>'` — explicitly non-interactive ("Run one prompt non-interactively and print the response") — so the pane printed and exited. The suffix only survived in the legacy/V1 `agent-settings` command path (`buildPromptCommandFromAgentConfig`), not in the V2 host path.

## Fix

Thread the suffix through the **same per-preset code hook** already used for model/effort args (`buildAgentModelArgs` / `buildAgentEffortArgs`), so no DB column, schema, or UI change is needed:

- `packages/shared/src/agent-command.ts` — add `getAgentPromptSuffix(presetId)`, sourcing the existing `promptCommandSuffix` from the builtin agent definition (single source of truth).
- `packages/host-service/.../agents.ts` — `buildAgentCommandString` appends the suffix after the prompt (argv transport) / passes it to `buildPromptCommandString` (stdin transport). Promptless launches skip it, since the base command is already interactive.

Result: `'kimi' '-p' '<prompt>' ; kimi --auto --continue`. Also fixes Mastracode, the other suffix-based agent.

## Verification

- `buildAgentCommandString` with a Kimi config now emits the resume suffix; promptless launch stays `'kimi'`.
- Ran the generated command in a real PTY — it reaches the interactive Kimi TUI (input box, `auto` mode status bar, bracketed-paste + kitty-keyboard input enabled).
- Confirmed from the Kimi binary that print mode and interactive mode share `createSession` + `session_index` persistence (print mode only changes `loopControl` defaults), so a successful `kimi -p` writes a per-workdir session that `--continue` resumes.
- Typecheck + lint clean; added tests for the argv suffix and the promptless-skip case, and mutation-checked that the new test fails without the wiring.

## Not yet tested end-to-end
A fully authenticated run wasn't possible on this machine (Kimi has no model configured / not logged in, so `kimi -p` aborts before creating a session). To be validated after `kimi` `/login`.

## Known caveat
The first turn always runs headless before the TUI paints — inherent to `-p` + `--continue`, since Kimi's CLI has no flag to seed a prompt directly into its TUI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kimi task launches so they stay in the interactive TUI after running the initial prompt. Also applies to Mastracode.

- Bug Fixes
  - Append the per-preset prompt resume suffix after the prompt in `buildAgentCommandString` (argv) and pass it through for stdin; skip when no prompt (e.g., "kimi -p '<prompt>' ; kimi --auto --continue").
  - Added `getAgentPromptSuffix(presetId)` in `@superset/shared/agent-command`, sourced from the builtin agent definition (no schema/UI changes).
  - Tests cover Kimi suffix append and the promptless skip case.

<sup>Written for commit 1f29a9d720d6aa8f49a9dfe10f44c8fbaf1fcca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved agent launch commands to support interactive prompt resumption for compatible presets.
  * Prompt resumption is applied when launching with an initial prompt and omitted for promptless launches.

* **Bug Fixes**
  * Improved handling of prompt delivery across supported launch methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->