### PR TITLE
feat(desktop): add PostHog usage tracking for terminal rich input

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -357,12 +357,12 @@ export function TerminalPane({
 
 	useHotkey(
 		"TOGGLE_TERMINAL_RICH_INPUT",
-		() => terminalRichInputOpenStore.toggle(),
+		() => terminalRichInputOpenStore.toggle("hotkey"),
 		{ enabled: ctx.isActive, preventDefault: true },
 	);
 
 	const closeRichInput = useCallback(() => {
-		terminalRichInputOpenStore.close();
+		terminalRichInputOpenStore.close("escape");
 		terminalRuntimeRegistry
 			.getTerminal(terminalId, terminalInstanceId)
 			?.focus();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/TerminalPaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/TerminalPaneHeaderExtras.tsx
@@ -38,7 +38,7 @@ export function TerminalPaneHeaderExtras({
 				<TooltipTrigger asChild>
 					<button
 						type="button"
-						onClick={() => terminalRichInputOpenStore.toggle()}
+						onClick={() => terminalRichInputOpenStore.toggle("header_button")}
 						aria-label={label}
 						aria-pressed={isOpen}
 						className={cn(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalRichInput/TerminalRichInput.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalRichInput/TerminalRichInput.tsx
@@ -12,6 +12,7 @@ import { ArrowUpIcon } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
 import { TiptapPromptEditor } from "renderer/components/Chat/ChatInterface/components/TiptapPromptEditor/TiptapPromptEditor";
 import { useHotkeyDisplay } from "renderer/hotkeys";
+import { track } from "renderer/lib/analytics";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { TerminalPaneIcon } from "../TerminalPaneIcon";
 import { prepareTerminalSubmission } from "./prepareTerminalSubmission";
@@ -106,8 +107,13 @@ function TerminalRichInputInner({
 			terminalRuntimeRegistry.writeInput(terminalId, "\r", terminalInstanceId);
 			terminalRuntimeRegistry.scrollToBottom(terminalId, terminalInstanceId);
 			controller.textInput.clear();
+			track("terminal_rich_input_submitted", {
+				workspace_id: workspaceId,
+				message_length: text.length,
+				line_count: text.split("\n").length,
+			});
 		},
-		[terminalId, terminalInstanceId, controller],
+		[terminalId, terminalInstanceId, controller, workspaceId],
 	);
 
 	// Persist the draft as it changes. terminalId is stable for this provider

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/richInputOpenStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/richInputOpenStore.ts
@@ -1,4 +1,7 @@
 import { useSyncExternalStore } from "react";
+import { track } from "renderer/lib/analytics";
+
+export type RichInputToggleSource = "hotkey" | "header_button" | "escape";
 
 /**
  * Whether the rich-input overlay is open. Global (universal on/off for every
@@ -19,24 +22,25 @@ function readPersisted(): boolean {
 	}
 }
 
-function set(next: boolean) {
+function set(next: boolean, source: RichInputToggleSource) {
 	if (isOpen === next) return;
 	isOpen = next;
 	try {
 		localStorage.setItem(STORAGE_KEY, next ? "true" : "false");
 	} catch {}
+	track("terminal_rich_input_toggled", { open: next, source });
 	for (const listener of listeners) listener();
 }
 
 export const terminalRichInputOpenStore = {
-	open() {
-		set(true);
+	open(source: RichInputToggleSource) {
+		set(true, source);
 	},
-	close() {
-		set(false);
+	close(source: RichInputToggleSource) {
+		set(false, source);
 	},
-	toggle() {
-		set(!isOpen);
+	toggle(source: RichInputToggleSource) {
+		set(!isOpen, source);
 	},
 	subscribe(listener: () => void) {
 		listeners.add(listener);


### PR DESCRIPTION
## Summary

The v2 terminal rich-input overlay (⌘I composer) had no analytics, so there was no way to measure its adoption. This adds two PostHog events via the existing `track()` helper:

- **`terminal_rich_input_toggled`** — emitted centrally in `richInputOpenStore.set()` so it only fires on real state changes; carries `open` and `source` (`hotkey` | `header_button` | `escape`). The store methods now require a source, so future call sites can't skip attribution.
- **`terminal_rich_input_submitted`** — emitted after the sanitize/empty gate passes and the text is written to the PTY; carries `workspace_id`, `message_length`, `line_count`. No prompt content is captured.

The submit event is the real adoption signal — open state persists in localStorage across reloads, so toggles alone undercount usage.

## Test Plan

- [x] Biome clean on the TerminalPane subtree
- [x] `tsc --noEmit` shows no errors in touched files (pre-existing route-tree errors in this worktree are unrelated)
- [ ] Verify both events appear in PostHog after toggling (⌘I / header button / Esc) and submitting a prompt in a dev build

https://claude.ai/code/session_01DyoAfqK9Hm3mNdvAsEkW1N

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5962">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PostHog usage tracking for the v2 terminal rich-input (⌘I) to measure adoption. Emits toggle and submit events with source attribution and basic metrics.

- **New Features**
  - `terminal_rich_input_toggled`: fired on real state changes in the store; includes `open` and `source` (`hotkey` | `header_button` | `escape`).
  - `terminal_rich_input_submitted`: fired after valid submit; includes `workspace_id`, `message_length`, `line_count` (no prompt content).

- **Migration**
  - `terminalRichInputOpenStore.open/close/toggle` now require a `source` argument. Update callers to pass `"hotkey"`, `"header_button"`, or `"escape"`.

<sup>Written for commit 75d177388adf7b934349d23d4224c15ebed99c31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved terminal rich-input controls when opened from the keyboard shortcut or header button.
  - Rich-input closing via Escape now behaves consistently.
  - Terminal rich-input submissions now include workspace context and basic submission details in product analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->