### PR TITLE
fix(desktop): ungate onboarding project browse from host readiness

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
@@ -66,7 +66,10 @@ mock.module("renderer/react-query/projects", () => ({
 mock.module(
 	"renderer/routes/_authenticated/providers/LocalHostServiceProvider",
 	() => ({
-		useLocalHostService: () => ({ activeHostUrl: hostUrl }),
+		useLocalHostService: () => ({
+			activeHostUrl: hostUrl,
+			waitForHostReady: async () => hostUrl,
+		}),
 	}),
 );
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.ts
@@ -24,22 +24,15 @@ export function useFolderFirstImport(options?: {
 	onMultipleProjects?: (input: { candidates: MatchingProject[] }) => void;
 }): UseFolderFirstImportResult {
 	const hostService = useLocalHostService();
-	const { activeHostUrl } = hostService;
+	const { waitForHostReady } = hostService;
 	const finalizeSetup = useFinalizeProjectSetup();
 	const selectDirectory = electronTrpc.window.selectDirectory.useMutation();
 	const requestGitInit = useRequestGitInitConfirm();
 	const { onError, onMultipleProjects } = options ?? {};
 
 	const start = useCallback(async (): Promise<ProjectSetupResult | null> => {
-		if (!activeHostUrl) {
-			onError?.(
-				getHostServiceUnavailableMessage(hostService, {
-					action: "import a folder",
-				}),
-			);
-			return null;
-		}
-
+		// Pick the folder first — the native dialog is a local Electron call and
+		// must not wait on the host service. Only the registration below needs it.
 		let repoPath: string;
 		try {
 			const picked = await selectDirectory.mutateAsync({
@@ -49,6 +42,16 @@ export function useFolderFirstImport(options?: {
 			repoPath = picked.path;
 		} catch (err) {
 			onError?.(err instanceof Error ? err.message : String(err));
+			return null;
+		}
+
+		const activeHostUrl = await waitForHostReady();
+		if (!activeHostUrl) {
+			onError?.(
+				getHostServiceUnavailableMessage(hostService, {
+					action: "import a folder",
+				}),
+			);
 			return null;
 		}
 
@@ -118,7 +121,7 @@ export function useFolderFirstImport(options?: {
 			return null;
 		}
 	}, [
-		activeHostUrl,
+		waitForHostReady,
 		finalizeSetup,
 		hostService,
 		onError,

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
@@ -5,7 +5,6 @@ import { toast } from "@superset/ui/sonner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { type FormEvent, type ReactNode, useState } from "react";
 import { LuFolderOpen, LuGitBranch, LuLayoutTemplate } from "react-icons/lu";
-import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
@@ -31,9 +30,7 @@ function OnboardingProjectPage() {
 	const navigate = useNavigate();
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	const { refetch: refetchSession } = authClient.useSession();
-	const { activeHostUrl } = useLocalHostService();
-	const hostReady = !isV2CloudEnabled || activeHostUrl !== null;
-	const hostConnectTimedOut = useDelayElapsed(!hostReady, 15_000);
+	const { waitForHostReady } = useLocalHostService();
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const { data: homeDir } = electronTrpc.window.getHomeDir.useQuery();
 	const cloneTargetDir = homeDir ? `${homeDir}/.superset/projects` : null;
@@ -111,10 +108,14 @@ function OnboardingProjectPage() {
 		e.preventDefault();
 		const trimmed = url.trim();
 		if (!trimmed || !cloneTargetDir) return;
-		if (isV2CloudEnabled && !activeHostUrl) return;
 		setBusy(true);
 		try {
-			if (isV2CloudEnabled && activeHostUrl) {
+			if (isV2CloudEnabled) {
+				const activeHostUrl = await waitForHostReady();
+				if (!activeHostUrl) {
+					toast.error("Local host service isn't ready yet. Please try again.");
+					return;
+				}
 				const hostService = getHostServiceClientByUrl(activeHostUrl);
 				const created = await hostService.project.create.mutate({
 					name: repoNameFromUrl(trimmed),
@@ -152,9 +153,9 @@ function OnboardingProjectPage() {
 					variant="outline"
 					size="sm"
 					onClick={handleOpenFolder}
-					disabled={!hostReady || busy}
+					disabled={busy}
 				>
-					{hostReady ? "Browse…" : "Connecting…"}
+					Browse…
 				</Button>
 			</Card>
 
@@ -174,12 +175,12 @@ function OnboardingProjectPage() {
 						placeholder="git@github.com:org/repo.git"
 						value={url}
 						onChange={(e) => setUrl(e.target.value)}
-						disabled={busy || !hostReady}
+						disabled={busy}
 						className="flex-1"
 					/>
 					<Button
 						type="submit"
-						disabled={!url.trim() || busy || !hostReady || !cloneTargetDir}
+						disabled={!url.trim() || busy || !cloneTargetDir}
 					>
 						{busy ? "Cloning…" : "Clone"}
 					</Button>
@@ -200,25 +201,11 @@ function OnboardingProjectPage() {
 					variant="outline"
 					size="sm"
 					onClick={() => setTemplateOpen(true)}
-					disabled={!hostReady || busy}
+					disabled={busy}
 				>
-					{hostReady ? "Browse…" : "Connecting…"}
+					Browse…
 				</Button>
 			</Card>
-
-			{hostConnectTimedOut && (
-				<p className="text-xs text-muted-foreground text-center select-text cursor-text">
-					Still connecting to the local host service.{" "}
-					<button
-						type="button"
-						className="underline hover:text-foreground transition-colors"
-						onClick={() => window.location.reload()}
-					>
-						Reload
-					</button>{" "}
-					if this persists.
-				</p>
-			)}
 
 			<TemplateGalleryModal
 				open={templateOpen}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -103,25 +103,39 @@ export function LocalHostServiceProvider({
 		async (timeoutMs = 20_000): Promise<string | null> => {
 			const orgId = activeOrganizationId;
 			if (!orgId) return null;
+			// Resolve the live host URL if a port is up, else null. Swallows
+			// transient IPC/tRPC fetch failures so a poll error never rejects the
+			// nullable contract callers rely on.
+			const tryGetHostUrl = async (): Promise<string | null> => {
+				try {
+					const connection =
+						await utils.hostServiceCoordinator.getConnection.fetch({
+							organizationId: orgId,
+						});
+					if (connection?.port) {
+						const hostUrl = `http://127.0.0.1:${connection.port}`;
+						if (connection.secret)
+							setHostServiceSecret(hostUrl, connection.secret);
+						return hostUrl;
+					}
+				} catch (error) {
+					console.warn("[host-service] connection poll failed:", error);
+				}
+				return null;
+			};
 			const deadline = Date.now() + timeoutMs;
 			while (Date.now() < deadline) {
-				const connection =
-					await utils.hostServiceCoordinator.getConnection.fetch({
-						organizationId: orgId,
-					});
-				if (connection?.port) {
-					const hostUrl = `http://127.0.0.1:${connection.port}`;
-					if (connection.secret)
-						setHostServiceSecret(hostUrl, connection.secret);
-					return hostUrl;
-				}
+				const hostUrl = await tryGetHostUrl();
+				if (hostUrl) return hostUrl;
 				// Re-attempt the idempotent, local-only start each iteration so a
 				// transient failure (auth token not yet persisted, spawn miss)
 				// self-heals instead of polling a host that never came up.
 				startHostService({ organizationId: orgId });
 				await new Promise((resolve) => setTimeout(resolve, 1_000));
 			}
-			return null;
+			// Final check: the last start may have brought the host up during the
+			// trailing sleep, after the deadline elapsed.
+			return await tryGetHostUrl();
 		},
 		[activeOrganizationId, startHostService, utils],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -2,6 +2,7 @@ import { toast } from "@superset/ui/sonner";
 import {
 	createContext,
 	type ReactNode,
+	useCallback,
 	useContext,
 	useEffect,
 	useMemo,
@@ -22,6 +23,12 @@ interface LocalHostServiceContextValue {
 	activeOrganizationId: string | null;
 	activeOrganizationName: string | null;
 	hostServiceStatus: HostServiceAvailabilityStatus;
+	/**
+	 * Resolve once the local host service is live, returning its loopback URL
+	 * (or null on timeout). Use this at the point of a host-backed action so
+	 * local-first UI can act immediately without gating on `activeHostUrl`.
+	 */
+	waitForHostReady: (timeoutMs?: number) => Promise<string | null>;
 }
 
 const LocalHostServiceContext =
@@ -32,6 +39,7 @@ export function LocalHostServiceProvider({
 }: {
 	children: ReactNode;
 }) {
+	const utils = electronTrpc.useUtils();
 	const { data: session } = authClient.useSession();
 	const { data: activeOrganization } = authClient.useActiveOrganization();
 	const { mutate: startHostService } =
@@ -41,7 +49,10 @@ export function LocalHostServiceProvider({
 				console.error("[host-service] start failed:", error);
 				// Auth preconditions resolve once the token lands; not a real failure.
 				if (error.data?.code === "UNAUTHORIZED") return;
+				// A stable id collapses repeated retry failures into one toast
+				// instead of stacking a new one every retry interval.
 				toast.error("Host service failed to start", {
+					id: "host-service-start-failed",
 					description: error.message,
 				});
 			},
@@ -50,15 +61,6 @@ export function LocalHostServiceProvider({
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION
 		? MOCK_ORG_ID
 		: (session?.session?.activeOrganizationId ?? null);
-
-	// Local capability must never wait on cloud sync: main starts services for
-	// every previously-hosted org at boot; this covers a brand-new active org
-	// (no host dir yet) straight from the session.
-	useEffect(() => {
-		if (activeOrganizationId) {
-			startHostService({ organizationId: activeOrganizationId });
-		}
-	}, [activeOrganizationId, startHostService]);
 
 	const { data: machineIdData } = electronTrpc.device.getMachineId.useQuery(
 		undefined,
@@ -86,6 +88,44 @@ export function LocalHostServiceProvider({
 			},
 		);
 
+	// Proactively start the local host when the active org resolves so it's ready
+	// before the user acts. Main already starts previously-hosted orgs at boot and
+	// on token-saved; this covers a brand-new active org (no host dir yet) from the
+	// session. A failed start here (e.g. token not yet persisted) is recovered by
+	// waitForHostReady, which re-attempts on demand.
+	useEffect(() => {
+		if (activeOrganizationId) {
+			startHostService({ organizationId: activeOrganizationId });
+		}
+	}, [activeOrganizationId, startHostService]);
+
+	const waitForHostReady = useCallback(
+		async (timeoutMs = 20_000): Promise<string | null> => {
+			const orgId = activeOrganizationId;
+			if (!orgId) return null;
+			const deadline = Date.now() + timeoutMs;
+			while (Date.now() < deadline) {
+				const connection =
+					await utils.hostServiceCoordinator.getConnection.fetch({
+						organizationId: orgId,
+					});
+				if (connection?.port) {
+					const hostUrl = `http://127.0.0.1:${connection.port}`;
+					if (connection.secret)
+						setHostServiceSecret(hostUrl, connection.secret);
+					return hostUrl;
+				}
+				// Re-attempt the idempotent, local-only start each iteration so a
+				// transient failure (auth token not yet persisted, spawn miss)
+				// self-heals instead of polling a host that never came up.
+				startHostService({ organizationId: orgId });
+				await new Promise((resolve) => setTimeout(resolve, 1_000));
+			}
+			return null;
+		},
+		[activeOrganizationId, startHostService, utils],
+	);
+
 	const activeOrganizationName = activeOrganization?.name ?? null;
 
 	const value = useMemo<LocalHostServiceContextValue | null>(() => {
@@ -103,6 +143,7 @@ export function LocalHostServiceProvider({
 				activeOrganizationId: activeOrganizationId ?? null,
 				activeOrganizationName,
 				hostServiceStatus,
+				waitForHostReady,
 			};
 		}
 
@@ -117,6 +158,7 @@ export function LocalHostServiceProvider({
 			activeOrganizationId: activeOrganizationId ?? null,
 			activeOrganizationName,
 			hostServiceStatus,
+			waitForHostReady,
 		};
 	}, [
 		machineIdData,
@@ -124,6 +166,7 @@ export function LocalHostServiceProvider({
 		activeOrganizationId,
 		activeOrganizationName,
 		processStatus?.status,
+		waitForHostReady,
 	]);
 
 	if (!value) return null;


### PR DESCRIPTION
## Problem

On the onboarding **project** step, the folder picker (a purely local Electron dialog) was gated behind `activeHostUrl`: the "Browse…" / template / clone controls showed **"Connecting…"** and were disabled whenever the local host service wasn't up yet. Only the *downstream* project registration (`findByPath`/`create`/`setup`, clone) actually needs the host.

Worse, the provider fired `start` **exactly once** and silently swallowed `UNAUTHORIZED` (thrown when the auth token isn't persisted yet — a real race). If that first start failed, nothing retried, so the UI could sit on "Connecting…" indefinitely with only a reload/tray-restart escape.

This is inconsistent with the v2 local-first direction where surfaces render optimistically without host-reachability gates. v1 already opens the folder picker with purely local IPC.

## Fix

- **Ungate the picker** — `useFolderFirstImport` and the onboarding page now pick the folder immediately and await host readiness only at the host-backed registration call. Buttons are no longer disabled by host state, and "Connecting…" is gone.
- **`LocalHostService.waitForHostReady()`** — new context method that polls the live connection and **re-attempts the idempotent, local-only `start` each iteration**, so a transient failure (late token, spawn miss) self-heals on demand. Used at the point of each host-backed action. No standalone timer; the original single-shot proactive start effect is unchanged.
- **Toast dedupe** — repeated start-failure toasts collapse into one (stable id) instead of stacking.

The shared `useFolderFirstImport` hook is used by onboarding, FileMenuListener, ProjectPickerPill, and DashboardSidebarHeader, so all folder-import entry points benefit.

## Scope

Kept intentionally tight to the reported onboarding surface + the provider. The `NewProjectModal` / `TemplateGalleryModal` already degraded gracefully (toast, not a lock) and were left unchanged.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean (apps/desktop)
- [ ] Manual: onboarding project step with host service still starting — picker opens immediately; picking a folder / cloning completes once host comes up
- [ ] Manual: simulate a late auth token — confirm host self-heals via `waitForHostReady` instead of stranding on "Connecting…"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ungated the onboarding project folder picker so users can browse immediately; we now await host readiness only when registering or cloning. Added `waitForHostReady()` with resilient polling (retries start each poll, swallows transient errors, final check) and removed the “Connecting…” disabled state.

- **Bug Fixes**
  - Folder picker opens immediately; buttons no longer disabled and the timeout/reload hint is removed.
  - Clone/template actions wait for host readiness at the registration point; error toast shown if not ready.
  - Repeated start-failure toasts are deduped.
  - Polling swallows transient `getConnection` errors and performs a final check after the loop.
  - Tests: updated `useFolderFirstImport` test to mock `waitForHostReady()`.

- **New Features**
  - `LocalHostService.waitForHostReady()` polls the connection and retries the local start until ready or timeout; returns the loopback URL or null.
  - Used in `useFolderFirstImport` and the onboarding page; all folder-import entry points using this hook benefit.

<sup>Written for commit 8d466606ab3a9b46cf18275abfd4796d1ac7c1be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Open a folder” and repository cloning flows by waiting for the local host service after folder selection and before proceeding.
  * Updated project onboarding to use an async local host readiness check instead of the previous connecting/timeout UI.
  * Improved messaging and early exit behavior when the local host service never becomes available.
  * Prevented repeated local host service failure toasts during retries.
* **Tests**
  * Updated local host service mocks to include host readiness behavior for coverage consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->