### PR TITLE
feat(desktop): create blank projects from Superset

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/modules/addProject/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/addProject/commands.tsx
@@ -1,4 +1,9 @@
-import { FolderInputIcon, LayoutTemplateIcon, PlusIcon } from "lucide-react";
+import {
+	FolderInputIcon,
+	FolderPlusIcon,
+	LayoutTemplateIcon,
+	PlusIcon,
+} from "lucide-react";
 import { useAddRepositoryModalStore } from "renderer/stores/add-repository-modal";
 import { useFolderImportIntent } from "renderer/stores/folder-import-intent";
 import type { Command, CommandProvider } from "../../core/types";
@@ -7,6 +12,16 @@ export const addProjectProvider: CommandProvider = {
 	id: "add-project",
 	provide: () => {
 		const commands: Command[] = [
+			{
+				id: "addProject.createNew",
+				title: "Create new project",
+				section: "add-project",
+				icon: FolderPlusIcon,
+				keywords: ["add project", "new", "blank", "empty", "folder", "init"],
+				run: () => {
+					void useAddRepositoryModalStore.getState().openEmptyProject();
+				},
+			},
 			{
 				id: "addProject.cloneFromUrl",
 				title: "Clone from URL",

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -13,10 +13,11 @@ import { toast } from "@superset/ui/sonner";
 import { useEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenProject } from "renderer/react-query/projects";
-import { useOpenNewProjectModal } from "renderer/stores/add-repository-modal";
+import { useOpenEmptyProjectModal } from "renderer/stores/add-repository-modal";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
+	useOpenNewWorkspaceModal,
 	usePreSelectedProjectId,
 } from "renderer/stores/new-workspace-modal";
 import { NewWorkspaceModalContent } from "./components/NewWorkspaceModalContent";
@@ -46,7 +47,8 @@ export function NewWorkspaceModal() {
 	const isOpen = useNewWorkspaceModalOpen();
 	const closeModal = useCloseNewWorkspaceModal();
 	const { openNew } = useOpenProject();
-	const openNewProject = useOpenNewProjectModal();
+	const openEmptyProject = useOpenEmptyProjectModal();
+	const openNewWorkspace = useOpenNewWorkspaceModal();
 	const preSelectedProjectId = usePreSelectedProjectId();
 
 	// Prevents AgentSelect from flashing "No agent" while presets load after refresh.
@@ -64,9 +66,10 @@ export function NewWorkspaceModal() {
 		}
 	};
 
-	const handleNewProject = () => {
+	const handleNewProject = async () => {
 		closeModal();
-		openNewProject();
+		const result = await openEmptyProject();
+		if (result) openNewWorkspace(result.projectId);
 	};
 
 	return (

--- a/apps/desktop/src/renderer/react-query/projects/useCreateV1Project.ts
+++ b/apps/desktop/src/renderer/react-query/projects/useCreateV1Project.ts
@@ -7,33 +7,59 @@ interface CloneInput {
 	parentDir: string;
 }
 
+interface EmptyProjectInput {
+	name: string;
+	parentDir: string;
+	onError?: (message: string) => void;
+}
+
+type CreateProjectMutationResult =
+	| { success: true; project: { id: string } }
+	| { success: false; error?: string };
+
 export function useCreateV1Project() {
 	const cloneRepo = electronTrpc.projects.cloneRepo.useMutation();
+	const createEmptyRepo = electronTrpc.projects.createEmptyRepo.useMutation();
 	const utils = electronTrpc.useUtils();
 
-	const cloneFromUrl = useCallback(
-		async ({ url, parentDir }: CloneInput): Promise<string | null> => {
+	const runCreate = useCallback(
+		async (
+			create: () => Promise<CreateProjectMutationResult>,
+			onError?: (message: string) => void,
+		): Promise<string | null> => {
+			const reportError = (message: string) => {
+				if (onError) {
+					onError(message);
+					return;
+				}
+				toast.error("Could not create project", { description: message });
+			};
+
 			try {
-				const result = await cloneRepo.mutateAsync({
-					url,
-					targetDirectory: parentDir,
-				});
+				const result = await create();
 				if (!result.success) {
-					toast.error("Could not create project", {
-						description: result.error,
-					});
+					reportError(result.error ?? "An unknown error occurred");
 					return null;
 				}
 				await utils.projects.getRecents.invalidate();
 				return result.project.id;
 			} catch (err) {
-				toast.error("Could not create project", {
-					description: err instanceof Error ? err.message : String(err),
-				});
+				reportError(err instanceof Error ? err.message : String(err));
 				return null;
 			}
 		},
-		[cloneRepo, utils],
+		[utils],
+	);
+
+	const cloneFromUrl = useCallback(
+		({ url, parentDir }: CloneInput): Promise<string | null> =>
+			runCreate(() =>
+				cloneRepo.mutateAsync({
+					url,
+					targetDirectory: parentDir,
+				}),
+			),
+		[cloneRepo, runCreate],
 	);
 
 	const createFromTemplate = useCallback(
@@ -42,5 +68,19 @@ export function useCreateV1Project() {
 		[cloneFromUrl],
 	);
 
-	return { cloneFromUrl, createFromTemplate, isPending: cloneRepo.isPending };
+	const createEmpty = useCallback(
+		({ name, parentDir, onError }: EmptyProjectInput): Promise<string | null> =>
+			runCreate(
+				() => createEmptyRepo.mutateAsync({ name, parentDir }),
+				onError,
+			),
+		[createEmptyRepo, runCreate],
+	);
+
+	return {
+		cloneFromUrl,
+		createEmpty,
+		createFromTemplate,
+		isPending: cloneRepo.isPending || createEmptyRepo.isPending,
+	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/AddRepositoryModals.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/AddRepositoryModals.tsx
@@ -1,4 +1,5 @@
 import { toast } from "@superset/ui/sonner";
+import { EmptyProjectModal } from "renderer/routes/_authenticated/components/EmptyProjectModal";
 import { TemplateGalleryModal } from "renderer/routes/_authenticated/components/TemplateGalleryModal";
 import {
 	useAddRepositoryModalActive,
@@ -15,6 +16,17 @@ export function AddRepositoryModals() {
 
 	return (
 		<>
+			<EmptyProjectModal
+				open={active.kind === "empty-project"}
+				onOpenChange={(open) => {
+					if (!open) close();
+				}}
+				onSuccess={(result) => {
+					toast.success("Project created.");
+					resolveNewProject({ projectId: result.projectId });
+				}}
+				onError={(message) => toast.error(`Create failed: ${message}`)}
+			/>
 			<NewProjectModal
 				open={active.kind === "new-project"}
 				onOpenChange={(open) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -36,6 +36,7 @@ import {
 } from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
 import { STROKE_WIDTH_THICK } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import {
+	useOpenEmptyProjectModal,
 	useOpenNewProjectModal,
 	useOpenTemplateGalleryModal,
 } from "renderer/stores/add-repository-modal";
@@ -49,6 +50,7 @@ export function DashboardSidebarHeader({
 	isCollapsed = false,
 }: DashboardSidebarHeaderProps) {
 	const openModal = useOpenNewWorkspaceModal();
+	const openEmptyProject = useOpenEmptyProjectModal();
 	const openNewProject = useOpenNewProjectModal();
 	const openTemplateGallery = useOpenTemplateGalleryModal();
 	const navigate = useNavigate();
@@ -256,6 +258,10 @@ export function DashboardSidebarHeader({
 						align="start"
 						onCloseAutoFocus={(event) => event.preventDefault()}
 					>
+						<DropdownMenuItem onSelect={() => openEmptyProject()}>
+							<LuFolderPlus className="size-4" />
+							Create new project
+						</DropdownMenuItem>
 						<DropdownMenuItem onSelect={() => openNewProject()}>
 							<HiMiniPlus className="size-4" />
 							Clone from URL

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
@@ -12,6 +12,7 @@ import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
 import { LuFolderInput, LuFolderPlus, LuLayoutTemplate } from "react-icons/lu";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
 import {
+	useOpenEmptyProjectModal,
 	useOpenNewProjectModal,
 	useOpenTemplateGalleryModal,
 } from "renderer/stores/add-repository-modal";
@@ -20,6 +21,7 @@ import { useSidebarWorkspacesCollapseStore } from "renderer/stores/sidebar-works
 export function DashboardSidebarWorkspacesHeader() {
 	const isCollapsed = useSidebarWorkspacesCollapseStore((s) => s.isCollapsed);
 	const toggleCollapsed = useSidebarWorkspacesCollapseStore((s) => s.toggle);
+	const openEmptyProject = useOpenEmptyProjectModal();
 	const openNewProject = useOpenNewProjectModal();
 	const openTemplateGallery = useOpenTemplateGalleryModal();
 	const navigate = useNavigate();
@@ -88,6 +90,10 @@ export function DashboardSidebarWorkspacesHeader() {
 					align="end"
 					onCloseAutoFocus={(event) => event.preventDefault()}
 				>
+					<DropdownMenuItem onSelect={() => openEmptyProject()}>
+						<LuFolderPlus className="size-4" />
+						Create new project
+					</DropdownMenuItem>
 					<DropdownMenuItem onSelect={() => openNewProject()}>
 						<HiMiniPlus className="size-4" />
 						Clone from URL

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/ProjectPickerPill/ProjectPickerPill.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/ProjectPickerPill/ProjectPickerPill.tsx
@@ -13,10 +13,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { HiCheck, HiChevronUpDown, HiMiniPlus } from "react-icons/hi2";
-import { LuFolderInput, LuTriangleAlert } from "react-icons/lu";
+import { LuFolderInput, LuFolderPlus, LuTriangleAlert } from "react-icons/lu";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
 import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
-import { useOpenNewProjectModal } from "renderer/stores/add-repository-modal";
+import {
+	useOpenEmptyProjectModal,
+	useOpenNewProjectModal,
+} from "renderer/stores/add-repository-modal";
 import type { ProjectOption } from "../../types";
 import { FormPickerTrigger } from "../FormPickerTrigger";
 
@@ -32,6 +35,7 @@ export function ProjectPickerPill({
 	onSelectProject,
 }: ProjectPickerPillProps) {
 	const [open, setOpen] = useState(false);
+	const openEmptyProject = useOpenEmptyProjectModal();
 	const openNewProject = useOpenNewProjectModal();
 	const navigate = useNavigate();
 	const folderImport = useFolderFirstImport({
@@ -50,6 +54,12 @@ export function ProjectPickerPill({
 	});
 
 	const handleCreateNewProject = async () => {
+		setOpen(false);
+		const result = await openEmptyProject();
+		if (result) onSelectProject(result.projectId);
+	};
+
+	const handleCloneProject = async () => {
 		setOpen(false);
 		const result = await openNewProject();
 		if (result) onSelectProject(result.projectId);
@@ -123,6 +133,10 @@ export function ProjectPickerPill({
 					<CommandSeparator alwaysRender />
 					<CommandGroup forceMount>
 						<CommandItem forceMount onSelect={handleCreateNewProject}>
+							<LuFolderPlus className="size-4" />
+							Create new project
+						</CommandItem>
+						<CommandItem forceMount onSelect={handleCloneProject}>
 							<HiMiniPlus className="size-4" />
 							Clone from URL
 						</CommandItem>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/EmptyProjectModal/EmptyProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/EmptyProjectModal/EmptyProjectModal.tsx
@@ -1,0 +1,231 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { useEffect, useState } from "react";
+import { LuFolderOpen, LuLoaderCircle } from "react-icons/lu";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { showHostServiceUnavailableToast } from "renderer/lib/host-service-unavailable";
+import {
+	useCreateV1Project,
+	useFinalizeProjectSetup,
+} from "renderer/react-query/projects";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+
+interface EmptyProjectModalProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSuccess?: (result: { projectId: string }) => void;
+	onError?: (message: string) => void;
+}
+
+export function EmptyProjectModal({
+	open,
+	onOpenChange,
+	onSuccess,
+	onError,
+}: EmptyProjectModalProps) {
+	const isV2CloudEnabled = useIsV2CloudEnabled();
+	const hostService = useLocalHostService();
+	const finalizeSetup = useFinalizeProjectSetup();
+	const createV1Project = useCreateV1Project();
+	const selectDirectory = electronTrpc.window.selectDirectory.useMutation();
+	const { data: homeDir } = electronTrpc.window.getHomeDir.useQuery();
+
+	const [parentDir, setParentDir] = useState("");
+	const [name, setName] = useState("");
+	const [working, setWorking] = useState(false);
+
+	useEffect(() => {
+		if (parentDir || !homeDir) return;
+		setParentDir(`${homeDir}/.superset/projects`);
+	}, [homeDir, parentDir]);
+
+	const reset = () => {
+		setName("");
+		setWorking(false);
+	};
+
+	const handleOpenChange = (next: boolean) => {
+		if (!next && working) return;
+		if (!next) reset();
+		onOpenChange(next);
+	};
+
+	const handleBrowse = async () => {
+		try {
+			const result = await selectDirectory.mutateAsync({
+				title: "Select project location",
+				defaultPath: parentDir || undefined,
+			});
+			if (!result.canceled && result.path) {
+				setParentDir(result.path);
+			}
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : String(err));
+		}
+	};
+
+	const createProject = async () => {
+		const trimmedName = name.trim();
+		const trimmedParent = parentDir.trim();
+		if (!trimmedName) {
+			toast.error("Please enter a project name");
+			return;
+		}
+		if (!trimmedParent) {
+			toast.error("Please select a project location");
+			return;
+		}
+
+		setWorking(true);
+		try {
+			if (!isV2CloudEnabled) {
+				const projectId = await createV1Project.createEmpty({
+					name: trimmedName,
+					parentDir: trimmedParent,
+					onError: (message) => {
+						if (onError) {
+							onError(message);
+						} else {
+							toast.error("Could not create project", {
+								description: message,
+							});
+						}
+					},
+				});
+				if (!projectId) return;
+				onSuccess?.({ projectId });
+				reset();
+				onOpenChange(false);
+				return;
+			}
+
+			const activeHostUrl = await hostService.waitForHostReady();
+			if (!activeHostUrl) {
+				showHostServiceUnavailableToast(hostService, {
+					action: "create the project",
+				});
+				return;
+			}
+
+			const client = getHostServiceClientByUrl(activeHostUrl);
+			const result = await client.project.create.mutate({
+				name: trimmedName,
+				mode: { kind: "empty", parentDir: trimmedParent },
+			});
+			finalizeSetup(activeHostUrl, result);
+			onSuccess?.({ projectId: result.projectId });
+			reset();
+			onOpenChange(false);
+		} catch (err) {
+			const raw = err instanceof Error ? err.message : String(err);
+			const isLeakedSql = raw.startsWith("Failed query:");
+			if (isLeakedSql) console.error("[EmptyProjectModal] create failed", err);
+			const message = isLeakedSql
+				? "Could not create project. Please try a different name or check the logs."
+				: raw;
+			if (onError) {
+				onError(message);
+			} else {
+				toast.error("Could not create project", { description: message });
+			}
+		} finally {
+			setWorking(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange} modal>
+			<DialogContent className="max-w-[420px]">
+				<DialogHeader>
+					<DialogTitle>Create a new project</DialogTitle>
+					<DialogDescription>
+						Create a blank folder and initialize it as a Git repository.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-4">
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="empty-project-name" className="text-xs">
+							Project name
+						</Label>
+						<Input
+							id="empty-project-name"
+							value={name}
+							onChange={(event) => setName(event.target.value)}
+							placeholder="my-project"
+							disabled={working}
+							onKeyDown={(event) => {
+								if (event.key === "Enter" && !working) {
+									void createProject();
+								}
+							}}
+							autoFocus
+						/>
+					</div>
+
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="empty-project-path" className="text-xs">
+							Location
+						</Label>
+						<div className="flex gap-1.5">
+							<Input
+								id="empty-project-path"
+								value={parentDir}
+								onChange={(event) => setParentDir(event.target.value)}
+								disabled={working}
+								className="flex-1 font-mono text-xs"
+							/>
+							<Button
+								type="button"
+								variant="outline"
+								size="icon"
+								onClick={handleBrowse}
+								disabled={working || selectDirectory.isPending}
+								className="shrink-0"
+								aria-label="Browse for directory"
+							>
+								<LuFolderOpen className="size-4" />
+							</Button>
+						</div>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={() => handleOpenChange(false)}
+						disabled={working}
+					>
+						Cancel
+					</Button>
+					<Button
+						onClick={() => void createProject()}
+						disabled={working || !name.trim() || !parentDir.trim()}
+					>
+						{working ? (
+							<>
+								<LuLoaderCircle className="size-4 animate-spin" />
+								Creating…
+							</>
+						) : (
+							"Create project"
+						)}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/EmptyProjectModal/EmptyProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/EmptyProjectModal/EmptyProjectModal.tsx
@@ -94,15 +94,7 @@ export function EmptyProjectModal({
 				const projectId = await createV1Project.createEmpty({
 					name: trimmedName,
 					parentDir: trimmedParent,
-					onError: (message) => {
-						if (onError) {
-							onError(message);
-						} else {
-							toast.error("Could not create project", {
-								description: message,
-							});
-						}
-					},
+					onError,
 				});
 				if (!projectId) return;
 				onSuccess?.({ projectId });

--- a/apps/desktop/src/renderer/routes/_authenticated/components/EmptyProjectModal/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/EmptyProjectModal/index.ts
@@ -1,0 +1,1 @@
+export { EmptyProjectModal } from "./EmptyProjectModal";

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/layout.tsx
@@ -30,8 +30,8 @@ const STEPS = [
 	{
 		path: "/onboarding/project",
 		match: (p: string) => p === "/onboarding/project",
-		title: "Point Superset at some code",
-		subtitle: "Open a folder or clone a repo to finish setup.",
+		title: "Create or add a project",
+		subtitle: "Start from scratch, open a folder, or clone a repo.",
 	},
 ] as const;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/project/page.tsx
@@ -4,7 +4,12 @@ import { Input } from "@superset/ui/input";
 import { toast } from "@superset/ui/sonner";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { type FormEvent, type ReactNode, useState } from "react";
-import { LuFolderOpen, LuGitBranch, LuLayoutTemplate } from "react-icons/lu";
+import {
+	LuFolderOpen,
+	LuFolderPlus,
+	LuGitBranch,
+	LuLayoutTemplate,
+} from "react-icons/lu";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { track } from "renderer/lib/analytics";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
@@ -18,6 +23,7 @@ import {
 } from "renderer/react-query/projects";
 import { useOpenMainRepoWorkspace } from "renderer/react-query/workspaces";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
+import { EmptyProjectModal } from "renderer/routes/_authenticated/components/EmptyProjectModal";
 import { TemplateGalleryModal } from "renderer/routes/_authenticated/components/TemplateGalleryModal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
@@ -36,6 +42,7 @@ function OnboardingProjectPage() {
 	const cloneTargetDir = homeDir ? `${homeDir}/.superset/projects` : null;
 	const [url, setUrl] = useState("");
 	const [busy, setBusy] = useState(false);
+	const [emptyProjectOpen, setEmptyProjectOpen] = useState(false);
 	const [templateOpen, setTemplateOpen] = useState(false);
 
 	const folderImport = useFolderFirstImport({
@@ -142,6 +149,26 @@ function OnboardingProjectPage() {
 	return (
 		<div className="flex flex-col gap-3">
 			<Card className="flex-row items-center gap-4 p-5">
+				<ProjectIcon icon={<LuFolderPlus className="size-4.5" />} />
+				<div className="min-w-0 flex-1">
+					<p className="text-sm font-medium text-foreground">
+						Create a new project
+					</p>
+					<p className="text-xs text-muted-foreground">
+						Start from scratch in a new folder.
+					</p>
+				</div>
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={() => setEmptyProjectOpen(true)}
+					disabled={busy}
+				>
+					Create
+				</Button>
+			</Card>
+
+			<Card className="flex-row items-center gap-4 p-5">
 				<ProjectIcon icon={<LuFolderOpen className="size-4.5" />} />
 				<div className="min-w-0 flex-1">
 					<p className="text-sm font-medium text-foreground">Open a folder</p>
@@ -212,6 +239,14 @@ function OnboardingProjectPage() {
 				onOpenChange={setTemplateOpen}
 				onCreated={(result) => {
 					setTemplateOpen(false);
+					finish(result.projectId);
+				}}
+			/>
+			<EmptyProjectModal
+				open={emptyProjectOpen}
+				onOpenChange={setEmptyProjectOpen}
+				onSuccess={(result) => {
+					setEmptyProjectOpen(false);
 					finish(result.projectId);
 				}}
 			/>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarFooter.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarFooter.tsx
@@ -17,6 +17,7 @@ import { UpdatesPill } from "renderer/components/UpdatesPill";
 import { useOpenProject } from "renderer/react-query/projects";
 import { useOpenMainRepoWorkspace } from "renderer/react-query/workspaces";
 import {
+	useOpenEmptyProjectModal,
 	useOpenNewProjectModal,
 	useOpenTemplateGalleryModal,
 } from "renderer/stores/add-repository-modal";
@@ -31,6 +32,7 @@ export function WorkspaceSidebarFooter({
 }: WorkspaceSidebarFooterProps) {
 	const { openNew, isPending: isOpenPending } = useOpenProject();
 	const openMainRepoWorkspace = useOpenMainRepoWorkspace();
+	const openEmptyProject = useOpenEmptyProjectModal();
 	const openNewProject = useOpenNewProjectModal();
 	const openTemplateGallery = useOpenTemplateGalleryModal();
 
@@ -74,6 +76,11 @@ export function WorkspaceSidebarFooter({
 		if (result) await openMainWorkspaceForProject(result.projectId);
 	};
 
+	const handleCreateProject = async () => {
+		const result = await openEmptyProject();
+		if (result) await openMainWorkspaceForProject(result.projectId);
+	};
+
 	const handleTemplateProject = async () => {
 		const result = await openTemplateGallery();
 		if (result) await openMainWorkspaceForProject(result.projectId);
@@ -102,6 +109,10 @@ export function WorkspaceSidebarFooter({
 						<TooltipContent side="right">Add repository</TooltipContent>
 					</Tooltip>
 					<DropdownMenuContent side="top" align="start">
+						<DropdownMenuItem onClick={handleCreateProject}>
+							<LuFolderPlus className="size-4" strokeWidth={STROKE_WIDTH} />
+							Create new project
+						</DropdownMenuItem>
 						<DropdownMenuItem onClick={handleOpenProject} disabled={isLoading}>
 							<LuFolderOpen className="size-4" strokeWidth={STROKE_WIDTH} />
 							Open project
@@ -135,6 +146,10 @@ export function WorkspaceSidebarFooter({
 					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent side="top" align="start">
+					<DropdownMenuItem onClick={handleCreateProject}>
+						<LuFolderPlus className="size-4" strokeWidth={STROKE_WIDTH} />
+						Create new project
+					</DropdownMenuItem>
 					<DropdownMenuItem onClick={handleOpenProject} disabled={isLoading}>
 						<LuFolderOpen className="size-4" strokeWidth={STROKE_WIDTH} />
 						Open project

--- a/apps/desktop/src/renderer/stores/add-repository-modal.test.ts
+++ b/apps/desktop/src/renderer/stores/add-repository-modal.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { useAddRepositoryModalStore } from "./add-repository-modal";
+
+describe("add repository modal store", () => {
+	afterEach(() => {
+		useAddRepositoryModalStore.getState().close();
+	});
+
+	it("opens the empty-project flow and resolves the created project", async () => {
+		const resultPromise = useAddRepositoryModalStore
+			.getState()
+			.openEmptyProject();
+
+		expect(useAddRepositoryModalStore.getState().active).toEqual({
+			kind: "empty-project",
+		});
+
+		useAddRepositoryModalStore
+			.getState()
+			.resolveNewProject({ projectId: "project-1" });
+
+		expect(await resultPromise).toEqual({ projectId: "project-1" });
+		expect(useAddRepositoryModalStore.getState().active).toEqual({
+			kind: "none",
+		});
+	});
+
+	it("resolves with null when the empty-project flow is closed", async () => {
+		const resultPromise = useAddRepositoryModalStore
+			.getState()
+			.openEmptyProject();
+
+		useAddRepositoryModalStore.getState().close();
+
+		expect(await resultPromise).toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/stores/add-repository-modal.ts
+++ b/apps/desktop/src/renderer/stores/add-repository-modal.ts
@@ -8,6 +8,7 @@ export interface NewProjectResult {
 type ActiveModal =
 	| { kind: "none" }
 	| { kind: "new-project" }
+	| { kind: "empty-project" }
 	| { kind: "template-gallery" };
 
 interface AddRepositoryModalState {
@@ -16,10 +17,11 @@ interface AddRepositoryModalState {
 	 * Opens the modal and resolves with the created project (or `null` if the
 	 * user closed it). Only one open call can be in flight at a time — calling
 	 * again while a previous open is pending resolves the prior promise to
-	 * `null` before opening fresh. Safe today because there is only one global
-	 * `NewProjectModal` instance.
+	 * `null` before opening fresh. The discriminated `active` state ensures only
+	 * one global add-project modal can be active at a time.
 	 */
 	openNewProject: () => Promise<NewProjectResult | null>;
+	openEmptyProject: () => Promise<NewProjectResult | null>;
 	openTemplateGallery: () => Promise<NewProjectResult | null>;
 	resolveNewProject: (result: NewProjectResult | null) => void;
 	close: () => void;
@@ -39,6 +41,13 @@ export const useAddRepositoryModalStore = create<AddRepositoryModalState>()(
 				return new Promise<NewProjectResult | null>((resolve) => {
 					pendingResolve = resolve;
 					set({ active: { kind: "new-project" } });
+				});
+			},
+			openEmptyProject: () => {
+				pendingResolve?.(null);
+				return new Promise<NewProjectResult | null>((resolve) => {
+					pendingResolve = resolve;
+					set({ active: { kind: "empty-project" } });
 				});
 			},
 			openTemplateGallery: () => {
@@ -69,6 +78,8 @@ export const useAddRepositoryModalActive = () =>
 	useAddRepositoryModalStore((state) => state.active);
 export const useOpenNewProjectModal = () =>
 	useAddRepositoryModalStore((state) => state.openNewProject);
+export const useOpenEmptyProjectModal = () =>
+	useAddRepositoryModalStore((state) => state.openEmptyProject);
 export const useOpenTemplateGalleryModal = () =>
 	useAddRepositoryModalStore((state) => state.openTemplateGallery);
 export const useResolveNewProjectModal = () =>


### PR DESCRIPTION
## What & why

Superset can clone a repository, open an existing folder, or start from a template, but it cannot create a blank project for someone starting an app from scratch.

This adds a first-class **Create new project** action to the new-workspace picker, project menus, command palette, legacy workspace flow, and onboarding. The new modal creates a named folder, initializes a Git repository on `main` with an initial commit, registers the project, and makes it available for workspace creation without leaving Superset. It uses the existing host-service empty-project mode and adds the equivalent v1 desktop path.

## How I tested it

- `bun run lint` — passed with no warnings
- `bun run typecheck` — 35/35 tasks passed
- `cd apps/desktop && bun test src/renderer/stores/add-repository-modal.test.ts` — 2/2 passed
- `cd packages/host-service && bun test test/integration/project-setup.integration.test.ts` — 8/8 passed
- End-to-end in the signed-in desktop app from this managed worktree at renderer `http://localhost:3085`: New Workspace → project picker → Create new project → enter name/location → Create project → select No agent → create workspace. Verified the resulting folder is a Git repository on `main` with an initial commit and no remote, and that Superset created and opened the workspace.

## Screenshots

**Create new project entry point**

<img width="1200" alt="New Workspace project picker showing Create new project" src="https://github.com/user-attachments/assets/f9e1e3e4-4f2d-4c94-bf8b-e639a6dc8547" />

**Blank project form**

<img width="1200" alt="Create a new project form with project name and location" src="https://github.com/user-attachments/assets/459ef4a9-53a1-4f80-abf7-bed5e238e62a" />

**Created project and workspace**

<img width="1200" alt="Superset workspace created from the new blank project" src="https://github.com/user-attachments/assets/8dba0521-0c57-480a-bc57-885a4304e29c" />

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Create new project” flow to the desktop app so users can start from a blank folder without leaving Superset. Creates a named directory, initializes a Git repo on `main` with an initial commit, registers the project, and returns users to workspace creation with the project selected.

- **New Features**
  - New `EmptyProjectModal` to name a project and pick a location, with browse, progress, and error toasts.
  - Entry points in command palette, dashboard sidebar menus, workspace sidebar footer, new workspace picker, and an onboarding card.
  - v1 and v2 support: uses `electronTrpc.projects.createEmptyRepo` and host-service `project.create` (empty mode); invalidates `projects.getRecents` and finalizes setup.
  - Store and flow updates: adds `empty-project` via `useOpenEmptyProjectModal`, ensures only one add-project modal at a time, and workspace/onboarding flows preselect the newly created project.

- **Refactors**
  - Centralized v1 creation error handling with `runCreate` and `onError` passthrough in `useCreateV1Project`; unified pending state with `createEmptyRepo`.

<sup>Written for commit c5a6b5ae73f031b3659eb7b8b8a6e1a5ebd47a95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Create new project” (empty project) actions across the dashboard, workspace sidebar, command palette, and onboarding.
  * Introduced an Empty Project dialog to enter a name, pick/browse a directory, and create the project with progress feedback.
  * Enabled end-to-end empty project creation in both supported setup environments.
* **Bug Fixes**
  * Improved completion, error, and cancellation handling in the empty project flow (including clearer failure toasts and safer close behavior).
* **Tests**
  * Added coverage for opening, resolving success, and canceling the empty-project modal/store flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->