### PR TITLE
fix(desktop): report true commit count when branch exceeds 500-commit display cap

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.test.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { executeGitTask, MAX_COMMIT_LIST_COUNT } from "./git-task-handlers";
+
+const TEST_DIR = join(
+	realpathSync(tmpdir()),
+	`superset-test-git-tasks-${process.pid}`,
+);
+
+function run(repoPath: string, command: string): string {
+	return execSync(command, { cwd: repoPath, encoding: "utf8" });
+}
+
+function createBranchWithCommits(name: string, commitCount: number): string {
+	const repoPath = join(TEST_DIR, name);
+	mkdirSync(repoPath, { recursive: true });
+	run(repoPath, "git init -q -b main");
+	run(repoPath, "git config user.email test@test.com");
+	run(repoPath, "git config user.name Test");
+	run(repoPath, "git commit -q --allow-empty -m base");
+	const baseHash = run(repoPath, "git rev-parse HEAD").trim();
+	run(repoPath, `git update-ref refs/remotes/origin/main ${baseHash}`);
+	run(repoPath, "git checkout -q -b feature");
+
+	// Bulk-create commits with a single fast-import instead of one process per commit.
+	let stream = "";
+	for (let i = 1; i <= commitCount; i++) {
+		const message = `commit ${i}\n`;
+		stream += `commit refs/heads/feature\n`;
+		stream += `committer Test <test@test.com> ${1700000000 + i} +0000\n`;
+		stream += `data ${Buffer.byteLength(message)}\n${message}`;
+		if (i === 1) stream += `from refs/heads/feature^0\n`;
+		stream += "\n";
+	}
+	execSync("git fast-import --quiet", { cwd: repoPath, input: stream });
+	run(repoPath, "git reset -q --hard feature");
+	return repoPath;
+}
+
+beforeAll(() => {
+	mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterAll(() => {
+	rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("getStatus commit counting", () => {
+	test("caps the commit list at the display limit but reports the true total", async () => {
+		const commitCount = MAX_COMMIT_LIST_COUNT + 25;
+		const repoPath = createBranchWithCommits("over-cap", commitCount);
+
+		const status = await executeGitTask("getStatus", {
+			worktreePath: repoPath,
+			defaultBranch: "main",
+			persistedWorktree: null,
+		});
+
+		expect(status.commits).toHaveLength(MAX_COMMIT_LIST_COUNT);
+		expect(status.totalCommitCount).toBe(commitCount);
+		expect(status.ahead).toBe(commitCount);
+	}, 60_000);
+
+	test("total matches the list length under the display limit", async () => {
+		const repoPath = createBranchWithCommits("under-cap", 3);
+
+		const status = await executeGitTask("getStatus", {
+			worktreePath: repoPath,
+			defaultBranch: "main",
+			persistedWorktree: null,
+		});
+
+		expect(status.commits).toHaveLength(3);
+		expect(status.totalCommitCount).toBe(3);
+	}, 60_000);
+});

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -23,10 +23,13 @@ import type {
 
 interface BranchComparison {
 	commits: GitChangesStatus["commits"];
+	totalCommitCount: number;
 	againstBase: ChangedFile[];
 	ahead: number;
 	behind: number;
 }
+
+export const MAX_COMMIT_LIST_COUNT = 500;
 
 interface TrackingStatus {
 	pushCount: number;
@@ -168,6 +171,7 @@ async function getBranchComparison(
 	defaultBranch: string,
 ): Promise<BranchComparison> {
 	let commits: GitChangesStatus["commits"] = [];
+	let totalCommitCount = 0;
 	let againstBase: ChangedFile[] = [];
 	let ahead = 0;
 	let behind = 0;
@@ -186,10 +190,11 @@ async function getBranchComparison(
 		const logOutput = await git.raw([
 			"log",
 			`origin/${defaultBranch}..HEAD`,
-			"--max-count=500",
+			`--max-count=${MAX_COMMIT_LIST_COUNT}`,
 			"--format=%H|%h|%s|%an|%aI",
 		]);
 		commits = parseGitLog(logOutput);
+		totalCommitCount = ahead;
 
 		if (ahead > 0) {
 			const nameStatus = await git.raw([
@@ -212,7 +217,7 @@ async function getBranchComparison(
 		);
 	}
 
-	return { commits, againstBase, ahead, behind };
+	return { commits, totalCommitCount, againstBase, ahead, behind };
 }
 
 async function getTrackingBranchStatus(
@@ -276,6 +281,7 @@ async function computeStatus({
 		defaultBranch: effectiveBaseBranch,
 		againstBase: branchComparison.againstBase,
 		commits: branchComparison.commits,
+		totalCommitCount: branchComparison.totalCommitCount,
 		staged: parsed.staged,
 		unstaged: parsed.unstaged,
 		untracked: parsed.untracked,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -598,6 +598,7 @@ export function ChangesView({
 		againstBaseFiles,
 		onAgainstBaseFileSelect: (file) => handleFileSelect(file, "against-base"),
 		commitsWithFiles,
+		totalCommitCount: status?.totalCommitCount ?? commits.length,
 		expandedCommits,
 		onCommitToggle: handleCommitToggle,
 		onCommitFileSelect: handleCommitFileSelect,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.test.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.test.tsx
@@ -37,6 +37,7 @@ const emptyArgs = {
 	againstBaseFiles: [] as ChangedFile[],
 	onAgainstBaseFileSelect: () => {},
 	commitsWithFiles: [] as CommitInfo[],
+	totalCommitCount: 0,
 	expandedCommits: new Set<string>(),
 	onCommitToggle: () => {},
 	onCommitFileSelect: () => {},
@@ -75,6 +76,7 @@ describe("useOrderedSections", () => {
 					files: [],
 				},
 			],
+			totalCommitCount: 1,
 		});
 
 		const committedSection = sections.find(
@@ -83,6 +85,27 @@ describe("useOrderedSections", () => {
 
 		expect(committedSection).toBeDefined();
 		expect(committedSection?.count).toBe(1);
+	});
+
+	test("shows the true commit total when the list is capped for display", () => {
+		const commitsWithFiles = Array.from({ length: 500 }, (_, index) => ({
+			hash: `hash-${index}`,
+			shortHash: `h${index}`,
+			message: `commit ${index}`,
+			author: "Test User",
+			date: new Date("2026-03-06T12:00:00.000Z"),
+			files: [],
+		}));
+
+		const sections = useOrderedSections({
+			...emptyArgs,
+			commitsWithFiles,
+			totalCommitCount: 512,
+		});
+
+		expect(sections.find((section) => section.id === "committed")?.count).toBe(
+			512,
+		);
 	});
 
 	test("does not change other section counts", () => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
@@ -36,6 +36,7 @@ interface UseOrderedSectionsInput {
 	againstBaseFiles: ChangedFile[];
 	onAgainstBaseFileSelect: (file: ChangedFile) => void;
 	commitsWithFiles: CommitInfo[];
+	totalCommitCount: number;
 	expandedCommits: Set<string>;
 	onCommitToggle: (commitHash: string) => void;
 	onCommitFileSelect: (file: ChangedFile, commitHash: string) => void;
@@ -74,6 +75,7 @@ export function useOrderedSections({
 	againstBaseFiles,
 	onAgainstBaseFileSelect,
 	commitsWithFiles,
+	totalCommitCount,
 	expandedCommits,
 	onCommitToggle,
 	onCommitFileSelect,
@@ -97,8 +99,6 @@ export function useOrderedSections({
 	isStageAllPending,
 	isUnstagedActioning,
 }: UseOrderedSectionsInput) {
-	const commitCount = commitsWithFiles.length;
-
 	const sectionDefinitions: Record<ChangeCategory, OrderedSection> = {
 		"against-base": {
 			id: "against-base",
@@ -123,7 +123,7 @@ export function useOrderedSections({
 		committed: {
 			id: "committed",
 			title: "Commits",
-			count: commitCount,
+			count: totalCommitCount,
 			isExpanded: expandedSections.committed,
 			onToggle: () => toggleSection("committed"),
 			content: expandedSections.committed ? (

--- a/apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.test.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.test.ts
@@ -6,6 +6,7 @@ const status: GitChangesStatus = {
 	defaultBranch: "release",
 	againstBase: [],
 	commits: [],
+	totalCommitCount: 0,
 	staged: [],
 	unstaged: [],
 	untracked: [],

--- a/apps/desktop/src/shared/changes-types.ts
+++ b/apps/desktop/src/shared/changes-types.ts
@@ -43,7 +43,8 @@ export interface GitChangesStatus {
 	branch: string;
 	defaultBranch: string; // Default branch (main/master)
 	againstBase: ChangedFile[]; // All files changed vs base branch
-	commits: CommitInfo[]; // Individual commits on branch (not on default)
+	commits: CommitInfo[]; // Individual commits on branch (not on default), capped for display
+	totalCommitCount: number; // True number of commits on branch, even beyond the display cap
 	staged: ChangedFile[];
 	unstaged: ChangedFile[];
 	untracked: ChangedFile[];


### PR DESCRIPTION
## Problem

In the v1 Changes sidebar, the "Commits" section header showed at most 500 even when the branch had more commits. The commit list is fetched with `git log origin/<base>..HEAD --max-count=500` (intentional display cap), but the section count was derived from that truncated list's length, so the reported total capped at 500 too.

## Fix

- The git status worker now returns an explicit `totalCommitCount` on `GitChangesStatus`, taken from the `git rev-list --left-right --count` result already computed for `ahead`/`behind` over the same range — no extra git invocation.
- The v1 `useOrderedSections` Commits header uses `totalCommitCount` instead of the list length. The displayed list stays capped at 500 (`MAX_COMMIT_LIST_COUNT`, previously an inline literal).
- `totalCommitCount` is assigned only after the log parse succeeds, so a partial failure can't report a count with an empty list.

## Tests

- New `git-task-handlers.test.ts`: builds a real temp repo with 525 commits (bulk-created via one `git fast-import`) and asserts `commits.length === 500` while `totalCommitCount === 525`; plus an under-cap case.
- `useOrderedSections.test.tsx`: new case asserting the section count shows the true total (512) when the list is capped at 500.

Note: running `useOrderedSections.test.tsx` and `useGitChangesStatus.test.ts` in the same bun process fails due to a pre-existing `mock.module` leak — verified identical on `main`; each file passes standalone.

https://claude.ai/code/session_017KtvfRLyvveKk5hnUNg2dg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Changes sidebar so the Commits header shows the true commit total even when a branch exceeds the 500-commit display cap, while keeping the list capped at 500.

- **Bug Fixes**
  - Worker now returns `totalCommitCount` from existing `git rev-list --left-right --count` (no extra git call).
  - Commits section uses `totalCommitCount`; falls back to list length if missing.
  - Introduced `MAX_COMMIT_LIST_COUNT = 500` and applied to `git log`.
  - Tests cover over-cap (e.g., 525 total → 500 listed) and under-cap cases.

<sup>Written for commit 8a67204ceacaa17f243cb40dda773fdaf7d78efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

