### PR TITLE
fix(codex): bypass hook trust prompts

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts
@@ -42,7 +42,10 @@ describe("createDefaultV2TerminalPresetRows", () => {
 					presetId: "codex",
 					label: "Codex",
 					command: "codex",
-					args: ["--dangerously-bypass-approvals-and-sandbox"],
+					args: [
+						"--dangerously-bypass-approvals-and-sandbox",
+						"--dangerously-bypass-hook-trust",
+					],
 					order: 1,
 				}),
 				createAgent({
@@ -94,7 +97,7 @@ describe("createDefaultV2TerminalPresetRows", () => {
 			"claude --dangerously-skip-permissions",
 		]);
 		expect(rows[1]?.commands).toEqual([
-			"codex --dangerously-bypass-approvals-and-sandbox",
+			"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
 		]);
 		expect(rows[2]?.commands).toEqual(["opencode"]);
 		expect(rows[3]?.commands).toEqual(["copilot --allow-tool=write"]);

--- a/apps/docs/content/docs/terminal-presets.mdx
+++ b/apps/docs/content/docs/terminal-presets.mdx
@@ -45,7 +45,7 @@ Pre-configured presets for popular AI agents. Defaults mirror the bundled Supers
 
 - **amp** - `amp` (built-in permission rules auto-deny destructive ops)
 - **claude** - `claude --dangerously-skip-permissions`
-- **codex** - `codex --dangerously-bypass-approvals-and-sandbox` (most permissive)
+- **codex** - `codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust` (most permissive)
 - **gemini** - `gemini --approval-mode=auto_edit`
 - **copilot** - `copilot --allow-tool=write`
 - **cursor-agent** - `cursor-agent` (prompts for every action)

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -70,7 +70,7 @@ describe("agentConfigsRouter", () => {
 			expect(claude?.args).toEqual(["--dangerously-skip-permissions"]);
 		});
 
-		it("seeds Codex with its most permissive flag", async () => {
+		it("seeds Codex with its most permissive flags", async () => {
 			const caller = createCaller();
 			const result = await caller.list();
 			const codex = result.find((row) => row.presetId === "codex");
@@ -80,6 +80,7 @@ describe("agentConfigsRouter", () => {
 			);
 			expect(codex?.args).toEqual([
 				"--dangerously-bypass-approvals-and-sandbox",
+				"--dangerously-bypass-hook-trust",
 			]);
 			expect(codex?.args).not.toContain("--sandbox");
 			expect(codex?.args).not.toContain("--ask-for-approval");

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -16,7 +16,7 @@ describe("buildAgentPromptCommand", () => {
 		});
 
 		expect(command).toContain(
-			"codex --dangerously-bypass-approvals-and-sandbox -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
+			"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
 		);
 		expect(command).toContain("- Only modified file: runtime.ts");
 	});

--- a/packages/shared/src/agent-launch-request.test.ts
+++ b/packages/shared/src/agent-launch-request.test.ts
@@ -45,7 +45,8 @@ describe("buildPromptAgentLaunchRequest", () => {
 			kind: "terminal",
 			agentType: "codex",
 			terminal: {
-				command: "codex --dangerously-bypass-approvals-and-sandbox",
+				command:
+					"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
 			},
 		});
 	});

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -81,8 +81,10 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		label: "Codex",
 		description:
 			"OpenAI's coding agent for reading, modifying, and running code across tasks.",
-		command: "codex --dangerously-bypass-approvals-and-sandbox",
-		promptCommand: "codex --dangerously-bypass-approvals-and-sandbox --",
+		command:
+			"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust",
+		promptCommand:
+			"codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust --",
 		nonInteractiveCommand: "codex exec --skip-git-repo-check",
 		includeInDefaultTerminalPresets: true,
 	}),


### PR DESCRIPTION
## What changed

- add `--dangerously-bypass-hook-trust` to the bundled Codex interactive and prompt launch commands
- update host-service/default terminal preset expectations and documentation
- keep the separate read-only non-interactive workspace-naming command unchanged

## Why

Codex treats hook trust separately from approvals and sandboxing. As a result, Superset's existing `--dangerously-bypass-approvals-and-sandbox` default still stopped users at the "Hooks need review" dialog when a hook was new or its hash changed.

The new flag keeps hooks enabled and lets them run for the invocation without requiring persisted trust.

## Impact

Bundled Codex terminal sessions no longer block on hook trust review. Codex still shows its non-blocking warning that enabled hooks may run without review.

## Validation

- `bun test packages/shared/src/agent-command.test.ts packages/shared/src/agent-launch-request.test.ts packages/host-service/src/trpc/router/settings/agent-configs.test.ts apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useDefaultV2TerminalPresets/default-v2-terminal-presets.test.ts` — 50 passed
- `bun run lint:fix`
- `bun run lint`
- terminal E2E with Codex 0.144.6 and an isolated untrusted `SessionStart` hook:
  - without the flag, the TUI displayed the blocking "Hooks need review" dialog
  - with the bundled command, the TUI opened without the dialog
  - the hook completed and wrote its event payload
  - no trust hash was persisted


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass `codex` hook trust prompts by adding `--dangerously-bypass-hook-trust` to bundled interactive and prompt commands. Terminal sessions no longer block on “Hooks need review”; hooks run with the usual non-blocking warning and without persisting trust.

- **Bug Fixes**
  - Added `--dangerously-bypass-hook-trust` to `codex` `command` and `promptCommand`.
  - Updated default terminal presets, seed expectations, tests, and docs.
  - Left read-only non-interactive `codex exec` unchanged.

<sup>Written for commit b1d8159212db40f0fd68b375b7e03b6cbab53d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the built-in Codex terminal preset to include the hook-trust bypass option alongside its existing permissive settings.
  * Updated the Codex quick-add template and generated launch commands to use the revised command configuration.
* **Documentation**
  * Updated terminal preset documentation with the additional Codex option.
* **Tests**
  * Updated automated checks to reflect the revised Codex command and preset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->