### PR TITLE
fix(host-service): repair project list from main workspaces

### DIFF
--- a/packages/host-service/src/trpc/router/project/project.ts
+++ b/packages/host-service/src/trpc/router/project/project.ts
@@ -5,7 +5,7 @@ import {
 } from "@superset/shared/github-remote";
 import { BRANCH_PREFIX_MODES } from "@superset/shared/workspace-launch";
 import { TRPCError } from "@trpc/server";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
 import {
@@ -35,8 +35,33 @@ import {
 	validateDirectoryPath,
 } from "./utils/resolve-repo";
 
+function ensureProjectsForMainWorkspaces(
+	ctx: Parameters<typeof persistLocalProject>[0],
+): void {
+	const orphanedMainWorkspaces = ctx.db
+		.select({
+			projectId: workspaces.projectId,
+			worktreePath: workspaces.worktreePath,
+		})
+		.from(workspaces)
+		.leftJoin(projects, eq(projects.id, workspaces.projectId))
+		.where(and(isNull(projects.id), eq(workspaces.type, "main")))
+		.all();
+
+	for (const workspace of orphanedMainWorkspaces) {
+		persistLocalProject(
+			ctx,
+			workspace.projectId,
+			{ repoPath: workspace.worktreePath, parsed: null, remoteName: null },
+			{ name: basename(workspace.worktreePath) },
+		);
+	}
+}
+
 export const projectRouter = router({
 	list: protectedProcedure.query(({ ctx }) => {
+		ensureProjectsForMainWorkspaces(ctx);
+
 		return ctx.db
 			.select()
 			.from(projects)

--- a/packages/host-service/src/trpc/router/project/utils/persist-project.ts
+++ b/packages/host-service/src/trpc/router/project/utils/persist-project.ts
@@ -12,7 +12,7 @@ export interface ProjectIdentityFields {
 }
 
 export function persistLocalProject(
-	ctx: HostServiceContext,
+	ctx: Pick<HostServiceContext, "db" | "eventBus">,
 	projectId: string,
 	resolved: ResolvedRepo,
 	identity?: ProjectIdentityFields,

--- a/packages/host-service/test/integration/project.integration.test.ts
+++ b/packages/host-service/test/integration/project.integration.test.ts
@@ -1,6 +1,9 @@
+import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { TRPCClientError } from "@trpc/client";
+import { eq } from "drizzle-orm";
+import { projects } from "../../src/db/schema";
 import { createTestHost } from "../helpers/createTestHost";
 import { createGitFixture } from "../helpers/git-fixture";
 import { createProjectScenario } from "../helpers/scenarios";
@@ -33,6 +36,43 @@ describe("project router integration", () => {
 		const result = await host.trpc.project.list.query();
 		const ids = result.map((p) => p.id).sort();
 		expect(ids).toEqual([a.id, b.id].sort());
+	});
+
+	test("list repairs a main workspace whose project row is missing", async () => {
+		const host = await createTestHost();
+		const repo = await createGitFixture();
+		dispose = async () => {
+			await host.dispose();
+			repo.dispose();
+		};
+
+		const projectId = randomUUID();
+		const workspaceId = randomUUID();
+		const sqlite = new Database(host.dbPath);
+		try {
+			sqlite.exec("PRAGMA foreign_keys = OFF");
+			sqlite
+				.query(
+					`INSERT INTO workspaces (id, project_id, worktree_path, branch, name, type, created_at, updated_at)
+					 VALUES (?, ?, ?, 'main', 'main', 'main', ?, ?)`,
+				)
+				.run(workspaceId, projectId, repo.repoPath, Date.now(), Date.now());
+		} finally {
+			sqlite.close();
+		}
+
+		const result = await host.trpc.project.list.query();
+
+		expect(result).toContainEqual(
+			expect.objectContaining({
+				id: projectId,
+				repoPath: repo.repoPath,
+			}),
+		);
+		const repaired = host.db.query.projects
+			.findFirst({ where: eq(projects.id, projectId) })
+			.sync();
+		expect(repaired?.repoPath).toBe(repo.repoPath);
 	});
 
 	test("get returns project by id, null when missing", async () => {


### PR DESCRIPTION
## What & why

Fixes #5892.

`superset projects create --local` reported success and left a `main` workspace
behind, but `superset projects list` kept returning `No results.`

`project.list` selected only from the local `projects` table. When the local DB
ends up in a state where a `main` workspace row exists but its parent `projects`
row doesn't, the workspace is visible via `workspaces list --local` while the
project is invisible everywhere — and there was no path to notice or recover
from it. The FK (`workspaces.project_id → projects.id`, `onDelete: cascade`) is
only enforced at write time, so an orphan that already exists on disk survives
indefinitely.

This makes the read path self-healing: before listing, `project.list` finds
`main` workspaces whose `project_id` has no matching `projects` row and rebuilds
a minimal project row from the workspace's `projectId` + `worktreePath` (name
falls back to the folder basename, same rule as `toProjectSnapshot`). After
that, listing proceeds as before, so `projects list` and `workspaces list`
agree.

Also narrows `persistLocalProject`'s first parameter from the full
`HostServiceContext` to `Pick<HostServiceContext, "db" | "eventBus">` so the
repair path can reuse it with only the fields it actually needs.


## How I tested it

- New integration regression test, `list repairs a main workspace whose project
  row is missing`: inserts the exact broken state (workspace row present,
  project row absent, via `PRAGMA foreign_keys = OFF`), then asserts
  `project.list` returns the project *and* that the row was persisted back into
  `projects`.
- `bun test packages/host-service/test/integration/project.integration.test.ts`
  — 8 pass, 0 fail.
- `bun run lint` — clean.
- `bun run typecheck --filter=@superset/host-service` — clean.

No UI changes.

## Checklist
- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5959">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes projects list returning no results when a `main` workspace exists without its parent project. The list endpoint now self-heals by rebuilding missing project rows from `main` workspaces to keep projects and workspaces in sync.

- **Bug Fixes**
  - Before listing, detect `main` workspaces with no matching `projects` row and persist a minimal project from `projectId` and `worktreePath` (name = folder basename).
  - Narrowed `persistLocalProject` context to `Pick<HostServiceContext, "db" | "eventBus">` to reuse it in the repair path.
  - Added an integration test that inserts the orphaned state and verifies the list output and the repaired `projects` row.

<sup>Written for commit 20e1a944f3b8b95b14aa1f9ae1e942e4632bb609. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project listings now automatically restore missing local project records for main workspaces.
  * Repaired projects retain the correct project identifier and repository path.
* **Reliability**
  * Improved consistency between workspace and project data when records become out of sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->