### PR TITLE
feat(marketing): mobile hero remind-me-on-desktop CTA experiment

### DIFF
--- a/apps/marketing/docs/mobile-hero-reminder-cta-experiment.md
+++ b/apps/marketing/docs/mobile-hero-reminder-cta-experiment.md
@@ -1,0 +1,65 @@
+# Mobile hero reminder CTA experiment — PostHog setup
+
+Code for this experiment ships behind the `mobile-hero-reminder-cta` flag
+(SUPER-1625). The flag and experiment do **not** exist yet in PostHog — this
+doc is the exact setup to create them. Project: **Production** (id `264803`,
+us.posthog.com).
+
+## What the code does
+
+On mobile viewports (`Platform.Mobile` via user-agent detection), the hero's
+primary CTA depends on the flag variant:
+
+- `control` — existing Download dropdown (unchanged).
+- `test` — "Remind me on desktop" button that opens an email-capture modal
+  ("Send me a reminder"). Submitting fires a signup event carrying the email.
+
+Desktop/tablet visitors always see the existing CTA regardless of variant, so
+the flag can roll out to 100% of users — mobile gating happens in code.
+
+The variant is bootstrapped synchronously at `posthog.init` (same pattern as
+`landing-hero-positioning`, PR #5884): `hero-flag-bootstrap.ts` computes the
+deterministic assignment locally so there is no control→test flash and the
+first pageview already carries `$feature/mobile-hero-reminder-cta`.
+
+## Experiment to create
+
+- **Name**: Mobile hero reminder CTA
+- **Feature flag key**: `mobile-hero-reminder-cta` (must match exactly —
+  `MOBILE_HERO_REMINDER_FLAG` in
+  `apps/marketing/src/lib/analytics/hero-flag-bootstrap.ts`)
+- **Variants**: `control` / `test`, 50/50 split, in that order. The bootstrap
+  mirrors variant order + split in `FLAG_VARIANTS`; if you change either,
+  update that constant in the same change (drift is safe but reintroduces the
+  swap-on-response flash).
+- **Participants**: 100% of users, no property filters (code already gates to
+  mobile). If you prefer to scope participation, filter on
+  `mobile_hero_cta_impression` exposure rather than device properties.
+
+## Metrics
+
+All three events carry a `variant` property (`control` | `test`) plus the
+automatic `$feature/mobile-hero-reminder-cta` property:
+
+| Event | Fires when |
+|---|---|
+| `mobile_hero_cta_impression` | Hero renders on a mobile viewport (once per pageload, both arms) |
+| `mobile_hero_cta_clicked` | Primary hero CTA tapped — reminder button (test) or Download trigger (control) |
+| `mobile_hero_reminder_signup` | Reminder modal email submitted (test arm only; `email` property holds the address) |
+
+- **Primary metric**: funnel `mobile_hero_cta_impression` →
+  `mobile_hero_reminder_signup`. Control converts ~0 by construction; the
+  experiment answers whether the reminder CTA captures meaningful signup
+  volume without hurting `download_clicked` / `waitlist_clicked` on mobile.
+- **Secondary metric**: downstream desktop activation for captured emails —
+  join `mobile_hero_reminder_signup.email` against later signed-in desktop
+  activity (activation campaign audience comes from this event, same
+  email-on-event pattern as `waitlist_signup`).
+
+## Launch order caveat
+
+Until the experiment is launched, `/flags` responses do not include the flag,
+so after the bootstrap value is overwritten mobile visitors settle on the
+control CTA (a test-arm first paint may briefly appear for ~50% of them).
+Launch the experiment at (or just before) the marketing deploy to avoid that
+window, and log it in Notion → Growth → Experiment Log.

--- a/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -11,6 +11,7 @@ interface DownloadButtonProps {
 	size?: "sm" | "md";
 	className?: string;
 	onJoinWaitlist?: () => void;
+	onCtaClick?: () => void;
 }
 
 const INTERSTITIAL_PATH = "/download";
@@ -19,6 +20,7 @@ export function DownloadButton({
 	size = "md",
 	className = "",
 	onJoinWaitlist,
+	onCtaClick,
 }: DownloadButtonProps) {
 	const router = useRouter();
 	const { platform } = usePlatform();
@@ -100,7 +102,7 @@ export function DownloadButton({
 		];
 
 		const trigger = (
-			<button type="button" className={buttonClasses}>
+			<button type="button" className={buttonClasses} onClick={onCtaClick}>
 				Download
 				<HiMiniArrowDownTray className="size-4" />
 			</button>

--- a/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/components/HeroSection/HeroSection.tsx
@@ -3,12 +3,17 @@
 import { COMPANY } from "@superset/shared/constants";
 import { useScroll } from "framer-motion";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FaGithub } from "react-icons/fa";
-import { HERO_POSITIONING_FLAG } from "@/lib/analytics/hero-flag-bootstrap";
-import { isMacPlatform, usePlatform } from "../../hooks/useOS";
+import { track } from "@/lib/analytics";
+import {
+	HERO_POSITIONING_FLAG,
+	MOBILE_HERO_REMINDER_FLAG,
+} from "@/lib/analytics/hero-flag-bootstrap";
+import { isMacPlatform, Platform, usePlatform } from "../../hooks/useOS";
 import { DownloadButton } from "../DownloadButton";
 import { WaitlistModal } from "../WaitlistModal";
+import { MobileReminderCta } from "./components/MobileReminderCta";
 import { ProductDemo } from "./components/ProductDemo";
 import { TypewriterText } from "./components/TypewriterText";
 
@@ -51,6 +56,23 @@ export function HeroSection() {
 	const demoRef = useRef<HTMLDivElement>(null);
 	const { platform } = usePlatform();
 	const heroVariant = useFeatureFlagVariantKey(HERO_POSITIONING_FLAG);
+	const reminderVariant = useFeatureFlagVariantKey(MOBILE_HERO_REMINDER_FLAG);
+	const isMobile = platform === Platform.Mobile;
+	const showReminderCta = isMobile && reminderVariant === "test";
+	const reminderImpressionTracked = useRef(false);
+
+	useEffect(() => {
+		if (
+			!isMobile ||
+			typeof reminderVariant !== "string" ||
+			reminderImpressionTracked.current
+		) {
+			return;
+		}
+		reminderImpressionTracked.current = true;
+		track("mobile_hero_cta_impression", { variant: reminderVariant });
+	}, [isMobile, reminderVariant]);
+
 	const copy =
 		isMacPlatform(platform) &&
 		typeof heroVariant === "string" &&
@@ -96,7 +118,21 @@ export function HeroSection() {
 						</div>
 
 						<div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4 mt-6 sm:mt-8">
-							<DownloadButton onJoinWaitlist={() => setIsWaitlistOpen(true)} />
+							{showReminderCta ? (
+								<MobileReminderCta />
+							) : (
+								<DownloadButton
+									onJoinWaitlist={() => setIsWaitlistOpen(true)}
+									onCtaClick={
+										isMobile && typeof reminderVariant === "string"
+											? () =>
+													track("mobile_hero_cta_clicked", {
+														variant: reminderVariant,
+													})
+											: undefined
+									}
+								/>
+							)}
 							<button
 								type="button"
 								className="px-4 py-2.5 sm:px-6 sm:py-3 text-sm sm:text-base font-normal bg-background border border-border text-foreground hover:bg-muted transition-colors flex items-center gap-2"

--- a/apps/marketing/src/app/components/HeroSection/components/MobileReminderCta/MobileReminderCta.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/MobileReminderCta/MobileReminderCta.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import { HiMiniBellAlert } from "react-icons/hi2";
+import { track } from "@/lib/analytics";
+import { ReminderModal } from "./components/ReminderModal";
+
+export function MobileReminderCta() {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<>
+			<button
+				type="button"
+				className="bg-foreground text-background px-3 sm:px-6 py-2 sm:py-3 text-sm sm:text-base font-normal hover:opacity-90 transition-opacity flex items-center gap-2 whitespace-nowrap shrink-0"
+				onClick={() => {
+					track("mobile_hero_cta_clicked", { variant: "test" });
+					setIsOpen(true);
+				}}
+			>
+				Remind me on desktop
+				<HiMiniBellAlert className="size-4" />
+			</button>
+			<ReminderModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+		</>
+	);
+}

--- a/apps/marketing/src/app/components/HeroSection/components/MobileReminderCta/components/ReminderModal/ReminderModal.tsx
+++ b/apps/marketing/src/app/components/HeroSection/components/MobileReminderCta/components/ReminderModal/ReminderModal.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useEffect, useState } from "react";
+import { track } from "@/lib/analytics";
+
+interface ReminderModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export function ReminderModal({ isOpen, onClose }: ReminderModalProps) {
+	const [email, setEmail] = useState("");
+	const [submitted, setSubmitted] = useState(false);
+
+	useEffect(() => {
+		if (isOpen) {
+			document.body.style.overflow = "hidden";
+		} else {
+			document.body.style.overflow = "unset";
+		}
+
+		return () => {
+			document.body.style.overflow = "unset";
+		};
+	}, [isOpen]);
+
+	if (!isOpen) return null;
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		if (!email) return;
+
+		const wasOptedOut = posthog.has_opted_out_capturing();
+		if (wasOptedOut) {
+			posthog.opt_in_capturing();
+		}
+
+		track("mobile_hero_reminder_signup", { email, variant: "test" });
+
+		if (wasOptedOut) {
+			posthog.opt_out_capturing();
+		}
+
+		setSubmitted(true);
+	}
+
+	return (
+		<>
+			<button
+				type="button"
+				className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 cursor-default"
+				onClick={onClose}
+				aria-label="Close modal backdrop"
+			/>
+
+			<div className="fixed inset-0 flex items-center justify-center z-50 pointer-events-none">
+				<div className="pointer-events-auto w-full max-w-md mx-4 bg-background rounded-2xl shadow-2xl border border-border overflow-hidden p-8 relative">
+					<button
+						type="button"
+						onClick={onClose}
+						className="absolute top-4 right-4 z-10 text-muted-foreground hover:text-foreground transition-colors"
+						aria-label="Close modal"
+					>
+						<svg
+							width="24"
+							height="24"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							aria-hidden="true"
+						>
+							<line x1="18" y1="6" x2="6" y2="18" />
+							<line x1="6" y1="6" x2="18" y2="18" />
+						</svg>
+					</button>
+
+					{submitted ? (
+						<div>
+							<h2 className="mb-2 text-xl font-medium text-foreground">
+								Reminder set!
+							</h2>
+							<p className="text-sm text-muted-foreground">
+								We'll email you a link so you can check out Superset from your
+								desktop.
+							</p>
+						</div>
+					) : (
+						<>
+							<h2 className="mb-2 text-xl font-medium text-foreground">
+								Remind me on desktop
+							</h2>
+							<p className="mb-6 text-sm text-muted-foreground">
+								Superset is a desktop app. Leave your email and we'll send you a
+								link to check it out when you're back at your computer.
+							</p>
+							<form onSubmit={handleSubmit} className="flex flex-col gap-3">
+								<input
+									type="email"
+									required
+									placeholder="you@example.com"
+									value={email}
+									onChange={(e) => setEmail(e.target.value)}
+									className="w-full rounded-lg border border-border bg-background px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+								/>
+								<button
+									type="submit"
+									className="w-full rounded-lg bg-foreground py-2.5 text-sm font-medium text-background transition-opacity hover:opacity-90"
+								>
+									Send me a reminder
+								</button>
+							</form>
+						</>
+					)}
+				</div>
+			</div>
+		</>
+	);
+}

--- a/apps/marketing/src/app/components/HeroSection/components/MobileReminderCta/components/ReminderModal/index.ts
+++ b/apps/marketing/src/app/components/HeroSection/components/MobileReminderCta/components/ReminderModal/index.ts
@@ -1,0 +1,1 @@
+export { ReminderModal } from "./ReminderModal";

--- a/apps/marketing/src/app/components/HeroSection/components/MobileReminderCta/index.ts
+++ b/apps/marketing/src/app/components/HeroSection/components/MobileReminderCta/index.ts
@@ -1,0 +1,1 @@
+export { MobileReminderCta } from "./MobileReminderCta";

--- a/apps/marketing/src/lib/analytics/hero-flag-bootstrap.ts
+++ b/apps/marketing/src/lib/analytics/hero-flag-bootstrap.ts
@@ -2,14 +2,26 @@ import { POSTHOG_COOKIE_NAME } from "@superset/shared/constants";
 import type { PostHogConfig } from "posthog-js";
 
 export const HERO_POSITIONING_FLAG = "landing-hero-positioning";
+export const MOBILE_HERO_REMINDER_FLAG = "mobile-hero-reminder-cta";
 
-// Must mirror the PostHog flag config for landing-hero-positioning (variant
-// order and rollout split) and PostHog's cross-SDK assignment hash. Drift is
-// safe but reintroduces the swap-on-/flags-response this bootstrap removes.
-const VARIANTS = [
-	{ key: "control", rolloutPercentage: 50 },
-	{ key: "capability-mac", rolloutPercentage: 50 },
-];
+interface FlagVariant {
+	key: string;
+	rolloutPercentage: number;
+}
+
+// Must mirror the PostHog flag config for each flag (variant order and rollout
+// split) and PostHog's cross-SDK assignment hash. Drift is safe but
+// reintroduces the swap-on-/flags-response this bootstrap removes.
+const FLAG_VARIANTS: Record<string, FlagVariant[]> = {
+	[HERO_POSITIONING_FLAG]: [
+		{ key: "control", rolloutPercentage: 50 },
+		{ key: "capability-mac", rolloutPercentage: 50 },
+	],
+	[MOBILE_HERO_REMINDER_FLAG]: [
+		{ key: "control", rolloutPercentage: 50 },
+		{ key: "test", rolloutPercentage: 50 },
+	],
+};
 
 const LONG_SCALE = 2 ** 60 - 1;
 
@@ -84,18 +96,22 @@ function sha1Hex(input: string): string {
 		.join("");
 }
 
-function variantForDistinctId(distinctId: string): string {
+function variantForDistinctId(
+	flagKey: string,
+	variants: FlagVariant[],
+	distinctId: string,
+): string {
 	const hashValue =
 		Number.parseInt(
-			sha1Hex(`${HERO_POSITIONING_FLAG}.${distinctId}variant`).slice(0, 15),
+			sha1Hex(`${flagKey}.${distinctId}variant`).slice(0, 15),
 			16,
 		) / LONG_SCALE;
 	let cumulative = 0;
-	for (const variant of VARIANTS) {
+	for (const variant of variants) {
 		cumulative += variant.rolloutPercentage / 100;
 		if (hashValue < cumulative) return variant.key;
 	}
-	return VARIANTS[VARIANTS.length - 1]?.key ?? "control";
+	return variants[variants.length - 1]?.key ?? "control";
 }
 
 function distinctIdFromCookie(): string | undefined {
@@ -122,8 +138,11 @@ export function getHeroFlagBootstrap(): NonNullable<
 	return {
 		distinctID: distinctId,
 		isIdentifiedID: false,
-		featureFlags: {
-			[HERO_POSITIONING_FLAG]: variantForDistinctId(distinctId),
-		},
+		featureFlags: Object.fromEntries(
+			Object.entries(FLAG_VARIANTS).map(([flagKey, variants]) => [
+				flagKey,
+				variantForDistinctId(flagKey, variants, distinctId),
+			]),
+		),
 	};
 }


### PR DESCRIPTION
## Why

On mobile viewports the hero's Download CTA converts poorly — Superset is a desktop product. SUPER-1625: test a "remind me on desktop" CTA that captures the visitor's email for the desktop activation campaign instead.

## What

- New `mobile-hero-reminder-cta` flag (variants `control`/`test`) added to the instant sticky-assignment bootstrap from #5884: `hero-flag-bootstrap.ts` now holds a per-flag variant table and computes both hero flags synchronously at `posthog.init`, so there is no control→test flash and the first pageview carries `$feature/mobile-hero-reminder-cta`.
- `HeroSection`: on mobile in the `test` arm, the Download dropdown is replaced by a "Remind me on desktop" button (`MobileReminderCta`) that opens an email-capture modal mirroring the waitlist form (including the opt-out capture dance).
- Instrumentation, all with a `variant` prop: `mobile_hero_cta_impression` (hero render on mobile, both arms), `mobile_hero_cta_clicked` (reminder button in test; Download trigger in control via a new optional `onCtaClick` on `DownloadButton`), `mobile_hero_reminder_signup` (email submitted, carries `email`).
- `apps/marketing/docs/mobile-hero-reminder-cta-experiment.md`: exact PostHog flag + experiment setup for Satya to create — **no PostHog flags or experiments were created or modified**, and until the experiment is launched mobile visitors settle on control.

## Verification

- `bun run lint` exits 0; `turbo typecheck --filter=@superset/marketing` clean.
- Assignment hash is the same parameterized routine #5884 verified against production `/flags` responses.

https://claude.ai/code/session_01WTU8t43dHMoHYYsbvw6DyP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mobile hero CTA experiment (SUPER-1625) that tests replacing the Download dropdown with a “Remind me on desktop” email capture on mobile. Synchronous flag bootstrap avoids control→test flicker and tags the first pageview.

- **New Features**
  - New `mobile-hero-reminder-cta` flag with instant sticky assignment; `hero-flag-bootstrap.ts` now bootstraps both hero flags at `posthog.init`.
  - Mobile `test` variant shows `MobileReminderCta` with a modal to collect email; `control` keeps the Download dropdown.
  - Events added with `variant`: `mobile_hero_cta_impression`, `mobile_hero_cta_clicked`, `mobile_hero_reminder_signup` (includes `email`); control click tracked via new `onCtaClick` on `DownloadButton`.
  - Docs with exact PostHog setup: `apps/marketing/docs/mobile-hero-reminder-cta-experiment.md`.

- **Migration**
  - Create PostHog flag `mobile-hero-reminder-cta` with `control`/`test` at 50/50 and roll out to 100% (mobile gating happens in code); match variant order to the bootstrap.
  - Launch the experiment at or before deploy to avoid a brief test-first-paint before `/flags` returns control.
  - Use the provided events for the primary funnel (`mobile_hero_cta_impression` → `mobile_hero_reminder_signup`) and downstream activation analysis.

<sup>Written for commit a5a22c598955475150f2b3a025645894d1319126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile “Remind me on desktop” hero CTA with an email signup modal and confirmation state.
  * Added mobile hero experiment variants with deterministic rollout behavior.
  * Added analytics tracking for CTA impressions, clicks, and reminder signups.

* **Documentation**
  * Added setup and launch guidance for configuring the mobile hero experiment and feature flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->