### PR TITLE
feat(email): add churn win-back template and Resend automation spec

### DIFF
--- a/packages/email/src/emails/churn-winback.tsx
+++ b/packages/email/src/emails/churn-winback.tsx
@@ -1,0 +1,111 @@
+import {
+	Body,
+	Container,
+	Head,
+	Html,
+	Link,
+	Preview,
+	Text,
+} from "@react-email/components";
+
+interface ChurnWinbackEmailProps {
+	ownerName?: string;
+	organizationName?: string;
+	planName?: string;
+}
+
+export function ChurnWinbackEmail({
+	ownerName = "{{{ownerName|there}}}",
+	organizationName = "{{{organizationName|your team}}}",
+	planName = "{{{plan|paid}}}",
+}: ChurnWinbackEmailProps) {
+	return (
+		<Html>
+			<Head />
+			<Preview>One question before you go</Preview>
+			<Body style={body}>
+				<Container style={container}>
+					<Text style={paragraph}>Hi {ownerName},</Text>
+
+					<Text style={paragraph}>
+						Satya here, one of the founders of Superset. I saw that the{" "}
+						{planName} subscription for {organizationName} ended last week, and
+						I wanted to reach out myself.
+					</Text>
+
+					<Text style={paragraph}>
+						No hard feelings — but I'd genuinely like to know what didn't work.
+						A missing feature, the price, a bug that got in the way? Just hit
+						reply and tell me. I read and answer every one of these.
+					</Text>
+
+					<Text style={paragraph}>
+						And if it was just timing, you can{" "}
+						<Link href="https://app.superset.sh/settings/billing" style={link}>
+							restart your plan
+						</Link>{" "}
+						in about a minute — your workspaces and team are right where you
+						left them.
+					</Text>
+
+					<Text style={paragraph}>
+						Either way, thanks for giving Superset a real shot.
+					</Text>
+
+					<Text style={paragraph}>
+						— Satya
+						<br />
+						Co-founder, Superset
+					</Text>
+
+					<Text style={footer}>
+						Don't want emails like this?{" "}
+						<Link href="{{{RESEND_UNSUBSCRIBE_URL}}}" style={footerLink}>
+							Unsubscribe
+						</Link>
+						.
+					</Text>
+				</Container>
+			</Body>
+		</Html>
+	);
+}
+
+export default ChurnWinbackEmail;
+
+const body = {
+	backgroundColor: "#FFFFFF",
+	fontFamily:
+		"-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+	margin: "0",
+};
+
+const container = {
+	margin: "0 auto",
+	maxWidth: "560px",
+	padding: "32px 20px",
+};
+
+const paragraph = {
+	color: "#242424",
+	fontSize: "15px",
+	lineHeight: "24px",
+	margin: "0 0 16px 0",
+};
+
+const link = {
+	color: "#242424",
+	textDecoration: "underline",
+};
+
+const footer = {
+	color: "#8E8E8E",
+	fontSize: "12px",
+	lineHeight: "18px",
+	margin: "32px 0 0 0",
+};
+
+const footerLink = {
+	color: "#8E8E8E",
+	textDecoration: "underline",
+};

--- a/plans/20260724-churn-winback-resend-automation.md
+++ b/plans/20260724-churn-winback-resend-automation.md
@@ -1,0 +1,77 @@
+# Churn win-back — Resend Automation spec
+
+Evergreen win-back flow: `subscription.canceled` Resend event → 7-day delay → founder-style win-back email. This doc describes the automation to click together in the Resend dashboard once the event emission ships. Nothing has been created in Resend yet.
+
+## Pieces and where they live
+
+| Piece | Where | Status |
+| --- | --- | --- |
+| Event emission | `packages/auth/src/lib/lifecycle.ts` (`emitLifecycleEvent`) + Stripe cancel handler in `packages/auth/src/server.ts` | On branch `churn-user-reactivation`, lands with that PR — do not duplicate |
+| Email template | `packages/email/src/emails/churn-winback.tsx` | This branch |
+| Automation | Resend dashboard | Not created — build only after the `churn-user-reactivation` PR is deployed to prod, otherwise the trigger event never fires |
+
+## Trigger event
+
+Emitted once per organization owner when a Stripe subscription is canceled:
+
+```json
+{
+	"name": "subscription.canceled",
+	"email": "<owner email>",
+	"payload": {
+		"organizationId": "…",
+		"organizationName": "…",
+		"plan": "…",
+		"ownerName": "…"
+	}
+}
+```
+
+Note: multi-owner orgs emit one event per owner, so each owner independently enters the automation and gets their own email. That is intended (each owner can resubscribe).
+
+## Template
+
+`churn-winback.tsx` is written so its rendered output is paste-ready for Resend: the default prop values are the Resend placeholder strings, so `bun run export` (in `packages/email`, output in `out/churn-winback.html`) produces HTML containing the placeholders verbatim. No manual substitution.
+
+Placeholder → payload mapping:
+
+| Placeholder in HTML | Payload key | Fallback |
+| --- | --- | --- |
+| `{{{ownerName\|there}}}` | `ownerName` | "there" |
+| `{{{organizationName\|your team}}}` | `organizationName` | "your team" |
+| `{{{plan\|paid}}}` | `plan` (payload key is `plan`, not `planName` — the React prop name differs) | "paid" |
+| `{{{RESEND_UNSUBSCRIBE_URL}}}` | built-in Resend variable | — |
+
+The email is deliberately plain: no logo, no button, no card layout. Founder voice, one CTA link (`https://app.superset.sh/settings/billing`), and a reply prompt as the second ask.
+
+## Automation config (click together in Resend)
+
+1. **Trigger**: Event received — `subscription.canceled`.
+2. **Delay**: Wait 7 days.
+3. **Send email**:
+   - Template: paste exported `churn-winback.html` as a new Resend template named `churn-winback`. Record the template id here after creation: `TBD`.
+   - Subject: `One question before you go`
+   - From: `Satya from Superset <satya@superset.sh>` — not `noreply@superset.sh`; the email asks people to hit reply, so the from address must accept replies.
+   - Reply-to: `satya@superset.sh`
+4. **Exit conditions**:
+   - Contact unsubscribed → exit (Resend handles this via the audience; the template includes `{{{RESEND_UNSUBSCRIBE_URL}}}`).
+   - Resubscribed before day 7 → should exit, but no `subscription.resubscribed` / `subscription.started` Resend event is emitted today, so this exit cannot be configured yet. Known gap: an owner who resubscribes within the 7-day window still gets the email. Follow-up: emit a resubscribe lifecycle event from the Stripe subscription-created/updated handler and add it as an exit rule.
+
+## Prerequisites to verify before enabling
+
+- The `churn-user-reactivation` PR is deployed to prod (events actually fire).
+- Canceled owners exist as contacts in the Resend audience — `{{{RESEND_UNSUBSCRIBE_URL}}}` only resolves for audience contacts. If `events/send` does not auto-create the contact, add a contact-upsert step to the emission path before enabling.
+
+## Testing
+
+1. Fire a synthetic event at your own address:
+
+   ```bash
+   curl -X POST https://api.resend.com/events/send \
+   	-H "Authorization: Bearer $RESEND_API_KEY" \
+   	-H "Content-Type: application/json" \
+   	-d '{"name":"subscription.canceled","email":"satya@superset.sh","payload":{"organizationId":"test","organizationName":"Test Org","plan":"Pro","ownerName":"Satya"}}'
+   ```
+
+2. Temporarily set the delay to 5 minutes, confirm delivery, placeholder substitution, fallbacks (send a second event with an empty payload), and the unsubscribe link.
+3. Set the delay back to 7 days before enabling.


### PR DESCRIPTION
## Summary
- Adds `packages/email/src/emails/churn-winback.tsx` — plain-text-look, founder-voice win-back email with a single resubscribe CTA, a reply prompt, and `{{{RESEND_UNSUBSCRIBE_URL}}}`. Default props are the Resend placeholder strings, so `bun run export` produces paste-ready template HTML with no manual substitution.
- Adds `plans/20260724-churn-winback-resend-automation.md` — spec for the Resend Automation to click together: `subscription.canceled` trigger, 7-day delay, template/subject/from config, exit conditions (including the known resubscribe-exit gap), prereqs, and a test recipe.

## Notes
- Pairs with the `subscription.canceled` event emission on branch `churn-user-reactivation` (`packages/auth/src/lib/lifecycle.ts`); no event wiring is duplicated here.
- Nothing was created in the Resend dashboard — per the spec, the automation should only be built after the emission PR is deployed.

Task: [SUPER-1624](https://linear.app/superset-sh/issue/SUPER-1624/evergreen-churn-win-back-email-resend-automation-spec)

https://claude.ai/code/session_01HCfaNxHzqc72iqDT7gg9VD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a win-back email template and a Resend automation plan that sends it 7 days after a subscription is canceled. Supports SUPER-1624 by enabling evergreen churn recovery and feedback.

- **New Features**
  - Added `packages/email/src/emails/churn-winback.tsx` using `@react-email/components`. Defaults to Resend placeholders so export HTML is paste-ready; includes `{{{RESEND_UNSUBSCRIBE_URL}}}`, a single billing CTA, and a reply prompt.
  - Added `plans/20260724-churn-winback-resend-automation.md` with the `subscription.canceled` trigger, 7-day delay, subject/from/reply-to, exit rules (unsubscribed; resubscribe gap noted), and a test recipe. Pairs with event emission on `churn-user-reactivation` (no wiring here).

- **Migration**
  - Build the automation in Resend only after `churn-user-reactivation` is deployed (events must fire).
  - Before enabling: confirm canceled owners exist as Resend contacts; test via a synthetic event, then set delay back to 7 days.

<sup>Written for commit 259832a762406144929f3fb7f13e26a269b9e202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a churn win-back email template with personalized recipient, organization, and plan details.
  * Included a link for restarting a canceled plan and an unsubscribe option.
  * Added a documented automation workflow for sending the message after a subscription cancellation.

* **Documentation**
  * Added setup prerequisites and manual testing guidance for the win-back automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->