### PR TITLE
feat(auth): wire lifecycle emails — welcome on signup, PostHog-gated Resend events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -703,6 +703,7 @@
         "better-auth": "1.6.13",
         "dotenv": "17.3.1",
         "drizzle-orm": "0.45.2",
+        "posthog-node": "5.45.2",
         "resend": "4.8.0",
         "stripe": "20.4.1",
         "zod": "4.3.6",
@@ -2369,6 +2370,8 @@
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
     "@posthog/core": ["@posthog/core@1.9.0", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-j7KSWxJTUtNyKynLt/p0hfip/3I46dWU2dk+pt7dKRoz2l5CYueHuHK4EO7Wlgno5yo1HO4sc4s30MXMTICHJw=="],
+
+    "@posthog/types": ["@posthog/types@1.397.0", "", {}, "sha512-Pa7FtsBo3V0XrhY4y8Xquwp8U07syuZ2IGQdlsRyxhz0yejQLceFjI58UssCXE5zDCDj3km5l7H3ufD6rHChCg=="],
 
     "@prisma/instrumentation": ["@prisma/instrumentation@6.11.1", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA=="],
 
@@ -7192,6 +7195,8 @@
 
     "@storybook/react-native/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
+    "@superset/auth/posthog-node": ["posthog-node@5.45.2", "", { "dependencies": { "@posthog/core": "^1.43.1" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-QhHw/xL0ntMG/DzqA/qdiKu8JY8ChK5Obm8m1nMJor5sjJ7+pfVJSx1yAynC7iUAJfJ9V+OhBNhDCyi5IFWC0Q=="],
+
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
@@ -8371,6 +8376,8 @@
     "@sentry/vite-plugin/@sentry/bundler-plugin-core/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "@sentry/vite-plugin/@sentry/bundler-plugin-core/magic-string": ["magic-string@0.30.8", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ=="],
+
+    "@superset/auth/posthog-node/@posthog/core": ["@posthog/core@1.43.1", "", { "dependencies": { "@posthog/types": "^1.396.0" } }, "sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -42,6 +42,7 @@
 		"better-auth": "1.6.13",
 		"dotenv": "17.3.1",
 		"drizzle-orm": "0.45.2",
+		"posthog-node": "5.45.2",
 		"resend": "4.8.0",
 		"stripe": "20.4.1",
 		"zod": "4.3.6"

--- a/packages/auth/src/env.ts
+++ b/packages/auth/src/env.ts
@@ -25,6 +25,11 @@ export const env = createEnv({
 	},
 	clientPrefix: "NEXT_PUBLIC_",
 	client: {
+		NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+		NEXT_PUBLIC_POSTHOG_HOST: z
+			.string()
+			.url()
+			.default("https://us.i.posthog.com"),
 		NEXT_PUBLIC_COOKIE_DOMAIN: z.string(),
 		NEXT_PUBLIC_API_URL: z.string().url(),
 		NEXT_PUBLIC_WEB_URL: z.string().url(),

--- a/packages/auth/src/lib/lifecycle.ts
+++ b/packages/auth/src/lib/lifecycle.ts
@@ -1,0 +1,50 @@
+import { PostHog } from "posthog-node";
+
+import { env } from "../env";
+
+export const ACTIVATION_CAMPAIGN_FLAG = "activation-email-campaign";
+
+const posthog = env.NEXT_PUBLIC_POSTHOG_KEY
+	? new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
+			host: env.NEXT_PUBLIC_POSTHOG_HOST,
+			flushAt: 1,
+			flushInterval: 0,
+		})
+	: null;
+
+export async function getActivationVariant(
+	userId: string,
+): Promise<"control" | "test"> {
+	if (!posthog) return "test";
+	try {
+		const variant = await posthog.getFeatureFlag(
+			ACTIVATION_CAMPAIGN_FLAG,
+			userId,
+		);
+		await posthog.flush();
+		return variant === "control" ? "control" : "test";
+	} catch (error) {
+		console.error("[lifecycle] Failed to evaluate activation flag:", error);
+		return "test";
+	}
+}
+
+export async function emitLifecycleEvent(
+	name: string,
+	email: string,
+	payload?: Record<string, string>,
+) {
+	const response = await fetch("https://api.resend.com/events/send", {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${env.RESEND_API_KEY}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ name, email, payload }),
+	});
+	if (!response.ok) {
+		throw new Error(
+			`Resend event ${name} failed: ${response.status} ${await response.text()}`,
+		);
+	}
+}

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -15,6 +15,7 @@ import { OrganizationInvitationEmail } from "@superset/email/emails/organization
 import { PaymentFailedEmail } from "@superset/email/emails/payment-failed";
 import { SubscriptionCancelledEmail } from "@superset/email/emails/subscription-cancelled";
 import { SubscriptionStartedEmail } from "@superset/email/emails/subscription-started";
+import { WelcomeEmail } from "@superset/email/emails/welcome";
 import { canInvite, type OrganizationRole } from "@superset/shared/auth";
 import { getTrustedVercelPreviewOrigins } from "@superset/shared/vercel-preview-origins";
 import { Client } from "@upstash/qstash";
@@ -27,6 +28,7 @@ import type Stripe from "stripe";
 import { env } from "./env";
 import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
 import { generateMagicTokenForInvite } from "./lib/generate-magic-token";
+import { emitLifecycleEvent, getActivationVariant } from "./lib/lifecycle";
 import { invitationRateLimit } from "./lib/rate-limit";
 import { resend } from "./lib/resend";
 import {
@@ -196,6 +198,35 @@ export const auth = betterAuth({
 							.update(authSchema.sessions)
 							.set({ activeOrganizationId: enrolledOrgId })
 							.where(eq(authSchema.sessions.userId, user.id));
+					}
+
+					try {
+						await resend.emails.send({
+							from: "Superset <noreply@superset.sh>",
+							to: user.email,
+							subject: "Welcome to Superset",
+							react: WelcomeEmail({ userName: user.name }),
+						});
+					} catch (error) {
+						console.error(
+							`[lifecycle] Failed to send welcome email to ${user.id}:`,
+							error,
+						);
+					}
+
+					try {
+						const variant = await getActivationVariant(user.id);
+						if (variant === "test") {
+							await emitLifecycleEvent("user.signed_up", user.email, {
+								userId: user.id,
+								name: user.name,
+							});
+						}
+					} catch (error) {
+						console.error(
+							`[lifecycle] Failed to emit signup event for ${user.id}:`,
+							error,
+						);
 					}
 				},
 			},
@@ -1005,6 +1036,22 @@ export const auth = betterAuth({
 							}),
 						})),
 					);
+
+					for (const owner of owners) {
+						try {
+							await emitLifecycleEvent("subscription.canceled", owner.email, {
+								organizationId: subscription.referenceId,
+								organizationName: org.name,
+								plan: subscription.plan,
+								ownerName: owner.name,
+							});
+						} catch (error) {
+							console.error(
+								`[lifecycle] Failed to emit cancel event for ${owner.email}:`,
+								error,
+							);
+						}
+					}
 
 					try {
 						await qstash.publishJSON({


### PR DESCRIPTION
## What

Foundations for the activation email campaign (and the evergreen churn win-back that builds on it):

- **Welcome email on signup** — wires the previously-orphaned `WelcomeEmail` template into better-auth's `user.create.after` hook, sent from `noreply@superset.sh`. Failures are logged, never block signup.
- **`packages/auth/src/lib/lifecycle.ts`** — new module:
  - `getActivationVariant(userId)`: evaluates the `activation-email-campaign` PostHog flag server-side via `posthog-node` (new dep). Exposure events flow to PostHog automatically. Fails open to `test`.
  - `emitLifecycleEvent(name, email, payload)`: raw POST to Resend's `/events/send` (Automations triggers).
- **`user.signed_up` Resend event** fired at signup for `test`-variant users only — `control` gets the welcome and nothing else. Payload: `{ userId, name }`.
- **`subscription.canceled` Resend event** fired per org owner in `onSubscriptionCancel`. Payload: `{ organizationId, organizationName, plan, ownerName }`.
- Env: `NEXT_PUBLIC_POSTHOG_KEY` (optional) + `NEXT_PUBLIC_POSTHOG_HOST` added to `packages/auth` env schema.

## Why

Trigger layer for two Resend Automations: activation nudges (24h/3d/7d, exits on activation) and the 7-day churn win-back. Measurement runs through [PostHog experiment 387868](https://us.posthog.com/project/264803/experiments/387868) (draft; 50/50 control/test; primary metric: real workspace created ≤14d). Until the experiment launches, the disabled flag means everyone takes the test path — no behavior change beyond the welcome email until automations exist in Resend.

## Notes

- No DB changes; suppression is Resend contact-level (`{{{RESEND_UNSUBSCRIBE_URL}}}` in automation templates).
- Related in-flight branches: `feat/churn-winback-automation`, `feat/resend-webhook-posthog`, `feat/paid-winback-send-script`, `feat/mobile-hero-reminder-cta`.
- Lint + typecheck clean.

https://claude.ai/code/session_01JyADHR4KkZBQ9HmVJPHNPv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lifecycle emails: welcome on signup and PostHog-gated `resend` events to power activation nudges and churn win-back. Users get a welcome email; events trigger Automations without blocking signup.

- **New Features**
  - Send `WelcomeEmail` on user creation from `noreply@superset.sh` (errors logged, non-blocking).
  - Add `packages/auth/src/lib/lifecycle.ts` with `getActivationVariant` (server-side via `posthog-node`) and `emitLifecycleEvent` (POST to Resend Automations).
  - On signup, fire `user.signed_up` for `test` variant users; `control` receives only the welcome.
  - On subscription cancel, fire `subscription.canceled` per org owner.
  - Env: `NEXT_PUBLIC_POSTHOG_KEY` (optional) and `NEXT_PUBLIC_POSTHOG_HOST` (default US).

- **Dependencies**
  - Add `posthog-node`.

<sup>Written for commit 780f7437baaf675aa0e0c989fa7f681c2a330ce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added welcome emails to the signup and onboarding experience.
  * Added activation campaign tracking and lifecycle events for signups and subscription cancellations.
  * Added optional PostHog configuration for activation experiment measurement.

* **Bug Fixes**
  * Signup and lifecycle notification failures are now handled without interrupting the user flow.
  * Subscription cancellation events are processed independently for each owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->