### PR TITLE
feat(mcp-v2,docs,api): MCP server instructions and destructive/read-only tool annotations

### DIFF
--- a/apps/api/src/app/.well-known/mcp.json/route.ts
+++ b/apps/api/src/app/.well-known/mcp.json/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../mcp/route";

--- a/apps/api/src/app/.well-known/mcp/server-card.json/route.ts
+++ b/apps/api/src/app/.well-known/mcp/server-card.json/route.ts
@@ -15,6 +15,7 @@ async function listTools() {
 		return tools.map((tool) => ({
 			name: tool.name,
 			description: tool.description,
+			...(tool.annotations ? { annotations: tool.annotations } : {}),
 			inputSchema: tool.inputSchema,
 		}));
 	} finally {

--- a/apps/api/src/app/openapi.json/route.ts
+++ b/apps/api/src/app/openapi.json/route.ts
@@ -101,6 +101,8 @@ const SPEC = {
 				"` and served live via the MCP `tools/list` method.",
 			"",
 			`Authentication is OAuth 2.1 authorization code + PKCE with RFC 7591 dynamic client registration, or a user-issued Superset API key sent as a Bearer token. Agent walkthrough: ${MARKETING_URL}/auth.md`,
+			"",
+			`Versioning and deprecation: the current surface is v2, versioned in the URL path (/api/v2/...). Deprecated surfaces stay available during a migration window — the v1 MCP server at /api/agent/mcp remains served for existing integrations — and deprecations are announced in the changelog (${MARKETING_URL}/changelog).`,
 		].join("\n"),
 		contact: {
 			name: "Superset support",
@@ -406,7 +408,23 @@ const SPEC = {
 							"Resource metadata naming the authorization server and supported scopes.",
 						content: {
 							"application/json": {
-								schema: { type: "object", additionalProperties: true },
+								schema: {
+									type: "object",
+									properties: {
+										resource: { type: "string", format: "uri" },
+										authorization_servers: {
+											type: "array",
+											items: { type: "string", format: "uri" },
+										},
+										scopes_supported: {
+											type: "array",
+											items: { type: "string" },
+										},
+										resource_name: { type: "string" },
+										resource_documentation: { type: "string", format: "uri" },
+									},
+									required: ["resource", "authorization_servers"],
+								},
 							},
 						},
 					},
@@ -426,7 +444,34 @@ const SPEC = {
 						description: "Authorization server metadata.",
 						content: {
 							"application/json": {
-								schema: { type: "object", additionalProperties: true },
+								schema: {
+									type: "object",
+									properties: {
+										issuer: { type: "string", format: "uri" },
+										authorization_endpoint: { type: "string", format: "uri" },
+										token_endpoint: { type: "string", format: "uri" },
+										registration_endpoint: { type: "string", format: "uri" },
+										revocation_endpoint: { type: "string", format: "uri" },
+										scopes_supported: {
+											type: "array",
+											items: { type: "string" },
+										},
+										agent_auth: {
+											type: "object",
+											properties: {
+												skill: { type: "string", format: "uri" },
+												register_uri: { type: "string", format: "uri" },
+												revocation_uri: { type: "string", format: "uri" },
+												identity_types_supported: {
+													type: "array",
+													items: { type: "string", enum: ["anonymous"] },
+												},
+											},
+										},
+									},
+									required: ["issuer"],
+									additionalProperties: true,
+								},
 							},
 						},
 					},
@@ -446,7 +491,43 @@ const SPEC = {
 						description: "MCP server card.",
 						content: {
 							"application/json": {
-								schema: { type: "object", additionalProperties: true },
+								schema: {
+									type: "object",
+									properties: {
+										name: { type: "string" },
+										description: { type: "string" },
+										version: { type: "string" },
+										serverUrl: { type: "string", format: "uri" },
+										transport: { type: "string", enum: ["streamable-http"] },
+										documentationUrl: { type: "string", format: "uri" },
+										authentication: {
+											type: "object",
+											properties: {
+												type: { type: "string" },
+												resourceMetadataUrl: {
+													type: "string",
+													format: "uri",
+												},
+											},
+										},
+										tools: {
+											type: "array",
+											items: {
+												type: "object",
+												properties: {
+													name: { type: "string" },
+													description: { type: "string" },
+													inputSchema: {
+														type: "object",
+														additionalProperties: true,
+													},
+												},
+												required: ["name"],
+											},
+										},
+									},
+									required: ["name", "version", "serverUrl", "tools"],
+								},
 							},
 						},
 					},
@@ -464,7 +545,16 @@ const SPEC = {
 						description: "OpenAPI 3.1 specification.",
 						content: {
 							"application/json": {
-								schema: { type: "object", additionalProperties: true },
+								schema: {
+									type: "object",
+									properties: {
+										openapi: { type: "string" },
+										info: { type: "object", additionalProperties: true },
+										paths: { type: "object", additionalProperties: true },
+										components: { type: "object", additionalProperties: true },
+									},
+									required: ["openapi", "info", "paths"],
+								},
 							},
 						},
 					},

--- a/apps/docs/src/app/mcp/route.ts
+++ b/apps/docs/src/app/mcp/route.ts
@@ -4,13 +4,20 @@ import { z } from "zod";
 import { getLLMText, source } from "@/lib/source";
 
 function createDocsMcpServer(): McpServer {
-	const server = new McpServer({ name: "superset-docs", version: "1.0.0" });
+	const server = new McpServer(
+		{ name: "superset-docs", version: "1.0.0" },
+		{
+			instructions:
+				"Read-only access to the Superset documentation (docs.superset.sh). Superset runs parallel AI coding agents in isolated Git worktrees. Call docs_search to find pages by keyword, then docs_read to fetch a page as markdown. No authentication required; nothing here mutates state. To act on a Superset account (workspaces, agents, tasks), use the product MCP server at https://api.superset.sh/mcp instead.",
+		},
+	);
 
 	server.registerTool(
 		"docs_search",
 		{
 			description:
 				"Search the Superset documentation by keyword. Returns matching pages with path, title, and description. Use docs_read to fetch a page's full content.",
+			annotations: { readOnlyHint: true },
 			inputSchema: {
 				query: z
 					.string()
@@ -60,6 +67,7 @@ function createDocsMcpServer(): McpServer {
 		{
 			description:
 				"Read one Superset documentation page as markdown. Pass the path from docs_search (e.g. /mcp-server, /cli/getting-started).",
+			annotations: { readOnlyHint: true },
 			inputSchema: {
 				path: z.string().describe("Page path, e.g. /automations"),
 			},

--- a/apps/marketing/src/app/.well-known/mcp.json/route.ts
+++ b/apps/marketing/src/app/.well-known/mcp.json/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../mcp/route";

--- a/packages/mcp-v2/src/define-tool.ts
+++ b/packages/mcp-v2/src/define-tool.ts
@@ -1,5 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+	CallToolResult,
+	ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { ZodRawShape, z } from "zod";
 import { isMcpUnauthorized, type McpContext } from "./auth";
 import { getMcpContextFromExtra, type McpRequestExtra } from "./context-utils";
@@ -10,6 +13,7 @@ export interface ToolDef<
 > {
 	name: string;
 	description: string;
+	annotations?: ToolAnnotations;
 	inputSchema?: Input;
 	outputSchema?: Output;
 	handler: (
@@ -101,6 +105,7 @@ export function defineTool<
 		def.name,
 		{
 			description: def.description,
+			...(def.annotations ? { annotations: def.annotations } : {}),
 			inputSchema: (def.inputSchema ?? {}) as Input,
 			...(def.outputSchema ? { outputSchema: def.outputSchema } : {}),
 		},

--- a/packages/mcp-v2/src/server.ts
+++ b/packages/mcp-v2/src/server.ts
@@ -10,7 +10,11 @@ export interface McpServerOptions {
 export function createMcpServer(options?: McpServerOptions): McpServer {
 	const server = new McpServer(
 		{ name: "superset-v2", version: packageJson.version },
-		{ capabilities: { tools: {} } },
+		{
+			capabilities: { tools: {} },
+			instructions:
+				"Superset orchestrates parallel AI coding agents in isolated Git worktrees on a user's registered machines. Use these tools to manage tasks, create workspaces (branch- or PR-scoped worktrees), launch coding-agent sessions, open terminals, and schedule recurring automations on behalf of the authenticated user. IDs are host-scoped: call hosts_list first, then projects_list/workspaces_list on that host. Tools annotated destructive (deletes) remove real user data — confirm with the user before calling them.",
+		},
 	);
 	registerTools(server, { onToolCall: options?.onToolCall });
 	return server;

--- a/packages/mcp-v2/src/tools/agents/create.ts
+++ b/packages/mcp-v2/src/tools/agents/create.ts
@@ -6,6 +6,7 @@ import { hostServiceCall } from "../../host-service-client";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "agents_create",
+		annotations: { destructiveHint: false },
 		description:
 			"Create (launch) an agent session inside an existing workspace on its host: runs the named agent preset (or HostAgentConfig instance) with the given prompt in a fresh terminal session. Use hosts_list / workspaces_list to find the hostId. Use this to start a second agent in a workspace that already exists; for create-and-spawn in a single call, pass `agents` to workspaces_create instead.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/agents/list.ts
+++ b/packages/mcp-v2/src/tools/agents/list.ts
@@ -18,6 +18,7 @@ interface HostAgentConfig {
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "agents_list",
+		annotations: { readOnlyHint: true },
 		description:
 			"List terminal-agent instances configured on a host (the rows in Settings → Agents on that machine). Returns each row with its instance UUID, presetId, label, command, args, and env. Use to find an `agent` value for `agents_create` or to confirm what's installed before launching.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/create.ts
+++ b/packages/mcp-v2/src/tools/automations/create.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_create",
+		annotations: { destructiveHint: false },
 		description:
 			"Schedule a recurring agent run. Provide an RFC 5545 RRULE body for the schedule. Either v2ProjectId (run in a fresh workspace) or v2WorkspaceId (reuse an existing workspace) is required — call projects_list or workspaces_list first to get IDs. `agent` is the host-agent instance id (or presetId fallback) that runs the prompt; pass 'superset' for the built-in chat agent.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/delete.ts
+++ b/packages/mcp-v2/src/tools/automations/delete.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_delete",
+		annotations: { destructiveHint: true },
 		description:
 			"Delete an automation. The recurring schedule stops immediately; past runs remain. Caller must be the owner.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/get.ts
+++ b/packages/mcp-v2/src/tools/automations/get.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_get",
+		annotations: { readOnlyHint: true },
 		description:
 			"Get a single automation's metadata. Returns name, schedule, agent, host — the prompt body is omitted (call automations_get_prompt to fetch it). For run history, call automations_logs. Caller must be the automation's owner.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/get_prompt.ts
+++ b/packages/mcp-v2/src/tools/automations/get_prompt.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_get_prompt",
+		annotations: { readOnlyHint: true },
 		description:
 			"Fetch the full prompt body (markdown) for one automation. Use this when you need to read or edit the prompt — automations_get and automations_list omit the body to keep responses small. Caller must be the automation's owner.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/list.ts
+++ b/packages/mcp-v2/src/tools/automations/list.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_list",
+		annotations: { readOnlyHint: true },
 		description:
 			"List automations (scheduled agent runs) the calling user owns in the active organization. Returns a summary shape — call automations_get_prompt to fetch the prompt for one automation, or automations_get for the rest of its config. Pass `name` to filter rows by case-insensitive substring match on the automation name.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/logs.ts
+++ b/packages/mcp-v2/src/tools/automations/logs.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_logs",
+		annotations: { readOnlyHint: true },
 		description:
 			"List recent runs for an automation. Returns up to `limit` runs ordered newest-first. Caller must be the automation's owner.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/pause.ts
+++ b/packages/mcp-v2/src/tools/automations/pause.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_pause",
+		annotations: { destructiveHint: false, idempotentHint: true },
 		description:
 			"Pause an automation. The recurring schedule stops firing until resumed. Caller must be the owner.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/resume.ts
+++ b/packages/mcp-v2/src/tools/automations/resume.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_resume",
+		annotations: { destructiveHint: false, idempotentHint: true },
 		description:
 			"Resume a paused automation. The next scheduled fire is recomputed from the RRULE. Caller must be the owner.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/run.ts
+++ b/packages/mcp-v2/src/tools/automations/run.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_run",
+		annotations: { destructiveHint: false },
 		description:
 			"Dispatch an automation immediately, outside its normal schedule. Returns the new run ID; does not wait for completion. Use automations_logs to track progress.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/set_prompt.ts
+++ b/packages/mcp-v2/src/tools/automations/set_prompt.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_set_prompt",
+		annotations: { destructiveHint: false, idempotentHint: true },
 		description:
 			"Replace the full prompt body (markdown) for one automation. The new prompt fully overwrites the old one — fetch with automations_get_prompt first if you only want to edit. Caller must be the automation's owner.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/automations/update.ts
+++ b/packages/mcp-v2/src/tools/automations/update.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_update",
+		annotations: { destructiveHint: false, idempotentHint: true },
 		description:
 			"Update metadata on an existing automation (name, schedule, agent, host). Only the fields you pass change. Caller must be the automation's owner. Use automations_set_prompt to change the prompt body.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/hosts/list.ts
+++ b/packages/mcp-v2/src/tools/hosts/list.ts
@@ -5,6 +5,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "hosts_list",
+		annotations: { readOnlyHint: true },
 		description:
 			"List the hosts (registered machines) the calling user has access to in the active organization. Use this to find a host's id before creating a workspace or scheduling an automation.",
 		handler: async (_input, ctx) => {

--- a/packages/mcp-v2/src/tools/organization/members/list.ts
+++ b/packages/mcp-v2/src/tools/organization/members/list.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "organization_members_list",
+		annotations: { readOnlyHint: true },
 		description:
 			"List members of the active organization. Use this to look up a user's id by name or email before assigning a task or filtering by assignee.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/projects/list.ts
+++ b/packages/mcp-v2/src/tools/projects/list.ts
@@ -6,6 +6,7 @@ import { hostServiceCall } from "../../host-service-client";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "projects_list",
+		annotations: { readOnlyHint: true },
 		description:
 			"List projects set up on a host. A project is a checked-out repo; projects are host-owned — use hosts_list first to get the hostId. Use this to find a project's id before creating a workspace or scheduling an automation.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/tasks/create.ts
+++ b/packages/mcp-v2/src/tools/tasks/create.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "tasks_create",
+		annotations: { destructiveHint: false },
 		description:
 			"Create a task in the active organization. Use this when the user describes work they want to track. The task is auto-assigned a default status if statusId is omitted.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/tasks/delete.ts
+++ b/packages/mcp-v2/src/tools/tasks/delete.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "tasks_delete",
+		annotations: { destructiveHint: true },
 		description:
 			"Delete a task by UUID (soft delete — the row is tombstoned, not purged).",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/tasks/get.ts
+++ b/packages/mcp-v2/src/tools/tasks/get.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "tasks_get",
+		annotations: { readOnlyHint: true },
 		description:
 			"Fetch one task by UUID or human slug. Use this when you have a task ID or slug from a list call or the user.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/tasks/list.ts
+++ b/packages/mcp-v2/src/tools/tasks/list.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "tasks_list",
+		annotations: { readOnlyHint: true },
 		description:
 			"List tasks in the active organization, optionally filtered by status, priority, assignee, or a free-text search. Use this when the user asks 'what tasks are open', 'find tasks about X', or 'what's assigned to me'.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/tasks/statuses/list.ts
+++ b/packages/mcp-v2/src/tools/tasks/statuses/list.ts
@@ -5,6 +5,7 @@ import { defineTool } from "../../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "tasks_statuses_list",
+		annotations: { readOnlyHint: true },
 		description:
 			"List the available task statuses in the active organization. Use this to look up a status id by name (e.g. 'In Progress', 'Done') before creating or updating a task.",
 		handler: async (_input, ctx) => {

--- a/packages/mcp-v2/src/tools/tasks/update.ts
+++ b/packages/mcp-v2/src/tools/tasks/update.ts
@@ -6,6 +6,7 @@ import { defineTool } from "../../define-tool";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "tasks_update",
+		annotations: { destructiveHint: false, idempotentHint: true },
 		description:
 			"Update fields on an existing task. Only the fields you pass are changed. Omitting a field preserves its current value (set null explicitly to clear nullable fields).",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/terminals/create.ts
+++ b/packages/mcp-v2/src/tools/terminals/create.ts
@@ -6,6 +6,7 @@ import { hostServiceCall } from "../../host-service-client";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "terminals_create",
+		annotations: { destructiveHint: false },
 		description:
 			"Create a terminal session in an existing workspace on its host: opens a fresh PTY in the worktree. Use hosts_list / workspaces_list to find the hostId. Pass `command` to run a one-off shell command, or omit it to open an interactive shell. For create-and-run in a single call, pass `command` to workspaces_create instead.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/workspaces/create.ts
+++ b/packages/mcp-v2/src/tools/workspaces/create.ts
@@ -22,6 +22,7 @@ const agentLaunchSchema = z.object({
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_create",
+		annotations: { destructiveHint: false },
 		description:
 			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. Provide exactly one of `branch` or `pr`. Optionally pass `agents` to spawn one or more agents in the workspace as soon as it is ready (each entry runs the equivalent of `agents_create` against the new workspace), and/or pass `command` to run a one-off shell command in the worktree. Use projects_list and hosts_list first to get the projectId and hostId.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/workspaces/delete.ts
+++ b/packages/mcp-v2/src/tools/workspaces/delete.ts
@@ -6,6 +6,7 @@ import { hostServiceCall } from "../../host-service-client";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_delete",
+		annotations: { destructiveHint: true },
 		description:
 			"Delete a workspace by UUID on its host. The host service removes the git worktree from disk before returning. Cannot delete 'main'-type workspaces. Use hosts_list / workspaces_list to find the hostId.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/workspaces/list.ts
+++ b/packages/mcp-v2/src/tools/workspaces/list.ts
@@ -6,6 +6,7 @@ import { hostServiceCall } from "../../host-service-client";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_list",
+		annotations: { readOnlyHint: true },
 		description:
 			"List workspaces (branch-scoped working copies) on a host. Workspaces are host-owned — use hosts_list first to get the hostId. Rows include the host-served projectName. Use this to find a workspace ID for automations_create's v2WorkspaceId.",
 		inputSchema: {

--- a/packages/mcp-v2/src/tools/workspaces/update.ts
+++ b/packages/mcp-v2/src/tools/workspaces/update.ts
@@ -6,6 +6,7 @@ import { hostServiceCall } from "../../host-service-client";
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_update",
+		annotations: { destructiveHint: false, idempotentHint: true },
 		description:
 			"Rename a workspace on its host. Use hosts_list / workspaces_list to find the hostId.",
 		inputSchema: {


### PR DESCRIPTION
## Summary
- Add `instructions` to both MCP servers' initialize responses and behavioral annotations to every tool: `readOnlyHint` on the 12 list/get tools, `destructiveHint` on the 3 deletes, `idempotentHint` on updates/pause/resume, `destructiveHint: false` on creates/dispatch.
- This is the genuinely useful slice of the latest orank rescan: it graded our new docs MCP server and flagged missing instructions/annotations — the same gaps existed invisibly in the product mcp-v2 server, where they matter for real agent safety (an agent can now decline `workspaces_delete` without user confirmation instead of guessing).

## Why / Context
Follow-up to #5910/#5912. The rescan (77/100) surfaced three real MCP-quality items alongside a pile of REST-isms we're deliberately not chasing. Per the MCP spec, an unannotated tool defaults to "assume destructive" — annotating makes the safe majority of our catalog explicitly safe and the dangerous minority explicitly dangerous.

## How It Works
- `defineTool` (mcp-v2) gains an `annotations` pass-through; each of the 27 tool definitions declares its hints inline.
- `createMcpServer` sets `instructions` (host-scoped ID guidance + destructive-tool warning) in the initialize response.
- Docs MCP server gets instructions + `readOnlyHint` on both tools.
- The live-introspected server card now carries annotations per tool.
- Also: `/.well-known/mcp.json` manifest alias (marketing + api), typed response schemas for the 4 discovery operations in openapi.json, and a factual versioning/deprecation paragraph (v1 MCP stays served during migration; changes announced in changelog).

## Manual QA Checklist
- [x] `tools/list` on mcp-v2 (via server card introspection): all 27 tools annotated, deletes carry `destructiveHint`, lists carry `readOnlyHint`, none unannotated
- [x] Docs MCP `initialize` returns instructions; both tools `readOnlyHint: true`
- [x] `/.well-known/mcp.json` serves on the api app (marketing route is an identical re-export)
- [x] Invalid tool call / bad args verified to return structured `-32602` errors (SDK behavior, unchanged)

## Testing
- `bun run typecheck` (mcp-v2, api, docs, marketing)
- `bun run lint` (exits 0)

## Known Limitations
- The scanner's "MCP error handling" warning wants raw JSON-RPC errors where the MCP SDK intentionally returns `isError` tool results with the code in the message — not ours to patch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP server `instructions` and explicit tool annotations to `mcp-v2` and the docs server so agents can safely distinguish read-only, idempotent, and destructive calls. Also surfaces annotations in the server card, adds a `/.well-known/mcp.json` manifest alias, and types discovery endpoints in `openapi.json` with versioning notes.

- **New Features**
  - `mcp-v2`: `initialize` now returns `instructions` (host-scoped ID guidance + destructive-tool warning). All 27 tools annotated: `readOnlyHint` on list/get, `destructiveHint` on deletes (and `destructiveHint: false` on creates/dispatch), `idempotentHint` on updates/pause/resume.
  - Docs MCP: added `instructions`; both tools set `readOnlyHint: true`.
  - Server card now includes per-tool `annotations`; new `/.well-known/mcp.json` alias on `api` and `marketing` for manifest probes.
  - `openapi.json`: adds typed response schemas for resource metadata, authorization server metadata, MCP server card, and the OpenAPI document; documents path-based versioning (v2) and deprecation policy (v1 MCP remains available during migration).

<sup>Written for commit 045cea314bbaa4c073a5355179f7cc698c97c3a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tools now expose clear read-only, destructive, and idempotent operation indicators.
  * MCP server guidance now explains supported behavior, tool usage, and safety considerations.
  * MCP discovery endpoints are available through standardized metadata routes.

* **Documentation**
  * API documentation now provides more precise schemas for discovery and server-card responses.
  * Versioning and migration guidance has been added to the API documentation.

* **Improvements**
  * Server cards now include tool annotations for richer client experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->