### PR TITLE
fix(host-service): source workspace session lists from daemon+DB truth so background agents survive restarts

### DIFF
--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -13,7 +13,7 @@ import {
 	scanForTerminalTitle,
 	type TerminalTitleScanState,
 } from "@superset/shared/terminal-title-scanner";
-import { and, eq, isNull, ne } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne } from "drizzle-orm";
 import type { Hono } from "hono";
 import { isProcessAlive, readPtyDaemonManifest } from "../daemon/manifest.ts";
 import type { HostDb } from "../db/index.ts";
@@ -417,33 +417,68 @@ export function listTerminalSessions(
 		}));
 }
 
-export function countTerminalSessions(
-	options: {
-		workspaceId?: string;
-		includeExited?: boolean;
-		excludeTerminalIds?: Iterable<string>;
-	} = {},
-): number {
-	const includeExited = options.includeExited ?? true;
-	const excludedTerminalIds = options.excludeTerminalIds
-		? new Set(options.excludeTerminalIds)
-		: null;
-	let count = 0;
+/**
+ * Workspace session list sourced from truth, not from this process's memory.
+ *
+ * The in-memory map is attachment plumbing: it empties on every host-service
+ * restart while the detached pty-daemon keeps PTYs alive, and it only
+ * repopulates when a renderer attaches. Reading it alone made every pane-less
+ * session (background agents) invisible to the session dropdown, the
+ * background-terminals dropdown, and pane auto-adoption after a restart.
+ *
+ * So: in-memory sessions first (they carry liveness, titles, attachment, and
+ * respect `listed` for hidden internal sessions), then every other alive
+ * daemon session joined to an active workspace-owned row. Dispose-stamped
+ * rows are scheduled kills awaiting the reaper — never resurfaced. A session
+ * only the daemon knows has never been attached in this process's lifetime,
+ * hence `attached: false, title: null`.
+ */
+export async function listWorkspaceTerminalSessions(
+	db: HostDb,
+	workspaceId: string,
+): Promise<TerminalSessionSummary[]> {
+	const known = listTerminalSessions({ workspaceId, includeExited: false });
 
-	for (const session of sessions.values()) {
-		if (!session.listed) continue;
-		if (
-			options.workspaceId !== undefined &&
-			session.workspaceId !== options.workspaceId
-		) {
-			continue;
-		}
-		if (!includeExited && session.exited) continue;
-		if (excludedTerminalIds?.has(session.terminalId)) continue;
-		count += 1;
+	let daemonSessionIds: string[];
+	try {
+		const daemon = await getDaemonClient();
+		daemonSessionIds = (await daemon.list())
+			.filter((session) => session.alive && !sessions.has(session.id))
+			.map((session) => session.id);
+	} catch {
+		// Daemon unreachable — degrade to what this process knows.
+		return known;
 	}
+	if (daemonSessionIds.length === 0) return known;
 
-	return count;
+	const rows = db
+		.select({
+			id: terminalSessions.id,
+			originWorkspaceId: terminalSessions.originWorkspaceId,
+			status: terminalSessions.status,
+			createdAt: terminalSessions.createdAt,
+			disposeRequestedAt: terminalSessions.disposeRequestedAt,
+		})
+		.from(terminalSessions)
+		.where(inArray(terminalSessions.id, daemonSessionIds))
+		.all();
+
+	const merged = [...known];
+	for (const row of rows) {
+		if (row.originWorkspaceId !== workspaceId) continue;
+		if (row.status !== "active") continue;
+		if (row.disposeRequestedAt != null) continue;
+		merged.push({
+			terminalId: row.id,
+			workspaceId,
+			createdAt: row.createdAt,
+			exited: false,
+			exitCode: 0,
+			attached: false,
+			title: null,
+		});
+	}
+	return merged;
 }
 
 export function writeInputToSession({

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -437,18 +437,32 @@ export async function listWorkspaceTerminalSessions(
 	db: HostDb,
 	workspaceId: string,
 ): Promise<TerminalSessionSummary[]> {
-	const known = listTerminalSessions({ workspaceId, includeExited: false });
-
-	let daemonSessionIds: string[];
+	// `getDaemonClient` gates on the daemon bootstrap (waitForDaemonReady +
+	// supervisor.ensure), so a query racing a host-service restart blocks
+	// until the daemon is adopted instead of observing it as unreachable.
+	let daemonAliveIds: string[] | null;
 	try {
 		const daemon = await getDaemonClient();
-		daemonSessionIds = (await daemon.list())
-			.filter((session) => session.alive && !sessions.has(session.id))
+		daemonAliveIds = (await daemon.list())
+			.filter((session) => session.alive)
 			.map((session) => session.id);
-	} catch {
-		// Daemon unreachable — degrade to what this process knows.
-		return known;
+	} catch (error) {
+		// Daemon genuinely down — its PTYs died with it, so the in-memory
+		// view is the whole truth. The dropdowns' polls re-query, so a
+		// transient connection failure self-heals.
+		console.warn(
+			"[terminal] listWorkspaceTerminalSessions: daemon unreachable, serving in-memory view",
+			{ workspaceId, error },
+		);
+		daemonAliveIds = null;
 	}
+
+	// Snapshot memory AFTER the daemon await so a session disposed while the
+	// lookup was in flight can't be returned with stale live state.
+	const known = listTerminalSessions({ workspaceId, includeExited: false });
+	if (daemonAliveIds === null) return known;
+
+	const daemonSessionIds = daemonAliveIds.filter((id) => !sessions.has(id));
 	if (daemonSessionIds.length === 0) return known;
 
 	const rows = db

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -4,12 +4,11 @@ import { z } from "zod";
 import { getSupervisor, waitForDaemonReady } from "../../../daemon";
 import { terminalSessions, workspaces } from "../../../db/schema";
 import {
-	countTerminalSessions,
 	createTerminalSessionInternal,
 	disposeSessionAndWait,
 	disposeSessionsByWorkspaceId,
 	disposeSessionsByWorktreePath,
-	listTerminalSessions,
+	listWorkspaceTerminalSessions,
 	parseThemeType,
 	sessionHasRunningProcess,
 	writeInputToSession,
@@ -125,11 +124,8 @@ export const terminalRouter = router({
 				workspaceId: z.string(),
 			}),
 		)
-		.query(({ input }) => ({
-			sessions: listTerminalSessions({
-				workspaceId: input.workspaceId,
-				includeExited: false,
-			}),
+		.query(async ({ ctx, input }) => ({
+			sessions: await listWorkspaceTerminalSessions(ctx.db, input.workspaceId),
 		})),
 
 	countBackgroundSessions: protectedProcedure
@@ -139,13 +135,17 @@ export const terminalRouter = router({
 				attachedTerminalIds: z.array(z.string()).default([]),
 			}),
 		)
-		.query(({ input }) => ({
-			count: countTerminalSessions({
-				workspaceId: input.workspaceId,
-				includeExited: false,
-				excludeTerminalIds: input.attachedTerminalIds,
-			}),
-		})),
+		.query(async ({ ctx, input }) => {
+			const sessions = await listWorkspaceTerminalSessions(
+				ctx.db,
+				input.workspaceId,
+			);
+			const attached = new Set(input.attachedTerminalIds);
+			return {
+				count: sessions.filter((session) => !attached.has(session.terminalId))
+					.length,
+			};
+		}),
 
 	hasRunningProcess: protectedProcedure
 		.input(

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -386,6 +386,105 @@ describe("terminal router integration", () => {
 		}
 	}, 20_000);
 
+	test("listSessions and countBackgroundSessions see unattached daemon sessions after a host-service restart", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "host-service-session-truth-"));
+		const socketPath = join(tmp, "pty-daemon.sock");
+		const terminalId = randomUUID();
+		const stampedTerminalId = randomUUID();
+		let daemonProcess: ChildProcess | null = null;
+		try {
+			const daemonBundlePath = fileURLToPath(
+				new URL("../../../pty-daemon/dist/pty-daemon.js", import.meta.url),
+			);
+			ensureDaemonBundle(daemonBundlePath);
+			daemonProcess = spawn(
+				"node",
+				[daemonBundlePath, `--socket=${socketPath}`],
+				{
+					stdio: ["ignore", "ignore", "pipe"],
+					env: { ...process.env },
+				},
+			);
+			await waitFor(() => existsSync(socketPath), 3000);
+			process.env.SUPERSET_PTY_DAEMON_SOCKET = socketPath;
+			process.env.SUPERSET_HOME_DIR = tmp;
+
+			await scenario.host.trpc.terminal.createSession.mutate({
+				workspaceId: scenario.workspaceId,
+				terminalId,
+			});
+			await scenario.host.trpc.terminal.createSession.mutate({
+				workspaceId: scenario.workspaceId,
+				terminalId: stampedTerminalId,
+			});
+			const daemon = await getDaemonClient();
+			const findAlive = async (id: string) =>
+				(await daemon.list()).find(
+					(session) => session.id === id && session.alive,
+				) ?? null;
+			const deadline = Date.now() + 5000;
+			while (
+				(await findAlive(terminalId)) === null ||
+				(await findAlive(stampedTerminalId)) === null
+			) {
+				if (Date.now() > deadline) throw new Error("daemon sessions not alive");
+				await new Promise((resolve) => setTimeout(resolve, 150));
+			}
+			const before = await findAlive(terminalId);
+
+			// A dispose was requested but the kill never confirmed: this row is
+			// the reaper's to kill, and must never resurface in session lists.
+			scenario.host.db
+				.update(terminalSessions)
+				.set({ disposeRequestedAt: Date.now() })
+				.where(eq(terminalSessions.id, stampedTerminalId))
+				.run();
+
+			// Simulate a host-service restart: the daemon keeps both PTYs, this
+			// process forgets them. No renderer pane ever attaches — the
+			// background-agent case. The list must be correct immediately, with
+			// no reaper pass, warm-up, or renderer attach in between.
+			__resetSessionsForTesting();
+
+			const listed = await scenario.host.trpc.terminal.listSessions.query({
+				workspaceId: scenario.workspaceId,
+			});
+			expect(listed.sessions.map((session) => session.terminalId)).toEqual([
+				terminalId,
+			]);
+			const restored = listed.sessions[0];
+			expect(restored?.exited).toBe(false);
+			expect(restored?.attached).toBe(false);
+			expect(restored?.title).toBeNull();
+
+			const count =
+				await scenario.host.trpc.terminal.countBackgroundSessions.query({
+					workspaceId: scenario.workspaceId,
+					attachedTerminalIds: [],
+				});
+			expect(count.count).toBe(1);
+			const excludedCount =
+				await scenario.host.trpc.terminal.countBackgroundSessions.query({
+					workspaceId: scenario.workspaceId,
+					attachedTerminalIds: [terminalId],
+				});
+			expect(excludedCount.count).toBe(0);
+
+			// Listing is read-only: the live PTY must be untouched.
+			const after = await findAlive(terminalId);
+			expect(after?.pid).toBe(before?.pid as number);
+		} finally {
+			for (const id of [terminalId, stampedTerminalId]) {
+				await scenario.host.trpc.terminal.killSession
+					.mutate({ workspaceId: scenario.workspaceId, terminalId: id })
+					.catch(() => {});
+			}
+			await disposeDaemonClient();
+			await stopDaemonProcess(daemonProcess);
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	}, 20_000);
+
 	test("resource sessions are daemon-sourced and joined to active DB rows", () => {
 		const activeTerminalId = randomUUID();
 		const disposedTerminalId = randomUUID();


### PR DESCRIPTION
## Summary
- After any host-service restart (app update, tray restart, crash), every pane-less terminal session — i.e. background agents — vanished from the session dropdown, the background-terminals dropdown, and pane auto-adoption, while the agent kept running under the detached pty-daemon. Verified live: 17 daemon-owned PTYs (9 running agents: 8 Claude, 1 Codex) invisible right after the 1.16.0 update restarted the host-service.
- `terminal.listSessions` / `terminal.countBackgroundSessions` now answer from the source of truth (in-memory sessions ∪ daemon-alive ⨝ DB-active rows) instead of the in-memory session map alone.

## Why / Context
The in-memory session map is attachment plumbing: it empties on restart and only repopulates when a renderer attaches a pane. Reading it alone to answer "what sessions exist" made the answer wrong exactly when it matters — a background agent has no pane, so nothing ever re-registers it. It's also a deadlock: auto-adoption (#5740/#5808) is the thing that would attach a pane, but it reads the same blind `listSessions`. Meanwhile the sidebar agent chips (DB-joined bindings) still showed the agent, so users saw "there's a Claude in the background" while every terminal surface denied it existed.

This is the session-map twin of the port-detection gap fixed in #5325/#5430 — same root: host-service restart empties process-local state while the detached daemon keeps PTYs alive.

## How It Works
New `listWorkspaceTerminalSessions(db, workspaceId)` in `terminal.ts`:
1. In-memory sessions first — they own liveness, titles, socket-attachment, and respect `listed` for hidden internal sessions (teardown runners).
2. Union with every *other* alive daemon session joined to an `active`, workspace-owned, non-dispose-stamped row (`attached: false, title: null` — honest state for a session nothing has attached to since the restart). Dispose-stamped rows are the reaper's scheduled kills (workspace close, #5752) and are never resurfaced.
3. If the daemon is unreachable, degrade to the memory view — never worse than the old behavior.

Both router endpoints derive from this one function, so the dropdown and its count can never disagree. The now-callerless map-based `countTerminalSessions` is deleted. An earlier draft warmed the map back up via a reaper reconcile instead; rejected in favor of fixing the read at its source — no eventual-consistency window, no standing daemon subscriptions for unattached sessions.

## Manual QA — real before/after
Ran an isolated end-to-end harness: real host-service (source), its own production-style detached pty-daemon, one session, then a real `kill -TERM` + respawn of the host-service (the app-update scenario), no renderer ever attaching.

- [x] **Before (pre-fix code):** post-restart the daemon (same pid) still owns the alive PTY, but `listSessions` → `[]` and `countBackgroundSessions` → `0`
- [x] **After (this fix):** post-restart `listSessions` → the session, `count` → `1`, immediately on the first query — same daemon pid across the restart, PTY untouched
- [x] Fresh queries are read-only: daemon PTY pid unchanged before/after listing

## Testing
- New integration test (real pty-daemon): after a simulated restart the session is listed immediately with `attached:false`/`title:null`, counted as background, exclusion works, PTY pid untouched, and a dispose-stamped session never resurfaces. Mutation-checked: forcing the read back to map-only fails the test.
- `bun test` (packages/host-service): 892 pass / 0 fail
- `bun run typecheck` (host-service + desktop), `bun run lint` clean

## Known Limitations
- A restored session shows `title: null` ("Terminal") and `Detached` until something attaches — the daemon doesn't know renderer-side titles. Auto-adoption now sees the session and attaches, which restores the title.
- `listSessions`/`count` now do one `daemon.list()` round trip per query (local unix socket, same call the resources panel already makes). Renderer polls are 2s/10s while the respective dropdown is open.
- `terminal.writeInput` to a not-yet-attached restored session still returns NOT_FOUND (pre-existing); renderer flows attach before writing. Adopt-on-miss there is a possible follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session listing to read from the daemon + DB so background agents remain visible after host-service restarts. Prevents missing sessions in dropdowns and restores auto-adoption behavior.

- **Bug Fixes**
  - Session lists now union in-memory sessions with alive daemon sessions joined to active, non-disposed DB rows.
  - Restored sessions appear with attached:false and title:null until something attaches.
  - Snapshot in-memory state after the daemon lookup to avoid returning sessions disposed mid-flight.
  - Both `listSessions` and `countBackgroundSessions` use `listWorkspaceTerminalSessions`; count excludes `attachedTerminalIds` and falls back to in-memory with a warning if the daemon is unreachable.

<sup>Written for commit a0fe156c91d75c0b5193eb3c47f9b4b5b6e0239b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace terminal session listings now incorporate active sessions managed by the PTY service, including after host service restarts.
  - Returned sessions present consistent “detached” metadata (such as blank titles and default exit values) when applicable.
- **Bug Fixes**
  - Sessions with a pending disposal request no longer appear in active session lists or background-session counts.
  - Background-session counts remain accurate by excluding sessions already attached to this host process.
  - Session discovery gracefully falls back to in-process results if the PTY service is temporarily unreachable.
- **Tests**
  - Added an integration test covering post-restart listing/count behavior and ensuring daemon PTY state is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->