### PR TITLE
fix(desktop,mcp): honor device-local agent preset overrides in MCP-launched sessions

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-agent-session.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-agent-session.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AgentLaunchRequest } from "@superset/shared/agent-launch";
+import {
+	indexResolvedAgentConfigs,
+	resolveAgentConfigs,
+} from "@superset/shared/agent-settings";
+import type { ToolContext } from "./types";
+
+let capturedRequest: AgentLaunchRequest | null = null;
+
+const queueMock = mock((input: { request: AgentLaunchRequest }) => {
+	capturedRequest = input.request;
+	return {
+		workspaceId: input.request.workspaceId,
+		tabId: null,
+		paneId: null,
+		sessionId: null,
+		status: "queued" as const,
+		error: null,
+	};
+});
+
+const launchMock = mock(async (request: AgentLaunchRequest) => {
+	capturedRequest = request;
+	return {
+		workspaceId: request.workspaceId,
+		tabId: "tab-1",
+		paneId: "pane-1",
+		sessionId: null,
+		status: "running" as const,
+		error: null,
+	};
+});
+
+mock.module("renderer/lib/agent-session-orchestrator", () => ({
+	queueAgentSessionLaunch: queueMock,
+	launchAgentSession: launchMock,
+}));
+
+const { startAgentSession } = await import("./start-agent-session");
+
+const OVERRIDE_COMMAND =
+	"claude --permission-mode plan --dangerously-skip-permissions";
+const BAKED_PROMPT_COMMAND =
+	"claude --dangerously-skip-permissions BAKED-PROMPT";
+const BAKED_FILE_COMMAND = "claude --dangerously-skip-permissions BAKED-FILE";
+
+function configsById(
+	presets: {
+		id: string;
+		enabled?: boolean;
+		command?: string;
+		promptCommand?: string;
+	}[],
+) {
+	return indexResolvedAgentConfigs(
+		resolveAgentConfigs({
+			overrideEnvelope: { version: 1, presets },
+		}),
+	);
+}
+
+function makeContext(
+	getResolvedAgentConfigsById?: ToolContext["getResolvedAgentConfigsById"],
+): ToolContext {
+	return {
+		getWorkspaces: () => [
+			{ id: "workspace-1", projectId: "project-1", branch: "main" },
+		],
+		getResolvedAgentConfigsById,
+	} as unknown as ToolContext;
+}
+
+function promptParams() {
+	return {
+		workspaceId: "workspace-1",
+		command: BAKED_PROMPT_COMMAND,
+		name: "Claude",
+		agentType: "claude" as const,
+		request: {
+			kind: "terminal" as const,
+			workspaceId: "workspace-1",
+			agentType: "claude" as const,
+			terminal: {
+				command: BAKED_PROMPT_COMMAND,
+				name: "Claude",
+				prompt: "Fix the failing tests",
+			},
+		},
+	};
+}
+
+function taskParams() {
+	return {
+		workspaceId: "workspace-1",
+		command: BAKED_FILE_COMMAND,
+		name: "demo-task",
+		agentType: "claude" as const,
+		request: {
+			kind: "terminal" as const,
+			workspaceId: "workspace-1",
+			agentType: "claude" as const,
+			terminal: {
+				command: BAKED_FILE_COMMAND,
+				name: "demo-task",
+				taskPromptContent: "Do the task",
+				taskPromptFileName: "task-demo-task.md",
+			},
+		},
+	};
+}
+
+describe("start-agent-session device command resolution", () => {
+	beforeEach(() => {
+		capturedRequest = null;
+		queueMock.mockClear();
+		launchMock.mockClear();
+	});
+
+	it("re-resolves a prompt launch from a claude override", async () => {
+		const ctx = makeContext(() =>
+			configsById([{ id: "claude", promptCommand: OVERRIDE_COMMAND }]),
+		);
+
+		const result = await startAgentSession.execute(promptParams(), ctx);
+
+		expect(result.success).toBe(true);
+		const command =
+			capturedRequest?.kind === "terminal"
+				? capturedRequest.terminal.command
+				: undefined;
+		expect(command).toContain("--permission-mode plan");
+		expect(command).toContain("Fix the failing tests");
+		expect(command).not.toBe(BAKED_PROMPT_COMMAND);
+	});
+
+	it("re-resolves a task launch into the overridden file command", async () => {
+		const ctx = makeContext(() =>
+			configsById([{ id: "claude", promptCommand: OVERRIDE_COMMAND }]),
+		);
+
+		await startAgentSession.execute(taskParams(), ctx);
+
+		const command =
+			capturedRequest?.kind === "terminal"
+				? capturedRequest.terminal.command
+				: undefined;
+		expect(command).toContain("--permission-mode plan");
+		expect(command).toContain(".superset/task-demo-task.md");
+		expect(command).not.toBe(BAKED_FILE_COMMAND);
+	});
+
+	it("preserves server-authoritative fields when re-resolving", async () => {
+		const ctx = makeContext(() =>
+			configsById([{ id: "claude", promptCommand: OVERRIDE_COMMAND }]),
+		);
+
+		await startAgentSession.execute(taskParams(), ctx);
+
+		expect(capturedRequest?.kind).toBe("terminal");
+		if (capturedRequest?.kind === "terminal") {
+			expect(capturedRequest.terminal.name).toBe("demo-task");
+			expect(capturedRequest.terminal.taskPromptContent).toBe("Do the task");
+			expect(capturedRequest.terminal.taskPromptFileName).toBe(
+				"task-demo-task.md",
+			);
+		}
+	});
+
+	it("keeps the baked command when the config is disabled", async () => {
+		const ctx = makeContext(() =>
+			configsById([{ id: "claude", enabled: false }]),
+		);
+
+		await startAgentSession.execute(promptParams(), ctx);
+
+		const command =
+			capturedRequest?.kind === "terminal"
+				? capturedRequest.terminal.command
+				: undefined;
+		expect(command).toBe(BAKED_PROMPT_COMMAND);
+	});
+
+	it("keeps the baked command when no config matches the agent", async () => {
+		const ctx = makeContext(() => new Map());
+
+		await startAgentSession.execute(promptParams(), ctx);
+
+		const command =
+			capturedRequest?.kind === "terminal"
+				? capturedRequest.terminal.command
+				: undefined;
+		expect(command).toBe(BAKED_PROMPT_COMMAND);
+	});
+
+	it("keeps the baked command for an old-server request lacking prompt fields", async () => {
+		const ctx = makeContext(() =>
+			configsById([{ id: "claude", promptCommand: OVERRIDE_COMMAND }]),
+		);
+
+		await startAgentSession.execute(
+			{
+				workspaceId: "workspace-1",
+				command: BAKED_PROMPT_COMMAND,
+				name: "Claude",
+				request: {
+					kind: "terminal" as const,
+					workspaceId: "workspace-1",
+					terminal: { command: BAKED_PROMPT_COMMAND, name: "Claude" },
+				},
+			},
+			ctx,
+		);
+
+		const command =
+			capturedRequest?.kind === "terminal"
+				? capturedRequest.terminal.command
+				: undefined;
+		expect(command).toBe(BAKED_PROMPT_COMMAND);
+	});
+
+	it("keeps the baked command when the resolver getter is absent", async () => {
+		const ctx = makeContext(undefined);
+
+		await startAgentSession.execute(promptParams(), ctx);
+
+		const command =
+			capturedRequest?.kind === "terminal"
+				? capturedRequest.terminal.command
+				: undefined;
+		expect(command).toBe(BAKED_PROMPT_COMMAND);
+	});
+
+	it("never touches a chat/superset launch", async () => {
+		const ctx = makeContext(() =>
+			configsById([{ id: "claude", promptCommand: OVERRIDE_COMMAND }]),
+		);
+
+		await startAgentSession.execute(
+			{
+				workspaceId: "workspace-1",
+				openChatPane: true,
+				agentType: "superset" as const,
+				chatLaunchConfig: { initialPrompt: "Chat prompt" },
+				request: {
+					kind: "chat" as const,
+					workspaceId: "workspace-1",
+					agentType: "superset" as const,
+					chat: { initialPrompt: "Chat prompt" },
+				},
+			},
+			ctx,
+		);
+
+		expect(capturedRequest?.kind).toBe("chat");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-agent-session.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-agent-session.ts
@@ -1,8 +1,14 @@
+import type { AgentDefinitionId } from "@superset/shared/agent-catalog";
 import {
+	type AgentLaunchRequest,
 	chatLaunchConfigSchema,
 	normalizeAgentLaunchRequest,
 	STARTABLE_AGENT_TYPES,
 } from "@superset/shared/agent-launch";
+import {
+	buildFileCommandFromAgentConfig,
+	buildPromptCommandFromAgentConfig,
+} from "@superset/shared/agent-settings";
 import {
 	launchAgentSession,
 	queueAgentSessionLaunch,
@@ -55,7 +61,10 @@ async function execute(
 			params.request && typeof params.request === "object"
 				? { ...fallbackRequest, ...(params.request as Record<string, unknown>) }
 				: fallbackRequest;
-		const request = normalizeAgentLaunchRequest(mergedRequest);
+		const request = resolveDeviceLocalCommand(
+			normalizeAgentLaunchRequest(mergedRequest),
+			ctx,
+		);
 
 		if (request.workspaceId !== params.workspaceId) {
 			return {
@@ -108,6 +117,48 @@ async function execute(
 					: "Failed to start agent session",
 		};
 	}
+}
+
+/**
+ * Re-resolves a terminal launch command from the device-local agent presets,
+ * so MCP-launched sessions honor the user's UI-configured command/flags.
+ *
+ * The server sends a baked builtin command as a fallback plus the raw prompt
+ * (or task prompt file name) needed to re-resolve here. Falls back to the baked
+ * command whenever the presets, a matching enabled terminal config, or the
+ * prompt fields are unavailable — keeping old renderers and old servers working.
+ */
+function resolveDeviceLocalCommand(
+	request: AgentLaunchRequest,
+	ctx: ToolContext,
+): AgentLaunchRequest {
+	if (request.kind !== "terminal" || !request.agentType) return request;
+
+	const config = ctx
+		.getResolvedAgentConfigsById?.()
+		?.get(request.agentType as AgentDefinitionId);
+	if (!config || !config.enabled || config.kind !== "terminal") return request;
+
+	const { taskPromptFileName, prompt } = request.terminal;
+	const command = taskPromptFileName
+		? buildFileCommandFromAgentConfig({
+				filePath: `.superset/${taskPromptFileName}`,
+				config,
+			})
+		: prompt
+			? buildPromptCommandFromAgentConfig({
+					prompt,
+					randomId: crypto.randomUUID(),
+					config,
+				})
+			: null;
+
+	if (!command) return request;
+
+	return {
+		...request,
+		terminal: { ...request.terminal, command },
+	};
 }
 
 export const startAgentSession: ToolDefinition<typeof schema> = {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/types.ts
@@ -1,4 +1,6 @@
 import type { SelectProject, SelectWorkspace } from "@superset/local-db";
+import type { AgentDefinitionId } from "@superset/shared/agent-catalog";
+import type { ResolvedAgentConfig } from "@superset/shared/agent-settings";
 import type { electronTrpc } from "renderer/lib/electron-trpc";
 import type { z } from "zod";
 
@@ -62,6 +64,11 @@ export interface ToolContext {
 	getProjects: () => SelectProject[] | undefined;
 	getActiveWorkspaceId: () => string | null;
 	getWorktreePathByWorkspaceId: (workspaceId: string) => string | undefined;
+	// Device-local agent presets, indexed by id. Absence (older renderer)
+	// signals callers to fall back to the server-baked command.
+	getResolvedAgentConfigsById?: () =>
+		| Map<AgentDefinitionId, ResolvedAgentConfig>
+		| undefined;
 }
 
 // Tool definition with schema and execute function

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -38,7 +38,6 @@ export function useCommandWatcher() {
 	const remoteAgentDisabled = useFeatureFlagEnabled(
 		FEATURE_FLAGS.DISABLE_REMOTE_AGENT,
 	);
-	const shouldWatch = !!deviceInfo && !!organizationId && !remoteAgentDisabled;
 
 	const createWorktree = useCreateWorkspace({ skipNavigation: true });
 	const setActive = electronTrpc.workspaces.setActive.useMutation();
@@ -53,12 +52,26 @@ export function useCommandWatcher() {
 	const { data: workspaceGroups } =
 		electronTrpc.workspaces.getAllGrouped.useQuery();
 	const { data: projects } = electronTrpc.projects.getRecents.useQuery();
-	const { data: agentPresets } =
+	const { data: agentPresets, isFetched: agentPresetsFetched } =
 		electronTrpc.settings.getAgentPresets.useQuery();
+	// `undefined` until the presets query settles, so a command isn't resolved
+	// against an empty index during the startup race and permanently marked
+	// handled with the server-baked command before the overrides load.
 	const resolvedAgentConfigsById = useMemo(
-		() => indexResolvedAgentConfigs(agentPresets ?? []),
-		[agentPresets],
+		() =>
+			agentPresetsFetched
+				? indexResolvedAgentConfigs(agentPresets ?? [])
+				: undefined,
+		[agentPresets, agentPresetsFetched],
 	);
+
+	// Hold off processing commands until device-local agent presets are known,
+	// otherwise MCP launches race the presets query and ignore user overrides.
+	const shouldWatch =
+		!!deviceInfo &&
+		!!organizationId &&
+		!remoteAgentDisabled &&
+		agentPresetsFetched;
 	const worktreePathByWorkspaceId = useMemo(() => {
 		const pathByWorkspaceId = new Map<string, string>();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -1,3 +1,4 @@
+import { indexResolvedAgentConfigs } from "@superset/shared/agent-settings";
 import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
@@ -52,6 +53,12 @@ export function useCommandWatcher() {
 	const { data: workspaceGroups } =
 		electronTrpc.workspaces.getAllGrouped.useQuery();
 	const { data: projects } = electronTrpc.projects.getRecents.useQuery();
+	const { data: agentPresets } =
+		electronTrpc.settings.getAgentPresets.useQuery();
+	const resolvedAgentConfigsById = useMemo(
+		() => indexResolvedAgentConfigs(agentPresets ?? []),
+		[agentPresets],
+	);
 	const worktreePathByWorkspaceId = useMemo(() => {
 		const pathByWorkspaceId = new Map<string, string>();
 
@@ -91,6 +98,7 @@ export function useCommandWatcher() {
 			getActiveWorkspaceId: getCurrentWorkspaceIdFromRoute,
 			getWorktreePathByWorkspaceId: (workspaceId) =>
 				worktreePathByWorkspaceId.get(workspaceId),
+			getResolvedAgentConfigsById: () => resolvedAgentConfigsById,
 		}),
 		[
 			createWorktree,
@@ -104,6 +112,7 @@ export function useCommandWatcher() {
 			projects,
 			getCurrentWorkspaceIdFromRoute,
 			worktreePathByWorkspaceId,
+			resolvedAgentConfigsById,
 		],
 	);
 

--- a/packages/mcp/src/tools/devices/start-agent-session/shared.ts
+++ b/packages/mcp/src/tools/devices/start-agent-session/shared.ts
@@ -2,7 +2,7 @@ import { db } from "@superset/db/client";
 import { taskStatuses, tasks } from "@superset/db/schema";
 import {
 	type AGENT_TYPES,
-	buildAgentCommand,
+	buildAgentFileCommand,
 	buildAgentPromptCommand,
 	buildAgentTaskPrompt,
 } from "@superset/shared/agent-command";
@@ -161,18 +161,22 @@ export function buildTaskLaunchRequest({
 		};
 	}
 
+	const taskPromptFileName = `task-${task.slug}.md`;
 	return {
 		kind: "terminal",
 		workspaceId,
 		agentType: agent,
 		source: "mcp",
 		terminal: {
-			command: buildAgentCommand({
-				task,
-				randomId: crypto.randomUUID(),
+			// Baked fallback command; a new device re-resolves the effective
+			// command from the file using its local agent presets.
+			command: buildAgentFileCommand({
+				filePath: `.superset/${taskPromptFileName}`,
 				agent: agent as (typeof AGENT_TYPES)[number],
 			}),
 			name: task.slug,
+			taskPromptContent: buildAgentTaskPrompt(task),
+			taskPromptFileName,
 			...(paneId ? { paneId } : {}),
 		},
 	};
@@ -209,12 +213,15 @@ export function buildPromptLaunchRequest({
 		agentType: agent,
 		source: "mcp",
 		terminal: {
+			// Baked fallback command; a new device re-resolves the effective
+			// command from `prompt` using its local agent presets.
 			command: buildAgentPromptCommand({
 				prompt,
 				randomId: crypto.randomUUID(),
 				agent: agent as (typeof AGENT_TYPES)[number],
 			}),
 			name: STARTABLE_AGENT_LABELS[agent],
+			prompt,
 			...(paneId ? { paneId } : {}),
 		},
 	};

--- a/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.test.ts
+++ b/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.test.ts
@@ -109,7 +109,12 @@ describe("session launch MCP tools", () => {
 			params: {
 				request: {
 					kind: string;
-					terminal?: { name?: string; command: string };
+					terminal?: {
+						name?: string;
+						command: string;
+						taskPromptContent?: string;
+						taskPromptFileName?: string;
+					};
 				};
 			};
 		};
@@ -119,8 +124,16 @@ describe("session launch MCP tools", () => {
 			kind: "terminal",
 			terminal: {
 				name: "demo-task",
+				taskPromptFileName: "task-demo-task.md",
 			},
 		});
+		// Carries the task prompt so the device can re-resolve and write the file.
+		expect(
+			launchInput.params.request.terminal?.taskPromptContent,
+		).toBeDefined();
+		expect(launchInput.params.request.terminal?.command).toContain(
+			".superset/task-demo-task.md",
+		);
 	});
 
 	it("launches prompt-only terminal sessions without fetching a task", async () => {
@@ -146,7 +159,7 @@ describe("session launch MCP tools", () => {
 				request: {
 					kind: string;
 					agentType: string;
-					terminal?: { name?: string; command: string };
+					terminal?: { name?: string; command: string; prompt?: string };
 				};
 			};
 		};
@@ -158,6 +171,8 @@ describe("session launch MCP tools", () => {
 			agentType: "codex",
 			terminal: {
 				name: "Codex",
+				// Trimmed raw prompt carried for device-local re-resolution.
+				prompt: "Fix the failing tests",
 			},
 		});
 		expect(launchInput.params.request.terminal?.command).toContain(

--- a/packages/shared/src/agent-launch.test.ts
+++ b/packages/shared/src/agent-launch.test.ts
@@ -21,6 +21,26 @@ describe("normalizeAgentLaunchRequest", () => {
 		expect(normalized).toEqual(request);
 	});
 
+	it("round-trips the optional prompt on a terminal launch", () => {
+		const request: AgentLaunchRequest = {
+			kind: "terminal",
+			workspaceId: "ws-1",
+			source: "mcp",
+			agentType: "claude",
+			terminal: {
+				command: "claude --dangerously-skip-permissions",
+				name: "Claude",
+				prompt: "Fix the failing tests",
+			},
+		};
+
+		const normalized = normalizeAgentLaunchRequest(request);
+		expect(normalized).toEqual(request);
+		expect(
+			normalized.kind === "terminal" ? normalized.terminal.prompt : undefined,
+		).toBe("Fix the failing tests");
+	});
+
 	it("maps legacy terminal launch params", () => {
 		const normalized = normalizeAgentLaunchRequest({
 			workspaceId: "ws-1",

--- a/packages/shared/src/agent-launch.ts
+++ b/packages/shared/src/agent-launch.ts
@@ -51,6 +51,10 @@ export const terminalLaunchConfigSchema = z.object({
 	command: z.string().min(1),
 	name: z.string().min(1).optional(),
 	paneId: z.string().min(1).optional(),
+	// Raw prompt carried alongside the baked command so a device can
+	// re-resolve the effective command from device-local agent presets.
+	// Older devices ignore it and run the baked command verbatim.
+	prompt: z.string().min(1).optional(),
 	taskPromptContent: z.string().min(1).optional(),
 	taskPromptFileName: z.string().min(1).optional(),
 	autoExecute: z.boolean().optional(),


### PR DESCRIPTION
## Problem

In Superset, a user can customize each agent's launch command in the desktop UI (e.g. set `claude` to `claude --permission-mode plan --dangerously-skip-permissions`). The **desktop UI honors these overrides**, but **MCP-launched sessions ignore them** — an agent started via `start_agent_session` / `start_agent_session_with_prompt` always ran the hardcoded builtin command, so the user's plan-mode / custom flags never took effect.

Root cause: user overrides (`agentPresetOverrides`, `agentCustomDefinitions`) are stored **device-local** in SQLite (`packages/local-db` settings). They are **not** in Postgres, so the cloud MCP server can't read them and bakes the command from builtins only. The device command-watcher trusts that baked command verbatim, even though the device **has** the presets via `settings.getAgentPresets`.

## Approach — device re-resolves; additive & rolling-update-safe

Overrides only exist on the device, so the effective command can only be resolved there. The change is additive over the server→device `agent_commands` queue so it stays compatible across rolling updates:

- The MCP server keeps sending the baked builtin command as a **fallback**, and now *additionally* carries what the device needs to re-resolve: the raw `prompt` (prompt launches) and `taskPromptContent`/`taskPromptFileName` (task launches, matching how UI task launches already behave).
- A **new device** prefers local re-resolution from the user's presets via the existing `resolveAgentConfigs` path; it falls back to the baked command when the presets, a matching enabled terminal config, or the prompt fields are absent.
- An **old device** ignores the new fields and runs the baked command (unchanged). A **new device** tolerates old-server requests that lack the fields.

Only the command string is overwritten — server-provided `name`/`paneId`/files/`taskPromptContent` stay authoritative. Chat/superset launches are never touched.

## Changes

- `packages/shared/src/agent-launch.ts` — add optional `prompt` to `terminalLaunchConfigSchema`.
- `packages/mcp/.../start-agent-session/shared.ts` — prompt launch carries `prompt`; task launch switched to the UI file-command shape (`buildAgentFileCommand` + `taskPromptContent` + `taskPromptFileName`).
- `.../useCommandWatcher/tools/types.ts` — add optional `getResolvedAgentConfigsById` getter to `ToolContext`.
- `.../useCommandWatcher/useCommandWatcher.ts` — wire `settings.getAgentPresets` → memoized `indexResolvedAgentConfigs` → the `toolContext` getter.
- `.../useCommandWatcher/tools/start-agent-session.ts` — `resolveDeviceLocalCommand` re-resolves the terminal command from local presets (task → file command, prompt → prompt command), falling back to the baked command in every gap.

## Tests

- New device test (`tools/start-agent-session.test.ts`): override prompt/task launches use the overridden command; authoritative fields preserved; baked-command fallback for disabled config, missing config, absent resolver getter, and old-server requests; chat/superset untouched.
- MCP test: prompt request carries `terminal.prompt`; task request uses file command + prompt content/filename.
- Shared schema round-trip test for `prompt`.
- Full suites green (shared 697, mcp 7, AgentHooks 17); desktop `tsc --noEmit`, shared/mcp typechecks, and biome all clean.

## Out of scope (separate follow-up)

The **cwd/worktree-readiness spawn race** — `create_workspace` returns before the worktree dir exists (`initializeWorkspaceWorktree` is fire-and-forget), so a PTY spawned immediately after can die. It's a different code path (main-process init vs renderer command resolution) and should ship as its own change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCP-launched agent sessions now honor device-local agent preset overrides from the desktop UI. Commands are resolved on the device using local presets with baked fallbacks, and MCP command processing is deferred until presets load to avoid a startup race that could ignore overrides.

- **Bug Fixes**
  - Server continues sending a baked builtin command and now also includes `terminal.prompt` or `taskPromptContent`/`taskPromptFileName`; the device prefers local re-resolution and falls back when data or presets are missing (rolling-update safe).
  - Added optional `prompt` to `terminalLaunchConfigSchema` in `@superset/shared` to carry raw prompts for device-side resolution.
  - Desktop command watcher indexes presets, defers MCP command processing until the presets query settles, and exposes `getResolvedAgentConfigsById`; only `terminal.command` is replaced, while `name`/`paneId`/files remain authoritative. Chat/superset launches are untouched.
  - Tests cover override application, fallbacks for old servers/devices, and schema round-trips.

<sup>Written for commit 4ffddd25a58c36c4b021934df4cc7dd8b66696b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal-based agent sessions now use the latest device-local agent settings when available.
  * Prompt and task launches preserve the information needed to rebuild commands locally.
  * Task sessions now reference their associated prompt files for more reliable launches.
  * Older devices and unsupported configurations continue using the original launch command.

* **Tests**
  * Added coverage for prompt, task, chat, fallback, and compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->