### PR TITLE
feat(desktop): add Appearance setting to show the Workspaces sidebar tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -40,9 +40,7 @@ import {
 	useOpenTemplateGalleryModal,
 } from "renderer/stores/add-repository-modal";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
-
-// Temporarily hidden, not removed — flip to true to restore the Workspaces tab.
-const SHOW_WORKSPACES_TAB = false;
+import { useIsWorkspacesTabVisible } from "renderer/stores/sidebar-workspaces-tab";
 
 interface DashboardSidebarHeaderProps {
 	isCollapsed?: boolean;
@@ -54,6 +52,7 @@ export function DashboardSidebarHeader({
 	const openModal = useOpenNewWorkspaceModal();
 	const openNewProject = useOpenNewProjectModal();
 	const openTemplateGallery = useOpenTemplateGalleryModal();
+	const showWorkspacesTab = useIsWorkspacesTabVisible();
 	const navigate = useNavigate();
 	const folderImport = useFolderFirstImport({
 		onError: (message) => {
@@ -171,7 +170,7 @@ export function DashboardSidebarHeader({
 					</TooltipContent>
 				</Tooltip>
 
-				{SHOW_WORKSPACES_TAB && (
+				{showWorkspacesTab && (
 					<Tooltip delayDuration={300}>
 						<TooltipTrigger asChild>
 							<button
@@ -351,7 +350,7 @@ export function DashboardSidebarHeader({
 				)}
 			</button>
 
-			{SHOW_WORKSPACES_TAB && (
+			{showWorkspacesTab && (
 				<button
 					type="button"
 					onClick={handleWorkspacesClick}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
@@ -7,6 +7,7 @@ import {
 import { FontSettingSection } from "./components/FontSettingSection";
 import { MarkdownStyleSection } from "./components/MarkdownStyleSection";
 import { ThemeSection } from "./components/ThemeSection";
+import { WorkspacesTabSection } from "./components/WorkspacesTabSection";
 
 /**
  * Renders a list of visible sections with automatic border separators.
@@ -49,6 +50,10 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 		SETTING_ITEM_ID.APPEARANCE_CUSTOM_THEMES,
 		visibleItems,
 	);
+	const showWorkspacesTab = isItemVisible(
+		SETTING_ITEM_ID.APPEARANCE_WORKSPACES_TAB,
+		visibleItems,
+	);
 	const showThemeSection = showTheme || showCustomThemes;
 
 	return (
@@ -69,6 +74,7 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 				{showTerminalFont && (
 					<FontSettingSection key="terminal-font" variant="terminal" />
 				)}
+				{showWorkspacesTab && <WorkspacesTabSection key="workspaces-tab" />}
 			</SectionList>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/WorkspacesTabSection/WorkspacesTabSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/WorkspacesTabSection/WorkspacesTabSection.tsx
@@ -1,0 +1,30 @@
+import { Label } from "@superset/ui/label";
+import { Switch } from "@superset/ui/switch";
+import {
+	useIsWorkspacesTabVisible,
+	useSetWorkspacesTabVisible,
+} from "renderer/stores/sidebar-workspaces-tab";
+
+export function WorkspacesTabSection() {
+	const isVisible = useIsWorkspacesTabVisible();
+	const setVisible = useSetWorkspacesTabVisible();
+
+	return (
+		<div className="flex items-center justify-between">
+			<div className="space-y-0.5">
+				<Label htmlFor="show-workspaces-tab" className="text-sm font-medium">
+					Show Workspaces tab
+				</Label>
+				<p className="text-xs text-muted-foreground">
+					Add a Workspaces entry to the sidebar that opens the full workspace
+					list. It is also reachable from the command palette.
+				</p>
+			</div>
+			<Switch
+				id="show-workspaces-tab"
+				checked={isVisible}
+				onCheckedChange={setVisible}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/WorkspacesTabSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/WorkspacesTabSection/index.ts
@@ -1,0 +1,1 @@
+export { WorkspacesTabSection } from "./WorkspacesTabSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -20,6 +20,7 @@ export const SETTING_ITEM_ID = {
 	APPEARANCE_CUSTOM_THEMES: "appearance-custom-themes",
 	APPEARANCE_EDITOR_FONT: "appearance-editor-font",
 	APPEARANCE_TERMINAL_FONT: "appearance-terminal-font",
+	APPEARANCE_WORKSPACES_TAB: "appearance-workspaces-tab",
 
 	RINGTONES_NOTIFICATION: "ringtones-notification",
 
@@ -132,6 +133,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.APPEARANCE_CUSTOM_THEMES]: "shared",
 	[SETTING_ITEM_ID.APPEARANCE_EDITOR_FONT]: "shared",
 	[SETTING_ITEM_ID.APPEARANCE_TERMINAL_FONT]: "shared",
+	[SETTING_ITEM_ID.APPEARANCE_WORKSPACES_TAB]: "v2",
 
 	[SETTING_ITEM_ID.RINGTONES_NOTIFICATION]: "shared",
 
@@ -410,6 +412,23 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"display",
 			"md",
 			"readme",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.APPEARANCE_WORKSPACES_TAB,
+		section: "appearance",
+		title: "Show Workspaces Tab",
+		description: "Show a Workspaces entry in the sidebar",
+		keywords: [
+			"appearance",
+			"workspaces",
+			"tab",
+			"sidebar",
+			"nav",
+			"navigation",
+			"show",
+			"hide",
+			"list",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/stores/sidebar-workspaces-tab.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-workspaces-tab.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+interface SidebarWorkspacesTabState {
+	isVisible: boolean;
+	setVisible: (isVisible: boolean) => void;
+}
+
+export const useSidebarWorkspacesTabStore = create<SidebarWorkspacesTabState>()(
+	devtools(
+		persist(
+			(set) => ({
+				isVisible: false,
+				setVisible: (isVisible) => {
+					set({ isVisible });
+				},
+			}),
+			{ name: "sidebar-workspaces-tab" },
+		),
+		{ name: "SidebarWorkspacesTabStore" },
+	),
+);
+
+export const useIsWorkspacesTabVisible = () =>
+	useSidebarWorkspacesTabStore((state) => state.isVisible);
+export const useSetWorkspacesTabVisible = () =>
+	useSidebarWorkspacesTabStore((state) => state.setVisible);


### PR DESCRIPTION
## Summary

The Workspaces sidebar entry is gated behind a hardcoded constant, so today the `/v2-workspaces` list is reachable only through the command palette. This replaces the constant with a persisted, device-local preference and surfaces it as an **Appearance → Show Workspaces tab** toggle.

**The default is `false`, so nothing changes for anyone unless they turn it on.** This is deliberate — the tab was hidden on purpose in the sidebar/header reorg, and this PR is not trying to relitigate that. It just gives users who relied on the entry point a supported way back, instead of it being unreachable in a shipped build.

Closes #5881.

## Motivation

Reported in #5881. `apps/desktop/plans/20260721-sidebar-header-reorg-notes.md` records the intent:

> **Workspaces tab hidden, not deleted** — `SHOW_WORKSPACES_TAB = false` flag; flip to true to restore.

That flag is a build-time constant, so "flip to true to restore" isn't available to anyone running a released build — it requires compiling from source. Since the const is module-scope and the guards are `{FLAG && …}`, both blocks are constant-folded out of the production bundle entirely, so there is no in-app or patch-level workaround either. A one-bit device preference seemed like the smallest thing that closes that gap without touching the default.

## How it works

- New `sidebar-workspaces-tab` store (persisted zustand, `renderer/stores/`), mirroring the existing `sidebar-workspaces-collapse` sidebar store.
- `DashboardSidebarHeader` reads it in place of the constant. Both gated blocks — collapsed rail and expanded row — are otherwise **untouched**.
- Registered in settings-search as `APPEARANCE_WORKSPACES_TAB`, variant `v2` (the `/v2-workspaces` route is a v2 concept).
- Rendered as an Appearance section, following `MarkdownStyleSection`.

Nothing behind the gate changed: `handleWorkspacesClick` and the `/v2-workspaces` route were already live and are what the command palette already navigates to.

### Why renderer-side and not the `settings` table

#5303 used the local-db tier for a comparable sidebar toggle (schema column + migration + tRPC procedures — 9 files, ~1.6k lines with the drizzle snapshot). This is purely device-local renderer UI state with no main-process consumer, so it follows the lighter `MarkdownStyleSection`/`markdown-preferences` pattern instead: no migration, no IPC. Happy to move it to the settings table if you'd rather have it alongside the other behaviour toggles — it's a contained change.

## Testing

- `biome check` on all changed files — clean.
- `tsc --noEmit` for `apps/desktop`: **69 errors before, 69 after, none in the changed files.** The pre-existing errors are all missing-`routeTree.gen.ts` route-id errors from not having run codegen locally.
- `bun test settings-search.test.ts` — 8 pass / 0 fail.

**No screenshot, and I want to be upfront about why** rather than leave it implied: `bun install` fails on this machine at the `@electron/rebuild` step for `native-keymap` (headless Linux, no X11 headers), so I could not launch the desktop app. What limits the visual risk is that this PR adds no new sidebar markup — the restored button JSX is exactly the markup already in the file, and the settings row reuses the `Switch` + `Label` pattern from `BehaviorSettings` verbatim. Glad to add a capture if a maintainer wants one before merging.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Appearance toggle to show the Workspaces tab in the sidebar, replacing the build-time flag with a device-local setting. Default is off, so existing behavior is unchanged; users can enable it to access the `/v2-workspaces` list from the sidebar. Addresses #5881.

- **New Features**
  - Added persisted `zustand` store `sidebar-workspaces-tab` for visibility state.
  - Added Appearance → “Show Workspaces tab” switch; registered as `APPEARANCE_WORKSPACES_TAB` (variant `v2`) in settings search.
  - Sidebar header now reads the store to conditionally render the Workspaces entry; no route or handler changes.

<sup>Written for commit e33f6325ed7d3ab6ce091b7b36773016bb298456. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Appearance setting to show or hide the Workspaces tab.
  * The Workspaces tab visibility preference is saved and applied throughout the sidebar.
  * Added the setting to Appearance search results with descriptive help text.
  * Sidebar layouts now consistently reflect the selected visibility preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->