### PR TITLE
fix(desktop): make prev/next workspace hotkeys work during worktree creation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -59,11 +59,7 @@ export function useDashboardSidebarShortcuts(
 		() =>
 			groups
 				.flatMap((project) => getProjectChildrenWorkspaces(project.children))
-				.filter(
-					(workspace) =>
-						workspace.pendingTransaction?.type !== "insert" &&
-						!isDeleting(workspace.id),
-				),
+				.filter((workspace) => !isDeleting(workspace.id)),
 		[groups, isDeleting],
 	);
 	const workspaceShortcutLabels =
@@ -143,7 +139,6 @@ export function useDashboardSidebarShortcuts(
 		const index = flattenedWorkspaces.findIndex(
 			(w) => w.id === currentWorkspaceId,
 		);
-		if (index === -1) return;
 		const prevIndex = index <= 0 ? flattenedWorkspaces.length - 1 : index - 1;
 		const target = flattenedWorkspaces[prevIndex];
 		revealWorkspace(target.id);
@@ -155,7 +150,6 @@ export function useDashboardSidebarShortcuts(
 		const index = flattenedWorkspaces.findIndex(
 			(w) => w.id === currentWorkspaceId,
 		);
-		if (index === -1) return;
 		const nextIndex = index >= flattenedWorkspaces.length - 1 ? 0 : index + 1;
 		const target = flattenedWorkspaces[nextIndex];
 		revealWorkspace(target.id);


### PR DESCRIPTION
## Summary
- Prev/next workspace hotkeys (⌘⌥↑/⌘⌥↓) and ⌘1–9 jumps now include workspaces whose worktree is still being created, and prev/next no longer go dead when the current workspace is missing from the navigable list.

## Why / Context
User report: create a workspace, then try to hotkey-navigate away while the worktree is still being created — nothing happens. `useDashboardSidebarShortcuts` filtered out workspaces with a pending `insert` transaction, and that transaction spans the whole create flow (worktree add + agent/terminal launches, per `useWorkspaceCreates.ts`). Since the app navigates you to the new workspace immediately, the *current* workspace wasn't in the list, `findIndex` returned -1, and the handlers bailed — the hotkeys appeared completely broken. The filter is a leftover from an older `isSynced` guard (778131d9d); the v2 route has since handled pending workspaces fine (`WorkspaceCreatingState`), and clicking a creating workspace's sidebar row already navigates to it.

## How It Works
- Drop the `pendingTransaction?.type !== "insert"` exclusion from `flattenedWorkspaces` (mid-delete workspaces stay excluded — they'd land on not-found).
- Drop the `index === -1` bails: the existing wrap arithmetic already degrades sensibly (-1 → last workspace for prev, first for next), so navigation keeps working even from a workspace hidden from the sidebar.

## Manual QA Checklist
Not manually QA'd — verified statically only. Suggested checks:
- [ ] Create a workspace; while "Creating workspace…" is shown, ⌘⌥↑/⌘⌥↓ navigates to the neighboring workspace
- [ ] From another workspace, prev/next lands on the creating workspace (shows `WorkspaceCreatingState`) and continues past it
- [ ] ⌘1–9 label on a creating workspace's sidebar row matches its jump target
- [ ] Prev/next still skips workspaces that are being deleted

## Testing
- `bun run typecheck` (desktop)
- `bun run lint`
- `bun test src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar src/renderer/hotkeys` — 158 pass (Bun 1.3.14, matches CI)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5976">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes prev/next workspace hotkeys (⌘⌥↑/⌘⌥↓) and number jumps (⌘1–9) so they work during worktree creation. Navigation no longer stalls when the current workspace isn’t in the sidebar list.

- **Bug Fixes**
  - Include pending-create workspaces in the navigation list; still skip deleting ones.
  - Remove the early return on missing index and wrap to first/last workspace instead.

<sup>Written for commit 65f5f4e2654ff7566213a3d43e7a1bc53c522df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace navigation shortcuts to continue working reliably when the current workspace is not visible in the workspace list.
  * Updated workspace switching to include workspaces with pending actions, while still excluding workspaces currently being deleted.
  * Preserved wrap-around behavior when navigating between workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->