### PR TITLE
feat(desktop): filter and sort projects in the dashboard sidebar

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -6,6 +6,7 @@ import {
 	DEFAULT_V2_USER_PREFERENCES,
 	type LinkAction,
 	type LinkTierMap,
+	type SidebarProjectSortMode,
 	V2_USER_PREFERENCES_ID,
 	type V2UserPreferencesRow,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
@@ -24,6 +25,7 @@ export interface V2UserPreferencesApi {
 	setDeleteLocalBranch: (next: boolean) => void;
 	setShowPresetsBar: (next: boolean | ((prev: boolean) => boolean)) => void;
 	toggleShowPresetsBar: () => void;
+	setSidebarProjectSortMode: (next: SidebarProjectSortMode) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -200,6 +202,25 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setShowPresetsBar((prev) => !prev);
 	}, [setShowPresetsBar]);
 
+	const setSidebarProjectSortMode = useCallback(
+		(next: SidebarProjectSortMode) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					sidebarProjectSortMode: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.sidebarProjectSortMode = next;
+			});
+		},
+		[collections],
+	);
+
 	return {
 		preferences,
 		setFileLinks,
@@ -212,5 +233,6 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setDeleteLocalBranch,
 		setShowPresetsBar,
 		toggleShowPresetsBar,
+		setSidebarProjectSortMode,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/PreviousRunsList/PreviousRunsList.tsx
@@ -23,8 +23,8 @@ function describeRunError(error: string): string {
 const STATUS_DOT: Record<SelectAutomationRun["status"], string> = {
 	dispatched: "bg-emerald-500",
 	dispatching: "bg-amber-500",
-	skipped_offline: "bg-red-500",
-	dispatch_failed: "bg-red-500",
+	skipped_offline: "bg-destructive",
+	dispatch_failed: "bg-destructive",
 };
 
 interface PreviousRunsListProps {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
@@ -48,8 +48,8 @@ const LAST_RUN_META: Record<
 > = {
 	dispatched: { dot: "bg-emerald-500", label: "ran" },
 	dispatching: { dot: "bg-amber-500", label: "running" },
-	skipped_offline: { dot: "bg-red-500", label: "failed", failed: true },
-	dispatch_failed: { dot: "bg-red-500", label: "failed", failed: true },
+	skipped_offline: { dot: "bg-destructive", label: "failed", failed: true },
+	dispatch_failed: { dot: "bg-destructive", label: "failed", failed: true },
 };
 
 export function AutomationRow({
@@ -196,7 +196,7 @@ export function AutomationRow({
 									<span
 										className={cn(
 											"flex items-center gap-1.5",
-											meta.failed && "text-red-600 dark:text-red-400",
+											meta.failed && "text-destructive",
 										)}
 									>
 										<span

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -58,6 +58,10 @@ interface SortableProjectWrapperProps {
 	isCollapsed: boolean;
 	isDraggingProject: boolean;
 	isDragDisabled: boolean;
+	// Inner (workspace/section) drag is gated separately: a non-manual sort
+	// only reorders projects, but an active filter prunes children, and a
+	// drop committed from a pruned list would corrupt hidden siblings' order.
+	isInnerDragDisabled: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: (projectId: string) => void;
@@ -68,6 +72,7 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 	isCollapsed,
 	isDraggingProject,
 	isDragDisabled,
+	isInnerDragDisabled,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onToggleCollapse,
@@ -94,6 +99,7 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 				project={project}
 				isSidebarCollapsed={isCollapsed}
 				isDraggingProject={isDraggingProject}
+				isDragDisabled={isInnerDragDisabled}
 				workspaceShortcutLabels={workspaceShortcutLabels}
 				onWorkspaceHover={onWorkspaceHover}
 				onToggleCollapse={onToggleCollapse}
@@ -265,6 +271,7 @@ export function DashboardSidebar({
 													isCollapsed={isCollapsed}
 													isDraggingProject={activeProject != null}
 													isDragDisabled={isDragDisabled}
+													isInnerDragDisabled={isFilterActive}
 													workspaceShortcutLabels={workspaceShortcutLabels}
 													onWorkspaceHover={refreshWorkspacePullRequest}
 													onToggleCollapse={toggleProjectCollapsed}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -27,6 +27,7 @@ import { createPortal } from "react-dom";
 import { HiOutlineCog6Tooth } from "react-icons/hi2";
 import { HiringBanner } from "renderer/components/HiringBanner";
 import { UpdatesPill } from "renderer/components/UpdatesPill";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
@@ -45,6 +46,8 @@ import { useDashboardSidebarShortcuts } from "./hooks/useDashboardSidebarShortcu
 import { DashboardSidebarHoverProvider } from "./providers/DashboardSidebarHoverProvider";
 import { DashboardSidebarPortsProvider } from "./providers/DashboardSidebarPortsProvider";
 import type { DashboardSidebarProject } from "./types";
+import { filterDashboardSidebarProjects } from "./utils/filterDashboardSidebarProjects";
+import { sortDashboardSidebarProjects } from "./utils/sortDashboardSidebarProjects";
 
 interface DashboardSidebarProps {
 	isCollapsed?: boolean;
@@ -54,6 +57,7 @@ interface SortableProjectWrapperProps {
 	project: DashboardSidebarProject;
 	isCollapsed: boolean;
 	isDraggingProject: boolean;
+	isDragDisabled: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: (projectId: string) => void;
@@ -63,6 +67,7 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 	project,
 	isCollapsed,
 	isDraggingProject,
+	isDragDisabled,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onToggleCollapse,
@@ -74,7 +79,7 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 		transform,
 		transition,
 		isDragging,
-	} = useSortable({ id: project.id });
+	} = useSortable({ id: project.id, disabled: isDragDisabled });
 
 	return (
 		<div
@@ -116,6 +121,14 @@ export function DashboardSidebar({
 	const workspacesListCollapsed = useSidebarWorkspacesCollapseStore(
 		(s) => s.isCollapsed,
 	);
+	const { preferences, setSidebarProjectSortMode } = useV2UserPreferences();
+	const sortMode = preferences.sidebarProjectSortMode;
+	const [projectFilterQuery, setProjectFilterQuery] = useState("");
+	// The icon-only sidebar hides the header (and its filter input); a filter
+	// left active there would invisibly hide projects.
+	useEffect(() => {
+		if (isCollapsed) setProjectFilterQuery("");
+	}, [isCollapsed]);
 
 	const sensors = useSensors(
 		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
@@ -145,7 +158,25 @@ export function DashboardSidebar({
 			.filter((g): g is DashboardSidebarProject => g != null);
 	}, [groups, projectOrder]);
 
-	const workspaceShortcutLabels = useDashboardSidebarShortcuts(orderedGroups);
+	const sortedGroups = useMemo(
+		() =>
+			sortMode === "manual"
+				? orderedGroups
+				: sortDashboardSidebarProjects(groups, sortMode),
+		[sortMode, orderedGroups, groups],
+	);
+
+	const displayedGroups = useMemo(
+		() => filterDashboardSidebarProjects(sortedGroups, projectFilterQuery),
+		[sortedGroups, projectFilterQuery],
+	);
+
+	const isFilterActive = projectFilterQuery.trim() !== "";
+	const isDragDisabled = sortMode !== "manual" || isFilterActive;
+
+	// Sorted but unfiltered, so shortcut labels stay stable while typing a
+	// filter query.
+	const workspaceShortcutLabels = useDashboardSidebarShortcuts(sortedGroups);
 
 	const activeV2Project = useMemo(() => {
 		if (!activeV2WorkspaceId) return null;
@@ -169,6 +200,10 @@ export function DashboardSidebar({
 
 	const handleDragEnd = useCallback(
 		({ active, over }: DragEndEvent) => {
+			if (isDragDisabled) {
+				setActiveProject(null);
+				return;
+			}
 			if (over && active.id !== over.id) {
 				const oldIndex = projectOrder.indexOf(String(active.id));
 				const newIndex = projectOrder.indexOf(String(over.id));
@@ -180,7 +215,7 @@ export function DashboardSidebar({
 			}
 			setActiveProject(null);
 		},
-		[projectOrder, reorderProjects],
+		[isDragDisabled, projectOrder, reorderProjects],
 	);
 
 	return (
@@ -191,7 +226,14 @@ export function DashboardSidebar({
 						<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
 							<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
-							{!isCollapsed && <DashboardSidebarWorkspacesHeader />}
+							{!isCollapsed && (
+								<DashboardSidebarWorkspacesHeader
+									sortMode={sortMode}
+									onSortModeChange={setSidebarProjectSortMode}
+									filterQuery={projectFilterQuery}
+									onFilterQueryChange={setProjectFilterQuery}
+								/>
+							)}
 
 							<OverflowFadeContainer
 								fadeEdges={["top", "bottom"]}
@@ -205,6 +247,7 @@ export function DashboardSidebar({
 											droppable: { strategy: MeasuringStrategy.Always },
 										}}
 										onDragStart={({ active }) => {
+											if (isDragDisabled) return;
 											const project = groups.find((p) => p.id === active.id);
 											setActiveProject(project ?? null);
 										}}
@@ -212,21 +255,28 @@ export function DashboardSidebar({
 										onDragCancel={() => setActiveProject(null)}
 									>
 										<SortableContext
-											items={projectOrder}
+											items={displayedGroups.map((project) => project.id)}
 											strategy={verticalListSortingStrategy}
 										>
-											{orderedGroups.map((project) => (
+											{displayedGroups.map((project) => (
 												<SortableProjectWrapper
 													key={project.id}
 													project={project}
 													isCollapsed={isCollapsed}
 													isDraggingProject={activeProject != null}
+													isDragDisabled={isDragDisabled}
 													workspaceShortcutLabels={workspaceShortcutLabels}
 													onWorkspaceHover={refreshWorkspacePullRequest}
 													onToggleCollapse={toggleProjectCollapsed}
 												/>
 											))}
 										</SortableContext>
+
+										{isFilterActive && displayedGroups.length === 0 && (
+											<div className="select-text cursor-text px-4 py-2 text-xs text-muted-foreground">
+												No projects match "{projectFilterQuery.trim()}"
+											</div>
+										)}
 
 										{createPortal(
 											<DragOverlay dropAnimation={null}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -16,6 +16,7 @@ interface DashboardSidebarProjectSectionProps {
 	project: DashboardSidebarProject;
 	isSidebarCollapsed?: boolean;
 	isDraggingProject?: boolean;
+	isDragDisabled?: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: (projectId: string) => void;
@@ -27,6 +28,7 @@ export function DashboardSidebarProjectSection({
 	project,
 	isSidebarCollapsed = false,
 	isDraggingProject = false,
+	isDragDisabled = false,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onToggleCollapse,
@@ -124,6 +126,7 @@ export function DashboardSidebarProjectSection({
 							projectId={project.id}
 							isCollapsed={project.isCollapsed}
 							projectChildren={project.children}
+							isDragDisabled={isDragDisabled}
 							workspaceShortcutLabels={workspaceShortcutLabels}
 							onWorkspaceHover={onWorkspaceHover}
 							onDeleteSection={deleteSection}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -16,6 +16,7 @@ interface DashboardSidebarExpandedProjectContentProps {
 	projectId: string;
 	isCollapsed: boolean;
 	projectChildren: DashboardSidebarProjectChild[];
+	isDragDisabled?: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onDeleteSection: (sectionId: string) => void;
@@ -27,6 +28,7 @@ export function DashboardSidebarExpandedProjectContent({
 	projectId,
 	isCollapsed,
 	projectChildren,
+	isDragDisabled = false,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onDeleteSection,
@@ -48,7 +50,7 @@ export function DashboardSidebarExpandedProjectContent({
 		workspacesById,
 		sectionsById,
 		handlers,
-	} = useSidebarDnd({ projectId, projectChildren });
+	} = useSidebarDnd({ projectId, projectChildren, disabled: isDragDisabled });
 
 	return (
 		<AnimatePresence initial={false}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
@@ -8,6 +8,7 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { HiChevronRight } from "react-icons/hi2";
 import {
 	VscFolderOpened,
@@ -16,16 +17,38 @@ import {
 	VscNewFolder,
 } from "react-icons/vsc";
 import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
+import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import {
 	useOpenEmptyProjectModal,
 	useOpenNewProjectModal,
 	useOpenTemplateGalleryModal,
 } from "renderer/stores/add-repository-modal";
 import { useSidebarWorkspacesCollapseStore } from "renderer/stores/sidebar-workspaces-collapse";
+import { DashboardSidebarProjectsFilterInput } from "./components/DashboardSidebarProjectsFilterInput";
+import { DashboardSidebarProjectsSortMenu } from "./components/DashboardSidebarProjectsSortMenu";
 
-export function DashboardSidebarWorkspacesHeader() {
+interface DashboardSidebarWorkspacesHeaderProps {
+	sortMode: SidebarProjectSortMode;
+	onSortModeChange: (mode: SidebarProjectSortMode) => void;
+	filterQuery: string;
+	onFilterQueryChange: (query: string) => void;
+}
+
+export function DashboardSidebarWorkspacesHeader({
+	sortMode,
+	onSortModeChange,
+	filterQuery,
+	onFilterQueryChange,
+}: DashboardSidebarWorkspacesHeaderProps) {
 	const isCollapsed = useSidebarWorkspacesCollapseStore((s) => s.isCollapsed);
 	const toggleCollapsed = useSidebarWorkspacesCollapseStore((s) => s.toggle);
+	const [isFilterExpanded, setIsFilterExpanded] = useState(false);
+
+	const handleFilterExpandedChange = (expanded: boolean) => {
+		setIsFilterExpanded(expanded);
+		// Filtering a hidden list is useless — reveal it when the search opens.
+		if (expanded && isCollapsed) toggleCollapsed();
+	};
 	const openEmptyProject = useOpenEmptyProjectModal();
 	const openNewProject = useOpenNewProjectModal();
 	const openTemplateGallery = useOpenTemplateGalleryModal();
@@ -66,14 +89,28 @@ export function DashboardSidebarWorkspacesHeader() {
 			}}
 			className="group flex min-h-8 w-full shrink-0 items-center gap-1.5 py-1.5 pl-4 pr-2 text-[10px] font-semibold uppercase tracking-[0.075em] text-muted-foreground transition-colors"
 		>
-			<span className="min-w-0 truncate text-left">Projects</span>
-			<HiChevronRight
-				className={cn(
-					"size-3 shrink-0 text-muted-foreground opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100 group-focus-visible:opacity-100",
-					!isCollapsed && "rotate-90",
-				)}
+			{!isFilterExpanded && (
+				<>
+					<span className="min-w-0 truncate text-left">Projects</span>
+					<HiChevronRight
+						className={cn(
+							"size-3 shrink-0 text-muted-foreground opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100 group-focus-visible:opacity-100",
+							!isCollapsed && "rotate-90",
+						)}
+					/>
+					<div className="min-w-0 flex-1" />
+				</>
+			)}
+			<DashboardSidebarProjectsFilterInput
+				query={filterQuery}
+				onQueryChange={onFilterQueryChange}
+				isExpanded={isFilterExpanded}
+				onExpandedChange={handleFilterExpandedChange}
 			/>
-			<div className="min-w-0 flex-1" />
+			<DashboardSidebarProjectsSortMenu
+				sortMode={sortMode}
+				onSortModeChange={onSortModeChange}
+			/>
 			<DropdownMenu>
 				<Tooltip delayDuration={700}>
 					<TooltipTrigger asChild>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/DashboardSidebarWorkspacesHeader.tsx
@@ -132,6 +132,11 @@ export function DashboardSidebarWorkspacesHeader({
 				<DropdownMenuContent
 					align="end"
 					onCloseAutoFocus={(event) => event.preventDefault()}
+					// The content portals to body but React events still bubble up the
+					// component tree — without these, selecting an item triggers the
+					// header row's collapse toggle.
+					onClick={(event) => event.stopPropagation()}
+					onKeyDown={(event) => event.stopPropagation()}
 				>
 					<DropdownMenuItem onSelect={handleImportFolder}>
 						<VscFolderOpened className="size-4" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/DashboardSidebarProjectsFilterInput.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/DashboardSidebarProjectsFilterInput.tsx
@@ -74,9 +74,13 @@ export function DashboardSidebarProjectsFilterInput({
 				<button
 					type="button"
 					aria-label="Clear filter"
-					// onMouseDown so the click wins over the input's onBlur collapse
+					// preventDefault on mousedown so the input never blurs; the
+					// clearing lives in onClick so keyboard activation works too
 					onMouseDown={(event) => {
 						event.preventDefault();
+						event.stopPropagation();
+					}}
+					onClick={(event) => {
 						event.stopPropagation();
 						onQueryChange("");
 						inputRef.current?.focus();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/DashboardSidebarProjectsFilterInput.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/DashboardSidebarProjectsFilterInput.tsx
@@ -1,0 +1,92 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useEffect, useRef } from "react";
+import { HiXMark } from "react-icons/hi2";
+import { VscListFilter } from "react-icons/vsc";
+
+interface DashboardSidebarProjectsFilterInputProps {
+	query: string;
+	onQueryChange: (query: string) => void;
+	isExpanded: boolean;
+	onExpandedChange: (expanded: boolean) => void;
+}
+
+export function DashboardSidebarProjectsFilterInput({
+	query,
+	onQueryChange,
+	isExpanded,
+	onExpandedChange,
+}: DashboardSidebarProjectsFilterInputProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (isExpanded) inputRef.current?.focus();
+	}, [isExpanded]);
+
+	if (!isExpanded) {
+		return (
+			<Tooltip delayDuration={700}>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="Filter projects"
+						onClick={(event) => {
+							event.stopPropagation();
+							onExpandedChange(true);
+						}}
+						onKeyDown={(event) => event.stopPropagation()}
+						className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
+					>
+						<VscListFilter className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">Filter projects</TooltipContent>
+			</Tooltip>
+		);
+	}
+
+	const collapse = () => {
+		onQueryChange("");
+		onExpandedChange(false);
+	};
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: stops the header row's collapse toggle from firing on input interaction
+		<div
+			className="flex min-w-0 flex-1 items-center gap-1 rounded-md bg-fill-hover px-1.5"
+			onClick={(event) => event.stopPropagation()}
+			onKeyDown={(event) => {
+				event.stopPropagation();
+				if (event.key === "Escape") collapse();
+			}}
+		>
+			<VscListFilter className="size-3 shrink-0 text-muted-foreground" />
+			<input
+				ref={inputRef}
+				value={query}
+				onChange={(event) => onQueryChange(event.target.value)}
+				onBlur={() => {
+					if (query.trim() === "") collapse();
+				}}
+				placeholder="Filter projects…"
+				aria-label="Filter projects"
+				className="h-6 w-full min-w-0 bg-transparent text-xs font-normal normal-case tracking-normal text-foreground placeholder:text-muted-foreground focus:outline-none"
+			/>
+			{query !== "" && (
+				<button
+					type="button"
+					aria-label="Clear filter"
+					// onMouseDown so the click wins over the input's onBlur collapse
+					onMouseDown={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+						onQueryChange("");
+						inputRef.current?.focus();
+					}}
+					className="flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+				>
+					<HiXMark className="size-3" />
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/DashboardSidebarProjectsFilterInput.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/DashboardSidebarProjectsFilterInput.tsx
@@ -1,7 +1,6 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useEffect, useRef } from "react";
-import { HiXMark } from "react-icons/hi2";
-import { VscListFilter } from "react-icons/vsc";
+import { HiMagnifyingGlass, HiXMark } from "react-icons/hi2";
 
 interface DashboardSidebarProjectsFilterInputProps {
 	query: string;
@@ -36,7 +35,7 @@ export function DashboardSidebarProjectsFilterInput({
 						onKeyDown={(event) => event.stopPropagation()}
 						className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
 					>
-						<VscListFilter className="size-3.5" />
+						<HiMagnifyingGlass className="size-3.5" />
 					</button>
 				</TooltipTrigger>
 				<TooltipContent side="bottom">Filter projects</TooltipContent>
@@ -59,7 +58,7 @@ export function DashboardSidebarProjectsFilterInput({
 				if (event.key === "Escape") collapse();
 			}}
 		>
-			<VscListFilter className="size-3 shrink-0 text-muted-foreground" />
+			<HiMagnifyingGlass className="size-3 shrink-0 text-muted-foreground" />
 			<input
 				ref={inputRef}
 				value={query}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsFilterInput/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarProjectsFilterInput } from "./DashboardSidebarProjectsFilterInput";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
@@ -53,6 +53,11 @@ export function DashboardSidebarProjectsSortMenu({
 			<DropdownMenuContent
 				align="end"
 				onCloseAutoFocus={(event) => event.preventDefault()}
+				// The content portals to body but React events still bubble up the
+				// component tree — without these, selecting an item triggers the
+				// header row's collapse toggle.
+				onClick={(event) => event.stopPropagation()}
+				onKeyDown={(event) => event.stopPropagation()}
 			>
 				<DropdownMenuRadioGroup
 					value={sortMode}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
@@ -1,0 +1,76 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { HiOutlineArrowsUpDown } from "react-icons/hi2";
+import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+
+const SORT_MODE_LABELS: Record<SidebarProjectSortMode, string> = {
+	manual: "Manual",
+	created: "Date created",
+	updated: "Last updated",
+};
+
+interface DashboardSidebarProjectsSortMenuProps {
+	sortMode: SidebarProjectSortMode;
+	onSortModeChange: (mode: SidebarProjectSortMode) => void;
+}
+
+export function DashboardSidebarProjectsSortMenu({
+	sortMode,
+	onSortModeChange,
+}: DashboardSidebarProjectsSortMenuProps) {
+	return (
+		<DropdownMenu>
+			<Tooltip delayDuration={700}>
+				<TooltipTrigger asChild>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							aria-label="Sort projects"
+							onClick={(event) => event.stopPropagation()}
+							onKeyDown={(event) => event.stopPropagation()}
+							className={cn(
+								"flex size-6 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-fill-hover hover:text-foreground",
+								sortMode === "manual"
+									? "text-muted-foreground"
+									: "text-foreground",
+							)}
+						>
+							<HiOutlineArrowsUpDown className="size-3.5" />
+						</button>
+					</DropdownMenuTrigger>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">
+					Sort projects ({SORT_MODE_LABELS[sortMode]})
+				</TooltipContent>
+			</Tooltip>
+			<DropdownMenuContent
+				align="end"
+				onCloseAutoFocus={(event) => event.preventDefault()}
+			>
+				<DropdownMenuRadioGroup
+					value={sortMode}
+					onValueChange={(value) =>
+						onSortModeChange(value as SidebarProjectSortMode)
+					}
+				>
+					<DropdownMenuRadioItem value="manual">
+						{SORT_MODE_LABELS.manual}
+					</DropdownMenuRadioItem>
+					<DropdownMenuRadioItem value="created">
+						{SORT_MODE_LABELS.created}
+					</DropdownMenuRadioItem>
+					<DropdownMenuRadioItem value="updated">
+						{SORT_MODE_LABELS.updated}
+					</DropdownMenuRadioItem>
+				</DropdownMenuRadioGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
@@ -1,8 +1,8 @@
 import {
 	DropdownMenu,
+	DropdownMenuCheckboxItem,
 	DropdownMenuContent,
-	DropdownMenuRadioGroup,
-	DropdownMenuRadioItem,
+	DropdownMenuLabel,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
@@ -11,10 +11,12 @@ import { VscListFilter } from "react-icons/vsc";
 import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 
 const SORT_MODE_LABELS: Record<SidebarProjectSortMode, string> = {
-	manual: "Manual",
+	manual: "Manual order",
 	created: "Date created",
 	updated: "Last updated",
 };
+
+const SORT_MODES: SidebarProjectSortMode[] = ["updated", "created", "manual"];
 
 interface DashboardSidebarProjectsSortMenuProps {
 	sortMode: SidebarProjectSortMode;
@@ -59,22 +61,18 @@ export function DashboardSidebarProjectsSortMenu({
 				onClick={(event) => event.stopPropagation()}
 				onKeyDown={(event) => event.stopPropagation()}
 			>
-				<DropdownMenuRadioGroup
-					value={sortMode}
-					onValueChange={(value) =>
-						onSortModeChange(value as SidebarProjectSortMode)
-					}
-				>
-					<DropdownMenuRadioItem value="manual">
-						{SORT_MODE_LABELS.manual}
-					</DropdownMenuRadioItem>
-					<DropdownMenuRadioItem value="created">
-						{SORT_MODE_LABELS.created}
-					</DropdownMenuRadioItem>
-					<DropdownMenuRadioItem value="updated">
-						{SORT_MODE_LABELS.updated}
-					</DropdownMenuRadioItem>
-				</DropdownMenuRadioGroup>
+				<DropdownMenuLabel className="font-normal text-muted-foreground">
+					Sort by
+				</DropdownMenuLabel>
+				{SORT_MODES.map((mode) => (
+					<DropdownMenuCheckboxItem
+						key={mode}
+						checked={sortMode === mode}
+						onCheckedChange={() => onSortModeChange(mode)}
+					>
+						{SORT_MODE_LABELS[mode]}
+					</DropdownMenuCheckboxItem>
+				))}
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
@@ -16,7 +16,7 @@ const SORT_MODE_LABELS: Record<SidebarProjectSortMode, string> = {
 	updated: "Last updated",
 };
 
-const SORT_MODES: SidebarProjectSortMode[] = ["updated", "created", "manual"];
+const SORT_MODES: SidebarProjectSortMode[] = ["manual", "updated", "created"];
 
 interface DashboardSidebarProjectsSortMenuProps {
 	sortMode: SidebarProjectSortMode;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
@@ -61,7 +61,7 @@ export function DashboardSidebarProjectsSortMenu({
 				onClick={(event) => event.stopPropagation()}
 				onKeyDown={(event) => event.stopPropagation()}
 			>
-				<DropdownMenuLabel className="font-normal text-muted-foreground">
+				<DropdownMenuLabel className="text-xs font-normal text-muted-foreground/70">
 					Sort by
 				</DropdownMenuLabel>
 				{SORT_MODES.map((mode) => (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
@@ -7,7 +7,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { HiOutlineArrowsUpDown } from "react-icons/hi2";
+import { VscListFilter } from "react-icons/vsc";
 import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 
 const SORT_MODE_LABELS: Record<SidebarProjectSortMode, string> = {
@@ -42,7 +42,7 @@ export function DashboardSidebarProjectsSortMenu({
 									: "text-foreground",
 							)}
 						>
-							<HiOutlineArrowsUpDown className="size-3.5" />
+							<VscListFilter className="size-3.5" />
 						</button>
 					</DropdownMenuTrigger>
 				</TooltipTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarProjectsSortMenu } from "./DashboardSidebarProjectsSortMenu";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -98,16 +98,21 @@ function parseFlatItems(items: UniqueIdentifier[]): ParsedFlatItems {
 interface UseSidebarDndOptions {
 	projectId: string;
 	projectChildren: DashboardSidebarProjectChild[];
+	// While the sidebar filter is active, projectChildren is a pruned subset —
+	// committing a drop from it would rewrite tabOrder against incomplete data
+	// and corrupt the order of the hidden siblings.
+	disabled?: boolean;
 }
 
 export function useSidebarDnd({
 	projectId,
 	projectChildren,
+	disabled = false,
 }: UseSidebarDndOptions) {
 	const { reorderProjectChildren, moveWorkspaceToSectionAtIndex } =
 		useDashboardSidebarState();
 
-	const sensors = useSensors(
+	const enabledSensors = useSensors(
 		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
 		useSensor(TouchSensor, {
 			activationConstraint: { delay: 200, tolerance: 5 },
@@ -290,10 +295,11 @@ export function useSidebarDnd({
 
 	const onDragStart = useCallback(
 		({ active }: DragStartEvent) => {
+			if (disabled) return;
 			setActiveId(active.id);
 			clonedRef.current = [...flatItems];
 		},
-		[flatItems],
+		[disabled, flatItems],
 	);
 
 	const onDragOver = useCallback(({ over }: DragOverEvent) => {
@@ -372,7 +378,8 @@ export function useSidebarDnd({
 	}, []);
 
 	return {
-		sensors,
+		// No sensors means dnd-kit can never activate a drag.
+		sensors: disabled ? [] : enabledSensors,
 		measuring,
 		collisionDetection: closestCenter,
 		flatItems,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import {
+	makeProject,
+	makeSection,
+	makeWorkspace,
+} from "../testProjectFixtures";
+import { filterDashboardSidebarProjects } from "./filterDashboardSidebarProjects";
+
+const projects = [
+	makeProject({
+		id: "p-superset",
+		name: "Superset",
+		isCollapsed: true,
+		children: [
+			{
+				type: "workspace",
+				workspace: makeWorkspace({ id: "w1", name: "fix-login" }),
+			},
+			{
+				type: "section",
+				section: makeSection({
+					id: "s1",
+					name: "Backend",
+					isCollapsed: true,
+					workspaces: [
+						makeWorkspace({ id: "w2", name: "api-cleanup" }),
+						makeWorkspace({ id: "w3", name: "db-migration" }),
+					],
+				}),
+			},
+		],
+	}),
+	makeProject({
+		id: "p-marketing",
+		name: "Marketing Site",
+		children: [
+			{
+				type: "workspace",
+				workspace: makeWorkspace({ id: "w4", name: "hero-redesign" }),
+			},
+		],
+	}),
+];
+
+describe("filterDashboardSidebarProjects", () => {
+	it("returns the same array reference for an empty or whitespace query", () => {
+		expect(filterDashboardSidebarProjects(projects, "")).toBe(projects);
+		expect(filterDashboardSidebarProjects(projects, "   ")).toBe(projects);
+	});
+
+	it("keeps a name-matched project whole but expanded", () => {
+		const result = filterDashboardSidebarProjects(projects, "SUPER");
+		expect(result).toHaveLength(1);
+		expect(result[0]?.id).toBe("p-superset");
+		expect(result[0]?.isCollapsed).toBe(false);
+		expect(result[0]?.children).toHaveLength(2);
+	});
+
+	it("prunes to matching workspaces and expands their project and section", () => {
+		const result = filterDashboardSidebarProjects(projects, "api");
+		expect(result).toHaveLength(1);
+		const project = result[0];
+		expect(project?.isCollapsed).toBe(false);
+		expect(project?.children).toHaveLength(1);
+		const child = project?.children[0];
+		if (child?.type !== "section") throw new Error("expected section");
+		expect(child.section.isCollapsed).toBe(false);
+		expect(child.section.workspaces.map((w) => w.id)).toEqual(["w2"]);
+	});
+
+	it("keeps a whole section when the section name matches", () => {
+		const result = filterDashboardSidebarProjects(projects, "backend");
+		const child = result[0]?.children[0];
+		if (child?.type !== "section") throw new Error("expected section");
+		expect(child.section.workspaces).toHaveLength(2);
+	});
+
+	it("drops projects with no match anywhere", () => {
+		expect(filterDashboardSidebarProjects(projects, "hero")).toHaveLength(1);
+		expect(filterDashboardSidebarProjects(projects, "zzz")).toHaveLength(0);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.test.ts
@@ -79,4 +79,14 @@ describe("filterDashboardSidebarProjects", () => {
 		expect(filterDashboardSidebarProjects(projects, "hero")).toHaveLength(1);
 		expect(filterDashboardSidebarProjects(projects, "zzz")).toHaveLength(0);
 	});
+
+	it("keeps object references when nothing changes (memo stability)", () => {
+		// p-marketing is already expanded and all its workspaces match, so the
+		// original object must pass through untouched.
+		const byName = filterDashboardSidebarProjects(projects, "marketing");
+		expect(byName[0]).toBe(projects[1]);
+
+		const byWorkspace = filterDashboardSidebarProjects(projects, "hero");
+		expect(byWorkspace[0]).toBe(projects[1]);
+	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.ts
@@ -7,6 +7,23 @@ function matches(text: string, normalizedQuery: string): boolean {
 	return text.toLowerCase().includes(normalizedQuery);
 }
 
+// Reuse the input objects whenever nothing about them changes — the sidebar's
+// memoized rows rely on referential stability, and the filter reruns on every
+// keystroke.
+function expandProject(
+	project: DashboardSidebarProject,
+): DashboardSidebarProject {
+	return project.isCollapsed ? { ...project, isCollapsed: false } : project;
+}
+
+function expandSection(
+	child: Extract<DashboardSidebarProjectChild, { type: "section" }>,
+): DashboardSidebarProjectChild {
+	return child.section.isCollapsed
+		? { type: "section", section: { ...child.section, isCollapsed: false } }
+		: child;
+}
+
 function filterChildren(
 	children: DashboardSidebarProjectChild[],
 	normalizedQuery: string,
@@ -16,14 +33,15 @@ function filterChildren(
 			return matches(child.workspace.name, normalizedQuery) ? [child] : [];
 		}
 		if (matches(child.section.name, normalizedQuery)) {
-			return [
-				{ type: "section", section: { ...child.section, isCollapsed: false } },
-			];
+			return [expandSection(child)];
 		}
 		const workspaces = child.section.workspaces.filter((workspace) =>
 			matches(workspace.name, normalizedQuery),
 		);
 		if (workspaces.length === 0) return [];
+		if (workspaces.length === child.section.workspaces.length) {
+			return [expandSection(child)];
+		}
 		return [
 			{
 				type: "section",
@@ -49,10 +67,14 @@ export function filterDashboardSidebarProjects(
 
 	return projects.flatMap((project): DashboardSidebarProject[] => {
 		if (matches(project.name, normalizedQuery)) {
-			return [{ ...project, isCollapsed: false }];
+			return [expandProject(project)];
 		}
 		const children = filterChildren(project.children, normalizedQuery);
 		if (children.length === 0) return [];
+		const childrenUnchanged =
+			children.length === project.children.length &&
+			children.every((child, index) => child === project.children[index]);
+		if (childrenUnchanged) return [expandProject(project)];
 		return [{ ...project, isCollapsed: false, children }];
 	});
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/filterDashboardSidebarProjects.ts
@@ -1,0 +1,58 @@
+import type {
+	DashboardSidebarProject,
+	DashboardSidebarProjectChild,
+} from "../../types";
+
+function matches(text: string, normalizedQuery: string): boolean {
+	return text.toLowerCase().includes(normalizedQuery);
+}
+
+function filterChildren(
+	children: DashboardSidebarProjectChild[],
+	normalizedQuery: string,
+): DashboardSidebarProjectChild[] {
+	return children.flatMap((child): DashboardSidebarProjectChild[] => {
+		if (child.type === "workspace") {
+			return matches(child.workspace.name, normalizedQuery) ? [child] : [];
+		}
+		if (matches(child.section.name, normalizedQuery)) {
+			return [
+				{ type: "section", section: { ...child.section, isCollapsed: false } },
+			];
+		}
+		const workspaces = child.section.workspaces.filter((workspace) =>
+			matches(workspace.name, normalizedQuery),
+		);
+		if (workspaces.length === 0) return [];
+		return [
+			{
+				type: "section",
+				section: { ...child.section, isCollapsed: false, workspaces },
+			},
+		];
+	});
+}
+
+/**
+ * Case-insensitive substring filter over projects. A project survives when its
+ * name matches (kept whole) or when any of its workspaces/sections match
+ * (pruned to the matches). Surviving projects and matched sections come back
+ * expanded so the matches are actually visible; the persisted collapse state
+ * is never written.
+ */
+export function filterDashboardSidebarProjects(
+	projects: DashboardSidebarProject[],
+	query: string,
+): DashboardSidebarProject[] {
+	const normalizedQuery = query.trim().toLowerCase();
+	if (normalizedQuery === "") return projects;
+
+	return projects.flatMap((project): DashboardSidebarProject[] => {
+		if (matches(project.name, normalizedQuery)) {
+			return [{ ...project, isCollapsed: false }];
+		}
+		const children = filterChildren(project.children, normalizedQuery);
+		if (children.length === 0) return [];
+		return [{ ...project, isCollapsed: false, children }];
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/filterDashboardSidebarProjects/index.ts
@@ -1,0 +1,1 @@
+export { filterDashboardSidebarProjects } from "./filterDashboardSidebarProjects";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/index.ts
@@ -1,0 +1,4 @@
+export {
+	getProjectActivityTimestamp,
+	sortDashboardSidebarProjects,
+} from "./sortDashboardSidebarProjects";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import {
+	makeProject,
+	makeSection,
+	makeWorkspace,
+} from "../testProjectFixtures";
+import {
+	getProjectActivityTimestamp,
+	sortDashboardSidebarProjects,
+} from "./sortDashboardSidebarProjects";
+
+describe("getProjectActivityTimestamp", () => {
+	it("uses the most recently updated workspace, including inside sections", () => {
+		const project = makeProject({
+			id: "p1",
+			name: "Alpha",
+			updatedAt: new Date("2026-06-01"),
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w1",
+						name: "one",
+						updatedAt: new Date("2026-02-01"),
+					}),
+				},
+				{
+					type: "section",
+					section: makeSection({
+						id: "s1",
+						name: "Section",
+						workspaces: [
+							makeWorkspace({
+								id: "w2",
+								name: "two",
+								updatedAt: new Date("2026-03-01"),
+							}),
+						],
+					}),
+				},
+			],
+		});
+		expect(getProjectActivityTimestamp(project)).toBe(
+			new Date("2026-03-01").getTime(),
+		);
+	});
+
+	it("falls back to the project's own updatedAt when there are no workspaces", () => {
+		const project = makeProject({
+			id: "p1",
+			name: "Alpha",
+			updatedAt: new Date("2026-05-01"),
+		});
+		expect(getProjectActivityTimestamp(project)).toBe(
+			new Date("2026-05-01").getTime(),
+		);
+	});
+});
+
+describe("sortDashboardSidebarProjects", () => {
+	const older = makeProject({
+		id: "p-older",
+		name: "Older",
+		createdAt: new Date("2026-01-01"),
+		children: [
+			{
+				type: "workspace",
+				workspace: makeWorkspace({
+					id: "w1",
+					name: "busy",
+					updatedAt: new Date("2026-07-01"),
+				}),
+			},
+		],
+	});
+	const newer = makeProject({
+		id: "p-newer",
+		name: "Newer",
+		createdAt: new Date("2026-04-01"),
+		children: [
+			{
+				type: "workspace",
+				workspace: makeWorkspace({
+					id: "w2",
+					name: "idle",
+					updatedAt: new Date("2026-05-01"),
+				}),
+			},
+		],
+	});
+
+	it("returns the input untouched in manual mode", () => {
+		const projects = [older, newer];
+		expect(sortDashboardSidebarProjects(projects, "manual")).toBe(projects);
+	});
+
+	it("sorts newest created first in created mode", () => {
+		expect(
+			sortDashboardSidebarProjects([older, newer], "created").map((p) => p.id),
+		).toEqual(["p-newer", "p-older"]);
+	});
+
+	it("sorts by workspace activity in updated mode", () => {
+		expect(
+			sortDashboardSidebarProjects([newer, older], "updated").map((p) => p.id),
+		).toEqual(["p-older", "p-newer"]);
+	});
+
+	it("breaks timestamp ties by name", () => {
+		const a = makeProject({ id: "p-a", name: "Apple" });
+		const b = makeProject({ id: "p-b", name: "Banana" });
+		expect(
+			sortDashboardSidebarProjects([b, a], "created").map((p) => p.id),
+		).toEqual(["p-a", "p-b"]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
@@ -1,0 +1,44 @@
+import type { SidebarProjectSortMode } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import type { DashboardSidebarProject } from "../../types";
+import { getProjectChildrenWorkspaces } from "../projectChildren";
+
+// The host only bumps a project's own updatedAt on metadata patches (e.g.
+// rename), so "recent activity" comes from the workspaces inside it.
+export function getProjectActivityTimestamp(
+	project: DashboardSidebarProject,
+): number {
+	const workspaces = getProjectChildrenWorkspaces(project.children);
+	if (workspaces.length === 0) {
+		return project.updatedAt?.getTime() ?? project.createdAt.getTime();
+	}
+	return Math.max(
+		...workspaces.map((workspace) => workspace.updatedAt.getTime()),
+	);
+}
+
+function compareStable(
+	left: DashboardSidebarProject,
+	right: DashboardSidebarProject,
+	byTimestamp: (project: DashboardSidebarProject) => number,
+): number {
+	const diff = byTimestamp(right) - byTimestamp(left);
+	if (diff !== 0) return diff;
+	const byName = left.name.localeCompare(right.name);
+	if (byName !== 0) return byName;
+	return left.id.localeCompare(right.id);
+}
+
+export function sortDashboardSidebarProjects(
+	projects: DashboardSidebarProject[],
+	mode: SidebarProjectSortMode,
+): DashboardSidebarProject[] {
+	if (mode === "manual") return projects;
+	if (mode === "created") {
+		return [...projects].sort((left, right) =>
+			compareStable(left, right, (project) => project.createdAt.getTime()),
+		);
+	}
+	return [...projects].sort((left, right) =>
+		compareStable(left, right, getProjectActivityTimestamp),
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
@@ -1,0 +1,59 @@
+import type {
+	DashboardSidebarProject,
+	DashboardSidebarSection,
+	DashboardSidebarWorkspace,
+} from "../types";
+
+export function makeWorkspace(
+	overrides: Partial<DashboardSidebarWorkspace> & { id: string; name: string },
+): DashboardSidebarWorkspace {
+	return {
+		projectId: "project-1",
+		hostId: "host-1",
+		hostType: "local-device",
+		type: "worktree",
+		hostIsOnline: true,
+		accentColor: null,
+		branch: overrides.name,
+		pullRequest: null,
+		repoUrl: null,
+		branchExistsOnRemote: false,
+		previewUrl: null,
+		needsRebase: null,
+		behindCount: null,
+		createdAt: new Date("2026-01-01"),
+		updatedAt: new Date("2026-01-01"),
+		taskId: null,
+		pendingTransaction: null,
+		...overrides,
+	};
+}
+
+export function makeSection(
+	overrides: Partial<DashboardSidebarSection> & { id: string; name: string },
+): DashboardSidebarSection {
+	return {
+		projectId: "project-1",
+		createdAt: new Date("2026-01-01"),
+		isCollapsed: false,
+		tabOrder: 0,
+		color: null,
+		workspaces: [],
+		...overrides,
+	};
+}
+
+export function makeProject(
+	overrides: Partial<DashboardSidebarProject> & { id: string; name: string },
+): DashboardSidebarProject {
+	return {
+		githubOwner: null,
+		githubRepoName: null,
+		iconUrl: null,
+		createdAt: new Date("2026-01-01"),
+		updatedAt: new Date("2026-01-01"),
+		isCollapsed: false,
+		children: [],
+		...overrides,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -322,6 +322,12 @@ function isCompleteLinkTierMap(
 	);
 }
 
+const sidebarProjectSortModeSchema = z.enum(["manual", "created", "updated"]);
+
+export type SidebarProjectSortMode = z.infer<
+	typeof sidebarProjectSortModeSchema
+>;
+
 export const v2UserPreferencesSchema = z.object({
 	id: z.literal("preferences"),
 	fileLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
@@ -334,6 +340,7 @@ export const v2UserPreferencesSchema = z.object({
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
 	showPresetsBar: z.boolean().default(true),
+	sidebarProjectSortMode: sidebarProjectSortModeSchema.default("manual"),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
@@ -352,6 +359,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	rightSidebarWidth: 340,
 	deleteLocalBranch: false,
 	showPresetsBar: true,
+	sidebarProjectSortMode: "manual",
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds a **sort mode** for sidebar projects — Manual (existing drag order, default), Date created, Last updated — persisted per-user in `v2UserPreferences` and switchable from a new radio dropdown in the PROJECTS header.
- Adds an **inline filter**: a `VscListFilter` icon in the PROJECTS header expands into a text input; case-insensitive substring match over project, workspace, and section names.

## Why / Context
The project list was ordered solely by manual drag (`tabOrder`), with no way to find a project/workspace by name or surface recently active work. Inspired by PostHog Code's sidebar (sort by created/updated + searchable switcher).

## How It Works
- Sorting/filtering are applied as derived memos in `DashboardSidebar` — the data hook (`useDashboardSidebarData`) and the persisted `tabOrder` remain untouched, so switching back to Manual restores the hand-arranged order exactly.
- **"Last updated" sorts by the most recently updated workspace** in each project (including inside sections), not the project's own `updatedAt` — the host only bumps project `updatedAt` on metadata patches (e.g. rename), so workspace timestamps are the real activity signal.
- The filter helper returns derived project/section objects with `isCollapsed: false` so matches are auto-expanded and non-matching siblings pruned; persisted collapse state is never written. In the default state (manual + empty query) the original array references pass through, preserving existing memo stability.
- Drag-to-reorder is disabled (`useSortable({ disabled })` + drag-start/end guards) while a non-manual sort or filter is active, so a sorted/pruned order can never be persisted into `tabOrder`.
- Filter state is ephemeral `useState`; it auto-clears when the sidebar collapses to icon-only (the input is hidden there, and an invisible filter would silently hide projects). Shortcut labels (⌘1–⌘9) are computed from the sorted-but-unfiltered list so they stay stable while typing.

## Manual QA Checklist

### Sort
- [ ] Switching Manual → Date created → Last updated reorders projects; drag handles are inert in non-manual modes
- [ ] Sort mode persists after app restart
- [ ] Switching back to Manual restores the original drag order; dragging works again
- [ ] Touching a workspace raises its project in "Last updated"

### Filter
- [ ] Typing a workspace-name match auto-expands its project/section and prunes non-matching siblings
- [ ] A project-name match keeps all its children
- [ ] Garbage query shows the "No projects match" row; Esc clears and restores collapse state and DnD
- [ ] Expanding the filter while the PROJECTS list is collapsed expands the list
- [ ] Collapsing the sidebar to icon-only with an active filter shows all projects again
- [ ] ⌘1–⌘9 target the same workspaces while a filter is typed

## Testing
- `bun run typecheck`
- `bun run lint`
- `bun test src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils` — 11 new tests for the sort/filter helpers

## Design Decisions
- **Sort in the component, not the data hook**: sort is a view preference with one consumer; keeping `useDashboardSidebarData` on `tabOrder` preserves its referential-stability machinery and the optimistic drag path.
- **Derived expansion instead of a `forceExpanded` prop**: avoids threading a prop through 3+ components and guarantees persisted collapse state is never mutated by filtering.
- **No branch-name matching**: v2 workspace names are branch-derived; matching hidden text would surface rows whose visible label doesn't contain the query.

https://claude.ai/code/session_01MycxWhiezTmQAbvPR4tcYW

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5956">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sorting and inline filtering to Projects in the dashboard sidebar so you can quickly find work and organize lists. “Last updated” uses recent workspace activity and the chosen sort persists per user.

- **New Features**
  - Sort menu in the PROJECTS header: Manual (default), Last updated, Date created; preference saved in `v2UserPreferences`. Switching back to Manual restores drag order. Uses a list-filter icon and a dim “Sort by” label with checkmarks.
  - Inline filter with a magnifier; case-insensitive match on project, section, and workspace names. Matches auto-expand, non-matching siblings are hidden, and a “No projects match” message appears when empty. Esc clears, and the filter auto-clears when the sidebar collapses.
  - Dragging is gated to protect ordering: project drag is disabled while a non-manual sort or a filter is active; workspace/section drag is disabled while a filter is active so pruned lists can’t write a bad `tabOrder`. ⌘1–⌘9 shortcuts remain stable while typing.

- **Bug Fixes**
  - Clicking items in the sort menu or Add Project menu no longer toggles the Projects collapse; dropdown events are stopped from bubbling.
  - Filter clear button is keyboard-operable and doesn’t blur the input.
  - Filtering preserves object identity when items don’t change, keeping memoized rows stable and avoiding flicker.
  - Use the theme’s destructive color for failed automation statuses for better contrast across themes.

<sup>Written for commit 119f90ada9b4886f0f7202410016c9f02b020fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dashboard sidebar sorting controls (manual, created, recent activity) with your selection saved for future sessions.
  * Added an inline project filter that searches projects, workspaces, and sections; matching items auto-expand, and a “No projects match …” message appears when nothing matches.
* **Bug Fixes**
  * Improved header interactions so filter/sort controls don’t unintentionally collapse the sidebar.
  * Disabled drag-and-drop reordering while filtering is active or when sorting isn’t set to manual.
* **Tests**
  * Added coverage for sorting (including tie-breaking) and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->