### PR TITLE
fix(desktop): remove browser pane tooltips and restyle pane/preset tooltips

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -198,7 +198,7 @@ export function V2PresetsBar({
 			style={{ scrollbarWidth: "none" }}
 		>
 			<DropdownMenu>
-				<Tooltip>
+				<Tooltip delayDuration={1000}>
 					<TooltipTrigger asChild>
 						<DropdownMenuTrigger asChild>
 							<Button
@@ -210,7 +210,12 @@ export function V2PresetsBar({
 							</Button>
 						</DropdownMenuTrigger>
 					</TooltipTrigger>
-					<TooltipContent side="bottom" sideOffset={4}>
+					<TooltipContent
+						side="bottom"
+						sideOffset={4}
+						showArrow={false}
+						className="rounded-sm border border-border bg-background px-1.5 py-0.5 font-medium text-muted-foreground shadow-sm"
+					>
 						Manage Presets
 					</TooltipContent>
 				</Tooltip>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultPaneActions/useDefaultPaneActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultPaneActions/useDefaultPaneActions.tsx
@@ -35,7 +35,6 @@ export function useDefaultPaneActions({
 			{
 				key: "close",
 				icon: <HiMiniXMark className="size-3.5" />,
-				tooltip: <HotkeyLabel label="Close pane" id="CLOSE_PANE" />,
 				onClick: (ctx) => ctx.actions.close(),
 			},
 		],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -1,4 +1,3 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	TbArrowLeft,
@@ -109,54 +108,33 @@ export function BrowserToolbar({
 	return (
 		<div className="flex h-full min-w-0 flex-1 items-center px-2">
 			<div className="flex shrink-0 items-center gap-0.5">
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={onGoBack}
-							disabled={!canGoBack}
-							className={`rounded p-1 transition-colors ${canGoBack ? "text-muted-foreground/60 hover:text-muted-foreground" : "opacity-30 pointer-events-none"}`}
-						>
-							<TbArrowLeft className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						Go Back
-					</TooltipContent>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={onGoForward}
-							disabled={!canGoForward}
-							className={`rounded p-1 transition-colors ${canGoForward ? "text-muted-foreground/60 hover:text-muted-foreground" : "opacity-30 pointer-events-none"}`}
-						>
-							<TbArrowRight className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						Go Forward
-					</TooltipContent>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={onReload}
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-						>
-							{isLoading ? (
-								<TbLoader2 className="size-3.5 animate-spin" />
-							) : (
-								<TbRefresh className="size-3.5" />
-							)}
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						{isLoading ? "Loading..." : "Reload"}
-					</TooltipContent>
-				</Tooltip>
+				<button
+					type="button"
+					onClick={onGoBack}
+					disabled={!canGoBack}
+					className={`rounded p-1 transition-colors ${canGoBack ? "text-muted-foreground/60 hover:text-muted-foreground" : "opacity-30 pointer-events-none"}`}
+				>
+					<TbArrowLeft className="size-3.5" />
+				</button>
+				<button
+					type="button"
+					onClick={onGoForward}
+					disabled={!canGoForward}
+					className={`rounded p-1 transition-colors ${canGoForward ? "text-muted-foreground/60 hover:text-muted-foreground" : "opacity-30 pointer-events-none"}`}
+				>
+					<TbArrowRight className="size-3.5" />
+				</button>
+				<button
+					type="button"
+					onClick={onReload}
+					className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+				>
+					{isLoading ? (
+						<TbLoader2 className="size-3.5 animate-spin" />
+					) : (
+						<TbRefresh className="size-3.5" />
+					)}
+				</button>
 			</div>
 			<div className="mx-1.5 h-3.5 w-px shrink-0 bg-muted-foreground/60" />
 			<div className="relative flex min-w-0 flex-1 items-center">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -89,7 +89,6 @@ export function BrowserPane({
 							splitOrientation={handlers.splitOrientation}
 							onSplitPane={handlers.onSplitPane}
 							onClosePane={handlers.onClosePane}
-							closeHotkeyId="CLOSE_TERMINAL"
 							leadingActions={
 								<>
 									<Tooltip>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -1,4 +1,3 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	TbArrowLeft,
@@ -114,54 +113,33 @@ export function BrowserToolbar({
 	return (
 		<div className="flex h-full flex-1 min-w-0 items-center px-2">
 			<div className="flex items-center gap-0.5 shrink-0">
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={onGoBack}
-							disabled={!canGoBack}
-							className={`rounded p-1 transition-colors ${canGoBack ? "text-muted-foreground/60 hover:text-muted-foreground" : "opacity-30 pointer-events-none"}`}
-						>
-							<TbArrowLeft className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						Go Back
-					</TooltipContent>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={onGoForward}
-							disabled={!canGoForward}
-							className={`rounded p-1 transition-colors ${canGoForward ? "text-muted-foreground/60 hover:text-muted-foreground" : "opacity-30 pointer-events-none"}`}
-						>
-							<TbArrowRight className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						Go Forward
-					</TooltipContent>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={onReload}
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-						>
-							{isLoading ? (
-								<TbLoader2 className="size-3.5 animate-spin" />
-							) : (
-								<TbRefresh className="size-3.5" />
-							)}
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						{isLoading ? "Loading..." : "Reload"}
-					</TooltipContent>
-				</Tooltip>
+				<button
+					type="button"
+					onClick={onGoBack}
+					disabled={!canGoBack}
+					className={`rounded p-1 transition-colors ${canGoBack ? "text-muted-foreground/60 hover:text-muted-foreground" : "opacity-30 pointer-events-none"}`}
+				>
+					<TbArrowLeft className="size-3.5" />
+				</button>
+				<button
+					type="button"
+					onClick={onGoForward}
+					disabled={!canGoForward}
+					className={`rounded p-1 transition-colors ${canGoForward ? "text-muted-foreground/60 hover:text-muted-foreground" : "opacity-30 pointer-events-none"}`}
+				>
+					<TbArrowRight className="size-3.5" />
+				</button>
+				<button
+					type="button"
+					onClick={onReload}
+					className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+				>
+					{isLoading ? (
+						<TbLoader2 className="size-3.5 animate-spin" />
+					) : (
+						<TbRefresh className="size-3.5" />
+					)}
+				</button>
 			</div>
 			<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
 			<div className="relative flex flex-1 min-w-0 items-center">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
@@ -155,7 +155,6 @@ export function ChatPane({
 								splitOrientation={handlers.splitOrientation}
 								onSplitPane={handlers.onSplitPane}
 								onClosePane={handlers.onClosePane}
-								closeHotkeyId="CLOSE_TERMINAL"
 							/>
 						</div>
 					)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/CommentPane/CommentPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/CommentPane/CommentPane.tsx
@@ -128,7 +128,6 @@ export function CommentPane({
 						splitOrientation={handlers.splitOrientation}
 						onSplitPane={handlers.onSplitPane}
 						onClosePane={handlers.onClosePane}
-						closeHotkeyId="CLOSE_TERMINAL"
 					/>
 				</div>
 			)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
@@ -51,7 +51,6 @@ export function DevToolsPane({
 						splitOrientation={handlers.splitOrientation}
 						onSplitPane={handlers.onSplitPane}
 						onClosePane={handlers.onClosePane}
-						closeHotkeyId="CLOSE_TERMINAL"
 					/>
 				</div>
 			)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -122,7 +122,6 @@ export function TabPane({
 						splitOrientation={handlers.splitOrientation}
 						onSplitPane={handlers.onSplitPane}
 						onClosePane={handlers.onClosePane}
-						closeHotkeyId="CLOSE_TERMINAL"
 					/>
 				</div>
 			)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneToolbarActions/PaneToolbarActions.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneToolbarActions/PaneToolbarActions.tsx
@@ -1,7 +1,6 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { HiMiniXMark } from "react-icons/hi2";
 import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
-import type { HotkeyId } from "renderer/hotkeys";
 import { HotkeyLabel } from "renderer/hotkeys";
 import type { SplitOrientation } from "../../hooks";
 
@@ -10,8 +9,6 @@ interface PaneToolbarActionsProps {
 	onSplitPane: (e: React.MouseEvent) => void;
 	onClosePane: (e: React.MouseEvent) => void;
 	leadingActions?: React.ReactNode;
-	/** Hotkey ID to display for the close action. Defaults to CLOSE_PANE. */
-	closeHotkeyId?: HotkeyId;
 }
 
 export function PaneToolbarActions({
@@ -19,7 +16,6 @@ export function PaneToolbarActions({
 	onSplitPane,
 	onClosePane,
 	leadingActions,
-	closeHotkeyId = "CLOSE_PANE",
 }: PaneToolbarActionsProps) {
 	const splitIcon =
 		splitOrientation === "vertical" ? (
@@ -31,7 +27,7 @@ export function PaneToolbarActions({
 	return (
 		<div className="flex items-center gap-0.5">
 			{leadingActions}
-			<Tooltip>
+			<Tooltip delayDuration={1000}>
 				<TooltipTrigger asChild>
 					<button
 						type="button"
@@ -41,24 +37,22 @@ export function PaneToolbarActions({
 						{splitIcon}
 					</button>
 				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
+				<TooltipContent
+					side="bottom"
+					sideOffset={4}
+					showArrow={false}
+					className="rounded-sm border border-border bg-background px-1.5 py-0.5 font-medium text-muted-foreground shadow-sm"
+				>
 					<HotkeyLabel label="Split pane" id="SPLIT_AUTO" />
 				</TooltipContent>
 			</Tooltip>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={onClosePane}
-						className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-					>
-						<HiMiniXMark className="size-3.5" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					<HotkeyLabel label="Close pane" id={closeHotkeyId} />
-				</TooltipContent>
-			</Tooltip>
+			<button
+				type="button"
+				onClick={onClosePane}
+				className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+			>
+				<HiMiniXMark className="size-3.5" />
+			</button>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
@@ -343,7 +343,7 @@ export function PresetsBar() {
 			style={{ scrollbarWidth: "none" }}
 		>
 			<DropdownMenu>
-				<Tooltip>
+				<Tooltip delayDuration={1000}>
 					<TooltipTrigger asChild>
 						<DropdownMenuTrigger asChild>
 							<Button variant="ghost" size="icon" className="size-6 shrink-0">
@@ -351,7 +351,12 @@ export function PresetsBar() {
 							</Button>
 						</DropdownMenuTrigger>
 					</TooltipTrigger>
-					<TooltipContent side="bottom" sideOffset={4}>
+					<TooltipContent
+						side="bottom"
+						sideOffset={4}
+						showArrow={false}
+						className="rounded-sm border border-border bg-background px-1.5 py-0.5 font-medium text-muted-foreground shadow-sm"
+					>
 						Manage Presets
 					</TooltipContent>
 				</Tooltip>

--- a/packages/panes/src/react/components/PaneHeaderActions/PaneHeaderActions.tsx
+++ b/packages/panes/src/react/components/PaneHeaderActions/PaneHeaderActions.tsx
@@ -1,4 +1,5 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { Fragment } from "react";
 import type { PaneActionConfig, RendererContext } from "../../types";
 
 export function PaneHeaderActions<TData>({
@@ -24,18 +25,29 @@ export function PaneHeaderActions<TData>({
 						? action.tooltip(context)
 						: action.tooltip;
 
+				const button = (
+					<button
+						type="button"
+						onClick={() => action.onClick(context)}
+						className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+					>
+						{icon}
+					</button>
+				);
+
+				if (tooltip == null) {
+					return <Fragment key={action.key}>{button}</Fragment>;
+				}
+
 				return (
-					<Tooltip key={action.key}>
-						<TooltipTrigger asChild>
-							<button
-								type="button"
-								onClick={() => action.onClick(context)}
-								className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-							>
-								{icon}
-							</button>
-						</TooltipTrigger>
-						<TooltipContent side="bottom" showArrow={false}>
+					<Tooltip key={action.key} delayDuration={1000}>
+						<TooltipTrigger asChild>{button}</TooltipTrigger>
+						<TooltipContent
+							side="bottom"
+							sideOffset={4}
+							showArrow={false}
+							className="rounded-sm border border-border bg-background px-1.5 py-0.5 font-medium text-muted-foreground shadow-sm"
+						>
 							{tooltip}
 						</TooltipContent>
 					</Tooltip>

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -6,7 +6,7 @@ import type { Pane, Tab } from "../types";
 export interface PaneActionConfig<TData> {
 	key: string;
 	icon: ReactNode | ((context: RendererContext<TData>) => ReactNode);
-	tooltip: ReactNode | ((context: RendererContext<TData>) => ReactNode);
+	tooltip?: ReactNode | ((context: RendererContext<TData>) => ReactNode);
 	onClick: (context: RendererContext<TData>) => void;
 }
 


### PR DESCRIPTION
## Summary

- Remove tooltips from the browser pane's back, forward, and reload buttons (both the v1 and v2 workspace copies of `BrowserToolbar`)
- Remove the close-pane tooltip from the shared pane header actions: v1 `PaneToolbarActions` and v2 `useDefaultPaneActions` (made `tooltip` optional in `@superset/panes` `PaneActionConfig` and render a plain button when absent)
- Drop the now-dead `closeHotkeyId` prop from `PaneToolbarActions` and its five call sites
- Restyle the "Manage Presets" and split-pane tooltips to the subtle hotkey-chip style (bordered `bg-background`, no arrow) with a 1s hover delay, matching the preset-item `HotkeyTooltip`s

## Test Plan

- [x] `bun run lint` passes
- [x] `turbo typecheck` passes for `@superset/desktop` and `@superset/panes`
- [ ] Hover browser back/forward/reload and close-pane buttons — no tooltips
- [ ] Hover the presets cog and split-pane buttons — chip-style tooltip appears after ~1s

https://claude.ai/code/session_01CxPkcBBWZeaNygsF9dwMCH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed tooltips from browser pane navigation and close actions, and restyled split-pane and “Manage Presets” tooltips to a subtle hotkey-chip style with a 1s hover delay.

- **Refactors**
  - Made `tooltip` optional in `@superset/panes` `PaneActionConfig` and render a plain button when absent.
  - Removed `closeHotkeyId` from desktop `PaneToolbarActions` and all call sites.

<sup>Written for commit d054648f8d45027bd18117180be91bd7a353c904. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated preset and pane-action tooltips with a consistent appearance, positioning, and one-second delay.
  * Removed tooltips from browser navigation and reload controls for a cleaner toolbar.
  * Removed close-pane hotkey hints from pane controls while preserving close functionality.
  * Improved toolbar behavior for actions without tooltips, preventing unnecessary tooltip containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->