### PR TITLE
chore(sdk): declare homepage/repository/bugs/keywords in package.json

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,6 +2,23 @@
 	"name": "@superset/sdk",
 	"version": "0.0.1-alpha.12",
 	"description": "TypeScript SDK for the Superset API",
+	"homepage": "https://superset.sh",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/superset-sh/superset.git",
+		"directory": "packages/sdk"
+	},
+	"bugs": {
+		"url": "https://github.com/superset-sh/superset/issues"
+	},
+	"keywords": [
+		"superset",
+		"coding-agents",
+		"agent-orchestration",
+		"git-worktree",
+		"mcp",
+		"sdk"
+	],
 	"private": true,
 	"type": "module",
 	"license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- `@superset_sh/sdk` on npm currently ships with no `homepage`, `repository`, or `bugs` fields — these are what agents, npm's UI, and package-directory scanners use to verify a package is the official Superset SDK and link it back to superset.sh.

## Testing
- Biome check on the file; metadata-only, takes effect on the next SDK publish.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add homepage, repository, bugs, and keywords metadata to the `@superset/sdk` package.json so npm and tooling can verify it as the official SDK and link back to superset.sh and GitHub. No runtime changes; takes effect on the next publish.

<sup>Written for commit ccb0980f774705ea8c698a7006df444832eaf4a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added package metadata, including homepage, repository, issue-reporting, and keyword information.
  * Improved package discoverability and provided clearer links for project resources and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->