### PR TITLE
fix(desktop): preserve space after softbreak following inline marks

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -36,6 +36,7 @@ import { BubbleMenu } from "@tiptap/react/menus";
 import { common, createLowlight } from "lowlight";
 import { useEffect, useRef } from "react";
 import { BubbleMenuToolbar } from "renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/BubbleMenuToolbar";
+import { PreserveSoftbreakSpaces } from "renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces";
 import { env } from "renderer/env.renderer";
 import { useInlineUrlPolicy } from "renderer/lib/clickPolicy";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
@@ -330,6 +331,7 @@ export function MarkdownEditor({
 				transformPastedText: true,
 				transformCopiedText: true,
 			}),
+			PreserveSoftbreakSpaces,
 			...(showSlashCommand ? [SlashCommand] : []),
 			...(showEmoji ? [EmojiSuggestion] : []),
 			...(showFileMention

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -34,6 +34,7 @@ import { Markdown } from "tiptap-markdown";
 import { EditableCodeBlockView } from "./components/EditableCodeBlockView";
 import { ReadOnlyCodeBlockView } from "./components/ReadOnlyCodeBlockView";
 import { ReadOnlySafeImageView } from "./components/ReadOnlySafeImageView";
+import { PreserveSoftbreakSpaces } from "./preserveSoftbreakSpaces";
 import {
 	serializeMarkdownTable,
 	serializeSelectionForClipboard,
@@ -241,6 +242,7 @@ export function createMarkdownExtensions({
 			transformPastedText: true,
 			transformCopiedText: true,
 		}),
+		PreserveSoftbreakSpaces,
 		TableClipboardMarkdown,
 		EditorHotkeys.configure({
 			onSaveRef,

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/index.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/index.ts
@@ -1,0 +1,5 @@
+export {
+	PreserveSoftbreakSpaces,
+	preserveSoftbreakSpacesInDOM,
+	softbreakNewlineToSpace,
+} from "./preserveSoftbreakSpaces";

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.test.ts
@@ -1,5 +1,77 @@
-import { describe, expect, it } from "bun:test";
-import { softbreakNewlineToSpace } from "./preserveSoftbreakSpaces";
+import { beforeAll, describe, expect, it } from "bun:test";
+import {
+	PreserveSoftbreakSpaces,
+	preserveSoftbreakSpacesInDOM,
+	softbreakNewlineToSpace,
+} from "./preserveSoftbreakSpaces";
+
+beforeAll(() => {
+	globalThis.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 } as typeof Node;
+});
+
+type TestNode = TestElement | TestText;
+
+class TestText {
+	readonly nodeType = 3;
+	textContent: string;
+	nextSibling: TestNode | null = null;
+
+	constructor(text: string) {
+		this.textContent = text;
+	}
+}
+
+class TestElement {
+	readonly nodeType = 1;
+	nextSibling: TestNode | null = null;
+	parentElement: TestElement | null = null;
+	childNodes: TestNode[] = [];
+
+	constructor(readonly tagName: string) {}
+
+	closest(selector: string): TestElement | null {
+		const tag = selector.toUpperCase();
+		let current: TestElement | null = this;
+		while (current) {
+			if (current.tagName === tag) {
+				return current;
+			}
+			current = current.parentElement;
+		}
+		return null;
+	}
+
+	querySelectorAll(selector: string): TestElement[] {
+		if (selector !== "*") {
+			throw new Error(`test DOM only supports "*" (got ${selector})`);
+		}
+		const out: TestElement[] = [];
+		const walk = (node: TestNode) => {
+			if (node instanceof TestElement) {
+				out.push(node);
+				for (const child of node.childNodes) {
+					walk(child);
+				}
+			}
+		};
+		for (const child of this.childNodes) {
+			walk(child);
+		}
+		return out;
+	}
+}
+
+function append(parent: TestElement, children: TestNode[]): void {
+	parent.childNodes = children;
+	for (let i = 0; i < children.length; i++) {
+		const child = children[i];
+		if (!child) continue;
+		child.nextSibling = children[i + 1] ?? null;
+		if (child instanceof TestElement) {
+			child.parentElement = parent;
+		}
+	}
+}
 
 describe("softbreakNewlineToSpace", () => {
 	it("turns a softbreak before a word into a space (Mem0 README case)", () => {
@@ -8,12 +80,21 @@ describe("softbreakNewlineToSpace", () => {
 		);
 	});
 
+	it("turns a lone softbreak between marks into a space", () => {
+		expect(softbreakNewlineToSpace("\n", { followedByElement: true })).toBe(
+			" ",
+		);
+	});
+
 	it("leaves already-spaced text alone", () => {
 		expect(softbreakNewlineToSpace(" assistants")).toBe(" assistants");
 	});
 
-	it("leaves a lone newline alone (block separator whitespace)", () => {
+	it("leaves a lone newline alone when not followed by an element", () => {
 		expect(softbreakNewlineToSpace("\n")).toBe("\n");
+		expect(softbreakNewlineToSpace("\n", { followedByElement: false })).toBe(
+			"\n",
+		);
 	});
 
 	it("leaves a newline before more whitespace alone", () => {
@@ -24,11 +105,73 @@ describe("softbreakNewlineToSpace", () => {
 	it("does not touch text without a leading newline", () => {
 		expect(softbreakNewlineToSpace("assistants")).toBe("assistants");
 	});
+});
 
-	it("survives tiptap-markdown normalizeDOM strip after conversion", () => {
-		const afterUpdateDom = softbreakNewlineToSpace("\nassistants.");
-		// Same strip tiptap-markdown applies after updateDOM hooks.
-		const afterNormalize = afterUpdateDom.replace(/^\n/, "");
-		expect(afterNormalize).toBe(" assistants.");
+describe("preserveSoftbreakSpacesInDOM", () => {
+	it("inserts a space after a mark when softbreak shares the following text node", () => {
+		const root = new TestElement("DIV");
+		const p = new TestElement("P");
+		const strong = new TestElement("STRONG");
+		append(strong, [new TestText("and")]);
+		const after = new TestText("\nassistants.");
+		append(p, [new TestText("AI agents "), strong, after]);
+		append(root, [p]);
+
+		preserveSoftbreakSpacesInDOM(root as unknown as ParentNode);
+
+		expect(after.textContent).toBe(" assistants.");
+	});
+
+	it("inserts a space for a lone softbreak between consecutive marks", () => {
+		const root = new TestElement("DIV");
+		const p = new TestElement("P");
+		const first = new TestElement("STRONG");
+		const second = new TestElement("STRONG");
+		append(first, [new TestText("word1")]);
+		append(second, [new TestText("word2")]);
+		const softbreak = new TestText("\n");
+		append(p, [first, softbreak, second]);
+		append(root, [p]);
+
+		preserveSoftbreakSpacesInDOM(root as unknown as ParentNode);
+
+		expect(softbreak.textContent).toBe(" ");
+	});
+
+	it("does not rewrite softbreaks inside pre", () => {
+		const root = new TestElement("DIV");
+		const pre = new TestElement("PRE");
+		const code = new TestElement("CODE");
+		append(code, [new TestText("x")]);
+		const after = new TestText("\ny");
+		append(pre, [code, after]);
+		append(root, [pre]);
+
+		preserveSoftbreakSpacesInDOM(root as unknown as ParentNode);
+
+		expect(after.textContent).toBe("\ny");
+	});
+});
+
+describe("PreserveSoftbreakSpaces", () => {
+	it("registers a markdown parse.updateDOM hook that walks the DOM", () => {
+		const addStorage = PreserveSoftbreakSpaces.config.addStorage;
+		expect(typeof addStorage).toBe("function");
+		const storage = addStorage?.call({}) as {
+			markdown?: { parse?: { updateDOM?: (el: HTMLElement) => void } };
+		};
+		const updateDOM = storage.markdown?.parse?.updateDOM;
+		expect(typeof updateDOM).toBe("function");
+
+		const root = new TestElement("DIV");
+		const p = new TestElement("P");
+		const strong = new TestElement("STRONG");
+		append(strong, [new TestText("and")]);
+		const after = new TestText("\nassistants.");
+		append(p, [new TestText("AI agents "), strong, after]);
+		append(root, [p]);
+
+		updateDOM?.(root as unknown as HTMLElement);
+		expect(after.textContent).toBe(" assistants.");
 	});
 });

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { softbreakNewlineToSpace } from "./preserveSoftbreakSpaces";
+
+describe("softbreakNewlineToSpace", () => {
+	it("turns a softbreak before a word into a space (Mem0 README case)", () => {
+		expect(softbreakNewlineToSpace("\nassistants. It provides")).toBe(
+			" assistants. It provides",
+		);
+	});
+
+	it("leaves already-spaced text alone", () => {
+		expect(softbreakNewlineToSpace(" assistants")).toBe(" assistants");
+	});
+
+	it("leaves a lone newline alone (block separator whitespace)", () => {
+		expect(softbreakNewlineToSpace("\n")).toBe("\n");
+	});
+
+	it("leaves a newline before more whitespace alone", () => {
+		expect(softbreakNewlineToSpace("\n\n")).toBe("\n\n");
+		expect(softbreakNewlineToSpace("\n ")).toBe("\n ");
+	});
+
+	it("does not touch text without a leading newline", () => {
+		expect(softbreakNewlineToSpace("assistants")).toBe("assistants");
+	});
+
+	it("survives tiptap-markdown normalizeDOM strip after conversion", () => {
+		const afterUpdateDom = softbreakNewlineToSpace("\nassistants.");
+		// Same strip tiptap-markdown applies after updateDOM hooks.
+		const afterNormalize = afterUpdateDom.replace(/^\n/, "");
+		expect(afterNormalize).toBe(" assistants.");
+	});
+});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.ts
@@ -1,7 +1,16 @@
 import { Extension } from "@tiptap/core";
 
-export function softbreakNewlineToSpace(text: string): string {
-	return /^\n\S/.test(text) ? ` ${text.slice(1)}` : text;
+export function softbreakNewlineToSpace(
+	text: string,
+	options?: { followedByElement?: boolean },
+): string {
+	if (/^\n\S/.test(text)) {
+		return ` ${text.slice(1)}`;
+	}
+	if (text === "\n" && options?.followedByElement) {
+		return " ";
+	}
+	return text;
 }
 
 export function preserveSoftbreakSpacesInDOM(root: ParentNode): void {
@@ -16,7 +25,9 @@ export function preserveSoftbreakSpacesInDOM(root: ParentNode): void {
 			return;
 		}
 
-		const fixed = softbreakNewlineToSpace(text);
+		const fixed = softbreakNewlineToSpace(text, {
+			followedByElement: next.nextSibling?.nodeType === Node.ELEMENT_NODE,
+		});
 		if (fixed !== text) {
 			next.textContent = fixed;
 		}

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.ts
@@ -1,0 +1,40 @@
+import { Extension } from "@tiptap/core";
+
+export function softbreakNewlineToSpace(text: string): string {
+	return /^\n\S/.test(text) ? ` ${text.slice(1)}` : text;
+}
+
+export function preserveSoftbreakSpacesInDOM(root: ParentNode): void {
+	root.querySelectorAll("*").forEach((el) => {
+		const next = el.nextSibling;
+		if (next?.nodeType !== Node.TEXT_NODE || el.closest("pre")) {
+			return;
+		}
+
+		const text = next.textContent;
+		if (text == null) {
+			return;
+		}
+
+		const fixed = softbreakNewlineToSpace(text);
+		if (fixed !== text) {
+			next.textContent = fixed;
+		}
+	});
+}
+
+export const PreserveSoftbreakSpaces = Extension.create({
+	name: "preserveSoftbreakSpaces",
+
+	addStorage() {
+		return {
+			markdown: {
+				parse: {
+					updateDOM(element: HTMLElement) {
+						preserveSoftbreakSpacesInDOM(element);
+					},
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
<!--
PR titles become the squash-merge commit subject, so use conventional commit format:
  feat(desktop): add copy-logs button to failed CI checks
  fix(web): guard against missing PR in workspace header
-->

## What & why

Fixes #5286 

TipTap markdown preview dropped the space after a soft line break that followed an inline mark. Hard-wrapped source like `**and**\nassistants` rendered as **and**assistants (seen on the Mem0 README).

`tiptap-markdown` keeps markdown-it softbreaks as `\n`, then `normalizeDOM` strips a leading `\n` after every element — removing the CommonMark-required space. Added a `PreserveSoftbreakSpaces` parse hook (before that strip) in the file markdown viewer and the comment/editor TipTap path so `\n` + non-whitespace becomes a real space.

## How I tested it

- Unit tests: `bun test src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/preserveSoftbreakSpaces/preserveSoftbreakSpaces.test.ts`
- Manually opened a markdown file with `**word**` at a soft line wrap and confirmed the following word is spaced correctly in preview

### Screenshots

**Before**

<img width="1097" height="105" alt="Screenshot From 2026-07-21 18-40-54" src="https://github.com/user-attachments/assets/23a05686-aace-4b9f-80d1-de6d7de9aa0b" />


---

<img width="322" height="86" alt="Screenshot From 2026-07-21 18-40-35" src="https://github.com/user-attachments/assets/a77b7076-5b2a-480e-a3e7-11d402d02f8e" />

---

**After**

<img width="1097" height="105" alt="Screenshot From 2026-07-21 18-52-41" src="https://github.com/user-attachments/assets/b1013acb-ff5a-4d8f-bd7c-9551c4427531" />

---

<img width="1097" height="105" alt="Screenshot From 2026-07-21 18-52-51" src="https://github.com/user-attachments/assets/990531ed-5733-4583-a70c-a14da6eb4cff" />

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves spaces after soft line breaks in the desktop Markdown viewer and editor, including after inline marks and between consecutive marks, so hard-wrapped text like `**and**\nassistants` renders as “and assistants,” not “andassistants.” Fixes #5286.

- **Bug Fixes**
  - Added `PreserveSoftbreakSpaces` extension to convert softbreak `\n` to a space when followed by text or placed between adjacent inline elements during `tiptap-markdown` parse.
  - Enabled in both the file renderer and the editor.
  - Skips inside `<pre>` blocks; added unit tests for both scenarios.

<sup>Written for commit d689841ec4da7241a406b46398535f9ee09038e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown editing and rendering to preserve spaces after soft line breaks.
  * Prevented soft-break formatting from unintentionally removing leading spaces before text.
  * Preserved expected behavior for multiline content and code blocks.

* **Tests**
  * Added coverage for soft-break spacing, newline variations, and normalized Markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->