### PR TITLE
fix(host-service): add shell-ready timeout so preset commands can't be dropped forever

### DIFF
--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -200,13 +200,29 @@ type TerminalSocket = {
 // ---------------------------------------------------------------------------
 
 /**
+ * Upper bound on the OSC 133;A wait before queued automation runs anyway.
+ * Wrapper files on disk don't guarantee the marker reaches the scanner —
+ * a user rc can exec another process or re-point ZDOTDIR so our .zlogin
+ * never runs — and an unbounded wait silently drops preset/agent commands
+ * (#4963, regressed by #5774). 15s covers heavy setups like Nix devenv
+ * via direnv; same budget as the v1 stack.
+ */
+const SHELL_READY_TIMEOUT_MS = 15_000;
+
+/**
  * Shell readiness lifecycle:
  * - `pending`     — shell initialising; scanner active
  * - `ready`       — OSC 133;A detected; scanner off
+ * - `timed_out`   — marker never arrived in time; queued automation runs anyway
  * - `unsupported` — launch config has no marker; scanner never started
  * - `cancelled`   — session ended before readiness; queued automation cancelled
  */
-type ShellReadyState = "pending" | "ready" | "unsupported" | "cancelled";
+type ShellReadyState =
+	| "pending"
+	| "ready"
+	| "timed_out"
+	| "unsupported"
+	| "cancelled";
 
 interface TerminalSession {
 	terminalId: string;
@@ -248,6 +264,7 @@ interface TerminalSession {
 	shellReadyState: ShellReadyState;
 	shellReadyResolve: (() => void) | null;
 	shellReadyPromise: Promise<void>;
+	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
 	scanState: ShellReadyScanState;
 	initialCommandQueued: boolean;
 
@@ -658,10 +675,32 @@ export function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
 	sendBytes(socket, combined);
 }
 
-/** Transition out of `pending` after the scanner matches the prompt marker. */
-function resolveShellReady(session: TerminalSession): void {
+function clearShellReadyTimeout(session: TerminalSession): void {
+	if (session.shellReadyTimeoutId) {
+		clearTimeout(session.shellReadyTimeoutId);
+		session.shellReadyTimeoutId = null;
+	}
+}
+
+/** Transition out of `pending` on marker match or timeout expiry. */
+function resolveShellReady(
+	session: TerminalSession,
+	state: "ready" | "timed_out",
+): void {
 	if (session.shellReadyState !== "pending") return;
-	session.shellReadyState = "ready";
+	session.shellReadyState = state;
+	clearShellReadyTimeout(session);
+	// On timeout the scanner may be withholding a partial marker prefix that
+	// never completed — those bytes are real output and must be released.
+	if (session.scanState.heldBytes.length > 0) {
+		const heldBytes = Uint8Array.from(session.scanState.heldBytes);
+		session.scanState.heldBytes.length = 0;
+		session.scanState.matchPos = 0;
+		session.modeTracker.feed(heldBytes);
+		if (broadcastBytes(session, heldBytes) === 0) {
+			bufferOutput(session, heldBytes);
+		}
+	}
 	if (session.shellReadyResolve) {
 		session.shellReadyResolve();
 		session.shellReadyResolve = null;
@@ -672,6 +711,7 @@ function resolveShellReady(session: TerminalSession): void {
 function cancelShellReady(session: TerminalSession): void {
 	if (session.shellReadyState !== "pending") return;
 	session.shellReadyState = "cancelled";
+	clearShellReadyTimeout(session);
 	if (session.shellReadyResolve) {
 		session.shellReadyResolve();
 		session.shellReadyResolve = null;
@@ -690,7 +730,9 @@ function queueInitialCommand(
 	// Marker-backed shells can run interactive startup hooks that read or flush
 	// PTY input before the first prompt (direnv/devenv is one example). Wait for
 	// that prompt so the command cannot be consumed as startup input. Launches
-	// without a verified marker resolve this promise immediately.
+	// without a verified marker resolve this promise immediately, and a missing
+	// marker resolves it via SHELL_READY_TIMEOUT_MS — the command must
+	// eventually run; only session teardown may cancel it.
 	void session.shellReadyPromise.then(() => {
 		if (!session.exited && session.shellReadyState !== "cancelled") {
 			session.pty.write(cmd);
@@ -1232,6 +1274,7 @@ export async function createTerminalSessionInternal({
 				: "unsupported",
 		shellReadyResolve,
 		shellReadyPromise,
+		shellReadyTimeoutId: null,
 		scanState: createScanState(),
 		// Adopted sessions have already run their initialCommand in the prior
 		// host-service lifetime — flag it as queued so we don't double-fire it.
@@ -1241,6 +1284,12 @@ export async function createTerminalSessionInternal({
 	};
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
+
+	if (session.shellReadyState === "pending") {
+		session.shellReadyTimeoutId = setTimeout(() => {
+			resolveShellReady(session, "timed_out");
+		}, SHELL_READY_TIMEOUT_MS);
+	}
 
 	session.unsubscribeDaemon = daemon.subscribe(
 		terminalId,
@@ -1263,7 +1312,7 @@ export async function createTerminalSessionInternal({
 					const result = scanForShellReady(session.scanState, chunk);
 					bytes = result.output;
 					if (result.matched) {
-						resolveShellReady(session);
+						resolveShellReady(session, "ready");
 					}
 				}
 				if (bytes.byteLength === 0) return;


### PR DESCRIPTION
## Problem

Since desktop-v1.16.1 (published 2026-07-21), launching an agent preset (e.g. the Claude preset) can open a terminal that never runs the agent command — the user is left with a plain empty shell.

**Root cause:** #5774 reintroduced marker-gating of `initialCommand` in `queueInitialCommand` — the exact behavior #4963 removed ("gating turned broken/missing markers into a guaranteed stall") — and additionally deleted the timeout fallback. The command waits on `shellReadyPromise`, which only resolves when the OSC 133;A prompt marker reaches the scanner. `shellLaunchExpectsReadyMarker` only checks that wrapper files exist on disk; it cannot guarantee the marker is ever emitted:

- user rc `exec`s another process (tmux, another shell), so our `.zlogin` never runs
- user config re-points `ZDOTDIR`
- rc files blocking on stdin / broken hooks (all listed in #4963's commit message)

For affected shell configs the drop is deterministic: the PTY and shell start fine, but the queued command never writes and is never retried. Third regression of this bug (v1 #3478, v2 #4963, now #5774).

## Fix

Keep #5774's first-prompt wait — it's a real fix for direnv/devenv startup hooks consuming PTY input — but bound it:

- `SHELL_READY_TIMEOUT_MS = 15_000` (same budget as the v1 stack's gate, covers Nix devenv via direnv) armed when a session starts `pending`
- On expiry the readiness promise resolves as a new `timed_out` state and the queued command writes anyway — failure mode degrades from "dropped forever" to "delayed at most 15s"
- Restores the flush of partially-matched marker bytes the scanner withholds (deleted by #5774), so a never-completed marker prefix isn't dropped from output
- Timer cleared on every exit from `pending` (marker match, timeout, all `cancelShellReady` teardown paths); a late timer no-ops after cancellation

## Verification

- `bun run lint` clean, `tsc --noEmit` in `packages/host-service` passes
- `terminal.adoption.node-test.ts` (holds the #4963/#5774 regression tests) could not run locally — better-sqlite3 in this worktree is built for the Electron ABI; relying on CI for that suite
- No live end-to-end repro (needs a shell config that suppresses the marker)

https://claude.ai/code/session_01KEmzD2DhH34tRA6GUuRgri


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 15s shell-ready timeout so preset/agent commands always run even if the OSC 133;A prompt marker never arrives. Prevents terminals that launch into an empty shell with no command executed (regression from #5774).

- **Bug Fixes**
  - Keep the first-prompt wait but bound it at 15s; on expiry resolve as `timed_out` and run the queued command.
  - Flush any partial marker bytes the scanner was holding so output isn’t lost.
  - Clear the timeout on every exit from `pending` (`ready`, `timed_out`, `cancelled`); late timers no-op.
  - `queueInitialCommand` now proceeds on `ready`, `timed_out`, or `unsupported`; only session teardown cancels it.

<sup>Written for commit 72106910ac53b71758a8ccfd618a3647058502c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 15-second fallback when shell readiness cannot be detected.
  * Prevented terminal output from being lost when readiness detection times out.
  * Improved cleanup of readiness timers when terminal sessions are cancelled or closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->