### PR TITLE
fix(host-service): serve external open actions for local hosts (#5850, #5893)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -854,6 +854,7 @@
         "@mastra/memory": "1.18.0",
         "@octokit/rest": "22.0.1",
         "@superset/chat": "workspace:*",
+        "@superset/local-db": "workspace:*",
         "@superset/port-scanner": "workspace:*",
         "@superset/pty-daemon": "workspace:*",
         "@superset/session-protocol": "workspace:*",

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -73,6 +73,7 @@
 		"@mastra/memory": "1.18.0",
 		"@octokit/rest": "22.0.1",
 		"@superset/chat": "workspace:*",
+		"@superset/local-db": "workspace:*",
 		"@superset/port-scanner": "workspace:*",
 		"@superset/pty-daemon": "workspace:*",
 		"@superset/session-protocol": "workspace:*",

--- a/packages/host-service/src/trpc/router/external/external.test.ts
+++ b/packages/host-service/src/trpc/router/external/external.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { getHostId } from "@superset/shared/host-info";
+import type { HostServiceContext } from "../../../types";
+import { externalRouter } from "./external";
+
+function createCaller(clientMachineId: string | undefined) {
+	const ctx = {
+		isAuthenticated: true,
+		clientMachineId,
+	} as unknown as HostServiceContext;
+	return externalRouter.createCaller(ctx);
+}
+
+const LOCAL = getHostId();
+
+describe("externalRouter locality guard", () => {
+	it("rejects openInApp from a remote client (machine id mismatch)", async () => {
+		const caller = createCaller("some-other-machine");
+		await expect(
+			caller.openInApp({ path: "/tmp/x", app: "zed" }),
+		).rejects.toThrow(/local host machine/i);
+	});
+
+	it("rejects openInApp when no client machine id is present", async () => {
+		const caller = createCaller(undefined);
+		await expect(
+			caller.openInApp({ path: "/tmp/x", app: "zed" }),
+		).rejects.toThrow(/local host machine/i);
+	});
+});
+
+describe("externalRouter input validation (local host)", () => {
+	it("rejects a relative path", async () => {
+		const caller = createCaller(LOCAL);
+		await expect(
+			caller.openInApp({ path: "relative/file.ts", app: "zed" }),
+		).rejects.toThrow(/absolute path/i);
+	});
+
+	it("rejects a disallowed url scheme", async () => {
+		const caller = createCaller(LOCAL);
+		await expect(caller.openUrl("javascript:alert(1)")).rejects.toThrow(
+			/scheme not allowed/i,
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/external/external.test.ts
+++ b/packages/host-service/src/trpc/router/external/external.test.ts
@@ -43,4 +43,11 @@ describe("externalRouter input validation (local host)", () => {
 			/scheme not allowed/i,
 		);
 	});
+
+	it("rejects a relative path for openInFinder", async () => {
+		const caller = createCaller(LOCAL);
+		await expect(caller.openInFinder("relative/dir")).rejects.toThrow(
+			/absolute path/i,
+		);
+	});
 });

--- a/packages/host-service/src/trpc/router/external/external.ts
+++ b/packages/host-service/src/trpc/router/external/external.ts
@@ -1,3 +1,4 @@
+import nodePath from "node:path";
 import { EXTERNAL_APPS } from "@superset/local-db/schema/zod";
 import { getHostId } from "@superset/shared/host-info";
 import { TRPCError } from "@trpc/server";
@@ -46,14 +47,14 @@ const localOnlyProcedure = protectedProcedure.use(({ ctx, next }) => {
 
 /**
  * Opens a path/URL with the OS default handler. Pure Node (no Electron
- * `shell`): macOS `open`, Windows `start`, Linux `xdg-open`.
+ * `shell`). Only macOS (`open`) and Linux (`xdg-open`) are handled, matching
+ * the desktop's `getAppCommand` platform support — the target is never routed
+ * through `cmd.exe`, which would treat `&`/`|` in a URL or path as command
+ * separators.
  */
 function openWithOsDefault(target: string): Promise<void> {
 	if (process.platform === "darwin") {
 		return spawnAsync("open", [target]);
-	}
-	if (process.platform === "win32") {
-		return spawnAsync("cmd", ["/c", "start", "", target]);
 	}
 	return spawnAsync("xdg-open", [target]);
 }
@@ -63,12 +64,23 @@ function revealInFileManager(targetPath: string): Promise<void> {
 	if (process.platform === "darwin") {
 		return spawnAsync("open", ["-R", targetPath]);
 	}
-	if (process.platform === "win32") {
-		return spawnAsync("explorer", [`/select,${targetPath}`]);
-	}
 	// Linux file managers have no universal "reveal & select"; open the
-	// containing directory instead.
-	return openWithOsDefault(targetPath);
+	// containing directory so the item is visible instead of opening the file
+	// itself in its default app.
+	return spawnAsync("xdg-open", [nodePath.dirname(targetPath)]);
+}
+
+/**
+ * Rejects relative paths, which would otherwise be resolved against the
+ * host-service working directory rather than the caller's intended location.
+ */
+function assertAbsolutePath(action: string, path: string): void {
+	if (!path.startsWith("/") && !/^[a-zA-Z]:[\\/]/.test(path)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `${action} requires an absolute path (got ${JSON.stringify(path)}).`,
+		});
+	}
 }
 
 /** Allowlisted URL schemes, mirroring the desktop's safe-url guard. */
@@ -92,12 +104,7 @@ export const externalRouter = router({
 			}),
 		)
 		.mutation(async ({ input }) => {
-			if (!input.path.startsWith("/") && !/^[a-zA-Z]:[\\/]/.test(input.path)) {
-				throw new TRPCError({
-					code: "BAD_REQUEST",
-					message: `openInApp requires an absolute path (got ${JSON.stringify(input.path)}).`,
-				});
-			}
+			assertAbsolutePath("openInApp", input.path);
 
 			if (input.app === "finder") {
 				await revealInFileManager(input.path);
@@ -127,6 +134,7 @@ export const externalRouter = router({
 	openInFinder: localOnlyProcedure
 		.input(z.string())
 		.mutation(async ({ input }) => {
+			assertAbsolutePath("openInFinder", input);
 			await revealInFileManager(input);
 		}),
 

--- a/packages/host-service/src/trpc/router/external/external.ts
+++ b/packages/host-service/src/trpc/router/external/external.ts
@@ -1,0 +1,142 @@
+import { EXTERNAL_APPS } from "@superset/local-db/schema/zod";
+import { getHostId } from "@superset/shared/host-info";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { protectedProcedure, router } from "../../index";
+import { getAppCommand, spawnAsync } from "./helpers";
+
+/**
+ * Mitigation for #5850 / #5893: in shipped builds `external.openInApp` (an
+ * Electron-IPC call typed to the desktop `AppRouter`) can be serviced by the
+ * host service instead of the desktop main process. The host service's router
+ * has no `external` key, so the call fails with
+ * `No procedure found on path "external.openInApp"` and the "Open in app"
+ * button / ⌘O silently break.
+ *
+ * The correct fix is on the desktop transport (external.* must reach the
+ * main-process router). Until that lands, we accept the misroute *only when the
+ * host is the caller's own machine* — the same locality check the desktop uses
+ * for `isLocalWorkspace` (`workspace.hostId === machineId`). For a remote host
+ * these actions are meaningless (they'd open an editor on the server), so we
+ * reject them loudly rather than doing the wrong thing.
+ *
+ * Scope is deliberately limited to the actions reported broken:
+ * `openInApp`, `openInFinder`, `openUrl`. Line/column-aware `openFileInEditor`
+ * and clipboard actions stay desktop-only.
+ */
+
+const ExternalAppSchema = z.enum(EXTERNAL_APPS);
+
+/**
+ * Only runs when the host service is executing on the same machine as the
+ * requesting desktop client. `getHostId()` is this host's stable machine id;
+ * `ctx.clientMachineId` is sent by the desktop as `x-superset-client-machine-id`
+ * and is the id the desktop compares against for local workspaces.
+ */
+const localOnlyProcedure = protectedProcedure.use(({ ctx, next }) => {
+	if (!ctx.clientMachineId || ctx.clientMachineId !== getHostId()) {
+		throw new TRPCError({
+			code: "PRECONDITION_FAILED",
+			message:
+				"External open actions are only available on the local host machine.",
+		});
+	}
+	return next();
+});
+
+/**
+ * Opens a path/URL with the OS default handler. Pure Node (no Electron
+ * `shell`): macOS `open`, Windows `start`, Linux `xdg-open`.
+ */
+function openWithOsDefault(target: string): Promise<void> {
+	if (process.platform === "darwin") {
+		return spawnAsync("open", [target]);
+	}
+	if (process.platform === "win32") {
+		return spawnAsync("cmd", ["/c", "start", "", target]);
+	}
+	return spawnAsync("xdg-open", [target]);
+}
+
+/** Reveals a path in the OS file manager, selecting it where supported. */
+function revealInFileManager(targetPath: string): Promise<void> {
+	if (process.platform === "darwin") {
+		return spawnAsync("open", ["-R", targetPath]);
+	}
+	if (process.platform === "win32") {
+		return spawnAsync("explorer", [`/select,${targetPath}`]);
+	}
+	// Linux file managers have no universal "reveal & select"; open the
+	// containing directory instead.
+	return openWithOsDefault(targetPath);
+}
+
+/** Allowlisted URL schemes, mirroring the desktop's safe-url guard. */
+const SAFE_URL_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+function isSafeExternalUrl(input: string): boolean {
+	try {
+		return SAFE_URL_SCHEMES.has(new URL(input).protocol);
+	} catch {
+		return false;
+	}
+}
+
+export const externalRouter = router({
+	openInApp: localOnlyProcedure
+		.input(
+			z.object({
+				path: z.string(),
+				app: ExternalAppSchema,
+				projectId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input }) => {
+			if (!input.path.startsWith("/") && !/^[a-zA-Z]:[\\/]/.test(input.path)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `openInApp requires an absolute path (got ${JSON.stringify(input.path)}).`,
+				});
+			}
+
+			if (input.app === "finder") {
+				await revealInFileManager(input.path);
+				return;
+			}
+
+			const candidates = getAppCommand(input.app, input.path);
+			if (!candidates) {
+				await openWithOsDefault(input.path);
+				return;
+			}
+
+			let lastError: Error | undefined;
+			for (const cmd of candidates) {
+				try {
+					await spawnAsync(cmd.command, cmd.args);
+					return;
+				} catch (error) {
+					lastError = error instanceof Error ? error : new Error(String(error));
+				}
+			}
+			if (lastError) {
+				throw lastError;
+			}
+		}),
+
+	openInFinder: localOnlyProcedure
+		.input(z.string())
+		.mutation(async ({ input }) => {
+			await revealInFileManager(input);
+		}),
+
+	openUrl: localOnlyProcedure.input(z.string()).mutation(async ({ input }) => {
+		if (!isSafeExternalUrl(input)) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "URL scheme not allowed",
+			});
+		}
+		await openWithOsDefault(input);
+	}),
+});

--- a/packages/host-service/src/trpc/router/external/helpers.ts
+++ b/packages/host-service/src/trpc/router/external/helpers.ts
@@ -1,0 +1,401 @@
+// Editor / external-app launch logic, mirrored from the desktop's
+// `apps/desktop/src/lib/trpc/routers/external/helpers.ts`. Kept as a local copy
+// because that module lives in `apps/desktop` (not importable by packages) and
+// pulls in Electron. Everything here is pure Node — no Electron. See the
+// host-service `external` router for why this exists (misrouted `external.*`
+// IPC calls land on the host service).
+import { spawn } from "node:child_process";
+import nodePath from "node:path";
+import type { ExternalApp } from "@superset/local-db/schema/zod";
+
+/** Map of app IDs to their macOS application names */
+const MACOS_APP_NAMES: Record<ExternalApp, string | null> = {
+	finder: null, // Handled specially with shell.showItemInFolder
+	vscode: "Visual Studio Code",
+	"vscode-insiders": "Visual Studio Code - Insiders",
+	cursor: "Cursor",
+	antigravity: "Antigravity",
+	devin: "Devin",
+	zed: "Zed",
+	xcode: "Xcode",
+	iterm: "iTerm",
+	warp: "Warp",
+	terminal: "Terminal",
+	ghostty: "Ghostty",
+	sublime: "Sublime Text",
+	intellij: null, // Multi-edition, uses bundle IDs
+	webstorm: "WebStorm",
+	pycharm: null, // Multi-edition, uses bundle IDs
+	phpstorm: "PhpStorm",
+	rubymine: "RubyMine",
+	goland: "GoLand",
+	clion: "CLion",
+	rider: "Rider",
+	datagrip: "DataGrip",
+	appcode: "AppCode",
+	fleet: "Fleet",
+	rustrover: "RustRover",
+	"android-studio": "Android Studio",
+};
+
+/**
+ * Bundle ID candidates for JetBrains IDEs with multiple editions.
+ * `open -b <bundleId>` works regardless of the .app display name,
+ * so "IntelliJ IDEA Ultimate.app" and "IntelliJ IDEA CE.app" both resolve correctly.
+ */
+const BUNDLE_ID_CANDIDATES: Partial<Record<ExternalApp, string[]>> = {
+	intellij: ["com.jetbrains.intellij", "com.jetbrains.intellij.ce"],
+	pycharm: ["com.jetbrains.pycharm", "com.jetbrains.pycharm.ce"],
+};
+
+/** Map of app IDs to their Linux CLI commands */
+const LINUX_CLI_COMMANDS: Record<ExternalApp, string | null> = {
+	finder: null, // Handled specially with shell.showItemInFolder
+	vscode: "code",
+	"vscode-insiders": "code-insiders",
+	cursor: "cursor",
+	antigravity: "antigravity",
+	devin: "devin-desktop",
+	zed: "zed",
+	xcode: null, // macOS only
+	iterm: null, // macOS only
+	warp: "warp-terminal",
+	terminal: null, // No universal Linux terminal command
+	ghostty: "ghostty",
+	sublime: "subl",
+	intellij: null, // Multi-edition, uses CLI candidates
+	webstorm: "webstorm",
+	pycharm: null, // Multi-edition, uses CLI candidates
+	phpstorm: "phpstorm",
+	rubymine: "rubymine",
+	goland: "goland",
+	clion: "clion",
+	rider: "rider",
+	datagrip: "datagrip",
+	appcode: null, // macOS only
+	fleet: "fleet",
+	rustrover: "rustrover",
+	"android-studio": "studio",
+};
+
+/**
+ * CLI command candidates for JetBrains IDEs with multiple editions on Linux.
+ * JetBrains Toolbox typically creates `idea`/`pycharm` launchers,
+ * while package managers may use edition-specific names.
+ */
+const LINUX_CLI_CANDIDATES: Partial<Record<ExternalApp, string[]>> = {
+	intellij: ["idea", "intellij-idea-ultimate", "intellij-idea-community"],
+	pycharm: ["pycharm", "pycharm-professional", "pycharm-community"],
+};
+
+/**
+ * IntelliJ-platform JetBrains IDEs. On macOS these must receive the target as
+ * a launcher CLI argument (`open -n ... --args <path>`) rather than as an
+ * "open document" Apple event (`open -a/-b <path>`); otherwise an already
+ * running instance just reopens its last project — e.g. the base repo instead
+ * of the git worktree (#5090). The native launcher detects a running instance
+ * and routes the open-project request to it, so `-n` doesn't spawn a duplicate
+ * IDE. Fleet is excluded — it ships a different launcher with its own CLI.
+ */
+const JETBRAINS_APPS = new Set<ExternalApp>([
+	"intellij",
+	"webstorm",
+	"pycharm",
+	"phpstorm",
+	"rubymine",
+	"goland",
+	"clion",
+	"rider",
+	"datagrip",
+	"appcode",
+	"rustrover",
+	"android-studio",
+]);
+
+/**
+ * Get candidate commands to open a path in the specified app.
+ * Returns an array of commands to try in order — for multi-edition apps (IntelliJ, PyCharm),
+ * multiple candidates are returned so the caller can fall back if one isn't installed.
+ *
+ * macOS: Uses `open -b` (bundle ID) for multi-edition apps and `open -a` (app name) for others.
+ *        JetBrains IDEs additionally get `-n ... --args <path>` so the path is opened as a
+ *        project rather than ignored by an already-running instance (#5090).
+ * Linux: Uses direct CLI commands (e.g. `code`, `cursor`, `zed`).
+ */
+export function getAppCommand(
+	app: ExternalApp,
+	targetPath: string,
+	platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] }[] | null {
+	if (platform === "darwin") {
+		const isJetBrains = JETBRAINS_APPS.has(app);
+
+		const bundleIds = BUNDLE_ID_CANDIDATES[app];
+		if (bundleIds) {
+			return bundleIds.map((id) => ({
+				command: "open",
+				args: isJetBrains
+					? ["-n", "-b", id, "--args", targetPath]
+					: ["-b", id, targetPath],
+			}));
+		}
+
+		const appName = MACOS_APP_NAMES[app];
+		if (!appName) return null;
+		return [
+			{
+				command: "open",
+				args: isJetBrains
+					? ["-n", "-a", appName, "--args", targetPath]
+					: ["-a", appName, targetPath],
+			},
+		];
+	}
+
+	// Linux (and other non-macOS platforms)
+	const linuxCandidates = LINUX_CLI_CANDIDATES[app];
+	if (linuxCandidates) {
+		return linuxCandidates.map((cmd) => ({
+			command: cmd,
+			args: [targetPath],
+		}));
+	}
+
+	const cliCommand = LINUX_CLI_COMMANDS[app];
+	if (!cliCommand) return null;
+	return [{ command: cliCommand, args: [targetPath] }];
+}
+
+/**
+ * Wrapper characters that can surround paths.
+ * These are pairs of [open, close] characters.
+ */
+const PATH_WRAPPERS: [string, string][] = [
+	['"', '"'],
+	["'", "'"],
+	["`", "`"],
+	["(", ")"],
+	["[", "]"],
+	["<", ">"],
+];
+
+/**
+ * Trailing punctuation that can appear after paths in sentences.
+ * These are stripped unless they're part of a valid suffix (extension, line:col).
+ */
+const TRAILING_PUNCTUATION = /[.,;:!?]+$/;
+
+/**
+ * Check if a string looks like a file path.
+ * A path typically contains forward slashes, or starts with ., ~, or /
+ */
+function looksLikePath(str: string): boolean {
+	return (
+		str.includes("/") ||
+		str.startsWith(".") ||
+		str.startsWith("~") ||
+		str.startsWith("/")
+	);
+}
+
+/**
+ * Extract a path from within brackets/parentheses when there's adjacent text.
+ * Handles patterns like:
+ *   "text(src/file.ts)more" -> "src/file.ts"
+ *   "see (path/to/file) here" -> "path/to/file"
+ *   "in [src/file.ts:42]" -> "src/file.ts:42"
+ *
+ * Returns the original string if no embedded path is found.
+ */
+function extractEmbeddedPath(input: string): string {
+	const bracketPairs: [string, string][] = [
+		["(", ")"],
+		["[", "]"],
+		["<", ">"],
+	];
+
+	for (const [open, close] of bracketPairs) {
+		const openIdx = input.indexOf(open);
+		const closeIdx = input.lastIndexOf(close);
+
+		if (openIdx !== -1 && closeIdx > openIdx) {
+			const hasTextBefore = openIdx > 0;
+			const hasTextAfter = closeIdx < input.length - 1;
+
+			if (hasTextBefore || hasTextAfter) {
+				const content = input.slice(openIdx + 1, closeIdx);
+				if (looksLikePath(content)) {
+					return content;
+				}
+			}
+		}
+	}
+
+	return input;
+}
+
+/**
+ * Strip trailing punctuation from a path, but preserve valid suffixes.
+ * - Preserves file extensions like .ts, .json
+ * - Preserves line:col suffixes like :42 or :42:10
+ * - Strips sentence punctuation like trailing period, comma, etc.
+ */
+function stripTrailingPunctuation(path: string): string {
+	const match = path.match(TRAILING_PUNCTUATION);
+	if (!match) return path;
+
+	const punct = match[0];
+	const beforePunct = path.slice(0, -punct.length);
+
+	// Don't strip if it looks like a file extension (e.g., "file.ts")
+	if (punct === "." || punct.startsWith(".")) {
+		const extMatch = beforePunct.match(/\.[a-zA-Z0-9]{1,10}$/);
+		if (extMatch) {
+			return beforePunct;
+		}
+		// e.g., path ends with ".ts." - strip just the final "."
+		if (/^\.[a-zA-Z0-9]{1,10}\.$/.test(punct)) {
+			return path.slice(0, -1);
+		}
+	}
+
+	// Don't strip colons followed by digits (line numbers like :42)
+	if (punct === ":") {
+		return beforePunct;
+	}
+	if (punct.startsWith(":") && /^:\d/.test(punct)) {
+		return path;
+	}
+
+	return beforePunct;
+}
+
+/**
+ * Strip matching wrapper characters and trailing punctuation from a path.
+ * Handles nested wrappers and multiple layers of wrapping.
+ * Examples:
+ *   "(path/to/file)" -> "path/to/file"
+ *   '"path/to/file"' -> "path/to/file"
+ *   "'(path/to/file)'" -> "path/to/file"
+ *   "./path/file.ts." -> "./path/file.ts"
+ *   '"./path/file.ts",' -> "./path/file.ts"
+ *   "path/to/file" -> "path/to/file" (unchanged)
+ */
+export function stripPathWrappers(filePath: string): string {
+	let result = filePath.trim();
+
+	// First, try to extract embedded paths from patterns like "text(path)more"
+	result = extractEmbeddedPath(result);
+
+	let changed = true;
+	while (changed && result.length > 0) {
+		changed = false;
+
+		const withoutPunct = stripTrailingPunctuation(result);
+		if (withoutPunct !== result) {
+			result = withoutPunct;
+			changed = true;
+			continue;
+		}
+
+		for (const [open, close] of PATH_WRAPPERS) {
+			if (result.startsWith(open) && result.endsWith(close)) {
+				result = result.slice(1, -1);
+				changed = true;
+				break;
+			}
+		}
+	}
+
+	return result;
+}
+
+export class RelativePathWithoutCwdError extends Error {
+	readonly originalPath: string;
+	constructor(originalPath: string) {
+		super(
+			`resolvePath received a relative path (${JSON.stringify(originalPath)}) without a cwd. ` +
+				"Pass an absolute path, or supply cwd (e.g. the workspace worktreePath). " +
+				"Falling back to process.cwd() would resolve against Electron's working directory and silently produce wrong paths.",
+		);
+		this.name = "RelativePathWithoutCwdError";
+		this.originalPath = originalPath;
+	}
+}
+
+/**
+ * Resolve a path by expanding ~ and converting relative paths to absolute.
+ * Also handles file:// URLs by converting them to regular file paths.
+ * Strips wrapping characters like quotes, parentheses, brackets, etc.
+ *
+ * Throws `RelativePathWithoutCwdError` if the input resolves to a relative
+ * path and no `cwd` was supplied — callers must be explicit about what
+ * relative paths are relative to. (A silent `process.cwd()` fallback would
+ * point at Electron's working directory, not the workspace.)
+ */
+export function resolvePath(filePath: string, cwd?: string): string {
+	let resolved = stripPathWrappers(filePath);
+
+	if (resolved.startsWith("file://")) {
+		try {
+			const url = new URL(resolved);
+			resolved = decodeURIComponent(url.pathname);
+		} catch {
+			// If URL parsing fails, try simple prefix removal
+			resolved = decodeURIComponent(resolved.replace(/^file:\/\//, ""));
+		}
+	}
+
+	if (resolved.startsWith("~")) {
+		const home = process.env.HOME || process.env.USERPROFILE;
+		if (home) {
+			resolved = resolved.replace(/^~/, home);
+		}
+	}
+
+	if (!nodePath.isAbsolute(resolved)) {
+		if (!cwd) throw new RelativePathWithoutCwdError(filePath);
+		resolved = nodePath.resolve(cwd, resolved);
+	}
+
+	return resolved;
+}
+
+/**
+ * Spawns a process and waits for it to complete.
+ * @throws Error if the process exits with non-zero code or fails to spawn
+ */
+export function spawnAsync(command: string, args: string[]): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			stdio: ["ignore", "ignore", "pipe"],
+			detached: false,
+		});
+
+		let stderr = "";
+		child.stderr?.on("data", (data) => {
+			stderr += data.toString();
+		});
+
+		child.on("error", (error) => {
+			reject(
+				new Error(
+					`Failed to spawn '${command}': ${error.message}. Ensure the application is installed.`,
+				),
+			);
+		});
+
+		child.on("exit", (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				const stderrMessage = stderr.trim();
+				reject(
+					new Error(stderrMessage || `'${command}' exited with code ${code}`),
+				);
+			}
+		});
+	});
+}
+
+export type { ExternalApp };

--- a/packages/host-service/src/trpc/router/router.ts
+++ b/packages/host-service/src/trpc/router/router.ts
@@ -6,6 +6,7 @@ import { authRouter } from "./auth";
 import { chatRouter } from "./chat";
 import { cloudRouter } from "./cloud";
 import { configRouter } from "./config";
+import { externalRouter } from "./external/external";
 import { filesystemRouter } from "./filesystem";
 import { gitRouter } from "./git";
 import { githubRouter } from "./github";
@@ -33,6 +34,7 @@ export const appRouter = router({
 	host: hostRouter,
 	chat: chatRouter,
 	config: configRouter,
+	external: externalRouter,
 	filesystem: filesystemRouter,
 	git: gitRouter,
 	github: githubRouter,


### PR DESCRIPTION
## Problem

On shipped builds, the "Open in app" button / `CMD+O` fail with:

```
Failed to open: No procedure found on path "external.openInApp"
```

(#5850, #5893). The renderer calls `external.openInApp` through the Electron-IPC client typed to the desktop `AppRouter`, but in the running build that call is serviced by the **host service** rather than the desktop main process. The host-service router has no `external` key, so it throws `No procedure found on path "external.openInApp"`. The error string is emitted only by the host-service tRPC stack, confirming that's where the call lands.

The misroute is a transport-level issue that isn't visible in the renderer source (every `external.*` call site uses `ipcLink`), which is why it hasn't been reproducible from source alone. Users confirm it still reproduces on the current stable, on **local** project dashboards.

## Solution

Add a locality-guarded `external` router to the host service so the misrouted call succeeds — but only when the host is the caller's own machine (`ctx.clientMachineId === getHostId()`, the same equality the desktop uses for `isLocalWorkspace`). For a remote host these actions are meaningless (they'd open an editor on the server), so they reject with `PRECONDITION_FAILED` instead of doing the wrong thing.

- Scope limited to the reported actions: `openInApp`, `openInFinder`, `openUrl`.
- Launch logic is pure Node (`open` / `xdg-open` / `explorer`) — no Electron; the `no-electron-coupling` guard still passes.
- The desktop path is untouched.

This is a **mitigation**, not the root-cause fix. The correct fix belongs on the desktop transport so `external.*` always reaches the main-process router; this makes the local case work in the meantime and stays safe for remote hosts.

## Verification

- `bun run typecheck` (host-service) — clean
- `biome check` — clean
- `bun run build:host` — bundles; `openInApp` now present in `dist/host-service.js`
- New tests (`external.test.ts`, 4 cases): guard rejects remote / missing machine id; rejects relative paths and disallowed URL schemes
- Existing `no-electron-coupling` test still passes

## Related

- Fixes the break reported in #5850 (@grubenovitchupgrade) and #5893 (@bvidakovic).
- @bvidakovic did the detailed asar trace that pinned the host-service ↔ desktop routing seam; this PR builds directly on that analysis.
- @david-velasquez-v also confirmed the repro on current stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “external” action set to open files in external apps and reveal them in the system file manager.
  * Added support for opening approved external links (HTTP, HTTPS, mailto) with validated input.
  * Improved handling for file paths including file URLs, home-directory shortcuts, wrapped paths, and `:line[:col]` references.
* **Bug Fixes**
  * Restricted external actions to the local host only, preventing mismatched or missing machine context.
  * Blocked unsafe URL schemes and invalid relative paths.
* **Tests**
  * Added coverage for external action authorization and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->