### PR TITLE
feat(desktop): add workspace pinning to the v2 dashboard sidebar

### DIFF
--- a/apps/desktop/plans/done/20260725-1947-sidebar-workspace-pinning.md
+++ b/apps/desktop/plans/done/20260725-1947-sidebar-workspace-pinning.md
@@ -1,0 +1,178 @@
+# Add user-controlled workspace pinning to the v2 dashboard sidebar
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Reference: This plan follows conventions from AGENTS.md and the ExecPlan template in `.agents/skills/create-plan/SKILL.md`.
+
+## Purpose / Big Picture
+
+Users with many workspaces across several projects have no way to keep the handful they care about within one glance and one click. After this change, a user can right-click any workspace row in the v2 dashboard sidebar and choose "Pin". The workspace then appears in a "Pinned" section at the very top of the sidebar, above all project groups, and disappears from its project group. Unpinning (same context menu) returns it to exactly where it was — same project, same section, same manual order position. Pins survive app restarts. To see it working: run `bun dev`, open the desktop app, right-click a workspace in the sidebar, choose "Pin", and observe it move to a new "Pinned" section at the top.
+
+The design is modeled on a task-pinning implementation reviewed (2026-07-25) in another agent-workspace desktop app — "the reference app" below — (a `pinnedAt` nullable timestamp, a partitioned "Pinned" section rendered above the recency list, unpin-on-archive), while deliberately fixing its two weaknesses: their API is toggle-only (their `unpin` is a racy "toggle, then toggle again if the result was wrong" hack), and they store `pinnedAt` but never use it for ordering, so their pinned section reorders itself by activity. We use an idempotent `setWorkspacePinned(workspaceId, projectId, pinned)` mutation and order the pinned section by `pinnedAt` ascending (new pins append at the bottom, like pinned browser tabs — stable, predictable).
+
+## Assumptions
+
+- Pinning is a v2-sidebar-only feature. The v1 sidebar (`apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/`) is not touched.
+- Pin state is per-device, per-organization local UI state, like every other sidebar-placement concern (order, sections, hidden). It does not sync across devices. This matches where `tabOrder`, `sectionId`, and `isHidden` already live and requires no Postgres migration, no Electric shape change, and no host-service change.
+- A "main" workspace (the always-present local checkout of a project, `type === "main"`) can be pinned like any other workspace. The existing behavior that main workspaces sort first *within their project group* is unrelated and unchanged.
+
+## Open Questions
+
+- Should the pinned section support manual drag reordering in v1 of this feature? Plan says no (order by `pinnedAt`); dnd-kit is already in the sidebar so it is a mechanical follow-up if wanted. → Decision Log placeholder D6.
+- Should pinned rows also get entries in the keyboard shortcut map (`useDashboardSidebarShortcuts`) ahead of project workspaces? Plan says defer. → Decision Log placeholder D7.
+- Should the row get a hover push-pin button in addition to the context-menu item? the reference app offers both (a `group-hover` pin button on every row plus the right-click menu). Superset rows already show hover chips (agents, ports), so v1 is context-menu-only to avoid hover-affordance crowding; revisit after use. → Decision Log placeholder D8.
+
+## Progress
+
+- [x] (2026-07-25 19:47Z) Reviewed the reference app's pinning implementation end-to-end (see Purpose for takeaways).
+- [x] (2026-07-25 19:47Z) Mapped the Superset v2 sidebar data flow (see Context and Orientation).
+- [x] (2026-07-25 19:47Z) Drafted this plan.
+- [x] (2026-07-25 19:55Z) Cross-checked the draft against two independent full-repo explorations (the reference app and Superset); no contradictions found. Folded in: single tombstone site for `isHidden`, collapsed-rail rendering constraint, hover-button open question (D8), analytics note.
+- [x] (2026-07-25 20:05Z) Plan approved by Avi ("ok can you implement the pinning system").
+- [x] (2026-07-25 20:25Z) Milestone 1: `pinnedAt` schema field + heal defaults + tests; `setWorkspacePinned` in `useDashboardSidebarState`; tombstone clears `pinnedAt`; `isPinned`→`isLocalMainWorkspace` and `normalizePinnedFirst`→`normalizeMainFirst` renames.
+- [x] (2026-07-25 20:35Z) Milestone 2: `partitionSidebarWorkspacesByPinned` + `buildDashboardSidebarPinnedWorkspaces` (sharing a new `decorateSidebarWorkspace` helper with the projects builder) + tests; `useDashboardSidebarData` returns `pinnedWorkspaces`; `DashboardSidebarWorkspace` gained `isPinned`.
+- [x] (2026-07-25 20:45Z) Milestone 3: `DashboardSidebarPinnedSection` component (expanded + collapsed icon-stack modes), Pin/Unpin context-menu item at first position, `pinnedContext` project avatar on pinned rows, `activeV2Project` lookup covers pinned rows.
+- [x] (2026-07-25 20:50Z) Milestone 4 (automated): `bun run typecheck` clean, `bun run lint` clean, schema + builder tests pass (23/23), full `_authenticated` route suite green except one pre-existing unrelated failure (`paneScrollStateCache`, fails on a clean tree too).
+- [ ] Milestone 4 (manual): CDP walkthrough in the running dev app per Validation and Acceptance.
+
+## Surprises & Discoveries
+
+- Observation: The sidebar codebase already uses the word "pinned" for an unrelated concept — main workspaces are forced to the top of their project group, and `DashboardSidebarWorkspaceContextMenu` takes an `isPinned` prop that actually means "is a local main workspace" (it hides remove/hide items). `useSidebarDnd.ts:245-267` has a `normalizePinnedFirst` helper for the same thing.
+  Evidence: `DashboardSidebarWorkspaceItem.tsx:158` passes `isPinned={isMainWorkspace && hostType === "local-device"}`.
+  Consequence: Milestone 1 renames that prop/concept to `isMainWorkspace` before introducing real pinning, so the two never collide.
+
+- Observation: A full independent exploration of the reference app (2026-07-25) confirmed the review this plan is based on, and added: the reference app has no keyboard shortcut for pin, no max pin count, and fires analytics events on pin/unpin (`pin`/`unpin` in their `analytics-events.ts`). It also exposes pinning through both a hover button and the context menu (see Open Question / D8).
+  Consequence: If the desktop app has an analytics surface for sidebar actions, Milestone 3 should emit pin/unpin events through it; check analytics usage near the existing context-menu actions during implementation and mirror whatever the sibling actions (hide, toggle-unread) do.
+
+- Observation: A full independent exploration of the Superset repo (2026-07-25) confirmed the plan's approach and pinned down three details. First, `sidebarState.isHidden` is set to `true` in exactly one place — `tombstoneSidebarWorkspaceRecord` in `useDashboardSidebarState/sidebarMutations.ts` (insert at line ~49, update at line ~60) — so Milestone 1's lifecycle cleanup is a single edit there (the separate hard-delete path deletes the whole row, nothing to clean). Second, the collapsed sidebar rail renders no section chrome at all — `DashboardSidebarCollapsedProjectContent.tsx` filters to workspace icons only — so the collapsed Pinned section is a plain icon list at the top of the rail, no header. Third, `isHidden` is also read outside the sidebar by the v2-workspaces list route (`useAccessibleV2Workspaces.ts`, `V2WorkspaceRow.tsx`); pinning deliberately does not surface there in v1. Also for future grep hygiene: `packages/panes` has its own unrelated `pinned` (pane/tab pinning) and `shared/tabs-types.ts` an `isPinned` (file-tab preview state); neither collides with this work.
+  Evidence: superset-explorer agent report, 2026-07-25.
+
+- Observation: Merging `origin/main` (2026-07-25, after implementation) brought in #5956 "filter and sort projects in the dashboard sidebar", which touches the same files. One compile fix was needed (its new `testProjectFixtures.ts` constructs `DashboardSidebarWorkspace` and needed `isPinned: false`). Two deliberate semantic interactions to know about: the sidebar's project **filter** does not filter the Pinned section (pins are quick access and stay visible), and the "last updated" project **sort** ranks projects by the workspaces inside their group — a pinned workspace no longer contributes to its project's activity ranking because it is partitioned out. Both acceptable for v1; revisit if either surprises users.
+  Evidence: merge commit `1c4cd970d`, fix commit `48e12bcec`; `sortDashboardSidebarProjects.ts` reads `project.children` only.
+
+## Decision Log
+
+- Decision (D1): Pin workspaces (the v2 sidebar's row entity), not projects or tasks.
+  Rationale: Matches what the sidebar lists and what the reference app pins (their "task" is the analogous unit of work).
+  Date/Author: 2026-07-25 / Claude (planning session with Avi).
+
+- Decision (D2): Store pin state as `pinnedAt: number | null` (epoch milliseconds) inside `sidebarState` in the existing `v2WorkspaceLocalState` localStorage collection, not in Postgres.
+  Rationale: All sibling placement state (`tabOrder`, `sectionId`, `isHidden`) lives there; the collection already has read-time healing for added fields, so old persisted rows need no migration. A timestamp (not a boolean) gives us stable ordering for free — the thing the reference app stored but forgot to use.
+  Date/Author: 2026-07-25 / Claude.
+
+- Decision (D3): Idempotent `setWorkspacePinned(workspaceId, pinned: boolean)` instead of a toggle. (Signature later widened to three args by D9.)
+  Rationale: the reference app's toggle-only API forced a racy double-toggle `unpin` implementation, duplicated in two files. An idempotent setter cannot land in the wrong state when called twice.
+  Date/Author: 2026-07-25 / Claude.
+
+- Decision (D4): Global "Pinned" section at the top of the sidebar, above all project groups; pinned workspaces are partitioned out of (not mirrored in) their project group.
+  Rationale: A cross-project section is what makes pinning more useful than the existing per-project manual ordering the sidebar already has. Partitioning (the reference app's model) avoids double rows, double active-highlight, and double-counting in the keyboard-shortcut map. Because unpinning only clears `pinnedAt` and never touches `projectId`/`sectionId`/`tabOrder`, the workspace returns to its exact prior spot. Pinned rows render a small project avatar so cross-project context isn't lost.
+  Date/Author: 2026-07-25 / Claude.
+
+- Decision (D5): Pin ordering is `pinnedAt` ascending — new pins append at the bottom of the Pinned section.
+  Rationale: Stable and predictable (pins never reorder themselves), matches pinned-tab conventions, and fixes the reference app's self-reordering pinned section.
+  Date/Author: 2026-07-25 / Claude.
+
+- Decision (D9): `setWorkspacePinned(workspaceId, projectId, pinned)` — three positional args, not the two the plan drafted.
+  Rationale: pinning an auto-included local main workspace (which has no `v2WorkspaceLocalState` row) must create the row first via `ensureSidebarWorkspaceRecord`, and that needs the projectId. Without it, pinning a main workspace — the user's primary checkout — would silently no-op. Positional args match the sibling mutations in the same hook (`moveWorkspaceToSection(workspaceId, projectId, sectionId)`).
+  Date/Author: 2026-07-25 / Claude (implementation).
+
+- D6 (placeholder): drag reordering of pins — pending answer to Open Question 1.
+- D7 (placeholder): shortcut-map treatment of pins — pending answer to Open Question 2.
+- D8 (placeholder): hover pin button on rows — pending answer to Open Question 3.
+
+## Outcomes & Retrospective
+
+Shipped as planned, in one pass, with one small API deviation (D9: `setWorkspacePinned` gained a `projectId` arg so pinning an auto-included main workspace can create its local-state row). The localStorage-collection storage choice did what it promised: zero migrations, zero server surface, and live-query reactivity meant no optimistic-update machinery at all. The pre-implementation renames (`isLocalMainWorkspace`, `normalizeMainFirst`) kept the overloaded "pinned" vocabulary from colliding. Mid-flight, `main` landed project filter/sort (#5956) in the same files; the merge cost one fixture fix and surfaced two accepted interactions (pins ignore the project filter; pinned rows don't count toward a project's activity sort). Header styling converged on the sidebar's 10px uppercase micro-label convention, text-only, with extra padding below the section. Open questions D6-D8 (pin drag-reorder, shortcut-map entries, hover pin button) remain deliberate v1 exclusions. Remaining validation: the manual CDP walkthrough.
+
+## Context and Orientation
+
+Affected app: `apps/desktop` only (the Electron desktop app's renderer process — browser environment, no Node imports). No packages change; no IPC (inter-process communication between Electron's main and renderer processes) is added, because pin state never leaves the renderer.
+
+How the v2 sidebar works today, from storage to pixels:
+
+The renderer keeps per-organization client-side collections in TanStack DB (an in-memory reactive database whose collections components query with `useLiveQuery`). They are created in `apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts`. Some collections sync from Postgres via Electric; the three that describe *sidebar placement* are plain localStorage-backed collections, created around lines 747–803:
+
+- `v2SidebarProjects` — which projects show in the sidebar and their order (`tabOrder`) and collapse state.
+- `v2WorkspaceLocalState` — one row per workspace, keyed by `workspaceId`. Its `sidebarState` object holds `projectId`, `tabOrder`, `sectionId`, `isHidden`, plus per-workspace view prefs. This is where pinning will live.
+- `v2SidebarSections` — user-created named groupings inside a project.
+
+The Zod schemas for these rows live in `apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts`. `workspaceLocalStateSchema` (line ~122) defines `sidebarState`; `SIDEBAR_STATE_DEFAULTS` (line ~164) plus `healWorkspaceLocalState` (line ~363) fill in defaults when a stored row predates a field — this is why adding a field needs no migration. Ordering helpers `getPrependTabOrder`/`getNextTabOrder` live in `dashboardSidebarLocal/tabOrder.ts` ("lower tabOrder = earlier; queries sort ASC").
+
+Mutations to these collections are plain synchronous `collection.update(key, (draft) => { ... })` calls, centralized in `apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts` (e.g. `writeProjectTopLevelOrder` at line ~88 rewrites `sidebarState` fields) with lower-level helpers in the sibling `sidebarMutations.ts` (e.g. `tombstoneSidebarWorkspaceRecord`, used when a workspace is deleted).
+
+Rendering: `apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx` composes the sidebar. Its data comes from `hooks/useDashboardSidebarData/useDashboardSidebarData.ts`, which live-queries the three collections, joins them with host-provided workspace/project identity (`useHostWorkspaces`, `useHostProjects`), decorates rows with PR status, and calls `buildDashboardSidebarProjects` (same folder) to produce `DashboardSidebarProject[]` — each with `children` that are either bare workspaces or sections of workspaces (types in `DashboardSidebar/types.ts`). `DashboardSidebar.tsx` renders those groups inside a dnd-kit `DndContext`/`SortableContext` (project reordering), with `DashboardSidebarProjectSection` → `DashboardSidebarWorkspaceItem` (one row; has expanded and collapsed variants) → `DashboardSidebarWorkspaceContextMenu` (right-click menu). Within-project workspace/section drag lives in `hooks/useSidebarDnd/useSidebarDnd.ts`.
+
+Terminology guard: throughout the existing sidebar code, "pinned" currently means "local main workspace forced to the top of its project group" (see Surprises & Discoveries). This plan renames that to `isMainWorkspace` and reserves "pinned" for the new user-controlled feature.
+
+## Plan of Work
+
+### Milestone 1 — Schema field, mutation API, lifecycle cleanup
+
+In `dashboardSidebarLocal/schema.ts`, add `pinnedAt: z.number().int().nullable().default(null)` to the `sidebarState` object of `workspaceLocalStateSchema`, and `pinnedAt: null` to `SIDEBAR_STATE_DEFAULTS` so `healWorkspaceLocalState` backfills old rows. Extend `dashboardSidebarLocal/schema.test.ts` with a case proving a stored row without `pinnedAt` heals to `null`.
+
+In `useDashboardSidebarState.ts`, add and export from the hook:
+
+    setWorkspacePinned(workspaceId: string, projectId: string, pinned: boolean): void
+
+Implementation: if the `v2WorkspaceLocalState` row is missing, no-op. Otherwise `collections.v2WorkspaceLocalState.update(workspaceId, (draft) => { ... })`: when pinning, set `sidebarState.pinnedAt = Date.now()` only if currently null (idempotent — repinning must not move the row to the bottom of the pinned list) and set `sidebarState.isHidden = false` (a pin is an explicit "show me this"); when unpinning, set `pinnedAt = null` and touch nothing else, so the row rejoins its project at its old `sectionId`/`tabOrder`.
+
+Lifecycle cleanup (the reference app's unpin-on-archive, applied to our equivalents): in `sidebarMutations.ts`, make `tombstoneSidebarWorkspaceRecord` clear `pinnedAt` in both its insert and update branches. That is the only place in the codebase that sets `isHidden = true` (verified 2026-07-25 — every hide/remove path funnels through it; the hard-delete path removes the row entirely, so it needs nothing). Invariant after this milestone: a row can never be simultaneously hidden and pinned.
+
+Rename the collision: in `DashboardSidebarWorkspaceContextMenu.tsx` and its call sites in `DashboardSidebarWorkspaceItem.tsx`, rename prop `isPinned` → `isMainWorkspace`; in `useSidebarDnd.ts` rename `normalizePinnedFirst` → `normalizeMainFirst` and update its comment. Pure rename, no behavior change.
+
+### Milestone 2 — Data layer: partition pinned workspaces
+
+In `useDashboardSidebarData.ts`, add `pinnedAt` to the fields selected in the `v2WorkspaceLocalState` live query (line ~219) and carry it through `rawSidebarWorkspaces`. After `visibleSidebarWorkspaces` is computed, partition: rows with `pinnedAt != null` become `pinnedWorkspaces` (sorted by `pinnedAt` ascending, decorated with the same PR/host status the project path gets, plus the owning project's `name`/`iconUrl` looked up from `sidebarProjects` for the row's avatar); the remainder feeds `buildDashboardSidebarProjects` unchanged, which is what removes pinned rows from their project group. Return `pinnedWorkspaces` alongside `groups`. Note: pinned workspaces must still be included in `pullRequestQueryTargets` derivation (they are — derive targets from the pre-partition `visibleSidebarWorkspaces`).
+
+Add `pinnedWorkspaces: DashboardSidebarPinnedWorkspace[]` to `DashboardSidebar/types.ts`, where `DashboardSidebarPinnedWorkspace` is `DashboardSidebarWorkspace` plus `projectName: string` and `projectIconUrl: string | null`.
+
+Keep the partition logic as a small pure exported function (per the shared-helpers preference) with a unit test: given rows with mixed `pinnedAt`, it returns pinned-sorted-ascending and the untouched remainder.
+
+### Milestone 3 — UI
+
+New component folder `DashboardSidebar/components/DashboardSidebarPinnedSection/` (standard `ComponentName/ComponentName.tsx` + `index.ts` layout per AGENTS.md). It renders nothing when `pinnedWorkspaces` is empty; otherwise a section header ("Pinned", styled like `DashboardSidebarSectionHeader`'s label treatment) followed by one `DashboardSidebarWorkspaceItem` per pinned workspace. Mount it in `DashboardSidebar.tsx` inside the `OverflowFadeContainer`, above the projects `DndContext` (line ~201), in both collapsed and expanded sidebar modes. In collapsed mode the rail renders no section chrome anywhere (`DashboardSidebarCollapsedProjectContent.tsx` shows workspace icons only), so the collapsed Pinned section is just a stack of `DashboardSidebarCollapsedWorkspaceButton` icons at the top of the rail, separated from the project thumbnails below by a thin divider — no header.
+
+`DashboardSidebarWorkspaceItem` gains an optional `pinnedContext?: { projectName: string; projectIconUrl: string | null }` prop: when present, the row shows a small project avatar before the workspace name and suppresses the within-project drag-handle wiring (pinned rows are not sortable in v1).
+
+Context menu: add to `DashboardSidebarWorkspaceContextMenu` a first-position item — "Pin" (`LuPin` icon) when `pinnedAt == null`, "Unpin" (`LuPinOff`) otherwise — invoking `setWorkspacePinned`. Thread the workspace's pinned state and the callback through `DashboardSidebarWorkspaceItem` the same way `onToggleUnread` already is (via `useDashboardSidebarWorkspaceItemActions`).
+
+Active-workspace handling: `DashboardSidebar.tsx`'s `activeV2Project` lookup (line ~150) scans `groups` to find the active workspace's project for the setup-script card; extend the scan to also cover `pinnedWorkspaces` so pinning the active workspace doesn't lose that affordance.
+
+## Concrete Steps
+
+All commands from the repo root.
+
+    bun run typecheck        # after each milestone; expected: exit 0
+    bun run lint:fix         # before any push (CI fails on warnings)
+    bun run lint             # must exit 0 — CI treats warnings as errors
+    bun test apps/desktop    # expected: all pass, including new schema/partition tests
+
+Manual walkthrough after Milestone 3: `bun dev`, in the desktop app right-click a workspace → "Pin" → row moves to new top "Pinned" section with project avatar; pin a second workspace → it appends below the first; restart the app → pins persist; right-click → "Unpin" → row returns to its original project position; hide a pinned workspace via its menu → it leaves the Pinned section too.
+
+## Validation and Acceptance
+
+Acceptance is the manual walkthrough above, verified over CDP against this worktree's own dev instance per the "CDP UI Verification" rules in the root AGENTS.md and `apps/desktop/AGENTS.md` (match the renderer by this workspace's `DESKTOP_VITE_PORT`; use real UI interactions — actual right-clicks on the row — not DOM property assignment; capture before/after screenshots; include a restart/remount in the lifecycle exercised, since persistence is part of the claim). Localstorage evidence: the org's `v2-workspace-local-state-<orgId>` key shows `sidebarState.pinnedAt` set and cleared as the UI changes.
+
+## Idempotence and Recovery
+
+Every step is additive and re-runnable. `setWorkspacePinned` is idempotent by construction. The schema change is heal-forward: old rows read fine (pinnedAt heals to null), and if the feature is reverted, the stray `pinnedAt` key in localStorage is ignored by the old schema's `.passthrough`-free parse via healing — no data cleanup needed. No Postgres, Electric, or host-service surface changes, so there is nothing to roll back outside the renderer bundle.
+
+## Interfaces and Dependencies
+
+No new dependencies — dnd-kit, TanStack DB, zod, and react-icons (`LuPin`/`LuPinOff` from `react-icons/lu`) are already in use in this exact component tree. Signatures that must exist at the end:
+
+    // useDashboardSidebarState.ts
+    setWorkspacePinned: (workspaceId: string, projectId: string, pinned: boolean) => void
+
+    // useDashboardSidebarData.ts return value gains
+    pinnedWorkspaces: DashboardSidebarPinnedWorkspace[]
+
+    // DashboardSidebar/types.ts
+    export type DashboardSidebarPinnedWorkspace = DashboardSidebarWorkspace & {
+      projectName: string;
+      projectIconUrl: string | null;
+    };
+
+---
+
+Revision note (2026-07-25 19:55Z): After the initial draft, two independent repo explorations (one of the reference app, one of Superset) were completed and cross-checked against the plan. No design changes resulted. Edits: Milestone 1's lifecycle cleanup narrowed from "audit every isHidden write site" to the single `tombstoneSidebarWorkspaceRecord` edit (verified sole `isHidden = true` writer); Milestone 3's collapsed-mode description corrected to an icon-only stack (the collapsed rail renders no section chrome anywhere); added Open Question 3 / D8 (hover pin button — the reference app has one, v1 here is context-menu-only) and an analytics note (the reference app emits pin/unpin events). Reason: keep the plan's instructions matched to verified code reality before the approval gate.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -36,6 +36,7 @@ import { useInlineWorkspacePortsEnabled } from "renderer/stores/inline-workspace
 import { useSidebarWorkspacesCollapseStore } from "renderer/stores/sidebar-workspaces-collapse";
 import { DashboardSidebarHeader } from "./components/DashboardSidebarHeader";
 import { DashboardSidebarHoverCardOverlay } from "./components/DashboardSidebarHoverCardOverlay";
+import { DashboardSidebarPinnedSection } from "./components/DashboardSidebarPinnedSection";
 import { DashboardSidebarPortsList } from "./components/DashboardSidebarPortsList";
 import { DashboardSidebarProjectSection } from "./components/DashboardSidebarProjectSection";
 import { DashboardSidebarSectionRenameProvider } from "./components/DashboardSidebarSectionRenameContext";
@@ -113,8 +114,12 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 export function DashboardSidebar({
 	isCollapsed = false,
 }: DashboardSidebarProps) {
-	const { groups, refreshWorkspacePullRequest, toggleProjectCollapsed } =
-		useDashboardSidebarData();
+	const {
+		groups,
+		pinnedWorkspaces,
+		refreshWorkspacePullRequest,
+		toggleProjectCollapsed,
+	} = useDashboardSidebarData();
 	const { reorderProjects } = useDashboardSidebarState();
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -186,6 +191,14 @@ export function DashboardSidebar({
 
 	const activeV2Project = useMemo(() => {
 		if (!activeV2WorkspaceId) return null;
+		// A pinned active workspace renders outside its project group, so
+		// resolve its project by id instead.
+		const pinned = pinnedWorkspaces.find(
+			(workspace) => workspace.id === activeV2WorkspaceId,
+		);
+		if (pinned) {
+			return groups.find((project) => project.id === pinned.projectId) ?? null;
+		}
 		for (const project of groups) {
 			for (const child of project.children) {
 				if (
@@ -202,7 +215,7 @@ export function DashboardSidebar({
 			}
 		}
 		return null;
-	}, [groups, activeV2WorkspaceId]);
+	}, [groups, pinnedWorkspaces, activeV2WorkspaceId]);
 
 	const handleDragEnd = useCallback(
 		({ active, over }: DragEndEvent) => {
@@ -245,6 +258,13 @@ export function DashboardSidebar({
 								fadeEdges={["top", "bottom"]}
 								className="flex-1 overflow-y-auto hide-scrollbar"
 							>
+								{(isCollapsed || !workspacesListCollapsed) && (
+									<DashboardSidebarPinnedSection
+										pinnedWorkspaces={pinnedWorkspaces}
+										isCollapsed={isCollapsed}
+										onWorkspaceHover={refreshWorkspacePullRequest}
+									/>
+								)}
 								{(isCollapsed || !workspacesListCollapsed) && (
 									<DndContext
 										sensors={sensors}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPinnedSection/DashboardSidebarPinnedSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPinnedSection/DashboardSidebarPinnedSection.tsx
@@ -1,0 +1,58 @@
+import type { DashboardSidebarPinnedWorkspace } from "../../types";
+import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
+
+interface DashboardSidebarPinnedSectionProps {
+	pinnedWorkspaces: DashboardSidebarPinnedWorkspace[];
+	isCollapsed?: boolean;
+	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
+}
+
+/**
+ * Top-level "Pinned" section rendered above all project groups. Rows are
+ * ordered by pin time ascending (new pins append at the bottom) and are
+ * exempt from project grouping. The collapsed rail renders no section chrome
+ * anywhere, so collapsed mode is a plain icon stack with a trailing divider.
+ */
+export function DashboardSidebarPinnedSection({
+	pinnedWorkspaces,
+	isCollapsed = false,
+	onWorkspaceHover,
+}: DashboardSidebarPinnedSectionProps) {
+	if (pinnedWorkspaces.length === 0) return null;
+
+	if (isCollapsed) {
+		return (
+			<div className="flex flex-col gap-0.5 py-1">
+				{pinnedWorkspaces.map((workspace) => (
+					<DashboardSidebarWorkspaceItem
+						key={workspace.id}
+						workspace={workspace}
+						isCollapsed
+						onHoverCardOpen={() => onWorkspaceHover(workspace.id)}
+					/>
+				))}
+				<div className="mx-3 mt-1 border-b border-border" />
+			</div>
+		);
+	}
+
+	return (
+		<div className="mt-1 pb-3 first:mt-0">
+			{/* Micro-label styled to match the PROJECTS header above the groups. */}
+			<div className="flex min-h-8 items-center py-1.5 pl-4 pr-2 text-[10px] font-semibold uppercase tracking-[0.075em] text-muted-foreground">
+				<span className="min-w-0 truncate">Pinned</span>
+			</div>
+			{pinnedWorkspaces.map((workspace) => (
+				<DashboardSidebarWorkspaceItem
+					key={workspace.id}
+					workspace={workspace}
+					pinnedContext={{
+						projectName: workspace.projectName,
+						projectIconUrl: workspace.projectIconUrl,
+					}}
+					onHoverCardOpen={() => onWorkspaceHover(workspace.id)}
+				/>
+			))}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPinnedSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPinnedSection/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarPinnedSection } from "./DashboardSidebarPinnedSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -18,6 +18,11 @@ interface DashboardSidebarWorkspaceItemProps {
 	shortcutLabel?: string;
 	isCollapsed?: boolean;
 	isInSection?: boolean;
+	/**
+	 * Set when the row renders inside the top-level Pinned section: shows the
+	 * owning project's avatar for cross-project context.
+	 */
+	pinnedContext?: { projectName: string; projectIconUrl: string | null };
 }
 
 export function DashboardSidebarWorkspaceItem({
@@ -26,6 +31,7 @@ export function DashboardSidebarWorkspaceItem({
 	shortcutLabel,
 	isCollapsed = false,
 	isInSection = false,
+	pinnedContext,
 }: DashboardSidebarWorkspaceItemProps) {
 	const {
 		id,
@@ -51,6 +57,7 @@ export function DashboardSidebarWorkspaceItem({
 		handleDeleted,
 		handleOpenInFinder,
 		handleRemoveFromSidebar,
+		handleTogglePin,
 		handleToggleUnread,
 		isActive,
 		isDeleteDialogOpen,
@@ -68,6 +75,7 @@ export function DashboardSidebarWorkspaceItem({
 		workspaceName: name,
 		branch,
 		isMainWorkspace,
+		isPinned: workspace.isPinned,
 	});
 
 	const { v2Workspaces: v2WorkspaceActions } = useOptimisticCollectionActions();
@@ -155,7 +163,11 @@ export function DashboardSidebarWorkspaceItem({
 							isUnread={isUnread}
 							hasStatus={!!workspaceStatus}
 							isLocalWorkspace={hostType === "local-device"}
-							isPinned={isMainWorkspace && hostType === "local-device"}
+							isLocalMainWorkspace={
+								isMainWorkspace && hostType === "local-device"
+							}
+							isPinned={workspace.isPinned}
+							onTogglePin={handleTogglePin}
 							onCreateSection={handleCreateSection}
 							showDeleteHotkey={isActive}
 							onMoveToSection={(targetSectionId) =>
@@ -214,6 +226,7 @@ export function DashboardSidebarWorkspaceItem({
 				isRenaming={isRenaming}
 				renameValue={renameValue}
 				shortcutLabel={shortcutLabel}
+				pinnedContext={pinnedContext}
 				diffStats={isPending ? null : diffStats}
 				workspaceStatus={workspaceStatus}
 				isInSection={isInSection}
@@ -245,7 +258,11 @@ export function DashboardSidebarWorkspaceItem({
 							moveWorkspaceToSection(id, projectId, targetSectionId)
 						}
 						isLocalWorkspace={hostType === "local-device"}
-						isPinned={isMainWorkspace && hostType === "local-device"}
+						isLocalMainWorkspace={
+							isMainWorkspace && hostType === "local-device"
+						}
+						isPinned={workspace.isPinned}
+						onTogglePin={handleTogglePin}
 						onOpenInFinder={handleOpenInFinder}
 						showDeleteHotkey={isActive}
 						onCopyPath={handleCopyPath}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -10,6 +10,7 @@ import { HiMiniMinus, HiMiniXMark } from "react-icons/hi2";
 import type { DiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import type { ActivePaneStatus } from "shared/tabs-types";
 import type {
@@ -41,6 +42,8 @@ interface DashboardSidebarExpandedWorkspaceRowProps
 	diffStats: DiffStats | null;
 	workspaceStatus?: ActivePaneStatus | null;
 	isInSection?: boolean;
+	/** Present when rendered in the Pinned section: shows the project avatar. */
+	pinnedContext?: { projectName: string; projectIconUrl: string | null };
 	onClick?: () => void;
 	onDoubleClick?: () => void;
 	onCloseWorkspaceClick: () => void;
@@ -64,6 +67,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			diffStats,
 			workspaceStatus = null,
 			isInSection = false,
+			pinnedContext,
 			onClick,
 			onDoubleClick,
 			onCloseWorkspaceClick,
@@ -223,6 +227,23 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 							)}
 						</TooltipContent>
 					</Tooltip>
+
+					{pinnedContext && (
+						<Tooltip delayDuration={500}>
+							<TooltipTrigger asChild>
+								<div className="mr-1.5 flex shrink-0 items-center">
+									<ProjectThumbnail
+										projectName={pinnedContext.projectName}
+										iconUrl={pinnedContext.projectIconUrl}
+										className="size-3.5 text-[8px]"
+									/>
+								</div>
+							</TooltipTrigger>
+							<TooltipContent side="right" sideOffset={8}>
+								{pinnedContext.projectName}
+							</TooltipContent>
+						</Tooltip>
+					)}
 
 					<div className="grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5">
 						{isRenaming ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -22,6 +22,8 @@ import {
 	LuFolderPlus,
 	LuGitBranch,
 	LuPencil,
+	LuPin,
+	LuPinOff,
 	LuRadioTower,
 	LuTrash2,
 	LuX,
@@ -37,10 +39,12 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 	projectId: string;
 	isInSection?: boolean;
 	isLocalWorkspace: boolean;
-	isPinned?: boolean;
+	isLocalMainWorkspace?: boolean;
+	isPinned: boolean;
 	isUnread: boolean;
 	hasStatus: boolean;
 	showDeleteHotkey?: boolean;
+	onTogglePin: () => void;
 	onCreateSection: () => void;
 	onMoveToSection: (sectionId: string | null) => void;
 	onOpenInFinder: () => void;
@@ -59,10 +63,12 @@ export function DashboardSidebarWorkspaceContextMenu({
 	projectId,
 	isInSection,
 	isLocalWorkspace,
-	isPinned = false,
+	isLocalMainWorkspace = false,
+	isPinned,
 	isUnread,
 	hasStatus,
 	showDeleteHotkey = false,
+	onTogglePin,
 	onCreateSection,
 	onMoveToSection,
 	onOpenInFinder,
@@ -108,6 +114,20 @@ export function DashboardSidebarWorkspaceContextMenu({
 		<ContextMenu onOpenChange={setContextMenuOpen}>
 			<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
 			<ContextMenuContent onCloseAutoFocus={(event) => event.preventDefault()}>
+				<ContextMenuItem onSelect={onTogglePin}>
+					{isPinned ? (
+						<>
+							<LuPinOff className="size-4 mr-2" />
+							Unpin
+						</>
+					) : (
+						<>
+							<LuPin className="size-4 mr-2" />
+							Pin
+						</>
+					)}
+				</ContextMenuItem>
+				<ContextMenuSeparator />
 				{onRename && (
 					<ContextMenuItem onSelect={onRename}>
 						<LuPencil className="size-4 mr-2" />
@@ -152,7 +172,9 @@ export function DashboardSidebarWorkspaceContextMenu({
 						Clear Status
 					</ContextMenuItem>
 				)}
-				{!isPinned && (
+				{/* Group actions mutate placement (sectionId/tabOrder), which a pinned
+				    row doesn't display — the change would only surface on unpin. */}
+				{!isPinned && !isLocalMainWorkspace && (
 					<>
 						<ContextMenuSeparator />
 						<ContextMenuItem onSelect={onCreateSection}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -24,6 +24,7 @@ interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	workspaceName: string;
 	branch: string;
 	isMainWorkspace?: boolean;
+	isPinned?: boolean;
 }
 
 export function useDashboardSidebarWorkspaceItemActions({
@@ -32,6 +33,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 	workspaceName,
 	branch,
 	isMainWorkspace = false,
+	isPinned = false,
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -51,8 +53,12 @@ export function useDashboardSidebarWorkspaceItemActions({
 		clearManualUnread(workspaceId);
 		markWorkspaceTerminalsSeen();
 	};
-	const { createSection, moveWorkspaceToSection, removeWorkspaceFromSidebar } =
-		useDashboardSidebarState();
+	const {
+		createSection,
+		moveWorkspaceToSection,
+		removeWorkspaceFromSidebar,
+		setWorkspacePinned,
+	} = useDashboardSidebarState();
 
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [renameValue, setRenameValue] = useState(workspaceName);
@@ -159,6 +165,10 @@ export function useDashboardSidebarWorkspaceItemActions({
 		}
 	};
 
+	const handleTogglePin = () => {
+		setWorkspacePinned(workspaceId, projectId, !isPinned);
+	};
+
 	// Clears manual + review marks locally, then forces the host's bindings
 	// to Stop — the escape hatch for a wedged working/permission dot (an
 	// interrupted agent fires no Stop hook). Live agents re-assert on their
@@ -205,6 +215,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 		handleDeleted,
 		handleOpenInFinder,
 		handleRemoveFromSidebar,
+		handleTogglePin,
 		handleToggleUnread,
 		isActive,
 		isDeleteDialogOpen,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
+	buildDashboardSidebarPinnedWorkspaces,
 	buildDashboardSidebarProjects,
+	partitionSidebarWorkspacesByPinned,
 	type SidebarProjectInput,
 	type SidebarSectionInput,
 	type SidebarWorkspaceInput,
@@ -56,6 +58,7 @@ function makeWorkspace(
 		updatedAt: DATE,
 		tabOrder: 1,
 		sectionId: null,
+		pinnedAt: null,
 		pendingTransaction: null,
 		...overrides,
 	};
@@ -164,5 +167,50 @@ describe("buildDashboardSidebarProjects", () => {
 			"orphan-late",
 			"section:section-1",
 		]);
+	});
+});
+
+describe("partitionSidebarWorkspacesByPinned", () => {
+	it("splits pinned rows out and sorts them by pin time ascending", () => {
+		const { pinned, unpinned } = partitionSidebarWorkspacesByPinned([
+			makeWorkspace({ id: "unpinned-1" }),
+			makeWorkspace({ id: "pinned-late", pinnedAt: 2000 }),
+			makeWorkspace({ id: "unpinned-2" }),
+			makeWorkspace({ id: "pinned-early", pinnedAt: 1000 }),
+		]);
+
+		expect(pinned.map((workspace) => workspace.id)).toEqual([
+			"pinned-early",
+			"pinned-late",
+		]);
+		expect(unpinned.map((workspace) => workspace.id)).toEqual([
+			"unpinned-1",
+			"unpinned-2",
+		]);
+	});
+});
+
+describe("buildDashboardSidebarPinnedWorkspaces", () => {
+	it("decorates pinned rows with project identity and drops project-less rows", () => {
+		const rows = buildDashboardSidebarPinnedWorkspaces({
+			pinnedSidebarWorkspaces: [
+				makeWorkspace({ id: "pinned-1", pinnedAt: 1000 }),
+				makeWorkspace({
+					id: "pinned-orphan",
+					projectId: "removed-project",
+					pinnedAt: 2000,
+				}),
+			],
+			sidebarProjects: [
+				makeProject({ id: "project-1", name: "Superset", iconUrl: "icon.png" }),
+			],
+			machineId: MACHINE_ID,
+			pullRequestsByWorkspaceId: new Map(),
+		});
+
+		expect(rows.map((row) => row.id)).toEqual(["pinned-1"]);
+		expect(rows[0].projectName).toBe("Superset");
+		expect(rows[0].projectIconUrl).toBe("icon.png");
+		expect(rows[0].isPinned).toBe(true);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceTransactionSnapshot } from "renderer/stores/workspace-creates";
 import { getV2WorkspaceDisplayName } from "renderer/utils/getV2WorkspaceDisplayName";
 import type {
+	DashboardSidebarPinnedWorkspace,
 	DashboardSidebarProject,
 	DashboardSidebarProjectChild,
 	DashboardSidebarSection,
@@ -44,7 +45,102 @@ export interface SidebarWorkspaceInput {
 	updatedAt: Date;
 	tabOrder: number;
 	sectionId: string | null;
+	pinnedAt: number | null;
 	pendingTransaction: WorkspaceTransactionSnapshot | null;
+}
+
+/**
+ * Splits the visible rows into pinned (sorted by pin time ascending, so new
+ * pins append at the bottom of the Pinned section) and everything else. The
+ * caller feeds `unpinned` to {@link buildDashboardSidebarProjects} and
+ * `pinned` to {@link buildDashboardSidebarPinnedWorkspaces} — a pinned
+ * workspace renders only in the Pinned section, never in its project group.
+ */
+export function partitionSidebarWorkspacesByPinned<
+	Workspace extends { pinnedAt: number | null },
+>(workspaces: Workspace[]): { pinned: Workspace[]; unpinned: Workspace[] } {
+	const pinned: Workspace[] = [];
+	const unpinned: Workspace[] = [];
+	for (const workspace of workspaces) {
+		(workspace.pinnedAt != null ? pinned : unpinned).push(workspace);
+	}
+	pinned.sort((left, right) => (left.pinnedAt ?? 0) - (right.pinnedAt ?? 0));
+	return { pinned, unpinned };
+}
+
+function decorateSidebarWorkspace(
+	workspace: SidebarWorkspaceInput,
+	project: Pick<SidebarProjectInput, "githubOwner" | "githubRepoName">,
+	machineId: string,
+	pullRequestsByWorkspaceId: Map<string, SidebarPullRequest>,
+): DashboardSidebarWorkspace {
+	const hostType: DashboardSidebarWorkspace["hostType"] =
+		workspace.hostId === machineId ? "local-device" : "remote-device";
+
+	return {
+		id: workspace.id,
+		projectId: workspace.projectId,
+		hostId: workspace.hostId,
+		hostType,
+		type: workspace.type,
+		hostIsOnline: hostType === "remote-device" ? workspace.hostIsOnline : null,
+		accentColor: null,
+		name: getV2WorkspaceDisplayName(workspace),
+		branch: workspace.branch,
+		pullRequest: pullRequestsByWorkspaceId.get(workspace.id) ?? null,
+		repoUrl:
+			project.githubOwner && project.githubRepoName
+				? `https://github.com/${project.githubOwner}/${project.githubRepoName}`
+				: null,
+		branchExistsOnRemote:
+			project.githubOwner !== null && project.githubRepoName !== null,
+		previewUrl: null,
+		needsRebase: null,
+		behindCount: null,
+		createdAt: workspace.createdAt,
+		updatedAt: workspace.updatedAt,
+		taskId: workspace.taskId,
+		isPinned: workspace.pinnedAt != null,
+		pendingTransaction: workspace.pendingTransaction,
+	};
+}
+
+/**
+ * Decorates pinned rows for the sidebar's top-level Pinned section. Rows keep
+ * their partition order (pin time ascending). A pinned workspace whose project
+ * is no longer in the sidebar is dropped, matching how
+ * {@link buildDashboardSidebarProjects} treats project-less rows.
+ */
+export function buildDashboardSidebarPinnedWorkspaces({
+	pinnedSidebarWorkspaces,
+	sidebarProjects,
+	machineId,
+	pullRequestsByWorkspaceId,
+}: {
+	pinnedSidebarWorkspaces: SidebarWorkspaceInput[];
+	sidebarProjects: SidebarProjectInput[];
+	machineId: string;
+	pullRequestsByWorkspaceId: Map<string, SidebarPullRequest>;
+}): DashboardSidebarPinnedWorkspace[] {
+	const projectsById = new Map(
+		sidebarProjects.map((project) => [project.id, project]),
+	);
+	return pinnedSidebarWorkspaces.flatMap((workspace) => {
+		const project = projectsById.get(workspace.projectId);
+		if (!project) return [];
+		return [
+			{
+				...decorateSidebarWorkspace(
+					workspace,
+					project,
+					machineId,
+					pullRequestsByWorkspaceId,
+				),
+				projectName: project.name,
+				projectIconUrl: project.iconUrl,
+			},
+		];
+	});
 }
 
 export interface BuildDashboardSidebarProjectsParams {
@@ -110,35 +206,12 @@ export function buildDashboardSidebarProjects({
 		const project = projectsById.get(workspace.projectId);
 		if (!project) continue;
 
-		const hostType: DashboardSidebarWorkspace["hostType"] =
-			workspace.hostId === machineId ? "local-device" : "remote-device";
-
-		const sidebarWorkspace: DashboardSidebarWorkspace = {
-			id: workspace.id,
-			projectId: workspace.projectId,
-			hostId: workspace.hostId,
-			hostType,
-			type: workspace.type,
-			hostIsOnline:
-				hostType === "remote-device" ? workspace.hostIsOnline : null,
-			accentColor: null,
-			name: getV2WorkspaceDisplayName(workspace),
-			branch: workspace.branch,
-			pullRequest: pullRequestsByWorkspaceId.get(workspace.id) ?? null,
-			repoUrl:
-				project.githubOwner && project.githubRepoName
-					? `https://github.com/${project.githubOwner}/${project.githubRepoName}`
-					: null,
-			branchExistsOnRemote:
-				project.githubOwner !== null && project.githubRepoName !== null,
-			previewUrl: null,
-			needsRebase: null,
-			behindCount: null,
-			createdAt: workspace.createdAt,
-			updatedAt: workspace.updatedAt,
-			taskId: workspace.taskId,
-			pendingTransaction: workspace.pendingTransaction,
-		};
+		const sidebarWorkspace = decorateSidebarWorkspace(
+			workspace,
+			project,
+			machineId,
+			pullRequestsByWorkspaceId,
+		);
 
 		if (workspace.sectionId) {
 			const section = project.sectionMap.get(workspace.sectionId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -14,10 +14,15 @@ import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/Host
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useWorkspaceTransactionsStore } from "renderer/stores/workspace-creates";
 import type {
+	DashboardSidebarPinnedWorkspace,
 	DashboardSidebarProject,
 	DashboardSidebarWorkspace,
 } from "../../types";
-import { buildDashboardSidebarProjects } from "./buildDashboardSidebarProjects";
+import {
+	buildDashboardSidebarPinnedWorkspaces,
+	buildDashboardSidebarProjects,
+	partitionSidebarWorkspacesByPinned,
+} from "./buildDashboardSidebarProjects";
 import {
 	derivePullRequestQueryTargets,
 	getDashboardSidebarPullRequestQueryKey,
@@ -85,6 +90,26 @@ function useStablePullRequestsByWorkspaceId(
 		previousRef.current = { fingerprint, map };
 		return map;
 	}, [rows]);
+}
+
+/**
+ * Returns the previous reference while the JSON serialization is unchanged.
+ * Same purpose as the fingerprinted hooks below: the sidebar builders produce
+ * fresh arrays every run, and downstream memoization needs stable identities.
+ */
+function useJsonStable<Value>(value: Value): Value {
+	const previousRef = useRef<{ fingerprint: string; value: Value } | null>(
+		null,
+	);
+	return useMemo(() => {
+		const fingerprint = JSON.stringify(value);
+		const previous = previousRef.current;
+		if (previous?.fingerprint === fingerprint) {
+			return previous.value;
+		}
+		previousRef.current = { fingerprint, value };
+		return value;
+	}, [value]);
 }
 
 function useStableDashboardSidebarProjects(
@@ -230,6 +255,7 @@ export function useDashboardSidebarData() {
 					tabOrder: sidebarWorkspaces.sidebarState.tabOrder,
 					sectionId: sidebarWorkspaces.sidebarState.sectionId,
 					isHidden: sidebarWorkspaces.sidebarState.isHidden,
+					pinnedAt: sidebarWorkspaces.sidebarState.pinnedAt,
 				})),
 		[collections],
 	);
@@ -252,6 +278,7 @@ export function useDashboardSidebarData() {
 						tabOrder: localState.tabOrder,
 						sectionId: localState.sectionId,
 						isHidden: localState.isHidden,
+						pinnedAt: localState.pinnedAt,
 					},
 				];
 			}),
@@ -293,6 +320,9 @@ export function useDashboardSidebarData() {
 					updatedAt: workspace.updatedAt,
 					tabOrder: MAIN_WORKSPACE_TAB_ORDER,
 					sectionId: null as string | null,
+					// Auto-included mains have no local-state row; pinning one
+					// creates a row first (see setWorkspacePinned).
+					pinnedAt: null as number | null,
 				})),
 		[hostWorkspaces],
 	);
@@ -392,12 +422,20 @@ export function useDashboardSidebarData() {
 	const pullRequestsByWorkspaceId =
 		useStablePullRequestsByWorkspaceId(pullRequestRows);
 
+	// Pinned rows render only in the top-level Pinned section, so they are
+	// partitioned out before the per-project tree is built. PR polling targets
+	// derive from the pre-partition list above, so pinned rows keep PR status.
+	const { pinned: pinnedRows, unpinned: unpinnedRows } = useMemo(
+		() => partitionSidebarWorkspacesByPinned(visibleSidebarWorkspaces),
+		[visibleSidebarWorkspaces],
+	);
+
 	const computedGroups = useMemo<DashboardSidebarProject[]>(
 		() =>
 			buildDashboardSidebarProjects({
 				sidebarProjects,
 				sidebarSections,
-				visibleSidebarWorkspaces,
+				visibleSidebarWorkspaces: unpinnedRows,
 				machineId,
 				pullRequestsByWorkspaceId,
 			}),
@@ -406,13 +444,26 @@ export function useDashboardSidebarData() {
 			pullRequestsByWorkspaceId,
 			sidebarProjects,
 			sidebarSections,
-			visibleSidebarWorkspaces,
+			unpinnedRows,
 		],
 	);
 	const groups = useStableDashboardSidebarProjects(computedGroups);
 
+	const computedPinnedWorkspaces = useMemo<DashboardSidebarPinnedWorkspace[]>(
+		() =>
+			buildDashboardSidebarPinnedWorkspaces({
+				pinnedSidebarWorkspaces: pinnedRows,
+				sidebarProjects,
+				machineId,
+				pullRequestsByWorkspaceId,
+			}),
+		[machineId, pinnedRows, pullRequestsByWorkspaceId, sidebarProjects],
+	);
+	const pinnedWorkspaces = useJsonStable(computedPinnedWorkspaces);
+
 	return {
 		groups,
+		pinnedWorkspaces,
 		refreshWorkspacePullRequest,
 		toggleProjectCollapsed,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -247,13 +247,13 @@ export function useSidebarDnd({
 		return null; // ungrouped — no section above
 	}, [activeId, overId, activeType, flatItems, sectionsById]);
 
-	// The sidebar data builder always pins local main workspaces first,
+	// The sidebar data builder always sorts local main workspaces first,
 	// so any drop that lands an item above one would silently revert on
 	// the next rebuild (e.g. when the sidebar collapses and remounts).
 	// Normalize drop results to match what actually persists.
-	const normalizePinnedFirst = useCallback(
+	const normalizeMainFirst = useCallback(
 		(items: UniqueIdentifier[]) => {
-			const pinned: UniqueIdentifier[] = [];
+			const mains: UniqueIdentifier[] = [];
 			const rest: UniqueIdentifier[] = [];
 			for (const id of items) {
 				const parsed = parseId(id);
@@ -262,12 +262,12 @@ export function useSidebarDnd({
 						? workspacesById.get(parsed.realId)
 						: null;
 				if (ws?.type === "main" && ws.hostType === "local-device") {
-					pinned.push(id);
+					mains.push(id);
 				} else {
 					rest.push(id);
 				}
 			}
-			return pinned.length > 0 ? [...pinned, ...rest] : items;
+			return mains.length > 0 ? [...mains, ...rest] : items;
 		},
 		[workspacesById],
 	);
@@ -348,7 +348,7 @@ export function useSidebarDnd({
 					rebuilt.push(...wsInSec);
 				}
 
-				const newItems = normalizePinnedFirst(rebuilt);
+				const newItems = normalizeMainFirst(rebuilt);
 				setFlatItems(newItems);
 				commitToDb(newItems);
 			} else {
@@ -358,14 +358,14 @@ export function useSidebarDnd({
 				if (oldIndex === -1 || overIndex === -1 || oldIndex === overIndex)
 					return;
 
-				const newItems = normalizePinnedFirst(
+				const newItems = normalizeMainFirst(
 					arrayMove(flatItems, oldIndex, overIndex),
 				);
 				setFlatItems(newItems);
 				commitToDb(newItems);
 			}
 		},
-		[flatItems, commitToDb, normalizePinnedFirst],
+		[flatItems, commitToDb, normalizeMainFirst],
 	);
 
 	const onDragCancel = useCallback(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts
@@ -43,8 +43,19 @@ export interface DashboardSidebarWorkspace {
 	createdAt: Date;
 	updatedAt: Date;
 	taskId: string | null;
+	isPinned: boolean;
 	pendingTransaction: WorkspaceTransactionSnapshot | null;
 }
+
+/**
+ * A pinned workspace rendered in the sidebar's top-level Pinned section.
+ * Carries its project's identity since the row renders outside any project
+ * group.
+ */
+export type DashboardSidebarPinnedWorkspace = DashboardSidebarWorkspace & {
+	projectName: string;
+	projectIconUrl: string | null;
+};
 
 export interface DashboardSidebarSection {
 	id: string;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/testProjectFixtures.ts
@@ -24,6 +24,7 @@ export function makeWorkspace(
 		createdAt: new Date("2026-01-01"),
 		updatedAt: new Date("2026-01-01"),
 		taskId: null,
+		isPinned: false,
 		pendingTransaction: null,
 		...overrides,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.test.ts
@@ -41,6 +41,7 @@ type LocalStateRow = {
 		tabOrder: number;
 		sectionId: string | null;
 		isHidden: boolean;
+		pinnedAt: number | null;
 	};
 	paneLayout: { version: number; tabs: unknown[]; activeTabId: string | null };
 };
@@ -58,6 +59,7 @@ function localStateRow(
 			tabOrder: 1,
 			sectionId: null,
 			isHidden: false,
+			pinnedAt: null,
 			...overrides,
 		},
 		paneLayout: { version: 1, tabs: [], activeTabId: null },
@@ -183,6 +185,33 @@ describe("removeProjectFromSidebarState", () => {
 		expect(collections.v2SidebarProjects.get("proj-1")).toBeUndefined();
 	});
 
+	it("clears the pin on a kept main-workspace row so it can't become an invisible orphan", () => {
+		// A pinned row is excluded from the project tree, and once the project
+		// record is deleted the pinned section drops it too — with the pin left
+		// set, the workspace would vanish with no context menu to unpin it.
+		const collections = makeCollections();
+		collections.v2WorkspaceLocalState.insert(
+			localStateRow("ws-main", "proj-1", { pinnedAt: 1753000000000 }),
+		);
+		const workspaces: SidebarWorkspaceRow[] = [
+			{ id: "ws-main", projectId: "proj-1", hostId: "machine-1", type: "main" },
+		];
+		collections.v2SidebarProjects.insert({ projectId: "proj-1" });
+
+		removeProjectFromSidebarState(
+			asRemoveArg(collections),
+			workspaces,
+			"proj-1",
+			"machine-1",
+			noopCleanup,
+		);
+
+		const row = collections.v2WorkspaceLocalState.get("ws-main");
+		expect(row?.sidebarState.pinnedAt).toBeNull();
+		// Still not hidden — re-adding the project restores the main workspace.
+		expect(row?.sidebarState.isHidden).toBe(false);
+	});
+
 	it("leaves workspaces from other projects untouched", () => {
 		const collections = makeCollections();
 		collections.v2WorkspaceLocalState.insert(
@@ -258,10 +287,13 @@ describe("tombstoneSidebarWorkspaceRecord", () => {
 		expect(cleaned).toEqual([]);
 	});
 
-	it("hides an existing row, clears its section, and runs pane cleanup", () => {
+	it("hides an existing row, clears its section and pin, and runs pane cleanup", () => {
 		const collections = makeCollections();
 		collections.v2WorkspaceLocalState.insert(
-			localStateRow("ws-1", "proj-1", { sectionId: "sec-1" }),
+			localStateRow("ws-1", "proj-1", {
+				sectionId: "sec-1",
+				pinnedAt: 1753000000000,
+			}),
 		);
 		const cleaned: string[] = [];
 
@@ -277,6 +309,7 @@ describe("tombstoneSidebarWorkspaceRecord", () => {
 		const row = collections.v2WorkspaceLocalState.get("ws-1");
 		expect(row?.sidebarState.isHidden).toBe(true);
 		expect(row?.sidebarState.sectionId).toBeNull();
+		expect(row?.sidebarState.pinnedAt).toBeNull();
 		expect(cleaned).toEqual(["ws-1"]);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/sidebarMutations.ts
@@ -58,6 +58,9 @@ export function tombstoneSidebarWorkspaceRecord(
 		draft.sidebarState.projectId = projectId;
 		draft.sidebarState.sectionId = null;
 		draft.sidebarState.isHidden = true;
+		// A row must never be hidden and pinned at once — a resurrected
+		// workspace would otherwise reappear pre-pinned.
+		draft.sidebarState.pinnedAt = null;
 		draft.paneLayout = createEmptyPaneLayout();
 	});
 }
@@ -123,6 +126,21 @@ export function removeProjectFromSidebarState(
 			projectId,
 			cleanupPaneRuntimes,
 		);
+	}
+
+	// Main workspaces keep their rows (see the doc comment above), but any pin
+	// must be cleared: a pinned row is excluded from the project tree, and with
+	// the project row gone the pinned section drops it too — leaving it fully
+	// invisible with no context menu to unpin it from.
+	for (const row of collections.v2WorkspaceLocalState.state.values()) {
+		if (
+			row.sidebarState.projectId === projectId &&
+			row.sidebarState.pinnedAt != null
+		) {
+			collections.v2WorkspaceLocalState.update(row.workspaceId, (draft) => {
+				draft.sidebarState.pinnedAt = null;
+			});
+		}
 	}
 
 	const sectionIds = Array.from(collections.v2SidebarSections.state.values())

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -444,6 +444,37 @@ export function useDashboardSidebarState() {
 		[collections],
 	);
 
+	const setWorkspacePinned = useCallback(
+		(workspaceId: string, projectId: string, pinned: boolean) => {
+			const existing = collections.v2WorkspaceLocalState.get(workspaceId);
+			if (!existing) {
+				if (!pinned) return;
+				// Auto-included local main workspaces have no local-state row yet;
+				// pinning is an explicit placement, so create one first.
+				ensureSidebarProjectRecord(collections, projectId);
+				ensureSidebarWorkspaceRecord(collections, workspaceId, projectId);
+			}
+			// Strictly greater than every existing pin so same-millisecond pins
+			// still order by pin sequence instead of collection iteration order.
+			const maxPinnedAt = Array.from(
+				collections.v2WorkspaceLocalState.state.values(),
+			).reduce((max, row) => Math.max(max, row.sidebarState.pinnedAt ?? 0), 0);
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				if (pinned) {
+					// Keep the original pin time on repeat pins so the row doesn't
+					// jump to the bottom of the Pinned section.
+					draft.sidebarState.pinnedAt ??= Math.max(Date.now(), maxPinnedAt + 1);
+					draft.sidebarState.isHidden = false;
+				} else {
+					// Only clear the pin — projectId/sectionId/tabOrder stay
+					// untouched so the row returns to its previous spot.
+					draft.sidebarState.pinnedAt = null;
+				}
+			});
+		},
+		[collections],
+	);
+
 	const removeWorkspaceFromSidebar = useCallback(
 		(workspaceId: string) => {
 			const workspace = collections.v2WorkspaceLocalState.get(workspaceId);
@@ -494,6 +525,7 @@ export function useDashboardSidebarState() {
 		reorderWorkspaces,
 		renameSection,
 		setSectionColor,
+		setWorkspacePinned,
 		toggleProjectCollapsed,
 		toggleSectionCollapsed,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -167,6 +167,18 @@ describe("healWorkspaceLocalState", () => {
 		expect(healed.sidebarState.changesFilter).toEqual({ kind: "all" });
 		expect(healed.sidebarState.activeTab).toBe("changes");
 		expect(healed.sidebarState.isHidden).toBe(false);
+		expect(healed.sidebarState.pinnedAt).toBeNull();
+	});
+
+	it("preserves a stored pinnedAt and defaults it on rows written before the field existed", () => {
+		expect(
+			healWorkspaceLocalState(baseStored).sidebarState.pinnedAt,
+		).toBeNull();
+		const healed = healWorkspaceLocalState({
+			...baseStored,
+			sidebarState: { ...baseStored.sidebarState, pinnedAt: 1753000000000 },
+		});
+		expect(healed.sidebarState.pinnedAt).toBe(1753000000000);
 	});
 
 	it("does not throw on null/non-object input (parser must never throw)", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -130,6 +130,9 @@ export const workspaceLocalStateSchema = z.object({
 		changesViewMode: z.enum(["folders", "tree"]).default("folders"),
 		activeTab: z.enum(["changes", "files", "review"]).default("changes"),
 		isHidden: z.boolean().default(false),
+		// Epoch ms when the user pinned this workspace to the sidebar's Pinned
+		// section; null = not pinned. Ordering is pinnedAt ascending.
+		pinnedAt: z.number().int().nullable().default(null),
 	}),
 	paneLayout: paneWorkspaceStateSchema,
 	viewedFiles: z.array(z.string()).default([]),
@@ -168,6 +171,7 @@ const SIDEBAR_STATE_DEFAULTS = {
 	changesViewMode: "folders",
 	activeTab: "changes",
 	isHidden: false,
+	pinnedAt: null,
 } as const;
 
 const WORKSPACE_LOCAL_STATE_OPTIONAL_DEFAULTS = {


### PR DESCRIPTION
## What

Right-click any workspace row in the v2 dashboard sidebar → **Pin**. The workspace moves into a new **Pinned** section at the very top of the sidebar, above all project groups, with a small project avatar for cross-project context. **Unpin** returns it to exactly the project/group/position it came from. Pins persist across restarts. In the collapsed rail, pins render as an icon stack above the project thumbnails.

## How

- **Storage**: nullable `pinnedAt` (epoch ms) on `sidebarState` in the `v2WorkspaceLocalState` localStorage collection — heal-forward, so no migration, no Postgres/Electric/host-service changes, and live-query reactivity for free.
- **Mutation**: idempotent `setWorkspacePinned(workspaceId, projectId, pinned)` in `useDashboardSidebarState`. Repeat pins keep the original pin time; pinning an auto-included local main workspace creates its local-state row first.
- **Ordering**: pinned section sorts by `pinnedAt` ascending — new pins append at the bottom, and pins never reorder themselves.
- **Partition, not mirror**: pinned rows are split out before the project tree is built (`partitionSidebarWorkspacesByPinned` + `buildDashboardSidebarPinnedWorkspaces`, sharing a new `decorateSidebarWorkspace` helper), so a pinned workspace renders only in the Pinned section.
- **Lifecycle**: `tombstoneSidebarWorkspaceRecord` (the sole `isHidden = true` writer) clears `pinnedAt`, so a hidden/removed workspace can never resurrect pre-pinned.
- **Rename**: the pre-existing "pinned" concept (local-main-first sort) is now `isLocalMainWorkspace` / `normalizeMainFirst` to avoid vocabulary collision.
- **Header style**: the Pinned header uses the same 10px uppercase micro-label treatment as the PROJECTS header.

Known v1 interactions with #5956: the project filter doesn't filter the Pinned section (pins stay visible), and pinned rows don't contribute to a project's "last updated" sort ranking.

## Validation

- `bun run typecheck` clean, `bun run lint` clean
- Schema heal + partition/pinned-builder unit tests added; full `_authenticated` route suite 250/250
- ExecPlan included at `apps/desktop/plans/done/20260725-1947-sidebar-workspace-pinning.md`

https://claude.ai/code/session_01WThJeeNfE44b1Xd1ZQsaLr

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add workspace pinning to the v2 dashboard sidebar. Right‑click a workspace to Pin it into a new top Pinned section with a project avatar; Unpin returns it to the same project/section/order, and pins persist across restarts.

- **New Features**
  - New Pinned section above projects; collapsed rail shows an icon stack with a divider.
  - Pinned rows show a project avatar, keep PR status, and the active‑project UI works when the active workspace is pinned.
  - Storage: `sidebarState.pinnedAt` in `v2WorkspaceLocalState` (heal‑forward); ordered by pin time ascending; tombstoning unpins; removing a project clears pins on kept main‑workspace rows.
  - API: idempotent `setWorkspacePinned(workspaceId, projectId, pinned)`; creates a local‑state row when pinning an auto‑included main workspace.
  - Partitioned rendering: pins are removed from project groups; project filter does not hide pins; pins don’t affect a project’s “last updated” sort; context menu adds Pin/Unpin as the first item.

- **Refactors**
  - Renamed the old “pinned” concept to `isLocalMainWorkspace` and `normalizeMainFirst`.
  - Added pinned partition/build helpers and tests; updated fixtures.

<sup>Written for commit 56fe958e04bca7d5598340b23e462f5b533d75c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspaces can now be pinned or unpinned from the sidebar context menu.
  * Pinned workspaces are shown in a dedicated top “Pinned” section, with support for both collapsed and expanded sidebar layouts.
  * Pinned state persists across app restarts, with newly pinned items added to the bottom of the pinned list.
* **Bug Fixes**
  * Workspaces that are hidden or removed no longer remain in the Pinned section.
  * Unpinning returns a workspace to its prior project/section and ordering position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->