### PR TITLE
fix(host-service): refresh non-default base branches before forking new workspaces

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, mock, test } from "bun:test";
+import { resolveNewBranchStartPoint } from "./resolve-new-branch-start-point";
+
+interface MockState {
+	existingRefs: Set<string>;
+	upstreams: Record<string, { remote: string; remoteBranch: string }>;
+	defaultBranch?: string;
+	fetchThrows?: Error;
+}
+
+function createMockGit(state: MockState) {
+	const fetch = mock(async (_args: string[]) => {
+		if (state.fetchThrows) throw state.fetchThrows;
+		return "";
+	});
+	const raw = mock(async (args: string[]) => {
+		if (args[0] === "rev-parse" && args[1] === "--verify") {
+			const ref = args[2]?.replace("^{commit}", "") ?? "";
+			if (state.existingRefs.has(ref)) return `${"0".repeat(40)}\n`;
+			throw new Error("fatal: Needed a single revision");
+		}
+		if (
+			args[0] === "symbolic-ref" &&
+			args[1] === "refs/remotes/origin/HEAD"
+		) {
+			if (state.defaultBranch) return `origin/${state.defaultBranch}`;
+			throw new Error("fatal: ref is not a symbolic ref");
+		}
+		if (args[0] === "config" && args[1] === "--get") {
+			// branch.<name>.remote / branch.<name>.merge
+			const key = args[2] ?? "";
+			const match = key.match(/^branch\.(.+)\.(remote|merge)$/);
+			if (!match) throw new Error("no such key");
+			const [, branch, kind] = match;
+			const upstream = branch ? state.upstreams[branch] : undefined;
+			if (!upstream) throw new Error("no such key");
+			return kind === "remote"
+				? upstream.remote
+				: `refs/heads/${upstream.remoteBranch}`;
+		}
+		throw new Error(`Unexpected raw args: ${args.join(" ")}`);
+	});
+	return { raw, fetch } as never;
+}
+
+describe("resolveNewBranchStartPoint", () => {
+	// The core regression: a non-default shared branch (e.g. `mirror-flier`)
+	// whose local ref is weeks stale must still get its upstream fetched
+	// before it's used as a fork point, or new workspaces open on the stale
+	// tip.
+	test("upgrades and fetches non-default local branch that has an upstream", async () => {
+		const git = createMockGit({
+			existingRefs: new Set([
+				"refs/heads/mirror-flier",
+				"refs/remotes/origin/mirror-flier",
+			]),
+			upstreams: {
+				"mirror-flier": { remote: "origin", remoteBranch: "mirror-flier" },
+			},
+			defaultBranch: "main",
+		});
+
+		const result = await resolveNewBranchStartPoint(git, "mirror-flier");
+
+		expect(result.kind).toBe("remote-tracking");
+		if (result.kind === "remote-tracking") {
+			expect(result.remoteShortName).toBe("origin/mirror-flier");
+		}
+		expect(git.fetch).toHaveBeenCalledWith([
+			"origin",
+			"mirror-flier",
+			"--quiet",
+			"--no-tags",
+		]);
+	});
+
+	test("upgrades and fetches the default branch (unchanged behavior)", async () => {
+		const git = createMockGit({
+			existingRefs: new Set([
+				"refs/heads/main",
+				"refs/remotes/origin/main",
+			]),
+			upstreams: { main: { remote: "origin", remoteBranch: "main" } },
+			defaultBranch: "main",
+		});
+
+		const result = await resolveNewBranchStartPoint(git, "main");
+
+		expect(result.kind).toBe("remote-tracking");
+		expect(git.fetch).toHaveBeenCalledWith([
+			"origin",
+			"main",
+			"--quiet",
+			"--no-tags",
+		]);
+	});
+
+	test("keeps local when no upstream is configured (workspace branch)", async () => {
+		const git = createMockGit({
+			existingRefs: new Set(["refs/heads/agreeable-ermine"]),
+			upstreams: {},
+		});
+
+		const result = await resolveNewBranchStartPoint(git, "agreeable-ermine");
+
+		expect(result.kind).toBe("local");
+		expect(git.fetch).not.toHaveBeenCalled();
+	});
+
+	test("keeps local when configured upstream ref doesn't exist locally", async () => {
+		// resolveUpstream succeeds but rev-parse origin/foo fails.
+		const git = createMockGit({
+			existingRefs: new Set(["refs/heads/foo"]),
+			upstreams: { foo: { remote: "origin", remoteBranch: "foo" } },
+		});
+
+		const result = await resolveNewBranchStartPoint(git, "foo");
+
+		expect(result.kind).toBe("local");
+		expect(git.fetch).not.toHaveBeenCalled();
+	});
+
+	test("swallows fetch errors and still returns the resolved start point", async () => {
+		const git = createMockGit({
+			existingRefs: new Set([
+				"refs/heads/main",
+				"refs/remotes/origin/main",
+			]),
+			upstreams: { main: { remote: "origin", remoteBranch: "main" } },
+			fetchThrows: new Error("network unreachable"),
+		});
+
+		const result = await resolveNewBranchStartPoint(git, "main");
+
+		expect(result.kind).toBe("remote-tracking");
+		expect(git.fetch).toHaveBeenCalled();
+	});
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
+import type { GitClient } from "../shared/types";
 import { resolveNewBranchStartPoint } from "./resolve-new-branch-start-point";
 
 interface MockState {
@@ -19,10 +20,7 @@ function createMockGit(state: MockState) {
 			if (state.existingRefs.has(ref)) return `${"0".repeat(40)}\n`;
 			throw new Error("fatal: Needed a single revision");
 		}
-		if (
-			args[0] === "symbolic-ref" &&
-			args[1] === "refs/remotes/origin/HEAD"
-		) {
+		if (args[0] === "symbolic-ref" && args[1] === "refs/remotes/origin/HEAD") {
 			if (state.defaultBranch) return `origin/${state.defaultBranch}`;
 			throw new Error("fatal: ref is not a symbolic ref");
 		}
@@ -40,7 +38,9 @@ function createMockGit(state: MockState) {
 		}
 		throw new Error(`Unexpected raw args: ${args.join(" ")}`);
 	});
-	return { raw, fetch } as never;
+	return { raw, fetch } as unknown as GitClient & {
+		fetch: typeof fetch;
+	};
 }
 
 describe("resolveNewBranchStartPoint", () => {
@@ -76,10 +76,7 @@ describe("resolveNewBranchStartPoint", () => {
 
 	test("upgrades and fetches the default branch (unchanged behavior)", async () => {
 		const git = createMockGit({
-			existingRefs: new Set([
-				"refs/heads/main",
-				"refs/remotes/origin/main",
-			]),
+			existingRefs: new Set(["refs/heads/main", "refs/remotes/origin/main"]),
 			upstreams: { main: { remote: "origin", remoteBranch: "main" } },
 			defaultBranch: "main",
 		});
@@ -122,10 +119,7 @@ describe("resolveNewBranchStartPoint", () => {
 
 	test("swallows fetch errors and still returns the resolved start point", async () => {
 		const git = createMockGit({
-			existingRefs: new Set([
-				"refs/heads/main",
-				"refs/remotes/origin/main",
-			]),
+			existingRefs: new Set(["refs/heads/main", "refs/remotes/origin/main"]),
 			upstreams: { main: { remote: "origin", remoteBranch: "main" } },
 			fetchThrows: new Error("network unreachable"),
 		});

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/resolve-new-branch-start-point.ts
@@ -1,0 +1,69 @@
+import {
+	asRemoteRef,
+	type ResolvedRef,
+	resolveUpstream,
+} from "../../../../runtime/git/refs";
+import type { GitClient } from "../shared/types";
+import { resolveStartPoint } from "./resolve-start-point";
+
+/**
+ * Resolve the start point a *new* branch should fork from. No
+ * `resolveRef(branch)` check — callers are responsible for guaranteeing
+ * the branch name is fresh (e.g. via `deduplicateBranchName`). Useful
+ * when the branch name is being chosen at the same time the start point
+ * is resolved (auto-gen + AI naming path), so it can run in parallel
+ * with the LLM call.
+ *
+ * Local refs of *any* base branch go stale — not just the default. If
+ * `main` gets `git fetch`ed regularly but a shared branch like
+ * `mirror-flier` hasn't been touched in weeks, forking from local
+ * `mirror-flier` silently produces a workspace weeks behind current
+ * work. So we upgrade local→remote-tracking + fetch whenever the base
+ * has a configured upstream, regardless of whether it's the default.
+ */
+export async function resolveNewBranchStartPoint(
+	git: GitClient,
+	baseBranch: string | undefined,
+): Promise<ResolvedRef> {
+	let startPoint = await resolveStartPoint(git, baseBranch);
+
+	if (startPoint.kind === "local") {
+		const upstream = await resolveUpstream(git, startPoint.shortName);
+		if (upstream) {
+			const remoteRef = asRemoteRef(upstream.remote, upstream.remoteBranch);
+			// `--quiet` confuses simple-git's `raw` (resolves on missing
+			// refs with empty stdout). Drop it; verify a sha was printed.
+			const remoteExists = await git
+				.raw(["rev-parse", "--verify", `${remoteRef}^{commit}`])
+				.then((out) => /^[0-9a-f]{40,}/.test(out.trim()))
+				.catch(() => false);
+			if (remoteExists) {
+				startPoint = {
+					kind: "remote-tracking",
+					fullRef: remoteRef,
+					shortName: upstream.remoteBranch,
+					remote: upstream.remote,
+					remoteShortName: `${upstream.remote}/${upstream.remoteBranch}`,
+				};
+			}
+		}
+	}
+
+	if (startPoint.kind === "remote-tracking") {
+		try {
+			await git.fetch([
+				startPoint.remote,
+				startPoint.shortName,
+				"--quiet",
+				"--no-tags",
+			]);
+		} catch (err) {
+			console.warn(
+				`[workspaces.create] fetch ${startPoint.remoteShortName} failed:`,
+				err,
+			);
+		}
+	}
+
+	return startPoint;
+}

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -5,13 +5,7 @@ import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
-import {
-	asRemoteRef,
-	type ResolvedRef,
-	resolveDefaultBranchName,
-	resolveRef,
-	resolveUpstream,
-} from "../../../runtime/git/refs";
+import { type ResolvedRef, resolveRef } from "../../../runtime/git/refs";
 import type { HostServiceContext } from "../../../types";
 import {
 	getLocalWorkspace,
@@ -50,7 +44,7 @@ import {
 	PrBranchConflictError,
 } from "../workspace-creation/utils/pr-branch-materialize";
 import { derivePrLocalBranchName } from "../workspace-creation/utils/pr-branch-name";
-import { resolveStartPoint } from "../workspace-creation/utils/resolve-start-point";
+import { resolveNewBranchStartPoint } from "../workspace-creation/utils/resolve-new-branch-start-point";
 import { deduplicateBranchName } from "../workspace-creation/utils/sanitize-branch";
 
 /**
@@ -243,66 +237,6 @@ interface BranchSourcePlan {
 	branch: string;
 	startPoint: ResolvedRef;
 	usedExistingBranch: boolean;
-}
-
-/**
- * Resolve the start point a *new* branch should fork from. No
- * `resolveRef(branch)` check — callers are responsible for guaranteeing
- * the branch name is fresh (e.g. via `deduplicateBranchName`). Useful
- * when the branch name is being chosen at the same time the start point
- * is resolved (auto-gen + AI naming path), so it can run in parallel
- * with the LLM call.
- */
-async function resolveNewBranchStartPoint(
-	git: GitClient,
-	baseBranch: string | undefined,
-): Promise<ResolvedRef> {
-	let startPoint = await resolveStartPoint(git, baseBranch);
-
-	// Fork from upstream of the default branch when the user didn't specify
-	// a base — locals are often stale.
-	if (startPoint.kind === "local") {
-		const defaultBranchName = await resolveDefaultBranchName(git);
-		if (startPoint.shortName === defaultBranchName) {
-			const upstream = await resolveUpstream(git, defaultBranchName);
-			if (upstream) {
-				const remoteRef = asRemoteRef(upstream.remote, upstream.remoteBranch);
-				// `--quiet` confuses simple-git's `raw` (resolves on missing
-				// refs with empty stdout). Drop it; verify a sha was printed.
-				const remoteExists = await git
-					.raw(["rev-parse", "--verify", `${remoteRef}^{commit}`])
-					.then((out) => /^[0-9a-f]{40,}/.test(out.trim()))
-					.catch(() => false);
-				if (remoteExists) {
-					startPoint = {
-						kind: "remote-tracking",
-						fullRef: remoteRef,
-						shortName: upstream.remoteBranch,
-						remote: upstream.remote,
-						remoteShortName: `${upstream.remote}/${upstream.remoteBranch}`,
-					};
-				}
-			}
-		}
-	}
-
-	if (startPoint.kind === "remote-tracking") {
-		try {
-			await git.fetch([
-				startPoint.remote,
-				startPoint.shortName,
-				"--quiet",
-				"--no-tags",
-			]);
-		} catch (err) {
-			console.warn(
-				`[workspaces.create] fetch ${startPoint.remoteShortName} failed:`,
-				err,
-			);
-		}
-	}
-
-	return startPoint;
 }
 
 async function planBranchSource(


### PR DESCRIPTION
## Summary

`resolveNewBranchStartPoint` only upgraded local→remote-tracking + fetched the base ref when the base was the default branch. For any other base branch — sticky localStorage default, explicit picker choice, an AI-suggested branch — the local ref was used as-is with no fetch. A shared branch that hadn't been touched in weeks silently forked new workspaces from a stale tip.

Concrete case that motivated this: workspace created with `baseBranch: mirror-flier`; local `mirror-flier` was 44 days behind `origin/mirror-flier`, producing a new workspace ~1700 commits behind current work. Reproduced from the git reflog in the affected worktree (`branch: Created from mirror-flier` at a June 9 commit, worktree pointer touched July 23).

## Change

- Extract `resolveNewBranchStartPoint` from `workspaces.ts` into `workspace-creation/utils/resolve-new-branch-start-point.ts` so it can be unit-tested.
- Drop the `startPoint.shortName === defaultBranchName` gate — the upgrade + fetch now applies to any local base branch that has a configured upstream. Default-branch behavior is unchanged.

Local branches without an upstream (workspace branches, purely-local dev branches) and cases where the remote-tracking ref doesn't exist locally continue to use the local ref unchanged — same behavior as before.

## Test plan

- [x] New unit tests in `resolve-new-branch-start-point.test.ts` cover: non-default branch with upstream (regression), default branch (unchanged), no upstream, remote ref missing, silent fetch failure.
- [ ] Manual: open a new workspace with a non-default base branch that's stale locally; verify the new worktree tip matches `origin/<base>` and not the pre-existing local ref.
- [ ] `bun test packages/host-service` passes.
- [ ] `bun run lint` and `bun run typecheck` clean.

## Known follow-ups (not in this PR)

Adjacent causes surfaced during the same investigation, deliberately left as separate work:

- **Sticky base-branch default.** `apps/desktop/src/renderer/stores/v2-workspace-create-defaults.ts` persists the last-picked base branch per project in localStorage indefinitely (`baseBranchesByProjectId`), and `PromptGroup.tsx:96-98` pre-fills it silently. A one-time accidental pick of a non-default branch becomes the sticky default forever, with no UI signal. Fix has design choices (drop persistence, badge inherited defaults, add a reset affordance) worth discussing on its own PR. With this PR merged the resulting workspaces at least fork from a *fresh* tip of the stuck branch, so the symptom drops from "weeks behind" to "sometimes not `main`."
- **Picker source hint dropped.** `buildStartPointFromHint` (`packages/host-service/src/trpc/router/workspace-creation/shared/start-point.ts:12`) is documented in `apps/desktop/docs/V2_WORKSPACE_CREATION.md` as the way the picker's explicit `local` / `remote-tracking` row choice reaches the server, but it's never called. `createInputSchema` has no `baseBranchSource` field and `useSubmitWorkspace.ts:117` only sends `baseBranch`. So clicking the `origin/main` row can still resolve to local `main` on the server. Wiring the hint end-to-end is a small but cross-package change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved new branch creation to recognize configured upstream branches and use available remote-tracking references.
  * Automatically refreshes remote branch information when resolving a branch’s starting point.

* **Bug Fixes**
  * Branch creation now safely falls back to local references when upstream information is unavailable.
  * Fetch failures no longer prevent branch creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->