### PR TITLE
fix(panes): match tab bar background to inactive tabs, active tab flows into content

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -273,9 +273,6 @@ export function V2PresetsBar({
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
-			{visiblePresets.length > 0 ? (
-				<div className="mx-1 h-3.5 w-px shrink-0 bg-border/60" />
-			) : null}
 			{visiblePresets.map(({ preset }, visibleIndex) => {
 				const hotkeyId = PRESET_HOTKEY_IDS[visibleIndex];
 				return (

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -169,11 +169,13 @@ export function TabBar<TData>({
 		return (
 			<div
 				ref={setRootRef}
-				// `drag`: the bar doubles as the Electron window-drag region (empty
-				// areas only — interactive clusters opt out with `no-drag`).
-				className="drag group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-border/30"
+				// No shade or bottom border with zero tabs: the empty bar blends into
+				// the content below. `drag`: the bar doubles as the Electron
+				// window-drag region (empty areas only — interactive clusters opt out
+				// with `no-drag`).
+				className="drag group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch"
 			>
-				<div className="no-drag flex h-full w-10 shrink-0 items-center justify-center bg-border/30">
+				<div className="no-drag flex h-full w-10 shrink-0 items-center justify-center">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 				<div className="flex min-w-0 flex-1 items-stretch" />

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -171,9 +171,9 @@ export function TabBar<TData>({
 				ref={setRootRef}
 				// `drag`: the bar doubles as the Electron window-drag region (empty
 				// areas only — interactive clusters opt out with `no-drag`).
-				className="drag group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch bg-background"
+				className="drag group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-border/30"
 			>
-				<div className="no-drag flex h-full w-10 shrink-0 items-center justify-center bg-background">
+				<div className="no-drag flex h-full w-10 shrink-0 items-center justify-center bg-border/30">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 				<div className="flex min-w-0 flex-1 items-stretch" />
@@ -189,11 +189,13 @@ export function TabBar<TData>({
 	return (
 		<div
 			ref={setRootRef}
-			// No border-b: the bar sits flush against whatever renders below it and
-			// the active tab draws its own frame. `drag`: the bar doubles as the
-			// Electron window-drag region (empty areas only — the tabs track and
-			// button clusters opt out with `no-drag`).
-			className="drag group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch bg-background"
+			// The bottom border is drawn on the bar's leaf elements (inactive tabs,
+			// the add-button cluster, the trailing region, and the flex filler) rather
+			// than the root, so the active tab can leave a real 1px gap and flow into
+			// the content below. `drag`: the bar doubles as the Electron window-drag
+			// region (empty areas only — the tabs track and button clusters opt out
+			// with `no-drag`).
+			className="drag group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch bg-border/30"
 		>
 			<OverflowFadeContainer
 				observeChildren
@@ -202,7 +204,7 @@ export function TabBar<TData>({
 			>
 				<div
 					ref={tabsTrackRef}
-					className="no-drag relative flex h-full items-stretch"
+					className="no-drag relative flex h-full flex-1 items-stretch"
 				>
 					{tabs.map((tab, i) => (
 						<div
@@ -233,19 +235,22 @@ export function TabBar<TData>({
 						/>
 					)}
 					{!hasHorizontalOverflow && (
-						<div className="flex h-full w-10 shrink-0 items-center justify-center">
+						<div className="flex h-full w-10 shrink-0 items-center justify-center border-b border-border">
 							<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 						</div>
 					)}
+					{/* Carries the bar's bottom border across the empty space to the
+					    right of the tabs (collapses to 0 when the tabs overflow). */}
+					<div className="h-full flex-1 border-b border-border" />
 				</div>
 			</OverflowFadeContainer>
 			{hasHorizontalOverflow && (
-				<div className="no-drag flex h-full w-10 shrink-0 items-center justify-center bg-background">
+				<div className="no-drag flex h-full w-10 shrink-0 items-center justify-center border-b border-border bg-border/30">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 			)}
 			{renderTabBarTrailing && (
-				<div className="no-drag flex h-full shrink-0 items-center px-1">
+				<div className="no-drag flex h-full shrink-0 items-center border-b border-border px-1">
 					{renderTabBarTrailing()}
 				</div>
 			)}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -116,14 +116,16 @@ export function TabItem<TData>({
 				<div
 					ref={setRef}
 					className={cn(
-						// Inverted scheme: inactive tabs carry the shaded block; the active
-						// tab blends into the content below and is framed by left/right/top
-						// borders. Every state keeps a 1px border on all sides (transparent
-						// where hidden) so tabs don't shift when switching.
-						"group relative flex h-full w-full items-center border transition-colors",
+						// The bar carries a bottom border and the inactive-tab shade. The
+						// active tab has NO bottom border (only left/right/top) and takes an
+						// opaque fill, so it flows straight into the content below. Inactive
+						// tabs keep a 1px border on all sides (transparent except the bottom
+						// line) so the bar's line runs unbroken beneath them and tabs don't
+						// shift when switching.
+						"group relative flex h-full w-full items-center transition-colors",
 						isActive
-							? "text-foreground border-border border-b-transparent"
-							: "bg-border/30 text-muted-foreground/70 hover:bg-border/20 hover:text-muted-foreground border-transparent",
+							? "border-x border-t border-border bg-background text-foreground"
+							: "border border-transparent border-b-border bg-border/30 text-muted-foreground/70 hover:bg-border/20 hover:text-muted-foreground",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",
 					)}


### PR DESCRIPTION
## Summary

The workspace tab bar background was `bg-background` (dark) while inactive tabs were `bg-border/30` (lighter), leaving an unshaded strip around the tabs, add-button, and Run button. This reworks the tab strip into a browser-style bar:

- **Bar background** now uses `bg-border/30` — the same shade as inactive tabs — for both the with-tabs and no-tabs states.
- **Bottom border** runs the full width of the bar. It's drawn on the bar's leaf elements (inactive tabs, the add-button cluster, the trailing/Run region, and a flex filler) rather than the root, because the tab strip scrolls inside an `overflow-y-hidden` container and a root-level border can't be cut out by the active tab.
- **Active tab** has an opaque `bg-background` fill and **no bottom border** (explicit `border-x border-t`, not `border` + `border-b-0`, to avoid the Tailwind width-shorthand override), so it punches through the line and flows seamlessly into the pane content below.

## Test Plan

- [ ] Tab bar background matches inactive tabs (with tabs and with no tabs)
- [ ] Continuous bottom border across the bar and under inactive tabs
- [ ] Active tab has no bottom border and flows into the content below
- [ ] Overflow/scroll case: filler collapses, line stays continuous

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Matches the tab bar background to inactive tabs and lets the active tab flow into the content by removing its bottom border. Also removes the divider between the preset settings gear and presets.

- **Bug Fixes**
  - Tab bar uses `bg-border/30` when tabs exist; zero-tabs state has no shade or bottom border.
  - Continuous bottom border drawn on leaf elements (inactive tabs, add button, trailing area, flex filler) so the line stays intact, including during overflow.
  - Active tab uses `bg-background` with no bottom border (only left/right/top) to flow into content.
  - Desktop: removed the gear/presets divider in the presets bar.

<sup>Written for commit 749e1a3b6e62c434109bcc4d9038572580b7a1bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the tab bar (empty and populated states) so it blends cleanly into the content area when no tabs exist.
  * Reworked bottom-border rendering across tabs and right-side regions to keep the line continuous and reduce visual shifting when switching active tabs.
  * Updated active/inactive tab border styling and background to improve consistency.
* **UI**
  * Simplified the V2 presets bar by removing a conditional divider so preset items render without the extra element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->