### PR TITLE
fix(deps): patch next, postcss, @hono/node-server security advisories

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -27,7 +27,7 @@
 		"date-fns": "4.1.0",
 		"drizzle-orm": "0.45.2",
 		"import-in-the-middle": "2.0.1",
-		"next": "16.2.6",
+		"next": "16.2.11",
 		"next-themes": "0.4.6",
 		"posthog-js": "1.310.1",
 		"react": "19.2.3",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,7 +41,7 @@
 		"import-in-the-middle": "2.0.1",
 		"jose": "6.2.2",
 		"lodash.chunk": "4.2.0",
-		"next": "16.2.6",
+		"next": "16.2.11",
 		"posthog-node": "5.28.8",
 		"react": "19.2.3",
 		"react-dom": "19.2.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -73,7 +73,7 @@
 		"@electric-sql/client": "1.5.23",
 		"@headless-tree/core": "1.6.3",
 		"@headless-tree/react": "1.6.3",
-		"@hono/node-server": "2.0.5",
+		"@hono/node-server": "2.0.10",
 		"@hookform/resolvers": "5.2.2",
 		"@lezer/highlight": "1.2.3",
 		"@mastra/core": "1.33.1",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,7 +24,7 @@
 		"fumadocs-mdx": "14.2.5",
 		"fumadocs-ui": "16.4.7",
 		"lucide-react": "0.563.0",
-		"next": "16.2.6",
+		"next": "16.2.11",
 		"posthog-js": "1.310.1",
 		"react": "19.2.3",
 		"react-dom": "19.2.3",
@@ -38,7 +38,7 @@
 		"@types/node": "24.12.0",
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",
-		"postcss": "8.5.10",
+		"postcss": "8.5.12",
 		"tailwindcss": "4.2.2",
 		"tailwindcss-animate": "1.0.7",
 		"typescript": "6.0.3"

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -27,7 +27,7 @@
 		"gray-matter": "4.0.3",
 		"import-in-the-middle": "2.0.1",
 		"lucide-react": "0.563.0",
-		"next": "16.2.6",
+		"next": "16.2.11",
 		"next-mdx-remote": "6.0.0",
 		"next-themes": "0.4.6",
 		"posthog-js": "1.310.1",

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -10,7 +10,7 @@
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {
-		"@hono/node-server": "2.0.5",
+		"@hono/node-server": "2.0.10",
 		"@hono/node-ws": "1.3.0",
 		"@sentry/node": "9.47.1",
 		"@superset/shared": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,7 +34,7 @@
 		"import-in-the-middle": "2.0.1",
 		"jose": "6.2.2",
 		"lucide-react": "0.563.0",
-		"next": "16.2.6",
+		"next": "16.2.11",
 		"next-themes": "0.4.6",
 		"posthog-js": "1.310.1",
 		"posthog-node": "5.28.8",

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
         "date-fns": "4.1.0",
         "drizzle-orm": "0.45.2",
         "import-in-the-middle": "2.0.1",
-        "next": "16.2.6",
+        "next": "16.2.11",
         "next-themes": "0.4.6",
         "posthog-js": "1.310.1",
         "react": "19.2.3",
@@ -96,7 +96,7 @@
         "import-in-the-middle": "2.0.1",
         "jose": "6.2.2",
         "lodash.chunk": "4.2.0",
-        "next": "16.2.6",
+        "next": "16.2.11",
         "posthog-node": "5.28.8",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -155,7 +155,7 @@
         "@electric-sql/client": "1.5.23",
         "@headless-tree/core": "1.6.3",
         "@headless-tree/react": "1.6.3",
-        "@hono/node-server": "2.0.5",
+        "@hono/node-server": "2.0.10",
         "@hookform/resolvers": "5.2.2",
         "@lezer/highlight": "1.2.3",
         "@mastra/core": "1.33.1",
@@ -393,7 +393,7 @@
         "fumadocs-mdx": "14.2.5",
         "fumadocs-ui": "16.4.7",
         "lucide-react": "0.563.0",
-        "next": "16.2.6",
+        "next": "16.2.11",
         "posthog-js": "1.310.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -407,7 +407,7 @@
         "@types/node": "24.12.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
-        "postcss": "8.5.10",
+        "postcss": "8.5.12",
         "tailwindcss": "4.2.2",
         "tailwindcss-animate": "1.0.7",
         "typescript": "6.0.3",
@@ -449,7 +449,7 @@
         "gray-matter": "4.0.3",
         "import-in-the-middle": "2.0.1",
         "lucide-react": "0.563.0",
-        "next": "16.2.6",
+        "next": "16.2.11",
         "next-mdx-remote": "6.0.0",
         "next-themes": "0.4.6",
         "posthog-js": "1.310.1",
@@ -609,7 +609,7 @@
       "name": "@superset/relay",
       "version": "0.1.0",
       "dependencies": {
-        "@hono/node-server": "2.0.5",
+        "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",
         "@sentry/node": "9.47.1",
         "@superset/shared": "workspace:*",
@@ -660,7 +660,7 @@
         "import-in-the-middle": "2.0.1",
         "jose": "6.2.2",
         "lucide-react": "0.563.0",
-        "next": "16.2.6",
+        "next": "16.2.11",
         "next-themes": "0.4.6",
         "posthog-js": "1.310.1",
         "posthog-node": "5.28.8",
@@ -848,7 +848,7 @@
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.56.0",
         "@agentclientprotocol/sdk": "1.2.0",
-        "@hono/node-server": "2.0.5",
+        "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",
         "@hono/trpc-server": "0.3.4",
         "@mastra/core": "1.33.1",
@@ -1855,7 +1855,7 @@
 
     "@headless-tree/react": ["@headless-tree/react@1.6.3", "", { "peerDependencies": { "@headless-tree/core": "*", "react": "*", "react-dom": "*" } }, "sha512-aiRwG6e2EPBSec9uLLy9GlTvAuCtSTouU30Nwcr5ZTsYjG/i7B/ouC8f8Zu4unzo/v1h5ztbemp+EH2TPTKh+g=="],
 
-    "@hono/node-server": ["@hono/node-server@2.0.5", "", { "peerDependencies": { "hono": "^4" } }, "sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g=="],
+    "@hono/node-server": ["@hono/node-server@2.0.10", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA=="],
 
     "@hono/node-ws": ["@hono/node-ws@1.3.0", "", { "dependencies": { "ws": "^8.17.0" }, "peerDependencies": { "@hono/node-server": "^1.19.2", "hono": "^4.6.0" } }, "sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q=="],
 
@@ -2087,23 +2087,23 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.2", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw=="],
 
-    "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
+    "@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
@@ -5311,7 +5311,7 @@
 
     "neverthrow": ["neverthrow@7.2.0", "", {}, "sha512-iGBUfFB7yPczHHtA8dksKTJ9E8TESNTAx1UQWW6TzMF280vo9jdPYpLUXrMN1BCkPdHFdNG3fxOt2CUad8KhAw=="],
 
-    "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
+    "next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
 
     "next-mdx-remote": ["next-mdx-remote@6.0.0", "", { "dependencies": { "@babel/code-frame": "^7.23.5", "@mdx-js/mdx": "^3.0.1", "@mdx-js/react": "^3.0.1", "unist-util-remove": "^4.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.1", "vfile-matter": "^5.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ=="],
 
@@ -5549,7 +5549,7 @@
 
     "portfinder": ["portfinder@1.0.38", "", { "dependencies": { "async": "^3.2.6", "debug": "^4.3.6" } }, "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg=="],
 
-    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
@@ -7667,7 +7667,7 @@
 
     "plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
-    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "posthog-node/@posthog/core": ["@posthog/core@1.24.3", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-nTyL1R/8V5vfdH37MbjXDYWFnUoxVijb2TnfJSNHz0+RBLtNnq0hNnBDCwWLl5yh1bzeJBYTT8UF+dV7D8y03w=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -7,7 +7,20 @@ minimumReleaseAge = 259200
 # this exclusion after 2026-07-16. (addon-ligatures stays on beta.220: its
 # beta.289 bundle imports node:diagnostics_channel, which breaks the vite
 # renderer build.)
+# next 16.2.11 (published 2026-07-21) is a security release fixing the SSRF,
+# cache-confusion, and middleware-bypass advisories flagged by Dependabot;
+# versions are pinned exact. Safe to remove this exclusion after 2026-07-24.
 minimumReleaseAgeExcludes = [
+	"next",
+	"@next/env",
+	"@next/swc-darwin-arm64",
+	"@next/swc-darwin-x64",
+	"@next/swc-linux-arm64-gnu",
+	"@next/swc-linux-arm64-musl",
+	"@next/swc-linux-x64-gnu",
+	"@next/swc-linux-x64-musl",
+	"@next/swc-win32-arm64-msvc",
+	"@next/swc-win32-x64-msvc",
 	"@xterm/xterm",
 	"@xterm/headless",
 	"@xterm/addon-clipboard",

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -66,7 +66,7 @@
 	"dependencies": {
 		"@agentclientprotocol/claude-agent-acp": "0.56.0",
 		"@agentclientprotocol/sdk": "1.2.0",
-		"@hono/node-server": "2.0.5",
+		"@hono/node-server": "2.0.10",
 		"@hono/node-ws": "1.3.0",
 		"@hono/trpc-server": "0.3.4",
 		"@mastra/core": "1.33.1",


### PR DESCRIPTION
## Summary

Resolves all 48 open Dependabot alerts via three dependency bumps:

- **next 16.2.6 → 16.2.11** (apps/web, marketing, docs, api, admin) — fixes SSRF in Server Actions and rewrites, cache confusion of response bodies, middleware/proxy bypass, unauthenticated server-function endpoint disclosure, and several DoS vectors (45 alerts)
- **postcss 8.5.10 → 8.5.12** (apps/docs) — fixes arbitrary file read via attacker-controlled sourceMappingURL in CSS comments (1 alert)
- **@hono/node-server 2.0.5 → 2.0.10** (apps/desktop, apps/relay, packages/host-service) — fixes unauthenticated memory-leak DoS via aborted WebSocket handshake (3 alerts)

## bunfig note

next 16.2.11 was published 2026-07-21, inside the repo's 3-day `minimumReleaseAge` gate, so `next` and its `@next/*` companion packages are added to `minimumReleaseAgeExcludes` following the existing `@xterm` pattern. Safe to remove the exclusion after 2026-07-24.

Older transitive copies remain in the lockfile (`@react-email/preview-server` pins next 16.0.7; next pins postcss 8.4.31 internally) — upstream pins, not flagged by Dependabot, left untouched.

## Validation

- `bun run typecheck` — all 35 tasks pass
- `bun run lint` — clean

https://claude.ai/code/session_01THb8nTeNPhJq6UWu1gUC4U

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches security advisories by upgrading `next`, `postcss`, and `@hono/node-server` across the repo, resolving all 48 Dependabot alerts. Addresses SSRF, cache confusion, middleware bypass, arbitrary file read, and DoS vectors.

- **Dependencies**
  - `next` 16.2.6 → 16.2.11 in apps/web, marketing, docs, api, admin.
  - `postcss` 8.5.10 → 8.5.12 in apps/docs.
  - `@hono/node-server` 2.0.5 → 2.0.10 in apps/desktop, apps/relay, packages/host-service.
  - Temporarily added `next` and `@next/*` to `minimumReleaseAgeExcludes` in `bunfig.toml` until 2026-07-24 to allow the security release through the 3‑day gate.

<sup>Written for commit 4ce1d2992684f5ba4b568e4ba3bca2114a8a6fa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Next.js to version 16.2.11 across supported applications.
  * Updated PostCSS to version 8.5.12.
  * Updated the Hono Node server package to version 2.0.10.

* **Security**
  * Enabled expedited availability for the Next.js 16.2.11 security release and its platform-specific packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->