### PR TITLE
fix(desktop,cli): surface readable errors when relay/API returns non-JSON

### DIFF
--- a/apps/desktop/src/renderer/lib/api-trpc-client.ts
+++ b/apps/desktop/src/renderer/lib/api-trpc-client.ts
@@ -3,6 +3,7 @@ import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 import { env } from "renderer/env.renderer";
 import superjson from "superjson";
 import { getAuthToken } from "./auth-client";
+import { createJsonGuardedFetch } from "./json-guarded-fetch";
 
 /**
  * HTTP tRPC client for calling the API server.
@@ -23,6 +24,7 @@ export const apiTrpcClient = createTRPCProxyClient<AppRouter>({
 				}
 				return {};
 			},
+			fetch: createJsonGuardedFetch(),
 		}),
 	],
 });

--- a/apps/desktop/src/renderer/lib/host-service-client.ts
+++ b/apps/desktop/src/renderer/lib/host-service-client.ts
@@ -2,6 +2,7 @@ import type { AppRouter } from "@superset/host-service";
 import { createTRPCClient, httpLink } from "@trpc/client";
 import superjson from "superjson";
 import { getHostServiceHeaders } from "./host-service-auth";
+import { createJsonGuardedFetch } from "./json-guarded-fetch";
 
 const clientCache = new Map<
 	string,
@@ -24,6 +25,7 @@ export function getHostServiceClientByUrl(hostUrl: string): HostServiceClient {
 				url: `${hostUrl}/trpc`,
 				transformer: superjson,
 				headers: () => getHostServiceHeaders(hostUrl),
+				fetch: createJsonGuardedFetch(),
 			}),
 		],
 	});

--- a/apps/desktop/src/renderer/lib/json-guarded-fetch.ts
+++ b/apps/desktop/src/renderer/lib/json-guarded-fetch.ts
@@ -1,0 +1,41 @@
+/**
+ * Fetch wrapper for tRPC links, which call `response.json()` unconditionally
+ * (through 11.18.0). When a proxy or CDN in front of the relay/API answers
+ * with a plain-text or HTML error page (e.g. Vercel's `DEPLOYMENT_NOT_FOUND`),
+ * that parse crashes with `Unexpected token 'T', "The deploy"... is not valid
+ * JSON` and the raw SyntaxError reaches the user. This throws a readable HTTP
+ * error instead.
+ */
+type FetchLike = (
+	input: Parameters<typeof fetch>[0],
+	init?: RequestInit,
+) => Promise<Response>;
+
+export function createJsonGuardedFetch(): FetchLike {
+	return async (input, init) => {
+		const response = await fetch(input, init);
+		const contentType = response.headers.get("content-type") ?? "";
+		if (response.status === 204 || contentType.includes("json")) {
+			return response;
+		}
+		const body = (await response.text()).replace(/\s+/g, " ").trim();
+		const detail = body ? `: ${body.slice(0, 160)}` : "";
+		throw new Error(
+			`${requestOrigin(input)} returned non-JSON (HTTP ${response.status})${detail}`,
+		);
+	};
+}
+
+function requestOrigin(input: Parameters<typeof fetch>[0]): string {
+	const url =
+		typeof input === "string"
+			? input
+			: input instanceof URL
+				? input.href
+				: input.url;
+	try {
+		return new URL(url).origin;
+	} catch {
+		return url;
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -49,6 +49,7 @@ import type { inferRouterOutputs } from "@trpc/server";
 import { env } from "renderer/env.renderer";
 import { track } from "renderer/lib/analytics";
 import { getAuthToken, getJwt } from "renderer/lib/auth-client";
+import { createJsonGuardedFetch } from "renderer/lib/json-guarded-fetch";
 import { refreshJwtAfterUnauthorized } from "renderer/lib/jwt-refresh";
 import superjson from "superjson";
 import { z } from "zod";
@@ -222,6 +223,7 @@ const apiClient = createTRPCProxyClient<AppRouter>({
 				return token ? { Authorization: `Bearer ${token}` } : {};
 			},
 			transformer: superjson,
+			fetch: createJsonGuardedFetch(),
 		}),
 	],
 });

--- a/packages/cli/src/lib/host-target/resolveHostTarget.ts
+++ b/packages/cli/src/lib/host-target/resolveHostTarget.ts
@@ -29,6 +29,48 @@ export interface ResolveHostTargetOptions {
 	userJwt: string;
 }
 
+/**
+ * Fetch wrapper for tRPC links, which call `response.json()` unconditionally
+ * (through 11.18.0). When a proxy or CDN in front of the relay answers with a
+ * plain-text or HTML error page (e.g. Vercel's `DEPLOYMENT_NOT_FOUND`), that
+ * parse crashes with `Unexpected token 'T', "The deploy"... is not valid JSON`
+ * and the raw SyntaxError reaches the user. This throws a readable HTTP error
+ * instead.
+ */
+type FetchLike = (
+	input: Parameters<typeof fetch>[0],
+	init?: RequestInit,
+) => Promise<Response>;
+
+function createJsonGuardedFetch(): FetchLike {
+	return async (input, init) => {
+		const response = await fetch(input, init);
+		const contentType = response.headers.get("content-type") ?? "";
+		if (response.status === 204 || contentType.includes("json")) {
+			return response;
+		}
+		const body = (await response.text()).replace(/\s+/g, " ").trim();
+		const detail = body ? `: ${body.slice(0, 160)}` : "";
+		throw new Error(
+			`${requestOrigin(input)} returned non-JSON (HTTP ${response.status})${detail}`,
+		);
+	};
+}
+
+function requestOrigin(input: Parameters<typeof fetch>[0]): string {
+	const url =
+		typeof input === "string"
+			? input
+			: input instanceof URL
+				? input.href
+				: input.url;
+	try {
+		return new URL(url).origin;
+	} catch {
+		return url;
+	}
+}
+
 export function resolveHostTarget(
 	options: ResolveHostTargetOptions,
 ): ResolvedHostTarget {
@@ -61,6 +103,7 @@ export function resolveHostTarget(
 							Authorization: `Bearer ${manifest.authToken}`,
 							"x-superset-client-machine-id": localHostId,
 						},
+						fetch: createJsonGuardedFetch(),
 					}),
 				],
 			}),
@@ -80,6 +123,7 @@ export function resolveHostTarget(
 						Authorization: `Bearer ${options.userJwt}`,
 						"x-superset-client-machine-id": localHostId,
 					},
+					fetch: createJsonGuardedFetch(),
 				}),
 			],
 		}),


### PR DESCRIPTION
## Summary

Addresses the `Unexpected token 'T', "The deploy"... is not valid JSON` error reported in #5861 (comment from @m4nd4r1n after the relay DNS fix).

**Root cause:** tRPC's `httpLink`/`httpBatchLink` call `response.json()` unconditionally — verified in the shipped dist of 11.16.0 and latest 11.18.0, and confirmed as a known upstream gap (trpc/trpc#3081, discussion #3640; the endorsed fix is a content-type check via the link's `fetch` option). When a proxy in front of the relay or API answers with a non-JSON body — here Vercel's plain-text `DEPLOYMENT_NOT_FOUND` page while relay.superset.sh pointed at a dead deployment during the domain transfer — the raw `SyntaxError` from `JSON.parse` propagated straight into the workspace-create failure UI and CLI output.

All hand-rolled relay clients in the repo (`packages/host-client`, `packages/mcp-v2`, web, SDK) already guard this; the tRPC-link clients were the only ones that didn't.

## Changes

- `apps/desktop/src/renderer/lib/json-guarded-fetch.ts`: fetch wrapper that passes JSON responses through and converts anything else into a readable error — `https://relay.superset.sh returned non-JSON (HTTP 404): The deployment could not be found on Vercel. DEPLOYMENT_NOT_FOUND`
- Wired into the desktop's tRPC clients: host-service client (the reported workspace-create path), `api-trpc-client`, and the CollectionsProvider API client
- Inlined the same guard in the CLI's `resolveHostTarget` for both the local and relay-routed host links

## Validation

- `bun run lint` exits 0
- `bun run typecheck` exits 0

https://claude.ai/code/session_01PqU6z23pXcT1jmRovyw2q2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents “Unexpected token… is not valid JSON” crashes by guarding `@trpc/client` links and surfacing clear HTTP errors when the relay/API returns non-JSON.

- **Bug Fixes**
  - Added a JSON-guarded fetch that passes JSON through and throws a readable error for non-JSON responses.
  - Wired into desktop tRPC clients: host-service, API client, and CollectionsProvider.
  - Applied the same guard in the CLI (`resolveHostTarget`) for local and relay links.
  - Users now see errors like: “https://relay.superset.sh returned non-JSON (HTTP 404): The deployment could not be found on Vercel. DEPLOYMENT_NOT_FOUND”.

<sup>Written for commit 17386587219b7019c71c085fe4391b87bf5be02e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected non-JSON responses from services.
  * Error messages now provide clearer context, including the request origin, HTTP status, and a brief response excerpt.
  * Prevented parsing failures for successful empty responses and valid JSON responses across desktop and CLI connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->