### PR TITLE
fix(security): update axios override to patched release (1.14.0 → 1.18.1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1259,7 +1259,7 @@
   ],
   "overrides": {
     "@types/hast": "3.0.5",
-    "axios": "1.14.0",
+    "axios": "1.18.1",
     "hono": "4.12.34",
     "kysely": "0.28.17",
     "rollup": "4.62.3",
@@ -3672,7 +3672,7 @@
 
     "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
-    "axios": ["axios@1.14.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ=="],
+    "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
 
     "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
 
@@ -7066,6 +7066,8 @@
 
     "ava/pretty-ms": ["pretty-ms@8.0.0", "", { "dependencies": { "parse-ms": "^3.0.0" } }, "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q=="],
 
+    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
@@ -8025,6 +8027,8 @@
     "ava/figures/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "ava/pretty-ms/parse-ms": ["parse-ms@3.0.0", "", {}, "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="],
+
+    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "builder-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	],
 	"overrides": {
 		"@types/hast": "3.0.5",
-		"axios": "1.14.0",
+		"axios": "1.18.1",
 		"hono": "4.12.34",
 		"kysely": "0.28.17",
 		"rollup": "4.62.3",


### PR DESCRIPTION
## Summary

Bump the repository-level `overrides.axios` from `1.14.0` → **`1.18.1`** (the latest release) and refresh `bun.lock` so every transitive Axios consumer resolves to the patched version.

## Why this matters

`main` still forces all Axios consumers to `1.14.0` via the root override. `bun audit` reports **28 advisory findings** against that pin — multiple **high-severity** — reaching the API through `@slack/web-api` and `@tavily/core`:

- Proxy-Authorization credential leak across HTTP→HTTPS redirect (`GHSA-p92q-9vqr-4j8v`)
- Full MITM / credential theft via prototype-pollution gadgets in config merge (`GHSA-35jp-ww65-95wh`, `GHSA-3g43-6gmg-66jw`)
- ReDoS via cookie-name injection (`GHSA-hfxv-24rg-xrqf`)
- Unrestricted cloud-metadata exfiltration / SSRF via `NO_PROXY` bypass

After the bump, `bun audit` reports **0 Axios advisories**.

## Verification (keyless)

```
# base main (axios 1.14.0)
$ bun audit | grep -c advisories   → 28 findings (high: SSRF, cred-leak, prototype-pollution MITM, ReDoS)

# this branch (axios 1.18.1)
$ bun audit                         → 0 axios advisories
$ bun install --frozen-lockfile     → lock consistent (single, minimal lock delta — regenerated with bun, not hand-merged)
```

## Notes

- The `bun.lock` change is a minimal, `bun`-regenerated delta (not a hand-edited hash).
- This supersedes #5478, which was closed while it carried a `bun.lock` merge conflict — that conflict is resolved here and the branch is rebased clean onto `main` (`mergeable`).
- @Kitenite — since `main` is still on the vulnerable pin, opening this as a ready-to-merge follow-up; entirely your call on whether/how to land it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update root override to `axios@1.18.1` and regenerate `bun.lock` so all transitive consumers use the patched release. Clears high‑severity `axios` advisories in `bun audit`; lock now includes upstream `https-proxy-agent`.

<sup>Written for commit c0e79d2d25b0bd70c75990200a40c51351e2ce15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Axios version used by the application to incorporate the latest available updates and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->