### PR TITLE
feat(desktop): attention sidebar prototype (dev-only, do not merge)

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/menu.ts
+++ b/apps/desktop/src/lib/trpc/routers/menu.ts
@@ -11,7 +11,9 @@ type MenuEvent =
 	| { type: "open-settings"; data: OpenSettingsEvent }
 	| { type: "open-workspace"; data: OpenWorkspaceEvent }
 	| { type: "open-project" }
-	| { type: "toggle-presets-bar" };
+	| { type: "toggle-presets-bar" }
+	// Dev menu only: the attention prototype route is dev-gated.
+	| { type: "open-attention-prototype" };
 
 export const createMenuRouter = () => {
 	return router({
@@ -33,16 +35,22 @@ export const createMenuRouter = () => {
 					emit.next({ type: "toggle-presets-bar" });
 				};
 
+				const onOpenAttentionPrototype = () => {
+					emit.next({ type: "open-attention-prototype" });
+				};
+
 				menuEmitter.on("open-settings", onOpenSettings);
 				menuEmitter.on("open-workspace", onOpenWorkspace);
 				menuEmitter.on("open-project", onOpenProject);
 				menuEmitter.on("toggle-presets-bar", onTogglePresetsBar);
+				menuEmitter.on("open-attention-prototype", onOpenAttentionPrototype);
 
 				return () => {
 					menuEmitter.off("open-settings", onOpenSettings);
 					menuEmitter.off("open-workspace", onOpenWorkspace);
 					menuEmitter.off("open-project", onOpenProject);
 					menuEmitter.off("toggle-presets-bar", onTogglePresetsBar);
+					menuEmitter.off("open-attention-prototype", onOpenAttentionPrototype);
 				};
 			});
 		}),

--- a/apps/desktop/src/main/lib/menu.ts
+++ b/apps/desktop/src/main/lib/menu.ts
@@ -158,6 +158,13 @@ export function createApplicationMenu() {
 				},
 				{ type: "separator" },
 				{
+					label: "Open Attention Prototype",
+					click: () => {
+						menuEmitter.emit("open-attention-prototype");
+					},
+				},
+				{ type: "separator" },
+				{
 					label: "Simulate Update Downloading",
 					click: () => simulateDownloading(),
 				},

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/AttentionHud/AttentionHud.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/AttentionHud/AttentionHud.tsx
@@ -1,0 +1,203 @@
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { cn } from "@superset/ui/utils";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
+import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
+import type { ActivePaneStatus } from "shared/tabs-types";
+import { rankForHud } from "../../model/buildPrototypeView";
+import { formatAge } from "../../model/formatAge";
+import type { PrototypeWorkspace } from "../../model/types";
+import { usePrototypeStore } from "../../store/usePrototypeStore";
+
+const REASON: Record<ActivePaneStatus, string> = {
+	permission: "Needs input",
+	failed: "Agent failed",
+	working: "Working",
+	review: "Ready for review",
+};
+
+function reasonFor(workspace: PrototypeWorkspace): string {
+	if (workspace.agentStatus !== "idle") return REASON[workspace.agentStatus];
+	if (workspace.pullRequest?.checksStatus === "failure")
+		return "Checks failing";
+	if (workspace.pullRequest?.reviewDecision === "changes_requested")
+		return "Changes requested";
+	return "Recently active";
+}
+
+/**
+ * ⌘J jump HUD (prototype). Mirrors the command-palette shell (Radix Dialog +
+ * app tokens) but drives its own keyboard model: attention-ranked list, ↑↓ to
+ * move, ↵ / 1–9 to jump, Esc to close. S/E are shown as visual verb stubs.
+ */
+export function AttentionHud() {
+	const open = usePrototypeStore((s) => s.hudOpen);
+	const setOpen = usePrototypeStore((s) => s.setHudOpen);
+	const workspaces = usePrototypeStore((s) => s.workspaces);
+	const now = usePrototypeStore((s) => s.now);
+	const revealWorkspace = usePrototypeStore((s) => s.revealWorkspace);
+
+	const ranked = useMemo(() => rankForHud(workspaces), [workspaces]);
+	const [selected, setSelected] = useState(0);
+	const listRef = useRef<HTMLDivElement>(null);
+
+	// Reset selection whenever the HUD opens.
+	useEffect(() => {
+		if (open) setSelected(0);
+	}, [open]);
+
+	const jumpTo = (workspace: PrototypeWorkspace | undefined) => {
+		if (!workspace) return;
+		// Reveal (select + expand its group if collapsed) so the jump always
+		// lands somewhere visible in the sidebar.
+		revealWorkspace(workspace.id);
+		setOpen(false);
+	};
+
+	const handleKeyDown = (event: React.KeyboardEvent) => {
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			setSelected((i) => Math.min(i + 1, ranked.length - 1));
+		} else if (event.key === "ArrowUp") {
+			event.preventDefault();
+			setSelected((i) => Math.max(i - 1, 0));
+		} else if (event.key === "Enter") {
+			event.preventDefault();
+			jumpTo(ranked[selected]);
+		} else if (/^[1-9]$/.test(event.key)) {
+			const index = Number(event.key) - 1;
+			if (index < ranked.length) {
+				event.preventDefault();
+				jumpTo(ranked[index]);
+			}
+		}
+	};
+
+	// Keep the selected row scrolled into view.
+	useEffect(() => {
+		const node = listRef.current?.querySelector<HTMLElement>(
+			`[data-index="${selected}"]`,
+		);
+		node?.scrollIntoView({ block: "nearest" });
+	}, [selected]);
+
+	const attentionCount = ranked.filter((w) => w.agentStatus !== "idle").length;
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogContent
+				showCloseButton={false}
+				onKeyDown={handleKeyDown}
+				// Top edge at 10% of the viewport: the panel is tall, so a higher
+				// anchor keeps its visual bulk out of the screen center.
+				// translate-y-0 cancels the base dialog's own centering.
+				// outline-none: with the rows unfocusable, Radix focuses this
+				// panel itself — without it the keyboard-modality focus ring
+				// wraps the whole dialog.
+				className="!max-w-[560px] top-[10%] max-h-[80vh] translate-y-0 overflow-hidden p-0 outline-none"
+			>
+				<DialogHeader className="sr-only">
+					<DialogTitle>Jump to workspace</DialogTitle>
+					<DialogDescription>
+						Attention-ranked list of workspaces. Use arrow keys and Enter to
+						jump.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex items-center justify-between border-border/60 border-b px-3 py-2.5">
+					<span className="font-medium text-[13px] text-foreground">
+						Jump to workspace
+					</span>
+					<span className="text-muted-foreground text-xs">
+						{attentionCount > 0
+							? `${attentionCount} need you`
+							: "nothing waiting"}
+					</span>
+				</div>
+
+				<div
+					ref={listRef}
+					className="hide-scrollbar max-h-[min(440px,calc(75vh-6rem))] overflow-y-auto p-1.5"
+				>
+					{ranked.map((workspace, index) => {
+						const activeStatus: ActivePaneStatus | null =
+							workspace.agentStatus === "idle" ? null : workspace.agentStatus;
+						const isSelected = index === selected;
+						return (
+							<button
+								type="button"
+								key={workspace.id}
+								data-index={index}
+								// The HUD has its own selection model (bg-accent row), so
+								// rows opt out of focus: without this, Radix focuses row 1
+								// on open and the first keypress paints a :focus-visible
+								// ring there while the selection has already moved on.
+								tabIndex={-1}
+								onMouseMove={() => setSelected(index)}
+								onClick={() => jumpTo(workspace)}
+								className={cn(
+									"flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left outline-none transition-colors",
+									isSelected ? "bg-accent" : "hover:bg-muted/50",
+								)}
+							>
+								<span className="w-4 shrink-0 text-center font-mono text-[10px] text-muted-foreground tabular-nums">
+									{index < 9 ? index + 1 : ""}
+								</span>
+								<span className="flex size-2 shrink-0 items-center justify-center">
+									{activeStatus ? (
+										<StatusIndicator status={activeStatus} />
+									) : (
+										<span className="size-1.5 rounded-full bg-muted-foreground/40" />
+									)}
+								</span>
+								<span className="flex min-w-0 flex-1 flex-col">
+									<span
+										className={cn(
+											"truncate text-[13px] leading-tight",
+											isSelected ? "text-foreground" : "text-foreground/80",
+										)}
+									>
+										{workspace.title}
+									</span>
+									<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+										<ProjectThumbnail
+											projectName={workspace.repo.name}
+											iconUrl={workspace.repo.iconUrl}
+											className="size-3 rounded-[3px] text-[7px]"
+										/>
+										<span className="truncate">{workspace.repo.name}</span>
+										<span className="text-muted-foreground/40">·</span>
+										<span className="truncate">{reasonFor(workspace)}</span>
+									</span>
+								</span>
+								<span className="shrink-0 font-mono text-[10px] text-muted-foreground tabular-nums">
+									{formatAge(now, workspace.lastActivityAt)}
+								</span>
+								{isSelected && (
+									<span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+										↵ go
+									</span>
+								)}
+							</button>
+						);
+					})}
+				</div>
+
+				<div className="flex items-center gap-3 border-border/60 border-t px-3 py-2 text-[11px] text-muted-foreground">
+					<span>↑↓ move</span>
+					<span>↵ jump</span>
+					<span>1–9 pick</span>
+					<span className="opacity-50">S snooze</span>
+					<span className="opacity-50">E archive</span>
+					<span className="ml-auto">esc close</span>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeCloseDialog/PrototypeCloseDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeCloseDialog/PrototypeCloseDialog.tsx
@@ -1,0 +1,83 @@
+import {
+	AlertDialog,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { Checkbox } from "@superset/ui/checkbox";
+import { Label } from "@superset/ui/label";
+import { useId, useState } from "react";
+
+interface PrototypeCloseDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	workspaceName: string;
+	onConfirm: () => void;
+}
+
+/**
+ * Fixture stand-in for the real DashboardSidebarDeleteDialog's confirm pane —
+ * same copy and layout, but "Delete" just removes the fixture workspace (the
+ * branch checkbox is cosmetic).
+ */
+export function PrototypeCloseDialog({
+	open,
+	onOpenChange,
+	workspaceName,
+	onConfirm,
+}: PrototypeCloseDialogProps) {
+	const checkboxId = useId();
+	const [deleteBranch, setDeleteBranch] = useState(false);
+
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent className="max-w-[340px] gap-0 p-0">
+				<AlertDialogHeader className="px-4 pt-4 pb-2">
+					<AlertDialogTitle className="font-medium">
+						Delete workspace "{workspaceName}"?
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						This removes the worktree from disk. The cloud workspace record will
+						also be removed.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<div className="px-4 pb-2">
+					<div className="flex items-center gap-2">
+						<Checkbox
+							id={checkboxId}
+							checked={deleteBranch}
+							onCheckedChange={(checked) => setDeleteBranch(checked === true)}
+						/>
+						<Label
+							htmlFor={checkboxId}
+							className="cursor-pointer select-none text-muted-foreground text-xs"
+						>
+							Also delete local branch
+						</Label>
+					</div>
+				</div>
+				<AlertDialogFooter className="flex-row justify-end gap-2 px-4 pt-2 pb-4">
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={onConfirm}
+					>
+						Delete
+					</Button>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypePortBadge/PrototypePortBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypePortBadge/PrototypePortBadge.tsx
@@ -1,0 +1,140 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import {
+	LuEllipsisVertical,
+	LuExternalLink,
+	LuSquareTerminal,
+	LuX,
+} from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { DashboardSidebarWorkspaceHostType } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types";
+import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
+import type { PrototypePort } from "../../model/types";
+
+interface PrototypePortBadgeProps {
+	port: PrototypePort;
+	hostType: DashboardSidebarWorkspaceHostType;
+	/** Prototype analogue of "Go to Workspace" — activates the fixture row. */
+	onGoToWorkspace: () => void;
+	/** Removes the fixture port (real app kills the process). */
+	onClose: () => void;
+}
+
+/**
+ * Fixture-driven copy of DashboardSidebarPortBadge: same pill/tooltip/dropdown
+ * presentation, with actions remapped to the prototype store — no ports
+ * provider, kill hook, or user preferences.
+ */
+export function PrototypePortBadge({
+	port,
+	hostType,
+	onGoToWorkspace,
+	onClose,
+}: PrototypePortBadgeProps) {
+	const openUrl = electronTrpc.external.openUrl.useMutation();
+	const canOpenInBrowser = hostType === "local-device";
+	const hostLabel =
+		hostType === "local-device" ? "Local device" : "Remote host";
+	const portUrl = `http://localhost:${port.port}`;
+
+	const handleOpenExternal = () => {
+		if (!canOpenInBrowser || openUrl.isPending) return;
+		openUrl.mutate(portUrl);
+	};
+
+	// Opening the port is the primary action; remote ports can't open a local
+	// browser tab, so clicking those jumps to the workspace instead.
+	const handlePrimaryClick = canOpenInBrowser
+		? handleOpenExternal
+		: onGoToWorkspace;
+
+	return (
+		<div
+			className={cn(
+				"group flex max-w-44 shrink-0 items-center rounded",
+				"bg-muted/60 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+			)}
+		>
+			<Tooltip delayDuration={700}>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={handlePrimaryClick}
+						className="flex min-w-0 items-center gap-1 rounded-l py-0.5 pl-1.5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					>
+						{port.label ? (
+							<>
+								<span className="min-w-0 truncate">{port.label}</span>
+								<span className="shrink-0 font-mono text-[10px] text-muted-foreground/60 tabular-nums">
+									{port.port}
+								</span>
+							</>
+						) : (
+							<span className="font-mono tabular-nums">{port.port}</span>
+						)}
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="top" sideOffset={6} showArrow={false}>
+					<div className="space-y-1 text-xs">
+						{port.label && <div className="font-medium">{port.label}</div>}
+						<div
+							className={`font-mono ${port.label ? "text-background/70" : "font-medium"}`}
+						>
+							localhost:{port.port}
+						</div>
+						<div className="text-background/70">{hostLabel}</div>
+						<div className="text-background/70">
+							{port.processName} (pid {port.pid})
+						</div>
+						<div className="text-[10px] text-background/60">
+							{canOpenInBrowser
+								? "Click to open in browser"
+								: "Click to open workspace"}
+						</div>
+					</div>
+				</TooltipContent>
+			</Tooltip>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						aria-label={`Actions for ${port.label || `port ${port.port}`}`}
+						className="flex shrink-0 items-center self-stretch rounded-r px-1 text-muted-foreground/50 opacity-0 transition-[opacity,color] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100 data-[state=open]:text-foreground data-[state=open]:opacity-100"
+					>
+						<LuEllipsisVertical className="size-3" strokeWidth={STROKE_WIDTH} />
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent
+					align="start"
+					onCloseAutoFocus={(event) => event.preventDefault()}
+				>
+					{canOpenInBrowser && (
+						<DropdownMenuItem
+							onSelect={handleOpenExternal}
+							disabled={openUrl.isPending}
+						>
+							<LuExternalLink />
+							Open in External Browser
+						</DropdownMenuItem>
+					)}
+					<DropdownMenuItem onSelect={onGoToWorkspace}>
+						<LuSquareTerminal />
+						Go to Workspace
+					</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem variant="destructive" onSelect={onClose}>
+						<LuX />
+						Close Port
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeProjectsHeader/PrototypeProjectsHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeProjectsHeader/PrototypeProjectsHeader.tsx
@@ -1,0 +1,157 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Kbd, KbdGroup } from "@superset/ui/kbd";
+import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
+import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
+import {
+	LuFolderInput,
+	LuFolderPlus,
+	LuLayers,
+	LuLayoutTemplate,
+} from "react-icons/lu";
+import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
+import {
+	useOpenNewProjectModal,
+	useOpenTemplateGalleryModal,
+} from "renderer/stores/add-repository-modal";
+import { usePrototypeStore } from "../../store/usePrototypeStore";
+
+/**
+ * "Projects" panel header: click collapses/expands the panel (view controls +
+ * grouped workspace list). The Add-repository dropdown is the real one —
+ * handlers copied from DashboardSidebarHeader, so Clone from URL / Open from
+ * folder / Start from a template all genuinely work.
+ */
+export function PrototypeProjectsHeader() {
+	const projectsCollapsed = usePrototypeStore((s) => s.projectsCollapsed);
+	const toggleProjectsCollapsed = usePrototypeStore(
+		(s) => s.toggleProjectsCollapsed,
+	);
+	const viewControlsCollapsed = usePrototypeStore(
+		(s) => s.viewControlsCollapsed,
+	);
+	const toggleViewControls = usePrototypeStore((s) => s.toggleViewControls);
+
+	const navigate = useNavigate();
+	const openNewProject = useOpenNewProjectModal();
+	const openTemplateGallery = useOpenTemplateGalleryModal();
+	const folderImport = useFolderFirstImport({
+		onError: (message) => {
+			toast.error(`Import failed: ${message}`);
+		},
+		onMultipleProjects: ({ candidates }) => {
+			toast.error("Import failed", {
+				description: `Multiple projects use this repository (${candidates.length}). Choose the project in settings to set it up on this device.`,
+				action: {
+					label: "Open Projects",
+					onClick: () => navigate({ to: "/settings/projects" }),
+				},
+			});
+		},
+	});
+
+	const handleImportFolder = async () => {
+		const result = await folderImport.start();
+		if (result) {
+			toast.success("Project ready — open it from the sidebar.");
+		}
+	};
+
+	return (
+		// biome-ignore lint/a11y/useSemanticElements: contains a nested dropdown trigger button, so the row can't be a <button>
+		<div
+			role="button"
+			tabIndex={0}
+			onClick={toggleProjectsCollapsed}
+			onKeyDown={(event) => {
+				if (event.key === "Enter" || event.key === " ") {
+					event.preventDefault();
+					toggleProjectsCollapsed();
+				}
+			}}
+			className="group flex w-full cursor-pointer items-center gap-2 py-1.5 pr-2 pl-3 font-medium text-muted-foreground text-sm transition-colors hover:bg-muted/50"
+		>
+			<div className="flex size-5 shrink-0 items-center justify-center">
+				<HiChevronRight
+					className={cn(
+						"size-4 text-muted-foreground transition-transform",
+						!projectsCollapsed && "rotate-90",
+					)}
+				/>
+			</div>
+			<span className="flex-1 truncate text-left">Projects</span>
+			<Tooltip delayDuration={300}>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="Groups & ordering"
+						aria-pressed={!viewControlsCollapsed}
+						onClick={(event) => {
+							event.stopPropagation();
+							toggleViewControls();
+						}}
+						className={cn(
+							"flex size-6 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-accent/50 hover:text-foreground",
+							viewControlsCollapsed
+								? "text-muted-foreground"
+								: "text-foreground",
+						)}
+					>
+						<LuLayers className="size-4" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">
+					<p className="flex items-center gap-2 text-xs">
+						Groups & ordering
+						<KbdGroup>
+							<Kbd>⇧</Kbd>
+							<Kbd>⌥</Kbd>
+							<Kbd>G</Kbd>
+						</KbdGroup>
+					</p>
+				</TooltipContent>
+			</Tooltip>
+			<DropdownMenu>
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<DropdownMenuTrigger asChild>
+							<button
+								type="button"
+								aria-label="Add repository"
+								onClick={(event) => event.stopPropagation()}
+								className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+							>
+								<LuFolderPlus className="size-4" />
+							</button>
+						</DropdownMenuTrigger>
+					</TooltipTrigger>
+					<TooltipContent side="right">Add repository</TooltipContent>
+				</Tooltip>
+				<DropdownMenuContent
+					align="end"
+					onCloseAutoFocus={(event) => event.preventDefault()}
+				>
+					<DropdownMenuItem onSelect={() => openNewProject()}>
+						<HiMiniPlus className="size-4" />
+						Clone from URL
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={handleImportFolder}>
+						<LuFolderInput className="size-4" />
+						Open from folder
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={() => openTemplateGallery()}>
+						<LuLayoutTemplate className="size-4" />
+						Start from a template
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebar/PrototypeSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebar/PrototypeSidebar.tsx
@@ -1,0 +1,1263 @@
+import {
+	type CollisionDetection,
+	closestCenter,
+	DndContext,
+	type DragEndEvent,
+	type DragOverEvent,
+	DragOverlay,
+	type DragStartEvent,
+	KeyboardSensor,
+	MeasuringStrategy,
+	MouseSensor,
+	pointerWithin,
+	TouchSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import {
+	arrayMove,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Kbd, KbdGroup } from "@superset/ui/kbd";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectSeparator,
+	SelectTrigger,
+} from "@superset/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { LayoutGroup, motion } from "framer-motion";
+import {
+	Fragment,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { createPortal } from "react-dom";
+import type { IconType } from "react-icons";
+import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
+import {
+	LuALargeSmall,
+	LuArrowDownWideNarrow,
+	LuArrowUpNarrowWide,
+	LuBot,
+	LuCalendarPlus,
+	LuCircle,
+	LuCircleAlert,
+	LuCircleCheck,
+	LuCircleDashed,
+	LuFolderGit2,
+	LuFoldVertical,
+	LuGitMerge,
+	LuGitPullRequestArrow,
+	LuGitPullRequestClosed,
+	LuGitPullRequestDraft,
+	LuGripVertical,
+	LuHistory,
+	LuList,
+	LuListChecks,
+	LuLoaderCircle,
+	LuMessageCircleQuestion,
+	LuMessageCircleWarning,
+	LuUnfoldVertical,
+} from "react-icons/lu";
+import { useHotkey } from "renderer/hotkeys";
+import { DashboardSidebarWorkspaceIcon } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon";
+import { StatusIcon } from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/StatusIcon";
+import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
+import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { COLLAPSED_WORKSPACE_SIDEBAR_WIDTH } from "renderer/stores/workspace-sidebar-state";
+import type { PaneStatus } from "shared/tabs-types";
+import { useLayoutAwareHotkey } from "../../hooks/useLayoutAwareHotkey";
+import { buildPrototypeView } from "../../model/buildPrototypeView";
+import type { GroupBy, OrderBy, PrBucket } from "../../model/types";
+import { usePrototypeStore } from "../../store/usePrototypeStore";
+import { PrototypeProjectsHeader } from "../PrototypeProjectsHeader/PrototypeProjectsHeader";
+import { PrototypeSidebarFooter } from "../PrototypeSidebarFooter/PrototypeSidebarFooter";
+import { PrototypeSidebarHeader } from "../PrototypeSidebarHeader/PrototypeSidebarHeader";
+import { PrototypeSidebarToggle } from "../PrototypeSidebarToggle/PrototypeSidebarToggle";
+import { PrototypeWorkspaceRow } from "../PrototypeWorkspaceRow/PrototypeWorkspaceRow";
+import { SortablePrototypeRow } from "../SortablePrototypeRow/SortablePrototypeRow";
+import {
+	HeaderFlashOverlay,
+	type HeaderFlashProfile,
+} from "./components/HeaderFlashOverlay/HeaderFlashOverlay";
+import {
+	GROUP_DROP_ID_PREFIX,
+	PrototypeGroupDroppable,
+} from "./components/PrototypeGroupDroppable/PrototypeGroupDroppable";
+import {
+	PrototypeTravelRow,
+	TRAVEL_DURATION_S,
+	TRAVEL_EASE_CSS,
+} from "./components/PrototypeTravelRow/PrototypeTravelRow";
+
+interface ViewOption {
+	value: string;
+	label: string;
+	icon: IconType;
+}
+
+/** The "off" option leads (separator after), the rest alphabetical. */
+const GROUP_BY_OPTIONS: ViewOption[] = [
+	{ value: "none", label: "No groups", icon: LuList },
+	{ value: "agent", label: "Agent activity", icon: LuBot },
+	{ value: "linear", label: "Linear status", icon: LuCircleDashed },
+	{ value: "pr", label: "Pull request", icon: LuGitPullRequestArrow },
+	{ value: "repository", label: "Repository", icon: LuFolderGit2 },
+];
+
+/** Manual leads (separator after), the rest alphabetical. */
+const ORDER_BY_OPTIONS: ViewOption[] = [
+	{ value: "manual", label: "Manual", icon: LuGripVertical },
+	{ value: "attention", label: "Agent activity", icon: LuBot },
+	{ value: "created", label: "Created", icon: LuCalendarPlus },
+	{ value: "title", label: "Name", icon: LuALargeSmall },
+	{ value: "recent", label: "Recent", icon: LuHistory },
+];
+
+/**
+ * Leading icon for agent-status group headers, playing the same role as a repo
+ * thumbnail or Linear StatusIcon. Proper icons (not dots) keep the dot
+ * vocabulary reserved for the pulsing corner StatusIndicator notifications;
+ * colors mirror StatusIndicator's so headers and rows speak the same language.
+ */
+const AGENT_GROUP_ICON: Record<
+	PaneStatus,
+	{ icon: IconType; className: string }
+> = {
+	permission: { icon: LuMessageCircleQuestion, className: "text-red-500" },
+	failed: { icon: LuCircleAlert, className: "text-red-500" },
+	working: { icon: LuLoaderCircle, className: "text-amber-500" },
+	review: { icon: LuCircleCheck, className: "text-green-500" },
+	idle: { icon: LuCircle, className: "text-muted-foreground/50" },
+};
+
+/**
+ * Leading icon per pull-request lifecycle bucket. Terminal-state buckets reuse
+ * the real PR icon vocabulary (DashboardSidebarWorkspaceIcon's state map);
+ * open-PR buckets get icons for their actionable signal.
+ */
+const PR_GROUP_ICON: Record<PrBucket, { icon: IconType; className: string }> = {
+	"checks-failing": { icon: LuCircleAlert, className: "text-red-500" },
+	"changes-requested": {
+		icon: LuMessageCircleWarning,
+		className: "text-orange-500",
+	},
+	"awaiting-review": {
+		icon: LuGitPullRequestArrow,
+		className: "text-emerald-500",
+	},
+	approved: { icon: LuCircleCheck, className: "text-green-500" },
+	queued: { icon: LuListChecks, className: "text-amber-500" },
+	draft: { icon: LuGitPullRequestDraft, className: "text-muted-foreground" },
+	merged: { icon: LuGitMerge, className: "text-purple-500" },
+	closed: { icon: LuGitPullRequestClosed, className: "text-destructive" },
+	"no-pr": { icon: LuCircleDashed, className: "text-muted-foreground/50" },
+};
+
+/**
+ * Delay before a collapsed DESTINATION header flashes when a visible card
+ * travels into it. Early enough that the header is already fully lit while
+ * the card (fading from ~55% of its 0.45s journey) melts into it — the glow
+ * must be there to "receive" the card, not pop on after it's gone.
+ */
+const DEST_FLASH_DELAY_MS = 150;
+/** Longer when the origin flashed first — sequences the journey. */
+const DEST_FLASH_DELAY_AFTER_ORIGIN_MS = 500;
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
+}
+
+export function PrototypeSidebar() {
+	const groupBy = usePrototypeStore((s) => s.groupBy);
+	const orderBy = usePrototypeStore((s) => s.orderBy);
+	const direction = usePrototypeStore((s) => s.direction);
+	const setGroupBy = usePrototypeStore((s) => s.setGroupBy);
+	const setOrderBy = usePrototypeStore((s) => s.setOrderBy);
+	const setDirection = usePrototypeStore((s) => s.setDirection);
+	const manualOrder = usePrototypeStore((s) => s.manualOrder);
+	const commitManualOrder = usePrototypeStore((s) => s.commitManualOrder);
+	const setLinearStatus = usePrototypeStore((s) => s.setLinearStatus);
+	const collapsedGroups = usePrototypeStore((s) => s.collapsedGroups);
+	const projectsCollapsed = usePrototypeStore((s) => s.projectsCollapsed);
+	const viewControlsCollapsed = usePrototypeStore(
+		(s) => s.viewControlsCollapsed,
+	);
+	const revealViewControls = usePrototypeStore((s) => s.revealViewControls);
+	const toggleViewControls = usePrototypeStore((s) => s.toggleViewControls);
+	const toggleSidebarCollapsed = usePrototypeStore(
+		(s) => s.toggleSidebarCollapsed,
+	);
+	const toggleGroupCollapsed = usePrototypeStore((s) => s.toggleGroupCollapsed);
+	const setGroupsCollapsed = usePrototypeStore((s) => s.setGroupsCollapsed);
+	const revealWorkspace = usePrototypeStore((s) => s.revealWorkspace);
+	const sidebarCollapsed = usePrototypeStore(
+		(s) => s.sidebarWidth === COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
+	);
+	// While the panel is being drag-resized, framer `layout` must be off: every
+	// width frame would otherwise be treated as a layout change and FLIP-tweened
+	// (visible text stretch/squash). The real sidebar reflows natively because
+	// its rows carry no layout animation at all.
+	const sidebarResizing = usePrototypeStore((s) => s.sidebarResizing);
+	const workspaces = usePrototypeStore((s) => s.workspaces);
+	const now = usePrototypeStore((s) => s.now);
+	const activeWorkspaceId = usePrototypeStore((s) => s.activeWorkspaceId);
+	const setActiveWorkspace = usePrototypeStore((s) => s.setActiveWorkspace);
+	const lastChangedId = usePrototypeStore((s) => s.lastChangedId);
+	const changeSeq = usePrototypeStore((s) => s.changeSeq);
+
+	const groups = useMemo(
+		() =>
+			buildPrototypeView(workspaces, {
+				groupBy,
+				orderBy,
+				direction,
+				manualOrder,
+			}),
+		[workspaces, groupBy, orderBy, direction, manualOrder],
+	);
+
+	const isGroupCollapsed = (key: string) =>
+		Boolean(collapsedGroups[`${groupBy}:${key}`]);
+
+	// ── Travel bookkeeping ─────────────────────────────────────────────────────
+	// Which group each workspace belonged to on the PREVIOUS commit, last-known
+	// viewport positions of headers/rows, and the flash queue for collapsed
+	// group headers. Together these let a status change animate its "journey":
+	// origin header flash → card travel → destination header flash.
+	const groupKeyByWorkspace = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const group of groups) {
+			for (const workspace of group.workspaces) {
+				map.set(workspace.id, group.key);
+			}
+		}
+		return map;
+	}, [groups]);
+
+	const prevGroupKeyRef = useRef<Map<string, string>>(new Map());
+	const consumedSeqRef = useRef(0);
+	const headerEls = useRef<Map<string, HTMLElement>>(new Map());
+	const rowEls = useRef<Map<string, HTMLElement>>(new Map());
+	// Positions (and row heights) from the previous commit — read during render
+	// (before this commit's measurement effect overwrites them) to aim travel
+	// animations.
+	const rectsRef = useRef<Map<string, { top: number; height: number }>>(
+		new Map(),
+	);
+	const [headerFlashes, setHeaderFlashes] = useState<
+		Record<
+			string,
+			{ seq: number; delayMs: number; profile: HeaderFlashProfile }
+		>
+	>({});
+
+	// Fresh cross-group move by the last-simulated workspace. Render-scoped:
+	// the effect below marks the seq consumed so later renders (collapse
+	// toggles, drags) don't re-trigger travel animations.
+	const transition = (() => {
+		if (!lastChangedId || changeSeq === consumedSeqRef.current) return null;
+		const from = prevGroupKeyRef.current.get(lastChangedId);
+		const to = groupKeyByWorkspace.get(lastChangedId);
+		if (!from || !to || from === to) return null;
+		return { id: lastChangedId, from, to };
+	})();
+
+	useEffect(() => {
+		if (transition) {
+			const fromCollapsed = isGroupCollapsed(transition.from);
+			const toCollapsed = isGroupCollapsed(transition.to);
+			const flashes: Record<
+				string,
+				{ seq: number; delayMs: number; profile: HeaderFlashProfile }
+			> = {};
+			// Only collapsed groups flash — in expanded groups the card itself is
+			// visible and carries its own highlight. Origin first, destination
+			// after the travel, so the journey reads start → end. When the card
+			// visibly travels OUT of the origin (destination expanded), the origin
+			// flash is brief — done by the time the card lands — so the eye hands
+			// off to the moving card instead of watching two long glows.
+			if (fromCollapsed) {
+				flashes[transition.from] = {
+					seq: changeSeq,
+					delayMs: 0,
+					profile: toCollapsed ? "hold" : "brief",
+				};
+			}
+			if (toCollapsed) {
+				flashes[transition.to] = {
+					seq: changeSeq,
+					delayMs: fromCollapsed
+						? DEST_FLASH_DELAY_AFTER_ORIGIN_MS
+						: DEST_FLASH_DELAY_MS,
+					profile: "hold",
+				};
+			}
+			if (Object.keys(flashes).length > 0) {
+				setHeaderFlashes((prev) => ({ ...prev, ...flashes }));
+			}
+		}
+		consumedSeqRef.current = changeSeq;
+	});
+
+	useEffect(() => {
+		prevGroupKeyRef.current = groupKeyByWorkspace;
+	}, [groupKeyByWorkspace]);
+
+	// Travel exit glide. By the time the exit starts, React has already moved
+	// the row's slot to its new DOM position — resting just under the collapsed
+	// destination header (its hidden siblings render nothing). So the journey
+	// starts translated back at the old position and ends one header-height UP
+	// from rest: the group is collapsed, so the row's would-be slot is empty
+	// space, and stopping there reads as overshooting — fading out ON the
+	// header reads as being absorbed into it. Measured pre-paint (layout
+	// effect) so the relocation is never visible. The exiting row's inner
+	// `layout` is disabled via useIsPresent, so the measurement here is the
+	// raw new DOM position, not a FLIP-transformed one.
+	useLayoutEffect(() => {
+		if (!transition || !isGroupCollapsed(transition.to)) return;
+		const slotEl = rowEls.current.get(transition.id);
+		const oldRect = rectsRef.current.get(`row:${transition.id}`);
+		if (!slotEl || !oldRect) return;
+		const startOffset = oldRect.top - slotEl.getBoundingClientRect().top;
+		if (!Number.isFinite(startOffset)) return;
+		// offsetHeight is transform-free, unlike a bounding rect mid-FLIP.
+		const endOffset = -(
+			headerEls.current.get(transition.to)?.offsetHeight ?? 0
+		);
+		if (Math.abs(startOffset - endOffset) < 4) return;
+		slotEl.animate(
+			[
+				{ transform: `translateY(${startOffset}px)` },
+				{ transform: `translateY(${endOffset}px)` },
+			],
+			{ duration: TRAVEL_DURATION_S * 1000, easing: TRAVEL_EASE_CSS },
+		);
+	});
+
+	// Record positions after every commit; render N+1 reads commit N's values.
+	useEffect(() => {
+		const rects = new Map<string, { top: number; height: number }>();
+		for (const [key, el] of headerEls.current) {
+			const rect = el.getBoundingClientRect();
+			rects.set(`header:${key}`, { top: rect.top, height: rect.height });
+		}
+		for (const [key, el] of rowEls.current) {
+			const rect = el.getBoundingClientRect();
+			rects.set(`row:${key}`, { top: rect.top, height: rect.height });
+		}
+		rectsRef.current = rects;
+	});
+
+	// Flatten groups into a single sibling list [header, row, row, header, …].
+	// Because every row is a direct sibling inside one LayoutGroup (rather than
+	// nested in per-group containers), a row keeps its React identity when it
+	// moves to a different group — so framer-motion tweens it the whole way
+	// instead of teleporting across containers.
+	const items = useMemo(() => {
+		const out: Array<
+			| {
+					kind: "header";
+					key: string;
+					group: (typeof groups)[number];
+					collapseKey: string;
+					isCollapsed: boolean;
+			  }
+			| {
+					kind: "row";
+					key: string;
+					workspace: (typeof groups)[number]["workspaces"][number];
+					groupKey: string;
+					isCollapsed: boolean;
+					shortcutLabel?: string;
+			  }
+		> = [];
+		// ⌘N numbers follow the FLAT row order, collapsed rows included — same
+		// as the real sidebar, whose first-9 numbering ignores collapse state so
+		// the shortcuts stay stable while groups fold.
+		let flatIndex = 0;
+		for (const group of groups) {
+			// Collapse keys are namespaced per group-by dimension so collapsing a
+			// repository doesn't also collapse a same-keyed bucket in another view.
+			const collapseKey = `${groupBy}:${group.key}`;
+			const isCollapsed = group.label
+				? Boolean(collapsedGroups[collapseKey])
+				: false;
+			if (group.label) {
+				out.push({
+					kind: "header",
+					key: `header:${group.key}`,
+					group,
+					collapseKey,
+					isCollapsed,
+				});
+			}
+			for (const workspace of group.workspaces) {
+				flatIndex += 1;
+				out.push({
+					kind: "row",
+					key: workspace.id,
+					workspace,
+					groupKey: group.key,
+					isCollapsed,
+					shortcutLabel: flatIndex <= 9 ? `⌘${flatIndex}` : undefined,
+				});
+			}
+		}
+		return out;
+	}, [groups, groupBy, collapsedGroups]);
+
+	/**
+	 * Travel roles for the row that just changed groups: an exit into a
+	 * collapsed destination (positioning handled by the glide effect above), or
+	 * an entrance from a collapsed origin header.
+	 */
+	const travelFor = (item: {
+		key: string;
+		workspace: { id: string };
+		isCollapsed: boolean;
+	}): { exitTravel: boolean; enterFromTop: number | null } => {
+		if (!transition || item.workspace.id !== transition.id) {
+			return { exitTravel: false, enterFromTop: null };
+		}
+		if (item.isCollapsed) {
+			// Row is being hidden into a collapsed destination.
+			return { exitTravel: true, enterFromTop: null };
+		}
+		if (isGroupCollapsed(transition.from)) {
+			// Row is emerging from a collapsed origin — enter from its header.
+			return {
+				exitTravel: false,
+				enterFromTop:
+					rectsRef.current.get(`header:${transition.from}`)?.top ?? null,
+			};
+		}
+		return { exitTravel: false, enterFromTop: null };
+	};
+
+	// Flat workspace-id order (headers excluded, collapsed rows INCLUDED so a
+	// manualOrder snapshot never silently drops hidden workspaces) — the
+	// sortable items, and the order committed as manualOrder on drop.
+	const rowIds = useMemo(
+		() => items.flatMap((item) => (item.kind === "row" ? [item.key] : [])),
+		[items],
+	);
+
+	// ⌘1–⌘9 via the real registry ids (layout-aware, override-aware). Like the
+	// real sidebar's useDashboardSidebarShortcuts, jumping reveals: the target's
+	// group expands if it was collapsed.
+	const jumpToIndex = (index: number) => {
+		const id = rowIds[index];
+		if (id) revealWorkspace(id);
+	};
+	useHotkey("JUMP_TO_WORKSPACE_1", () => jumpToIndex(0));
+	useHotkey("JUMP_TO_WORKSPACE_2", () => jumpToIndex(1));
+	useHotkey("JUMP_TO_WORKSPACE_3", () => jumpToIndex(2));
+	useHotkey("JUMP_TO_WORKSPACE_4", () => jumpToIndex(3));
+	useHotkey("JUMP_TO_WORKSPACE_5", () => jumpToIndex(4));
+	useHotkey("JUMP_TO_WORKSPACE_6", () => jumpToIndex(5));
+	useHotkey("JUMP_TO_WORKSPACE_7", () => jumpToIndex(6));
+	useHotkey("JUMP_TO_WORKSPACE_8", () => jumpToIndex(7));
+	useHotkey("JUMP_TO_WORKSPACE_9", () => jumpToIndex(8));
+
+	// Fold-all toggle state: like the Changes toolbar's collapse/expand-all,
+	// one button that collapses every group, flipping to expand-all once all
+	// of them are collapsed.
+	const groupCollapseKeys = useMemo(
+		() =>
+			groups
+				.filter((group) => group.label)
+				.map((group) => `${groupBy}:${group.key}`),
+		[groups, groupBy],
+	);
+	const allGroupsCollapsed =
+		groupCollapseKeys.length > 0 &&
+		groupCollapseKeys.every((key) => collapsedGroups[key]);
+
+	// Index span of each workspace's group within rowIds (groups are contiguous
+	// slices), used to clamp drops inside the dragged row's own group.
+	const groupBounds = useMemo(() => {
+		const bounds = new Map<string, { start: number; end: number }>();
+		let cursor = 0;
+		for (const group of groups) {
+			const start = cursor;
+			const end = cursor + group.workspaces.length - 1;
+			for (const workspace of group.workspaces) {
+				bounds.set(workspace.id, { start, end });
+			}
+			cursor = end + 1;
+		}
+		return bounds;
+	}, [groups]);
+
+	// ── dnd-kit wiring (copied from the real DashboardSidebar) ────────────────
+	const sensors = useSensors(
+		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 200, tolerance: 5 },
+		}),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	);
+
+	const [activeRowId, setActiveRowId] = useState<string | null>(null);
+	// Framer `layout` is off from drag start through the drop's commit render so
+	// dnd-kit's transforms and framer's layout projection never animate the same
+	// move; re-enabled one frame later, when positions are already settled.
+	const [suppressLayout, setSuppressLayout] = useState(false);
+
+	useEffect(() => {
+		if (activeRowId !== null || !suppressLayout) return;
+		const raf = requestAnimationFrame(() => setSuppressLayout(false));
+		return () => cancelAnimationFrame(raf);
+	}, [activeRowId, suppressLayout]);
+
+	// The group currently under the pointer during a drag — drives the
+	// destination-column highlight. A row id maps to its group; a `group:` id is
+	// the group itself (an empty column, a collapsed header, or group padding).
+	const [overGroupKey, setOverGroupKey] = useState<string | null>(null);
+
+	const handleDragStart = ({ active }: DragStartEvent) => {
+		setActiveRowId(String(active.id));
+		setSuppressLayout(true);
+	};
+
+	const handleDragCancel = () => {
+		setActiveRowId(null);
+		setOverGroupKey(null);
+	};
+
+	const groupKeyForOver = (overId: string): string | null =>
+		overId.startsWith(GROUP_DROP_ID_PREFIX)
+			? overId.slice(GROUP_DROP_ID_PREFIX.length)
+			: (groupKeyByWorkspace.get(overId) ?? null);
+
+	const handleDragOver = ({ over }: DragOverEvent) => {
+		setOverGroupKey(over ? groupKeyForOver(String(over.id)) : null);
+	};
+
+	// Under Linear grouping the whole group is a drop target, so prefer the
+	// precise pointer hit: a row (for reordering / column identity) over the
+	// group container beneath it. Other groupings keep dnd-kit's default.
+	const collisionDetection: CollisionDetection = (args) => {
+		if (groupBy !== "linear") return closestCenter(args);
+		const hits = pointerWithin(args);
+		if (hits.length === 0) return closestCenter(args);
+		const rowHit = hits.find(
+			(hit) => !String(hit.id).startsWith(GROUP_DROP_ID_PREFIX),
+		);
+		return rowHit ? [rowHit] : hits;
+	};
+
+	// Resolve the value setLinearStatus expects for a destination column key.
+	// The "no-status" bucket's header hint is a display placeholder; its real
+	// model value is null.
+	const linearStatusForGroupKey = (groupKey: string) =>
+		groupKey === "no-status"
+			? null
+			: (groups.find((group) => group.key === groupKey)?.linearStatus ?? null);
+
+	const handleDragEnd = ({ active, over }: DragEndEvent) => {
+		setActiveRowId(null);
+		setOverGroupKey(null);
+		if (!over) return;
+		const activeId = String(active.id);
+		const overId = String(over.id);
+
+		if (groupBy === "linear") {
+			// The whole group is a drop target: drop onto any of its rows, its
+			// header, or (for an empty column) its drag-time drop area.
+			const sourceGroup = groupKeyByWorkspace.get(activeId);
+			const targetGroup = groupKeyForOver(overId);
+			// Cross-column: reassign the workspace's Linear status. The view then
+			// re-sorts it into the column per the active ordering — no manual-order
+			// snapshot, so the Sort control is left untouched.
+			if (targetGroup && targetGroup !== sourceGroup) {
+				setLinearStatus(activeId, linearStatusForGroupKey(targetGroup));
+				return;
+			}
+			// Same column: reorder within it (only when dropped over a sibling row).
+			const from = rowIds.indexOf(activeId);
+			const to = rowIds.indexOf(overId);
+			if (from === -1 || to === -1 || from === to) return;
+			commitManualOrder(arrayMove(rowIds, from, to));
+			return;
+		}
+
+		// Repository / agent / PR groupings: reorder only, clamping a cross-group
+		// drop back into the dragged row's own group — those properties aren't
+		// drag-assignable (checks and reviews come from CI and reviewers).
+		if (active.id === over.id) return;
+		const from = rowIds.indexOf(activeId);
+		let to = rowIds.indexOf(overId);
+		if (from === -1 || to === -1) return;
+		if (groupBy !== "none") {
+			const bounds = groupBounds.get(activeId);
+			if (!bounds) return;
+			to = clamp(to, bounds.start, bounds.end);
+		}
+		if (from === to) return;
+		// Snapshot the visual order with the move applied; auto-switches the sort
+		// to Manual while keeping the current grouping.
+		commitManualOrder(arrayMove(rowIds, from, to));
+	};
+
+	const activeItem = useMemo(
+		() =>
+			activeRowId
+				? items.find((item) => item.kind === "row" && item.key === activeRowId)
+				: undefined,
+		[items, activeRowId],
+	);
+	const activeGroupKey =
+		activeItem?.kind === "row" ? activeItem.groupKey : null;
+
+	// The destination column to highlight: a different group hovered mid-drag,
+	// under Linear grouping (the only group-by where a drop reassigns status).
+	const dropTargetGroupKey =
+		groupBy === "linear" &&
+		activeRowId !== null &&
+		overGroupKey !== null &&
+		overGroupKey !== activeGroupKey
+			? overGroupKey
+			: null;
+
+	const handleOrderByChange = (value: OrderBy) => {
+		if (value === "manual" && orderBy !== "manual") {
+			// Freeze the current visual order so nothing jumps when switching.
+			commitManualOrder(rowIds);
+			return;
+		}
+		setOrderBy(value);
+	};
+
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
+
+	// Which ViewSelect dropdown is open. Hoisted (rather than local to each
+	// ViewSelect) so the hotkeys below can open a dropdown that isn't mounted
+	// yet: reveal the panel first, then render it open.
+	const [openSelect, setOpenSelect] = useState<"group" | "order" | null>(null);
+
+	// ⌥G / ⌥O open the dropdown (visible options + arrow keys + type-ahead)
+	// rather than blind-cycling — Linear's ⇧⌥G/⇧⌥O pattern, one modifier
+	// shorter. ⌘G/⌘O are off the table: Run Workspace Command and Open in App
+	// own them, and ⌘O is additionally an Electron File-menu accelerator that
+	// fires in the main process before the renderer ever sees it. The reveal
+	// chain makes them work from ANY collapsed state: rail → expanded sidebar,
+	// tucked Projects panel / controls row → revealed, then the menu opens.
+	const openViewSelect = (which: "group" | "order") => {
+		if (sidebarCollapsed) toggleSidebarCollapsed();
+		revealViewControls();
+		setOpenSelect(which);
+	};
+	useLayoutAwareHotkey("alt+g", () => openViewSelect("group"));
+	useLayoutAwareHotkey("alt+o", () => openViewSelect("order"));
+	// ⇧⌥G toggles the whole Groups & ordering panel — the keyboard twin of the
+	// LuLayers button. From the collapsed rail it expands the sidebar and reveals
+	// the controls (same reveal chain as ⌥G/⌥O); otherwise it just flips the row.
+	useLayoutAwareHotkey("shift+alt+g", () => {
+		if (sidebarCollapsed) {
+			toggleSidebarCollapsed();
+			revealViewControls();
+			return;
+		}
+		toggleViewControls();
+	});
+	// ⌥D / ⌥F act directly (no menu), so they skip the reveal: D = direction,
+	// F = fold. Both respect their buttons' disabled states.
+	useLayoutAwareHotkey("alt+d", () => {
+		if (orderBy !== "manual") {
+			setDirection(direction === "asc" ? "desc" : "asc");
+		}
+	});
+	useLayoutAwareHotkey("alt+f", () => {
+		if (groupCollapseKeys.length > 0) {
+			setGroupsCollapsed(groupCollapseKeys, !allGroupsCollapsed);
+		}
+	});
+
+	// Fully-collapsed rail, mirroring the real sidebar: a 52px column of size-8
+	// icon buttons (workspace icon + status dot survive), with view controls,
+	// grouping, and drag-reorder all disabled — the rail is fixed in place.
+	if (sidebarCollapsed) {
+		// The expand toggle is NOT here — like the real app, the collapsed rail is
+		// too narrow for the traffic-light pad, so the toggle moves to the top bar
+		// over the page content (PrototypeTopBar).
+		return (
+			// No border-r — the enclosing ResizablePanel draws the panel border.
+			<div className="flex h-full flex-col items-center bg-muted/45 dark:bg-muted/35">
+				<div className="drag h-12 w-full shrink-0" />
+				<div className="no-drag mt-1 flex w-full flex-1 flex-col items-center gap-1 overflow-y-auto pb-2 hide-scrollbar">
+					{groups
+						.flatMap((group) => group.workspaces)
+						.map((workspace) => (
+							<Tooltip key={workspace.id} delayDuration={300}>
+								<TooltipTrigger asChild>
+									<button
+										type="button"
+										onClick={() => setActiveWorkspace(workspace.id)}
+										className={cn(
+											"relative flex size-8 shrink-0 items-center justify-center rounded-md transition-colors",
+											workspace.id === activeWorkspaceId
+												? "bg-accent"
+												: "hover:bg-accent/50",
+										)}
+									>
+										<DashboardSidebarWorkspaceIcon
+											hostType={workspace.hostType}
+											workspaceType={workspace.workspaceType}
+											hostIsOnline={workspace.hostIsOnline}
+											isActive={workspace.id === activeWorkspaceId}
+											variant="collapsed"
+											workspaceStatus={
+												workspace.agentStatus === "idle"
+													? null
+													: workspace.agentStatus
+											}
+											isCreatePending={false}
+											pullRequestState={workspace.pullRequest?.state ?? null}
+										/>
+									</button>
+								</TooltipTrigger>
+								<TooltipContent side="right" sideOffset={6}>
+									<p className="text-xs">{workspace.title}</p>
+								</TooltipContent>
+							</Tooltip>
+						))}
+				</div>
+				<PrototypeSidebarFooter isCollapsed />
+			</div>
+		);
+	}
+
+	return (
+		// No border-r — the enclosing ResizablePanel draws the panel border.
+		<div className="flex h-full flex-col bg-muted/45 dark:bg-muted/35">
+			{/* Traffic-light row, matching the real sidebar header: a drag strip
+			    with an 80px left inset that clears the macOS window controls
+			    (titleBarStyle:hidden, lights at x/y = 16), hosting the collapse
+			    toggle right beside them. h-12 centers the toggle on the lights
+			    and matches PrototypeTopBar so the two headers read as one row. */}
+			<div className="drag flex h-12 shrink-0 items-center pl-20">
+				<PrototypeSidebarToggle />
+			</div>
+			{/* Real app chrome (live imports): org switcher + nav + New Workspace. */}
+			<PrototypeSidebarHeader />
+			{/* The Projects panel: view controls + grouped list collapse as one. */}
+			<PrototypeProjectsHeader />
+			{projectsCollapsed && <div className="flex-1" />}
+			{!projectsCollapsed && (
+				<>
+					{/* Icon-only triggers: the selected option's label lives in the
+					    hover tooltip instead of the trigger, so all four controls fit
+					    on one row at every panel width — no truncation, no reflow
+					    tiers. The whole row tucks away behind the Projects header's
+					    LuLayers toggle once a view is set up. */}
+					{!viewControlsCollapsed && (
+						<div className="no-drag flex items-center gap-2 border-border/60 border-b px-3 pb-1.5">
+							<ViewSelect
+								value={groupBy}
+								onChange={(v) => setGroupBy(v as GroupBy)}
+								options={GROUP_BY_OPTIONS}
+								conceptLabel="Group by"
+								hotkeyKeys={["⌥", "G"]}
+								open={openSelect === "group"}
+								onOpenChange={(open) => setOpenSelect(open ? "group" : null)}
+							/>
+							<ViewSelect
+								value={orderBy}
+								onChange={(v) => handleOrderByChange(v as OrderBy)}
+								options={ORDER_BY_OPTIONS}
+								conceptLabel="Order by"
+								hotkeyKeys={["⌥", "O"]}
+								open={openSelect === "order"}
+								onOpenChange={(open) => setOpenSelect(open ? "order" : null)}
+							/>
+							<div className="ml-auto flex shrink-0 items-center gap-2">
+								<Tooltip delayDuration={300}>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											// aria-disabled (not `disabled`) so the button stays
+											// hoverable and its tooltip still explains the control
+											// when Manual order makes direction moot — matching the
+											// real app's disabled-with-tooltip pattern
+											// (V2WorkspaceRow's "Can't unpin the current workspace").
+											onClick={() => {
+												if (orderBy === "manual") return;
+												setDirection(direction === "asc" ? "desc" : "asc");
+											}}
+											aria-disabled={orderBy === "manual"}
+											className={cn(
+												"flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+												orderBy === "manual" &&
+													"cursor-not-allowed opacity-40 hover:bg-transparent hover:text-muted-foreground",
+											)}
+										>
+											{direction === "asc" ? (
+												<LuArrowUpNarrowWide className="size-4" />
+											) : (
+												<LuArrowDownWideNarrow className="size-4" />
+											)}
+										</button>
+									</TooltipTrigger>
+									<TooltipContent side="bottom" sideOffset={4}>
+										<p className="flex items-center gap-2 text-xs">
+											{orderBy === "manual" ? (
+												"Manual order has no direction"
+											) : (
+												<>
+													{direction === "asc" ? "Ascending" : "Descending"}
+													<KbdGroup>
+														<Kbd>⌥</Kbd>
+														<Kbd>D</Kbd>
+													</KbdGroup>
+												</>
+											)}
+										</p>
+									</TooltipContent>
+								</Tooltip>
+								{/* Fold-all toggle, matching the Changes toolbar's collapse/
+					    expand-all button: one control that folds every group, then
+					    flips to unfold once everything is collapsed. */}
+								<Tooltip delayDuration={300}>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											onClick={() =>
+												setGroupsCollapsed(
+													groupCollapseKeys,
+													!allGroupsCollapsed,
+												)
+											}
+											disabled={groupCollapseKeys.length === 0}
+											className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+										>
+											{allGroupsCollapsed ? (
+												<LuUnfoldVertical className="size-4" />
+											) : (
+												<LuFoldVertical className="size-4" />
+											)}
+										</button>
+									</TooltipTrigger>
+									<TooltipContent side="bottom" sideOffset={4}>
+										<p className="flex items-center gap-2 text-xs">
+											{allGroupsCollapsed ? "Expand all" : "Collapse all"}
+											<KbdGroup>
+												<Kbd>⌥</Kbd>
+												<Kbd>F</Kbd>
+											</KbdGroup>
+										</p>
+									</TooltipContent>
+								</Tooltip>
+							</div>
+						</div>
+					)}
+
+					<motion.div
+						layoutScroll
+						className="hide-scrollbar flex-1 overflow-y-auto py-1"
+					>
+						<DndContext
+							sensors={sensors}
+							collisionDetection={collisionDetection}
+							measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+							onDragStart={handleDragStart}
+							onDragOver={handleDragOver}
+							onDragEnd={handleDragEnd}
+							onDragCancel={handleDragCancel}
+						>
+							<SortableContext
+								items={rowIds}
+								strategy={verticalListSortingStrategy}
+							>
+								<LayoutGroup>
+									{items.map((item) => {
+										if (item.kind === "header") {
+											const flash = headerFlashes[item.group.key];
+											const agentIcon = item.group.agentStatus
+												? AGENT_GROUP_ICON[item.group.agentStatus]
+												: undefined;
+											const AgentStatusIcon = agentIcon?.icon;
+											const prIcon = item.group.prBucket
+												? PR_GROUP_ICON[item.group.prBucket]
+												: undefined;
+											const PrBucketIcon = prIcon?.icon;
+											const isDropTarget =
+												item.group.key === dropTargetGroupKey;
+											const isEmptyColumn = item.group.workspaces.length === 0;
+											return (
+												// The whole group is a drop target under Linear grouping:
+												// this wraps the header (and an empty column's drag-time
+												// drop area) so a drop anywhere on the group reassigns
+												// status. Disabled for other groupings.
+												<PrototypeGroupDroppable
+													key={item.key}
+													groupKey={item.group.key}
+													disabled={groupBy !== "linear"}
+												>
+													<motion.div
+														ref={(el) => {
+															if (el) headerEls.current.set(item.group.key, el);
+															else headerEls.current.delete(item.group.key);
+														}}
+														layout={!sidebarResizing}
+														role="button"
+														tabIndex={0}
+														onClick={() =>
+															toggleGroupCollapsed(item.collapseKey)
+														}
+														onKeyDown={(event) => {
+															if (event.key === "Enter" || event.key === " ") {
+																event.preventDefault();
+																toggleGroupCollapsed(item.collapseKey);
+															}
+														}}
+														transition={{
+															layout: {
+																duration: 0.45,
+																ease: [0.22, 1, 0.36, 1],
+															},
+														}}
+														className={cn(
+															"group relative w-full cursor-pointer py-1.5 pr-2 pl-3 font-medium text-[13px] text-muted-foreground transition-colors hover:bg-muted/50",
+															isDropTarget && "bg-primary/10",
+														)}
+													>
+														<HeaderFlashOverlay
+															flashKey={flash?.seq ?? 0}
+															delayMs={flash?.delayMs ?? 0}
+															profile={flash?.profile ?? "hold"}
+														/>
+														<div className="relative z-10 flex min-h-5 w-full items-center gap-2">
+															{/* Leading cell copied from the real project row: the
+												    group icon at rest, swapped for the collapse chevron
+												    on hover (rotate-90 when expanded). The rollup
+												    status dot overlays the icon's top-right corner —
+												    the same relative position as on workspace rows, so
+												    it stays visible however narrow the panel gets. */}
+															<div className="relative flex size-5 shrink-0 items-center justify-center">
+																{item.group.repo ? (
+																	<ProjectThumbnail
+																		projectName={item.group.repo.name}
+																		iconUrl={item.group.repo.iconUrl}
+																		className="size-4 group-hover:hidden"
+																	/>
+																) : item.group.linearStatus ? (
+																	<StatusIcon
+																		type={item.group.linearStatus.iconType}
+																		color={item.group.linearStatus.color}
+																		progress={item.group.linearStatus.progress}
+																		className="group-hover:hidden"
+																	/>
+																) : AgentStatusIcon && agentIcon ? (
+																	<AgentStatusIcon
+																		className={cn(
+																			"size-4 group-hover:hidden",
+																			agentIcon.className,
+																		)}
+																	/>
+																) : PrBucketIcon && prIcon ? (
+																	<PrBucketIcon
+																		className={cn(
+																			"size-4 group-hover:hidden",
+																			prIcon.className,
+																		)}
+																	/>
+																) : (
+																	<span className="size-2 group-hover:hidden" />
+																)}
+																{/* The rollup notification dot only appears once the
+													    group is collapsed — while it's expanded, each
+													    workspace row already carries its own dot, so a
+													    header rollup would just double the noise. It stays
+												    visible through the hover icon→chevron swap: hiding
+												    it would read as the activity having stopped. */}
+																{item.isCollapsed &&
+																	item.group.rollupStatus && (
+																		<span className="-top-0.5 -right-0.5 absolute">
+																			<StatusIndicator
+																				status={item.group.rollupStatus}
+																			/>
+																		</span>
+																	)}
+																<HiChevronRight
+																	className={cn(
+																		"hidden size-4 text-muted-foreground transition-transform group-hover:block",
+																		!item.isCollapsed && "rotate-90",
+																	)}
+																/>
+															</div>
+															<span className="truncate font-semibold">
+																{item.group.label}
+															</span>
+															{item.group.repo ? (
+																// Trailing cell copied from the real project row
+																// (DashboardSidebarProjectRow): workspace count at
+																// rest, swapped for the New-workspace plus on hover.
+																// Repository groups only — the other group-bys
+																// aren't a "place" a new workspace gets created in.
+																<div className="ml-auto flex size-6 shrink-0 items-center justify-center">
+																	<Tooltip delayDuration={500}>
+																		<TooltipTrigger asChild>
+																			<button
+																				type="button"
+																				onClick={(event) => {
+																					event.stopPropagation();
+																					openNewWorkspaceModal();
+																				}}
+																				onKeyDown={(event) =>
+																					event.stopPropagation()
+																				}
+																				onContextMenu={(event) =>
+																					event.stopPropagation()
+																				}
+																				aria-label="New workspace"
+																				className="hidden size-full items-center justify-center rounded transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover:flex group-has-[:focus]:flex"
+																			>
+																				<HiMiniPlus className="size-4 text-muted-foreground" />
+																			</button>
+																		</TooltipTrigger>
+																		<TooltipContent
+																			side="bottom"
+																			sideOffset={4}
+																		>
+																			New workspace
+																		</TooltipContent>
+																	</Tooltip>
+																	<span className="font-normal text-[10px] text-muted-foreground tabular-nums group-hover:hidden group-has-[:focus]:hidden">
+																		{item.group.workspaces.length}
+																	</span>
+																</div>
+															) : (
+																<span className="ml-auto text-muted-foreground/70 text-xs tabular-nums">
+																	{item.group.workspaces.length}
+																</span>
+															)}
+														</div>
+													</motion.div>
+													{/* Empty columns get a drop area only while dragging —
+												    at rest they're just a header, so the board stays
+												    clean. It highlights when it's the drop target. */}
+													{isEmptyColumn && activeRowId !== null && (
+														<div
+															className={cn(
+																"mx-3 mt-0.5 mb-1 h-9 rounded-md border border-dashed transition-colors",
+																isDropTarget
+																	? "border-primary/60 bg-primary/5"
+																	: "border-border/50",
+															)}
+														/>
+													)}
+												</PrototypeGroupDroppable>
+											);
+										}
+
+										const travel = travelFor(item);
+										return (
+											<PrototypeTravelRow
+												key={item.key}
+												visible={!item.isCollapsed}
+												exitTravel={travel.exitTravel}
+												enterFromTop={travel.enterFromTop}
+												highlighted={item.groupKey === dropTargetGroupKey}
+												registerEl={(el) => {
+													if (el) rowEls.current.set(item.key, el);
+													else rowEls.current.delete(item.key);
+												}}
+											>
+												<SortablePrototypeRow
+													id={item.key}
+													// Unlike the real sidebar, main workspaces are draggable
+													// here — the prototype isn't bound by the pinned-main
+													// behaviour, and Linear-group drags need to work for
+													// every row.
+													dragDisabled={false}
+													// Cross-group droppables stay enabled under Linear
+													// grouping (dropping there re-assigns the status);
+													// repository/agent/PR groups disable them so drops
+													// clamp to the source group — those properties aren't
+													// drag-assignable (checks and reviews come from CI and
+													// reviewers, not from the sidebar).
+													droppableDisabled={
+														activeGroupKey !== null &&
+														(groupBy === "repository" ||
+															groupBy === "agent" ||
+															groupBy === "pr") &&
+														item.groupKey !== activeGroupKey
+													}
+												>
+													<PrototypeWorkspaceRow
+														workspace={item.workspace}
+														groupBy={groupBy}
+														now={now}
+														isActive={item.workspace.id === activeWorkspaceId}
+														shortcutLabel={item.shortcutLabel}
+														flashKey={
+															lastChangedId === item.workspace.id
+																? changeSeq
+																: 0
+														}
+														layoutEnabled={!suppressLayout && !sidebarResizing}
+														onClick={() =>
+															setActiveWorkspace(item.workspace.id)
+														}
+													/>
+												</SortablePrototypeRow>
+											</PrototypeTravelRow>
+										);
+									})}
+								</LayoutGroup>
+							</SortableContext>
+							{createPortal(
+								<DragOverlay dropAnimation={null}>
+									{activeItem?.kind === "row" && (
+										<div className="border-border border-b bg-background shadow-lg">
+											<PrototypeWorkspaceRow
+												workspace={activeItem.workspace}
+												groupBy={groupBy}
+												now={now}
+												isActive={activeItem.workspace.id === activeWorkspaceId}
+												flashKey={0}
+												layoutEnabled={false}
+												onClick={() => {}}
+											/>
+										</div>
+									)}
+								</DragOverlay>,
+								document.body,
+							)}
+						</DndContext>
+					</motion.div>
+				</>
+			)}
+			{/* Real app chrome (live imports): settings, updates pill, help. */}
+			<PrototypeSidebarFooter />
+		</div>
+	);
+}
+
+function ViewSelect({
+	value,
+	onChange,
+	options,
+	conceptLabel,
+	hotkeyKeys,
+	open,
+	onOpenChange,
+}: {
+	value: string;
+	onChange: (value: string) => void;
+	options: ViewOption[];
+	conceptLabel: string;
+	/** Display glyphs for the hotkey, shown as kbd chips in the tooltip. */
+	hotkeyKeys: string[];
+	/**
+	 * Open state lives in the parent: the ⌥G/⌥O hotkeys are registered there
+	 * so they can first reveal a tucked-away controls row, then mount this
+	 * select already open.
+	 */
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const selected = options.find((option) => option.value === value);
+	// The trigger is icon-only, showing the SELECTED option's icon — no label,
+	// so it never truncates at narrow panel widths. The hover tooltip carries
+	// both the control's identity and the current value.
+	const SelectedIcon = selected?.icon;
+
+	// The tooltip is controlled and purely hover-driven. Left to Radix, closing
+	// the select returns focus to the trigger, which re-opens the tooltip and
+	// leaves it stuck open after the pointer moves away.
+	const [hovered, setHovered] = useState(false);
+	const hoverTimer = useRef<number | null>(null);
+
+	const clearHoverTimer = () => {
+		if (hoverTimer.current !== null) {
+			window.clearTimeout(hoverTimer.current);
+			hoverTimer.current = null;
+		}
+	};
+
+	// Unmount cleanup only — inlined so the effect has no function dependency.
+	useEffect(() => {
+		return () => {
+			if (hoverTimer.current !== null) {
+				window.clearTimeout(hoverTimer.current);
+			}
+		};
+	}, []);
+
+	return (
+		<Select
+			value={value}
+			onValueChange={onChange}
+			open={open}
+			onOpenChange={onOpenChange}
+		>
+			<Tooltip open={hovered && !open}>
+				<TooltipTrigger asChild>
+					<SelectTrigger
+						size="sm"
+						// data-[size=sm]:h-8 in the base classes outranks a plain h-* on
+						// specificity, so the height override must use the same variant.
+						className="shrink-0 border-border/60 bg-transparent px-2 text-xs data-[size=sm]:h-7"
+						onPointerEnter={() => {
+							clearHoverTimer();
+							hoverTimer.current = window.setTimeout(
+								() => setHovered(true),
+								300,
+							);
+						}}
+						onPointerLeave={() => {
+							clearHoverTimer();
+							setHovered(false);
+						}}
+					>
+						{SelectedIcon && (
+							<SelectedIcon className="size-3.5 shrink-0 text-muted-foreground" />
+						)}
+					</SelectTrigger>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" sideOffset={4}>
+					<span className="flex items-center gap-2 text-xs">
+						{/* With no label on the trigger, the tooltip names both the
+						    control and its current value. */}
+						{conceptLabel}
+						{selected && (
+							<span className="text-muted-foreground">{selected.label}</span>
+						)}
+						<KbdGroup>
+							{hotkeyKeys.map((key) => (
+								<Kbd key={key}>{key}</Kbd>
+							))}
+						</KbdGroup>
+					</span>
+				</TooltipContent>
+			</Tooltip>
+			<SelectContent>
+				{options.map((option, index) => (
+					<Fragment key={option.value}>
+						<SelectItem value={option.value}>
+							<option.icon className="size-3.5" />
+							{option.label}
+						</SelectItem>
+						{/* The leading "off"/manual option stands apart from the
+						    alphabetical field options. */}
+						{index === 0 && <SelectSeparator />}
+					</Fragment>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebar/components/HeaderFlashOverlay/HeaderFlashOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebar/components/HeaderFlashOverlay/HeaderFlashOverlay.tsx
@@ -1,0 +1,71 @@
+import { motion, useAnimationControls } from "framer-motion";
+import { useEffect } from "react";
+
+export type HeaderFlashProfile = "hold" | "brief";
+
+/**
+ * Flash envelopes. "hold" is the standard ramp-hold-fade used by workspace
+ * rows — for headers that should linger (e.g. a hidden arrival the user may
+ * want to find). "brief" is bright for the first half of a 0.45s card travel
+ * and gone by its end — for an origin the card is visibly leaving, so the eye
+ * hands off from header to card instead of seeing two long glows.
+ */
+const PROFILES: Record<
+	HeaderFlashProfile,
+	{ duration: number; times: number[] }
+> = {
+	hold: { duration: 1.4, times: [0, 0.05, 0.5, 1] },
+	brief: { duration: 0.5, times: [0, 0.1, 0.4, 1] },
+};
+
+interface HeaderFlashOverlayProps {
+	/**
+	 * Monotonic value that changes when this header should flash (same contract
+	 * as the workspace row's flash). 0 = never.
+	 */
+	flashKey: number;
+	/**
+	 * Delay before the flash starts — used to sequence origin-then-destination
+	 * when a workspace travels between collapsed groups.
+	 */
+	delayMs: number;
+	profile: HeaderFlashProfile;
+}
+
+/**
+ * Group-header flash overlay: the same highlight as the workspace row, so a
+ * collapsed group can signal that a hidden workspace just left or entered it.
+ * Resting opacity lives in `style` (an enclosing AnimatePresence
+ * initial={false} would suppress an `initial` prop).
+ */
+export function HeaderFlashOverlay({
+	flashKey,
+	delayMs,
+	profile,
+}: HeaderFlashOverlayProps) {
+	const flash = useAnimationControls();
+
+	useEffect(() => {
+		if (flashKey <= 0) return;
+		const envelope = PROFILES[profile];
+		flash.set({ opacity: 0 });
+		flash.start({
+			opacity: [0, 1, 1, 0],
+			transition: {
+				delay: delayMs / 1000,
+				duration: envelope.duration,
+				times: envelope.times,
+				ease: "easeInOut",
+			},
+		});
+	}, [flashKey, delayMs, profile, flash]);
+
+	return (
+		<motion.span
+			aria-hidden
+			style={{ opacity: 0 }}
+			animate={flash}
+			className="pointer-events-none absolute inset-0 bg-foreground/25"
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebar/components/PrototypeGroupDroppable/PrototypeGroupDroppable.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebar/components/PrototypeGroupDroppable/PrototypeGroupDroppable.tsx
@@ -1,0 +1,36 @@
+import { useDroppable } from "@dnd-kit/core";
+import type { ReactNode } from "react";
+
+/** Prefix for a group's droppable id, e.g. `group:backlog`. */
+export const GROUP_DROP_ID_PREFIX = "group:";
+
+interface PrototypeGroupDroppableProps {
+	/** The group key a workspace dropped here is reassigned to. */
+	groupKey: string;
+	/**
+	 * Groups are drop targets only under Linear grouping, where a drop reassigns
+	 * the workspace's status. Disabled for every other group-by so drops keep
+	 * clamping to the source group.
+	 */
+	disabled?: boolean;
+	children: ReactNode;
+}
+
+/**
+ * Wraps a group's header (and, for an empty column, its drag-time drop area) in
+ * a dnd-kit droppable, so a workspace can be dropped anywhere on the group — not
+ * just onto one of its rows. Dropping reassigns the workspace's Linear status to
+ * this group; the view then re-sorts it into place per the active ordering.
+ */
+export function PrototypeGroupDroppable({
+	groupKey,
+	disabled,
+	children,
+}: PrototypeGroupDroppableProps) {
+	const { setNodeRef } = useDroppable({
+		id: `${GROUP_DROP_ID_PREFIX}${groupKey}`,
+		disabled,
+	});
+
+	return <div ref={setNodeRef}>{children}</div>;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebar/components/PrototypeTravelRow/PrototypeTravelRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebar/components/PrototypeTravelRow/PrototypeTravelRow.tsx
@@ -1,0 +1,180 @@
+import { AnimatePresence, motion, type Variants } from "framer-motion";
+import { type ReactNode, useLayoutEffect, useRef } from "react";
+
+/** Matches the row layout tween so travel reads at the same speed. */
+export const TRAVEL_DURATION_S = 0.45;
+const TRAVEL_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+export const TRAVEL_EASE_CSS = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+interface TravelCustom {
+	travel: boolean;
+}
+
+/**
+ * Outer "slot" element: opens/closes the row's space in the list. Plain
+ * collapse matches the real sidebar (0.15s easeOut height); a travel exit
+ * closes slowly in sync with the card's journey so siblings glide, not snap.
+ */
+const slotVariants: Variants = {
+	hidden: { height: 0 },
+	visible: {
+		height: "auto",
+		transition: { duration: 0.15, ease: "easeOut" },
+	},
+	exit: (custom: TravelCustom | undefined) => ({
+		height: 0,
+		transition: custom?.travel
+			? { duration: TRAVEL_DURATION_S, ease: TRAVEL_EASE }
+			: { duration: 0.15, ease: "easeOut" },
+	}),
+};
+
+/**
+ * Inner "card" element: on a travel exit the card stays opaque for most of
+ * the journey and fades out only on arrival. The journey itself (gliding from
+ * the old list position to the collapsed destination header) is a WAAPI
+ * translate the sidebar runs on the slot — by exit time React has already
+ * relocated the slot's DOM node to rest just under the destination header, so
+ * "arriving" simply means translating back to y 0. No aim math, no overshoot.
+ */
+const cardVariants: Variants = {
+	hidden: { opacity: 0 },
+	visible: {
+		opacity: 1,
+		transition: { duration: 0.15, ease: "easeOut" },
+	},
+	exit: (custom: TravelCustom | undefined) =>
+		custom?.travel
+			? {
+					opacity: [1, 0.9, 0],
+					transition: {
+						duration: TRAVEL_DURATION_S,
+						times: [0, 0.55, 1],
+						ease: "easeInOut",
+					},
+				}
+			: { opacity: 0, transition: { duration: 0.15, ease: "easeOut" } },
+};
+
+/**
+ * Highlight riding along on a travel exit. The row's own flash overlay can't
+ * fire here — AnimatePresence freezes exiting children with their previous
+ * props, so the fresh flashKey never reaches them — so the highlight is baked
+ * into the exit variant instead: bright almost immediately, then gone with
+ * the card.
+ */
+const travelHighlightVariants: Variants = {
+	hidden: { opacity: 0 },
+	visible: { opacity: 0 },
+	exit: (custom: TravelCustom | undefined) =>
+		custom?.travel
+			? {
+					opacity: [0, 1, 1],
+					transition: {
+						duration: TRAVEL_DURATION_S,
+						times: [0, 0.1, 1],
+						ease: "easeInOut",
+					},
+				}
+			: { opacity: 0 },
+};
+
+interface PrototypeTravelRowProps {
+	/** False when the row's group is collapsed — unmounts (animated) the row. */
+	visible: boolean;
+	/**
+	 * True on the render that hides the row into a collapsed destination.
+	 * Consumed by the exit variants via AnimatePresence `custom` (exiting
+	 * children are frozen with their previous props, so the fresh value must
+	 * travel through `custom`). The sidebar pairs this with a WAAPI glide on
+	 * the slot from its old position.
+	 */
+	exitTravel: boolean;
+	/**
+	 * Viewport-Y of the collapsed ORIGIN group header. Non-null only on the
+	 * render that mounts the row; the card then fades in quickly at that
+	 * location and glides to its final position.
+	 */
+	enterFromTop: number | null;
+	/** Registers the slot element for the sidebar's position bookkeeping. */
+	registerEl: (el: HTMLElement | null) => void;
+	/**
+	 * True while a drag is hovering this row's group as a cross-column drop
+	 * target — tints the row so the whole destination column reads as one.
+	 */
+	highlighted?: boolean;
+	children: ReactNode;
+}
+
+/**
+ * Collapse/expand wrapper for a prototype row (per-row AnimatePresence, as in
+ * the real DashboardSidebarExpandedProjectContent), extended with "travel"
+ * animations: exits gliding into a collapsed destination header, and
+ * entrances emerging from a collapsed origin header. Neither element is
+ * overflow-hidden — clipping would hide rows the moment dnd-kit translates
+ * them mid-drag.
+ */
+export function PrototypeTravelRow({
+	visible,
+	exitTravel,
+	enterFromTop,
+	registerEl,
+	highlighted = false,
+	children,
+}: PrototypeTravelRowProps) {
+	const cardRef = useRef<HTMLDivElement>(null);
+
+	// Travel entrance: framer can't know the offset before the row has laid
+	// out, so measure post-layout/pre-paint and run a transient WAAPI animation
+	// on top (it composites over framer's 0.15s opacity enter and leaves no
+	// inline styles behind).
+	useLayoutEffect(() => {
+		if (!visible || enterFromTop == null) return;
+		const el = cardRef.current;
+		if (!el) return;
+		const delta = enterFromTop - el.getBoundingClientRect().top;
+		if (!Number.isFinite(delta) || Math.abs(delta) < 4) return;
+		el.animate(
+			[
+				{ transform: `translateY(${delta}px)`, opacity: 0 },
+				{ transform: `translateY(${delta * 0.7}px)`, opacity: 1, offset: 0.3 },
+				{ transform: "translateY(0px)", opacity: 1 },
+			],
+			{ duration: TRAVEL_DURATION_S * 1000, easing: TRAVEL_EASE_CSS },
+		);
+	}, [visible, enterFromTop]);
+
+	return (
+		<AnimatePresence initial={false} custom={{ travel: exitTravel }}>
+			{visible && (
+				<motion.div
+					ref={registerEl}
+					variants={slotVariants}
+					initial="hidden"
+					animate="visible"
+					exit="exit"
+				>
+					<motion.div
+						ref={cardRef}
+						variants={cardVariants}
+						className="relative"
+					>
+						{children}
+						{highlighted && (
+							<span
+								aria-hidden
+								className="pointer-events-none absolute inset-0 bg-primary/10"
+							/>
+						)}
+						<motion.span
+							aria-hidden
+							style={{ opacity: 0 }}
+							variants={travelHighlightVariants}
+							className="pointer-events-none absolute inset-0 bg-foreground/25"
+						/>
+					</motion.div>
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebarFooter/PrototypeSidebarFooter.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebarFooter/PrototypeSidebarFooter.tsx
@@ -1,0 +1,82 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { HiOutlineCog6Tooth } from "react-icons/hi2";
+import { UpdatesPill } from "renderer/components/UpdatesPill";
+import { useHotkeyDisplay } from "renderer/hotkeys";
+import { DashboardSidebarHelpMenu } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHelpMenu";
+
+/**
+ * The real sidebar's bottom bar (Settings + updates pill + help menu), copied
+ * from DashboardSidebar's footer. Live imports: Settings really navigates,
+ * the updates pill and help menu are the real components.
+ */
+export function PrototypeSidebarFooter({
+	isCollapsed = false,
+}: {
+	isCollapsed?: boolean;
+}) {
+	const navigate = useNavigate();
+	const matchRoute = useMatchRoute();
+	const settingsHotkey = useHotkeyDisplay("OPEN_SETTINGS").text;
+	const isSettingsOpen = !!matchRoute({ to: "/settings", fuzzy: true });
+
+	return (
+		<div
+			className={cn(
+				"border-border border-t",
+				isCollapsed
+					? "flex flex-col items-center gap-1 py-1"
+					: "flex items-center gap-1 p-3",
+			)}
+		>
+			{isCollapsed ? (
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							aria-label="Settings"
+							onClick={() => navigate({ to: "/settings/account" })}
+							className={cn(
+								"flex size-8 items-center justify-center rounded-md transition-colors",
+								isSettingsOpen
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+							)}
+						>
+							<HiOutlineCog6Tooth className="size-4" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Settings</TooltipContent>
+				</Tooltip>
+			) : (
+				<button
+					type="button"
+					onClick={() => navigate({ to: "/settings/account" })}
+					className={cn(
+						"group flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 font-medium text-sm transition-colors",
+						isSettingsOpen
+							? "bg-accent text-foreground"
+							: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+					)}
+				>
+					<HiOutlineCog6Tooth className="size-4 shrink-0" />
+					<span className="flex-1 text-left">Settings</span>
+					{settingsHotkey !== "Unassigned" && (
+						<span
+							className={cn(
+								"shrink-0 font-mono text-[10px] text-muted-foreground/60 tabular-nums",
+								"opacity-0 transition-opacity group-focus-visible:opacity-100 group-hover:opacity-100",
+							)}
+						>
+							{settingsHotkey}
+						</span>
+					)}
+				</button>
+			)}
+
+			<UpdatesPill isCollapsed={isCollapsed} />
+			<DashboardSidebarHelpMenu isCollapsed={isCollapsed} />
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebarHeader/PrototypeSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebarHeader/PrototypeSidebarHeader.tsx
@@ -1,0 +1,135 @@
+import { cn } from "@superset/ui/utils";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { HiOutlineClipboardDocumentList } from "react-icons/hi2";
+import { LuClock, LuLayers, LuPlus } from "react-icons/lu";
+import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
+import { useHotkeyDisplay } from "renderer/hotkeys";
+import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
+import { useFailedAutomations } from "renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations";
+import {
+	tasksSearchFromFilters,
+	useTasksFilterStore,
+} from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
+import { STROKE_WIDTH_THICK } from "renderer/screens/main/components/WorkspaceSidebar/constants";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+
+/**
+ * The real sidebar's nav block (org switcher, Workspaces, Automations,
+ * Tasks & PRs, New Workspace), copied from DashboardSidebarHeader so the
+ * prototype reads as the actual app. These are LIVE imports — the prototype
+ * runs inside the authenticated shell, so the org dropdown shows the real
+ * org and every button really navigates (Dev ▸ Open Attention Prototype
+ * brings you back). Omitted vs the real header: the traffic-light row (the
+ * prototype has its own) and Add repository (moved onto the Projects panel).
+ */
+export function PrototypeSidebarHeader() {
+	const navigate = useNavigate();
+	const matchRoute = useMatchRoute();
+	const openModal = useOpenNewWorkspaceModal();
+	const shortcutText = useHotkeyDisplay("NEW_WORKSPACE").text;
+	const { gateFeature } = usePaywall();
+	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
+	const isTasksOpen = !!matchRoute({ to: "/tasks", fuzzy: true });
+	const isAutomationsOpen = !!matchRoute({ to: "/automations", fuzzy: true });
+	const { myFailedCount } = useFailedAutomations();
+
+	const {
+		tab: lastTab,
+		assignee: lastAssignee,
+		search: lastSearch,
+		typeTab: lastTypeTab,
+		projectFilter: lastProjectFilter,
+		linearProjectFilter: lastLinearProjectFilter,
+	} = useTasksFilterStore();
+
+	const handleTasksClick = () => {
+		gateFeature(GATED_FEATURES.TASKS, () => {
+			navigate({
+				to: "/tasks",
+				search: tasksSearchFromFilters({
+					tab: lastTab,
+					assignee: lastAssignee,
+					search: lastSearch,
+					typeTab: lastTypeTab,
+					projectFilter: lastProjectFilter,
+					linearProjectFilter: lastLinearProjectFilter,
+				}),
+			});
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-1 border-border border-b px-3 pb-2">
+			<OrganizationDropdown variant="expanded" />
+
+			<button
+				type="button"
+				onClick={() => navigate({ to: "/v2-workspaces" })}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 font-medium text-sm transition-colors",
+					isWorkspacesListOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<LuLayers className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Workspaces</span>
+			</button>
+
+			<button
+				type="button"
+				onClick={() => navigate({ to: "/automations" })}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 font-medium text-sm transition-colors",
+					isAutomationsOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<LuClock className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Automations</span>
+				{myFailedCount > 0 && (
+					<span
+						title={`${myFailedCount} of your automations failed their last run`}
+						className="flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-red-500/15 px-1 font-medium text-[10px] text-red-600 tabular-nums dark:text-red-400"
+					>
+						{myFailedCount > 9 ? "9+" : myFailedCount}
+					</span>
+				)}
+			</button>
+
+			<button
+				type="button"
+				onClick={handleTasksClick}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 font-medium text-sm transition-colors",
+					isTasksOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<HiOutlineClipboardDocumentList className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Tasks & PRs</span>
+			</button>
+
+			<button
+				type="button"
+				onClick={() => openModal()}
+				className="group flex w-full min-w-0 items-center gap-1.5 rounded-md px-2 py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:bg-accent/50 hover:text-foreground"
+			>
+				<LuPlus className="size-4 shrink-0" strokeWidth={STROKE_WIDTH_THICK} />
+				<span className="flex-1 truncate whitespace-nowrap text-left">
+					New Workspace
+				</span>
+				<span
+					className={cn(
+						"shrink-0 font-mono text-[10px] text-muted-foreground/60 tabular-nums",
+						"opacity-0 transition-opacity group-focus-visible:opacity-100 group-hover:opacity-100",
+					)}
+				>
+					{shortcutText}
+				</span>
+			</button>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebarToggle/PrototypeSidebarToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeSidebarToggle/PrototypeSidebarToggle.tsx
@@ -1,0 +1,52 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { LuPanelLeft, LuPanelLeftClose, LuPanelLeftOpen } from "react-icons/lu";
+import { HotkeyLabel } from "renderer/hotkeys";
+import { COLLAPSED_WORKSPACE_SIDEBAR_WIDTH } from "renderer/stores/workspace-sidebar-state";
+import { usePrototypeStore } from "../../store/usePrototypeStore";
+
+/**
+ * Verbatim copy of the real sidebar's SidebarToggle (LuPanelLeft at rest,
+ * close/open variant while hovered, right-side hotkey tooltip) rebound to the
+ * prototype store. The ⌘B hotkey itself is registered on the prototype page.
+ */
+export function PrototypeSidebarToggle() {
+	const collapsed = usePrototypeStore(
+		(s) => s.sidebarWidth === COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
+	);
+	const toggleCollapsed = usePrototypeStore((s) => s.toggleSidebarCollapsed);
+
+	const getToggleIcon = (isHovering: boolean) => {
+		if (collapsed) {
+			return isHovering ? (
+				<LuPanelLeftOpen className="size-4" strokeWidth={1.5} />
+			) : (
+				<LuPanelLeft className="size-4" strokeWidth={1.5} />
+			);
+		}
+		return isHovering ? (
+			<LuPanelLeftClose className="size-4" strokeWidth={1.5} />
+		) : (
+			<LuPanelLeft className="size-4" strokeWidth={1.5} />
+		);
+	};
+
+	return (
+		<Tooltip delayDuration={300}>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={toggleCollapsed}
+					className="no-drag group flex items-center justify-center size-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+				>
+					<span className="group-hover:hidden">{getToggleIcon(false)}</span>
+					<span className="hidden group-hover:block">
+						{getToggleIcon(true)}
+					</span>
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="right">
+				<HotkeyLabel label="Toggle sidebar" id="TOGGLE_WORKSPACE_SIDEBAR" />
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeTopBar/PrototypeTopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeTopBar/PrototypeTopBar.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@superset/ui/utils";
+import { Link } from "@tanstack/react-router";
+import { LuArrowLeft } from "react-icons/lu";
+import { COLLAPSED_WORKSPACE_SIDEBAR_WIDTH } from "renderer/stores/workspace-sidebar-state";
+import { usePrototypeStore } from "../../store/usePrototypeStore";
+import { PrototypeSidebarToggle } from "../PrototypeSidebarToggle/PrototypeSidebarToggle";
+
+/**
+ * Always-on header bar over the page content, mirroring the real TopBar: the
+ * expanded sidebar hosts the traffic-light pad + toggle, but once the sidebar
+ * collapses to the 52px rail (too narrow for the pad), the pad and toggle move
+ * here — so the macOS window controls never sit on top of the page title.
+ */
+export function PrototypeTopBar() {
+	const sidebarCollapsed = usePrototypeStore(
+		(s) => s.sidebarWidth === COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
+	);
+
+	return (
+		// h-12 matches the real TopBar (and the sidebar's traffic-light strip).
+		<div
+			className={cn(
+				"drag flex h-12 shrink-0 items-center gap-1.5 border-border border-b bg-muted/45 dark:bg-muted/35",
+				// 28px + the 52px rail puts the toggle at the same 80px
+				// traffic-light inset the expanded sidebar uses.
+				sidebarCollapsed ? "pl-7" : "pl-5",
+			)}
+		>
+			{sidebarCollapsed && <PrototypeSidebarToggle />}
+			<span className="font-semibold text-foreground text-sm">
+				Attention prototype
+			</span>
+			{/* The prototype route is full-screen, so this is the only way back
+			    into the real app (the persisted router history restores this
+			    route on every launch until you leave it). */}
+			<Link
+				to="/"
+				className="no-drag ml-auto mr-4 flex items-center gap-1.5 text-muted-foreground text-xs transition-colors hover:text-foreground"
+			>
+				<LuArrowLeft className="size-3.5" />
+				Back to app
+			</Link>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeWorkspaceDetails/PrototypeWorkspaceDetails.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeWorkspaceDetails/PrototypeWorkspaceDetails.tsx
@@ -1,0 +1,130 @@
+import { OverflowFadeContainer } from "@superset/ui/overflow-fade-container";
+import { cn } from "@superset/ui/utils";
+import type { CSSProperties } from "react";
+import { LuRadioTower, LuX } from "react-icons/lu";
+import { DashboardSidebarWorkspaceDetailsAction } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDetails/components/DashboardSidebarWorkspaceDetailsAction";
+import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
+import type { PrototypeWorkspace } from "../../model/types";
+import { usePrototypeStore } from "../../store/usePrototypeStore";
+import { PrototypePortBadge } from "../PrototypePortBadge/PrototypePortBadge";
+
+/**
+ * Unfold wrapper copied from the real DashboardSidebarWorkspaceDetails: the
+ * element's max-width/margin/opacity animate from zero when the row enters its
+ * `details-expanded` state (hover/focus of the `.group/item` row scope).
+ */
+const UNFOLD_WRAPPER = cn(
+	"invisible max-w-0 shrink-0 overflow-hidden opacity-0",
+	"transition-[max-width,margin,opacity,visibility] duration-500 ease-out motion-reduce:transition-none",
+	"details-expanded:visible details-expanded:ml-1.5 details-expanded:opacity-100 details-expanded:duration-200",
+);
+
+const MAX_STAGGERED_PORTS = 8;
+const STAGGER_STEP_MS = 25;
+
+interface PrototypeWorkspaceDetailsProps {
+	workspace: PrototypeWorkspace;
+	/** Selects the workspace when the strip's empty area is clicked. */
+	onClick?: () => void;
+}
+
+/**
+ * Fixture-driven copy of the real inline ports strip: a compact port-count
+ * pill at rest that unfolds into individual port badges (with stagger) while
+ * the row is hovered, plus a "close all" action when there are several.
+ */
+export function PrototypeWorkspaceDetails({
+	workspace,
+	onClick,
+}: PrototypeWorkspaceDetailsProps) {
+	const setActiveWorkspace = usePrototypeStore((s) => s.setActiveWorkspace);
+	const closePort = usePrototypeStore((s) => s.closePort);
+	const ports = workspace.ports;
+
+	if (ports.length === 0) return null;
+
+	return (
+		// Stop pointer/touch starts from bubbling to the sortable wrapper's drag
+		// listeners, so scrolling overflowing badges or pressing a badge control
+		// isn't captured as a workspace-reorder gesture. Clicks are handled here
+		// (not bubbled): badges keep their own actions, but a click on the
+		// strip's empty area selects the workspace — the row's own onClick never
+		// sees these because mousedown is stopped above it.
+		<OverflowFadeContainer
+			observeChildren
+			// 30px + the row's own pl-5 aligns the strip with the title at 50px,
+			// matching the real details strip's pl-[50px].
+			className="group/details flex h-[22px] cursor-pointer items-center overflow-x-auto pl-[30px] hide-scrollbar"
+			onMouseDown={(event) => event.stopPropagation()}
+			onTouchStart={(event) => event.stopPropagation()}
+			onClick={(event) => {
+				event.stopPropagation();
+				if (!onClick) return;
+				const target = event.target as HTMLElement;
+				// Radix menu selections render in a portal; React bubbling still
+				// reaches this handler but the target isn't inside the strip's DOM.
+				if (!event.currentTarget.contains(target)) return;
+				// Chips handle their own clicks (open port, close, menus); only
+				// clicks on the strip's empty area select the workspace. The
+				// interactive ancestor must be INSIDE the strip — the enclosing
+				// dnd-kit sortable wrapper carries role="button", so an unscoped
+				// closest() would match it from anywhere and swallow every click.
+				const interactive = target.closest(
+					"button, a, [role='button'], [role='menuitem']",
+				);
+				if (interactive && event.currentTarget.contains(interactive)) return;
+				onClick();
+			}}
+		>
+			<span
+				className={cn(
+					"flex h-[18px] shrink-0 items-center gap-1 overflow-hidden rounded-full bg-muted/60",
+					"font-medium text-[9px] text-muted-foreground tabular-nums",
+					"max-w-14 px-1.5 opacity-100",
+					"transition-[max-width,margin,padding,opacity] duration-500 ease-out motion-reduce:transition-none",
+					"details-expanded:ml-0 details-expanded:max-w-0 details-expanded:px-0 details-expanded:opacity-0 details-expanded:duration-200",
+				)}
+			>
+				<LuRadioTower
+					className="size-2.5 shrink-0"
+					strokeWidth={STROKE_WIDTH}
+				/>
+				{ports.length}
+			</span>
+
+			{ports.map((port, index) => (
+				<div
+					key={`${workspace.id}:${port.port}`}
+					className={cn(
+						UNFOLD_WRAPPER,
+						"details-expanded:max-w-44 details-expanded:[transition-delay:var(--unfold-delay)]",
+					)}
+					style={
+						{
+							"--unfold-delay": `${Math.min(index, MAX_STAGGERED_PORTS) * STAGGER_STEP_MS}ms`,
+						} as CSSProperties
+					}
+				>
+					<PrototypePortBadge
+						port={port}
+						hostType={workspace.hostType}
+						onGoToWorkspace={() => setActiveWorkspace(workspace.id)}
+						onClose={() => closePort(workspace.id, port.port)}
+					/>
+				</div>
+			))}
+
+			{ports.length > 1 && (
+				<div className={cn(UNFOLD_WRAPPER, "details-expanded:max-w-8")}>
+					<DashboardSidebarWorkspaceDetailsAction
+						label="Close all ports"
+						icon={<LuX className="size-3" strokeWidth={STROKE_WIDTH} />}
+						onClick={() => {
+							for (const port of ports) closePort(workspace.id, port.port);
+						}}
+					/>
+				</div>
+			)}
+		</OverflowFadeContainer>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeWorkspaceRow/PrototypeWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/PrototypeWorkspaceRow/PrototypeWorkspaceRow.tsx
@@ -1,0 +1,356 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { motion, useAnimationControls, useIsPresent } from "framer-motion";
+import { useEffect, useState } from "react";
+import { HiMiniMinus, HiMiniXMark } from "react-icons/hi2";
+import { DashboardSidebarWorkspaceDiffStats } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats";
+import { DashboardSidebarWorkspaceIcon } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon";
+import type { DashboardSidebarWorkspacePullRequest } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types";
+import { StatusIcon } from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/StatusIcon";
+import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
+import {
+	getStatusTooltip,
+	StatusIndicator,
+} from "renderer/screens/main/components/StatusIndicator";
+import type { ActivePaneStatus } from "shared/tabs-types";
+import { formatAge } from "../../model/formatAge";
+import type { GroupBy, PrototypeWorkspace } from "../../model/types";
+import { usePrototypeStore } from "../../store/usePrototypeStore";
+import { PrototypeCloseDialog } from "../PrototypeCloseDialog/PrototypeCloseDialog";
+import { PrototypeWorkspaceDetails } from "../PrototypeWorkspaceDetails/PrototypeWorkspaceDetails";
+
+/** Same labels as the real expanded row's icon tooltip. */
+const PR_STATE_LABEL: Record<
+	DashboardSidebarWorkspacePullRequest["state"],
+	string
+> = {
+	open: "Open",
+	merged: "Merged",
+	closed: "Closed",
+	draft: "Draft",
+	queued: "Queued",
+};
+
+interface PrototypeWorkspaceRowProps {
+	workspace: PrototypeWorkspace;
+	groupBy: GroupBy;
+	now: number;
+	isActive: boolean;
+	shortcutLabel?: string;
+	/**
+	 * A monotonic value that changes when THIS row should flash (i.e. it was the
+	 * workspace just mutated). 0 = never flashed. Changing it re-triggers.
+	 */
+	flashKey: number;
+	/**
+	 * Framer layout tween toggle. Disabled while a dnd-kit drag is active (and
+	 * through the drop's commit render) so the two systems never animate the
+	 * same move; sim-driven reorders keep it on.
+	 */
+	layoutEnabled?: boolean;
+	onClick: () => void;
+}
+
+/**
+ * Adaptive workspace row for the prototype. Composed from the REAL sidebar leaf
+ * atoms (icon, status overlay, diff stats) so it matches Superset pixel-for-pixel,
+ * then layers the view-system idea on top: it shows exactly the properties the
+ * current grouping does NOT already imply. Uses framer-motion `layout` so the row
+ * tweens to its new position when the list re-orders, plus a subtle landing flash.
+ */
+export function PrototypeWorkspaceRow({
+	workspace,
+	groupBy,
+	now,
+	isActive,
+	shortcutLabel,
+	flashKey,
+	layoutEnabled = true,
+	onClick,
+}: PrototypeWorkspaceRowProps) {
+	const flash = useAnimationControls();
+	// While the row is exiting (travel to a collapsed group), it must stop
+	// participating in LayoutGroup projection: React has already relocated its
+	// DOM node to the new list position, and a layout FLIP tween there would
+	// fight the travel transform (text drifting apart from its highlight).
+	// Presence context still reaches exiting children even though their props
+	// are frozen, so this — unlike a prop — flips in time.
+	const isPresent = useIsPresent();
+	const closeWorkspace = usePrototypeStore((s) => s.closeWorkspace);
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const isMainWorkspace = workspace.workspaceType === "main";
+
+	// Highlight the moving card so the eye can lock onto it: ramp up to full
+	// brightness near-instantly (the decelerating move tween covers most of its
+	// distance in its first ~150ms, so a slow ramp would miss short hops), HOLD
+	// bright while it travels, then fade slowly once it has landed.
+	useEffect(() => {
+		if (flashKey <= 0) return;
+		flash.set({ opacity: 0 });
+		flash.start({
+			opacity: [0, 1, 1, 0],
+			transition: {
+				duration: 1.4,
+				times: [0, 0.05, 0.5, 1],
+				ease: "easeInOut",
+			},
+		});
+	}, [flashKey, flash]);
+
+	const activeStatus: ActivePaneStatus | null =
+		workspace.agentStatus === "idle" ? null : workspace.agentStatus;
+
+	// A card shows the properties the current grouping does not imply.
+	const showRepo = groupBy !== "repository";
+	const showLinear = groupBy !== "linear" && workspace.linearStatus !== null;
+
+	return (
+		<motion.div
+			layout={layoutEnabled && isPresent}
+			transition={{
+				layout: { duration: 0.45, ease: [0.22, 1, 0.36, 1] },
+			}}
+			onClick={onClick}
+			className={cn(
+				// group/item scopes the ports strip's `details-expanded` hover state,
+				// exactly like the real DashboardSidebarWorkspaceItem wrapper.
+				"group group/item relative w-full cursor-pointer py-2 pr-2 pl-5 text-left",
+				isActive ? "bg-accent" : "hover:bg-muted/50",
+			)}
+		>
+			{/* Tracking highlight overlay (ramps up, holds through the move, fades).
+			    Resting opacity lives in `style`, not `initial` — an enclosing
+			    AnimatePresence initial={false} suppresses `initial` on first mount,
+			    which would leave the overlay at full opacity (grey wash). */}
+			<motion.span
+				aria-hidden
+				style={{ opacity: 0 }}
+				animate={flash}
+				className="pointer-events-none absolute inset-0 bg-foreground/25"
+			/>
+
+			{isActive && (
+				<span
+					className="absolute top-0 bottom-0 left-0 z-10 w-0.5 rounded-r"
+					style={{ backgroundColor: "var(--color-foreground)" }}
+				/>
+			)}
+
+			<div className="relative z-10 flex w-full items-center">
+				{/* Icon cell copied from the real expanded row: size-5 + mr-2.5, so a
+				    grouped row's title starts 10px deeper than its header label and
+				    children read as children. `relative` anchors the status-dot
+				    overlay (-top-0.5 -right-0.5) to the icon itself. The tooltip
+				    mirrors the real row's icon tooltip — the glyph packs PR state,
+				    workspace kind, and the agent dot into one small cluster, so
+				    hover is where those colors get decoded. */}
+				<Tooltip delayDuration={500}>
+					<TooltipTrigger asChild>
+						<span className="relative mr-2.5 flex size-5 shrink-0 items-center justify-center">
+							{/* Desaturation experiment: the PR/kind glyph rests in
+							    grayscale and regains color on row hover or selection.
+							    The wrapper deliberately excludes the attention signals:
+							    the working spinner (which replaces the glyph, hence the
+							    !== "working" condition) and the status dot (re-rendered
+							    below, outside the filter, at the icon component's own
+							    overlay position). */}
+							<span
+								className={cn(
+									"flex items-center justify-center transition-[filter] duration-150",
+									!isActive &&
+										activeStatus !== "working" &&
+										"grayscale group-hover:grayscale-0",
+								)}
+							>
+								<DashboardSidebarWorkspaceIcon
+									hostType={workspace.hostType}
+									workspaceType={workspace.workspaceType}
+									hostIsOnline={workspace.hostIsOnline}
+									isActive={isActive}
+									variant="expanded"
+									workspaceStatus={
+										activeStatus === "working" ? "working" : null
+									}
+									isCreatePending={false}
+									pullRequestState={workspace.pullRequest?.state ?? null}
+								/>
+							</span>
+							{activeStatus && activeStatus !== "working" && (
+								<span className="-top-0.5 -right-0.5 absolute">
+									<StatusIndicator status={activeStatus} />
+								</span>
+							)}
+						</span>
+					</TooltipTrigger>
+					<TooltipContent side="right" sideOffset={8}>
+						{workspace.pullRequest ? (
+							<>
+								<p className="font-medium text-xs">
+									PR #{workspace.pullRequest.number} —{" "}
+									{PR_STATE_LABEL[workspace.pullRequest.state]}
+								</p>
+								<p className="max-w-56 truncate text-muted-foreground text-xs">
+									{workspace.pullRequest.title}
+								</p>
+							</>
+						) : (
+							<>
+								<p className="font-medium text-xs">
+									{isMainWorkspace
+										? "Main workspace"
+										: workspace.hostType === "local-device"
+											? "Local workspace"
+											: workspace.hostType === "remote-device"
+												? workspace.hostIsOnline === false
+													? "Remote workspace — device offline"
+													: "Remote workspace"
+												: "Cloud workspace"}
+								</p>
+								<p className="text-muted-foreground text-xs">
+									{isMainWorkspace
+										? "Uses the repository checkout on this host"
+										: workspace.hostType === "local-device"
+											? "Running on this device"
+											: workspace.hostType === "remote-device"
+												? workspace.hostIsOnline === false
+													? "The associated device isn't reachable right now"
+													: "Running on a paired device"
+												: "Hosted in the cloud"}
+								</p>
+							</>
+						)}
+						{activeStatus && (
+							<p className="mt-1 text-muted-foreground text-xs">
+								Agent: {getStatusTooltip(activeStatus)}
+							</p>
+						)}
+					</TooltipContent>
+				</Tooltip>
+
+				<span className="flex min-w-0 flex-1 flex-col gap-0.5">
+					{/* Title line copied from the real expanded row: a two-column grid
+					    so the trailing cluster is vertically aligned with the TITLE
+					    text, not centered against the whole multi-line row. */}
+					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5">
+						<span
+							className={cn(
+								"truncate text-[13px] leading-tight",
+								isActive ? "text-foreground" : "text-foreground/80",
+							)}
+						>
+							{workspace.title}
+						</span>
+						{/* Same grid-overlap swap as the real row: age + diff stats at
+						    rest, replaced wholesale by the ⌘N hint + close cluster on
+						    hover. */}
+						<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center justify-items-end [&>*]:col-start-1 [&>*]:row-start-1">
+							<span className="flex items-center gap-2 group-hover:hidden">
+								<span className="font-mono text-[10px] text-muted-foreground tabular-nums">
+									{formatAge(now, workspace.lastActivityAt)}
+								</span>
+								<DashboardSidebarWorkspaceDiffStats
+									additions={workspace.diff.additions}
+									deletions={workspace.diff.deletions}
+									isActive={isActive}
+								/>
+							</span>
+							<div className="hidden items-center justify-end gap-1.5 group-hover:flex">
+								{shortcutLabel && (
+									<span className="shrink-0 font-mono text-[10px] text-muted-foreground tabular-nums">
+										{shortcutLabel}
+									</span>
+								)}
+								{isMainWorkspace ? (
+									<Tooltip delayDuration={300}>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={(event) => {
+													event.stopPropagation();
+													closeWorkspace(workspace.id);
+												}}
+												className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+												aria-label="Remove from sidebar"
+											>
+												<HiMiniMinus className="size-3.5" />
+											</button>
+										</TooltipTrigger>
+										<TooltipContent side="top" sideOffset={4}>
+											<p className="text-xs">Remove from sidebar</p>
+										</TooltipContent>
+									</Tooltip>
+								) : (
+									<Tooltip delayDuration={300}>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={(event) => {
+													event.stopPropagation();
+													setConfirmOpen(true);
+												}}
+												className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+												aria-label="Close workspace"
+											>
+												<HiMiniXMark className="size-3.5" />
+											</button>
+										</TooltipTrigger>
+										<TooltipContent side="top" sideOffset={4}>
+											<p className="text-xs">Close workspace</p>
+										</TooltipContent>
+									</Tooltip>
+								)}
+							</div>
+						</div>
+					</div>
+					{(showRepo || showLinear) && (
+						<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+							{showRepo && (
+								<span className="flex items-center gap-1">
+									<ProjectThumbnail
+										projectName={workspace.repo.name}
+										iconUrl={workspace.repo.iconUrl}
+										className="size-3.5 rounded-[3px] text-[8px]"
+									/>
+									<span className="truncate">{workspace.repo.name}</span>
+								</span>
+							)}
+							{showRepo && showLinear && (
+								<span className="text-muted-foreground/40">·</span>
+							)}
+							{showLinear && workspace.linearStatus && (
+								<span className="flex items-center gap-1">
+									<StatusIcon
+										type={workspace.linearStatus.iconType}
+										color={workspace.linearStatus.color}
+										progress={workspace.linearStatus.progress}
+										// Same desaturation experiment as the PR glyph: color
+										// returns on row hover/selection.
+										className={cn(
+											"scale-90 transition-[filter] duration-150",
+											!isActive && "grayscale group-hover:grayscale-0",
+										)}
+									/>
+									<span className="truncate">
+										{workspace.linearStatus.label}
+									</span>
+								</span>
+							)}
+						</span>
+					)}
+				</span>
+			</div>
+
+			<PrototypeWorkspaceDetails workspace={workspace} onClick={onClick} />
+
+			<PrototypeCloseDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				workspaceName={workspace.title}
+				onConfirm={() => {
+					setConfirmOpen(false);
+					closeWorkspace(workspace.id);
+				}}
+			/>
+		</motion.div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/SimulationDriver/SimulationDriver.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/SimulationDriver/SimulationDriver.tsx
@@ -1,0 +1,203 @@
+import { cn } from "@superset/ui/utils";
+import { useMemo } from "react";
+import { FIXTURE_NOW } from "../../fixtures/workspaces";
+import { formatAge } from "../../model/formatAge";
+import { usePrototypeStore } from "../../store/usePrototypeStore";
+
+/**
+ * Dev control strip: mutate the fixture fleet so the view system and ⌘J HUD can
+ * be felt live — block/finish agents, bump activity, and advance a virtual clock.
+ */
+export function SimulationDriver() {
+	const workspaces = usePrototypeStore((s) => s.workspaces);
+	const now = usePrototypeStore((s) => s.now);
+	const activeWorkspaceId = usePrototypeStore((s) => s.activeWorkspaceId);
+	const revealWorkspace = usePrototypeStore((s) => s.revealWorkspace);
+
+	// Alphabetical, independent of the sidebar's view config: the table is a
+	// lookup surface, so a stable scannable order beats mirroring the sidebar.
+	const sortedWorkspaces = useMemo(
+		() =>
+			[...workspaces].sort((a, b) =>
+				a.title.localeCompare(b.title, undefined, { sensitivity: "base" }),
+			),
+		[workspaces],
+	);
+	const blockOnInput = usePrototypeStore((s) => s.blockOnInput);
+	const finishTurn = usePrototypeStore((s) => s.finishTurn);
+	const setAgentStatus = usePrototypeStore((s) => s.setAgentStatus);
+	const bumpActivity = usePrototypeStore((s) => s.bumpActivity);
+	const advanceClock = usePrototypeStore((s) => s.advanceClock);
+	const reset = usePrototypeStore((s) => s.reset);
+	const toggleHud = usePrototypeStore((s) => s.toggleHud);
+
+	return (
+		<div className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-background p-5">
+			{/* The page title lives in PrototypeTopBar, alongside the window chrome. */}
+			<p className="mb-4 max-w-prose text-muted-foreground text-sm">
+				A dev-only playground for the proposed view system (group-by / order-by,
+				adaptive cards) and the ⌘J jump HUD. Everything is fixtures + simulation
+				— no live workspaces are touched. Use the controls below to change agent
+				state and watch the sidebar re-group and re-order.
+			</p>
+
+			<div className="mb-4 flex flex-wrap items-center gap-2">
+				<ClockButton onClick={() => advanceClock(5)}>+5m</ClockButton>
+				<ClockButton onClick={() => advanceClock(60)}>+1h</ClockButton>
+				<ClockButton onClick={() => advanceClock(60 * 24)}>+1d</ClockButton>
+				<button
+					type="button"
+					onClick={toggleHud}
+					className="rounded-md border border-border bg-muted/40 px-2.5 py-1 font-medium text-xs transition-colors hover:bg-accent"
+				>
+					Open ⌘J HUD
+				</button>
+				<button
+					type="button"
+					onClick={reset}
+					className="rounded-md border border-border px-2.5 py-1 font-medium text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground"
+				>
+					Reset
+				</button>
+				<span className="ml-auto text-muted-foreground text-xs">
+					clock: fixture now + {Math.round((now - FIXTURE_NOW) / 60_000)}m
+				</span>
+			</div>
+
+			<div className="overflow-hidden rounded-lg border border-border">
+				<table className="w-full text-sm">
+					<thead>
+						{/* Fixed widths on the variable-content columns so a status
+						    change ("permission" → "failed") doesn't reflow the row and
+						    move the Simulate buttons out from under the pointer. */}
+						<tr className="border-border border-b bg-muted/30 text-left text-muted-foreground text-xs">
+							<th className="px-3 py-2 font-medium">Workspace</th>
+							<th className="w-28 px-3 py-2 font-medium">Status</th>
+							<th className="w-24 px-3 py-2 font-medium">Last activity</th>
+							<th className="px-3 py-2 font-medium">Simulate</th>
+						</tr>
+					</thead>
+					<tbody>
+						{sortedWorkspaces.map((workspace) => (
+							// Selection is synced both ways with the sidebar: clicking a
+							// board row reveals the workspace there (like a ⌘J jump), and
+							// a sidebar selection highlights the row here.
+							<tr
+								key={workspace.id}
+								onClick={() => revealWorkspace(workspace.id)}
+								className={cn(
+									"cursor-pointer border-border/60 border-b transition-colors last:border-b-0",
+									workspace.id === activeWorkspaceId
+										? "bg-accent"
+										: "hover:bg-muted/40",
+								)}
+							>
+								<td className="px-3 py-2">
+									<div className="font-medium text-foreground">
+										{workspace.title}
+									</div>
+									<div className="text-muted-foreground text-xs">
+										{workspace.repo.name}
+									</div>
+								</td>
+								<td className="px-3 py-2">
+									<StatusPill status={workspace.agentStatus} />
+								</td>
+								<td className="px-3 py-2 font-mono text-muted-foreground text-xs tabular-nums">
+									{formatAge(now, workspace.lastActivityAt)}
+								</td>
+								<td className="px-3 py-2">
+									<div className="flex flex-wrap gap-1">
+										{/* Ordered to mirror the sidebar's agent-status group
+										    order: Needs input, Failed, Working, Ready for review. */}
+										<SimButton onClick={() => blockOnInput(workspace.id)}>
+											Block
+										</SimButton>
+										<SimButton
+											onClick={() => setAgentStatus(workspace.id, "failed")}
+										>
+											Fail
+										</SimButton>
+										<SimButton
+											onClick={() => setAgentStatus(workspace.id, "working")}
+										>
+											Work
+										</SimButton>
+										<SimButton onClick={() => finishTurn(workspace.id)}>
+											Finish
+										</SimButton>
+										<SimButton onClick={() => bumpActivity(workspace.id)}>
+											Bump
+										</SimButton>
+									</div>
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}
+
+function ClockButton({
+	onClick,
+	children,
+}: {
+	onClick: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className="rounded-md border border-border bg-muted/40 px-2.5 py-1 font-medium font-mono text-xs transition-colors hover:bg-accent"
+		>
+			{children}
+		</button>
+	);
+}
+
+function SimButton({
+	onClick,
+	children,
+}: {
+	onClick: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			// Sim actions shouldn't also change the selection — the row's own
+			// click handles select-and-reveal.
+			onClick={(event) => {
+				event.stopPropagation();
+				onClick();
+			}}
+			className="rounded border border-border px-2 py-0.5 text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground"
+		>
+			{children}
+		</button>
+	);
+}
+
+const STATUS_PILL: Record<string, string> = {
+	permission: "bg-red-500/15 text-red-500",
+	failed: "bg-red-500/15 text-red-500",
+	working: "bg-amber-500/15 text-amber-500",
+	review: "bg-green-500/15 text-green-500",
+	idle: "bg-muted text-muted-foreground",
+};
+
+function StatusPill({ status }: { status: string }) {
+	return (
+		<span
+			className={cn(
+				"inline-flex rounded-full px-2 py-0.5 font-medium text-xs",
+				STATUS_PILL[status] ?? STATUS_PILL.idle,
+			)}
+		>
+			{status}
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/SortablePrototypeRow/SortablePrototypeRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/components/SortablePrototypeRow/SortablePrototypeRow.tsx
@@ -1,0 +1,55 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { ReactNode } from "react";
+
+interface SortablePrototypeRowProps {
+	id: string;
+	/** Real sidebar disables dragging the local main workspace. */
+	dragDisabled?: boolean;
+	/**
+	 * While a drag is active, rows outside the dragged row's group disable their
+	 * droppable so closestCenter never targets them — other groups' rows don't
+	 * shift and the drop stays clamped inside the source group.
+	 */
+	droppableDisabled?: boolean;
+	children: ReactNode;
+}
+
+/**
+ * dnd-kit wrapper for a prototype row — copy of the real sidebar's
+ * SortableWorkspaceItem. A plain outer div takes the dnd translate so it never
+ * fights framer-motion's transform management on the inner motion element.
+ */
+export function SortablePrototypeRow({
+	id,
+	dragDisabled = false,
+	droppableDisabled = false,
+	children,
+}: SortablePrototypeRowProps) {
+	const {
+		setNodeRef,
+		attributes,
+		listeners,
+		isDragging,
+		transform,
+		transition,
+	} = useSortable({
+		id,
+		disabled: { draggable: dragDisabled, droppable: droppableDisabled },
+	});
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Translate.toString(transform),
+				transition,
+				opacity: isDragging ? 0.5 : undefined,
+			}}
+			{...attributes}
+			{...listeners}
+		>
+			{children}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/fixtures/workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/fixtures/workspaces.ts
@@ -1,0 +1,315 @@
+import type {
+	DashboardSidebarWorkspacePullRequest,
+	DashboardSidebarWorkspacePullRequestCheck,
+} from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types";
+import type {
+	PrototypeLinearStatus,
+	PrototypeRepo,
+	PrototypeWorkspace,
+} from "../model/types";
+
+/**
+ * Fixture "now". Fixed constant (no Date.now()) so fixtures are deterministic;
+ * the store advances a virtual clock relative to this.
+ */
+export const FIXTURE_NOW = new Date("2026-07-20T14:00:00.000Z").getTime();
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+const REPOS = {
+	dotfile: {
+		id: "repo-dotfile",
+		name: "dotfile",
+		owner: "dotfile",
+		iconUrl: null,
+	},
+	dotskills: {
+		id: "repo-dotskills",
+		name: "dotskills",
+		owner: "dotfile",
+		iconUrl: null,
+	},
+	infrastructure: {
+		id: "repo-infra",
+		name: "infrastructure",
+		owner: "dotfile",
+		iconUrl: null,
+	},
+	superset: {
+		id: "repo-superset",
+		name: "superset",
+		owner: "superset-sh",
+		iconUrl: null,
+	},
+} satisfies Record<string, PrototypeRepo>;
+
+const LINEAR = {
+	inProgress: {
+		label: "In Progress",
+		type: "in-progress",
+		iconType: "started",
+		color: "#f59e0b",
+		progress: 50,
+	},
+	inReview: {
+		label: "In Review",
+		type: "in-review",
+		iconType: "started",
+		color: "#3b82f6",
+		progress: 75,
+	},
+	todo: {
+		label: "Todo",
+		type: "todo",
+		iconType: "unstarted",
+		color: "#9ca3af",
+	},
+	backlog: {
+		label: "Backlog",
+		type: "backlog",
+		iconType: "backlog",
+		color: "#9ca3af",
+	},
+	done: {
+		label: "Done",
+		type: "done",
+		iconType: "completed",
+		color: "#22c55e",
+	},
+} satisfies Record<string, PrototypeLinearStatus>;
+
+function check(
+	name: string,
+	status: DashboardSidebarWorkspacePullRequestCheck["status"],
+): DashboardSidebarWorkspacePullRequestCheck {
+	return { name, status, url: null };
+}
+
+function pr(
+	number: number,
+	state: DashboardSidebarWorkspacePullRequest["state"],
+	overrides: Partial<DashboardSidebarWorkspacePullRequest> = {},
+): DashboardSidebarWorkspacePullRequest {
+	return {
+		url: `https://github.com/dotfile/repo/pull/${number}`,
+		number,
+		title: `PR #${number}`,
+		state,
+		reviewDecision: null,
+		checksStatus: "none",
+		checks: [],
+		...overrides,
+	};
+}
+
+/**
+ * A hand-authored fleet spanning repos, agent statuses, PR states, linear
+ * statuses, and activity ages — chosen to exercise every group-by/order-by
+ * combination and the ⌘J ranking.
+ */
+export const FIXTURE_WORKSPACES: PrototypeWorkspace[] = [
+	{
+		id: "ws-re-review",
+		title: "Re-review !5620",
+		repo: REPOS.dotfile,
+		agentStatus: "permission",
+		pullRequest: pr(5620, "open", {
+			reviewDecision: "changes_requested",
+			checksStatus: "success",
+			checks: [check("build", "success"), check("test", "success")],
+		}),
+		linearStatus: LINEAR.inReview,
+		lastActivityAt: FIXTURE_NOW - 12 * MIN,
+		createdAt: FIXTURE_NOW - 2 * DAY,
+		diff: { additions: 47, deletions: 9 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [],
+	},
+	{
+		id: "ws-push-hook",
+		title: "Push hook check for invalid refs",
+		repo: REPOS.dotfile,
+		agentStatus: "review",
+		pullRequest: pr(5644, "open", {
+			reviewDecision: "pending",
+			checksStatus: "failure",
+			checks: [check("build", "success"), check("e2e", "failure")],
+		}),
+		linearStatus: LINEAR.inReview,
+		lastActivityAt: FIXTURE_NOW - 26 * MIN,
+		createdAt: FIXTURE_NOW - 1 * DAY,
+		diff: { additions: 307, deletions: 5 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [],
+	},
+	{
+		id: "ws-risk-score",
+		title: "Per category risk score",
+		repo: REPOS.dotfile,
+		agentStatus: "working",
+		pullRequest: null,
+		linearStatus: LINEAR.inProgress,
+		lastActivityAt: FIXTURE_NOW - 40 * 1000,
+		createdAt: FIXTURE_NOW - 5 * HOUR,
+		diff: { additions: 147, deletions: 65 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [
+			{ port: 3000, label: "web", processName: "next-server", pid: 52301 },
+			{ port: 5881, label: "api", processName: "next-server", pid: 52302 },
+		],
+	},
+	{
+		id: "ws-stress-test",
+		title: "Stress test",
+		repo: REPOS.dotfile,
+		agentStatus: "working",
+		pullRequest: null,
+		linearStatus: LINEAR.inProgress,
+		lastActivityAt: FIXTURE_NOW - 3 * MIN,
+		createdAt: FIXTURE_NOW - 6 * HOUR,
+		diff: { additions: 362, deletions: 0 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [
+			{ port: 6006, label: "storybook", processName: "node", pid: 51877 },
+		],
+	},
+	{
+		id: "ws-spf",
+		title: "SPF issue",
+		repo: REPOS.dotfile,
+		agentStatus: "idle",
+		pullRequest: null,
+		linearStatus: LINEAR.todo,
+		lastActivityAt: FIXTURE_NOW - 6 * DAY,
+		createdAt: FIXTURE_NOW - 7 * DAY,
+		diff: { additions: 0, deletions: 0 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [],
+	},
+	{
+		id: "ws-debounce",
+		title: "Debounce InfoCamere",
+		repo: REPOS.dotfile,
+		agentStatus: "idle",
+		pullRequest: pr(5601, "merged"),
+		linearStatus: LINEAR.done,
+		lastActivityAt: FIXTURE_NOW - 3 * DAY,
+		createdAt: FIXTURE_NOW - 4 * DAY,
+		diff: { additions: 244, deletions: 20 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [],
+	},
+	{
+		id: "ws-audit-skills",
+		title: "Audit write-skills",
+		repo: REPOS.dotskills,
+		agentStatus: "review",
+		pullRequest: pr(212, "open", {
+			reviewDecision: "pending",
+			checksStatus: "pending",
+			checks: [check("lint", "pending")],
+		}),
+		linearStatus: LINEAR.inReview,
+		lastActivityAt: FIXTURE_NOW - 1 * HOUR,
+		createdAt: FIXTURE_NOW - 2 * DAY,
+		diff: { additions: 213, deletions: 1230 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [],
+	},
+	{
+		id: "ws-split-skills",
+		title: "Split monorepo skills",
+		repo: REPOS.dotskills,
+		agentStatus: "failed",
+		pullRequest: null,
+		linearStatus: LINEAR.inProgress,
+		lastActivityAt: FIXTURE_NOW - 18 * MIN,
+		createdAt: FIXTURE_NOW - 8 * HOUR,
+		diff: { additions: 0, deletions: 0 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [],
+	},
+	{
+		id: "ws-harness-obs",
+		title: "Harness observability",
+		repo: REPOS.dotskills,
+		agentStatus: "idle",
+		pullRequest: pr(198, "draft"),
+		linearStatus: LINEAR.todo,
+		lastActivityAt: FIXTURE_NOW - 2 * DAY,
+		createdAt: FIXTURE_NOW - 3 * DAY,
+		diff: { additions: 580, deletions: 0 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [],
+	},
+	{
+		id: "ws-paragon-queue",
+		title: "Paragon queue",
+		repo: REPOS.infrastructure,
+		agentStatus: "working",
+		pullRequest: null,
+		linearStatus: LINEAR.inProgress,
+		lastActivityAt: FIXTURE_NOW - 90 * 1000,
+		createdAt: FIXTURE_NOW - 4 * HOUR,
+		diff: { additions: 15, deletions: 7 },
+		hostType: "remote-device",
+		workspaceType: "worktree",
+		hostIsOnline: true,
+		ports: [
+			{ port: 8080, label: null, processName: "docker-proxy", pid: 40112 },
+		],
+	},
+	{
+		id: "ws-tune-monitor",
+		title: "Tune monitor 106893117",
+		repo: REPOS.infrastructure,
+		agentStatus: "review",
+		pullRequest: pr(4411, "open", {
+			reviewDecision: "approved",
+			checksStatus: "success",
+			checks: [check("plan", "success")],
+		}),
+		linearStatus: LINEAR.inReview,
+		lastActivityAt: FIXTURE_NOW - 2 * HOUR,
+		createdAt: FIXTURE_NOW - 1 * DAY,
+		diff: { additions: 45, deletions: 1 },
+		hostType: "remote-device",
+		workspaceType: "worktree",
+		hostIsOnline: false,
+		ports: [],
+	},
+	{
+		id: "ws-improve-report",
+		title: "local",
+		repo: REPOS.superset,
+		agentStatus: "idle",
+		pullRequest: null,
+		linearStatus: LINEAR.backlog,
+		lastActivityAt: FIXTURE_NOW - 5 * DAY,
+		createdAt: FIXTURE_NOW - 5 * DAY,
+		diff: { additions: 15642, deletions: 50165 },
+		hostType: "local-device",
+		workspaceType: "main",
+		hostIsOnline: null,
+		ports: [],
+	},
+];

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/hooks/useAttentionHudHotkey.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/hooks/useAttentionHudHotkey.ts
@@ -1,0 +1,15 @@
+import { usePrototypeStore } from "../store/usePrototypeStore";
+import { useLayoutAwareHotkey } from "./useLayoutAwareHotkey";
+
+/**
+ * PROTOTYPE-LOCAL ⌘J binding for the attention HUD.
+ *
+ * ⌘J is already bound to FOCUS_CHAT_INPUT in the global hotkey registry
+ * (hotkeys/registry.ts). To keep this prototype self-contained and avoid
+ * touching shared config, we bind ⌘J locally, scoped to the prototype route.
+ * A real implementation would resolve the collision in the registry instead.
+ */
+export function useAttentionHudHotkey() {
+	const toggleHud = usePrototypeStore((s) => s.toggleHud);
+	useLayoutAwareHotkey("meta+j", toggleHud);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/hooks/useLayoutAwareHotkey.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/hooks/useLayoutAwareHotkey.ts
@@ -1,0 +1,38 @@
+import { useRef } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { useEffectiveLayoutMap } from "renderer/hotkeys/stores/keyboardPreferencesStore";
+import { bindingToDispatchChord } from "renderer/hotkeys/utils/binding";
+
+/**
+ * Prototype-local hotkey binding that respects the user's keyboard layout.
+ *
+ * react-hotkeys-hook matches letters by physical key code, so a bare
+ * useHotkeys("meta+j") fires on the QWERTY J position even under Dvorak or
+ * AZERTY. The app's own `useHotkey` solves this by translating a LOGICAL chord
+ * through the keyboard-layout map into the equivalent code-based chord — but
+ * it requires a registry HotkeyId. This hook applies the same translation to
+ * an inline chord, for prototype shortcuts that shouldn't touch the shared
+ * registry.
+ */
+export function useLayoutAwareHotkey(
+	logicalChord: string,
+	callback: (event: KeyboardEvent) => void,
+): void {
+	const layoutMap = useEffectiveLayoutMap();
+	const chord =
+		bindingToDispatchChord(
+			{ version: 2, mode: "logical", chord: logicalChord },
+			layoutMap,
+		) ?? logicalChord;
+	const callbackRef = useRef(callback);
+	callbackRef.current = callback;
+	useHotkeys(
+		chord,
+		(event) => {
+			event.preventDefault();
+			callbackRef.current(event);
+		},
+		{ enableOnFormTags: true, enableOnContentEditable: true },
+		[chord],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/model/buildPrototypeView.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/model/buildPrototypeView.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, it } from "bun:test";
+import type { PaneStatus } from "shared/tabs-types";
+import { buildPrototypeView, rankForHud } from "./buildPrototypeView";
+import type {
+	PrototypeLinearStatus,
+	PrototypeWorkspace,
+	ViewConfig,
+} from "./types";
+
+const NOW = new Date("2026-07-20T12:00:00.000Z").getTime();
+const MIN = 60_000;
+
+const LINEAR: Record<string, PrototypeLinearStatus> = {
+	inProgress: {
+		label: "In Progress",
+		type: "in-progress",
+		iconType: "started",
+		color: "#f59e0b",
+		progress: 50,
+	},
+	inReview: {
+		label: "In Review",
+		type: "in-review",
+		iconType: "started",
+		color: "#3b82f6",
+		progress: 75,
+	},
+	done: {
+		label: "Done",
+		type: "done",
+		iconType: "completed",
+		color: "#22c55e",
+	},
+};
+
+function makeWorkspace(
+	overrides: Partial<PrototypeWorkspace> = {},
+): PrototypeWorkspace {
+	return {
+		id: "ws-1",
+		title: "Workspace",
+		repo: { id: "repo-a", name: "alpha", owner: "acme", iconUrl: null },
+		agentStatus: "idle",
+		pullRequest: null,
+		linearStatus: null,
+		lastActivityAt: NOW,
+		createdAt: NOW,
+		diff: { additions: 0, deletions: 0 },
+		hostType: "local-device",
+		workspaceType: "worktree",
+		hostIsOnline: null,
+		ports: [],
+		...overrides,
+	};
+}
+
+const config = (overrides: Partial<ViewConfig> = {}): ViewConfig => ({
+	groupBy: "none",
+	orderBy: "recent",
+	direction: "desc",
+	manualOrder: [],
+	...overrides,
+});
+
+describe("buildPrototypeView — grouping", () => {
+	it("returns a single unlabeled group for group-by none", () => {
+		const groups = buildPrototypeView(
+			[makeWorkspace({ id: "a" }), makeWorkspace({ id: "b" })],
+			config({ groupBy: "none" }),
+		);
+		expect(groups).toHaveLength(1);
+		expect(groups[0]?.key).toBe("all");
+		expect(groups[0]?.label).toBe("");
+		expect(groups[0]?.workspaces).toHaveLength(2);
+	});
+
+	it("groups by repository and orders groups alphabetically by name", () => {
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({
+					id: "b",
+					repo: { id: "repo-b", name: "zeta", owner: null, iconUrl: null },
+				}),
+				makeWorkspace({
+					id: "a",
+					repo: { id: "repo-a", name: "alpha", owner: null, iconUrl: null },
+				}),
+			],
+			config({ groupBy: "repository" }),
+		);
+		expect(groups.map((g) => g.label)).toEqual(["alpha", "zeta"]);
+		expect(groups[0]?.repo?.id).toBe("repo-a");
+	});
+
+	it("groups by agent status ordered by priority (most urgent first)", () => {
+		const statuses: PaneStatus[] = [
+			"review",
+			"permission",
+			"working",
+			"idle",
+			"failed",
+		];
+		const groups = buildPrototypeView(
+			statuses.map((s, i) => makeWorkspace({ id: `ws-${i}`, agentStatus: s })),
+			config({ groupBy: "agent" }),
+		);
+		expect(groups.map((g) => g.key)).toEqual([
+			"permission",
+			"failed",
+			"working",
+			"review",
+			"idle",
+		]);
+	});
+
+	it("groups by pull request into lifecycle buckets, most actionable first", () => {
+		const prBase = {
+			url: "https://example.com/pr/1",
+			number: 1,
+			title: "PR",
+			checks: [],
+		};
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "none", pullRequest: null }),
+				makeWorkspace({
+					id: "merged",
+					pullRequest: {
+						...prBase,
+						state: "merged",
+						reviewDecision: null,
+						checksStatus: "none",
+					},
+				}),
+				makeWorkspace({
+					id: "failing",
+					// Failing checks beat the approved review decision.
+					pullRequest: {
+						...prBase,
+						state: "open",
+						reviewDecision: "approved",
+						checksStatus: "failure",
+					},
+				}),
+				makeWorkspace({
+					id: "awaiting",
+					pullRequest: {
+						...prBase,
+						state: "open",
+						reviewDecision: "pending",
+						checksStatus: "success",
+					},
+				}),
+			],
+			config({ groupBy: "pr" }),
+		);
+		expect(groups.map((g) => g.key)).toEqual([
+			"checks-failing",
+			"awaiting-review",
+			"merged",
+			"no-pr",
+		]);
+		expect(groups.map((g) => g.label)).toEqual([
+			"Checks failing",
+			"Awaiting review",
+			"Merged",
+			"No pull request",
+		]);
+	});
+
+	it("groups by linear status as a full board: every column present, empty ones included, 'No status' last", () => {
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "a", linearStatus: LINEAR.done }),
+				makeWorkspace({ id: "b", linearStatus: null }),
+				makeWorkspace({ id: "c", linearStatus: LINEAR.inProgress }),
+			],
+			config({ groupBy: "linear" }),
+		);
+		expect(groups.map((g) => g.label)).toEqual([
+			"In Progress",
+			"In Review",
+			"Todo",
+			"Backlog",
+			"Done",
+			"Canceled",
+			"No status",
+		]);
+		const byKey = new Map(groups.map((g) => [g.key, g]));
+		expect(byKey.get("in-progress")?.workspaces.map((w) => w.id)).toEqual([
+			"c",
+		]);
+		expect(byKey.get("done")?.workspaces.map((w) => w.id)).toEqual(["a"]);
+		expect(byKey.get("no-status")?.workspaces.map((w) => w.id)).toEqual(["b"]);
+		// Columns no workspace occupies still render — they are empty drop targets.
+		expect(byKey.get("in-review")?.workspaces).toEqual([]);
+		expect(byKey.get("backlog")?.workspaces).toEqual([]);
+		expect(byKey.get("canceled")?.workspaces).toEqual([]);
+	});
+
+	it("shows all linear columns even when every workspace already has a status", () => {
+		const groups = buildPrototypeView(
+			[makeWorkspace({ id: "a", linearStatus: LINEAR.inProgress })],
+			config({ groupBy: "linear" }),
+		);
+		// All six board columns present; no "No status" column, since nothing is unset.
+		expect(groups.map((g) => g.key)).toEqual([
+			"in-progress",
+			"in-review",
+			"todo",
+			"backlog",
+			"done",
+			"canceled",
+		]);
+	});
+});
+
+describe("buildPrototypeView — ordering", () => {
+	it("orders by recent descending by default", () => {
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "old", lastActivityAt: NOW - 10 * MIN }),
+				makeWorkspace({ id: "new", lastActivityAt: NOW }),
+				makeWorkspace({ id: "mid", lastActivityAt: NOW - 5 * MIN }),
+			],
+			config({ orderBy: "recent", direction: "desc" }),
+		);
+		expect(groups[0]?.workspaces.map((w) => w.id)).toEqual([
+			"new",
+			"mid",
+			"old",
+		]);
+	});
+
+	it("respects ascending direction", () => {
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "new", lastActivityAt: NOW }),
+				makeWorkspace({ id: "old", lastActivityAt: NOW - 10 * MIN }),
+			],
+			config({ orderBy: "recent", direction: "asc" }),
+		);
+		expect(groups[0]?.workspaces.map((w) => w.id)).toEqual(["old", "new"]);
+	});
+
+	it("orders by attention (ungrouped, descending) exactly like the ⌘J HUD", () => {
+		const workspaces = [
+			makeWorkspace({
+				id: "idle-new",
+				agentStatus: "idle",
+				lastActivityAt: NOW,
+			}),
+			makeWorkspace({
+				id: "review-old",
+				agentStatus: "review",
+				lastActivityAt: NOW - 30 * MIN,
+			}),
+			makeWorkspace({
+				id: "blocked",
+				agentStatus: "permission",
+				lastActivityAt: NOW - 60 * MIN,
+			}),
+			makeWorkspace({
+				id: "working",
+				agentStatus: "working",
+				lastActivityAt: NOW - 5 * MIN,
+			}),
+		];
+		const groups = buildPrototypeView(
+			workspaces,
+			config({ groupBy: "none", orderBy: "attention", direction: "desc" }),
+		);
+		expect(groups[0]?.workspaces.map((w) => w.id)).toEqual(
+			rankForHud(workspaces).map((w) => w.id),
+		);
+	});
+
+	it("orders by title", () => {
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "c", title: "Charlie" }),
+				makeWorkspace({ id: "a", title: "Alpha" }),
+				makeWorkspace({ id: "b", title: "Bravo" }),
+			],
+			config({ orderBy: "title", direction: "asc" }),
+		);
+		expect(groups[0]?.workspaces.map((w) => w.title)).toEqual([
+			"Alpha",
+			"Bravo",
+			"Charlie",
+		]);
+	});
+
+	it("orders by manual rank within each group, ignoring direction", () => {
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "a" }),
+				makeWorkspace({ id: "b" }),
+				makeWorkspace({ id: "c" }),
+			],
+			config({
+				orderBy: "manual",
+				direction: "asc",
+				manualOrder: ["c", "a", "b"],
+			}),
+		);
+		expect(groups[0]?.workspaces.map((w) => w.id)).toEqual(["c", "a", "b"]);
+	});
+
+	it("sorts ids missing from manualOrder last, keeping insertion order", () => {
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "x" }),
+				makeWorkspace({ id: "b" }),
+				makeWorkspace({ id: "y" }),
+				makeWorkspace({ id: "a" }),
+			],
+			config({ orderBy: "manual", manualOrder: ["a", "b"] }),
+		);
+		expect(groups[0]?.workspaces.map((w) => w.id)).toEqual([
+			"a",
+			"b",
+			"x",
+			"y",
+		]);
+	});
+
+	it("applies manual order per group when grouped", () => {
+		const repoA = { id: "repo-a", name: "alpha", owner: null, iconUrl: null };
+		const repoB = { id: "repo-b", name: "beta", owner: null, iconUrl: null };
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "a1", repo: repoA }),
+				makeWorkspace({ id: "b1", repo: repoB }),
+				makeWorkspace({ id: "a2", repo: repoA }),
+				makeWorkspace({ id: "b2", repo: repoB }),
+			],
+			config({
+				groupBy: "repository",
+				orderBy: "manual",
+				manualOrder: ["a2", "b2", "a1", "b1"],
+			}),
+		);
+		expect(groups.map((g) => g.workspaces.map((w) => w.id))).toEqual([
+			["a2", "a1"],
+			["b2", "b1"],
+		]);
+	});
+});
+
+describe("buildPrototypeView — rollup", () => {
+	it("computes worst-case active status per group", () => {
+		const groups = buildPrototypeView(
+			[
+				makeWorkspace({ id: "a", agentStatus: "review" }),
+				makeWorkspace({ id: "b", agentStatus: "permission" }),
+				makeWorkspace({ id: "c", agentStatus: "working" }),
+			],
+			config({ groupBy: "none" }),
+		);
+		expect(groups[0]?.rollupStatus).toBe("permission");
+	});
+
+	it("returns null rollup when all idle", () => {
+		const groups = buildPrototypeView(
+			[makeWorkspace({ id: "a", agentStatus: "idle" })],
+			config({ groupBy: "none" }),
+		);
+		expect(groups[0]?.rollupStatus).toBeNull();
+	});
+
+	it("does not mutate the input array", () => {
+		const input = [
+			makeWorkspace({ id: "old", lastActivityAt: NOW - MIN }),
+			makeWorkspace({ id: "new", lastActivityAt: NOW }),
+		];
+		const snapshot = input.map((w) => w.id);
+		buildPrototypeView(input, config({ orderBy: "recent", direction: "desc" }));
+		expect(input.map((w) => w.id)).toEqual(snapshot);
+	});
+});
+
+describe("rankForHud", () => {
+	it("ranks by status priority, then recency", () => {
+		const ranked = rankForHud([
+			makeWorkspace({
+				id: "idle-new",
+				agentStatus: "idle",
+				lastActivityAt: NOW,
+			}),
+			makeWorkspace({
+				id: "perm-old",
+				agentStatus: "permission",
+				lastActivityAt: NOW - 60 * MIN,
+			}),
+			makeWorkspace({
+				id: "review-new",
+				agentStatus: "review",
+				lastActivityAt: NOW,
+			}),
+			makeWorkspace({
+				id: "perm-new",
+				agentStatus: "permission",
+				lastActivityAt: NOW,
+			}),
+		]);
+		expect(ranked.map((w) => w.id)).toEqual([
+			"perm-new",
+			"perm-old",
+			"review-new",
+			"idle-new",
+		]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/model/buildPrototypeView.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/model/buildPrototypeView.ts
@@ -1,0 +1,323 @@
+import {
+	getHighestPriorityStatus,
+	type PaneStatus,
+	STATUS_PRIORITY,
+} from "shared/tabs-types";
+import type {
+	GroupBy,
+	PrBucket,
+	PrototypeGroup,
+	PrototypeLinearStatus,
+	PrototypeLinearStatusType,
+	PrototypeWorkspace,
+	ViewConfig,
+} from "./types";
+
+/** Display order for the agent-status group-by (most urgent first). */
+const AGENT_STATUS_LABEL: Record<PaneStatus, string> = {
+	permission: "Needs input",
+	failed: "Failed",
+	working: "Working",
+	review: "Ready for review",
+	idle: "Idle",
+};
+
+/** Display order + labels for the linear-status group-by. */
+const LINEAR_STATUS_ORDER: PrototypeLinearStatusType[] = [
+	"in-progress",
+	"in-review",
+	"todo",
+	"backlog",
+	"done",
+	"canceled",
+];
+
+/** Synthetic status for the "no Linear status" bucket's header icon. */
+const NO_LINEAR_STATUS: PrototypeLinearStatus = {
+	label: "No status",
+	type: "todo",
+	iconType: "unstarted",
+	color: "#6b7280",
+};
+
+/**
+ * Canonical display metadata for every Linear status. Grouping by Linear seeds
+ * all of these up front so a status no workspace currently holds still renders
+ * as an (empty) column — a drop target you can drag a workspace into, exactly
+ * like a kanban board. Keep the colors/icons in sync with the fixtures.
+ */
+const LINEAR_STATUS_CATALOG: Record<
+	PrototypeLinearStatusType,
+	PrototypeLinearStatus
+> = {
+	"in-progress": {
+		label: "In Progress",
+		type: "in-progress",
+		iconType: "started",
+		color: "#f59e0b",
+		progress: 50,
+	},
+	"in-review": {
+		label: "In Review",
+		type: "in-review",
+		iconType: "started",
+		color: "#3b82f6",
+		progress: 75,
+	},
+	todo: {
+		label: "Todo",
+		type: "todo",
+		iconType: "unstarted",
+		color: "#9ca3af",
+	},
+	backlog: {
+		label: "Backlog",
+		type: "backlog",
+		iconType: "backlog",
+		color: "#9ca3af",
+	},
+	done: {
+		label: "Done",
+		type: "done",
+		iconType: "completed",
+		color: "#22c55e",
+	},
+	canceled: {
+		label: "Canceled",
+		type: "canceled",
+		iconType: "canceled",
+		color: "#9ca3af",
+	},
+};
+
+/** Display order for the pull-request group-by (most actionable first). */
+const PR_BUCKET_ORDER: PrBucket[] = [
+	"checks-failing",
+	"changes-requested",
+	"awaiting-review",
+	"approved",
+	"queued",
+	"draft",
+	"merged",
+	"closed",
+	"no-pr",
+];
+
+const PR_BUCKET_LABEL: Record<PrBucket, string> = {
+	"checks-failing": "Checks failing",
+	"changes-requested": "Changes requested",
+	"awaiting-review": "Awaiting review",
+	approved: "Approved",
+	queued: "Queued",
+	draft: "Draft",
+	merged: "Merged",
+	closed: "Closed",
+	"no-pr": "No pull request",
+};
+
+/**
+ * Review-lifecycle bucket for a workspace's PR. Terminal states come from the
+ * PR state itself; an open PR is classified by its most actionable signal:
+ * failing checks beat a review decision, changes-requested beats approved.
+ */
+export function prBucketFor(workspace: PrototypeWorkspace): PrBucket {
+	const pr = workspace.pullRequest;
+	if (!pr) return "no-pr";
+	if (pr.state === "merged") return "merged";
+	if (pr.state === "closed") return "closed";
+	if (pr.state === "draft") return "draft";
+	if (pr.state === "queued") return "queued";
+	if (pr.checksStatus === "failure") return "checks-failing";
+	if (pr.reviewDecision === "changes_requested") return "changes-requested";
+	if (pr.reviewDecision === "approved") return "approved";
+	return "awaiting-review";
+}
+
+function compareWorkspaces(
+	a: PrototypeWorkspace,
+	b: PrototypeWorkspace,
+	config: ViewConfig,
+	manualRank: Map<string, number>,
+): number {
+	const dir = config.direction === "asc" ? 1 : -1;
+	switch (config.orderBy) {
+		case "recent":
+			return (a.lastActivityAt - b.lastActivityAt) * dir;
+		case "attention": {
+			// The ⌘J HUD's ranking as a sort: agent-status priority first, most
+			// recent activity as the tiebreak (descending = exactly the HUD).
+			// Under the agent-activity GROUPING this degenerates gracefully:
+			// every group member shares a status, so recency decides.
+			const byStatus =
+				STATUS_PRIORITY[a.agentStatus] - STATUS_PRIORITY[b.agentStatus];
+			if (byStatus !== 0) return byStatus * dir;
+			return (a.lastActivityAt - b.lastActivityAt) * dir;
+		}
+		case "created":
+			return (a.createdAt - b.createdAt) * dir;
+		case "title":
+			return a.title.localeCompare(b.title) * dir;
+		case "manual": {
+			// Manual order is literal — direction deliberately ignored. Ids missing
+			// from the snapshot sort last, keeping their insertion order (stable sort).
+			const ra = manualRank.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+			const rb = manualRank.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+			return ra - rb;
+		}
+		default:
+			return 0;
+	}
+}
+
+function rollup(workspaces: PrototypeWorkspace[]) {
+	return getHighestPriorityStatus(workspaces.map((w) => w.agentStatus));
+}
+
+/**
+ * Assign each workspace to a group bucket keyed by the active group-by.
+ * Returns groups in a stable, meaningful order (not insertion order).
+ */
+function groupWorkspaces(
+	workspaces: PrototypeWorkspace[],
+	groupBy: GroupBy,
+): PrototypeGroup[] {
+	if (groupBy === "none") {
+		return [
+			{
+				key: "all",
+				label: "",
+				rollupStatus: rollup(workspaces),
+				workspaces,
+			},
+		];
+	}
+
+	const buckets = new Map<string, PrototypeGroup>();
+
+	const ensure = (
+		key: string,
+		init: Omit<PrototypeGroup, "workspaces" | "rollupStatus">,
+	): PrototypeGroup => {
+		let group = buckets.get(key);
+		if (!group) {
+			group = { ...init, rollupStatus: null, workspaces: [] };
+			buckets.set(key, group);
+		}
+		return group;
+	};
+
+	if (groupBy === "linear") {
+		// Seed every board column so statuses no workspace currently holds still
+		// render as empty, droppable columns.
+		for (const type of LINEAR_STATUS_ORDER) {
+			ensure(type, {
+				key: type,
+				label: LINEAR_STATUS_CATALOG[type].label,
+				linearStatus: LINEAR_STATUS_CATALOG[type],
+			});
+		}
+	}
+
+	for (const workspace of workspaces) {
+		if (groupBy === "repository") {
+			ensure(workspace.repo.id, {
+				key: workspace.repo.id,
+				label: workspace.repo.name,
+				repo: workspace.repo,
+			}).workspaces.push(workspace);
+		} else if (groupBy === "linear") {
+			const status = workspace.linearStatus ?? NO_LINEAR_STATUS;
+			const key = workspace.linearStatus?.type ?? "no-status";
+			ensure(key, {
+				key,
+				label: status.label,
+				linearStatus: status,
+			}).workspaces.push(workspace);
+		} else if (groupBy === "pr") {
+			const bucket = prBucketFor(workspace);
+			ensure(bucket, {
+				key: bucket,
+				label: PR_BUCKET_LABEL[bucket],
+				prBucket: bucket,
+			}).workspaces.push(workspace);
+		} else {
+			// agent
+			const key = workspace.agentStatus;
+			ensure(key, {
+				key,
+				label: AGENT_STATUS_LABEL[workspace.agentStatus],
+				agentStatus: workspace.agentStatus,
+			}).workspaces.push(workspace);
+		}
+	}
+
+	for (const group of buckets.values()) {
+		group.rollupStatus = rollup(group.workspaces);
+	}
+
+	return sortGroups([...buckets.values()], groupBy);
+}
+
+function sortGroups(
+	groups: PrototypeGroup[],
+	groupBy: GroupBy,
+): PrototypeGroup[] {
+	if (groupBy === "repository") {
+		return groups.sort((a, b) => a.label.localeCompare(b.label));
+	}
+	if (groupBy === "agent") {
+		return groups.sort(
+			(a, b) =>
+				STATUS_PRIORITY[b.key as PaneStatus] -
+				STATUS_PRIORITY[a.key as PaneStatus],
+		);
+	}
+	if (groupBy === "linear") {
+		const rank = (key: string) => {
+			const idx = LINEAR_STATUS_ORDER.indexOf(key as PrototypeLinearStatusType);
+			return idx === -1 ? LINEAR_STATUS_ORDER.length : idx;
+		};
+		return groups.sort((a, b) => rank(a.key) - rank(b.key));
+	}
+	if (groupBy === "pr") {
+		const rank = (key: string) => {
+			const idx = PR_BUCKET_ORDER.indexOf(key as PrBucket);
+			return idx === -1 ? PR_BUCKET_ORDER.length : idx;
+		};
+		return groups.sort((a, b) => rank(a.key) - rank(b.key));
+	}
+	return groups;
+}
+
+/**
+ * Pure view builder for the attention prototype: group, then order within each
+ * group, and compute a worst-case status rollup per group.
+ */
+export function buildPrototypeView(
+	workspaces: PrototypeWorkspace[],
+	config: ViewConfig,
+): PrototypeGroup[] {
+	const manualRank = new Map(config.manualOrder.map((id, i) => [id, i]));
+	const groups = groupWorkspaces(workspaces, config.groupBy);
+	for (const group of groups) {
+		group.workspaces = [...group.workspaces].sort((a, b) =>
+			compareWorkspaces(a, b, config, manualRank),
+		);
+	}
+	return groups;
+}
+
+/**
+ * Ranking for the ⌘J HUD: attention-first (by status priority), then by most
+ * recent activity. Independent of the list's group-by/order-by.
+ */
+export function rankForHud(
+	workspaces: PrototypeWorkspace[],
+): PrototypeWorkspace[] {
+	return [...workspaces].sort((a, b) => {
+		const byStatus =
+			STATUS_PRIORITY[b.agentStatus] - STATUS_PRIORITY[a.agentStatus];
+		if (byStatus !== 0) return byStatus;
+		return b.lastActivityAt - a.lastActivityAt;
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/model/formatAge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/model/formatAge.ts
@@ -1,0 +1,14 @@
+/**
+ * Compact relative age ("now", "12m", "3h", "6d") from a virtual clock.
+ * Prototype-local; the real app uses date-fns formatDistanceToNow.
+ */
+export function formatAge(now: number, timestamp: number): string {
+	const seconds = Math.max(0, Math.round((now - timestamp) / 1000));
+	if (seconds < 45) return "now";
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+	const days = Math.round(hours / 24);
+	return `${days}d`;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/model/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/model/types.ts
@@ -1,0 +1,134 @@
+import type {
+	DashboardSidebarWorkspaceHostType,
+	DashboardSidebarWorkspacePullRequest,
+	DashboardSidebarWorkspaceType,
+} from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types";
+import type { StatusType } from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/StatusIcon";
+import type { ActivePaneStatus, PaneStatus } from "shared/tabs-types";
+
+/**
+ * PROTOTYPE-ONLY view model.
+ *
+ * This is a flattened, self-contained shape for the attention-prototype route.
+ * It deliberately carries fields that do NOT exist on the real
+ * `DashboardSidebarWorkspace` today, so we can play with the proposed
+ * group-by/order-by view system without touching live data:
+ *
+ *  - `agentStatus`   — real status is a `PaneStatus` resolved per-workspace via
+ *                      hooks (useTerminalAgentStatuses); it is NOT a field on the
+ *                      workspace object. Modeled inline here for the fixtures.
+ *  - `lastActivityAt`— "Recent" ordering key. The real analogue lives on the
+ *                      terminal binding (`TerminalAgentBinding.lastEventAt`), not
+ *                      on the workspace. Net-new here.
+ *  - `linearStatus`  — there is no dedicated "Linear status" field in the app; it
+ *                      is the generic task status (SelectTaskStatus.type/name/color)
+ *                      with Linear only as sync provenance. Reused + relabeled here.
+ */
+export interface PrototypeRepo {
+	id: string;
+	name: string;
+	owner: string | null;
+	iconUrl: string | null;
+}
+
+/** Reuses the generic Superset task-status vocabulary, relabeled "Linear". */
+export type PrototypeLinearStatusType =
+	| "backlog"
+	| "todo"
+	| "in-progress"
+	| "in-review"
+	| "done"
+	| "canceled";
+
+export interface PrototypeLinearStatus {
+	label: string;
+	type: PrototypeLinearStatusType;
+	/** Icon variant in the real StatusIcon's Linear vocabulary. */
+	iconType: StatusType;
+	/** Hex stroke color for the StatusIcon (real app stores hex on the status). */
+	color: string;
+	/** 0-100 pie fill for "started" icons (In Progress vs In Review). */
+	progress?: number;
+}
+
+/** Fixture stand-in for a detected dev-server port on a workspace. */
+export interface PrototypePort {
+	port: number;
+	label: string | null;
+	processName: string;
+	pid: number;
+}
+
+export interface PrototypeWorkspace {
+	id: string;
+	title: string;
+	repo: PrototypeRepo;
+	/** Net-new on the workspace (see file docblock). */
+	agentStatus: PaneStatus;
+	pullRequest: DashboardSidebarWorkspacePullRequest | null;
+	linearStatus: PrototypeLinearStatus | null;
+	/** ms epoch — the "Recent" (last interacted) ordering key. Net-new. */
+	lastActivityAt: number;
+	/** ms epoch. */
+	createdAt: number;
+	diff: { additions: number; deletions: number };
+	hostType: DashboardSidebarWorkspaceHostType;
+	workspaceType: DashboardSidebarWorkspaceType;
+	hostIsOnline: boolean | null;
+	/** Running dev-server ports (real app resolves these via the ports provider). */
+	ports: PrototypePort[];
+}
+
+export type GroupBy = "none" | "repository" | "linear" | "agent" | "pr";
+
+/**
+ * Review-lifecycle buckets for the pull-request group-by. Deliberately
+ * provider-neutral semantics (GitLab MRs have the same lifecycle); only the
+ * display strings say "pull request", matching the app's current vocabulary.
+ */
+export type PrBucket =
+	| "checks-failing"
+	| "changes-requested"
+	| "awaiting-review"
+	| "approved"
+	| "queued"
+	| "draft"
+	| "merged"
+	| "closed"
+	| "no-pr";
+export type OrderBy = "recent" | "title" | "created" | "manual" | "attention";
+export type Direction = "asc" | "desc";
+
+export interface ViewConfig {
+	groupBy: GroupBy;
+	orderBy: OrderBy;
+	direction: Direction;
+	/**
+	 * Flat workspace-id order used by the "manual" order-by. A snapshot of the
+	 * full visual order at the moment the user last dragged (or picked Manual),
+	 * so sorting each group by rank reproduces that layout exactly.
+	 */
+	manualOrder: string[];
+}
+
+export interface PrototypeGroup {
+	/** Stable key for React and grouping identity. */
+	key: string;
+	/** Human label for the group header ("" for the single "none" group). */
+	label: string;
+	/**
+	 * Optional presentational hints for the header's leading icon, depending on
+	 * group-by:
+	 *  - repository → repo for a ProjectThumbnail
+	 *  - linear     → status for a real Linear StatusIcon
+	 *  - agent      → the bucket's own PaneStatus for a status icon
+	 *  - pr         → the bucket id for a PR-lifecycle icon
+	 */
+	repo?: PrototypeRepo;
+	linearStatus?: PrototypeLinearStatus;
+	agentStatus?: PaneStatus;
+	prBucket?: PrBucket;
+	/** Worst-case (highest-priority) active status across the group, if any. */
+	rollupStatus: ActivePaneStatus | null;
+	workspaces: PrototypeWorkspace[];
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/page.tsx
@@ -1,0 +1,81 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { env } from "renderer/env.renderer";
+import { useHotkey } from "renderer/hotkeys";
+import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel/ResizablePanel";
+import {
+	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
+	DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
+	MAX_WORKSPACE_SIDEBAR_WIDTH,
+} from "renderer/stores/workspace-sidebar-state";
+import { AttentionHud } from "./components/AttentionHud/AttentionHud";
+import { PrototypeSidebar } from "./components/PrototypeSidebar/PrototypeSidebar";
+import { PrototypeTopBar } from "./components/PrototypeTopBar/PrototypeTopBar";
+import { SimulationDriver } from "./components/SimulationDriver/SimulationDriver";
+import { useAttentionHudHotkey } from "./hooks/useAttentionHudHotkey";
+import { usePrototypeStore } from "./store/usePrototypeStore";
+
+export const Route = createFileRoute("/_authenticated/attention-prototype/")({
+	component: AttentionPrototypePage,
+});
+
+function AttentionPrototypePage() {
+	// Dev-only surface. Follows the repo pattern of env.NODE_ENV gating rather
+	// than a route-level guard (the route tree is static).
+	if (env.NODE_ENV !== "development") {
+		return (
+			<div className="flex h-screen items-center justify-center bg-background text-muted-foreground text-sm">
+				<div className="max-w-sm text-center">
+					<p>This prototype is only available in development builds.</p>
+					<Link to="/" className="mt-2 inline-block text-foreground underline">
+						Back to app
+					</Link>
+				</div>
+			</div>
+		);
+	}
+
+	return <AttentionPrototypeContent />;
+}
+
+function AttentionPrototypeContent() {
+	useAttentionHudHotkey();
+	const sidebarWidth = usePrototypeStore((s) => s.sidebarWidth);
+	const setSidebarWidth = usePrototypeStore((s) => s.setSidebarWidth);
+	const sidebarResizing = usePrototypeStore((s) => s.sidebarResizing);
+	const setSidebarResizing = usePrototypeStore((s) => s.setSidebarResizing);
+	const toggleSidebarCollapsed = usePrototypeStore(
+		(s) => s.toggleSidebarCollapsed,
+	);
+	// The route isn't under the _dashboard layout, so the real ⌘B registration
+	// isn't active here — bind it to the prototype's own sidebar instead.
+	useHotkey("TOGGLE_WORKSPACE_SIDEBAR", toggleSidebarCollapsed);
+
+	return (
+		<div className="flex h-screen overflow-hidden bg-background">
+			{/* Same panel + props as the real dashboard sidebar: raw drag widths go
+			    to the store (clampWidth off), which snaps below 120px to the 52px
+			    rail and clamps the expanded range to [220, 400]. Double-click the
+			    handle to restore the 280px default. */}
+			<ResizablePanel
+				width={sidebarWidth}
+				onWidthChange={setSidebarWidth}
+				isResizing={sidebarResizing}
+				onResizingChange={setSidebarResizing}
+				minWidth={COLLAPSED_WORKSPACE_SIDEBAR_WIDTH}
+				maxWidth={MAX_WORKSPACE_SIDEBAR_WIDTH}
+				handleSide="right"
+				clampWidth={false}
+				onDoubleClickHandle={() =>
+					setSidebarWidth(DEFAULT_WORKSPACE_SIDEBAR_WIDTH)
+				}
+			>
+				<PrototypeSidebar />
+			</ResizablePanel>
+			<div className="flex min-h-0 min-w-0 flex-1 flex-col">
+				<PrototypeTopBar />
+				<SimulationDriver />
+			</div>
+			<AttentionHud />
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/store/usePrototypeStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/attention-prototype/store/usePrototypeStore.ts
@@ -1,0 +1,300 @@
+import {
+	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
+	DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
+	MAX_WORKSPACE_SIDEBAR_WIDTH,
+} from "renderer/stores/workspace-sidebar-state";
+import type { PaneStatus } from "shared/tabs-types";
+import { create } from "zustand";
+import { FIXTURE_NOW, FIXTURE_WORKSPACES } from "../fixtures/workspaces";
+import { prBucketFor } from "../model/buildPrototypeView";
+import type {
+	Direction,
+	GroupBy,
+	OrderBy,
+	PrototypeLinearStatus,
+	PrototypeWorkspace,
+} from "../model/types";
+
+// Not exported by workspace-sidebar-state — duplicated so the prototype's
+// resize behaviour (snap-to-collapse + clamped expanded range) matches exactly.
+const MIN_WORKSPACE_SIDEBAR_WIDTH = 220;
+const COLLAPSE_THRESHOLD = 120;
+
+/**
+ * The collapse key a workspace's group would use under a group-by dimension —
+ * must mirror buildPrototypeView's bucket keys.
+ */
+function groupKeyFor(
+	workspace: PrototypeWorkspace,
+	groupBy: GroupBy,
+): string | null {
+	if (groupBy === "repository") return workspace.repo.id;
+	if (groupBy === "linear") return workspace.linearStatus?.type ?? "no-status";
+	if (groupBy === "agent") return workspace.agentStatus;
+	if (groupBy === "pr") return prBucketFor(workspace);
+	return null;
+}
+
+interface PrototypeState {
+	// View config
+	groupBy: GroupBy;
+	orderBy: OrderBy;
+	direction: Direction;
+	setGroupBy: (groupBy: GroupBy) => void;
+	setOrderBy: (orderBy: OrderBy) => void;
+	setDirection: (direction: Direction) => void;
+
+	// Manual ordering: a flat snapshot of workspace ids. Committing one (from a
+	// drag, or from picking "Manual" in the dropdown) switches orderBy to manual
+	// while leaving groupBy untouched.
+	manualOrder: string[];
+	commitManualOrder: (order: string[]) => void;
+
+	// Collapsed group headers, keyed "<groupBy>:<groupKey>" so collapsing a
+	// repository doesn't also collapse the same-named bucket in another view.
+	// (Real sidebar persists isCollapsed on the project/section records.)
+	collapsedGroups: Record<string, boolean>;
+	toggleGroupCollapsed: (key: string) => void;
+	/** Collapse or expand a set of groups at once (the fold-all toggle). */
+	setGroupsCollapsed: (keys: string[], collapsed: boolean) => void;
+
+	// The "Projects" panel (view controls + grouped workspace list) collapses
+	// as one unit, like the real sidebar's project sections.
+	projectsCollapsed: boolean;
+	toggleProjectsCollapsed: () => void;
+
+	// The "Groups & ordering" controls row (group/sort dropdowns + direction +
+	// fold-all) can be tucked away via the LuLayers toggle on the Projects
+	// header once a view is set up.
+	viewControlsCollapsed: boolean;
+	toggleViewControls: () => void;
+	/** Un-tuck the controls row AND the Projects panel (hotkey reveal path). */
+	revealViewControls: () => void;
+
+	// Sidebar width, mirroring the real workspace-sidebar-state store: drag
+	// resize clamps to [220, 400], dragging below 120 snaps to the 52px rail,
+	// and toggling collapse restores the last expanded width.
+	sidebarWidth: number;
+	lastExpandedWidth: number;
+	sidebarResizing: boolean;
+	setSidebarWidth: (width: number) => void;
+	setSidebarResizing: (resizing: boolean) => void;
+	toggleSidebarCollapsed: () => void;
+
+	// Fixture data + virtual clock
+	workspaces: PrototypeWorkspace[];
+	now: number;
+	activeWorkspaceId: string | null;
+
+	// Reorder-flash bookkeeping: which workspace last changed, and a monotonic
+	// counter so the same workspace changing twice still re-triggers the flash.
+	lastChangedId: string | null;
+	changeSeq: number;
+
+	// ⌘J HUD
+	hudOpen: boolean;
+	setHudOpen: (open: boolean) => void;
+	toggleHud: () => void;
+
+	// Navigation
+	setActiveWorkspace: (id: string) => void;
+	/**
+	 * Select a workspace AND expand its group under the current group-by, so a
+	 * jump (⌘J HUD) always lands somewhere visible.
+	 */
+	revealWorkspace: (id: string) => void;
+
+	/**
+	 * Re-assign the workspace's Linear status (a cross-group drag while grouped
+	 * by Linear status — the board-column semantics). Deliberately no
+	 * touchWorkspace: user drags don't trigger the "look here" flash.
+	 */
+	setLinearStatus: (id: string, status: PrototypeLinearStatus | null) => void;
+
+	// Simulation actions
+	setAgentStatus: (id: string, status: PaneStatus) => void;
+	finishTurn: (id: string) => void;
+	blockOnInput: (id: string) => void;
+	bumpActivity: (id: string) => void;
+	advanceClock: (minutes: number) => void;
+	closeWorkspace: (id: string) => void;
+	closePort: (workspaceId: string, port: number) => void;
+	reset: () => void;
+}
+
+function patchWorkspace(
+	workspaces: PrototypeWorkspace[],
+	id: string,
+	patch: Partial<PrototypeWorkspace>,
+): PrototypeWorkspace[] {
+	return workspaces.map((w) => (w.id === id ? { ...w, ...patch } : w));
+}
+
+/**
+ * Stamp a workspace with fresh activity. Each sim event advances the virtual
+ * clock by 1s so timestamps are unique and monotonic in click order — without
+ * this, two events in a row tie on lastActivityAt and the "Recent" sort falls
+ * back to fixture-array order instead of most-recently-touched-first.
+ */
+function touchWorkspace(
+	s: PrototypeState,
+	id: string,
+	patch: Partial<PrototypeWorkspace>,
+) {
+	const now = s.now + 1_000;
+	return {
+		now,
+		workspaces: patchWorkspace(s.workspaces, id, {
+			...patch,
+			lastActivityAt: now,
+		}),
+		lastChangedId: id,
+		changeSeq: s.changeSeq + 1,
+	};
+}
+
+export const usePrototypeStore = create<PrototypeState>((set) => ({
+	groupBy: "repository",
+	orderBy: "recent",
+	direction: "desc",
+	setGroupBy: (groupBy) => set({ groupBy }),
+	setOrderBy: (orderBy) => set({ orderBy }),
+	setDirection: (direction) => set({ direction }),
+
+	manualOrder: FIXTURE_WORKSPACES.map((w) => w.id),
+	// Note: deliberately does NOT bump lastChangedId/changeSeq — a user-driven
+	// drag should not trigger the "look here" flash.
+	commitManualOrder: (order) => set({ manualOrder: order, orderBy: "manual" }),
+
+	collapsedGroups: {},
+	toggleGroupCollapsed: (key) =>
+		set((s) => ({
+			collapsedGroups: { ...s.collapsedGroups, [key]: !s.collapsedGroups[key] },
+		})),
+
+	setGroupsCollapsed: (keys, collapsed) =>
+		set((s) => {
+			const next = { ...s.collapsedGroups };
+			for (const key of keys) next[key] = collapsed;
+			return { collapsedGroups: next };
+		}),
+
+	projectsCollapsed: false,
+	toggleProjectsCollapsed: () =>
+		set((s) => ({ projectsCollapsed: !s.projectsCollapsed })),
+
+	viewControlsCollapsed: false,
+	toggleViewControls: () =>
+		set((s) => ({
+			viewControlsCollapsed: !s.viewControlsCollapsed,
+			// Revealing the controls must land somewhere visible: if the Projects
+			// panel is collapsed, expand it too.
+			projectsCollapsed: s.viewControlsCollapsed ? false : s.projectsCollapsed,
+		})),
+
+	revealViewControls: () =>
+		set({ viewControlsCollapsed: false, projectsCollapsed: false }),
+
+	sidebarWidth: DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
+	lastExpandedWidth: DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
+	sidebarResizing: false,
+
+	setSidebarWidth: (width) =>
+		set(() => {
+			// Snap to collapsed if below threshold (never close completely via drag).
+			if (width < COLLAPSE_THRESHOLD) {
+				return { sidebarWidth: COLLAPSED_WORKSPACE_SIDEBAR_WIDTH };
+			}
+			const clamped = Math.max(
+				MIN_WORKSPACE_SIDEBAR_WIDTH,
+				Math.min(MAX_WORKSPACE_SIDEBAR_WIDTH, width),
+			);
+			return { sidebarWidth: clamped, lastExpandedWidth: clamped };
+		}),
+
+	setSidebarResizing: (sidebarResizing) => set({ sidebarResizing }),
+
+	toggleSidebarCollapsed: () =>
+		set((s) =>
+			s.sidebarWidth === COLLAPSED_WORKSPACE_SIDEBAR_WIDTH
+				? { sidebarWidth: s.lastExpandedWidth }
+				: { sidebarWidth: COLLAPSED_WORKSPACE_SIDEBAR_WIDTH },
+		),
+
+	workspaces: FIXTURE_WORKSPACES,
+	now: FIXTURE_NOW,
+	activeWorkspaceId: null,
+	lastChangedId: null,
+	changeSeq: 0,
+
+	hudOpen: false,
+	setHudOpen: (hudOpen) => set({ hudOpen }),
+	toggleHud: () => set((s) => ({ hudOpen: !s.hudOpen })),
+
+	setActiveWorkspace: (id) => set({ activeWorkspaceId: id }),
+
+	revealWorkspace: (id) =>
+		set((s) => {
+			const workspace = s.workspaces.find((w) => w.id === id);
+			const groupKey = workspace ? groupKeyFor(workspace, s.groupBy) : null;
+			const collapseKey = groupKey === null ? null : `${s.groupBy}:${groupKey}`;
+			return {
+				activeWorkspaceId: id,
+				// A jump must land somewhere visible: expand the Projects panel
+				// and the target's group if either is collapsed.
+				projectsCollapsed: false,
+				collapsedGroups:
+					collapseKey && s.collapsedGroups[collapseKey]
+						? { ...s.collapsedGroups, [collapseKey]: false }
+						: s.collapsedGroups,
+			};
+		}),
+
+	setLinearStatus: (id, linearStatus) =>
+		set((s) => ({
+			workspaces: patchWorkspace(s.workspaces, id, { linearStatus }),
+		})),
+
+	setAgentStatus: (id, status) =>
+		set((s) => touchWorkspace(s, id, { agentStatus: status })),
+
+	finishTurn: (id) =>
+		set((s) => touchWorkspace(s, id, { agentStatus: "review" })),
+
+	blockOnInput: (id) =>
+		set((s) => touchWorkspace(s, id, { agentStatus: "permission" })),
+
+	bumpActivity: (id) => set((s) => touchWorkspace(s, id, {})),
+
+	advanceClock: (minutes) => set((s) => ({ now: s.now + minutes * 60_000 })),
+
+	closeWorkspace: (id) =>
+		set((s) => ({
+			workspaces: s.workspaces.filter((w) => w.id !== id),
+			manualOrder: s.manualOrder.filter((wsId) => wsId !== id),
+			activeWorkspaceId:
+				s.activeWorkspaceId === id ? null : s.activeWorkspaceId,
+			lastChangedId: s.lastChangedId === id ? null : s.lastChangedId,
+		})),
+
+	closePort: (workspaceId, port) =>
+		set((s) => ({
+			workspaces: s.workspaces.map((w) =>
+				w.id === workspaceId
+					? { ...w, ports: w.ports.filter((p) => p.port !== port) }
+					: w,
+			),
+		})),
+
+	reset: () =>
+		set({
+			workspaces: FIXTURE_WORKSPACES,
+			manualOrder: FIXTURE_WORKSPACES.map((w) => w.id),
+			collapsedGroups: {},
+			now: FIXTURE_NOW,
+			activeWorkspaceId: null,
+			hudOpen: false,
+			lastChangedId: null,
+			changeSeq: 0,
+		}),
+}));

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -187,6 +187,9 @@ function AuthenticatedLayout() {
 				navigate({ to: `/settings/${section}` as "/settings/account" });
 			} else if (event.type === "open-workspace") {
 				navigate({ to: `/workspace/${event.data.workspaceId}` });
+			} else if (event.type === "open-attention-prototype") {
+				// Dev menu only — the route itself is dev-gated.
+				navigate({ to: "/attention-prototype" });
 			}
 		},
 	});

--- a/plans/20260720-workspace-attention.md
+++ b/plans/20260720-workspace-attention.md
@@ -1,0 +1,137 @@
+# Workspace Attention: notifications, navigation & cleanup
+
+**Status:** Design approved (brainstorm 2026-07-20) — ready for implementation planning
+**Scope:** apps/desktop (v2 path), packages/host-service (minor)
+**Mockups:** https://claude.ai/code/artifact/d0002b08-0fc1-4c22-a542-d3595417b9e8
+
+## Problem
+
+As repositories, groups, and workspaces multiply, Superset gives no guidance on **which agent to attend to next**. Attention data exists (derived pane status, PR state, checks) but feeds only a passive dock badge. Groups ("Active/Review/Complete") are maintained by hand and device-local; merged workspaces accumulate until manually deleted; workspace shortcuts are positional, not attention-aware.
+
+Competitive research (Conductor, Devin, Codex, Cursor, Vibe Kanban, Crystal, Amp, Omnara, plus PagerDuty/Superhuman/EEMUA alarm management) shows the coding-agent field has settled on status taxonomies and archive-on-merge, while **urgency ranking, interruption budgeting, snooze/aging, and load-aware foregrounding remain unclaimed** — those are the differentiating pieces of this design.
+
+## Direction
+
+Chosen: **B + C hybrid** — a self-organizing sidebar plus a queue-pop flow. A dedicated ranked inbox view (direction A, "Mission Control") is the deliberate future evolution; this design builds its ranking engine without committing to the extra surface yet.
+
+## Non-goals
+
+- No new top-level Attention view in this phase (direction A).
+- No changes to v1 (`WorkspaceSidebar`) — v2 path only.
+- No mobile/web surface; macOS desktop only.
+- No team-level attention (another user's workspaces).
+
+---
+
+## 1. Attention model
+
+Every workspace gets one derived **attention state**: `(tier, since, reason)`.
+
+| Tier | Meaning | Derived from |
+|---|---|---|
+| `blocked` | Agent needs input | Terminal binding `PermissionRequest`; ACP session `pendingPermissions` (new source) |
+| `failed` | Agent errored | `Failed` lifecycle event |
+| `external` | Workspace (not agent) needs action | PR record: `checksStatus` failing, `reviewDecision` = changes requested, merged-but-dirty (§5). (Review-comment events are not tracked on PR records today; add later if the runtime grows that field.) |
+| `ready` | Turn finished, unreviewed | `Stop` with `lastEventAt > terminalSeenAt` (today's `review` status) |
+| `quiet` | Running, or seen-idle | `working` / `idle` |
+
+Rules:
+
+- **One state per workspace.** Multiple signals dedupe to the max tier; the rest render as secondary chips on the row, never separate queue entries.
+- **Ranking = tier, then age** (oldest first within tier). Time is always the secondary axis, never the primary: recency feeds (Cursor's "Today/Yesterday") answer *what happened*, not *who needs me*.
+- **Staleness is an escalator, not a tier.** A `ready` item past the staleness threshold (default 3 days, configurable) climbs in prominence; at 2× threshold it surfaces a resume / snooze / archive prompt.
+- **Every state carries its human-readable reason** ("asked: push the amended commit?", "2 checks failing on !5644") — shown on row hover, in the ⌘J HUD, and in notifications. Explainability is what makes ranking trustworthy.
+- **Exit conditions (ack vs. resolve).** Action-required tiers clear only by action: `blocked` when the prompt is answered; `failed` on re-prompt/restart/explicit clear. Review tiers clear by attention: opening the workspace acks `external` and `ready` (the condition chip stays on the row until CI/review actually resolves). Snooze and archive always remove from the queue.
+- **Snooze** removes a workspace from the queue until a trigger (duration or "when checks finish"); snoozed rows show a clock chip.
+- **Color = heat; green = done.** Attention states use red (`blocked`/`failed`) → orange (`external`) → gold (`ready`); aging shifts hue hotter, never calmer. Green is reserved for genuinely resolved states (merged, checks passing, all-quiet rollups) and never appears in the Needs-you band.
+
+## 2. Self-organizing sidebar
+
+- **"Needs you" band** pinned above the project list: top **3** globally ranked items (tier dot, name, repo, age chip; reason on hover), "+N more" opens the full queue popover. Band absent when nothing needs attention — a calm sidebar means calm.
+- **Auto-derived lanes replace manual status sections** per repo: `Needs input` → `Review` → `Working` → `Idle`. Rows move automatically on state change (animated; a "moved to Review" toast only for the currently-open workspace). Empty lanes don't render. Merged workspaces leave the tree for the Archive.
+- **Manual control without manual upkeep:** per-workspace pin-to-top; custom free-form sections remain for non-status groupings, rendered above the lanes. One-time migration maps existing sections onto lanes (Complete → suggest archiving contents).
+- **Worst-case rollups:** collapsed repos show a single max-tier dot + attention count. Optional setting: auto-collapse all-quiet repos.
+- **Visible aging:** rows past the staleness threshold fade and gain a day chip ("6d").
+- **Sidebar state syncs** via user preferences instead of device-local localStorage (pins, custom sections, collapse state; lanes are derived, nothing to sync).
+
+## 3. Navigation & keyboard model
+
+Principle: **every attention feature ships with its keyboard path; the mouse is the alternate input.** All new commands register in the hotkey registry (rebindable) and the ⌘⇧K command palette.
+
+- **⌘J — "next needs-me"** (the universal verb). Transient HUD: top of queue + two peeked; `↵` go, repeat-tap cycles, `⌘⇧J` cycles back (position 0 = "return to where I was"). In-HUD: `↑↓` move, `1..9` pick, `S` snooze, `A` answer/approve blocked items inline, `E` archive, `Esc` dismiss.
+- **⌘⇧L — sidebar focus mode:** `↑↓`/`j k` walk rows, `← →` collapse/expand, `↵` open; single-letter verbs on the focused row: `s` snooze, `e` archive, `p` pin, `m` mute. Hints render inline on the focused row. The Needs-you band occupies focus positions 1–3, so `⌘⇧L ↵` = open the most urgent thing.
+- **Positional shortcuts unchanged:** `⌘1..9`, `⌘⌥↑/↓` keep muscle-memory semantics; ⌘J is the attention-aware counterpart.
+- **Notification actions always have in-app keyboard twins** (macOS banner buttons are mouse-bound by the OS; the HUD carries the same verbs).
+- Direction A's future inbox inherits the same queue and letter verbs (`j/k`, `↵`, `e`, `s`, `a`, `u` undo) — zero relearning if/when it ships.
+
+## 4. Notifications & channel discipline
+
+Loudness maps to tier; every channel has a suppression story.
+
+| Tier | Banner | Sound | Dock / menu-bar count |
+|---|---|---|---|
+| `blocked` / `failed` | Yes, with Approve / Open / Snooze actions | "Blocked" sound | Counted |
+| `external` | Yes, plain | None (default) | Counted |
+| `ready` | Quiet tier (default on) | "Done" chime (distinct) | Counted |
+| `quiet` | Never | Never | Never |
+
+- **Two sound identities:** split today's single ringtone into "needs you" vs "finished" (two pickers over the existing ringtone library).
+- **Zero-latency digest collapse:** first completion notifies immediately; further completions within a sliding ~20s window **replace the delivered banner in place** ("3 agents finished — …"), sound only on the first. Blocked events never collapse.
+- **Actionable banners:** Approve / Open / Snooze on blocked notifications (macOS notification actions); click-to-jump preserved.
+- **Controls (synced via user preferences):** per-workspace mute, global snooze-all (30m / 1h / today — banners+sounds pause, badge keeps counting), per-tier banner/sound toggles. Existing suppression (target pane visible + window focused) preserved.
+- **Escalation:** off by default; single opt-in "re-notify once if blocked > N minutes." No nag ladders.
+- **Menu-bar item (optional):** needs-you count + dropdown queue, for hidden-Dock setups. Dock badge count keeps its current meaning.
+
+## 5. Auto-archive & cleanup
+
+- **Trigger:** existing PR runtime detects `state === "merged"` → tear down worktree, keep workspace record + session history, move to **Archive**. No confirmation.
+- **Safety gate:** reuse destroy preflight — unpushed commits (`git rev-list HEAD --not --remotes`) + uncommitted changes. Dirty ⇒ no auto-archive; instead a "merged, but has local changes" queue item (`external` tier). Auto only when provably safe.
+- **Undo/restore:** post-archive toast with Undo; Archive view offers Restore (recreates worktree from branch). Transcripts/PR links browsable read-only without restoring.
+- **Closed-without-merge:** suggested cleanup, never automatic.
+- **Stale path:** at 2× staleness threshold, resume / snooze / archive prompt; bulk palette command "Archive all workspaces idle > 2 weeks…" with a review list.
+- **Archive surface:** per-repo entry ("Archive · 9 merged this week") + global view; grouped Today / Yesterday / This week / Older; searchable. "Complete" sections stop existing.
+- **Remote workspaces** use the same flow via host-service teardown.
+
+---
+
+## Architecture notes
+
+Grounded in the current v2 implementation:
+
+- **Attention selector layer** over existing sources — terminal agent bindings (`useTerminalAgentStatuses`), PR records (`pull_requests` rows from `PullRequestRuntimeManager`), seen-state (`stores/v2-notifications`). New: ACP/chat sessions contribute `blocked` via `pendingPermissions` (today only terminal agents drive sidebar status). Extends the existing `PaneStatus` priority (`shared/tabs-types.ts`) rather than replacing it.
+- **New synced store** for snoozes, per-workspace mute, pins, staleness threshold, tier toggles — via `useV2UserPreferences` (fixes device-local sections/settings gaps).
+- **Lanes** are a pure regrouping in `buildDashboardSidebarProjects.ts` keyed off attention state + PR state; migration path for `v2SidebarSections`.
+- **⌘J HUD** = new hotkey in `hotkeys/registry.ts` + a queue selector shared with the band/popover; palette entries alongside.
+- **Digest/replacement notifications** extend `V2NotificationController`/`lifecycleEvents.ts` and `notifications.showNative` (stable notification identifier for in-place replacement); notification actions via Electron/macOS notification API.
+- **Auto-archive** = new host-service-driven rule: on PR-merged transition, run destroy preflight; if clean, invoke the existing `workspaceCleanup.destroy` teardown path minus record deletion, flag workspace `archived`. Archive view reads archived workspaces + existing PR metadata.
+- **Data gaps to fill:** none blocking; `mergeable`/`behindCount` on PR records would improve `external` fidelity later.
+
+## Edge cases
+
+- Agent interrupted via Esc/Ctrl+C fires no hook — existing `clearWorkspaceStatuses` escape hatch remains; a `blocked` item whose terminal dies falls back to `failed` after binding liveness expires.
+- Multiple sessions per workspace: workspace tier = max over its sessions; per-session detail in hover card.
+- Clock skew: `since` timestamps use host-clock ms (consistent with `terminalSeenAt` monotonic handling).
+- Merged-PR detection latency: ≤5 min worst case (existing sweep) — acceptable for archiving.
+- Snooze trigger "when checks finish" depends on checks refresh cadence; fall back to time-based resurface if PR polling errors.
+
+## Phased rollout
+
+1. **Attention engine + Needs-you band + ⌘J** (the core loop; band and HUD share one queue selector).
+2. **Notification upgrade** — split sounds, digest replacement, actionable banners, per-workspace mute, snooze-all, menu-bar item.
+3. **Auto-lanes + rollups + aging + synced sidebar state** (includes sections migration).
+4. **Auto-archive + Archive view + stale prompts + bulk command.**
+5. *(Later, optional)* Direction A inbox view on top of the same engine.
+
+Each phase ships independently and is gated by a setting on first release (per project preference for settings over changed defaults).
+
+## Testing
+
+- Unit: attention-state derivation (tier dedupe, age ordering, exit conditions, snooze) as pure selectors; lane regrouping in `buildDashboardSidebarProjects` (existing test suite pattern); digest window merge/replace logic.
+- Integration: lifecycle-event → notification pipeline (Stop/PermissionRequest fan-in, suppression, replacement identifiers); auto-archive preflight outcomes (clean, unpushed, dirty).
+- E2E/CDP: ⌘J jump lands on highest-tier workspace; band exit conditions (blocked persists after open, ready clears); undo restores worktree. Baseline-then-fix evidence per AGENTS.md CDP rules.
+
+## Open questions (deferred, non-blocking)
+
+- Exact staleness defaults (3d escalate / 2× prompt) — tune after dogfooding.
+- Whether `external` should include "PR approved, ready to merge" as an action item.
+- Menu-bar item default-on vs default-off.

--- a/plans/20260720-workspace-attention.md
+++ b/plans/20260720-workspace-attention.md
@@ -1,8 +1,8 @@
 # Workspace Attention: notifications, navigation & cleanup
 
-**Status:** Design approved (brainstorm 2026-07-20) — ready for implementation planning
+**Status:** Design approved (brainstorm 2026-07-20, revised 2026-07-21) — ready for implementation planning
 **Scope:** apps/desktop (v2 path), packages/host-service (minor)
-**Mockups:** https://claude.ai/code/artifact/d0002b08-0fc1-4c22-a542-d3595417b9e8
+**Mockups:** https://claude.ai/code/artifact/d0002b08-0fc1-4c22-a542-d3595417b9e8 (note: the "Needs-you band" and fixed-lane sidebar shown in direction B were superseded by the view system in §2)
 
 ## Problem
 
@@ -12,7 +12,14 @@ Competitive research (Conductor, Devin, Codex, Cursor, Vibe Kanban, Crystal, Amp
 
 ## Direction
 
-Chosen: **B + C hybrid** — a self-organizing sidebar plus a queue-pop flow. A dedicated ranked inbox view (direction A, "Mission Control") is the deliberate future evolution; this design builds its ranking engine without committing to the extra surface yet.
+Four composed pieces:
+
+1. A **view system** for the workspaces panel — group-by and order-by dropdowns over workspace properties (Linear's view-options model), replacing the manual Group concept entirely.
+2. An **attention engine** — one derived, explainable urgency state per workspace, powering row indicators, the jump HUD, and notifications.
+3. A **queue-pop navigation flow** — ⌘J jump HUD, keyboard-first throughout.
+4. **Auto-archive on merge** plus stale-workspace cleanup.
+
+A dedicated ranked inbox view ("Mission Control", direction A in the mockups) remains the deliberate future evolution; this design builds its ranking engine without committing to the extra surface yet.
 
 ## Non-goals
 
@@ -38,30 +45,39 @@ Every workspace gets one derived **attention state**: `(tier, since, reason)`.
 Rules:
 
 - **One state per workspace.** Multiple signals dedupe to the max tier; the rest render as secondary chips on the row, never separate queue entries.
-- **Ranking = tier, then age** (oldest first within tier). Time is always the secondary axis, never the primary: recency feeds (Cursor's "Today/Yesterday") answer *what happened*, not *who needs me*.
+- **Queue ranking = tier, then age** (oldest first within tier). Used by the ⌘J HUD and notifications; the list itself is ordered by the user's chosen order-by (§2) — the attention state stays visible there through row indicators regardless of sort.
 - **Staleness is an escalator, not a tier.** A `ready` item past the staleness threshold (default 3 days, configurable) climbs in prominence; at 2× threshold it surfaces a resume / snooze / archive prompt.
 - **Every state carries its human-readable reason** ("asked: push the amended commit?", "2 checks failing on !5644") — shown on row hover, in the ⌘J HUD, and in notifications. Explainability is what makes ranking trustworthy.
 - **Exit conditions (ack vs. resolve).** Action-required tiers clear only by action: `blocked` when the prompt is answered; `failed` on re-prompt/restart/explicit clear. Review tiers clear by attention: opening the workspace acks `external` and `ready` (the condition chip stays on the row until CI/review actually resolves). Snooze and archive always remove from the queue.
 - **Snooze** removes a workspace from the queue until a trigger (duration or "when checks finish"); snoozed rows show a clock chip.
-- **Color = heat; green = done.** Attention states use red (`blocked`/`failed`) → orange (`external`) → gold (`ready`); aging shifts hue hotter, never calmer. Green is reserved for genuinely resolved states (merged, checks passing, all-quiet rollups) and never appears in the Needs-you band.
+- **Color = heat; green = done.** Attention states use red (`blocked`/`failed`) → orange (`external`) → gold (`ready`); aging shifts hue hotter, never calmer. Green is reserved for genuinely resolved states (merged, checks passing) and never indicates "waiting for you" — an old unreviewed workspace must not wear a color that says "fine". Row indicators keep today's form (pulsing dot for blocked/failed, static dot otherwise) with these color semantics.
 
-## 2. Self-organizing sidebar
+## 2. View system (group-by / order-by)
 
-- **"Needs you" band** pinned above the project list: top **3** globally ranked items (tier dot, name, repo, age chip; reason on hover), "+N more" opens the full queue popover. Band absent when nothing needs attention — a calm sidebar means calm.
-- **Auto-derived lanes replace manual status sections** per repo: `Needs input` → `Review` → `Working` → `Idle`. Rows move automatically on state change (animated; a "moved to Review" toast only for the currently-open workspace). Empty lanes don't render. Merged workspaces leave the tree for the Archive.
-- **Manual control without manual upkeep:** per-workspace pin-to-top; custom free-form sections remain for non-status groupings, rendered above the lanes. One-time migration maps existing sections onto lanes (Complete → suggest archiving contents).
-- **Worst-case rollups:** collapsed repos show a single max-tier dot + attention count. Optional setting: auto-collapse all-quiet repos.
-- **Visible aging:** rows past the staleness threshold fade and gain a day chip ("6d").
-- **Sidebar state syncs** via user preferences instead of device-local localStorage (pins, custom sections, collapse state; lanes are derived, nothing to sync).
+The workspaces panel gains two dropdowns; the manual Group/section concept is **removed**.
+
+**Workspace properties:** Title, Repository, Linear status (from the linked task; "No task" bucket for unlinked workspaces), Agent status (attention tier), Last interacted.
+
+- **Group-by:** None · Repository · Linear status · Agent status. (Title and timestamps make poor groups; they stay order-by only.)
+- **Order-by:** Recent (last activity) · Title · Created — each ascending/descending. Applies within groups, and to the flat list when group-by is None.
+- **"Recent" = any activity**: user interaction OR agent/workspace events (turn finished, permission requested, status change, PR event) bump the workspace. An agent finishing work surfaces its workspace even while you're elsewhere; a blocked agent's own permission event bumps it at the moment it blocks.
+- **Adaptive cards:** a card shows every property **not implied by the current grouping** — grouped by Repository, cards omit the repo icon/name (as today); grouped by None or a status, cards gain the repo icon + name; grouped by Agent status, the status dot is redundant on the card but repo and age chips matter. One rendering rule, not per-view special cases.
+- **Group headers** show worst-case rollup (max-tier dot + attention count) and collapse/expand; collapsed groups persist their state.
+- **Defaults:** group-by Repository, order-by Recent-desc — preserves today's shape while making order meaningful. View config is a synced user preference (one global config, not per-repo).
+- **Migration:** existing manual sections are dropped; group colors/pins die with them. One-time migration notes section names in a toast/release note; workspaces are untouched. (Sections are device-local localStorage today and don't sync, so the loss is smaller than it looks.)
+- **Pin-to-top** survives as a per-workspace flag that floats a workspace above its group's ordering.
+
+Old fixed "auto-lanes" from the original design are subsumed: group-by Agent status *is* the lane view; group-by Linear status recreates Active/Review/Complete derived from real state.
 
 ## 3. Navigation & keyboard model
 
 Principle: **every attention feature ships with its keyboard path; the mouse is the alternate input.** All new commands register in the hotkey registry (rebindable) and the ⌘⇧K command palette.
 
-- **⌘J — "next needs-me"** (the universal verb). Transient HUD: top of queue + two peeked; `↵` go, repeat-tap cycles, `⌘⇧J` cycles back (position 0 = "return to where I was"). In-HUD: `↑↓` move, `1..9` pick, `S` snooze, `A` answer/approve blocked items inline, `E` archive, `Esc` dismiss.
-- **⌘⇧L — sidebar focus mode:** `↑↓`/`j k` walk rows, `← →` collapse/expand, `↵` open; single-letter verbs on the focused row: `s` snooze, `e` archive, `p` pin, `m` mute. Hints render inline on the focused row. The Needs-you band occupies focus positions 1–3, so `⌘⇧L ↵` = open the most urgent thing.
-- **Positional shortcuts unchanged:** `⌘1..9`, `⌘⌥↑/↓` keep muscle-memory semantics; ⌘J is the attention-aware counterpart.
+- **⌘J — the jump HUD** (the universal verb). A transient panel listing **attention items first (queue-ranked), then recently-active workspaces** — jump between live workspaces primarily via keyboard, mouse-friendly too. `↵` opens the top item, repeat-tap cycles, `⌘⇧J` cycles back (position 0 = "return to where I was"). In-HUD: `↑↓` move, `1..9` pick, `S` snooze, `A` answer/approve blocked items inline, `E` archive, `Esc` dismiss.
+- **⌘⇧L — sidebar focus mode:** `↑↓`/`j k` walk rows, `← →` collapse/expand groups, `↵` open; single-letter verbs on the focused row: `s` snooze, `e` archive, `p` pin, `m` mute. Hints render inline on the focused row.
+- **Positional shortcuts unchanged:** `⌘1..9`, `⌘⌥↑/↓` keep muscle-memory semantics over the visible list order; ⌘J is the attention-aware counterpart.
 - **Notification actions always have in-app keyboard twins** (macOS banner buttons are mouse-bound by the OS; the HUD carries the same verbs).
+- **View controls are keyboard-reachable:** palette commands for "Group by …" / "Order by …" so switching views never requires the dropdowns.
 - Direction A's future inbox inherits the same queue and letter verbs (`j/k`, `↵`, `e`, `s`, `a`, `u` undo) — zero relearning if/when it ships.
 
 ## 4. Notifications & channel discipline
@@ -89,7 +105,7 @@ Loudness maps to tier; every channel has a suppression story.
 - **Undo/restore:** post-archive toast with Undo; Archive view offers Restore (recreates worktree from branch). Transcripts/PR links browsable read-only without restoring.
 - **Closed-without-merge:** suggested cleanup, never automatic.
 - **Stale path:** at 2× staleness threshold, resume / snooze / archive prompt; bulk palette command "Archive all workspaces idle > 2 weeks…" with a review list.
-- **Archive surface:** per-repo entry ("Archive · 9 merged this week") + global view; grouped Today / Yesterday / This week / Older; searchable. "Complete" sections stop existing.
+- **Archive surface:** per-repo entry ("Archive · 9 merged this week") + global view; grouped Today / Yesterday / This week / Older; searchable. Time-bucket grouping belongs here (history), not in the live list.
 - **Remote workspaces** use the same flow via host-service teardown.
 
 ---
@@ -98,27 +114,30 @@ Loudness maps to tier; every channel has a suppression story.
 
 Grounded in the current v2 implementation:
 
-- **Attention selector layer** over existing sources — terminal agent bindings (`useTerminalAgentStatuses`), PR records (`pull_requests` rows from `PullRequestRuntimeManager`), seen-state (`stores/v2-notifications`). New: ACP/chat sessions contribute `blocked` via `pendingPermissions` (today only terminal agents drive sidebar status). Extends the existing `PaneStatus` priority (`shared/tabs-types.ts`) rather than replacing it.
-- **New synced store** for snoozes, per-workspace mute, pins, staleness threshold, tier toggles — via `useV2UserPreferences` (fixes device-local sections/settings gaps).
-- **Lanes** are a pure regrouping in `buildDashboardSidebarProjects.ts` keyed off attention state + PR state; migration path for `v2SidebarSections`.
-- **⌘J HUD** = new hotkey in `hotkeys/registry.ts` + a queue selector shared with the band/popover; palette entries alongside.
+- **Attention selector layer** over existing sources — terminal agent bindings (`useTerminalAgentStatuses`), PR records (`pull_requests` rows from `PullRequestRuntimeManager`), seen-state (`stores/v2-notifications`). New: ACP/chat sessions contribute `blocked` via `pendingPermissions` (today only terminal agents drive sidebar status). Extends the existing `PaneStatus` priority (`shared/tabs-types.ts`).
+- **`lastActivityAt` per workspace** for Recent ordering: max of terminal binding `lastEventAt`, user-open events, and PR `lastFetchedAt`-driven state changes; host-clock ms, consistent with `terminalSeenAt` handling.
+- **View system** replaces section logic in `buildDashboardSidebarProjects.ts` with a pure `groupBy × orderBy` pipeline; `v2SidebarSections` collection and its DnD/mutation surface are removed. View config, pins, snoozes, per-workspace mute, staleness threshold, tier toggles all live in a **synced store** (`useV2UserPreferences`), fixing the device-local gaps.
+- **Adaptive cards:** card renderer takes the active group-by and elides implied properties.
+- **⌘J HUD** = new hotkey in `hotkeys/registry.ts` + a queue selector (attention-ranked, then recent-active) shared with notifications; palette entries alongside.
 - **Digest/replacement notifications** extend `V2NotificationController`/`lifecycleEvents.ts` and `notifications.showNative` (stable notification identifier for in-place replacement); notification actions via Electron/macOS notification API.
 - **Auto-archive** = new host-service-driven rule: on PR-merged transition, run destroy preflight; if clean, invoke the existing `workspaceCleanup.destroy` teardown path minus record deletion, flag workspace `archived`. Archive view reads archived workspaces + existing PR metadata.
+- **Linear status** comes via the linked task (`taskId`); unlinked workspaces bucket as "No task".
 - **Data gaps to fill:** none blocking; `mergeable`/`behindCount` on PR records would improve `external` fidelity later.
 
 ## Edge cases
 
 - Agent interrupted via Esc/Ctrl+C fires no hook — existing `clearWorkspaceStatuses` escape hatch remains; a `blocked` item whose terminal dies falls back to `failed` after binding liveness expires.
 - Multiple sessions per workspace: workspace tier = max over its sessions; per-session detail in hover card.
-- Clock skew: `since` timestamps use host-clock ms (consistent with `terminalSeenAt` monotonic handling).
+- Reorder churn: with order-by Recent, agent events reorder the list while the user reads it — animate moves, and never reorder within ~1s of pointer hover over the panel (interaction guard).
+- Clock skew: `since`/`lastActivityAt` use host-clock ms (consistent with `terminalSeenAt` monotonic handling).
 - Merged-PR detection latency: ≤5 min worst case (existing sweep) — acceptable for archiving.
 - Snooze trigger "when checks finish" depends on checks refresh cadence; fall back to time-based resurface if PR polling errors.
 
 ## Phased rollout
 
-1. **Attention engine + Needs-you band + ⌘J** (the core loop; band and HUD share one queue selector).
-2. **Notification upgrade** — split sounds, digest replacement, actionable banners, per-workspace mute, snooze-all, menu-bar item.
-3. **Auto-lanes + rollups + aging + synced sidebar state** (includes sections migration).
+1. **Attention engine + ⌘J HUD** (queue selector, reasons, exit conditions, heat-ramp indicator colors).
+2. **View system** — group-by/order-by dropdowns, adaptive cards, rollup headers, sections removal + migration, synced view config.
+3. **Notification upgrade** — split sounds, digest replacement, actionable banners, per-workspace mute, snooze-all, menu-bar item.
 4. **Auto-archive + Archive view + stale prompts + bulk command.**
 5. *(Later, optional)* Direction A inbox view on top of the same engine.
 
@@ -126,12 +145,13 @@ Each phase ships independently and is gated by a setting on first release (per p
 
 ## Testing
 
-- Unit: attention-state derivation (tier dedupe, age ordering, exit conditions, snooze) as pure selectors; lane regrouping in `buildDashboardSidebarProjects` (existing test suite pattern); digest window merge/replace logic.
+- Unit: attention-state derivation (tier dedupe, age ordering, exit conditions, snooze) as pure selectors; `groupBy × orderBy` pipeline + adaptive-card property elision (existing `buildDashboardSidebarProjects` test-suite pattern); digest window merge/replace logic; `lastActivityAt` aggregation.
 - Integration: lifecycle-event → notification pipeline (Stop/PermissionRequest fan-in, suppression, replacement identifiers); auto-archive preflight outcomes (clean, unpushed, dirty).
-- E2E/CDP: ⌘J jump lands on highest-tier workspace; band exit conditions (blocked persists after open, ready clears); undo restores worktree. Baseline-then-fix evidence per AGENTS.md CDP rules.
+- E2E/CDP: ⌘J jump lands on highest-tier workspace; blocked row persists after open while ready row clears; Recent ordering bumps on agent Stop; undo restores worktree. Baseline-then-fix evidence per AGENTS.md CDP rules.
 
 ## Open questions (deferred, non-blocking)
 
 - Exact staleness defaults (3d escalate / 2× prompt) — tune after dogfooding.
 - Whether `external` should include "PR approved, ready to merge" as an action item.
 - Menu-bar item default-on vs default-off.
+- Whether pin-to-top earns its keep once Recent ordering exists, or gets cut for simplicity.


### PR DESCRIPTION
> **Don't merge this.** It's a dev-only prototype I built to demo a proposed group-by / order-by "attention" system for the workspace sidebar, plus a "jump to workspace" modal. It's intended for Superset devs to review and decide if any of these UX/UI ideas are worth pursuing.

## Demo
[![YouTube](https://i.ibb.co/CpzXd0Zp/SCR-20260725-szip.png)](https://www.youtube.com/watch?v=JkKAUotyTnM)

## What & why

The current workspace sidebar only has one top-level grouping (repositories), with manually created and managed sub-groups. When you work with a large number of repositories and workspaces, it becomes difficult to see which workspaces currently need your attention, and slow to organise them around your current task focus.

This prototype adds automated grouping, ordering, and collapsing/expanding. Which enable users to quickly understand which workspace(s) they should focus on for their current task. For example, group by "Linear status" turns the panel into a vertical kanban, so you can focus in on workspaces with one particular status. Or group by "Agent activity" gives you a prioritised list of workspaces that are blocked waiting on human input.

### Why the `⌘J` "Jump to workspace" modal exists

The group-by and order-by controls let you manage your workspace focus, by giving you answers to particular questions. For example, group by "Linear status" can answer "which workspaces should I focus on to clear my reviews?".

That's the core idea behind this attention focus system, but it comes with a cost. Once the list is arranged around answering a question, the workspaces with the freshest agent activity can be sitting in other columns, sorted near the bottom, or folded away. You shouldn't have to adjust your workspace view just to understand which of your agents have just completed their task, and where you should jump to next.

That's what `⌘J` is for. It opens a command-palette-style modal that is always ranked by attention (needs input, failed, working, review, idle) and then by most recent activity, no matter how the sidebar is grouped or sorted. So the workspace list can stay set up for your current task, and you can still see and reach the latest activity whenever you need to Type or use the arrow keys to move within the modal, `↵` or `1` to `9` to jump. Jumping selects the workspace and expands its group if it was collapsed.

<img width="3024" height="1897" alt="SCR-20260724-lyoa" src="https://github.com/user-attachments/assets/02fc556d-d21c-4c7f-bd2f-b0ee82041d3c" />

## How I tested it

Try it yourself: run a dev build and open **Dev ▸ Open Attention Prototype**. The menu item and the route both only exist in development builds.

1. **Group by Linear status.** Hit `⌥G` and pick Linear status. The sidebar turns into a vertical kanban, one column per status, empty columns and all.
2. **Drag a workspace between columns.** Grab a row and drag it over another status. The whole target column lights up so you can see where it will land, and dropping reassigns the status and re-sorts the row into place. Empty columns only show a drop area while you are dragging.
3. **Reorder inside a column.** Drag within a group to arrange by hand. Order-by flips to Manual.
4. **Order and direction.** `⌥O` opens order-by, `⌥D` flips ascending and descending. Under Manual the direction toggle is disabled and tells you why on hover.
5. **Fold and panel.** `⌥F` folds and unfolds every group. `⇧⌥G` toggles the Groups & ordering panel (the layers button on the Projects header).
6. **Jump to workspace.** `⌘J` opens the attention-ranked modal described above. `⌘1` to `⌘9` jump straight to a workspace and expand its group if it is collapsed.
7. **Simulate activity.** The Simulation Driver panel drives a virtual clock and the fixtures, so you can watch a status change animate its journey: the origin header flashes, the card travels, the destination flashes.
8. **Resize.** Drag the panel edge. Rows stay put instead of FLIP-tweening while you drag.

Automated checks:

- `bun run typecheck`: clean.
- `bun run lint`: clean (CI fails on warnings too).
- `bun test …/model/buildPrototypeView.test.ts`: 17 passing.
- No automated UI tests. It's a prototype, and I drove the behaviour by hand over a lot of rounds.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<details>
<summary>Implementation notes (optional reading)</summary>

### How it's put together

Everything lives under `apps/desktop/src/renderer/routes/_authenticated/attention-prototype/`, rendered inside the authenticated shell so it can import real components live. Three shared files change, only to wire up the dev entry point: `main/lib/menu.ts`, `lib/trpc/routers/menu.ts`, and `layout.tsx`.

- `page.tsx` gates on dev and mounts the sidebar.
- `store/usePrototypeStore.ts` is the zustand store: fixtures, the virtual clock, view config (group, order, direction, manual order), sidebar width, collapse state, and the Linear-status setter.
- `model/` holds the pure view builder `buildPrototypeView.ts` and its 17 tests, `types.ts` (the prototype view model, with notes on which fields are net-new), and `formatAge.ts`.
- `fixtures/workspaces.ts` has the sample workspaces, repos, statuses, PRs, and ports.
- `hooks/` has `useLayoutAwareHotkey.ts` (Dvorak-safe inline chords) and `useAttentionHudHotkey.ts`.
- `components/` is built around `PrototypeSidebar`, the roughly 1,260-line hub. Around it sit the header, footer, toggle, top bar, projects header, workspace row and details, port badge, close dialog, the attention HUD, the simulation driver, and the sortable row wrapper, plus `HeaderFlashOverlay`, `PrototypeTravelRow`, and `PrototypeGroupDroppable`.

### What's real and what's faked

- Real, imported straight from the app: the sidebar header and footer, workspace and project icons, the status indicators, the new-workspace and add-repository modals, the `⌘1` to `⌘9` hotkey registry, and the keyboard-layout map.
- Faked: the workspaces themselves, plus the fields the view system needs that the real `DashboardSidebarWorkspace` doesn't have yet (`agentStatus`, `lastActivityAt`, `linearStatus`, `ports`), the virtual clock, and the simulation driver. `model/types.ts` spells out each net-new field and what it maps to in the real app.
- The PR-grouping data is real, though: `github_pull_requests` (`review_decision`, `checks_status`) flowing in through GitHub App webhooks, Electric SQL, and TanStack DB.

### What was tricky

- framer-motion: you have to switch off `layout` during both drag and panel resize, or every row FLIP-tweens on each frame. `AnimatePresence` freezes exiting children with their old props, so the travel highlight is baked into the exit variant rather than passed in fresh. The list is one flat `LayoutGroup` with no per-group wrappers, on purpose, so a card whose status changes can tween across column boundaries instead of teleporting.
- dnd-kit: `useSortable` spreads `role="button"` onto the row, so an unscoped `closest("[role='button']")` always matches an ancestor and bails out. The fix scopes it to `event.currentTarget.contains(...)`. The real sidebar has the same bug, for what it's worth. Cross-column dragging uses group-level droppables and a `pointerWithin`-first collision check (prefer the row under the pointer, fall back to the group) so reordering inside a column stays precise while whole-column targeting still works.
- react-hotkeys-hook matches physical key codes, so a bare chord breaks on Dvorak or AZERTY. Everything goes through `useLayoutAwareHotkey`, which maps a logical chord through the app's layout table first.
- Disabled controls keep their tooltip by using `aria-disabled` and `cursor-not-allowed` instead of `disabled` and `pointer-events-none`, matching what `V2WorkspaceRow` already does, and the tooltip says why the control is off.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev-only prototype of an attention-focused workspace sidebar with group-by/order-by controls to test how users find what needs attention. Includes a Cmd-J “Jump to workspace” HUD and drag interactions to evaluate the UX before integrating into the real sidebar.

- **New Features**
  - Dev-only route `/attention-prototype` and Dev menu entry to open it.
  - Group by repository, Linear status (kanban), agent status, or PR state; fold/unfold groups.
  - Order by recent activity, created, name, attention rank, or manual; asc/desc; layout-aware hotkeys.
  - Keyboard: `⌘J` attention-ranked jump modal; `⌘1`–`⌘9` quick jumps.
  - Drag-and-drop: reorder within groups; drag between Linear columns to reassign status; smooth travel animations.
  - Fixture-backed store, port badges, details panel, and a simulation driver to generate activity.
  - Pure view builder (`buildPrototypeView`) with 17 unit tests; minimal shared wiring in `menu.ts`, TRPC menu router, and authenticated layout to open the prototype.

<sup>Written for commit 704b370a0944f485df675a2737bfc7726f705c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development-only Attention Prototype workspace experience.
  * View and organize workspaces by repository, status, pull request, or activity, with drag-and-drop ordering.
  * Added keyboard-driven workspace navigation, including a jump HUD and shortcuts.
  * Added workspace status simulations, port actions, workspace removal, and confirmation dialogs.
  * Added a development menu shortcut to open the prototype.
* **Documentation**
  * Added a design specification for workspace attention, notifications, navigation, and archiving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->