### PR TITLE
fix(marketing): bootstrap hero experiment flag for instant, sticky assignment

### DIFF
--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -5,13 +5,12 @@ import { useScroll } from "framer-motion";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { useRef, useState } from "react";
 import { FaGithub } from "react-icons/fa";
+import { HERO_POSITIONING_FLAG } from "@/lib/analytics/hero-flag-bootstrap";
 import { isMacPlatform, usePlatform } from "../../hooks/useOS";
 import { DownloadButton } from "../DownloadButton";
 import { WaitlistModal } from "../WaitlistModal";
 import { ProductDemo } from "./components/ProductDemo";
 import { TypewriterText } from "./components/TypewriterText";
-
-const HERO_POSITIONING_FLAG = "landing-hero-positioning";
 
 const PIXEL_FONT_STYLE = {
 	fontFamily: "var(--font-geist-pixel-grid)",

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -3,9 +3,11 @@ import { POSTHOG_COOKIE_NAME } from "@superset/shared/constants";
 import posthog from "posthog-js";
 
 import { env } from "@/env";
+import { getHeroFlagBootstrap } from "@/lib/analytics/hero-flag-bootstrap";
 import { ANALYTICS_CONSENT_KEY } from "@/lib/constants";
 
 posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
+	bootstrap: getHeroFlagBootstrap(),
 	api_host: "/ingest",
 	ui_host: "https://us.posthog.com",
 	defaults: "2025-11-30",

--- a/apps/marketing/src/lib/analytics/hero-flag-bootstrap.ts
+++ b/apps/marketing/src/lib/analytics/hero-flag-bootstrap.ts
@@ -1,0 +1,129 @@
+import { POSTHOG_COOKIE_NAME } from "@superset/shared/constants";
+import type { PostHogConfig } from "posthog-js";
+
+export const HERO_POSITIONING_FLAG = "landing-hero-positioning";
+
+// Must mirror the PostHog flag config for landing-hero-positioning (variant
+// order and rollout split) and PostHog's cross-SDK assignment hash. Drift is
+// safe but reintroduces the swap-on-/flags-response this bootstrap removes.
+const VARIANTS = [
+	{ key: "control", rolloutPercentage: 50 },
+	{ key: "capability-mac", rolloutPercentage: 50 },
+];
+
+const LONG_SCALE = 2 ** 60 - 1;
+
+function sha1Hex(input: string): string {
+	const bytes = new TextEncoder().encode(input);
+	const paddedLength = (((bytes.length + 8) >> 6) + 1) << 6;
+	const padded = new Uint8Array(paddedLength);
+	padded.set(bytes);
+	padded[bytes.length] = 0x80;
+	const view = new DataView(padded.buffer);
+	const bitLength = bytes.length * 8;
+	view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000));
+	view.setUint32(paddedLength - 4, bitLength >>> 0);
+
+	let h0 = 0x67452301;
+	let h1 = 0xefcdab89;
+	let h2 = 0x98badcfe;
+	let h3 = 0x10325476;
+	let h4 = 0xc3d2e1f0;
+	const w = new Uint32Array(80);
+
+	for (let block = 0; block < paddedLength; block += 64) {
+		for (let i = 0; i < 16; i++) {
+			w[i] = view.getUint32(block + i * 4);
+		}
+		for (let i = 16; i < 80; i++) {
+			const n =
+				(w[i - 3] ?? 0) ^ (w[i - 8] ?? 0) ^ (w[i - 14] ?? 0) ^ (w[i - 16] ?? 0);
+			w[i] = ((n << 1) | (n >>> 31)) >>> 0;
+		}
+
+		let a = h0;
+		let b = h1;
+		let c = h2;
+		let d = h3;
+		let e = h4;
+
+		for (let i = 0; i < 80; i++) {
+			let f: number;
+			let k: number;
+			if (i < 20) {
+				f = (b & c) | (~b & d);
+				k = 0x5a827999;
+			} else if (i < 40) {
+				f = b ^ c ^ d;
+				k = 0x6ed9eba1;
+			} else if (i < 60) {
+				f = (b & c) | (b & d) | (c & d);
+				k = 0x8f1bbcdc;
+			} else {
+				f = b ^ c ^ d;
+				k = 0xca62c1d6;
+			}
+			const temp =
+				((((a << 5) | (a >>> 27)) >>> 0) + f + e + k + (w[i] ?? 0)) >>> 0;
+			e = d;
+			d = c;
+			c = ((b << 30) | (b >>> 2)) >>> 0;
+			b = a;
+			a = temp;
+		}
+
+		h0 = (h0 + a) >>> 0;
+		h1 = (h1 + b) >>> 0;
+		h2 = (h2 + c) >>> 0;
+		h3 = (h3 + d) >>> 0;
+		h4 = (h4 + e) >>> 0;
+	}
+
+	return [h0, h1, h2, h3, h4]
+		.map((word) => word.toString(16).padStart(8, "0"))
+		.join("");
+}
+
+function variantForDistinctId(distinctId: string): string {
+	const hashValue =
+		Number.parseInt(
+			sha1Hex(`${HERO_POSITIONING_FLAG}.${distinctId}variant`).slice(0, 15),
+			16,
+		) / LONG_SCALE;
+	let cumulative = 0;
+	for (const variant of VARIANTS) {
+		cumulative += variant.rolloutPercentage / 100;
+		if (hashValue < cumulative) return variant.key;
+	}
+	return VARIANTS[VARIANTS.length - 1]?.key ?? "control";
+}
+
+function distinctIdFromCookie(): string | undefined {
+	const match = document.cookie
+		.split("; ")
+		.find((row) => row.startsWith(`${POSTHOG_COOKIE_NAME}=`));
+	if (!match) return undefined;
+	try {
+		const parsed = JSON.parse(
+			decodeURIComponent(match.slice(POSTHOG_COOKIE_NAME.length + 1)),
+		);
+		return typeof parsed.distinct_id === "string"
+			? parsed.distinct_id
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function getHeroFlagBootstrap(): NonNullable<
+	PostHogConfig["bootstrap"]
+> {
+	const distinctId = distinctIdFromCookie() ?? crypto.randomUUID();
+	return {
+		distinctID: distinctId,
+		isIdentifiedID: false,
+		featureFlags: {
+			[HERO_POSITIONING_FLAG]: variantForDistinctId(distinctId),
+		},
+	};
+}


### PR DESCRIPTION
## Why

The `landing-hero-positioning` experiment evaluates its flag client-side after the `/flags` network round trip, so first-time visitors see the control hero flash before the variant swaps in, and events fired before the response lands don't carry the `$feature` property.

## What

- New `hero-flag-bootstrap.ts`: computes the variant synchronously at `posthog.init` using PostHog's cross-SDK deterministic assignment hash (`sha1("<flag>.<distinct_id>variant")` first 15 hex digits / `2^60-1`, mapped over the 50/50 variant rollouts), seeded from the existing `superset` cookie identity — or a freshly generated UUID that posthog-js adopts via `bootstrap.distinctID` and persists, so refreshes always hash the same identity and can never flip buckets.
- `instrumentation-client.ts` passes the bootstrap into `posthog.init`, so `useFeatureFlagVariantKey` resolves at hydration instead of after the network round trip.
- `HeroSection` imports the flag key from the new module (single source of truth).

## Verification

- Assignment equivalence proven against production: 25+ random distinct_ids computed locally all matched the live `us.i.posthog.com/flags` response variant exactly.
- `bun run lint` clean; `turbo typecheck --filter=@superset/marketing` clean.

## Caveat

The variant order + 50/50 split are mirrored from the flag config (noted in a code comment). If the experiment's rollout changes, drift is safe — behavior falls back to today's swap-on-response — but the bootstrap constant should be updated alongside.

https://claude.ai/code/session_013HwZR8BoCF3QBis8b3x7pm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps the `landing-hero-positioning` flag at `posthog-js` init so the hero renders the right variant during hydration. Removes the control-to-variant flash and ensures the first pageview includes `$feature`.

- **Bug Fixes**
  - Computes the variant synchronously using PostHog’s deterministic hash (`sha1("<flag>.<distinct_id>variant")`), seeded from the `superset` cookie or a new UUID adopted via `bootstrap.distinctID` for sticky assignment.
  - Passes the bootstrap to `posthog.init`, and centralizes the flag key in `hero-flag-bootstrap` with `HeroSection` importing it as the single source of truth.

- **Migration**
  - If the experiment’s rollout or variant order changes, update `VARIANTS` in `hero-flag-bootstrap.ts` to keep parity; otherwise behavior safely falls back to server-evaluated swapping.

<sup>Written for commit b228a536671ea41f32c4062632379f5c3b8ddc67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent assignment for the landing page hero experience, supporting controlled variants such as Control and Capability Mac.

* **Bug Fixes**
  * Improved hero experiment initialization so visitors receive a stable variant during page loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->