### PR TITLE
fix(desktop): close terminal pane on clean shell exit

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -32,6 +32,7 @@ import {
 	sendDispose,
 	sendInput,
 	sendResize,
+	type TerminalExitListener,
 	type TerminalLogEntry,
 	type TerminalTransport,
 } from "./terminal-ws-transport";
@@ -598,6 +599,19 @@ class TerminalRuntimeRegistryImpl {
 		entry.transport.logListeners.add(listener);
 		return () => {
 			entry.transport.logListeners.delete(listener);
+		};
+	}
+
+	/** Fires when the PTY behind this terminal exits (not on transport drops). */
+	onExit(
+		terminalId: string,
+		listener: TerminalExitListener,
+		instanceId = terminalId,
+	): () => void {
+		const entry = this.getOrCreateEntry(terminalId, instanceId);
+		entry.transport.exitListeners.add(listener);
+		return () => {
+			entry.transport.exitListeners.delete(listener);
 		};
 	}
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -268,10 +268,15 @@ describe("PTY output write coalescing", () => {
 		]);
 	});
 
-	test("notifies exit listeners with the PTY exit status", () => {
-		const { transport, socket } = connectWithRecordingTerminal();
+	function recordExits(transport: ReturnType<typeof createTransport>) {
 		const seen: Array<{ exitCode: number; signal: number }> = [];
 		transport.exitListeners.add((exit) => seen.push(exit));
+		return seen;
+	}
+
+	test("notifies exit listeners with the PTY exit status", () => {
+		const { transport, socket } = connectWithRecordingTerminal();
+		const seen = recordExits(transport);
 
 		socket.message(JSON.stringify({ type: "exit", exitCode: 3, signal: 9 }));
 
@@ -280,8 +285,7 @@ describe("PTY output write coalescing", () => {
 
 	test("does not notify exit listeners when the socket merely drops", () => {
 		const { transport, socket } = connectWithRecordingTerminal();
-		const seen: Array<{ exitCode: number; signal: number }> = [];
-		transport.exitListeners.add((exit) => seen.push(exit));
+		const seen = recordExits(transport);
 
 		socket.drop(1006, "host restart");
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -268,6 +268,26 @@ describe("PTY output write coalescing", () => {
 		]);
 	});
 
+	test("notifies exit listeners with the PTY exit status", () => {
+		const { transport, socket } = connectWithRecordingTerminal();
+		const seen: Array<{ exitCode: number; signal: number }> = [];
+		transport.exitListeners.add((exit) => seen.push(exit));
+
+		socket.message(JSON.stringify({ type: "exit", exitCode: 3, signal: 9 }));
+
+		expect(seen).toEqual([{ exitCode: 3, signal: 9 }]);
+	});
+
+	test("does not notify exit listeners when the socket merely drops", () => {
+		const { transport, socket } = connectWithRecordingTerminal();
+		const seen: Array<{ exitCode: number; signal: number }> = [];
+		transport.exitListeners.add((exit) => seen.push(exit));
+
+		socket.drop(1006, "host restart");
+
+		expect(seen).toEqual([]);
+	});
+
 	test("does not flush pending PTY bytes for non-writing control messages", () => {
 		const { writes, socket } = connectWithRecordingTerminal();
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -16,6 +16,11 @@ export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
 
 export type TerminalLogLevel = "info" | "warn" | "error";
 
+export type TerminalExitListener = (exit: {
+	exitCode: number;
+	signal: number;
+}) => void;
+
 export interface TerminalLogEntry {
 	id: number;
 	timestamp: number;
@@ -48,6 +53,12 @@ export interface TerminalTransport {
 	 */
 	logs: TerminalLogEntry[];
 	logListeners: Set<() => void>;
+	/**
+	 * Notified when the server reports the PTY exited, so a pane can react to a
+	 * shell ending (e.g. close itself on a clean `exit`). Not fired for
+	 * transport-level closes — those reconnect.
+	 */
+	exitListeners: Set<TerminalExitListener>;
 	/**
 	 * Why the connection is down, once it has failed enough consecutive attempts
 	 * to be worth surfacing (or access was denied / the session ended). Null
@@ -251,6 +262,7 @@ export function createTransport(): TerminalTransport {
 		titleListeners: new Set(),
 		logs: [],
 		logListeners: new Set(),
+		exitListeners: new Set(),
 		lastDiagnosis: null,
 		_socket: null,
 		_terminal: null,
@@ -574,6 +586,9 @@ function attachSocketListeners(
 			terminal.writeln(
 				`\r\n[terminal] exited with code ${message.exitCode} (signal ${message.signal})`,
 			);
+			for (const listener of transport.exitListeners) {
+				listener({ exitCode: message.exitCode, signal: message.signal });
+			}
 		}
 	});
 
@@ -719,4 +734,5 @@ export function disposeTransport(transport: TerminalTransport) {
 	transport.titleListeners.clear();
 	transport.logs = [];
 	transport.logListeners.clear();
+	transport.exitListeners.clear();
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -31,6 +31,7 @@ import type {
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { openUrlInV2Workspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openUrlInV2Workspace";
 import { useWorkspaceWsUrl } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { ScrollToBottomButton } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton";
 import { TerminalSearch } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/TerminalSearch";
 import { useTheme } from "renderer/stores/theme";
@@ -163,6 +164,31 @@ export function TerminalPane({
 			terminalRuntimeRegistry.detach(terminalId, terminalInstanceId);
 		};
 	}, [terminalId, terminalInstanceId]);
+
+	const collections = useCollections();
+	// ctx.actions.close is a fresh identity every render; ref it so the exit
+	// listener below isn't re-subscribed on every keystroke.
+	const closePaneRef = useRef(ctx.actions.close);
+	closePaneRef.current = ctx.actions.close;
+
+	// A clean `exit` closes the pane, matching the v1 terminal. A non-zero or
+	// signalled exit leaves it open so the "[terminal] exited with code N" line
+	// stays readable, and a workspace-run pane always stays — its output is the
+	// point of the pane, so it has to outlive the process.
+	useEffect(
+		() =>
+			terminalRuntimeRegistry.onExit(
+				terminalId,
+				({ exitCode, signal }) => {
+					if (exitCode !== 0 || signal !== 0) return;
+					const localState = collections.v2WorkspaceLocalState.get(workspaceId);
+					if (localState?.workspaceRunTerminals?.[terminalId]) return;
+					closePaneRef.current();
+				},
+				terminalInstanceId,
+			),
+		[terminalId, terminalInstanceId, collections, workspaceId],
+	);
 
 	useEffect(() => {
 		if (!ctx.isActive) return;


### PR DESCRIPTION
## What & why

I kept typing `exit` out of habit and getting a dead pane back a `[terminal] exited with code 0 (signal 0)` sitting there until I closed it by hand. Did it enough times that I took a weekend to fix it.

The v1 terminal closed the pane on a clean exit (`useTerminalStream` `removePane`, comment: "Clean exit (e.g. typing `exit`) close the pane/tab"), but the v2 WebSocket transport never surfaced the PTY exit, so nothing acted on
it.

Adds an exit listener to the transport, exposes it as `terminalRuntimeRegistry.onExit()`, and has `TerminalPane` close itself when the shell exits `0` with no signal. Non-zero and signalled exits keep the pane so the status line stays readable, and workspace-run panes are exempt - their output has to outlive the process.

Fixes #4757. (#4758 did this and was closed unmerged; happy to adjust if that was a design call rather than bot-PR cleanup.)

## How I tested it

Ran the dev app against the local stack:

- `exit` - pane closes
- `exit 3` -  pane stays, shows `[terminal] exited with code 3 (signal 0)`
- `sleep 60` then close the pane - "a process is still running" confirm still appears
- workspace-run pane finishing cleanly - pane stays

`bun test apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts` covers both listener cases. `bun run lint` and `bun run typecheck` pass.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superset-sh/superset/pull/5977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically closes a terminal pane when the shell exits cleanly, restoring v1 behavior and preventing “dead” panes. Adds PTY exit events to the v2 WebSocket transport so the UI can react.

- **Bug Fixes**
  - Added PTY exit listener in `terminal-ws-transport`, emitting `{exitCode, signal}` and exposed `terminalRuntimeRegistry.onExit()`; listeners are cleared on dispose.
  - `TerminalPane` auto-closes on clean exit (`exitCode: 0`, `signal: 0`); non-zero/signalled exits stay open; workspace-run panes never auto-close.
  - Exit events aren’t emitted on socket drops; tests cover exit vs drop, with a small helper to record exits.

<sup>Written for commit 8bc63e555e3d48a5df5ff04f3ec30630a3d9e4fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/5977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal panes now respond to terminal process exits.
  * Cleanly completed terminals close automatically when appropriate.
  * Terminals associated with active workspace runs remain open.

* **Bug Fixes**
  * Unexpected terminal failures no longer close the pane automatically, keeping exit details visible.
  * Terminal disconnects are distinguished from confirmed process exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->