### PR TITLE
fix(host-service): attempt daemon auto-update even when live sessions are present

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -955,7 +955,6 @@ describe("DaemonSupervisor auto-update best effort", () => {
 	test("leaves the predecessor running when the background smooth update returns ok:false", async () => {
 		const instance = staleInstance("0.0.9");
 		seedDaemonInstance(sup, "org-auto-best-effort", instance);
-		mockListSessions(sup, []);
 		const runUpdateMock = mock(async () => ({
 			ok: false as const,
 			reason: "snapshot write failed: ENOSPC",
@@ -993,7 +992,6 @@ describe("DaemonSupervisor auto-update best effort", () => {
 	test("leaves the predecessor running when the background smooth update throws", async () => {
 		const instance = staleInstance("0.0.8");
 		seedDaemonInstance(sup, "org-auto-throw", instance);
-		mockListSessions(sup, []);
 		const runUpdateMock = mock(async () => {
 			throw new Error("transport: ECONNRESET");
 		});
@@ -1029,7 +1027,6 @@ describe("DaemonSupervisor auto-update best effort", () => {
 	test("does not overwrite the current daemon if the failed update changed it", async () => {
 		const instance = staleInstance("0.0.7");
 		seedDaemonInstance(sup, "org-auto-changed", instance);
-		mockListSessions(sup, []);
 		const runUpdateMock = mock(async () => {
 			seedDaemonInstance(sup, "org-auto-changed", {
 				...instance,
@@ -1069,7 +1066,7 @@ describe("DaemonSupervisor auto-update best effort", () => {
 		).toBe(true);
 	});
 
-	test("defers the background update when live sessions are present", async () => {
+	test("attempts the handoff even when live sessions are present", async () => {
 		const instance = staleInstance("0.0.6");
 		seedDaemonInstance(sup, "org-auto-live", instance);
 		mockListSessions(sup, [aliveSession()]);
@@ -1083,14 +1080,12 @@ describe("DaemonSupervisor auto-update best effort", () => {
 		invokeKickoffAutoUpdate(sup, "org-auto-live", instance);
 		await flushAutoUpdate();
 
-		expect(runUpdateMock).not.toHaveBeenCalled();
+		expect(runUpdateMock).toHaveBeenCalledWith("org-auto-live");
 		expect(
 			loggedEvents.some(
 				(e) =>
-					e.event === "pty_daemon_auto_update_deferred" &&
-					e.props.reason === "live_sessions_present" &&
-					e.props.aliveSessionCount === 1 &&
-					e.props.pid === instance.pid,
+					e.event === "pty_daemon_auto_update_ok" &&
+					e.props.successorPid === 7777,
 			),
 		).toBe(true);
 	});
@@ -1098,7 +1093,6 @@ describe("DaemonSupervisor auto-update best effort", () => {
 	test("joins an existing manual update without adding a destructive fallback", async () => {
 		const instance = staleInstance("0.0.6");
 		seedDaemonInstance(sup, "org-auto-coalesced", instance);
-		mockListSessions(sup, []);
 		const deferred = createDeferred<{ ok: false; reason: string }>();
 		const runUpdateMock = mock(() => deferred.promise);
 		const forceRestartMock = mock(async () => ({ success: true as const }));

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -89,7 +89,6 @@ const VERSION_PROBE_TIMEOUT_MS = 1_500;
 const HANDOFF_PREDECESSOR_EXIT_TIMEOUT_MS = 3_000;
 const HANDOFF_PROBE_TOTAL_TIMEOUT_MS = 3_000;
 const DAEMON_TERMINATE_TIMEOUT_MS = 1_000;
-const AUTO_UPDATE_SESSION_LIST_TIMEOUT_MS = 1_500;
 const ADOPTION_PROBE_TOTAL_TIMEOUT_MS = 3_000;
 
 /**
@@ -642,10 +641,9 @@ export class DaemonSupervisor {
 	/**
 	 * Auto-update: best-effort opportunistic handoff when the adopted
 	 * daemon is older than the bundled binary. Runs after host-service
-	 * boot, fire-and-track, doesn't block anything. The background path
-	 * is intentionally conservative: live sessions keep running on the
-	 * predecessor and the foreground Settings UI remains the place for
-	 * user-approved handoff/restart.
+	 * boot, fire-and-track, doesn't block anything. Live sessions are
+	 * fine — the handoff is non-destructive (fd-handoff carries them to
+	 * the successor), and on failure the predecessor keeps running.
 	 */
 	private kickoffAutoUpdate(
 		organizationId: string,
@@ -678,26 +676,6 @@ export class DaemonSupervisor {
 		organizationId: string,
 		instance: DaemonInstance,
 	): Promise<void> {
-		const sessions = await this.listSessions(
-			organizationId,
-			AUTO_UPDATE_SESSION_LIST_TIMEOUT_MS,
-		);
-		if (sessions === null) {
-			this.deferAutoUpdate(
-				organizationId,
-				instance,
-				"session_list_unavailable",
-			);
-			return;
-		}
-		const aliveSessionCount = countAliveSessions(sessions);
-		if (aliveSessionCount > 0) {
-			this.deferAutoUpdate(organizationId, instance, "live_sessions_present", {
-				aliveSessionCount,
-			});
-			return;
-		}
-
 		const update = this.startUpdate(organizationId);
 		try {
 			const result = await update.promise;
@@ -775,22 +753,6 @@ export class DaemonSupervisor {
 			reason,
 			failedAt,
 		};
-	}
-
-	private deferAutoUpdate(
-		organizationId: string,
-		instance: DaemonInstance,
-		reason: string,
-		extra: Record<string, unknown> = {},
-	): void {
-		logEvent("pty_daemon_auto_update_deferred", {
-			organizationId,
-			pid: instance.pid,
-			runningVersion: instance.runningVersion,
-			expectedVersion: instance.expectedVersion,
-			reason,
-			...extra,
-		});
 	}
 
 	/**
@@ -1228,10 +1190,6 @@ function pipeWithPrefix(
 		if (pending) target.write(`${tag} ${pending}\n`);
 		pending = "";
 	});
-}
-
-function countAliveSessions(sessions: SessionInfo[]): number {
-	return sessions.filter((session) => session.alive).length;
 }
 
 /**


### PR DESCRIPTION
## Summary

Background daemon auto-update deferred whenever the org had any alive PTY session (`live_sessions_present`) and never retried until the next host-service restart. For a busy org this means auto-update effectively never runs and the user has to click Update daemon manually (which is how the v1.16.0-era 0.2.5 daemons stayed behind after canary moved to 0.2.6).

The gate protected nothing: `update()` is the non-destructive fd-handoff (live sessions move to the successor, original shell PIDs survive), and on failure the predecessor keeps running with `updatePending` still set and the failure surfaced in Settings.

- `runAutoUpdate` now goes straight to `startUpdate()`; removed the `listSessions` prelude and the `live_sessions_present` / `session_list_unavailable` defer paths
- Deleted the now-dead `deferAutoUpdate`, `countAliveSessions`, and `AUTO_UPDATE_SESSION_LIST_TIMEOUT_MS`
- Existing `updateInFlight` coalescing still prevents an auto-update racing a manual click

## Test Plan

- [x] Replaced the defer test with "attempts the handoff even when live sessions are present" (still seeds a live session; fails if a session gate is reintroduced, verified by mutating the impl)
- [x] `bun test src/daemon/DaemonSupervisor.test.ts` 51/51 pass
- [x] host-service typecheck and `bun run lint` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-update now runs even when live PTY sessions are active, so busy orgs no longer get stuck on old daemons. The handoff is still non-destructive; if it fails, the predecessor keeps running.

- **Bug Fixes**
  - `runAutoUpdate` calls `startUpdate()` directly; removed session list gating and defer paths.
  - Deleted dead code: `deferAutoUpdate`, `countAliveSessions`, `AUTO_UPDATE_SESSION_LIST_TIMEOUT_MS`.
  - Existing `updateInFlight` coalescing still prevents races with manual updates.

<sup>Written for commit bab7c97f1e5898fe7d2488b79320fd7c029162d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

