### PR TITLE
chore(deps): bump hono to 4.12.27 and @hono/node-server to 2.0.5

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -73,7 +73,7 @@
 		"@electric-sql/client": "1.5.23",
 		"@headless-tree/core": "1.6.3",
 		"@headless-tree/react": "1.6.3",
-		"@hono/node-server": "1.19.13",
+		"@hono/node-server": "2.0.5",
 		"@hookform/resolvers": "5.2.2",
 		"@lezer/highlight": "1.2.3",
 		"@mastra/core": "1.33.1",

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -10,7 +10,7 @@
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {
-		"@hono/node-server": "1.19.13",
+		"@hono/node-server": "2.0.5",
 		"@hono/node-ws": "1.3.0",
 		"@sentry/node": "9.47.1",
 		"@superset/shared": "workspace:*",
@@ -18,7 +18,7 @@
 		"@t3-oss/env-core": "0.13.11",
 		"@trpc/client": "11.16.0",
 		"@upstash/redis": "1.37.0",
-		"hono": "4.12.25",
+		"hono": "4.12.27",
 		"jose": "6.2.2",
 		"lru-cache": "11.2.7",
 		"superjson": "2.2.6",

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "@superset/repo",
+      "dependencies": {
+        "hono": "4.12.27",
+      },
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
         "@types/bun": "1.3.14",
@@ -1210,7 +1213,7 @@
   ],
   "overrides": {
     "axios": "1.14.0",
-    "hono": "4.12.25",
+    "hono": "4.12.27",
     "kysely": "0.28.17",
     "shell-quote": "1.9.0",
   },
@@ -4679,7 +4682,7 @@
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
-    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 
     "hono-openapi": ["hono-openapi@1.3.0", "", { "peerDependencies": { "@hono/standard-validator": "^0.2.0", "@standard-community/standard-json": "^0.3.5", "@standard-community/standard-openapi": "^0.2.9", "@types/json-schema": "^7.0.15", "hono": "^4.8.3", "openapi-types": "^12.1.3" }, "optionalPeers": ["@hono/standard-validator", "hono"] }, "sha512-xDvCWpWEIv0weEmnl3EjRQzqbHIO8LnfzMuYOCmbuyE5aes6aXxLg4vM3ybnoZD5TiTUkA6PuRQPJs3R7WRBig=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -152,7 +152,7 @@
         "@electric-sql/client": "1.5.23",
         "@headless-tree/core": "1.6.3",
         "@headless-tree/react": "1.6.3",
-        "@hono/node-server": "1.19.13",
+        "@hono/node-server": "2.0.5",
         "@hookform/resolvers": "5.2.2",
         "@lezer/highlight": "1.2.3",
         "@mastra/core": "1.33.1",
@@ -605,7 +605,7 @@
       "name": "@superset/relay",
       "version": "0.1.0",
       "dependencies": {
-        "@hono/node-server": "1.19.13",
+        "@hono/node-server": "2.0.5",
         "@hono/node-ws": "1.3.0",
         "@sentry/node": "9.47.1",
         "@superset/shared": "workspace:*",
@@ -613,7 +613,7 @@
         "@t3-oss/env-core": "0.13.11",
         "@trpc/client": "11.16.0",
         "@upstash/redis": "1.37.0",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "jose": "6.2.2",
         "lru-cache": "11.2.7",
         "superjson": "2.2.6",
@@ -724,7 +724,7 @@
         "@trpc/client": "11.16.0",
         "@trpc/server": "11.16.0",
         "ai": "6.0.141",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "mastracode": "0.18.1",
         "superjson": "2.2.6",
         "zod": "4.3.6",
@@ -844,7 +844,7 @@
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@agentclientprotocol/sdk": "1.2.0",
-        "@hono/node-server": "1.19.13",
+        "@hono/node-server": "2.0.5",
         "@hono/node-ws": "1.3.0",
         "@hono/trpc-server": "0.3.4",
         "@mastra/core": "1.33.1",
@@ -863,7 +863,7 @@
         "@xterm/headless": "6.1.0-beta.289",
         "better-sqlite3": "12.6.2",
         "drizzle-orm": "0.45.2",
-        "hono": "4.12.25",
+        "hono": "4.12.27",
         "mastracode": "0.18.1",
         "mime-types": "3.0.2",
         "node-pty": "1.2.0-beta.14",
@@ -1851,7 +1851,7 @@
 
     "@headless-tree/react": ["@headless-tree/react@1.6.3", "", { "peerDependencies": { "@headless-tree/core": "*", "react": "*", "react-dom": "*" } }, "sha512-aiRwG6e2EPBSec9uLLy9GlTvAuCtSTouU30Nwcr5ZTsYjG/i7B/ouC8f8Zu4unzo/v1h5ztbemp+EH2TPTKh+g=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+    "@hono/node-server": ["@hono/node-server@2.0.5", "", { "peerDependencies": { "hono": "^4" } }, "sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g=="],
 
     "@hono/node-ws": ["@hono/node-ws@1.3.0", "", { "dependencies": { "ws": "^8.17.0" }, "peerDependencies": { "@hono/node-server": "^1.19.2", "hono": "^4.6.0" } }, "sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q=="],
 
@@ -6983,6 +6983,8 @@
 
     "@gorhom/portal/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "@hono/node-ws/@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@langchain/core/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -7883,6 +7885,8 @@
 
     "@ai-sdk/ui-utils-v5/@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "@anthropic-ai/claude-agent-sdk/@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
     "@anthropic-ai/claude-agent-sdk/@modelcontextprotocol/sdk/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
@@ -8163,9 +8167,15 @@
 
     "@jest/types/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "@mastra/core/@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
     "@mastra/core/@modelcontextprotocol/sdk/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
+    "@mastra/mcp/@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
     "@mastra/mcp/@modelcontextprotocol/sdk/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "@modelcontextprotocol/ext-apps/@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
     "@modelcontextprotocol/ext-apps/@modelcontextprotocol/sdk/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	],
 	"overrides": {
 		"axios": "1.14.0",
-		"hono": "4.12.25",
+		"hono": "4.12.27",
 		"kysely": "0.28.17",
 		"shell-quote": "1.9.0"
 	},
@@ -73,5 +73,8 @@
 		"sharp",
 		"utf-8-validate",
 		"workerd"
-	]
+	],
+	"dependencies": {
+		"hono": "4.12.27"
+	}
 }

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -44,7 +44,7 @@
 		"@trpc/client": "11.16.0",
 		"@trpc/server": "11.16.0",
 		"ai": "6.0.141",
-		"hono": "4.12.25",
+		"hono": "4.12.27",
 		"mastracode": "0.18.1",
 		"superjson": "2.2.6",
 		"zod": "4.3.6"

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -66,7 +66,7 @@
 	"dependencies": {
 		"@agentclientprotocol/claude-agent-acp": "0.56.0",
 		"@agentclientprotocol/sdk": "1.2.0",
-		"@hono/node-server": "1.19.13",
+		"@hono/node-server": "2.0.5",
 		"@hono/node-ws": "1.3.0",
 		"@hono/trpc-server": "0.3.4",
 		"@mastra/core": "1.33.1",
@@ -85,7 +85,7 @@
 		"@xterm/headless": "6.1.0-beta.289",
 		"better-sqlite3": "12.6.2",
 		"drizzle-orm": "0.45.2",
-		"hono": "4.12.25",
+		"hono": "4.12.27",
 		"mastracode": "0.18.1",
 		"mime-types": "3.0.2",
 		"node-pty": "1.2.0-beta.14",


### PR DESCRIPTION
## Summary

Absorbs the three open Dependabot PRs (#5847, #5839, #5840) and unifies the versions across the workspace so `sherif` stays green.

- `hono` 4.12.25 → **4.12.27** (relay, chat, host-service) — patch
- `@hono/node-server` 1.19.13 → **2.0.5** (desktop, relay, host-service) — **major**

Dependabot bumped these piecemeal (only desktop for `@hono/node-server`, only relay/chat for `hono`), which breaks `sherif`'s single-version rule. This PR bumps the remaining manifests to match.

### On the `@hono/node-server` v1 → v2 major bump

The documented v2 breaking changes (drop Node 18, remove the Vercel adapter) don't affect us. The real risk is that `@hono/node-ws@1.3.0` — used by all three packages via `injectWebSocket` — peer-declares `@hono/node-server@^1.19.x` and has **no v2-compatible release**. Verified it is runtime-safe for our usage:

- v2 still sets `env.incoming` on normal requests (what node-ws's `upgradeWebSocket` reads).
- v2's new built-in WS support is only wired via node-server's own `upgradeWebSocket` export; plain `serve()` never attaches it, so no conflict with node-ws's `injectWebSocket`.
- All three call sites use the unchanged `serve({ fetch, port, hostname }, cb)` API returning a Node `http.Server`.

## Test Plan

- [x] `sherif` — clean (single version per dep)
- [x] `typecheck` — desktop, relay, chat, host-service all pass
- [x] `bun test` — host-service (892 pass / 0 fail) + chat pass; relay is typecheck-only
- [x] Runtime WS smoke test — node-ws `injectWebSocket` upgrade + message round-trip on node-server 2.0.5
- [x] Live CDP E2E — booted the dev desktop, drove the running host-service (bundled v2) for the signed-in org: HTTP auth routing (401 on missing/bad token), real WS upgrade via `injectWebSocket`, and full-duplex `/events` round-trip
- [x] `lint` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `hono` and `@hono/node-server` versions across the workspace and pins `hono` at the root to keep the single-version rule green. Upgrades `hono` to 4.12.27 and `@hono/node-server` to 2.0.5 without runtime changes.

- **Dependencies**
  - `hono`: 4.12.25 → 4.12.27 (relay, chat, host-service, root override + root dep)
  - `@hono/node-server`: 1.19.13 → 2.0.5 (desktop, relay, host-service)
  - Compatibility: `@hono/node-ws@1.3.0` peers `@hono/node-server@^1.19.x`; usage is runtime-safe on v2 (`env.incoming`, `serve({ fetch, port, hostname }, cb)`, no `injectWebSocket` conflict).

<sup>Written for commit 5fe979870ad5a1fe004b4f66d16b2037019c77f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated server framework components to newer versions across desktop, relay, chat, and host services.
  - Refreshed related runtime dependencies (including the Node.js server integration and the core framework) to the latest patch releases for continued compatibility and maintenance.
  - Applied consistent versioning at the workspace level to ensure the intended framework version is used across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->