### PR TITLE
fix(automations): store portable agent slug so runs survive host config reseeds

### DIFF
--- a/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
@@ -20,6 +20,8 @@ export interface AgentSelectAgent {
 	id: string;
 	label: string;
 	iconId?: string;
+	/** Host preset slug ("claude", "custom", …) — stable across hosts and DB re-seeds, unlike `id`. */
+	presetId?: string;
 }
 
 interface AgentSelectProps<T extends string> {

--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
@@ -28,6 +28,7 @@ export function useV2AgentChoices(
 				// Prefer the user's icon override (built-in key or uploaded data
 				// URI); fall back to the preset-implied icon.
 				iconId: config.iconId ?? config.presetId,
+				presetId: config.presetId,
 			}),
 		);
 		return [...terminalAgents, SUPERSET_AGENT];

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailSidebar/AutomationDetailSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailSidebar/AutomationDetailSidebar.tsx
@@ -6,6 +6,8 @@ import { formatDateTimeInTimezone } from "@superset/shared/rrule";
 import { cn } from "@superset/ui/utils";
 import { useMutation } from "@tanstack/react-query";
 import { useRecentProjects } from "renderer/hooks/host-projects/useRecentProjects";
+import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { DevicePicker } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker";
 import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions";
@@ -15,6 +17,7 @@ import { RelayOfflineNotice } from "../../../components/RelayOfflineNotice";
 import { SchedulePicker } from "../../../components/SchedulePicker";
 import { TimezonePicker } from "../../../components/TimezonePicker";
 import { WorkspacePicker } from "../../../components/WorkspacePicker";
+import { matchAgentChoice } from "../../../utils/agentIdentity";
 import { PreviousRunsList } from "../PreviousRunsList";
 import { Row } from "./components/Row";
 import { Section } from "./components/Section";
@@ -36,6 +39,14 @@ export function AutomationDetailSidebar({
 	);
 
 	const hostId = automation.targetHostId ?? localHostId ?? null;
+
+	const hostUrl = useHostUrl(hostId);
+	const { agents: hostAgents } = useV2AgentChoices(hostUrl);
+	// Only warn once the host's terminal configs have loaded — the list always
+	// contains the built-in Superset chat entry, so length 1 means "not loaded
+	// yet / host unreachable", not "agent missing".
+	const agentMissing =
+		hostAgents.length > 1 && !matchAgentChoice(hostAgents, automation.agent);
 
 	const updateMutation = useMutation({
 		mutationFn: (
@@ -163,10 +174,12 @@ export function AutomationDetailSidebar({
 								hostId={hostId}
 								value={automation.agent}
 								onChange={(id) => {
-									// The picker is scoped to `hostId`; if the automation
-									// was previously auto-routed (targetHostId null), pin it
-									// to the host this id came from so a UUID-shaped agent
-									// can't be dispatched to a host that's never seen it.
+									// The picker is scoped to `hostId` and emits a preset slug
+									// when unambiguous, falling back to the instance UUID. If
+									// the automation was previously auto-routed (targetHostId
+									// null), pin it to the host this value came from so a
+									// UUID-shaped agent can't be dispatched to a host that's
+									// never seen it.
 									const patch: { agent: string; targetHostId?: string } = {
 										agent: id,
 									};
@@ -178,6 +191,12 @@ export function AutomationDetailSidebar({
 							/>
 						}
 					/>
+					{agentMissing && (
+						<p className="select-text cursor-text text-xs text-amber-600 dark:text-amber-500">
+							This agent no longer exists on the selected device (its agents may
+							have been reset). Runs will fail until you pick a new one.
+						</p>
+					)}
 					<Row
 						label="Timezone"
 						value={

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
@@ -94,7 +94,12 @@ export function PreviousRunsList({ runs }: PreviousRunsListProps) {
 					<li key={run.id}>
 						{run.error ? (
 							<Tooltip>
-								<TooltipTrigger asChild>{row}</TooltipTrigger>
+								{/* Wrap in a span: runs with no workspace render `row` as a
+								    disabled button, which emits no pointer events and would
+								    otherwise hide the error tooltip on hover. */}
+								<TooltipTrigger asChild>
+									<span className="block">{row}</span>
+								</TooltipTrigger>
 								<TooltipContent
 									side="left"
 									className="max-w-xs whitespace-pre-wrap"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
@@ -8,6 +8,17 @@ import {
 	HOST_OFFLINE_HELP,
 	isHostOfflineError,
 } from "../../../utils/hostOfflineError";
+import {
+	isStaleAgentError,
+	STALE_AGENT_HELP,
+} from "../../../utils/staleAgentError";
+
+function describeRunError(error: string): string {
+	if (isHostOfflineError(error)) return `${error}. ${HOST_OFFLINE_HELP}`;
+	// Lead with the plain-language fix; keep the raw host error for reports.
+	if (isStaleAgentError(error)) return `${STALE_AGENT_HELP}\n\n(${error})`;
+	return error;
+}
 
 const STATUS_DOT: Record<SelectAutomationRun["status"], string> = {
 	dispatched: "bg-emerald-500",
@@ -88,9 +99,7 @@ export function PreviousRunsList({ runs }: PreviousRunsListProps) {
 									side="left"
 									className="max-w-xs whitespace-pre-wrap"
 								>
-									{isHostOfflineError(run.error)
-										? `${run.error}. ${HOST_OFFLINE_HELP}`
-										: run.error}
+									{describeRunError(run.error)}
 								</TooltipContent>
 							</Tooltip>
 						) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
@@ -13,6 +13,7 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { HostOfflineRunDialog } from "../components/HostOfflineRunDialog";
 import { isHostOfflineError } from "../utils/hostOfflineError";
+import { isStaleAgentError, STALE_AGENT_HELP } from "../utils/staleAgentError";
 import { AutomationBody } from "./components/AutomationBody";
 import { AutomationDetailHeader } from "./components/AutomationDetailHeader";
 import { AutomationDetailSidebar } from "./components/AutomationDetailSidebar";
@@ -78,6 +79,10 @@ function AutomationDetailPage() {
 			const message = error instanceof Error ? error.message : null;
 			if (isHostOfflineError(message)) {
 				setHostOfflineOpen(true);
+				return;
+			}
+			if (isStaleAgentError(message)) {
+				toast.error(STALE_AGENT_HELP);
 				return;
 			}
 			toast.error(message ?? "Failed to trigger run");

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AgentCell/AgentCell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AgentCell/AgentCell.tsx
@@ -3,6 +3,7 @@ import { LuCpu } from "react-icons/lu";
 import { usePresetIcon } from "renderer/assets/app-icons/preset-icons";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
+import { matchAgentChoice } from "../../utils/agentIdentity";
 
 export function AgentCell({
 	agentId,
@@ -13,7 +14,7 @@ export function AgentCell({
 }) {
 	const hostUrl = useHostUrl(hostId);
 	const { agents } = useV2AgentChoices(hostUrl);
-	const hostMatch = agents.find((option) => option.id === agentId);
+	const hostMatch = matchAgentChoice(agents, agentId);
 	const presetMatch = hostMatch ? null : getPresetById(agentId);
 	const label = hostMatch?.label ?? presetMatch?.label ?? agentId;
 	const iconKey = hostMatch?.iconId ?? presetMatch?.presetId ?? agentId;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AgentPicker/AgentPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AgentPicker/AgentPicker.tsx
@@ -14,6 +14,10 @@ import { useIsDarkTheme } from "renderer/assets/app-icons/preset-icons";
 import { PickerTrigger } from "renderer/components/PickerTrigger";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
+import {
+	matchAgentChoice,
+	portableAgentValue,
+} from "../../utils/agentIdentity";
 
 interface AgentPickerProps {
 	hostId: string | null | undefined;
@@ -32,7 +36,7 @@ export function AgentPicker({
 	const hostUrl = useHostUrl(hostId);
 	const { agents } = useV2AgentChoices(hostUrl);
 	const isDark = useIsDarkTheme();
-	const hostMatch = agents.find((agent) => agent.id === value);
+	const hostMatch = matchAgentChoice(agents, value);
 	const presetMatch = hostMatch ? null : getPresetById(value);
 	const selectedLabel =
 		hostMatch?.label ?? presetMatch?.label ?? (value ? value : null);
@@ -66,7 +70,7 @@ export function AgentPicker({
 					return (
 						<DropdownMenuItem
 							key={agent.id}
-							onSelect={() => onChange(agent.id)}
+							onSelect={() => onChange(portableAgentValue(agents, agent))}
 						>
 							{icon ? (
 								<img
@@ -78,7 +82,7 @@ export function AgentPicker({
 								<LuCpu className="size-4 shrink-0" />
 							)}
 							<span className="flex-1 truncate">{agent.label}</span>
-							{value === agent.id && <HiCheck className="size-4" />}
+							{hostMatch?.id === agent.id && <HiCheck className="size-4" />}
 						</DropdownMenuItem>
 					);
 				})}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
@@ -22,6 +22,10 @@ import { useWorkspaceHostOptions } from "renderer/routes/_authenticated/componen
 import { hideAll as hideAllTippy } from "tippy.js";
 import { useProjectFileSearch } from "../../hooks/useProjectFileSearch";
 import type { AutomationTemplate } from "../../templates";
+import {
+	matchAgentChoice,
+	portableAgentValue,
+} from "../../utils/agentIdentity";
 import { AgentPicker } from "../AgentPicker";
 import { ProjectPicker } from "../ProjectPicker";
 import { RelayOfflineNotice } from "../RelayOfflineNotice";
@@ -77,11 +81,12 @@ export function CreateAutomationDialog({
 	const selectedProject = recentProjects.find(
 		(project) => project.id === selectedProjectId,
 	);
-	const selectedAgent = hostAgents.find((option) => option.id === agent);
+	const selectedAgent = matchAgentChoice(hostAgents, agent);
 
 	useEffect(() => {
-		if (agent && hostAgents.some((option) => option.id === agent)) return;
-		const fallback = hostAgents[0]?.id ?? null;
+		if (agent && matchAgentChoice(hostAgents, agent)) return;
+		const first = hostAgents[0];
+		const fallback = first ? portableAgentValue(hostAgents, first) : null;
 		if (fallback !== agent) setAgent(fallback);
 	}, [agent, hostAgents]);
 
@@ -125,9 +130,10 @@ export function CreateAutomationDialog({
 		const match = hostAgents.find(
 			(option) =>
 				option.id === initialTemplate.agentType ||
+				option.presetId === initialTemplate.agentType ||
 				option.iconId === initialTemplate.agentType,
 		);
-		if (match) setAgent(match.id);
+		if (match) setAgent(portableAgentValue(hostAgents, match));
 		appliedAgentForTemplateRef.current = initialTemplate;
 	}, [open, initialTemplate, hostAgents]);
 
@@ -153,7 +159,9 @@ export function CreateAutomationDialog({
 			return apiTrpcClient.automation.create.mutate({
 				name,
 				prompt,
-				agent: selectedAgent.id,
+				// Preset slug when unambiguous — instance UUIDs die when the host's
+				// agent-config table is re-seeded, orphaning the automation.
+				agent: portableAgentValue(hostAgents, selectedAgent),
 				targetHostId: targetHostId ?? null,
 				v2ProjectId: selectedProjectId,
 				v2WorkspaceId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/CreateAutomationDialog/CreateAutomationDialog.tsx
@@ -127,12 +127,12 @@ export function CreateAutomationDialog({
 		if (!initialTemplate?.agentType) return;
 		if (appliedAgentForTemplateRef.current === initialTemplate) return;
 		if (hostAgents.length === 0) return;
-		const match = hostAgents.find(
-			(option) =>
-				option.id === initialTemplate.agentType ||
-				option.presetId === initialTemplate.agentType ||
-				option.iconId === initialTemplate.agentType,
-		);
+		// Resolve id/preset across the whole list first; an earlier agent's
+		// `iconId` override must not win over a later agent whose real presetId
+		// matches, so iconId is only a legacy fallback.
+		const match =
+			matchAgentChoice(hostAgents, initialTemplate.agentType) ??
+			hostAgents.find((option) => option.iconId === initialTemplate.agentType);
 		if (match) setAgent(portableAgentValue(hostAgents, match));
 		appliedAgentForTemplateRef.current = initialTemplate;
 	}, [open, initialTemplate, hostAgents]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -52,6 +52,7 @@ import { CreateAutomationDialog } from "./components/CreateAutomationDialog";
 import { HostOfflineRunDialog } from "./components/HostOfflineRunDialog";
 import type { AutomationTemplate } from "./templates";
 import { isHostOfflineError } from "./utils/hostOfflineError";
+import { isStaleAgentError, STALE_AGENT_HELP } from "./utils/staleAgentError";
 
 export const Route = createFileRoute("/_authenticated/_dashboard/automations/")(
 	{
@@ -93,6 +94,10 @@ function AutomationsPage() {
 			const message = error instanceof Error ? error.message : null;
 			if (isHostOfflineError(message)) {
 				setHostOfflineRun({ hostId: targetHostId });
+				return;
+			}
+			if (isStaleAgentError(message)) {
+				toast.error(STALE_AGENT_HELP);
 				return;
 			}
 			toast.error(message ?? "Failed to trigger run");

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/agentIdentity/agentIdentity.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/agentIdentity/agentIdentity.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentSelectAgent } from "renderer/components/AgentSelect";
+import { matchAgentChoice, portableAgentValue } from "./agentIdentity";
+
+const claude: AgentSelectAgent = {
+	id: "11111111-1111-4111-8111-111111111111",
+	label: "Claude Code",
+	presetId: "claude",
+};
+const claudeYolo: AgentSelectAgent = {
+	id: "22222222-2222-4222-8222-222222222222",
+	label: "Claude YOLO",
+	presetId: "claude",
+};
+const codex: AgentSelectAgent = {
+	id: "33333333-3333-4333-8333-333333333333",
+	label: "Codex",
+	presetId: "codex",
+};
+const custom: AgentSelectAgent = {
+	id: "44444444-4444-4444-8444-444444444444",
+	label: "My Agent",
+	presetId: "custom",
+};
+const superset: AgentSelectAgent = {
+	id: "superset",
+	label: "Superset",
+	iconId: "superset",
+};
+
+describe("matchAgentChoice", () => {
+	it("matches by instance id first", () => {
+		expect(matchAgentChoice([claude, codex], codex.id)).toBe(codex);
+	});
+
+	it("falls back to preset slug", () => {
+		expect(matchAgentChoice([claude, codex], "codex")).toBe(codex);
+	});
+
+	it("prefers the first (display-order) config among duplicate presets, like the host does", () => {
+		expect(matchAgentChoice([claude, claudeYolo], "claude")).toBe(claude);
+	});
+
+	it("matches the superset chat agent by its literal id", () => {
+		expect(matchAgentChoice([claude, superset], "superset")).toBe(superset);
+	});
+
+	it("returns undefined for a stale UUID from a re-seeded host", () => {
+		expect(
+			matchAgentChoice([claude, codex], "4525b6cf-8b54-43cb-89ab-d1533d708635"),
+		).toBeUndefined();
+	});
+
+	it("returns undefined for empty values", () => {
+		expect(matchAgentChoice([claude], "")).toBeUndefined();
+		expect(matchAgentChoice([claude], null)).toBeUndefined();
+	});
+});
+
+describe("portableAgentValue", () => {
+	it("stores the preset slug when it names exactly one config", () => {
+		expect(portableAgentValue([claude, codex, custom], claude)).toBe("claude");
+	});
+
+	it("keeps the instance id when two configs share the preset", () => {
+		expect(portableAgentValue([claude, claudeYolo, codex], claudeYolo)).toBe(
+			claudeYolo.id,
+		);
+		expect(portableAgentValue([claude, claudeYolo, codex], claude)).toBe(
+			claude.id,
+		);
+	});
+
+	it("keeps the instance id for custom agents", () => {
+		expect(portableAgentValue([claude, custom], custom)).toBe(custom.id);
+	});
+
+	it("keeps the id for choices without a preset (superset chat)", () => {
+		expect(portableAgentValue([claude, superset], superset)).toBe("superset");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/agentIdentity/agentIdentity.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/agentIdentity/agentIdentity.ts
@@ -1,0 +1,39 @@
+import type { AgentSelectAgent } from "renderer/components/AgentSelect";
+
+/**
+ * Resolve a stored `automations.agent` value against a host's agent choices:
+ * exact instance id first, then preset slug. Mirrors the host-side
+ * `resolveHostAgentConfig` order (choices arrive in display order, so the
+ * first preset match is the one the host would launch).
+ */
+export function matchAgentChoice(
+	agents: AgentSelectAgent[],
+	value: string | null | undefined,
+): AgentSelectAgent | undefined {
+	if (!value) return undefined;
+	return (
+		agents.find((agent) => agent.id === value) ??
+		agents.find((agent) => agent.presetId === value)
+	);
+}
+
+/**
+ * The identifier persisted on an automation for a chosen agent. Host config
+ * instance ids are random UUIDs regenerated on every seed/reset, so any
+ * automation pinned to one breaks when the host DB is rebuilt. Preset slugs
+ * survive that (and transfer across hosts), so prefer the slug whenever it
+ * names exactly one config on this host. Keep the instance id only when
+ * needed to disambiguate: duplicate configs of one preset, or "custom"
+ * configs where the slug doesn't identify an agent at all.
+ */
+export function portableAgentValue(
+	agents: AgentSelectAgent[],
+	choice: AgentSelectAgent,
+): string {
+	const presetId = choice.presetId;
+	if (!presetId || presetId === "custom") return choice.id;
+	const sharingPreset = agents.filter(
+		(agent) => agent.presetId === presetId,
+	).length;
+	return sharingPreset === 1 ? presetId : choice.id;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/agentIdentity/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/agentIdentity/index.ts
@@ -1,0 +1,1 @@
+export { matchAgentChoice, portableAgentValue } from "./agentIdentity";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/staleAgentError/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/staleAgentError/index.ts
@@ -1,0 +1,1 @@
+export { isStaleAgentError, STALE_AGENT_HELP } from "./staleAgentError";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/staleAgentError/staleAgentError.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/utils/staleAgentError/staleAgentError.ts
@@ -1,0 +1,10 @@
+// Stable marker in host-service's runTerminalAgent NOT_FOUND — present in
+// both the pre-1.17 terse message and the current user-worded one.
+const STALE_AGENT_ERROR_MARKER = "No host agent config matching";
+
+export const STALE_AGENT_HELP =
+	"The agent this automation was set to run no longer exists on its host — the host's agents may have been reset or removed. Re-select an agent in the automation's settings.";
+
+export function isStaleAgentError(error: string | null | undefined): boolean {
+	return !!error && error.includes(STALE_AGENT_ERROR_MARKER);
+}

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -233,9 +233,12 @@ async function runTerminalAgent(
 ): Promise<AgentRunResult> {
 	const config = resolveHostAgentConfig(ctx.db, input.agent);
 	if (!config) {
+		// Worded for end users (automation run errors show this verbatim), but
+		// keep "No host agent config matching" — the desktop matches on it to
+		// attach re-select guidance.
 		throw new TRPCError({
 			code: "NOT_FOUND",
-			message: `No host agent config matching '${input.agent}' (tried instance id then preset id).`,
+			message: `No host agent config matching '${input.agent}' — the agent may have been removed or this host's agents were reset. Re-select an agent (or use a preset id like "claude").`,
 		});
 	}
 


### PR DESCRIPTION
## Problem

Automations were failing at dispatch with:

> dispatch: agents.run: No host agent config matching '4525b6cf-…' (tried instance id then preset id)

The workspace gets created, but the agent never launches. Reported against the daily email automation.

## Root cause

`automations.agent` stored the host's `host_agent_configs` **instance UUID**. Those ids are `randomUUID()` minted at seed time, so any host.db rebuild or Settings → Agents "Reset to defaults" regenerates them — orphaning every automation pinned to an old id. The desktop automations Agent picker has emitted UUIDs since #4481 (2026-05); the failure surfaces once the host's configs are regenerated (the affected host's configs are stamped newer than the automation).

Dispatch creating the workspace but not the agent is the exact reported symptom: project ids are portable, agent UUIDs are not.

## Fix

Store the **preset slug** (`claude`, `codex`, …) when it unambiguously names one config on the target host; keep the instance UUID only where the slug can't identify the agent — duplicate configs of one preset, `custom` agents, and the `superset` chat entry. Slugs survive reseeds and transfer across hosts (the host already resolves preset ids). Stored values are read id-first-then-preset everywhere they're displayed.

- `agentIdentity` util (`portableAgentValue` + `matchAgentChoice`) with unit tests
- wired into the Agent picker, the automations list cell, and the create dialog
- `AgentSelectAgent` now carries `presetId`

## Clearer errors (follow-up ask)

Runs fail unattended, so the error needs to be legible where users actually see it:

- host `agents.run` message rewritten for end users (keeps the stable marker string)
- plain-language run-error tooltip in the run history
- Run-now toast on the list + detail pages
- **proactive inline warning on the Agent row** when the pinned agent no longer resolves on its host — catches it before the next scheduled run fails

## Verification

CDP-driven against the real dev desktop + local relay + host, same signed-in session, on the actual stale automation:

- **Before:** Run now → `workspaces.create 200` then `agents.run 404`; run row `dispatch_failed`; workspace created, no agent.
- **After:** re-picking Claude stores `"claude"` (not a UUID); Run now → `workspaces.create 200` then **`agents.run 200`**; run `dispatched`/`terminal`; **Claude agent launches and runs the prompt** in the new workspace.

`bun run lint`, `typecheck`, and the new unit tests are green (unit tests mutation-checked).

## Note for existing automations

Automations already holding a dead UUID need a one-time agent re-pick (no code can recover a slug from a UUID the host never had). With this fix the re-pick stores the slug and they're immune to future reseeds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store a portable agent preset slug (e.g., `claude`) instead of instance UUIDs so automations keep running after host agent configs are reset. Adds clear guidance and friendlier errors when a pinned agent no longer exists.

- **Bug Fixes**
  - Persist the preset slug when it uniquely identifies a config; fall back to the instance UUID for duplicate presets, `custom`, and `superset`.
  - Resolve stored values by id, then preset, across the picker, list cell, and create dialog; template defaults now prefer id/preset over `iconId`; `AgentSelectAgent` now includes `presetId`.
  - Clearer failures: updated host error (keeps the "No host agent config matching" marker), run list tooltip and toasts, plus an inline warning when the pinned agent is missing on the selected device; tooltip now shows even when the run row is disabled.
  - Added unit tests for `matchAgentChoice` and `portableAgentValue`.

- **Migration**
  - Existing automations that store a stale UUID need a one-time agent re-pick. The new value will be a slug and will survive future reseeds.

<sup>Written for commit 85b2b968623ec6db5ada7981d8372f5fe1054352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation agent selection is now more resilient across host resets using stable preset identity when available.
  * Agent pickers and automation setup now preserve a portable agent value to keep selections valid.
  * Added an amber warning when an automation’s configured agent no longer exists on the selected host.
* **Bug Fixes**
  * Improved “Run now” and previous-run error tooltips with dedicated stale-agent guidance.
  * Enhanced agent matching for templates, existing automations, and host-specific identity checks.
  * Clearer stale-agent error messaging when host agent lookup fails.
* **Tests**
  * Added unit tests for agent identity matching and portable value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->