### PR TITLE
feat(desktop): move workspaces list into settings

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/modules/settings/commands.ts
+++ b/apps/desktop/src/renderer/commandPalette/modules/settings/commands.ts
@@ -10,6 +10,7 @@ import {
 	GitBranchIcon,
 	KeyboardIcon,
 	KeyRoundIcon,
+	LayersIcon,
 	LinkIcon,
 	type LucideIcon,
 	PaletteIcon,
@@ -104,6 +105,13 @@ const TABS: SettingsTab[] = [
 		title: "Projects",
 		path: "/settings/projects",
 		icon: FolderIcon,
+	},
+	{
+		id: "workspaces",
+		title: "Workspaces",
+		path: "/settings/workspaces",
+		icon: LayersIcon,
+		keywords: ["workspace", "worktree"],
 	},
 	{
 		id: "ringtones",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
@@ -20,7 +20,7 @@ import {
 	HiOutlineUser,
 	HiOutlineUserGroup,
 } from "react-icons/hi2";
-import { LuBrain, LuGitBranch, LuKeyboard } from "react-icons/lu";
+import { LuBrain, LuGitBranch, LuKeyboard, LuLayers } from "react-icons/lu";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { SettingsSection } from "renderer/stores/settings-state";
@@ -50,6 +50,7 @@ type SettingsRoute =
 	| "/settings/security"
 	| "/settings/permissions"
 	| "/settings/projects"
+	| "/settings/workspaces"
 	| "/settings/hosts";
 
 interface SectionItem {
@@ -156,6 +157,12 @@ const SECTION_GROUPS: SectionGroup[] = [
 				section: "project",
 				label: "Projects",
 				icon: <HiOutlineFolder className="h-4 w-4" />,
+			},
+			{
+				id: "/settings/workspaces",
+				section: "workspaces",
+				label: "Workspaces",
+				icon: <LuLayers className="h-4 w-4" />,
 			},
 			{
 				id: "/settings/hosts",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -43,6 +43,7 @@ const SECTION_ORDER: SettingsSection[] = [
 	"billing",
 	"apikeys",
 	"permissions",
+	"workspaces",
 	"hosts",
 	"experimental",
 ];
@@ -63,6 +64,7 @@ function getSectionFromPath(pathname: string): SettingsSection | null {
 	if (pathname.includes("/settings/integrations")) return "integrations";
 	if (pathname.includes("/settings/permissions")) return "permissions";
 	if (pathname.includes("/settings/hosts")) return "hosts";
+	if (pathname.includes("/settings/workspaces")) return "workspaces";
 	if (pathname.includes("/settings/project")) return "project";
 	return null;
 }
@@ -99,6 +101,8 @@ function getPathFromSection(section: SettingsSection): string {
 			return "/settings/permissions";
 		case "hosts":
 			return "/settings/hosts";
+		case "workspaces":
+			return "/settings/workspaces";
 		case "project":
 			return "/settings/projects";
 		default:
@@ -162,10 +166,11 @@ function SettingsLayout() {
 		[navigate, location.pathname, originRoute],
 	);
 
-	const usesInnerSidebar =
+	const usesFullBleedContent =
 		location.pathname.startsWith("/settings/projects") ||
 		location.pathname.startsWith("/settings/hosts") ||
-		location.pathname.startsWith("/settings/agents");
+		location.pathname.startsWith("/settings/agents") ||
+		location.pathname.startsWith("/settings/workspaces");
 
 	return (
 		<div className="flex flex-col h-screen w-screen bg-tertiary">
@@ -188,7 +193,7 @@ function SettingsLayout() {
 							onClear={() => setSearchQuery("")}
 						/>
 					)}
-					{usesInnerSidebar ? (
+					{usesFullBleedContent ? (
 						<Outlet />
 					) : (
 						<div className="mx-auto max-w-4xl">

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -89,6 +89,8 @@ export const SETTING_ITEM_ID = {
 	HOST_MEMBER_ROLE: "host-member-role",
 	HOST_WORKTREE_LOCATION: "host-worktree-location",
 	HOST_DELETE: "host-delete",
+
+	WORKSPACES_LIST: "workspaces-list",
 } as const;
 
 export type SettingItemId =
@@ -202,6 +204,8 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.HOST_MEMBER_ROLE]: "shared",
 	[SETTING_ITEM_ID.HOST_WORKTREE_LOCATION]: "v2",
 	[SETTING_ITEM_ID.HOST_DELETE]: "shared",
+
+	[SETTING_ITEM_ID.WORKSPACES_LIST]: "v2",
 };
 
 export function isItemAllowedForVariant(
@@ -1443,6 +1447,21 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"workspace",
 			"owner",
 			"danger zone",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.WORKSPACES_LIST,
+		section: "workspaces",
+		title: "Workspaces",
+		description: "Browse all workspaces across your projects and devices",
+		keywords: [
+			"workspace",
+			"workspaces",
+			"worktree",
+			"branch",
+			"list",
+			"all",
+			"device",
 		],
 	},
 ];

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/workspaces/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/workspaces/page.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { V2WorkspacesHeader } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader";
+import { V2WorkspacesList } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList";
+import { useAccessibleV2Workspaces } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { useV2WorkspacesFilterStore } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+
+export const Route = createFileRoute("/_authenticated/settings/workspaces/")({
+	component: WorkspacesSettingsPage,
+});
+
+function WorkspacesSettingsPage() {
+	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
+	const deviceFilter = useV2WorkspacesFilterStore(
+		(state) => state.deviceFilter,
+	);
+	const projectFilter = useV2WorkspacesFilterStore(
+		(state) => state.projectFilter,
+	);
+	const setSearchQuery = useV2WorkspacesFilterStore(
+		(state) => state.setSearchQuery,
+	);
+
+	useEffect(() => {
+		setSearchQuery("");
+	}, [setSearchQuery]);
+
+	const { all, counts, hostOptions, projectOptions, hostsById, projectsById } =
+		useAccessibleV2Workspaces({
+			searchQuery,
+			deviceFilter,
+			projectFilter,
+		});
+
+	return (
+		<div className="flex h-full w-full flex-1 flex-col overflow-hidden">
+			<V2WorkspacesHeader
+				counts={counts}
+				hostOptions={hostOptions}
+				projectOptions={projectOptions}
+				hostsById={hostsById}
+				projectsById={projectsById}
+			/>
+			<V2WorkspacesList workspaces={all} />
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/stores/settings-state.ts
+++ b/apps/desktop/src/renderer/stores/settings-state.ts
@@ -21,7 +21,8 @@ export type SettingsSection =
 	| "permissions"
 	| "security"
 	| "project"
-	| "hosts";
+	| "hosts"
+	| "workspaces";
 
 interface SettingsState {
 	activeSection: SettingsSection;


### PR DESCRIPTION
## Summary

The sidebar Workspaces tab was hidden behind `SHOW_WORKSPACES_TAB = false` (#5824), leaving the `/v2-workspaces` list page unreachable. This surfaces it in Settings instead:

- New **Settings → Workspaces** page at `/settings/workspaces`, reusing the existing `V2WorkspacesHeader` + `V2WorkspacesList` components, filter store, and data hook — no duplication
- Sidebar nav item in the Organization group (between Projects and Hosts), same `LuLayers` icon as the old tab; gated to v2 via the settings item variant
- Wired into settings search (`workspaces-list` item), section/path mapping in the settings layout, and the command palette Settings submenu
- The page renders full-bleed (renamed `usesInnerSidebar` → `usesFullBleedContent`) so the workspace table gets full width

The hidden sidebar tab lever and the original `/v2-workspaces` route are left untouched; both routes render the same shared components.

## Test Plan

- [ ] Settings sidebar shows a Workspaces item under Organization (v2 users)
- [ ] `/settings/workspaces` renders the workspace list with search + project/device filters working
- [ ] Clicking a workspace row navigates to that workspace
- [ ] Settings search for "workspace" surfaces the section; command palette → Settings → Workspaces navigates there
- [ ] `bun run typecheck` and `bun run lint` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Workspaces list into Settings at `/settings/workspaces`, restoring access now that the sidebar tab is hidden. Reuses the existing V2 components and supports settings search and the command palette.

- **New Features**
  - New Settings page at `/settings/workspaces` using `V2WorkspacesHeader` + `V2WorkspacesList` and the existing filter store/hook.
  - Adds “Workspaces” under Organization in the Settings sidebar (v2), with the `LuLayers` icon, plus a command palette Settings entry.
  - Indexed in Settings search as `workspaces-list` with keywords and proper section↔path mapping.
  - Renders full-bleed for a wider table; the original `/v2-workspaces` route remains and shares the same components.

<sup>Written for commit b83b8f8eb59160696e32ef5346db13363567d612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated **Workspaces** section in Settings.
  - Workspaces can be opened from the Settings sidebar and command palette.
  - Added workspace search and filtering by device and project.
  - Workspace results now display accessible workspaces with counts and filter options.
  - Added Workspaces to Settings search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->