### PR TITLE
fix(marketing): header breakpoint cleanup + tighter hero copy

### DIFF
--- a/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -28,7 +28,7 @@ export function DownloadButton({
 			? "px-2 sm:px-4 py-2 text-sm"
 			: "px-3 sm:px-6 py-2 sm:py-3 text-sm sm:text-base";
 
-	const buttonClasses = `bg-foreground text-background ${sizeClasses} font-normal hover:opacity-90 transition-opacity flex items-center gap-2 ${className}`;
+	const buttonClasses = `bg-foreground text-background ${sizeClasses} font-normal hover:opacity-90 transition-opacity flex items-center gap-2 whitespace-nowrap shrink-0 ${className}`;
 
 	const goToInterstitial = () => {
 		track("download_clicked");

--- a/apps/marketing/src/app/components/Header/Header.tsx
+++ b/apps/marketing/src/app/components/Header/Header.tsx
@@ -35,15 +35,15 @@ export function Header({ ctaButtons, starCounter }: HeaderProps) {
 					</motion.div>
 
 					<motion.div
-						className="hidden md:flex items-center gap-4"
+						className="hidden lg:flex items-center gap-4"
 						initial={{ opacity: 0 }}
 						animate={{ opacity: 1 }}
 						transition={{ duration: 0.3, delay: 0.1 }}
 					>
 						<DesktopNav />
-						<div className="h-4 w-px bg-border" />
-						{starCounter}
-						<div className="flex items-center gap-2">{ctaButtons}</div>
+						<div className="hidden xl:block h-4 w-px bg-border" />
+						<div className="hidden xl:block">{starCounter}</div>
+						<div className="flex items-center gap-2 shrink-0">{ctaButtons}</div>
 					</motion.div>
 
 					<MobileNav ctaButtons={ctaButtons} starCounter={starCounter} />

--- a/apps/marketing/src/app/components/Header/components/MobileNav/MobileNav.tsx
+++ b/apps/marketing/src/app/components/Header/components/MobileNav/MobileNav.tsx
@@ -21,7 +21,10 @@ export function MobileNav({ ctaButtons, starCounter }: MobileNavProps) {
 	const close = () => setIsOpen(false);
 
 	return (
-		<div className="md:hidden">
+		<div className="lg:hidden flex items-center gap-2">
+			<div className="hidden sm:flex items-center gap-2 shrink-0">
+				{ctaButtons}
+			</div>
 			<button
 				type="button"
 				className="p-2 text-muted-foreground hover:text-foreground transition-colors"

--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -23,7 +23,7 @@ interface HeroCopy {
 }
 
 const TEST_SUBHEADLINE =
-	"Isolated workspaces for Claude Code, Codex, and any CLI agent — run them side by side and review every change from one dashboard. Free to start.";
+	"Isolated workspaces for Claude Code, Codex, and any CLI agent. Review every change from one dashboard. Free to start.";
 
 const HERO_COPY = {
 	control: {
@@ -70,7 +70,7 @@ export function HeroSection() {
 					<div className="flex flex-col items-center text-center">
 						<div className="space-y-4 sm:space-y-6">
 							<h1
-								className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-medium tracking-tight leading-[1.1] text-foreground relative"
+								className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-medium tracking-tight leading-[1.1] text-foreground relative max-w-6xl mx-auto"
 								style={{
 									fontFamily: "var(--font-ibm-plex-mono), monospace",
 								}}


### PR DESCRIPTION
## Breakpoint audit

The header's content (logo + 5 nav items + stars + Dashboard + CTA) needs ~1,100px, but the desktop nav activated at `md` (768px) — everything between 768 and ~1,150px was crushed, and the Download CTA wrapped to two lines.

| Range | Before | After |
|---|---|---|
| < 640 | hamburger only | hamburger only (unchanged) |
| 640–1023 | crushed desktop nav | hamburger + inline Download CTA (+ Dashboard when signed in) |
| 1024–1279 | crushed, CTA wrapping | full nav, no star counter, CTA intact |
| 1280+ | occasionally wrapping CTA | everything, CTA can never wrap (`whitespace-nowrap shrink-0`) |

## Hero

- Headline capped at `max-w-6xl` — ultrawide viewports get two balanced lines instead of a ~1,900px strip.
- capability-mac subheadline shortened 154 → 118 chars: "Isolated workspaces for Claude Code, Codex, and any CLI agent. Review every change from one dashboard. Free to start."

## ⚠️ Experiment note

The subheadline + headline-width changes alter the `landing-hero-positioning` treatment presentation mid-flight (second stimulus change after the bootstrap deploy). The experiment's exposure window should be reset once this deploys so the analysis covers a single consistent stimulus.

Verify visually on the Vercel preview at 640 / 768 / 1024 / 1280 / 1600 / 1920 widths.

`bun run lint` + `turbo typecheck --filter=@superset/marketing` clean.

https://claude.ai/code/session_013HwZR8BoCF3QBis8b3x7pm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes header breakpoints to prevent nav/CTA overlap and improves hero readability on wide screens. The Download CTA now stays visible and never wraps.

- **Bug Fixes**
  - Desktop nav now activates at `lg` (1024px); mobile hamburger remains below `lg`.
  - Download CTA shows inline from `sm` and never wraps (`whitespace-nowrap shrink-0`).
  - Star counter only renders at `xl` (1280px+); divider/star hidden on `lg` to preserve space.
  - Hero: cap headline at `max-w-6xl`; shorten capability-mac subheadline copy.

- **Migration**
  - Reset the `landing-hero-positioning` experiment exposure window after deploy.

<sup>Written for commit f35890e4cf71c36687374db7079ee6f802e7b088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

