### PR TITLE
fix(host-service): restore workspace_created/deleted telemetry lost in local-first migration

### DIFF
--- a/packages/host-service/src/trpc/router/project/project.ts
+++ b/packages/host-service/src/trpc/router/project/project.ts
@@ -710,7 +710,7 @@ export const projectRouter = router({
 			try {
 				// Per-row so each deletion broadcasts.
 				for (const ws of localWorkspaces) {
-					deleteLocalWorkspace({ db: ctx.db, eventBus: ctx.eventBus }, ws.id);
+					deleteLocalWorkspace(ctx, ws.id);
 				}
 				ctx.db.delete(projects).where(eq(projects.id, input.projectId)).run();
 				emitProjectChanged(ctx.eventBus, "deleted", input.projectId);

--- a/packages/host-service/src/trpc/router/project/utils/ensure-main-workspace.ts
+++ b/packages/host-service/src/trpc/router/project/utils/ensure-main-workspace.ts
@@ -10,7 +10,10 @@ import {
 export type EnsureMainWorkspaceContext = Pick<
 	HostServiceContext,
 	"db" | "git" | "eventBus"
->;
+> &
+	Partial<
+		Pick<HostServiceContext, "api" | "organizationId" | "clientMachineId">
+	>;
 
 async function getCurrentBranchName(
 	git: Awaited<ReturnType<EnsureMainWorkspaceContext["git"]>>,
@@ -73,7 +76,13 @@ export async function ensureMainWorkspaceStrict(
 		});
 	}
 
-	const store = { db: ctx.db, eventBus: ctx.eventBus };
+	const store = {
+		db: ctx.db,
+		eventBus: ctx.eventBus,
+		api: ctx.api,
+		organizationId: ctx.organizationId,
+		clientMachineId: ctx.clientMachineId,
+	};
 
 	const existing = ctx.db.query.workspaces
 		.findFirst({

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -341,10 +341,7 @@ async function runDestroy(
 	// The local row is the commit point and the only record. The cloud
 	// delete is best-effort legacy cleanup for rows mirrored before
 	// workspaces went fully local.
-	deleteLocalWorkspace(
-		{ db: ctx.db, eventBus: ctx.eventBus },
-		input.workspaceId,
-	);
+	deleteLocalWorkspace(ctx, input.workspaceId);
 	let cloudDeleted = false;
 	try {
 		await ctx.api.v2Workspace.delete.mutate({ id: input.workspaceId });

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/adopt-existing-worktree.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/adopt-existing-worktree.ts
@@ -72,7 +72,13 @@ export async function adoptExistingWorktree(
 		idempotencyId,
 		taskId,
 	} = args;
-	const store: WorkspaceStoreContext = { db: ctx.db, eventBus: ctx.eventBus };
+	const store: WorkspaceStoreContext = {
+		db: ctx.db,
+		eventBus: ctx.eventBus,
+		api: ctx.api,
+		organizationId: ctx.organizationId,
+		clientMachineId: ctx.clientMachineId,
+	};
 
 	if (existingWorkspaceId) {
 		await recordBaseBranch(git, branch, baseBranch);

--- a/packages/host-service/src/workspaces/local-workspace-store.ts
+++ b/packages/host-service/src/workspaces/local-workspace-store.ts
@@ -37,23 +37,27 @@ function trackWorkspaceEvent(
 ): void {
 	if (!ctx.api) return;
 	const clientMachineId = ctx.clientMachineId ?? getHostId();
-	void ctx.api.analytics.captureEvent
-		.mutate({
-			source: "host_service",
-			event,
-			properties: {
-				workspace_id: row.id,
-				project_id: row.projectId,
-				organization_id: ctx.organizationId ?? null,
-				host_id: getHostId(),
-				branch: row.branch,
-				type: row.type,
-				host_kind: clientMachineId === getHostId() ? "local" : "remote",
-				client_machine_id: clientMachineId,
-				host_service_version: hostServicePackageJson.version,
-			},
-		})
-		.catch(() => {});
+	try {
+		void ctx.api.analytics.captureEvent
+			.mutate({
+				source: "host_service",
+				event,
+				properties: {
+					workspace_id: row.id,
+					project_id: row.projectId,
+					organization_id: ctx.organizationId ?? null,
+					host_id: getHostId(),
+					branch: row.branch,
+					type: row.type,
+					host_kind: clientMachineId === getHostId() ? "local" : "remote",
+					client_machine_id: clientMachineId,
+					host_service_version: hostServicePackageJson.version,
+				},
+			})
+			.catch(() => {});
+	} catch {
+		// Telemetry must never fail the workspace operation.
+	}
 }
 
 /**

--- a/packages/host-service/src/workspaces/local-workspace-store.ts
+++ b/packages/host-service/src/workspaces/local-workspace-store.ts
@@ -1,16 +1,59 @@
 import { randomUUID } from "node:crypto";
+import hostServicePackageJson from "@superset/host-service/package.json" with {
+	type: "json",
+};
 import { getHostId } from "@superset/shared/host-info";
 import { eq } from "drizzle-orm";
 import type { HostDb } from "../db";
 import { workspaces } from "../db/schema";
 import type { EventBus } from "../events";
 import type { WorkspaceSnapshot } from "../events/types";
+import type { ApiClient } from "../types";
 
 export type HostWorkspaceRow = typeof workspaces.$inferSelect;
 
+/**
+ * `api`/`organizationId`/`clientMachineId` mirror `HostServiceContext` field
+ * names so a full request context satisfies this interface as-is. When `api`
+ * is absent the store still works but skips telemetry.
+ */
 export interface WorkspaceStoreContext {
 	db: HostDb;
 	eventBus: EventBus;
+	api?: ApiClient;
+	organizationId?: string;
+	clientMachineId?: string;
+}
+
+/**
+ * Workspaces have no cloud mirror since local-first (#5731), so the cloud
+ * capture in `v2Workspace.create`/`delete` never fires for local rows —
+ * the host relays the event through `analytics.captureEvent` instead.
+ */
+function trackWorkspaceEvent(
+	ctx: WorkspaceStoreContext,
+	event: "workspace_created" | "workspace_deleted",
+	row: HostWorkspaceRow,
+): void {
+	if (!ctx.api) return;
+	const clientMachineId = ctx.clientMachineId ?? getHostId();
+	void ctx.api.analytics.captureEvent
+		.mutate({
+			source: "host_service",
+			event,
+			properties: {
+				workspace_id: row.id,
+				project_id: row.projectId,
+				organization_id: ctx.organizationId ?? null,
+				host_id: getHostId(),
+				branch: row.branch,
+				type: row.type,
+				host_kind: clientMachineId === getHostId() ? "local" : "remote",
+				client_machine_id: clientMachineId,
+				host_service_version: hostServicePackageJson.version,
+			},
+		})
+		.catch(() => {});
 }
 
 /**
@@ -115,6 +158,7 @@ export function insertLocalWorkspace(
 	const row = getLocalWorkspace(ctx.db, id);
 	if (!row) throw new Error(`Workspace insert readback failed: ${id}`);
 	emitWorkspaceChanged(ctx.eventBus, "created", row);
+	trackWorkspaceEvent(ctx, "workspace_created", row);
 	return row;
 }
 
@@ -161,6 +205,7 @@ export function deleteLocalWorkspace(
 			workspace: null,
 			occurredAt: Date.now(),
 		});
+		trackWorkspaceEvent(ctx, "workspace_deleted", existing);
 	}
 }
 


### PR DESCRIPTION
## Problem

`workspace_created` dropped ~30–40%/day starting 2026-07-21 — flagged as a possible product bug, but it's an instrumentation gap:

- Typed v2 events (`type=worktree|main`) were captured **cloud-side** in `v2Workspace.create`/`delete`, firing only on an actual `v2Workspaces` insert/delete.
- The only high-volume caller was host-service `workspace-cloud-sync.ts`, which #5731 (local-first projects, shipped in **1.16.0**) deleted. The local-first creation path emitted no analytics at all.
- Typed daily counts fell 5,041 (7/20) → 1,973 (7/23), tracking 1.16 fleet adoption almost exactly (57% adoption → −50% on 7/22; 60% → −61% on 7/23). v1 events, `workspace_opened`, `workspace_initialized`, and `agent_session_launch` all stayed flat — no real usage drop, no error spike.

## Fix

Emit `workspace_created` / `workspace_deleted` from the local store's choke points (`insertLocalWorkspace` after a real insert, `deleteLocalWorkspace` when the row existed), relayed through the authenticated `analytics.captureEvent` cloud endpoint — the same pattern the CLI uses, so no PostHog SDK or key in the host build and `distinctId` comes from the host's authenticated user, matching the retired cloud capture.

- Property parity with the old cloud events (`workspace_id`, `project_id`, `organization_id`, `host_id`, `branch`, `type`, `host_kind`, `client_machine_id`, same `clientMachineId ?? getHostId()` host_kind semantics), plus new `host_service_version` and `source=host_service`.
- `WorkspaceStoreContext` gains optional `api`/`organizationId`/`clientMachineId` mirroring `HostServiceContext` field names, so sites passing full `ctx` get emission with no changes; literal constructions now pass the fields.
- Fire-and-forget with swallowed rejection — an unreachable cloud can't fail a workspace operation.

## Non-changes / caveats

- The cloud-side captures stay: they're still the only emitters for ≤1.15 hosts (long tail still creating ~700/day) and web `/workspaces`. No create double-count is possible — upgraded hosts have no code path to the cloud capture, old hosts don't have the relay.
- Deletes of pre-7/20 mirrored rows by upgraded hosts double-fire (relay + legacy cloud cleanup) until legacy mirrors are gone; relay events are distinguishable via `source=host_service`.
- The 7/21 → release-adoption window remains unbackfillable in PostHog.

## Testing

- `packages/host-service` typecheck clean; workspace-related integration tests (37) pass; root lint clean.

https://claude.ai/code/session_01JGkCApsJ22Ujd2hadHEftJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `workspace_created` and `workspace_deleted` telemetry in `@superset/host-service` after the local-first migration. Events now emit on local insert/delete and relay to cloud analytics without affecting workspace operations.

- **Bug Fixes**
  - Emit events from `insertLocalWorkspace` and `deleteLocalWorkspace` via the authenticated `analytics.captureEvent` relay (fire-and-forget; no SDK or keys in the host).
  - Keep property parity with the old cloud events; add `host_service_version` and `source=host_service`.
  - Extend `WorkspaceStoreContext` with optional `api`/`organizationId`/`clientMachineId`; thread through ensure-main-workspace, adopt-existing-worktree, project delete, and destroy; calls now use `deleteLocalWorkspace(ctx, id)`.
  - Guard telemetry against partial or missing `api` routes and network failures; swallow both sync throws and rejections so reporting never interrupts workspace flows.
  - Retain legacy cloud captures for ≤1.15 hosts and web; deletes of old mirrored rows may double-fire until mirrors are gone.

<sup>Written for commit c035d9bb8bb82a32c75b72fb71d1ef23124e0a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of local workspace deletion by passing the full execution context through all deletion phases.
  - Enhanced local workspace adoption and “main workspace” handling by providing additional host identity and API context where needed, preserving expected workspace/project state.

- **Improvements**
  - Added optional telemetry for local workspace create/delete events, including host identity details, with failures isolated so operations continue uninterrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->