### PR TITLE
feat(desktop): open chat subagents in stacked right panes

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
@@ -1,4 +1,7 @@
+import type { WorkspaceStore } from "@superset/panes";
 import type { ChatLaunchConfig } from "shared/tabs-types";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData } from "../../../../types";
 import { ChatPaneInterface as WorkspaceChatInterface } from "./components/WorkspaceChatInterface";
 import { useWorkspaceChatController } from "./hooks/useWorkspaceChatController";
 
@@ -8,12 +11,18 @@ export function ChatPane({
 	workspaceId,
 	initialLaunchConfig,
 	onConsumeLaunchConfig,
+	paneId = null,
+	tabId = null,
+	store = null,
 }: {
 	onSessionIdChange: (sessionId: string | null) => void;
 	sessionId: string | null;
 	workspaceId: string;
 	initialLaunchConfig?: ChatLaunchConfig | null;
 	onConsumeLaunchConfig?: () => void;
+	paneId?: string | null;
+	tabId?: string | null;
+	store?: StoreApi<WorkspaceStore<PaneViewerData>> | null;
 }) {
 	const { organizationId, workspacePath, handleNewChat, getOrCreateSession } =
 		useWorkspaceChatController({
@@ -33,6 +42,9 @@ export function ChatPane({
 			workspaceId={workspaceId}
 			organizationId={organizationId}
 			cwd={workspacePath}
+			paneId={paneId}
+			tabId={tabId}
+			store={store}
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
@@ -22,6 +22,7 @@ import {
 } from "renderer/lib/dev-chat";
 import { posthog } from "renderer/lib/posthog";
 import { useChatPreferencesStore } from "renderer/stores/chat-preferences";
+import { useAutoOpenSubagentPanes } from "../../hooks/useAutoOpenSubagentPanes";
 import {
 	type UseChatDisplayReturn,
 	useChatDisplay,
@@ -198,6 +199,9 @@ export function ChatPaneInterface({
 	getOrCreateSession,
 	onResetSession,
 	onUserMessageSubmitted,
+	paneId = null,
+	tabId = null,
+	store = null,
 }: ChatPaneInterfaceProps) {
 	const { models: availableModels, defaultModel } = useAvailableModels();
 	const selectedModelId = useChatPreferencesStore(
@@ -309,6 +313,13 @@ export function ChatPaneInterface({
 		pendingPlanApproval = null,
 		pendingQuestion = null,
 	} = chat;
+	useAutoOpenSubagentPanes({
+		store,
+		tabId,
+		parentPaneId: paneId,
+		sessionId,
+		activeSubagents,
+	});
 	const isAwaitingAssistant =
 		isRunning || submitStatus === "submitted" || submitStatus === "streaming";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/types.ts
@@ -1,4 +1,7 @@
+import type { WorkspaceStore } from "@superset/panes";
 import type { ChatLaunchConfig } from "shared/tabs-types";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData } from "../../../../../../types";
 
 export interface ChatPaneInterfaceProps {
 	sessionId: string | null;
@@ -16,4 +19,7 @@ export interface ChatPaneInterfaceProps {
 	getOrCreateSession: () => Promise<string>;
 	onResetSession: () => Promise<void>;
 	onUserMessageSubmitted?: (message: string) => void;
+	paneId?: string | null;
+	tabId?: string | null;
+	store?: StoreApi<WorkspaceStore<PaneViewerData>> | null;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useAutoOpenSubagentPanes/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useAutoOpenSubagentPanes/index.ts
@@ -1,0 +1,1 @@
+export { useAutoOpenSubagentPanes } from "./useAutoOpenSubagentPanes";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useAutoOpenSubagentPanes/useAutoOpenSubagentPanes.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useAutoOpenSubagentPanes/useAutoOpenSubagentPanes.ts
@@ -1,0 +1,86 @@
+import type { WorkspaceStore } from "@superset/panes";
+import { useEffect, useRef } from "react";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData } from "../../../../../../types";
+import { openSubagentPane } from "../../../../../../utils/openSubagentPane";
+import type { UseChatDisplayReturn } from "../useWorkspaceChatDisplay";
+
+type ChatActiveSubagents = NonNullable<UseChatDisplayReturn["activeSubagents"]>;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return null;
+	}
+	return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function listSubagentEntries(
+	activeSubagents: ChatActiveSubagents | undefined | null,
+): Array<{
+	toolCallId: string;
+	task?: string;
+	agentType?: string;
+}> {
+	if (!activeSubagents || typeof activeSubagents.entries !== "function") {
+		return [];
+	}
+
+	const entries: Array<{
+		toolCallId: string;
+		task?: string;
+		agentType?: string;
+	}> = [];
+	for (const [toolCallId, subagent] of activeSubagents.entries()) {
+		if (typeof toolCallId !== "string" || toolCallId.length === 0) continue;
+		const record = asRecord(subagent);
+		entries.push({
+			toolCallId,
+			task: asString(record?.task),
+			agentType: asString(record?.agentType) ?? asString(record?.displayName),
+		});
+	}
+	return entries;
+}
+
+export function useAutoOpenSubagentPanes({
+	store,
+	tabId,
+	parentPaneId,
+	sessionId,
+	activeSubagents,
+}: {
+	store: StoreApi<WorkspaceStore<PaneViewerData>> | null;
+	tabId: string | null;
+	parentPaneId: string | null;
+	sessionId: string | null;
+	activeSubagents: ChatActiveSubagents | undefined | null;
+}) {
+	const openedToolCallIdsRef = useRef(new Set<string>());
+
+	useEffect(() => {
+		openedToolCallIdsRef.current.clear();
+	}, []);
+
+	useEffect(() => {
+		if (!store || !tabId || !parentPaneId || !sessionId) return;
+
+		for (const entry of listSubagentEntries(activeSubagents)) {
+			if (openedToolCallIdsRef.current.has(entry.toolCallId)) continue;
+			openedToolCallIdsRef.current.add(entry.toolCallId);
+			openSubagentPane(store, {
+				tabId,
+				parentPaneId,
+				parentSessionId: sessionId,
+				toolCallId: entry.toolCallId,
+				task: entry.task,
+				agentType: entry.agentType,
+			});
+		}
+	}, [activeSubagents, parentPaneId, sessionId, store, tabId]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useAutoOpenSubagentPanes/useAutoOpenSubagentPanes.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useAutoOpenSubagentPanes/useAutoOpenSubagentPanes.ts
@@ -2,7 +2,10 @@ import type { WorkspaceStore } from "@superset/panes";
 import { useEffect, useRef } from "react";
 import type { StoreApi } from "zustand/vanilla";
 import type { PaneViewerData } from "../../../../../../types";
-import { openSubagentPane } from "../../../../../../utils/openSubagentPane";
+import {
+	findSubagentPaneLocation,
+	openSubagentPane,
+} from "../../../../../../utils/openSubagentPane";
 import type { UseChatDisplayReturn } from "../useWorkspaceChatDisplay";
 
 type ChatActiveSubagents = NonNullable<UseChatDisplayReturn["activeSubagents"]>;
@@ -65,14 +68,17 @@ export function useAutoOpenSubagentPanes({
 
 	useEffect(() => {
 		openedToolCallIdsRef.current.clear();
-	}, []);
+	}, [sessionId, parentPaneId]);
 
 	useEffect(() => {
 		if (!store || !tabId || !parentPaneId || !sessionId) return;
 
+		const state = store.getState();
 		for (const entry of listSubagentEntries(activeSubagents)) {
 			if (openedToolCallIdsRef.current.has(entry.toolCallId)) continue;
 			openedToolCallIdsRef.current.add(entry.toolCallId);
+			if (findSubagentPaneLocation(state, entry.toolCallId)) continue;
+
 			openSubagentPane(store, {
 				tabId,
 				parentPaneId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/SubagentPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/SubagentPane.tsx
@@ -1,0 +1,54 @@
+import type { RendererContext } from "@superset/panes";
+import { useMemo } from "react";
+import type { PaneViewerData, SubagentPaneData } from "../../../../types";
+import { SubagentExecutionMessage } from "../ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/SubagentExecutionMessage";
+import { useChatDisplay } from "../ChatPane/hooks/useWorkspaceChatDisplay";
+import { resolveSubagentEntries } from "./utils/resolveSubagentEntries";
+
+interface SubagentPaneProps {
+	context: RendererContext<PaneViewerData>;
+	workspaceId: string;
+}
+
+export function SubagentPane({ context, workspaceId }: SubagentPaneProps) {
+	const data = context.pane.data as SubagentPaneData;
+	const chat = useChatDisplay({
+		sessionId: data.parentSessionId,
+		workspaceId,
+		enabled: Boolean(data.parentSessionId),
+	});
+
+	const entries = useMemo(
+		() =>
+			resolveSubagentEntries({
+				toolCallId: data.toolCallId,
+				activeSubagents: chat.activeSubagents,
+				messages: chat.messages ?? [],
+				fallback: {
+					task: data.task,
+					agentType: data.agentType,
+				},
+			}),
+		[
+			chat.activeSubagents,
+			chat.messages,
+			data.agentType,
+			data.task,
+			data.toolCallId,
+		],
+	);
+
+	return (
+		<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
+			<div className="min-h-0 flex-1 overflow-y-auto p-3 select-text">
+				{entries.length > 0 ? (
+					<SubagentExecutionMessage subagents={entries} inline />
+				) : (
+					<div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+						Waiting for subagent activity…
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/components/SubagentPaneTitle/SubagentPaneTitle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/components/SubagentPaneTitle/SubagentPaneTitle.tsx
@@ -1,0 +1,55 @@
+import type { RendererContext } from "@superset/panes";
+import { cn } from "@superset/ui/utils";
+import { useMemo } from "react";
+import type { PaneViewerData, SubagentPaneData } from "../../../../../../types";
+import { useChatDisplay } from "../../../ChatPane/hooks/useWorkspaceChatDisplay";
+import { resolveSubagentTitle } from "../../utils/resolveSubagentEntries";
+
+interface SubagentPaneTitleProps {
+	context: RendererContext<PaneViewerData>;
+	workspaceId: string;
+}
+
+export function SubagentPaneTitle({
+	context,
+	workspaceId,
+}: SubagentPaneTitleProps) {
+	const data = context.pane.data as SubagentPaneData;
+	const chat = useChatDisplay({
+		sessionId: data.parentSessionId,
+		workspaceId,
+		enabled: Boolean(data.parentSessionId),
+	});
+
+	const title = useMemo(
+		() =>
+			resolveSubagentTitle({
+				toolCallId: data.toolCallId,
+				activeSubagents: chat.activeSubagents,
+				messages: chat.messages ?? [],
+				fallback: {
+					task: data.task,
+					agentType: data.agentType,
+				},
+			}),
+		[
+			chat.activeSubagents,
+			chat.messages,
+			data.agentType,
+			data.task,
+			data.toolCallId,
+		],
+	);
+
+	return (
+		<div
+			className={cn(
+				"flex min-w-0 items-center gap-1.5 text-xs transition-colors duration-150",
+				context.isActive ? "text-foreground" : "text-muted-foreground",
+			)}
+			title={data.task ?? title}
+		>
+			<span className="min-w-0 truncate">{title}</span>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/components/SubagentPaneTitle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/components/SubagentPaneTitle/index.ts
@@ -1,0 +1,1 @@
+export { SubagentPaneTitle } from "./SubagentPaneTitle";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/index.ts
@@ -1,0 +1,1 @@
+export { SubagentPane } from "./SubagentPane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/utils/resolveSubagentEntries/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/utils/resolveSubagentEntries/index.ts
@@ -1,0 +1,4 @@
+export {
+	resolveSubagentEntries,
+	resolveSubagentTitle,
+} from "./resolveSubagentEntries";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/utils/resolveSubagentEntries/resolveSubagentEntries.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/utils/resolveSubagentEntries/resolveSubagentEntries.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { resolveSubagentEntries } from "./resolveSubagentEntries";
+
+describe("resolveSubagentEntries", () => {
+	it("prefers live activeSubagents state", () => {
+		const activeSubagents = new Map([
+			[
+				"tool-1",
+				{
+					agentType: "explore",
+					task: "Find files",
+					textDelta: "Searching…",
+					toolCalls: [{ name: "bash", isError: false }],
+					status: "running" as const,
+				},
+			],
+		]);
+
+		const entries = resolveSubagentEntries({
+			toolCallId: "tool-1",
+			activeSubagents,
+			messages: [],
+			fallback: { task: "fallback" },
+		});
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.[0]).toBe("tool-1");
+		expect((entries[0]?.[1] as { task: string }).task).toBe("Find files");
+	});
+
+	it("falls back to message history when subagent left the live map", () => {
+		const entries = resolveSubagentEntries({
+			toolCallId: "tool-2",
+			activeSubagents: new Map(),
+			messages: [
+				{
+					id: "msg-1",
+					role: "assistant",
+					content: [
+						{
+							type: "tool_call",
+							id: "tool-2",
+							name: "subagent",
+							args: { task: "Summarize", agentType: "explore" },
+						},
+						{
+							type: "tool_result",
+							id: "tool-2",
+							result: "All done",
+							isError: false,
+						},
+					],
+					createdAt: new Date(),
+				},
+			] as never,
+			fallback: {},
+		});
+
+		expect(entries).toHaveLength(1);
+		expect((entries[0]?.[1] as { status: string }).status).toBe("completed");
+		expect((entries[0]?.[1] as { result?: string }).result).toBe("All done");
+	});
+
+	it("uses fallback when nothing is known yet", () => {
+		const entries = resolveSubagentEntries({
+			toolCallId: "tool-3",
+			activeSubagents: undefined,
+			messages: [],
+			fallback: { task: "Bootstrapping", agentType: "execute" },
+		});
+
+		expect(entries).toHaveLength(1);
+		expect((entries[0]?.[1] as { agentType: string }).agentType).toBe(
+			"execute",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/utils/resolveSubagentEntries/resolveSubagentEntries.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/SubagentPane/utils/resolveSubagentEntries/resolveSubagentEntries.ts
@@ -1,0 +1,149 @@
+import { parseSubagentToolResult } from "renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/SubagentToolCall/utils/parseSubagentToolResult";
+import { normalizeToolName } from "renderer/components/Chat/ChatInterface/utils/tool-helpers";
+import {
+	type SubagentEntries,
+	toSubagentViewModels,
+} from "../../../ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/SubagentExecutionMessage/utils/toSubagentViewModels";
+import type { UseChatDisplayReturn } from "../../../ChatPane/hooks/useWorkspaceChatDisplay";
+
+type ChatMessage = NonNullable<UseChatDisplayReturn["messages"]>[number];
+type ChatMessageContent = ChatMessage["content"][number];
+type ChatToolCall = Extract<ChatMessageContent, { type: "tool_call" }>;
+type ChatToolResult = Extract<ChatMessageContent, { type: "tool_result" }>;
+type ChatActiveSubagents = NonNullable<UseChatDisplayReturn["activeSubagents"]>;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return null;
+	}
+	return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function findToolCallAndResult(
+	messages: ChatMessage[],
+	toolCallId: string,
+): { call: ChatToolCall | null; result: ChatToolResult | null } {
+	let call: ChatToolCall | null = null;
+	let result: ChatToolResult | null = null;
+
+	for (const message of messages) {
+		for (const part of message.content) {
+			if (part.type === "tool_call" && part.id === toolCallId) {
+				call = part;
+			}
+			if (part.type === "tool_result" && part.id === toolCallId) {
+				result = part;
+			}
+		}
+	}
+
+	return { call, result };
+}
+
+function subagentFromMessages(
+	messages: ChatMessage[],
+	toolCallId: string,
+	fallback: { task?: string; agentType?: string },
+): SubagentEntries[number] | null {
+	const { call, result } = findToolCallAndResult(messages, toolCallId);
+	if (!call || normalizeToolName(call.name) !== "subagent") {
+		if (!fallback.task && !fallback.agentType) return null;
+		return [
+			toolCallId,
+			{
+				agentType: fallback.agentType ?? "subagent",
+				task: fallback.task ?? "Working on task...",
+				textDelta: "",
+				toolCalls: [],
+				status: "running",
+			},
+		];
+	}
+
+	const args = asRecord(call.args) ?? {};
+	const rawResult = result?.result;
+	const parsed =
+		typeof rawResult === "string"
+			? parseSubagentToolResult({ content: rawResult })
+			: parseSubagentToolResult(rawResult);
+	const status = result
+		? result.isError
+			? ("error" as const)
+			: ("completed" as const)
+		: ("running" as const);
+
+	const resultText =
+		parsed.text ||
+		(typeof rawResult === "string" ? rawResult.trim() : "") ||
+		undefined;
+
+	return [
+		toolCallId,
+		{
+			agentType: asString(args.agentType) ?? fallback.agentType ?? "subagent",
+			task: asString(args.task) ?? fallback.task ?? "Working on task...",
+			modelId: parsed.modelId,
+			textDelta: "",
+			result: status === "running" ? undefined : resultText,
+			durationMs: parsed.durationMs,
+			toolCalls: parsed.tools.map((tool) => ({
+				name: tool.name,
+				isError: tool.isError,
+				args: tool.args,
+				result: tool.result,
+			})),
+			status,
+			...(result?.isError ? { error: resultText || "Failed" } : {}),
+		},
+	];
+}
+
+export function resolveSubagentEntries({
+	toolCallId,
+	activeSubagents,
+	messages,
+	fallback,
+}: {
+	toolCallId: string;
+	activeSubagents: ChatActiveSubagents | undefined | null;
+	messages: ChatMessage[];
+	fallback: { task?: string; agentType?: string };
+}): SubagentEntries {
+	const live = activeSubagents?.get?.(toolCallId);
+	if (live !== undefined && live !== null) {
+		return [[toolCallId, live]];
+	}
+
+	const fromMessages = subagentFromMessages(messages, toolCallId, fallback);
+	return fromMessages ? [fromMessages] : [];
+}
+
+export function resolveSubagentTitle({
+	toolCallId,
+	activeSubagents,
+	messages,
+	fallback,
+}: {
+	toolCallId: string;
+	activeSubagents: ChatActiveSubagents | undefined | null;
+	messages: ChatMessage[];
+	fallback: { task?: string; agentType?: string };
+}): string {
+	const entries = resolveSubagentEntries({
+		toolCallId,
+		activeSubagents,
+		messages,
+		fallback,
+	});
+	const [viewModel] = toSubagentViewModels(entries);
+	if (!viewModel) {
+		return fallback.agentType ?? fallback.task ?? "Subagent";
+	}
+	return viewModel.agentType || viewModel.task || "Subagent";
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -8,7 +8,13 @@ import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { Circle, GitCompareArrows, Globe, MessageSquare } from "lucide-react";
+import {
+	Bot,
+	Circle,
+	GitCompareArrows,
+	Globe,
+	MessageSquare,
+} from "lucide-react";
 import { useCallback, useMemo } from "react";
 import {
 	LuArrowDownToLine,
@@ -42,6 +48,7 @@ import type {
 	DevtoolsPaneData,
 	FilePaneData,
 	PaneViewerData,
+	SubagentPaneData,
 	TerminalPaneData,
 } from "../../types";
 import type { TerminalLauncher } from "../useV2TerminalLauncher";
@@ -55,6 +62,8 @@ import { DiffPane } from "./components/DiffPane";
 import { DiffPaneHeaderExtras } from "./components/DiffPane/components/DiffPaneHeaderExtras";
 import { FilePane } from "./components/FilePane";
 import { FilePaneHeaderExtras } from "./components/FilePane/components/FilePaneHeaderExtras";
+import { SubagentPane } from "./components/SubagentPane";
+import { SubagentPaneTitle } from "./components/SubagentPane/components/SubagentPaneTitle";
 import { TerminalPane } from "./components/TerminalPane";
 import { TerminalPaneHeaderExtras } from "./components/TerminalPane/components/TerminalPaneHeaderExtras";
 import { TerminalPaneIcon } from "./components/TerminalPane/components/TerminalPaneIcon";
@@ -520,12 +529,32 @@ export function usePaneRegistry({
 							onConsumeLaunchConfig={() =>
 								ctx.actions.updateData({ ...data, launchConfig: null })
 							}
+							paneId={ctx.pane.id}
+							tabId={ctx.tab.id}
+							store={ctx.store}
 						/>
 					);
 				},
 				contextMenuActions: (_ctx, defaults) =>
 					defaults.map((d) =>
 						d.key === "close-pane" ? { ...d, label: "Close Chat" } : d,
+					),
+			},
+			subagent: {
+				getIcon: () => <Bot className="size-3.5" />,
+				getTitle: (pane) => {
+					const data = pane.data as SubagentPaneData;
+					return data.agentType || data.task || "Subagent";
+				},
+				renderTitle: (ctx: RendererContext<PaneViewerData>) => (
+					<SubagentPaneTitle context={ctx} workspaceId={workspaceId} />
+				),
+				renderPane: (ctx: RendererContext<PaneViewerData>) => (
+					<SubagentPane context={ctx} workspaceId={workspaceId} />
+				),
+				contextMenuActions: (_ctx, defaults) =>
+					defaults.map((d) =>
+						d.key === "close-pane" ? { ...d, label: "Close Subagent" } : d,
 					),
 			},
 			comment: {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -29,6 +29,14 @@ export interface ChatPaneData {
 	} | null;
 }
 
+export interface SubagentPaneData {
+	parentSessionId: string;
+	parentPaneId: string;
+	toolCallId: string;
+	task?: string;
+	agentType?: string;
+}
+
 export interface BrowserPaneData {
 	url: string;
 	pageTitle?: string;
@@ -67,6 +75,7 @@ export type PaneViewerData =
 	| FilePaneData
 	| TerminalPaneData
 	| ChatPaneData
+	| SubagentPaneData
 	| BrowserPaneData
 	| DevtoolsPaneData
 	| DiffPaneData

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openSubagentPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openSubagentPane/index.ts
@@ -1,0 +1,2 @@
+export type { OpenSubagentPaneResult } from "./openSubagentPane";
+export { findSubagentPaneLocation, openSubagentPane } from "./openSubagentPane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openSubagentPane/openSubagentPane.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openSubagentPane/openSubagentPane.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createWorkspaceStore,
+	type LayoutNode,
+	type WorkspaceState,
+} from "@superset/panes";
+import type {
+	ChatPaneData,
+	PaneViewerData,
+	SubagentPaneData,
+} from "../../types";
+import { findSubagentPaneLocation, openSubagentPane } from "./openSubagentPane";
+
+function chatPane(id: string, sessionId: string) {
+	return {
+		id,
+		kind: "chat",
+		data: { sessionId } as ChatPaneData as PaneViewerData,
+	};
+}
+
+function subagentPane(
+	id: string,
+	data: SubagentPaneData,
+): {
+	id: string;
+	kind: string;
+	data: PaneViewerData;
+} {
+	return {
+		id,
+		kind: "subagent",
+		data: data as PaneViewerData,
+	};
+}
+
+function paneLayout(paneId: string): LayoutNode {
+	return { type: "pane", paneId };
+}
+
+function workspaceWithChat(): WorkspaceState<PaneViewerData> {
+	return {
+		version: 1,
+		activeTabId: "tab-1",
+		tabs: [
+			{
+				id: "tab-1",
+				createdAt: 1,
+				activePaneId: "chat-1",
+				layout: paneLayout("chat-1"),
+				panes: {
+					"chat-1": chatPane("chat-1", "session-1"),
+				},
+			},
+		],
+	};
+}
+
+describe("openSubagentPane", () => {
+	it("opens the first subagent to the right of the parent chat", () => {
+		const store = createWorkspaceStore<PaneViewerData>({
+			initialState: workspaceWithChat(),
+		});
+
+		expect(
+			openSubagentPane(store, {
+				tabId: "tab-1",
+				parentPaneId: "chat-1",
+				parentSessionId: "session-1",
+				toolCallId: "tool-1",
+				task: "Explore codebase",
+				agentType: "explore",
+			}),
+		).toBe("opened-right");
+
+		const tab = store.getState().getTab("tab-1");
+		expect(tab).toBeTruthy();
+		const subagentPanes = Object.values(tab?.panes ?? {}).filter(
+			(pane) => pane.kind === "subagent",
+		);
+		expect(subagentPanes).toHaveLength(1);
+		expect((subagentPanes[0]?.data as SubagentPaneData).toolCallId).toBe(
+			"tool-1",
+		);
+		expect(tab?.activePaneId).toBe("chat-1");
+	});
+
+	it("stacks subsequent subagents under the right column", () => {
+		const store = createWorkspaceStore<PaneViewerData>({
+			initialState: workspaceWithChat(),
+		});
+
+		openSubagentPane(store, {
+			tabId: "tab-1",
+			parentPaneId: "chat-1",
+			parentSessionId: "session-1",
+			toolCallId: "tool-1",
+			agentType: "explore",
+		});
+		expect(
+			openSubagentPane(store, {
+				tabId: "tab-1",
+				parentPaneId: "chat-1",
+				parentSessionId: "session-1",
+				toolCallId: "tool-2",
+				agentType: "execute",
+			}),
+		).toBe("stacked");
+
+		const tab = store.getState().getTab("tab-1");
+		const subagentPanes = Object.values(tab?.panes ?? {}).filter(
+			(pane) => pane.kind === "subagent",
+		);
+		expect(subagentPanes).toHaveLength(2);
+	});
+
+	it("focuses an existing pane for the same toolCallId", () => {
+		const store = createWorkspaceStore<PaneViewerData>({
+			initialState: workspaceWithChat(),
+		});
+
+		openSubagentPane(store, {
+			tabId: "tab-1",
+			parentPaneId: "chat-1",
+			parentSessionId: "session-1",
+			toolCallId: "tool-1",
+		});
+
+		expect(
+			openSubagentPane(store, {
+				tabId: "tab-1",
+				parentPaneId: "chat-1",
+				parentSessionId: "session-1",
+				toolCallId: "tool-1",
+			}),
+		).toBe("focused");
+
+		const tab = store.getState().getTab("tab-1");
+		const subagentPanes = Object.values(tab?.panes ?? {}).filter(
+			(pane) => pane.kind === "subagent",
+		);
+		expect(subagentPanes).toHaveLength(1);
+	});
+
+	it("finds an existing subagent pane location", () => {
+		const store = createWorkspaceStore<PaneViewerData>({
+			initialState: {
+				version: 1,
+				activeTabId: "tab-1",
+				tabs: [
+					{
+						id: "tab-1",
+						createdAt: 1,
+						activePaneId: "chat-1",
+						layout: paneLayout("sub-1"),
+						panes: {
+							"chat-1": chatPane("chat-1", "session-1"),
+							"sub-1": subagentPane("sub-1", {
+								parentSessionId: "session-1",
+								parentPaneId: "chat-1",
+								toolCallId: "tool-9",
+							}),
+						},
+					},
+				],
+			},
+		});
+
+		expect(findSubagentPaneLocation(store.getState(), "tool-9")).toEqual({
+			tabId: "tab-1",
+			paneId: "sub-1",
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openSubagentPane/openSubagentPane.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openSubagentPane/openSubagentPane.ts
@@ -1,0 +1,165 @@
+import {
+	getSpatialNeighborPaneId,
+	type WorkspaceState,
+	type WorkspaceStore,
+} from "@superset/panes";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData, SubagentPaneData } from "../../types";
+
+interface SubagentPaneLocation {
+	tabId: string;
+	paneId: string;
+}
+
+export type OpenSubagentPaneResult = "focused" | "opened-right" | "stacked";
+
+function isSubagentPaneData(data: unknown): data is SubagentPaneData {
+	if (typeof data !== "object" || data === null) return false;
+	const record = data as Record<string, unknown>;
+	return (
+		typeof record.parentSessionId === "string" &&
+		typeof record.parentPaneId === "string" &&
+		typeof record.toolCallId === "string"
+	);
+}
+
+function matchesParentColumn(
+	data: SubagentPaneData,
+	parentPaneId: string,
+	parentSessionId: string,
+): boolean {
+	return (
+		data.parentPaneId === parentPaneId &&
+		data.parentSessionId === parentSessionId
+	);
+}
+
+export function findSubagentPaneLocation(
+	state: WorkspaceState<PaneViewerData>,
+	toolCallId: string,
+): SubagentPaneLocation | null {
+	for (const tab of state.tabs) {
+		for (const pane of Object.values(tab.panes)) {
+			if (pane.kind !== "subagent") continue;
+			if (!isSubagentPaneData(pane.data)) continue;
+			if (pane.data.toolCallId !== toolCallId) continue;
+			return { tabId: tab.id, paneId: pane.id };
+		}
+	}
+	return null;
+}
+
+function findBottommostSubagentInColumn(
+	state: WorkspaceState<PaneViewerData>,
+	tabId: string,
+	startPaneId: string,
+	parentPaneId: string,
+	parentSessionId: string,
+): string {
+	const tab = state.tabs.find((candidate) => candidate.id === tabId);
+	if (!tab?.layout) return startPaneId;
+
+	let current = startPaneId;
+	while (true) {
+		const downId = getSpatialNeighborPaneId(tab.layout, current, "down");
+		if (!downId) return current;
+		const downPane = tab.panes[downId];
+		if (downPane?.kind !== "subagent" || !isSubagentPaneData(downPane.data)) {
+			return current;
+		}
+		if (!matchesParentColumn(downPane.data, parentPaneId, parentSessionId)) {
+			return current;
+		}
+		current = downId;
+	}
+}
+
+function findRightSubagentColumnRoot(
+	state: WorkspaceState<PaneViewerData>,
+	tabId: string,
+	parentPaneId: string,
+	parentSessionId: string,
+): string | null {
+	const tab = state.tabs.find((candidate) => candidate.id === tabId);
+	if (!tab?.layout) return null;
+
+	const rightId = getSpatialNeighborPaneId(tab.layout, parentPaneId, "right");
+	if (!rightId) return null;
+
+	const rightPane = tab.panes[rightId];
+	if (rightPane?.kind !== "subagent" || !isSubagentPaneData(rightPane.data)) {
+		return null;
+	}
+	if (!matchesParentColumn(rightPane.data, parentPaneId, parentSessionId)) {
+		return null;
+	}
+	return rightId;
+}
+
+export function openSubagentPane(
+	store: StoreApi<WorkspaceStore<PaneViewerData>>,
+	input: {
+		tabId: string;
+		parentPaneId: string;
+		parentSessionId: string;
+		toolCallId: string;
+		task?: string;
+		agentType?: string;
+	},
+): OpenSubagentPaneResult {
+	const state = store.getState();
+	const existing = findSubagentPaneLocation(state, input.toolCallId);
+	if (existing) {
+		state.setActiveTab(existing.tabId);
+		state.setActivePane(existing);
+		return "focused";
+	}
+
+	const newPane = {
+		kind: "subagent" as const,
+		titleOverride:
+			input.agentType?.trim() ||
+			(input.task?.trim() ? input.task.trim().slice(0, 40) : "Subagent"),
+		data: {
+			parentSessionId: input.parentSessionId,
+			parentPaneId: input.parentPaneId,
+			toolCallId: input.toolCallId,
+			task: input.task,
+			agentType: input.agentType,
+		} satisfies SubagentPaneData,
+	};
+
+	const columnRoot = findRightSubagentColumnRoot(
+		state,
+		input.tabId,
+		input.parentPaneId,
+		input.parentSessionId,
+	);
+
+	if (columnRoot) {
+		const leaf = findBottommostSubagentInColumn(
+			state,
+			input.tabId,
+			columnRoot,
+			input.parentPaneId,
+			input.parentSessionId,
+		);
+		store.getState().splitPane({
+			tabId: input.tabId,
+			paneId: leaf,
+			position: "bottom",
+			newPane,
+			selectNewPane: false,
+		});
+		return "stacked";
+	}
+
+	store.getState().splitPane({
+		tabId: input.tabId,
+		paneId: input.parentPaneId,
+		position: "right",
+		newPane,
+		selectNewPane: false,
+	});
+	return "opened-right";
+}


### PR DESCRIPTION
## What & why

When a Mastra chat agent spawns subagents, their activity was only visible inline in the parent chat (or after navigating into nested tool UI). This adds automatic side panes so you can watch the parent and each subagent at once — first subagent opens to the right of the parent chat; later ones stack underneath that column.

- New `subagent` pane kind bound to `{ parentSessionId, toolCallId }`
- Auto-open on new `activeSubagents` entries (idempotent per `toolCallId`)
- Live activity from harness state, with message-history fallback after completion

Addresses the “display subagent activity in a new pane” request (#5077).

## How I tested it

- image:
<img width="1920" height="1080" alt="Screenshot From 2026-07-21 20-22-13" src="https://github.com/user-attachments/assets/9ec46b4b-9f56-439f-afe6-0ee75d329590" />

- Unit tests:
  - `openSubagentPane` (open right / stack / focus existing)
  - `resolveSubagentEntries` (live map vs message history vs fallback)
- Manual (v2 workspace **Chat** pane, not terminal agents):
  1. Open `+` → **Chat**
  2. Prompt: “Use 2–3 explore subagents in parallel to investigate X, Y, and Z.”
  3. Confirm stacked right panes open and update while subagents run

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Chat subagents now open in stacked right panes so you can watch the parent chat and each subagent at the same time. First opens to the right; later ones stack in the same column, and we don’t refocus if the pane already exists. Addresses #5077.

- **New Features**
  - Added a `subagent` pane keyed by `{ parentSessionId, toolCallId }` with live updates and message-history fallback.
  - Auto-open from `activeSubagents`; idempotent per `toolCallId`; skips existing panes (no focus steal).
  - Layout: opens to the right of the parent chat; subsequent subagents stack underneath.
  - Introduced `useAutoOpenSubagentPanes`, `openSubagentPane`, and `SubagentPane`/`SubagentPaneTitle` with tests for open/stack/no-refocus and entry/title resolution.

<sup>Written for commit d6b0db9a711530f89339f8df302902f9e0a786ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated subagent panes to the workspace dashboard.
  * Automatically opens subagent panes as activity begins, avoiding duplicates.
  * Displays subagent status, task details, results, errors, and execution information.
  * Organizes multiple subagent panes beside the related chat and focuses existing panes when applicable.
  * Added descriptive subagent titles and a Bot icon for easier identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->