### PR TITLE
fix(desktop): link hiring banner CTA to YC job board

### DIFF
--- a/apps/desktop/src/renderer/components/HiringBanner/HiringBanner.tsx
+++ b/apps/desktop/src/renderer/components/HiringBanner/HiringBanner.tsx
@@ -26,7 +26,7 @@ export function HiringBanner({ surface, isCollapsed }: HiringBannerProps) {
 
 	function handleViewRoles() {
 		track("hiring_banner_clicked");
-		openUrlMutation.mutate(COMPANY.JOIN_US_ROLES_URL);
+		openUrlMutation.mutate(COMPANY.CAREERS_URL);
 	}
 
 	function handleDismiss() {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -36,9 +36,7 @@ export const COMPANY = {
 	STATUS_URL: "https://status.superset.sh",
 	TRUST_URL: "https://trust.superset.sh",
 	JOIN_US_URL: `${process.env.NEXT_PUBLIC_MARKETING_URL || "https://superset.sh"}/join-us`,
-	/** The open-roles section of the join-us page; product surfaces link here. */
-	JOIN_US_ROLES_URL: `${process.env.NEXT_PUBLIC_MARKETING_URL || "https://superset.sh"}/join-us#open-roles`,
-	/** The formal YC listing. `JOIN_US_URL` is our own page and the one we link from product surfaces. */
+	/** The formal YC listing; product surfaces link here. `JOIN_US_URL` is our own marketing page. */
 	CAREERS_URL: "https://www.ycombinator.com/companies/superset/jobs",
 } as const;
 


### PR DESCRIPTION
## Summary
- The "View open roles" action on the desktop hiring banner now opens the YC job board (`COMPANY.CAREERS_URL`) instead of `superset.sh/join-us#open-roles`, which landed users on the marketing page scrolled to the bottom.
- Removed the now-unused `JOIN_US_ROLES_URL` constant (the banner was its only consumer) and updated the `CAREERS_URL` doc comment.

## Why / Context
The banner targets our most active users; sending them to the YC listing puts them where they can actually apply, instead of an anchor-scrolled marketing page.

## Testing
- `bun run lint`
- `bun run typecheck`
- Not manually clicked through in the running app — the change is a constant swap on an existing, already-wired `openUrl` mutation; `hiring_banner_clicked` tracking is unchanged.

https://claude.ai/code/session_012iqPVUREJcjwUjafmR7xKk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the desktop hiring banner CTA to open the YC job board (`COMPANY.CAREERS_URL`) so users land on the application page instead of a marketing page anchor. Removed the unused `JOIN_US_ROLES_URL` constant and clarified the `CAREERS_URL` doc comment.

<sup>Written for commit 8bd22c2a00af9d895c77860d0263e568960fd0b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

