### PR TITLE
fix(desktop,marketing,web): make PostHog tracking integrity-first

### DIFF
--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -27,7 +27,7 @@ export function initPostHog() {
 		app_name: "desktop",
 		// Event-level version (person-profile desktop_version reflects the
 		// current install, not the build that emitted a given event).
-		app_version: window.App.appVersion,
+		app_version: window.App?.appVersion,
 		platform: window.navigator.platform,
 	});
 

--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -18,15 +18,11 @@ export function initPostHog() {
 		capture_pageview: false,
 		capture_pageleave: false,
 		capture_exceptions: true,
-		// Anonymous visitors must be full persons — identified_only makes
-		// pre-sign-in abandonment structurally invisible to person-level funnels.
 		person_profiles: "always",
 		persistence: "localStorage",
 		debug: false,
 	});
 
-	// Register synchronously (bundled SDK, init is sync) — inside `loaded` these
-	// super-properties race identify()/first pageviews and land missing.
 	posthogFull.register({
 		app_name: "desktop",
 		// Event-level version (person-profile desktop_version reflects the

--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -18,18 +18,21 @@ export function initPostHog() {
 		capture_pageview: false,
 		capture_pageleave: false,
 		capture_exceptions: true,
-		person_profiles: "identified_only",
+		// Anonymous visitors must be full persons — identified_only makes
+		// pre-sign-in abandonment structurally invisible to person-level funnels.
+		person_profiles: "always",
 		persistence: "localStorage",
 		debug: false,
-		loaded: (ph) => {
-			ph.register({
-				app_name: "desktop",
-				// Event-level version (person-profile desktop_version reflects the
-				// current install, not the build that emitted a given event).
-				app_version: window.App.appVersion,
-				platform: window.navigator.platform,
-			});
-		},
+	});
+
+	// Register synchronously (bundled SDK, init is sync) — inside `loaded` these
+	// super-properties race identify()/first pageviews and land missing.
+	posthogFull.register({
+		app_name: "desktop",
+		// Event-level version (person-profile desktop_version reflects the
+		// current install, not the build that emitted a given event).
+		app_version: window.App.appVersion,
+		platform: window.navigator.platform,
 	});
 
 	// Relay socket health (event bus / workspace "disconnected" surface). At

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -14,20 +14,25 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	capture_exceptions: true,
 	debug: false,
 	cross_subdomain_cookie: true,
+	// Anonymous visitors must be full persons — the identified_only default
+	// breaks person-level funnels over anonymous traffic.
+	person_profiles: "always",
 	persistence: "cookie",
 	persistence_name: POSTHOG_COOKIE_NAME,
 	disable_session_recording: true,
 	loaded: (posthog) => {
-		posthog.register({
-			app_name: "marketing",
-			domain: window.location.hostname,
-		});
-
 		const consent = localStorage.getItem(ANALYTICS_CONSENT_KEY);
 		if (consent === "declined") {
 			posthog.opt_out_capturing();
 		}
 	},
+});
+
+// Register synchronously — inside `loaded` these super-properties race the
+// first captured events and land missing.
+posthog.register({
+	app_name: "marketing",
+	domain: window.location.hostname,
 });
 
 Sentry.init({

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -14,8 +14,6 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	capture_exceptions: true,
 	debug: false,
 	cross_subdomain_cookie: true,
-	// Anonymous visitors must be full persons — the identified_only default
-	// breaks person-level funnels over anonymous traffic.
 	person_profiles: "always",
 	persistence: "cookie",
 	persistence_name: POSTHOG_COOKIE_NAME,
@@ -28,8 +26,6 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	},
 });
 
-// Register synchronously — inside `loaded` these super-properties race the
-// first captured events and land missing.
 posthog.register({
 	app_name: "marketing",
 	domain: window.location.hostname,

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -13,15 +13,11 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	capture_exceptions: true,
 	debug: false,
 	cross_subdomain_cookie: true,
-	// Anonymous visitors must be full persons — the identified_only default
-	// breaks person-level funnels over anonymous traffic.
 	person_profiles: "always",
 	persistence: "cookie",
 	persistence_name: POSTHOG_COOKIE_NAME,
 });
 
-// Register synchronously — inside `loaded` these super-properties race the
-// first captured events and land missing.
 posthog.register({
 	app_name: "web",
 	domain: window.location.hostname,

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -13,14 +13,18 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	capture_exceptions: true,
 	debug: false,
 	cross_subdomain_cookie: true,
+	// Anonymous visitors must be full persons — the identified_only default
+	// breaks person-level funnels over anonymous traffic.
+	person_profiles: "always",
 	persistence: "cookie",
 	persistence_name: POSTHOG_COOKIE_NAME,
-	loaded: (posthog) => {
-		posthog.register({
-			app_name: "web",
-			domain: window.location.hostname,
-		});
-	},
+});
+
+// Register synchronously — inside `loaded` these super-properties race the
+// first captured events and land missing.
+posthog.register({
+	app_name: "web",
+	domain: window.location.hostname,
 });
 
 Sentry.init({


### PR DESCRIPTION
## What

Two config-level fixes across all three PostHog inits (desktop, marketing, web), prioritizing tracking integrity over event-cost optimization:

**1. `person_profiles: "always"`** (desktop was explicitly `identified_only`; marketing/web silently inherited that default). Consequence of the old setting, discovered during today's funnel audit: anonymous visitors have no person rows, so person-level funnels showed literally zero sign-in abandoners — true device-level abandonment (~17%) was structurally invisible. Forward-only: historical anonymous events remain personless (the device-level insight `SvyOhftm` covers pre-change history). Accepted trade-off: anonymous events now bill at the person-profile rate.

**2. `register()` called synchronously after `init()` instead of inside the `loaded` callback.** Super-properties raced `identify()` and first events — measured impact: ~83% of desktop `$identify` events were missing `app_name`. The SDKs are bundled/synchronous; there is no reason for registration to be deferred.

With these two, the built-in `$identify` event becomes the canonical "signed in" signal (correct labels, and anonymous→identified transitions now happen between two fully-tracked person states) — no custom auth event needed.

## Context

Part of the tracking-integrity audit that also removed `auth_completed` (#5841) and corrected the activation funnels (superset-step consumption, pre-auth pageview pollution). Remaining known issue tracked separately: React #185 redirect loop at the desktop sign-in screen (PostHog error issue 019d39d9-958e-7672-9d6e-40aa4c68360f).

https://claude.ai/code/session_01CALU4gFuyo3ABdp1Cc7BJh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make PostHog tracking integrity-first across desktop, marketing, and web. Person-level funnels now include anonymous traffic, super-properties are on `$identify` and first events, and desktop registration is resilient when `window.App` is missing.

- **Bug Fixes**
  - Set `person_profiles: "always"` in desktop, marketing, and web so anonymous visitors have person rows and pre-sign-in abandonment is measurable.
  - Run `register()` immediately after `init()` (not in `loaded`) so `app_name`/`app_version`/`platform`/`domain` attach before identify/first events.
  - Desktop: guard `app_version` (`window.App?.appVersion`) so register doesn’t throw on broken preload and events stay labeled.

- **Refactors**
  - Removed explanatory comments from PostHog config blocks.

<sup>Written for commit 00a521f69a8bcddbd888f95e866347ec96efe9f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Enabled person profile collection for anonymous visitors across desktop, marketing, and web.
  * Moved app/site metadata registration to occur immediately after analytics initialization for more consistent context.
  * Retained existing consent-based analytics opt-out behavior (when declined, capturing is still disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->