### PR TITLE
fix(desktop,host-service): show Cursor Composer instead of stale Claude for Cursor sessions

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-cursor.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-cursor.ts
@@ -14,7 +14,7 @@ import { HOOKS_DIR } from "./paths";
 export const CURSOR_HOOK_SCRIPT_NAME = "cursor-hook.sh";
 
 const CURSOR_HOOK_SIGNATURE = "# Superset cursor hook";
-const CURSOR_HOOK_VERSION = "v3";
+const CURSOR_HOOK_VERSION = "v4";
 export const CURSOR_HOOK_MARKER = `${CURSOR_HOOK_SIGNATURE} ${CURSOR_HOOK_VERSION}`;
 
 const CURSOR_HOOK_TEMPLATE_PATH = path.join(

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -747,7 +747,7 @@ exit 0
 
 	it("bumps hook script markers when hook semantics change", () => {
 		expect(COPILOT_HOOK_MARKER).toBe("# Superset copilot hook v2");
-		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v3");
+		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v4");
 		expect(GEMINI_HOOK_MARKER).toBe("# Superset gemini hook v3");
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -56,20 +56,20 @@ describe("getNotifyScriptContent", () => {
 });
 
 describe("per-agent hook scripts dispatch to v2", () => {
-	const expectedV2Payload =
-		'PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$SUPERSET_AGENT_ID")\\",\\"sessionId\\":\\"$(json_escape "$HOOK_SESSION_ID")\\"}}}"';
+	const buildExpectedV2Payload = (agentIdVar: string) =>
+		`PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$${agentIdVar}")\\",\\"sessionId\\":\\"$(json_escape "$HOOK_SESSION_ID")\\"}}}"`;
 
-	for (const template of [
-		"cursor-hook.template.sh",
-		"copilot-hook.template.sh",
-		"gemini-hook.template.sh",
-	]) {
+	for (const [template, agentIdVar] of [
+		["cursor-hook.template.sh", "AGENT_ID"],
+		["copilot-hook.template.sh", "SUPERSET_AGENT_ID"],
+		["gemini-hook.template.sh", "SUPERSET_AGENT_ID"],
+	] as const) {
 		it(`${template} posts v2 first and falls back to v1`, () => {
 			const script = readFileSync(
 				path.join(import.meta.dir, "templates", template),
 				"utf-8",
 			);
-			expect(script).toContain(expectedV2Payload);
+			expect(script).toContain(buildExpectedV2Payload(agentIdVar));
 			expect(script).toContain('curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL"');
 			expect(script).toContain(
 				'if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -n "$SUPERSET_TERMINAL_ID" ]; then',

--- a/apps/desktop/src/main/lib/agent-setup/templates/cursor-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/cursor-hook.template.sh
@@ -30,8 +30,20 @@ json_escape() {
   printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
 }
 
+# This script only fires for Cursor sessions, so an unset SUPERSET_AGENT_ID
+# means Cursor ran outside a Superset wrapper: the cursor-agent CLI stamps
+# CURSOR_AGENT/CURSOR_CLI into its env; anything else is the IDE Composer.
+AGENT_ID="$SUPERSET_AGENT_ID"
+if [ -z "$AGENT_ID" ]; then
+  if [ -n "$CURSOR_AGENT" ] || [ -n "$CURSOR_CLI" ]; then
+    AGENT_ID="cursor-agent"
+  else
+    AGENT_ID="cursor-composer"
+  fi
+fi
+
 if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -n "$SUPERSET_TERMINAL_ID" ]; then
-  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\"}}}"
+  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$AGENT_ID")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\"}}}"
 
   STATUS_CODE=$(curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL" \
     --connect-timeout 2 --max-time 5 \

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
@@ -1,6 +1,6 @@
 import {
-	BUILTIN_AGENT_LABELS,
-	type BuiltinAgentId,
+	AGENT_IDENTITY_LABELS,
+	type AgentIdentityId,
 } from "@superset/shared/agent-catalog";
 import { useMemo } from "react";
 import { useTerminalAgentBindings } from "renderer/hooks/host-service/useTerminalAgentBindings";
@@ -20,8 +20,8 @@ export interface DashboardSidebarRunningAgent {
 	source: V2NotificationSource;
 	/** Host terminal the agent is bound to. */
 	terminalId: string;
-	/** Built-in agent id (`claude`, `codex`, …) — drives label + icon. */
-	agentId: BuiltinAgentId;
+	/** Agent identity id (`claude`, `codex`, …) — drives label + icon. */
+	agentId: AgentIdentityId;
 	/** `idle` | `working` | `permission` | `review`. */
 	status: RunningAgentStatus;
 	/** When the agent process was bound (ms since epoch), used for stable order. */
@@ -55,7 +55,7 @@ export function useDashboardSidebarWorkspaceRunningAgents(
 				agentId: binding.agentId,
 				status: statuses.get(binding.terminalId) ?? "idle",
 				startedAt: binding.startedAt,
-				label: BUILTIN_AGENT_LABELS[binding.agentId] ?? binding.agentId,
+				label: AGENT_IDENTITY_LABELS[binding.agentId] ?? binding.agentId,
 			});
 		}
 		agents.sort((a, b) => a.startedAt - b.startedAt);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/TerminalPaneIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneIcon/TerminalPaneIcon.tsx
@@ -1,4 +1,4 @@
-import { BUILTIN_AGENT_LABELS } from "@superset/shared/agent-catalog";
+import { AGENT_IDENTITY_LABELS } from "@superset/shared/agent-catalog";
 import { TerminalSquare } from "lucide-react";
 import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
 import { useTerminalAgentBinding } from "renderer/hooks/host-service/useTerminalAgentBindings";
@@ -24,8 +24,8 @@ export function TerminalPaneIcon({
 
 	if (agentId && iconSrc) {
 		const label =
-			(agentId in BUILTIN_AGENT_LABELS &&
-				BUILTIN_AGENT_LABELS[agentId as keyof typeof BUILTIN_AGENT_LABELS]) ||
+			(agentId in AGENT_IDENTITY_LABELS &&
+				AGENT_IDENTITY_LABELS[agentId as keyof typeof AGENT_IDENTITY_LABELS]) ||
 			agentId;
 		return (
 			<img

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -1,6 +1,6 @@
 import {
-	BUILTIN_AGENT_LABELS,
-	type BuiltinAgentId,
+	AGENT_IDENTITY_LABELS,
+	type AgentIdentityId,
 } from "@superset/shared/agent-catalog";
 import type {
 	AgentIdentity,
@@ -30,8 +30,8 @@ export function getV2NativeNotificationContent({
 function getAgentLabel(agent: AgentIdentity | undefined): string {
 	const agentId = cleanLabel(agent?.agentId);
 	if (!agentId) return "Agent";
-	if (agentId in BUILTIN_AGENT_LABELS) {
-		return BUILTIN_AGENT_LABELS[agentId as BuiltinAgentId];
+	if (agentId in AGENT_IDENTITY_LABELS) {
+		return AGENT_IDENTITY_LABELS[agentId as AgentIdentityId];
 	}
 	return humanizeIdentifier(agentId);
 }

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -1,7 +1,7 @@
 import type { HarnessKind, StopReason } from "@superset/session-protocol";
 import type {
 	AgentDefinitionId,
-	BuiltinAgentId,
+	AgentIdentityId,
 } from "@superset/shared/agent-catalog";
 import type { BranchPrefixMode } from "@superset/shared/workspace-launch";
 import { sql } from "drizzle-orm";
@@ -50,7 +50,7 @@ export const terminalAgentBindings = sqliteTable(
 			.primaryKey()
 			.references(() => terminalSessions.id, { onDelete: "cascade" }),
 		workspaceId: text("workspace_id").notNull(),
-		agentId: text("agent_id").notNull().$type<BuiltinAgentId>(),
+		agentId: text("agent_id").notNull().$type<AgentIdentityId>(),
 		agentSessionId: text("agent_session_id"),
 		definitionId: text("definition_id").$type<AgentDefinitionId>(),
 		startedAt: integer("started_at").notNull(),

--- a/packages/host-service/src/terminal-agents/types.ts
+++ b/packages/host-service/src/terminal-agents/types.ts
@@ -1,9 +1,9 @@
 import type {
 	AgentDefinitionId,
-	BuiltinAgentId,
+	AgentIdentityId,
 } from "@superset/shared/agent-catalog";
 
-export type TerminalAgentId = BuiltinAgentId;
+export type TerminalAgentId = AgentIdentityId;
 
 /**
  * One live agent process bound to a terminal. Created on the first hook

--- a/packages/shared/src/agent-catalog.ts
+++ b/packages/shared/src/agent-catalog.ts
@@ -23,6 +23,19 @@ export const BUILTIN_AGENT_IDS = [
 export type BuiltinAgentId = (typeof BUILTIN_AGENT_IDS)[number];
 export type AgentDefinitionId = BuiltinAgentId | `custom:${string}`;
 
+/**
+ * Agents Superset can identify via lifecycle hooks but cannot launch —
+ * they run in an external app whose hooks land on a Superset terminal.
+ */
+export const EXTERNAL_AGENT_IDS = ["cursor-composer"] as const;
+
+export const AGENT_IDENTITY_IDS = [
+	...BUILTIN_AGENT_IDS,
+	...EXTERNAL_AGENT_IDS,
+] as const;
+
+export type AgentIdentityId = (typeof AGENT_IDENTITY_IDS)[number];
+
 export type {
 	AgentDefinition,
 	AgentDefinitionSource,
@@ -37,6 +50,11 @@ export const BUILTIN_AGENT_LABELS: Record<BuiltinAgentId, string> = {
 	),
 	superset: "Superset",
 } as Record<BuiltinAgentId, string>;
+
+export const AGENT_IDENTITY_LABELS: Record<AgentIdentityId, string> = {
+	...BUILTIN_AGENT_LABELS,
+	"cursor-composer": "Cursor Composer",
+};
 
 const BUILTIN_CHAT_AGENT: ChatAgentDefinition = {
 	id: "superset",

--- a/packages/shared/src/agent-identity.ts
+++ b/packages/shared/src/agent-identity.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinitionId, BuiltinAgentId } from "./agent-catalog";
+import type { AgentDefinitionId, AgentIdentityId } from "./agent-catalog";
 
 /**
  * Runtime identity of an agent process detected by a Superset terminal hook.
@@ -6,13 +6,13 @@ import type { AgentDefinitionId, BuiltinAgentId } from "./agent-catalog";
  * Reported by the in-shell `notify-hook.sh` script, broadcast over the
  * host-service event bus, and stored in renderer state keyed by terminalId.
  *
- * `agentId` is the wrapper-level id and matches `BuiltinAgentId` /
+ * `agentId` is the wrapper-level id and matches `AgentIdentityId` /
  * `PRESET_ICONS`. `definitionId` is the user-customized id when the launch
  * path stamps it; it's reserved for a future PR — wrappers can't distinguish
  * user definitions on their own.
  */
 export interface AgentIdentity {
-	agentId: BuiltinAgentId;
+	agentId: AgentIdentityId;
 	sessionId?: string;
 	definitionId?: AgentDefinitionId;
 }

--- a/packages/ui/src/assets/icons/preset-icons/index.ts
+++ b/packages/ui/src/assets/icons/preset-icons/index.ts
@@ -37,6 +37,7 @@ export const PRESET_ICONS: Record<string, PresetIconSet> = {
 	polygraph: { light: polygraphIcon, dark: polygraphWhiteIcon },
 	superset: { light: supersetIcon, dark: supersetIcon },
 	"cursor-agent": { light: cursorAgentIcon, dark: cursorAgentIcon },
+	"cursor-composer": { light: cursorAgentIcon, dark: cursorAgentIcon },
 	droid: { light: droidIcon, dark: droidWhiteIcon },
 	mastracode: { light: mastracodeIcon, dark: mastracodeWhiteIcon },
 	opencode: { light: opencodeIcon, dark: opencodeWhiteIcon },


### PR DESCRIPTION
## Problem

User report (Discord): two Cursor Composer agent windows open, but the workspace sidebar showed two **Claude** badges with "Agent working" tooltips.

Root cause chain:
1. Superset installs a global `~/.cursor/hooks.json` whose hooks fire for **every** Cursor session — including the in-IDE Composer, not just the `cursor-agent` CLI.
2. Only the `cursor-agent` PATH wrapper stamps `SUPERSET_AGENT_ID`; Composer never runs through it, so its hook events posted an **empty** agent id.
3. `TerminalAgentStore.recordEvent` inherits the terminal's prior `agentId` when an event carries none — and since `claude` is the seeded first default preset, the binding almost always stayed `"claude"` while Composer refreshed its status.

Cursor's hook payload has no surface/client field (verified against cursor.com/docs/hooks and the shipped app/CLI bundles), so the identity has to be resolved at the hook script.

## Fix

- `cursor-hook.template.sh` now resolves the agent id itself: unset `SUPERSET_AGENT_ID` + `CURSOR_AGENT`/`CURSOR_CLI` in env → unwrapped `cursor-agent` CLI; otherwise → new `cursor-composer` id. The hook never posts an empty identity, which also neutralizes the stale-inherit path (the store replaces the identity when the id changes).
- New identity-only agent concept: `EXTERNAL_AGENT_IDS` / `AGENT_IDENTITY_IDS` / `AGENT_IDENTITY_LABELS` in `agent-catalog.ts`. `cursor-composer` ("Cursor Composer", Cursor icon) is identifiable but deliberately **not** in `BUILTIN_AGENT_IDS`, so it never surfaces as a startable preset in MCP/command-watcher enums.
- Widened `AgentIdentity.agentId` / `TerminalAgentId` / binding schema `$type` to `AgentIdentityId` (type-only; the sqlite column is plain TEXT — no migration).
- Binding display sites (sidebar badge, pane icon, native notifications) resolve labels via `AGENT_IDENTITY_LABELS`.
- Bumped `CURSOR_HOOK_MARKER` to v4 so existing installs pick up the new script.

## Verification

- Simulated the rendered hook script with a stubbed `curl` for all three cases — Composer → `cursor-composer`, unwrapped CLI (`CURSOR_AGENT=1`) → `cursor-agent`, wrapped CLI → `cursor-agent`.
- `bun run typecheck`, `bun run lint` clean; agent-setup + terminal-agents tests pass (bun 1.3.14, matching `.bun-version`).

https://claude.ai/code/session_01GCN4TfHwbXbKTYFVnNiLFR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect "Claude" badges for Cursor sessions by identifying the in-IDE Composer as "Cursor Composer" and sending a non-empty agent id from the Cursor hook. UI now shows the right label and icon across the sidebar, terminal panes, and notifications.

- **Bug Fixes**
  - Updated `cursor-hook.template.sh` to resolve `agentId`: `cursor-agent` for CLI, `cursor-composer` for IDE; never posts empty ids.
  - Added identity-only agents via `AGENT_IDENTITY_IDS` and `AGENT_IDENTITY_LABELS` (includes "Cursor Composer") while keeping it out of `BUILTIN_AGENT_IDS`.
  - Broadened types to `AgentIdentityId` in host/renderer (`schema.ts`, terminal agent types, and `@superset/shared/agent-catalog`); DB column remains TEXT, no migration.
  - UI uses `AGENT_IDENTITY_LABELS` for labels/icons in the dashboard sidebar, terminal pane icon, and native notifications; added icon mapping for `cursor-composer`.
  - Bumped hook marker to v4 to force script update; adjusted tests to match.

<sup>Written for commit 82dcb7ff4d029b7a6d4cec7f069dc30a2d6a7588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cursor Composer as a recognized agent, including its display label and preset icon.
  * Running agents and terminal sessions now show consistent labels for built-in and external agents.
  * Cursor hooks now identify the appropriate agent automatically when no agent ID is configured.

* **Bug Fixes**
  * Updated Cursor hook markers to the latest version.
  * Improved agent identity handling across sessions and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->