### PR TITLE
ci(mobile): make Maestro E2E label-triggered instead of running on every mobile PR

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,7 +12,6 @@ concurrency:
 
 env:
   VERCEL_CLI_VERSION: 50.22.1
-  EAS_CLI_VERSION: 20.5.1
   PR_NUMBER: ${{ github.event.pull_request.number }}
   API_ALIAS: api-pr-${{ github.event.pull_request.number }}-superset.vercel.app
   WEB_ALIAS: web-pr-${{ github.event.pull_request.number }}-superset.vercel.app
@@ -676,63 +675,6 @@ jobs:
         with:
           name: docs-status
           path: docs-status.env
-
-  e2e-mobile:
-    name: E2E Mobile (Maestro on EAS)
-    runs-on: ubuntu-latest
-    environment: preview
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      pull-requests: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Detect mobile-related changes
-        id: changes
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
-          if echo "$files" | grep -qE '^(apps/mobile/|packages/auth/|packages/shared/|packages/trpc/|\.github/workflows/deploy-preview\.yml)'; then
-            echo "mobile=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "mobile=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Setup Bun
-        if: steps.changes.outputs.mobile == 'true'
-        id: setup-bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version-file: .bun-version
-
-      - name: Cache dependencies
-        if: steps.changes.outputs.mobile == 'true'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-revision }}-${{ hashFiles('bun.lock') }}
-
-      - name: Install dependencies
-        if: steps.changes.outputs.mobile == 'true'
-        run: bun install --frozen --ignore-scripts
-
-      - name: Install EAS CLI
-        if: steps.changes.outputs.mobile == 'true'
-        run: npm install --global eas-cli@$EAS_CLI_VERSION
-
-      - name: Run EAS e2e workflow and wait
-        if: steps.changes.outputs.mobile == 'true'
-        working-directory: apps/mobile
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: |
-          eas workflow:run e2e-ios.yml \
-            -F api_url=https://${{ env.API_ALIAS }} \
-            --non-interactive --wait
 
   post-final-comment:
     name: Post Deployment Comment

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -1,0 +1,58 @@
+name: E2E Mobile
+
+# Expensive on-demand lane: EAS builds an iOS simulator app and runs the
+# Maestro flows against the PR's preview API. Trigger it by adding the
+# `e2e-mobile` label to the PR (remove and re-add to re-run). The preview
+# deployment from deploy-preview.yml must exist for the target PR.
+on:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: e2e-mobile-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  EAS_CLI_VERSION: 20.5.1
+  API_ALIAS: api-pr-${{ github.event.pull_request.number }}-superset.vercel.app
+
+jobs:
+  e2e-mobile:
+    name: E2E Mobile (Maestro on EAS)
+    if: github.event.label.name == 'e2e-mobile'
+    runs-on: ubuntu-latest
+    environment: preview
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Bun
+        id: setup-bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Cache dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-revision }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen --ignore-scripts
+
+      - name: Install EAS CLI
+        run: npm install --global eas-cli@$EAS_CLI_VERSION
+
+      - name: Run EAS e2e workflow and wait
+        working-directory: apps/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          eas workflow:run e2e-ios.yml \
+            -F api_url=https://${{ env.API_ALIAS }} \
+            --non-interactive --wait


### PR DESCRIPTION
## Why

The `e2e-mobile` job in `deploy-preview.yml` ran on every PR touching `apps/mobile/`, `packages/auth/`, `packages/shared/`, or `packages/trpc/` — each run doing a full EAS iOS simulator build plus a Maestro run. That's too expensive to pay on every push; it should only run when someone asks for it.

## What

- Removed the `e2e-mobile` job (and the now-unused `EAS_CLI_VERSION` env) from `deploy-preview.yml`.
- Added `.github/workflows/e2e-mobile.yml`: the same EAS/Maestro job, triggered only when the **`e2e-mobile` label** is added to a PR. Remove and re-add the label to re-run. The old path-detection step is gone — applying the label is the request.
- Created the `e2e-mobile` label on the repo so the trigger works immediately.

## Notes

- The run still depends on the PR's preview API (`api-pr-<n>-superset.vercel.app`), which `deploy-preview.yml` keeps deploying on every PR push; the EAS workflow's pre-test hook waits up to 10 minutes for it to become healthy.
- Nothing else referenced the old job — it was never in the deployment comment's `needs` list.

https://claude.ai/code/session_01GeSutfJHWQQ8hZ7qkBxGis

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make mobile Maestro E2E runs on-demand via an `e2e-mobile` label instead of on every PR, reducing CI time and cost. The same EAS iOS simulator + Maestro flow now runs only when requested.

- **New Features**
  - Moved the E2E job into `.github/workflows/e2e-mobile.yml`, triggered when the `e2e-mobile` label is added to a PR.
  - Removed the old `e2e-mobile` job and `EAS_CLI_VERSION` env from `deploy-preview.yml`.

- **Migration**
  - To run E2E: add the `e2e-mobile` label to the PR (remove and re-add to re-run).
  - Requires the PR’s preview API (`api-pr-<n>-superset.vercel.app`) from `deploy-preview.yml` to be available.

<sup>Written for commit 08b63f663442bc388cf41568eaa2fd4783c3bfe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-demand mobile end-to-end testing workflow triggered by the `e2e-mobile` pull request label.
  * Mobile tests now run against the pull request’s preview environment with isolated, cancellable runs.

* **Chores**
  * Removed the previous automatic mobile test detection and execution workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->