### PR TITLE
fix(desktop): sync Claude hooks into CLAUDE_CONFIG_DIR profiles

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { env } from "shared/env.shared";
 import {
 	buildWrapperScript,
 	createWrapper,
@@ -90,24 +91,24 @@ function isManagedClaudeHookCommand(
 }
 
 function readExistingClaudeSettings(
-	globalPath: string,
+	settingsPath: string,
 ): ClaudeSettingsJson | null {
-	if (!fs.existsSync(globalPath)) {
+	if (!fs.existsSync(settingsPath)) {
 		return {};
 	}
 
 	try {
-		const parsed = JSON.parse(fs.readFileSync(globalPath, "utf-8"));
+		const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
 		if (!isPlainObject(parsed)) {
 			console.warn(
-				"[agent-setup] Expected ~/.claude/settings.json to contain a JSON object; skipping Claude hook merge",
+				`[agent-setup] Expected ${settingsPath} to contain a JSON object; skipping Claude hook merge`,
 			);
 			return null;
 		}
 		return parsed;
 	} catch (error) {
 		console.warn(
-			"[agent-setup] Could not parse existing ~/.claude/settings.json; skipping Claude hook merge:",
+			`[agent-setup] Could not parse existing ${settingsPath}; skipping Claude hook merge:`,
 			error,
 		);
 		return null;
@@ -148,18 +149,18 @@ export function getClaudeGlobalSettingsJsonPath(): string {
 }
 
 /**
- * Reads existing ~/.claude/settings.json, merges our hook definitions
- * (identified by notify script path), and preserves any user-defined hooks
- * and all non-hook settings.
+ * Reads existing settings.json at `settingsPath`, merges our hook
+ * definitions (identified by notify script path), and preserves any
+ * user-defined hooks and all non-hook settings.
  *
  * Claude Code uses the same nested hook structure as Droid:
  *   { hooks: { EventName: [{ matcher?, hooks: [{ type, command }] }] } }
  */
-export function getClaudeGlobalSettingsJsonContent(
+export function getClaudeSettingsJsonContent(
+	settingsPath: string,
 	notifyScriptPath: string,
 ): string | null {
-	const globalPath = getClaudeGlobalSettingsJsonPath();
-	const existing = readExistingClaudeSettings(globalPath);
+	const existing = readExistingClaudeSettings(settingsPath);
 	if (!existing) return null;
 	const managedHookCommand = getClaudeManagedHookCommand();
 
@@ -250,7 +251,7 @@ export function getClaudeGlobalSettingsJsonContent(
 export function createClaudeSettingsJson(): void {
 	const notifyScriptPath = getNotifyScriptPath();
 	const globalPath = getClaudeGlobalSettingsJsonPath();
-	const content = getClaudeGlobalSettingsJsonContent(notifyScriptPath);
+	const content = getClaudeSettingsJsonContent(globalPath, notifyScriptPath);
 	if (content === null) return;
 
 	const dir = path.dirname(globalPath);
@@ -259,6 +260,35 @@ export function createClaudeSettingsJson(): void {
 	console.log(
 		`[agent-setup] ${changed ? "Updated" : "Verified"} Claude settings.json`,
 	);
+}
+
+/**
+ * Merges Superset's managed Claude hooks into `settings.json` inside an
+ * arbitrary directory. Claude Code reads its hooks from `$CLAUDE_CONFIG_DIR`
+ * when set (e.g. `alias claude-work='CLAUDE_CONFIG_DIR=~/.claude-work claude'`),
+ * so createClaudeSettingsJson()'s write to the default `~/.claude` never
+ * reaches that profile. Called from the claude wrapper's runtime sync
+ * request (see buildClaudeWrapperExecLine) whenever CLAUDE_CONFIG_DIR is set.
+ */
+export function syncClaudeSettingsForConfigDir(
+	configDirInput: string,
+): boolean {
+	const trimmed = configDirInput.trim();
+	if (!trimmed) return false;
+	const resolvedDir = trimmed.startsWith("~")
+		? path.join(os.homedir(), trimmed.slice(1))
+		: trimmed;
+	if (!path.isAbsolute(resolvedDir)) return false;
+
+	const settingsPath = path.join(resolvedDir, "settings.json");
+	const content = getClaudeSettingsJsonContent(
+		settingsPath,
+		getNotifyScriptPath(),
+	);
+	if (content === null) return false;
+
+	fs.mkdirSync(resolvedDir, { recursive: true });
+	return writeFileIfChanged(settingsPath, content, 0o644);
 }
 
 /**
@@ -272,15 +302,33 @@ export function getOpenCodePluginContent(notifyPath: string): string {
 }
 
 /**
- * Pass-through wrapper for Claude. Hooks live in ~/.claude/settings.json
- * (createClaudeSettingsJson); the wrapper exists only to forward SUPERSET_*
- * env vars into the agent process tree.
+ * Wrapper for Claude. Hooks normally live in ~/.claude/settings.json
+ * (createClaudeSettingsJson), but when CLAUDE_CONFIG_DIR points elsewhere
+ * (e.g. a claude-work/claude-personal profile alias), Claude Code reads
+ * hooks from that directory instead, so the boot-time write never reaches
+ * it. Ask the running app to sync hooks into that directory first — best
+ * effort, and a no-op for a plain `claude` invocation.
  */
 export function createClaudeWrapper(): void {
-	const script = buildWrapperScript("claude", `exec "$REAL_BIN" "$@"`, {
+	const script = buildWrapperScript("claude", buildClaudeWrapperExecLine(), {
 		agentId: "claude",
 	});
 	createWrapper("claude", script);
+}
+
+/**
+ * Builds the Claude wrapper's exec block, including the CLAUDE_CONFIG_DIR
+ * hook-sync request. Mirrors the timeout/data-urlencode/fail-open
+ * conventions already used by notify-hook.template.sh.
+ */
+export function buildClaudeWrapperExecLine(): string {
+	return `if [ -n "$CLAUDE_CONFIG_DIR" ]; then
+  curl -sG "http://127.0.0.1:\${SUPERSET_PORT:-${env.DESKTOP_NOTIFICATIONS_PORT}}/hook/claude-config-sync" \\
+    --connect-timeout 1 --max-time 3 \\
+    --data-urlencode "configDir=$CLAUDE_CONFIG_DIR" \\
+    -o /dev/null 2>/dev/null || true
+fi
+exec "$REAL_BIN" "$@"`;
 }
 
 /**

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -60,6 +60,7 @@ const {
 	AMP_PLUGIN_MARKER,
 	createAmpPlugin,
 	createAmpWrapper,
+	buildClaudeWrapperExecLine,
 	buildCodexWrapperExecLine,
 	buildCopilotWrapperExecLine,
 	buildWrapperScript,
@@ -72,8 +73,9 @@ const {
 	createDroidWrapper,
 	createMastraWrapper,
 	createPiExtension,
-	getClaudeGlobalSettingsJsonContent,
+	getClaudeGlobalSettingsJsonPath,
 	getClaudeManagedHookCommand,
+	getClaudeSettingsJsonContent,
 	getCodexGlobalHooksJsonContent,
 	getCursorHooksJsonContent,
 	getCopilotHookScriptPath,
@@ -86,6 +88,7 @@ const {
 	getPiExtensionContent,
 	getPiExtensionPath,
 	PI_EXTENSION_MARKER,
+	syncClaudeSettingsForConfigDir,
 } = await import("./agent-wrappers");
 const { reconcileManagedEntries } = await import("./agent-wrappers-common");
 
@@ -973,7 +976,10 @@ describe("agent-wrappers claude settings.json", () => {
 
 	it("creates Claude settings.json with hooks when no file exists", () => {
 		const notifyPath = "/tmp/.superset/hooks/notify.sh";
-		const content = getClaudeGlobalSettingsJsonContent(notifyPath);
+		const content = getClaudeSettingsJsonContent(
+			getClaudeGlobalSettingsJsonPath(),
+			notifyPath,
+		);
 		expect(content).not.toBeNull();
 		if (content === null) throw new Error("Expected content");
 
@@ -1036,7 +1042,10 @@ describe("agent-wrappers claude settings.json", () => {
 		);
 
 		const notifyPath = "/tmp/.superset/hooks/notify.sh";
-		const content = getClaudeGlobalSettingsJsonContent(notifyPath);
+		const content = getClaudeSettingsJsonContent(
+			getClaudeGlobalSettingsJsonPath(),
+			notifyPath,
+		);
 		expect(content).not.toBeNull();
 		if (content === null) throw new Error("Expected content");
 
@@ -1109,13 +1118,14 @@ describe("agent-wrappers claude settings.json", () => {
 			),
 		);
 
-		const content = getClaudeGlobalSettingsJsonContent(currentHookPath);
+		const claudePath = getClaudeGlobalSettingsJsonPath();
+		const content = getClaudeSettingsJsonContent(claudePath, currentHookPath);
 		expect(content).not.toBeNull();
 		if (content === null) throw new Error("Expected content");
 
 		// Second run should be idempotent
 		writeFileSync(claudeSettingsPath, content);
-		const content2 = getClaudeGlobalSettingsJsonContent(currentHookPath);
+		const content2 = getClaudeSettingsJsonContent(claudePath, currentHookPath);
 		expect(content2).not.toBeNull();
 
 		const parsed = JSON.parse(content) as {
@@ -1172,7 +1182,10 @@ describe("agent-wrappers claude settings.json", () => {
 		writeFileSync(claudeSettingsPath, invalidJson);
 
 		expect(
-			getClaudeGlobalSettingsJsonContent("/tmp/.superset/hooks/notify.sh"),
+			getClaudeSettingsJsonContent(
+				getClaudeGlobalSettingsJsonPath(),
+				"/tmp/.superset/hooks/notify.sh",
+			),
 		).toBeNull();
 
 		createClaudeSettingsJson();
@@ -1192,8 +1205,67 @@ describe("agent-wrappers claude settings.json", () => {
 		writeFileSync(claudeSettingsPath, JSON.stringify("not-an-object"));
 
 		expect(
-			getClaudeGlobalSettingsJsonContent("/tmp/.superset/hooks/notify.sh"),
+			getClaudeSettingsJsonContent(
+				getClaudeGlobalSettingsJsonPath(),
+				"/tmp/.superset/hooks/notify.sh",
+			),
 		).toBeNull();
+	});
+
+	it("syncs Claude hooks into an arbitrary CLAUDE_CONFIG_DIR", () => {
+		const configDir = path.join(TEST_ROOT, "claude-work");
+		const settingsPath = path.join(configDir, "settings.json");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({ permissions: { defaultMode: "auto" } }, null, 2),
+		);
+
+		const changed = syncClaudeSettingsForConfigDir(configDir);
+		expect(changed).toBe(true);
+
+		const parsed = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(parsed.permissions).toEqual({ defaultMode: "auto" });
+		expect(
+			parsed.hooks.Stop.some((def: { hooks: Array<{ command: string }> }) =>
+				def.hooks.some(
+					(hook: { command: string }) =>
+						hook.command === managedClaudeHookCommand,
+				),
+			),
+		).toBe(true);
+	});
+
+	it("creates the config dir and settings.json when none exists yet", () => {
+		const configDir = path.join(TEST_ROOT, "claude-personal");
+
+		const changed = syncClaudeSettingsForConfigDir(configDir);
+		expect(changed).toBe(true);
+
+		const parsed = JSON.parse(
+			readFileSync(path.join(configDir, "settings.json"), "utf-8"),
+		);
+		expect(
+			parsed.hooks.Stop.some((def: { hooks: Array<{ command: string }> }) =>
+				def.hooks.some(
+					(hook: { command: string }) =>
+						hook.command === managedClaudeHookCommand,
+				),
+			),
+		).toBe(true);
+	});
+
+	it("no-ops for an empty or non-absolute config dir", () => {
+		expect(syncClaudeSettingsForConfigDir("")).toBe(false);
+		expect(syncClaudeSettingsForConfigDir("   ")).toBe(false);
+		expect(syncClaudeSettingsForConfigDir("relative/path")).toBe(false);
+	});
+
+	it("includes the CLAUDE_CONFIG_DIR sync request in the wrapper exec line", () => {
+		const execLine = buildClaudeWrapperExecLine();
+		expect(execLine).toContain('[ -n "$CLAUDE_CONFIG_DIR" ]');
+		expect(execLine).toContain("/hook/claude-config-sync");
+		expect(execLine).toContain('exec "$REAL_BIN" "$@"');
 	});
 });
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -7,6 +7,7 @@ export {
 	getAmpPluginContent,
 } from "./agent-wrappers-amp";
 export {
+	buildClaudeWrapperExecLine,
 	buildCodexWrapperExecLine,
 	cleanupGlobalOpenCodePlugin,
 	createClaudeSettingsJson,
@@ -15,9 +16,9 @@ export {
 	createCodexWrapper,
 	createOpenCodePlugin,
 	createOpenCodeWrapper,
-	getClaudeGlobalSettingsJsonContent,
 	getClaudeGlobalSettingsJsonPath,
 	getClaudeManagedHookCommand,
+	getClaudeSettingsJsonContent,
 	getCodexGlobalHooksJsonContent,
 	getCodexGlobalHooksJsonPath,
 	getOpenCodeGlobalPluginPath,
@@ -25,6 +26,7 @@ export {
 	getOpenCodePluginPath,
 	OPENCODE_PLUGIN_FILE,
 	OPENCODE_PLUGIN_MARKER,
+	syncClaudeSettingsForConfigDir,
 } from "./agent-wrappers-claude-codex-opencode";
 export {
 	buildWrapperScript,

--- a/apps/desktop/src/main/lib/notifications/server.ts
+++ b/apps/desktop/src/main/lib/notifications/server.ts
@@ -5,6 +5,7 @@ import { handleAuthCallback } from "lib/trpc/routers/auth/utils/auth-functions";
 import { NOTIFICATION_EVENTS } from "shared/constants";
 import { env } from "shared/env.shared";
 import type { AgentLifecycleEvent } from "shared/notification-types";
+import { syncClaudeSettingsForConfigDir } from "../agent-setup/agent-wrappers-claude-codex-opencode";
 import { HOOK_PROTOCOL_VERSION } from "../terminal/env";
 import { mapEventType } from "./map-event-type";
 import { resolvePaneId } from "./resolve-pane-id";
@@ -124,6 +125,25 @@ app.get("/hook/complete", (req, res) => {
 	notificationsEmitter.emit(NOTIFICATION_EVENTS.AGENT_LIFECYCLE, event);
 
 	res.json({ success: true, paneId: resolvedPaneId, tabId });
+});
+
+// Requested by the claude wrapper when CLAUDE_CONFIG_DIR is set (e.g. a
+// claude-work/claude-personal profile alias), so Claude Code reads hooks
+// from a directory other than ~/.claude — sync our managed hooks into it
+// too. Best-effort and fail-open: never blocks the agent from launching.
+app.get("/hook/claude-config-sync", (req, res) => {
+	const { configDir } = req.query;
+	try {
+		if (typeof configDir === "string") {
+			syncClaudeSettingsForConfigDir(configDir);
+		}
+	} catch (error) {
+		console.warn(
+			"[notifications] Failed to sync Claude settings for config dir:",
+			error,
+		);
+	}
+	res.json({ success: true });
 });
 
 // Health check


### PR DESCRIPTION
## What & why

Superset derives Claude pane activity status (processing/waiting-for-input/idle)
and notifications entirely from Claude Code's native lifecycle hooks, which
Superset installs by writing directly into `~/.claude/settings.json`.

When Claude Code is launched with `CLAUDE_CONFIG_DIR` pointing at a different
profile directory — a common pattern for running multiple accounts/orgs side
by side, e.g.:

```bash
alias claude-work='CLAUDE_CONFIG_DIR=~/.claude-work claude'
alias claude-personal='CLAUDE_CONFIG_DIR=~/.claude-personal claude'
```

Claude Code reads its hooks from that directory instead, which never receives
Superset's managed hooks. The result is a silent failure: activity status
stays stuck at idle and no notifications fire, with no error surfaced.

The generated `claude` wrapper now checks `$CLAUDE_CONFIG_DIR` at invocation
time. When set, it asks the running app (via the existing local hook server,
same pattern as `/hook/complete`) to merge Superset's managed hooks into that
directory's `settings.json` before exec'ing the real binary. The merge reuses
the existing hook-merge logic (now parameterized by path instead of hardcoded
to `~/.claude`), so existing user settings/hooks in that file are preserved.
For a plain `claude` invocation (no `CLAUDE_CONFIG_DIR`), this is a complete
no-op.

Scoped to Claude only, matching the bug I noticed myself. Codex has an analogous
per-profile override (`CODEX_HOME`) that isn't handled here — flagging as
possible follow-up scope rather than bundling it into this PR since I do not use Codex myself at the moment.

As an aside: users can work around this today without a code change, by
copying the same `hooks` block Superset writes into `~/.claude/settings.json`
directly into their profile directories. That works (the hook command
resolves `$SUPERSET_HOME_DIR` at runtime, so it's install-independent), but
it's a static one-time copy — it won't cover profiles created later, and
won't pick up future changes to the managed hook the way `~/.claude/settings.json`
does automatically on every app boot. This PR fixes it at the source instead.

## Video of the fix in action

https://github.com/user-attachments/assets/d09a7c30-6680-4c41-b283-270e260e9013

## How I tested it

- Added unit tests covering the new sync function (merges into an arbitrary
  directory, preserves existing settings, creates the directory/file when
  missing, no-ops on empty/relative input) and the wrapper's exec line.
- `bun run test` (desktop package): 2251 pass, 0 fail.
- `bun run lint` clean.
- Verified end-to-end against a running dev build: confirmed the regenerated
  wrapper contains the new logic, then hit the new endpoint directly against
  a real `settings.json`, confirming existing settings are preserved and
  hooks are merged in correctly.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing activity status and notifications for Claude when launched with `CLAUDE_CONFIG_DIR` by syncing Superset-managed hooks into that profile’s `settings.json` at runtime. No change for default `~/.claude` setups.

- **Bug Fixes**
  - Claude wrapper checks `$CLAUDE_CONFIG_DIR` and calls `/hook/claude-config-sync` to merge managed hooks before exec; no-op otherwise.
  - Added `/hook/claude-config-sync` endpoint that merges hooks into the target `settings.json`, preserving existing settings; shared merge logic now accepts a path.
  - Added tests for config-dir sync, wrapper exec line, and path-based merge behavior.

<sup>Written for commit f6e92d5c99f8367c033dcaff33d6f2f6546acbf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

