### PR TITLE
fix(desktop): remove misleading auth_completed event + label pageview pathnames

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
+++ b/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
@@ -1,9 +1,5 @@
 import { useEffect } from "react";
-import {
-	ACTIVE_ORG_ID_KEY,
-	AUTH_COMPLETED_KEY,
-} from "renderer/hooks/useSignOut";
-import { track } from "renderer/lib/analytics";
+import { ACTIVE_ORG_ID_KEY } from "renderer/hooks/useSignOut";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { posthog } from "../../lib/posthog";
@@ -23,12 +19,6 @@ export function PostHogUserIdentifier() {
 		});
 		posthog.reloadFeatureFlags();
 		setUserId({ userId: user.id });
-
-		const trackedUserId = localStorage.getItem(AUTH_COMPLETED_KEY);
-		if (trackedUserId !== user.id) {
-			track("auth_completed");
-			localStorage.setItem(AUTH_COMPLETED_KEY, user.id);
-		}
 	}, [user, setUserId]);
 
 	useEffect(() => {

--- a/apps/desktop/src/renderer/hooks/useSignOut/index.ts
+++ b/apps/desktop/src/renderer/hooks/useSignOut/index.ts
@@ -1,5 +1,1 @@
-export {
-	ACTIVE_ORG_ID_KEY,
-	AUTH_COMPLETED_KEY,
-	useSignOut,
-} from "./useSignOut";
+export { ACTIVE_ORG_ID_KEY, useSignOut } from "./useSignOut";

--- a/apps/desktop/src/renderer/hooks/useSignOut/useSignOut.ts
+++ b/apps/desktop/src/renderer/hooks/useSignOut/useSignOut.ts
@@ -2,7 +2,6 @@ import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { posthog } from "renderer/lib/posthog";
 
-export const AUTH_COMPLETED_KEY = "superset_auth_completed";
 export const ACTIVE_ORG_ID_KEY = "active_organization_id";
 
 // An unreachable auth server must not block local sign-out (#5729)
@@ -15,7 +14,6 @@ export function useSignOut() {
 	return async () => {
 		posthog.reset();
 		setAnalyticsUserId.mutate({ userId: null });
-		localStorage.removeItem(AUTH_COMPLETED_KEY);
 		localStorage.removeItem(ACTIVE_ORG_ID_KEY);
 		await Promise.race([
 			authClient.signOut({ fetchOptions: { throw: false } }).catch(() => {}),

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -37,6 +37,7 @@ const router = createRouter({
 const unsubscribe = router.subscribe("onResolved", (event) => {
 	posthog.capture("$pageview", {
 		$current_url: event.toLocation.pathname,
+		$pathname: event.toLocation.pathname,
 	});
 });
 


### PR DESCRIPTION
## What

**Removes the `auth_completed` event.** It fired from `PostHogUserIdentifier` whenever a session became visible and a localStorage guard didn't match — silent token restores, storage resets, and account switches all counted as "completed auth." Measured: only 44.2% of auth_completed events had a sign-in click (`auth_started`) in the preceding hour, and the June identity-stitching rollout (#5207) re-triggered the guard across the installed base, inflating weekly "auth" persons ~2.8x vs real OAuth completions (`/auth/desktop/success` redirects).

Analytics replacement (no new event): "signed in" = desktop `$pageview` on any route except `/sign-in`. Validated on identical cohorts (65.1% vs 67.3% sign-in→signed-in; the delta is the inflation). The 10 saved PostHog insights referencing auth_completed are being migrated to the pageview definition.

**Also stamps `$pathname` on the manual router pageview capture** — previously only `$current_url` carried the route while `$pathname` held the asar file path, hiding desktop routes from pathname-based queries and web-analytics views.

## Notes

- Old desktop builds keep emitting auth_completed until they update; dashboards are migrated off it, so this is harmless.
- `AUTH_COMPLETED_KEY` localStorage guard removed with the event (stale keys left behind are inert).

https://claude.ai/code/session_01CALU4gFuyo3ABdp1Cc7BJh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the misleading `auth_completed` event and tags desktop `$pageview` with `$pathname` to fix sign-in analytics and enable pathname-based queries.

- **Bug Fixes**
  - Stop emitting `auth_completed` and remove the `AUTH_COMPLETED_KEY` guard. Treat “signed in” as any desktop `$pageview` on routes except `/sign-in`.
  - Add `$pathname` to manual `$pageview` using the router path so desktop routes appear in pathname-based reports.

<sup>Written for commit ead4d84d7c96351a6df5c49b105e850590f38293. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Analytics**
  - Improved page-view tracking with pathname details.
  - Streamlined user identification and feature-flag refresh behavior.

- **Bug Fixes**
  - Simplified sign-out cleanup by removing obsolete authentication state handling.
  - Improved consistency of analytics state across authentication and sign-out flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->