### PR TITLE
feat(marketing): hero positioning A/B test + solid primary download CTA

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
@@ -22,17 +22,15 @@ interface CommitRowProps {
 	wrap?: boolean;
 }
 
-export function CommitRow({ commit, isSelected, wrap = false }: CommitRowProps) {
+export function CommitRow({
+	commit,
+	isSelected,
+	wrap = false,
+}: CommitRowProps) {
 	return (
 		<div className="flex min-w-0 flex-1 items-start justify-between gap-2">
 			<div className="min-w-0 flex-1 overflow-hidden">
-				<div
-					className={
-						wrap
-							? "text-sm wrap-break-word"
-							: "truncate text-sm"
-					}
-				>
+				<div className={wrap ? "text-sm wrap-break-word" : "truncate text-sm"}>
 					{commit.message}
 				</div>
 				<div className="truncate text-xs text-muted-foreground">

--- a/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -28,7 +28,7 @@ export function DownloadButton({
 			? "px-2 sm:px-4 py-2 text-sm"
 			: "px-3 sm:px-6 py-2 sm:py-3 text-sm sm:text-base";
 
-	const buttonClasses = `bg-brand/10 text-[#ff8c3a] border border-brand/20 ${sizeClasses} font-normal hover:bg-brand/15 hover:border-brand/35 transition-colors flex items-center gap-2 ${className}`;
+	const buttonClasses = `bg-foreground text-background ${sizeClasses} font-normal hover:opacity-90 transition-opacity flex items-center gap-2 ${className}`;
 
 	const goToInterstitial = () => {
 		track("download_clicked");

--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -2,16 +2,62 @@
 
 import { COMPANY } from "@superset/shared/constants";
 import { useScroll } from "framer-motion";
+import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { useRef, useState } from "react";
 import { FaGithub } from "react-icons/fa";
+import { isMacPlatform, usePlatform } from "../../hooks/useOS";
 import { DownloadButton } from "../DownloadButton";
 import { WaitlistModal } from "../WaitlistModal";
 import { ProductDemo } from "./components/ProductDemo";
 import { TypewriterText } from "./components/TypewriterText";
 
+const HERO_POSITIONING_FLAG = "landing-hero-positioning";
+
+const PIXEL_FONT_STYLE = {
+	fontFamily: "var(--font-geist-pixel-grid)",
+} satisfies React.CSSProperties;
+
+interface HeroCopy {
+	headline: string;
+	segments: { text: string; style?: React.CSSProperties }[];
+	subheadline: string;
+}
+
+const TEST_SUBHEADLINE =
+	"Isolated workspaces for Claude Code, Codex, and any CLI agent — run them side by side and review every change from one dashboard. Free to start.";
+
+const HERO_COPY = {
+	control: {
+		headline: "The Code Editor for AI Agents.",
+		segments: [
+			{ text: "The Code Editor for " },
+			{ text: "AI Agents.", style: PIXEL_FONT_STYLE },
+		],
+		subheadline:
+			"Orchestrate 100+ coding agents in parallel. Works for any agents. Built for the AI era.",
+	},
+	"capability-mac": {
+		headline: "Run parallel coding agents on your Mac.",
+		segments: [
+			{ text: "Run " },
+			{ text: "parallel coding agents", style: PIXEL_FONT_STYLE },
+			{ text: " on your Mac." },
+		],
+		subheadline: TEST_SUBHEADLINE,
+	},
+} satisfies Record<string, HeroCopy>;
+
 export function HeroSection() {
 	const [isWaitlistOpen, setIsWaitlistOpen] = useState(false);
 	const demoRef = useRef<HTMLDivElement>(null);
+	const { platform } = usePlatform();
+	const heroVariant = useFeatureFlagVariantKey(HERO_POSITIONING_FLAG);
+	const copy =
+		isMacPlatform(platform) &&
+		typeof heroVariant === "string" &&
+		heroVariant in HERO_COPY
+			? HERO_COPY[heroVariant as keyof typeof HERO_COPY]
+			: HERO_COPY.control;
 
 	const { scrollYProgress } = useScroll({
 		target: demoRef,
@@ -31,27 +77,19 @@ export function HeroSection() {
 								}}
 							>
 								<span className="invisible" aria-hidden="true">
-									The Code Editor for AI Agents.
+									{copy.headline}
 								</span>
 								<span className="absolute inset-0">
 									<TypewriterText
-										segments={[
-											{ text: "The Code Editor for " },
-											{
-												text: "AI Agents.",
-												style: {
-													fontFamily: "var(--font-geist-pixel-grid)",
-												},
-											},
-										]}
+										key={copy.headline}
+										segments={copy.segments}
 										speed={40}
 										delay={600}
 									/>
 								</span>
 							</h1>
 							<p className="text-base sm:text-xl font-light text-muted-foreground max-w-4xl mx-auto">
-								Orchestrate 100+ coding agents in parallel. Works for any
-								agents. Built for the AI era.
+								{copy.subheadline}
 							</p>
 						</div>
 


### PR DESCRIPTION
## What

**Hero positioning experiment** (`landing-hero-positioning`, [PostHog experiment 386395](https://us.posthog.com/project/264803/experiments/386395), draft — launch after this deploys):
- `control` — current "The Code Editor for AI Agents."
- `capability-mac` — "Run parallel coding agents on your Mac." with improved subheadline ("Isolated workspaces for Claude Code, Codex, and any CLI agent — run them side by side and review every change from one dashboard. Free to start.")
- Variant only applies to Mac platforms (`isMacPlatform`); Windows/Linux/mobile always see control. Experiment exposure is additionally filtered to `$os = Mac OS X` in PostHog so non-Mac flag evaluations don't dilute analysis.
- Baseline: ~4,400 Mac visitors/wk on superset.sh, ~25% visitor→download click. 10% relative MDE, 50/50 split, 3-week pre-registered runtime.

**Download CTA restyle** (ship-lane change, no experiment): transparent orange → solid primary (`bg-foreground text-background`), matching the design system's primary button (e.g. WaitlistForm submit).

**Drive-by**: Biome format fix on desktop `CommitRow.tsx` (was committed unformatted; repo-wide `lint:fix` picked it up).

## Notes

- Flag read via `useFeatureFlagVariantKey`; the hero's 600ms typewriter delay masks flag-load latency, so no flicker handling needed.
- Experiment tracked in Notion: Growth → Experiment Log.

https://claude.ai/code/session_01CALU4gFuyo3ABdp1Cc7BJh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Mac-only hero copy A/B test and updates the Download CTA to the solid primary button for a clearer, more consistent landing experience.

- **New Features**
  - Adds `landing-hero-positioning` experiment (PostHog 386395): `control` vs `capability-mac` headline/subheadline, shown to Mac visitors only. Uses `useFeatureFlagVariantKey` from `posthog-js/react`; the typewriter delay masks flag load.
  - Restyles Download CTA to solid primary (`bg-foreground text-background`) with opacity hover.

- **Refactors**
  - Biome format fix in `CommitRow.tsx` (no behavior change).

<sup>Written for commit 8ac6f71a53837595af120fa3b6d1595480696a4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform- and variant-specific messaging to the marketing hero section.
  * Updated hero headlines and supporting text dynamically based on active configuration.

* **Style**
  * Refined the download button appearance with improved contrast and opacity-based hover feedback.

* **Refactor**
  * Simplified commit row formatting without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->