### PR TITLE
fix(agents): restore defaults and add settings deep links

### DIFF
--- a/apps/desktop/src/renderer/lib/agent-launch-command.test.ts
+++ b/apps/desktop/src/renderer/lib/agent-launch-command.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	findLinkedAgent,
 	getAgentCommandText,
 	parseAgentCommandText,
 	resolvePresetLaunchCommands,
@@ -60,6 +61,20 @@ describe("agent launch command helpers", () => {
 		).toEqual([
 			"ANTHROPIC_BASE_URL=https://example.test ANTHROPIC_AUTH_TOKEN=abc claude --dangerously-skip-permissions",
 		]);
+	});
+
+	it("resolves agent settings targets by UUID or built-in preset id", () => {
+		const secondAgent = {
+			...agent,
+			id: "codex-config-uuid",
+			presetId: "codex",
+			command: "codex",
+		};
+		const agents = [agent, secondAgent];
+
+		expect(findLinkedAgent(agents, "codex-config-uuid")).toBe(secondAgent);
+		expect(findLinkedAgent(agents, "codex")).toBe(secondAgent);
+		expect(findLinkedAgent(agents, "missing")).toBeNull();
 	});
 
 	it("falls back to snapshot commands when the linked agent is unavailable", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/$agentId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/$agentId/page.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AgentsSettingsPage } from "../components/AgentsSettingsPage";
+
+export const Route = createFileRoute(
+	"/_authenticated/settings/agents/$agentId/",
+)({
+	component: AgentSettingsRoute,
+});
+
+function AgentSettingsRoute() {
+	const { agentId } = Route.useParams();
+	return <AgentsSettingsPage initialAgentId={agentId} />;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettings/AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettings/AgentsSettings.tsx
@@ -10,17 +10,17 @@ import { AgentCard } from "./components/AgentCard";
 
 interface AgentsSettingsProps {
 	visibleItems?: SettingItemId[] | null;
-	/** Builtin preset id to pre-select in v2 (`?agent=claude`). Ignored in v1. */
-	initialAgentPresetId?: string | null;
+	/** Config UUID or built-in preset id to select in v2. Ignored in v1. */
+	initialAgentId?: string | null;
 }
 
 export function AgentsSettings({
 	visibleItems,
-	initialAgentPresetId,
+	initialAgentId,
 }: AgentsSettingsProps) {
 	const isV2CloudEnabled = useIsV2CloudEnabled();
 	if (isV2CloudEnabled) {
-		return <V2AgentsSettings initialAgentPresetId={initialAgentPresetId} />;
+		return <V2AgentsSettings initialAgentId={initialAgentId} />;
 	}
 	return <V1AgentsSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettingsPage/AgentsSettingsPage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettingsPage/AgentsSettingsPage.tsx
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import { getMatchingItemsForSection } from "../../../utils/settings-search";
+import { AgentsSettings } from "../AgentsSettings";
+
+interface AgentsSettingsPageProps {
+	initialAgentId?: string | null;
+}
+
+export function AgentsSettingsPage({
+	initialAgentId = null,
+}: AgentsSettingsPageProps) {
+	const searchQuery = useSettingsSearchQuery();
+
+	const visibleItems = useMemo(() => {
+		if (!searchQuery) return null;
+		return getMatchingItemsForSection(searchQuery, "agents").map(
+			(item) => item.id,
+		);
+	}, [searchQuery]);
+
+	return (
+		<AgentsSettings
+			visibleItems={visibleItems}
+			initialAgentId={initialAgentId}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettingsPage/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettingsPage/index.ts
@@ -1,0 +1,1 @@
+export { AgentsSettingsPage } from "./AgentsSettingsPage";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -6,13 +6,17 @@ import {
 import { Skeleton } from "@superset/ui/skeleton";
 import { toast } from "@superset/ui/sonner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { Bot } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
 	V2_AGENT_CONFIGS_QUERY_KEY as QUERY_KEY,
 	useV2AgentConfigs,
 } from "renderer/hooks/useV2AgentConfigs";
-import { getAgentCommandText } from "renderer/lib/agent-launch-command";
+import {
+	findLinkedAgent,
+	getAgentCommandText,
+} from "renderer/lib/agent-launch-command";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { getHostServiceUnavailableMessage } from "renderer/lib/host-service-unavailable";
@@ -65,19 +69,17 @@ function insertLinkedTerminalPreset(
 }
 
 interface V2AgentsSettingsProps {
-	/**
-	 * Builtin preset id to pre-select on mount (e.g. "claude"). Resolved
-	 * against `HostAgentConfig.presetId`. Consumed once per visit.
-	 */
-	initialAgentPresetId?: string | null;
+	/** Config UUID or built-in preset id to select from the current route. */
+	initialAgentId?: string | null;
 }
 
 export function V2AgentsSettings({
-	initialAgentPresetId,
+	initialAgentId,
 }: V2AgentsSettingsProps = {}) {
 	const hostService = useLocalHostService();
 	const { activeHostUrl } = hostService;
 	const queryClient = useQueryClient();
+	const navigate = useNavigate();
 
 	const configsQuery = useV2AgentConfigs(activeHostUrl);
 	const queryKey = [...QUERY_KEY, activeHostUrl] as const;
@@ -219,6 +221,7 @@ export function V2AgentsSettings({
 		onSuccess: () => {
 			setIsCreating(false);
 			setSelectedAgentId(null);
+			void navigate({ to: "/settings/agents" });
 			invalidate();
 		},
 		onError: (err) =>
@@ -240,32 +243,30 @@ export function V2AgentsSettings({
 	const detailRef = useScrollReset<HTMLDivElement>(
 		isCreating ? "new" : selectedAgentId,
 	);
-	const consumedInitialPresetIdRef = useRef(false);
+	const consumedInitialAgentIdRef = useRef<string | null>(null);
 
 	// Auto-select first agent when none selected, and clear selection when the
-	// selected agent disappears. If `initialAgentPresetId` is provided (deep
-	// link from a preset's "Open" button), prefer the matching config the
-	// first time configs become available. The route param accepts both the
-	// unique config id and the built-in preset id for older links.
+	// selected agent disappears. If `initialAgentId` is provided, prefer
+	// the matching config whenever the route target changes. Route targets may
+	// be either a unique config id or a built-in preset id.
 	useEffect(() => {
 		if (configs.length === 0) {
 			if (selectedAgentId !== null) setSelectedAgentId(null);
 			return;
 		}
-		if (initialAgentPresetId && !consumedInitialPresetIdRef.current) {
-			const match = configs.find(
-				(c) =>
-					c.id === initialAgentPresetId || c.presetId === initialAgentPresetId,
-			);
+		if (!initialAgentId) {
+			consumedInitialAgentIdRef.current = null;
+		} else if (consumedInitialAgentIdRef.current !== initialAgentId) {
+			const match = findLinkedAgent(configs, initialAgentId);
 			if (match) {
-				consumedInitialPresetIdRef.current = true;
+				consumedInitialAgentIdRef.current = initialAgentId;
 				setSelectedAgentId(match.id);
 				return;
 			}
 		}
 		const stillExists = configs.some((c) => c.id === selectedAgentId);
 		if (!stillExists) setSelectedAgentId(configs[0].id);
-	}, [configs, selectedAgentId, initialAgentPresetId]);
+	}, [configs, selectedAgentId, initialAgentId]);
 
 	const selectedAgent = configs.find((c) => c.id === selectedAgentId) ?? null;
 
@@ -292,6 +293,10 @@ export function V2AgentsSettings({
 					onSelectAgent={(id) => {
 						setSelectedAgentId(id);
 						setIsCreating(false);
+						void navigate({
+							to: "/settings/agents/$agentId",
+							params: { agentId: id },
+						});
 					}}
 					onAddAgent={(preset) => addMutation.mutate(preset)}
 					onCreateCustomAgent={() => setIsCreating(true)}
@@ -322,6 +327,7 @@ export function V2AgentsSettings({
 						}}
 						onDeleted={() => {
 							setSelectedAgentId(null);
+							void navigate({ to: "/settings/agents" });
 							invalidate();
 						}}
 					/>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentDetail/AgentDetail.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentDetail/AgentDetail.tsx
@@ -1,10 +1,22 @@
 import type { HostAgentConfig } from "@superset/host-service/settings";
 import type { PromptTransport } from "@superset/shared/agent-prompt-launch";
+import { getPresetById } from "@superset/shared/host-agent-presets";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
 import { toast } from "@superset/ui/sonner";
 import { useMutation } from "@tanstack/react-query";
-import { Trash2 } from "lucide-react";
+import { RotateCcw, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
 	getAgentCommandText,
@@ -38,6 +50,7 @@ export function AgentDetail({
 	const hostService = useLocalHostService();
 	const { activeHostUrl } = hostService;
 	const isCustom = config.presetId === "custom";
+	const hasBundledDefault = getPresetById(config.presetId) !== undefined;
 
 	const [label, setLabel] = useState(config.label);
 	const [commandText, setCommandText] = useState(getAgentCommandText(config));
@@ -108,6 +121,29 @@ export function AgentDetail({
 		onSuccess: () => onDeleted(),
 		onError: (err) =>
 			toast.error(err instanceof Error ? err.message : "Failed to remove"),
+	});
+
+	const restoreDefaultMutation = useMutation({
+		mutationFn: () => {
+			if (!activeHostUrl) {
+				throw new Error(
+					getHostServiceUnavailableMessage(hostService, {
+						action: "restore the agent defaults",
+					}),
+				);
+			}
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.restoreDefault.mutate({ id: config.id });
+		},
+		onSuccess: (updated) => {
+			onChanged(updated);
+			toast.success(`${updated.label} restored to defaults`);
+		},
+		onError: (err) =>
+			toast.error(
+				err instanceof Error ? err.message : "Failed to restore defaults",
+			),
 	});
 
 	const handleLabelBlur = () => {
@@ -188,7 +224,56 @@ export function AgentDetail({
 					onPromptTransportChange={handleTransportChange}
 				/>
 
-				<div className="pt-2 border-t border-border">
+				{hasBundledDefault ? (
+					<div className="pt-2 border-t border-border">
+						<div className="flex items-center justify-between gap-8">
+							<div className="min-w-0 flex-1">
+								<div className="text-sm font-medium">Restore default</div>
+								<p className="text-sm text-muted-foreground mt-0.5">
+									Replace this agent's launch settings with the current bundled
+									configuration.
+								</p>
+							</div>
+							<AlertDialog>
+								<AlertDialogTrigger asChild>
+									<Button
+										variant="outline"
+										size="sm"
+										disabled={restoreDefaultMutation.isPending}
+										className="shrink-0 gap-1.5"
+									>
+										<RotateCcw className="size-3.5" />
+										Restore
+									</Button>
+								</AlertDialogTrigger>
+								<AlertDialogContent>
+									<AlertDialogHeader>
+										<AlertDialogTitle>
+											Restore {config.label} to defaults?
+										</AlertDialogTitle>
+										<AlertDialogDescription>
+											This replaces its label, command, arguments, prompt
+											settings, environment variables, and icon with the current
+											bundled configuration.
+										</AlertDialogDescription>
+									</AlertDialogHeader>
+									<AlertDialogFooter>
+										<AlertDialogCancel>Cancel</AlertDialogCancel>
+										<AlertDialogAction
+											onClick={() => restoreDefaultMutation.mutate()}
+										>
+											Restore defaults
+										</AlertDialogAction>
+									</AlertDialogFooter>
+								</AlertDialogContent>
+							</AlertDialog>
+						</div>
+					</div>
+				) : null}
+
+				<div
+					className={hasBundledDefault ? "pt-6" : "pt-2 border-t border-border"}
+				>
 					<div className="flex items-center justify-between gap-8">
 						<div className="min-w-0 flex-1">
 							<div className="text-sm font-medium">Delete agent</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/page.tsx
@@ -1,39 +1,22 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useMemo } from "react";
-import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
-import { AgentsSettings } from "./components/AgentsSettings";
+import { AgentsSettingsPage } from "./components/AgentsSettingsPage";
 
 export type AgentsSettingsSearch = {
 	/**
-	 * Builtin agent preset id (e.g. "claude", "codex"). When set, the v2
-	 * agents page selects the matching host config on mount. v1 ignores it.
+	 * Config UUID or built-in preset id (e.g. "claude", "codex"). Retained for
+	 * compatibility with older deep links; new links use the path parameter.
 	 */
 	agent?: string;
 };
 
 export const Route = createFileRoute("/_authenticated/settings/agents/")({
-	component: AgentsSettingsPage,
+	component: AgentsSettingsIndexRoute,
 	validateSearch: (search: Record<string, unknown>): AgentsSettingsSearch => ({
 		agent: typeof search.agent === "string" ? search.agent : undefined,
 	}),
 });
 
-function AgentsSettingsPage() {
-	const searchQuery = useSettingsSearchQuery();
+function AgentsSettingsIndexRoute() {
 	const { agent } = Route.useSearch();
-
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "agents").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
-
-	return (
-		<AgentsSettings
-			visibleItems={visibleItems}
-			initialAgentPresetId={agent ?? null}
-		/>
-	);
+	return <AgentsSettingsPage initialAgentId={agent} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
@@ -209,7 +209,6 @@ export function PresetEditorDialog({
 		return findLinkedAgent(agents, presetAgentId);
 	}, [preset, agents]);
 	const linkedAgentId = (preset as PresetWithAgent | null)?.agentId;
-	const isLinked = !!linkedAgentId;
 	const liveCommands = useMemo(
 		() =>
 			preset
@@ -369,7 +368,7 @@ export function PresetEditorDialog({
 						</DialogHeader>
 
 						<div className="space-y-3">
-							{isLinked ? (
+							{linkedAgentId ? (
 								<div className="py-2.5 space-y-2">
 									<div className="flex items-center justify-between gap-3">
 										<Label
@@ -383,8 +382,8 @@ export function PresetEditorDialog({
 											Command
 										</Label>
 										<Link
-											to="/settings/agents"
-											search={{ agent: linkedAgentId }}
+											to="/settings/agents/$agentId"
+											params={{ agentId: linkedAgentId }}
 											onClick={() => onOpenChange(false)}
 											className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
 										>

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -391,6 +391,71 @@ describe("agentConfigsRouter", () => {
 		});
 	});
 
+	describe("restoreDefault()", () => {
+		it("repairs a malformed built-in config without replacing its row", async () => {
+			const caller = createCaller();
+			const configs = await caller.list();
+			const codex = configs.find((row) => row.presetId === "codex");
+			expect(codex).toBeDefined();
+			if (!codex) return;
+
+			await caller.update({
+				id: codex.id,
+				patch: {
+					label: "Broken Codex",
+					command: "codex",
+					args: [
+						"-c",
+						"model_reasoning_summary=detailed",
+						" ",
+						"--dangerously-bypass-approvals-and-sandbox",
+					],
+					promptTransport: "stdin",
+					promptArgs: ["--prompt"],
+					env: { CODEX_HOME: "/tmp/old-codex" },
+					iconId: "claude",
+				},
+			});
+
+			const restored = await caller.restoreDefault({ id: codex.id });
+			const preset = getPresetById("codex");
+			expect(preset).toBeDefined();
+			if (!preset) return;
+
+			expect(restored).toMatchObject({
+				id: codex.id,
+				presetId: "codex",
+				iconId: null,
+				label: preset.label,
+				command: preset.command,
+				args: preset.args,
+				promptTransport: preset.promptTransport,
+				promptArgs: preset.promptArgs,
+				env: preset.env,
+				order: codex.order,
+			});
+		});
+
+		it("rejects custom agents and unknown ids", async () => {
+			const caller = createCaller();
+			const custom = await caller.add({
+				label: "Custom",
+				command: "custom",
+				args: [],
+				promptTransport: "argv",
+				promptArgs: [],
+				env: {},
+			});
+
+			await expect(caller.restoreDefault({ id: custom.id })).rejects.toThrow(
+				/no bundled default/i,
+			);
+			await expect(
+				caller.restoreDefault({ id: "does-not-exist" }),
+			).rejects.toThrow(/not found/i);
+		});
+	});
+
 	describe("reorder()", () => {
 		it("persists the submitted id order", async () => {
 			const caller = createCaller();

--- a/packages/host-service/src/trpc/router/settings/agent-configs.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { PromptTransport } from "@superset/shared/agent-prompt-launch";
 import {
 	getDefaultSeedPresets,
+	getPresetById,
 	type HostAgentPreset,
 } from "@superset/shared/host-agent-presets";
 import { TRPCError } from "@trpc/server";
@@ -279,6 +280,63 @@ export const agentConfigsRouter = router({
 				});
 			}
 			return toOutput(updated);
+		}),
+
+	/**
+	 * Restore one configured built-in agent to the bundled definition while
+	 * preserving its stable id and display order. This repairs stale defaults
+	 * without replacing unrelated custom agents or breaking linked presets.
+	 */
+	restoreDefault: protectedProcedure
+		.input(z.object({ id: z.string().min(1) }))
+		.mutation(({ ctx, input }) => {
+			const existing = ctx.db
+				.select()
+				.from(hostAgentConfigs)
+				.where(eq(hostAgentConfigs.id, input.id))
+				.get();
+			if (!existing) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `Host agent config not found: ${input.id}`,
+				});
+			}
+
+			const preset = getPresetById(existing.presetId);
+			if (!preset) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Agent config '${input.id}' has no bundled default`,
+				});
+			}
+
+			ctx.db
+				.update(hostAgentConfigs)
+				.set({
+					iconId: null,
+					label: preset.label,
+					command: preset.command,
+					argsJson: JSON.stringify(preset.args),
+					promptTransport: preset.promptTransport,
+					promptArgsJson: JSON.stringify(preset.promptArgs),
+					envJson: JSON.stringify(preset.env),
+					updatedAt: Date.now(),
+				})
+				.where(eq(hostAgentConfigs.id, input.id))
+				.run();
+
+			const restored = ctx.db
+				.select()
+				.from(hostAgentConfigs)
+				.where(eq(hostAgentConfigs.id, input.id))
+				.get();
+			if (!restored) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to read back restored host agent config",
+				});
+			}
+			return toOutput(restored);
 		}),
 
 	/** Delete a single host agent config by id. Throws NOT_FOUND if missing. */


### PR DESCRIPTION
## What changed

- Add a per-agent **Restore default** action for bundled V2 terminal agents.
- Restore the selected row from the current bundled preset while preserving its stable ID and display order.
- Add `/settings/agents/$agentId` routes that accept either a built-in slug such as `codex` or a configured-agent UUID.
- Update the preset editor to deep-link to the exact linked agent UUID.
- Keep sidebar selection synchronized with the route and retain `?agent=` compatibility for older links.
- Add regression coverage for malformed Codex configuration and UUID/preset-id target resolution.

## Why

Some users can retain old or malformed V2 agent configuration indefinitely. In the reported Codex case, a literal whitespace argument was interpreted as the first positional prompt, causing the real task prompt to be rejected as a second positional argument.

Built-in defaults are seeded only when the agent table is empty, so later default changes do not repair existing rows. The previous global reset also replaced every agent configuration, including unrelated customizations. Agent settings additionally lacked a stable path for opening the specific agent referenced by a terminal preset.

## Impact

Users can repair one stale built-in agent without deleting it, resetting unrelated agents, or breaking shortcuts linked to that agent's UUID. Preset editors and other callers can navigate directly to either `/settings/agents/codex` or `/settings/agents/<uuid>`. Custom agents remain delete-only because they have no bundled definition.

## Validation

- `bun test apps/desktop/src/renderer/lib/agent-launch-command.test.ts packages/host-service/src/trpc/router/settings/agent-configs.test.ts` — 36 passing
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Restore default” option for bundled agents, with a confirmation dialog.
  * Restoring resets the agent’s configuration while preserving its existing identity.
  * Added success/error notifications and disabled the restore action while it’s processing.
* **Improvements**
  * Enhanced agents settings deep-linking and selection behavior to consistently reflect the chosen agent in the URL (including after reset/delete).
* **Tests**
  * Added coverage for restore-default scenarios and for resolving agents by UUID or preset identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->