### PR TITLE
feat(desktop): headless v1→v2 migrator core + first migration-ledger writers

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/migration/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/migration/index.ts
@@ -1,7 +1,21 @@
-import { projects, workspaces, worktrees } from "@superset/local-db";
-import { isNotNull, isNull } from "drizzle-orm";
+import {
+	projects,
+	v1MigrationState,
+	workspaces,
+	worktrees,
+} from "@superset/local-db";
+import { eq, isNotNull, isNull } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
+import { z } from "zod";
 import { publicProcedure, router } from "../..";
+
+const ledgerEntrySchema = z.object({
+	v1Id: z.string().min(1),
+	kind: z.enum(["project", "workspace", "preset", "settings", "terminal"]),
+	status: z.enum(["success", "linked", "error", "skipped"]),
+	v2Id: z.string().nullish(),
+	reason: z.string().nullish(),
+});
 
 export const createMigrationRouter = () => {
 	return router({
@@ -27,5 +41,51 @@ export const createMigrationRouter = () => {
 		readV1Worktrees: publicProcedure.query(() => {
 			return localDb.select().from(worktrees).all();
 		}),
+
+		ledgerList: publicProcedure
+			.input(z.object({ organizationId: z.string().min(1) }))
+			.query(({ input }) => {
+				return localDb
+					.select()
+					.from(v1MigrationState)
+					.where(eq(v1MigrationState.organizationId, input.organizationId))
+					.all();
+			}),
+
+		ledgerRecord: publicProcedure
+			.input(
+				z.object({
+					organizationId: z.string().min(1),
+					entries: z.array(ledgerEntrySchema).min(1),
+				}),
+			)
+			.mutation(({ input }) => {
+				for (const entry of input.entries) {
+					localDb
+						.insert(v1MigrationState)
+						.values({
+							organizationId: input.organizationId,
+							v1Id: entry.v1Id,
+							kind: entry.kind,
+							status: entry.status,
+							v2Id: entry.v2Id ?? null,
+							reason: entry.reason ?? null,
+						})
+						.onConflictDoUpdate({
+							target: [
+								v1MigrationState.organizationId,
+								v1MigrationState.v1Id,
+								v1MigrationState.kind,
+							],
+							set: {
+								status: entry.status,
+								v2Id: entry.v2Id ?? null,
+								reason: entry.reason ?? null,
+								migratedAt: Date.now(),
+							},
+						})
+						.run();
+				}
+			}),
 	});
 };

--- a/apps/desktop/src/renderer/lib/v1-migration/index.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/index.ts
@@ -1,0 +1,38 @@
+export {
+	isTerminalStatus,
+	ledgerKey,
+	loadV1MigrationLedger,
+	recordV1MigrationOutcome,
+	recordV1MigrationOutcomes,
+	type V1LedgerOutcome,
+} from "./ledger";
+export {
+	type AgentConfigLike,
+	buildV2TerminalPresetRow,
+	type ResolvedPresetImport,
+	resolvePresetImport,
+	type V2PresetLike,
+} from "./presets";
+export {
+	decideProjectImport,
+	expectedRemoteUrlFor,
+	extractExistingPath,
+	findProjectByPath,
+	importV1Project,
+	isAlreadySetUpElsewhereError,
+	isProjectAlreadyImported,
+	type ProjectFindByPathResult,
+	type ProjectImportOutcome,
+	type V1ProjectLike,
+} from "./projects";
+export {
+	type RunV1MigrationDeps,
+	runV1Migration,
+	type V1MigrationSummary,
+} from "./runV1Migration";
+export {
+	type AdoptPlanEntry,
+	adoptV1Workspace,
+	planWorkspaceAdoptions,
+	type WorkspacePlan,
+} from "./workspaces";

--- a/apps/desktop/src/renderer/lib/v1-migration/ledger.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/ledger.ts
@@ -1,0 +1,61 @@
+import type { V1MigrationKind, V1MigrationStatus } from "@superset/local-db";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+
+export interface V1LedgerOutcome {
+	v1Id: string;
+	kind: V1MigrationKind;
+	status: V1MigrationStatus;
+	v2Id?: string | null;
+	reason?: string | null;
+}
+
+export type V1LedgerMap = Map<
+	string,
+	{ status: V1MigrationStatus; v2Id: string | null }
+>;
+
+export function ledgerKey(kind: V1MigrationKind, v1Id: string): string {
+	return `${kind}\0${v1Id}`;
+}
+
+/** An entity is done when it migrated or linked; error/skipped retry next run. */
+export function isTerminalStatus(status: V1MigrationStatus): boolean {
+	return status === "success" || status === "linked";
+}
+
+export async function loadV1MigrationLedger(
+	organizationId: string,
+): Promise<V1LedgerMap> {
+	const rows = await electronTrpcClient.migration.ledgerList.query({
+		organizationId,
+	});
+	const map: V1LedgerMap = new Map();
+	for (const row of rows) {
+		map.set(ledgerKey(row.kind, row.v1Id), {
+			status: row.status,
+			v2Id: row.v2Id,
+		});
+	}
+	return map;
+}
+
+export async function recordV1MigrationOutcomes(
+	organizationId: string,
+	entries: V1LedgerOutcome[],
+): Promise<void> {
+	if (entries.length === 0) return;
+	await electronTrpcClient.migration.ledgerRecord.mutate({
+		organizationId,
+		entries,
+	});
+}
+
+/** Fire-and-forget variant for UI call sites — the ledger is advisory there. */
+export function recordV1MigrationOutcome(
+	organizationId: string,
+	entry: V1LedgerOutcome,
+): void {
+	void recordV1MigrationOutcomes(organizationId, [entry]).catch((err) => {
+		console.error("[v1-migration] ledger record failed", { entry, err });
+	});
+}

--- a/apps/desktop/src/renderer/lib/v1-migration/presets.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/presets.ts
@@ -1,0 +1,83 @@
+import type { TerminalPreset } from "@superset/local-db";
+import {
+	AGENT_LABELS,
+	AGENT_TYPES,
+	type AgentType,
+} from "@superset/shared/agent-command";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+
+const BUILTIN_AGENT_IDS = new Set<string>(AGENT_TYPES);
+
+export interface AgentConfigLike {
+	id: string;
+	presetId: string;
+}
+
+export interface V2PresetLike {
+	name: string;
+	agentId?: string | null;
+}
+
+export interface ResolvedPresetImport {
+	v2Name: string;
+	linkedAgentId: string | undefined;
+	/** Keep-v2 collision policy: an existing v2 preset by agentId/name wins. */
+	alreadyImported: boolean;
+}
+
+export function resolvePresetImport(
+	preset: Pick<TerminalPreset, "name">,
+	agents: AgentConfigLike[],
+	v2Presets: V2PresetLike[],
+): ResolvedPresetImport {
+	const importedAgentIds = new Set(
+		v2Presets.flatMap((p) => (p.agentId ? [p.agentId] : [])),
+	);
+	const importedNames = new Set(
+		v2Presets.flatMap((p) => (p.agentId ? [] : [p.name])),
+	);
+
+	const agentConfigIdByPresetId = new Map<AgentType, string>();
+	for (const agent of agents) {
+		if (!BUILTIN_AGENT_IDS.has(agent.presetId)) continue;
+		const presetId = agent.presetId as AgentType;
+		if (agentConfigIdByPresetId.has(presetId)) continue;
+		agentConfigIdByPresetId.set(presetId, agent.id);
+	}
+
+	const builtInAgentId = BUILTIN_AGENT_IDS.has(preset.name)
+		? (preset.name as AgentType)
+		: undefined;
+	const linkedAgentId = builtInAgentId
+		? (agentConfigIdByPresetId.get(builtInAgentId) ?? builtInAgentId)
+		: undefined;
+	const v2Name = builtInAgentId ? AGENT_LABELS[builtInAgentId] : preset.name;
+	const alreadyImported = linkedAgentId
+		? importedAgentIds.has(linkedAgentId) ||
+			(!!builtInAgentId && importedAgentIds.has(builtInAgentId))
+		: importedNames.has(v2Name);
+
+	return { v2Name, linkedAgentId, alreadyImported };
+}
+
+export function buildV2TerminalPresetRow(
+	preset: TerminalPreset,
+	tabOrder: number,
+	resolved: Pick<ResolvedPresetImport, "v2Name" | "linkedAgentId">,
+): V2TerminalPresetRow {
+	return {
+		id: crypto.randomUUID(),
+		name: resolved.v2Name,
+		description: preset.description,
+		cwd: preset.cwd,
+		commands: preset.commands,
+		projectIds: preset.projectIds ?? null,
+		pinnedToBar: preset.pinnedToBar,
+		applyOnWorkspaceCreated: preset.applyOnWorkspaceCreated,
+		applyOnNewTab: preset.applyOnNewTab,
+		executionMode: preset.executionMode ?? "new-tab",
+		tabOrder,
+		createdAt: new Date(),
+		agentId: resolved.linkedAgentId,
+	};
+}

--- a/apps/desktop/src/renderer/lib/v1-migration/projects.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/projects.ts
@@ -1,0 +1,157 @@
+import type { HostServiceClient } from "renderer/lib/host-service-client";
+import { getBaseName } from "renderer/lib/pathBasename";
+
+export interface V1ProjectLike {
+	id: string;
+	name: string;
+	mainRepoPath: string;
+	githubOwner: string | null;
+}
+
+export type ProjectFindByPathResult = Awaited<
+	ReturnType<HostServiceClient["project"]["findByPath"]["query"]>
+>;
+
+export type ProjectImportOutcome =
+	| {
+			kind: "imported";
+			v2ProjectId: string;
+			mainWorkspaceId: string | null;
+			repoPath: string;
+	  }
+	| { kind: "needs-relocate"; v2ProjectId: string; message: string };
+
+export type ProjectImportDecision =
+	| { kind: "already-imported"; v2ProjectId: string }
+	| { kind: "import" }
+	| { kind: "skip"; reason: "multiple-candidates" | "cloud-unreachable" };
+
+/**
+ * Decide what to do with a v1 project from its findByPath result. Mirrors
+ * the wizard's "Import all" rules: a `local-path` candidate means the repo
+ * is already a v2 project on this host; multiple cloud candidates need a
+ * human to pick; cloud errors with no candidate mean we can't tell whether
+ * a legacy cloud project exists, so don't risk creating a duplicate.
+ */
+export function decideProjectImport(
+	result: Pick<ProjectFindByPathResult, "candidates" | "cloudErrors">,
+): ProjectImportDecision {
+	const local = result.candidates.find((c) => c.source === "local-path");
+	if (local) return { kind: "already-imported", v2ProjectId: local.id };
+	if (result.candidates.length > 1) {
+		return { kind: "skip", reason: "multiple-candidates" };
+	}
+	if (result.candidates.length === 0 && result.cloudErrors.length > 0) {
+		return { kind: "skip", reason: "cloud-unreachable" };
+	}
+	return { kind: "import" };
+}
+
+export function isProjectAlreadyImported(
+	findByPathResult: ProjectFindByPathResult | undefined,
+): boolean {
+	return !!findByPathResult?.candidates.find((c) => c.source === "local-path");
+}
+
+export function expectedRemoteUrlFor(
+	project: Pick<V1ProjectLike, "mainRepoPath" | "githubOwner">,
+): string | undefined {
+	if (!project.githubOwner) return undefined;
+	const repoName = getBaseName(project.mainRepoPath);
+	if (!repoName) return undefined;
+	return `https://github.com/${project.githubOwner}/${repoName}`;
+}
+
+export function findProjectByPath(
+	hostClient: HostServiceClient,
+	project: V1ProjectLike,
+): Promise<ProjectFindByPathResult> {
+	return hostClient.project.findByPath.query({
+		repoPath: project.mainRepoPath,
+		walkAllRemotes: true,
+		expectedRemoteUrl: expectedRemoteUrlFor(project),
+	});
+}
+
+export function isAlreadySetUpElsewhereError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	return err.message.includes("Project is already set up on this device at");
+}
+
+export function extractExistingPath(message: string): string | null {
+	const match = message.match(
+		/already set up on this device at (.+?)\.\s+Remove/,
+	);
+	return match?.[1] ?? null;
+}
+
+/**
+ * Import one v1 project into v2: link it onto an existing v2 project
+ * candidate via `project.setup`, or create a fresh local-first project via
+ * `project.create {kind:'importLocal'}`. Pure host-service calls — UI side
+ * effects (sidebar, query invalidation) are the caller's job.
+ */
+export async function importV1Project({
+	hostClient,
+	project,
+	findByPathResult,
+	linkToProjectId,
+	allowRelocate = false,
+}: {
+	hostClient: HostServiceClient;
+	project: V1ProjectLike;
+	findByPathResult: ProjectFindByPathResult | undefined;
+	linkToProjectId?: string;
+	allowRelocate?: boolean;
+}): Promise<ProjectImportOutcome> {
+	const candidates = findByPathResult?.candidates ?? [];
+
+	const targetCandidate = linkToProjectId
+		? candidates.find((c) => c.id === linkToProjectId)
+		: candidates[0];
+
+	if (linkToProjectId && !targetCandidate) {
+		throw new Error(
+			"Selected v2 project is no longer in the candidate list. Refresh and pick again.",
+		);
+	}
+
+	if (targetCandidate) {
+		try {
+			const result = await hostClient.project.setup.mutate({
+				projectId: targetCandidate.id,
+				mode: {
+					kind: "import",
+					repoPath: project.mainRepoPath,
+					allowRelocate,
+				},
+			});
+			return {
+				kind: "imported",
+				v2ProjectId: targetCandidate.id,
+				mainWorkspaceId: result.mainWorkspaceId,
+				repoPath: result.repoPath,
+			};
+		} catch (err) {
+			if (isAlreadySetUpElsewhereError(err) && !allowRelocate) {
+				return {
+					kind: "needs-relocate",
+					v2ProjectId: targetCandidate.id,
+					message: err instanceof Error ? err.message : String(err),
+				};
+			}
+			throw err;
+		}
+	}
+
+	const result = await hostClient.project.create.mutate({
+		name: project.name,
+		mode: { kind: "importLocal", repoPath: project.mainRepoPath },
+	});
+	return {
+		kind: "imported",
+		v2ProjectId: result.projectId,
+		mainWorkspaceId: result.mainWorkspaceId,
+		repoPath: result.repoPath,
+	};
+}

--- a/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.ts
@@ -85,12 +85,32 @@ export async function runV1Migration(
 	const { organizationId } = deps;
 	const ledger = await loadV1MigrationLedger(organizationId);
 	const outcomes: V1LedgerOutcome[] = [];
+	// Flush between stages (and on failure) so a throw in a later stage
+	// can't discard outcomes for host mutations that already committed.
+	const flush = async () => {
+		const batch = outcomes.splice(0);
+		try {
+			await recordV1MigrationOutcomes(organizationId, batch);
+		} catch (err) {
+			outcomes.unshift(...batch);
+			throw err;
+		}
+	};
 
-	const projects = await migrateProjects(deps, ledger, outcomes);
-	const workspaces = await migrateWorkspaces(deps, ledger, outcomes);
-	const presets = await migratePresets(deps, ledger, outcomes);
-
-	await recordV1MigrationOutcomes(organizationId, outcomes);
+	let projects = emptySummary();
+	let workspaces = emptySummary();
+	let presets = emptySummary();
+	try {
+		projects = await migrateProjects(deps, ledger, outcomes);
+		await flush();
+		workspaces = await migrateWorkspaces(deps, ledger, outcomes);
+		await flush();
+		presets = await migratePresets(deps, ledger, outcomes);
+	} finally {
+		await flush().catch((err) => {
+			console.error("[v1-migration] ledger flush failed", err);
+		});
+	}
 
 	const gateComplete =
 		projects.failed + projects.skipped + projects.deferred === 0 &&
@@ -167,7 +187,16 @@ async function migrateProjects(
 				status: "success",
 				v2Id: result.v2ProjectId,
 			});
-			deps.onProjectImported?.(result);
+			// The host mutation committed — a UI callback failure must not
+			// overwrite the success outcome with an error.
+			try {
+				deps.onProjectImported?.(result);
+			} catch (err) {
+				console.error("[v1-migration] onProjectImported callback failed", {
+					v1ProjectId: project.id,
+					err,
+				});
+			}
 		} catch (err) {
 			summary.failed++;
 			pushOutcome(ledger, outcomes, {
@@ -285,7 +314,14 @@ async function migrateWorkspaces(
 				status: "success",
 				v2Id: result.workspace.id,
 			});
-			deps.onWorkspaceAdopted?.(result.workspace.id, entry.v2ProjectId);
+			try {
+				deps.onWorkspaceAdopted?.(result.workspace.id, entry.v2ProjectId);
+			} catch (err) {
+				console.error("[v1-migration] onWorkspaceAdopted callback failed", {
+					v1WorkspaceId: entry.v1WorkspaceId,
+					err,
+				});
+			}
 		} catch (err) {
 			summary.failed++;
 			pushOutcome(ledger, outcomes, {

--- a/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.ts
@@ -1,0 +1,368 @@
+import type { HostServiceClient } from "renderer/lib/host-service-client";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import {
+	isTerminalStatus,
+	ledgerKey,
+	loadV1MigrationLedger,
+	recordV1MigrationOutcomes,
+	type V1LedgerMap,
+	type V1LedgerOutcome,
+} from "./ledger";
+import {
+	type AgentConfigLike,
+	buildV2TerminalPresetRow,
+	resolvePresetImport,
+	type V2PresetLike,
+} from "./presets";
+import {
+	decideProjectImport,
+	findProjectByPath,
+	importV1Project,
+} from "./projects";
+import {
+	adoptV1Workspace,
+	planWorkspaceAdoptions,
+	type V1WorktreeLike,
+} from "./workspaces";
+
+export interface KindSummary {
+	migrated: number;
+	linked: number;
+	skipped: number;
+	failed: number;
+	/** Entities we deliberately left for a later run (e.g. project not yet imported). */
+	deferred: number;
+}
+
+export interface V1MigrationSummary {
+	projects: KindSummary;
+	workspaces: KindSummary;
+	presets: KindSummary;
+	/** D4 flip gate: every v1 project and workspace is success/linked in the ledger. */
+	gateComplete: boolean;
+}
+
+export interface RunV1MigrationDeps {
+	organizationId: string;
+	hostClient: HostServiceClient;
+	/**
+	 * Preset targets live in renderer-only TanStack collections, so the
+	 * caller supplies reads/writes. Omit to skip the preset step (it never
+	 * gates the flip).
+	 */
+	presetTarget?: {
+		agents: AgentConfigLike[];
+		existing: V2PresetLike[];
+		insert: (row: V2TerminalPresetRow) => void;
+	};
+	onProjectImported?: (result: {
+		v2ProjectId: string;
+		mainWorkspaceId: string | null;
+		repoPath: string;
+	}) => void;
+	onWorkspaceAdopted?: (v2WorkspaceId: string, v2ProjectId: string) => void;
+}
+
+function emptySummary(): KindSummary {
+	return { migrated: 0, linked: 0, skipped: 0, failed: 0, deferred: 0 };
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Headless v1→v2 migration pass: projects → workspaces → presets, every
+ * outcome recorded in the v1_migration_state ledger. Idempotent — ledger
+ * rows with success/linked are skipped, and the underlying host calls
+ * (findByPath, adopt) re-derive existing state rather than duplicating.
+ * Safe to run on every boot while the user is still on v1.
+ */
+export async function runV1Migration(
+	deps: RunV1MigrationDeps,
+): Promise<V1MigrationSummary> {
+	const { organizationId } = deps;
+	const ledger = await loadV1MigrationLedger(organizationId);
+	const outcomes: V1LedgerOutcome[] = [];
+
+	const projects = await migrateProjects(deps, ledger, outcomes);
+	const workspaces = await migrateWorkspaces(deps, ledger, outcomes);
+	const presets = await migratePresets(deps, ledger, outcomes);
+
+	await recordV1MigrationOutcomes(organizationId, outcomes);
+
+	const gateComplete =
+		projects.failed + projects.skipped + projects.deferred === 0 &&
+		workspaces.failed + workspaces.skipped + workspaces.deferred === 0;
+
+	return { projects, workspaces, presets, gateComplete };
+}
+
+async function migrateProjects(
+	deps: RunV1MigrationDeps,
+	ledger: V1LedgerMap,
+	outcomes: V1LedgerOutcome[],
+): Promise<KindSummary> {
+	const summary = emptySummary();
+	const v1Projects = await electronTrpcClient.migration.readV1Projects.query();
+
+	for (const project of v1Projects) {
+		const existing = ledger.get(ledgerKey("project", project.id));
+		if (existing && isTerminalStatus(existing.status)) continue;
+
+		try {
+			const findByPathResult = await findProjectByPath(deps.hostClient, {
+				id: project.id,
+				name: project.name,
+				mainRepoPath: project.mainRepoPath,
+				githubOwner: project.githubOwner,
+			});
+			const decision = decideProjectImport(findByPathResult);
+
+			if (decision.kind === "already-imported") {
+				summary.linked++;
+				pushOutcome(ledger, outcomes, {
+					v1Id: project.id,
+					kind: "project",
+					status: "linked",
+					v2Id: decision.v2ProjectId,
+				});
+				continue;
+			}
+
+			if (decision.kind === "skip") {
+				summary.skipped++;
+				pushOutcome(ledger, outcomes, {
+					v1Id: project.id,
+					kind: "project",
+					status: "skipped",
+					reason: decision.reason,
+				});
+				continue;
+			}
+
+			const result = await importV1Project({
+				hostClient: deps.hostClient,
+				project,
+				findByPathResult,
+			});
+
+			if (result.kind === "needs-relocate") {
+				summary.skipped++;
+				pushOutcome(ledger, outcomes, {
+					v1Id: project.id,
+					kind: "project",
+					status: "skipped",
+					v2Id: result.v2ProjectId,
+					reason: "needs-relocate",
+				});
+				continue;
+			}
+
+			summary.migrated++;
+			pushOutcome(ledger, outcomes, {
+				v1Id: project.id,
+				kind: "project",
+				status: "success",
+				v2Id: result.v2ProjectId,
+			});
+			deps.onProjectImported?.(result);
+		} catch (err) {
+			summary.failed++;
+			pushOutcome(ledger, outcomes, {
+				v1Id: project.id,
+				kind: "project",
+				status: "error",
+				reason: errorMessage(err),
+			});
+		}
+	}
+
+	return summary;
+}
+
+async function migrateWorkspaces(
+	deps: RunV1MigrationDeps,
+	ledger: V1LedgerMap,
+	outcomes: V1LedgerOutcome[],
+): Promise<KindSummary> {
+	const summary = emptySummary();
+	const [v1Projects, v1Workspaces, v1Worktrees, hostProjects, hostWorkspaces] =
+		await Promise.all([
+			electronTrpcClient.migration.readV1Projects.query(),
+			electronTrpcClient.migration.readV1Workspaces.query(),
+			electronTrpcClient.migration.readV1Worktrees.query(),
+			deps.hostClient.project.list.query(),
+			deps.hostClient.workspace.list.query(),
+		]);
+
+	// v1 project → v2 project via the ledger first (authoritative mapping
+	// written by the project step), falling back to repo-path equality.
+	const v2ProjectIdByV1ProjectId = new Map<string, string>();
+	const v2ByRepoPath = new Map<string, string>();
+	for (const p of hostProjects) {
+		if (!v2ByRepoPath.has(p.repoPath)) v2ByRepoPath.set(p.repoPath, p.id);
+	}
+	for (const v1 of v1Projects) {
+		const fromLedger = ledger.get(ledgerKey("project", v1.id));
+		const v2Id =
+			(fromLedger && isTerminalStatus(fromLedger.status)
+				? fromLedger.v2Id
+				: null) ?? v2ByRepoPath.get(v1.mainRepoPath);
+		if (v2Id) v2ProjectIdByV1ProjectId.set(v1.id, v2Id);
+	}
+
+	const pendingWorkspaces = v1Workspaces.filter((w) => {
+		const existing = ledger.get(ledgerKey("workspace", w.id));
+		return !existing || !isTerminalStatus(existing.status);
+	});
+
+	const mappedV2ProjectIds = new Set(
+		pendingWorkspaces
+			.map((w) => v2ProjectIdByV1ProjectId.get(w.projectId))
+			.filter((id): id is string => !!id),
+	);
+	const onDiskBranchesByV2ProjectId = new Map<string, Set<string>>();
+	await Promise.all(
+		Array.from(mappedV2ProjectIds, async (v2ProjectId) => {
+			try {
+				const result =
+					await deps.hostClient.workspaceCreation.listProjectWorktrees.query({
+						projectId: v2ProjectId,
+					});
+				onDiskBranchesByV2ProjectId.set(
+					v2ProjectId,
+					new Set(result.worktrees.map((w) => w.branch)),
+				);
+			} catch {
+				// Leave unset: planWorkspaceAdoptions treats unknown as adoptable
+				// and lets adopt() decide.
+			}
+		}),
+	);
+
+	const v1WorktreesById = new Map<string, V1WorktreeLike>(
+		v1Worktrees.map((w) => [w.id, w]),
+	);
+	const plan = planWorkspaceAdoptions({
+		v1Workspaces: pendingWorkspaces,
+		v1WorktreesById,
+		v2ProjectIdByV1ProjectId,
+		hostWorkspaces,
+		onDiskBranchesByV2ProjectId,
+	});
+
+	summary.deferred += plan.unmappedProject.length;
+
+	for (const adopted of plan.alreadyAdopted) {
+		summary.linked++;
+		pushOutcome(ledger, outcomes, {
+			v1Id: adopted.v1WorkspaceId,
+			kind: "workspace",
+			status: "linked",
+			v2Id: adopted.v2WorkspaceId,
+		});
+	}
+
+	for (const missing of plan.missingWorktree) {
+		summary.skipped++;
+		pushOutcome(ledger, outcomes, {
+			v1Id: missing.v1WorkspaceId,
+			kind: "workspace",
+			status: "skipped",
+			reason: "no-worktree-on-disk",
+		});
+	}
+
+	for (const entry of plan.toAdopt) {
+		try {
+			const result = await adoptV1Workspace(deps.hostClient, entry);
+			summary.migrated++;
+			pushOutcome(ledger, outcomes, {
+				v1Id: entry.v1WorkspaceId,
+				kind: "workspace",
+				status: "success",
+				v2Id: result.workspace.id,
+			});
+			deps.onWorkspaceAdopted?.(result.workspace.id, entry.v2ProjectId);
+		} catch (err) {
+			summary.failed++;
+			pushOutcome(ledger, outcomes, {
+				v1Id: entry.v1WorkspaceId,
+				kind: "workspace",
+				status: "error",
+				reason: errorMessage(err),
+			});
+		}
+	}
+
+	return summary;
+}
+
+async function migratePresets(
+	deps: RunV1MigrationDeps,
+	ledger: V1LedgerMap,
+	outcomes: V1LedgerOutcome[],
+): Promise<KindSummary> {
+	const summary = emptySummary();
+	const target = deps.presetTarget;
+	if (!target) return summary;
+
+	const v1Presets =
+		await electronTrpcClient.settings.getTerminalPresets.query();
+
+	// Mutable copy: an insert this run must count as "existing" for the next
+	// preset so two identically-named v1 presets don't both import.
+	const existing = [...target.existing];
+
+	for (const [index, preset] of v1Presets.entries()) {
+		const done = ledger.get(ledgerKey("preset", preset.id));
+		if (done && isTerminalStatus(done.status)) continue;
+
+		try {
+			const resolved = resolvePresetImport(preset, target.agents, existing);
+			if (resolved.alreadyImported) {
+				summary.linked++;
+				pushOutcome(ledger, outcomes, {
+					v1Id: preset.id,
+					kind: "preset",
+					status: "linked",
+				});
+				continue;
+			}
+			const row = buildV2TerminalPresetRow(preset, index, resolved);
+			target.insert(row);
+			existing.push({ name: row.name, agentId: row.agentId });
+			summary.migrated++;
+			pushOutcome(ledger, outcomes, {
+				v1Id: preset.id,
+				kind: "preset",
+				status: "success",
+				v2Id: row.id,
+			});
+		} catch (err) {
+			summary.failed++;
+			pushOutcome(ledger, outcomes, {
+				v1Id: preset.id,
+				kind: "preset",
+				status: "error",
+				reason: errorMessage(err),
+			});
+		}
+	}
+
+	return summary;
+}
+
+function pushOutcome(
+	ledger: V1LedgerMap,
+	outcomes: V1LedgerOutcome[],
+	outcome: V1LedgerOutcome,
+): void {
+	outcomes.push(outcome);
+	ledger.set(ledgerKey(outcome.kind, outcome.v1Id), {
+		status: outcome.status,
+		v2Id: outcome.v2Id ?? null,
+	});
+}

--- a/apps/desktop/src/renderer/lib/v1-migration/v1-migration.test.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/v1-migration.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePresetImport } from "./presets";
+import { decideProjectImport } from "./projects";
+import { planWorkspaceAdoptions } from "./workspaces";
+
+type Candidate = { id: string; source: string };
+const findByPath = (candidates: Candidate[], cloudErrors: unknown[] = []) =>
+	// Structural subset of ProjectFindByPathResult — decideProjectImport only
+	// reads candidates/cloudErrors.
+	({ candidates, cloudErrors }) as Parameters<typeof decideProjectImport>[0];
+
+describe("decideProjectImport", () => {
+	test("local-path candidate means already imported", () => {
+		expect(
+			decideProjectImport(
+				findByPath([
+					{ id: "cloud-1", source: "github-remote" },
+					{ id: "v2-local", source: "local-path" },
+				]),
+			),
+		).toEqual({ kind: "already-imported", v2ProjectId: "v2-local" });
+	});
+
+	test("multiple cloud candidates need a human", () => {
+		expect(
+			decideProjectImport(
+				findByPath([
+					{ id: "a", source: "github-remote" },
+					{ id: "b", source: "github-remote" },
+				]),
+			),
+		).toEqual({ kind: "skip", reason: "multiple-candidates" });
+	});
+
+	test("no candidates but cloud errors: don't risk a duplicate", () => {
+		expect(
+			decideProjectImport(findByPath([], [{ url: "x", message: "boom" }])),
+		).toEqual({ kind: "skip", reason: "cloud-unreachable" });
+	});
+
+	test("single candidate or none imports", () => {
+		expect(
+			decideProjectImport(findByPath([{ id: "a", source: "github-remote" }])),
+		).toEqual({ kind: "import" });
+		expect(decideProjectImport(findByPath([]))).toEqual({ kind: "import" });
+	});
+});
+
+describe("planWorkspaceAdoptions", () => {
+	const base = {
+		v1WorktreesById: new Map([
+			["wt-1", { id: "wt-1", path: "/tree/feat", baseBranch: "main" }],
+		]),
+		v2ProjectIdByV1ProjectId: new Map([["v1-proj", "v2-proj"]]),
+		hostWorkspaces: [{ id: "v2-ws", projectId: "v2-proj", branch: "done" }],
+		onDiskBranchesByV2ProjectId: new Map([
+			["v2-proj", new Set(["feat", "done"])],
+		]),
+	};
+	const ws = (
+		over: Partial<
+			Parameters<typeof planWorkspaceAdoptions>[0]["v1Workspaces"][0]
+		>,
+	) => ({
+		id: "v1-ws",
+		projectId: "v1-proj",
+		worktreeId: "wt-1" as string | null,
+		name: "Feat",
+		branch: "feat",
+		...over,
+	});
+
+	test("adoptable workspace carries worktree path and base branch", () => {
+		const plan = planWorkspaceAdoptions({ ...base, v1Workspaces: [ws({})] });
+		expect(plan.toAdopt).toEqual([
+			{
+				v1WorkspaceId: "v1-ws",
+				v1ProjectId: "v1-proj",
+				v2ProjectId: "v2-proj",
+				name: "Feat",
+				branch: "feat",
+				worktreePath: "/tree/feat",
+				baseBranch: "main",
+			},
+		]);
+	});
+
+	test("branch already on host is linked, not re-adopted", () => {
+		const plan = planWorkspaceAdoptions({
+			...base,
+			v1Workspaces: [ws({ branch: "done" })],
+		});
+		expect(plan.toAdopt).toHaveLength(0);
+		expect(plan.alreadyAdopted[0]?.v2WorkspaceId).toBe("v2-ws");
+	});
+
+	test("branch with no on-disk worktree is unadoptable", () => {
+		const plan = planWorkspaceAdoptions({
+			...base,
+			v1Workspaces: [ws({ branch: "gone" })],
+		});
+		expect(plan.missingWorktree).toHaveLength(1);
+		expect(plan.toAdopt).toHaveLength(0);
+	});
+
+	test("unknown on-disk state stays adoptable (adopt decides)", () => {
+		const plan = planWorkspaceAdoptions({
+			...base,
+			onDiskBranchesByV2ProjectId: new Map(),
+			v1Workspaces: [ws({ branch: "gone", worktreeId: null })],
+		});
+		expect(plan.toAdopt).toHaveLength(1);
+		expect(plan.toAdopt[0]?.worktreePath).toBeUndefined();
+	});
+
+	test("unmapped project defers the workspace", () => {
+		const plan = planWorkspaceAdoptions({
+			...base,
+			v1Workspaces: [ws({ projectId: "other" })],
+		});
+		expect(plan.unmappedProject).toEqual(["v1-ws"]);
+	});
+});
+
+describe("resolvePresetImport", () => {
+	const agents = [{ id: "agent-cfg-1", presetId: "claude" }];
+
+	test("built-in preset links to its agent config and keeps v2 on collision", () => {
+		const resolved = resolvePresetImport({ name: "claude" }, agents, [
+			{ name: "Claude Code", agentId: "agent-cfg-1" },
+		]);
+		expect(resolved.linkedAgentId).toBe("agent-cfg-1");
+		expect(resolved.alreadyImported).toBe(true);
+	});
+
+	test("custom preset dedups by name", () => {
+		expect(
+			resolvePresetImport({ name: "my setup" }, agents, [
+				{ name: "my setup", agentId: null },
+			]).alreadyImported,
+		).toBe(true);
+		expect(
+			resolvePresetImport({ name: "my setup" }, agents, []).alreadyImported,
+		).toBe(false);
+	});
+
+	test("built-in preset without an agent config links to the raw agent id", () => {
+		const resolved = resolvePresetImport({ name: "claude" }, [], []);
+		expect(resolved.linkedAgentId).toBe("claude");
+		expect(resolved.alreadyImported).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/lib/v1-migration/workspaces.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/workspaces.ts
@@ -1,0 +1,174 @@
+import type { HostServiceClient } from "renderer/lib/host-service-client";
+
+export interface V1WorkspaceLike {
+	id: string;
+	projectId: string;
+	worktreeId: string | null;
+	name: string;
+	branch: string;
+}
+
+export interface V1WorktreeLike {
+	id: string;
+	path: string;
+	baseBranch: string | null;
+}
+
+export interface HostWorkspaceLike {
+	id: string;
+	projectId: string;
+	branch: string;
+}
+
+export interface AdoptPlanEntry {
+	v1WorkspaceId: string;
+	v1ProjectId: string;
+	v2ProjectId: string;
+	name: string;
+	branch: string;
+	worktreePath: string | undefined;
+	baseBranch: string | null;
+}
+
+export interface WorkspacePlan {
+	toAdopt: AdoptPlanEntry[];
+	alreadyAdopted: Array<{
+		v1WorkspaceId: string;
+		v1ProjectId: string;
+		v2ProjectId: string;
+		v2WorkspaceId: string;
+		name: string;
+		branch: string;
+	}>;
+	/** Branch has no on-disk worktree under the v2 project — nothing to adopt. */
+	missingWorktree: Array<{
+		v1WorkspaceId: string;
+		v2ProjectId: string;
+		branch: string;
+	}>;
+	/** v1 project not (yet) imported — retried after projects migrate. */
+	unmappedProject: string[];
+}
+
+function hostWorkspaceKey(projectId: string, branch: string): string {
+	return `${projectId}\0${branch}`;
+}
+
+/**
+ * Classify every v1 workspace against current host state. "Already adopted"
+ * is decided from the host's local workspace list (host.db is the authority
+ * post-local-first — cloud rows are stale). Workspaces whose branch has no
+ * on-disk worktree are unadoptable, matching the wizard's visibility filter.
+ */
+export function planWorkspaceAdoptions({
+	v1Workspaces,
+	v1WorktreesById,
+	v2ProjectIdByV1ProjectId,
+	hostWorkspaces,
+	onDiskBranchesByV2ProjectId,
+}: {
+	v1Workspaces: V1WorkspaceLike[];
+	v1WorktreesById: Map<string, V1WorktreeLike>;
+	v2ProjectIdByV1ProjectId: Map<string, string>;
+	hostWorkspaces: HostWorkspaceLike[];
+	onDiskBranchesByV2ProjectId: Map<string, Set<string>>;
+}): WorkspacePlan {
+	const hostByKey = new Map<string, string>();
+	for (const w of hostWorkspaces) {
+		hostByKey.set(hostWorkspaceKey(w.projectId, w.branch), w.id);
+	}
+
+	const plan: WorkspacePlan = {
+		toAdopt: [],
+		alreadyAdopted: [],
+		missingWorktree: [],
+		unmappedProject: [],
+	};
+
+	for (const workspace of v1Workspaces) {
+		const v2ProjectId = v2ProjectIdByV1ProjectId.get(workspace.projectId);
+		if (!v2ProjectId) {
+			plan.unmappedProject.push(workspace.id);
+			continue;
+		}
+
+		const v2WorkspaceId = hostByKey.get(
+			hostWorkspaceKey(v2ProjectId, workspace.branch),
+		);
+		if (v2WorkspaceId) {
+			plan.alreadyAdopted.push({
+				v1WorkspaceId: workspace.id,
+				v1ProjectId: workspace.projectId,
+				v2ProjectId,
+				v2WorkspaceId,
+				name: workspace.name,
+				branch: workspace.branch,
+			});
+			continue;
+		}
+
+		const onDiskBranches = onDiskBranchesByV2ProjectId.get(v2ProjectId);
+		if (onDiskBranches !== undefined && !onDiskBranches.has(workspace.branch)) {
+			plan.missingWorktree.push({
+				v1WorkspaceId: workspace.id,
+				v2ProjectId,
+				branch: workspace.branch,
+			});
+			continue;
+		}
+
+		const worktree = workspace.worktreeId
+			? v1WorktreesById.get(workspace.worktreeId)
+			: undefined;
+		plan.toAdopt.push({
+			v1WorkspaceId: workspace.id,
+			v1ProjectId: workspace.projectId,
+			v2ProjectId,
+			name: workspace.name,
+			branch: workspace.branch,
+			worktreePath: worktree?.path,
+			baseBranch: worktree?.baseBranch ?? null,
+		});
+	}
+
+	return plan;
+}
+
+function trpcCode(err: unknown): string | null {
+	if (typeof err !== "object" || err === null) return null;
+	const data = (err as { data?: unknown }).data;
+	if (typeof data !== "object" || data === null) return null;
+	const code = (data as { code?: unknown }).code;
+	return typeof code === "string" ? code : null;
+}
+
+/**
+ * Adopt one v1 workspace's worktree into a v2 workspace row. Tries the
+ * explicit v1 worktree path first; if the daemon can't find a worktree
+ * there (moved/pruned), falls back to branch-name adoption.
+ */
+export async function adoptV1Workspace(
+	hostClient: HostServiceClient,
+	entry: Pick<
+		AdoptPlanEntry,
+		"v2ProjectId" | "name" | "branch" | "worktreePath" | "baseBranch"
+	>,
+) {
+	const adoptArgs = {
+		projectId: entry.v2ProjectId,
+		workspaceName: entry.name,
+		branch: entry.branch,
+		baseBranch: entry.baseBranch ?? undefined,
+	};
+	try {
+		return await hostClient.workspaceCreation.adopt.mutate({
+			...adoptArgs,
+			worktreePath: entry.worktreePath,
+		});
+	} catch (err) {
+		if (entry.worktreePath && trpcCode(err) === "NOT_FOUND") {
+			return await hostClient.workspaceCreation.adopt.mutate(adoptArgs);
+		}
+		throw err;
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportPresetsPage/ImportPresetsPage.tsx
@@ -1,14 +1,14 @@
 import type { TerminalPreset } from "@superset/local-db";
-import {
-	AGENT_LABELS,
-	AGENT_TYPES,
-	type AgentType,
-} from "@superset/shared/agent-command";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { LuTerminal } from "react-icons/lu";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	buildV2TerminalPresetRow,
+	recordV1MigrationOutcome,
+	resolvePresetImport,
+} from "renderer/lib/v1-migration";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -18,8 +18,6 @@ import { ImportRow, type RowAction } from "../components/ImportRow";
 interface ImportPresetsPageProps {
 	organizationId: string;
 }
-
-const BUILTIN_AGENT_IDS = new Set<string>(AGENT_TYPES);
 
 export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 	const collections = useCollections();
@@ -33,31 +31,8 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 		[collections],
 	);
 
-	const importedAgentIds = useMemo(
-		() => new Set(v2Presets.flatMap((p) => (p.agentId ? [p.agentId] : []))),
-		[v2Presets],
-	);
-	const importedNames = useMemo(
-		() => new Set(v2Presets.flatMap((p) => (p.agentId ? [] : [p.name]))),
-		[v2Presets],
-	);
-
 	const isLoading = presetsQuery.isPending;
 	const presets = presetsQuery.data ?? [];
-	const agentConfigIdByPresetId = useMemo(() => {
-		const map = new Map<AgentType, string>();
-		for (const agent of agents) {
-			if (!BUILTIN_AGENT_IDS.has(agent.presetId)) {
-				continue;
-			}
-			const presetId = agent.presetId as AgentType;
-			if (map.has(presetId)) {
-				continue;
-			}
-			map.set(presetId, agent.id);
-		}
-		return map;
-	}, [agents]);
 
 	const refresh = async () => {
 		setIsRefreshing(true);
@@ -79,27 +54,15 @@ export function ImportPresetsPage({ organizationId }: ImportPresetsPageProps) {
 			isRefreshing={isRefreshing}
 		>
 			{presets.map((preset, index) => {
-				const builtInAgentId = BUILTIN_AGENT_IDS.has(preset.name)
-					? (preset.name as AgentType)
-					: undefined;
-				const linkedAgentId = builtInAgentId
-					? (agentConfigIdByPresetId.get(builtInAgentId) ?? builtInAgentId)
-					: undefined;
-				const v2Name = builtInAgentId
-					? AGENT_LABELS[builtInAgentId]
-					: preset.name;
-				const alreadyImported = linkedAgentId
-					? importedAgentIds.has(linkedAgentId) ||
-						(!!builtInAgentId && importedAgentIds.has(builtInAgentId))
-					: importedNames.has(v2Name);
+				const resolved = resolvePresetImport(preset, agents, v2Presets);
 				return (
 					<PresetRow
 						key={preset.id}
 						preset={preset}
 						tabOrder={index}
-						linkedAgentId={linkedAgentId}
-						v2Name={v2Name}
-						alreadyImported={alreadyImported}
+						linkedAgentId={resolved.linkedAgentId}
+						v2Name={resolved.v2Name}
+						alreadyImported={resolved.alreadyImported}
 						organizationId={organizationId}
 					/>
 				);
@@ -133,22 +96,18 @@ function PresetRow({
 		setRunning(true);
 		setErrorMessage(null);
 		try {
-			const row: V2TerminalPresetRow = {
-				id: crypto.randomUUID(),
-				name: v2Name,
-				description: preset.description,
-				cwd: preset.cwd,
-				commands: preset.commands,
-				projectIds: preset.projectIds ?? null,
-				pinnedToBar: preset.pinnedToBar,
-				applyOnWorkspaceCreated: preset.applyOnWorkspaceCreated,
-				applyOnNewTab: preset.applyOnNewTab,
-				executionMode: preset.executionMode ?? "new-tab",
+			const row: V2TerminalPresetRow = buildV2TerminalPresetRow(
+				preset,
 				tabOrder,
-				createdAt: new Date(),
-				agentId: linkedAgentId,
-			};
+				{ v2Name, linkedAgentId },
+			);
 			collections.v2TerminalPresets.insert(row);
+			recordV1MigrationOutcome(organizationId, {
+				v1Id: preset.id,
+				kind: "preset",
+				status: "success",
+				v2Id: row.id,
+			});
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			setErrorMessage(message);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportProjectsPage/ImportProjectsPage.tsx
@@ -5,11 +5,17 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { LuFolder } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import {
-	getHostServiceClientByUrl,
-	type HostServiceClient,
-} from "renderer/lib/host-service-client";
-import { getBaseName } from "renderer/lib/pathBasename";
+	decideProjectImport,
+	expectedRemoteUrlFor,
+	extractExistingPath,
+	importV1Project,
+	isProjectAlreadyImported,
+	type ProjectFindByPathResult,
+	type ProjectImportOutcome,
+	recordV1MigrationOutcome,
+} from "renderer/lib/v1-migration";
 import { useFinalizeProjectSetup } from "renderer/react-query/projects";
 import { ImportPageShell } from "../components/ImportPageShell";
 import { ImportRow, type RowAction } from "../components/ImportRow";
@@ -28,10 +34,6 @@ type V1Project = {
 	mainRepoPath: string;
 	githubOwner: string | null;
 };
-
-type ProjectFindByPathResult = Awaited<
-	ReturnType<HostServiceClient["project"]["findByPath"]["query"]>
->;
 
 export function ImportProjectsPage({
 	organizationId,
@@ -78,20 +80,12 @@ export function ImportProjectsPage({
 						project,
 						activeHostUrl,
 					);
-					if (isProjectAlreadyImported(findByPathResult)) {
-						continue;
-					}
-					if (findByPathResult.candidates.length > 1) {
-						continue;
-					}
-					if (
-						findByPathResult.candidates.length === 0 &&
-						findByPathResult.cloudErrors.length > 0
-					) {
+					if (decideProjectImport(findByPathResult).kind !== "import") {
 						continue;
 					}
 					const result = await importProject({
 						project,
+						organizationId,
 						activeHostUrl,
 						findByPathResult,
 						finalizeSetup,
@@ -161,29 +155,6 @@ interface ProjectRowProps {
 	activeHostUrl: string;
 }
 
-function isAlreadySetUpElsewhereError(err: unknown): boolean {
-	if (!(err instanceof Error)) return false;
-	return err.message.includes("Project is already set up on this device at");
-}
-
-function extractExistingPath(message: string): string | null {
-	const match = message.match(
-		/already set up on this device at (.+?)\.\s+Remove/,
-	);
-	return match?.[1] ?? null;
-}
-
-function expectedRemoteUrlFor(project: {
-	name: string;
-	mainRepoPath: string;
-	githubOwner: string | null;
-}): string | undefined {
-	if (!project.githubOwner) return undefined;
-	const repoName = getBaseName(project.mainRepoPath);
-	if (!repoName) return undefined;
-	return `https://github.com/${project.githubOwner}/${repoName}`;
-}
-
 function projectFindByPathQueryKey(project: V1Project, activeHostUrl: string) {
 	return [
 		...FIND_BY_PATH_KEY_PREFIX,
@@ -216,16 +187,12 @@ function fetchProjectFindByPath(
 	});
 }
 
-function isProjectAlreadyImported(
-	findByPathResult: ProjectFindByPathResult | undefined,
-) {
-	return !!findByPathResult?.candidates.find((c) => c.source === "local-path");
-}
-
 type FinalizeProjectSetup = ReturnType<typeof useFinalizeProjectSetup>;
 
+/** Shared import plus the wizard's UI side effects and ledger record. */
 async function importProject({
 	project,
+	organizationId,
 	activeHostUrl,
 	findByPathResult,
 	finalizeSetup,
@@ -233,72 +200,34 @@ async function importProject({
 	allowRelocate = false,
 }: {
 	project: V1Project;
+	organizationId: string;
 	activeHostUrl: string;
 	findByPathResult: ProjectFindByPathResult | undefined;
 	finalizeSetup: FinalizeProjectSetup;
 	linkToProjectId?: string;
 	allowRelocate?: boolean;
-}): Promise<
-	| { kind: "imported"; v2ProjectId: string }
-	| { kind: "needs-relocate"; v2ProjectId: string; message: string }
-> {
-	const client = getHostServiceClientByUrl(activeHostUrl);
-	const candidates = findByPathResult?.candidates ?? [];
-
-	let v2ProjectId: string;
-	let mainWorkspaceId: string | null = null;
-	let repoPath = project.mainRepoPath;
-
-	const targetCandidate = linkToProjectId
-		? candidates.find((c) => c.id === linkToProjectId)
-		: candidates[0];
-
-	if (linkToProjectId && !targetCandidate) {
-		throw new Error(
-			"Selected v2 project is no longer in the candidate list. Refresh and pick again.",
-		);
-	}
-
-	if (targetCandidate) {
-		try {
-			const result = await client.project.setup.mutate({
-				projectId: targetCandidate.id,
-				mode: {
-					kind: "import",
-					repoPath: project.mainRepoPath,
-					allowRelocate,
-				},
-			});
-			v2ProjectId = targetCandidate.id;
-			mainWorkspaceId = result.mainWorkspaceId;
-			repoPath = result.repoPath;
-		} catch (err) {
-			if (isAlreadySetUpElsewhereError(err) && !allowRelocate) {
-				return {
-					kind: "needs-relocate",
-					v2ProjectId: targetCandidate.id,
-					message: err instanceof Error ? err.message : String(err),
-				};
-			}
-			throw err;
-		}
-	} else {
-		const result = await client.project.create.mutate({
-			name: project.name,
-			mode: { kind: "importLocal", repoPath: project.mainRepoPath },
-		});
-		v2ProjectId = result.projectId;
-		mainWorkspaceId = result.mainWorkspaceId;
-		repoPath = result.repoPath;
-	}
-
-	finalizeSetup(activeHostUrl, {
-		projectId: v2ProjectId,
-		repoPath,
-		mainWorkspaceId,
+}): Promise<ProjectImportOutcome> {
+	const result = await importV1Project({
+		hostClient: getHostServiceClientByUrl(activeHostUrl),
+		project,
+		findByPathResult,
+		linkToProjectId,
+		allowRelocate,
 	});
-
-	return { kind: "imported", v2ProjectId };
+	if (result.kind === "imported") {
+		finalizeSetup(activeHostUrl, {
+			projectId: result.v2ProjectId,
+			repoPath: result.repoPath,
+			mainWorkspaceId: result.mainWorkspaceId,
+		});
+		recordV1MigrationOutcome(organizationId, {
+			v1Id: project.id,
+			kind: "project",
+			status: "success",
+			v2Id: result.v2ProjectId,
+		});
+	}
+	return result;
 }
 
 function invalidateProjectImportQueries(
@@ -349,6 +278,7 @@ function ProjectRow({
 		try {
 			const result = await importProject({
 				project,
+				organizationId,
 				activeHostUrl,
 				findByPathResult: findByPathQuery.data,
 				finalizeSetup,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1ImportModal/ImportWorkspacesPage/ImportWorkspacesPage.tsx
@@ -5,6 +5,10 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { LuLayoutGrid } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import {
+	adoptV1Workspace,
+	recordV1MigrationOutcome,
+} from "renderer/lib/v1-migration";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { ImportPageShell } from "../components/ImportPageShell";
 import { ImportRow, type RowAction } from "../components/ImportRow";
@@ -15,16 +19,8 @@ interface ImportWorkspacesPageProps {
 }
 
 const WORKTREE_LIST_KEY_PREFIX = ["v1-import", "projectWorktrees"] as const;
-const WORKSPACE_CLOUD_LIST_KEY = ["v1-import", "workspaceCloudList"] as const;
+const WORKSPACE_LIST_KEY = ["v1-import", "hostWorkspaceList"] as const;
 const HOST_PROJECT_LIST_KEY_PREFIX = ["v1-import", "hostProjectList"] as const;
-
-function trpcCode(err: unknown): string | null {
-	if (typeof err !== "object" || err === null) return null;
-	const data = (err as { data?: unknown }).data;
-	if (typeof data !== "object" || data === null) return null;
-	const code = (data as { code?: unknown }).code;
-	return typeof code === "string" ? code : null;
-}
 
 type AdoptStatus =
 	| { kind: "idle" }
@@ -53,29 +49,21 @@ export function ImportWorkspacesPage({
 		retry: false,
 	});
 
-	const cloudWorkspacesQuery = useQuery({
-		queryKey: [...WORKSPACE_CLOUD_LIST_KEY, organizationId, activeHostUrl],
+	// Host-local list (host.db is the authority post-local-first; the old
+	// cloud list never sees newly-adopted workspaces).
+	const hostWorkspacesQuery = useQuery({
+		queryKey: [...WORKSPACE_LIST_KEY, organizationId, activeHostUrl],
 		queryFn: async () => {
 			const client = getHostServiceClientByUrl(activeHostUrl);
-			return client.workspace.cloudList.query();
+			return client.workspace.list.query();
 		},
 		retry: false,
 	});
 
 	const v2ProjectIdByV1Id = useMemo(() => {
-		const projectIdsInCloud = new Set(
-			(cloudWorkspacesQuery.data ?? []).map((w) => w.projectId),
-		);
 		const v2ByPath = new Map<string, string>();
 		for (const v2 of hostProjectListQuery.data ?? []) {
-			const existing = v2ByPath.get(v2.repoPath);
-			if (!existing) {
-				v2ByPath.set(v2.repoPath, v2.id);
-				continue;
-			}
-			if (projectIdsInCloud.has(v2.id) && !projectIdsInCloud.has(existing)) {
-				v2ByPath.set(v2.repoPath, v2.id);
-			}
+			if (!v2ByPath.has(v2.repoPath)) v2ByPath.set(v2.repoPath, v2.id);
 		}
 		const map = new Map<string, string>();
 		for (const v1 of projectsQuery.data ?? []) {
@@ -83,19 +71,15 @@ export function ImportWorkspacesPage({
 			if (v2Id) map.set(v1.id, v2Id);
 		}
 		return map;
-	}, [
-		hostProjectListQuery.data,
-		projectsQuery.data,
-		cloudWorkspacesQuery.data,
-	]);
+	}, [hostProjectListQuery.data, projectsQuery.data]);
 
-	const cloudWorkspaceKeys = useMemo(() => {
+	const hostWorkspaceKeys = useMemo(() => {
 		const set = new Set<string>();
-		for (const w of cloudWorkspacesQuery.data ?? []) {
+		for (const w of hostWorkspacesQuery.data ?? []) {
 			set.add(`${w.projectId}\0${w.branch}`);
 		}
 		return set;
-	}, [cloudWorkspacesQuery.data]);
+	}, [hostWorkspacesQuery.data]);
 
 	const importedV2ProjectIds = Array.from(new Set(v2ProjectIdByV1Id.values()));
 
@@ -133,7 +117,7 @@ export function ImportWorkspacesPage({
 		workspacesQuery.isPending ||
 		worktreesQuery.isPending ||
 		hostProjectListQuery.isPending ||
-		cloudWorkspacesQuery.isPending ||
+		hostWorkspacesQuery.isPending ||
 		worktreeListQueries.some((q) => q.isPending);
 
 	const [isRefreshing, setIsRefreshing] = useState(false);
@@ -145,7 +129,7 @@ export function ImportWorkspacesPage({
 				workspacesQuery.refetch(),
 				worktreesQuery.refetch(),
 				hostProjectListQuery.refetch(),
-				cloudWorkspacesQuery.refetch(),
+				hostWorkspacesQuery.refetch(),
 				queryClient.invalidateQueries({
 					queryKey: WORKTREE_LIST_KEY_PREFIX,
 				}),
@@ -175,7 +159,7 @@ export function ImportWorkspacesPage({
 		const v2ProjectId = v2ProjectIdByV1Id.get(workspace.projectId);
 		if (!v2ProjectId) continue;
 
-		const alreadyImported = cloudWorkspaceKeys.has(
+		const alreadyImported = hostWorkspaceKeys.has(
 			`${v2ProjectId}\0${workspace.branch}`,
 		);
 		if (!alreadyImported) {
@@ -223,32 +207,24 @@ export function ImportWorkspacesPage({
 			updateAdoptStatus(workspace.id, { kind: "running" });
 			try {
 				const client = getHostServiceClientByUrl(activeHostUrl);
-				const adoptArgs = {
-					projectId: v2ProjectId,
-					workspaceName: workspace.name,
+				const result = await adoptV1Workspace(client, {
+					v2ProjectId,
+					name: workspace.name,
 					branch: workspace.branch,
-					baseBranch: baseBranch ?? undefined,
-				};
-				let result: Awaited<
-					ReturnType<typeof client.workspaceCreation.adopt.mutate>
-				>;
-				try {
-					result = await client.workspaceCreation.adopt.mutate({
-						...adoptArgs,
-						worktreePath,
-					});
-				} catch (err) {
-					if (worktreePath && trpcCode(err) === "NOT_FOUND") {
-						result = await client.workspaceCreation.adopt.mutate(adoptArgs);
-					} else {
-						throw err;
-					}
-				}
+					worktreePath,
+					baseBranch,
+				});
 
 				ensureWorkspaceInSidebar(result.workspace.id, v2ProjectId);
+				recordV1MigrationOutcome(organizationId, {
+					v1Id: workspace.id,
+					kind: "workspace",
+					status: "success",
+					v2Id: result.workspace.id,
+				});
 				updateAdoptStatus(workspace.id, { kind: "imported" });
 				await queryClient.invalidateQueries({
-					queryKey: WORKSPACE_CLOUD_LIST_KEY,
+					queryKey: WORKSPACE_LIST_KEY,
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -240,7 +240,12 @@ export const settings = sqliteTable("settings", {
 export type InsertSettings = typeof settings.$inferInsert;
 export type SelectSettings = typeof settings.$inferSelect;
 
-export type V1MigrationKind = "project" | "workspace" | "preset";
+export type V1MigrationKind =
+	| "project"
+	| "workspace"
+	| "preset"
+	| "settings"
+	| "terminal";
 export type V1MigrationStatus = "success" | "linked" | "error" | "skipped";
 
 export const v1MigrationState = sqliteTable(

--- a/plans/20260716-v1-to-v2-auto-migration.md
+++ b/plans/20260716-v1-to-v2-auto-migration.md
@@ -1,0 +1,93 @@
+# v1 → v2 Seamless Auto-Migration & v1 Sunset
+
+Goal: silently move every remaining v1 desktop user onto v2 — no wizard, no banners, no empty states — then delete v1.
+
+## Current state (verified in code, post local-first merge 2026-07-19)
+
+- **The v1/v2 switch is 100% client-local.** `useIsV2CloudEnabled` (`apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts`) resolves `optInV2 ?? (isV2OnlyUser(createdAt) || dev)`. `optInV2` lives in localStorage (`v2-local-override-v2`); an explicit `false` (user tried v2 and switched back) wins over everything. No server flag — migration ships in a desktop release.
+- **All migration machinery already exists — it's just manual.** The `V1ImportModal` wizard (Experimental Settings → "Import from v1") reads v1 local.db via the `migration` router (`apps/desktop/src/lib/trpc/routers/migration/`), writes v2 via host-service: `project.findByPath` → `project.setup` (link) or `project.create {kind:'importLocal'}`, then `workspaceCreation.adopt` per workspace, then presets.
+- **v2 is fully local (#5731/#5786).** `project.create` makes zero cloud calls (`persistFromResolved`, `packages/host-service/src/trpc/router/project/handlers.ts:40`); workspace cloud sync is retired. Migration is offline-capable end to end. Only remaining cloud call: `findByPath {walkAllRemotes:true}` discovery of pre-local-first cloud projects — keep for linking legacy rows, never block on it.
+- **Idempotency = `adopt.alreadyExists` + ledger.** `adopt` reuses rows by id / branch+path / path. The wizard's `workspace.cloudList` dedup is a stale no-op post-local-first — do NOT carry it into the migrator (and its "Imported" badge misreports; fix during extraction).
+- **`v1_migration_state` ledger exists but is dormant.** `packages/local-db/src/schema/schema.ts:246` — PK `(orgId, v1Id, kind)`, kind ∈ project|workspace|preset, status ∈ success|linked|error|skipped. Zero readers/writers; we add the first.
+- **Never migrated:** live terminal processes (v1 main-process `DaemonTerminalManager` vs v2 host-service `DaemonClient` — no session handoff; ceiling = fresh shell at same cwd, equal to v1's own cold restore), abandoned projects (`tabOrder = null`), workspaces mid-delete (`deletingAt`).
+- **Out of scope by decision (2026-07-19):** scrollback replay and chat GUI continuity (chat panes, chat-history relink). Terminal continuity — right terminals, right cwd, right workspace — is the bar.
+- **Measurement exists:** super property `surface` (v1|v2) on every event; person props `surface_ever_v2`, `surface_first_v2_at` isolate the switched-back cohort.
+
+## Design: per-machine migrate-then-flip
+
+Data migrates silently while the user is still on v1; each machine flips to v2 only once its own ledger says migration is complete. The flip is instant and never lands in an empty state. One release carries both the migrator and the gated flip.
+
+### Boot flow (every launch, while surface = v1)
+
+Preconditions: signed in, `activeOrganizationId` set, onboarded, local host-service up.
+
+1. Run headless `runV1Migration()` (extracted from the wizard pages, shared with the manual path): projects (`findByPath` → setup/create) → workspaces (`adopt`, keeping the no-`worktreePath` NOT_FOUND fallback) → settings → presets → pending terminals. Only projects+workspaces gate the flip; the rest are best-effort and keep retrying post-flip.
+2. Ledger: skip entities already `success`/`linked`; record every outcome. Prevents resurrecting v2 entities the user deleted. Host UUIDs are stable/never re-keyed, so ledger `v2_id` mappings are safe.
+3. On full success, mark the org complete. **Next launch**, `useIsV2CloudEnabled` returns true. No mid-session flip.
+4. On failure (repo moved, host-service down): stay on v1, retry next boot. Invisible.
+5. Emit PostHog `v1_auto_migration_completed` / `_failed` with per-kind counts + reasons.
+
+Backstop: after app version X, flip regardless of ledger state; the manual "Import from v1" button remains the recovery path.
+
+### Seam-closers
+
+- **Continuity of place**: map v1 `settings.lastActiveWorkspaceId` through the ledger; first v2 launch opens there, not on a dashboard.
+- **Sidebar familiarity**: seed `v2SidebarProjects` / `v2SidebarSections` from v1 `tabOrder` + `workspace_sections`. Derive v2 project identity from the host fan-out (`project.list` / `useHostProjects`) — Electric v2Projects is gone.
+- **Terminals at their old cwd**: `terminal.createSession({ terminalId, cwd })` per v1 terminal pane (new `readV1TabsState` procedure over `app-state.json`); #5740's `useAutoAdoptBackgroundSessions` then builds panes automatically on first open. Default layout, no v1 split geometry.
+- **One-time "what changed" note** in v2 (dismissible, not a wizard) — the UI change is the only unavoidable visible seam.
+
+### Fidelity follow-up (post-MVP, only if feedback warrants)
+
+- Terminal split-geometry translation: write `paneLayout` explicitly via `writeWorkspacePaneLayout` instead of relying on #5740 auto-adopt (set the "backgrounded" marker to suppress double-adoption). Caveat: v1 split geometry lives in the renderer Mosaic overlay, not base `tabsState` — verify readability first. Browser/file-viewer panes could ride along field-level if we're in there anyway.
+
+### Deletion (gated on telemetry)
+
+Once PostHog shows surface=v1 collapsed to noise:
+
+- Remove cohort logic and the opt-in toggle (the `optInV2` override already stopped mattering at flip time per D5).
+- Delete v1 surfaces per `plans/v1-v2-delete-patterns-audit.md`: `workspace/`+`workspaces/` routes, `WorkspaceSidebar`, v1 `ChatPane`, v1 workspace data layer; then `packages/chat` and `packages/mcp` per `plans/v1-to-v2-fast-migration.md` P6.
+- **Keep** `@superset/local-db` read access, the `migration` router, the headless migrator, and the import button indefinitely — tiny cost, and late updaters jump straight from v1 to a post-deletion build.
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| No v1 data | Ledger trivially complete → flip immediately (matches new-user default anyway). |
+| Offline at boot | Create/adopt are fully local — migration proceeds; legacy-cloud discovery retries later without blocking the flip. |
+| Concurrent app instances | Migrator takes a per-org single-flight lock (cf. #5791 for host services). |
+| v1 branch-type workspace (no worktree) | Maps to the v2 `main` workspace (both one-per-project); verify during extraction. |
+| User deleted a migrated v2 workspace | Ledger `success` row → skip; never resurrect. |
+| Dirty/active worktrees | `adopt` only registers the existing path, never touches the working tree. |
+| Multiple orgs | Ledger is org-keyed; migrate the active org; re-run on org switch. Flip gates on active org's ledger. |
+| Repo already in v2 (manual importer ran) | `findByPath` links instead of duplicating; ledger records `linked`. |
+| Opt-out cohort (`optInV2 === false`) | Data migrates regardless; override stops being honored once the ledger completes (D5) — flips with everyone. |
+| One entity keeps failing | Others proceed; org stays unflipped until backstop; `_failed` telemetry identifies the cohort. |
+
+## Decisions (Kiet, 2026-07-20 /decide walkthrough)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Settings scope | Migrate **all mappable v1 settings** (worktreeBaseDir/branch prefix → host.db `hostSettings`; editor/font/notification prefs → `v2UserPreferences`); add `settings` kind to the ledger (TS-only enum change). Field-by-field mapping audit is a work item. |
+| 2 | Terminal timing | **Lazy**: migrator writes pending `{terminalId, cwd}` per workspace into `v2WorkspaceLocalState`; sessions created on first workspace open, panes via #5740 auto-adopt. No eager PTY storm. |
+| 3 | Preset conflicts | **Keep v2, link**: existing v2 preset (incl. #5745 auto-created) wins on agentId/name collision; ledger records `linked`, v1 preset skipped. |
+| 4 | Flip gate | **Projects + workspaces only** gate the flip; settings/presets/pending-terminals are best-effort and keep retrying after the flip. |
+| 5 | Opt-out cohort | **Flip with everyone** — `optInV2 === false` stops being honored once the ledger completes; no grace release. |
+
+Remaining open: backstop version for machines whose migration never completes.
+
+## Work items
+
+Core (MVP — everything needed to flip and sunset):
+
+- [ ] Extract wizard logic into shared headless `runV1Migration()` (drop stale `cloudList` dedup; fix wizard "Imported" badge)
+- [ ] `v1_migration_state` reads/writes + electron-main tRPC procedures for the ledger; add `settings` kind
+- [ ] Settings mapping audit + migrator: v1 `settings` row → `hostSettings` + `v2UserPreferences` (D1)
+- [ ] Boot trigger with preconditions, per-boot retry, org-complete marker, per-org single-flight lock
+- [ ] Gate `useIsV2CloudEnabled` on projects+workspaces ledger completion, ignoring `optInV2 === false` (D4, D5) + backstop force-flip
+- [ ] Continuity: lastActiveWorkspaceId → v2 route, sidebar order/sections seeding
+- [ ] `readV1TabsState` + pending-terminals record in `v2WorkspaceLocalState`, created lazily on workspace open (D2)
+- [ ] Preset migration with keep-v2-link collision policy (D3)
+- [ ] PostHog events + dashboard update (`plans/20260427-posthog-v1-v2-dashboard.md` is stale re: flag mechanism — fix while there)
+- [ ] Deletion pass per `v1-v2-delete-patterns-audit.md` once surface=v1 collapses
+
+Fidelity follow-up (separate PR, only if warranted): terminal split-geometry translation (Mosaic readability spike first). Scrollback replay and chat continuity are out of scope by decision.


### PR DESCRIPTION
## Summary

PR 1 of the v1→v2 auto-migration plan (SUPER-1534 / SUPER-1577, design doc `plans/20260716-v1-to-v2-auto-migration.md`): extract the V1ImportModal wizard's import logic into a shared headless module and give the dormant `v1_migration_state` ledger its first readers/writers.

- **New `renderer/lib/v1-migration/` module**: `runV1Migration()` orchestrator (projects → workspaces → presets, every outcome ledger-recorded, idempotent per boot) plus the extracted pure logic: `decideProjectImport`, `planWorkspaceAdoptions`, `resolvePresetImport` (keep-v2 preset collision policy), `importV1Project`, `adoptV1Workspace` (worktree-path NOT_FOUND fallback preserved).
- **Ledger live**: `migration.ledgerList` / `migration.ledgerRecord` electron tRPC procedures (upsert on `(org, v1Id, kind)`); `V1MigrationKind` extended with `settings` + `terminal` for the follow-up PRs.
- **Wizard fixes**: pages consume the shared module and record ledger outcomes; `ImportWorkspacesPage` dedups against host-local `workspace.list` instead of the stale cloud `cloudList` (post-local-first, newly adopted workspaces never appear in cloud, so the old "Imported" badge misreported); removed the now-moot cloud tiebreak in v1→v2 project mapping.

The boot trigger + flip gate land in a later PR — nothing runs automatically yet; the wizard behavior is unchanged apart from the badge fix.

## Test Plan

- [x] `bun test src/renderer/lib/v1-migration/` — 12 tests over the extracted decision logic (each mutation-verified to fail on a seeded regression)
- [x] `bun run typecheck` (desktop) and root `bun run lint` clean
- [ ] Manual wizard pass on a machine with v1 data: import project + workspace + preset, confirm `v1_migration_state` rows land and re-running shows Imported/Linked

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Built the headless v1→v2 migrator core and activated the migration ledger to prepare desktop for automated migration (SUPER-1534, SUPER-1577). Added per-stage ledger flushing and guarded UI callbacks; the wizard now uses the shared module with fixed workspace dedup. Nothing runs automatically yet.

- **New Features**
  - Added `renderer/lib/v1-migration/` with `runV1Migration()` (projects → workspaces → presets; idempotent; records outcomes).
  - Extracted pure logic: `decideProjectImport`, `planWorkspaceAdoptions`, `resolvePresetImport`, `importV1Project`, `adoptV1Workspace`.
  - Enabled `migration.ledgerList` and `migration.ledgerRecord` tRPC procedures; upsert on `(org, v1Id, kind)`.
  - Extended `V1MigrationKind` with `settings` and `terminal` for follow-up migrations.

- **Bug Fixes**
  - Flush ledger outcomes between stages and guard `onProjectImported`/`onWorkspaceAdopted` callbacks to avoid dropping committed results on later errors.
  - Wizard pages consume the shared module and record outcomes to the ledger; `ImportWorkspacesPage` dedups against host-local `workspace.list`, and `ImportPresetsPage` uses the shared resolver and writes ledger results.

<sup>Written for commit 9aae0674d117c6f2d297a10cb51e4b0bb138bec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resumable v1 → v2 migration support for projects, workspaces, and terminal presets, with ledger-based progress tracking to safely skip completed items and retry partial runs.
  * Introduced an idempotent, headless migration runner with clearer per-item results and an overall completion gate.
  * Updated the import screens to use the shared migration flow, improving project eligibility decisions, preset collision handling, and workspace adoption behavior.
* **Documentation**
  * Added a seamless auto-migration plan and v1 sunset roadmap.
* **Tests**
  * Added coverage for project, workspace, and preset migration decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->